### PR TITLE
feat(desktop): bring your own ACP harness (no Claude/Codex required)

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -100,16 +100,17 @@ whatever that harness expects:
 export BUZZ_ACP_AGENT_COMMAND="agent"
 export BUZZ_ACP_AGENT_ARGS="acp"
 
-# Absolute path to a custom adapter / harness (yoak, OpenCode, …)
-export BUZZ_ACP_AGENT_COMMAND="/usr/local/bin/yoak"
-export BUZZ_ACP_AGENT_ARGS="acp"
+# Absolute path to your own ACP adapter
+export BUZZ_ACP_AGENT_COMMAND="/usr/local/bin/my-acp-agent"
+export BUZZ_ACP_AGENT_ARGS=""
 
 buzz-acp
 ```
 
 In Buzz Desktop, choose **Bring your own harness** during onboarding (or
 **Custom command** under Settings → Agent defaults / Edit agent) and enter the
-same command + args. No Claude Code or Codex install is required.
+same command + args. No Claude Code or Codex install is required. The harness
+must already speak ACP — Buzz does not wrap arbitrary CLIs.
 
 ## Configuration
 

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -89,6 +89,28 @@ buzz-acp
 Older installs that still expose `claude-code-acp` are also supported. `buzz-acp`
 treats both Claude ACP command names as the same zero-arg runtime.
 
+## Running with a custom ACP harness
+
+Any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio works.
+Point `BUZZ_ACP_AGENT_COMMAND` at the binary and set `BUZZ_ACP_AGENT_ARGS` to
+whatever that harness expects:
+
+```bash
+# Cursor Agent CLI (native ACP)
+export BUZZ_ACP_AGENT_COMMAND="agent"
+export BUZZ_ACP_AGENT_ARGS="acp"
+
+# Absolute path to a custom adapter / harness (yoak, OpenCode, …)
+export BUZZ_ACP_AGENT_COMMAND="/usr/local/bin/yoak"
+export BUZZ_ACP_AGENT_ARGS="acp"
+
+buzz-acp
+```
+
+In Buzz Desktop, choose **Bring your own harness** during onboarding (or
+**Custom command** under Settings → Agent defaults / Edit agent) and enter the
+same command + args. No Claude Code or Codex install is required.
+
 ## Configuration
 
 All configuration is via environment variables (or CLI flags — every env var has a matching flag).

--- a/desktop/src-tauri/src/managed_agents/global_config/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/global_config/mod.rs
@@ -65,8 +65,22 @@ pub struct GlobalAgentConfig {
     pub model: Option<String>,
 
     /// Preferred ACP runtime for definitions without an explicit runtime.
+    ///
+    /// Use `"custom"` together with [`Self::preferred_agent_command`] when the
+    /// user brings their own ACP harness (Cursor `agent`, yoak, OpenCode, …)
+    /// instead of a catalog runtime like Claude Code or Codex.
     #[serde(default)]
     pub preferred_runtime: Option<String>,
+
+    /// Command for a bring-your-own ACP harness when `preferred_runtime` is
+    /// `"custom"` (binary name or absolute path). Ignored otherwise.
+    #[serde(default)]
+    pub preferred_agent_command: Option<String>,
+
+    /// Args for a bring-your-own ACP harness when `preferred_runtime` is
+    /// `"custom"` (e.g. `["acp"]`). Ignored otherwise.
+    #[serde(default)]
+    pub preferred_agent_args: Option<Vec<String>>,
 }
 
 /// Validate a `GlobalAgentConfig` before persisting it.
@@ -137,6 +151,55 @@ pub fn validate_global_config(config: &GlobalAgentConfig) -> Result<(), String> 
         }
     }
 
+    // Bring-your-own harness: `"custom"` requires a non-blank command.
+    let preferred = config
+        .preferred_runtime
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if preferred == Some("custom") {
+        let command = config
+            .preferred_agent_command
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("");
+        if command.is_empty() {
+            return Err(
+                "preferred_agent_command is required when preferred_runtime is \"custom\""
+                    .to_string(),
+            );
+        }
+        if command.contains('\0') {
+            return Err(
+                "global config `preferred_agent_command` must not contain NUL bytes".to_string(),
+            );
+        }
+        if command.len() > MAX_ENV_VALUE_BYTES {
+            return Err(format!(
+                "global config `preferred_agent_command` exceeds the maximum allowed length \
+                 ({} bytes)",
+                MAX_ENV_VALUE_BYTES
+            ));
+        }
+        if let Some(args) = &config.preferred_agent_args {
+            for arg in args {
+                if arg.contains('\0') {
+                    return Err(
+                        "global config `preferred_agent_args` must not contain NUL bytes"
+                            .to_string(),
+                    );
+                }
+                if arg.len() > MAX_ENV_VALUE_BYTES {
+                    return Err(format!(
+                        "global config `preferred_agent_args` exceeds the maximum allowed length \
+                         ({} bytes)",
+                        MAX_ENV_VALUE_BYTES
+                    ));
+                }
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -149,12 +212,15 @@ pub fn strip_empty_env_vars(config: &mut GlobalAgentConfig) {
     config.env_vars.retain(|_, v| !v.is_empty());
 }
 
-/// Normalize `provider` and `model` to `None` when blank or whitespace-only.
+/// Normalize blank optional fields to `None`.
 ///
 /// `Some("")` and `Some("  ")` have no meaningful value and break
 /// unset/fallback semantics (a blank provider would be treated as "provider
 /// explicitly set to nothing" rather than "inherit"). Normalizing to `None`
 /// preserves the invariant that `Some(s)` always contains a non-blank string.
+///
+/// When `preferred_runtime` is not `"custom"`, BYO command/args fields are
+/// cleared so a leftover custom pin cannot shadow a catalog preference.
 ///
 /// Called from [`save_global_agent_config`] so normalization is applied at
 /// every persist boundary.
@@ -168,6 +234,40 @@ pub fn normalize_global_config_fields(config: &mut GlobalAgentConfig) {
         if v.trim().is_empty() {
             config.model = None;
         }
+    }
+    if let Some(v) = &config.preferred_runtime {
+        if v.trim().is_empty() {
+            config.preferred_runtime = None;
+        }
+    }
+    if let Some(v) = &config.preferred_agent_command {
+        let trimmed = v.trim();
+        if trimmed.is_empty() {
+            config.preferred_agent_command = None;
+        } else if trimmed != v.as_str() {
+            config.preferred_agent_command = Some(trimmed.to_string());
+        }
+    }
+    if let Some(args) = &config.preferred_agent_args {
+        let cleaned: Vec<String> = args
+            .iter()
+            .map(|arg| arg.trim().to_string())
+            .filter(|arg| !arg.is_empty())
+            .collect();
+        config.preferred_agent_args = if cleaned.is_empty() {
+            None
+        } else {
+            Some(cleaned)
+        };
+    }
+
+    let is_custom = config
+        .preferred_runtime
+        .as_deref()
+        .is_some_and(|runtime| runtime.trim() == "custom");
+    if !is_custom {
+        config.preferred_agent_command = None;
+        config.preferred_agent_args = None;
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/global_config/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/global_config/tests.rs
@@ -258,6 +258,9 @@ fn default_config_is_all_none_empty() {
     assert!(config.env_vars.is_empty());
     assert!(config.provider.is_none());
     assert!(config.model.is_none());
+    assert!(config.preferred_runtime.is_none());
+    assert!(config.preferred_agent_command.is_none());
+    assert!(config.preferred_agent_args.is_none());
 }
 
 #[test]
@@ -267,10 +270,47 @@ fn roundtrip_serialization() {
         provider: Some("anthropic".to_string()),
         model: Some("claude-opus-4".to_string()),
         preferred_runtime: Some("claude".to_string()),
+        preferred_agent_command: None,
+        preferred_agent_args: None,
     };
     let json = serde_json::to_string(&config).expect("serialize");
     let back: GlobalAgentConfig = serde_json::from_str(&json).expect("deserialize");
     assert_eq!(config, back);
+}
+
+#[test]
+fn custom_runtime_requires_command() {
+    let missing = GlobalAgentConfig {
+        preferred_runtime: Some("custom".to_string()),
+        preferred_agent_command: None,
+        ..Default::default()
+    };
+    let err = validate_global_config(&missing).unwrap_err();
+    assert!(
+        err.contains("preferred_agent_command"),
+        "expected custom-command error, got: {err}"
+    );
+
+    let ok = GlobalAgentConfig {
+        preferred_runtime: Some("custom".to_string()),
+        preferred_agent_command: Some("agent".to_string()),
+        preferred_agent_args: Some(vec!["acp".to_string()]),
+        ..Default::default()
+    };
+    assert!(validate_global_config(&ok).is_ok());
+}
+
+#[test]
+fn normalize_clears_custom_command_when_runtime_is_catalog() {
+    let mut config = GlobalAgentConfig {
+        preferred_runtime: Some("claude".to_string()),
+        preferred_agent_command: Some("agent".to_string()),
+        preferred_agent_args: Some(vec!["acp".to_string()]),
+        ..Default::default()
+    };
+    normalize_global_config_fields(&mut config);
+    assert!(config.preferred_agent_command.is_none());
+    assert!(config.preferred_agent_args.is_none());
 }
 
 #[test]
@@ -584,6 +624,8 @@ fn populated_global_config_round_trips() {
         provider: Some("anthropic".to_string()),
         model: Some("claude-opus-4-5".to_string()),
         preferred_runtime: None,
+        preferred_agent_command: None,
+        preferred_agent_args: None,
     };
     let json = serde_json::to_string(&original).expect("serialization must not fail");
     let decoded: GlobalAgentConfig =

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -62,12 +62,17 @@ with a TypeScript lookup table or an id comparison in a component.
    via `synthesizeEmptyDiscoveryStatus()` and is intentionally **not cached**
    so that closing → reopening the dialog re-runs discovery after the user
    installs or signs into the CLI (`isCacheableDiscoveryResponse()`).
-7. **Onboarding setup detects readiness; it does not select defaults.** The
-   setup page derives visible and ready harnesses from the runtime catalog and
-   only offers install or sign-in actions. The following defaults page is the
-   sole onboarding surface that chooses and persists `preferred_runtime`.
-   `onboarding-agent-defaults.spec.ts` is the acceptance gate for anything
-   touching this flow or the shared renderer.
+7. **Onboarding setup detects readiness; it does not select catalog defaults.**
+   The setup page derives visible and ready harnesses from the runtime catalog
+   and offers install or sign-in actions for Claude Code / Codex. It also
+   offers **Bring your own harness** (`preferred_runtime: "custom"` +
+   `preferred_agent_command` / `preferred_agent_args`) so users can continue
+   without those CLIs. The following defaults page is the sole onboarding
+   surface that chooses and persists a catalog `preferred_runtime` (or revises
+   the BYO command). `custom` is a sentinel outside `KnownAcpRuntime` — it has
+   no catalog capability facts; components must not invent provider/model UI
+   for it. `onboarding-agent-defaults.spec.ts` is the acceptance gate for
+   anything touching this flow or the shared renderer.
 
 ## The tests that enforce this
 

--- a/desktop/src/features/agents/lib/agentConfigCore.test.mjs
+++ b/desktop/src/features/agents/lib/agentConfigCore.test.mjs
@@ -7,6 +7,8 @@ const config = {
   env_vars: { BUZZ_AGENT_THINKING_EFFORT: "high" },
   model: "test-model",
   preferred_runtime: null,
+  preferred_agent_command: null,
+  preferred_agent_args: null,
   provider: "anthropic",
 };
 

--- a/desktop/src/features/agents/lib/customHarness.test.mjs
+++ b/desktop/src/features/agents/lib/customHarness.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   CUSTOM_RUNTIME_ID,
+  applyCustomHarnessPreference,
   buildCustomAcpRuntime,
   formatAgentArgsInput,
   isCustomRuntimeId,
@@ -42,10 +43,30 @@ test("resolvePreferredCustomRuntime only resolves the custom sentinel", () => {
   );
   const runtime = resolvePreferredCustomRuntime({
     preferred_runtime: "custom",
-    preferred_agent_command: "yoak",
+    preferred_agent_command: "agent",
     preferred_agent_args: ["acp"],
   });
   assert.ok(runtime);
-  assert.equal(runtime.command, "yoak");
+  assert.equal(runtime.command, "agent");
   assert.equal(isCustomRuntimeId(runtime.id), true);
+});
+
+test("applyCustomHarnessPreference clears provider/model", () => {
+  const next = applyCustomHarnessPreference(
+    {
+      env_vars: { KEEP: "1" },
+      model: "opus",
+      preferred_runtime: "claude",
+      preferred_agent_command: null,
+      preferred_agent_args: null,
+      provider: "anthropic",
+    },
+    { command: " agent ", args: "acp, --x" },
+  );
+  assert.equal(next.preferred_runtime, "custom");
+  assert.equal(next.preferred_agent_command, "agent");
+  assert.deepEqual(next.preferred_agent_args, ["acp", "--x"]);
+  assert.equal(next.provider, null);
+  assert.equal(next.model, null);
+  assert.equal(next.env_vars.KEEP, "1");
 });

--- a/desktop/src/features/agents/lib/customHarness.test.mjs
+++ b/desktop/src/features/agents/lib/customHarness.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CUSTOM_RUNTIME_ID,
+  buildCustomAcpRuntime,
+  formatAgentArgsInput,
+  isCustomRuntimeId,
+  parseAgentArgsInput,
+  resolvePreferredCustomRuntime,
+} from "./customHarness.ts";
+
+test("buildCustomAcpRuntime requires a non-blank command", () => {
+  assert.equal(buildCustomAcpRuntime(""), null);
+  assert.equal(buildCustomAcpRuntime("   "), null);
+});
+
+test("buildCustomAcpRuntime synthesizes an available ACP runtime", () => {
+  const runtime = buildCustomAcpRuntime("agent", ["acp", ""]);
+  assert.ok(runtime);
+  assert.equal(runtime.id, CUSTOM_RUNTIME_ID);
+  assert.equal(runtime.command, "agent");
+  assert.deepEqual(runtime.defaultArgs, ["acp"]);
+  assert.equal(runtime.availability, "available");
+  assert.equal(runtime.authStatus.status, "not_applicable");
+});
+
+test("parse/format agent args round-trip comma lists", () => {
+  assert.deepEqual(parseAgentArgsInput("acp, --flag"), ["acp", "--flag"]);
+  assert.equal(formatAgentArgsInput(["acp", "--flag"]), "acp, --flag");
+  assert.equal(formatAgentArgsInput(null), "");
+});
+
+test("resolvePreferredCustomRuntime only resolves the custom sentinel", () => {
+  assert.equal(
+    resolvePreferredCustomRuntime({
+      preferred_runtime: "claude",
+      preferred_agent_command: "agent",
+      preferred_agent_args: ["acp"],
+    }),
+    null,
+  );
+  const runtime = resolvePreferredCustomRuntime({
+    preferred_runtime: "custom",
+    preferred_agent_command: "yoak",
+    preferred_agent_args: ["acp"],
+  });
+  assert.ok(runtime);
+  assert.equal(runtime.command, "yoak");
+  assert.equal(isCustomRuntimeId(runtime.id), true);
+});

--- a/desktop/src/features/agents/lib/customHarness.ts
+++ b/desktop/src/features/agents/lib/customHarness.ts
@@ -1,0 +1,72 @@
+import type { AcpRuntime, GlobalAgentConfig } from "@/shared/api/types";
+
+/** Sentinel preferred_runtime / selector id for a bring-your-own ACP command. */
+export const CUSTOM_RUNTIME_ID = "custom";
+
+export const CUSTOM_RUNTIME_LABEL = "Custom command";
+
+/**
+ * Build a synthetic available runtime for a user-supplied ACP command.
+ *
+ * Custom harnesses are outside the Rust `KNOWN_ACP_RUNTIMES` catalog — they
+ * have no install/auth/model capability metadata. Spawn still works because
+ * buzz-acp accepts any stdio ACP server via `BUZZ_ACP_AGENT_COMMAND`.
+ */
+export function buildCustomAcpRuntime(
+  command: string,
+  args: readonly string[] = [],
+): AcpRuntime | null {
+  const trimmed = command.trim();
+  if (!trimmed) return null;
+
+  return {
+    id: CUSTOM_RUNTIME_ID,
+    label: CUSTOM_RUNTIME_LABEL,
+    avatarUrl: "",
+    availability: "available",
+    command: trimmed,
+    binaryPath: trimmed,
+    defaultArgs: args.map((arg) => arg.trim()).filter((arg) => arg.length > 0),
+    mcpCommand: null,
+    modelEnvVar: null,
+    providerEnvVar: null,
+    thinkingEnvVar: null,
+    installHint:
+      "Point Buzz at any ACP-speaking binary (Cursor `agent`, yoak, OpenCode, …).",
+    installInstructionsUrl: "https://agentclientprotocol.com/",
+    canAutoInstall: false,
+    underlyingCliPath: null,
+    nodeRequired: false,
+    authStatus: { status: "not_applicable" },
+    loginHint: null,
+  };
+}
+
+export function isCustomRuntimeId(runtimeId: string | null | undefined) {
+  return (runtimeId ?? "").trim() === CUSTOM_RUNTIME_ID;
+}
+
+export function parseAgentArgsInput(value: string): string[] {
+  return value
+    .split(",")
+    .map((arg) => arg.trim())
+    .filter((arg) => arg.length > 0);
+}
+
+export function formatAgentArgsInput(args: readonly string[] | null | undefined) {
+  return (args ?? []).join(", ");
+}
+
+/** Resolve the effective preferred harness, including a BYO custom command. */
+export function resolvePreferredCustomRuntime(
+  config: Pick<
+    GlobalAgentConfig,
+    "preferred_runtime" | "preferred_agent_command" | "preferred_agent_args"
+  >,
+): AcpRuntime | null {
+  if (!isCustomRuntimeId(config.preferred_runtime)) return null;
+  return buildCustomAcpRuntime(
+    config.preferred_agent_command ?? "",
+    config.preferred_agent_args ?? [],
+  );
+}

--- a/desktop/src/features/agents/lib/customHarness.ts
+++ b/desktop/src/features/agents/lib/customHarness.ts
@@ -5,12 +5,17 @@ export const CUSTOM_RUNTIME_ID = "custom";
 
 export const CUSTOM_RUNTIME_LABEL = "Custom command";
 
+export type ByoHarnessDraft = {
+  args: string;
+  command: string;
+};
+
 /**
- * Build a synthetic available runtime for a user-supplied ACP command.
+ * Build a synthetic runtime for a user-supplied ACP command.
  *
- * Custom harnesses are outside the Rust `KNOWN_ACP_RUNTIMES` catalog — they
- * have no install/auth/model capability metadata. Spawn still works because
- * buzz-acp accepts any stdio ACP server via `BUZZ_ACP_AGENT_COMMAND`.
+ * Custom harnesses are outside `KNOWN_ACP_RUNTIMES`. `availability: "available"`
+ * means the user configured a command — not that PATH was probed. Spawn resolves
+ * the binary later the same way it does for any `agent_command` pin.
  */
 export function buildCustomAcpRuntime(
   command: string,
@@ -25,6 +30,8 @@ export function buildCustomAcpRuntime(
     avatarUrl: "",
     availability: "available",
     command: trimmed,
+    // Mirror command: spawn uses the command string; absolute paths work as-is,
+    // bare names are resolved on PATH at spawn time.
     binaryPath: trimmed,
     defaultArgs: args.map((arg) => arg.trim()).filter((arg) => arg.length > 0),
     mcpCommand: null,
@@ -32,7 +39,31 @@ export function buildCustomAcpRuntime(
     providerEnvVar: null,
     thinkingEnvVar: null,
     installHint:
-      "Point Buzz at any ACP-speaking binary (Cursor `agent`, yoak, OpenCode, …).",
+      "Any ACP-over-stdio binary. Buzz does not verify PATH until the agent starts.",
+    installInstructionsUrl: "https://agentclientprotocol.com/",
+    canAutoInstall: false,
+    underlyingCliPath: null,
+    nodeRequired: false,
+    authStatus: { status: "not_applicable" },
+    loginHint: null,
+  };
+}
+
+/** Placeholder catalog entry while the custom command field is still empty. */
+export function customHarnessCatalogStub(): AcpRuntime {
+  return {
+    id: CUSTOM_RUNTIME_ID,
+    label: CUSTOM_RUNTIME_LABEL,
+    avatarUrl: "",
+    availability: "available",
+    command: "",
+    binaryPath: "",
+    defaultArgs: [],
+    mcpCommand: null,
+    modelEnvVar: null,
+    providerEnvVar: null,
+    thinkingEnvVar: null,
+    installHint: "",
     installInstructionsUrl: "https://agentclientprotocol.com/",
     canAutoInstall: false,
     underlyingCliPath: null,
@@ -53,8 +84,25 @@ export function parseAgentArgsInput(value: string): string[] {
     .filter((arg) => arg.length > 0);
 }
 
-export function formatAgentArgsInput(args: readonly string[] | null | undefined) {
+export function formatAgentArgsInput(
+  args: readonly string[] | null | undefined,
+) {
   return (args ?? []).join(", ");
+}
+
+export function applyCustomHarnessPreference(
+  config: GlobalAgentConfig,
+  draft: ByoHarnessDraft,
+): GlobalAgentConfig {
+  return {
+    ...config,
+    preferred_runtime: CUSTOM_RUNTIME_ID,
+    preferred_agent_command: draft.command.trim(),
+    preferred_agent_args: parseAgentArgsInput(draft.args),
+    // Custom harnesses don't use Buzz provider/model knobs.
+    model: null,
+    provider: null,
+  };
 }
 
 /** Resolve the effective preferred harness, including a BYO custom command. */

--- a/desktop/src/features/agents/lib/instanceInputForDefinition.test.mjs
+++ b/desktop/src/features/agents/lib/instanceInputForDefinition.test.mjs
@@ -245,6 +245,67 @@ test("row 1: resolves the configured runtime when available", () => {
   assert.deepEqual(warnings, []);
 });
 
+test("row 1: preferred custom + persona custom starts on BYO command", () => {
+  const { runtime, warnings } = resolveStartRuntimeForDefinition(
+    persona({ runtime: "custom" }),
+    [gooseRuntime, claudeRuntime],
+    {
+      preferred_runtime: "custom",
+      preferred_agent_command: "agent",
+      preferred_agent_args: ["acp"],
+    },
+  );
+  assert.equal(runtime.id, "custom");
+  assert.equal(runtime.command, "agent");
+  assert.deepEqual(runtime.defaultArgs, ["acp"]);
+  assert.deepEqual(warnings, []);
+});
+
+test("row 1: persona custom without global BYO refuses rather than silently switching", () => {
+  assert.throws(
+    () =>
+      resolveStartRuntimeForDefinition(
+        persona({ runtime: "custom" }),
+        [gooseRuntime, claudeRuntime],
+        { preferred_runtime: "claude" },
+      ),
+    /custom harness|not available/i,
+  );
+});
+
+test("row 1: no preference with preferred custom uses BYO command", () => {
+  const { runtime, warnings } = resolveStartRuntimeForDefinition(
+    persona({ runtime: undefined }),
+    [gooseRuntime, claudeRuntime],
+    {
+      preferred_runtime: "custom",
+      preferred_agent_command: "yoak",
+      preferred_agent_args: ["acp"],
+    },
+  );
+  assert.equal(runtime.id, "custom");
+  assert.equal(runtime.command, "yoak");
+  assert.deepEqual(warnings, []);
+});
+
+test("buildInstanceInputForDefinition pins BYO command when persona runtime is custom", async () => {
+  const customRuntime = {
+    ...gooseRuntime,
+    id: "custom",
+    label: "Custom command",
+    command: "agent",
+    defaultArgs: ["acp"],
+    mcpCommand: null,
+  };
+  const input = await buildInstanceInputForDefinition(
+    persona({ runtime: "custom" }),
+    customRuntime,
+  );
+  assert.equal(input.agentCommand, "agent");
+  assert.deepEqual(input.agentArgs, ["acp"]);
+  assert.equal(input.harnessOverride, true);
+});
+
 test("row 1: no preference resolves the default with no warnings", () => {
   const { runtime, warnings } = resolveStartRuntimeForDefinition(
     persona({ runtime: undefined }),

--- a/desktop/src/features/agents/lib/instanceInputForDefinition.ts
+++ b/desktop/src/features/agents/lib/instanceInputForDefinition.ts
@@ -3,7 +3,9 @@ import type {
   AcpRuntimeCatalogEntry,
   AgentPersona,
   CreateManagedAgentInput,
+  GlobalAgentConfig,
 } from "@/shared/api/types";
+import { buildCustomAcpRuntime } from "./customHarness";
 import {
   getDefaultPersonaRuntime,
   resolvePersonaRuntime,
@@ -45,12 +47,21 @@ export async function availableRuntimesForStart(
 export function resolveStartRuntimeForDefinition(
   persona: AgentPersona,
   runtimes: readonly AcpRuntime[],
-  preferredRuntimeId?: string | null,
+  preferred?: Pick<
+    GlobalAgentConfig,
+    "preferred_runtime" | "preferred_agent_command" | "preferred_agent_args"
+  > | null,
 ): { runtime: AcpRuntime; warnings: string[] } {
-  // Use the buzz-agent-first preference (buzz-agent → goose → first available)
-  // so a freshly installed goose never beats the bundled buzz-agent sidecar
-  // for runtime-less personas (item 13 regression guard).
-  const defaultRuntime = getDefaultPersonaRuntime(runtimes, preferredRuntimeId);
+  // Prefer an explicit BYO command when the global preference is custom,
+  // otherwise use the buzz-agent-first catalog preference.
+  const preferredRuntimeId = preferred?.preferred_runtime ?? null;
+  const defaultRuntime =
+    preferredRuntimeId === "custom"
+      ? (buildCustomAcpRuntime(
+          preferred?.preferred_agent_command ?? "",
+          preferred?.preferred_agent_args ?? [],
+        ) ?? getDefaultPersonaRuntime(runtimes, null))
+      : getDefaultPersonaRuntime(runtimes, preferredRuntimeId);
   const { runtime, warnings, isOverridden }: ResolvePersonaRuntimeResult =
     resolvePersonaRuntime(persona.runtime, runtimes, defaultRuntime);
 

--- a/desktop/src/features/agents/lib/resolvePersonaRuntime.test.mjs
+++ b/desktop/src/features/agents/lib/resolvePersonaRuntime.test.mjs
@@ -3,8 +3,11 @@ import test from "node:test";
 
 import {
   collectRuntimeWarnings,
+  getDefaultPersonaRuntime,
   resolvePersonaRuntime,
+  resolvePreferredHarness,
 } from "./resolvePersonaRuntime.ts";
+import { buildCustomAcpRuntime } from "./customHarness.ts";
 
 function makeRuntime(id, label = `${id} label`) {
   return { id, label, command: id, avatarUrl: "" };
@@ -176,4 +179,56 @@ test("collectRuntimeWarnings — override=false behaves identically to no overri
 
 test("collectRuntimeWarnings — empty personas array always returns empty", () => {
   assert.deepEqual(collectRuntimeWarnings([], runtimes, goose, true), []);
+});
+
+test("getDefaultPersonaRuntime — preferred_runtime custom returns null", () => {
+  assert.equal(getDefaultPersonaRuntime(runtimes, "custom"), null);
+});
+
+test("resolvePreferredHarness — builds custom runtime from global command/args", () => {
+  const runtime = resolvePreferredHarness(runtimes, {
+    preferred_runtime: "custom",
+    preferred_agent_command: "agent",
+    preferred_agent_args: ["acp"],
+  });
+  assert.equal(runtime?.id, "custom");
+  assert.equal(runtime?.command, "agent");
+  assert.deepEqual(runtime?.defaultArgs, ["acp"]);
+  assert.equal(runtime?.availability, "available");
+});
+
+test("resolvePreferredHarness — incomplete custom falls back to catalog", () => {
+  const available = [
+    { ...claude, availability: "available" },
+    { ...goose, availability: "available" },
+  ];
+  const runtime = resolvePreferredHarness(available, {
+    preferred_runtime: "custom",
+    preferred_agent_command: "  ",
+    preferred_agent_args: [],
+  });
+  // Preference order without buzz-agent: goose, then first available.
+  assert.equal(runtime?.id, "goose");
+});
+
+test("resolvePersonaRuntime — persona custom + global custom uses BYO runtime", () => {
+  const custom = buildCustomAcpRuntime("agent", ["acp"]);
+  const result = resolvePersonaRuntime("custom", runtimes, custom);
+  assert.equal(result.runtime, custom);
+  assert.deepEqual(result.warnings, []);
+  assert.equal(result.isOverridden, false);
+});
+
+test("resolvePersonaRuntime — persona custom without global BYO falls back with override", () => {
+  const result = resolvePersonaRuntime("custom", runtimes, claude);
+  assert.equal(result.runtime, claude);
+  assert.equal(result.isOverridden, true);
+  assert.match(result.warnings[0], /custom harness/);
+});
+
+test("resolvePersonaRuntime — persona custom with no default returns null", () => {
+  const result = resolvePersonaRuntime("custom", runtimes, null);
+  assert.equal(result.runtime, null);
+  assert.equal(result.isOverridden, false);
+  assert.match(result.warnings[0], /no custom command/);
 });

--- a/desktop/src/features/agents/lib/resolvePersonaRuntime.ts
+++ b/desktop/src/features/agents/lib/resolvePersonaRuntime.ts
@@ -54,11 +54,16 @@ export function resolvePreferredHarness(
 ): AcpRuntime | null {
   const custom = resolvePreferredCustomRuntime(config);
   if (custom) return custom;
+  const available = runtimes.filter(
+    (runtime): runtime is AcpRuntime => runtime.availability === "available",
+  );
+  // Incomplete BYO (preferred_runtime custom, empty command) must not poison
+  // catalog fallback — getDefaultPersonaRuntime returns null for "custom".
   return getDefaultPersonaRuntime(
-    runtimes.filter(
-      (runtime): runtime is AcpRuntime => runtime.availability === "available",
-    ),
-    config.preferred_runtime,
+    available,
+    isCustomRuntimeId(config.preferred_runtime)
+      ? null
+      : config.preferred_runtime,
   );
 }
 

--- a/desktop/src/features/agents/lib/resolvePersonaRuntime.ts
+++ b/desktop/src/features/agents/lib/resolvePersonaRuntime.ts
@@ -1,4 +1,13 @@
-import type { AcpRuntime, AcpRuntimeCatalogEntry } from "@/shared/api/types";
+import type {
+  AcpRuntime,
+  AcpRuntimeCatalogEntry,
+  GlobalAgentConfig,
+} from "@/shared/api/types";
+import {
+  buildCustomAcpRuntime,
+  isCustomRuntimeId,
+  resolvePreferredCustomRuntime,
+} from "./customHarness";
 
 /**
  * Select the best default runtime from a catalog, using the same preference
@@ -9,11 +18,17 @@ import type { AcpRuntime, AcpRuntimeCatalogEntry } from "@/shared/api/types";
  * list) returns AcpRuntime | null while passing AcpRuntimeCatalogEntry[]
  * (the full catalog) returns AcpRuntimeCatalogEntry | null.  Both call sites
  * share one preference-order implementation.
+ *
+ * When `preferredRuntimeId` is `"custom"`, returns null — callers that need
+ * BYO resolution should use [`resolvePreferredHarness`].
  */
 export function getDefaultPersonaRuntime<T extends AcpRuntimeCatalogEntry>(
   runtimes: readonly T[],
   preferredRuntimeId?: string | null,
 ): T | null {
+  if (isCustomRuntimeId(preferredRuntimeId)) {
+    return null;
+  }
   const available = runtimes.filter(
     (runtime) => runtime.availability === "available",
   );
@@ -23,6 +38,27 @@ export function getDefaultPersonaRuntime<T extends AcpRuntimeCatalogEntry>(
     available.find((runtime) => runtime.id === "goose") ??
     available[0] ??
     null
+  );
+}
+
+/**
+ * Resolve the user's preferred harness from global config, including a
+ * bring-your-own ACP command outside the Rust catalog.
+ */
+export function resolvePreferredHarness(
+  runtimes: readonly AcpRuntimeCatalogEntry[],
+  config: Pick<
+    GlobalAgentConfig,
+    "preferred_runtime" | "preferred_agent_command" | "preferred_agent_args"
+  >,
+): AcpRuntime | null {
+  const custom = resolvePreferredCustomRuntime(config);
+  if (custom) return custom;
+  return getDefaultPersonaRuntime(
+    runtimes.filter(
+      (runtime): runtime is AcpRuntime => runtime.availability === "available",
+    ),
+    config.preferred_runtime,
   );
 }
 
@@ -69,8 +105,35 @@ export function resolvePersonaRuntime(
       warnings: defaultRuntime
         ? []
         : [
-            "No agent runtimes are available. Install a runtime (e.g. Goose) to deploy agents.",
+            "No agent runtimes are available. Install a runtime or bring your own ACP command to deploy agents.",
           ],
+      isOverridden: false,
+    };
+  }
+
+  // Case 1b: Persona explicitly pins a custom/BYO command.
+  if (isCustomRuntimeId(personaRuntimeId)) {
+    if (defaultRuntime && isCustomRuntimeId(defaultRuntime.id)) {
+      return {
+        runtime: defaultRuntime,
+        warnings: [],
+        isOverridden: false,
+      };
+    }
+    if (defaultRuntime) {
+      return {
+        runtime: defaultRuntime,
+        warnings: [
+          `This agent is configured for a custom harness but none is set globally. Using ${defaultRuntime.label} instead.`,
+        ],
+        isOverridden: true,
+      };
+    }
+    return {
+      runtime: null,
+      warnings: [
+        "This agent is configured for a custom harness, but no custom command is configured.",
+      ],
       isOverridden: false,
     };
   }
@@ -142,3 +205,5 @@ export function collectRuntimeWarnings(
   }
   return warnings;
 }
+
+export { buildCustomAcpRuntime, isCustomRuntimeId };

--- a/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
+++ b/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
@@ -13,8 +13,8 @@ import {
 } from "@/features/agents/lib/teamPersonas";
 import {
   collectRuntimeWarnings,
-  getDefaultPersonaRuntime,
   resolvePersonaRuntime,
+  resolvePreferredHarness,
 } from "@/features/agents/lib/resolvePersonaRuntime";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
@@ -69,12 +69,8 @@ export function AddTeamToChannelDialog({
   );
 
   const runtimes = providersQuery.data ?? [];
-  // Use the buzz-agent-first preference so the team-deploy fallback mirrors the
-  // single-agent start path (buzz-agent → goose → first available).
-  const defaultProvider = getDefaultPersonaRuntime(
-    runtimes,
-    globalConfig.preferred_runtime,
-  );
+  // Prefer BYO custom command when configured; otherwise buzz-agent-first.
+  const defaultProvider = resolvePreferredHarness(runtimes, globalConfig);
 
   const teamPersonaResolution = React.useMemo(
     () =>

--- a/desktop/src/features/agents/ui/AgentConfigFields.tsx
+++ b/desktop/src/features/agents/ui/AgentConfigFields.tsx
@@ -57,6 +57,8 @@ export const EMPTY_GLOBAL_CONFIG: GlobalAgentConfig = {
   provider: null,
   model: null,
   preferred_runtime: null,
+  preferred_agent_command: null,
+  preferred_agent_args: null,
 };
 
 /** Baked env keys that route to structured controls, not the generic env editor. */

--- a/desktop/src/features/agents/ui/AgentDefaultsEditor.tsx
+++ b/desktop/src/features/agents/ui/AgentDefaultsEditor.tsx
@@ -26,12 +26,21 @@ import {
   resetConfigForHarnessChange,
   sortPersonaRuntimes,
 } from "@/features/agents/ui/agentConfigOptions";
+import {
+  CUSTOM_RUNTIME_ID,
+  CUSTOM_RUNTIME_LABEL,
+  formatAgentArgsInput,
+  isCustomRuntimeId,
+  parseAgentArgsInput,
+  resolvePreferredCustomRuntime,
+} from "@/features/agents/lib/customHarness";
 import { AgentDropdownSelect } from "@/features/agents/ui/agentConfigControls";
 import {
   AgentConfigFields,
   EMPTY_GLOBAL_CONFIG,
 } from "@/features/agents/ui/AgentConfigFields";
 import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 
@@ -120,21 +129,51 @@ export function AgentDefaultsEditor({
   // A missing/stale preference displays the same effective fallback the backend
   // would use; it is persisted only after the user edits and saves this form.
   // Keep persona ordering here so this shared editor matches agent dialogs.
-  const selectedRuntime = React.useMemo(
-    () =>
+  const customRuntime = React.useMemo(
+    () => resolvePreferredCustomRuntime(config),
+    [config],
+  );
+  const selectedRuntime = React.useMemo(() => {
+    if (isCustomRuntimeId(config.preferred_runtime)) {
+      return (
+        customRuntime ?? {
+          id: CUSTOM_RUNTIME_ID,
+          label: CUSTOM_RUNTIME_LABEL,
+          avatarUrl: "",
+          availability: "available" as const,
+          command: config.preferred_agent_command ?? "",
+          binaryPath: config.preferred_agent_command ?? "",
+          defaultArgs: config.preferred_agent_args ?? [],
+          mcpCommand: null,
+          modelEnvVar: null,
+          providerEnvVar: null,
+          thinkingEnvVar: null,
+          installHint: "",
+          installInstructionsUrl: "https://agentclientprotocol.com/",
+          canAutoInstall: false,
+          underlyingCliPath: null,
+          nodeRequired: false,
+          authStatus: { status: "not_applicable" as const },
+          loginHint: null,
+        }
+      );
+    }
+    return (
       sortedRuntimes.find(
         (runtime) => runtime.id === config.preferred_runtime,
       ) ??
       getDefaultPersonaRuntime(sortedRuntimes) ??
-      sortedRuntimes[0],
-    [config.preferred_runtime, sortedRuntimes],
-  );
+      sortedRuntimes[0]
+    );
+  }, [config, customRuntime, sortedRuntimes]);
   const harnessOptions = React.useMemo(
-    () =>
-      sortedRuntimes.map((runtime) => ({
+    () => [
+      ...sortedRuntimes.map((runtime) => ({
         label: formatRuntimeOptionLabel(runtime),
         value: runtime.id,
       })),
+      { label: CUSTOM_RUNTIME_LABEL, value: CUSTOM_RUNTIME_ID },
+    ],
     [sortedRuntimes],
   );
   const configSurfaceLoading = isLoading || runtimesQuery.isLoading;
@@ -142,6 +181,11 @@ export function AgentDefaultsEditor({
     loadError ||
     runtimesQuery.isError ||
     (!configSurfaceLoading && selectedRuntime === undefined);
+  const isCustomSelected = isCustomRuntimeId(selectedRuntime?.id);
+  const customCommandValid =
+    !isCustomSelected ||
+    (config.preferred_agent_command ?? "").trim().length > 0;
+  const formIsValid = configIsValid && customCommandValid;
 
   function handleConfigChange(next: GlobalAgentConfig) {
     configRef.current = next;
@@ -232,18 +276,74 @@ export function AgentDefaultsEditor({
               value={selectedRuntime?.id ?? ""}
             />
           </div>
-          <AgentConfigFields
-            bakedEnv={bakedEnv}
-            selectedRuntime={selectedRuntime}
-            config={config}
-            isCustomModelEditing={isCustomModelEditing}
-            isCustomProvider={isCustomProvider}
-            onConfigChange={handleConfigChange}
-            onCustomModelEditingChange={setIsCustomModelEditing}
-            onIsCustomProviderChange={setIsCustomProvider}
-            onValidityChange={setConfigIsValid}
-            useCustomSelect
-          />
+          {isCustomSelected ? (
+            <div className="space-y-4">
+              <div className="space-y-1.5">
+                <label
+                  className="text-sm font-medium text-foreground"
+                  htmlFor="global-agent-custom-command"
+                >
+                  Agent command
+                </label>
+                <Input
+                  autoCorrect="off"
+                  data-testid="global-agent-custom-command"
+                  id="global-agent-custom-command"
+                  onChange={(event) =>
+                    handleConfigChange({
+                      ...config,
+                      preferred_agent_command: event.target.value,
+                      preferred_runtime: CUSTOM_RUNTIME_ID,
+                    })
+                  }
+                  placeholder="Full path or shell command (e.g. agent, yoak)"
+                  spellCheck={false}
+                  value={config.preferred_agent_command ?? ""}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label
+                  className="text-sm font-medium text-foreground"
+                  htmlFor="global-agent-custom-args"
+                >
+                  Agent runtime args
+                  <span className="ml-1 text-xs font-normal text-muted-foreground">
+                    Optional
+                  </span>
+                </label>
+                <Input
+                  autoCorrect="off"
+                  data-testid="global-agent-custom-args"
+                  id="global-agent-custom-args"
+                  onChange={(event) =>
+                    handleConfigChange({
+                      ...config,
+                      preferred_agent_args: parseAgentArgsInput(
+                        event.target.value,
+                      ),
+                      preferred_runtime: CUSTOM_RUNTIME_ID,
+                    })
+                  }
+                  placeholder="Comma-separated (e.g. acp)"
+                  spellCheck={false}
+                  value={formatAgentArgsInput(config.preferred_agent_args)}
+                />
+              </div>
+            </div>
+          ) : (
+            <AgentConfigFields
+              bakedEnv={bakedEnv}
+              selectedRuntime={selectedRuntime}
+              config={config}
+              isCustomModelEditing={isCustomModelEditing}
+              isCustomProvider={isCustomProvider}
+              onConfigChange={handleConfigChange}
+              onCustomModelEditingChange={setIsCustomModelEditing}
+              onIsCustomProviderChange={setIsCustomProvider}
+              onValidityChange={setConfigIsValid}
+              useCustomSelect
+            />
+          )}
         </>
       )}
 
@@ -269,7 +369,7 @@ export function AgentDefaultsEditor({
           <div className="ml-auto flex items-center gap-3">
             {secondaryAction}
             <Button
-              disabled={!dirty || !configIsValid || saveState === "saving"}
+              disabled={!dirty || !formIsValid || saveState === "saving"}
               onClick={() => void handleSave()}
               size="sm"
             >

--- a/desktop/src/features/agents/ui/AgentDefaultsEditor.tsx
+++ b/desktop/src/features/agents/ui/AgentDefaultsEditor.tsx
@@ -29,18 +29,19 @@ import {
 import {
   CUSTOM_RUNTIME_ID,
   CUSTOM_RUNTIME_LABEL,
+  applyCustomHarnessPreference,
+  customHarnessCatalogStub,
   formatAgentArgsInput,
   isCustomRuntimeId,
-  parseAgentArgsInput,
   resolvePreferredCustomRuntime,
 } from "@/features/agents/lib/customHarness";
+import { CustomHarnessFields } from "@/features/agents/ui/CustomHarnessFields";
 import { AgentDropdownSelect } from "@/features/agents/ui/agentConfigControls";
 import {
   AgentConfigFields,
   EMPTY_GLOBAL_CONFIG,
 } from "@/features/agents/ui/AgentConfigFields";
 import { Button } from "@/shared/ui/button";
-import { Input } from "@/shared/ui/input";
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 
@@ -135,28 +136,7 @@ export function AgentDefaultsEditor({
   );
   const selectedRuntime = React.useMemo(() => {
     if (isCustomRuntimeId(config.preferred_runtime)) {
-      return (
-        customRuntime ?? {
-          id: CUSTOM_RUNTIME_ID,
-          label: CUSTOM_RUNTIME_LABEL,
-          avatarUrl: "",
-          availability: "available" as const,
-          command: config.preferred_agent_command ?? "",
-          binaryPath: config.preferred_agent_command ?? "",
-          defaultArgs: config.preferred_agent_args ?? [],
-          mcpCommand: null,
-          modelEnvVar: null,
-          providerEnvVar: null,
-          thinkingEnvVar: null,
-          installHint: "",
-          installInstructionsUrl: "https://agentclientprotocol.com/",
-          canAutoInstall: false,
-          underlyingCliPath: null,
-          nodeRequired: false,
-          authStatus: { status: "not_applicable" as const },
-          loginHint: null,
-        }
-      );
+      return customRuntime ?? customHarnessCatalogStub();
     }
     return (
       sortedRuntimes.find(
@@ -165,7 +145,7 @@ export function AgentDefaultsEditor({
       getDefaultPersonaRuntime(sortedRuntimes) ??
       sortedRuntimes[0]
     );
-  }, [config, customRuntime, sortedRuntimes]);
+  }, [config.preferred_runtime, customRuntime, sortedRuntimes]);
   const harnessOptions = React.useMemo(
     () => [
       ...sortedRuntimes.map((runtime) => ({
@@ -277,59 +257,30 @@ export function AgentDefaultsEditor({
             />
           </div>
           {isCustomSelected ? (
-            <div className="space-y-4">
-              <div className="space-y-1.5">
-                <label
-                  className="text-sm font-medium text-foreground"
-                  htmlFor="global-agent-custom-command"
-                >
-                  Agent command
-                </label>
-                <Input
-                  autoCorrect="off"
-                  data-testid="global-agent-custom-command"
-                  id="global-agent-custom-command"
-                  onChange={(event) =>
-                    handleConfigChange({
-                      ...config,
-                      preferred_agent_command: event.target.value,
-                      preferred_runtime: CUSTOM_RUNTIME_ID,
-                    })
-                  }
-                  placeholder="Full path or shell command (e.g. agent, yoak)"
-                  spellCheck={false}
-                  value={config.preferred_agent_command ?? ""}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <label
-                  className="text-sm font-medium text-foreground"
-                  htmlFor="global-agent-custom-args"
-                >
-                  Agent runtime args
-                  <span className="ml-1 text-xs font-normal text-muted-foreground">
-                    Optional
-                  </span>
-                </label>
-                <Input
-                  autoCorrect="off"
-                  data-testid="global-agent-custom-args"
-                  id="global-agent-custom-args"
-                  onChange={(event) =>
-                    handleConfigChange({
-                      ...config,
-                      preferred_agent_args: parseAgentArgsInput(
-                        event.target.value,
-                      ),
-                      preferred_runtime: CUSTOM_RUNTIME_ID,
-                    })
-                  }
-                  placeholder="Comma-separated (e.g. acp)"
-                  spellCheck={false}
-                  value={formatAgentArgsInput(config.preferred_agent_args)}
-                />
-              </div>
-            </div>
+            <CustomHarnessFields
+              args={formatAgentArgsInput(config.preferred_agent_args)}
+              argsId="global-agent-custom-args"
+              argsTestId="global-agent-custom-args"
+              command={config.preferred_agent_command ?? ""}
+              commandId="global-agent-custom-command"
+              commandTestId="global-agent-custom-command"
+              onArgsChange={(value) =>
+                handleConfigChange(
+                  applyCustomHarnessPreference(config, {
+                    command: config.preferred_agent_command ?? "",
+                    args: value,
+                  }),
+                )
+              }
+              onCommandChange={(value) =>
+                handleConfigChange(
+                  applyCustomHarnessPreference(config, {
+                    command: value,
+                    args: formatAgentArgsInput(config.preferred_agent_args),
+                  }),
+                )
+              }
+            />
           ) : (
             <AgentConfigFields
               bakedEnv={bakedEnv}

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -67,6 +67,11 @@ import {
   MODEL_DISCOVERY_LOADING_VALUE,
   usePersonaModelDiscovery,
 } from "./usePersonaModelDiscovery";
+import {
+  CUSTOM_RUNTIME_ID,
+  CUSTOM_RUNTIME_LABEL,
+  isCustomRuntimeId,
+} from "../lib/customHarness";
 import { useBakedBuildEnvKeysQuery, useRuntimeFileConfigQuery } from "../hooks";
 import { useAgentDialogDefaults } from "./useAgentDialogDefaults";
 import { AgentAiDefaultsNotice } from "./AgentAiDefaults";
@@ -324,7 +329,15 @@ export function AgentDefinitionDialog({
     void handleSubmit();
   }
 
-  const selectedRuntime = runtimes.find((p) => p.id === runtime);
+  // BYO is outside the Rust catalog; resolve via the synthetic defaultRuntime
+  // so create/submit availability matches AgentDefaultsEditor.
+  const selectedRuntime =
+    runtimes.find((p) => p.id === runtime) ??
+    (isCustomRuntimeId(runtime) &&
+    defaultRuntime &&
+    isCustomRuntimeId(defaultRuntime.id)
+      ? defaultRuntime
+      : undefined);
   const blankRuntimeModelProviderEditable =
     initialModelProviderEditableWithoutRuntime && runtime.trim().length === 0;
   const runtimeCanChooseLlmProvider =
@@ -561,6 +574,9 @@ export function AgentDefinitionDialog({
     : isCreateMode
       ? "Choose a harness"
       : "No preference (use app default)";
+  const customRuntimeOptionAvailable =
+    Boolean(defaultRuntime && isCustomRuntimeId(defaultRuntime.id)) ||
+    isCustomRuntimeId(runtime);
   const runtimeDropdownOptions: PersonaDropdownOption[] = [
     ...(!isCreateMode
       ? [
@@ -577,6 +593,25 @@ export function AgentDefinitionDialog({
       }`,
       value: candidate.id,
     })),
