### PR TITLE
fix(desktop): stop UserProfilePopover from nesting two focusable elements

### DIFF
--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -49,6 +49,7 @@ import { Popover, PopoverAnchor, PopoverContent } from "@/shared/ui/popover";
 import { BotIdenticon } from "@/features/messages/ui/BotIdenticon";
 import { useNow } from "@/shared/lib/useNow";
 import { Button } from "@/shared/ui/button";
+import { triggerShouldOwnFocus } from "@/features/profile/ui/userProfilePopoverTrigger";
 import { Spinner } from "@/shared/ui/spinner";
 
 type UserProfilePopoverProps = {
@@ -206,6 +207,23 @@ export function UserProfilePopover({
   const { canOpenAgentActivity, openAgentActivity } = useOpenAgentActivity();
   const { openProfilePanel } = useProfilePanel();
   const canOpenProfilePanel = enableProfilePanel && Boolean(openProfilePanel);
+  // When the child is already an interactive element (most call sites pass a
+  // <button>), let it be the single Tab stop instead of stacking the wrapper's
+  // own role/tabIndex on top of it. The wrapper still handles the click via
+  // onClick below, which the child's activation bubbles up to.
+  const singleTriggerChild =
+    React.Children.count(children) === 1
+      ? React.Children.toArray(children)[0]
+      : null;
+  const triggerOwnsFocus = triggerShouldOwnFocus(
+    React.isValidElement(singleTriggerChild)
+      ? {
+          type: singleTriggerChild.type,
+          props: singleTriggerChild.props as Record<string, unknown>,
+        }
+      : null,
+    canOpenProfilePanel,
+  );
   const relayAgent = relayAgentsQuery.data?.find((a) => a.pubkey === pubkey);
   const managedAgent = managedAgentsQuery.data?.find(
     (a) => a.pubkey === pubkey,
@@ -554,22 +572,26 @@ export function UserProfilePopover({
       <PopoverAnchor asChild>
         <TriggerElement
           aria-label={triggerAriaLabel}
-          role={canOpenProfilePanel ? "button" : undefined}
-          tabIndex={canOpenProfilePanel ? 0 : undefined}
+          role={triggerOwnsFocus ? "button" : undefined}
+          tabIndex={triggerOwnsFocus ? 0 : undefined}
           onClick={handleTriggerClick}
-          onKeyDown={(e) => {
-            if (
-              (e.key === "Enter" || e.key === " ") &&
-              canOpenProfilePanel &&
-              openProfilePanel
-            ) {
-              e.preventDefault();
-              e.stopPropagation();
-              clearHoverTimer();
-              setOpen(false);
-              openProfilePanel(pubkey);
-            }
-          }}
+          onKeyDown={
+            triggerOwnsFocus
+              ? (e) => {
+                  if (
+                    (e.key === "Enter" || e.key === " ") &&
+                    canOpenProfilePanel &&
+                    openProfilePanel
+                  ) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    clearHoverTimer();
+                    setOpen(false);
+                    openProfilePanel(pubkey);
+                  }
+                }
+              : undefined
+          }
           onMouseEnter={handleTriggerMouseEnter}
           onMouseLeave={handleMouseLeave}
           className={cn(

--- a/desktop/src/features/profile/ui/userProfilePopoverTrigger.test.mjs
+++ b/desktop/src/features/profile/ui/userProfilePopoverTrigger.test.mjs
@@ -1,0 +1,103 @@
+// Tests for the popover trigger's focus-ownership decision. The wrapper should
+// carry its own role/tabIndex only when the panel can open and the child is not
+// already a focusable control; otherwise two nested Tab stops land on one
+// avatar (block/buzz#2394). No jsdom here, so the decision is a pure predicate
+// over the child's { type, props } shape and is tested directly.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isInteractiveTriggerChild,
+  triggerShouldOwnFocus,
+} from "./userProfilePopoverTrigger.ts";
+
+const button = { type: "button", props: {} };
+const span = { type: "span", props: {} };
+
+test("triggerShouldOwnFocus_defersToInteractiveChild", () => {
+  assert.equal(triggerShouldOwnFocus(button, true), false);
+});
+
+test("triggerShouldOwnFocus_keepsFocusForNonInteractiveChild", () => {
+  // SystemMessageRow mention chips pass a span, so the wrapper is the only Tab
+  // stop and must keep owning focus.
+  assert.equal(triggerShouldOwnFocus(span, true), true);
+});
+
+test("triggerShouldOwnFocus_neverOwnsFocusWhenPanelCannotOpen", () => {
+  assert.equal(triggerShouldOwnFocus(button, false), false);
+  assert.equal(triggerShouldOwnFocus(span, false), false);
+});
+
+test("isInteractiveTriggerChild_button", () => {
+  assert.equal(isInteractiveTriggerChild(button), true);
+});
+
+test("isInteractiveTriggerChild_span", () => {
+  assert.equal(isInteractiveTriggerChild(span), false);
+});
+
+test("isInteractiveTriggerChild_selectAndTextarea", () => {
+  assert.equal(isInteractiveTriggerChild({ type: "select", props: {} }), true);
+  assert.equal(
+    isInteractiveTriggerChild({ type: "textarea", props: {} }),
+    true,
+  );
+});
+
+test("isInteractiveTriggerChild_anchorNeedsHref", () => {
+  assert.equal(
+    isInteractiveTriggerChild({ type: "a", props: { href: "#" } }),
+    true,
+  );
+  assert.equal(isInteractiveTriggerChild({ type: "a", props: {} }), false);
+});
+
+test("isInteractiveTriggerChild_inputExceptHidden", () => {
+  assert.equal(isInteractiveTriggerChild({ type: "input", props: {} }), true);
+  assert.equal(
+    isInteractiveTriggerChild({ type: "input", props: { type: "hidden" } }),
+    false,
+  );
+});
+
+test("isInteractiveTriggerChild_disabledControlIsNotFocusable", () => {
+  // A disabled control is not in the tab order, so the wrapper must keep focus
+  // rather than defer to a child that cannot take it.
+  assert.equal(
+    isInteractiveTriggerChild({ type: "button", props: { disabled: true } }),
+    false,
+  );
+  assert.equal(
+    isInteractiveTriggerChild({ type: "input", props: { disabled: true } }),
+    false,
+  );
+});
+
+test("isInteractiveTriggerChild_tabIndexOverridesElementType", () => {
+  // An explicit tabIndex decides focusability for any element.
+  assert.equal(
+    isInteractiveTriggerChild({ type: "span", props: { tabIndex: 0 } }),
+    true,
+  );
+  assert.equal(
+    isInteractiveTriggerChild({ type: "button", props: { tabIndex: -1 } }),
+    false,
+  );
+});
+
+test("isInteractiveTriggerChild_componentChildIsNotInteractive", () => {
+  // A component child cannot be introspected, so the wrapper keeps focus (the
+  // safe default that preserves prior behavior).
+  const Component = () => null;
+  assert.equal(
+    isInteractiveTriggerChild({ type: Component, props: {} }),
+    false,
+  );
+});
+
+test("isInteractiveTriggerChild_missingChild", () => {
+  assert.equal(isInteractiveTriggerChild(null), false);
+  assert.equal(isInteractiveTriggerChild(undefined), false);
+});

--- a/desktop/src/features/profile/ui/userProfilePopoverTrigger.ts
+++ b/desktop/src/features/profile/ui/userProfilePopoverTrigger.ts
@@ -1,0 +1,48 @@
+// The popover trigger wraps its children. When the profile panel can open, the
+// wrapper takes role="button" + tabIndex so it is clickable and focusable. Most
+// call sites pass a real <button> child, which is already focusable, so the
+// wrapper would add a second Tab stop for one control (block/buzz#2394). These
+// helpers decide whether the wrapper should own focus, which it should only when
+// the child is not itself a focusable element.
+
+type TriggerChild =
+  | { type: unknown; props: Record<string, unknown> }
+  | null
+  | undefined;
+
+const INTERACTIVE_ELEMENTS = new Set(["button", "select", "textarea"]);
+
+// True when the resolved single child is itself in the tab order, so the wrapper
+// should defer to it. Only intrinsic elements are inspectable; a component child
+// is treated as non-focusable so the wrapper keeps its own focus behavior.
+export function isInteractiveTriggerChild(child: TriggerChild): boolean {
+  if (!child || typeof child.type !== "string") {
+    return false;
+  }
+  // An explicit tabIndex decides focusability for any element: >= 0 is a Tab
+  // stop, < 0 is removed from the tab order.
+  if (typeof child.props.tabIndex === "number") {
+    return child.props.tabIndex >= 0;
+  }
+  if (child.type === "a") {
+    return child.props.href != null;
+  }
+  if (child.type === "input") {
+    return child.props.type !== "hidden" && child.props.disabled !== true;
+  }
+  if (INTERACTIVE_ELEMENTS.has(child.type)) {
+    // Form controls drop out of the tab order when disabled.
+    return child.props.disabled !== true;
+  }
+  return false;
+}
+
+// Whether the trigger wrapper should carry its own role/tabIndex/onKeyDown: only
+// when the panel can open and the child does not already provide a focusable,
+// keyboard-activatable element.
+export function triggerShouldOwnFocus(
+  child: TriggerChild,
+  canOpenProfilePanel: boolean,
+): boolean {
+  return canOpenProfilePanel && !isInteractiveTriggerChild(child);
+}


### PR DESCRIPTION
Tabbing through a channel timeline stops on the same avatar or author name twice before moving on.

`UserProfilePopover` wraps its children in a trigger element that takes `role="button"` and `tabIndex={0}` whenever the profile panel can open (the default). Most call sites pass a real `<button>` as the child, so the wrapper and the inner button are both in the tab order: two stops for one visual control.

The trigger now keeps its own `role`/`tabIndex`/`onKeyDown` only when the child is not already a focusable element. When the child is a button it becomes the single Tab stop; the wrapper keeps its `onClick`, so click and keyboard activation still open the profile panel by bubbling up. Non-interactive children (the `<span>` mention chips in `SystemMessageRow`) are unchanged, since there the wrapper is the only focusable element. The focus decision is a small pure helper with unit coverage, so no call sites needed to change.

Validation:
- `pnpm --dir desktop test` (unit suite): pass, including new coverage for the focus decision
- `tsc --noEmit`: pass
- `biome check` on the changed files: pass

Closes #2394
