### PR TITLE
fix(desktop): make composer attachment removal keyboard accessible

### DIFF
--- a/desktop/src/features/messages/ui/ComposerAttachments.tsx
+++ b/desktop/src/features/messages/ui/ComposerAttachments.tsx
@@ -480,9 +480,11 @@ const MediaAttachmentItem = React.forwardRef<
         <Tooltip disableHoverableContent>
           <TooltipTrigger asChild>
             <button
+              aria-label={`Remove attachment ${hash}`}
+              data-testid="composer-media-attachment-remove"
               type="button"
               onClick={() => onRemove(attachment.url)}
-              className="absolute -right-1 -top-1 hidden h-4 w-4 items-center justify-center rounded-full bg-foreground text-background group-hover:flex"
+              className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-foreground text-background opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
             >
               <X className="h-2.5 w-2.5" />
             </button>
@@ -573,9 +575,11 @@ export const ComposerAttachments = React.memo(function ComposerAttachments({
                   <Tooltip disableHoverableContent>
                     <TooltipTrigger asChild>
                       <button
+                        aria-label={`Remove ${label}`}
+                        data-testid="composer-file-attachment-remove"
                         type="button"
                         onClick={() => onRemove(attachment.url)}
-                        className="absolute -right-1 -top-1 hidden h-4 w-4 items-center justify-center rounded-full bg-foreground text-background group-hover:flex"
+                        className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-foreground text-background opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100"
                       >
                         <X className="h-2.5 w-2.5" />
                       </button>

--- a/desktop/tests/e2e/file-attachment.spec.ts
+++ b/desktop/tests/e2e/file-attachment.spec.ts
@@ -63,6 +63,32 @@ test("upload a file and see a FileCard in the timeline", async ({ page }) => {
     .toContain("download_file");
 });
 
+test("keyboard users can remove a composer file attachment", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+
+  await page.getByRole("button", { name: "Attach image" }).click();
+  await expect(page.getByTestId("message-composer")).toContainText(
+    "quarterly-report.pdf",
+  );
+
+  const removeButton = page.getByTestId("composer-file-attachment-remove");
+
+  // The control may be visually quiet until hover/focus, but must remain in
+  // the tab order. Moving away and back with Tab proves it is keyboard reachable.
+  await removeButton.focus();
+  await page.keyboard.press("Shift+Tab");
+  await page.keyboard.press("Tab");
+  await expect(removeButton).toBeFocused();
+
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("message-composer")).not.toContainText(
+    "quarterly-report.pdf",
+  );
+});
+
 test("dropping a file on the channel column attaches it to the composer", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- keep composer attachment remove controls in the tab order while visually revealing them on hover or focus
- add accessible names for media and file attachment removal
- add a Playwright regression test that removes a file attachment via keyboard

Fixes #2389

## Testing
- `pnpm --dir desktop check`
- `pnpm --dir desktop test:e2e -- tests/e2e/file-attachment.spec.ts --project=smoke`