### PR TITLE
Auto-connect configured production relay

### DIFF
--- a/desktop/src/features/communities/communityStorage.test.mjs
+++ b/desktop/src/features/communities/communityStorage.test.mjs
@@ -58,6 +58,12 @@ test("signed-build relay defaults auto-connect during first-run onboarding", () 
   assert.equal(shouldAutoConnectDefaultRelay("ws://127.0.0.1:3000"), false);
   assert.equal(shouldAutoConnectDefaultRelay("ws://[::1]:3000"), false);
   assert.equal(shouldAutoConnectDefaultRelay("ws://0.0.0.0:3000"), false);
+  assert.equal(shouldAutoConnectDefaultRelay("http://localhost:3000"), false);
+  assert.equal(
+    shouldAutoConnectDefaultRelay("https://relay.example.com"),
+    false,
+  );
+  assert.equal(shouldAutoConnectDefaultRelay("relay.example.com"), false);
   assert.equal(shouldAutoConnectDefaultRelay("not a valid relay"), false);
 });
 

--- a/desktop/src/features/communities/communityStorage.test.mjs
+++ b/desktop/src/features/communities/communityStorage.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   clearCommunityStorage,
   migrateLegacyCommunityStorage,
+  shouldAutoConnectDefaultRelay,
 } from "./communityStorage.ts";
 
 function createMemoryStorage(initial = {}) {
@@ -44,6 +45,16 @@ test("migrateLegacyCommunityStorage does not overwrite new community state", () 
 
   assert.equal(storage.getItem("buzz-communities"), '[{"id":"new"}]');
   assert.equal(storage.getItem("buzz-active-community-id"), "new");
+});
+
+test("signed-build relay defaults auto-connect during first-run onboarding", () => {
+  assert.equal(
+    shouldAutoConnectDefaultRelay("wss://buzz.block.builderlab.xyz"),
+    true,
+  );
+  assert.equal(shouldAutoConnectDefaultRelay("ws://localhost:3000"), false);
+  assert.equal(shouldAutoConnectDefaultRelay("ws://127.0.0.1:3000"), false);
+  assert.equal(shouldAutoConnectDefaultRelay("not a valid relay"), false);
 });
 
 test("clearCommunityStorage removes new and legacy state", () => {

--- a/desktop/src/features/communities/communityStorage.test.mjs
+++ b/desktop/src/features/communities/communityStorage.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   clearCommunityStorage,
+  initFirstCommunity,
   migrateLegacyCommunityStorage,
   shouldAutoConnectDefaultRelay,
 } from "./communityStorage.ts";
@@ -10,6 +11,7 @@ import {
 function createMemoryStorage(initial = {}) {
   const values = new Map(Object.entries(initial));
   return {
+    values,
     getItem: (key) => values.get(key) ?? null,
     setItem: (key, value) => values.set(key, String(value)),
     removeItem: (key) => values.delete(key),
@@ -57,6 +59,28 @@ test("signed-build relay defaults auto-connect during first-run onboarding", () 
   assert.equal(shouldAutoConnectDefaultRelay("ws://[::1]:3000"), false);
   assert.equal(shouldAutoConnectDefaultRelay("ws://0.0.0.0:3000"), false);
   assert.equal(shouldAutoConnectDefaultRelay("not a valid relay"), false);
+});
+
+test("failed first-community write preserves existing community data", () => {
+  const storage = createMemoryStorage({
+    "buzz-communities": '[{"id":"existing"}]',
+    "buzz-workspaces": '[{"id":"legacy"}]',
+    "buzz-active-workspace-id": "legacy",
+  });
+  storage.setItem = (key, value) => {
+    if (key === "buzz-communities") {
+      throw new Error("QuotaExceededError");
+    }
+    storage.values.set(key, String(value));
+  };
+  globalThis.localStorage = storage;
+  globalThis.window = { localStorage: storage };
+
+  assert.equal(initFirstCommunity("wss://relay.example.com", "pubkey"), null);
+  assert.equal(storage.getItem("buzz-communities"), '[{"id":"existing"}]');
+  assert.equal(storage.getItem("buzz-active-community-id"), null);
+  assert.equal(storage.getItem("buzz-workspaces"), '[{"id":"legacy"}]');
+  assert.equal(storage.getItem("buzz-active-workspace-id"), "legacy");
 });
 
 test("clearCommunityStorage removes new and legacy state", () => {

--- a/desktop/src/features/communities/communityStorage.test.mjs
+++ b/desktop/src/features/communities/communityStorage.test.mjs
@@ -54,6 +54,8 @@ test("signed-build relay defaults auto-connect during first-run onboarding", () 
   );
   assert.equal(shouldAutoConnectDefaultRelay("ws://localhost:3000"), false);
   assert.equal(shouldAutoConnectDefaultRelay("ws://127.0.0.1:3000"), false);
+  assert.equal(shouldAutoConnectDefaultRelay("ws://[::1]:3000"), false);
+  assert.equal(shouldAutoConnectDefaultRelay("ws://0.0.0.0:3000"), false);
   assert.equal(shouldAutoConnectDefaultRelay("not a valid relay"), false);
 });
 

--- a/desktop/src/features/communities/communityStorage.ts
+++ b/desktop/src/features/communities/communityStorage.ts
@@ -81,8 +81,11 @@ export function loadCommunities(): Community[] {
   }
 }
 
-export function saveCommunities(communities: Community[]): void {
-  setLocalStorageItemWithRecovery(COMMUNITIES_KEY, JSON.stringify(communities));
+export function saveCommunities(communities: Community[]): boolean {
+  return setLocalStorageItemWithRecovery(
+    COMMUNITIES_KEY,
+    JSON.stringify(communities),
+  );
 }
 
 export function clearCommunityStorage(storage: Storage = localStorage): void {
@@ -97,8 +100,8 @@ export function loadActiveCommunityId(): string | null {
   return localStorage.getItem(ACTIVE_COMMUNITY_KEY);
 }
 
-export function saveActiveCommunityId(id: string): void {
-  setLocalStorageItemWithRecovery(ACTIVE_COMMUNITY_KEY, id);
+export function saveActiveCommunityId(id: string): boolean {
+  return setLocalStorageItemWithRecovery(ACTIVE_COMMUNITY_KEY, id);
 }
 
 export function normalizeRelayUrl(url: string): string {
@@ -111,7 +114,9 @@ export function normalizeRelayUrl(url: string): string {
 export function shouldAutoConnectDefaultRelay(relayUrl: string): boolean {
   try {
     const parsed = new URL(normalizeRelayUrl(relayUrl));
-    return parsed.hostname !== "localhost" && parsed.hostname !== "127.0.0.1";
+    return !["localhost", "127.0.0.1", "[::1]", "0.0.0.0"].includes(
+      parsed.hostname,
+    );
   } catch {
     return false;
   }
@@ -145,7 +150,7 @@ export function initFirstCommunity(
   relayUrl: string,
   pubkey: string,
   name?: string,
-): Community {
+): Community | null {
   const normalizedUrl = normalizeRelayUrl(relayUrl);
   const trimmedName = name?.trim();
   const community: Community = {
@@ -155,7 +160,16 @@ export function initFirstCommunity(
     pubkey,
     addedAt: new Date().toISOString(),
   };
-  saveCommunities([community]);
-  saveActiveCommunityId(community.id);
+  const didSaveCommunities = saveCommunities([community]);
+  const didSaveActiveCommunity =
+    didSaveCommunities && saveActiveCommunityId(community.id);
+
+  // The quota-recovery helper reports failure instead of throwing. Do not let
+  // callers reload unless both writes landed; otherwise first launch can loop.
+  if (!didSaveCommunities || !didSaveActiveCommunity) {
+    clearCommunityStorage();
+    return null;
+  }
+
   return community;
 }

--- a/desktop/src/features/communities/communityStorage.ts
+++ b/desktop/src/features/communities/communityStorage.ts
@@ -160,14 +160,26 @@ export function initFirstCommunity(
     pubkey,
     addedAt: new Date().toISOString(),
   };
-  const didSaveCommunities = saveCommunities([community]);
-  const didSaveActiveCommunity =
-    didSaveCommunities && saveActiveCommunityId(community.id);
+  const previousActiveCommunityId = localStorage.getItem(ACTIVE_COMMUNITY_KEY);
+  const didSaveActiveCommunity = saveActiveCommunityId(community.id);
+  if (!didSaveActiveCommunity) {
+    return null;
+  }
 
-  // The quota-recovery helper reports failure instead of throwing. Do not let
-  // callers reload unless both writes landed; otherwise first launch can loop.
-  if (!didSaveCommunities || !didSaveActiveCommunity) {
-    clearCommunityStorage();
+  if (!saveCommunities([community])) {
+    // A failed setItem leaves the existing communities value untouched. Roll
+    // back only the active-ID write so inconsistent pre-existing data is never
+    // destroyed while recovering from a quota failure.
+    try {
+      if (previousActiveCommunityId === null) {
+        localStorage.removeItem(ACTIVE_COMMUNITY_KEY);
+      } else {
+        localStorage.setItem(ACTIVE_COMMUNITY_KEY, previousActiveCommunityId);
+      }
+    } catch {
+      // Best effort: persistence is already unavailable, and callers will stay
+      // on setup instead of reloading.
+    }
     return null;
   }
 

--- a/desktop/src/features/communities/communityStorage.ts
+++ b/desktop/src/features/communities/communityStorage.ts
@@ -108,6 +108,15 @@ export function normalizeRelayUrl(url: string): string {
   return url;
 }
 
+export function shouldAutoConnectDefaultRelay(relayUrl: string): boolean {
+  try {
+    const parsed = new URL(normalizeRelayUrl(relayUrl));
+    return parsed.hostname !== "localhost" && parsed.hostname !== "127.0.0.1";
+  } catch {
+    return false;
+  }
+}
+
 export function deriveCommunityName(relayUrl: string): string {
   try {
     const url = new URL(

--- a/desktop/src/features/communities/communityStorage.ts
+++ b/desktop/src/features/communities/communityStorage.ts
@@ -111,11 +111,16 @@ export function normalizeRelayUrl(url: string): string {
   return url;
 }
 
+function isLocalRelayHost(hostname: string): boolean {
+  return ["localhost", "127.0.0.1", "[::1]", "0.0.0.0"].includes(hostname);
+}
+
 export function shouldAutoConnectDefaultRelay(relayUrl: string): boolean {
   try {
-    const parsed = new URL(normalizeRelayUrl(relayUrl));
-    return !["localhost", "127.0.0.1", "[::1]", "0.0.0.0"].includes(
-      parsed.hostname,
+    const parsed = new URL(relayUrl);
+    return (
+      (parsed.protocol === "ws:" || parsed.protocol === "wss:") &&
+      !isLocalRelayHost(parsed.hostname)
     );
   } catch {
     return false;
@@ -128,7 +133,7 @@ export function deriveCommunityName(relayUrl: string): string {
       relayUrl.replace("ws://", "http://").replace("wss://", "https://"),
     );
     const host = url.hostname;
-    if (host === "localhost" || host === "127.0.0.1") {
+    if (isLocalRelayHost(host)) {
       return "Local Dev";
     }
     const parts = host.split(".");
@@ -157,6 +162,8 @@ export function initFirstCommunity(
     id: crypto.randomUUID(),
     name: trimmedName || deriveCommunityName(normalizedUrl),
     relayUrl: normalizedUrl,
+    // Compiled default relays must admit the first token-less connection; there
+    // is no invite-token prompt on this auto-connect path.
     pubkey,
     addedAt: new Date().toISOString(),
   };

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -23,7 +23,10 @@ import { resetSidebarRelayConnectionCardState } from "@/features/sidebar/ui/useS
 import { clearMarkdownNodeCache } from "@/shared/ui/markdown/nodeCache";
 import { resetVideoPlayerState } from "@/shared/ui/videoPlayerState";
 
-import { initFirstCommunity } from "./communityStorage";
+import {
+  initFirstCommunity,
+  shouldAutoConnectDefaultRelay,
+} from "./communityStorage";
 import type { Community } from "./types";
 
 /**
@@ -94,7 +97,14 @@ export function useCommunityInit(
         try {
           const defaultRelayUrl = await getDefaultRelayUrl();
 
-          if (isSharedIdentity) {
+          // Signed builds carry a reviewed production relay. Treat that as the
+          // user's first community so first-run onboarding proceeds directly
+          // from machine setup into profile/team setup. Local development keeps
+          // the explicit add-a-community flow for ws://localhost defaults.
+          if (
+            isSharedIdentity ||
+            shouldAutoConnectDefaultRelay(defaultRelayUrl)
+          ) {
             const identity = await getIdentity();
             if (cancelled) return;
             initFirstCommunity(defaultRelayUrl, identity.pubkey);

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -107,9 +107,20 @@ export function useCommunityInit(
           ) {
             const identity = await getIdentity();
             if (cancelled) return;
-            initFirstCommunity(defaultRelayUrl, identity.pubkey);
-            if (!cancelled) {
+            const community = initFirstCommunity(
+              defaultRelayUrl,
+              identity.pubkey,
+            );
+            if (community && !cancelled) {
               window.location.reload();
+              return;
+            }
+            if (!cancelled) {
+              setResult({
+                isReady: false,
+                needsSetup: true,
+                defaultRelayUrl,
+              });
             }
             return;
           }

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -560,6 +560,46 @@ test("first-launch key import continues to machine setup", async ({ page }) => {
   await expect(page.getByTestId("app-loading-gate")).toHaveCount(0);
 });
 
+test("non-local default auto-connects the first community", async ({
+  page,
+}) => {
+  await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
+  await page.addInitScript((pubkey) => {
+    window.localStorage.setItem(
+      `buzz-machine-onboarding-complete.v2:${pubkey}`,
+      "true",
+    );
+  }, BLANK_TYLER_IDENTITY.pubkey);
+  await installMockBridge(page, undefined, {
+    relayWsUrl: "wss://default.example.com",
+    skipOnboardingSeed: true,
+    skipCommunitySeed: true,
+  });
+  await page.goto("/");
+
+  await expectIncompleteOnboarding(page);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const raw = window.localStorage.getItem("buzz-communities");
+        const communities = raw
+          ? (JSON.parse(raw) as Array<{ id: string; relayUrl: string }>)
+          : [];
+        return {
+          activeMatchesCommunity:
+            communities.length === 1 &&
+            window.localStorage.getItem("buzz-active-community-id") ===
+              communities[0]?.id,
+          relayUrl: communities[0]?.relayUrl ?? null,
+        };
+      }),
+    )
+    .toEqual({
+      activeMatchesCommunity: true,
+      relayUrl: "wss://default.example.com",
+    });
+});
+
 test("first-community choices route join, create, owner, and member intents", async ({
   page,
 }) => {
@@ -1298,7 +1338,7 @@ test("connected first-community profile step offers equal-width Next and Back co
           id: "txn-profile-step",
           source: "first-community",
           stage: "profile",
-          relayUrl: "wss://default.example.com",
+          relayUrl: "ws://localhost:3000",
           communityName: "Default",
           communityId: "e2e-default-community",
           addedCommunity: true,
@@ -1346,7 +1386,7 @@ test("connected first-community profile step offers equal-width Next and Back co
       ],
     },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
     },
   );

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -571,7 +571,7 @@ test("first-community choices route join, create, owner, and member intents", as
     );
   }, BLANK_TYLER_IDENTITY.pubkey);
   await installMockBridge(page, undefined, {
-    relayWsUrl: "wss://default.example.com",
+    relayWsUrl: "ws://localhost:3000",
     skipOnboardingSeed: true,
     skipCommunitySeed: true,
   });
@@ -657,7 +657,7 @@ test("first-community owner can connect an existing hosted community", async ({
       ],
     },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -715,7 +715,7 @@ test("first-community owner can create and connect a hosted community", async ({
     page,
     {},
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -789,7 +789,7 @@ test("hosted community address line stays within the card for a long name", asyn
     page,
     {},
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -860,7 +860,7 @@ test("first-community reports a created community without a relay address", asyn
       },
     },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -891,7 +891,7 @@ test("first-community X cancels a pending sign-in", async ({ page }) => {
     page,
     { builderlabLoginDelayMs: 5_000 },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -933,7 +933,7 @@ test("first-community owner can replace a mismatched account identity", async ({
       builderlabIdentity: { pubkey_hex: "f".repeat(64) },
     },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -983,7 +983,7 @@ test("first-community explains when the local identity belongs to another accoun
       builderlabBindError: { code: "pubkey_already_bound" },
     },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -1024,7 +1024,7 @@ test("back clears Builderlab auth before returning to first-community choices", 
       builderlabIdentity: { pubkey_hex: BLANK_TYLER_IDENTITY.pubkey },
     },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -1112,7 +1112,7 @@ test("first-community direct join reaches profile", async ({ page }) => {
     );
   }, BLANK_TYLER_IDENTITY.pubkey);
   await installMockBridge(page, undefined, {
-    relayWsUrl: "wss://onboarding.communities.buzz.xyz",
+    relayWsUrl: "ws://localhost:3000",
     skipOnboardingSeed: true,
     skipCommunitySeed: true,
   });
@@ -1167,7 +1167,7 @@ test("first-community direct join cancel returns to request access", async ({
     page,
     { applyCommunityDelayMs: 5_000 },
     {
-      relayWsUrl: "wss://onboarding.communities.buzz.xyz",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },


### PR DESCRIPTION
## Why
Internal desktop releases now ship with a production relay, so fresh installs should enter it without asking employees to add a community manually.

## What
- Auto-create the first community when the compiled default is a non-local relay
- Production first-runs with a non-local configured relay skip the community-selection wizard and proceed directly to profile setup
- Preserve the explicit community selection flow for localhost development builds and storage-failure recovery
- Cover production and local relay classification with a unit test

## Risk Assessment
Medium — changes first-run routing only when no community exists and the build has a non-local default relay. Existing users and local development are unchanged.

## References
- Companion release-config PR: https://github.com/squareup/buzz-releases/pull/new/baxen/production-relay
- `wss://buzz.block.builderlab.xyz` responds with Buzz NIP-11 metadata
- Desktop unit suite: 3,384 passed; TypeScript typecheck passed

Generated with Goose

