### PR TITLE
Show team count separately in channel template rows

### DIFF
--- a/desktop/src/features/settings/ui/ChannelTemplatesSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ChannelTemplatesSettingsCard.tsx
@@ -1,4 +1,5 @@
 import {
+  Bot,
   Copy,
   MessageSquare,
   MoreHorizontal,
@@ -199,8 +200,8 @@ function TemplateRow({
   onDuplicate: () => void;
   onDelete: () => void;
 }) {
-  const agentCount =
-    template.agents.personas.length + template.agents.teams.length;
+  const personaCount = template.agents.personas.length;
+  const teamCount = template.agents.teams.length;
 
   return (
     <div className="group flex items-center gap-3 rounded-lg px-3 py-2.5 hover:bg-muted/50">
@@ -219,10 +220,16 @@ function TemplateRow({
           </p>
         ) : null}
         <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
-          {agentCount > 0 ? (
+          {personaCount > 0 ? (
+            <span className="flex items-center gap-1">
+              <Bot className="h-4 w-4" />
+              {personaCount} {personaCount === 1 ? "agent" : "agents"}
+            </span>
+          ) : null}
+          {teamCount > 0 ? (
             <span className="flex items-center gap-1">
               <Users className="h-4 w-4" />
-              {agentCount} {agentCount === 1 ? "agent" : "agents"}
+              {teamCount} {teamCount === 1 ? "team" : "teams"}
             </span>
           ) : null}
           {template.canvasTemplate ? (


### PR DESCRIPTION
Template rows in Settings summed personas and teams into one count, so a template containing a single team displayed "1 agent".

This splits the label: personas show as "N agent(s)" with a Bot icon, teams show as "N team(s)" with the Users icon (matching the team chips in the edit dialog).

Reported by Wes with screenshots — "Buzz (rick and morty)" template contains one team, was labeled "1 agent"; now reads "1 team".

Reviewed by beth: APPROVE. Noted NIT (left as-is): the row uses the app-wide `Bot` icon for personas while the edit dialog renders personas with `ProfileAvatar` — intentional, `Bot` is the standard agent glyph elsewhere (MembersSidebar, WelcomeComposerBanner).
