### PR TITLE
fix(acp): follow threads the agent participates in (#2270)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,6 +194,17 @@ RUST_LOG=buzz_relay=debug,buzz_db=debug,buzz_auth=debug,buzz_pubsub=debug,tower_
 # Set to true to disable the @-mention filter in mentions mode.
 # BUZZ_ACP_NO_MENTION_FILTER=false
 
+# Follow unmentioned replies in threads the agent participates in (default).
+# Set to true to restore strict mention-per-message behavior.
+# BUZZ_ACP_NO_FOLLOW_THREADS=false
+
+# Follow-only author policy: "humans" (safe default) or "all". Under
+# "humans", agent and unknown identities still require an explicit mention.
+# BUZZ_ACP_FOLLOW_THREAD_AUTHORS=humans
+
+# Sliding inactivity TTL for followed thread roots, in seconds (24 hours).
+# BUZZ_ACP_THREAD_FOLLOW_TTL_SECS=86400
+
 # Path to TOML config file for rule-based subscriptions (config mode).
 # BUZZ_ACP_CONFIG=./buzz-acp.toml
 

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -161,6 +161,26 @@ Owner control commands must be kind:9 stream messages from the owner, must menti
 
 > **Note:** The default mode is `owner-only`. Agents without a registered `agent_owner_pubkey` will not respond to any events until the owner is resolved. Set `--respond-to anyone` to disable the gate entirely.
 
+### Followed Threads
+
+In the default `mentions` subscription mode, a mention starts following that
+specific thread. Subsequent unmentioned replies in the thread can trigger the
+agent until the sliding inactivity TTL expires. Other channel messages remain
+mention-gated.
+
+| Flag | Env Var | Default | Description |
+|------|---------|---------|-------------|
+| `--no-follow-threads` | `BUZZ_ACP_NO_FOLLOW_THREADS` | `false` | Restore strict mention-per-message behavior. |
+| `--follow-thread-authors` | `BUZZ_ACP_FOLLOW_THREAD_AUTHORS` | `humans` | `humans` admits only positively classified human members; `all` also admits agent/unknown authors and accepts auto-continuation risk. Explicit mentions are unaffected. |
+| `--thread-follow-ttl-secs` | `BUZZ_ACP_THREAD_FOLLOW_TTL_SECS` | `86400` | Sliding inactivity TTL for followed roots. |
+
+Follow state is in-memory, isolated per channel, capped at 64 roots per
+channel, and cleared when the agent leaves the channel. The safe `humans`
+policy fails closed: a valid NIP-OA attestation or channel `bot` role proves an
+agent, normal member roles prove a human, and unresolved identities still need
+an explicit mention. Use `--follow-thread-authors all` only when every admitted
+author is trusted and agent-to-agent auto-continuation is intentional.
+
 **Examples:**
 
 ```bash

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -54,6 +54,16 @@ pub enum SubscribeMode {
     Config,
 }
 
+/// Author policy for followed-thread admissions (#2270 loop guard).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum FollowThreadAuthors {
+    /// Admit unmentioned followed-thread replies from humans only (default).
+    Humans,
+    /// Admit unmentioned followed-thread replies from any author, including
+    /// agents. Opting in accepts the risk of agent↔agent auto-continuation.
+    All,
+}
+
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 pub enum DedupMode {
     Drop,
@@ -344,6 +354,18 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_NO_FOLLOW_THREADS")]
     pub no_follow_threads: bool,
 
+    /// Whose unmentioned replies a followed thread admits. `humans` (default)
+    /// admits human authors only — agent-authored replies still require an
+    /// explicit @mention, so two agents sharing a thread can never
+    /// auto-continue each other. `all` admits any author.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_FOLLOW_THREAD_AUTHORS",
+        default_value = "humans",
+        value_enum
+    )]
+    pub follow_thread_authors: FollowThreadAuthors,
+
     /// Sliding inactivity TTL, in seconds, for followed threads. A thread the
     /// agent participated in stops being followed after this long without
     /// activity; a fresh @mention re-joins it.
@@ -542,6 +564,8 @@ pub struct Config {
     pub follow_threads: bool,
     /// Sliding inactivity TTL for followed thread roots, in seconds.
     pub thread_follow_ttl_secs: u64,
+    /// Author policy for followed-thread admissions (loop guard).
+    pub follow_thread_authors: FollowThreadAuthors,
     pub config_path: PathBuf,
     pub context_message_limit: u32,
     /// Maximum turns per session before proactive rotation. 0 = disabled.
@@ -1085,6 +1109,7 @@ impl Config {
             no_mention_filter: args.no_mention_filter,
             follow_threads: !args.no_follow_threads,
             thread_follow_ttl_secs: args.thread_follow_ttl_secs,
+            follow_thread_authors: args.follow_thread_authors,
             config_path: args.config,
             context_message_limit: args.context_message_limit,
             max_turns_per_session: args.max_turns_per_session,
@@ -1466,6 +1491,7 @@ mod tests {
             no_mention_filter: false,
             follow_threads: true,
             thread_follow_ttl_secs: 86_400,
+            follow_thread_authors: FollowThreadAuthors::Humans,
             config_path: PathBuf::from("./buzz-acp.toml"),
             context_message_limit: 12,
             max_turns_per_session: 0,

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -338,6 +338,22 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_NO_MENTION_FILTER")]
     pub no_mention_filter: bool,
 
+    /// Disable thread-following. With this set, a mention-gated agent only
+    /// sees messages that explicitly @mention it — even untagged replies in
+    /// threads it is already participating in (the pre-#2270 behavior).
+    #[arg(long, env = "BUZZ_ACP_NO_FOLLOW_THREADS")]
+    pub no_follow_threads: bool,
+
+    /// Sliding inactivity TTL, in seconds, for followed threads. A thread the
+    /// agent participated in stops being followed after this long without
+    /// activity; a fresh @mention re-joins it.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_THREAD_FOLLOW_TTL_SECS",
+        default_value_t = 86_400
+    )]
+    pub thread_follow_ttl_secs: u64,
+
     #[arg(long, env = "BUZZ_ACP_CONFIG", default_value = "./buzz-acp.toml")]
     pub config: PathBuf,
 
@@ -486,6 +502,12 @@ pub struct ChannelFilter {
     pub kinds: Option<Vec<u32>>,
     /// Whether to include `#p` tag filter for agent pubkey.
     pub require_mention: bool,
+    /// Thread roots the agent follows in this channel. When non-empty and
+    /// `require_mention` is set, the REQ carries a second filter clause
+    /// (`#h` + `#e`) so untagged replies in these threads are delivered
+    /// alongside explicit mentions. Ignored when `require_mention` is false
+    /// (the mention-less clause already delivers everything).
+    pub thread_roots: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -515,6 +537,11 @@ pub struct Config {
     pub kinds_override: Option<Vec<u32>>,
     pub channels_override: Option<Vec<String>>,
     pub no_mention_filter: bool,
+    /// Whether the agent follows threads it has participated in (#2270).
+    /// Only consulted in Mentions mode — All mode delivers everything anyway.
+    pub follow_threads: bool,
+    /// Sliding inactivity TTL for followed thread roots, in seconds.
+    pub thread_follow_ttl_secs: u64,
     pub config_path: PathBuf,
     pub context_message_limit: u32,
     /// Maximum turns per session before proactive rotation. 0 = disabled.
@@ -1056,6 +1083,8 @@ impl Config {
             kinds_override: args.kinds,
             channels_override: args.channels,
             no_mention_filter: args.no_mention_filter,
+            follow_threads: !args.no_follow_threads,
+            thread_follow_ttl_secs: args.thread_follow_ttl_secs,
             config_path: args.config,
             context_message_limit: args.context_message_limit,
             max_turns_per_session: args.max_turns_per_session,
@@ -1243,6 +1272,7 @@ pub fn resolve_channel_filters(
                     ChannelFilter {
                         kinds: Some(kinds.clone()),
                         require_mention,
+                        thread_roots: Vec::new(),
                     },
                 );
             }
@@ -1254,6 +1284,7 @@ pub fn resolve_channel_filters(
                     ChannelFilter {
                         kinds: config.kinds_override.clone(),
                         require_mention: false,
+                        thread_roots: Vec::new(),
                     },
                 );
             }
@@ -1289,6 +1320,7 @@ pub fn resolve_channel_filters(
                         ChannelFilter {
                             kinds: merged_kinds,
                             require_mention,
+                            thread_roots: Vec::new(),
                         },
                     );
                 }
@@ -1342,10 +1374,12 @@ pub fn resolve_dynamic_channel_filter(
                 ]
             })),
             require_mention: !config.no_mention_filter,
+            thread_roots: Vec::new(),
         }),
         SubscribeMode::All => Some(ChannelFilter {
             kinds: config.kinds_override.clone(),
             require_mention: false,
+            thread_roots: Vec::new(),
         }),
         SubscribeMode::Config => {
             // Same merge logic as resolve_channel_filters() Config branch:
@@ -1383,6 +1417,7 @@ pub fn resolve_dynamic_channel_filter(
             Some(ChannelFilter {
                 kinds: merged_kinds,
                 require_mention,
+                thread_roots: Vec::new(),
             })
         }
     }
