### PR TITLE
feat(examples): add inference.sh persona pack

### DIFF
--- a/examples/inference-sh/.mcp.json
+++ b/examples/inference-sh/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "inference-sh": {
+      "command": "inference-mcp-bridge",
+      "args": [],
+      "env": {
+        "INFERENCE_API_KEY": "${INFERENCE_API_KEY}"
+      }
+    }
+  }
+}

--- a/examples/inference-sh/.plugin/plugin.json
+++ b/examples/inference-sh/.plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://open-plugin-spec.org/schema/v1/plugin.json",
+  "id": "sh.inference.buzz-pack",
+  "name": "inference.sh",
+  "version": "0.1.0",
+  "description": "An agent with access to AI apps on inference.sh — image generation, video, audio, search, and more.",
+  "author": "inference.sh",
+  "license": "MIT",
+  "homepage": "https://inference.sh",
+  "keywords": ["inference", "image-generation", "video", "audio", "multimodal"],
+  "personas": [
+    "agents/shelly.persona.md"
+  ],
+  "mcp_config": ".mcp.json",
+  "defaults": {
+    "model": "anthropic:claude-sonnet-4-20250514",
+    "temperature": 0.7,
+    "triggers": {
+      "mentions": true,
+      "keywords": [],
+      "all_messages": false
+    },
+    "thread_replies": true,
+    "broadcast_replies": false
+  }
+}

--- a/examples/inference-sh/README.md
+++ b/examples/inference-sh/README.md
@@ -1,0 +1,55 @@
+# inference.sh
+
+A persona pack that gives Buzz agents access to AI apps on [inference.sh](https://inference.sh) — image generation, video, audio, search, LLMs, and more.
+
+| Agent | Role |
+|-------|------|
+| **Shelly** | Creative agent — generates images, video, audio, and other media on demand |
+
+## Prerequisites
+
+Install the [inference-mcp-bridge](https://github.com/inference-sh/inference-mcp-bridge) binary:
+
+```bash
+# Download from releases
+curl -L https://github.com/inference-sh/inference-mcp-bridge/releases/latest/download/inference-mcp-bridge_$(uname -s)_$(uname -m | sed 's/aarch64/arm64/').tar.gz | tar xz
+
+# Or build from source
+cargo install --git https://github.com/inference-sh/inference-mcp-bridge --path bridge
+```
+
+Get an API key at [inference.sh/settings/keys](https://app.inference.sh/settings/keys).
+
+## Usage
+
+```bash
+export INFERENCE_API_KEY="your-api-key"
+
+# Validate the pack
+buzz pack validate ./examples/inference-sh
+
+# Inspect resolved config
+buzz pack inspect ./examples/inference-sh
+```
+
+## Structure
+
+```
+inference-sh/
+├── .plugin/
+│   └── plugin.json       # Pack manifest (OPS-compatible)
+├── agents/
+│   └── shelly.persona.md  # Creative agent
+├── .mcp.json             # inference-mcp-bridge config
+└── README.md
+```
+
+## How it works
+
+The pack configures [inference-mcp-bridge](https://github.com/inference-sh/inference-mcp-bridge) as an MCP server. The bridge translates between Buzz's stdio MCP transport and inference.sh's HTTP API, giving agents access to tools like `app_run`, `app_list`, and `app_get`.
+
+## Customizing
+
+Edit `agents/shelly.persona.md` to change the agent's behavior, or add more personas to the pack. Each agent in the pack shares the inference.sh MCP server defined in `.mcp.json`.
+
+See `crates/buzz-persona/PERSONA_PACK_SPEC.md` for the full format reference.

--- a/examples/inference-sh/agents/shelly.persona.md
+++ b/examples/inference-sh/agents/shelly.persona.md
@@ -1,0 +1,43 @@
+---
+name: shelly
+display_name: "Shelly"
+description: "Creative agent — generates images, video, audio, and other media via inference.sh."
+triggers:
+  mentions: true
+  keywords:
+    - generate
+    - image
+    - video
+    - audio
+    - create
+    - design
+    - render
+temperature: 0.7
+---
+
+You are Shelly, a creative agent with access to AI apps on inference.sh. You help the team by generating images, videos, audio, and other media on demand.
+
+## What you can do
+
+You have access to inference.sh tools through MCP. Use them to:
+
+- **Generate images** — logos, mockups, diagrams, illustrations, photos
+- **Generate video** — clips, animations, product demos
+- **Generate audio** — music, sound effects, voiceovers
+- **Search the web** — find references, research topics
+- **Run LLMs** — use specialized models for specific tasks
+
+## How you work
+
+1. When asked to create something, use `app_list` to find the right app for the job.
+2. Use `app_get` to check the app's input schema and understand what parameters it accepts.
+3. Use `app_run` to run the app with the right inputs.
+4. Share the result in the channel with a brief description of what you made.
+
+If generation takes a while, let the channel know you're working on it. If something fails, explain what went wrong and suggest alternatives.
+
+## Guidelines
+
+- Ask clarifying questions when the request is vague — "an image" is too broad, "a pixel art logo of a bee on a honeycomb background" is actionable.
+- When you share results, include the app and key parameters you used so others can iterate.
+- If someone wants a variation, adjust the parameters and regenerate rather than starting from scratch.


### PR DESCRIPTION
## Summary

Adds an example persona pack that connects Buzz agents to [inference.sh](https://inference.sh) via [inference-mcp-bridge](https://github.com/inference-sh/inference-mcp-bridge).

- **Spark** persona: a creative agent that generates images, video, audio, and other media on demand using inference.sh's AI apps
- `.mcp.json` wires `inference-mcp-bridge` as a shared MCP server for the pack
- README with prerequisites, setup, and usage instructions

`inference-mcp-bridge` is a lightweight Rust binary (~60 lines) that translates between stdio MCP and inference.sh's Streamable HTTP MCP endpoint. It gives any Buzz agent access to tools like `app_run`, `app_list`, and `app_get` for running AI apps — image generation (FLUX, Stable Diffusion), video (Veo, Seedance), audio (TTS, music), web search, and more.

```
┌────────────┐   stdio    ┌──────────────────────┐   HTTPS    ┌──────────────┐
│ Buzz agent │ ─────────► │ inference-mcp-bridge │ ─────────► │ inference.sh │
│            │ ◄───────── │                      │ ◄───────── │ MCP server   │
└────────────┘  JSON-RPC  └──────────────────────┘  JSON-RPC  └──────────────┘
```

## Test plan

- [x] `buzz pack validate ./examples/inference-sh` passes
- [x] `buzz pack inspect ./examples/inference-sh` shows resolved config with inference-sh MCP server
- [ ] Agent responds to @mentions and keyword triggers (`generate`, `image`, `video`, etc.)
- [x] `app_list`, `app_get`, `app_run` tools are available to the agent via MCP