+    ...(customRuntimeOptionAvailable
+      ? [
+          {
+            disabled:
+              isCreateMode &&
+              !(
+                defaultRuntime &&
+                isCustomRuntimeId(defaultRuntime.id) &&
+                defaultRuntime.availability === "available"
+              ),
+            label: `${CUSTOM_RUNTIME_LABEL}${
+              isCreateMode && defaultRuntime?.id === CUSTOM_RUNTIME_ID
+                ? " (default)"
+                : ""
+            }`,
+            value: CUSTOM_RUNTIME_ID,
+          },
+        ]
+      : []),
   ];
   if (
     runtime.trim().length > 0 &&

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -39,11 +39,11 @@ import {
   CUSTOM_PROVIDER_DROPDOWN_VALUE,
   computeLocalModeGate,
   formatRuntimeOptionLabel,
-  getDefaultPersonaRuntime,
   getPersonaModelOptions,
   getPersonaProviderOptions,
   getRuntimePersonaModelOptions,
   NO_RUNTIME_DROPDOWN_VALUE,
+  resolvePreferredHarness,
   runtimeSupportsLlmProviderSelection,
   type PersonaDropdownOption,
   PERSONA_FIELD_CONTROL_CLASS,
@@ -167,8 +167,8 @@ export function AgentDefinitionDialog({
     inheritedEnvVars: inheritedEnvVarsForAdvanced,
   } = useAgentDialogDefaults({ open });
   const defaultRuntime = React.useMemo(
-    () => getDefaultPersonaRuntime(runtimes, globalConfig.preferred_runtime),
-    [globalConfig.preferred_runtime, runtimes],
+    () => resolvePreferredHarness(runtimes, globalConfig),
+    [globalConfig, runtimes],
   );
   const shouldReduceMotion = useReducedMotion();
   const initialModelProviderEditableWithoutRuntime = Boolean(

--- a/desktop/src/features/agents/ui/CustomHarnessFields.tsx
+++ b/desktop/src/features/agents/ui/CustomHarnessFields.tsx
@@ -35,11 +35,18 @@ export function CustomHarnessFields({
   const onboarding = size === "onboarding";
 
   return (
-    <div className={cn("space-y-4", onboarding && "grid gap-3 sm:grid-cols-2 sm:space-y-0")}>
+    <div
+      className={cn(
+        "space-y-4",
+        onboarding && "grid gap-3 sm:grid-cols-2 sm:space-y-0",
+      )}
+    >
       <div className="space-y-1.5">
         <label
           className={cn(
-            onboarding ? "text-xs font-medium text-foreground" : "text-sm font-medium text-foreground",
+            onboarding
+              ? "text-xs font-medium text-foreground"
+              : "text-sm font-medium text-foreground",
             !onboarding && "pl-0",
           )}
           htmlFor={commandId}
@@ -85,7 +92,9 @@ export function CustomHarnessFields({
       <div className="space-y-1.5">
         <label
           className={cn(
-            onboarding ? "text-xs font-medium text-foreground" : "text-sm font-medium text-foreground",
+            onboarding
+              ? "text-xs font-medium text-foreground"
+              : "text-sm font-medium text-foreground",
           )}
           htmlFor={argsId}
         >

--- a/desktop/src/features/agents/ui/CustomHarnessFields.tsx
+++ b/desktop/src/features/agents/ui/CustomHarnessFields.tsx
@@ -1,0 +1,147 @@
+import { cn } from "@/shared/lib/cn";
+import { Input } from "@/shared/ui/input";
+import {
+  PERSONA_FIELD_CONTROL_CLASS,
+  PERSONA_FIELD_SHELL_CLASS,
+  PERSONA_LABEL_OPTIONAL_CLASS,
+} from "@/features/agents/ui/agentConfigOptions";
+
+type CustomHarnessFieldsProps = {
+  args: string;
+  command: string;
+  commandTestId?: string;
+  argsTestId?: string;
+  commandId: string;
+  argsId: string;
+  disabled?: boolean;
+  /** Larger onboarding-style controls vs compact settings controls. */
+  size?: "default" | "onboarding";
+  onArgsChange: (value: string) => void;
+  onCommandChange: (value: string) => void;
+};
+
+export function CustomHarnessFields({
+  args,
+  command,
+  commandTestId,
+  argsTestId,
+  commandId,
+  argsId,
+  disabled,
+  size = "default",
+  onArgsChange,
+  onCommandChange,
+}: CustomHarnessFieldsProps) {
+  const onboarding = size === "onboarding";
+
+  return (
+    <div className={cn("space-y-4", onboarding && "grid gap-3 sm:grid-cols-2 sm:space-y-0")}>
+      <div className="space-y-1.5">
+        <label
+          className={cn(
+            onboarding ? "text-xs font-medium text-foreground" : "text-sm font-medium text-foreground",
+            !onboarding && "pl-0",
+          )}
+          htmlFor={commandId}
+        >
+          Agent command
+        </label>
+        {onboarding ? (
+          <Input
+            autoCorrect="off"
+            className="h-10 rounded-xl border-foreground/15 bg-white"
+            data-testid={commandTestId}
+            disabled={disabled}
+            id={commandId}
+            onChange={(event) => onCommandChange(event.target.value)}
+            placeholder="agent"
+            spellCheck={false}
+            value={command}
+          />
+        ) : (
+          <div
+            className={cn(
+              "flex min-h-11 items-center px-3",
+              PERSONA_FIELD_SHELL_CLASS,
+            )}
+          >
+            <Input
+              autoCorrect="off"
+              className={cn(
+                "h-8 px-0 py-0 leading-6",
+                PERSONA_FIELD_CONTROL_CLASS,
+              )}
+              data-testid={commandTestId}
+              disabled={disabled}
+              id={commandId}
+              onChange={(event) => onCommandChange(event.target.value)}
+              placeholder="Full path or command on PATH (e.g. agent)"
+              spellCheck={false}
+              value={command}
+            />
+          </div>
+        )}
+      </div>
+      <div className="space-y-1.5">
+        <label
+          className={cn(
+            onboarding ? "text-xs font-medium text-foreground" : "text-sm font-medium text-foreground",
+          )}
+          htmlFor={argsId}
+        >
+          Args
+          <span
+            className={
+              onboarding
+                ? "ml-1 font-normal text-muted-foreground"
+                : PERSONA_LABEL_OPTIONAL_CLASS
+            }
+          >
+            Optional
+          </span>
+        </label>
+        {onboarding ? (
+          <Input
+            autoCorrect="off"
+            className="h-10 rounded-xl border-foreground/15 bg-white"
+            data-testid={argsTestId}
+            disabled={disabled}
+            id={argsId}
+            onChange={(event) => onArgsChange(event.target.value)}
+            placeholder="acp"
+            spellCheck={false}
+            value={args}
+          />
+        ) : (
+          <div
+            className={cn(
+              "flex min-h-11 items-center px-3",
+              PERSONA_FIELD_SHELL_CLASS,
+            )}
+          >
+            <Input
+              autoCorrect="off"
+              className={cn(
+                "h-8 px-0 py-0 leading-6",
+                PERSONA_FIELD_CONTROL_CLASS,
+              )}
+              data-testid={argsTestId}
+              disabled={disabled}
+              id={argsId}
+              onChange={(event) => onArgsChange(event.target.value)}
+              placeholder="Comma-separated (e.g. acp)"
+              spellCheck={false}
+              value={args}
+            />
+          </div>
+        )}
+        {!onboarding ? (
+          <p className="text-xs text-muted-foreground">
+            Must speak ACP over stdio. Buzz resolves the command on PATH when
+            the agent starts.
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/agents/ui/agentConfigOptions.test.mjs
+++ b/desktop/src/features/agents/ui/agentConfigOptions.test.mjs
@@ -85,6 +85,11 @@ test("getDefaultPersonaRuntime honors an available global preference", () => {
   assert.equal(getDefaultPersonaRuntime(runtimes, "claude")?.id, "claude");
 });
 
+test("getDefaultPersonaRuntime returns null for preferred custom sentinel", () => {
+  const runtimes = [makeRuntime("buzz-agent"), makeRuntime("claude")];
+  assert.equal(getDefaultPersonaRuntime(runtimes, "custom"), null);
+});
+
 test("getDefaultPersonaRuntime ignores an unavailable global preference", () => {
   const runtimes = [
     makeRuntime("buzz-agent"),
@@ -151,6 +156,8 @@ test("resetConfigForHarnessChange clears harness-specific values", () => {
     env_vars: { BUZZ_AGENT_THINKING_EFFORT: "high", KEEP_ME: "yes" },
     model: "claude-opus",
     preferred_runtime: "buzz-agent",
+    preferred_agent_command: "agent",
+    preferred_agent_args: ["acp"],
     provider: "anthropic",
   };
 
@@ -158,6 +165,8 @@ test("resetConfigForHarnessChange clears harness-specific values", () => {
     env_vars: { KEEP_ME: "yes" },
     model: null,
     preferred_runtime: "claude",
+    preferred_agent_command: null,
+    preferred_agent_args: null,
     provider: null,
   });
 });
@@ -167,6 +176,8 @@ test("resetConfigForHarnessChange preserves compatible provider selection", () =
     env_vars: { KEEP_ME: "yes" },
     model: "old-model",
     preferred_runtime: "claude",
+    preferred_agent_command: null,
+    preferred_agent_args: null,
     provider: "anthropic",
   };
 
@@ -174,6 +185,8 @@ test("resetConfigForHarnessChange preserves compatible provider selection", () =
     env_vars: { KEEP_ME: "yes" },
     model: null,
     preferred_runtime: "goose",
+    preferred_agent_command: null,
+    preferred_agent_args: null,
     provider: "anthropic",
   });
 });
@@ -187,6 +200,26 @@ test("resetConfigForHarnessChange does not carry relay mesh to Goose", () => {
   };
 
   assert.equal(resetConfigForHarnessChange(config, "goose").provider, null);
+});
+
+test("resetConfigForHarnessChange to custom keeps existing BYO command/args", () => {
+  const config = {
+    env_vars: {},
+    model: "x",
+    preferred_runtime: "claude",
+    preferred_agent_command: "agent",
+    preferred_agent_args: ["acp"],
+    provider: null,
+  };
+
+  assert.deepEqual(resetConfigForHarnessChange(config, "custom"), {
+    env_vars: {},
+    model: null,
+    preferred_runtime: "custom",
+    preferred_agent_command: "agent",
+    preferred_agent_args: ["acp"],
+    provider: null,
+  });
 });
 
 // ── getPersonaModelOptions — codex/claude do not use global provider ──────────

--- a/desktop/src/features/agents/ui/agentConfigOptions.tsx
+++ b/desktop/src/features/agents/ui/agentConfigOptions.tsx
@@ -6,7 +6,10 @@ import { BUZZ_AGENT_THINKING_EFFORT } from "./buzzAgentConfig";
 import type { RuntimeFileConfigSubset } from "@/shared/api/tauri";
 // Dialogs import getDefaultPersonaRuntime via this re-export; lib code imports
 // directly from lib/resolvePersonaRuntime.
-export { getDefaultPersonaRuntime } from "../lib/resolvePersonaRuntime";
+export {
+  getDefaultPersonaRuntime,
+  resolvePreferredHarness,
+} from "../lib/resolvePersonaRuntime";
 
 /**
  * Provider ids suppressed from the selection list on internal Block builds.
@@ -185,11 +188,16 @@ export function resetConfigForHarnessChange(
   const nextEnvVars = { ...config.env_vars };
   delete nextEnvVars[BUZZ_AGENT_THINKING_EFFORT];
 
+  const isCustom = runtimeId.trim() === "custom";
   return {
     ...config,
     env_vars: nextEnvVars,
     model: null,
     preferred_runtime: runtimeId || null,
+    // Catalog harness switches clear BYO pins; custom keeps existing command/args
+    // so the editor can revise them without wiping on every re-select.
+    preferred_agent_command: isCustom ? config.preferred_agent_command : null,
+    preferred_agent_args: isCustom ? config.preferred_agent_args : null,
     provider:
       runtimeSupportsLlmProviderSelection(runtimeId) &&
       config.provider !== "relay-mesh"

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -195,7 +195,7 @@ export function useManagedAgentActions() {
       const { runtime, warnings } = resolveStartRuntimeForDefinition(
         persona,
         runtimes,
-        globalConfig.preferred_runtime,
+        globalConfig,
       );
       const input = await buildInstanceInputForDefinition(persona, runtime);
 

--- a/desktop/src/features/agents/useGlobalAgentConfig.ts
+++ b/desktop/src/features/agents/useGlobalAgentConfig.ts
@@ -19,6 +19,8 @@ const EMPTY_CONFIG: GlobalAgentConfig = {
   provider: null,
   model: null,
   preferred_runtime: null,
+  preferred_agent_command: null,
+  preferred_agent_args: null,
 };
 
 export const globalAgentConfigQueryKey = ["globalAgentConfig"] as const;

--- a/desktop/src/features/onboarding/ui/BringYourOwnHarnessCard.tsx
+++ b/desktop/src/features/onboarding/ui/BringYourOwnHarnessCard.tsx
@@ -1,0 +1,78 @@
+import { Card } from "@/shared/ui/card";
+import { cn } from "@/shared/lib/cn";
+import { CustomHarnessFields } from "@/features/agents/ui/CustomHarnessFields";
+
+export function BringYourOwnHarnessCard({
+  args,
+  command,
+  onArgsChange,
+  onCommandChange,
+  onSelectedChange,
+  selected,
+}: {
+  args: string;
+  command: string;
+  onArgsChange: (value: string) => void;
+  onCommandChange: (value: string) => void;
+  onSelectedChange: (selected: boolean) => void;
+  selected: boolean;
+}) {
+  const ready = selected && command.trim().length > 0;
+
+  return (
+    <Card
+      className={cn(
+        "w-full max-w-[592px] select-none items-stretch px-5 py-5 text-left",
+        ready && "ring-1 ring-[var(--buzz-welcome-chartreuse)]/50",
+      )}
+      data-ready={ready ? "true" : "false"}
+      data-testid="onboarding-runtime-custom"
+      variant="textured"
+    >
+      <label className="flex cursor-pointer items-start gap-3">
+        <input
+          checked={selected}
+          className="mt-1"
+          data-testid="onboarding-runtime-custom-toggle"
+          onChange={(event) => onSelectedChange(event.target.checked)}
+          type="checkbox"
+        />
+        <span className="min-w-0 flex-1 space-y-1">
+          <span className="block text-sm font-medium text-foreground">
+            Bring your own harness
+          </span>
+          <span className="block text-xs leading-5 text-muted-foreground">
+            Any binary that speaks{" "}
+            <a
+              className="underline underline-offset-2"
+              href="https://agentclientprotocol.com/"
+              rel="noreferrer"
+              target="_blank"
+            >
+              ACP
+            </a>{" "}
+            over stdio — for example Cursor{" "}
+            <code className="font-mono text-2xs">agent acp</code> or your own
+            adapter. Buzz does not verify PATH until the agent starts.
+          </span>
+        </span>
+      </label>
+
+      {selected ? (
+        <div className="mt-4">
+          <CustomHarnessFields
+            args={args}
+            argsId="onboarding-custom-args"
+            argsTestId="onboarding-custom-args"
+            command={command}
+            commandId="onboarding-custom-command"
+            commandTestId="onboarding-custom-command"
+            onArgsChange={onArgsChange}
+            onCommandChange={onCommandChange}
+            size="onboarding"
+          />
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -7,6 +7,14 @@ import {
 } from "@/features/agents/ui/AgentConfigFields";
 import { resetConfigForHarnessChange } from "@/features/agents/ui/agentConfigOptions";
 import { AgentDropdownSelect } from "@/features/agents/ui/agentConfigControls";
+import {
+  CUSTOM_RUNTIME_ID,
+  CUSTOM_RUNTIME_LABEL,
+  buildCustomAcpRuntime,
+  formatAgentArgsInput,
+  isCustomRuntimeId,
+  parseAgentArgsInput,
+} from "@/features/agents/lib/customHarness";
 import { createSaveCoalescer } from "./saveCoalescer";
 import { getBakedBuildEnv, type BakedEnvEntry } from "@/shared/api/tauri";
 import {
@@ -18,6 +26,7 @@ import type {
   GlobalAgentConfig,
 } from "@/shared/api/types";
 import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
 import { Spinner } from "@/shared/ui/spinner";
 import { ONBOARDING_PRIMARY_CTA_CLASS } from "./OnboardingChrome";
 import { OnboardingFooter } from "./OnboardingFooter";
@@ -39,6 +48,7 @@ type DefaultConfigStepProps = {
 
 function formatHarnessLabel(runtime: AcpRuntimeCatalogEntry | undefined) {
   if (!runtime) return "Select a harness";
+  if (isCustomRuntimeId(runtime.id)) return CUSTOM_RUNTIME_LABEL;
   return runtime.id === "buzz-agent" ? "Buzz" : runtime.label;
 }
 
@@ -110,6 +120,7 @@ function AgentDefaultsSection({
     };
   }, []);
 
+  const customReady = readyRuntimeIds.includes(CUSTOM_RUNTIME_ID);
   const effectiveReadyRuntimeIds = React.useMemo(
     () =>
       readyRuntimeIds.length > 0
@@ -125,13 +136,56 @@ function AgentDefaultsSection({
   );
   // Setup already confirmed readiness. Re-filter only for onboarding
   // visibility here; a transient auth recheck must not invalidate that handoff.
-  const readyRuntimes = React.useMemo(
+  const readyCatalogRuntimes = React.useMemo(
     () =>
       getVisibleOnboardingRuntimes(runtimesQuery.data ?? []).filter((runtime) =>
         readyRuntimeIdSet.has(runtime.id),
       ),
     [readyRuntimeIdSet, runtimesQuery.data],
   );
+  const customRuntime = React.useMemo(
+    () =>
+      customReady || isCustomRuntimeId(config.preferred_runtime)
+        ? buildCustomAcpRuntime(
+            config.preferred_agent_command ?? "",
+            config.preferred_agent_args ?? [],
+          )
+        : null,
+    [
+      config.preferred_agent_args,
+      config.preferred_agent_command,
+      config.preferred_runtime,
+      customReady,
+    ],
+  );
+  const readyRuntimes = React.useMemo(() => {
+    const items: AcpRuntimeCatalogEntry[] = [...readyCatalogRuntimes];
+    if (customRuntime) {
+      items.push(customRuntime);
+    } else if (customReady) {
+      items.push({
+        id: CUSTOM_RUNTIME_ID,
+        label: CUSTOM_RUNTIME_LABEL,
+        avatarUrl: "",
+        availability: "available",
+        command: null,
+        binaryPath: null,
+        defaultArgs: [],
+        mcpCommand: null,
+        modelEnvVar: null,
+        providerEnvVar: null,
+        thinkingEnvVar: null,
+        installHint: "",
+        installInstructionsUrl: "https://agentclientprotocol.com/",
+        canAutoInstall: false,
+        underlyingCliPath: null,
+        nodeRequired: false,
+        authStatus: { status: "not_applicable" },
+        loginHint: null,
+      });
+    }
+    return items;
+  }, [customReady, customRuntime, readyCatalogRuntimes]);
   const selectedRuntime = React.useMemo(
     () =>
       readyRuntimes.find((runtime) => runtime.id === config.preferred_runtime),
@@ -139,6 +193,7 @@ function AgentDefaultsSection({
   );
   const selectedRuntimeId = selectedRuntime?.id ?? "";
   const configSurfaceLoading = isLoading || runtimesQuery.isLoading;
+  const isCustomSelected = isCustomRuntimeId(selectedRuntimeId);
 
   const configSurfaceError =
     runtimesQuery.isError ||
@@ -165,6 +220,32 @@ function AgentDefaultsSection({
     [config],
   );
 
+  const handleCustomCommandChange = React.useCallback(
+    (command: string) => {
+      const next: GlobalAgentConfig = {
+        ...config,
+        preferred_agent_command: command,
+        preferred_runtime: CUSTOM_RUNTIME_ID,
+      };
+      setConfig(next);
+      coalescerRef.current?.enqueue(next);
+    },
+    [config],
+  );
+
+  const handleCustomArgsChange = React.useCallback(
+    (value: string) => {
+      const next: GlobalAgentConfig = {
+        ...config,
+        preferred_agent_args: parseAgentArgsInput(value),
+        preferred_runtime: CUSTOM_RUNTIME_ID,
+      };
+      setConfig(next);
+      coalescerRef.current?.enqueue(next);
+    },
+    [config],
+  );
+
   React.useEffect(() => {
     if (configSurfaceLoading || selectedRuntimeId) return;
     if (readyRuntimes.length !== 1) return;
@@ -180,12 +261,22 @@ function AgentDefaultsSection({
     () => coalescerRef.current?.flush() ?? Promise.resolve(),
     [],
   );
+  const customCommandReady =
+    !isCustomSelected ||
+    (config.preferred_agent_command ?? "").trim().length > 0;
   React.useEffect(() => {
     onPersistenceStateChange({
-      canComplete: selectedRuntimeId.length > 0 && !isSaving,
+      canComplete:
+        selectedRuntimeId.length > 0 && customCommandReady && !isSaving,
       flush: flushPersistence,
     });
-  }, [flushPersistence, isSaving, onPersistenceStateChange, selectedRuntimeId]);
+  }, [
+    customCommandReady,
+    flushPersistence,
+    isSaving,
+    onPersistenceStateChange,
+    selectedRuntimeId,
+  ]);
 
   return (
     <section className="w-full space-y-4 text-left text-sm">
@@ -219,27 +310,80 @@ function AgentDefaultsSection({
             />
           </div>
 
-          <AgentConfigFields
-            bakedEnv={bakedEnv}
-            selectedRuntime={selectedRuntime}
-            config={config}
-            isCustomModelEditing={isCustomModelEditing}
-            isCustomProvider={isCustomProvider}
-            onConfigChange={(next) => {
-              // Always apply optimistically so the UI never reverts mid-save,
-              // then enqueue the persist — the coalescer serialises multiple
-              // rapid edits into a single trailing request.
-              setConfig(next);
-              coalescerRef.current?.enqueue(next);
-            }}
-            onCustomModelEditingChange={setIsCustomModelEditing}
-            onIsCustomProviderChange={setIsCustomProvider}
-            placeholderClassName="text-foreground/70"
-            selectClassName="h-12 rounded-2xl border-foreground/15 bg-white px-4 py-2 text-sm shadow-none hover:bg-white/95"
-            disclosure="onboarding-essential"
-            unstyled
-            useCustomSelect
-          />
+          {isCustomSelected ? (
+            <div className="space-y-4">
+              <div className="space-y-1.5">
+                <label
+                  className="pl-3 text-sm font-medium"
+                  htmlFor="global-agent-custom-command"
+                >
+                  Agent command
+                </label>
+                <Input
+                  autoCorrect="off"
+                  className="h-12 rounded-2xl border-foreground/15 bg-white px-4 text-sm shadow-none"
+                  data-testid="global-agent-custom-command"
+                  id="global-agent-custom-command"
+                  onChange={(event) =>
+                    handleCustomCommandChange(event.target.value)
+                  }
+                  placeholder="agent"
+                  spellCheck={false}
+                  value={config.preferred_agent_command ?? ""}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label
+                  className="pl-3 text-sm font-medium"
+                  htmlFor="global-agent-custom-args"
+                >
+                  Agent args
+                  <span className="ml-1 text-xs font-normal text-muted-foreground">
+                    Optional
+                  </span>
+                </label>
+                <Input
+                  autoCorrect="off"
+                  className="h-12 rounded-2xl border-foreground/15 bg-white px-4 text-sm shadow-none"
+                  data-testid="global-agent-custom-args"
+                  id="global-agent-custom-args"
+                  onChange={(event) =>
+                    handleCustomArgsChange(event.target.value)
+                  }
+                  placeholder="acp"
+                  spellCheck={false}
+                  value={formatAgentArgsInput(config.preferred_agent_args)}
+                />
+                <p className="pl-3 text-xs text-muted-foreground">
+                  Comma-separated. Example:{" "}
+                  <code className="font-mono">acp</code> for Cursor, or leave
+                  blank for zero-arg adapters.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <AgentConfigFields
+              bakedEnv={bakedEnv}
+              selectedRuntime={selectedRuntime}
+              config={config}
+              isCustomModelEditing={isCustomModelEditing}
+              isCustomProvider={isCustomProvider}
+              onConfigChange={(next) => {
+                // Always apply optimistically so the UI never reverts mid-save,
+                // then enqueue the persist — the coalescer serialises multiple
+                // rapid edits into a single trailing request.
+                setConfig(next);
+                coalescerRef.current?.enqueue(next);
+              }}
+              onCustomModelEditingChange={setIsCustomModelEditing}
+              onIsCustomProviderChange={setIsCustomProvider}
+              placeholderClassName="text-foreground/70"
+              selectClassName="h-12 rounded-2xl border-foreground/15 bg-white px-4 py-2 text-sm shadow-none hover:bg-white/95"
+              disclosure="onboarding-essential"
+              unstyled
+              useCustomSelect
+            />
+          )}
         </div>
       )}
     </section>

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -10,11 +10,14 @@ import { AgentDropdownSelect } from "@/features/agents/ui/agentConfigControls";
 import {
   CUSTOM_RUNTIME_ID,
   CUSTOM_RUNTIME_LABEL,
+  applyCustomHarnessPreference,
   buildCustomAcpRuntime,
+  customHarnessCatalogStub,
   formatAgentArgsInput,
   isCustomRuntimeId,
-  parseAgentArgsInput,
+  type ByoHarnessDraft,
 } from "@/features/agents/lib/customHarness";
+import { CustomHarnessFields } from "@/features/agents/ui/CustomHarnessFields";
 import { createSaveCoalescer } from "./saveCoalescer";
 import { getBakedBuildEnv, type BakedEnvEntry } from "@/shared/api/tauri";
 import {
@@ -26,7 +29,6 @@ import type {
   GlobalAgentConfig,
 } from "@/shared/api/types";
 import { Button } from "@/shared/ui/button";
-import { Input } from "@/shared/ui/input";
 import { Spinner } from "@/shared/ui/spinner";
 import { ONBOARDING_PRIMARY_CTA_CLASS } from "./OnboardingChrome";
 import { OnboardingFooter } from "./OnboardingFooter";
@@ -42,6 +44,7 @@ import type { DefaultConfigStepActions } from "./types";
 
 type DefaultConfigStepProps = {
   actions: DefaultConfigStepActions;
+  byoDraft?: ByoHarnessDraft | null;
   direction: OnboardingTransitionDirection;
   readyRuntimeIds: readonly string[];
 };
@@ -53,9 +56,11 @@ function formatHarnessLabel(runtime: AcpRuntimeCatalogEntry | undefined) {
 }
 
 function AgentDefaultsSection({
+  byoDraft,
   onPersistenceStateChange,
   readyRuntimeIds,
 }: {
+  byoDraft?: ByoHarnessDraft | null;
   onPersistenceStateChange: (state: {
     canComplete: boolean;
     flush: () => Promise<void>;
@@ -75,35 +80,12 @@ function AgentDefaultsSection({
     cancel: () => void;
   } | null>(null);
   const [isSaving, setIsSaving] = React.useState(false);
+  const seededByoRef = React.useRef(false);
 
   React.useEffect(() => {
     let unmounted = false;
 
-    async function loadDefaults() {
-      const [configResult, bakedEnvResult] = await Promise.allSettled([
-        getGlobalAgentConfig(),
-        getBakedBuildEnv(),
-      ]);
-
-      if (unmounted) return;
-
-      if (configResult.status === "fulfilled") {
-        setConfig(configResult.value);
-      }
-      if (bakedEnvResult.status === "fulfilled") {
-        setBakedEnv(bakedEnvResult.value);
-      }
-      setIsLoading(false);
-    }
-
-    void loadDefaults();
-
-    // The coalescer serializes autosaves and drains any edit that arrived
-    // while a previous save was in flight. Cancel on unmount so a slow
-    // in-flight request never calls setState on an unmounted component.
     const coalescer = createSaveCoalescer<GlobalAgentConfig>(
-      // set_global_agent_config returns a save result (config + restart
-      // counts); the coalescer round-trips the persisted config only.
       async (next) => (await setGlobalAgentConfig(next)).config,
       (saving) => {
         if (!unmounted) setIsSaving(saving);
@@ -114,11 +96,37 @@ function AgentDefaultsSection({
     );
     coalescerRef.current = coalescer;
 
+    async function loadDefaults() {
+      const [configResult, bakedEnvResult] = await Promise.allSettled([
+        getGlobalAgentConfig(),
+        getBakedBuildEnv(),
+      ]);
+
+      if (unmounted) return;
+
+      let next =
+        configResult.status === "fulfilled"
+          ? configResult.value
+          : EMPTY_GLOBAL_CONFIG;
+      if (byoDraft?.command.trim() && !seededByoRef.current) {
+        next = applyCustomHarnessPreference(next, byoDraft);
+        seededByoRef.current = true;
+        coalescer.enqueue(next);
+      }
+      setConfig(next);
+      if (bakedEnvResult.status === "fulfilled") {
+        setBakedEnv(bakedEnvResult.value);
+      }
+      setIsLoading(false);
+    }
+
+    void loadDefaults();
+
     return () => {
       unmounted = true;
       coalescer.cancel();
     };
-  }, []);
+  }, [byoDraft]);
 
   const customReady = readyRuntimeIds.includes(CUSTOM_RUNTIME_ID);
   const effectiveReadyRuntimeIds = React.useMemo(
@@ -162,30 +170,11 @@ function AgentDefaultsSection({
     const items: AcpRuntimeCatalogEntry[] = [...readyCatalogRuntimes];
     if (customRuntime) {
       items.push(customRuntime);
-    } else if (customReady) {
-      items.push({
-        id: CUSTOM_RUNTIME_ID,
-        label: CUSTOM_RUNTIME_LABEL,
-        avatarUrl: "",
-        availability: "available",
-        command: null,
-        binaryPath: null,
-        defaultArgs: [],
-        mcpCommand: null,
-        modelEnvVar: null,
-        providerEnvVar: null,
-        thinkingEnvVar: null,
-        installHint: "",
-        installInstructionsUrl: "https://agentclientprotocol.com/",
-        canAutoInstall: false,
-        underlyingCliPath: null,
-        nodeRequired: false,
-        authStatus: { status: "not_applicable" },
-        loginHint: null,
-      });
+    } else if (customReady || isCustomRuntimeId(config.preferred_runtime)) {
+      items.push(customHarnessCatalogStub());
     }
     return items;
-  }, [customReady, customRuntime, readyCatalogRuntimes]);
+  }, [config.preferred_runtime, customReady, customRuntime, readyCatalogRuntimes]);
   const selectedRuntime = React.useMemo(
     () =>
       readyRuntimes.find((runtime) => runtime.id === config.preferred_runtime),
@@ -222,11 +211,10 @@ function AgentDefaultsSection({
 
   const handleCustomCommandChange = React.useCallback(
     (command: string) => {
-      const next: GlobalAgentConfig = {
-        ...config,
-        preferred_agent_command: command,
-        preferred_runtime: CUSTOM_RUNTIME_ID,
-      };
+      const next = applyCustomHarnessPreference(config, {
+        command,
+        args: formatAgentArgsInput(config.preferred_agent_args),
+      });
       setConfig(next);
       coalescerRef.current?.enqueue(next);
     },
@@ -235,11 +223,10 @@ function AgentDefaultsSection({
 
   const handleCustomArgsChange = React.useCallback(
     (value: string) => {
-      const next: GlobalAgentConfig = {
-        ...config,
-        preferred_agent_args: parseAgentArgsInput(value),
-        preferred_runtime: CUSTOM_RUNTIME_ID,
-      };
+      const next = applyCustomHarnessPreference(config, {
+        command: config.preferred_agent_command ?? "",
+        args: value,
+      });
       setConfig(next);
       coalescerRef.current?.enqueue(next);
     },
@@ -311,56 +298,17 @@ function AgentDefaultsSection({
           </div>
 
           {isCustomSelected ? (
-            <div className="space-y-4">
-              <div className="space-y-1.5">
-                <label
-                  className="pl-3 text-sm font-medium"
-                  htmlFor="global-agent-custom-command"
-                >
-                  Agent command
-                </label>
-                <Input
-                  autoCorrect="off"
-                  className="h-12 rounded-2xl border-foreground/15 bg-white px-4 text-sm shadow-none"
-                  data-testid="global-agent-custom-command"
-                  id="global-agent-custom-command"
-                  onChange={(event) =>
-                    handleCustomCommandChange(event.target.value)
-                  }
-                  placeholder="agent"
-                  spellCheck={false}
-                  value={config.preferred_agent_command ?? ""}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <label
-                  className="pl-3 text-sm font-medium"
-                  htmlFor="global-agent-custom-args"
-                >
-                  Agent args
-                  <span className="ml-1 text-xs font-normal text-muted-foreground">
-                    Optional
-                  </span>
-                </label>
-                <Input
-                  autoCorrect="off"
-                  className="h-12 rounded-2xl border-foreground/15 bg-white px-4 text-sm shadow-none"
-                  data-testid="global-agent-custom-args"
-                  id="global-agent-custom-args"
-                  onChange={(event) =>
-                    handleCustomArgsChange(event.target.value)
-                  }
-                  placeholder="acp"
-                  spellCheck={false}
-                  value={formatAgentArgsInput(config.preferred_agent_args)}
-                />
-                <p className="pl-3 text-xs text-muted-foreground">
-                  Comma-separated. Example:{" "}
-                  <code className="font-mono">acp</code> for Cursor, or leave
-                  blank for zero-arg adapters.
-                </p>
-              </div>
-            </div>
+            <CustomHarnessFields
+              args={formatAgentArgsInput(config.preferred_agent_args)}
+              argsId="global-agent-custom-args"
+              argsTestId="global-agent-custom-args"
+              command={config.preferred_agent_command ?? ""}
+              commandId="global-agent-custom-command"
+              commandTestId="global-agent-custom-command"
+              onArgsChange={handleCustomArgsChange}
+              onCommandChange={handleCustomCommandChange}
+              size="onboarding"
+            />
           ) : (
             <AgentConfigFields
               bakedEnv={bakedEnv}
@@ -369,9 +317,6 @@ function AgentDefaultsSection({
               isCustomModelEditing={isCustomModelEditing}
               isCustomProvider={isCustomProvider}
               onConfigChange={(next) => {
-                // Always apply optimistically so the UI never reverts mid-save,
-                // then enqueue the persist — the coalescer serialises multiple
-                // rapid edits into a single trailing request.
                 setConfig(next);
                 coalescerRef.current?.enqueue(next);
               }}
@@ -397,6 +342,7 @@ function AgentDefaultsSection({
  */
 export function DefaultConfigStep({
   actions,
+  byoDraft = null,
   direction,
   readyRuntimeIds,
 }: DefaultConfigStepProps) {
@@ -408,6 +354,9 @@ export function DefaultConfigStep({
     null,
   );
   const [isCompleting, setIsCompleting] = React.useState(false);
+  const customOnly =
+    readyRuntimeIds.length === 1 &&
+    isCustomRuntimeId(readyRuntimeIds[0] ?? "");
 
   const handleComplete = React.useCallback(async () => {
     setIsCompleting(true);
@@ -430,18 +379,21 @@ export function DefaultConfigStep({
     >
       <div className="w-full max-w-[500px] text-center">
         <h1 className="text-title font-normal text-foreground">
-          Configure your default model settings
+          {customOnly
+            ? "Confirm your custom harness"
+            : "Configure your default model settings"}
         </h1>
         <p className="mx-auto mt-3 max-w-[440px] text-sm leading-5 text-foreground/80">
-          This will be set as your default model configuration across Buzz. You
-          can always change this in your Settings or give specific agents a
-          different configuration.
+          {customOnly
+            ? "Buzz will spawn this ACP command for new agents. Make sure the binary speaks ACP over stdio and is on your PATH."
+            : "This will be set as your default model configuration across Buzz. You can always change this in your Settings or give specific agents a different configuration."}
         </p>
       </div>
 
       <div className="flex w-full flex-1 items-center justify-center py-10">
         <div className="w-full max-w-[328px]">
           <AgentDefaultsSection
+            byoDraft={byoDraft}
             onPersistenceStateChange={setPersistenceState}
             readyRuntimeIds={readyRuntimeIds}
           />

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -112,6 +112,20 @@ function AgentDefaultsSection({
         next = applyCustomHarnessPreference(next, byoDraft);
         seededByoRef.current = true;
         coalescer.enqueue(next);
+      } else if (
+        !byoDraft?.command.trim() &&
+        isCustomRuntimeId(next.preferred_runtime) &&
+        !readyRuntimeIds.includes(CUSTOM_RUNTIME_ID)
+      ) {
+        // Setup advanced without BYO (or cleared it after Back). Drop a
+        // custom preference seeded on an earlier pass through this step.
+        const fallbackId = readyRuntimeIds.find(
+          (id) => id !== CUSTOM_RUNTIME_ID,
+        );
+        if (fallbackId) {
+          next = resetConfigForHarnessChange(next, fallbackId);
+          coalescer.enqueue(next);
+        }
       }
       setConfig(next);
       if (bakedEnvResult.status === "fulfilled") {
@@ -126,7 +140,7 @@ function AgentDefaultsSection({
       unmounted = true;
       coalescer.cancel();
     };
-  }, [byoDraft]);
+  }, [byoDraft, readyRuntimeIds]);
 
   const customReady = readyRuntimeIds.includes(CUSTOM_RUNTIME_ID);
   const effectiveReadyRuntimeIds = React.useMemo(

--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -174,7 +174,12 @@ function AgentDefaultsSection({
       items.push(customHarnessCatalogStub());
     }
     return items;
-  }, [config.preferred_runtime, customReady, customRuntime, readyCatalogRuntimes]);
+  }, [
+    config.preferred_runtime,
+    customReady,
+    customRuntime,
+    readyCatalogRuntimes,
+  ]);
   const selectedRuntime = React.useMemo(
     () =>
       readyRuntimes.find((runtime) => runtime.id === config.preferred_runtime),
@@ -355,8 +360,7 @@ export function DefaultConfigStep({
   );
   const [isCompleting, setIsCompleting] = React.useState(false);
   const customOnly =
-    readyRuntimeIds.length === 1 &&
-    isCustomRuntimeId(readyRuntimeIds[0] ?? "");
+    readyRuntimeIds.length === 1 && isCustomRuntimeId(readyRuntimeIds[0] ?? "");
 
   const handleComplete = React.useCallback(async () => {
     setIsCompleting(true);

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -223,6 +223,7 @@ export function MachineOnboardingFlow({
                 },
               }}
               direction="forward"
+              initialByoDraft={byoDraft}
               onReadyRuntimeIdsChange={handleReadyRuntimeIdsChange}
             />
           ) : (

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -20,6 +20,7 @@ import {
 import { OnboardingFooterProvider } from "./OnboardingFooter";
 import { OnboardingSlideTransition } from "./OnboardingSlideTransition";
 import { SetupStep } from "./SetupStep";
+import type { ByoHarnessDraft } from "@/features/agents/lib/customHarness";
 
 export type MachineOnboardingPage =
   | "identity"
@@ -51,6 +52,7 @@ export function MachineOnboardingFlow({
     null,
   );
   const [readyRuntimeIds, setReadyRuntimeIds] = React.useState<string[]>([]);
+  const [byoDraft, setByoDraft] = React.useState<ByoHarnessDraft | null>(null);
   const handleReadyRuntimeIdsChange = React.useCallback(
     (runtimeIds: readonly string[]) => {
       setReadyRuntimeIds(Array.from(new Set(runtimeIds)));
@@ -214,8 +216,9 @@ export function MachineOnboardingFlow({
               actions={{
                 back: () =>
                   setPage(identityWasImported ? "key-import" : "backup"),
-                next: (runtimeIds) => {
+                next: (runtimeIds, draft) => {
                   setReadyRuntimeIds(Array.from(runtimeIds));
+                  setByoDraft(draft ?? null);
                   setPage("config");
                 },
               }}
@@ -228,6 +231,7 @@ export function MachineOnboardingFlow({
                 back: () => setPage("setup"),
                 complete: () => complete(selectedPubkey ?? undefined),
               }}
+              byoDraft={byoDraft}
               direction="forward"
               readyRuntimeIds={readyRuntimeIds}
             />

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -40,6 +40,8 @@ import type { SetupStepActions, SetupStepState } from "./types";
 type SetupStepProps = {
   actions: SetupStepActions;
   direction: OnboardingTransitionDirection;
+  /** Restored when returning from the config step so BYO fields survive remount. */
+  initialByoDraft?: ByoHarnessDraft | null;
   onReadyRuntimeIdsChange: (runtimeIds: readonly string[]) => void;
 };
 
@@ -669,15 +671,22 @@ function RuntimeProvidersSection({
 function SetupStepContent({
   actions,
   direction,
+  initialByoDraft = null,
   onReadyRuntimeIdsChange,
   state,
 }: SetupStepContentProps) {
   const { runtimeProviders } = state;
   const [installResults, setInstallResults] =
     React.useState<InstallResultsState>({});
-  const [byoSelected, setByoSelected] = React.useState(false);
-  const [byoCommand, setByoCommand] = React.useState("");
-  const [byoArgs, setByoArgs] = React.useState("acp");
+  const [byoSelected, setByoSelected] = React.useState(() =>
+    Boolean(initialByoDraft?.command.trim()),
+  );
+  const [byoCommand, setByoCommand] = React.useState(
+    () => initialByoDraft?.command ?? "",
+  );
+  const [byoArgs, setByoArgs] = React.useState(
+    () => initialByoDraft?.args ?? "acp",
+  );
 
   const catalogReadyIds = React.useMemo(
     () =>
@@ -756,6 +765,7 @@ function SetupStepContent({
 export function SetupStep({
   actions,
   direction,
+  initialByoDraft = null,
   onReadyRuntimeIdsChange,
 }: SetupStepProps) {
   const state = useSetupStepState();
@@ -764,6 +774,7 @@ export function SetupStep({
     <SetupStepContent
       actions={actions}
       direction={direction}
+      initialByoDraft={initialByoDraft}
       onReadyRuntimeIdsChange={onReadyRuntimeIdsChange}
       state={state}
     />

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -17,6 +17,15 @@ import { Card } from "@/shared/ui/card";
 import { FlappingBee } from "@/shared/ui/buzz-logo/FlappingBee";
 import { Spinner } from "@/shared/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+import { Input } from "@/shared/ui/input";
+import {
+  CUSTOM_RUNTIME_ID,
+  parseAgentArgsInput,
+} from "@/features/agents/lib/customHarness";
+import {
+  getGlobalAgentConfig,
+  setGlobalAgentConfig,
+} from "@/shared/api/tauriGlobalAgentConfig";
 import {
   getReadyOnboardingRuntimes,
   getVisibleOnboardingRuntimes,
@@ -547,12 +556,119 @@ function RuntimeProvidersLoadingState() {
   );
 }
 
+function BringYourOwnHarnessCard({
+  args,
+  command,
+  onArgsChange,
+  onCommandChange,
+  onSelectedChange,
+  selected,
+}: {
+  args: string;
+  command: string;
+  onArgsChange: (value: string) => void;
+  onCommandChange: (value: string) => void;
+  onSelectedChange: (selected: boolean) => void;
+  selected: boolean;
+}) {
+  const commandReady = command.trim().length > 0;
+  const ready = selected && commandReady;
+
+  return (
+    <Card
+      className={cn(
+        "w-full max-w-[592px] select-none items-stretch px-5 py-5 text-left",
+        ready && "ring-1 ring-[var(--buzz-welcome-chartreuse)]/50",
+      )}
+      data-ready={ready ? "true" : "false"}
+      data-testid="onboarding-runtime-custom"
+      variant="textured"
+    >
+      <label className="flex cursor-pointer items-start gap-3">
+        <input
+          checked={selected}
+          className="mt-1"
+          data-testid="onboarding-runtime-custom-toggle"
+          onChange={(event) => onSelectedChange(event.target.checked)}
+          type="checkbox"
+        />
+        <span className="min-w-0 flex-1 space-y-1">
+          <span className="block text-sm font-medium text-foreground">
+            Bring your own harness
+          </span>
+          <span className="block text-xs leading-5 text-muted-foreground">
+            Any ACP-speaking command works — Cursor{" "}
+            <code className="font-mono text-2xs">agent acp</code>, yoak,
+            OpenCode, or your own adapter.
+          </span>
+        </span>
+      </label>
+
+      {selected ? (
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5 sm:col-span-1">
+            <label
+              className="text-xs font-medium text-foreground"
+              htmlFor="onboarding-custom-command"
+            >
+              Command
+            </label>
+            <Input
+              autoCorrect="off"
+              className="h-10 rounded-xl border-foreground/15 bg-white"
+              data-testid="onboarding-custom-command"
+              id="onboarding-custom-command"
+              onChange={(event) => onCommandChange(event.target.value)}
+              placeholder="agent"
+              spellCheck={false}
+              value={command}
+            />
+          </div>
+          <div className="space-y-1.5 sm:col-span-1">
+            <label
+              className="text-xs font-medium text-foreground"
+              htmlFor="onboarding-custom-args"
+            >
+              Args
+              <span className="ml-1 font-normal text-muted-foreground">
+                Optional
+              </span>
+            </label>
+            <Input
+              autoCorrect="off"
+              className="h-10 rounded-xl border-foreground/15 bg-white"
+              data-testid="onboarding-custom-args"
+              id="onboarding-custom-args"
+              onChange={(event) => onArgsChange(event.target.value)}
+              placeholder="acp"
+              spellCheck={false}
+              value={args}
+            />
+          </div>
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
 function RuntimeProvidersSection({
+  byoArgs,
+  byoCommand,
+  byoSelected,
   installResults,
+  onByoArgsChange,
+  onByoCommandChange,
+  onByoSelectedChange,
   onInstallResultsChange,
   runtimeProviders,
 }: {
+  byoArgs: string;
+  byoCommand: string;
+  byoSelected: boolean;
   installResults: InstallResultsState;
+  onByoArgsChange: (value: string) => void;
+  onByoCommandChange: (value: string) => void;
+  onByoSelectedChange: (selected: boolean) => void;
   onInstallResultsChange: React.Dispatch<
     React.SetStateAction<InstallResultsState>
   >;
@@ -596,8 +712,8 @@ function RuntimeProvidersSection({
           Set up your agent harnesses
         </h1>
         <p className="mx-auto mt-3 max-w-[760px] text-sm leading-6 text-foreground/90">
-          Buzz detected the harnesses available on this machine. Install or sign
-          in to at least one to continue.
+          Install or sign in to Claude Code or Codex, or bring your own ACP
+          harness (Cursor, yoak, OpenCode, and any other stdio ACP server).
         </p>
       </div>
 
@@ -624,10 +740,19 @@ function RuntimeProvidersSection({
             className="max-w-[560px] rounded-2xl bg-white/70 px-6 py-6 text-sm text-muted-foreground"
             data-testid="onboarding-acp-empty"
           >
-            No supported agent harnesses were detected yet. Install Claude Code
-            or Codex, then check again.
+            No bundled harnesses were detected yet. Install Claude Code or
+            Codex, or bring your own ACP command below.
           </p>
         )}
+
+        <BringYourOwnHarnessCard
+          args={byoArgs}
+          command={byoCommand}
+          onArgsChange={onByoArgsChange}
+          onCommandChange={onByoCommandChange}
+          selected={byoSelected}
+          onSelectedChange={onByoSelectedChange}
+        />
 
         {errorMessage ? (
           <p className="max-w-[560px] rounded-2xl bg-destructive/10 px-6 py-3 text-sm text-destructive">
@@ -648,12 +773,26 @@ function SetupStepContent({
   const { runtimeProviders } = state;
   const [installResults, setInstallResults] =
     React.useState<InstallResultsState>({});
-  const readyRuntimeIds = React.useMemo(
+  const [byoSelected, setByoSelected] = React.useState(false);
+  const [byoCommand, setByoCommand] = React.useState("");
+  const [byoArgs, setByoArgs] = React.useState("acp");
+  const [isAdvancing, setIsAdvancing] = React.useState(false);
+  const [advanceError, setAdvanceError] = React.useState<string | null>(null);
+
+  const catalogReadyIds = React.useMemo(
     () =>
       getReadyOnboardingRuntimes(runtimeProviders.items).map(
         (runtime) => runtime.id,
       ),
     [runtimeProviders.items],
+  );
+  const byoIsReady = byoSelected && byoCommand.trim().length > 0;
+  const readyRuntimeIds = React.useMemo(
+    () =>
+      byoIsReady
+        ? [...catalogReadyIds, CUSTOM_RUNTIME_ID]
+        : catalogReadyIds,
+    [byoIsReady, catalogReadyIds],
   );
   const readyRuntimeIdsKey = readyRuntimeIds.join("\0");
   // The key prevents catalog object refreshes from creating an effect loop
@@ -663,6 +802,34 @@ function SetupStepContent({
     onReadyRuntimeIdsChange(readyRuntimeIds);
   }, [onReadyRuntimeIdsChange, readyRuntimeIdsKey]);
 
+  const canAdvance = readyRuntimeIds.length > 0 && !isAdvancing;
+
+  async function handleNext() {
+    setAdvanceError(null);
+    setIsAdvancing(true);
+    try {
+      if (byoIsReady) {
+        const existing = await getGlobalAgentConfig().catch(() => null);
+        await setGlobalAgentConfig({
+          env_vars: existing?.env_vars ?? {},
+          model: existing?.model ?? null,
+          preferred_agent_args: parseAgentArgsInput(byoArgs),
+          preferred_agent_command: byoCommand.trim(),
+          preferred_runtime: CUSTOM_RUNTIME_ID,
+          provider: existing?.provider ?? null,
+        });
+      }
+      actions.next(readyRuntimeIds);
+    } catch (cause) {
+      setAdvanceError(
+        cause instanceof Error
+          ? cause.message
+          : "Couldn't save your custom harness.",
+      );
+      setIsAdvancing(false);
+    }
+  }
+
   return (
     <OnboardingSlideTransition
       className="flex min-h-full w-full flex-col items-center"
@@ -671,20 +838,32 @@ function SetupStepContent({
       transitionKey={`setup-${direction}`}
     >
       <RuntimeProvidersSection
+        byoArgs={byoArgs}
+        byoCommand={byoCommand}
+        byoSelected={byoSelected}
         installResults={installResults}
+        onByoArgsChange={setByoArgs}
+        onByoCommandChange={setByoCommand}
+        onByoSelectedChange={setByoSelected}
         onInstallResultsChange={setInstallResults}
         runtimeProviders={runtimeProviders}
       />
+
+      {advanceError ? (
+        <p className="mb-4 max-w-[560px] text-sm text-destructive" role="alert">
+          {advanceError}
+        </p>
+      ) : null}
 
       <OnboardingFooter>
         <Button
           className={`${ONBOARDING_PRIMARY_CTA_CLASS} text-sm`}
           data-testid="onboarding-setup-next"
-          disabled={readyRuntimeIds.length === 0}
-          onClick={() => actions.next(readyRuntimeIds)}
+          disabled={!canAdvance}
+          onClick={() => void handleNext()}
           type="button"
         >
-          Next
+          {isAdvancing ? "Saving…" : "Next"}
         </Button>
 
         <Button

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -689,9 +689,7 @@ function SetupStepContent({
   const byoIsReady = byoSelected && byoCommand.trim().length > 0;
   const readyRuntimeIds = React.useMemo(
     () =>
-      byoIsReady
-        ? [...catalogReadyIds, CUSTOM_RUNTIME_ID]
-        : catalogReadyIds,
+      byoIsReady ? [...catalogReadyIds, CUSTOM_RUNTIME_ID] : catalogReadyIds,
     [byoIsReady, catalogReadyIds],
   );
   const readyRuntimeIdsKey = readyRuntimeIds.join("\0");

--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -17,15 +17,11 @@ import { Card } from "@/shared/ui/card";
 import { FlappingBee } from "@/shared/ui/buzz-logo/FlappingBee";
 import { Spinner } from "@/shared/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
-import { Input } from "@/shared/ui/input";
 import {
   CUSTOM_RUNTIME_ID,
-  parseAgentArgsInput,
+  type ByoHarnessDraft,
 } from "@/features/agents/lib/customHarness";
-import {
-  getGlobalAgentConfig,
-  setGlobalAgentConfig,
-} from "@/shared/api/tauriGlobalAgentConfig";
+import { BringYourOwnHarnessCard } from "./BringYourOwnHarnessCard";
 import {
   getReadyOnboardingRuntimes,
   getVisibleOnboardingRuntimes,
@@ -556,101 +552,6 @@ function RuntimeProvidersLoadingState() {
   );
 }
 
-function BringYourOwnHarnessCard({
-  args,
-  command,
-  onArgsChange,
-  onCommandChange,
-  onSelectedChange,
-  selected,
-}: {
-  args: string;
-  command: string;
-  onArgsChange: (value: string) => void;
-  onCommandChange: (value: string) => void;
-  onSelectedChange: (selected: boolean) => void;
-  selected: boolean;
-}) {
-  const commandReady = command.trim().length > 0;
-  const ready = selected && commandReady;
-
-  return (
-    <Card
-      className={cn(
-        "w-full max-w-[592px] select-none items-stretch px-5 py-5 text-left",
-        ready && "ring-1 ring-[var(--buzz-welcome-chartreuse)]/50",
-      )}
-      data-ready={ready ? "true" : "false"}
-      data-testid="onboarding-runtime-custom"
-      variant="textured"
-    >
-      <label className="flex cursor-pointer items-start gap-3">
-        <input
-          checked={selected}
-          className="mt-1"
-          data-testid="onboarding-runtime-custom-toggle"
-          onChange={(event) => onSelectedChange(event.target.checked)}
-          type="checkbox"
-        />
-        <span className="min-w-0 flex-1 space-y-1">
-          <span className="block text-sm font-medium text-foreground">
-            Bring your own harness
-          </span>
-          <span className="block text-xs leading-5 text-muted-foreground">
-            Any ACP-speaking command works — Cursor{" "}
-            <code className="font-mono text-2xs">agent acp</code>, yoak,
-            OpenCode, or your own adapter.
-          </span>
-        </span>
-      </label>
-
-      {selected ? (
-        <div className="mt-4 grid gap-3 sm:grid-cols-2">
-          <div className="space-y-1.5 sm:col-span-1">
-            <label
-              className="text-xs font-medium text-foreground"
-              htmlFor="onboarding-custom-command"
-            >
-              Command
-            </label>
-            <Input
-              autoCorrect="off"
-              className="h-10 rounded-xl border-foreground/15 bg-white"
-              data-testid="onboarding-custom-command"
-              id="onboarding-custom-command"
-              onChange={(event) => onCommandChange(event.target.value)}
-              placeholder="agent"
-              spellCheck={false}
-              value={command}
-            />
-          </div>
-          <div className="space-y-1.5 sm:col-span-1">
-            <label
-              className="text-xs font-medium text-foreground"
-              htmlFor="onboarding-custom-args"
-            >
-              Args
-              <span className="ml-1 font-normal text-muted-foreground">
-                Optional
-              </span>
-            </label>
-            <Input
-              autoCorrect="off"
-              className="h-10 rounded-xl border-foreground/15 bg-white"
-              data-testid="onboarding-custom-args"
-              id="onboarding-custom-args"
-              onChange={(event) => onArgsChange(event.target.value)}
-              placeholder="acp"
-              spellCheck={false}
-              value={args}
-            />
-          </div>
-        </div>
-      ) : null}
-    </Card>
-  );
-}
-
 function RuntimeProvidersSection({
   byoArgs,
   byoCommand,
@@ -713,7 +614,8 @@ function RuntimeProvidersSection({
         </h1>
         <p className="mx-auto mt-3 max-w-[760px] text-sm leading-6 text-foreground/90">
           Install or sign in to Claude Code or Codex, or bring your own ACP
-          harness (Cursor, yoak, OpenCode, and any other stdio ACP server).
+          harness — any stdio ACP server such as Cursor{" "}
+          <code className="font-mono text-2xs">agent acp</code>.
         </p>
       </div>
 
@@ -776,8 +678,6 @@ function SetupStepContent({
   const [byoSelected, setByoSelected] = React.useState(false);
   const [byoCommand, setByoCommand] = React.useState("");
   const [byoArgs, setByoArgs] = React.useState("acp");
-  const [isAdvancing, setIsAdvancing] = React.useState(false);
-  const [advanceError, setAdvanceError] = React.useState<string | null>(null);
 
   const catalogReadyIds = React.useMemo(
     () =>
@@ -802,32 +702,13 @@ function SetupStepContent({
     onReadyRuntimeIdsChange(readyRuntimeIds);
   }, [onReadyRuntimeIdsChange, readyRuntimeIdsKey]);
 
-  const canAdvance = readyRuntimeIds.length > 0 && !isAdvancing;
+  const canAdvance = readyRuntimeIds.length > 0;
 
-  async function handleNext() {
-    setAdvanceError(null);
-    setIsAdvancing(true);
-    try {
-      if (byoIsReady) {
-        const existing = await getGlobalAgentConfig().catch(() => null);
-        await setGlobalAgentConfig({
-          env_vars: existing?.env_vars ?? {},
-          model: existing?.model ?? null,
-          preferred_agent_args: parseAgentArgsInput(byoArgs),
-          preferred_agent_command: byoCommand.trim(),
-          preferred_runtime: CUSTOM_RUNTIME_ID,
-          provider: existing?.provider ?? null,
-        });
-      }
-      actions.next(readyRuntimeIds);
-    } catch (cause) {
-      setAdvanceError(
-        cause instanceof Error
-          ? cause.message
-          : "Couldn't save your custom harness.",
-      );
-      setIsAdvancing(false);
-    }
+  function handleNext() {
+    const draft: ByoHarnessDraft | null = byoIsReady
+      ? { command: byoCommand.trim(), args: byoArgs }
+      : null;
+    actions.next(readyRuntimeIds, draft);
   }
 
   return (
@@ -849,21 +730,15 @@ function SetupStepContent({
         runtimeProviders={runtimeProviders}
       />
 
-      {advanceError ? (
-        <p className="mb-4 max-w-[560px] text-sm text-destructive" role="alert">
-          {advanceError}
-        </p>
-      ) : null}
-
       <OnboardingFooter>
         <Button
           className={`${ONBOARDING_PRIMARY_CTA_CLASS} text-sm`}
           data-testid="onboarding-setup-next"
           disabled={!canAdvance}
-          onClick={() => void handleNext()}
+          onClick={handleNext}
           type="button"
         >
-          {isAdvancing ? "Saving…" : "Next"}
+          Next
         </Button>
 
         <Button

--- a/desktop/src/features/onboarding/ui/agentReadiness.test.mjs
+++ b/desktop/src/features/onboarding/ui/agentReadiness.test.mjs
@@ -238,6 +238,23 @@ test("resolveAgentReadiness_legacy_config_does_not_treat_goose_binary_as_ready",
 // Preferred runtime isolation
 // ---------------------------------------------------------------------------
 
+test("resolveAgentReadiness_preferred_goose_does_not_borrow_ready_buzz_agent_config", () => {
+  const runtimes = [
+    makeRuntime({ id: "goose", label: "Goose" }),
+    makeRuntime({ id: "buzz-agent", label: "Buzz Agent" }),
+  ];
+  const result = resolveAgentReadiness(
+    runtimes,
+    makeConfig({
+      provider: "anthropic",
+      model: null,
+      env_vars: { ANTHROPIC_API_KEY: "sk-ant-test" },
+    }),
+    "preferred",
+  );
+  assert.equal(result.ready, false);
+});
+
 test("resolveAgentReadiness_preferred_custom_command_is_ready", () => {
   const result = resolveAgentReadiness(
     [],

--- a/desktop/src/features/onboarding/ui/agentReadiness.test.mjs
+++ b/desktop/src/features/onboarding/ui/agentReadiness.test.mjs
@@ -31,6 +31,8 @@ function makeConfig(overrides = {}) {
     provider: null,
     model: null,
     preferred_runtime: "goose",
+    preferred_agent_command: null,
+    preferred_agent_args: null,
     ...overrides,
   };
 }
@@ -236,19 +238,31 @@ test("resolveAgentReadiness_legacy_config_does_not_treat_goose_binary_as_ready",
 // Preferred runtime isolation
 // ---------------------------------------------------------------------------
 
-test("resolveAgentReadiness_preferred_goose_does_not_borrow_ready_buzz_agent_config", () => {
-  const runtimes = [
-    makeRuntime({ id: "goose", label: "Goose" }),
-    makeRuntime({ id: "buzz-agent", label: "Buzz Agent" }),
-  ];
+test("resolveAgentReadiness_preferred_custom_command_is_ready", () => {
   const result = resolveAgentReadiness(
-    runtimes,
+    [],
     makeConfig({
-      provider: "anthropic",
-      model: null,
-      env_vars: { ANTHROPIC_API_KEY: "sk-ant-test" },
+      preferred_runtime: "custom",
+      preferred_agent_command: "yoak",
+      preferred_agent_args: ["acp"],
     }),
     "preferred",
   );
-  assert.equal(result.ready, false);
+  assert.deepEqual(result, {
+    ready: true,
+    reason: "cli",
+    runtimeLabel: "Custom command",
+  });
+});
+
+test("resolveAgentReadiness_preferred_custom_without_command_is_not_ready", () => {
+  const result = resolveAgentReadiness(
+    [],
+    makeConfig({
+      preferred_runtime: "custom",
+      preferred_agent_command: "  ",
+    }),
+    "preferred",
+  );
+  assert.deepEqual(result, { ready: false });
 });

--- a/desktop/src/features/onboarding/ui/agentReadiness.ts
+++ b/desktop/src/features/onboarding/ui/agentReadiness.ts
@@ -12,7 +12,8 @@ export type AgentReadinessResult =
 /**
  * Determine whether the user has a working agent path configured.
  *
- * CLI path: the preferred Claude or Codex runtime is available and logged in.
+ * CLI path: the preferred Claude or Codex runtime is available and logged in,
+ * or a bring-your-own ACP command is configured.
  * Provider path: the preferred Buzz Agent or Goose runtime has provider and
  * model set, plus all required credential env vars for that provider.
  *
@@ -23,6 +24,17 @@ export function resolveAgentReadiness(
   globalConfig: GlobalAgentConfig,
   scope: "any" | "preferred" = "any",
 ): AgentReadinessResult {
+  if (
+    globalConfig.preferred_runtime === "custom" &&
+    (globalConfig.preferred_agent_command ?? "").trim().length > 0
+  ) {
+    return {
+      ready: true,
+      reason: "cli",
+      runtimeLabel: "Custom command",
+    };
+  }
+
   if (scope === "any") {
     for (const runtime of runtimes) {
       if (runtime.id === "buzz-agent") continue;

--- a/desktop/src/features/onboarding/ui/types.ts
+++ b/desktop/src/features/onboarding/ui/types.ts
@@ -58,7 +58,10 @@ export type ProfileStepActions = {
 
 export type SetupStepActions = {
   back: () => void;
-  next: (readyRuntimeIds: readonly string[]) => void;
+  next: (
+    readyRuntimeIds: readonly string[],
+    byoDraft?: { command: string; args: string } | null,
+  ) => void;
 };
 
 export type DefaultConfigStepActions = {

--- a/desktop/src/features/onboarding/welcomeGuide.ts
+++ b/desktop/src/features/onboarding/welcomeGuide.ts
@@ -16,6 +16,7 @@ import type {
   AcpRuntime,
   AgentPersona,
   CreateManagedAgentInput,
+  GlobalAgentConfig,
   ManagedAgent,
 } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
@@ -210,13 +211,16 @@ export async function buildWelcomeStarterCreateInput(
   starter: WelcomeTeamStarterDefinition,
   persona: AgentPersona,
   runtimes: readonly AcpRuntime[],
-  preferredRuntimeId: string | null,
+  preferred: Pick<
+    GlobalAgentConfig,
+    "preferred_runtime" | "preferred_agent_command" | "preferred_agent_args"
+  > | null,
   relayUrl?: string | null,
 ): Promise<CreateManagedAgentInput> {
   const { runtime } = resolveStartRuntimeForDefinition(
     persona,
     runtimes,
-    preferredRuntimeId,
+    preferred,
   );
   return {
     ...(await buildInstanceInputForDefinition(persona, runtime)),
@@ -293,7 +297,7 @@ async function provisionWelcomeTeam(
       starter,
       persona,
       runtimes,
-      globalConfig.preferred_runtime,
+      globalConfig,
       relayUrl,
     );
     const existing = pickWelcomeTeamStarterAgentForRelay(

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -421,7 +421,7 @@ export function UserProfilePanel({
       const { runtime, warnings } = resolveStartRuntimeForDefinition(
         personaToStart,
         runtimes,
-        globalConfig.preferred_runtime,
+        globalConfig,
       );
 
       for (const warning of warnings) {
@@ -442,6 +442,8 @@ export function UserProfilePanel({
       availableRuntimesQuery,
       createAgentMutation.mutateAsync,
       globalConfig.preferred_runtime,
+      globalConfig.preferred_agent_command,
+      globalConfig.preferred_agent_args,
       managedAgentsQuery.refetch,
       relayAgentsQuery.refetch,
     ],

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -995,6 +995,16 @@ export type GlobalAgentConfig = {
   model: string | null;
   /** Preferred ACP runtime for agents without a persona-specific runtime. */
   preferred_runtime: string | null;
+  /**
+   * Command for a bring-your-own ACP harness when `preferred_runtime` is
+   * `"custom"` (binary name or absolute path). Null when unused.
+   */
+  preferred_agent_command: string | null;
+  /**
+   * Args for a bring-your-own ACP harness when `preferred_runtime` is
+   * `"custom"` (e.g. `["acp"]`). Null when unused.
+   */
+  preferred_agent_args: string[] | null;
 };
 
 /**

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -341,6 +341,8 @@ type E2eConfig = {
       provider: string | null;
       model: string | null;
       preferred_runtime?: string | null;
+      preferred_agent_command?: string | null;
+      preferred_agent_args?: string[] | null;
     };
     /** Baked build env returned by the display and key-name Tauri commands. */
     bakedBuildEnv?: Array<{
@@ -6947,6 +6949,8 @@ let mockGlobalAgentConfig: {
   provider: string | null;
   model: string | null;
   preferred_runtime?: string | null;
+  preferred_agent_command?: string | null;
+  preferred_agent_args?: string[] | null;
 } | null = null;
 
 // Per-page get_nsec call counter for sequenced error testing.
@@ -10106,6 +10110,8 @@ export function maybeInstallE2eTauriMocks() {
             provider: null,
             model: null,
             preferred_runtime: null,
+            preferred_agent_command: null,
+            preferred_agent_args: null,
           }
         );
       }
@@ -10120,6 +10126,8 @@ export function maybeInstallE2eTauriMocks() {
               provider: string | null;
               model: string | null;
               preferred_runtime: string | null;
+              preferred_agent_command: string | null;
+              preferred_agent_args: string[] | null;
             };
           }
         ).config;

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -81,7 +81,56 @@ test("setup shows only Claude Code and Codex as detected harnesses", async ({
   await expect(page.getByTestId("onboarding-runtime-buzz-agent")).toHaveCount(
     0,
   );
-  await expect(page.getByRole("checkbox")).toHaveCount(0);
+  await expect(page.getByTestId("onboarding-runtime-custom")).toBeVisible();
+  await expect(
+    page.getByTestId("onboarding-runtime-custom-toggle"),
+  ).not.toBeChecked();
+});
+
+test("bring-your-own harness enables Next without Claude or Codex", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime("claude", "not_installed", { status: "logged_out" }),
+        runtime("codex", "not_installed", { status: "logged_out" }),
+      ],
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  await expect(page.getByTestId("onboarding-setup-next")).toBeDisabled();
+  await page.getByTestId("onboarding-runtime-custom-toggle").check();
+  await expect(page.getByTestId("onboarding-setup-next")).toBeDisabled();
+  await page.getByTestId("onboarding-custom-command").fill("agent");
+  await page.getByTestId("onboarding-custom-args").fill("acp");
+  await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
+  await page.getByTestId("onboarding-setup-next").click();
+
+  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
+  await expect(page.getByTestId("global-agent-default-harness")).toHaveText(
+    "Custom command",
+  );
+  expect(await readSavedRuntime(page)).toBe("custom");
+  const saved = await page.evaluate(async () => {
+    return await (
+      window as Window & {
+        __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+          command: string,
+          payload: unknown,
+        ) => Promise<{
+          preferred_agent_command?: string | null;
+          preferred_agent_args?: string[] | null;
+        }>;
+      }
+    ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__?.("get_global_agent_config", null);
+  });
+  expect(saved?.preferred_agent_command).toBe("agent");
+  expect(saved?.preferred_agent_args).toEqual(["acp"]);
 });
 
 test("ready state is detected and enables Next without persisting a default", async ({

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -115,7 +115,13 @@ test("bring-your-own harness enables Next without Claude or Codex", async ({
   await expect(page.getByTestId("global-agent-default-harness")).toHaveText(
     "Custom command",
   );
-  expect(await readSavedRuntime(page)).toBe("custom");
+  await expect(page.getByTestId("global-agent-custom-command")).toHaveValue(
+    "agent",
+  );
+  // Preference is persisted from the config step (not Setup Next).
+  await expect
+    .poll(() => readSavedRuntime(page))
+    .toBe("custom");
   const saved = await page.evaluate(async () => {
     return await (
       window as Window & {

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -380,6 +380,8 @@ type MockBridgeOptions = {
     provider: string | null;
     model: string | null;
     preferred_runtime?: string | null;
+    preferred_agent_command?: string | null;
+    preferred_agent_args?: string[] | null;
   };
   bakedBuildEnv?: Array<{
     key: string;


### PR DESCRIPTION
## Summary
- Onboarding adds a **Bring your own harness** path so users can continue without installing Claude Code or Codex.
- Persists `preferred_runtime: "custom"` with `preferred_agent_command` / `preferred_agent_args`, and wires that preference through defaults, agent create/start, and readiness.
- Documents that any **ACP-over-stdio** binary works (e.g. Cursor `agent acp`); Buzz does not wrap arbitrary CLIs.

Closes #2278

## Test plan
- [x] Unit: `customHarness`, `agentReadiness`, `resolvePersonaRuntime`, `onboardingRuntimeSelection`
- [x] `pnpm typecheck` in `desktop/`
- [x] Biome check on touched onboarding/agent files
- [x] DCO sign-off on all commits
- [ ] E2E: `onboarding-agent-defaults.spec.ts` — BYO enables Next without Claude/Codex and saves custom preference from the config step
- [ ] Manual: onboarding → Bring your own → command `agent` args `acp` → finish → create agent uses that command
- [ ] Manual: Settings → Agent defaults → Custom command → start agent
- [ ] Manual: Claude Code / Codex path still works when installed