### PR TITLE
test(buzz-db): normalize replica fence timestamp precision

### DIFF
--- a/crates/buzz-db/src/replica_fence.rs
+++ b/crates/buzz-db/src/replica_fence.rs
@@ -508,6 +508,7 @@ pub async fn run_probe(writer: PgPool, replica: PgPool, fence: Arc<ReplicaFence>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::SubsecRound;
 
     const TEST_DB_URL: &str = "postgres://buzz:buzz_dev@localhost:5432/buzz"; // sadscan:disable np.postgres.1
 
@@ -521,7 +522,7 @@ mod tests {
         assert!(fence.verified_through().is_none(), "must start closed");
         assert!(!fence.covers(Utc::now() - chrono::Duration::days(365)));
 
-        let ts = Utc::now();
+        let ts = Utc::now().trunc_subsecs(6);
         fence.advance(ts);
         assert_eq!(fence.verified_through(), Some(ts));
         assert!(fence.covers(ts - chrono::Duration::seconds(1)));


### PR DESCRIPTION
## Summary

- Normalize the replica-fence unit test timestamp to the fence's microsecond storage precision.
- Prevent the Linux-only assertion failure when `Utc::now()` includes nanosecond precision.

## Root cause

`ReplicaFence` stores Unix microseconds, but the test compared its reconstructed timestamp with an un-normalized clock value. On platforms that retain nanoseconds, the comparison differed below the storage precision.

## Validation

- `cargo fmt --check`
- `cargo clippy -p buzz-db --tests -- -D warnings`
- `cargo test -p buzz-db --lib`