### PR TITLE
docs: get buzz on your phone pairing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="VISION_AGENT.md">Agents</a> ·
   <a href="ARCHITECTURE.md">Architecture</a> ·
   <a href="RELEASING.md">Releasing</a> ·
+  <a href="docs/get-buzz-on-your-phone.md">Mobile</a> ·
   <a href="LICENSE">Apache 2.0</a>
 </p>
 

--- a/docs/get-buzz-on-your-phone.md
+++ b/docs/get-buzz-on-your-phone.md
@@ -1,0 +1,38 @@
+# Get Buzz on your phone
+
+Pair the Buzz mobile app with desktop so your identity and communities show up on your phone. Pairing copies *your* identity to a device you own. To onboard someone else, send them a community invite link instead.
+
+## Install the mobile app
+
+Search your store for **Buzz — chat with your hive**:
+
+- **iOS:** App Store
+- **Android:** Google Play (`xyz.block.buzz.mobile`)
+
+Update the desktop app before pairing so both sides speak the same protocol.
+
+## Pair with desktop
+
+1. On desktop, open **Settings** (⌘, on Mac, or click your user icon in the bottom-left).
+2. Open the **Mobile** tab and click **Pair Mobile Device**. A QR code appears: “Scan this QR code with the Buzz mobile app to securely pair.”
+3. On your phone, open Buzz. On the welcome screen, tap **Scan QR Code** and point the camera at the desktop QR.
+   - No camera handy? Use **Copy pairing code** on desktop and paste it on the phone.
+4. A short **security code** appears on both screens. Confirm they match, then confirm on **both** devices. Only confirm a pairing you started yourself.
+5. When you see “Your mobile device is now paired,” your identity and communities are on the phone.
+
+## Good to know
+
+- **Codes don’t match?** Pairing cancels itself for security — start over from desktop.
+- **Pairing vs invite:** pairing copies your existing identity to another of *your* devices. Use a community **invite link** when onboarding a teammate.
+- **Push notifications** are supported on hosted communities.
+- You can pair more than one phone; each device goes through the same flow.
+
+## For workplace rollouts
+
+Hand teammates this page (or a printout) with:
+
+1. Store install links / QR codes for iOS and Android
+2. The six pairing steps above
+3. The community invite link for people who don’t already have a Buzz identity
+
+Admins: after someone joins on desktop, point them to **Settings → Mobile → Pair Mobile Device**.


### PR DESCRIPTION
## Summary
- add an end-user how-to for mobile install + desktop pairing (QR / security code)
- link it from the README so workplace rollouts have something shareable

Closes #2324

## Test plan
- [ ] skim `docs/get-buzz-on-your-phone.md` against Settings → Mobile → Pair Mobile Device copy
- [ ] README Mobile link opens the new page


Made with [Cursor](https://cursor.com)