### PR TITLE
fix(dev): restore shared worktree identity from keyring

### DIFF
--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -47,14 +47,36 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
         # identifier is kept so concurrent instances don't collide on
         # tauri-plugin-single-instance or the app data directory.
         if [[ "${BUZZ_SHARE_IDENTITY:-0}" == "1" ]]; then
+            KEYRING_SERVICE="buzz-desktop-dev"
+            KEYRING_BLOB=""
+            case "$(uname -s)" in
+                Darwin)
+                    if command -v security &>/dev/null; then
+                        KEYRING_BLOB="$(security find-generic-password -s "$KEYRING_SERVICE" -a secrets -w 2>/dev/null || true)"
+                    fi
+                    ;;
+                Linux)
+                    if command -v secret-tool &>/dev/null; then
+                        KEYRING_BLOB="$(secret-tool lookup service "$KEYRING_SERVICE" username secrets target default 2>/dev/null || true)"
+                    fi
+                    ;;
+            esac
+
+            KEYRING_IDENTITY="$(printf '%s' "$KEYRING_BLOB" | python3 -c 'import json, sys; value = json.load(sys.stdin).get("identity", ""); print(value if isinstance(value, str) else "")' 2>/dev/null || true)"
             CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.buzz.app.dev/identity.key"
             LEGACY_CANONICAL_KEY="$HOME/Library/Application Support/xyz.block.sprout.app.dev/identity.key"
-            if [[ -f "$CANONICAL_KEY" ]]; then
-                export BUZZ_PRIVATE_KEY="$(cat "$CANONICAL_KEY")"
-            elif [[ -f "$LEGACY_CANONICAL_KEY" ]]; then
-                export BUZZ_PRIVATE_KEY="$(cat "$LEGACY_CANONICAL_KEY")"
+
+            SHARED_IDENTITY="$KEYRING_IDENTITY"
+            if [[ -z "$SHARED_IDENTITY" && -f "$CANONICAL_KEY" ]]; then
+                SHARED_IDENTITY="$(cat "$CANONICAL_KEY")"
+            elif [[ -z "$SHARED_IDENTITY" && -f "$LEGACY_CANONICAL_KEY" ]]; then
+                SHARED_IDENTITY="$(cat "$LEGACY_CANONICAL_KEY")"
+            fi
+
+            if [[ -n "$SHARED_IDENTITY" ]]; then
+                export BUZZ_PRIVATE_KEY="$SHARED_IDENTITY"
             else
-                echo "⚠ BUZZ_SHARE_IDENTITY=1 but no identity found at $CANONICAL_KEY or $LEGACY_CANONICAL_KEY — run Buzz from repo root first" >&2
+                echo "⚠ BUZZ_SHARE_IDENTITY=1 but no identity found in keyring service $KEYRING_SERVICE, at $CANONICAL_KEY, or at $LEGACY_CANONICAL_KEY — run Buzz from repo root first" >&2
             fi
         fi
 


### PR DESCRIPTION
## Summary

- restore `BUZZ_SHARE_IDENTITY=1` after the desktop identity migration removed `identity.key`
- read the canonical `buzz-desktop-dev` keyring blob first on macOS and Linux, extracting its `identity` entry
- preserve the existing canonical and legacy file fallbacks for pre-migration installs
- tolerate unavailable, missing, or malformed keyring entries without aborting worktree startup
