### PR TITLE
fix(desktop): deliver deep links on Linux

### DIFF
--- a/desktop/src-tauri/linux/main.desktop
+++ b/desktop/src-tauri/linux/main.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Categories={{categories}}
+{{#if comment}}
+Comment={{comment}}
+{{/if}}
+Exec={{exec}} %u
+StartupWMClass={{exec}}
+Icon={{icon}}
+Name={{name}}
+Terminal=false
+Type=Application
+{{#if mime_type}}
+MimeType={{mime_type}}
+{{/if}}

--- a/desktop/src-tauri/src/deep_link.rs
+++ b/desktop/src-tauri/src/deep_link.rs
@@ -433,6 +433,23 @@ mod tests {
         assert!(queue.first().is_none());
     }
 
+    /// The bundled Linux `.desktop` template must keep a `%u` field code on
+    /// `Exec`. Per the freedesktop Desktop Entry spec a launcher only passes
+    /// the URL to a handler whose `Exec` carries a field code, and Tauri's
+    /// default template emits `MimeType=x-scheme-handler/buzz` *without* one.
+    /// Shipping that template meant `buzz://join?…` started Buzz with empty
+    /// argv, silently dropping every invite opened on Linux.
+    #[test]
+    fn linux_desktop_template_forwards_the_url_to_the_app() {
+        let template = include_str!("../linux/main.desktop");
+        let exec = template
+            .lines()
+            .find(|line| line.starts_with("Exec="))
+            .expect("template defines Exec");
+        assert_eq!(exec, "Exec={{exec}} %u");
+        assert!(template.contains("MimeType={{mime_type}}"));
+    }
+
     fn valid_nostr_bind_url() -> Url {
         Url::parse(
             "buzz://nostr-bind?challenge_id=550e8400-e29b-41d4-a716-446655440000&nonce=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi01234567&verification_code=123456&audience=buzz%3Anostr-identity&action=bind_nostr_identity&protocol=buzz-nostr-identity&version=1&origin=https%3A%2F%2Fexample.com&expires_at=2999-01-01T00%3A00%3A00Z&return=clipboard",

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -553,6 +553,30 @@ pub fn run() {
                         handle_deep_link_url(&dl_handle, url.as_str());
                     }
                 });
+
+                // Linux and Windows deliver a cold-start deep link as a CLI
+                // argument, which the plugin turns into a one-shot
+                // `deep-link://new-url` event during its own setup — before
+                // the listener above exists. Nothing replays it, so an invite
+                // that launches the app would be dropped. Read the launch URL
+                // back explicitly; `handle_deep_link_url` parks it on the
+                // pending queue for the frontend to drain once it mounts.
+                // macOS is excluded because there the OS delivers cold starts
+                // through `on_open_url` after setup, so this would double-fire.
+                #[cfg(any(target_os = "linux", windows))]
+                {
+                    let launch_urls = match app.deep_link().get_current() {
+                        Ok(urls) => urls.unwrap_or_default(),
+                        Err(error) => {
+                            eprintln!("buzz-desktop: failed to read launch deep link: {error}");
+                            Vec::new()
+                        }
+                    };
+                    let launch_handle = app.handle().clone();
+                    for url in launch_urls {
+                        handle_deep_link_url(&launch_handle, url.as_str());
+                    }
+                }
             }
 
             // Defer launch-time agent restoration until `apply_workspace` has

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -66,6 +66,14 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "linux": {
+      "deb": {
+        "desktopTemplate": "linux/main.desktop"
+      },
+      "rpm": {
+        "desktopTemplate": "linux/main.desktop"
+      }
+    },
     "macOS": {
       "infoPlist": "Info.plist",
       "entitlements": "Entitlements.plist",


### PR DESCRIPTION
Invite links opened on Linux silently did nothing — the app started or focused, and the invite vanished. Two separate defects caused it.

Tauri's bundled .desktop template emits `MimeType=x-scheme-handler/buzz` but no field code on Exec. The freedesktop Desktop Entry spec only hands the URL to a handler whose Exec carries `%u` or `%U`, so the launcher ran buzz-desktop with empty argv. A custom template restores `%u` for deb and rpm; AppImage inherits the deb-generated entry, so all three targets are covered.

Even with argv fixed, cold starts still dropped the link. The deep-link plugin emits the launch URL during its own setup, before the app registers `on_open_url`, and nothing replays it. Reading `get_current()` on Linux and Windows parks the URL on the existing pending queue for the frontend to drain. macOS is excluded because it delivers cold starts through `on_open_url` after setup.