### PR TITLE
fix(mobile): keep NIP-02 petname out of the relay url slot

### DIFF
--- a/mobile/lib/features/pulse/pulse_models.dart
+++ b/mobile/lib/features/pulse/pulse_models.dart
@@ -135,5 +135,10 @@ class ContactEntry {
 
   const ContactEntry({required this.pubkey, this.relayUrl, this.petname});
 
-  List<String> toTag() => ['p', pubkey.toLowerCase(), ?relayUrl, ?petname];
+  List<String> toTag() => [
+    'p',
+    pubkey.toLowerCase(),
+    relayUrl ?? '',
+    petname ?? '',
+  ];
 }

--- a/mobile/test/features/pulse/pulse_models_test.dart
+++ b/mobile/test/features/pulse/pulse_models_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:buzz/features/pulse/pulse_models.dart';
+import 'package:buzz/features/pulse/pulse_provider.dart';
+import 'package:buzz/shared/relay/nostr_models.dart';
+
+NostrEvent _contactList(List<List<String>> tags) => NostrEvent(
+  id: 'event-id',
+  pubkey: 'author',
+  createdAt: 0,
+  kind: 3,
+  tags: tags,
+  content: '',
+  sig: '',
+);
+
+void main() {
+  group('ContactEntry.toTag', () {
+    test('keeps petname in the NIP-02 petname slot without a relay url', () {
+      const entry = ContactEntry(pubkey: 'DEADBEEF', petname: 'alice');
+
+      expect(entry.toTag(), ['p', 'deadbeef', '', 'alice']);
+    });
+
+    test('emits relay url and petname in order', () {
+      const entry = ContactEntry(
+        pubkey: 'deadbeef',
+        relayUrl: 'wss://relay.example.com',
+        petname: 'alice',
+      );
+
+      expect(entry.toTag(), [
+        'p',
+        'deadbeef',
+        'wss://relay.example.com',
+        'alice',
+      ]);
+    });
+
+    test(
+      'emits empty trailing slots when relay url and petname are absent',
+      () {
+        const entry = ContactEntry(pubkey: 'deadbeef');
+
+        expect(entry.toTag(), ['p', 'deadbeef', '', '']);
+      },
+    );
+
+    test('round-trips a petname through the contact list parser', () {
+      const entry = ContactEntry(pubkey: 'deadbeef', petname: 'alice');
+
+      final parsed = contactsFromEvents([
+        _contactList([entry.toTag()]),
+      ]);
+
+      expect(parsed.single.pubkey, 'deadbeef');
+      expect(parsed.single.relayUrl, isNull);
+      expect(parsed.single.petname, 'alice');
+    });
+  });
+}


### PR DESCRIPTION
## Problem

`ContactEntry.toTag()` builds the kind:3 `p` tag with null-aware elements:

```dart
List<String> toTag() => ['p', pubkey.toLowerCase(), ?relayUrl, ?petname];
```

A null `relayUrl` is *omitted* rather than emitted as an empty string. NIP-02 `p` tags are positional — `["p", <pubkey>, <relay url>, <petname>]` — so a contact with a petname but no relay URL serializes to `["p", <pubkey>, <petname>]`, putting the petname in the relay slot.

It doesn't round-trip through mobile's own parser, which reads index 2 as the relay URL and index 3 as the petname (`pulse_provider.dart:154-155`).

Mobile has no UI that sets a petname, so this is invisible when testing mobile alone — `followUser` always builds `ContactEntry(pubkey: ...)` with both optional fields null, which serializes harmlessly. The damage happens to petnames set elsewhere: `followUser` re-serializes the **entire** contact list on every follow (`pulse_actions.dart:76-83`), and kind:3 is replaceable, so one tap on an unrelated Follow button rewrites a desktop-set petname into the relay slot and drops it for every client.

Desktop handles this correctly in both directions — the Rust writer always emits four elements padded with empty strings (`desktop/src-tauri/src/events.rs:764-769`), and the TS reader takes `t[2]`/`t[3]` (`desktop/src/shared/api/social.ts:138-139`).

## Fix

Always emit both trailing slots, matching the desktop writer:

```dart
List<String> toTag() => ['p', pubkey.toLowerCase(), relayUrl ?? '', petname ?? ''];
```

The parser already treats empty strings as absent (`tag[2].isNotEmpty`), so decoding is unchanged. I went with unconditional padding over conditionally padding only when a petname is present — it makes the tag structurally incapable of the bug rather than avoiding it, and matches the existing Rust implementation.

## Testing

New `mobile/test/features/pulse/pulse_models_test.dart` covers the three slot combinations plus a round-trip through `contactsFromEvents`. Against the unfixed code 3 of 4 fail, with the round-trip case reporting `relayUrl` as `'alice'` — the corruption itself.

Manual check against a live relay:

```bash
buzz social set-contact-list --contacts '[{"pubkey":"<hex>","petname":"alice"}]'
# in the app: Pulse -> any note -> Follow
buzz social get-contact-list <your-pubkey>
```

Before this change the petname comes back in the relay slot; after, it survives.

## Checklist

- [x] `just ci` passes (fmt + clippy + desktop/web check + unit tests + mobile)
- [ ] Integration tests (`just test`) — not run; Dart-only change, no `buzz-relay` / `buzz-db` / `buzz-auth` code touched
- [x] Regression test included
- [x] No new `unwrap()` / `unsafe` (Dart-only)