### PR TITLE
fix(desktop): allow skipping harness setup onboarding

### DIFF
--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -215,7 +215,14 @@ export function MachineOnboardingFlow({
                 back: () =>
                   setPage(identityWasImported ? "key-import" : "backup"),
                 next: (runtimeIds) => {
-                  setReadyRuntimeIds(Array.from(runtimeIds));
+                  const ids = Array.from(runtimeIds);
+                  setReadyRuntimeIds(ids);
+                  // Harness install can fail (Windows/PATH/network). Don't soft-lock
+                  // onboarding — users can finish setup later in Settings → Agents.
+                  if (ids.length === 0) {
+                    complete(selectedPubkey ?? undefined);
+                    return;
+                  }
                   setPage("config");
                 },
               }}

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -689,6 +689,16 @@ function SetupStepContent({
 
         <Button
           className="h-9 rounded-full bg-foreground/10 px-6 text-sm hover:bg-foreground/15"
+          data-testid="onboarding-setup-skip"
+          onClick={() => actions.next([])}
+          type="button"
+          variant="ghost"
+        >
+          Skip for now
+        </Button>
+
+        <Button
+          className="h-9 rounded-full bg-foreground/10 px-6 text-sm hover:bg-foreground/15"
           data-testid="onboarding-back"
           onClick={actions.back}
           type="button"


### PR DESCRIPTION
## Summary
- harness install failures left Next disabled with no way into the app
- add Skip for now on the harness setup step; empty selection finishes onboarding so users can configure agents later in Settings

Closes #2325

## Test plan
- [ ] onboarding with failed installs: Skip for now enters the app
- [ ] with a ready harness: Next still works and continues to default config


Made with [Cursor](https://cursor.com)