### PR TITLE
feat(desktop): surface hosted community creation

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -546,6 +546,11 @@ export function AppShell() {
     [goSettings],
   );
 
+  const handleCreateHostedCommunity = React.useCallback(
+    () => handleOpenSettings("hosted-communities"),
+    [handleOpenSettings],
+  );
+
   const handleCloseSettings = React.useCallback(
     () => closeSettings(),
     [closeSettings],
@@ -713,6 +718,7 @@ export function AppShell() {
                         communitiesHook.activeCommunity?.id ?? null
                       }
                       onAddCommunity={addCommunityDialog.openDialog}
+                      onCreateHostedCommunity={handleCreateHostedCommunity}
                       onRemoveCommunity={communitiesHook.removeCommunity}
                       onSwitchCommunity={handleSwitchCommunity}
                       onUpdateCommunity={communitiesHook.updateCommunity}

--- a/desktop/src/features/communities/ui/CommunitySwitcher.tsx
+++ b/desktop/src/features/communities/ui/CommunitySwitcher.tsx
@@ -2,6 +2,7 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
+  Cloud,
   MoreHorizontal,
   Plus,
   WifiOff,
@@ -47,6 +48,7 @@ type CommunitySwitcherProps = {
   variant?: "sidebar" | "profile" | "profile-menu";
   onSwitchCommunity: (id: string) => void;
   onAddCommunity: () => void;
+  onCreateHostedCommunity: () => void;
   onUpdateCommunity: (
     id: string,
     updates: Partial<Pick<Community, "name" | "relayUrl" | "token">>,
@@ -89,6 +91,7 @@ export function CommunitySwitcher({
   variant = "sidebar",
   onSwitchCommunity,
   onAddCommunity,
+  onCreateHostedCommunity,
   onUpdateCommunity,
   onRemoveCommunity,
 }: CommunitySwitcherProps) {
@@ -267,13 +270,25 @@ export function CommunitySwitcher({
               className="flex min-h-9 w-full items-center gap-2 rounded-lg py-2 pl-2 pr-4 text-left text-sm outline-hidden transition-colors hover:bg-muted/50 focus:bg-muted/50 focus:outline-none focus-visible:bg-muted/50 focus-visible:outline-none"
               onClick={() => {
                 setDropdownOpen(false);
+                onCreateHostedCommunity();
+              }}
+              role="menuitem"
+              type="button"
+            >
+              <Cloud className="h-4 w-4" />
+              <span>Create a hosted community</span>
+            </button>
+            <button
+              className="flex min-h-9 w-full items-center gap-2 rounded-lg py-2 pl-2 pr-4 text-left text-sm outline-hidden transition-colors hover:bg-muted/50 focus:bg-muted/50 focus:outline-none focus-visible:bg-muted/50 focus-visible:outline-none"
+              onClick={() => {
+                setDropdownOpen(false);
                 onAddCommunity();
               }}
               role="menuitem"
               type="button"
             >
               <Plus className="h-4 w-4" />
-              <span>Add Community</span>
+              <span>Connect an existing community</span>
             </button>
           </div>
         </PopoverContent>
@@ -352,9 +367,13 @@ export function CommunitySwitcher({
           </DropdownMenuItem>
         ))}
         <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onCreateHostedCommunity}>
+          <Cloud className="h-4 w-4" />
+          <span>Create a hosted community</span>
+        </DropdownMenuItem>
         <DropdownMenuItem onSelect={onAddCommunity}>
           <Plus className="h-4 w-4" />
-          <span>Add Community</span>
+          <span>Connect an existing community</span>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -54,6 +54,7 @@ import { useDeferredModalOpen } from "@/shared/ui/deferredModalOpen";
 import { SidebarUpdateCard } from "@/features/settings/SidebarUpdateCard";
 import { useUpdaterContext } from "@/features/settings/hooks/UpdaterProvider";
 import { shouldShowSidebarUpdateCard } from "@/features/settings/sidebarUpdateCardVisibility";
+import type { SettingsSection } from "@/features/settings/ui/SettingsPanels";
 import type {
   Channel,
   ChannelVisibility,
@@ -154,7 +155,7 @@ type AppSidebarProps = {
    */
   searchChannels: Channel[];
   searchFocusRequest: number;
-  onSelectSettings: (section?: "profile" | "appearance") => void;
+  onSelectSettings: (section?: SettingsSection) => void;
   onSetPresenceStatus?: (status: "online" | "away" | "offline") => void;
   onSetUserStatus: (text: string, emoji: string) => void;
   onClearUserStatus: () => void;

--- a/desktop/src/features/sidebar/ui/CommunityRail.tsx
+++ b/desktop/src/features/sidebar/ui/CommunityRail.tsx
@@ -1,4 +1,4 @@
-import { CheckCheck, Link2, Plus, Settings2 } from "lucide-react";
+import { CheckCheck, Cloud, Link2, Plus, Settings2 } from "lucide-react";
 import * as React from "react";
 
 import type { Community } from "@/features/communities/types";
@@ -16,6 +16,12 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/shared/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { cn } from "@/shared/lib/cn";
 import { getInitials } from "@/shared/lib/initials";
@@ -28,6 +34,7 @@ type CommunityRailProps = {
   activeCommunityId: string | null;
   onSwitchCommunity: (id: string) => void;
   onAddCommunity: () => void;
+  onCreateHostedCommunity: () => void;
   onUpdateCommunity: (
     id: string,
     updates: Partial<Pick<Community, "name" | "relayUrl" | "token">>,
@@ -167,6 +174,7 @@ export function CommunityRail({
   activeCommunityId,
   onSwitchCommunity,
   onAddCommunity,
+  onCreateHostedCommunity,
   onUpdateCommunity,
   onRemoveCommunity,
 }: CommunityRailProps) {
@@ -247,20 +255,33 @@ export function CommunityRail({
           community={community}
         />
       ))}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            aria-label="Add community"
-            className="flex h-9 w-9 items-center justify-center rounded-2xl bg-sidebar-accent/60 text-sidebar-foreground/70 outline-hidden transition-all hover:rounded-xl hover:bg-primary/80 hover:text-primary-foreground focus:outline-none focus-visible:outline-none"
-            data-testid="community-rail-add"
-            onClick={onAddCommunity}
-            type="button"
-          >
+      <DropdownMenu modal={false}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                aria-label="Add community"
+                className="flex h-9 w-9 items-center justify-center rounded-2xl bg-sidebar-accent/60 text-sidebar-foreground/70 outline-hidden transition-all hover:rounded-xl hover:bg-primary/80 hover:text-primary-foreground focus:outline-none focus-visible:outline-none"
+                data-testid="community-rail-add"
+                type="button"
+              >
+                <Plus className="h-4 w-4" />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="right">Add community</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="start" side="right" sideOffset={6}>
+          <DropdownMenuItem onSelect={onCreateHostedCommunity}>
+            <Cloud className="h-4 w-4" />
+            Create a hosted community
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onAddCommunity}>
             <Plus className="h-4 w-4" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="right">Add community</TooltipContent>
-      </Tooltip>
+            Connect an existing community
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <EditCommunityDialog
         canRemove={communities.length > 1}
         onOpenChange={(open) => {

--- a/desktop/src/features/sidebar/ui/SidebarProfileCard.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarProfileCard.tsx
@@ -12,6 +12,7 @@ import { ProfilePopover } from "@/features/profile/ui/ProfilePopover";
 import { StatusEmoji } from "@/features/user-status/ui/StatusEmoji";
 import type { Community } from "@/features/communities/types";
 import { CommunitySwitcher } from "@/features/communities/ui/CommunitySwitcher";
+import type { SettingsSection } from "@/features/settings/ui/SettingsPanels";
 import type { PresenceStatus, Profile, UserStatus } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 
@@ -19,7 +20,7 @@ type SidebarProfileCardProps = {
   activeCommunity: Community | null;
   isPresencePending?: boolean;
   onOpenAddCommunity: () => void;
-  onOpenSettings: (section?: "profile" | "appearance") => void;
+  onOpenSettings: (section?: SettingsSection) => void;
   onRemoveCommunity: (id: string) => void;
   onSendFeedback?: () => void;
   onSetPresenceStatus?: (status: PresenceStatus) => void;
@@ -76,6 +77,10 @@ export function SidebarProfileCard({
     [toggleProfilePopover],
   );
   const hasStatus = Boolean(selfUserStatus?.text || selfUserStatus?.emoji);
+  const handleCreateHostedCommunity = React.useCallback(
+    () => onOpenSettings("hosted-communities"),
+    [onOpenSettings],
+  );
   const communityLabel = activeCommunity?.name ?? "No community";
   const readonlyCommunityLabel = (
     <span
@@ -160,6 +165,7 @@ export function SidebarProfileCard({
               <CommunitySwitcher
                 activeCommunity={activeCommunity}
                 onAddCommunity={onOpenAddCommunity}
+                onCreateHostedCommunity={handleCreateHostedCommunity}
                 onRemoveCommunity={onRemoveCommunity}
                 onSwitchCommunity={onSwitchCommunity}
                 onUpdateCommunity={onUpdateCommunity}

--- a/desktop/tests/e2e/deep-link-invite.spec.ts
+++ b/desktop/tests/e2e/deep-link-invite.spec.ts
@@ -170,7 +170,9 @@ test("add-community deep link opens one editable prefill and acknowledges the qu
 
   await page.getByTestId("sidebar-profile-avatar-button").click();
   await page.getByTestId("community-switcher").click();
-  await page.getByRole("menuitem", { name: "Add Community" }).click();
+  await page
+    .getByRole("menuitem", { name: "Connect an existing community" })
+    .click();
   await expect(relayInput).toHaveValue("");
   await expect(nameInput).toHaveValue("");
 

--- a/desktop/tests/e2e/navigation.spec.ts
+++ b/desktop/tests/e2e/navigation.spec.ts
@@ -48,6 +48,67 @@ test("global back and forward move across channel routes", async ({ page }) => {
   await expect(page.getByTestId("chat-title")).toHaveText("random");
 });
 
+test("community switcher routes hosted creation to hosted settings", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByTestId("sidebar-profile-avatar-button").click();
+  await page.getByTestId("community-switcher").click();
+
+  await expect(
+    page.getByRole("menuitem", { name: "Connect an existing community" }),
+  ).toBeVisible();
+  await page
+    .getByRole("menuitem", { name: "Create a hosted community" })
+    .click();
+
+  await expect(page).toHaveURL(/#\/settings\?section=hosted-communities/);
+  await expect(
+    page.getByTestId("settings-panel-hosted-communities"),
+  ).toBeVisible();
+  await expect(page.getByTestId("hosted-communities-settings")).toBeVisible();
+});
+
+test("community rail routes hosted creation to hosted settings", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "buzz-communities",
+      JSON.stringify([
+        {
+          id: "rail-community-a",
+          name: "Alpha",
+          relayUrl: "ws://localhost:3000",
+          addedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          id: "rail-community-b",
+          name: "Bravo",
+          relayUrl: "ws://localhost:3001",
+          addedAt: "2026-01-02T00:00:00.000Z",
+        },
+      ]),
+    );
+    window.localStorage.setItem("buzz-active-community-id", "rail-community-a");
+  });
+  await page.goto("/");
+
+  await page.getByTestId("community-rail-add").click();
+  await expect(
+    page.getByRole("menuitem", { name: "Connect an existing community" }),
+  ).toBeVisible();
+  await page
+    .getByRole("menuitem", { name: "Create a hosted community" })
+    .click();
+
+  await expect(page).toHaveURL(/#\/settings\?section=hosted-communities/);
+  await expect(
+    page.getByTestId("settings-panel-hosted-communities"),
+  ).toBeVisible();
+});
+
 // FIXME: the forum post "Back to posts" header renders under the fixed top
 // chrome drag region, which intercepts the click. Pre-existing breakage —
 // this spec file was never registered in playwright.config.ts until now.

--- a/desktop/tests/e2e/sidebar.spec.ts
+++ b/desktop/tests/e2e/sidebar.spec.ts
@@ -80,7 +80,9 @@ test("automatically shows relay join requirements near the relay URL", async ({
   await page.goto("/");
 
   await page.getByTestId("sidebar-profile-card").click();
-  await page.getByText("Add Community", { exact: true }).click();
+  await page
+    .getByText("Connect an existing community", { exact: true })
+    .click();
   await page.getByLabel("Relay URL").fill("wss://policy.example.com");
 
   const ageConfirmation = page.getByLabel("I am 18 years of age or older.");


### PR DESCRIPTION
## Summary

- distinguish hosted creation from connecting an existing relay in both community entry points
- route hosted creation to **Settings → Hosted communities**
- add regression coverage for the profile switcher and multi-community rail

## Why

After a user already has a community, the existing “Add community” actions only opened the manual relay connector. That made the supported hosted creation flow difficult to discover. This is a narrow post-onboarding discoverability improvement related to #2312.

## Validation

- `just ci`
- `cd desktop && pnpm exec playwright test tests/e2e/navigation.spec.ts --project=smoke --grep "community (switcher|rail) routes hosted creation"`
- `cd desktop && pnpm exec playwright test tests/e2e/sidebar.spec.ts tests/e2e/deep-link-invite.spec.ts --project=integration`

No relay, database, or auth behavior changed, so the infrastructure-backed `just test` suite is not applicable.