@@ -1429,6 +1464,8 @@ mod tests {
             kinds_override: None,
             channels_override: None,
             no_mention_filter: false,
+            follow_threads: true,
+            thread_follow_ttl_secs: 86_400,
             config_path: PathBuf::from("./buzz-acp.toml"),
             context_message_limit: 12,
             max_turns_per_session: 0,

--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -154,6 +154,11 @@ pub struct MatchedRule {
     pub rule_index: usize,
     /// Prompt tag to use (rule's `prompt_tag` or its `name`).
     pub prompt_tag: String,
+    /// True when the winning rule required a mention that was absent and the
+    /// event was admitted only because its thread root is followed (#2270).
+    /// The caller applies the followed-thread author policy to exactly these
+    /// admissions — mention-based matches are never subject to it.
+    pub admitted_via_follow: bool,
 }
 
 /// Maximum expression length accepted by `evaluate_filter`.
@@ -387,6 +392,8 @@ pub async fn match_event(
     });
 
     for (index, rule) in rules.iter().enumerate() {
+        let mut admitted_via_follow = false;
+
         // 1. Channel scope check.
         if !rule.channels.matches(&channel_id) {
             continue;
@@ -406,8 +413,11 @@ pub async fn match_event(
                 s.first().map(|k| k.as_str()) == Some("p")
                     && s.get(1).map(|v| v.as_str()) == Some(agent_pubkey_hex)
             });
-            if !mentioned && followed_thread_root.is_none() {
-                continue;
+            if !mentioned {
+                if followed_thread_root.is_none() {
+                    continue;
+                }
+                admitted_via_follow = true;
             }
         }
 
@@ -466,6 +476,7 @@ pub async fn match_event(
         return Some(MatchedRule {
             rule_index: index,
             prompt_tag,
+            admitted_via_follow,
         });
     }
 
@@ -527,10 +538,32 @@ mod tests {
             .await
             .is_none());
 
-        // With the thread followed, the same unmentioned reply is admitted.
+        // With the thread followed, the same unmentioned reply is admitted —
+        // and flagged as a follow admission so the author policy can act.
         let followed: HashSet<String> = [root].into_iter().collect();
         let matched = match_event(&event, channel_id, &rules, "agent-pk", Some(&followed)).await;
-        assert!(matched.is_some());
+        assert!(matched.as_ref().is_some_and(|m| m.admitted_via_follow));
+    }
+
+    #[tokio::test]
+    async fn test_match_event_mention_admission_is_not_flagged_as_follow() {
+        let channel_id = any_channel();
+        let rules = vec![make_rule(
+            "mentions",
+            ChannelScope::All("all".into()),
+            vec![9],
+            true,
+            None,
+            None,
+        )];
+        // Explicitly mentioned event in a followed thread: admitted via the
+        // mention, so the follow flag must stay false (the author policy
+        // never applies to explicit mentions).
+        let root = "e".repeat(64);
+        let followed: HashSet<String> = [root].into_iter().collect();
+        let event = make_event_with_p_tag(9, "hey @agent", "agent-pk");
+        let matched = match_event(&event, channel_id, &rules, "agent-pk", Some(&followed)).await;
+        assert!(matched.as_ref().is_some_and(|m| !m.admitted_via_follow));
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -5,6 +5,7 @@
 //! - Evaluating boolean filter expressions with a hard timeout
 //! - Matching events against ordered subscription rules (first match wins)
 
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -351,7 +352,10 @@ const MAX_CONSECUTIVE_TIMEOUTS: u32 = 5;
 /// 2. **kinds** — if non-empty, the event kind must be in the list.
 /// 3. **require_mention** — if `true`, a `p` tag matching `agent_pubkey_hex` must
 ///    exist. Tag kind is checked via `tag.as_slice()` for stable, library-independent
-///    access.
+///    access. An unmentioned event still passes this check when its NIP-10
+///    thread root is in `followed_roots` — the agent is participating in that
+///    thread, so untagged replies stay audible (#2270). Following relaxes only
+///    the mention gate; channel scope, kinds, and expression filters still apply.
 /// 4. **filter** — if `Some`, the evalexpr expression must evaluate to `true`.
 ///
 /// # Fail-closed filter error handling
@@ -370,8 +374,17 @@ pub async fn match_event(
     channel_id: uuid::Uuid,
     rules: &[SubscriptionRule],
     agent_pubkey_hex: &str,
+    followed_roots: Option<&HashSet<String>>,
 ) -> Option<MatchedRule> {
     let filter_ctx = FilterContext::from_event(event, channel_id);
+
+    // Resolved once per event: the NIP-10 thread root, iff the caller passed a
+    // followed set and the root is in it. `None` either way otherwise.
+    let followed_thread_root: Option<String> = followed_roots.and_then(|roots| {
+        crate::queue::parse_thread_tags(event)
+            .root_event_id
+            .filter(|root| roots.contains(root))
+    });
 
     for (index, rule) in rules.iter().enumerate() {
         // 1. Channel scope check.
@@ -393,7 +406,7 @@ pub async fn match_event(
                 s.first().map(|k| k.as_str()) == Some("p")
                     && s.get(1).map(|v| v.as_str()) == Some(agent_pubkey_hex)
             });
-            if !mentioned {
+            if !mentioned && followed_thread_root.is_none() {
                 continue;
             }
         }
@@ -482,6 +495,100 @@ mod tests {
             .tags([p_tag])
             .sign_with_keys(&keys)
             .unwrap()
+    }
+
+    /// Build a test event that is an untagged reply in a NIP-10 thread
+    /// (marker-based `e` root tag, no `p` mention).
+    fn make_event_in_thread(kind: u32, content: &str, root_hex: &str) -> nostr::Event {
+        let keys = Keys::generate();
+        let e_tag = Tag::parse(["e", root_hex, "", "root"]).expect("tag parse");
+        EventBuilder::new(Kind::Custom(kind as u16), content)
+            .tags([e_tag])
+            .sign_with_keys(&keys)
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_match_event_followed_thread_admits_unmentioned_reply() {
+        let channel_id = any_channel();
+        let rules = vec![make_rule(
+            "mentions",
+            ChannelScope::All("all".into()),
+            vec![9],
+            true,
+            None,
+            None,
+        )];
+        let root = "a".repeat(64);
+        let event = make_event_in_thread(9, "yes, go ahead", &root);
+
+        // Without a followed set the reply is gated (pre-#2270 behavior).
+        assert!(match_event(&event, channel_id, &rules, "agent-pk", None)
+            .await
+            .is_none());
+
+        // With the thread followed, the same unmentioned reply is admitted.
+        let followed: HashSet<String> = [root].into_iter().collect();
+        let matched = match_event(&event, channel_id, &rules, "agent-pk", Some(&followed)).await;
+        assert!(matched.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_match_event_followed_thread_ignores_other_threads() {
+        let channel_id = any_channel();
+        let rules = vec![make_rule(
+            "mentions",
+            ChannelScope::All("all".into()),
+            vec![9],
+            true,
+            None,
+            None,
+        )];
+        let followed: HashSet<String> = [("b".repeat(64))].into_iter().collect();
+
+        // Reply in a different thread stays gated.
+        let other_thread = make_event_in_thread(9, "unrelated", &"c".repeat(64));
+        assert!(match_event(
+            &other_thread,
+            channel_id,
+            &rules,
+            "agent-pk",
+            Some(&followed)
+        )
+        .await
+        .is_none());
+
+        // Top-level message with no thread tags stays gated too.
+        let top_level = make_event(9, "no thread here");
+        assert!(
+            match_event(&top_level, channel_id, &rules, "agent-pk", Some(&followed))
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_match_event_followed_thread_relaxes_only_the_mention_gate() {
+        let channel_id = any_channel();
+        // Rule matches kind 9 only — a followed-thread event of kind 45001
+        // must still be dropped: following bypasses the mention check, not
+        // the kind or channel gates.
+        let rules = vec![make_rule(
+            "mentions",
+            ChannelScope::All("all".into()),
+            vec![9],
+            true,
+            None,
+            None,
+        )];
+        let root = "d".repeat(64);
+        let followed: HashSet<String> = [root.clone()].into_iter().collect();
+        let wrong_kind = make_event_in_thread(45001, "still gated", &root);
+        assert!(
+            match_event(&wrong_kind, channel_id, &rules, "agent-pk", Some(&followed))
+                .await
+                .is_none()
+        );
     }
 
     fn any_channel() -> Uuid {
@@ -601,7 +708,9 @@ mod tests {
             ),
         ];
 
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
+        let matched = match_event(&event, channel_id, &rules, "", None)
+            .await
+            .unwrap();
         assert_eq!(matched.rule_index, 0);
         assert_eq!(matched.prompt_tag, "tag-first");
     }
@@ -630,7 +739,9 @@ mod tests {
             ),
         ];
 
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
+        let matched = match_event(&event, channel_id, &rules, "", None)
+            .await
+            .unwrap();
         assert_eq!(matched.rule_index, 1);
         assert_eq!(matched.prompt_tag, "matched");
     }
@@ -653,11 +764,11 @@ mod tests {
         )];
 
         // Without mention — no match.
-        let result = match_event(&event_no_mention, channel_id, &rules, agent_pubkey).await;
+        let result = match_event(&event_no_mention, channel_id, &rules, agent_pubkey, None).await;
         assert!(result.is_none());
 
         // With mention — matches.
-        let matched = match_event(&event_with_mention, channel_id, &rules, agent_pubkey)
+        let matched = match_event(&event_with_mention, channel_id, &rules, agent_pubkey, None)
             .await
             .unwrap();
         assert_eq!(matched.prompt_tag, "mentioned");
@@ -677,7 +788,7 @@ mod tests {
             None,
         )];
 
-        let result = match_event(&event, channel_id, &rules, "").await;
+        let result = match_event(&event, channel_id, &rules, "", None).await;
         assert!(result.is_none());
     }
 
@@ -725,7 +836,9 @@ mod tests {
             None, // no explicit tag
         )];
 
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
+        let matched = match_event(&event, channel_id, &rules, "", None)
+            .await
+            .unwrap();
         assert_eq!(matched.prompt_tag, "my-rule");
     }
 
@@ -755,7 +868,7 @@ mod tests {
         ];
 
         // Must return None — not "catch-all".
