### PR TITLE
fix(desktop): label generic attachment action as Attach file

### DIFF
--- a/desktop/src/features/messages/ui/MessageComposerToolbar.tsx
+++ b/desktop/src/features/messages/ui/MessageComposerToolbar.tsx
@@ -179,7 +179,7 @@ export const MessageComposerToolbar = React.memo(
                 <Tooltip disableHoverableContent>
                   <TooltipTrigger asChild>
                     <Button
-                      aria-label="Attach image"
+                      aria-label="Attach file"
                       disabled={composerDisabled || isUploading}
                       onClick={onPaperclip}
                       onMouseDown={onCaptureSelection}
@@ -190,7 +190,7 @@ export const MessageComposerToolbar = React.memo(
                       <Paperclip />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent>Attach image</TooltipContent>
+                  <TooltipContent>Attach file</TooltipContent>
                 </Tooltip>
                 <ComposerEmojiPicker
                   disabled={composerDisabled}

--- a/desktop/tests/e2e/composer-image-draw.spec.ts
+++ b/desktop/tests/e2e/composer-image-draw.spec.ts
@@ -75,7 +75,7 @@ test("draw on an uploaded image, save replaces it, revert restores in place", as
   await expect(page.getByTestId("chat-title")).toHaveText("general");
 
   // Attach the original image via the mocked paperclip flow.
-  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByRole("button", { name: "Attach file" }).click();
   const composer = page.getByTestId("message-composer");
   await expect(composer.getByAltText("Attachment aaaa")).toBeVisible();
 
@@ -153,7 +153,7 @@ test("spoiler marking survives drawing on the attachment", async ({ page }) => {
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
 
-  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByRole("button", { name: "Attach file" }).click();
   const composer = page.getByTestId("message-composer");
   await expect(composer.getByAltText("Attachment aaaa")).toBeVisible();
 

--- a/desktop/tests/e2e/file-attachment.spec.ts
+++ b/desktop/tests/e2e/file-attachment.spec.ts
@@ -30,7 +30,7 @@ test("upload a file and see a FileCard in the timeline", async ({ page }) => {
   await expect(page.getByTestId("chat-title")).toHaveText("general");
 
   // Paperclip → mocked pick_and_upload_media returns the PDF descriptor.
-  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByRole("button", { name: "Attach file" }).click();
 
   // The composer shows a chip with the original filename.
   await expect(page.getByTestId("message-composer")).toContainText(
@@ -108,7 +108,7 @@ test("forum posts emit a FileCard for generic attachments, not a broken image", 
   await page.getByRole("button", { name: "Start a new post..." }).click();
 
   // Paperclip → mocked pick_and_upload_media returns the PDF descriptor.
-  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByRole("button", { name: "Attach file" }).click();
 
   // Submit the (attachment-only) forum post.
   await page.getByTestId("send-message").click();

--- a/desktop/tests/e2e/image-attachment-gallery.spec.ts
+++ b/desktop/tests/e2e/image-attachment-gallery.spec.ts
@@ -123,7 +123,7 @@ test("image bundle lightbox navigates as a gallery", async ({ page }) => {
   await expect(page.getByTestId("chat-title")).toHaveText("general");
 
   await page.getByTestId("message-input").fill("gallery bundle");
-  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByRole("button", { name: "Attach file" }).click();
   await page.getByTestId("send-message").click();
   await expect(page.getByText("Sending")).toHaveCount(0);
 
@@ -667,7 +667,7 @@ test("mosaic image context menu is portaled outside the clipped gallery", async 
   await expect(page.getByTestId("chat-title")).toHaveText("general");
 
   await page.getByTestId("message-input").fill("mosaic context menu");
-  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByRole("button", { name: "Attach file" }).click();
   await page.getByTestId("send-message").click();
   await expect(page.getByText("Sending")).toHaveCount(0);
 
@@ -709,7 +709,7 @@ test("lightbox image context menu stays inside the dialog focus scope", async ({
   await expect(page.getByTestId("chat-title")).toHaveText("general");
 
   await page.getByTestId("message-input").fill("lightbox context menu");
-  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByRole("button", { name: "Attach file" }).click();
   await page.getByTestId("send-message").click();
   await expect(page.getByText("Sending")).toHaveCount(0);
 
@@ -751,7 +751,7 @@ test("right-click image shows Copy image and invokes copy command", async ({
   await expect(page.getByTestId("chat-title")).toHaveText("general");
 
   await page.getByTestId("message-input").fill("copy me");
-  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByRole("button", { name: "Attach file" }).click();
   await page.getByTestId("send-message").click();
   await expect(page.getByText("Sending")).toHaveCount(0);
 

--- a/desktop/tests/e2e/spoiler.spec.ts
+++ b/desktop/tests/e2e/spoiler.spec.ts
@@ -96,7 +96,7 @@ test("image attachments can be marked and sent as hidden spoilers", async ({
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
 
-  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByRole("button", { name: "Attach file" }).click();
 
   const composer = page.getByTestId("message-composer");
   await expect(composer.getByAltText("Attachment cccc")).toBeVisible();
@@ -137,7 +137,7 @@ test("text spoiler stays usable while attachment upload is pending", async ({
 
   // Kick off the (delayed) upload first — the attach button lives in the
   // passive toolbar, which is replaced while formatting is expanded.
-  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByRole("button", { name: "Attach file" }).click();
 
   await page.getByRole("button", { name: "Toggle formatting" }).click();
   const spoilerButton = page.getByRole("button", {

--- a/desktop/tests/e2e/video-attachment.spec.ts
+++ b/desktop/tests/e2e/video-attachment.spec.ts
@@ -177,7 +177,7 @@ async function openReviewWithPostedTimecode(
   await expect(page.getByTestId("chat-title")).toHaveText("general");
   await waitForMockLiveSubscription(page, "general");
 
-  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByRole("button", { name: "Attach file" }).click();
   await expect(
     page.getByTestId("message-composer").getByAltText("Video attachment bbbb"),
   ).toBeVisible();
@@ -232,7 +232,7 @@ test("video upload previews use poster frames and inline videos open review mode
   await expect(page.getByTestId("chat-title")).toHaveText("general");
   await waitForMockLiveSubscription(page, "general");
 
-  await page.getByRole("button", { name: "Attach image" }).click();
+  await page.getByRole("button", { name: "Attach file" }).click();
 
   const composer = page.getByTestId("message-composer");
   const composerPoster = composer.getByAltText("Video attachment bbbb");


### PR DESCRIPTION
## Summary

- rename the generic message-composer paperclip tooltip from `Attach image` to `Attach file`
- update the button accessible name to match the image, video, PDF, archive, and generic-file picker behavior
- update all affected Desktop E2E selectors
- leave the feedback dialog’s image-only attachment wording unchanged

Closes #2381

## Validation

- `pnpm --dir desktop check`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop test` — 3,371 passed
- `pnpm --dir desktop test:e2e` — build passed; 47 smoke tests passed before the broad 818-test serial run was stopped due runtime
- affected E2E specs — 27/28 passed; the remaining long video-review test passes the updated `Attach file` interaction, then reproducibly fails at its unrelated existing `Unrelated chatter mid-review` live-message assertion (`video-attachment.spec.ts:626`)

## Scope

No attachment behavior changes; this only corrects the generic composer’s visible and accessible label.