### PR TITLE
test(db): fix replica fence test microsecond precision mismatch

### DIFF
--- a/crates/buzz-db/src/replica_fence.rs
+++ b/crates/buzz-db/src/replica_fence.rs
@@ -521,7 +521,11 @@ mod tests {
         assert!(fence.verified_through().is_none(), "must start closed");
         assert!(!fence.covers(Utc::now() - chrono::Duration::days(365)));
 
-        let ts = Utc::now();
+        // ReplicaFence stores Unix microseconds (fence_micros), so
+        // verified_through() returns a microsecond-truncated timestamp.
+        // Truncate ts to match the contract — the fence's unit IS micros.
+        let ts = DateTime::from_timestamp_micros(Utc::now().timestamp_micros())
+            .expect("valid microsecond timestamp");
         fence.advance(ts);
         assert_eq!(fence.verified_through(), Some(ts));
         assert!(fence.covers(ts - chrono::Duration::seconds(1)));


### PR DESCRIPTION
## Problem

`just test-unit` under Rust 1.95 deterministically fails `buzz-db::replica_fence::tests::fence_starts_closed_and_opens_on_advance`.

`ReplicaFence` stores Unix **microseconds** (`fence_micros: AtomicI64`, line 76). `advance()` calls `fence.timestamp_micros()` which truncates nanos. `verified_through()` reconstructs via `DateTime::from_timestamp_micros()` which yields zero sub-microsecond nanos.

The test at line 524 captured `let ts = Utc::now()` at full **nanosecond** precision, then asserted `assert_eq!(fence.verified_through(), Some(ts))` — comparing a micros-truncated left side against a nanos right side. The left side always drops the sub-microsecond digits; the right side retains them. Deterministic failure on any system clock with non-zero sub-microsecond nanos.

## Fix

Construct `ts` via `DateTime::from_timestamp_micros(Utc::now().timestamp_micros())` so the round-trip through `advance()` → `verified_through()` is exact. This matches the fence's documented microsecond contract — the `fence_micros` field IS the contract, and the test was asserting against a precision the fence never claimed to preserve.

No fence semantics are weakened. The fence still fails closed, still stores micros, still compares the same way. Only the test's input timestamp was corrected to match the contract.

## Verification

```
$ just test-unit
  Passed (5):
    pass buzz-core tests
    pass buzz-auth unit tests
    pass buzz-db unit tests       ← was failing, now passes
    pass buzz-conformance tests
    pass buzz-push-gateway tests

  All tests passed!
```

Also verified determinism with 5 consecutive isolated runs of the specific test — all pass.

## Checklist

- [x] `just test-unit` passes
- [x] No new `unwrap()` or `expect()` in production paths (test-only `expect()` on a value just constructed from a valid micros timestamp)
- [x] No new `unsafe` blocks
- [x] One logical change, focused