### PR TITLE
fix(desktop): preserve channel intro action focus rings

### DIFF
--- a/desktop/src/features/messages/ui/ChannelIntroBlock.tsx
+++ b/desktop/src/features/messages/ui/ChannelIntroBlock.tsx
@@ -63,7 +63,10 @@ export function ChannelIntroBlock({
         </p>
       ) : null}
       {intro.actions?.length ? (
-        <div className="mt-4 flex max-w-full flex-nowrap gap-3 overflow-x-auto pb-1">
+        <div
+          className="-mx-1 mt-3 flex max-w-[calc(100%+0.5rem)] flex-nowrap gap-3 overflow-x-auto p-1"
+          data-testid="message-channel-intro-actions"
+        >
           {intro.actions.map((action) => {
             const hasDescription = Boolean(action.description);
 

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1507,6 +1507,11 @@ test("empty channel shows intro actions", async ({ page }) => {
   await expect(page.getByTestId("welcome-composer-guide-banner")).toHaveCount(
     0,
   );
+  // Horizontal scrolling creates a clipping context. The padded, offset row
+  // leaves space for the cards' focus rings without changing their alignment.
+  const introActions = page.getByTestId("message-channel-intro-actions");
+  await expect(introActions).toHaveCSS("padding-top", "4px");
+  await expect(introActions).toHaveCSS("padding-bottom", "4px");
   await expectIntroActionCardLayout(page, "channel-intro-action-create-agent");
   await expectIntroActionsShareRow(page, [
     "channel-intro-action-create-agent",


### PR DESCRIPTION
## Summary

Fixes #2392.

The horizontally scrollable channel-intro action row now has a one-pixel offset and padding. This gives the cards’ focus-visible rings space to paint without changing their visual alignment or scroll behavior.

## Testing

- `pnpm --dir desktop check`
- `pnpm --dir desktop exec playwright test tests/e2e/channels.spec.ts --project=smoke --grep "empty channel shows intro actions"`

Added a regression assertion for the vertical focus-ring clearance.