### PR TITLE
fix(desktop): remove bundled libsystemd from AppImage

### DIFF
--- a/desktop/scripts/fix-appimage.sh
+++ b/desktop/scripts/fix-appimage.sh
@@ -88,7 +88,7 @@ if ! compgen -G "$LIBDIR/libwayland-client.so*" > /dev/null; then
   exit 1
 fi
 
-echo "==> Removing infra libs that conflict with system Mesa / GLib / GStreamer"
+echo "==> Removing infra libs that conflict with system Mesa / GLib / GStreamer / systemd"
 rm -f \
   "$LIBDIR"/libwayland-client.so* \
   "$LIBDIR"/libwayland-cursor.so* \
@@ -101,6 +101,7 @@ rm -f \
   "$LIBDIR"/libmount.so* \
   "$LIBDIR"/libblkid.so* \
   "$LIBDIR"/libselinux.so* \
+  "$LIBDIR"/libsystemd.so* \
   "$LIBDIR"/libpcre2-8.so* \
   "$LIBDIR"/libgst*.so* \
   "$LIBDIR"/libzstd.so* \


### PR DESCRIPTION
## Summary
- AppImage bundles an older `libsystemd.so.0` that shadows the system copy after `libmount` is already removed
- on systemd ≥ 251 (Arch, Fedora 41+, etc.) launch fails with `LIBSYSTEMD_251` not found
- add `libsystemd.so*` to the existing removal list in `fix-appimage.sh`

Closes #2335

## Test plan
- [ ] rebuild / repack an AppImage with the updated script
- [ ] launch on a distro with systemd ≥ 251 without `LD_PRELOAD` workaround


Made with [Cursor](https://cursor.com)