### PR TITLE
fix(desktop): clarify identity key button when key exists

### DIFF
--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -157,7 +157,11 @@ export function MachineOnboardingFlow({
                   onClick={() => void loadFreshIdentity()}
                   type="button"
                 >
-                  {isPending ? "Saving identity…" : "Create a new identity key"}
+                  {isPending
+                    ? "Saving identity…"
+                    : selectedPubkey
+                      ? "Continue with existing identity key"
+                      : "Create a new identity key"}
                 </Button>
                 <Button
                   className="h-9 rounded-full bg-foreground/10 px-5 hover:bg-foreground/15"

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -158,9 +158,9 @@ export function MachineOnboardingFlow({
                   type="button"
                 >
                   {isPending
-                    ? "Saving identity…"
+                    ? "Loading identity…"
                     : selectedPubkey
-                      ? "Continue with existing identity key"
+                      ? "Continue setup"
                       : "Create a new identity key"}
                 </Button>
                 <Button
@@ -170,7 +170,9 @@ export function MachineOnboardingFlow({
                   type="button"
                   variant="ghost"
                 >
-                  Use an existing key
+                  {selectedPubkey
+                    ? "Use a different key instead"
+                    : "Use an existing key"}
                 </Button>
               </div>
               <IdentityKeyHelpDialog />

--- a/desktop/tests/e2e/onboarding-backup.spec.ts
+++ b/desktop/tests/e2e/onboarding-backup.spec.ts
@@ -85,8 +85,13 @@ test("backup step back button returns to machine identity choice", async ({
   await expect(page.getByTestId("onboarding-page-backup")).toBeVisible();
   await page.getByTestId("onboarding-back").click();
 
+  // Backing out preserves the loaded key — primary CTA continues setup rather
+  // than minting another identity (#2318).
   await expect(
-    page.getByRole("button", { name: "Create a new identity key" }),
+    page.getByRole("button", { name: "Continue setup" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Use a different key instead" }),
   ).toBeVisible();
 });
 


### PR DESCRIPTION
## Summary
- backing out of the backup step and clicking the CTA again reuses the existing key
- the button still said "Create a new identity key", which is misleading for a security-sensitive action
- when a key is already loaded, label it "Continue with existing identity key"

Closes #2318

## Test plan
- [ ] first-run: button still says "Create a new identity key"
- [ ] create key → backup → back: button says "Continue with existing identity key" and shows the same key


Made with [Cursor](https://cursor.com)