### PR TITLE
fix(relay): preserve multi-channel workflow queries

### DIFF
--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -271,27 +271,24 @@ pub async fn handle_req(
         .iter()
         .enumerate()
         .map(|(idx, filter)| {
+            let requested_channels = extract_channel_ids_from_filter(filter);
             // Use per-filter #h channel scope when available, falling back to the
             // subscription-level channel_id. This prevents unrelated accessible-channel
             // rows from consuming the LIMIT when filters target specific channels but
             // the subscription is global (multiple distinct #h values across filters).
-            let per_filter_channel = {
-                let h = nostr::SingleLetterTag::lowercase(nostr::Alphabet::H);
-                filter
-                    .generic_tags
-                    .get(&h)
-                    .and_then(|vs| {
-                        if vs.len() == 1 {
-                            vs.iter().next()?.parse::<uuid::Uuid>().ok()
-                        } else {
-                            None
-                        }
-                    })
-                    .or(channel_id)
-            };
+            let per_filter_channel = extract_channel_id_from_filter(filter).or(channel_id);
             let mut params =
                 filter_to_query_params(filter, per_filter_channel, conn.tenant.community());
-            apply_access_scope_to_query(&mut params, per_filter_channel, &accessible_channels);
+            if requested_channels.is_empty() {
+                apply_access_scope_to_query(&mut params, per_filter_channel, &accessible_channels);
+            } else {
+                apply_requested_access_scope_to_query(
+                    &mut params,
+                    per_filter_channel,
+                    &accessible_channels,
+                    &requested_channels,
+                );
+            }
             (idx, per_filter_channel, params)
         })
         .collect();
@@ -847,6 +844,18 @@ fn extract_channel_id_from_filter(filter: &Filter) -> Option<uuid::Uuid> {
     extract_channel_id_from_filters(std::slice::from_ref(filter))
 }
 
+/// Extract every valid channel UUID requested by one filter.
+fn extract_channel_ids_from_filter(filter: &Filter) -> Vec<uuid::Uuid> {
+    let h = nostr::SingleLetterTag::lowercase(nostr::Alphabet::H);
+    filter
+        .generic_tags
+        .get(&h)
+        .into_iter()
+        .flatten()
+        .filter_map(|value| value.parse::<uuid::Uuid>().ok())
+        .collect()
+}
+
 /// Convert a single NIP-01 filter into an [`EventQuery`] for the database.
 ///
 /// Each filter is queried independently so that per-filter `limit` and time
@@ -991,6 +1000,24 @@ pub(crate) fn apply_access_scope_to_query(
 ) {
     if channel_id.is_none() {
         query.channel_ids = Some(accessible_channels.to_vec());
+    }
+}
+
+/// Push only explicitly requested channels that the caller may access.
+fn apply_requested_access_scope_to_query(
+    query: &mut EventQuery,
+    channel_id: Option<uuid::Uuid>,
+    accessible_channels: &[uuid::Uuid],
+    requested_channels: &[uuid::Uuid],
+) {
+    if channel_id.is_none() {
+        query.channel_ids = Some(
+            requested_channels
+                .iter()
+                .copied()
+                .filter(|channel| accessible_channels.contains(channel))
+                .collect(),
+        );
     }
 }
 
@@ -1253,6 +1280,22 @@ mod tests {
 
         assert!(query.channel_ids.is_none());
         assert_eq!(query.channel_id, Some(channel));
+    }
+
+    #[test]
+    fn multi_channel_filters_push_requested_accessible_scope_before_limit() {
+        let requested_accessible = uuid::Uuid::new_v4();
+        let requested_inaccessible = uuid::Uuid::new_v4();
+        let unrelated_accessible = uuid::Uuid::new_v4();
+        let accessible = vec![requested_accessible, unrelated_accessible];
+        let requested = vec![requested_accessible, requested_inaccessible];
+        let mut query = EventQuery::for_community(buzz_core::tenant::CommunityId::from_uuid(
+            uuid::Uuid::new_v4(),
+        ));
+
+        apply_requested_access_scope_to_query(&mut query, None, &accessible, &requested);
+
+        assert_eq!(query.channel_ids, Some(vec![requested_accessible]));
     }
 
     /// S2 invariant: the bounded-concurrency pipeline (phase 2) must yield

--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -838,19 +838,13 @@ fn filters_are_nip43_membership_only(filters: &[Filter]) -> bool {
         })
 }
 
-/// Extract a channel UUID from a single filter's `#h` tag.
+/// Extract a channel UUID when a single filter targets exactly one channel.
+///
+/// Multiple distinct `#h` values cannot be represented by the single-channel
+/// SQL predicate, so they fall back to the accessible-channel query and Nostr
+/// post-filtering.
 fn extract_channel_id_from_filter(filter: &Filter) -> Option<uuid::Uuid> {
-    for (tag_key, tag_values) in filter.generic_tags.iter() {
-        let key = tag_key.to_string();
-        if key == "h" {
-            for val in tag_values {
-                if let Ok(id) = val.parse::<uuid::Uuid>() {
-                    return Some(id);
-                }
-            }
-        }
-    }
-    None
+    extract_channel_id_from_filters(std::slice::from_ref(filter))
 }
 
 /// Convert a single NIP-01 filter into an [`EventQuery`] for the database.
@@ -1405,6 +1399,18 @@ mod tests {
         let channel_id = uuid::Uuid::new_v4();
         let filters = vec![filter_with_channel(channel_id)];
         assert_eq!(extract_channel_id_from_filters(&filters), Some(channel_id));
+    }
+
+    #[test]
+    fn test_extract_channel_id_from_filter_multiple_channels_is_not_pushed_down() {
+        let channel_a = uuid::Uuid::new_v4();
+        let channel_b = uuid::Uuid::new_v4();
+        let filter = Filter::new().custom_tags(
+            SingleLetterTag::lowercase(Alphabet::H),
+            [channel_a.to_string(), channel_b.to_string()],
+        );
+
+        assert_eq!(extract_channel_id_from_filter(&filter), None);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Stop collapsing a multi-channel `#h` filter into a single channel predicate.
- Intersect explicitly requested channels with the caller's accessible channels before the SQL limit is applied.
- Add regressions for multi-channel extraction and access scoping.

## Why

Desktop batches the Workflows overview into one Nostr filter containing every member channel. The HTTP relay bridge previously selected one `#h` value for SQL pushdown, so workflows in every other requested channel were filtered out. A broad fallback alone was also insufficient because unrelated accessible-channel rows could consume the query limit before requested rows reached Nostr post-filtering.

This made valid workflows invisible in Desktop even though direct single-channel workflow queries could retrieve them.

## User impact

The Workflows overview can list workflows across all accessible channels in one request, including workflows created by agents in DMs. Single-channel queries keep their existing fast path.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p buzz-relay --all-targets -- -D warnings`
- `cargo test -p buzz-relay --lib -- --skip api::mesh_demo::tests::demo_join_forwarded_arm_round_trips_echo` — 717 passed, 23 ignored, 1 filtered out
- `./scripts/check-branch-skew.sh`

The unfiltered relay package run had one unrelated existing failure: `api::mesh_demo::tests::demo_join_forwarded_arm_round_trips_echo` returned 504 instead of 200. All changed request-filter tests passed.