-        let result = match_event(&event, channel_id, &rules, "").await;
+        let result = match_event(&event, channel_id, &rules, "", None).await;
         assert!(
             result.is_none(),
             "filter error must fail closed, not fall through to next rule"
@@ -781,7 +894,7 @@ mod tests {
             .store(MAX_CONSECUTIVE_TIMEOUTS, Ordering::Relaxed);
 
         let rules = vec![rule];
-        let result = match_event(&event, channel_id, &rules, "").await;
+        let result = match_event(&event, channel_id, &rules, "", None).await;
         assert!(result.is_none(), "disabled rule must return None");
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -154,10 +154,9 @@ struct OwnerCache {
     pubkey: Option<String>,
     /// author_hex → is_sibling (true = same owner, false = not)
     siblings: std::sync::Mutex<HashMap<String, bool>>,
-    /// author_hex → is_agent (NIP-OA auth tag present on kind:0).
-    /// Used by the followed-thread author policy (#2270 loop guard), not by
-    /// the security gate — same heuristic weight as prompt reply anchoring.
-    agent_flags: std::sync::Mutex<HashMap<String, bool>>,
+    /// Authors whose kind:0 contains a cryptographically valid NIP-OA
+    /// attestation. Negative/unknown results are never cached.
+    verified_agents: std::sync::Mutex<HashSet<String>>,
 }
 
 impl OwnerCache {
@@ -165,25 +164,23 @@ impl OwnerCache {
         Self {
             pubkey: initial,
             siblings: std::sync::Mutex::new(HashMap::new()),
-            agent_flags: std::sync::Mutex::new(HashMap::new()),
+            verified_agents: std::sync::Mutex::new(HashSet::new()),
         }
     }
 
-    /// Check the agent-flag cache. `None` = never looked up.
-    fn known_agent_flag(&self, author: &str) -> Option<bool> {
-        self.agent_flags
+    fn is_verified_agent(&self, author: &str) -> bool {
+        self.verified_agents
             .lock()
-            .ok()
-            .and_then(|map| map.get(author).copied())
+            .is_ok_and(|authors| authors.contains(author))
     }
 
-    /// Cache an agent-flag lookup result (capped like the sibling cache).
-    fn cache_agent_flag(&self, author: String, is_agent: bool) {
-        if let Ok(mut map) = self.agent_flags.lock() {
-            if map.len() >= 256 {
-                map.clear();
+    /// Cache a positively verified agent identity (capped like sibling state).
+    fn cache_verified_agent(&self, author: String) {
+        if let Ok(mut authors) = self.verified_agents.lock() {
+            if authors.len() >= 256 {
+                authors.clear();
             }
-            map.insert(author, is_agent);
+            authors.insert(author);
         }
     }
 
@@ -239,48 +236,122 @@ async fn is_owner_or_sibling(
     is_sibling
 }
 
-/// Is this author an agent (NIP-OA `auth` tag on their kind:0 profile)?
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FollowAuthorClass {
+    Human,
+    Agent,
+    Unknown,
+}
+
+/// Classify an author for the followed-thread anti-loop boundary.
 ///
-/// Used by the followed-thread author policy: an *unmentioned* event admitted
-/// only because its thread is followed must not fire a turn when its author
-/// is another agent, or two agents sharing a thread auto-continue each other
-/// indefinitely (the loop #2270 requires stay impossible). Presence/shape
-/// heuristic per [`pool::profile_event_is_agent`] — same weight as prompt
-/// reply anchoring; the security gate remains [`author_allowed`]. Unknown or
-/// unfetchable identities classify as human (fail open for visibility,
-/// matching `turn_is_human_facing`); explicit mentions are never affected.
-async fn author_is_agent(
+/// This path deliberately fails closed: only the configured human owner or a
+/// non-bot channel member is positively admitted as human. A valid NIP-OA
+/// attestation or the channel's `bot` role proves agenthood. Missing profiles,
+/// membership state, malformed events, and relay failures remain `Unknown` and
+/// therefore require an explicit mention under the default `humans` policy.
+async fn classify_follow_author(
     author: &str,
+    channel_id: Uuid,
     owner_cache: &OwnerCache,
     rest_client: &relay::RestClient,
-) -> bool {
-    if let Some(cached) = owner_cache.known_agent_flag(author) {
-        return cached;
+) -> FollowAuthorClass {
+    if owner_cache.get() == Some(author) {
+        return FollowAuthorClass::Human;
+    }
+    if owner_cache.is_verified_agent(author) {
+        return FollowAuthorClass::Agent;
     }
 
     let author_pk = match nostr::PublicKey::from_hex(author) {
         Ok(pk) => pk,
-        Err(_) => return false,
+        Err(_) => return FollowAuthorClass::Unknown,
     };
-    let filter = nostr::Filter::new()
+    let profile_filter = nostr::Filter::new()
         .kind(nostr::Kind::Metadata)
         .author(author_pk)
         .limit(1);
-
-    let is_agent =
-        match tokio::time::timeout(Duration::from_millis(2000), rest_client.query(&[filter])).await
+    if let Ok(Ok(resp)) = tokio::time::timeout(
+        Duration::from_millis(2000),
+        rest_client.query(&[profile_filter]),
+    )
+    .await
+    {
+        if resp
+            .as_array()
+            .and_then(|events| events.first())
+            .is_some_and(|event| profile_has_valid_agent_attestation(event, &author_pk))
         {
-            Ok(Ok(resp)) => resp
-                .as_array()
-                .and_then(|events| events.first())
-                .is_some_and(pool::profile_event_is_agent),
-            // Timeout/error — treat as human (fail open) but do NOT cache, so a
-            // transient relay hiccup can't pin an agent as human for the session.
-            _ => return false,
-        };
+            owner_cache.cache_verified_agent(author.to_string());
+            return FollowAuthorClass::Agent;
+        }
+    }
 
-    owner_cache.cache_agent_flag(author.to_string(), is_agent);
-    is_agent
+    use nostr::{Alphabet, SingleLetterTag};
+    let membership_filter = nostr::Filter::new()
+        .kind(nostr::Kind::Custom(
+            buzz_core::kind::KIND_NIP29_GROUP_MEMBERS as u16,
+        ))
+        .custom_tags(
+            SingleLetterTag::lowercase(Alphabet::D),
+            [channel_id.to_string()],
+        )
+        .limit(1);
+    let membership = match tokio::time::timeout(
+        Duration::from_millis(2000),
+        rest_client.query(&[membership_filter]),
+    )
+    .await
+    {
+        Ok(Ok(resp)) => resp,
+        _ => return FollowAuthorClass::Unknown,
+    };
+
+    membership
+        .as_array()
+        .and_then(|events| events.first())
+        .and_then(|event| member_role(event, author))
+        .map_or(FollowAuthorClass::Unknown, |role| {
+            if role == "bot" {
+                FollowAuthorClass::Agent
+            } else {
+                FollowAuthorClass::Human
+            }
+        })
+}
+
+fn profile_has_valid_agent_attestation(
+    event: &serde_json::Value,
+    agent_pubkey: &nostr::PublicKey,
+) -> bool {
+    event
+        .get("tags")
+        .and_then(|tags| tags.as_array())
+        .is_some_and(|tags| {
+            tags.iter().any(|tag| {
+                serde_json::to_string(tag).is_ok_and(|tag_json| {
+                    buzz_sdk::nip_oa::verify_auth_tag(&tag_json, agent_pubkey).is_ok()
+                })
+            })
+        })
+}
+
+fn member_role<'a>(event: &'a serde_json::Value, author: &str) -> Option<&'a str> {
+    event
+        .get("tags")?
+        .as_array()?
+        .iter()
+        .filter_map(|tag| tag.as_array())
+        .find(|parts| {
+            parts.first().and_then(|v| v.as_str()) == Some("p")
+                && parts
+                    .get(1)
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|pubkey| pubkey.eq_ignore_ascii_case(author))
+        })
+        .and_then(|parts| parts.get(3))
+        .and_then(|role| role.as_str())
+        .filter(|role| matches!(*role, "owner" | "admin" | "member" | "guest" | "bot"))
 }
 
 /// Whether a followed-thread admission should be suppressed for this author.
@@ -292,9 +363,11 @@ async fn author_is_agent(
 fn suppress_follow_admission(
     admitted_via_follow: bool,
     policy: config::FollowThreadAuthors,
-    author_is_agent: bool,
+    author_class: FollowAuthorClass,
 ) -> bool {
-    admitted_via_follow && matches!(policy, config::FollowThreadAuthors::Humans) && author_is_agent
+    admitted_via_follow
+        && matches!(policy, config::FollowThreadAuthors::Humans)
+        && author_class != FollowAuthorClass::Human
 }
 
 /// Inbound author gate decision: does this author's event fire a turn?
@@ -2316,22 +2389,28 @@ async fn tokio_main() -> Result<()> {
                             // lookup runs only on follow-admitted events.
                             if admitted_via_follow {
                                 let author = buzz_event.event.pubkey.to_hex();
-                                let is_agent_author = match config.follow_thread_authors {
+                                let author_class = match config.follow_thread_authors {
                                     config::FollowThreadAuthors::Humans => {
-                                        author_is_agent(&author, &owner_cache, &ctx.rest_client)
-                                            .await
+                                        classify_follow_author(
+                                            &author,
+                                            buzz_event.channel_id,
+                                            &owner_cache,
+                                            &ctx.rest_client,
+                                        )
+                                        .await
                                     }
-                                    config::FollowThreadAuthors::All => false,
+                                    config::FollowThreadAuthors::All => FollowAuthorClass::Human,
                                 };
                                 if suppress_follow_admission(
                                     admitted_via_follow,
                                     config.follow_thread_authors,
-                                    is_agent_author,
+                                    author_class,
                                 ) {
                                     tracing::debug!(
                                         channel_id = %buzz_event.channel_id,
                                         author = %author,
-                                        "followed-thread admission suppressed for agent author"
+                                        ?author_class,
+                                        "followed-thread admission suppressed for non-human author"
                                     );
                                     continue;
                                 }
@@ -4573,7 +4652,7 @@ mod follow_author_policy_tests {
         assert!(!suppress_follow_admission(
             true,
             FollowThreadAuthors::Humans,
-            false
+            FollowAuthorClass::Human
         ));
     }
 
@@ -4585,7 +4664,16 @@ mod follow_author_policy_tests {
         assert!(suppress_follow_admission(
             true,
             FollowThreadAuthors::Humans,
-            true
+            FollowAuthorClass::Agent
+        ));
+    }
+
+    #[test]
+    fn unknown_unmentioned_reply_in_followed_root_is_dropped() {
+        assert!(suppress_follow_admission(
+            true,
+            FollowThreadAuthors::Humans,
+            FollowAuthorClass::Unknown
         ));
     }
 
@@ -4596,12 +4684,12 @@ mod follow_author_policy_tests {
         assert!(!suppress_follow_admission(
             false,
             FollowThreadAuthors::Humans,
-            true
+            FollowAuthorClass::Agent
         ));
         assert!(!suppress_follow_admission(
             false,
             FollowThreadAuthors::All,
-            true
+            FollowAuthorClass::Agent
         ));
     }
 
@@ -4610,7 +4698,7 @@ mod follow_author_policy_tests {
         assert!(!suppress_follow_admission(
             true,
             FollowThreadAuthors::All,
-            true
+            FollowAuthorClass::Agent
         ));
     }
 
@@ -4622,9 +4710,52 @@ mod follow_author_policy_tests {
         // A ever replied anyway, B's harness would face the identical
         // decision — also suppressed. Under the default policy the cycle
         // cannot begin from either side.
-        let a_fires = !suppress_follow_admission(true, FollowThreadAuthors::Humans, true);
-        let b_fires = !suppress_follow_admission(true, FollowThreadAuthors::Humans, true);
+        let a_fires =
+            !suppress_follow_admission(true, FollowThreadAuthors::Humans, FollowAuthorClass::Agent);
+        let b_fires =
+            !suppress_follow_admission(true, FollowThreadAuthors::Humans, FollowAuthorClass::Agent);
         assert!(!a_fires && !b_fires);
+    }
+
+    #[test]
+    fn profile_agent_classification_requires_a_valid_attestation() {
+        let owner = nostr::Keys::generate();
+        let agent = nostr::Keys::generate();
+        let auth = buzz_sdk::nip_oa::compute_auth_tag(&owner, &agent.public_key(), "")
+            .expect("compute auth tag");
+        let auth: serde_json::Value = serde_json::from_str(&auth).expect("parse auth tag");
+
+        let valid_profile = serde_json::json!({"tags": [auth]});
+        assert!(profile_has_valid_agent_attestation(
+            &valid_profile,
+            &agent.public_key()
+        ));
+
+        let malformed_profile = serde_json::json!({
+            "tags": [["auth", owner.public_key().to_hex(), "", "not-a-signature"]]
+        });
+        assert!(!profile_has_valid_agent_attestation(
+            &malformed_profile,
+            &agent.public_key()
+        ));
+    }
+
+    #[test]
+    fn membership_role_requires_a_known_role_for_the_exact_author() {
+        let author = "aa";
+        let event = serde_json::json!({
+            "tags": [
+                ["d", "channel"],
+                ["p", "bb", "", "bot"],
+                ["p", author, "", "member"]
+            ]
+        });
+        assert_eq!(member_role(&event, author), Some("member"));
+        assert_eq!(member_role(&event, "bb"), Some("bot"));
+        assert_eq!(member_role(&event, "cc"), None);
+
+        let unknown_role = serde_json::json!({"tags": [["p", author, "", "robot"]]});
+        assert_eq!(member_role(&unknown_role, author), None);
     }
 }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -154,6 +154,10 @@ struct OwnerCache {
     pubkey: Option<String>,
     /// author_hex → is_sibling (true = same owner, false = not)
     siblings: std::sync::Mutex<HashMap<String, bool>>,
+    /// author_hex → is_agent (NIP-OA auth tag present on kind:0).
+    /// Used by the followed-thread author policy (#2270 loop guard), not by
+    /// the security gate — same heuristic weight as prompt reply anchoring.
+    agent_flags: std::sync::Mutex<HashMap<String, bool>>,
 }
 
 impl OwnerCache {
@@ -161,6 +165,25 @@ impl OwnerCache {
         Self {
             pubkey: initial,
             siblings: std::sync::Mutex::new(HashMap::new()),
+            agent_flags: std::sync::Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Check the agent-flag cache. `None` = never looked up.
+    fn known_agent_flag(&self, author: &str) -> Option<bool> {
+        self.agent_flags
+            .lock()
+            .ok()
+            .and_then(|map| map.get(author).copied())
+    }
+
+    /// Cache an agent-flag lookup result (capped like the sibling cache).
+    fn cache_agent_flag(&self, author: String, is_agent: bool) {
+        if let Ok(mut map) = self.agent_flags.lock() {
+            if map.len() >= 256 {
+                map.clear();
+            }
+            map.insert(author, is_agent);
         }
     }
 
@@ -214,6 +237,64 @@ async fn is_owner_or_sibling(
     let is_sibling = check_sibling_via_profile(author, my_owner, rest_client).await;
     owner_cache.cache_sibling(author.to_string(), is_sibling);
     is_sibling
+}
+
+/// Is this author an agent (NIP-OA `auth` tag on their kind:0 profile)?
+///
+/// Used by the followed-thread author policy: an *unmentioned* event admitted
+/// only because its thread is followed must not fire a turn when its author
+/// is another agent, or two agents sharing a thread auto-continue each other
+/// indefinitely (the loop #2270 requires stay impossible). Presence/shape
+/// heuristic per [`pool::profile_event_is_agent`] — same weight as prompt
+/// reply anchoring; the security gate remains [`author_allowed`]. Unknown or
+/// unfetchable identities classify as human (fail open for visibility,
+/// matching `turn_is_human_facing`); explicit mentions are never affected.
+async fn author_is_agent(
+    author: &str,
+    owner_cache: &OwnerCache,
+    rest_client: &relay::RestClient,
+) -> bool {
+    if let Some(cached) = owner_cache.known_agent_flag(author) {
+        return cached;
+    }
+
+    let author_pk = match nostr::PublicKey::from_hex(author) {
+        Ok(pk) => pk,
+        Err(_) => return false,
+    };
+    let filter = nostr::Filter::new()
+        .kind(nostr::Kind::Metadata)
+        .author(author_pk)
+        .limit(1);
+
+    let is_agent =
+        match tokio::time::timeout(Duration::from_millis(2000), rest_client.query(&[filter])).await
+        {
+            Ok(Ok(resp)) => resp
+                .as_array()
+                .and_then(|events| events.first())
+                .is_some_and(pool::profile_event_is_agent),
+            // Timeout/error — treat as human (fail open) but do NOT cache, so a
+            // transient relay hiccup can't pin an agent as human for the session.
+            _ => return false,
+        };
+
+    owner_cache.cache_agent_flag(author.to_string(), is_agent);
+    is_agent
+}
+
+/// Whether a followed-thread admission should be suppressed for this author.
+///
+/// Pure decision core of the #2270 loop guard, kept separate for testability:
+/// only events admitted *via the follow bypass* (unmentioned, followed root)
+/// are ever suppressed, and only under the `humans` policy when the author is
+/// an agent. Mentioned events and normally-matched events pass untouched.
+fn suppress_follow_admission(
+    admitted_via_follow: bool,
+    policy: config::FollowThreadAuthors,
+    author_is_agent: bool,
+) -> bool {
+    admitted_via_follow && matches!(policy, config::FollowThreadAuthors::Humans) && author_is_agent
 }
 
 /// Inbound author gate decision: does this author's event fire a turn?
@@ -2219,13 +2300,42 @@ async fn tokio_main() -> Result<()> {
                                 .enabled()
                                 .then(|| thread_follow.live_roots(buzz_event.channel_id));
                             let matched = filter::match_event(&buzz_event.event, buzz_event.channel_id, &rules, &pubkey_hex, followed_roots.as_ref()).await;
-                            let prompt_tag = match matched {
-                                Some(m) => m.prompt_tag,
+                            let (prompt_tag, admitted_via_follow) = match matched {
+                                Some(m) => (m.prompt_tag, m.admitted_via_follow),
                                 None => {
                                     tracing::debug!(channel_id = %buzz_event.channel_id, kind = buzz_event.event.kind.as_u16(), "event matched no rule — dropping");
                                     continue;
                                 }
                             };
+                            // #2270 loop guard: an admission that exists only
+                            // because the thread is followed must not fire on
+                            // agent authors (policy `humans`, the default) —
+                            // otherwise two agents sharing a thread would
+                            // auto-continue each other indefinitely. Explicit
+                            // mentions never take this path, and the profile
+                            // lookup runs only on follow-admitted events.
+                            if admitted_via_follow {
+                                let author = buzz_event.event.pubkey.to_hex();
+                                let is_agent_author = match config.follow_thread_authors {
+                                    config::FollowThreadAuthors::Humans => {
+                                        author_is_agent(&author, &owner_cache, &ctx.rest_client)
+                                            .await
+                                    }
+                                    config::FollowThreadAuthors::All => false,
+                                };
+                                if suppress_follow_admission(
+                                    admitted_via_follow,
+                                    config.follow_thread_authors,
+                                    is_agent_author,
+                                ) {
+                                    tracing::debug!(
+                                        channel_id = %buzz_event.channel_id,
+                                        author = %author,
+                                        "followed-thread admission suppressed for agent author"
+                                    );
+                                    continue;
+                                }
+                            }
                             // An admitted event in a followed thread is live
                             // conversation — slide that thread's TTL forward.
                             if thread_follow.enabled() {
@@ -2618,7 +2728,7 @@ async fn tokio_main() -> Result<()> {
                             None,
                         );
                         for (channel_id, thread_tags) in
-                            dispatch_pending(&mut pool, &mut queue, &ctx)
+                            dispatch_pending(&mut pool, &mut queue, &ctx, &mut thread_follow)
                         {
                             typing_channels.insert(channel_id, thread_tags);
                         }
@@ -4454,6 +4564,71 @@ mod owner_cache_tests {
 }
 
 #[cfg(test)]
+mod follow_author_policy_tests {
+    use super::*;
+    use config::FollowThreadAuthors;
+
+    #[test]
+    fn human_unmentioned_reply_in_followed_root_is_admitted() {
+        assert!(!suppress_follow_admission(
+            true,
+            FollowThreadAuthors::Humans,
+            false
+        ));
+    }
+
+    #[test]
+    fn agent_unmentioned_reply_in_followed_root_is_dropped() {
+        // Covers both the same-owner sibling case (passes the author gate)
+        // and the external-agent-under-RespondTo::Anyone case — the policy
+        // classifies by agenthood, not by gate mode.
+        assert!(suppress_follow_admission(
+            true,
+            FollowThreadAuthors::Humans,
+            true
+        ));
+    }
+
+    #[test]
+    fn mentioned_admissions_are_never_suppressed() {
+        // A mention-based match has admitted_via_follow == false, so the
+        // policy cannot touch it regardless of author kind or policy value.
+        assert!(!suppress_follow_admission(
+            false,
+            FollowThreadAuthors::Humans,
+            true
+        ));
+        assert!(!suppress_follow_admission(
+            false,
+            FollowThreadAuthors::All,
+            true
+        ));
+    }
+
+    #[test]
+    fn all_policy_opts_into_agent_authors() {
+        assert!(!suppress_follow_admission(
+            true,
+            FollowThreadAuthors::All,
+            true
+        ));
+    }
+
+    #[test]
+    fn two_agents_sharing_a_followed_root_cannot_auto_continue() {
+        // Simulate the #2270 loop hazard at the decision layer: agents A and
+        // B both follow root T. B posts an unmentioned reply; A's harness
+        // sees a follow-only admission from an agent author — suppressed. If
+        // A ever replied anyway, B's harness would face the identical
+        // decision — also suppressed. Under the default policy the cycle
+        // cannot begin from either side.
+        let a_fires = !suppress_follow_admission(true, FollowThreadAuthors::Humans, true);
+        let b_fires = !suppress_follow_admission(true, FollowThreadAuthors::Humans, true);
+        assert!(!a_fires && !b_fires);
+    }
+}
+
+#[cfg(test)]
 mod author_gate_tests {
     use super::*;
 
@@ -5055,6 +5230,7 @@ mod build_mcp_servers_tests {
             no_mention_filter: false,
             follow_threads: true,
             thread_follow_ttl_secs: 86_400,
+            follow_thread_authors: config::FollowThreadAuthors::Humans,
             config_path: std::path::PathBuf::from("./buzz-acp.toml"),
             context_message_limit: 12,
             max_turns_per_session: 0,
@@ -5278,6 +5454,7 @@ mod error_outcome_emission_tests {
             no_mention_filter: false,
             follow_threads: true,
             thread_follow_ttl_secs: 86_400,
+            follow_thread_authors: config::FollowThreadAuthors::Humans,
             config_path: std::path::PathBuf::from("./buzz-acp.toml"),
             context_message_limit: 12,
             max_turns_per_session: 0,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -155,8 +155,15 @@ struct OwnerCache {
     /// author_hex → is_sibling (true = same owner, false = not)
     siblings: std::sync::Mutex<HashMap<String, bool>>,
     /// Authors whose kind:0 contains a cryptographically valid NIP-OA
-    /// attestation. Negative/unknown results are never cached.
+    /// attestation. Identity-level and immutable, so this is global.
+    /// Negative/unknown results are never cached.
     verified_agents: std::sync::Mutex<HashSet<String>>,
+    /// (channel_id, author_hex) → class proven from that channel's member
+    /// roles. Roles are per-channel, so this key must stay channel-scoped —
+    /// an author may be a plain member in one channel and a `bot` in another.
+    /// `Unknown` is never cached: it means "not proven", and pinning it would
+    /// let one failed lookup suppress an author until the cache clears.
+    member_classes: std::sync::Mutex<HashMap<(Uuid, String), FollowAuthorClass>>,
 }
 
 impl OwnerCache {
@@ -165,6 +172,7 @@ impl OwnerCache {
             pubkey: initial,
             siblings: std::sync::Mutex::new(HashMap::new()),
             verified_agents: std::sync::Mutex::new(HashSet::new()),
+            member_classes: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
@@ -181,6 +189,26 @@ impl OwnerCache {
                 authors.clear();
             }
             authors.insert(author);
+        }
+    }
+
+    /// Membership-derived class for this author in this channel, if proven.
+    fn known_member_class(&self, channel_id: Uuid, author: &str) -> Option<FollowAuthorClass> {
+        self.member_classes
+            .lock()
+            .ok()
+            .and_then(|classes| classes.get(&(channel_id, author.to_string())).copied())
+    }
+
+    fn cache_member_class(&self, channel_id: Uuid, author: String, class: FollowAuthorClass) {
+        if class == FollowAuthorClass::Unknown {
+            return;
+        }
+        if let Ok(mut classes) = self.member_classes.lock() {
+            if classes.len() >= 256 {
+                classes.clear();
+            }
+            classes.insert((channel_id, author), class);
         }
     }
 
@@ -262,6 +290,12 @@ async fn classify_follow_author(
     if owner_cache.is_verified_agent(author) {
         return FollowAuthorClass::Agent;
     }
+    // Proven member role for this channel — skips both round-trips on the hot
+    // path (a human replying repeatedly in a followed thread is the common
+    // case this feature exists to serve).
+    if let Some(cached) = owner_cache.known_member_class(channel_id, author) {
+        return cached;
+    }
 
     let author_pk = match nostr::PublicKey::from_hex(author) {
         Ok(pk) => pk,
@@ -307,7 +341,7 @@ async fn classify_follow_author(
         _ => return FollowAuthorClass::Unknown,
     };
 
-    membership
+    let class = membership
         .as_array()
         .and_then(|events| events.first())
         .and_then(|event| member_role(event, author))
@@ -317,7 +351,9 @@ async fn classify_follow_author(
             } else {
                 FollowAuthorClass::Human
             }
-        })
+        });
+    owner_cache.cache_member_class(channel_id, author.to_string(), class);
+    class
 }
 
 fn profile_has_valid_agent_attestation(
@@ -4738,6 +4774,28 @@ mod follow_author_policy_tests {
             &malformed_profile,
             &agent.public_key()
         ));
+    }
+
+    #[test]
+    fn member_class_cache_is_channel_scoped_and_never_pins_unknown() {
+        let cache = OwnerCache::new(None);
+        let author = "aa".to_string();
+        let channel_a = Uuid::new_v4();
+        let channel_b = Uuid::new_v4();
+
+        cache.cache_member_class(channel_a, author.clone(), FollowAuthorClass::Human);
+        assert_eq!(
+            cache.known_member_class(channel_a, &author),
+            Some(FollowAuthorClass::Human)
+        );
+        // Roles are per-channel: a human member of A must not be assumed human
+        // in B, where the same identity may hold the `bot` role.
+        assert_eq!(cache.known_member_class(channel_b, &author), None);
+
+        // A failed lookup must stay unproven rather than suppressing the
+        // author for the life of the cache.
+        cache.cache_member_class(channel_b, author.clone(), FollowAuthorClass::Unknown);
+        assert_eq!(cache.known_member_class(channel_b, &author), None);
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -10,6 +10,7 @@ mod pool_lifecycle;
 mod queue;
 mod relay;
 mod setup_mode;
+mod thread_follow;
 mod usage;
 
 pub use usage::TurnUsage;
@@ -1526,6 +1527,12 @@ async fn tokio_main() -> Result<()> {
         );
     }
 
+    // Thread-following (#2270): track the threads this agent participates in
+    // so untagged replies in them stay audible under mention gating. Disabled
+    // trackers are inert — every call below becomes a no-op.
+    let mut thread_follow =
+        thread_follow::ThreadFollowState::new(config.thread_follow_ttl_secs, config.follow_threads);
+
     let base_prompt_content = config.base_prompt_content.take();
     let ctx = Arc::new(PromptContext {
         mcp_servers: build_mcp_servers(&config),
@@ -1742,6 +1749,37 @@ async fn tokio_main() -> Result<()> {
             }
         }
 
+        // #2270: keep followed-thread REQ clauses in sync. take_dirty() is
+        // empty on almost every iteration; when a dispatch records a new
+        // thread (or a root expires) the affected channels get their
+        // subscription re-issued with an updated `#e` clause. The re-REQ
+        // replays from last_seen minus skew, so replies that land between
+        // dispatch and re-subscribe are recovered by replay, not lost.
+        // Runs regardless of pool readiness — this is relay subscription
+        // state; expiry-narrowing must proceed while a lazy pool sleeps.
+        thread_follow.compact_if_due();
+        for ch in thread_follow.take_dirty() {
+            if !subscribed_channel_ids.contains(&ch) {
+                continue;
+            }
+            let base = channel_filters
+                .get(&ch)
+                .cloned()
+                .or_else(|| config::resolve_dynamic_channel_filter(&config, ch, &rules));
+            if let Some(mut filter) = base {
+                if filter.require_mention {
+                    filter.thread_roots = thread_follow.roots_for_filter(ch);
+                    if let Err(e) = relay.subscribe_channel(ch, filter).await {
+                        tracing::warn!(
+                            channel_id = %ch,
+                            error = %e,
+                            "failed to refresh followed-thread subscription"
+                        );
+                    }
+                }
+            }
+        }
+
         if pool_ready && last_maintenance.elapsed() >= maintenance_interval {
             last_maintenance = std::time::Instant::now();
             queue.compact_expired_state();
@@ -1776,7 +1814,9 @@ async fn tokio_main() -> Result<()> {
             // called on relay events or pool results, neither of which
             // arrive when the channel is silent.
             if queue.has_flushable_work() {
-                for (channel_id, thread_tags) in dispatch_pending(&mut pool, &mut queue, &ctx) {
+                for (channel_id, thread_tags) in
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut thread_follow)
+                {
                     typing_channels.insert(channel_id, thread_tags);
                 }
             }
@@ -1812,7 +1852,9 @@ async fn tokio_main() -> Result<()> {
         // this, batches requeued during crash recovery sit idle until the
         // next relay event arrives — which can be minutes on quiet channels.
         if respawn_collected {
-            for (channel_id, thread_tags) in dispatch_pending(&mut pool, &mut queue, &ctx) {
+            for (channel_id, thread_tags) in
+                dispatch_pending(&mut pool, &mut queue, &ctx, &mut thread_follow)
+            {
                 typing_channels.insert(channel_id, thread_tags);
             }
         }
@@ -1994,6 +2036,7 @@ async fn tokio_main() -> Result<()> {
                                     } else {
                                         0
                                     };
+                                    thread_follow.clear_channel(ch);
                                     // Track removed channels so checked-out agents get
                                     // their sessions stripped when they return to the pool.
                                     removed_channels.insert(ch);
@@ -2172,7 +2215,10 @@ async fn tokio_main() -> Result<()> {
                                 }
                             }
 
-                            let matched = filter::match_event(&buzz_event.event, buzz_event.channel_id, &rules, &pubkey_hex).await;
+                            let followed_roots = thread_follow
+                                .enabled()
+                                .then(|| thread_follow.live_roots(buzz_event.channel_id));
+                            let matched = filter::match_event(&buzz_event.event, buzz_event.channel_id, &rules, &pubkey_hex, followed_roots.as_ref()).await;
                             let prompt_tag = match matched {
                                 Some(m) => m.prompt_tag,
                                 None => {
@@ -2180,6 +2226,15 @@ async fn tokio_main() -> Result<()> {
                                     continue;
                                 }
                             };
+                            // An admitted event in a followed thread is live
+                            // conversation — slide that thread's TTL forward.
+                            if thread_follow.enabled() {
+                                if let Some(root) =
+                                    queue::parse_thread_tags(&buzz_event.event).root_event_id
+                                {
+                                    thread_follow.touch(buzz_event.channel_id, &root);
+                                }
+                            }
                             // Capture author pubkey before queue.push() moves
                             // buzz_event.event (needed for mode gate below).
                             let author_hex = buzz_event.event.pubkey.to_hex();
@@ -2260,7 +2315,7 @@ async fn tokio_main() -> Result<()> {
                             }
                             if pool_ready {
                                 for (channel_id, thread_tags) in
-                                    dispatch_pending(&mut pool, &mut queue, &ctx)
+                                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut thread_follow)
                                 {
                                     typing_channels.insert(channel_id, thread_tags);
                                 }
@@ -2289,7 +2344,7 @@ async fn tokio_main() -> Result<()> {
                     } else if queue.has_flushable_work() {
                         tracing::debug!("heartbeat_skipped_events");
                         for (channel_id, thread_tags) in
-                            dispatch_pending(&mut pool, &mut queue, &ctx)
+                            dispatch_pending(&mut pool, &mut queue, &ctx, &mut thread_follow)
                         {
                             typing_channels.insert(channel_id, thread_tags);
                         }
@@ -2387,7 +2442,9 @@ async fn tokio_main() -> Result<()> {
                 {
                     break;
                 }
-                for (channel_id, thread_tags) in dispatch_pending(&mut pool, &mut queue, &ctx) {
+                for (channel_id, thread_tags) in
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut thread_follow)
+                {
                     typing_channels.insert(channel_id, thread_tags);
                 }
             }
@@ -2410,7 +2467,9 @@ async fn tokio_main() -> Result<()> {
                     tracing::error!("all agents dead — exiting");
                     break;
                 }
-                for (channel_id, thread_tags) in dispatch_pending(&mut pool, &mut queue, &ctx) {
+                for (channel_id, thread_tags) in
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut thread_follow)
+                {
                     typing_channels.insert(channel_id, thread_tags);
                 }
             }
@@ -2530,7 +2589,9 @@ async fn tokio_main() -> Result<()> {
                 // tear down the in-flight task; on its completion the
                 // queue drains. We still try here in case the in-flight
                 // task has already returned.
-                for (channel_id, thread_tags) in dispatch_pending(&mut pool, &mut queue, &ctx) {
+                for (channel_id, thread_tags) in
+                    dispatch_pending(&mut pool, &mut queue, &ctx, &mut thread_follow)
+                {
                     typing_channels.insert(channel_id, thread_tags);
                 }
             }
@@ -2891,6 +2952,7 @@ fn dispatch_pending(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     ctx: &Arc<PromptContext>,
+    follow: &mut thread_follow::ThreadFollowState,
 ) -> Vec<(Uuid, ThreadTags)> {
     let mut dispatched_channels = Vec::new();
     loop {
@@ -2904,6 +2966,15 @@ fn dispatch_pending(
             .last()
             .map(|event| queue::parse_thread_tags(&event.event))
             .unwrap_or_default();
+        // #2270: the thread this dispatch participates in — the batch's NIP-10
+        // root, or the triggering event itself when the agent's reply will
+        // start a new thread (mirrors resolve_reply_anchor's root resolution).
+        let follow_root = batch.events.last().map(|be| {
+            typing_scope
+                .root_event_id
+                .clone()
+                .unwrap_or_else(|| be.event.id.to_hex())
+        });
         let affinity_hit = pool.has_session_for(channel_id);
         let mut agent = match pool.try_claim(Some(channel_id)) {
             Some(a) => a,
@@ -2969,6 +3040,9 @@ fn dispatch_pending(
                 steer_tx,
             },
         );
+        if let Some(root) = follow_root {
+            follow.record(channel_id, &root);
+        }
         dispatched_channels.push((channel_id, typing_scope));
     }
     tracing::debug!(
@@ -4979,6 +5053,8 @@ mod build_mcp_servers_tests {
             kinds_override: None,
             channels_override: None,
             no_mention_filter: false,
+            follow_threads: true,
+            thread_follow_ttl_secs: 86_400,
             config_path: std::path::PathBuf::from("./buzz-acp.toml"),
             context_message_limit: 12,
             max_turns_per_session: 0,
@@ -5200,6 +5276,8 @@ mod error_outcome_emission_tests {
             kinds_override: None,
             channels_override: None,
             no_mention_filter: false,
+            follow_threads: true,
+            thread_follow_ttl_secs: 86_400,
             config_path: std::path::PathBuf::from("./buzz-acp.toml"),
             context_message_limit: 12,
             max_turns_per_session: 0,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -2635,7 +2635,7 @@ fn collect_prompt_pubkeys(
 /// cheap routing heuristic for reply anchoring, not a verified security gate
 /// (the signing path in `lib.rs::check_sibling_via_profile` does full
 /// verification where it matters).
-fn profile_event_is_agent(ev: &serde_json::Value) -> bool {
+pub(crate) fn profile_event_is_agent(ev: &serde_json::Value) -> bool {
     ev.get("tags")
         .and_then(|t| t.as_array())
         .is_some_and(|tags| {

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -3148,13 +3148,66 @@ async fn wait_for_reconnect(
     }
 }
 
-/// Send a NIP-01 REQ for a channel, built from a [`ChannelFilter`].
+/// Build the NIP-01 REQ filter clauses for a channel subscription.
 ///
+/// Base clause (always present):
 /// - `kinds` is included only when `filter.kinds` is `Some`; `None` = wildcard.
-/// - `#p` is included only when `filter.require_mention` is `true`.
 /// - `#h` is always included (channel-scoped subscription).
-/// - On first subscribe (`since` is `None`) adds `since=now` to avoid replaying
-///   history. On reconnect (`since` is `Some`) subtracts [`SINCE_SKEW_SECS`].
+/// - `#p` is included only when `filter.require_mention` is `true`.
+///
+/// Followed-threads clause (#2270) — emitted only when `require_mention` is
+/// `true` AND `filter.thread_roots` is non-empty:
+/// - same `kinds` and `#h` scope, plus `#e` limited to the followed roots, so
+///   the relay also delivers untagged replies in threads the agent
+///   participates in. The mention gate stays intact for everything else; when
+///   `require_mention` is `false` the base clause already delivers the whole
+///   channel and no second clause is needed.
+///
+/// Both clauses carry the same `since`.
+fn build_req_filters(
+    channel_id: Uuid,
+    agent_pubkey_hex: &str,
+    since_ts: u64,
+    filter: &ChannelFilter,
+) -> Vec<Value> {
+    let mut base = serde_json::Map::new();
+
+    // kinds — omit entirely for wildcard subscriptions.
+    if let Some(ref kinds) = filter.kinds {
+        base.insert("kinds".into(), json!(kinds));
+    }
+
+    // #h — always present (channel scope).
+    base.insert("#h".into(), json!([channel_id.to_string()]));
+
+    // #p — only when require_mention is true.
+    if filter.require_mention {
+        base.insert("#p".into(), json!([agent_pubkey_hex]));
+    }
+
+    base.insert("since".into(), json!(since_ts));
+
+    let mut clauses = vec![Value::Object(base)];
+
+    if filter.require_mention && !filter.thread_roots.is_empty() {
+        let mut threads = serde_json::Map::new();
+        if let Some(ref kinds) = filter.kinds {
+            threads.insert("kinds".into(), json!(kinds));
+        }
+        threads.insert("#h".into(), json!([channel_id.to_string()]));
+        threads.insert("#e".into(), json!(filter.thread_roots));
+        threads.insert("since".into(), json!(since_ts));
+        clauses.push(Value::Object(threads));
+    }
+
+    clauses
+}
+
+/// Send a NIP-01 REQ for a channel, built from a [`ChannelFilter`] via
+/// [`build_req_filters`].
+///
+/// On first subscribe (`since` is `None`) adds `since=now` to avoid replaying
+/// history. On reconnect (`since` is `Some`) subtracts [`SINCE_SKEW_SECS`].
 ///
 /// Returns `true` if the REQ was successfully written to the WebSocket.
 async fn send_subscribe(
@@ -3167,21 +3220,6 @@ async fn send_subscribe(
 ) -> bool {
     let sub_id = channel_sub_id(channel_id);
 
-    let mut req_filter = serde_json::Map::new();
-
-    // kinds — omit entirely for wildcard subscriptions.
-    if let Some(ref kinds) = filter.kinds {
-        req_filter.insert("kinds".into(), json!(kinds));
-    }
-
-    // #h — always present (channel scope).
-    req_filter.insert("#h".into(), json!([channel_id.to_string()]));
-
-    // #p — only when require_mention is true.
-    if filter.require_mention {
-        req_filter.insert("#p".into(), json!([agent_pubkey_hex]));
-    }
-
     // since — on first subscribe use current time to skip history; on reconnect
     // subtract skew buffer to catch events missed during the disconnect window.
     let since_ts = match since {
@@ -3191,9 +3229,15 @@ async fn send_subscribe(
             .unwrap_or_default()
             .as_secs(),
     };
-    req_filter.insert("since".into(), json!(since_ts));
 
-    let req = json!(["REQ", sub_id, Value::Object(req_filter)]);
+    let mut req = vec![json!("REQ"), json!(sub_id)];
+    req.extend(build_req_filters(
+        channel_id,
+        agent_pubkey_hex,
+        since_ts,
+        filter,
+    ));
+    let req = Value::Array(req);
 
     match serde_json::to_string(&req) {
         Ok(text) => {
@@ -4370,7 +4414,64 @@ mod tests {
         ChannelFilter {
             kinds: Some(vec![9]),
             require_mention: false,
+            thread_roots: Vec::new(),
         }
+    }
+
+    #[test]
+    fn build_req_filters_base_clause_only() {
+        let channel_id = Uuid::new_v4();
+        let filter = ChannelFilter {
+            kinds: Some(vec![9]),
+            require_mention: true,
+            thread_roots: Vec::new(),
+        };
+        let clauses = build_req_filters(channel_id, "agent-pk", 1_000, &filter);
+        assert_eq!(clauses.len(), 1);
+        assert_eq!(clauses[0]["#h"], json!([channel_id.to_string()]));
+        assert_eq!(clauses[0]["#p"], json!(["agent-pk"]));
+        assert_eq!(clauses[0]["since"], json!(1_000));
+        assert!(clauses[0].get("#e").is_none());
+    }
+
+    #[test]
+    fn build_req_filters_ignores_roots_without_mention_gate() {
+        // require_mention=false already delivers the whole channel — a second
+        // clause would be redundant relay load.
+        let filter = ChannelFilter {
+            kinds: None,
+            require_mention: false,
+            thread_roots: vec!["aa".repeat(32)],
+        };
+        let clauses = build_req_filters(Uuid::new_v4(), "agent-pk", 1_000, &filter);
+        assert_eq!(clauses.len(), 1);
+        assert!(clauses[0].get("#e").is_none());
+        assert!(clauses[0].get("#p").is_none());
+    }
+
+    #[test]
+    fn build_req_filters_adds_followed_threads_clause() {
+        let channel_id = Uuid::new_v4();
+        let roots = vec!["aa".repeat(32), "bb".repeat(32)];
+        let filter = ChannelFilter {
+            kinds: Some(vec![9, 45003]),
+            require_mention: true,
+            thread_roots: roots.clone(),
+        };
+        let clauses = build_req_filters(channel_id, "agent-pk", 2_000, &filter);
+        assert_eq!(clauses.len(), 2);
+
+        // Base clause: mention-gated, no #e.
+        assert_eq!(clauses[0]["#p"], json!(["agent-pk"]));
+        assert!(clauses[0].get("#e").is_none());
+
+        // Followed-threads clause: same channel + kinds + since scope,
+        // #e-limited, and NOT #p-gated.
+        assert_eq!(clauses[1]["#h"], json!([channel_id.to_string()]));
+        assert_eq!(clauses[1]["kinds"], json!([9, 45003]));
+        assert_eq!(clauses[1]["#e"], json!(roots));
+        assert_eq!(clauses[1]["since"], json!(2_000));
+        assert!(clauses[1].get("#p").is_none());
     }
 
     fn seed_test_subscription(state: &mut BgState, channel_id: Uuid) {
@@ -4840,6 +4941,7 @@ mod tests {
         let filter = ChannelFilter {
             kinds: Some(vec![9]),
             require_mention: true,
+            thread_roots: Vec::new(),
         };
 
         apply_command_to_state(
@@ -4931,6 +5033,7 @@ mod tests {
                 filter: ChannelFilter {
                     kinds: Some(vec![9]),
                     require_mention: false,
+                    thread_roots: Vec::new(),
                 },
                 replay_since: Some(1_000),
             },
@@ -6045,6 +6148,7 @@ mod tests {
                 filter: ChannelFilter {
                     kinds: Some(vec![9]),
                     require_mention: false,
+                    thread_roots: Vec::new(),
                 },
                 replay_since: Some(1_000),
             },
@@ -6136,6 +6240,7 @@ mod tests {
                 filter: ChannelFilter {
                     kinds: Some(vec![9]),
                     require_mention: false,
+                    thread_roots: Vec::new(),
                 },
                 replay_since: None,
             },
@@ -6175,6 +6280,7 @@ mod tests {
                 filter: ChannelFilter {
                     kinds: Some(vec![9]),
                     require_mention: false,
+                    thread_roots: Vec::new(),
                 },
                 replay_since: None,
             },
@@ -6210,6 +6316,7 @@ mod tests {
                 filter: ChannelFilter {
                     kinds: Some(vec![9]),
                     require_mention: false,
+                    thread_roots: Vec::new(),
                 },
                 replay_since: None,
             },

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -446,6 +446,9 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
             buzz_event.channel_id,
             &rules,
             &pubkey_hex,
+            // Setup mode has no dispatch loop, so there is no thread
+            // participation to follow — mention gating stays strict.
+            None,
         )
         .await
         .is_some();

--- a/crates/buzz-acp/src/thread_follow.rs
+++ b/crates/buzz-acp/src/thread_follow.rs
@@ -1,0 +1,320 @@
+//! Thread-participation tracking for mention-gated subscriptions.
+//!
+//! In [`SubscribeMode::Mentions`](crate::config::SubscribeMode) the harness
+//! only receives events that `#p`-tag the agent. That gate is correct for
+//! channel noise, but it also drops untagged replies in threads the agent is
+//! actively part of — a human answering "yes, go ahead" in the agent's own
+//! thread is never delivered, and the agent goes deaf mid-conversation
+//! (issue #2270).
+//!
+//! [`ThreadFollowState`] records the NIP-10 root ids of threads the agent has
+//! been dispatched into, per channel. Roots expire after a sliding TTL of
+//! inactivity and each channel is capped at [`MAX_FOLLOWED_ROOTS_PER_CHANNEL`]
+//! (stalest evicted first), so both the local set and the `#e` REQ filter
+//! clause built from it stay bounded.
+//!
+//! The set feeds two consumers:
+//! - [`relay`](crate::relay): a second REQ filter clause (`#h` + `#e`) so the
+//!   relay delivers untagged replies for followed threads only — the mention
+//!   gate stays intact for everything else.
+//! - [`filter::match_event`](crate::filter::match_event): local admission for
+//!   delivered events whose thread root is followed.
+//!
+//! All state is in-memory, matching the rest of the harness: after a restart
+//! the agent follows threads it is re-mentioned in, which is the pre-existing
+//! recovery semantic for every other subscription decision.
+
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+
+use tracing::debug;
+use uuid::Uuid;
+
+/// Upper bound on followed thread roots per channel.
+///
+/// Bounds both memory and the `#e` array length in the REQ filter clause
+/// (relays cap filter sizes). When the cap is hit, the least-recently-active
+/// root is evicted — the agent simply needs a fresh mention to rejoin that
+/// thread, which is the pre-fix behavior for all threads.
+pub const MAX_FOLLOWED_ROOTS_PER_CHANNEL: usize = 64;
+
+/// Tracks which thread roots the agent participates in, per channel.
+///
+/// A root is recorded when a batch is dispatched to the agent (the agent is
+/// about to speak in that thread) and refreshed whenever a followed-thread
+/// event is admitted, giving active conversations a sliding TTL.
+#[derive(Debug)]
+pub struct ThreadFollowState {
+    /// When `false` every method is a no-op and [`live_roots`](Self::live_roots)
+    /// is always empty — call sites never need their own gating.
+    enabled: bool,
+    ttl: Duration,
+    /// channel → (thread root event id, hex) → last-activity instant.
+    followed: HashMap<Uuid, HashMap<String, Instant>>,
+    /// Channels whose live root *set* changed since the last
+    /// [`take_dirty`](Self::take_dirty) — i.e. the `#e` REQ clause is stale.
+    dirty: HashSet<Uuid>,
+    /// Last periodic compaction, throttled to [`COMPACT_INTERVAL`].
+    last_compact: Instant,
+}
+
+/// Minimum interval between periodic compactions — the maintenance tick fires
+/// far more often than expiry resolution requires.
+const COMPACT_INTERVAL: Duration = Duration::from_secs(30);
+
+impl ThreadFollowState {
+    /// Create a tracker whose roots expire after `ttl_secs` of inactivity.
+    /// A disabled tracker never records or reports anything.
+    pub fn new(ttl_secs: u64, enabled: bool) -> Self {
+        Self {
+            enabled,
+            ttl: Duration::from_secs(ttl_secs),
+            followed: HashMap::new(),
+            dirty: HashSet::new(),
+            last_compact: Instant::now(),
+        }
+    }
+
+    /// Whether thread-following is active.
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Record participation in `root_id` on `channel_id`, refreshing its TTL.
+    ///
+    /// Marks the channel dirty when the root is new (the REQ clause must be
+    /// widened). Evicts the least-recently-active root when the per-channel
+    /// cap is exceeded.
+    pub fn record(&mut self, channel_id: Uuid, root_id: &str) {
+        self.record_at(channel_id, root_id, Instant::now());
+    }
+
+    fn record_at(&mut self, channel_id: Uuid, root_id: &str, now: Instant) {
+        if !self.enabled {
+            return;
+        }
+        let roots = self.followed.entry(channel_id).or_default();
+        let is_new = !roots.contains_key(root_id);
+        roots.insert(root_id.to_string(), now);
+
+        if roots.len() > MAX_FOLLOWED_ROOTS_PER_CHANNEL {
+            // Evict the stalest root. `max_by_key` on elapsed == oldest instant.
+            if let Some(stalest) = roots
+                .iter()
+                .min_by_key(|(_, seen)| **seen)
+                .map(|(root, _)| root.clone())
+            {
+                roots.remove(&stalest);
+                debug!(
+                    channel = %channel_id,
+                    evicted_root = %stalest,
+                    cap = MAX_FOLLOWED_ROOTS_PER_CHANNEL,
+                    "followed-thread cap reached — evicted least-recently-active root"
+                );
+                self.dirty.insert(channel_id);
+            }
+        }
+
+        if is_new {
+            debug!(channel = %channel_id, root = %root_id, "following thread");
+            self.dirty.insert(channel_id);
+        }
+    }
+
+    /// Refresh the TTL of `root_id` if it is currently followed.
+    ///
+    /// Called when a followed-thread event is admitted, so active
+    /// conversations keep sliding forward instead of expiring mid-exchange.
+    pub fn touch(&mut self, channel_id: Uuid, root_id: &str) {
+        self.touch_at(channel_id, root_id, Instant::now());
+    }
+
+    fn touch_at(&mut self, channel_id: Uuid, root_id: &str, now: Instant) {
+        if let Some(seen) = self
+            .followed
+            .get_mut(&channel_id)
+            .and_then(|roots| roots.get_mut(root_id))
+        {
+            *seen = now;
+        }
+    }
+
+    /// Live (unexpired) root ids for `channel_id`, for local admission checks.
+    pub fn live_roots(&self, channel_id: Uuid) -> HashSet<String> {
+        self.live_roots_at(channel_id, Instant::now())
+    }
+
+    fn live_roots_at(&self, channel_id: Uuid, now: Instant) -> HashSet<String> {
+        self.followed
+            .get(&channel_id)
+            .map(|roots| {
+                roots
+                    .iter()
+                    .filter(|(_, seen)| now.duration_since(**seen) < self.ttl)
+                    .map(|(root, _)| root.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Live root ids for `channel_id` in deterministic order, for building the
+    /// `#e` REQ filter clause.
+    pub fn roots_for_filter(&self, channel_id: Uuid) -> Vec<String> {
+        let mut roots: Vec<String> = self.live_roots(channel_id).into_iter().collect();
+        roots.sort_unstable();
+        roots
+    }
+
+    /// Drop expired roots, throttled to [`COMPACT_INTERVAL`]. Channels whose
+    /// set shrank are marked dirty so their REQ clause can be narrowed. Safe
+    /// to call on every maintenance tick.
+    pub fn compact_if_due(&mut self) {
+        let now = Instant::now();
+        if !self.enabled || now.duration_since(self.last_compact) < COMPACT_INTERVAL {
+            return;
+        }
+        self.last_compact = now;
+        self.compact_at(now);
+    }
+
+    fn compact_at(&mut self, now: Instant) {
+        let ttl = self.ttl;
+        let dirty = &mut self.dirty;
+        self.followed.retain(|channel_id, roots| {
+            let before = roots.len();
+            roots.retain(|_, seen| now.duration_since(*seen) < ttl);
+            if roots.len() != before {
+                dirty.insert(*channel_id);
+            }
+            !roots.is_empty()
+        });
+    }
+
+    /// Forget all state for a channel (e.g. after membership removal).
+    ///
+    /// Does not mark the channel dirty — the caller is tearing the
+    /// subscription down entirely, so there is no REQ left to update.
+    pub fn clear_channel(&mut self, channel_id: Uuid) {
+        self.followed.remove(&channel_id);
+        self.dirty.remove(&channel_id);
+    }
+
+    /// Drain the set of channels whose followed-root set changed since the
+    /// last call. Each returned channel needs its subscription re-issued with
+    /// a fresh `#e` clause.
+    pub fn take_dirty(&mut self) -> Vec<Uuid> {
+        self.dirty.drain().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ch(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
+    #[test]
+    fn record_marks_new_roots_dirty_once() {
+        let mut state = ThreadFollowState::new(60, true);
+        state.record(ch(1), "root-a");
+        assert_eq!(state.take_dirty(), vec![ch(1)]);
+
+        // Re-recording the same root refreshes TTL but is not a set change.
+        state.record(ch(1), "root-a");
+        assert!(state.take_dirty().is_empty());
+
+        assert!(state.live_roots(ch(1)).contains("root-a"));
+    }
+
+    #[test]
+    fn roots_expire_after_ttl_and_mark_dirty() {
+        let mut state = ThreadFollowState::new(60, true);
+        let start = Instant::now();
+        state.record_at(ch(1), "root-a", start);
+        state.take_dirty();
+
+        let later = start + Duration::from_secs(61);
+        assert!(state.live_roots_at(ch(1), later).is_empty());
+
+        state.compact_at(later);
+        assert_eq!(state.take_dirty(), vec![ch(1)]);
+        assert!(state.roots_for_filter(ch(1)).is_empty());
+    }
+
+    #[test]
+    fn touch_slides_expiry_forward() {
+        let mut state = ThreadFollowState::new(60, true);
+        let start = Instant::now();
+        state.record_at(ch(1), "root-a", start);
+
+        // Refresh at t+45; at t+75 the root is still live (75 - 45 < 60).
+        state.touch_at(ch(1), "root-a", start + Duration::from_secs(45));
+        let at_75 = start + Duration::from_secs(75);
+        assert!(state.live_roots_at(ch(1), at_75).contains("root-a"));
+
+        // Without further activity it expires at t+45+60.
+        let at_106 = start + Duration::from_secs(106);
+        assert!(state.live_roots_at(ch(1), at_106).is_empty());
+    }
+
+    #[test]
+    fn touch_ignores_unknown_roots() {
+        let mut state = ThreadFollowState::new(60, true);
+        state.touch(ch(1), "never-recorded");
+        assert!(state.live_roots(ch(1)).is_empty());
+        assert!(state.take_dirty().is_empty());
+    }
+
+    #[test]
+    fn cap_evicts_least_recently_active_root() {
+        let mut state = ThreadFollowState::new(3600, true);
+        let start = Instant::now();
+        for i in 0..MAX_FOLLOWED_ROOTS_PER_CHANNEL {
+            state.record_at(
+                ch(1),
+                &format!("root-{i:03}"),
+                start + Duration::from_secs(i as u64),
+            );
+        }
+        state.take_dirty();
+
+        // One over the cap evicts root-000 (the stalest), keeps the newcomer.
+        state.record_at(
+            ch(1),
+            "root-new",
+            start + Duration::from_secs(MAX_FOLLOWED_ROOTS_PER_CHANNEL as u64),
+        );
+        let live = state.live_roots_at(ch(1), start + Duration::from_secs(100));
+        assert_eq!(live.len(), MAX_FOLLOWED_ROOTS_PER_CHANNEL);
+        assert!(!live.contains("root-000"));
+        assert!(live.contains("root-new"));
+        assert_eq!(state.take_dirty(), vec![ch(1)]);
+    }
+
+    #[test]
+    fn channels_are_independent() {
+        let mut state = ThreadFollowState::new(60, true);
+        state.record(ch(1), "root-a");
+        state.record(ch(2), "root-b");
+
+        assert!(state.live_roots(ch(1)).contains("root-a"));
+        assert!(!state.live_roots(ch(1)).contains("root-b"));
+
+        state.clear_channel(ch(1));
+        assert!(state.live_roots(ch(1)).is_empty());
+        assert!(state.live_roots(ch(2)).contains("root-b"));
+        // clear_channel drops pending dirtiness for the removed channel.
+        assert_eq!(state.take_dirty(), vec![ch(2)]);
+    }
+
+    #[test]
+    fn roots_for_filter_is_sorted() {
+        let mut state = ThreadFollowState::new(60, true);
+        state.record(ch(1), "bbb");
+        state.record(ch(1), "aaa");
+        state.record(ch(1), "ccc");
+        assert_eq!(state.roots_for_filter(ch(1)), vec!["aaa", "bbb", "ccc"]);
+    }
+}

--- a/crates/buzz-test-client/Cargo.toml
+++ b/crates/buzz-test-client/Cargo.toml
@@ -41,3 +41,7 @@ buzz-sdk = { workspace = true }
 [[bin]]
 name = "buzz-test-cli"
 path = "src/main.rs"
+
+[[bin]]
+name = "stub-acp-agent"
+path = "tests/bin/stub_acp_agent.rs"

--- a/crates/buzz-test-client/tests/bin/stub_acp_agent.rs
+++ b/crates/buzz-test-client/tests/bin/stub_acp_agent.rs
@@ -1,0 +1,80 @@
+//! Minimal ACP-speaking stub agent for harness integration tests.
+//!
+//! Speaks newline-delimited JSON-RPC 2.0 over stdio — just enough of the
+//! Agent Client Protocol for `buzz-acp` to initialize, create a session, and
+//! run prompt turns. Each `session/prompt` appends one line to the file named
+//! by `STUB_TURN_LOG`, then immediately ends the turn — the test counts lines
+//! to observe exactly how many turns the harness dispatched. The stub never
+//! contacts the relay: thread participation is recorded by the harness at
+//! dispatch time, so turn counts alone prove admission/suppression behavior.
+
+use std::io::{BufRead, Write};
+
+fn respond(
+    stdout: &mut std::io::StdoutLock<'_>,
+    id: &serde_json::Value,
+    result: serde_json::Value,
+) {
+    let msg = serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result });
+    writeln!(stdout, "{msg}").expect("write response");
+    stdout.flush().expect("flush stdout");
+}
+
+fn main() {
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    let turn_log = std::env::var("STUB_TURN_LOG").ok();
+    let mut turn: u64 = 0;
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) if !l.trim().is_empty() => l,
+            Ok(_) => continue,
+            Err(_) => break,
+        };
+        let msg: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let id = msg.get("id").cloned();
+        let method = msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
+
+        let Some(id) = id else {
+            continue; // notification — nothing to answer
+        };
+
+        match method {
+            "initialize" => respond(
+                &mut out,
+                &id,
+                serde_json::json!({ "protocolVersion": 2, "agentCapabilities": {} }),
+            ),
+            "session/new" => respond(
+                &mut out,
+                &id,
+                serde_json::json!({ "sessionId": "stub-session-1" }),
+            ),
+            "session/prompt" => {
+                turn += 1;
+                if let Some(path) = &turn_log {
+                    let mut f = std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(path)
+                        .expect("open turn log");
+                    writeln!(f, "turn {turn}").expect("append turn log");
+                }
+                respond(
+                    &mut out,
+                    &id,
+                    serde_json::json!({ "stopReason": "end_turn" }),
+                );
+            }
+            // Anything else the harness asks for (config options, custom
+            // extensions): empty success keeps it moving; it tolerates both
+            // empty results and method-not-found for optional calls.
+            _ => respond(&mut out, &id, serde_json::json!({})),
+        }
+    }
+}

--- a/crates/buzz-test-client/tests/e2e_acp_thread_follow.rs
+++ b/crates/buzz-test-client/tests/e2e_acp_thread_follow.rs
@@ -1,0 +1,274 @@
+//! End-to-end test for buzz-acp thread-following (#2270) against a live relay.
+//!
+//! Drives the real `buzz-acp` binary with a stub ACP agent (`stub-acp-agent`,
+//! built from this crate) and asserts turn dispatch across the four cases from
+//! the #2375 review:
+//!
+//! 1. explicit @mention → one turn (thread becomes followed);
+//! 2. untagged human reply in the followed thread → one more turn;
+//! 3. untagged agent-authored reply in the followed thread → no turn
+//!    (followed-thread author policy, default `humans`);
+//! 4. untagged top-level message → no turn (mention gate intact).
+//!
+//! Turn observation: the stub appends a line to `STUB_TURN_LOG` per
+//! `session/prompt`. Participation is recorded by the harness at dispatch, so
+//! turn counts alone prove admission/suppression — the stub never contacts the
+//! relay (the agent's reply path is out-of-band by design; see #2459).
+//!
+//! Prerequisites:
+//! - relay + Postgres running (`just setup`, `just relay`); `RELAY_URL`
+//!   defaults to ws://localhost:3000
+//! - `cargo build -p buzz-acp` (or set `BUZZ_ACP_BIN`)
+//!
+//! Run: `cargo test -p buzz-test-client --test e2e_acp_thread_follow -- --ignored`
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use nostr::{EventBuilder, Keys, Kind, Tag};
+
+fn relay_url() -> String {
+    std::env::var("RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string())
+}
+
+fn relay_http_url() -> String {
+    relay_url()
+        .replace("wss://", "https://")
+        .replace("ws://", "http://")
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// Locate the buzz-acp binary: `BUZZ_ACP_BIN` override, else the workspace
+/// target dir (release preferred, debug fallback).
+fn buzz_acp_bin() -> PathBuf {
+    if let Ok(path) = std::env::var("BUZZ_ACP_BIN") {
+        return PathBuf::from(path);
+    }
+    let mut workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    workspace.pop();
+    workspace.pop();
+    for profile in ["release", "debug"] {
+        let candidate = workspace.join("target").join(profile).join("buzz-acp");
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    panic!("buzz-acp binary not found — run `cargo build -p buzz-acp` or set BUZZ_ACP_BIN");
+}
+
+/// POST a signed event to the relay's HTTP bridge.
+async fn post_event(event: &nostr::Event) {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/events", relay_http_url()))
+        .header("X-Pubkey", event.pubkey.to_hex())
+        .header("Content-Type", "application/json")
+        .body(serde_json::to_string(event).expect("serialize event"))
+        .send()
+        .await
+        .expect("submit event");
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.expect("parse event response");
+    assert!(
+        status.is_success() && body["accepted"].as_bool().unwrap_or(false),
+        "event not accepted: {status} {body}"
+    );
+}
+
+/// Create a channel via a signed kind:9007 event (creator becomes a member).
+async fn create_test_channel(keys: &Keys) -> uuid::Uuid {
+    let channel_uuid = uuid::Uuid::new_v4();
+    let event = EventBuilder::new(Kind::Custom(9007), "")
+        .tags(vec![
+            Tag::parse(["h", &channel_uuid.to_string()]).unwrap(),
+            Tag::parse(["name", &format!("acp-follow-e2e-{channel_uuid}")]).unwrap(),
+            Tag::parse(["channel_type", "stream"]).unwrap(),
+            Tag::parse(["visibility", "open"]).unwrap(),
+        ])
+        .sign_with_keys(keys)
+        .unwrap();
+    post_event(&event).await;
+    channel_uuid
+}
+
+/// Add a member to a channel (kind:9030, signed by the channel owner).
+async fn add_member(owner: &Keys, channel: uuid::Uuid, member: &Keys) {
+    let event = buzz_sdk::build_add_member(channel, &member.public_key().to_hex(), None)
+        .expect("build add-member")
+        .sign_with_keys(owner)
+        .expect("sign add-member");
+    post_event(&event).await;
+}
+
+/// Publish a kind:9 channel message. `mention` adds a `p` tag; `thread_root`
+/// adds a NIP-10 marker `e` tag.
+async fn send_channel_message(
+    keys: &Keys,
+    channel: uuid::Uuid,
+    content: &str,
+    mention: Option<&Keys>,
+    thread_root: Option<&str>,
+) -> String {
+    let mut tags = vec![Tag::parse(["h", &channel.to_string()]).unwrap()];
+    if let Some(m) = mention {
+        tags.push(Tag::parse(["p", &m.public_key().to_hex()]).unwrap());
+    }
+    if let Some(root) = thread_root {
+        tags.push(Tag::parse(["e", root, "", "root"]).unwrap());
+    }
+    let event = EventBuilder::new(Kind::Custom(9), content)
+        .tags(tags)
+        .sign_with_keys(keys)
+        .unwrap();
+    let id = event.id.to_hex();
+    post_event(&event).await;
+    id
+}
+
+fn turn_count(log: &std::path::Path) -> usize {
+    std::fs::read_to_string(log)
+        .map(|s| s.lines().count())
+        .unwrap_or(0)
+}
+
+/// Deadline-poll until `turn_count` reaches `expected` (same shape as the
+/// scheduler-push waits in e2e_event_reminder.rs).
+async fn await_turns(log: &std::path::Path, expected: usize, deadline: Duration) {
+    let start = Instant::now();
+    while start.elapsed() < deadline {
+        if turn_count(log) >= expected {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    panic!(
+        "expected {expected} dispatched turn(s) within {deadline:?}, saw {}",
+        turn_count(log)
+    );
+}
+
+/// Assert `turn_count` stays at `expected` for the whole `window`.
+async fn assert_no_new_turns(log: &std::path::Path, expected: usize, window: Duration) {
+    let start = Instant::now();
+    while start.elapsed() < window {
+        let n = turn_count(log);
+        assert!(
+            n <= expected,
+            "unexpected turn dispatched: saw {n}, expected {expected}"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Kills the harness on drop so a failing assertion can't leak the subprocess.
+struct HarnessGuard(std::process::Child);
+impl Drop for HarnessGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn thread_follow_admits_humans_and_suppresses_agents() {
+    let human = Keys::generate();
+    let agent = Keys::generate();
+    let other_agent = Keys::generate();
+
+    let channel = create_test_channel(&human).await;
+    add_member(&human, channel, &agent).await;
+    add_member(&human, channel, &other_agent).await;
+
+    // Publish a kind:0 for the second agent carrying the NIP-OA `auth` tag
+    // shape (4 elements) — the marker `profile_event_is_agent` classifies on.
+    let profile = EventBuilder::new(Kind::Metadata, r#"{"name":"other-agent"}"#)
+        .tags(vec![Tag::parse([
+            "auth",
+            &human.public_key().to_hex(),
+            "",
+            "e2e-attestation-placeholder",
+        ])
+        .unwrap()])
+        .sign_with_keys(&other_agent)
+        .unwrap();
+    post_event(&profile).await;
+
+    // Spawn the real harness with the stub ACP agent.
+    let scratch = std::env::temp_dir().join(format!("acp-follow-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&scratch).expect("create scratch dir");
+    let turn_log = scratch.join("turns.log");
+    let harness_log = scratch.join("harness.log");
+    let log_file = std::fs::File::create(&harness_log).expect("create harness log");
+
+    let child = std::process::Command::new(buzz_acp_bin())
+        .env("BUZZ_PRIVATE_KEY", agent.secret_key().to_secret_hex())
+        .env("BUZZ_RELAY_URL", relay_url())
+        .env(
+            "BUZZ_ACP_AGENT_COMMAND",
+            env!("CARGO_BIN_EXE_stub-acp-agent"),
+        )
+        .env("BUZZ_ACP_RESPOND_TO", "anyone")
+        .env("BUZZ_ACP_HEARTBEAT_INTERVAL", "0")
+        .env("BUZZ_ACP_AGENTS", "1")
+        .env("STUB_TURN_LOG", &turn_log)
+        .env("RUST_LOG", "buzz_acp=debug")
+        .stdout(log_file.try_clone().expect("clone log handle"))
+        .stderr(log_file)
+        .spawn()
+        .expect("spawn buzz-acp");
+    let _guard = HarnessGuard(child);
+
+    // Readiness: the harness logs its channel subscription.
+    let subscribed = format!("subscribed to channel {channel}");
+    let start = Instant::now();
+    loop {
+        let log = std::fs::read_to_string(&harness_log).unwrap_or_default();
+        if log.contains(&subscribed) {
+            break;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(30),
+            "harness did not subscribe to {channel} within 30s; log:\n{log}"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    // 1. Explicit mention → one turn; the thread root (= mention id) becomes followed.
+    let mention_id = send_channel_message(&human, channel, "@agent ping", Some(&agent), None).await;
+    await_turns(&turn_log, 1, Duration::from_secs(30)).await;
+
+    // 2. Untagged human reply in the followed thread → a second turn.
+    send_channel_message(
+        &human,
+        channel,
+        "untagged follow-up",
+        None,
+        Some(&mention_id),
+    )
+    .await;
+    await_turns(&turn_log, 2, Duration::from_secs(30)).await;
+
+    // 3. Untagged agent-authored reply in the followed thread → suppressed.
+    //    respond-to=anyone admits the author, so the followed-thread author
+    //    policy is the only gate exercised here.
+    send_channel_message(
+        &other_agent,
+        channel,
+        "untagged agent interjection",
+        None,
+        Some(&mention_id),
+    )
+    .await;
+    assert_no_new_turns(&turn_log, 2, Duration::from_secs(10)).await;
+    let log = std::fs::read_to_string(&harness_log).unwrap_or_default();
+    assert!(
+        log.contains("followed-thread admission suppressed for agent author"),
+        "expected suppression log line; harness log:\n{log}"
+    );
+
+    // 4. Untagged top-level message → no turn (mention gate intact).
+    send_channel_message(&human, channel, "no mention here", None, None).await;
+    assert_no_new_turns(&turn_log, 2, Duration::from_secs(10)).await;
+}

--- a/crates/buzz-test-client/tests/e2e_acp_thread_follow.rs
+++ b/crates/buzz-test-client/tests/e2e_acp_thread_follow.rs
@@ -191,12 +191,16 @@ impl Drop for HarnessGuard {
 #[ignore]
 async fn thread_follow_admits_humans_and_suppresses_agents() {
     let human = Keys::generate();
+    let second_human = Keys::generate();
     let agent = Keys::generate();
     let other_agent = Keys::generate();
 
     let channel = create_test_channel(&human).await;
     add_member(&human, channel, &agent).await;
     add_member(&human, channel, &other_agent).await;
+    // A non-owner human member: classification must come from the relay's
+    // materialized kind:39002 member roles, not the configured-owner shortcut.
+    add_member(&human, channel, &second_human).await;
 
     // Publish a kind:0 with a cryptographically valid NIP-OA attestation for
     // the second agent. The default humans-only policy must suppress it.
@@ -286,7 +290,29 @@ async fn thread_follow_admits_humans_and_suppresses_agents() {
     .await;
     await_exact_turn_delta(&turn_log, before_follow_up, 1, Duration::from_secs(30)).await;
 
-    // 4. Untagged agent-authored reply in the followed thread → suppressed.
+    // 4. Untagged reply from a NON-OWNER human member → exactly one more
+    //    turn. This author is not the configured owner and has no attestation,
+    //    so the fail-closed classifier must positively resolve them through
+    //    the kind:39002 member role — the path a wrong tag-shape assumption
+    //    would silently break (suppressing every legitimate human member).
+    let before_member = turn_count(&turn_log);
+    send_channel_message(
+        &second_human,
+        channel,
+        "second human untagged reply",
+        None,
+        Some(&mention_id),
+        Some(&agent_reply_id),
+    )
+    .await;
+    await_exact_turn_delta(&turn_log, before_member, 1, Duration::from_secs(30)).await;
+
+    // Every admitting step is done; nothing below may add a turn. Anchor the
+    // remaining assertions to the observed count rather than a literal, so
+    // inserting a case above can't silently weaken them.
+    let admitted_turns = turn_count(&turn_log);
+
+    // 6. Untagged agent-authored reply in the followed thread → suppressed.
     //    respond-to=anyone admits the author, so the followed-thread author
     //    policy is the only gate exercised here.
     send_channel_message(
@@ -298,14 +324,14 @@ async fn thread_follow_admits_humans_and_suppresses_agents() {
         Some(&agent_reply_id),
     )
     .await;
-    assert_no_new_turns(&turn_log, 2, Duration::from_secs(10)).await;
+    assert_no_new_turns(&turn_log, admitted_turns, Duration::from_secs(10)).await;
     let log = std::fs::read_to_string(&harness_log).unwrap_or_default();
     assert!(
         log.contains("followed-thread admission suppressed for non-human author"),
         "expected suppression log line; harness log:\n{log}"
     );
 
-    // 5. Untagged top-level message → no turn (mention gate intact).
+    // 7. Untagged top-level message → no turn (mention gate intact).
     send_channel_message(&human, channel, "no mention here", None, None, None).await;
-    assert_no_new_turns(&turn_log, 2, Duration::from_secs(10)).await;
+    assert_no_new_turns(&turn_log, admitted_turns, Duration::from_secs(10)).await;
 }

--- a/crates/buzz-test-client/tests/e2e_acp_thread_follow.rs
+++ b/crates/buzz-test-client/tests/e2e_acp_thread_follow.rs
@@ -1,14 +1,15 @@
 //! End-to-end test for buzz-acp thread-following (#2270) against a live relay.
 //!
 //! Drives the real `buzz-acp` binary with a stub ACP agent (`stub-acp-agent`,
-//! built from this crate) and asserts turn dispatch across the four cases from
-//! the #2375 review:
+//! built from this crate) and asserts the user-visible scenarios from the
+//! #2375 review:
 //!
-//! 1. explicit @mention → one turn (thread becomes followed);
-//! 2. untagged human reply in the followed thread → one more turn;
-//! 3. untagged agent-authored reply in the followed thread → no turn
+//! 1. explicit @mention → exactly one turn (thread becomes followed);
+//! 2. agent publishes a reply in that thread;
+//! 3. untagged human reply to the agent → exactly one more turn;
+//! 4. untagged agent-authored reply in the followed thread → no turn
 //!    (followed-thread author policy, default `humans`);
-//! 4. untagged top-level message → no turn (mention gate intact).
+//! 5. untagged top-level message → no turn.
 //!
 //! Turn observation: the stub appends a line to `STUB_TURN_LOG` per
 //! `session/prompt`. Participation is recorded by the harness at dispatch, so
@@ -109,6 +110,7 @@ async fn send_channel_message(
     content: &str,
     mention: Option<&Keys>,
     thread_root: Option<&str>,
+    parent_event: Option<&str>,
 ) -> String {
     let mut tags = vec![Tag::parse(["h", &channel.to_string()]).unwrap()];
     if let Some(m) = mention {
@@ -116,6 +118,9 @@ async fn send_channel_message(
     }
     if let Some(root) = thread_root {
         tags.push(Tag::parse(["e", root, "", "root"]).unwrap());
+    }
+    if let Some(parent) = parent_event {
+        tags.push(Tag::parse(["e", parent, "", "reply"]).unwrap());
     }
     let event = EventBuilder::new(Kind::Custom(9), content)
         .tags(tags)
@@ -132,18 +137,30 @@ fn turn_count(log: &std::path::Path) -> usize {
         .unwrap_or(0)
 }
 
-/// Deadline-poll until `turn_count` reaches `expected` (same shape as the
-/// scheduler-push waits in e2e_event_reminder.rs).
-async fn await_turns(log: &std::path::Path, expected: usize, deadline: Duration) {
+/// Wait for exactly `delta` new turns, then keep the count stable long enough
+/// to catch duplicate dispatches from the same event.
+async fn await_exact_turn_delta(
+    log: &std::path::Path,
+    before: usize,
+    delta: usize,
+    deadline: Duration,
+) {
+    let expected = before + delta;
     let start = Instant::now();
     while start.elapsed() < deadline {
-        if turn_count(log) >= expected {
+        let current = turn_count(log);
+        assert!(
+            current <= expected,
+            "event dispatched too many turns: saw {current}, expected exactly {expected}"
+        );
+        if current == expected {
+            assert_no_new_turns(log, expected, Duration::from_secs(2)).await;
             return;
         }
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
     panic!(
-        "expected {expected} dispatched turn(s) within {deadline:?}, saw {}",
+        "expected exactly {expected} dispatched turn(s) within {deadline:?}, saw {}",
         turn_count(log)
     );
 }
@@ -153,9 +170,9 @@ async fn assert_no_new_turns(log: &std::path::Path, expected: usize, window: Dur
     let start = Instant::now();
     while start.elapsed() < window {
         let n = turn_count(log);
-        assert!(
-            n <= expected,
-            "unexpected turn dispatched: saw {n}, expected {expected}"
+        assert_eq!(
+            n, expected,
+            "unexpected turn count: saw {n}, expected {expected}"
         );
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
@@ -181,16 +198,16 @@ async fn thread_follow_admits_humans_and_suppresses_agents() {
     add_member(&human, channel, &agent).await;
     add_member(&human, channel, &other_agent).await;
 
-    // Publish a kind:0 for the second agent carrying the NIP-OA `auth` tag
-    // shape (4 elements) — the marker `profile_event_is_agent` classifies on.
+    // Publish a kind:0 with a cryptographically valid NIP-OA attestation for
+    // the second agent. The default humans-only policy must suppress it.
+    let auth_tag_json = buzz_sdk::nip_oa::compute_auth_tag(&human, &other_agent.public_key(), "")
+        .expect("compute agent auth tag");
+    let auth_tag_parts: Vec<String> =
+        serde_json::from_str(&auth_tag_json).expect("parse agent auth tag");
     let profile = EventBuilder::new(Kind::Metadata, r#"{"name":"other-agent"}"#)
-        .tags(vec![Tag::parse([
-            "auth",
-            &human.public_key().to_hex(),
-            "",
-            "e2e-attestation-placeholder",
+        .tags(vec![
+            Tag::parse(auth_tag_parts).expect("build agent auth tag")
         ])
-        .unwrap()])
         .sign_with_keys(&other_agent)
         .unwrap();
     post_event(&profile).await;
@@ -210,6 +227,7 @@ async fn thread_follow_admits_humans_and_suppresses_agents() {
             env!("CARGO_BIN_EXE_stub-acp-agent"),
         )
         .env("BUZZ_ACP_RESPOND_TO", "anyone")
+        .env("BUZZ_ACP_AGENT_OWNER", human.public_key().to_hex())
         .env("BUZZ_ACP_HEARTBEAT_INTERVAL", "0")
         .env("BUZZ_ACP_AGENTS", "1")
         .env("STUB_TURN_LOG", &turn_log)
@@ -235,22 +253,40 @@ async fn thread_follow_admits_humans_and_suppresses_agents() {
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
 
-    // 1. Explicit mention → one turn; the thread root (= mention id) becomes followed.
-    let mention_id = send_channel_message(&human, channel, "@agent ping", Some(&agent), None).await;
-    await_turns(&turn_log, 1, Duration::from_secs(30)).await;
+    // 1. Explicit mention → exactly one turn; the mention id becomes the root.
+    let before = turn_count(&turn_log);
+    let mention_id =
+        send_channel_message(&human, channel, "@agent ping", Some(&agent), None, None).await;
+    await_exact_turn_delta(&turn_log, before, 1, Duration::from_secs(30)).await;
 
-    // 2. Untagged human reply in the followed thread → a second turn.
+    // 2. Publish the agent's visible reply, then verify ignore-self prevents a
+    // second turn. The next human message replies to this event, not merely to
+    // an abstract dispatch record.
+    let agent_reply_id = send_channel_message(
+        &agent,
+        channel,
+        "agent reply",
+        None,
+        Some(&mention_id),
+        Some(&mention_id),
+    )
+    .await;
+    assert_no_new_turns(&turn_log, before + 1, Duration::from_secs(2)).await;
+
+    // 3. Untagged human reply to the agent → exactly one additional turn.
+    let before_follow_up = turn_count(&turn_log);
     send_channel_message(
         &human,
         channel,
         "untagged follow-up",
         None,
         Some(&mention_id),
+        Some(&agent_reply_id),
     )
     .await;
-    await_turns(&turn_log, 2, Duration::from_secs(30)).await;
+    await_exact_turn_delta(&turn_log, before_follow_up, 1, Duration::from_secs(30)).await;
 
-    // 3. Untagged agent-authored reply in the followed thread → suppressed.
+    // 4. Untagged agent-authored reply in the followed thread → suppressed.
     //    respond-to=anyone admits the author, so the followed-thread author
     //    policy is the only gate exercised here.
     send_channel_message(
@@ -259,16 +295,17 @@ async fn thread_follow_admits_humans_and_suppresses_agents() {
         "untagged agent interjection",
         None,
         Some(&mention_id),
+        Some(&agent_reply_id),
     )
     .await;
     assert_no_new_turns(&turn_log, 2, Duration::from_secs(10)).await;
     let log = std::fs::read_to_string(&harness_log).unwrap_or_default();
     assert!(
-        log.contains("followed-thread admission suppressed for agent author"),
+        log.contains("followed-thread admission suppressed for non-human author"),
         "expected suppression log line; harness log:\n{log}"
     );
 
-    // 4. Untagged top-level message → no turn (mention gate intact).
-    send_channel_message(&human, channel, "no mention here", None, None).await;
+    // 5. Untagged top-level message → no turn (mention gate intact).
+    send_channel_message(&human, channel, "no mention here", None, None, None).await;
     assert_no_new_turns(&turn_log, 2, Duration::from_secs(10)).await;
 }


### PR DESCRIPTION
## Summary

A mention-gated agent (`SubscribeMode::Mentions`, the default) goes deaf in threads it has joined: once it replies, untagged follow-ups like "yes, go ahead" are never seen unless the human re-tags the agent on every message. The gate exists at two levels — the relay REQ's `#p` clause never delivers the reply, and `match_event`'s mention re-check would drop it anyway.

Fix: participation opens a thread; inactivity closes it.

- **`thread_follow.rs` (new):** per-channel set of followed NIP-10 thread roots with a sliding inactivity TTL (default 24h, `--thread-follow-ttl-secs` / `BUZZ_ACP_THREAD_FOLLOW_TTL_SECS`) and a hard per-channel cap (64, least-recently-active evicted). Participation is recorded at dispatch time: the batch's thread root, or the triggering event id when the agent's reply is about to start a new thread (mirrors `resolve_reply_anchor` — this is the exact repro case in #2270). Admitted followed-thread events refresh the TTL, so live conversations keep sliding.
- **Relay gate:** REQ construction is extracted into `build_req_filters()`, which emits a second filter clause — same `#h`/`kinds`/`since`, plus `#e` limited to followed roots — only when the base clause is mention-gated. The mention gate stays intact for everything else; no channel firehose. Subscription updates reuse the existing per-channel sub-id replacement path and replay from `last_seen` minus skew, so replies landing during the update window are recovered. Resubscribes fire only on thread join/expiry, not per message, staying inside the pacing envelope from #2199/#2217.
- **Local gate:** `match_event` takes the followed set and admits an unmentioned event only when its thread root is followed. Channel scope, kinds, and evalexpr filters still apply — following relaxes only the mention check.
- **Lifecycle:** channel unsubscribe clears its follow state; `--no-follow-threads` (`BUZZ_ACP_NO_FOLLOW_THREADS`) restores the previous strict-mention behavior. State is in-memory, matching the harness's existing recovery semantics (after restart, a fresh mention re-joins a thread).

### Related issue

Fixes #2270 (independently re-reported as #2332). The patch is confirmed by two affected users on the issue: [oveddan](https://github.com/block/buzz/issues/2270#issuecomment-5060656775) (owner-replied-in-thread repro) and [dmnyc](https://github.com/block/buzz/issues/2270#issuecomment-5061459537) (agent-perspective confirmation).

**Scope narrowing (explicit).** #2270 sketches per-rule `follow_participating_threads` / `follow_thread_authors`; this PR implements them as global CLI/env settings instead, and does not claim the rule-level contract. Reason: the followed-thread REQ clause is channel-scoped, so per-rule control needs union-at-REQ plus per-rule enforcement in `match_event`, and two rules disagreeing on the same channel have no coherent subscription answer. That is a subscription-design change rather than part of this fix. It is implementable on top of this (the REQ clause is a delivery optimization; correctness already lives in `match_event`) — happy to do it as a follow-up if the rule-level contract is wanted.

### Testing

- **Live-relay integration test** (`crates/buzz-test-client/tests/e2e_acp_thread_follow.rs`): drives the real `buzz-acp` binary with a stub ACP agent against a live relay — asserts a mention opens the thread, an untagged in-thread follow-up is admitted, untagged replies in unfollowed threads stay suppressed, and agent-authored unmentioned replies stay suppressed under `--respond-to anyone`.
- **13 unit tests** on the new surface: follow-state lifecycle (record/touch/TTL/cap/eviction/dirty-tracking/channel isolation), `match_event` followed-thread admission (admits followed, ignores unfollowed and top-level, relaxes only the mention gate), and `build_req_filters` clause construction (base-only, roots-ignored-without-mention-gate, two-clause shape).
- Full `cargo test -p buzz-acp`: 643 passed, 0 failed. `cargo clippy -p buzz-acp --all-targets` and `cargo fmt` clean.
- Manual end-to-end (Claude Code behind `claude-code-acp`, live local relay): mention answered in-thread; untagged human follow-up answered (~15s, `p` tags empty); untagged replies in unfollowed threads silent; agent-authored unmentioned replies suppressed under both `owner-only` and `--respond-to anyone` (transcripts in the review thread).
- Head `2af74400`: 647 unit tests pass (638 + 9), `cargo clippy -p buzz-acp --all-targets -- -D warnings` clean, `cargo fmt` clean, and the live-relay e2e passes against a local relay (~31s).
- The anti-loop boundary now **fails closed**: only the configured owner or an author positively resolved through the channel's kind:39002 member roles counts as human. A cryptographically verified NIP-OA attestation or the `bot` role proves an agent. Missing profiles, unresolved membership, malformed events, and relay timeouts stay `Unknown` and still require an explicit mention under the default `humans` policy.
- The live-relay test now asserts **exact per-message turn deltas** (never `>=`), publishes a visible agent reply so the human follow-up replies to a real message, and covers a **non-owner human member** — the case that exercises member-role resolution rather than the configured-owner shortcut.
- Operator settings are documented in the buzz-acp README and `.env.example`.

## Follow-up candidates (out of scope here)

- Surfacing followed-thread state to the desktop (ties into #1654's auto-continue UX).
- Optionally persisting follow state across harness restarts via the pending-turn ledger machinery from #2177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

