### PR TITLE
HOLD: harden disabled AEON Aspect workers (no live activation)

### DIFF
--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -74,7 +74,7 @@ evalexpr = { workspace = true }
 # Process-group kill (safe wrapper around killpg) — Unix-only; kill_process_group
 # has a #[cfg(not(unix))] fallback in acp.rs.
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["signal"] }
+nix = { version = "0.31", default-features = false, features = ["fs", "signal", "user"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -97,14 +97,18 @@ All configuration is via environment variables (or CLI flags — every env var h
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `BUZZ_PRIVATE_KEY` | **yes** | — | Agent's Nostr private key (`nsec1...`). Used for relay auth and agent identity. |
+| `BUZZ_PRIVATE_KEY` | one key source required | — | Agent's Nostr private key (`nsec1...`). Conflicts with `BUZZ_PRIVATE_KEY_FILE`. |
+| `BUZZ_PRIVATE_KEY_FILE` | one key source required | — | Absolute path to a current-user-owned, regular, non-symlink key file with mode `0600`. |
+| `BUZZ_EXPECTED_PUBLIC_KEY` | with key file in supervised deployments | — | Expected hex pubkey derived from `BUZZ_PRIVATE_KEY_FILE`; startup fails on mismatch. |
 | `BUZZ_RELAY_URL` | no | `ws://localhost:3000` | Relay WebSocket URL. |
 | `BUZZ_ACP_AGENT_COMMAND` | no | `goose` | Agent binary to spawn. |
 | `BUZZ_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
-| `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
+| `BUZZ_ACP_IDLE_TIMEOUT` | no | `900` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
+| `BUZZ_ACP_TURN_RECEIPTS` | no | `false` | OpenClaw-only opt-in that closes successful channel turns against signed Buzz reply and Gateway lineage evidence. Requires relay observer. |
+| `BUZZ_ACP_EXPECTED_GATEWAY_SESSION_KEY` | with turn receipts | — | Fixed Gateway session key that observed ACP lineage must match. |
 
 **Note:** `BUZZ_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
 

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -187,6 +187,11 @@ pub struct AcpClient {
     /// Other agents may leave this unset — readers must treat `None` as
     /// "no active run to steer into" and fall back to cancel+merge.
     active_run_id: Option<String>,
+    /// Most recent run ID observed during the current prompt, retained after
+    /// adapters clear their active-run marker at turn completion.
+    last_turn_run_id: Option<String>,
+    /// Stable backend session key reported by ACP session lineage metadata.
+    active_session_key: Option<String>,
     /// Per-turn channel for receiving goose-native non-cancelling steer
     /// requests from the main loop. Installed by
     /// [`install_steer_rx`](Self::install_steer_rx) at dispatch and
@@ -490,6 +495,8 @@ impl AcpClient {
             observer_agent_index: None,
             observer_context: ObserverContext::default(),
             active_run_id: None,
+            last_turn_run_id: None,
+            active_session_key: None,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
         })
@@ -764,6 +771,24 @@ impl AcpClient {
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn active_run_id(&self) -> Option<&str> {
         self.active_run_id.as_deref()
+    }
+
+    /// Stable backend session key observed from ACP session lineage evidence.
+    pub fn active_session_key(&self) -> Option<&str> {
+        self.active_session_key.as_deref()
+    }
+
+    /// Run ID observed during the current turn, including after active state clears.
+    pub fn turn_run_id(&self) -> Option<&str> {
+        self.active_run_id
+            .as_deref()
+            .or(self.last_turn_run_id.as_deref())
+    }
+
+    /// Reset turn-scoped evidence before issuing a new prompt.
+    pub fn begin_turn_evidence(&mut self) {
+        self.active_run_id = None;
+        self.last_turn_run_id = None;
     }
 
     /// Consume and return the per-turn usage record computed from the most
@@ -1591,19 +1616,30 @@ impl AcpClient {
                 // on the update object itself — nested inside `update`, not
                 // alongside it at the params level. Goose and buzz-agent both
                 // emit it at `params.update._meta.goose.activeRunId`.
-                let meta = msg["params"]["update"]
-                    .get("_meta")
-                    .and_then(|m| m.get("goose"));
-                if let Some(goose_meta) = meta {
-                    match goose_meta.get("activeRunId") {
-                        Some(serde_json::Value::String(run_id)) => {
+                let update_meta = msg["params"]["update"].get("_meta");
+                if let Some(session_key) = update_meta
+                    .and_then(|meta| meta.get("sessionKey"))
+                    .and_then(|value| value.as_str())
+                    .filter(|value| !value.trim().is_empty())
+                {
+                    self.active_session_key = Some(session_key.to_string());
+                }
+                let run_value = update_meta.and_then(|meta| {
+                    meta.get("activeRunId")
+                        .or_else(|| meta.get("runId"))
+                        .or_else(|| meta.get("goose").and_then(|goose| goose.get("activeRunId")))
+                });
+                if let Some(run_value) = run_value {
+                    match run_value {
+                        serde_json::Value::String(run_id) => {
                             tracing::debug!(
                                 target: "acp::update",
                                 "session_info_update: activeRunId={run_id}"
                             );
                             self.active_run_id = Some(run_id.clone());
+                            self.last_turn_run_id = Some(run_id.clone());
                         }
-                        Some(serde_json::Value::Null) => {
+                        serde_json::Value::Null => {
                             tracing::debug!(
                                 target: "acp::update",
                                 "session_info_update: activeRunId cleared"
@@ -3099,6 +3135,37 @@ mod tests {
             client.active_run_id().is_none(),
             "explicit null must clear active_run_id"
         );
+        assert_eq!(
+            client.turn_run_id(),
+            Some("run-xyz"),
+            "turn evidence must retain the completed run id"
+        );
+    }
+
+    #[tokio::test]
+    async fn openclaw_session_lineage_and_flat_run_id_are_captured() {
+        let mut client = spawn_inert_client().await;
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "acp-session",
+                "update": {
+                    "sessionUpdate": "session_info_update",
+                    "_meta": {
+                        "sessionKey": "agent:main:buzz-private",
+                        "runId": "gateway-run-42"
+                    }
+                }
+            }
+        });
+        let _ = client.handle_session_update(&msg);
+        assert_eq!(client.active_session_key(), Some("agent:main:buzz-private"));
+        assert_eq!(client.turn_run_id(), Some("gateway-run-42"));
+
+        client.begin_turn_evidence();
+        assert_eq!(client.active_session_key(), Some("agent:main:buzz-private"));
+        assert!(client.turn_run_id().is_none());
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -180,6 +180,9 @@ pub enum AcpError {
 
     #[error("Agent reported error (code {code}): {message}")]
     AgentError { code: i64, message: String },
+
+    #[error("Trusted inbound event refused: {0}")]
+    TrustedInboundEventRefused(&'static str),
 }
 
 /// Build an [`AcpError::AgentError`] from a JSON-RPC error object,

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -268,6 +268,10 @@ pub struct AcpClient {
     goose_usage: UsageTracker,
 }
 
+fn harness_bound_agent_env(key: &str) -> bool {
+    matches!(key, "BUZZ_RELAY_URL" | "BUZZ_PRIVATE_KEY")
+}
+
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
 /// collisions.  When both sides have an object for the same key, the merge recurses so
 /// unrelated nested keys from `base` are preserved.
@@ -491,7 +495,9 @@ impl AcpClient {
 
         // Per-persona env vars (e.g., GOOSE_PROVIDER, BUZZ_AGENT_PROVIDER).
         // For most keys, operator precedence wins: skip injection if already set
-        // in the parent environment.
+        // in the parent environment. Harness-bound Buzz credentials are the
+        // exception: they must match the validated relay identity even if the
+        // parent happens to carry credentials for another workspace.
         //
         // CODEX_CONFIG is handled specially via build_codex_config_env:
         //   • has_generated_codex_config=true: merge all CODEX_CONFIG entries + parent
@@ -518,7 +524,7 @@ impl AcpClient {
                 // Handled by build_codex_config_env; skip here to avoid double-setting.
                 continue;
             }
-            if std::env::var(key).is_err() {
+            if harness_bound_agent_env(key) || std::env::var(key).is_err() {
                 cmd.env(key, value);
             }
         }
@@ -2119,6 +2125,14 @@ fn kill_process_group(_pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn harness_buzz_credentials_override_parent_environment() {
+        assert!(harness_bound_agent_env("BUZZ_RELAY_URL"));
+        assert!(harness_bound_agent_env("BUZZ_PRIVATE_KEY"));
+        assert!(!harness_bound_agent_env("GOOSE_PROVIDER"));
+        assert!(!harness_bound_agent_env("CODEX_CONFIG"));
+    }
 
     fn signed_batch(
         channel_id: uuid::Uuid,

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -41,7 +41,10 @@ impl TrustedInboundEventEnvelope {
     /// failed signature verification produces no trusted metadata.
     pub(crate) fn from_prompt_batch(batch: Option<&crate::queue::FlushBatch>) -> Option<Self> {
         let batch = batch?;
-        if !batch.cancelled_events.is_empty() || batch.events.len() != 1 {
+        if batch.cancel_reason.is_some()
+            || !batch.cancelled_events.is_empty()
+            || batch.events.len() != 1
+        {
             return None;
         }
         let event = &batch.events[0].event;
@@ -2451,6 +2454,16 @@ mod tests {
         let mut cancelled = signed_batch(channel_id, vec![]);
         cancelled.cancelled_events.push(cancelled.events[0].clone());
         assert!(TrustedInboundEventEnvelope::from_prompt_batch(Some(&cancelled)).is_none());
+
+        // Queue fallback re-dispatches cancelled events in the regular event
+        // slot while preserving the cancellation reason. That shape must not
+        // regain trusted inbound authority merely because cancelled_events is
+        // empty after the move.
+        let mut cancelled_fallback = signed_batch(channel_id, vec![]);
+        cancelled_fallback.cancel_reason = Some(crate::queue::CancelReason::Steer);
+        assert!(
+            TrustedInboundEventEnvelope::from_prompt_batch(Some(&cancelled_fallback)).is_none()
+        );
 
         assert!(TrustedInboundEventEnvelope::from_prompt_batch(None).is_none());
     }

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -480,6 +480,7 @@ impl AcpClient {
         args: &[String],
         extra_env: &[(String, String)],
         has_generated_codex_config: bool,
+        forward_buzz_publisher_credentials: bool,
     ) -> Result<Self, AcpError> {
         use std::process::Stdio;
 
@@ -519,12 +520,22 @@ impl AcpClient {
         // entry falls through to the standard operator-wins treatment below.
         let codex_merge_active = codex_config_value.is_some();
 
+        // The harness can retain its relay/signer authority while the managed
+        // agent remains unable to publish directly. env_remove also closes the
+        // parent-process inheritance path when credentials configured the harness.
+        if !forward_buzz_publisher_credentials {
+            cmd.env_remove("BUZZ_RELAY_URL");
+            cmd.env_remove("BUZZ_PRIVATE_KEY");
+        }
+
         for (key, value) in extra_env {
             if key == "CODEX_CONFIG" && codex_merge_active {
                 // Handled by build_codex_config_env; skip here to avoid double-setting.
                 continue;
             }
-            if harness_bound_agent_env(key) || std::env::var(key).is_err() {
+            if (forward_buzz_publisher_credentials && harness_bound_agent_env(key))
+                || (!harness_bound_agent_env(key) && std::env::var(key).is_err())
+            {
                 cmd.env(key, value);
             }
         }
@@ -2134,6 +2145,38 @@ mod tests {
         assert!(!harness_bound_agent_env("CODEX_CONFIG"));
     }
 
+    #[tokio::test]
+    async fn isolated_child_cannot_read_explicit_publisher_credentials() {
+        let script = r#"
+            if test -n "$BUZZ_RELAY_URL" || test -n "$BUZZ_PRIVATE_KEY"; then
+                exit 23
+            fi
+            read -t 2 _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":1,"agentCapabilities":{}}}'
+        "#;
+        let publisher_env = vec![
+            (
+                "BUZZ_RELAY_URL".to_string(),
+                "ws://relay.invalid".to_string(),
+            ),
+            ("BUZZ_PRIVATE_KEY".to_string(), "secret".to_string()),
+        ];
+        let mut client = AcpClient::spawn(
+            "bash",
+            &["-c".to_string(), script.to_string()],
+            &publisher_env,
+            false,
+            false,
+        )
+        .await
+        .expect("spawn isolated child");
+
+        client
+            .initialize()
+            .await
+            .expect("child initializes only when publisher credentials are absent");
+    }
+
     fn signed_batch(
         channel_id: uuid::Uuid,
         extra_tags: Vec<nostr::Tag>,
@@ -2840,7 +2883,7 @@ mod tests {
     }
 
     async fn spawn_script(script: &str) -> AcpClient {
-        AcpClient::spawn("bash", &["-c".into(), script.into()], &[], false)
+        AcpClient::spawn("bash", &["-c".into(), script.into()], &[], false, true)
             .await
             .expect("failed to spawn test script")
     }
@@ -3296,7 +3339,7 @@ mod tests {
     /// which is fine — these tests don't read from the agent, they just
     /// feed JSON into the parser.
     async fn spawn_inert_client() -> AcpClient {
-        AcpClient::spawn("cat", &[], &[], false)
+        AcpClient::spawn("cat", &[], &[], false, true)
             .await
             .expect("spawn cat as inert client")
     }

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -39,17 +39,30 @@ impl TrustedInboundEventEnvelope {
     /// Build an envelope only for an unambiguous single-event batch whose
     /// signed `h` tag exactly matches the subscribed channel. Any ambiguity or
     /// failed signature verification produces no trusted metadata.
+    #[cfg(test)]
     pub(crate) fn from_prompt_batch(batch: Option<&crate::queue::FlushBatch>) -> Option<Self> {
-        let batch = batch?;
-        if batch.cancel_reason.is_some()
-            || !batch.cancelled_events.is_empty()
-            || batch.events.len() != 1
-        {
-            return None;
+        Self::try_from_prompt_batch(batch).ok()
+    }
+
+    /// Return a stable, secret-free refusal code when trusted metadata cannot
+    /// be derived. The worker logs this at the admission boundary so a missing
+    /// envelope cannot masquerade as an agent/tool-policy failure.
+    pub(crate) fn try_from_prompt_batch(
+        batch: Option<&crate::queue::FlushBatch>,
+    ) -> Result<Self, &'static str> {
+        let batch = batch.ok_or("missing_batch")?;
+        if batch.cancel_reason.is_some() {
+            return Err("cancelled_batch");
+        }
+        if !batch.cancelled_events.is_empty() {
+            return Err("cancelled_events_present");
+        }
+        if batch.events.len() != 1 {
+            return Err("ambiguous_event_count");
         }
         let event = &batch.events[0].event;
         if event.verify().is_err() {
-            return None;
+            return Err("invalid_signature");
         }
         let tags: Vec<Vec<String>> = event
             .tags
@@ -64,9 +77,9 @@ impl TrustedInboundEventEnvelope {
         if h_tags.len() != 1
             || h_tags[0].get(1).map(String::as_str) != Some(expected_channel.as_str())
         {
-            return None;
+            return Err("invalid_channel_binding");
         }
-        Some(Self {
+        Ok(Self {
             schema_version: 1,
             event_id: event.id.to_hex(),
             author_pubkey: event.pubkey.to_hex(),
@@ -2489,6 +2502,10 @@ mod tests {
         raw["content"] = serde_json::Value::String("tampered".into());
         tampered.events[0].event = serde_json::from_value(raw).expect("parse tampered event");
         assert!(TrustedInboundEventEnvelope::from_prompt_batch(Some(&tampered)).is_none());
+        assert_eq!(
+            TrustedInboundEventEnvelope::try_from_prompt_batch(Some(&tampered)).err(),
+            Some("invalid_signature")
+        );
 
         let second_h = nostr::Tag::parse(["h", channel_id.to_string().as_str()]).expect("h tag");
         let duplicate_room = signed_batch(channel_id, vec![second_h]);
@@ -2507,10 +2524,18 @@ mod tests {
         let mut multi = signed_batch(channel_id, vec![]);
         multi.events.push(multi.events[0].clone());
         assert!(TrustedInboundEventEnvelope::from_prompt_batch(Some(&multi)).is_none());
+        assert_eq!(
+            TrustedInboundEventEnvelope::try_from_prompt_batch(Some(&multi)).err(),
+            Some("ambiguous_event_count")
+        );
 
         let mut cancelled = signed_batch(channel_id, vec![]);
         cancelled.cancelled_events.push(cancelled.events[0].clone());
         assert!(TrustedInboundEventEnvelope::from_prompt_batch(Some(&cancelled)).is_none());
+        assert_eq!(
+            TrustedInboundEventEnvelope::try_from_prompt_batch(Some(&cancelled)).err(),
+            Some("cancelled_events_present")
+        );
 
         // Queue fallback re-dispatches cancelled events in the regular event
         // slot while preserving the cancellation reason. That shape must not
@@ -2520,6 +2545,10 @@ mod tests {
         cancelled_fallback.cancel_reason = Some(crate::queue::CancelReason::Steer);
         assert!(
             TrustedInboundEventEnvelope::from_prompt_batch(Some(&cancelled_fallback)).is_none()
+        );
+        assert_eq!(
+            TrustedInboundEventEnvelope::try_from_prompt_batch(Some(&cancelled_fallback)).err(),
+            Some("cancelled_batch")
         );
 
         assert!(TrustedInboundEventEnvelope::from_prompt_batch(None).is_none());

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -16,6 +16,64 @@ use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
 use crate::observer::{ObserverContext, ObserverHandle};
 use crate::usage::{TurnUsage, UsageTracker};
 
+/// ACP `_meta` key carrying a Buzz-verified triggering event.
+///
+/// The value is transport metadata, not a prompt content block. Adapters that
+/// do not explicitly consume the extension ignore it per ACP extensibility.
+pub(crate) const TRUSTED_INBOUND_EVENT_META_NAMESPACE: &str = "buzz";
+pub(crate) const TRUSTED_INBOUND_EVENT_META_FIELD: &str = "inboundEvent";
+
+/// Immutable evidence copied from one signature-verified triggering event.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TrustedInboundEventEnvelope {
+    schema_version: u8,
+    event_id: String,
+    author_pubkey: String,
+    kind: u16,
+    channel_id: String,
+    tags: Vec<Vec<String>>,
+}
+
+impl TrustedInboundEventEnvelope {
+    /// Build an envelope only for an unambiguous single-event batch whose
+    /// signed `h` tag exactly matches the subscribed channel. Any ambiguity or
+    /// failed signature verification produces no trusted metadata.
+    pub(crate) fn from_prompt_batch(batch: Option<&crate::queue::FlushBatch>) -> Option<Self> {
+        let batch = batch?;
+        if !batch.cancelled_events.is_empty() || batch.events.len() != 1 {
+            return None;
+        }
+        let event = &batch.events[0].event;
+        if event.verify().is_err() {
+            return None;
+        }
+        let tags: Vec<Vec<String>> = event
+            .tags
+            .iter()
+            .map(|tag| tag.as_slice().to_vec())
+            .collect();
+        let expected_channel = batch.channel_id.to_string();
+        let h_tags: Vec<&Vec<String>> = tags
+            .iter()
+            .filter(|tag| tag.first().map(String::as_str) == Some("h"))
+            .collect();
+        if h_tags.len() != 1
+            || h_tags[0].get(1).map(String::as_str) != Some(expected_channel.as_str())
+        {
+            return None;
+        }
+        Some(Self {
+            schema_version: 1,
+            event_id: event.id.to_hex(),
+            author_pubkey: event.pubkey.to_hex(),
+            kind: event.kind.as_u16(),
+            channel_id: expected_channel,
+            tags,
+        })
+    }
+}
+
 /// Maximum allowed size of a single NDJSON line from the agent's stdout.
 /// Lines exceeding this limit are rejected to prevent OOM from rogue agents.
 const MAX_LINE_SIZE: usize = 10_000_000; // 10 MB
@@ -683,7 +741,27 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
-        let params = build_prompt_params(session_id, prompt_blocks);
+        self.session_prompt_blocks_with_idle_timeout_and_meta(
+            session_id,
+            prompt_blocks,
+            None,
+            idle_timeout,
+            max_duration,
+        )
+        .await
+    }
+
+    /// Send `session/prompt`, optionally attaching a verified Buzz event as
+    /// ACP extension metadata outside the model-visible content blocks.
+    pub(crate) async fn session_prompt_blocks_with_idle_timeout_and_meta(
+        &mut self,
+        session_id: &str,
+        prompt_blocks: &[&str],
+        trusted_inbound_event: Option<&TrustedInboundEventEnvelope>,
+        idle_timeout: std::time::Duration,
+        max_duration: std::time::Duration,
+    ) -> Result<StopReason, AcpError> {
+        let params = build_prompt_params(session_id, prompt_blocks, trusted_inbound_event);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
 
@@ -1797,15 +1875,27 @@ impl AcpClient {
 }
 
 /// Build `session/prompt` params from one or more text content blocks.
-fn build_prompt_params(session_id: &str, prompt_blocks: &[&str]) -> serde_json::Value {
+fn build_prompt_params(
+    session_id: &str,
+    prompt_blocks: &[&str],
+    trusted_inbound_event: Option<&TrustedInboundEventEnvelope>,
+) -> serde_json::Value {
     let blocks: Vec<serde_json::Value> = prompt_blocks
         .iter()
         .map(|text| serde_json::json!({ "type": "text", "text": text }))
         .collect();
-    serde_json::json!({
+    let mut params = serde_json::json!({
         "sessionId": session_id,
         "prompt": blocks,
-    })
+    });
+    if let Some(envelope) = trusted_inbound_event {
+        params["_meta"] = serde_json::json!({
+            TRUSTED_INBOUND_EVENT_META_NAMESPACE: {
+                TRUSTED_INBOUND_EVENT_META_FIELD: envelope,
+            },
+        });
+    }
+    params
 }
 
 /// Build `_goose/unstable/session/steer` params from one or more text
@@ -2026,6 +2116,30 @@ fn kill_process_group(_pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn signed_batch(
+        channel_id: uuid::Uuid,
+        extra_tags: Vec<nostr::Tag>,
+    ) -> crate::queue::FlushBatch {
+        let keys = nostr::Keys::generate();
+        let mut tags =
+            vec![nostr::Tag::parse(["h", channel_id.to_string().as_str()]).expect("h tag")];
+        tags.extend(extra_tags);
+        let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "hello")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .expect("signed event");
+        crate::queue::FlushBatch {
+            channel_id,
+            events: vec![crate::queue::BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        }
+    }
 
     #[test]
     fn stop_reason_parses_all_known_values() {
@@ -2260,6 +2374,7 @@ mod tests {
                 "/goal ship it",
                 "[Buzz event: @mention]\nContent: @Eva /goal ship it",
             ],
+            None,
         );
         let prompt = params["prompt"].as_array().unwrap();
         assert_eq!(prompt.len(), 2);
@@ -2267,6 +2382,83 @@ mod tests {
         assert_eq!(prompt[0]["text"].as_str(), Some("/goal ship it"));
         assert!(prompt[0]["text"].as_str().unwrap().starts_with('/'));
         assert_eq!(prompt[1]["type"].as_str(), Some("text"));
+    }
+
+    #[test]
+    fn trusted_inbound_event_is_verified_and_stays_out_of_prompt_blocks() {
+        let channel_id = uuid::Uuid::new_v4();
+        let p_tag = nostr::Tag::parse(["p", "ab".repeat(32).as_str()]).expect("p tag");
+        let batch = signed_batch(channel_id, vec![p_tag]);
+        let envelope = TrustedInboundEventEnvelope::from_prompt_batch(Some(&batch))
+            .expect("valid signed single event");
+        let params = build_prompt_params("session", &["model-visible body"], Some(&envelope));
+
+        assert_eq!(params["prompt"][0]["text"], "model-visible body");
+        assert_eq!(params["prompt"].as_array().map(Vec::len), Some(1));
+        assert_eq!(
+            params["_meta"].as_object().map(|value| value.len()),
+            Some(1)
+        );
+        assert_eq!(
+            params["_meta"][TRUSTED_INBOUND_EVENT_META_NAMESPACE]
+                .as_object()
+                .map(|value| value.len()),
+            Some(1)
+        );
+        let metadata = &params["_meta"][TRUSTED_INBOUND_EVENT_META_NAMESPACE]
+            [TRUSTED_INBOUND_EVENT_META_FIELD];
+        assert_eq!(metadata["schemaVersion"], 1);
+        assert_eq!(metadata["eventId"], batch.events[0].event.id.to_hex());
+        assert_eq!(
+            metadata["authorPubkey"],
+            batch.events[0].event.pubkey.to_hex()
+        );
+        assert_eq!(metadata["kind"], 9);
+        assert_eq!(metadata["channelId"], channel_id.to_string());
+        assert_eq!(
+            metadata["tags"],
+            serde_json::json!([["h", channel_id.to_string()], ["p", "ab".repeat(32)],])
+        );
+    }
+
+    #[test]
+    fn trusted_inbound_event_fails_closed_for_tampering_or_ambiguous_room() {
+        let channel_id = uuid::Uuid::new_v4();
+        let mut tampered = signed_batch(channel_id, vec![]);
+        let mut raw = serde_json::to_value(&tampered.events[0].event).expect("serialize");
+        raw["content"] = serde_json::Value::String("tampered".into());
+        tampered.events[0].event = serde_json::from_value(raw).expect("parse tampered event");
+        assert!(TrustedInboundEventEnvelope::from_prompt_batch(Some(&tampered)).is_none());
+
+        let second_h = nostr::Tag::parse(["h", channel_id.to_string().as_str()]).expect("h tag");
+        let duplicate_room = signed_batch(channel_id, vec![second_h]);
+        assert!(TrustedInboundEventEnvelope::from_prompt_batch(Some(&duplicate_room)).is_none());
+
+        let other_channel = uuid::Uuid::new_v4();
+        let wrong_h =
+            nostr::Tag::parse(["h", other_channel.to_string().as_str()]).expect("wrong h tag");
+        let mut wrong_room = signed_batch(channel_id, vec![]);
+        wrong_room.events[0].event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "hello")
+            .tags([wrong_h])
+            .sign_with_keys(&nostr::Keys::generate())
+            .expect("signed wrong-room event");
+        assert!(TrustedInboundEventEnvelope::from_prompt_batch(Some(&wrong_room)).is_none());
+
+        let mut multi = signed_batch(channel_id, vec![]);
+        multi.events.push(multi.events[0].clone());
+        assert!(TrustedInboundEventEnvelope::from_prompt_batch(Some(&multi)).is_none());
+
+        let mut cancelled = signed_batch(channel_id, vec![]);
+        cancelled.cancelled_events.push(cancelled.events[0].clone());
+        assert!(TrustedInboundEventEnvelope::from_prompt_batch(Some(&cancelled)).is_none());
+
+        assert!(TrustedInboundEventEnvelope::from_prompt_batch(None).is_none());
+    }
+
+    #[test]
+    fn ordinary_prompt_params_have_no_trusted_metadata() {
+        let params = build_prompt_params("session", &["hello"], None);
+        assert!(params.get("_meta").is_none());
     }
 
     #[test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -4,6 +4,7 @@
 //! Config file (TOML) for complex subscription rules.
 
 use std::collections::{HashMap, HashSet};
+use std::io::Read;
 use std::path::PathBuf;
 
 use clap::Parser;
@@ -45,6 +46,51 @@ pub enum ConfigError {
 
     #[error("config file error: {0}")]
     ConfigFile(String),
+}
+
+fn read_owned_secret_file(path: &std::path::Path) -> Result<String, ConfigError> {
+    if !path.is_absolute() {
+        return Err(ConfigError::ConfigFile(
+            "--private-key-file must be an absolute path".into(),
+        ));
+    }
+    #[cfg(unix)]
+    let mut file = {
+        use nix::fcntl::{open, OFlag};
+        use nix::sys::stat::Mode;
+
+        let fd = open(path, OFlag::O_RDONLY | OFlag::O_NOFOLLOW, Mode::empty())
+            .map_err(std::io::Error::from)?;
+        std::fs::File::from(fd)
+    };
+    #[cfg(not(unix))]
+    let mut file = std::fs::OpenOptions::new().read(true).open(path)?;
+
+    // Validate metadata from the same no-follow handle that supplies the key.
+    // This avoids a validate-then-reopen race where the path could be swapped.
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(ConfigError::ConfigFile(
+            "--private-key-file must be a regular, non-symlink file".into(),
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        if metadata.permissions().mode() & 0o777 != 0o600 {
+            return Err(ConfigError::ConfigFile(
+                "--private-key-file permissions must be 0600".into(),
+            ));
+        }
+        if metadata.uid() != nix::unistd::getuid().as_raw() {
+            return Err(ConfigError::ConfigFile(
+                "--private-key-file must be owned by the current user".into(),
+            ));
+        }
+    }
+    let mut secret = String::new();
+    file.read_to_string(&mut secret)?;
+    Ok(secret.trim().to_string())
 }
 
 #[derive(Debug, Clone, PartialEq, clap::ValueEnum)]
@@ -240,8 +286,26 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_RELAY_URL", default_value = "ws://localhost:3000")]
     pub relay_url: String,
 
-    #[arg(long, env = "BUZZ_PRIVATE_KEY")]
-    pub private_key: String,
+    #[arg(
+        long,
+        env = "BUZZ_PRIVATE_KEY",
+        conflicts_with = "private_key_file",
+        required_unless_present = "private_key_file"
+    )]
+    pub private_key: Option<String>,
+
+    /// Read the Nostr private key from an operator-owned regular file.
+    #[arg(
+        long,
+        env = "BUZZ_PRIVATE_KEY_FILE",
+        conflicts_with = "private_key",
+        required_unless_present = "private_key"
+    )]
+    pub private_key_file: Option<PathBuf>,
+
+    /// Expected public key derived from `--private-key-file`.
+    #[arg(long, env = "BUZZ_EXPECTED_PUBLIC_KEY", requires = "private_key_file")]
+    pub expected_public_key: Option<String>,
 
     /// Agent owner pubkey (64-char hex). Used for --respond-to=owner-only gate.
     #[arg(long, env = "BUZZ_ACP_AGENT_OWNER")]
@@ -467,6 +531,24 @@ pub struct CliArgs {
     /// Publish encrypted ACP observer frames over the relay.
     #[arg(long, env = "BUZZ_ACP_RELAY_OBSERVER", default_value_t = false)]
     pub relay_observer: bool,
+
+    /// Close successful OpenClaw turns with request/reply/session/run evidence.
+    /// Default-off because most ACP adapters do not expose Gateway lineage.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_TURN_RECEIPTS",
+        default_value_t = false,
+        requires = "relay_observer"
+    )]
+    pub turn_receipts: bool,
+
+    /// Fixed Gateway session key that observed ACP lineage must match.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_EXPECTED_GATEWAY_SESSION_KEY",
+        requires = "turn_receipts"
+    )]
+    pub expected_gateway_session_key: Option<String>,
 }
 
 /// Merged NIP-01 subscription filter for a single channel.
@@ -537,6 +619,10 @@ pub struct Config {
     pub has_generated_codex_config: bool,
     /// Whether to publish encrypted observer frames through the relay.
     pub relay_observer: bool,
+    /// Whether successful channel turns require closed observer receipt evidence.
+    pub turn_receipts: bool,
+    /// Expected stable Gateway session key for receipt verification.
+    pub expected_gateway_session_key: Option<String>,
     /// Agent owner pubkey (hex). Used for `--respond-to=owner-only` gate.
     /// Replaces the old REST-based owner lookup.
     pub agent_owner: Option<String>,
@@ -732,13 +818,28 @@ impl Config {
     /// tests can construct `CliArgs` via `CliArgs::try_parse_from` and exercise the full
     /// validation path without going through process args.
     pub fn from_args(mut args: CliArgs) -> Result<Self, ConfigError> {
-        let keys = Keys::parse(&args.private_key)?;
+        let mut private_key = if let Some(value) = args.private_key.take() {
+            value
+        } else if let Some(path) = args.private_key_file.as_ref() {
+            read_owned_secret_file(path)?
+        } else {
+            return Err(ConfigError::ConfigFile(
+                "one of --private-key or --private-key-file is required".into(),
+            ));
+        };
+        let keys = Keys::parse(&private_key)?;
+        if let Some(expected) = args.expected_public_key.as_deref() {
+            if keys.public_key().to_hex() != expected.trim().to_ascii_lowercase() {
+                return Err(ConfigError::ConfigFile(
+                    "private-key file does not derive the expected public key".into(),
+                ));
+            }
+        }
         // Best-effort zeroize: overwrite the raw private key string to reduce
         // exposure via core dumps or heap inspection (#41). Without the `zeroize`
         // crate we can only clear the String — the allocator may retain copies.
-        args.private_key
-            .replace_range(.., &"0".repeat(args.private_key.len()));
-        args.private_key.clear();
+        private_key.replace_range(.., &"0".repeat(private_key.len()));
+        private_key.clear();
 
         let system_prompt = if let Some(text) = args.system_prompt {
             Some(text)
@@ -951,6 +1052,23 @@ impl Config {
             };
 
         validate_multiple_event_handling(args.multiple_event_handling, args.dedup)?;
+        if args.turn_receipts
+            && normalize_agent_command_identity(&agent_command).as_str() != "openclaw"
+        {
+            return Err(ConfigError::ConfigFile(
+                "--turn-receipts currently requires --agent-command=openclaw".into(),
+            ));
+        }
+        if args.turn_receipts
+            && args
+                .expected_gateway_session_key
+                .as_deref()
+                .is_none_or(|value| value.trim().is_empty())
+        {
+            return Err(ConfigError::ConfigFile(
+                "--turn-receipts requires a non-empty --expected-gateway-session-key".into(),
+            ));
+        }
 
         let config = Config {
             keys,
@@ -993,6 +1111,8 @@ impl Config {
             persona_env_vars,
             has_generated_codex_config,
             relay_observer: args.relay_observer,
+            turn_receipts: args.turn_receipts,
+            expected_gateway_session_key: args.expected_gateway_session_key,
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
             no_base_prompt: args.no_base_prompt,
             base_prompt_content,
@@ -1116,11 +1236,50 @@ pub fn load_rules(path: &std::path::Path) -> Result<Vec<SubscriptionRule>, Confi
                 )));
             }
         }
+        if rule.admit_invited_ephemeral
+            && !matches!(rule.channels, crate::filter::ChannelScope::List(_))
+        {
+            return Err(ConfigError::ConfigFile(format!(
+                "rule '{}': admit_invited_ephemeral requires channels to be a UUID list",
+                rule.name
+            )));
+        }
+        if rule.admit_invited_ephemeral && !rule.require_mention {
+            return Err(ConfigError::ConfigFile(format!(
+                "rule '{}': admit_invited_ephemeral requires require_mention=true",
+                rule.name
+            )));
+        }
         // Deserialization leaves consecutive_timeouts at its zero default; reset explicitly.
         rule.consecutive_timeouts = Arc::new(AtomicU32::new(0));
     }
 
     Ok(config.rules)
+}
+
+/// Add a metadata-verified ephemeral channel to every opt-in rule.
+pub fn admit_invited_ephemeral_channel(rules: &mut [SubscriptionRule], channel_id: Uuid) -> bool {
+    let channel = channel_id.to_string();
+    let mut admitted = false;
+    for rule in rules.iter_mut().filter(|rule| rule.admit_invited_ephemeral) {
+        if let crate::filter::ChannelScope::List(ids) = &mut rule.channels {
+            if !ids.contains(&channel) {
+                ids.push(channel.clone());
+            }
+            admitted = true;
+        }
+    }
+    admitted
+}
+
+/// Remove a departed ephemeral channel from opt-in rules.
+pub fn remove_invited_ephemeral_channel(rules: &mut [SubscriptionRule], channel_id: Uuid) {
+    let channel = channel_id.to_string();
+    for rule in rules.iter_mut().filter(|rule| rule.admit_invited_ephemeral) {
+        if let crate::filter::ChannelScope::List(ids) = &mut rule.channels {
+            ids.retain(|id| id != &channel);
+        }
+    }
 }
 
 /// Resolve per-channel NIP-01 filters from config + discovered channels.
@@ -1361,6 +1520,8 @@ mod tests {
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
+            turn_receipts: false,
+            expected_gateway_session_key: None,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -1375,9 +1536,12 @@ mod tests {
     ) -> SubscriptionRule {
         use std::sync::atomic::AtomicU32;
         use std::sync::Arc;
+
         SubscriptionRule {
             name: name.into(),
             channels,
+            admit_invited_ephemeral: false,
+            require_exact_channel_tag: false,
             kinds,
             require_mention: mention,
             filter: None,
@@ -1385,6 +1549,47 @@ mod tests {
             compiled_filter: None,
             consecutive_timeouts: Arc::new(AtomicU32::new(0)),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_key_file_requires_regular_owned_mode_0600_and_expected_pubkey() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let dir = std::env::temp_dir().join(format!("buzz-acp-key-test-{}", Uuid::new_v4()));
+        std::fs::create_dir(&dir).unwrap();
+        let path = dir.join("aspect.sk");
+        let keys = Keys::generate();
+        std::fs::write(&path, keys.secret_key().to_secret_hex()).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert_eq!(
+            read_owned_secret_file(&path).expect("owned 0600 regular file"),
+            keys.secret_key().to_secret_hex()
+        );
+
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key-file",
+            path.to_str().unwrap(),
+            "--expected-public-key",
+            &"f".repeat(64),
+        ])
+        .unwrap();
+        assert!(matches!(
+            Config::from_args(args),
+            Err(ConfigError::ConfigFile(message))
+                if message == "private-key file does not derive the expected public key"
+        ));
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(read_owned_secret_file(&path).is_err());
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let link = dir.join("aspect-link.sk");
+        symlink(&path, &link).unwrap();
+        assert!(read_owned_secret_file(&link).is_err());
+        std::fs::remove_file(link).unwrap();
+        std::fs::remove_file(path).unwrap();
+        std::fs::remove_dir(dir).unwrap();
     }
 
     #[test]
@@ -1752,6 +1957,169 @@ mod tests {
 
         let result = resolve_channel_filters(&config, &[ch], &rules);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn invited_ephemeral_rule_admits_and_removes_verified_channel() {
+        let private = Uuid::new_v4();
+        let huddle = Uuid::new_v4();
+        let mut private_rule = make_rule(
+            "private-office",
+            ChannelScope::List(vec![private.to_string()]),
+            vec![9],
+            false,
+        );
+        private_rule.admit_invited_ephemeral = false;
+        let mut huddle_rule =
+            make_rule("invited-huddle", ChannelScope::List(vec![]), vec![9], true);
+        huddle_rule.admit_invited_ephemeral = true;
+        let mut rules = vec![private_rule, huddle_rule];
+
+        assert!(admit_invited_ephemeral_channel(&mut rules, huddle));
+        let config = test_config(SubscribeMode::Config);
+        let filters = resolve_channel_filters(&config, &[private, huddle], &rules);
+        assert!(!filters[&private].require_mention);
+        assert!(filters[&huddle].require_mention);
+
+        remove_invited_ephemeral_channel(&mut rules, huddle);
+        let filters = resolve_channel_filters(&config, &[private, huddle], &rules);
+        assert!(filters.contains_key(&private));
+        assert!(!filters.contains_key(&huddle));
+    }
+
+    #[test]
+    fn ordinary_unlisted_channel_is_not_admitted() {
+        let private = Uuid::new_v4();
+        let concilium = Uuid::new_v4();
+        let private_rule = make_rule(
+            "private-office",
+            ChannelScope::List(vec![private.to_string()]),
+            vec![9],
+            false,
+        );
+        let mut huddle_rule =
+            make_rule("invited-huddle", ChannelScope::List(vec![]), vec![9], true);
+        huddle_rule.admit_invited_ephemeral = true;
+        let config = test_config(SubscribeMode::Config);
+
+        let filters =
+            resolve_channel_filters(&config, &[private, concilium], &[private_rule, huddle_rule]);
+        assert!(filters.contains_key(&private));
+        assert!(!filters.contains_key(&concilium));
+    }
+
+    #[test]
+    fn aeon_six_worker_configs_load_through_real_rules_and_clap() {
+        use clap::Parser as _;
+
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .expect("repository root");
+        let deploy = root.join("deploy/local/aeon-aspects");
+        let manifest: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(deploy.join("workers.json")).expect("workers manifest"),
+        )
+        .expect("valid workers manifest");
+        let architect = manifest["buzz"]["architectPubkey"]
+            .as_str()
+            .expect("architect pubkey");
+        let concilium = manifest["buzz"]["conciliumChannelId"]
+            .as_str()
+            .expect("concilium id");
+        let workers = manifest["workers"].as_array().expect("worker array");
+        assert_eq!(workers.len(), 6);
+
+        for worker in workers {
+            let aspect = worker["aspect"].as_str().expect("aspect");
+            let session = worker["sessionKey"].as_str().expect("session key");
+            let private = worker["privateChannelId"].as_str().expect("private room");
+            let config_path = deploy.join("config").join(format!("{aspect}.toml"));
+            let rules = load_rules(&config_path).expect("load production rule file");
+            assert_eq!(rules.len(), 2);
+            assert!(!rules[0].admit_invited_ephemeral);
+            assert!(rules[0].require_exact_channel_tag);
+            assert!(!rules[0].require_mention);
+            assert!(rules[1].admit_invited_ephemeral);
+            assert!(rules[1].require_exact_channel_tag);
+            assert!(rules[1].require_mention);
+            assert_eq!(rules[0].kinds, vec![9, 40002]);
+            assert_eq!(rules[1].kinds, vec![9, 40002]);
+            assert!(rules.iter().all(|rule| {
+                rule.filter
+                    .as_deref()
+                    .is_some_and(|filter| filter.contains(architect))
+            }));
+            let source = std::fs::read_to_string(&config_path).expect("config source");
+            assert!(source.contains(private));
+            assert!(!source.contains(concilium));
+
+            let agent_args = format!(
+                "acp,--session,{session},--require-existing,--token-file,/owned/token,--url,ws://127.0.0.1:18806,--provenance,meta+receipt,--no-prefix-cwd"
+            );
+            let cli = CliArgs::try_parse_from([
+                "buzz-acp",
+                "--private-key",
+                &"1".repeat(64),
+                "--agent-owner",
+                architect,
+                "--agent-command",
+                "openclaw",
+                "--agent-args",
+                &agent_args,
+                "--subscribe",
+                "config",
+                "--config",
+                config_path.to_str().expect("utf8 config path"),
+                "--respond-to",
+                "owner-only",
+                "--allowed-respond-to",
+                "owner-only",
+                "--no-memory",
+                "--no-base-prompt",
+                "--dedup",
+                "queue",
+                "--multiple-event-handling",
+                "queue",
+                "--relay-observer",
+                "--permission-mode",
+                "bypass-permissions",
+                "--heartbeat-interval",
+                "0",
+                "--turn-liveness-secs",
+                "10",
+                "--idle-timeout",
+                "900",
+                "--max-turn-duration",
+                "7200",
+                "--context-message-limit",
+                "12",
+                "--max-turns-per-session",
+                "0",
+                "--turn-receipts",
+                "--expected-gateway-session-key",
+                session,
+            ])
+            .expect("real Clap parser accepts rendered worker argv");
+            assert!(cli.no_memory);
+            assert!(cli.no_base_prompt);
+            assert!(cli.turn_receipts);
+            assert_eq!(cli.permission_mode, PermissionMode::BypassPermissions);
+            assert_eq!(cli.heartbeat_interval, 0);
+            assert_eq!(cli.turn_liveness_secs, 10);
+            assert_eq!(cli.idle_timeout, Some(900));
+            assert_eq!(cli.max_turn_duration, 7200);
+            assert_eq!(cli.context_message_limit, 12);
+            assert_eq!(cli.max_turns_per_session, 0);
+            assert!(cli.mcp_command.is_empty());
+            assert!(cli.model.is_none());
+            assert!(!cli.no_ignore_self);
+            assert!(!cli.no_presence);
+            assert!(!cli.no_typing);
+            assert_eq!(cli.expected_gateway_session_key.as_deref(), Some(session));
+            assert!(cli.agent_args.iter().any(|arg| arg == "--require-existing"));
+            assert!(cli.agent_args.iter().any(|arg| arg == "--no-prefix-cwd"));
+        }
     }
 
     #[test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use clap::ValueEnum;
-use nostr::Keys;
+use nostr::{Keys, PublicKey};
 use thiserror::Error;
 use url::Url;
 use uuid::Uuid;
@@ -1080,6 +1080,17 @@ impl Config {
                 "--turn-receipts requires a non-empty --expected-gateway-session-key".into(),
             ));
         }
+        if args.turn_receipts
+            && !receipt_owner_resolves(
+                &keys,
+                args.agent_owner.as_deref(),
+                std::env::var("BUZZ_AUTH_TAG").ok().as_deref(),
+            )
+        {
+            return Err(ConfigError::ConfigFile(
+                "--turn-receipts requires a valid --agent-owner or verified BUZZ_AUTH_TAG".into(),
+            ));
+        }
 
         let config = Config {
             keys,
@@ -1174,6 +1185,22 @@ impl Config {
             allowed_respond_to_detail,
         )
     }
+}
+
+fn receipt_owner_resolves(
+    keys: &Keys,
+    explicit_owner: Option<&str>,
+    auth_tag: Option<&str>,
+) -> bool {
+    let verified_auth_owner = auth_tag
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_some_and(|value| buzz_sdk::nip_oa::verify_auth_tag(value, &keys.public_key()).is_ok());
+    let valid_explicit_owner = explicit_owner
+        .map(str::trim)
+        .filter(|value| value.len() == 64)
+        .is_some_and(|value| PublicKey::from_hex(value).is_ok());
+    verified_auth_owner || valid_explicit_owner
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -1545,6 +1572,25 @@ mod tests {
             no_base_prompt: false,
             base_prompt_content: None,
         }
+    }
+
+    #[test]
+    fn receipt_owner_requires_verified_auth_or_valid_explicit_pubkey() {
+        let agent_keys = Keys::generate();
+        let owner_keys = Keys::generate();
+        let owner = owner_keys.public_key().to_hex();
+        let auth_tag =
+            buzz_sdk::nip_oa::compute_auth_tag(&owner_keys, &agent_keys.public_key(), "")
+                .expect("test auth tag");
+
+        assert!(receipt_owner_resolves(&agent_keys, Some(&owner), None));
+        assert!(receipt_owner_resolves(&agent_keys, None, Some(&auth_tag)));
+        assert!(!receipt_owner_resolves(&agent_keys, None, None));
+        assert!(!receipt_owner_resolves(
+            &agent_keys,
+            Some("not-a-pubkey"),
+            Some("not-an-auth-tag")
+        ));
     }
 
     fn make_rule(

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -558,6 +558,15 @@ pub struct CliArgs {
         default_value_t = false
     )]
     pub trusted_inbound_envelope: bool,
+
+    /// Keep Buzz publisher credentials inside the harness instead of forwarding
+    /// them to the managed ACP subprocess.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_NO_AGENT_PUBLISHER_CREDENTIALS",
+        default_value_t = false
+    )]
+    pub no_agent_publisher_credentials: bool,
 }
 
 /// Merged NIP-01 subscription filter for a single channel.
@@ -634,6 +643,8 @@ pub struct Config {
     pub expected_gateway_session_key: Option<String>,
     /// Whether to attach a verified, non-model inbound event envelope to ACP prompts.
     pub trusted_inbound_envelope: bool,
+    /// Whether the managed ACP subprocess may receive Buzz publisher credentials.
+    pub forward_agent_publisher_credentials: bool,
     /// Agent owner pubkey (hex). Used for `--respond-to=owner-only` gate.
     /// Replaces the old REST-based owner lookup.
     pub agent_owner: Option<String>,
@@ -1140,6 +1151,7 @@ impl Config {
             turn_receipts: args.turn_receipts,
             expected_gateway_session_key: args.expected_gateway_session_key,
             trusted_inbound_envelope: args.trusted_inbound_envelope,
+            forward_agent_publisher_credentials: !args.no_agent_publisher_credentials,
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
             no_base_prompt: args.no_base_prompt,
             base_prompt_content,
@@ -1164,7 +1176,7 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} agent_publisher_credentials={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1185,6 +1197,11 @@ impl Config {
             self.memory_enabled,
             self.model.as_deref().unwrap_or("(agent default)"),
             self.permission_mode,
+            if self.forward_agent_publisher_credentials {
+                "forwarded"
+            } else {
+                "harness-only"
+            },
             respond_to_detail,
             allowed_respond_to_detail,
         )
@@ -1199,6 +1216,9 @@ impl Config {
     pub fn agent_spawn_env(&self) -> Vec<(String, String)> {
         let mut env = self.persona_env_vars.clone();
         env.retain(|(key, _)| !matches!(key.as_str(), "BUZZ_RELAY_URL" | "BUZZ_PRIVATE_KEY"));
+        if !self.forward_agent_publisher_credentials {
+            return env;
+        }
         env.push(("BUZZ_RELAY_URL".into(), self.relay_url.clone()));
         env.push((
             "BUZZ_PRIVATE_KEY".into(),
@@ -1589,6 +1609,7 @@ mod tests {
             turn_receipts: false,
             expected_gateway_session_key: None,
             trusted_inbound_envelope: false,
+            forward_agent_publisher_credentials: true,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -1650,6 +1671,29 @@ mod tests {
             Some(expected_secret.as_str())
         );
         assert!(env.contains(&("SAFE_PERSONA_SETTING".into(), "kept".into())));
+    }
+
+    #[test]
+    fn isolated_agent_env_retains_harness_identity_but_omits_publisher_credentials() {
+        let mut config = test_config(SubscribeMode::All);
+        let harness_relay = config.relay_url.clone();
+        let harness_pubkey = config.keys.public_key().to_hex();
+        config.forward_agent_publisher_credentials = false;
+        config.persona_env_vars = vec![
+            ("BUZZ_RELAY_URL".into(), "ws://wrong.invalid".into()),
+            ("BUZZ_PRIVATE_KEY".into(), "wrong-secret".into()),
+            ("SAFE_PERSONA_SETTING".into(), "kept".into()),
+        ];
+
+        let env = config.agent_spawn_env();
+        assert!(!env.iter().any(|(key, _)| key == "BUZZ_RELAY_URL"));
+        assert!(!env.iter().any(|(key, _)| key == "BUZZ_PRIVATE_KEY"));
+        assert!(env.contains(&("SAFE_PERSONA_SETTING".into(), "kept".into())));
+        assert_eq!(config.relay_url, harness_relay);
+        assert_eq!(config.keys.public_key().to_hex(), harness_pubkey);
+        assert!(config
+            .summary()
+            .contains("agent_publisher_credentials=harness-only"));
     }
 
     fn make_rule(
@@ -2212,6 +2256,7 @@ mod tests {
                 "queue",
                 "--relay-observer",
                 "--trusted-inbound-envelope",
+                "--no-agent-publisher-credentials",
                 "--permission-mode",
                 "bypass-permissions",
                 "--heartbeat-interval",
@@ -2235,6 +2280,7 @@ mod tests {
             assert!(cli.no_base_prompt);
             assert!(cli.turn_receipts);
             assert!(cli.trusted_inbound_envelope);
+            assert!(cli.no_agent_publisher_credentials);
             assert_eq!(cli.permission_mode, PermissionMode::BypassPermissions);
             assert_eq!(cli.heartbeat_interval, 0);
             assert_eq!(cli.turn_liveness_secs, 10);
@@ -2906,6 +2952,7 @@ require_exact_channel_tag = false
         // Dedup default must remain `queue` so steering's requirement is met.
         assert!(matches!(args.dedup, DedupMode::Queue));
         assert!(!args.trusted_inbound_envelope);
+        assert!(!args.no_agent_publisher_credentials);
     }
 
     #[test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -549,6 +549,15 @@ pub struct CliArgs {
         requires = "turn_receipts"
     )]
     pub expected_gateway_session_key: Option<String>,
+
+    /// Attach one signature-verified triggering Buzz event to ACP request
+    /// metadata. This is never rendered into model-visible prompt text.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_TRUSTED_INBOUND_ENVELOPE",
+        default_value_t = false
+    )]
+    pub trusted_inbound_envelope: bool,
 }
 
 /// Merged NIP-01 subscription filter for a single channel.
@@ -623,6 +632,8 @@ pub struct Config {
     pub turn_receipts: bool,
     /// Expected stable Gateway session key for receipt verification.
     pub expected_gateway_session_key: Option<String>,
+    /// Whether to attach a verified, non-model inbound event envelope to ACP prompts.
+    pub trusted_inbound_envelope: bool,
     /// Agent owner pubkey (hex). Used for `--respond-to=owner-only` gate.
     /// Replaces the old REST-based owner lookup.
     pub agent_owner: Option<String>,
@@ -1113,6 +1124,7 @@ impl Config {
             relay_observer: args.relay_observer,
             turn_receipts: args.turn_receipts,
             expected_gateway_session_key: args.expected_gateway_session_key,
+            trusted_inbound_envelope: args.trusted_inbound_envelope,
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
             no_base_prompt: args.no_base_prompt,
             base_prompt_content,
@@ -1522,6 +1534,7 @@ mod tests {
             relay_observer: false,
             turn_receipts: false,
             expected_gateway_session_key: None,
+            trusted_inbound_envelope: false,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -2082,6 +2095,7 @@ mod tests {
                 "--multiple-event-handling",
                 "queue",
                 "--relay-observer",
+                "--trusted-inbound-envelope",
                 "--permission-mode",
                 "bypass-permissions",
                 "--heartbeat-interval",
@@ -2104,6 +2118,7 @@ mod tests {
             assert!(cli.no_memory);
             assert!(cli.no_base_prompt);
             assert!(cli.turn_receipts);
+            assert!(cli.trusted_inbound_envelope);
             assert_eq!(cli.permission_mode, PermissionMode::BypassPermissions);
             assert_eq!(cli.heartbeat_interval, 0);
             assert_eq!(cli.turn_liveness_secs, 10);
@@ -2749,6 +2764,7 @@ channels = "ALL"
         assert_eq!(args.multiple_event_handling, MultipleEventHandling::Steer);
         // Dedup default must remain `queue` so steering's requirement is met.
         assert!(matches!(args.dedup, DedupMode::Queue));
+        assert!(!args.trusted_inbound_envelope);
     }
 
     #[test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -1262,6 +1262,12 @@ pub fn load_rules(path: &std::path::Path) -> Result<Vec<SubscriptionRule>, Confi
                 rule.name
             )));
         }
+        if rule.admit_invited_ephemeral && !rule.require_exact_channel_tag {
+            return Err(ConfigError::ConfigFile(format!(
+                "rule '{}': admit_invited_ephemeral requires require_exact_channel_tag=true",
+                rule.name
+            )));
+        }
         // Deserialization leaves consecutive_timeouts at its zero default; reset explicitly.
         rule.consecutive_timeouts = Arc::new(AtomicU32::new(0));
     }
@@ -2293,6 +2299,31 @@ channels = "ALL"
 
         let err = load_rules(&path).unwrap_err();
         assert!(err.to_string().contains("must be \"all\" or a list"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn test_load_rules_invited_ephemeral_requires_exact_channel_tag() {
+        let dir = std::env::temp_dir().join("buzz-acp-test-invited-exact-h");
+        let path = dir.join("rules.toml");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            &path,
+            r#"
+[[rules]]
+name = "invited-huddle"
+channels = []
+require_mention = true
+admit_invited_ephemeral = true
+require_exact_channel_tag = false
+"#,
+        )
+        .unwrap();
+
+        let err = load_rules(&path).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("requires require_exact_channel_tag=true"));
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -696,7 +696,11 @@ pub(crate) fn normalize_agent_command_identity(command: &str) -> String {
         .next()
         .expect("rsplit always yields at least one element");
     let lower = basename.to_ascii_lowercase();
-    let stem = lower.strip_suffix(".exe").unwrap_or(&lower);
+    let stem = if lower == "openclaw.mjs" {
+        "openclaw"
+    } else {
+        lower.strip_suffix(".exe").unwrap_or(&lower)
+    };
     stem.chars()
         .map(|character| match character {
             ' ' | '_' => '-',
@@ -1830,6 +1834,11 @@ mod tests {
             "claude-code"
         );
         assert_eq!(normalize_agent_command_identity("Goose.EXE"), "goose");
+        assert_eq!(
+            normalize_agent_command_identity("/immutable/generation/openclaw.mjs"),
+            "openclaw"
+        );
+        assert_eq!(normalize_agent_command_identity("codex.mjs"), "codex.mjs");
         // Non-ASCII must not panic.
         assert_eq!(normalize_agent_command_identity("my-agënt"), "my-agënt");
         // Edge cases: empty, whitespace-only, bare separators.

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -1185,6 +1185,23 @@ impl Config {
             allowed_respond_to_detail,
         )
     }
+
+    /// Build the managed agent's runtime environment.
+    ///
+    /// Buzz transport credentials are derived from the already-validated
+    /// harness identity at spawn time. They are never stored in worker
+    /// manifests or supervisor artifacts, and they replace any persona-level
+    /// values for these reserved keys.
+    pub fn agent_spawn_env(&self) -> Vec<(String, String)> {
+        let mut env = self.persona_env_vars.clone();
+        env.retain(|(key, _)| !matches!(key.as_str(), "BUZZ_RELAY_URL" | "BUZZ_PRIVATE_KEY"));
+        env.push(("BUZZ_RELAY_URL".into(), self.relay_url.clone()));
+        env.push((
+            "BUZZ_PRIVATE_KEY".into(),
+            self.keys.secret_key().to_secret_hex(),
+        ));
+        env
+    }
 }
 
 fn receipt_owner_resolves(
@@ -1591,6 +1608,44 @@ mod tests {
             Some("not-a-pubkey"),
             Some("not-an-auth-tag")
         ));
+    }
+
+    #[test]
+    fn managed_agent_env_uses_validated_harness_buzz_identity() {
+        let mut config = test_config(SubscribeMode::All);
+        config.persona_env_vars = vec![
+            ("BUZZ_RELAY_URL".into(), "ws://wrong.invalid".into()),
+            ("BUZZ_PRIVATE_KEY".into(), "wrong-secret".into()),
+            ("SAFE_PERSONA_SETTING".into(), "kept".into()),
+        ];
+
+        let env = config.agent_spawn_env();
+        assert_eq!(
+            env.iter()
+                .filter(|(key, _)| key == "BUZZ_RELAY_URL")
+                .count(),
+            1
+        );
+        assert_eq!(
+            env.iter()
+                .find(|(key, _)| key == "BUZZ_RELAY_URL")
+                .map(|(_, value)| value.as_str()),
+            Some(config.relay_url.as_str())
+        );
+        assert_eq!(
+            env.iter()
+                .filter(|(key, _)| key == "BUZZ_PRIVATE_KEY")
+                .count(),
+            1
+        );
+        let expected_secret = config.keys.secret_key().to_secret_hex();
+        assert_eq!(
+            env.iter()
+                .find(|(key, _)| key == "BUZZ_PRIVATE_KEY")
+                .map(|(_, value)| value.as_str()),
+            Some(expected_secret.as_str())
+        );
+        assert!(env.contains(&("SAFE_PERSONA_SETTING".into(), "kept".into())));
     }
 
     fn make_rule(

--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -85,6 +85,13 @@ pub struct SubscriptionRule {
     pub name: String,
     /// Which channels this rule applies to.
     pub channels: ChannelScope,
+    /// Admit channels that the agent is invited to when their metadata carries
+    /// a positive TTL. Buzz huddles use TTL-scoped private channels.
+    #[serde(default)]
+    pub admit_invited_ephemeral: bool,
+    /// Require exactly one `h` tag equal to the resolved channel UUID.
+    #[serde(default)]
+    pub require_exact_channel_tag: bool,
     /// Nostr event kinds to match. Empty = wildcard (all kinds).
     #[serde(default)]
     pub kinds: Vec<u32>,
@@ -118,6 +125,8 @@ impl Default for SubscriptionRule {
         Self {
             name: String::new(),
             channels: ChannelScope::All("all".into()),
+            admit_invited_ephemeral: false,
+            require_exact_channel_tag: false,
             kinds: Vec::new(),
             require_mention: false,
             filter: None,
@@ -133,6 +142,8 @@ impl Clone for SubscriptionRule {
         Self {
             name: self.name.clone(),
             channels: self.channels.clone(),
+            admit_invited_ephemeral: self.admit_invited_ephemeral,
+            require_exact_channel_tag: self.require_exact_channel_tag,
             kinds: self.kinds.clone(),
             require_mention: self.require_mention,
             filter: self.filter.clone(),
@@ -379,6 +390,23 @@ pub async fn match_event(
             continue;
         }
 
+        if rule.require_exact_channel_tag {
+            let channel = channel_id.to_string();
+            let mut h_tag_count = 0;
+            let mut exact_channel = false;
+            for tag in event.tags.iter() {
+                let values = tag.as_slice();
+                if values.first().map(|value| value.as_str()) == Some("h") {
+                    h_tag_count += 1;
+                    exact_channel =
+                        values.get(1).map(|value| value.as_str()) == Some(channel.as_str());
+                }
+            }
+            if h_tag_count != 1 || !exact_channel {
+                continue;
+            }
+        }
+
         // 2. Kind filter (empty = wildcard).
         if !rule.kinds.is_empty() && !rule.kinds.contains(&(event.kind.as_u16() as u32)) {
             continue;
@@ -484,6 +512,28 @@ mod tests {
             .unwrap()
     }
 
+    fn make_event_with_h_tags(kind: u32, channels: &[Uuid]) -> nostr::Event {
+        let keys = Keys::generate();
+        let tags = channels
+            .iter()
+            .map(|channel| Tag::parse(["h".to_string(), channel.to_string()]).expect("h tag"));
+        EventBuilder::new(Kind::Custom(kind as u16), "hello")
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .unwrap()
+    }
+
+    fn make_event_with_valid_and_malformed_h_tag(kind: u32, channel: Uuid) -> nostr::Event {
+        let keys = Keys::generate();
+        EventBuilder::new(Kind::Custom(kind as u16), "hello")
+            .tags([
+                Tag::parse(["h".to_string(), channel.to_string()]).expect("valid h tag"),
+                Tag::parse(["h".to_string()]).expect("malformed h tag"),
+            ])
+            .sign_with_keys(&keys)
+            .unwrap()
+    }
+
     fn any_channel() -> Uuid {
         Uuid::new_v4()
     }
@@ -499,6 +549,8 @@ mod tests {
         SubscriptionRule {
             name: name.into(),
             channels,
+            admit_invited_ephemeral: false,
+            require_exact_channel_tag: false,
             kinds,
             require_mention: mention,
             filter: filter.map(|s| s.into()),
@@ -633,6 +685,55 @@ mod tests {
         let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
         assert_eq!(matched.rule_index, 1);
         assert_eq!(matched.prompt_tag, "matched");
+    }
+
+    #[tokio::test]
+    async fn test_match_event_exact_channel_tag_rejects_missing_wrong_or_multiple() {
+        let channel = any_channel();
+        let other = any_channel();
+        let mut rule = make_rule(
+            "exact-room",
+            ChannelScope::List(vec![channel.to_string()]),
+            vec![9],
+            false,
+            None,
+            None,
+        );
+        rule.require_exact_channel_tag = true;
+        assert!(
+            match_event(&make_event(9, "missing"), channel, &[rule.clone()], "")
+                .await
+                .is_none()
+        );
+        assert!(match_event(
+            &make_event_with_h_tags(9, &[other]),
+            channel,
+            &[rule.clone()],
+            ""
+        )
+        .await
+        .is_none());
+        assert!(match_event(
+            &make_event_with_h_tags(9, &[channel, other]),
+            channel,
+            &[rule.clone()],
+            ""
+        )
+        .await
+        .is_none());
+        assert!(match_event(
+            &make_event_with_valid_and_malformed_h_tag(9, channel),
+            channel,
+            &[rule.clone()],
+            ""
+        )
+        .await
+        .is_none());
+        assert!(
+            match_event(&make_event_with_h_tags(9, &[channel]), channel, &[rule], "")
+                .await
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1301,6 +1301,7 @@ async fn tokio_main() -> Result<()> {
     // spawn under a 60-second timeout; failures are logged and skipped. If ALL
     // agents fail we return an error. A partial pool is valid — the harness
     // continues with reduced capacity and logs a warning.
+    let agent_spawn_env = config.agent_spawn_env();
     let mut agent_slots: Vec<Option<OwnedAgent>> = Vec::with_capacity(config.agents as usize);
     for i in 0..config.agents as usize {
         // Spawn OUTSIDE the timeout so we always own the child for cleanup.
@@ -1310,7 +1311,7 @@ async fn tokio_main() -> Result<()> {
         let spawn_result = AcpClient::spawn(
             &config.agent_command,
             &config.agent_args,
-            &config.persona_env_vars,
+            &agent_spawn_env,
             config.has_generated_codex_config,
         )
         .await;
@@ -1799,7 +1800,7 @@ async fn tokio_main() -> Result<()> {
                 tracing::info!(agent = idx, "slot refill: spawning background respawn");
                 let cmd = config.agent_command.clone();
                 let args = config.agent_args.clone();
-                let env = config.persona_env_vars.clone();
+                let env = config.agent_spawn_env();
                 let has_codex = config.has_generated_codex_config;
                 let observer = observer.clone();
                 let guard = RespawnGuard::new(idx, respawn_tx.clone());
@@ -3507,7 +3508,7 @@ fn recover_panicked_agent(
     slot.respawn_in_flight = true;
     let cmd = config.agent_command.clone();
     let args = config.agent_args.clone();
-    let env = config.persona_env_vars.clone();
+    let env = config.agent_spawn_env();
     let has_codex = config.has_generated_codex_config;
     let guard = RespawnGuard::new(i, respawn_tx.clone());
     respawn_tasks.spawn(async move {
@@ -3685,7 +3686,7 @@ fn spawn_respawn_task(
     // Spawn the actual work (shutdown + sleep + spawn + init) off the main loop.
     let cmd = config.agent_command.clone();
     let args = config.agent_args.clone();
-    let env = config.persona_env_vars.clone();
+    let env = config.agent_spawn_env();
     let has_codex = config.has_generated_codex_config;
     let guard = RespawnGuard::new(index, respawn_tx.clone());
     respawn_tasks.spawn(async move {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -287,6 +287,63 @@ async fn check_sibling_via_profile(
     false
 }
 
+fn eligible_ephemeral_deadline(
+    current: &Result<Option<relay::ChannelInfo>, relay::RelayError>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<chrono::DateTime<chrono::Utc>> {
+    match current {
+        Ok(Some(info)) if info.is_ephemeral_at(now) => info.ttl_deadline,
+        Ok(_) | Err(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod ephemeral_admission_tests {
+    use super::*;
+
+    fn channel_info(
+        channel_type: &str,
+        ttl_seconds: Option<u64>,
+        deadline: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> relay::ChannelInfo {
+        relay::ChannelInfo {
+            name: "huddle".into(),
+            channel_type: channel_type.into(),
+            ttl_seconds,
+            ttl_deadline: deadline,
+            metadata_created_at: Some(1),
+            metadata_event_id: Some("a".repeat(64)),
+        }
+    }
+
+    #[test]
+    fn canonical_revalidation_fails_closed_and_accepts_only_future_private_ttl() {
+        let now = chrono::Utc::now();
+        let renewed = now + chrono::Duration::minutes(5);
+        assert_eq!(
+            eligible_ephemeral_deadline(
+                &Ok(Some(channel_info("private", Some(300), Some(renewed)))),
+                now
+            ),
+            Some(renewed)
+        );
+        for current in [
+            Ok(None),
+            Ok(Some(channel_info(
+                "private",
+                Some(300),
+                Some(now - chrono::Duration::seconds(1)),
+            ))),
+            Ok(Some(channel_info("private", Some(300), None))),
+            Ok(Some(channel_info("private", Some(0), Some(renewed)))),
+            Ok(Some(channel_info("stream", Some(300), Some(renewed)))),
+            Err(relay::RelayError::Timeout),
+        ] {
+            assert_eq!(eligible_ephemeral_deadline(&current, now), None);
+        }
+    }
+}
+
 const OBSERVER_PUBLISH_INTERVAL: Duration = Duration::from_millis(167);
 const OBSERVER_PUBLISH_LIMIT_PER_MINUTE: usize = 90;
 
@@ -1444,11 +1501,13 @@ async fn tokio_main() -> Result<()> {
     tracing::info!("discovered {} channel(s)", channel_info_map.len());
     let channel_ids: Vec<Uuid> = channel_info_map.keys().copied().collect();
 
-    let rules: Vec<SubscriptionRule> = match config.subscribe_mode {
+    let mut rules: Vec<SubscriptionRule> = match config.subscribe_mode {
         SubscribeMode::Mentions => {
             vec![SubscriptionRule {
                 name: "mentions".into(),
                 channels: filter::ChannelScope::All("all".into()),
+                admit_invited_ephemeral: false,
+                require_exact_channel_tag: false,
                 kinds: config.kinds_override.clone().unwrap_or_else(|| {
                     vec![
                         KIND_STREAM_MESSAGE,
@@ -1467,6 +1526,8 @@ async fn tokio_main() -> Result<()> {
             vec![SubscriptionRule {
                 name: "all".into(),
                 channels: filter::ChannelScope::All("all".into()),
+                admit_invited_ephemeral: false,
+                require_exact_channel_tag: false,
                 kinds: config.kinds_override.clone().unwrap_or_default(),
                 require_mention: false,
                 filter: None,
@@ -1480,6 +1541,22 @@ async fn tokio_main() -> Result<()> {
             config::load_rules(&config.config_path)?
         }
     };
+
+    let mut admitted_ephemeral_deadlines: HashMap<Uuid, chrono::DateTime<chrono::Utc>> =
+        HashMap::new();
+    for (channel_id, info) in &channel_info_map {
+        if info.is_ephemeral() && config::admit_invited_ephemeral_channel(&mut rules, *channel_id) {
+            if let Some(deadline) = info.ttl_deadline {
+                admitted_ephemeral_deadlines.insert(*channel_id, deadline);
+            }
+            tracing::debug!(
+                %channel_id,
+                metadata_created_at = ?info.metadata_created_at,
+                metadata_event_id = ?info.metadata_event_id,
+                "admitted canonical private TTL channel"
+            );
+        }
+    }
 
     let channel_filters = config::resolve_channel_filters(&config, &channel_ids, &rules);
     if channel_filters.is_empty() {
@@ -1555,6 +1632,8 @@ async fn tokio_main() -> Result<()> {
             .and_then(|hex| nostr::PublicKey::from_hex(hex).ok()),
         memory_enabled: config.memory_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
+        turn_receipts: config.turn_receipts,
+        expected_gateway_session_key: config.expected_gateway_session_key.clone(),
     });
 
     if !config.memory_enabled {
@@ -1594,6 +1673,10 @@ async fn tokio_main() -> Result<()> {
     } else {
         None
     };
+    let mut ephemeral_revalidation = tokio::time::interval_at(
+        tokio::time::Instant::now() + Duration::from_secs(15),
+        Duration::from_secs(15),
+    );
     let mut typing_channels: HashMap<Uuid, ThreadTags> = HashMap::new();
     let mut presence_task: Option<tokio::task::JoinHandle<()>> = None;
 
@@ -1888,26 +1971,61 @@ async fn tokio_main() -> Result<()> {
 
                                     if subscribed_channel_ids.contains(&ch) {
                                         tracing::debug!(channel_id = %ch, "membership notification: channel already subscribed");
-                                    } else if let Some(filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules) {
-                                        tracing::info!(channel_id = %ch, "membership notification: subscribing to new channel");
-                                        if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
-                                            tracing::warn!("failed to subscribe to new channel {ch}: {e}");
-                                        } else {
-                                            subscribed_channel_ids.insert(ch);
-                                        }
                                     } else {
-                                        tracing::debug!(channel_id = %ch, "membership notification: no matching rules — skipping");
+                                        let mut filter = config::resolve_dynamic_channel_filter(
+                                            &config, ch, &rules,
+                                        );
+                                        if filter.is_none() {
+                                            match relay.fetch_channel_info(ch).await {
+                                                Ok(Some(info)) if info.is_ephemeral() => {
+                                                    if config::admit_invited_ephemeral_channel(
+                                                        &mut rules, ch,
+                                                    ) {
+                                                        if let Some(deadline) = info.ttl_deadline {
+                                                            admitted_ephemeral_deadlines
+                                                                .insert(ch, deadline);
+                                                        }
+                                                        filter = config::resolve_dynamic_channel_filter(
+                                                            &config, ch, &rules,
+                                                        );
+                                                    }
+                                                }
+                                                Ok(_) => {}
+                                                Err(error) => {
+                                                    tracing::warn!(
+                                                        channel_id = %ch,
+                                                        %error,
+                                                        "membership metadata lookup failed — denying channel"
+                                                    );
+                                                }
+                                            }
+                                        }
+                                        if let Some(filter) = filter {
+                                            tracing::info!(channel_id = %ch, "membership notification: subscribing to new channel");
+                                            if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
+                                                tracing::warn!("failed to subscribe to new channel {ch}: {e}");
+                                            } else {
+                                                subscribed_channel_ids.insert(ch);
+                                            }
+                                        } else {
+                                            tracing::debug!(channel_id = %ch, "membership notification: no matching rules — skipping");
+                                        }
                                     }
                                 } else {
+                                    config::remove_invited_ephemeral_channel(&mut rules, ch);
+                                    admitted_ephemeral_deadlines.remove(&ch);
                                     subscribed_channel_ids.remove(&ch);
                                     tracing::info!(channel_id = %ch, "membership notification: unsubscribing from channel");
                                     if let Err(e) = relay.unsubscribe_channel(ch).await {
                                         tracing::warn!("failed to unsubscribe from channel {ch}: {e}");
                                     }
-                                    // Drain queued events and invalidate sessions for the
-                                    // removed channel. Events already in-flight will
-                                    // complete normally (the relay may reject actions if
-                                    // the agent lost access).
+                                    // Membership is an authorization boundary: cancel any
+                                    // in-flight turn before draining and invalidating state.
+                                    let _ = signal_in_flight_task(
+                                        &mut pool,
+                                        ch,
+                                        ControlSignal::Cancel,
+                                    );
                                     let drained_ids = queue.drain_channel(ch);
                                     let invalidated = pool.invalidate_channel_sessions(ch);
                                     // Track removed channels so checked-out agents get
@@ -1944,6 +2062,50 @@ async fn tokio_main() -> Result<()> {
                             if config.ignore_self && buzz_event.event.pubkey.to_hex() == pubkey_hex {
                                 tracing::debug!(channel_id = %buzz_event.channel_id, "dropping self-authored event");
                                 continue;
+                            }
+
+                            // Dynamic-room admission gates every event behavior,
+                            // including owner control commands. The periodic
+                            // timer is cleanup; it is never an authorization
+                            // grace window.
+                            if admitted_ephemeral_deadlines.contains_key(&buzz_event.channel_id) {
+                                let now = chrono::Utc::now();
+                                let current = relay.fetch_channel_info(buzz_event.channel_id).await;
+                                if let Some(deadline) = eligible_ephemeral_deadline(&current, now) {
+                                    if let Some(current_deadline) = admitted_ephemeral_deadlines.get_mut(&buzz_event.channel_id) {
+                                        *current_deadline = deadline;
+                                    }
+                                } else {
+                                    if let Err(error) = &current {
+                                        tracing::warn!(
+                                            channel_id = %buzz_event.channel_id,
+                                            %error,
+                                            "ephemeral metadata dispatch check failed — revoking channel"
+                                        );
+                                    }
+                                    admitted_ephemeral_deadlines.remove(&buzz_event.channel_id);
+                                    config::remove_invited_ephemeral_channel(&mut rules, buzz_event.channel_id);
+                                    subscribed_channel_ids.remove(&buzz_event.channel_id);
+                                    let _ = signal_in_flight_task(
+                                        &mut pool,
+                                        buzz_event.channel_id,
+                                        ControlSignal::Cancel,
+                                    );
+                                    if let Err(error) = relay.unsubscribe_channel(buzz_event.channel_id).await {
+                                        tracing::warn!(channel_id = %buzz_event.channel_id, %error, "failed to unsubscribe revoked ephemeral channel");
+                                    }
+                                    let drained_ids = queue.drain_channel(buzz_event.channel_id);
+                                    pool.invalidate_channel_sessions(buzz_event.channel_id);
+                                    removed_channels.insert(buzz_event.channel_id);
+                                    typing_channels.remove(&buzz_event.channel_id);
+                                    if !drained_ids.is_empty() {
+                                        let rest = ctx.rest_client.clone();
+                                        tokio::spawn(async move {
+                                            pool::clear_reactions(rest, drained_ids).await;
+                                        });
+                                    }
+                                    continue;
+                                }
                             }
 
                             // Check: kind:9, content "!shutdown", from owner, mentions THIS agent.
@@ -2051,8 +2213,8 @@ async fn tokio_main() -> Result<()> {
 
                             // Coarse security policy: drop events from disallowed
                             // authors before they reach subscription rules or the
-                            // agent. Must be AFTER !shutdown (owner can always
-                            // shut down regardless of gate mode).
+                            // agent. Owner control commands have already been
+                            // handled, after dynamic-room admission above.
                             //
                             // Both OwnerOnly and Allowlist accept events from
                             // "siblings" — pubkeys whose agent_owner_pubkey
@@ -2245,6 +2407,68 @@ async fn tokio_main() -> Result<()> {
                                 tracing::debug!("typing indicator dropped for {ch}: {e}");
                             }
                         }
+                    }
+                    None
+                }
+                _ = ephemeral_revalidation.tick() => {
+                    let _ = result_rx;
+                    let now = chrono::Utc::now();
+                    let channel_ids: Vec<Uuid> = admitted_ephemeral_deadlines
+                        .keys()
+                        .copied()
+                        .collect();
+                    let mut revoke = Vec::new();
+                    for channel_id in channel_ids {
+                        let eligible = match admitted_ephemeral_deadlines.get(&channel_id) {
+                            Some(_) => {
+                                let current = relay.fetch_channel_info(channel_id).await;
+                                if let Err(error) = &current {
+                                    tracing::warn!(
+                                        %channel_id,
+                                        %error,
+                                        "ephemeral metadata revalidation failed — revoking channel"
+                                    );
+                                }
+                                if let Some(deadline) = eligible_ephemeral_deadline(&current, now) {
+                                    admitted_ephemeral_deadlines.insert(channel_id, deadline);
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
+                            None => false,
+                        };
+                        if !eligible {
+                            revoke.push(channel_id);
+                        }
+                    }
+                    for channel_id in revoke {
+                        admitted_ephemeral_deadlines.remove(&channel_id);
+                        config::remove_invited_ephemeral_channel(&mut rules, channel_id);
+                        subscribed_channel_ids.remove(&channel_id);
+                        if let Err(error) = relay.unsubscribe_channel(channel_id).await {
+                            tracing::warn!(%channel_id, %error, "failed to unsubscribe revoked ephemeral channel");
+                        }
+                        let drained_ids = queue.drain_channel(channel_id);
+                        let _ = signal_in_flight_task(
+                            &mut pool,
+                            channel_id,
+                            ControlSignal::Cancel,
+                        );
+                        let invalidated = pool.invalidate_channel_sessions(channel_id);
+                        removed_channels.insert(channel_id);
+                        typing_channels.remove(&channel_id);
+                        if !drained_ids.is_empty() {
+                            let rest = ctx.rest_client.clone();
+                            tokio::spawn(async move {
+                                pool::clear_reactions(rest, drained_ids).await;
+                            });
+                        }
+                        tracing::info!(
+                            %channel_id,
+                            invalidated,
+                            "ephemeral channel expired or became ineligible — revoked"
+                        );
                     }
                     None
                 }
@@ -4395,6 +4619,8 @@ mod build_mcp_servers_tests {
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
+            turn_receipts: false,
+            expected_gateway_session_key: None,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -4560,6 +4786,8 @@ mod error_outcome_emission_tests {
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
+            turn_receipts: false,
+            expected_gateway_session_key: None,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2321,10 +2321,10 @@ async fn tokio_main() -> Result<()> {
                             });
                             // 👀 — immediate "seen" reaction, only if the event
                             // was actually queued (not dropped by DedupMode::Drop).
-                            // Fire-and-forget: on rare fast-failure paths the
-                            // guard's cleanup may race with this add, leaving a
-                            // cosmetic stale 👀. Acceptable — see ReactionGuard docs.
-                            if accepted {
+                            // Trusted-envelope turns add 👀 only after the
+                            // signed event passes admission in run_prompt_task.
+                            // That keeps terminal refusals free of stale state.
+                            if accepted && !ctx.trusted_inbound_envelope {
                                 let rc = ctx.rest_client.clone();
                                 let eid = event_id_hex.clone();
                                 tokio::spawn(async move {

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1634,6 +1634,7 @@ async fn tokio_main() -> Result<()> {
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         turn_receipts: config.turn_receipts,
         expected_gateway_session_key: config.expected_gateway_session_key.clone(),
+        trusted_inbound_envelope: config.trusted_inbound_envelope,
     });
 
     if !config.memory_enabled {
@@ -4621,6 +4622,7 @@ mod build_mcp_servers_tests {
             relay_observer: false,
             turn_receipts: false,
             expected_gateway_session_key: None,
+            trusted_inbound_envelope: false,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -4788,6 +4790,7 @@ mod error_outcome_emission_tests {
             relay_observer: false,
             turn_receipts: false,
             expected_gateway_session_key: None,
+            trusted_inbound_envelope: false,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1313,6 +1313,7 @@ async fn tokio_main() -> Result<()> {
             &config.agent_args,
             &agent_spawn_env,
             config.has_generated_codex_config,
+            config.forward_agent_publisher_credentials,
         )
         .await;
         match spawn_result {
@@ -1802,10 +1803,20 @@ async fn tokio_main() -> Result<()> {
                 let args = config.agent_args.clone();
                 let env = config.agent_spawn_env();
                 let has_codex = config.has_generated_codex_config;
+                let forward_publisher_credentials = config.forward_agent_publisher_credentials;
                 let observer = observer.clone();
                 let guard = RespawnGuard::new(idx, respawn_tx.clone());
                 respawn_tasks.spawn(async move {
-                    let result = spawn_and_init(&cmd, &args, &env, has_codex, idx, observer).await;
+                    let result = spawn_and_init(
+                        &cmd,
+                        &args,
+                        &env,
+                        has_codex,
+                        forward_publisher_credentials,
+                        idx,
+                        observer,
+                    )
+                    .await;
                     guard.send(result);
                 });
             }
@@ -3510,12 +3521,22 @@ fn recover_panicked_agent(
     let args = config.agent_args.clone();
     let env = config.agent_spawn_env();
     let has_codex = config.has_generated_codex_config;
+    let forward_publisher_credentials = config.forward_agent_publisher_credentials;
     let guard = RespawnGuard::new(i, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, i, observer).await;
+        let result = spawn_and_init(
+            &cmd,
+            &args,
+            &env,
+            has_codex,
+            forward_publisher_credentials,
+            i,
+            observer,
+        )
+        .await;
         guard.send(result);
     });
 }
@@ -3688,6 +3709,7 @@ fn spawn_respawn_task(
     let args = config.agent_args.clone();
     let env = config.agent_spawn_env();
     let has_codex = config.has_generated_codex_config;
+    let forward_publisher_credentials = config.forward_agent_publisher_credentials;
     let guard = RespawnGuard::new(index, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         // Shutdown old agent (reap child, prevent zombie).
@@ -3699,7 +3721,16 @@ fn spawn_respawn_task(
             tokio::time::sleep(delay).await;
         }
 
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, index, observer).await;
+        let result = spawn_and_init(
+            &cmd,
+            &args,
+            &env,
+            has_codex,
+            forward_publisher_credentials,
+            index,
+            observer,
+        )
+        .await;
         guard.send(result);
     });
 
@@ -3727,12 +3758,19 @@ async fn spawn_and_init(
     args: &[String],
     extra_env: &[(String, String)],
     has_generated_codex_config: bool,
+    forward_buzz_publisher_credentials: bool,
     agent_index: usize,
     observer: Option<observer::ObserverHandle>,
 ) -> Result<(AcpClient, u32, String)> {
-    let mut acp = AcpClient::spawn(command, args, extra_env, has_generated_codex_config)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
+    let mut acp = AcpClient::spawn(
+        command,
+        args,
+        extra_env,
+        has_generated_codex_config,
+        forward_buzz_publisher_credentials,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
     acp.set_observer(observer, agent_index);
 
     match acp.initialize().await {
@@ -3761,7 +3799,7 @@ async fn spawn_and_init(
 
 async fn spawn_auth_client(agent: &AuthAgentArgs) -> Result<AcpClient, acp::AcpError> {
     let agent_args = config::normalize_agent_args(&agent.agent_command, agent.agent_args.clone());
-    AcpClient::spawn(&agent.agent_command, &agent_args, &[], false).await
+    AcpClient::spawn(&agent.agent_command, &agent_args, &[], false, true).await
 }
 
 fn extract_auth_methods(init_result: &serde_json::Value) -> Vec<serde_json::Value> {
@@ -3891,7 +3929,7 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
     // Spawn outside the timeout so we always own the child for cleanup.
     // `models` subcommand doesn't use persona packs — no extra env, no codex config.
     let mut client =
-        match AcpClient::spawn(&args.agent.agent_command, &agent_args, &[], false).await {
+        match AcpClient::spawn(&args.agent.agent_command, &agent_args, &[], false, true).await {
             Ok(c) => c,
             Err(e) => {
                 eprintln!("error: failed to spawn agent: {e}");
@@ -4624,6 +4662,7 @@ mod build_mcp_servers_tests {
             turn_receipts: false,
             expected_gateway_session_key: None,
             trusted_inbound_envelope: false,
+            forward_agent_publisher_credentials: true,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -4792,6 +4831,7 @@ mod error_outcome_emission_tests {
             turn_receipts: false,
             expected_gateway_session_key: None,
             trusted_inbound_envelope: false,
+            forward_agent_publisher_credentials: true,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -4820,7 +4860,7 @@ mod error_outcome_emission_tests {
     async fn dummy_agent(index: usize) -> OwnedAgent {
         OwnedAgent {
             index,
-            acp: AcpClient::spawn("cat", &[], &[], false)
+            acp: AcpClient::spawn("cat", &[], &[], false, true)
                 .await
                 .expect("spawn cat as inert agent"),
             state: Default::default(),

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -5439,6 +5439,7 @@ mod tests {
             &["-c".to_string(), "sleep 10".to_string()],
             &[],
             false,
+            true,
         )
         .await
         .expect("failed to spawn test agent");
@@ -5497,6 +5498,7 @@ mod tests {
             &["-c".to_string(), "sleep 10".to_string()],
             &[],
             false,
+            true,
         )
         .await
         .expect("failed to spawn test agent");

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -473,6 +473,10 @@ pub struct PromptContext {
     /// Harness identity string for NIP-AM `harness` field. Derived from the
     /// configured `agent_command` at startup (e.g. `"goose"`, `"buzz-agent"`).
     pub harness_name: String,
+    /// Opt-in durable-evidence readback for OpenClaw-authored Buzz replies.
+    pub turn_receipts: bool,
+    /// Fixed Gateway session key that ACP lineage evidence must match.
+    pub expected_gateway_session_key: Option<String>,
 }
 
 impl AgentPool {
@@ -738,6 +742,173 @@ const CONTROL_CANCEL_GRACE: Duration = Duration::from_secs(5);
 
 /// Timeout for permission-mode requests (`session/set_config_option` with `configId: "mode"`).
 const PERMISSION_MODE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Number of relay readbacks used to resolve an out-of-band Buzz CLI reply.
+const RECEIPT_REPLY_READBACK_ATTEMPTS: usize = 5;
+/// Delay between successful relay queries that have not observed the reply yet.
+const RECEIPT_REPLY_READBACK_DELAY: Duration = Duration::from_millis(200);
+
+fn merge_anchored_replies(
+    accumulated: &mut Vec<crate::relay::AnchoredReply>,
+    observed: Vec<crate::relay::AnchoredReply>,
+) {
+    for reply in observed {
+        if !accumulated
+            .iter()
+            .any(|existing| existing.event_id == reply.event_id)
+        {
+            accumulated.push(reply);
+        }
+    }
+    accumulated.sort_by(|left, right| left.event_id.cmp(&right.event_id));
+}
+
+fn closed_receipt_payload(
+    request_event_ids: &[String],
+    reply_events: &[crate::relay::AnchoredReply],
+    gateway_session_key: Option<&str>,
+    expected_gateway_session_key: Option<&str>,
+    run_id: Option<&str>,
+    acp_session_id: &str,
+    turn_id: &str,
+) -> serde_json::Value {
+    let failure = |reason: &str| {
+        serde_json::json!({
+            "status": "failed",
+            "reason": reason,
+            "requestEventIds": request_event_ids,
+            "schemaVersion": 1,
+            "acpSessionId": acp_session_id,
+            "turnId": turn_id,
+        })
+    };
+    if request_event_ids.len() != 1 {
+        return failure("receipt_requires_exactly_one_request");
+    }
+    if reply_events.len() != 1 {
+        return failure(if reply_events.is_empty() {
+            "receipt_requires_one_anchored_reply_found_zero"
+        } else {
+            "receipt_requires_one_anchored_reply_found_multiple"
+        });
+    }
+    let Some(gateway_session_key) = gateway_session_key.filter(|value| !value.is_empty()) else {
+        return failure("gateway_session_key_evidence_missing");
+    };
+    let Some(expected_gateway_session_key) =
+        expected_gateway_session_key.filter(|value| !value.is_empty())
+    else {
+        return failure("expected_gateway_session_key_missing");
+    };
+    if gateway_session_key != expected_gateway_session_key {
+        return failure("gateway_session_key_mismatch");
+    }
+    let Some(run_id) = run_id.filter(|value| !value.is_empty()) else {
+        return failure("gateway_run_id_evidence_missing");
+    };
+    serde_json::json!({
+        "status": "closed",
+        "schemaVersion": 1,
+        "requestEventId": request_event_ids[0],
+        "replyEventId": reply_events[0].event_id,
+        "replyAnchor": reply_events[0].reply_to,
+        "gatewaySessionKey": gateway_session_key,
+        "expectedGatewaySessionKey": expected_gateway_session_key,
+        "runId": run_id,
+        "acpSessionId": acp_session_id,
+        "turnId": turn_id,
+    })
+}
+
+async fn observe_closed_turn_receipt(
+    agent: &AcpClient,
+    ctx: &PromptContext,
+    channel_id: Uuid,
+    request_event_ids: &[String],
+    expected_reply_anchor: Option<&str>,
+    acp_session_id: &str,
+    turn_id: &str,
+) {
+    let mut replies = Vec::new();
+    if request_event_ids.len() == 1 {
+        let Some(expected_reply_anchor) =
+            receipt_query_anchor(request_event_ids, expected_reply_anchor)
+        else {
+            agent.observe(
+                "turn_receipt",
+                closed_receipt_payload(
+                    request_event_ids,
+                    &replies,
+                    agent.active_session_key(),
+                    ctx.expected_gateway_session_key.as_deref(),
+                    agent.active_run_id(),
+                    acp_session_id,
+                    turn_id,
+                ),
+            );
+            return;
+        };
+        for attempt in 0..RECEIPT_REPLY_READBACK_ATTEMPTS {
+            match ctx
+                .rest_client
+                .query_anchored_replies(
+                    channel_id,
+                    ctx.agent_keys.public_key(),
+                    expected_reply_anchor,
+                )
+                .await
+            {
+                Ok(found) => {
+                    merge_anchored_replies(&mut replies, found);
+                    // Multiple distinct replies can never recover to a valid
+                    // receipt, so fail early. A single reply must remain under
+                    // observation for the complete bounded quiescence window
+                    // so a delayed duplicate cannot escape cardinality checks.
+                    if replies.len() > 1 {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    agent.observe(
+                        "turn_receipt",
+                        serde_json::json!({
+                            "status": "failed",
+                            "reason": "reply_evidence_query_failed",
+                            "requestEventIds": request_event_ids,
+                            "error": error.to_string(),
+                        }),
+                    );
+                    return;
+                }
+            }
+            if attempt + 1 < RECEIPT_REPLY_READBACK_ATTEMPTS {
+                tokio::time::sleep(RECEIPT_REPLY_READBACK_DELAY).await;
+            }
+        }
+    }
+    agent.observe(
+        "turn_receipt",
+        closed_receipt_payload(
+            request_event_ids,
+            &replies,
+            agent.active_session_key(),
+            ctx.expected_gateway_session_key.as_deref(),
+            agent.turn_run_id(),
+            acp_session_id,
+            turn_id,
+        ),
+    );
+}
+
+fn receipt_query_anchor<'a>(
+    request_event_ids: &[String],
+    expected_reply_anchor: Option<&'a str>,
+) -> Option<&'a str> {
+    (request_event_ids.len() == 1)
+        .then_some(expected_reply_anchor)
+        .flatten()
+        .filter(|anchor| !anchor.is_empty())
+}
 
 /// Create a new ACP session via `session_new_full()`, populate model capabilities
 /// on the agent (first session only), and apply `desired_model` if set.
@@ -1667,6 +1838,7 @@ pub async fn run_prompt_task(
     // (`prompt[0].text.startsWith("/")`) fires; the wrapped Buzz context
     // follows as a second block.
     let mut slash_command: Option<String> = None;
+    let mut expected_reply_anchor: Option<String> = None;
     let prompt_sections: Vec<String> = if let Some(text) = prompt_text {
         // Heartbeats create their session before this point, so a Goose method-not-found
         // probe has already selected the correct framing for this process.
@@ -1716,20 +1888,20 @@ pub async fn run_prompt_task(
             );
         }
 
-        crate::queue::format_prompt(
-            b,
-            &crate::queue::FormatPromptArgs {
-                agent_core: agent_core.as_deref(),
-                channel_info: channel_info.as_ref(),
-                conversation_context: conversation_context.as_ref(),
-                profile_lookup: profile_lookup.as_ref(),
-                has_system_prompt_support: agent.has_system_prompt_support(),
-                base_prompt: ctx.base_prompt,
-                system_prompt: ctx.system_prompt.as_deref(),
-                team_instructions: ctx.team_instructions.as_deref(),
-                agent_canvas: agent_canvas.as_deref(),
-            },
-        )
+        let format_args = crate::queue::FormatPromptArgs {
+            agent_core: agent_core.as_deref(),
+            channel_info: channel_info.as_ref(),
+            conversation_context: conversation_context.as_ref(),
+            profile_lookup: profile_lookup.as_ref(),
+            turn_receipts: ctx.turn_receipts,
+            has_system_prompt_support: agent.has_system_prompt_support(),
+            base_prompt: ctx.base_prompt,
+            system_prompt: ctx.system_prompt.as_deref(),
+            team_instructions: ctx.team_instructions.as_deref(),
+            agent_canvas: agent_canvas.as_deref(),
+        };
+        expected_reply_anchor = crate::queue::resolve_turn_reply_anchor(b, &format_args);
+        crate::queue::format_prompt(b, &format_args)
     } else {
         // Should not happen — batch is None only for heartbeats which have prompt_text.
         // Return the agent to the pool to prevent a permanent slot leak.
@@ -1772,6 +1944,7 @@ pub async fn run_prompt_task(
     // the main loop can cancel, interrupt, or rotate it. Heartbeats
     // (control_rx=None) take the simple await path — they are not controllable.
     //
+    agent.acp.begin_turn_evidence();
     let prompt_result = match control_rx {
         None => {
             // Heartbeat / non-cancellable path.
@@ -1910,6 +2083,20 @@ pub async fn run_prompt_task(
                             &source,
                             &control_signal,
                         );
+                        if ctx.turn_receipts {
+                            if let PromptSource::Channel(channel_id) = &source {
+                                observe_closed_turn_receipt(
+                                    &agent.acp,
+                                    &ctx,
+                                    *channel_id,
+                                    &triggering_event_ids,
+                                    expected_reply_anchor.as_deref(),
+                                    &session_id,
+                                    &turn_id,
+                                )
+                                .await;
+                            }
+                        }
                         let usage = agent.acp.take_turn_usage();
                         publish_agent_turn_metric(
                             &ctx,
@@ -1938,6 +2125,25 @@ pub async fn run_prompt_task(
     match prompt_result {
         Ok(stop_reason) => {
             log_stop_reason(&source, &stop_reason);
+
+            // OpenClaw publishes its Buzz reply out of band through buzz-cli.
+            // Close the observer receipt from durable relay evidence before the
+            // agent is returned to the pool. Other ACP adapters retain their
+            // existing behavior and do not pay for this readback.
+            if ctx.turn_receipts {
+                if let PromptSource::Channel(channel_id) = &source {
+                    observe_closed_turn_receipt(
+                        &agent.acp,
+                        &ctx,
+                        *channel_id,
+                        &triggering_event_ids,
+                        expected_reply_anchor.as_deref(),
+                        &session_id,
+                        &turn_id,
+                    )
+                    .await;
+                }
+            }
 
             let should_rotate = matches!(
                 stop_reason,
@@ -3589,7 +3795,7 @@ async fn react_working(rest: &crate::relay::RestClient, event_ids: &[String]) {
 /// Fire-and-forget: remove both 👀 and 💬 from all events. Spawned on turn complete.
 /// Capped at `REACTION_CONCURRENCY` concurrent requests per chunk to avoid
 /// unbounded HTTP fan-out on large batches.
-async fn clear_reactions(rest: crate::relay::RestClient, event_ids: Vec<String>) {
+pub(crate) async fn clear_reactions(rest: crate::relay::RestClient, event_ids: Vec<String>) {
     // Each event needs two removals (👀 and 💬); pair them and chunk by
     // REACTION_CONCURRENCY pairs so the total concurrent requests stay bounded.
     for chunk in event_ids.chunks(REACTION_CONCURRENCY) {
@@ -3608,6 +3814,195 @@ mod tests {
     use super::*;
     use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
     use serde_json::json;
+
+    #[test]
+    fn receipt_closes_only_with_one_request_reply_and_gateway_evidence() {
+        let payload = closed_receipt_payload(
+            &["a".repeat(64)],
+            &[crate::relay::AnchoredReply {
+                event_id: "b".repeat(64),
+                reply_to: "a".repeat(64),
+            }],
+            Some("agent:main:buzz-private"),
+            Some("agent:main:buzz-private"),
+            Some("run-1"),
+            "acp-1",
+            "turn-1",
+        );
+        assert_eq!(payload["status"], "closed");
+        assert_eq!(payload["requestEventId"], "a".repeat(64));
+        assert_eq!(payload["replyEventId"], "b".repeat(64));
+        assert_eq!(payload["replyAnchor"], "a".repeat(64));
+        assert_eq!(payload["gatewaySessionKey"], "agent:main:buzz-private");
+        assert_eq!(payload["runId"], "run-1");
+    }
+
+    #[test]
+    fn threaded_second_turn_receipt_queries_the_same_root_anchor_as_the_prompt() {
+        let root_id = "a".repeat(64);
+        let parent_id = "b".repeat(64);
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9), "second turn")
+            .tags([
+                Tag::parse(["e", root_id.as_str(), "", "root"]).expect("root tag"),
+                Tag::parse(["e", parent_id.as_str(), "", "reply"]).expect("reply tag"),
+            ])
+            .sign_with_keys(&keys)
+            .expect("signed request");
+        let request_id = event.id.to_hex();
+        let batch = FlushBatch {
+            channel_id: Uuid::new_v4(),
+            events: vec![crate::queue::BatchEvent {
+                event,
+                prompt_tag: "private-office".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let args = crate::queue::FormatPromptArgs::default();
+        let expected_anchor = crate::queue::resolve_turn_reply_anchor(&batch, &args);
+        let prompt = crate::queue::format_prompt(&batch, &args).join("\n\n");
+
+        assert_eq!(expected_anchor.as_deref(), Some(root_id.as_str()));
+        assert!(prompt.contains(&format!("--reply-to {root_id}")));
+        assert_eq!(
+            receipt_query_anchor(&[request_id], expected_anchor.as_deref()),
+            Some(root_id.as_str())
+        );
+    }
+
+    #[test]
+    fn top_level_dm_receipt_anchors_to_the_current_request() {
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9), "first DM turn")
+            .sign_with_keys(&keys)
+            .expect("signed request");
+        let request_id = event.id.to_hex();
+        let batch = FlushBatch {
+            channel_id: Uuid::new_v4(),
+            events: vec![crate::queue::BatchEvent {
+                event,
+                prompt_tag: "private-office".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let channel_info = PromptChannelInfo {
+            name: "Nexus private".into(),
+            channel_type: "dm".into(),
+        };
+        let args = crate::queue::FormatPromptArgs {
+            channel_info: Some(&channel_info),
+            turn_receipts: true,
+            ..Default::default()
+        };
+        let expected_anchor = crate::queue::resolve_turn_reply_anchor(&batch, &args);
+        let prompt = crate::queue::format_prompt(&batch, &args).join("\n\n");
+
+        assert_eq!(expected_anchor.as_deref(), Some(request_id.as_str()));
+        assert!(prompt.contains(&format!("--reply-to {request_id}")));
+        assert_eq!(
+            receipt_query_anchor(
+                std::slice::from_ref(&request_id),
+                expected_anchor.as_deref()
+            ),
+            Some(request_id.as_str())
+        );
+    }
+
+    #[test]
+    fn receipt_fails_closed_on_cardinality_or_missing_evidence() {
+        let request = vec!["a".repeat(64)];
+        assert_eq!(
+            closed_receipt_payload(
+                &request,
+                &[],
+                Some("session"),
+                Some("session"),
+                Some("run"),
+                "acp",
+                "turn"
+            )["reason"],
+            "receipt_requires_one_anchored_reply_found_zero"
+        );
+        let duplicate = vec![
+            crate::relay::AnchoredReply {
+                event_id: "b".repeat(64),
+                reply_to: request[0].clone(),
+            },
+            crate::relay::AnchoredReply {
+                event_id: "c".repeat(64),
+                reply_to: request[0].clone(),
+            },
+        ];
+        assert_eq!(
+            closed_receipt_payload(
+                &request,
+                &duplicate,
+                Some("session"),
+                Some("session"),
+                Some("run"),
+                "acp",
+                "turn"
+            )["reason"],
+            "receipt_requires_one_anchored_reply_found_multiple"
+        );
+        assert_eq!(
+            closed_receipt_payload(
+                &request,
+                &duplicate[..1],
+                None,
+                Some("session"),
+                Some("run"),
+                "acp",
+                "turn"
+            )["reason"],
+            "gateway_session_key_evidence_missing"
+        );
+        assert_eq!(
+            closed_receipt_payload(
+                &request,
+                &duplicate[..1],
+                Some("session"),
+                Some("session"),
+                None,
+                "acp",
+                "turn"
+            )["reason"],
+            "gateway_run_id_evidence_missing"
+        );
+    }
+
+    #[test]
+    fn delayed_duplicate_reply_is_retained_for_fail_closed_receipt() {
+        let request = vec!["a".repeat(64)];
+        let first = crate::relay::AnchoredReply {
+            event_id: "b".repeat(64),
+            reply_to: request[0].clone(),
+        };
+        let delayed = crate::relay::AnchoredReply {
+            event_id: "c".repeat(64),
+            reply_to: request[0].clone(),
+        };
+        let mut replies = Vec::new();
+        merge_anchored_replies(&mut replies, vec![first.clone()]);
+        merge_anchored_replies(&mut replies, vec![first, delayed]);
+        assert_eq!(replies.len(), 2);
+        assert_eq!(
+            closed_receipt_payload(
+                &request,
+                &replies,
+                Some("session"),
+                Some("session"),
+                Some("run"),
+                "acp",
+                "turn"
+            )["reason"],
+            "receipt_requires_one_anchored_reply_found_multiple"
+        );
+    }
 
     // These pin the initial_message dispatch path (run_prompt_task, ~line 855):
     // a legacy agent WITH a base_prompt must get [Base] prepended to the user
@@ -5254,6 +5649,8 @@ mod tests {
             agent_owner_pubkey: owner_pubkey,
             memory_enabled: false,
             harness_name: "goose".to_string(),
+            turn_receipts: false,
+            expected_gateway_session_key: None,
         }
     }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -31,6 +31,7 @@ use uuid::Uuid;
 use crate::acp::{
     extract_model_config_options, extract_model_state, model_in_catalog,
     resolve_model_switch_method, AcpClient, AcpError, McpServer, ModelSwitchMethod, StopReason,
+    TrustedInboundEventEnvelope,
 };
 use crate::config::{DedupMode, PermissionMode};
 use crate::observer;
@@ -477,6 +478,8 @@ pub struct PromptContext {
     pub turn_receipts: bool,
     /// Fixed Gateway session key that ACP lineage evidence must match.
     pub expected_gateway_session_key: Option<String>,
+    /// Attach one verified triggering event as non-model ACP metadata.
+    pub trusted_inbound_envelope: bool,
 }
 
 impl AgentPool {
@@ -1403,6 +1406,11 @@ pub async fn run_prompt_task(
         .as_ref()
         .map(|b| b.events.iter().map(|be| be.event.id.to_hex()).collect())
         .unwrap_or_default();
+    let trusted_inbound_envelope = if ctx.trusted_inbound_envelope {
+        TrustedInboundEventEnvelope::from_prompt_batch(batch.as_ref())
+    } else {
+        None
+    };
     agent.acp.observe(
         "turn_started",
         serde_json::json!({
@@ -1950,9 +1958,10 @@ pub async fn run_prompt_task(
             // Heartbeat / non-cancellable path.
             tokio::select! {
                 biased;
-                result = agent.acp.session_prompt_blocks_with_idle_timeout(
+                result = agent.acp.session_prompt_blocks_with_idle_timeout_and_meta(
                     &session_id,
                     &prompt_blocks,
+                    trusted_inbound_envelope.as_ref(),
                     ctx.idle_timeout,
                     ctx.max_turn_duration,
                 ) => result,
@@ -1961,9 +1970,10 @@ pub async fn run_prompt_task(
         Some(rx) => {
             tokio::select! {
                 biased;
-                result = agent.acp.session_prompt_blocks_with_idle_timeout(
+                result = agent.acp.session_prompt_blocks_with_idle_timeout_and_meta(
                     &session_id,
                     &prompt_blocks,
+                    trusted_inbound_envelope.as_ref(),
                     ctx.idle_timeout,
                     ctx.max_turn_duration,
                 ) => result,
@@ -5651,6 +5661,7 @@ mod tests {
             harness_name: "goose".to_string(),
             turn_receipts: false,
             expected_gateway_session_key: None,
+            trusted_inbound_envelope: false,
         }
     }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -823,19 +823,24 @@ fn closed_receipt_payload(
     })
 }
 
+struct ReplyReadbackScope<'a> {
+    expected_reply_anchor: Option<&'a str>,
+    prior_reply_event_ids: Result<&'a HashSet<String>, &'a str>,
+}
+
 async fn observe_closed_turn_receipt(
     agent: &AcpClient,
     ctx: &PromptContext,
     channel_id: Uuid,
     request_event_ids: &[String],
-    expected_reply_anchor: Option<&str>,
+    readback_scope: ReplyReadbackScope<'_>,
     acp_session_id: &str,
     turn_id: &str,
 ) {
     let mut replies = Vec::new();
     if request_event_ids.len() == 1 {
         let Some(expected_reply_anchor) =
-            receipt_query_anchor(request_event_ids, expected_reply_anchor)
+            receipt_query_anchor(request_event_ids, readback_scope.expected_reply_anchor)
         else {
             agent.observe(
                 "turn_receipt",
@@ -851,6 +856,21 @@ async fn observe_closed_turn_receipt(
             );
             return;
         };
+        let prior_reply_event_ids = match readback_scope.prior_reply_event_ids {
+            Ok(ids) => ids,
+            Err(error) => {
+                agent.observe(
+                    "turn_receipt",
+                    serde_json::json!({
+                        "status": "failed",
+                        "reason": "reply_evidence_baseline_query_failed",
+                        "requestEventIds": request_event_ids,
+                        "error": error,
+                    }),
+                );
+                return;
+            }
+        };
         for attempt in 0..RECEIPT_REPLY_READBACK_ATTEMPTS {
             match ctx
                 .rest_client
@@ -862,6 +882,7 @@ async fn observe_closed_turn_receipt(
                 .await
             {
                 Ok(found) => {
+                    let found = replies_for_current_turn(found, prior_reply_event_ids);
                     merge_anchored_replies(&mut replies, found);
                     // Multiple distinct replies can never recover to a valid
                     // receipt, so fail early. A single reply must remain under
@@ -901,6 +922,33 @@ async fn observe_closed_turn_receipt(
             turn_id,
         ),
     );
+}
+
+fn replies_for_current_turn(
+    mut replies: Vec<crate::relay::AnchoredReply>,
+    prior_reply_event_ids: &HashSet<String>,
+) -> Vec<crate::relay::AnchoredReply> {
+    replies.retain(|reply| !prior_reply_event_ids.contains(&reply.event_id));
+    replies
+}
+
+async fn capture_prior_reply_event_ids(
+    ctx: &PromptContext,
+    source: &PromptSource,
+    request_event_ids: &[String],
+    expected_reply_anchor: Option<&str>,
+) -> Result<HashSet<String>, String> {
+    let PromptSource::Channel(channel_id) = source else {
+        return Ok(HashSet::new());
+    };
+    let Some(anchor) = receipt_query_anchor(request_event_ids, expected_reply_anchor) else {
+        return Ok(HashSet::new());
+    };
+    ctx.rest_client
+        .query_anchored_replies(*channel_id, ctx.agent_keys.public_key(), anchor)
+        .await
+        .map(|replies| replies.into_iter().map(|reply| reply.event_id).collect())
+        .map_err(|error| error.to_string())
 }
 
 fn receipt_query_anchor<'a>(
@@ -1948,6 +1996,23 @@ pub async fn run_prompt_task(
         None => prompt_sections.iter().map(String::as_str).collect(),
     };
 
+    // Snapshot replies that already exist at this turn's effective anchor.
+    // Thread-root follow-ups intentionally reuse a stable NIP-10 anchor, so
+    // anchor-only readback would otherwise count replies from earlier turns.
+    // The post-turn receipt subtracts this exact baseline and closes only over
+    // reply events first observed for the current turn.
+    let prior_reply_event_ids = if ctx.turn_receipts {
+        capture_prior_reply_event_ids(
+            &ctx,
+            &source,
+            &triggering_event_ids,
+            expected_reply_anchor.as_deref(),
+        )
+        .await
+    } else {
+        Ok(HashSet::new())
+    };
+
     // When control_rx is Some (channel tasks), wrap the prompt in select! so
     // the main loop can cancel, interrupt, or rotate it. Heartbeats
     // (control_rx=None) take the simple await path — they are not controllable.
@@ -2100,7 +2165,12 @@ pub async fn run_prompt_task(
                                     &ctx,
                                     *channel_id,
                                     &triggering_event_ids,
-                                    expected_reply_anchor.as_deref(),
+                                    ReplyReadbackScope {
+                                        expected_reply_anchor: expected_reply_anchor.as_deref(),
+                                        prior_reply_event_ids: prior_reply_event_ids
+                                            .as_ref()
+                                            .map_err(String::as_str),
+                                    },
                                     &session_id,
                                     &turn_id,
                                 )
@@ -2147,7 +2217,12 @@ pub async fn run_prompt_task(
                         &ctx,
                         *channel_id,
                         &triggering_event_ids,
-                        expected_reply_anchor.as_deref(),
+                        ReplyReadbackScope {
+                            expected_reply_anchor: expected_reply_anchor.as_deref(),
+                            prior_reply_event_ids: prior_reply_event_ids
+                                .as_ref()
+                                .map_err(String::as_str),
+                        },
                         &session_id,
                         &turn_id,
                     )
@@ -4012,6 +4087,24 @@ mod tests {
             )["reason"],
             "receipt_requires_one_anchored_reply_found_multiple"
         );
+    }
+
+    #[test]
+    fn stable_thread_anchor_excludes_replies_from_prior_turns() {
+        let stable_root = "a".repeat(64);
+        let prior = crate::relay::AnchoredReply {
+            event_id: "b".repeat(64),
+            reply_to: stable_root.clone(),
+        };
+        let current = crate::relay::AnchoredReply {
+            event_id: "c".repeat(64),
+            reply_to: stable_root,
+        };
+        let prior_ids = HashSet::from([prior.event_id.clone()]);
+
+        let current_turn = replies_for_current_turn(vec![prior, current.clone()], &prior_ids);
+
+        assert_eq!(current_turn, vec![current]);
     }
 
     // These pin the initial_message dispatch path (run_prompt_task, ~line 855):

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1463,7 +1463,16 @@ pub async fn run_prompt_task(
         .map(|b| b.events.iter().map(|be| be.event.id.to_hex()).collect())
         .unwrap_or_default();
     let trusted_inbound_envelope = if ctx.trusted_inbound_envelope {
-        TrustedInboundEventEnvelope::from_prompt_batch(batch.as_ref())
+        match TrustedInboundEventEnvelope::try_from_prompt_batch(batch.as_ref()) {
+            Ok(envelope) => Some(envelope),
+            Err(reason) => {
+                tracing::warn!(
+                    refusal_code = reason,
+                    "trusted inbound event envelope refused"
+                );
+                None
+            }
+        }
     } else {
         None
     };

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1462,20 +1462,6 @@ pub async fn run_prompt_task(
         .as_ref()
         .map(|b| b.events.iter().map(|be| be.event.id.to_hex()).collect())
         .unwrap_or_default();
-    let trusted_inbound_envelope = if ctx.trusted_inbound_envelope {
-        match TrustedInboundEventEnvelope::try_from_prompt_batch(batch.as_ref()) {
-            Ok(envelope) => Some(envelope),
-            Err(reason) => {
-                tracing::warn!(
-                    refusal_code = reason,
-                    "trusted inbound event envelope refused"
-                );
-                None
-            }
-        }
-    } else {
-        None
-    };
     agent.acp.observe(
         "turn_started",
         serde_json::json!({
@@ -1497,6 +1483,54 @@ pub async fn run_prompt_task(
         observer_channel_id,
         turn_id.clone(),
     );
+
+    // Install reaction cleanup before trusted admission can return. Refused
+    // events are terminal and must not retain a stale seen/typing marker.
+    let reaction_ids: Vec<String> = batch
+        .as_ref()
+        .map(|b| b.events.iter().map(|be| be.event.id.to_hex()).collect())
+        .unwrap_or_default();
+    let _reaction_guard = ReactionGuard::new(ctx.rest_client.clone(), reaction_ids.clone());
+
+    let trusted_inbound_envelope = if ctx.trusted_inbound_envelope {
+        match &source {
+            PromptSource::Heartbeat => None,
+            PromptSource::Channel(_) => {
+                match TrustedInboundEventEnvelope::try_from_prompt_batch(batch.as_ref()) {
+                    Ok(envelope) => Some(envelope),
+                    Err(reason) => {
+                        tracing::warn!(
+                            refusal_code = reason,
+                            "trusted inbound event envelope refused"
+                        );
+                        agent.acp.observe(
+                            "trusted_inbound_event_refused",
+                            serde_json::json!({ "refusalCode": reason }),
+                        );
+                        send_prompt_result(
+                            &result_tx,
+                            &turn_id,
+                            agent,
+                            source,
+                            PromptOutcome::Error(AcpError::TrustedInboundEventRefused(reason)),
+                            None,
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+    } else {
+        None
+    };
+
+    // Trusted turns defer 👀 until signed-event admission succeeds. Awaiting
+    // it here orders the add before ReactionGuard can remove it.
+    if trusted_inbound_envelope.is_some() {
+        for event_id in &reaction_ids {
+            reaction_add(&ctx.rest_client, event_id, REACTION_SEEN).await;
+        }
+    }
 
     // Start liveness with `turn_started`, not the final session/prompt call:
     // session creation, context fetches, and an initial message can themselves
@@ -1525,15 +1559,6 @@ pub async fn run_prompt_task(
     );
     let liveness_handle = tokio::spawn(liveness);
     let liveness_guard = LivenessGuard::new(liveness_handle, liveness_state);
-
-    // Collects event IDs up front. On drop (any exit path — normal, early
-    // return, or panic), spawns best-effort cleanup of both 👀 and 💬.
-    // See `ReactionGuard` docs for ordering guarantees and known edge cases.
-    let reaction_ids: Vec<String> = batch
-        .as_ref()
-        .map(|b| b.events.iter().map(|be| be.event.id.to_hex()).collect())
-        .unwrap_or_default();
-    let _reaction_guard = ReactionGuard::new(ctx.rest_client.clone(), reaction_ids.clone());
 
     //
     // Core memory is delivered inside the system prompt the harness already
@@ -3367,11 +3392,9 @@ fn log_stop_reason(source: &PromptSource, stop_reason: &StopReason) {
 /// 💬 (`react_working`) is fire-and-forget (spawned before the prompt fires).
 /// A brief race where 💬 appears slightly after the agent starts is acceptable.
 ///
-/// 👀 (`react_seen`) is fire-and-forget from `main.rs` at queue-push time.
-/// On rare fast-failure paths (e.g., `session_new` error on an idle agent),
-/// the cleanup spawn may race with the 👀 add, leaving a stale 👀. This is
-/// accepted as a cosmetic edge case — the message will be retried and the
-/// stale 👀 is harmless.
+/// 👀 (`react_seen`) is normally fire-and-forget from `main.rs` at queue-push
+/// time. Trusted-envelope turns defer and await the add after admission so a
+/// terminal authority refusal cannot leave a stale reaction.
 struct ReactionGuard {
     rest: Option<crate::relay::RestClient>,
     ids: Vec<String>,
@@ -4924,6 +4947,61 @@ mod tests {
             cancelled_events: vec![],
             cancel_reason: None,
         }
+    }
+
+    #[tokio::test]
+    async fn trusted_channel_refusal_stops_before_session_prompt() {
+        let marker = std::env::temp_dir().join(format!(
+            "buzz-acp-unexpected-prompt-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let script = format!(
+            "IFS= read -r _line && : > '{}' ; sleep 10",
+            marker.display()
+        );
+        let acp = AcpClient::spawn("bash", &["-c".to_string(), script], &[], false, true)
+            .await
+            .expect("spawn test agent");
+        let agent = OwnedAgent {
+            index: 0,
+            acp,
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            agent_name: "test-agent".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 2,
+        };
+        let channel_id = Uuid::new_v4();
+        let batch = one_event_batch(channel_id);
+        let mut context = make_prompt_context_no_owner();
+        context.trusted_inbound_envelope = true;
+        let (result_tx, mut result_rx) = mpsc::unbounded_channel();
+
+        run_prompt_task(
+            agent,
+            Some(batch),
+            Some("must not reach the agent".into()),
+            Arc::new(context),
+            result_tx,
+            None,
+            "trusted-refusal-turn".into(),
+        )
+        .await;
+
+        let result = result_rx.recv().await.expect("terminal prompt result");
+        assert!(matches!(
+            result.outcome,
+            PromptOutcome::Error(AcpError::TrustedInboundEventRefused(
+                "invalid_channel_binding"
+            ))
+        ));
+        assert!(result.batch.is_none(), "refused authority must not requeue");
+        assert!(
+            !marker.exists(),
+            "session/prompt must not be written after trusted admission refusal"
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1272,9 +1272,9 @@ fn format_context_hints(
                     s.push_str(&format!("\nParent: {parent}"));
                 }
             }
-            if let Some(event_id) = reply_anchor {
-                append_reply_instruction(&mut s, event_id);
-            }
+        }
+        if let Some(event_id) = reply_anchor {
+            append_reply_instruction(&mut s, event_id);
         }
         s
     } else if let Some(ref root) = thread_tags.root_event_id {
@@ -1355,6 +1355,9 @@ pub struct FormatPromptArgs<'a> {
     pub channel_info: Option<&'a PromptChannelInfo>,
     pub conversation_context: Option<&'a ConversationContext>,
     pub profile_lookup: Option<&'a PromptProfileLookup>,
+    /// Require a durable reply anchor even for the first message in a DM so
+    /// turn-receipt readback can correlate the published response.
+    pub turn_receipts: bool,
     /// When true, base_prompt and system_prompt are delivered via the system
     /// role (session/new) and omitted from the user message. When false
     /// (legacy agents), they are injected as `[Base]` and `[System]` sections.
@@ -1383,26 +1386,37 @@ pub(crate) fn base_section(base_prompt: &str) -> String {
     format!("[Base]\n{}", base_prompt.trim_end())
 }
 
-/// Format a [`FlushBatch`] into the per-section prompt blocks for the agent.
+/// Resolve the exact reply anchor that will be instructed in this turn's prompt.
 ///
-/// Produces a stable prompt with these sections (in order):
-/// 0. `[Base]` — base prompt (only for legacy agents without systemPrompt support)
-/// 1. `[System]` — system prompt (only for legacy agents without systemPrompt support)
-/// 2. `[Agent Memory — core]` — if agent core memory is set
-/// 3. `[Context]` — scope, channel name, and contextual hints for the agent
-/// 4. `[Thread Context]` or `[Conversation Context]` — if fetched
-/// 5. `[Event]` / `[Buzz events]` — the triggering event(s)
+/// Receipt readback must reuse this value so a human thread follow-up flattened
+/// to the root is not mistakenly queried against the triggering child event.
+pub(crate) fn resolve_turn_reply_anchor(
+    batch: &FlushBatch,
+    args: &FormatPromptArgs<'_>,
+) -> Option<String> {
+    let last_event = batch.events.last()?;
+    let thread_tags = parse_thread_tags(&last_event.event);
+    let is_dm = args
+        .channel_info
+        .map(|ci| ci.channel_type == "dm")
+        .unwrap_or(false);
+    if is_dm {
+        return (thread_tags.root_event_id.is_some() || args.turn_receipts)
+            .then(|| last_event.event.id.to_hex());
+    }
+    resolve_reply_anchor(
+        &last_event.event.pubkey.to_hex(),
+        &thread_tags,
+        &last_event.event.id.to_hex(),
+        args.profile_lookup,
+    )
+}
+
+/// Format a [`FlushBatch`] into stable per-section prompt blocks for the agent.
 ///
-/// Each section is returned as its own block rather than one joined string so
-/// the observer frame's size trimmer (`fit_observer_event_to_budget`) elides
-/// the body of an oversized section in place, leaving every `[Header]` line at
-/// the head of its own leaf — so the desktop "Prompt context" panel always
-/// counts every section. The receiving agent reconstructs the full prompt by
-/// joining the blocks (legacy agents see a single `\n` between sections rather
-/// than a blank line; sections self-delimit with their `[Header]` line).
-///
-/// For agents with `protocol_version >= 2`, base_prompt and system_prompt are
-/// delivered via the system role in `session/new` and omitted from this message.
+/// Legacy agents receive base/system/memory/canvas sections here. Modern agents
+/// receive those via the system role in `session/new`; both receive context,
+/// conversation history, and triggering event sections.
 pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<String> {
     // Scope is always derived from the LAST event in the batch — that's the
     // one the agent is responding to. Thread/DM context is supplementary info
@@ -1464,20 +1478,7 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
     //   - top-level     → anchor to the triggering event (it becomes the root)
     // Agent↔agent turns get no forced anchor — deep nesting is intentional
     // there. DMs are always 1:1 with a human, so they always anchor.
-    let sender_pubkey = last_event.event.pubkey.to_hex();
-    let reply_anchor = if is_dm {
-        thread_tags
-            .root_event_id
-            .is_some()
-            .then(|| last_event.event.id.to_hex())
-    } else {
-        resolve_reply_anchor(
-            &sender_pubkey,
-            &thread_tags,
-            &last_event.event.id.to_hex(),
-            args.profile_lookup,
-        )
-    };
+    let reply_anchor = resolve_turn_reply_anchor(batch, args);
     sections.push(format_context_hints(
         batch.channel_id,
         args.channel_info,

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -336,7 +336,11 @@ pub struct RestClient {
 /// Durable reply evidence read back from the relay event log.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AnchoredReply {
+    /// Hex event ID of the verified agent-authored reply event.
     pub event_id: String,
+    /// Effective NIP-10 `reply` anchor used for relay readback. This can be the
+    /// thread root rather than the triggering request when a follow-up turn is
+    /// deliberately flattened onto its existing thread.
     pub reply_to: String,
 }
 

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -157,7 +157,7 @@ impl ChannelInfo {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct MetadataCandidate {
     created_at: u64,
     event_id: String,
@@ -166,6 +166,7 @@ struct MetadataCandidate {
     archived: bool,
     ttl_seconds: Option<u64>,
     ttl_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    malformed: bool,
 }
 
 impl MetadataCandidate {
@@ -190,90 +191,130 @@ fn merge_discovered_channels(
     meta_events: &serde_json::Value,
 ) -> HashMap<Uuid, ChannelInfo> {
     let mut meta_map: HashMap<Uuid, MetadataCandidate> = HashMap::new();
-    let mut malformed_channels = HashSet::new();
+    let mut unorderable_channels = HashSet::new();
     if let Some(arr) = meta_events.as_array() {
         for ev in arr {
             let tags = match ev.get("tags").and_then(|t| t.as_array()) {
                 Some(t) => t,
                 None => continue,
             };
-            let mut d_val = None;
             let mut name = None;
             let mut is_hidden = false;
             let mut is_private = false;
             let mut is_archived = false;
             let mut ttl_seconds = None;
             let mut ttl_deadline = None;
+            let mut seen_singletons = HashSet::new();
+            let mut referenced_channels = HashSet::new();
+            let mut malformed = false;
             for tag in tags {
-                if let Some(arr) = tag.as_array() {
-                    match arr.first().and_then(|v| v.as_str()) {
-                        Some("d") => d_val = arr.get(1).and_then(|v| v.as_str()),
-                        Some("name") => name = arr.get(1).and_then(|v| v.as_str()),
-                        Some("hidden") => is_hidden = true,
-                        Some("private") => is_private = true,
-                        Some("archived") => {
-                            is_archived = arr.get(1).and_then(|v| v.as_str()) == Some("true")
+                let Some(arr) = tag.as_array() else {
+                    continue;
+                };
+                let Some(kind) = arr.first().and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                if matches!(
+                    kind,
+                    "d" | "name" | "hidden" | "private" | "archived" | "ttl" | "ttl_deadline"
+                ) && !seen_singletons.insert(kind)
+                {
+                    malformed = true;
+                }
+                match kind {
+                    "d" => {
+                        let value = arr.get(1).and_then(|v| v.as_str());
+                        malformed |= arr.len() != 2 || value.is_none_or(str::is_empty);
+                        if let Some(value) = value {
+                            if let Ok(uuid) = value.parse::<Uuid>() {
+                                referenced_channels.insert(uuid);
+                            } else {
+                                malformed = true;
+                            }
                         }
-                        Some("ttl") => {
-                            ttl_seconds = arr
-                                .get(1)
-                                .and_then(|v| v.as_str())
-                                .and_then(|value| value.parse::<u64>().ok())
-                                .filter(|ttl| *ttl > 0)
-                        }
-                        Some("ttl_deadline") => {
-                            ttl_deadline = arr
-                                .get(1)
-                                .and_then(|v| v.as_str())
-                                .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
-                                .map(|deadline| deadline.with_timezone(&chrono::Utc))
-                        }
-                        _ => {}
                     }
+                    "name" => {
+                        name = arr.get(1).and_then(|v| v.as_str());
+                        malformed |= arr.len() != 2 || name.is_none();
+                    }
+                    "hidden" => {
+                        malformed |=
+                            arr.len() > 2 || arr.get(1).is_some_and(|v| v.as_str() != Some(""));
+                        is_hidden = true;
+                    }
+                    "private" => {
+                        malformed |=
+                            arr.len() > 2 || arr.get(1).is_some_and(|v| v.as_str() != Some(""));
+                        is_private = true;
+                    }
+                    "archived" => {
+                        let value = arr.get(1).and_then(|v| v.as_str());
+                        malformed |= arr.len() != 2 || !matches!(value, Some("true" | "false"));
+                        is_archived = value == Some("true");
+                    }
+                    "ttl" => {
+                        ttl_seconds = arr
+                            .get(1)
+                            .and_then(|v| v.as_str())
+                            .and_then(|value| value.parse::<u64>().ok())
+                            .filter(|ttl| *ttl > 0);
+                        malformed |= arr.len() != 2 || ttl_seconds.is_none();
+                    }
+                    "ttl_deadline" => {
+                        ttl_deadline = arr
+                            .get(1)
+                            .and_then(|v| v.as_str())
+                            .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+                            .map(|deadline| deadline.with_timezone(&chrono::Utc));
+                        malformed |= arr.len() != 2 || ttl_deadline.is_none();
+                    }
+                    _ => {}
                 }
             }
-            if let Some(d) = d_val {
-                if let Ok(uuid) = d.parse::<Uuid>() {
-                    let Some(created_at) = ev.get("created_at").and_then(|value| value.as_u64())
-                    else {
-                        warn!(channel_id = %uuid, "channel metadata missing created_at — failing channel metadata closed");
-                        malformed_channels.insert(uuid);
-                        continue;
-                    };
-                    let Some(event_id) =
-                        ev.get("id").and_then(|value| value.as_str()).filter(|id| {
-                            id.len() == 64
-                                && id.chars().all(|character| character.is_ascii_hexdigit())
-                        })
-                    else {
-                        warn!(channel_id = %uuid, "channel metadata missing valid event id — failing channel metadata closed");
-                        malformed_channels.insert(uuid);
-                        continue;
-                    };
-                    let ch_name = name.unwrap_or("unknown").to_string();
-                    // DMs have the "hidden" tag; private channels have "private".
-                    let ch_type = if is_hidden {
-                        "dm".to_string()
-                    } else if is_private {
-                        "private".to_string()
-                    } else {
-                        "stream".to_string()
-                    };
-                    let candidate = MetadataCandidate {
-                        created_at,
-                        event_id: event_id.to_ascii_lowercase(),
-                        name: ch_name,
-                        channel_type: ch_type,
-                        archived: is_archived,
-                        ttl_seconds,
-                        ttl_deadline,
-                    };
-                    let replace = meta_map
-                        .get(&uuid)
-                        .is_none_or(|current| candidate.is_newer_than(current));
-                    if replace {
-                        meta_map.insert(uuid, candidate);
-                    }
+            if referenced_channels.is_empty() {
+                continue;
+            }
+            let Some(created_at) = ev.get("created_at").and_then(|value| value.as_u64()) else {
+                for uuid in referenced_channels {
+                    warn!(channel_id = %uuid, "channel metadata missing created_at — failing channel metadata closed");
+                    unorderable_channels.insert(uuid);
+                }
+                continue;
+            };
+            let Some(event_id) = ev.get("id").and_then(|value| value.as_str()).filter(|id| {
+                id.len() == 64 && id.chars().all(|character| character.is_ascii_hexdigit())
+            }) else {
+                for uuid in referenced_channels {
+                    warn!(channel_id = %uuid, "channel metadata missing valid event id — failing channel metadata closed");
+                    unorderable_channels.insert(uuid);
+                }
+                continue;
+            };
+            let ch_name = name.unwrap_or("unknown").to_string();
+            // DMs have the "hidden" tag; private channels have "private".
+            let ch_type = if is_hidden {
+                "dm".to_string()
+            } else if is_private {
+                "private".to_string()
+            } else {
+                "stream".to_string()
+            };
+            let candidate = MetadataCandidate {
+                created_at,
+                event_id: event_id.to_ascii_lowercase(),
+                name: ch_name,
+                channel_type: ch_type,
+                archived: is_archived,
+                ttl_seconds,
+                ttl_deadline,
+                malformed,
+            };
+            for uuid in referenced_channels {
+                let replace = meta_map
+                    .get(&uuid)
+                    .is_none_or(|current| candidate.is_newer_than(current));
+                if replace {
+                    meta_map.insert(uuid, candidate.clone());
                 }
             }
         }
@@ -281,10 +322,14 @@ fn merge_discovered_channels(
 
     let mut map = HashMap::with_capacity(channel_uuids.len());
     for uuid in channel_uuids {
-        if malformed_channels.contains(&uuid) {
+        if unorderable_channels.contains(&uuid) {
             continue;
         }
         match meta_map.remove(&uuid) {
+            Some(candidate) if candidate.malformed => {
+                warn!(channel_id = %uuid, "canonical channel metadata has ambiguous or malformed singleton tags — failing channel metadata closed");
+                continue;
+            }
             Some(candidate) if candidate.archived => continue,
             Some(candidate) => {
                 map.insert(
@@ -4381,7 +4426,10 @@ mod tests {
         let map = merge_discovered_channels(vec![missing, expired, malformed], &meta);
         assert!(!map[&missing].is_ephemeral());
         assert!(!map[&expired].is_ephemeral());
-        assert!(!map[&malformed].is_ephemeral());
+        assert!(
+            !map.contains_key(&malformed),
+            "a malformed deadline fails the channel metadata closed"
+        );
     }
 
     #[test]
@@ -4507,8 +4555,183 @@ mod tests {
         ]);
 
         let map = merge_discovered_channels(vec![zero, invalid], &meta);
-        assert!(!map[&zero].is_ephemeral());
-        assert!(!map[&invalid].is_ephemeral());
+        assert!(!map.contains_key(&zero));
+        assert!(!map.contains_key(&invalid));
+    }
+
+    #[test]
+    fn merge_discovered_channels_rejects_duplicate_or_malformed_singletons() {
+        let duplicate_ttl = Uuid::new_v4();
+        let contradictory_archive = Uuid::new_v4();
+        let malformed_private = Uuid::new_v4();
+        let duplicate_d = Uuid::new_v4();
+        let other_d = Uuid::new_v4();
+
+        let mut duplicate_ttl_event = meta_event(
+            duplicate_ttl,
+            "duplicate ttl",
+            &[
+                "private",
+                "",
+                "ttl",
+                "3600",
+                "ttl_deadline",
+                "2999-01-01T00:00:00Z",
+            ],
+        );
+        duplicate_ttl_event["tags"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!(["ttl", "7200"]));
+
+        let mut contradictory_archive_event = meta_event(
+            contradictory_archive,
+            "archive conflict",
+            &["archived", "false"],
+        );
+        contradictory_archive_event["tags"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!(["archived", "true"]));
+
+        let mut malformed_private_event = meta_event(malformed_private, "bad private", &[]);
+        malformed_private_event["tags"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!(["private", "true"]));
+
+        let mut duplicate_d_event = meta_event(duplicate_d, "duplicate d", &[]);
+        duplicate_d_event["tags"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!(["d", other_d.to_string()]));
+
+        let map = merge_discovered_channels(
+            vec![
+                duplicate_ttl,
+                contradictory_archive,
+                malformed_private,
+                duplicate_d,
+                other_d,
+            ],
+            &serde_json::json!([
+                duplicate_ttl_event,
+                contradictory_archive_event,
+                malformed_private_event,
+                duplicate_d_event,
+            ]),
+        );
+        for channel in [
+            duplicate_ttl,
+            contradictory_archive,
+            malformed_private,
+            duplicate_d,
+            other_d,
+        ] {
+            assert!(
+                !map.contains_key(&channel),
+                "ambiguous singleton metadata must fail {channel} closed"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_discovered_channels_validates_only_the_canonical_latest_candidate() {
+        let recovered = Uuid::new_v4();
+        let poisoned = Uuid::new_v4();
+        let valid_latest = meta_event_at(recovered, "recovered", &["private", ""], 200, 'b');
+        let valid_stale = meta_event_at(poisoned, "stale", &["private", ""], 100, 'a');
+        let mut malformed_stale = meta_event_at(recovered, "bad stale", &[], 100, 'a');
+        malformed_stale["tags"].as_array_mut().unwrap().extend([
+            serde_json::json!(["ttl", "1"]),
+            serde_json::json!(["ttl", "2"]),
+        ]);
+        let mut malformed_latest = meta_event_at(poisoned, "bad latest", &[], 200, 'b');
+        malformed_latest["tags"].as_array_mut().unwrap().extend([
+            serde_json::json!(["archived", "false"]),
+            serde_json::json!(["archived", "true"]),
+        ]);
+
+        for events in [
+            serde_json::json!([
+                malformed_stale.clone(),
+                valid_latest.clone(),
+                valid_stale.clone(),
+                malformed_latest.clone(),
+            ]),
+            serde_json::json!([malformed_latest, valid_stale, valid_latest, malformed_stale]),
+        ] {
+            let map = merge_discovered_channels(vec![recovered, poisoned], &events);
+            assert_eq!(map[&recovered].name, "recovered");
+            assert!(!map.contains_key(&poisoned));
+        }
+    }
+
+    #[test]
+    fn merge_discovered_channels_covers_all_singleton_shapes() {
+        let duplicate_name = Uuid::new_v4();
+        let malformed_hidden = Uuid::new_v4();
+        let duplicate_deadline = Uuid::new_v4();
+        let invalid_archived = Uuid::new_v4();
+        let canonical_private = Uuid::new_v4();
+        let canonical_hidden = Uuid::new_v4();
+
+        let mut events = vec![];
+        for (channel, extra_tag) in [
+            (duplicate_name, serde_json::json!(["name", "again"])),
+            (malformed_hidden, serde_json::json!(["hidden", "true"])),
+            (
+                duplicate_deadline,
+                serde_json::json!(["ttl_deadline", "2998-01-01T00:00:00Z"]),
+            ),
+            (invalid_archived, serde_json::json!(["archived", "yes"])),
+        ] {
+            let mut event = meta_event(channel, "base", &["ttl_deadline", "2999-01-01T00:00:00Z"]);
+            event["tags"].as_array_mut().unwrap().push(extra_tag);
+            events.push(event);
+        }
+        events.push(serde_json::json!({
+            "id": "e".repeat(64),
+            "created_at": 100,
+            "tags": [
+                ["d", canonical_private.to_string()],
+                ["name", "private marker"],
+                ["private"],
+                ["ttl", "3600"],
+                ["ttl_deadline", "2999-01-01T00:00:00Z"]
+            ]
+        }));
+        events.push(serde_json::json!({
+            "id": "f".repeat(64),
+            "created_at": 100,
+            "tags": [
+                ["d", canonical_hidden.to_string()],
+                ["name", "hidden marker"],
+                ["hidden"]
+            ]
+        }));
+
+        let map = merge_discovered_channels(
+            vec![
+                duplicate_name,
+                malformed_hidden,
+                duplicate_deadline,
+                invalid_archived,
+                canonical_private,
+                canonical_hidden,
+            ],
+            &serde_json::Value::Array(events),
+        );
+        for channel in [
+            duplicate_name,
+            malformed_hidden,
+            duplicate_deadline,
+            invalid_archived,
+        ] {
+            assert!(!map.contains_key(&channel));
+        }
+        assert!(map[&canonical_private].is_ephemeral());
+        assert_eq!(map[&canonical_hidden].channel_type, "dm");
     }
 
     #[test]

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -627,13 +627,20 @@ fn parse_anchored_replies(
                     values.get(1).map(|value| value.as_str()) == Some(expected_channel.as_str());
             }
         }
-        let exact_reply = event.tags.iter().any(|tag| {
+        let mut reply_anchor_count = 0;
+        let mut exact_reply = false;
+        for tag in event.tags.iter() {
             let values = tag.as_slice();
-            values.first().map(|value| value.as_str()) == Some("e")
-                && values.get(1).map(|value| value.as_str()) == Some(request_event_id)
+            if values.first().map(|value| value.as_str()) == Some("e")
                 && values.get(3).map(|value| value.as_str()) == Some("reply")
-        });
-        if h_tag_count == 1 && exact_channel && exact_reply {
+            {
+                reply_anchor_count += 1;
+                exact_reply = values.len() == 4
+                    && values.get(1).map(|value| value.as_str()) == Some(request_event_id)
+                    && values.get(2).map(|value| value.as_str()) == Some("");
+            }
+        }
+        if h_tag_count == 1 && exact_channel && reply_anchor_count == 1 && exact_reply {
             replies.push(AnchoredReply {
                 event_id: event.id.to_hex(),
                 reply_to: request_event_id.to_ascii_lowercase(),
@@ -4852,6 +4859,45 @@ mod tests {
         )
         .unwrap();
         assert_eq!(replies.len(), 2);
+    }
+
+    #[test]
+    fn anchored_reply_parser_rejects_multiple_reply_markers_in_one_event() {
+        let keys = Keys::generate();
+        let channel = Uuid::new_v4();
+        let request = "a".repeat(64);
+        let ambiguous = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "ambiguous",
+        )
+        .tags([
+            Tag::parse(["h".to_string(), channel.to_string()]).unwrap(),
+            Tag::parse([
+                "e".to_string(),
+                request.clone(),
+                String::new(),
+                "reply".to_string(),
+            ])
+            .unwrap(),
+            Tag::parse([
+                "e".to_string(),
+                "b".repeat(64),
+                String::new(),
+                "reply".to_string(),
+            ])
+            .unwrap(),
+        ])
+        .sign_with_keys(&keys)
+        .unwrap();
+
+        assert!(parse_anchored_replies(
+            &serde_json::json!([ambiguous]),
+            channel,
+            keys.public_key(),
+            &request,
+        )
+        .unwrap()
+        .is_empty());
     }
 
     #[test]

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -133,6 +133,46 @@ use crate::config::ChannelFilter;
 pub struct ChannelInfo {
     pub name: String,
     pub channel_type: String,
+    /// Positive channel TTL in seconds, when declared by kind-39000 metadata.
+    pub ttl_seconds: Option<u64>,
+    /// Canonical absolute expiry from the `ttl_deadline` metadata tag.
+    pub ttl_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    /// Created-at timestamp of the canonical addressable metadata event.
+    pub metadata_created_at: Option<u64>,
+    /// Event ID of the canonical addressable metadata event.
+    pub metadata_event_id: Option<String>,
+}
+
+impl ChannelInfo {
+    /// Whether metadata proves that this is a currently-live TTL channel.
+    pub fn is_ephemeral(&self) -> bool {
+        self.is_ephemeral_at(chrono::Utc::now())
+    }
+
+    /// Evaluate ephemeral eligibility against an explicit clock.
+    pub fn is_ephemeral_at(&self, now: chrono::DateTime<chrono::Utc>) -> bool {
+        self.channel_type == "private"
+            && self.ttl_seconds.is_some_and(|ttl| ttl > 0)
+            && self.ttl_deadline.is_some_and(|deadline| deadline > now)
+    }
+}
+
+#[derive(Debug)]
+struct MetadataCandidate {
+    created_at: u64,
+    event_id: String,
+    name: String,
+    channel_type: String,
+    archived: bool,
+    ttl_seconds: Option<u64>,
+    ttl_deadline: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl MetadataCandidate {
+    fn is_newer_than(&self, other: &Self) -> bool {
+        self.created_at > other.created_at
+            || (self.created_at == other.created_at && self.event_id < other.event_id)
+    }
 }
 
 /// Build the discovered-channel subscribe set from the membership UUIDs and the
@@ -149,8 +189,8 @@ fn merge_discovered_channels(
     channel_uuids: Vec<Uuid>,
     meta_events: &serde_json::Value,
 ) -> HashMap<Uuid, ChannelInfo> {
-    let mut meta_map: HashMap<Uuid, (String, String)> = HashMap::new();
-    let mut archived: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
+    let mut meta_map: HashMap<Uuid, MetadataCandidate> = HashMap::new();
+    let mut malformed_channels = HashSet::new();
     if let Some(arr) = meta_events.as_array() {
         for ev in arr {
             let tags = match ev.get("tags").and_then(|t| t.as_array()) {
@@ -162,6 +202,8 @@ fn merge_discovered_channels(
             let mut is_hidden = false;
             let mut is_private = false;
             let mut is_archived = false;
+            let mut ttl_seconds = None;
+            let mut ttl_deadline = None;
             for tag in tags {
                 if let Some(arr) = tag.as_array() {
                     match arr.first().and_then(|v| v.as_str()) {
@@ -172,16 +214,42 @@ fn merge_discovered_channels(
                         Some("archived") => {
                             is_archived = arr.get(1).and_then(|v| v.as_str()) == Some("true")
                         }
+                        Some("ttl") => {
+                            ttl_seconds = arr
+                                .get(1)
+                                .and_then(|v| v.as_str())
+                                .and_then(|value| value.parse::<u64>().ok())
+                                .filter(|ttl| *ttl > 0)
+                        }
+                        Some("ttl_deadline") => {
+                            ttl_deadline = arr
+                                .get(1)
+                                .and_then(|v| v.as_str())
+                                .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+                                .map(|deadline| deadline.with_timezone(&chrono::Utc))
+                        }
                         _ => {}
                     }
                 }
             }
             if let Some(d) = d_val {
                 if let Ok(uuid) = d.parse::<Uuid>() {
-                    if is_archived {
-                        archived.insert(uuid);
+                    let Some(created_at) = ev.get("created_at").and_then(|value| value.as_u64())
+                    else {
+                        warn!(channel_id = %uuid, "channel metadata missing created_at — failing channel metadata closed");
+                        malformed_channels.insert(uuid);
                         continue;
-                    }
+                    };
+                    let Some(event_id) =
+                        ev.get("id").and_then(|value| value.as_str()).filter(|id| {
+                            id.len() == 64
+                                && id.chars().all(|character| character.is_ascii_hexdigit())
+                        })
+                    else {
+                        warn!(channel_id = %uuid, "channel metadata missing valid event id — failing channel metadata closed");
+                        malformed_channels.insert(uuid);
+                        continue;
+                    };
                     let ch_name = name.unwrap_or("unknown").to_string();
                     // DMs have the "hidden" tag; private channels have "private".
                     let ch_type = if is_hidden {
@@ -191,7 +259,21 @@ fn merge_discovered_channels(
                     } else {
                         "stream".to_string()
                     };
-                    meta_map.insert(uuid, (ch_name, ch_type));
+                    let candidate = MetadataCandidate {
+                        created_at,
+                        event_id: event_id.to_ascii_lowercase(),
+                        name: ch_name,
+                        channel_type: ch_type,
+                        archived: is_archived,
+                        ttl_seconds,
+                        ttl_deadline,
+                    };
+                    let replace = meta_map
+                        .get(&uuid)
+                        .is_none_or(|current| candidate.is_newer_than(current));
+                    if replace {
+                        meta_map.insert(uuid, candidate);
+                    }
                 }
             }
         }
@@ -199,13 +281,38 @@ fn merge_discovered_channels(
 
     let mut map = HashMap::with_capacity(channel_uuids.len());
     for uuid in channel_uuids {
-        if archived.contains(&uuid) {
+        if malformed_channels.contains(&uuid) {
             continue;
         }
-        let (name, channel_type) = meta_map
-            .remove(&uuid)
-            .unwrap_or_else(|| ("unknown".to_string(), "stream".to_string()));
-        map.insert(uuid, ChannelInfo { name, channel_type });
+        match meta_map.remove(&uuid) {
+            Some(candidate) if candidate.archived => continue,
+            Some(candidate) => {
+                map.insert(
+                    uuid,
+                    ChannelInfo {
+                        name: candidate.name,
+                        channel_type: candidate.channel_type,
+                        ttl_seconds: candidate.ttl_seconds,
+                        ttl_deadline: candidate.ttl_deadline,
+                        metadata_created_at: Some(candidate.created_at),
+                        metadata_event_id: Some(candidate.event_id),
+                    },
+                );
+            }
+            None => {
+                map.insert(
+                    uuid,
+                    ChannelInfo {
+                        name: "unknown".to_string(),
+                        channel_type: "stream".to_string(),
+                        ttl_seconds: None,
+                        ttl_deadline: None,
+                        metadata_created_at: None,
+                        metadata_event_id: None,
+                    },
+                );
+            }
+        }
     }
     map
 }
@@ -224,6 +331,13 @@ pub struct RestClient {
     pub keys: Keys,
     /// Optional NIP-OA auth tag JSON for `x-auth-tag` header (relay membership delegation).
     pub auth_tag_json: Option<String>,
+}
+
+/// Durable reply evidence read back from the relay event log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnchoredReply {
+    pub event_id: String,
+    pub reply_to: String,
 }
 
 /// Whether an HTTP status code is retriable (transient server/rate-limit errors).
@@ -393,6 +507,28 @@ impl RestClient {
             .map_err(|e| RelayError::Http(e.to_string()))
     }
 
+    /// Query agent-authored kind-9 replies with an exact NIP-10 `reply` anchor.
+    pub async fn query_anchored_replies(
+        &self,
+        channel_id: Uuid,
+        author: nostr::PublicKey,
+        request_event_id: &str,
+    ) -> Result<Vec<AnchoredReply>, RelayError> {
+        use nostr::{Alphabet, SingleLetterTag};
+
+        let h_tag = SingleLetterTag::lowercase(Alphabet::H);
+        let e_tag = SingleLetterTag::lowercase(Alphabet::E);
+        let channel = channel_id.to_string();
+        let filter = nostr::Filter::new()
+            .kind(Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16))
+            .author(author)
+            .custom_tags(h_tag, [channel.as_str()])
+            .custom_tags(e_tag, [request_event_id])
+            .limit(3);
+        let response = self.query(&[filter]).await?;
+        parse_anchored_replies(&response, channel_id, author, request_event_id)
+    }
+
     /// Submit a signed event via the HTTP bridge: `POST /events` with NIP-98 auth.
     ///
     /// The event must already be signed. Returns the relay response JSON.
@@ -409,6 +545,55 @@ impl RestClient {
         }
         serde_json::from_str(&text).map_err(|e| RelayError::Http(e.to_string()))
     }
+}
+
+fn parse_anchored_replies(
+    response: &Value,
+    channel_id: Uuid,
+    author: nostr::PublicKey,
+    request_event_id: &str,
+) -> Result<Vec<AnchoredReply>, RelayError> {
+    let events = response
+        .as_array()
+        .ok_or_else(|| RelayError::Http("expected JSON array from /query (replies)".into()))?;
+    let mut replies = Vec::new();
+    let expected_channel = channel_id.to_string();
+    for value in events {
+        let Ok(event) = serde_json::from_value::<Event>(value.clone()) else {
+            continue;
+        };
+        if event.verify().is_err()
+            || event.kind.as_u16() as u32 != buzz_core::kind::KIND_STREAM_MESSAGE
+            || event.pubkey != author
+        {
+            continue;
+        }
+        let mut h_tag_count = 0;
+        let mut exact_channel = false;
+        for tag in event.tags.iter() {
+            let values = tag.as_slice();
+            if values.first().map(|value| value.as_str()) == Some("h") {
+                h_tag_count += 1;
+                exact_channel =
+                    values.get(1).map(|value| value.as_str()) == Some(expected_channel.as_str());
+            }
+        }
+        let exact_reply = event.tags.iter().any(|tag| {
+            let values = tag.as_slice();
+            values.first().map(|value| value.as_str()) == Some("e")
+                && values.get(1).map(|value| value.as_str()) == Some(request_event_id)
+                && values.get(3).map(|value| value.as_str()) == Some("reply")
+        });
+        if h_tag_count == 1 && exact_channel && exact_reply {
+            replies.push(AnchoredReply {
+                event_id: event.id.to_hex(),
+                reply_to: request_event_id.to_ascii_lowercase(),
+            });
+        }
+    }
+    replies.sort_by(|left, right| left.event_id.cmp(&right.event_id));
+    replies.dedup_by(|left, right| left.event_id == right.event_id);
+    Ok(replies)
 }
 
 /// Events the harness cares about.
@@ -698,6 +883,25 @@ impl HarnessRelay {
 
         debug!("discovered {} channel(s)", map.len());
         Ok(map)
+    }
+
+    /// Fetch metadata for a newly invited channel. Missing, malformed, or
+    /// archived metadata returns `None`, allowing admission to fail closed.
+    pub async fn fetch_channel_info(
+        &self,
+        channel_id: Uuid,
+    ) -> Result<Option<ChannelInfo>, RelayError> {
+        use nostr::{Alphabet, SingleLetterTag};
+
+        let d_tag = SingleLetterTag::lowercase(Alphabet::D);
+        let channel = channel_id.to_string();
+        let filter = nostr::Filter::new()
+            .kind(Kind::Custom(
+                buzz_core::kind::KIND_NIP29_GROUP_METADATA as u16,
+            ))
+            .custom_tags(d_tag, [channel.as_str()]);
+        let events = self.rest_client().query(&[filter]).await?;
+        Ok(merge_discovered_channels(vec![channel_id], &events).remove(&channel_id))
     }
 
     /// Build a [`RestClient`] that shares this relay's HTTP credentials.
@@ -4056,6 +4260,16 @@ mod tests {
     }
 
     fn meta_event(uuid: Uuid, name: &str, extra: &[&str]) -> serde_json::Value {
+        meta_event_at(uuid, name, extra, 100, 'a')
+    }
+
+    fn meta_event_at(
+        uuid: Uuid,
+        name: &str,
+        extra: &[&str],
+        created_at: u64,
+        id_character: char,
+    ) -> serde_json::Value {
         let mut tags = vec![
             serde_json::json!(["d", uuid.to_string()]),
             serde_json::json!(["name", name]),
@@ -4068,7 +4282,11 @@ mod tests {
                 _ => {}
             }
         }
-        serde_json::json!({ "tags": tags })
+        serde_json::json!({
+            "id": id_character.to_string().repeat(64),
+            "created_at": created_at,
+            "tags": tags
+        })
     }
 
     #[test]
@@ -4110,6 +4328,186 @@ mod tests {
     }
 
     #[test]
+    fn merge_discovered_channels_marks_positive_ttl_ephemeral() {
+        let huddle = Uuid::new_v4();
+        let ordinary = Uuid::new_v4();
+        let meta = serde_json::json!([
+            meta_event(
+                huddle,
+                "huddle",
+                &[
+                    "private",
+                    "",
+                    "ttl",
+                    "3600",
+                    "ttl_deadline",
+                    "2999-01-01T00:00:00Z"
+                ]
+            ),
+            meta_event(ordinary, "concilium", &["private", ""]),
+        ]);
+
+        let map = merge_discovered_channels(vec![huddle, ordinary], &meta);
+
+        assert!(map[&huddle].is_ephemeral());
+        assert_eq!(map[&huddle].ttl_seconds, Some(3600));
+        assert!(map[&huddle].ttl_deadline.is_some());
+        assert!(!map[&ordinary].is_ephemeral());
+    }
+
+    #[test]
+    fn merge_discovered_channels_requires_future_deadline() {
+        let missing = Uuid::new_v4();
+        let expired = Uuid::new_v4();
+        let malformed = Uuid::new_v4();
+        let meta = serde_json::json!([
+            meta_event(missing, "missing", &["ttl", "3600"]),
+            meta_event(
+                expired,
+                "expired",
+                &["ttl", "3600", "ttl_deadline", "2000-01-01T00:00:00Z"]
+            ),
+            meta_event(
+                malformed,
+                "malformed",
+                &["ttl", "3600", "ttl_deadline", "tomorrow"]
+            ),
+        ]);
+
+        let map = merge_discovered_channels(vec![missing, expired, malformed], &meta);
+        assert!(!map[&missing].is_ephemeral());
+        assert!(!map[&expired].is_ephemeral());
+        assert!(!map[&malformed].is_ephemeral());
+    }
+
+    #[test]
+    fn merge_discovered_channels_selects_canonical_latest_metadata() {
+        let channel = Uuid::new_v4();
+        let latest = meta_event_at(
+            channel,
+            "latest",
+            &[
+                "private",
+                "",
+                "ttl",
+                "3600",
+                "ttl_deadline",
+                "2999-01-01T00:00:00Z",
+            ],
+            200,
+            'b',
+        );
+        let stale = meta_event_at(
+            channel,
+            "stale",
+            &[
+                "private",
+                "",
+                "ttl",
+                "3600",
+                "ttl_deadline",
+                "2000-01-01T00:00:00Z",
+            ],
+            100,
+            'a',
+        );
+
+        let forward = merge_discovered_channels(
+            vec![channel],
+            &serde_json::json!([stale.clone(), latest.clone()]),
+        );
+        let reverse = merge_discovered_channels(vec![channel], &serde_json::json!([latest, stale]));
+        assert_eq!(forward[&channel].name, "latest");
+        assert_eq!(reverse[&channel].name, "latest");
+        assert_eq!(
+            forward[&channel].metadata_event_id,
+            reverse[&channel].metadata_event_id
+        );
+        assert!(forward[&channel].is_ephemeral());
+    }
+
+    #[test]
+    fn merge_discovered_channels_latest_archived_metadata_revokes_channel() {
+        let channel = Uuid::new_v4();
+        let live = meta_event_at(
+            channel,
+            "live",
+            &["ttl", "3600", "ttl_deadline", "2999-01-01T00:00:00Z"],
+            100,
+            'a',
+        );
+        let archived = meta_event_at(channel, "archived", &["archived", "true"], 200, 'b');
+
+        let map = merge_discovered_channels(vec![channel], &serde_json::json!([archived, live]));
+        assert!(!map.contains_key(&channel));
+    }
+
+    #[test]
+    fn merge_discovered_channels_same_second_uses_lower_event_id() {
+        let channel = Uuid::new_v4();
+        let lower = meta_event_at(channel, "canonical", &["private", ""], 200, 'a');
+        let higher = meta_event_at(channel, "loser", &["archived", "true"], 200, 'b');
+        let forward = merge_discovered_channels(
+            vec![channel],
+            &serde_json::json!([higher.clone(), lower.clone()]),
+        );
+        let reverse = merge_discovered_channels(vec![channel], &serde_json::json!([lower, higher]));
+        assert_eq!(forward[&channel].name, "canonical");
+        assert_eq!(reverse[&channel].name, "canonical");
+    }
+
+    #[test]
+    fn merge_discovered_channels_requires_private_ttl_metadata() {
+        let public = Uuid::new_v4();
+        let private = Uuid::new_v4();
+        let deadline = ["ttl", "3600", "ttl_deadline", "2999-01-01T00:00:00Z"];
+        let meta = serde_json::json!([
+            meta_event(public, "public", &deadline),
+            meta_event(
+                private,
+                "private",
+                &[
+                    "private",
+                    "",
+                    "ttl",
+                    "3600",
+                    "ttl_deadline",
+                    "2999-01-01T00:00:00Z"
+                ]
+            )
+        ]);
+        let map = merge_discovered_channels(vec![public, private], &meta);
+        assert!(!map[&public].is_ephemeral());
+        assert!(map[&private].is_ephemeral());
+    }
+
+    #[test]
+    fn merge_discovered_channels_malformed_candidate_fails_channel_closed() {
+        let channel = Uuid::new_v4();
+        let valid = meta_event_at(channel, "valid", &["private", ""], 100, 'a');
+        let malformed = serde_json::json!({
+            "created_at": 200,
+            "tags": [["d", channel.to_string()], ["private", ""]]
+        });
+        let map = merge_discovered_channels(vec![channel], &serde_json::json!([valid, malformed]));
+        assert!(!map.contains_key(&channel));
+    }
+
+    #[test]
+    fn merge_discovered_channels_rejects_zero_or_invalid_ttl() {
+        let zero = Uuid::new_v4();
+        let invalid = Uuid::new_v4();
+        let meta = serde_json::json!([
+            meta_event(zero, "zero", &["ttl", "0"]),
+            meta_event(invalid, "invalid", &["ttl", "later"]),
+        ]);
+
+        let map = merge_discovered_channels(vec![zero, invalid], &meta);
+        assert!(!map[&zero].is_ephemeral());
+        assert!(!map[&invalid].is_ephemeral());
+    }
+
+    #[test]
     fn merge_discovered_channels_archived_false_is_kept() {
         // An explicit archived=false (e.g. after unarchive) must NOT be skipped.
         let ch = Uuid::new_v4();
@@ -4118,6 +4516,115 @@ mod tests {
         let map = merge_discovered_channels(vec![ch], &meta);
 
         assert!(map.contains_key(&ch), "archived=false is treated as live");
+    }
+
+    fn signed_reply_event(keys: &Keys, channel: Uuid, request_id: &str, marker: &str) -> Event {
+        EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "reply",
+        )
+        .tags([
+            Tag::parse(["h".to_string(), channel.to_string()]).unwrap(),
+            Tag::parse([
+                "e".to_string(),
+                request_id.to_string(),
+                String::new(),
+                marker.to_string(),
+            ])
+            .unwrap(),
+        ])
+        .sign_with_keys(keys)
+        .unwrap()
+    }
+
+    #[test]
+    fn anchored_reply_parser_verifies_signature_author_channel_and_marker() {
+        let keys = Keys::generate();
+        let channel = Uuid::new_v4();
+        let request = "a".repeat(64);
+        let valid = signed_reply_event(&keys, channel, &request, "reply");
+        let parsed = parse_anchored_replies(
+            &serde_json::json!([valid]),
+            channel,
+            keys.public_key(),
+            &request,
+        )
+        .unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].reply_to, request);
+
+        let wrong_marker = signed_reply_event(&keys, channel, &request, "root");
+        let wrong_channel = signed_reply_event(&keys, Uuid::new_v4(), &request, "reply");
+        let wrong_author = signed_reply_event(&Keys::generate(), channel, &request, "reply");
+        let mut tampered =
+            serde_json::to_value(signed_reply_event(&keys, channel, &request, "reply")).unwrap();
+        tampered["content"] = serde_json::json!("tampered");
+        let rejected = parse_anchored_replies(
+            &serde_json::json!([wrong_marker, wrong_channel, wrong_author, tampered]),
+            channel,
+            keys.public_key(),
+            &request,
+        )
+        .unwrap();
+        assert!(rejected.is_empty());
+
+        let malformed_extra_h = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "reply",
+        )
+        .tags([
+            Tag::parse(["h".to_string(), channel.to_string()]).unwrap(),
+            Tag::parse(["h".to_string()]).unwrap(),
+            Tag::parse([
+                "e".to_string(),
+                request.clone(),
+                String::new(),
+                "reply".to_string(),
+            ])
+            .unwrap(),
+        ])
+        .sign_with_keys(&keys)
+        .unwrap();
+        assert!(parse_anchored_replies(
+            &serde_json::json!([malformed_extra_h]),
+            channel,
+            keys.public_key(),
+            &request,
+        )
+        .unwrap()
+        .is_empty());
+    }
+
+    #[test]
+    fn anchored_reply_parser_preserves_multiple_distinct_replies_for_fail_closed_receipt() {
+        let keys = Keys::generate();
+        let channel = Uuid::new_v4();
+        let request = "a".repeat(64);
+        let first = signed_reply_event(&keys, channel, &request, "reply");
+        let second = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "second",
+        )
+        .tags([
+            Tag::parse(["h".to_string(), channel.to_string()]).unwrap(),
+            Tag::parse([
+                "e".to_string(),
+                request.clone(),
+                String::new(),
+                "reply".to_string(),
+            ])
+            .unwrap(),
+        ])
+        .sign_with_keys(&keys)
+        .unwrap();
+        let replies = parse_anchored_replies(
+            &serde_json::json!([first, second]),
+            channel,
+            keys.public_key(),
+            &request,
+        )
+        .unwrap();
+        assert_eq!(replies.len(), 2);
     }
 
     #[test]

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -542,6 +542,8 @@ fn mentions_rule(kinds: Vec<u32>) -> filter::SubscriptionRule {
     filter::SubscriptionRule {
         name: "setup-mentions".into(),
         channels: filter::ChannelScope::All("all".into()),
+        admit_invited_ephemeral: false,
+        require_exact_channel_tag: false,
         kinds,
         require_mention: true,
         filter: None,

--- a/deploy/local/aeon-aspects/README.md
+++ b/deploy/local/aeon-aspects/README.md
@@ -15,6 +15,13 @@ proactive count-based session rotation are off, thread/DM context is bounded to
 absolute cap. `bypassPermissions` is an explicit canary posture; it does not
 prove that a future interactive approval workflow is preserved.
 
+`--trusted-inbound-envelope` copies one signature-verified triggering event
+into the ACP request as `_meta.buzz.inboundEvent` (`schemaVersion: 1`). The
+envelope carries the signed event ID, author, kind, exact channel ID, and exact
+tag arrays outside the model-visible prompt. It is omitted for invalid,
+multi-event, cancelled/merged, or room-ambiguous batches; OpenClaw must preserve
+this trusted per-turn context before the Nexus reply tool can be enabled.
+
 Room admission uses two config rules per worker:
 
 - the fixed private-office UUID accepts Architect-authored kind-9 and

--- a/deploy/local/aeon-aspects/README.md
+++ b/deploy/local/aeon-aspects/README.md
@@ -1,0 +1,135 @@
+# AEON Aspect workers
+
+This package defines six disabled-by-default Buzz ACP workers. It renders and
+validates configuration only; it does not install, load, start, restart, or
+switch any live service.
+
+Each worker uses Buzz only as the conversation transport. `--no-memory` keeps
+Gateway as the sole memory and compaction owner, while `--no-base-prompt`
+prevents Buzz's generic agent/tool doctrine from replacing the canonical Aspect
+instructions. The adapter binds to a pre-created session with
+`openclaw acp --require-existing --session ...`. Existing Buzz ACP controls are
+pinned rather than inherited from changing defaults: heartbeat prompting and
+proactive count-based session rotation are off, thread/DM context is bounded to
+12 messages, presence and typing remain on, and turns use a 900-second idle timeout with a two-hour
+absolute cap. `bypassPermissions` is an explicit canary posture; it does not
+prove that a future interactive approval workflow is preserved.
+
+Room admission uses two config rules per worker:
+
+- the fixed private-office UUID accepts Architect-authored kind-9 and
+  kind-40002 stream posts without
+  requiring a mention;
+- a newly invited channel is added to the huddle rule only after canonical
+  kind-39000 metadata proves it is private, has a positive `ttl`, and has a
+  valid future `ttl_deadline`; huddle messages must mention the Aspect.
+
+Therefore Concilium and other ordinary rooms remain excluded. A metadata query
+failure also denies admission. The canonical addressable metadata winner is
+selected by newest `created_at`, then lowest event ID on a same-second tie.
+Eligibility is rechecked before every dynamic-room dispatch and periodically;
+expiry, archive, membership removal, or lookup failure unsubscribes the room,
+drains queued work, invalidates its session, and cancels an in-flight turn.
+
+Run the source validation without changing live state:
+
+```sh
+node deploy/local/aeon-aspects/validate.mjs
+node deploy/local/aeon-aspects/render-launchagents.mjs
+```
+
+The checked-in `launchagents/` previews are real, deterministic launchd
+definitions with `RunAtLoad=false` and `KeepAlive=false`. They contain only
+owned private-key file paths and expected public keys, never key or token
+values. `/REQUIRES_FLEET/...` paths intentionally make them non-runnable until
+Fleet supplies an immutable OpenClaw binary and owned token file. `buzz-acp`
+opens its private-key file once with no-follow semantics, validates metadata on
+that same handle (absolute path, regular file, current-user owner, mode `0600`),
+and verifies that it derives the expected Aspect pubkey. The token-file contract
+requires the same path, type, ownership, and permission posture, with Fleet
+responsible for the runtime permission readback.
+
+## Nexus resume and rollback packet
+
+Activation remains Fleet-gated. After the runtime lock is released, the
+operator must pre-create `agent:main:buzz-private`, provide an owned token file,
+provide the immutable Gateway generation and current OpenClaw ACP flag proof,
+prove that the fixed Nexus session has a caller-bound outbound Buzz publisher
+which signs as Nexus without accepting an arbitrary Aspect selector, verify the
+live private room contains exactly Architect and Nexus, confirm the legacy
+`aeon-buzz` private bridge is off, confirm no Gateway switch/restart is active,
+render the Nexus worker, and request a separate Nexus-only canary authorization.
+Rollback targets only
+`org.aeon.buzz-acp.nexus`; it does not change Gateway configuration or enable
+another reply path.
+
+## Evidence boundary
+
+The Rust runtime now carries the triggering request event ID through the turn,
+cryptographically verifies relay reply evidence, requires exactly one kind-9
+reply with the exact NIP-10 `reply` anchor instructed in the prompt, and checks
+the observed Gateway session key against the worker's fixed expected key. The session key is stable
+session-level evidence and is intentionally retained across turns; `runId` is
+cleared before each prompt and must be observed anew. Zero or multiple replies,
+missing evidence, or a session mismatch produce one failed `turn_receipt`; they
+never become a successful receipt or retry an otherwise completed user turn.
+The request event ID remains the receipt correlation key even when a follow-up
+turn is deliberately flattened onto the thread root; a two-turn contract test
+proves that prompt instruction and relay evidence query use that same root.
+
+Current OpenClaw ACP exposes `_meta.sessionKey` but does **not** yet expose its
+Gateway `runId` on the ACP wire. Therefore complete receipts remain blocked
+until Fleet supplies a version whose per-prompt session evidence includes both
+`sessionKey` and `runId`, with a fixture proving the exact wire contract.
+Observer frames are encrypted transient evidence transport, not the durable
+receipt store; the canary must materialize the verified tuple into the existing
+vault receipt.
+
+The package also does not by itself grant OpenClaw the Aspect private key or a
+Buzz CLI environment. Before activation, Fleet must prove the caller-bound
+Gateway outbound publisher described above on the exact fixed session. Without
+that authority there is no demonstrated signed reply path, so this checkpoint
+must remain held even if inbound ACP prompting succeeds.
+
+Socket reconnect deduplication is covered by the existing in-memory event-ID
+set and replay watermark. Exact-once behavior across a complete worker process
+restart is not proven because processed event IDs are not durable. Activation
+must keep this under `does_not_prove` until a durable inbox/outbox authority is
+selected. `restartOnFailure=false` and launchd `KeepAlive=false` intentionally
+block unattended production rather than claiming exactly-once behavior.
+
+Relay observer receipts also admit existing Architect-signed cancel and model
+control packets. `!cancel` maps to ACP cancellation, but `!rotate` only recreates
+the Buzz ACP layer against the same fixed `--require-existing` Gateway session;
+it is not Gateway memory compaction or a canonical session reset.
+
+Huddle audio remains text-mediated through Desktop STT and TTS. Kind-48106
+voice guidelines are posted before incremental agent membership and are not
+replayed by the stream-message worker subscription, so guideline query/injection
+is a named blocker before a spoken huddle canary; no raw-audio capability is
+claimed here.
+
+Avatar metadata is not present in the current AEON identity map. Source
+validation checks names, pubkeys, owners, private-room IDs, and the identity-map
+membership declaration, but that declaration is not live relay evidence. Exact
+live membership must be read back before the Nexus canary, and avatar validation
+remains an explicit blocker before broad UI rollout.
+
+## Existing-feature parity
+
+| Buzz surface | Worker integration | Remaining proof |
+| --- | --- | --- |
+| private chat, mentions, threads, deep links | kind-9 and kind-40002 intake; bounded thread/DM context; exact reply anchoring | one live Nexus request/reply and deep-link readback |
+| presence, typing, seen reaction | native `buzz-acp` behavior, enabled by the pinned posture | online/typing/clear/offline lifecycle in only the Nexus room |
+| agent activity and cancel | encrypted relay observer and turn receipts | Desktop observer readback plus one terminal receipt |
+| profiles and avatars | native Desktop kind-0 rendering | six approved profile events; avatars are missing from the identity contract |
+| canvas and scoped search | native Buzz context/CLI surfaces | caller-bound Gateway Buzz read tool on the fixed Aspect session |
+| media and authored reactions | native relay/Desktop surfaces | caller-bound Gateway publisher and bounded mutation authority |
+| huddle STT/TTS | private text path is admitted by the invited-huddle rule | canonical kind-48106 guideline replay before spoken use |
+| workflows | native Buzz workflow surface, intentionally not subscribed here | upstream approval/multi-room behavior and explicit AEON authority |
+
+The worker intentionally sets no Buzz MCP, model, system prompt, team
+instructions, or initial message. Those would duplicate or override Gateway's
+tools, skills, model, and Aspect identity. Concilium, workflows, raw audio,
+media mutations, broad A2A speech, and the other five live workers remain held
+past the Nexus text canary.

--- a/deploy/local/aeon-aspects/README.md
+++ b/deploy/local/aeon-aspects/README.md
@@ -21,6 +21,10 @@ envelope carries the signed event ID, author, kind, exact channel ID, and exact
 tag arrays outside the model-visible prompt. It is omitted for invalid,
 multi-event, cancelled/merged, or room-ambiguous batches; OpenClaw must preserve
 this trusted per-turn context before the Nexus reply tool can be enabled.
+`--no-agent-publisher-credentials` keeps the validated Buzz relay and signer
+inside `buzz-acp`; the spawned ACP agent receives neither `BUZZ_RELAY_URL` nor
+`BUZZ_PRIVATE_KEY`. This makes the trusted reply tool the only outbound
+publisher authority for AEON managed workers.
 
 Room admission uses two config rules per worker:
 

--- a/deploy/local/aeon-aspects/README.md
+++ b/deploy/local/aeon-aspects/README.md
@@ -45,6 +45,11 @@ node deploy/local/aeon-aspects/validate.mjs
 node deploy/local/aeon-aspects/render-launchagents.mjs
 ```
 
+The no-argument validator uses the checked-in synthetic identity fixture so it
+is runnable in any OSS checkout. To validate the private deployment contract,
+pass its identity map explicitly (for example,
+`node deploy/local/aeon-aspects/validate.mjs /absolute/path/identity-map.json`).
+
 The checked-in `launchagents/` previews are real, deterministic launchd
 definitions with `RunAtLoad=false` and `KeepAlive=false`. They contain only
 owned private-key file paths and expected public keys, never key or token

--- a/deploy/local/aeon-aspects/config/fontis.toml
+++ b/deploy/local/aeon-aspects/config/fontis.toml
@@ -1,0 +1,16 @@
+[[rules]]
+name = "fontis-private-office"
+channels = ["600cb602-ff2a-422b-bdb2-6353bb81100d"]
+kinds = [9, 40002]
+require_exact_channel_tag = true
+require_mention = false
+filter = 'author == "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"'
+
+[[rules]]
+name = "fontis-invited-huddle"
+channels = []
+admit_invited_ephemeral = true
+kinds = [9, 40002]
+require_exact_channel_tag = true
+require_mention = true
+filter = 'author == "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"'

--- a/deploy/local/aeon-aspects/config/mechanon.toml
+++ b/deploy/local/aeon-aspects/config/mechanon.toml
@@ -1,0 +1,16 @@
+[[rules]]
+name = "mechanon-private-office"
+channels = ["7d022bea-5e81-4d18-bd2e-176e9eda1971"]
+kinds = [9, 40002]
+require_exact_channel_tag = true
+require_mention = false
+filter = 'author == "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"'
+
+[[rules]]
+name = "mechanon-invited-huddle"
+channels = []
+admit_invited_ephemeral = true
+kinds = [9, 40002]
+require_exact_channel_tag = true
+require_mention = true
+filter = 'author == "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"'

--- a/deploy/local/aeon-aspects/config/nexus.toml
+++ b/deploy/local/aeon-aspects/config/nexus.toml
@@ -1,0 +1,16 @@
+[[rules]]
+name = "nexus-private-office"
+channels = ["7e8c4840-d401-4701-afc9-7ae7174cfc4e"]
+kinds = [9, 40002]
+require_exact_channel_tag = true
+require_mention = false
+filter = 'author == "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"'
+
+[[rules]]
+name = "nexus-invited-huddle"
+channels = []
+admit_invited_ephemeral = true
+kinds = [9, 40002]
+require_exact_channel_tag = true
+require_mention = true
+filter = 'author == "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"'

--- a/deploy/local/aeon-aspects/config/sapientis.toml
+++ b/deploy/local/aeon-aspects/config/sapientis.toml
@@ -1,0 +1,16 @@
+[[rules]]
+name = "sapientis-private-office"
+channels = ["4e9f115c-cf8d-4abe-a085-c2b2c64ef2c2"]
+kinds = [9, 40002]
+require_exact_channel_tag = true
+require_mention = false
+filter = 'author == "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"'
+
+[[rules]]
+name = "sapientis-invited-huddle"
+channels = []
+admit_invited_ephemeral = true
+kinds = [9, 40002]
+require_exact_channel_tag = true
+require_mention = true
+filter = 'author == "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"'

--- a/deploy/local/aeon-aspects/config/viatica.toml
+++ b/deploy/local/aeon-aspects/config/viatica.toml
@@ -1,0 +1,16 @@
+[[rules]]
+name = "viatica-private-office"
+channels = ["39560f3c-f638-41a1-945b-ed5400ec41fc"]
+kinds = [9, 40002]
+require_exact_channel_tag = true
+require_mention = false
+filter = 'author == "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"'
+
+[[rules]]
+name = "viatica-invited-huddle"
+channels = []
+admit_invited_ephemeral = true
+kinds = [9, 40002]
+require_exact_channel_tag = true
+require_mention = true
+filter = 'author == "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"'

--- a/deploy/local/aeon-aspects/config/voxis.toml
+++ b/deploy/local/aeon-aspects/config/voxis.toml
@@ -1,0 +1,16 @@
+[[rules]]
+name = "voxis-private-office"
+channels = ["d00b15e9-0dbe-4f35-895e-b6d36faa299e"]
+kinds = [9, 40002]
+require_exact_channel_tag = true
+require_mention = false
+filter = 'author == "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"'
+
+[[rules]]
+name = "voxis-invited-huddle"
+channels = []
+admit_invited_ephemeral = true
+kinds = [9, 40002]
+require_exact_channel_tag = true
+require_mention = true
+filter = 'author == "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"'

--- a/deploy/local/aeon-aspects/fixtures/identity-map.json
+++ b/deploy/local/aeon-aspects/fixtures/identity-map.json
@@ -1,0 +1,72 @@
+{
+  "members": {
+    "architect": {
+      "pubkey_hex": "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f"
+    },
+    "nexus": {
+      "display_name": "Nexus",
+      "pubkey_hex": "ca2bce90e858e12f399f7b4cd510b5fce74e4238352229ada47b8bdd1a7f3b97",
+      "gateway_agent_id": "main",
+      "secret_ref": "/fixtures/keys/nexus.nsec"
+    },
+    "mechanon": {
+      "display_name": "Mechanon",
+      "pubkey_hex": "44437bd6007641845f154bdb7698b1627745b0a1b1d9bdfcf4826fe82a37ca9d",
+      "gateway_agent_id": "mechanon",
+      "secret_ref": "/fixtures/keys/mechanon.nsec"
+    },
+    "fontis": {
+      "display_name": "Fontis",
+      "pubkey_hex": "3672ca65abf6b12effaf57475ce31260a4bc96e6d3acf01b909f9c2a44542147",
+      "gateway_agent_id": "fontis",
+      "secret_ref": "/fixtures/keys/fontis.nsec"
+    },
+    "sapientis": {
+      "display_name": "Sapientis",
+      "pubkey_hex": "1b7ddc51e6e7d688cd1816047b3ec35e7460014bf146813a505fee851e8b0d89",
+      "gateway_agent_id": "sapientis",
+      "secret_ref": "/fixtures/keys/sapientis.nsec"
+    },
+    "viatica": {
+      "display_name": "Viatica",
+      "pubkey_hex": "89a2f2679f83cd9033582f023a3b92e01ed2b5950587efae565045ae65bd03cc",
+      "gateway_agent_id": "viatica",
+      "secret_ref": "/fixtures/keys/viatica.nsec"
+    },
+    "voxis": {
+      "display_name": "Voxis",
+      "pubkey_hex": "e2b124c4728989a09d0f7df96cd2b1823635cc220ed9cdd4f97eaedc12a17fe4",
+      "gateway_agent_id": "voxis",
+      "secret_ref": "/fixtures/keys/voxis.nsec"
+    }
+  },
+  "channels": {
+    "concilium": {
+      "channel_id": "4ac1cee0-2238-483f-b25b-f99ec17eec46"
+    },
+    "aspect_nexus": {
+      "channel_id": "7e8c4840-d401-4701-afc9-7ae7174cfc4e",
+      "members": ["architect", "nexus"]
+    },
+    "aspect_mechanon": {
+      "channel_id": "7d022bea-5e81-4d18-bd2e-176e9eda1971",
+      "members": ["architect", "mechanon"]
+    },
+    "aspect_fontis": {
+      "channel_id": "600cb602-ff2a-422b-bdb2-6353bb81100d",
+      "members": ["architect", "fontis"]
+    },
+    "aspect_sapientis": {
+      "channel_id": "4e9f115c-cf8d-4abe-a085-c2b2c64ef2c2",
+      "members": ["architect", "sapientis"]
+    },
+    "aspect_viatica": {
+      "channel_id": "39560f3c-f638-41a1-945b-ed5400ec41fc",
+      "members": ["architect", "viatica"]
+    },
+    "aspect_voxis": {
+      "channel_id": "d00b15e9-0dbe-4f35-895e-b6d36faa299e",
+      "members": ["architect", "voxis"]
+    }
+  }
+}

--- a/deploy/local/aeon-aspects/fixtures/identity-map.json
+++ b/deploy/local/aeon-aspects/fixtures/identity-map.json
@@ -7,37 +7,37 @@
       "display_name": "Nexus",
       "pubkey_hex": "ca2bce90e858e12f399f7b4cd510b5fce74e4238352229ada47b8bdd1a7f3b97",
       "gateway_agent_id": "main",
-      "secret_ref": "/fixtures/keys/nexus.nsec"
+      "secret_ref": "/Volumes/AEON/Projects/buzz-data/keys/nexus.sk"
     },
     "mechanon": {
       "display_name": "Mechanon",
       "pubkey_hex": "44437bd6007641845f154bdb7698b1627745b0a1b1d9bdfcf4826fe82a37ca9d",
       "gateway_agent_id": "mechanon",
-      "secret_ref": "/fixtures/keys/mechanon.nsec"
+      "secret_ref": "/Volumes/AEON/Projects/buzz-data/keys/mechanon.sk"
     },
     "fontis": {
       "display_name": "Fontis",
       "pubkey_hex": "3672ca65abf6b12effaf57475ce31260a4bc96e6d3acf01b909f9c2a44542147",
       "gateway_agent_id": "fontis",
-      "secret_ref": "/fixtures/keys/fontis.nsec"
+      "secret_ref": "/Volumes/AEON/Projects/buzz-data/keys/fontis.sk"
     },
     "sapientis": {
       "display_name": "Sapientis",
       "pubkey_hex": "1b7ddc51e6e7d688cd1816047b3ec35e7460014bf146813a505fee851e8b0d89",
       "gateway_agent_id": "sapientis",
-      "secret_ref": "/fixtures/keys/sapientis.nsec"
+      "secret_ref": "/Volumes/AEON/Projects/buzz-data/keys/sapientis.sk"
     },
     "viatica": {
       "display_name": "Viatica",
       "pubkey_hex": "89a2f2679f83cd9033582f023a3b92e01ed2b5950587efae565045ae65bd03cc",
       "gateway_agent_id": "viatica",
-      "secret_ref": "/fixtures/keys/viatica.nsec"
+      "secret_ref": "/Volumes/AEON/Projects/buzz-data/keys/viatica.sk"
     },
     "voxis": {
       "display_name": "Voxis",
       "pubkey_hex": "e2b124c4728989a09d0f7df96cd2b1823635cc220ed9cdd4f97eaedc12a17fe4",
       "gateway_agent_id": "voxis",
-      "secret_ref": "/fixtures/keys/voxis.nsec"
+      "secret_ref": "/Volumes/AEON/Projects/buzz-data/keys/voxis.sk"
     }
   },
   "channels": {

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.fontis.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.fontis.plist
@@ -35,6 +35,7 @@
     <string>--multiple-event-handling</string>
     <string>queue</string>
     <string>--relay-observer</string>
+    <string>--trusted-inbound-envelope</string>
     <string>--permission-mode</string>
     <string>bypass-permissions</string>
     <string>--heartbeat-interval</string>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.fontis.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.fontis.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>org.aeon.buzz-acp.fontis</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Volumes/AEON/Projects/buzz/target/release/buzz-acp</string>
+    <string>--relay-url</string>
+    <string>ws://localhost:3000</string>
+    <string>--private-key-file</string>
+    <string>/Volumes/AEON/Projects/buzz-data/keys/fontis.sk</string>
+    <string>--expected-public-key</string>
+    <string>3672ca65abf6b12effaf57475ce31260a4bc96e6d3acf01b909f9c2a44542147</string>
+    <string>--agent-owner</string>
+    <string>73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f</string>
+    <string>--agent-command</string>
+    <string>/REQUIRES_FLEET/immutable-openclaw/bin/openclaw</string>
+    <string>--agent-args</string>
+    <string>acp,--session,agent:fontis:buzz-private,--require-existing,--token-file,/REQUIRES_FLEET/owned-token-file,--url,ws://127.0.0.1:18806,--provenance,meta+receipt,--no-prefix-cwd</string>
+    <string>--agents</string>
+    <string>1</string>
+    <string>--subscribe</string>
+    <string>config</string>
+    <string>--config</string>
+    <string>/Volumes/AEON/Projects/buzz/deploy/local/aeon-aspects/config/fontis.toml</string>
+    <string>--respond-to</string>
+    <string>owner-only</string>
+    <string>--allowed-respond-to</string>
+    <string>owner-only</string>
+    <string>--no-memory</string>
+    <string>--no-base-prompt</string>
+    <string>--dedup</string>
+    <string>queue</string>
+    <string>--multiple-event-handling</string>
+    <string>queue</string>
+    <string>--relay-observer</string>
+    <string>--permission-mode</string>
+    <string>bypass-permissions</string>
+    <string>--heartbeat-interval</string>
+    <string>0</string>
+    <string>--turn-liveness-secs</string>
+    <string>10</string>
+    <string>--idle-timeout</string>
+    <string>900</string>
+    <string>--max-turn-duration</string>
+    <string>7200</string>
+    <string>--context-message-limit</string>
+    <string>12</string>
+    <string>--max-turns-per-session</string>
+    <string>0</string>
+    <string>--turn-receipts</string>
+    <string>--expected-gateway-session-key</string>
+    <string>agent:fontis:buzz-private</string>
+  </array>
+  <key>WorkingDirectory</key><string>/Volumes/AEON/Projects/buzz</string>
+  <key>RunAtLoad</key><false/>
+  <key>KeepAlive</key><false/>
+  <key>ProcessType</key><string>Background</string>
+  <key>StandardOutPath</key><string>/Volumes/AEON/Projects/buzz-data/logs/fontis.buzz-acp.log</string>
+  <key>StandardErrorPath</key><string>/Volumes/AEON/Projects/buzz-data/logs/fontis.buzz-acp.err.log</string>
+</dict>
+</plist>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.fontis.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.fontis.plist
@@ -36,6 +36,7 @@
     <string>queue</string>
     <string>--relay-observer</string>
     <string>--trusted-inbound-envelope</string>
+    <string>--no-agent-publisher-credentials</string>
     <string>--permission-mode</string>
     <string>bypass-permissions</string>
     <string>--heartbeat-interval</string>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.mechanon.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.mechanon.plist
@@ -35,6 +35,7 @@
     <string>--multiple-event-handling</string>
     <string>queue</string>
     <string>--relay-observer</string>
+    <string>--trusted-inbound-envelope</string>
     <string>--permission-mode</string>
     <string>bypass-permissions</string>
     <string>--heartbeat-interval</string>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.mechanon.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.mechanon.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>org.aeon.buzz-acp.mechanon</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Volumes/AEON/Projects/buzz/target/release/buzz-acp</string>
+    <string>--relay-url</string>
+    <string>ws://localhost:3000</string>
+    <string>--private-key-file</string>
+    <string>/Volumes/AEON/Projects/buzz-data/keys/mechanon.sk</string>
+    <string>--expected-public-key</string>
+    <string>44437bd6007641845f154bdb7698b1627745b0a1b1d9bdfcf4826fe82a37ca9d</string>
+    <string>--agent-owner</string>
+    <string>73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f</string>
+    <string>--agent-command</string>
+    <string>/REQUIRES_FLEET/immutable-openclaw/bin/openclaw</string>
+    <string>--agent-args</string>
+    <string>acp,--session,agent:mechanon:buzz-private,--require-existing,--token-file,/REQUIRES_FLEET/owned-token-file,--url,ws://127.0.0.1:18806,--provenance,meta+receipt,--no-prefix-cwd</string>
+    <string>--agents</string>
+    <string>1</string>
+    <string>--subscribe</string>
+    <string>config</string>
+    <string>--config</string>
+    <string>/Volumes/AEON/Projects/buzz/deploy/local/aeon-aspects/config/mechanon.toml</string>
+    <string>--respond-to</string>
+    <string>owner-only</string>
+    <string>--allowed-respond-to</string>
+    <string>owner-only</string>
+    <string>--no-memory</string>
+    <string>--no-base-prompt</string>
+    <string>--dedup</string>
+    <string>queue</string>
+    <string>--multiple-event-handling</string>
+    <string>queue</string>
+    <string>--relay-observer</string>
+    <string>--permission-mode</string>
+    <string>bypass-permissions</string>
+    <string>--heartbeat-interval</string>
+    <string>0</string>
+    <string>--turn-liveness-secs</string>
+    <string>10</string>
+    <string>--idle-timeout</string>
+    <string>900</string>
+    <string>--max-turn-duration</string>
+    <string>7200</string>
+    <string>--context-message-limit</string>
+    <string>12</string>
+    <string>--max-turns-per-session</string>
+    <string>0</string>
+    <string>--turn-receipts</string>
+    <string>--expected-gateway-session-key</string>
+    <string>agent:mechanon:buzz-private</string>
+  </array>
+  <key>WorkingDirectory</key><string>/Volumes/AEON/Projects/buzz</string>
+  <key>RunAtLoad</key><false/>
+  <key>KeepAlive</key><false/>
+  <key>ProcessType</key><string>Background</string>
+  <key>StandardOutPath</key><string>/Volumes/AEON/Projects/buzz-data/logs/mechanon.buzz-acp.log</string>
+  <key>StandardErrorPath</key><string>/Volumes/AEON/Projects/buzz-data/logs/mechanon.buzz-acp.err.log</string>
+</dict>
+</plist>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.mechanon.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.mechanon.plist
@@ -36,6 +36,7 @@
     <string>queue</string>
     <string>--relay-observer</string>
     <string>--trusted-inbound-envelope</string>
+    <string>--no-agent-publisher-credentials</string>
     <string>--permission-mode</string>
     <string>bypass-permissions</string>
     <string>--heartbeat-interval</string>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.nexus.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.nexus.plist
@@ -35,6 +35,7 @@
     <string>--multiple-event-handling</string>
     <string>queue</string>
     <string>--relay-observer</string>
+    <string>--trusted-inbound-envelope</string>
     <string>--permission-mode</string>
     <string>bypass-permissions</string>
     <string>--heartbeat-interval</string>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.nexus.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.nexus.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>org.aeon.buzz-acp.nexus</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Volumes/AEON/Projects/buzz/target/release/buzz-acp</string>
+    <string>--relay-url</string>
+    <string>ws://localhost:3000</string>
+    <string>--private-key-file</string>
+    <string>/Volumes/AEON/Projects/buzz-data/keys/nexus.sk</string>
+    <string>--expected-public-key</string>
+    <string>ca2bce90e858e12f399f7b4cd510b5fce74e4238352229ada47b8bdd1a7f3b97</string>
+    <string>--agent-owner</string>
+    <string>73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f</string>
+    <string>--agent-command</string>
+    <string>/REQUIRES_FLEET/immutable-openclaw/bin/openclaw</string>
+    <string>--agent-args</string>
+    <string>acp,--session,agent:main:buzz-private,--require-existing,--token-file,/REQUIRES_FLEET/owned-token-file,--url,ws://127.0.0.1:18806,--provenance,meta+receipt,--no-prefix-cwd</string>
+    <string>--agents</string>
+    <string>1</string>
+    <string>--subscribe</string>
+    <string>config</string>
+    <string>--config</string>
+    <string>/Volumes/AEON/Projects/buzz/deploy/local/aeon-aspects/config/nexus.toml</string>
+    <string>--respond-to</string>
+    <string>owner-only</string>
+    <string>--allowed-respond-to</string>
+    <string>owner-only</string>
+    <string>--no-memory</string>
+    <string>--no-base-prompt</string>
+    <string>--dedup</string>
+    <string>queue</string>
+    <string>--multiple-event-handling</string>
+    <string>queue</string>
+    <string>--relay-observer</string>
+    <string>--permission-mode</string>
+    <string>bypass-permissions</string>
+    <string>--heartbeat-interval</string>
+    <string>0</string>
+    <string>--turn-liveness-secs</string>
+    <string>10</string>
+    <string>--idle-timeout</string>
+    <string>900</string>
+    <string>--max-turn-duration</string>
+    <string>7200</string>
+    <string>--context-message-limit</string>
+    <string>12</string>
+    <string>--max-turns-per-session</string>
+    <string>0</string>
+    <string>--turn-receipts</string>
+    <string>--expected-gateway-session-key</string>
+    <string>agent:main:buzz-private</string>
+  </array>
+  <key>WorkingDirectory</key><string>/Volumes/AEON/Projects/buzz</string>
+  <key>RunAtLoad</key><false/>
+  <key>KeepAlive</key><false/>
+  <key>ProcessType</key><string>Background</string>
+  <key>StandardOutPath</key><string>/Volumes/AEON/Projects/buzz-data/logs/nexus.buzz-acp.log</string>
+  <key>StandardErrorPath</key><string>/Volumes/AEON/Projects/buzz-data/logs/nexus.buzz-acp.err.log</string>
+</dict>
+</plist>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.nexus.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.nexus.plist
@@ -36,6 +36,7 @@
     <string>queue</string>
     <string>--relay-observer</string>
     <string>--trusted-inbound-envelope</string>
+    <string>--no-agent-publisher-credentials</string>
     <string>--permission-mode</string>
     <string>bypass-permissions</string>
     <string>--heartbeat-interval</string>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.sapientis.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.sapientis.plist
@@ -35,6 +35,7 @@
     <string>--multiple-event-handling</string>
     <string>queue</string>
     <string>--relay-observer</string>
+    <string>--trusted-inbound-envelope</string>
     <string>--permission-mode</string>
     <string>bypass-permissions</string>
     <string>--heartbeat-interval</string>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.sapientis.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.sapientis.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>org.aeon.buzz-acp.sapientis</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Volumes/AEON/Projects/buzz/target/release/buzz-acp</string>
+    <string>--relay-url</string>
+    <string>ws://localhost:3000</string>
+    <string>--private-key-file</string>
+    <string>/Volumes/AEON/Projects/buzz-data/keys/sapientis.sk</string>
+    <string>--expected-public-key</string>
+    <string>1b7ddc51e6e7d688cd1816047b3ec35e7460014bf146813a505fee851e8b0d89</string>
+    <string>--agent-owner</string>
+    <string>73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f</string>
+    <string>--agent-command</string>
+    <string>/REQUIRES_FLEET/immutable-openclaw/bin/openclaw</string>
+    <string>--agent-args</string>
+    <string>acp,--session,agent:sapientis:buzz-private,--require-existing,--token-file,/REQUIRES_FLEET/owned-token-file,--url,ws://127.0.0.1:18806,--provenance,meta+receipt,--no-prefix-cwd</string>
+    <string>--agents</string>
+    <string>1</string>
+    <string>--subscribe</string>
+    <string>config</string>
+    <string>--config</string>
+    <string>/Volumes/AEON/Projects/buzz/deploy/local/aeon-aspects/config/sapientis.toml</string>
+    <string>--respond-to</string>
+    <string>owner-only</string>
+    <string>--allowed-respond-to</string>
+    <string>owner-only</string>
+    <string>--no-memory</string>
+    <string>--no-base-prompt</string>
+    <string>--dedup</string>
+    <string>queue</string>
+    <string>--multiple-event-handling</string>
+    <string>queue</string>
+    <string>--relay-observer</string>
+    <string>--permission-mode</string>
+    <string>bypass-permissions</string>
+    <string>--heartbeat-interval</string>
+    <string>0</string>
+    <string>--turn-liveness-secs</string>
+    <string>10</string>
+    <string>--idle-timeout</string>
+    <string>900</string>
+    <string>--max-turn-duration</string>
+    <string>7200</string>
+    <string>--context-message-limit</string>
+    <string>12</string>
+    <string>--max-turns-per-session</string>
+    <string>0</string>
+    <string>--turn-receipts</string>
+    <string>--expected-gateway-session-key</string>
+    <string>agent:sapientis:buzz-private</string>
+  </array>
+  <key>WorkingDirectory</key><string>/Volumes/AEON/Projects/buzz</string>
+  <key>RunAtLoad</key><false/>
+  <key>KeepAlive</key><false/>
+  <key>ProcessType</key><string>Background</string>
+  <key>StandardOutPath</key><string>/Volumes/AEON/Projects/buzz-data/logs/sapientis.buzz-acp.log</string>
+  <key>StandardErrorPath</key><string>/Volumes/AEON/Projects/buzz-data/logs/sapientis.buzz-acp.err.log</string>
+</dict>
+</plist>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.sapientis.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.sapientis.plist
@@ -36,6 +36,7 @@
     <string>queue</string>
     <string>--relay-observer</string>
     <string>--trusted-inbound-envelope</string>
+    <string>--no-agent-publisher-credentials</string>
     <string>--permission-mode</string>
     <string>bypass-permissions</string>
     <string>--heartbeat-interval</string>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.viatica.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.viatica.plist
@@ -35,6 +35,7 @@
     <string>--multiple-event-handling</string>
     <string>queue</string>
     <string>--relay-observer</string>
+    <string>--trusted-inbound-envelope</string>
     <string>--permission-mode</string>
     <string>bypass-permissions</string>
     <string>--heartbeat-interval</string>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.viatica.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.viatica.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>org.aeon.buzz-acp.viatica</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Volumes/AEON/Projects/buzz/target/release/buzz-acp</string>
+    <string>--relay-url</string>
+    <string>ws://localhost:3000</string>
+    <string>--private-key-file</string>
+    <string>/Volumes/AEON/Projects/buzz-data/keys/viatica.sk</string>
+    <string>--expected-public-key</string>
+    <string>89a2f2679f83cd9033582f023a3b92e01ed2b5950587efae565045ae65bd03cc</string>
+    <string>--agent-owner</string>
+    <string>73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f</string>
+    <string>--agent-command</string>
+    <string>/REQUIRES_FLEET/immutable-openclaw/bin/openclaw</string>
+    <string>--agent-args</string>
+    <string>acp,--session,agent:viatica:buzz-private,--require-existing,--token-file,/REQUIRES_FLEET/owned-token-file,--url,ws://127.0.0.1:18806,--provenance,meta+receipt,--no-prefix-cwd</string>
+    <string>--agents</string>
+    <string>1</string>
+    <string>--subscribe</string>
+    <string>config</string>
+    <string>--config</string>
+    <string>/Volumes/AEON/Projects/buzz/deploy/local/aeon-aspects/config/viatica.toml</string>
+    <string>--respond-to</string>
+    <string>owner-only</string>
+    <string>--allowed-respond-to</string>
+    <string>owner-only</string>
+    <string>--no-memory</string>
+    <string>--no-base-prompt</string>
+    <string>--dedup</string>
+    <string>queue</string>
+    <string>--multiple-event-handling</string>
+    <string>queue</string>
+    <string>--relay-observer</string>
+    <string>--permission-mode</string>
+    <string>bypass-permissions</string>
+    <string>--heartbeat-interval</string>
+    <string>0</string>
+    <string>--turn-liveness-secs</string>
+    <string>10</string>
+    <string>--idle-timeout</string>
+    <string>900</string>
+    <string>--max-turn-duration</string>
+    <string>7200</string>
+    <string>--context-message-limit</string>
+    <string>12</string>
+    <string>--max-turns-per-session</string>
+    <string>0</string>
+    <string>--turn-receipts</string>
+    <string>--expected-gateway-session-key</string>
+    <string>agent:viatica:buzz-private</string>
+  </array>
+  <key>WorkingDirectory</key><string>/Volumes/AEON/Projects/buzz</string>
+  <key>RunAtLoad</key><false/>
+  <key>KeepAlive</key><false/>
+  <key>ProcessType</key><string>Background</string>
+  <key>StandardOutPath</key><string>/Volumes/AEON/Projects/buzz-data/logs/viatica.buzz-acp.log</string>
+  <key>StandardErrorPath</key><string>/Volumes/AEON/Projects/buzz-data/logs/viatica.buzz-acp.err.log</string>
+</dict>
+</plist>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.viatica.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.viatica.plist
@@ -36,6 +36,7 @@
     <string>queue</string>
     <string>--relay-observer</string>
     <string>--trusted-inbound-envelope</string>
+    <string>--no-agent-publisher-credentials</string>
     <string>--permission-mode</string>
     <string>bypass-permissions</string>
     <string>--heartbeat-interval</string>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.voxis.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.voxis.plist
@@ -35,6 +35,7 @@
     <string>--multiple-event-handling</string>
     <string>queue</string>
     <string>--relay-observer</string>
+    <string>--trusted-inbound-envelope</string>
     <string>--permission-mode</string>
     <string>bypass-permissions</string>
     <string>--heartbeat-interval</string>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.voxis.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.voxis.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>org.aeon.buzz-acp.voxis</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Volumes/AEON/Projects/buzz/target/release/buzz-acp</string>
+    <string>--relay-url</string>
+    <string>ws://localhost:3000</string>
+    <string>--private-key-file</string>
+    <string>/Volumes/AEON/Projects/buzz-data/keys/voxis.sk</string>
+    <string>--expected-public-key</string>
+    <string>e2b124c4728989a09d0f7df96cd2b1823635cc220ed9cdd4f97eaedc12a17fe4</string>
+    <string>--agent-owner</string>
+    <string>73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f</string>
+    <string>--agent-command</string>
+    <string>/REQUIRES_FLEET/immutable-openclaw/bin/openclaw</string>
+    <string>--agent-args</string>
+    <string>acp,--session,agent:voxis:buzz-private,--require-existing,--token-file,/REQUIRES_FLEET/owned-token-file,--url,ws://127.0.0.1:18806,--provenance,meta+receipt,--no-prefix-cwd</string>
+    <string>--agents</string>
+    <string>1</string>
+    <string>--subscribe</string>
+    <string>config</string>
+    <string>--config</string>
+    <string>/Volumes/AEON/Projects/buzz/deploy/local/aeon-aspects/config/voxis.toml</string>
+    <string>--respond-to</string>
+    <string>owner-only</string>
+    <string>--allowed-respond-to</string>
+    <string>owner-only</string>
+    <string>--no-memory</string>
+    <string>--no-base-prompt</string>
+    <string>--dedup</string>
+    <string>queue</string>
+    <string>--multiple-event-handling</string>
+    <string>queue</string>
+    <string>--relay-observer</string>
+    <string>--permission-mode</string>
+    <string>bypass-permissions</string>
+    <string>--heartbeat-interval</string>
+    <string>0</string>
+    <string>--turn-liveness-secs</string>
+    <string>10</string>
+    <string>--idle-timeout</string>
+    <string>900</string>
+    <string>--max-turn-duration</string>
+    <string>7200</string>
+    <string>--context-message-limit</string>
+    <string>12</string>
+    <string>--max-turns-per-session</string>
+    <string>0</string>
+    <string>--turn-receipts</string>
+    <string>--expected-gateway-session-key</string>
+    <string>agent:voxis:buzz-private</string>
+  </array>
+  <key>WorkingDirectory</key><string>/Volumes/AEON/Projects/buzz</string>
+  <key>RunAtLoad</key><false/>
+  <key>KeepAlive</key><false/>
+  <key>ProcessType</key><string>Background</string>
+  <key>StandardOutPath</key><string>/Volumes/AEON/Projects/buzz-data/logs/voxis.buzz-acp.log</string>
+  <key>StandardErrorPath</key><string>/Volumes/AEON/Projects/buzz-data/logs/voxis.buzz-acp.err.log</string>
+</dict>
+</plist>

--- a/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.voxis.plist
+++ b/deploy/local/aeon-aspects/launchagents/org.aeon.buzz-acp.voxis.plist
@@ -36,6 +36,7 @@
     <string>queue</string>
     <string>--relay-observer</string>
     <string>--trusted-inbound-envelope</string>
+    <string>--no-agent-publisher-credentials</string>
     <string>--permission-mode</string>
     <string>bypass-permissions</string>
     <string>--heartbeat-interval</string>

--- a/deploy/local/aeon-aspects/render-launchagents.mjs
+++ b/deploy/local/aeon-aspects/render-launchagents.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadJson, renderDisabledLaunchAgent, validateManifest } from "./worker.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const manifest = loadJson(join(here, "workers.json"));
+const identityMap = loadJson(process.argv[2] ?? manifest.identityMap);
+const validation = validateManifest(manifest, identityMap);
+if (!validation.ok) {
+  console.error(validation.errors.join("\n"));
+  process.exit(1);
+}
+const artifacts = Object.fromEntries(
+  manifest.workers.map((worker) => {
+    const artifact = renderDisabledLaunchAgent(manifest, identityMap, worker.aspect);
+    return [`${artifact.label}.plist`, artifact.plist];
+  }),
+);
+process.stdout.write(`${JSON.stringify({ schema: "aeon_disabled_launchagents_v1", artifacts }, null, 2)}\n`);

--- a/deploy/local/aeon-aspects/render-launchagents.mjs
+++ b/deploy/local/aeon-aspects/render-launchagents.mjs
@@ -5,7 +5,7 @@ import { loadJson, renderDisabledLaunchAgent, validateManifest } from "./worker.
 
 const here = dirname(fileURLToPath(import.meta.url));
 const manifest = loadJson(join(here, "workers.json"));
-const identityMap = loadJson(process.argv[2] ?? manifest.identityMap);
+const identityMap = loadJson(process.argv[2] ?? join(here, "fixtures", "identity-map.json"));
 const validation = validateManifest(manifest, identityMap);
 if (!validation.ok) {
   console.error(validation.errors.join("\n"));

--- a/deploy/local/aeon-aspects/validate.mjs
+++ b/deploy/local/aeon-aspects/validate.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadJson, renderDisabledLaunchAgent, renderWorker, validateManifest } from "./worker.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const manifestPath = join(here, "workers.json");
+const manifest = loadJson(manifestPath);
+const identityMap = loadJson(process.argv[2] ?? manifest.identityMap);
+const validation = validateManifest(manifest, identityMap);
+const rendered = validation.ok ? manifest.workers.map((worker) => renderWorker(manifest, identityMap, worker.aspect)) : [];
+const launchAgents = [];
+if (validation.ok) {
+  for (const worker of manifest.workers) {
+    const artifact = renderDisabledLaunchAgent(manifest, identityMap, worker.aspect);
+    const path = join(here, "launchagents", `${artifact.label}.plist`);
+    if (!fs.existsSync(path) || fs.readFileSync(path, "utf8") !== artifact.plist) {
+      validation.errors.push(`${worker.aspect}: checked-in LaunchAgent preview drift`);
+    }
+    launchAgents.push({ label: artifact.label, path, runAtLoad: artifact.runAtLoad, keepAlive: artifact.keepAlive });
+  }
+  validation.ok = validation.errors.length === 0;
+}
+console.log(JSON.stringify({ ...validation, workers: rendered, launchAgents }, null, 2));
+process.exitCode = validation.ok ? 0 : 1;

--- a/deploy/local/aeon-aspects/validate.mjs
+++ b/deploy/local/aeon-aspects/validate.mjs
@@ -7,7 +7,8 @@ import { loadJson, renderDisabledLaunchAgent, renderWorker, validateManifest } f
 const here = dirname(fileURLToPath(import.meta.url));
 const manifestPath = join(here, "workers.json");
 const manifest = loadJson(manifestPath);
-const identityMap = loadJson(process.argv[2] ?? manifest.identityMap);
+const identityMapPath = process.argv[2] ?? join(here, "fixtures", "identity-map.json");
+const identityMap = loadJson(identityMapPath);
 const validation = validateManifest(manifest, identityMap);
 const rendered = validation.ok ? manifest.workers.map((worker) => renderWorker(manifest, identityMap, worker.aspect)) : [];
 const launchAgents = [];

--- a/deploy/local/aeon-aspects/worker.mjs
+++ b/deploy/local/aeon-aspects/worker.mjs
@@ -82,7 +82,7 @@ export function renderWorker(manifest, identityMap, aspect, tokenFile = "${AEON_
       "--agent-args", ["acp", "--session", worker.sessionKey, "--require-existing", "--token-file", tokenFile, "--url", manifest.gateway.url, "--provenance", manifest.gateway.provenance, "--no-prefix-cwd"].join(","),
       "--agents", "1", "--subscribe", "config", "--config", configPath,
       "--respond-to", "owner-only", "--allowed-respond-to", "owner-only",
-      "--no-memory", "--no-base-prompt", "--dedup", "queue", "--multiple-event-handling", "queue", "--relay-observer", "--trusted-inbound-envelope",
+      "--no-memory", "--no-base-prompt", "--dedup", "queue", "--multiple-event-handling", "queue", "--relay-observer", "--trusted-inbound-envelope", "--no-agent-publisher-credentials",
       "--permission-mode", manifest.posture.permissionMode,
       "--heartbeat-interval", String(manifest.posture.heartbeatIntervalSecs),
       "--turn-liveness-secs", String(manifest.posture.turnLivenessSecs),

--- a/deploy/local/aeon-aspects/worker.mjs
+++ b/deploy/local/aeon-aspects/worker.mjs
@@ -114,6 +114,7 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
   const buzzAcpPath = options.buzzAcpPath ?? "/Volumes/AEON/Projects/buzz/target/release/buzz-acp";
   const openclawPath = options.openclawPath ?? "/REQUIRES_FLEET/immutable-openclaw/bin/openclaw";
   const tokenFile = options.tokenFile ?? "/REQUIRES_FLEET/owned-token-file";
+  const privateKeyFile = options.privateKeyFile ?? identityMap.members[aspect].secret_ref;
   const workingDirectory = options.workingDirectory ?? "/Volumes/AEON/Projects/buzz";
   const configPath = options.configPath ?? null;
   const stdoutPath = options.stdoutPath ?? null;
@@ -139,6 +140,7 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
     buzzAcpPath,
     openclawPath,
     tokenFile,
+    privateKeyFile,
     workingDirectory,
     ...(configPath !== null ? { configPath } : {}),
     ...(stdoutPath !== null ? { stdoutPath } : {}),
@@ -159,7 +161,14 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
     }
     assertArgSafe(executablePath, "executablePath");
   }
