### PR TITLE
docs: point readme at deploy compose bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Relay on `ws://localhost:3000`. Desktop app pops up. You're in.
 
 For a split-terminal workflow (relay logs separate from Vite output), use `just relay` in one terminal and `just desktop-dev` in another.
 
+Want a single-node / VPS relay instead of the local-dev stack? Use the production Compose bundle in [`deploy/compose/`](deploy/compose/README.md) (`docker compose` + Postgres, Redis, MinIO, optional Caddy/TLS). The root [`docker-compose.yml`](docker-compose.yml) is for day-to-day development only.
+
 For agents, set `BUZZ_PRIVATE_KEY` and use [`buzz-cli`](crates/buzz-cli) — JSON in, JSON out, designed for LLM tool calls.
 
 ---


### PR DESCRIPTION
## Summary
- production Compose already lives under `deploy/compose/`; root README only described the local-dev stack
- add a one-liner so VPS / single-node setups find the right bundle (follow-up to #2323)

## Test plan
- [ ] README Quick start links to `deploy/compose/README.md` and clarifies root `docker-compose.yml` is for local dev


Made with [Cursor](https://cursor.com)