-  const rendered = renderWorker(manifest, identityMap, aspect, tokenFile);
+  const launchIdentityMap = {
+    ...identityMap,
+    members: {
+      ...identityMap.members,
+      [aspect]: { ...identityMap.members[aspect], secret_ref: privateKeyFile },
+    },
+  };
+  const rendered = renderWorker(manifest, launchIdentityMap, aspect, tokenFile);
   const agentCommandIndex = rendered.args.indexOf("--agent-command") + 1;
   rendered.args[agentCommandIndex] = openclawPath;
   if (agentCommandPrefixArgs.length > 0) {
@@ -193,7 +202,7 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
     runAtLoad: false,
     keepAlive: false,
     argv,
-    privateKeyFile: identityMap.members[aspect].secret_ref,
+    privateKeyFile,
     tokenFile,
     tokenFileContract: manifest.gateway.tokenFileContract,
     expectedPublicKey: worker.pubkey,

--- a/deploy/local/aeon-aspects/worker.mjs
+++ b/deploy/local/aeon-aspects/worker.mjs
@@ -115,6 +115,7 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
   const openclawPath = options.openclawPath ?? "/REQUIRES_FLEET/immutable-openclaw/bin/openclaw";
   const tokenFile = options.tokenFile ?? "/REQUIRES_FLEET/owned-token-file";
   const workingDirectory = options.workingDirectory ?? "/Volumes/AEON/Projects/buzz";
+  const launcherPath = options.launcherPath ?? null;
   const executablePath = options.executablePath ?? null;
   const openclawConfigPath = options.openclawConfigPath ?? null;
   const openclawStateDir = options.openclawStateDir ?? null;
@@ -123,6 +124,7 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
     openclawPath,
     tokenFile,
     workingDirectory,
+    ...(launcherPath !== null ? { launcherPath } : {}),
     ...(openclawConfigPath !== null ? { openclawConfigPath } : {}),
     ...(openclawStateDir !== null ? { openclawStateDir } : {}),
   })) {
@@ -143,7 +145,9 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
   rendered.args[agentCommandIndex] = openclawPath;
   const configIndex = rendered.args.indexOf("--config") + 1;
   rendered.args[configIndex] = `${workingDirectory}/${rendered.args[configIndex]}`;
-  const argv = [buzzAcpPath, ...rendered.args];
+  // launchd may reject direct execution of provenance-marked development binaries.
+  // A Fleet-owned system launcher keeps the binary and its digest explicit in argv.
+  const argv = [...(launcherPath ? [launcherPath] : []), buzzAcpPath, ...rendered.args];
   const worker = manifest.workers.find((item) => item.aspect === aspect);
   const stdout = `/Volumes/AEON/Projects/buzz-data/logs/${aspect}.buzz-acp.log`;
   const stderr = `/Volumes/AEON/Projects/buzz-data/logs/${aspect}.buzz-acp.err.log`;

--- a/deploy/local/aeon-aspects/worker.mjs
+++ b/deploy/local/aeon-aspects/worker.mjs
@@ -19,6 +19,7 @@ export function validateManifest(manifest, identityMap) {
   if (manifest.posture?.presence !== true) errors.push("presence must remain enabled");
   if (manifest.posture?.typing !== true) errors.push("typing must remain enabled");
   if (manifest.posture?.relayObserver !== true) errors.push("relay observer must remain enabled for receipts");
+  if (manifest.posture?.trustedInboundEnvelope !== true) errors.push("trusted inbound envelope must remain enabled");
   if (manifest.posture?.permissionMode !== "bypass-permissions") errors.push("permission mode must be explicitly bypass-permissions");
   if (manifest.posture?.heartbeatIntervalSecs !== 0) errors.push("ACP heartbeat prompting must be disabled");
   if (manifest.posture?.turnLivenessSecs !== 10) errors.push("turn liveness must be 10 seconds");
@@ -81,7 +82,7 @@ export function renderWorker(manifest, identityMap, aspect, tokenFile = "${AEON_
       "--agent-args", ["acp", "--session", worker.sessionKey, "--require-existing", "--token-file", tokenFile, "--url", manifest.gateway.url, "--provenance", manifest.gateway.provenance, "--no-prefix-cwd"].join(","),
       "--agents", "1", "--subscribe", "config", "--config", configPath,
       "--respond-to", "owner-only", "--allowed-respond-to", "owner-only",
-      "--no-memory", "--no-base-prompt", "--dedup", "queue", "--multiple-event-handling", "queue", "--relay-observer",
+      "--no-memory", "--no-base-prompt", "--dedup", "queue", "--multiple-event-handling", "queue", "--relay-observer", "--trusted-inbound-envelope",
       "--permission-mode", manifest.posture.permissionMode,
       "--heartbeat-interval", String(manifest.posture.heartbeatIntervalSecs),
       "--turn-liveness-secs", String(manifest.posture.turnLivenessSecs),

--- a/deploy/local/aeon-aspects/worker.mjs
+++ b/deploy/local/aeon-aspects/worker.mjs
@@ -115,9 +115,16 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
   const openclawPath = options.openclawPath ?? "/REQUIRES_FLEET/immutable-openclaw/bin/openclaw";
   const tokenFile = options.tokenFile ?? "/REQUIRES_FLEET/owned-token-file";
   const workingDirectory = options.workingDirectory ?? "/Volumes/AEON/Projects/buzz";
+  const executablePath = options.executablePath ?? null;
   for (const [label, value] of Object.entries({ buzzAcpPath, openclawPath, tokenFile, workingDirectory })) {
     if (!value.startsWith("/")) throw new Error(`${label} must be absolute`);
     assertArgSafe(value, label);
+  }
+  if (executablePath !== null) {
+    if (!executablePath.split(":").every((entry) => entry.startsWith("/"))) {
+      throw new Error("executablePath entries must be absolute");
+    }
+    assertArgSafe(executablePath, "executablePath");
   }
   const rendered = renderWorker(manifest, identityMap, aspect, tokenFile);
   const agentCommandIndex = rendered.args.indexOf("--agent-command") + 1;
@@ -129,6 +136,9 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
   const stdout = `/Volumes/AEON/Projects/buzz-data/logs/${aspect}.buzz-acp.log`;
   const stderr = `/Volumes/AEON/Projects/buzz-data/logs/${aspect}.buzz-acp.err.log`;
   const argsXml = argv.map((arg) => `    <string>${xml(arg)}</string>`).join("\n");
+  const environmentXml = executablePath
+    ? `\n  <key>EnvironmentVariables</key>\n  <dict><key>PATH</key><string>${xml(executablePath)}</string></dict>`
+    : "";
   return {
     aspect,
     label: rendered.label,
@@ -150,7 +160,7 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
   <array>
 ${argsXml}
   </array>
-  <key>WorkingDirectory</key><string>${xml(workingDirectory)}</string>
+  <key>WorkingDirectory</key><string>${xml(workingDirectory)}</string>${environmentXml}
   <key>RunAtLoad</key><false/>
   <key>KeepAlive</key><false/>
   <key>ProcessType</key><string>Background</string>

--- a/deploy/local/aeon-aspects/worker.mjs
+++ b/deploy/local/aeon-aspects/worker.mjs
@@ -115,6 +115,9 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
   const openclawPath = options.openclawPath ?? "/REQUIRES_FLEET/immutable-openclaw/bin/openclaw";
   const tokenFile = options.tokenFile ?? "/REQUIRES_FLEET/owned-token-file";
   const workingDirectory = options.workingDirectory ?? "/Volumes/AEON/Projects/buzz";
+  const configPath = options.configPath ?? null;
+  const stdoutPath = options.stdoutPath ?? null;
+  const stderrPath = options.stderrPath ?? null;
   const launcherPath = options.launcherPath ?? null;
   const executablePath = options.executablePath ?? null;
   const openclawConfigPath = options.openclawConfigPath ?? null;
@@ -124,6 +127,9 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
     openclawPath,
     tokenFile,
     workingDirectory,
+    ...(configPath !== null ? { configPath } : {}),
+    ...(stdoutPath !== null ? { stdoutPath } : {}),
+    ...(stderrPath !== null ? { stderrPath } : {}),
     ...(launcherPath !== null ? { launcherPath } : {}),
     ...(openclawConfigPath !== null ? { openclawConfigPath } : {}),
     ...(openclawStateDir !== null ? { openclawStateDir } : {}),
@@ -144,13 +150,13 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
   const agentCommandIndex = rendered.args.indexOf("--agent-command") + 1;
   rendered.args[agentCommandIndex] = openclawPath;
   const configIndex = rendered.args.indexOf("--config") + 1;
-  rendered.args[configIndex] = `${workingDirectory}/${rendered.args[configIndex]}`;
+  rendered.args[configIndex] = configPath ?? `${workingDirectory}/${rendered.args[configIndex]}`;
   // launchd may reject direct execution of provenance-marked development binaries.
   // A Fleet-owned system launcher keeps the binary and its digest explicit in argv.
   const argv = [...(launcherPath ? [launcherPath] : []), buzzAcpPath, ...rendered.args];
   const worker = manifest.workers.find((item) => item.aspect === aspect);
-  const stdout = `/Volumes/AEON/Projects/buzz-data/logs/${aspect}.buzz-acp.log`;
-  const stderr = `/Volumes/AEON/Projects/buzz-data/logs/${aspect}.buzz-acp.err.log`;
+  const stdout = stdoutPath ?? `/Volumes/AEON/Projects/buzz-data/logs/${aspect}.buzz-acp.log`;
+  const stderr = stderrPath ?? `/Volumes/AEON/Projects/buzz-data/logs/${aspect}.buzz-acp.err.log`;
   const argsXml = argv.map((arg) => `    <string>${xml(arg)}</string>`).join("\n");
   const environment = {
     ...(executablePath ? { PATH: executablePath } : {}),

--- a/deploy/local/aeon-aspects/worker.mjs
+++ b/deploy/local/aeon-aspects/worker.mjs
@@ -1,0 +1,171 @@
+import fs from "node:fs";
+
+export function loadJson(path) {
+  return JSON.parse(fs.readFileSync(path, "utf8"));
+}
+
+export function validateManifest(manifest, identityMap) {
+  const errors = [];
+  const warnings = [];
+  if (manifest.enabled !== false) errors.push("package must be disabled by default");
+  if (manifest.workers?.length !== 6) errors.push("exactly six Aspect workers are required");
+  if (manifest.buzz?.relayUrl !== "ws://localhost:3000") errors.push("Buzz relay must use localhost");
+  if (manifest.posture?.memory !== false) errors.push("Buzz memory injection must be disabled");
+  if (manifest.posture?.basePrompt !== false) errors.push("Buzz base prompt must be disabled");
+  if (manifest.posture?.respondTo !== "owner-only") errors.push("respondTo must be owner-only");
+  if (manifest.posture?.agents !== 1) errors.push("each worker must have one ACP subprocess");
+  if (manifest.posture?.dedup !== "queue") errors.push("dedup must be queue");
+  if (manifest.posture?.multipleEventHandling !== "queue") errors.push("multipleEventHandling must be queue");
+  if (manifest.posture?.presence !== true) errors.push("presence must remain enabled");
+  if (manifest.posture?.typing !== true) errors.push("typing must remain enabled");
+  if (manifest.posture?.relayObserver !== true) errors.push("relay observer must remain enabled for receipts");
+  if (manifest.posture?.permissionMode !== "bypass-permissions") errors.push("permission mode must be explicitly bypass-permissions");
+  if (manifest.posture?.heartbeatIntervalSecs !== 0) errors.push("ACP heartbeat prompting must be disabled");
+  if (manifest.posture?.turnLivenessSecs !== 10) errors.push("turn liveness must be 10 seconds");
+  if (manifest.posture?.idleTimeoutSecs !== 900) errors.push("idle timeout must be 900 seconds");
+  if (manifest.posture?.maxTurnDurationSecs !== 7200) errors.push("max turn duration must be 7200 seconds");
+  if (manifest.posture?.contextMessageLimit !== 12) errors.push("context message limit must be 12");
+  if (manifest.posture?.maxTurnsPerSession !== 0) errors.push("Buzz session rotation must be disabled");
+  const tokenContract = manifest.gateway?.tokenFileContract;
+  if (
+    tokenContract?.absolute !== true || tokenContract?.regular !== true ||
+    tokenContract?.symlink !== false || tokenContract?.owner !== "current-user" ||
+    tokenContract?.mode !== "0600"
+  ) {
+    errors.push("Gateway token file contract must require absolute regular non-symlink current-user 0600");
+  }
+  if (manifest.supervisor?.runAtLoad !== false || manifest.supervisor?.startOnAppLaunch !== false) {
+    errors.push("workers must not start automatically");
+  }
+  if (manifest.supervisor?.restartOnFailure !== false) {
+    errors.push("restartOnFailure must remain false until durable request state exists");
+  }
+  const concilium = identityMap.channels?.concilium;
+  if (concilium?.channel_id !== manifest.buzz?.conciliumChannelId) errors.push("Concilium UUID drift");
+  const architect = identityMap.members?.architect;
+  if (architect?.pubkey_hex !== manifest.buzz?.architectPubkey) errors.push("Architect pubkey drift");
+
+  for (const worker of manifest.workers ?? []) {
+    const member = identityMap.members?.[worker.aspect];
+    const channel = identityMap.channels?.[`aspect_${worker.aspect}`];
+    if (!member) { errors.push(`${worker.aspect}: missing identity-map member`); continue; }
+    if (worker.displayName !== member.display_name) errors.push(`${worker.aspect}: display name drift`);
+    if (worker.pubkey !== member.pubkey_hex) errors.push(`${worker.aspect}: pubkey drift`);
+    if (worker.gatewayAgentId !== member.gateway_agent_id) errors.push(`${worker.aspect}: Gateway agent drift`);
+    if (worker.privateChannelId !== channel?.channel_id) errors.push(`${worker.aspect}: private room drift`);
+    const expectedMembers = JSON.stringify(["architect", worker.aspect]);
+    if (JSON.stringify(channel?.members) !== expectedMembers) errors.push(`${worker.aspect}: private room membership is not exact`);
+    if (concilium?.channel_id === worker.privateChannelId) errors.push(`${worker.aspect}: private room is Concilium`);
+    if (worker.sessionKey !== `agent:${worker.gatewayAgentId}:buzz-private`) errors.push(`${worker.aspect}: unstable session key`);
+    if (!member.secret_ref) errors.push(`${worker.aspect}: missing private-key reference`);
+  }
+  warnings.push("avatar metadata is absent from identity-map.json; live profile avatar validation remains open");
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+export function renderWorker(manifest, identityMap, aspect, tokenFile = "${AEON_GATEWAY_TOKEN_FILE}") {
+  const worker = manifest.workers.find((item) => item.aspect === aspect);
+  if (!worker) throw new Error(`unknown Aspect: ${aspect}`);
+  const member = identityMap.members[aspect];
+  const configPath = `deploy/local/aeon-aspects/config/${aspect}.toml`;
+  return {
+    enabled: false,
+    label: `org.aeon.buzz-acp.${aspect}`,
+    command: "buzz-acp",
+    args: [
+      "--relay-url", manifest.buzz.relayUrl,
+      "--private-key-file", member.secret_ref,
+      "--expected-public-key", worker.pubkey,
+      "--agent-owner", manifest.buzz.architectPubkey,
+      "--agent-command", "openclaw",
+      "--agent-args", ["acp", "--session", worker.sessionKey, "--require-existing", "--token-file", tokenFile, "--url", manifest.gateway.url, "--provenance", manifest.gateway.provenance, "--no-prefix-cwd"].join(","),
+      "--agents", "1", "--subscribe", "config", "--config", configPath,
+      "--respond-to", "owner-only", "--allowed-respond-to", "owner-only",
+      "--no-memory", "--no-base-prompt", "--dedup", "queue", "--multiple-event-handling", "queue", "--relay-observer",
+      "--permission-mode", manifest.posture.permissionMode,
+      "--heartbeat-interval", String(manifest.posture.heartbeatIntervalSecs),
+      "--turn-liveness-secs", String(manifest.posture.turnLivenessSecs),
+      "--idle-timeout", String(manifest.posture.idleTimeoutSecs),
+      "--max-turn-duration", String(manifest.posture.maxTurnDurationSecs),
+      "--context-message-limit", String(manifest.posture.contextMessageLimit),
+      "--max-turns-per-session", String(manifest.posture.maxTurnsPerSession),
+      "--turn-receipts", "--expected-gateway-session-key", worker.sessionKey
+    ],
+    privateKeyRef: member.secret_ref,
+    sessionKey: worker.sessionKey,
+    supervisor: manifest.supervisor
+  };
+}
+
+function xml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function assertArgSafe(value, label) {
+  if (/[\0\r\n,]/.test(value)) throw new Error(`${label} contains a forbidden delimiter`);
+}
+
+export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options = {}) {
+  const buzzAcpPath = options.buzzAcpPath ?? "/Volumes/AEON/Projects/buzz/target/release/buzz-acp";
+  const openclawPath = options.openclawPath ?? "/REQUIRES_FLEET/immutable-openclaw/bin/openclaw";
+  const tokenFile = options.tokenFile ?? "/REQUIRES_FLEET/owned-token-file";
+  const workingDirectory = options.workingDirectory ?? "/Volumes/AEON/Projects/buzz";
+  for (const [label, value] of Object.entries({ buzzAcpPath, openclawPath, tokenFile, workingDirectory })) {
+    if (!value.startsWith("/")) throw new Error(`${label} must be absolute`);
+    assertArgSafe(value, label);
+  }
+  const rendered = renderWorker(manifest, identityMap, aspect, tokenFile);
+  const agentCommandIndex = rendered.args.indexOf("--agent-command") + 1;
+  rendered.args[agentCommandIndex] = openclawPath;
+  const configIndex = rendered.args.indexOf("--config") + 1;
+  rendered.args[configIndex] = `${workingDirectory}/${rendered.args[configIndex]}`;
+  const argv = [buzzAcpPath, ...rendered.args];
+  const worker = manifest.workers.find((item) => item.aspect === aspect);
+  const stdout = `/Volumes/AEON/Projects/buzz-data/logs/${aspect}.buzz-acp.log`;
+  const stderr = `/Volumes/AEON/Projects/buzz-data/logs/${aspect}.buzz-acp.err.log`;
+  const argsXml = argv.map((arg) => `    <string>${xml(arg)}</string>`).join("\n");
+  return {
+    aspect,
+    label: rendered.label,
+    enabled: false,
+    runAtLoad: false,
+    keepAlive: false,
+    argv,
+    privateKeyFile: identityMap.members[aspect].secret_ref,
+    tokenFile,
+    tokenFileContract: manifest.gateway.tokenFileContract,
+    expectedPublicKey: worker.pubkey,
+    rollback: ["launchctl", "bootout", `gui/<uid>/${rendered.label}`],
+    plist: `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${xml(rendered.label)}</string>
+  <key>ProgramArguments</key>
+  <array>
+${argsXml}
+  </array>
+  <key>WorkingDirectory</key><string>${xml(workingDirectory)}</string>
+  <key>RunAtLoad</key><false/>
+  <key>KeepAlive</key><false/>
+  <key>ProcessType</key><string>Background</string>
+  <key>StandardOutPath</key><string>${xml(stdout)}</string>
+  <key>StandardErrorPath</key><string>${xml(stderr)}</string>
+</dict>
+</plist>
+`,
+  };
+}
+
+export function correlateReceipt({ triggeringEventIds, replyEvents, sessionKey, runId }) {
+  if (!Array.isArray(triggeringEventIds) || triggeringEventIds.length !== 1) throw new Error("receipt requires exactly one request event");
+  const requestEventId = triggeringEventIds[0];
+  const matches = replyEvents.filter((event) => event.replyTo === requestEventId);
+  if (matches.length !== 1) throw new Error(`receipt requires exactly one anchored reply; found ${matches.length}`);
+  if (!sessionKey || !runId) throw new Error("receipt requires Gateway session key and run id");
+  return { requestEventId, replyEventId: matches[0].eventId, gatewaySessionKey: sessionKey, runId };
+}

--- a/deploy/local/aeon-aspects/worker.mjs
+++ b/deploy/local/aeon-aspects/worker.mjs
@@ -122,6 +122,19 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
   const executablePath = options.executablePath ?? null;
   const openclawConfigPath = options.openclawConfigPath ?? null;
   const openclawStateDir = options.openclawStateDir ?? null;
+  const agentCommandPrefixArgs = options.agentCommandPrefixArgs ?? [];
+  if (!Array.isArray(agentCommandPrefixArgs)) {
+    throw new Error("agentCommandPrefixArgs must be an array");
+  }
+  if (agentCommandPrefixArgs.length > 1) {
+    throw new Error("agentCommandPrefixArgs accepts exactly one OpenClaw entrypoint");
+  }
+  for (const [index, value] of agentCommandPrefixArgs.entries()) {
+    if (typeof value !== "string" || !value.startsWith("/") || !value.endsWith("/openclaw.mjs")) {
+      throw new Error(`agentCommandPrefixArgs[${index}] must be absolute`);
+    }
+    assertArgSafe(value, `agentCommandPrefixArgs[${index}]`);
+  }
   for (const [label, value] of Object.entries({
     buzzAcpPath,
     openclawPath,
@@ -149,6 +162,10 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
   const rendered = renderWorker(manifest, identityMap, aspect, tokenFile);
   const agentCommandIndex = rendered.args.indexOf("--agent-command") + 1;
   rendered.args[agentCommandIndex] = openclawPath;
+  if (agentCommandPrefixArgs.length > 0) {
+    const agentArgsIndex = rendered.args.indexOf("--agent-args") + 1;
+    rendered.args[agentArgsIndex] = [agentCommandPrefixArgs.join(","), rendered.args[agentArgsIndex]].join(",");
+  }
   const configIndex = rendered.args.indexOf("--config") + 1;
   rendered.args[configIndex] = configPath ?? `${workingDirectory}/${rendered.args[configIndex]}`;
   // launchd may reject direct execution of provenance-marked development binaries.

--- a/deploy/local/aeon-aspects/worker.mjs
+++ b/deploy/local/aeon-aspects/worker.mjs
@@ -116,9 +116,21 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
   const tokenFile = options.tokenFile ?? "/REQUIRES_FLEET/owned-token-file";
   const workingDirectory = options.workingDirectory ?? "/Volumes/AEON/Projects/buzz";
   const executablePath = options.executablePath ?? null;
-  for (const [label, value] of Object.entries({ buzzAcpPath, openclawPath, tokenFile, workingDirectory })) {
+  const openclawConfigPath = options.openclawConfigPath ?? null;
+  const openclawStateDir = options.openclawStateDir ?? null;
+  for (const [label, value] of Object.entries({
+    buzzAcpPath,
+    openclawPath,
+    tokenFile,
+    workingDirectory,
+    ...(openclawConfigPath !== null ? { openclawConfigPath } : {}),
+    ...(openclawStateDir !== null ? { openclawStateDir } : {}),
+  })) {
     if (!value.startsWith("/")) throw new Error(`${label} must be absolute`);
     assertArgSafe(value, label);
+  }
+  if ((openclawConfigPath === null) !== (openclawStateDir === null)) {
+    throw new Error("openclawConfigPath and openclawStateDir must be supplied together");
   }
   if (executablePath !== null) {
     if (!executablePath.split(":").every((entry) => entry.startsWith("/"))) {
@@ -136,8 +148,16 @@ export function renderDisabledLaunchAgent(manifest, identityMap, aspect, options
   const stdout = `/Volumes/AEON/Projects/buzz-data/logs/${aspect}.buzz-acp.log`;
   const stderr = `/Volumes/AEON/Projects/buzz-data/logs/${aspect}.buzz-acp.err.log`;
   const argsXml = argv.map((arg) => `    <string>${xml(arg)}</string>`).join("\n");
-  const environmentXml = executablePath
-    ? `\n  <key>EnvironmentVariables</key>\n  <dict><key>PATH</key><string>${xml(executablePath)}</string></dict>`
+  const environment = {
+    ...(executablePath ? { PATH: executablePath } : {}),
+    ...(openclawConfigPath ? { OPENCLAW_CONFIG_PATH: openclawConfigPath } : {}),
+    ...(openclawStateDir ? { OPENCLAW_STATE_DIR: openclawStateDir } : {}),
+  };
+  const environmentEntries = Object.entries(environment)
+    .map(([key, value]) => `<key>${key}</key><string>${xml(value)}</string>`)
+    .join("");
+  const environmentXml = environmentEntries
+    ? `\n  <key>EnvironmentVariables</key>\n  <dict>${environmentEntries}</dict>`
     : "";
   return {
     aspect,

--- a/deploy/local/aeon-aspects/worker.test.mjs
+++ b/deploy/local/aeon-aspects/worker.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import fs from "node:fs";
+import { correlateReceipt, loadJson, renderDisabledLaunchAgent, renderWorker, validateManifest } from "./worker.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const manifest = loadJson(join(here, "workers.json"));
+const identityMap = loadJson(manifest.identityMap);
+
+test("six-worker manifest matches the AEON identity map", () => {
+  const result = validateManifest(manifest, identityMap);
+  assert.equal(result.ok, true, result.errors.join("\n"));
+  assert.equal(manifest.workers.length, 6);
+  assert.match(result.warnings[0], /avatar metadata is absent/);
+});
+
+test("every rendered worker is disabled and binds an existing fixed session", () => {
+  for (const worker of manifest.workers) {
+    const rendered = renderWorker(manifest, identityMap, worker.aspect, "/owned/gateway.token");
+    const argv = rendered.args.join(" ");
+    assert.equal(rendered.enabled, false);
+    assert.equal(rendered.supervisor.runAtLoad, false);
+    assert.equal(rendered.supervisor.restartOnFailure, false);
+    assert.match(argv, /--no-memory/);
+    assert.match(argv, /--no-base-prompt/);
+    assert.match(argv, /--respond-to owner-only/);
+    assert.match(argv, /--allowed-respond-to owner-only/);
+    assert.match(argv, /--agents 1/);
+    assert.match(argv, /--dedup queue/);
+    assert.match(argv, /--multiple-event-handling queue/);
+    assert.match(argv, /--relay-observer/);
+    assert.match(argv, /--permission-mode bypass-permissions/);
+    assert.match(argv, /--heartbeat-interval 0/);
+    assert.match(argv, /--turn-liveness-secs 10/);
+    assert.match(argv, /--idle-timeout 900/);
+    assert.match(argv, /--max-turn-duration 7200/);
+    assert.match(argv, /--context-message-limit 12/);
+    assert.match(argv, /--max-turns-per-session 0/);
+    assert.match(argv, /--turn-receipts/);
+    assert.doesNotMatch(argv, /--no-presence|--no-typing|--no-ignore-self/);
+    assert.doesNotMatch(argv, /--mcp-command|--model|--system-prompt|--team-instructions|--initial-message/);
+    assert.match(argv, new RegExp(`--expected-gateway-session-key ${worker.sessionKey}`));
+    assert.match(argv, new RegExp(`--private-key-file ${identityMap.members[worker.aspect].secret_ref}`));
+    assert.match(argv, new RegExp(`--expected-public-key ${worker.pubkey}`));
+    assert.match(argv, /--agent-args acp,--session,agent:[a-z]+:buzz-private,--require-existing,--token-file,\/owned\/gateway.token,--url,ws:\/\/127.0.0.1:18806,--provenance,meta\+receipt,--no-prefix-cwd/);
+  }
+});
+
+test("six deterministic LaunchAgent previews are disabled and secret-free", () => {
+  const labels = new Set();
+  for (const worker of manifest.workers) {
+    const first = renderDisabledLaunchAgent(manifest, identityMap, worker.aspect);
+    const second = renderDisabledLaunchAgent(manifest, identityMap, worker.aspect);
+    assert.deepEqual(second, first);
+    assert.equal(first.runAtLoad, false);
+    assert.equal(first.keepAlive, false);
+    assert.deepEqual(first.tokenFileContract, {
+      absolute: true,
+      regular: true,
+      symlink: false,
+      owner: "current-user",
+      mode: "0600",
+    });
+    assert.match(first.plist, /<key>RunAtLoad<\/key><false\/>/);
+    assert.match(first.plist, /<key>KeepAlive<\/key><false\/>/);
+    assert.match(first.plist, /\/REQUIRES_FLEET\/immutable-openclaw\/bin\/openclaw/);
+    assert.match(first.plist, /\/REQUIRES_FLEET\/owned-token-file/);
+    assert.doesNotMatch(first.plist, /nsec1|BUZZ_PRIVATE_KEY=/);
+    assert.deepEqual(first.rollback, ["launchctl", "bootout", `gui/<uid>/${first.label}`]);
+    labels.add(first.label);
+  }
+  assert.equal(labels.size, 6);
+});
+
+test("LaunchAgent rendering rejects unsafe or relative runtime paths", () => {
+  assert.throws(
+    () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", { tokenFile: "relative.token" }),
+    /must be absolute/,
+  );
+  assert.throws(
+    () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", { openclawPath: "/bad,command" }),
+    /forbidden delimiter/,
+  );
+});
+
+test("worker restart renders the identical require-existing Gateway binding", () => {
+  const first = renderWorker(manifest, identityMap, "nexus", "/owned/gateway.token");
+  const restarted = renderWorker(manifest, identityMap, "nexus", "/owned/gateway.token");
+  assert.deepEqual(restarted, first);
+  assert.match(first.args.join(" "), /--session,agent:main:buzz-private,--require-existing/);
+});
+
+test("Nexus activation is not coupled to the legacy aeon-buzz bridge", () => {
+  const rendered = renderWorker(manifest, identityMap, "nexus");
+  const serialized = JSON.stringify(rendered);
+  assert.doesNotMatch(serialized, /aeon-buzz/);
+  assert.equal(rendered.sessionKey, "agent:main:buzz-private");
+});
+
+test("each room config enforces Architect-only private and huddle rules", () => {
+  for (const worker of manifest.workers) {
+    const source = fs.readFileSync(join(here, "config", `${worker.aspect}.toml`), "utf8");
+    assert.match(source, new RegExp(worker.privateChannelId));
+    assert.equal((source.match(/kinds = \[9, 40002\]/g) ?? []).length, 2);
+    assert.equal((source.match(/require_exact_channel_tag = true/g) ?? []).length, 2);
+    assert.match(source, /require_mention = false/);
+    assert.match(source, /admit_invited_ephemeral = true/);
+    assert.match(source, /require_mention = true/);
+    assert.equal((source.match(new RegExp(manifest.buzz.architectPubkey, "g")) ?? []).length, 2);
+    assert.doesNotMatch(source, new RegExp(manifest.buzz.conciliumChannelId));
+  }
+});
+
+test("receipt correlation joins one request, one anchored reply, session, and run", () => {
+  assert.deepEqual(
+    correlateReceipt({
+      triggeringEventIds: ["request-1"],
+      replyEvents: [{ eventId: "reply-1", replyTo: "request-1" }],
+      sessionKey: "agent:main:buzz-private",
+      runId: "run-1"
+    }),
+    {
+      requestEventId: "request-1",
+      replyEventId: "reply-1",
+      gatewaySessionKey: "agent:main:buzz-private",
+      runId: "run-1"
+    }
+  );
+});
+
+test("receipt correlation fails closed on zero or duplicate replies", () => {
+  const base = { triggeringEventIds: ["request-1"], sessionKey: "session", runId: "run" };
+  assert.throws(() => correlateReceipt({ ...base, replyEvents: [] }), /found 0/);
+  assert.throws(
+    () => correlateReceipt({ ...base, replyEvents: [
+      { eventId: "reply-1", replyTo: "request-1" },
+      { eventId: "reply-2", replyTo: "request-1" }
+    ] }),
+    /found 2/
+  );
+});

--- a/deploy/local/aeon-aspects/worker.test.mjs
+++ b/deploy/local/aeon-aspects/worker.test.mjs
@@ -171,6 +171,7 @@ test("Fleet can use a system launcher while retaining the exact Buzz binary", ()
 test("Fleet can keep launchd-owned paths local while Buzz reads its canonical config", () => {
   const rendered = renderDisabledLaunchAgent(manifest, identityMap, "nexus", {
     workingDirectory: "/Users/operator",
+    privateKeyFile: "/Users/operator/Library/Application Support/AEON/secrets/nexus.sk",
     configPath: "/Volumes/AEON/Projects/buzz/deploy/local/aeon-aspects/config/nexus.toml",
     stdoutPath: "/Users/operator/Library/Logs/AEON/nexus.buzz-acp.log",
     stderrPath: "/Users/operator/Library/Logs/AEON/nexus.buzz-acp.err.log",
@@ -178,6 +179,10 @@ test("Fleet can keep launchd-owned paths local while Buzz reads its canonical co
   assert.equal(
     rendered.argv[rendered.argv.indexOf("--config") + 1],
     "/Volumes/AEON/Projects/buzz/deploy/local/aeon-aspects/config/nexus.toml",
+  );
+  assert.equal(
+    rendered.argv[rendered.argv.indexOf("--private-key-file") + 1],
+    "/Users/operator/Library/Application Support/AEON/secrets/nexus.sk",
   );
   assert.match(rendered.plist, /<key>WorkingDirectory<\/key><string>\/Users\/operator<\/string>/);
   assert.match(rendered.plist, /<key>StandardOutPath<\/key><string>\/Users\/operator\/Library\/Logs\/AEON\/nexus\.buzz-acp\.log<\/string>/);

--- a/deploy/local/aeon-aspects/worker.test.mjs
+++ b/deploy/local/aeon-aspects/worker.test.mjs
@@ -34,6 +34,7 @@ test("every rendered worker is disabled and binds an existing fixed session", ()
     assert.match(argv, /--dedup queue/);
     assert.match(argv, /--multiple-event-handling queue/);
     assert.match(argv, /--relay-observer/);
+    assert.match(argv, /--trusted-inbound-envelope/);
     assert.match(argv, /--permission-mode bypass-permissions/);
     assert.match(argv, /--heartbeat-interval 0/);
     assert.match(argv, /--turn-liveness-secs 10/);

--- a/deploy/local/aeon-aspects/worker.test.mjs
+++ b/deploy/local/aeon-aspects/worker.test.mjs
@@ -105,6 +105,17 @@ test("LaunchAgent rendering rejects unsafe or relative runtime paths", () => {
     () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", { executablePath: "bin:/usr/bin" }),
     /entries must be absolute/,
   );
+  assert.throws(
+    () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", { openclawStateDir: "/state" }),
+    /must be supplied together/,
+  );
+  assert.throws(
+    () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", {
+      openclawConfigPath: "",
+      openclawStateDir: "/state",
+    }),
+    /must be absolute/,
+  );
 });
 
 test("Fleet can bind the immutable Node runtime without changing disabled previews", () => {
@@ -115,11 +126,15 @@ test("Fleet can bind the immutable Node runtime without changing disabled previe
   );
   const rendered = renderDisabledLaunchAgent(manifest, identityMap, "nexus", {
     executablePath: "/owned/service-runtime/bin:/usr/bin:/bin",
+    openclawConfigPath: "/owned/state/openclaw.json",
+    openclawStateDir: "/owned/state",
   });
   assert.match(
     rendered.plist,
     /<key>PATH<\/key><string>\/owned\/service-runtime\/bin:\/usr\/bin:\/bin<\/string>/,
   );
+  assert.match(rendered.plist, /<key>OPENCLAW_CONFIG_PATH<\/key><string>\/owned\/state\/openclaw.json<\/string>/);
+  assert.match(rendered.plist, /<key>OPENCLAW_STATE_DIR<\/key><string>\/owned\/state<\/string>/);
 });
 
 test("worker restart renders the identical require-existing Gateway binding", () => {

--- a/deploy/local/aeon-aspects/worker.test.mjs
+++ b/deploy/local/aeon-aspects/worker.test.mjs
@@ -35,6 +35,7 @@ test("every rendered worker is disabled and binds an existing fixed session", ()
     assert.match(argv, /--multiple-event-handling queue/);
     assert.match(argv, /--relay-observer/);
     assert.match(argv, /--trusted-inbound-envelope/);
+    assert.match(argv, /--no-agent-publisher-credentials/);
     assert.match(argv, /--permission-mode bypass-permissions/);
     assert.match(argv, /--heartbeat-interval 0/);
     assert.match(argv, /--turn-liveness-secs 10/);
@@ -72,6 +73,7 @@ test("six deterministic LaunchAgent previews are disabled and secret-free", () =
     assert.match(first.plist, /\/REQUIRES_FLEET\/immutable-openclaw\/bin\/openclaw/);
     assert.match(first.plist, /\/REQUIRES_FLEET\/owned-token-file/);
     assert.doesNotMatch(first.plist, /nsec1|BUZZ_PRIVATE_KEY=/);
+    assert.match(first.plist, /--no-agent-publisher-credentials/);
     assert.deepEqual(first.rollback, ["launchctl", "bootout", `gui/<uid>/${first.label}`]);
     labels.add(first.label);
   }

--- a/deploy/local/aeon-aspects/worker.test.mjs
+++ b/deploy/local/aeon-aspects/worker.test.mjs
@@ -7,9 +7,12 @@ import { correlateReceipt, loadJson, renderDisabledLaunchAgent, renderWorker, va
 
 const here = dirname(fileURLToPath(import.meta.url));
 const manifest = loadJson(join(here, "workers.json"));
-const identityMap = loadJson(manifest.identityMap);
+// Unit tests must be runnable by upstream contributors without the private AEON
+// vault mount. The live validator continues to load manifest.identityMap (or an
+// explicit operator-supplied path) and therefore retains its fail-closed check.
+const identityMap = loadJson(join(here, "fixtures", "identity-map.json"));
 
-test("six-worker manifest matches the AEON identity map", () => {
+test("six-worker manifest matches the synthetic identity-map contract", () => {
   const result = validateManifest(manifest, identityMap);
   assert.equal(result.ok, true, result.errors.join("\n"));
   assert.equal(manifest.workers.length, 6);

--- a/deploy/local/aeon-aspects/worker.test.mjs
+++ b/deploy/local/aeon-aspects/worker.test.mjs
@@ -110,6 +110,10 @@ test("LaunchAgent rendering rejects unsafe or relative runtime paths", () => {
     /must be absolute/,
   );
   assert.throws(
+    () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", { stdoutPath: "relative.log" }),
+    /must be absolute/,
+  );
+  assert.throws(
     () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", { openclawStateDir: "/state" }),
     /must be supplied together/,
   );
@@ -151,6 +155,21 @@ test("Fleet can use a system launcher while retaining the exact Buzz binary", ()
     rendered.plist,
     /<array>\n    <string>\/usr\/bin\/env<\/string>\n    <string>\/owned\/bin\/buzz-acp<\/string>/,
   );
+});
+
+test("Fleet can keep launchd-owned paths local while Buzz reads its canonical config", () => {
+  const rendered = renderDisabledLaunchAgent(manifest, identityMap, "nexus", {
+    workingDirectory: "/Users/operator",
+    configPath: "/Volumes/AEON/Projects/buzz/deploy/local/aeon-aspects/config/nexus.toml",
+    stdoutPath: "/Users/operator/Library/Logs/AEON/nexus.buzz-acp.log",
+    stderrPath: "/Users/operator/Library/Logs/AEON/nexus.buzz-acp.err.log",
+  });
+  assert.equal(
+    rendered.argv[rendered.argv.indexOf("--config") + 1],
+    "/Volumes/AEON/Projects/buzz/deploy/local/aeon-aspects/config/nexus.toml",
+  );
+  assert.match(rendered.plist, /<key>WorkingDirectory<\/key><string>\/Users\/operator<\/string>/);
+  assert.match(rendered.plist, /<key>StandardOutPath<\/key><string>\/Users\/operator\/Library\/Logs\/AEON\/nexus\.buzz-acp\.log<\/string>/);
 });
 
 test("worker restart renders the identical require-existing Gateway binding", () => {

--- a/deploy/local/aeon-aspects/worker.test.mjs
+++ b/deploy/local/aeon-aspects/worker.test.mjs
@@ -106,6 +106,10 @@ test("LaunchAgent rendering rejects unsafe or relative runtime paths", () => {
     /entries must be absolute/,
   );
   assert.throws(
+    () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", { launcherPath: "usr/bin/env" }),
+    /must be absolute/,
+  );
+  assert.throws(
     () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", { openclawStateDir: "/state" }),
     /must be supplied together/,
   );
@@ -135,6 +139,18 @@ test("Fleet can bind the immutable Node runtime without changing disabled previe
   );
   assert.match(rendered.plist, /<key>OPENCLAW_CONFIG_PATH<\/key><string>\/owned\/state\/openclaw.json<\/string>/);
   assert.match(rendered.plist, /<key>OPENCLAW_STATE_DIR<\/key><string>\/owned\/state<\/string>/);
+});
+
+test("Fleet can use a system launcher while retaining the exact Buzz binary", () => {
+  const rendered = renderDisabledLaunchAgent(manifest, identityMap, "nexus", {
+    buzzAcpPath: "/owned/bin/buzz-acp",
+    launcherPath: "/usr/bin/env",
+  });
+  assert.deepEqual(rendered.argv.slice(0, 2), ["/usr/bin/env", "/owned/bin/buzz-acp"]);
+  assert.match(
+    rendered.plist,
+    /<array>\n    <string>\/usr\/bin\/env<\/string>\n    <string>\/owned\/bin\/buzz-acp<\/string>/,
+  );
 });
 
 test("worker restart renders the identical require-existing Gateway binding", () => {

--- a/deploy/local/aeon-aspects/worker.test.mjs
+++ b/deploy/local/aeon-aspects/worker.test.mjs
@@ -101,6 +101,25 @@ test("LaunchAgent rendering rejects unsafe or relative runtime paths", () => {
     () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", { openclawPath: "/bad,command" }),
     /forbidden delimiter/,
   );
+  assert.throws(
+    () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", { executablePath: "bin:/usr/bin" }),
+    /entries must be absolute/,
+  );
+});
+
+test("Fleet can bind the immutable Node runtime without changing disabled previews", () => {
+  const defaultRendered = renderDisabledLaunchAgent(manifest, identityMap, "nexus");
+  assert.equal(
+    defaultRendered.plist,
+    fs.readFileSync(join(here, "launchagents", "org.aeon.buzz-acp.nexus.plist"), "utf8"),
+  );
+  const rendered = renderDisabledLaunchAgent(manifest, identityMap, "nexus", {
+    executablePath: "/owned/service-runtime/bin:/usr/bin:/bin",
+  });
+  assert.match(
+    rendered.plist,
+    /<key>PATH<\/key><string>\/owned\/service-runtime\/bin:\/usr\/bin:\/bin<\/string>/,
+  );
 });
 
 test("worker restart renders the identical require-existing Gateway binding", () => {

--- a/deploy/local/aeon-aspects/worker.test.mjs
+++ b/deploy/local/aeon-aspects/worker.test.mjs
@@ -114,6 +114,17 @@ test("LaunchAgent rendering rejects unsafe or relative runtime paths", () => {
     /must be absolute/,
   );
   assert.throws(
+    () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", { agentCommandPrefixArgs: ["relative.mjs"] }),
+    /must be absolute/,
+  );
+  assert.throws(
+    () =>
+      renderDisabledLaunchAgent(manifest, identityMap, "nexus", {
+        agentCommandPrefixArgs: ["/immutable/a/openclaw.mjs", "/immutable/b/openclaw.mjs"],
+      }),
+    /exactly one/,
+  );
+  assert.throws(
     () => renderDisabledLaunchAgent(manifest, identityMap, "nexus", { openclawStateDir: "/state" }),
     /must be supplied together/,
   );
@@ -170,6 +181,18 @@ test("Fleet can keep launchd-owned paths local while Buzz reads its canonical co
   );
   assert.match(rendered.plist, /<key>WorkingDirectory<\/key><string>\/Users\/operator<\/string>/);
   assert.match(rendered.plist, /<key>StandardOutPath<\/key><string>\/Users\/operator\/Library\/Logs\/AEON\/nexus\.buzz-acp\.log<\/string>/);
+});
+
+test("Fleet can launch immutable OpenClaw through a local Node identity", () => {
+  const rendered = renderDisabledLaunchAgent(manifest, identityMap, "nexus", {
+    openclawPath: "/owned/bin/openclaw",
+    agentCommandPrefixArgs: ["/immutable/generation/openclaw.mjs"],
+  });
+  assert.equal(rendered.argv[rendered.argv.indexOf("--agent-command") + 1], "/owned/bin/openclaw");
+  assert.equal(
+    rendered.argv[rendered.argv.indexOf("--agent-args") + 1],
+    "/immutable/generation/openclaw.mjs,acp,--session,agent:main:buzz-private,--require-existing,--token-file,/REQUIRES_FLEET/owned-token-file,--url,ws://127.0.0.1:18806,--provenance,meta+receipt,--no-prefix-cwd",
+  );
 });
 
 test("worker restart renders the identical require-existing Gateway binding", () => {

--- a/deploy/local/aeon-aspects/worker.test.mjs
+++ b/deploy/local/aeon-aspects/worker.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -7,9 +8,8 @@ import { correlateReceipt, loadJson, renderDisabledLaunchAgent, renderWorker, va
 
 const here = dirname(fileURLToPath(import.meta.url));
 const manifest = loadJson(join(here, "workers.json"));
-// Unit tests must be runnable by upstream contributors without the private AEON
-// vault mount. The live validator continues to load manifest.identityMap (or an
-// explicit operator-supplied path) and therefore retains its fail-closed check.
+// Source checks must be runnable by upstream contributors without the private
+// AEON vault mount. Operators can still supply an explicit identity-map path.
 const identityMap = loadJson(join(here, "fixtures", "identity-map.json"));
 
 test("six-worker manifest matches the synthetic identity-map contract", () => {
@@ -76,6 +76,20 @@ test("six deterministic LaunchAgent previews are disabled and secret-free", () =
     labels.add(first.label);
   }
   assert.equal(labels.size, 6);
+});
+
+test("no-argument LaunchAgent renderer uses the checked-in identity fixture", () => {
+  const output = execFileSync(process.execPath, [join(here, "render-launchagents.mjs")], {
+    cwd: here,
+    encoding: "utf8",
+  });
+  const rendered = JSON.parse(output);
+  assert.equal(rendered.schema, "aeon_disabled_launchagents_v1");
+  assert.equal(Object.keys(rendered.artifacts).length, 6);
+  for (const worker of manifest.workers) {
+    const expected = renderDisabledLaunchAgent(manifest, identityMap, worker.aspect);
+    assert.equal(rendered.artifacts[`${expected.label}.plist`], expected.plist);
+  }
 });
 
 test("LaunchAgent rendering rejects unsafe or relative runtime paths", () => {

--- a/deploy/local/aeon-aspects/workers.json
+++ b/deploy/local/aeon-aspects/workers.json
@@ -1,0 +1,49 @@
+{
+  "schema": "aeon_buzz_acp_workers_v1",
+  "enabled": false,
+  "identityMap": "/Volumes/AEON/aeon-vault/aeon-v6-workspace/contracts/buzz/identity-map.json",
+  "gateway": {
+    "url": "ws://127.0.0.1:18806",
+    "tokenFileEnv": "AEON_GATEWAY_TOKEN_FILE",
+    "tokenFileContract": {"absolute":true,"regular":true,"symlink":false,"owner":"current-user","mode":"0600"},
+    "provenance": "meta+receipt"
+  },
+  "buzz": {
+    "relayUrl": "ws://localhost:3000",
+    "architectPubkey": "73ac8798fd9cedcc5d24645d7ed49332d94a28f2c937f4c1b638f92bf6e8e91f",
+    "conciliumChannelId": "4ac1cee0-2238-483f-b25b-f99ec17eec46"
+  },
+  "posture": {
+    "agents": 1,
+    "respondTo": "owner-only",
+    "allowedRespondTo": ["owner-only"],
+    "memory": false,
+    "basePrompt": false,
+    "dedup": "queue",
+    "multipleEventHandling": "queue",
+    "presence": true,
+    "typing": true,
+    "relayObserver": true,
+    "permissionMode": "bypass-permissions",
+    "heartbeatIntervalSecs": 0,
+    "turnLivenessSecs": 10,
+    "idleTimeoutSecs": 900,
+    "maxTurnDurationSecs": 7200,
+    "contextMessageLimit": 12,
+    "maxTurnsPerSession": 0
+  },
+  "supervisor": {
+    "startOnAppLaunch": false,
+    "runAtLoad": false,
+    "restartOnFailure": false,
+    "throttleSeconds": 10
+  },
+  "workers": [
+    {"aspect":"nexus","displayName":"Nexus","gatewayAgentId":"main","sessionKey":"agent:main:buzz-private","privateChannelId":"7e8c4840-d401-4701-afc9-7ae7174cfc4e","pubkey":"ca2bce90e858e12f399f7b4cd510b5fce74e4238352229ada47b8bdd1a7f3b97"},
+    {"aspect":"mechanon","displayName":"Mechanon","gatewayAgentId":"mechanon","sessionKey":"agent:mechanon:buzz-private","privateChannelId":"7d022bea-5e81-4d18-bd2e-176e9eda1971","pubkey":"44437bd6007641845f154bdb7698b1627745b0a1b1d9bdfcf4826fe82a37ca9d"},
+    {"aspect":"fontis","displayName":"Fontis","gatewayAgentId":"fontis","sessionKey":"agent:fontis:buzz-private","privateChannelId":"600cb602-ff2a-422b-bdb2-6353bb81100d","pubkey":"3672ca65abf6b12effaf57475ce31260a4bc96e6d3acf01b909f9c2a44542147"},
+    {"aspect":"sapientis","displayName":"Sapientis","gatewayAgentId":"sapientis","sessionKey":"agent:sapientis:buzz-private","privateChannelId":"4e9f115c-cf8d-4abe-a085-c2b2c64ef2c2","pubkey":"1b7ddc51e6e7d688cd1816047b3ec35e7460014bf146813a505fee851e8b0d89"},
+    {"aspect":"viatica","displayName":"Viatica","gatewayAgentId":"viatica","sessionKey":"agent:viatica:buzz-private","privateChannelId":"39560f3c-f638-41a1-945b-ed5400ec41fc","pubkey":"89a2f2679f83cd9033582f023a3b92e01ed2b5950587efae565045ae65bd03cc"},
+    {"aspect":"voxis","displayName":"Voxis","gatewayAgentId":"voxis","sessionKey":"agent:voxis:buzz-private","privateChannelId":"d00b15e9-0dbe-4f35-895e-b6d36faa299e","pubkey":"e2b124c4728989a09d0f7df96cd2b1823635cc220ed9cdd4f97eaedc12a17fe4"}
+  ]
+}

--- a/deploy/local/aeon-aspects/workers.json
+++ b/deploy/local/aeon-aspects/workers.json
@@ -24,6 +24,7 @@
     "presence": true,
     "typing": true,
     "relayObserver": true,
+    "trustedInboundEnvelope": true,
     "permissionMode": "bypass-permissions",
     "heartbeatIntervalSecs": 0,
     "turnLivenessSecs": 10,

--- a/desktop/src-tauri/src/archive/mod_tests.rs
+++ b/desktop/src-tauri/src/archive/mod_tests.rs
@@ -717,6 +717,110 @@ fn test_owner_p_24200_still_routes_to_ephemeral() {
     );
 }
 
+/// The archive persistence path retains a closed ACP receipt as the exact
+/// signed observer frame after the database is reopened.
+#[test]
+fn test_closed_turn_receipt_archives_exact_signed_frame() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().join("archive.db");
+    let owner_keys = Keys::generate();
+    let agent_keys = Keys::generate();
+    let owner_pk = owner_keys.public_key().to_hex();
+    let agent_pk = agent_keys.public_key().to_hex();
+    let relay_url = "wss://relay.example";
+    let request_event_id = "11".repeat(32);
+    let reply_event_id = "22".repeat(32);
+
+    let conn = store::open_archive_db(&db_path).expect("open archive db");
+    add_sub(&conn, &owner_pk, relay_url, "owner_p", &owner_pk, "[24200]");
+
+    let receipt = serde_json::json!({
+        "seq": 42,
+        "timestamp": "2026-07-22T20:25:04Z",
+        "kind": "turn_receipt",
+        "agentIndex": 0,
+        "channelId": "00000000-0000-4000-8000-000000000001",
+        "sessionId": "00000000-0000-4000-8000-000000000002",
+        "turnId": "5dc7e9cf-f30f-49bf-b7fc-e424afad2d3f",
+        "startedAt": "2026-07-22T20:24:00Z",
+        "payload": {
+            "status": "closed",
+            "schemaVersion": 1,
+            "requestEventId": request_event_id.clone(),
+            "replyEventId": reply_event_id,
+            "replyAnchor": request_event_id,
+            "gatewaySessionKey": "agent:main:buzz-private",
+            "expectedGatewaySessionKey": "agent:main:buzz-private",
+            "runId": "00000000-0000-4000-8000-000000000003",
+            "acpSessionId": "00000000-0000-4000-8000-000000000002",
+            "turnId": "5dc7e9cf-f30f-49bf-b7fc-e424afad2d3f"
+        }
+    });
+    let encrypted = buzz_core_pkg::observer::encrypt_observer_payload(
+        &agent_keys,
+        &owner_keys.public_key(),
+        &receipt,
+    )
+    .expect("encrypt receipt");
+    let event = buzz_sdk_pkg::build_agent_observer_frame(
+        &owner_pk,
+        &agent_pk,
+        OBSERVER_FRAME_TELEMETRY,
+        &encrypted,
+    )
+    .expect("build receipt frame")
+    .sign_with_keys(&agent_keys)
+    .expect("sign receipt frame");
+    let signed_json = event.as_json();
+
+    let result = run_batch_sync_with_keys(
+        vec![candidate(&event, ScopeType::OwnerP, &owner_pk)],
+        &owner_pk,
+        relay_url,
+        &conn,
+        Vec::new(),
+        &owner_keys,
+    );
+    assert_eq!(result.persisted, 1);
+    assert_eq!(result.dropped, 0);
+    drop(conn);
+
+    let read_conn = store::open_archive_db(&db_path).expect("reopen archive db");
+    let (kind, author, raw_json): (i64, String, String) = read_conn
+        .query_row(
+            "SELECT kind, pubkey, raw_json FROM archived_events
+             WHERE identity_pubkey = ?1 AND relay_url = ?2 AND id = ?3",
+            rusqlite::params![owner_pk, relay_url, event.id.to_hex()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("read archived receipt");
+    assert_eq!(kind, 24200);
+    assert_eq!(author, agent_pk);
+    assert_eq!(
+        raw_json, signed_json,
+        "archive must retain the signed frame"
+    );
+    let scope_count: i64 = read_conn
+        .query_row(
+            "SELECT COUNT(*) FROM archived_event_scopes
+             WHERE identity_pubkey = ?1 AND relay_url = ?2 AND id = ?3
+               AND scope_type = 'owner_p' AND scope_value = ?1",
+            rusqlite::params![owner_pk, relay_url, event.id.to_hex()],
+            |row| row.get(0),
+        )
+        .expect("read archived receipt scope");
+    assert_eq!(scope_count, 1, "receipt must retain its owner_p scope");
+
+    let stored_event = Event::from_json(&raw_json).expect("parse archived frame");
+    buzz_core_pkg::verify_event(&stored_event).expect("verify archived signature");
+    assert_eq!(stored_event.id, event.id);
+    let decoded: serde_json::Value =
+        buzz_core_pkg::observer::decrypt_observer_payload(&owner_keys, &stored_event)
+            .expect("decrypt archived receipt");
+    assert_eq!(decoded, receipt);
+    assert_eq!(decoded["payload"]["status"], "closed");
+}
+
 /// Decrypt success: plaintext payload JSON is stored, not raw ciphertext.
 #[test]
 fn test_turn_metric_decrypt_success_stores_plaintext() {


### PR DESCRIPTION
## HOLD — no live activation

This PR is a disabled source checkpoint for six AEON Aspect `buzz-acp` workers. It does not install, load, start, restart, switch, or mutate any live Gateway, session, token, worker, Fleet policy, or Concilium path. It makes no Voxis, A2A, or live-canary claim.

### What it hardens

- Canonical private ephemeral-room admission: positive `ttl`, valid future `ttl_deadline`, deterministic latest kind-39000 selection, strict singleton-tag parsing, exact `h` tag, and fail-closed revocation on expiry/archive/membership removal/query failure. Stale malformed metadata can recover through a newer valid canonical event; malformed canonical or unorderable evidence remains closed.
- Runtime receipt correlation from triggering request through ACP evidence to one cryptographically verified reply using exactly one canonical prompt anchor; delayed duplicates fail closed. Thread-root follow-ups reuse their effective root anchor while an exact pre-turn event-ID baseline excludes replies from earlier turns.
- Opt-in trusted inbound-event transport: one signature-verified event is carried outside prompt text at `_meta.buzz.inboundEvent`; invalid, ambiguous, multi-event, cancelled/merged, and heartbeat turns fail closed with no envelope.
- Stable fixed Gateway sessions with `--require-existing`, `--no-memory`, and `--no-base-prompt`; Gateway remains the identity, tools, skills, memory, and compaction owner.
- Existing Buzz ACP behavior is pinned explicitly: one process, queue/queue handling, presence/typing/observer on, bounded context, heartbeat/count rotation off, timeouts fixed, and Architect-approved `bypassPermissions` posture. No Buzz MCP/model/system/team/initial prompt is injected.
- Private-office and invited-huddle rules accept the native kind-9 and kind-40002 stream-message surfaces while retaining exact room, exact `h`, Architect author, and huddle mention gates.
- One-handle `O_NOFOLLOW` Aspect key reads with current-user/0600/expected-pubkey checks.
- Six deterministic, secret-free LaunchAgent previews with `RunAtLoad=false`, `KeepAlive=false`, Fleet placeholders, and one-worker rollback labels.
- Real six-TOML `load_rules()` and Clap parsing tests plus package validators. Receipt mode now requires verified owner authority before startup, and no-argument LaunchAgent rendering uses the checked-in OSS fixture.

### Proof

- `node --test deploy/local/aeon-aspects/worker.test.mjs` — 10/10
- `node deploy/local/aeon-aspects/validate.mjs` — OK
- `cargo test -p buzz-acp` — 602/602, including canonical metadata ambiguity/recovery, stable-thread-root receipt isolation, two-turn thread-root, top-level-DM, and trusted-envelope contracts
- `cargo clippy -p buzz-acp --all-targets -- -D warnings` — green
- `just ci` — format, workspace clippy, Desktop/web/mobile checks, Rust/JS tests, Desktop/Tauri builds, and mobile tests green on final head
- pre-push `rust-tests`, `desktop-tauri-test`, and branch-skew — green
- `git diff --check` — clean
- `detect-secrets` + manual changed/generated-file scan — no secrets; reported examples/test hex only
- All currently submitted automated review threads are addressed and resolved on the current head.

### Does not prove / resume blockers

- The AEON-v6 ACP run-ID/trusted per-run tool-context and Nexus reply-tool counterparts are accepted source commits awaiting Fleet's joined main checkpoint; they are not proven in a live immutable generation.
- The fixed Nexus session's caller-bound outbound Buzz publisher/signing path is source-reviewed but not yet proven live.
- Exact live relay membership is not proven by the identity-map declaration.
- Cross-process exactly-once is not durable; unattended restart therefore remains disabled.
- Kind-48106 huddle guideline delivery, broad avatar metadata, and spoken-huddle proof remain open.
- Workflow approval/multi-room behavior, media mutations, Concilium speech, broad A2A speech, and the other five live workers remain outside the Nexus text canary.

### Nexus-only resume checklist

After Fleet releases the runtime lock, all of these are required before requesting a separate Architect Nexus-only canary GO:

1. Supply the immutable Gateway generation identity and immutable OpenClaw binary path.
2. Prove pre-existing `agent:main:buzz-private` and current `openclaw acp --require-existing` flag behavior.
3. Supply the owned token-file path and read back: absolute, regular, non-symlink, current-user owner, mode 0600.
4. Supply an ACP wire fixture with fixed `sessionKey` and a fresh per-prompt `runId`.
5. Prove a caller-bound Nexus-session outbound Buzz publisher that cannot select an arbitrary Aspect and emits a Nexus-signed exact reply anchor.
6. Verify the live Nexus private room contains exactly Architect and Nexus.
7. Confirm the legacy `aeon-buzz` reply path is disabled and no Gateway switch/restart/validation is in progress.
8. Render replacements for Nexus only, start one worker only, perform one request/reply, retain both event IDs + session key + run ID, and materialize the receipt.
9. Roll back only `org.aeon.buzz-acp.nexus` if any proof fails.

The other five workers remain disabled and require separate later authorization.
