### PR TITLE
Prevent ghost-painted timeline messages in the desktop app

### DIFF
--- a/desktop/src/shared/styles/globals/motion.css
+++ b/desktop/src/shared/styles/globals/motion.css
@@ -1,7 +1,7 @@
 /*
  * Buzz motion system
  *
- * Keep shared timing, easing, distance, and semantic motion primitives here.
+ * Keep shared timing, easing, and semantic motion primitives here.
  * Features decide when motion runs; this layer defines how Buzz moves.
  */
 
@@ -15,13 +15,13 @@
   /* Easing: direct for feedback, confident deceleration for entrances. */
   --motion-ease-standard: cubic-bezier(0.25, 1, 0.5, 1);
   --motion-ease-arrival: cubic-bezier(0.16, 1, 0.3, 1);
-
-  /* Distances stay restrained so motion supports hierarchy without spectacle. */
-  --motion-distance-arrival: 0.75rem;
-  --motion-blur-arrival: 2px;
 }
 
-/* A newly-created conversational object settling into the timeline. */
+/*
+ * Keep message arrival opacity-only. Timeline rows are positioned with
+ * transforms by the virtualizer; adding a nested transform or filter here can
+ * leave stale text tiles behind in WKWebView when rows are rapidly remeasured.
+ */
 .motion-enter-conversation {
   animation: motion-enter-conversation var(--motion-duration-arrival)
     var(--motion-ease-arrival) both;
@@ -29,15 +29,11 @@
 
 @keyframes motion-enter-conversation {
   from {
-    filter: blur(var(--motion-blur-arrival));
     opacity: 0;
-    transform: translateY(var(--motion-distance-arrival));
   }
 
   to {
-    filter: blur(0);
     opacity: 1;
-    transform: translateY(0);
   }
 }
 
@@ -49,9 +45,7 @@
   @keyframes motion-enter-conversation {
     from,
     to {
-      filter: none;
       opacity: 1;
-      transform: none;
     }
   }
 }

--- a/desktop/src/shared/styles/globals/motion.test.mjs
+++ b/desktop/src/shared/styles/globals/motion.test.mjs
@@ -16,6 +16,17 @@ test("conversation arrival uses shared motion tokens", () => {
   );
 });
 
+test("conversation arrival avoids nested compositing effects", () => {
+  const keyframes = motionCss.match(
+    /@keyframes motion-enter-conversation\s*\{([\s\S]*?)\n\}/,
+  );
+
+  assert.ok(keyframes, "conversation arrival keyframes should exist");
+  assert.match(keyframes[1], /opacity:\s*0/);
+  assert.match(keyframes[1], /opacity:\s*1/);
+  assert.doesNotMatch(keyframes[1], /\b(?:filter|transform)\s*:/);
+});
+
 test("conversation arrival has a reduced-motion treatment", () => {
   assert.match(
     motionCss,

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -156,6 +156,56 @@ test("send a message and see it in timeline", async ({ page }) => {
   );
 });
 
+test("rapid same-author messages never overlap in a direct message", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-alice-tyler").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("alice-tyler");
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function",
+  );
+
+  const burstPrefix = `rapid-dm-${Date.now()}`;
+  await page.evaluate(
+    ({ channelName, createdAt, prefix, pubkey }) => {
+      for (let index = 0; index < 5; index += 1) {
+        window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+          channelName,
+          content: `${prefix}-${index}`,
+          createdAt,
+          pubkey,
+        });
+      }
+    },
+    {
+      channelName: "alice-tyler",
+      createdAt: Math.floor(Date.now() / 1_000),
+      prefix: burstPrefix,
+      pubkey: TEST_IDENTITIES.tyler.pubkey,
+    },
+  );
+
+  const burstRows = page
+    .getByTestId("message-row")
+    .filter({ hasText: burstPrefix });
+  await expect(burstRows).toHaveCount(5);
+
+  await expect
+    .poll(async () =>
+      burstRows.evaluateAll((rows) =>
+        rows
+          .map((row) => row.getBoundingClientRect())
+          .sort((left, right) => left.top - right.top)
+          .every(
+            (row, index, ordered) =>
+              index === 0 || row.top >= ordered[index - 1].bottom - 0.5,
+          ),
+      ),
+    )
+    .toBe(true);
+});
+
 test("long autolink wraps without widening the timeline", async ({ page }) => {
   await page.setViewportSize({ width: 800, height: 600 });
 


### PR DESCRIPTION
## Summary

- make message arrival animation opacity-only
- avoid nested transform/filter compositing inside transform-positioned Virtua rows
- add CSS and rapid same-author DM regressions

## Why

Rapid messages in the macOS desktop app can leave duplicated, overlapping text behind in the timeline. The timeline virtualizer positions rows with transforms, while each arriving message also used a blur plus translate animation. That nested compositing is unsafe in WKWebView when rows are appended and remeasured quickly, and can leave stale painted text tiles even though the DOM geometry is correct.

The arrival animation now preserves the fade without creating another transform/filter layer. This prevents the visual ghosting while keeping the existing motion duration and easing.

## Validation

- `pnpm --dir desktop check`
- `pnpm --dir desktop build:e2e`
- `pnpm --dir desktop test`
- `pnpm --dir desktop exec playwright test tests/e2e/messaging.spec.ts --project=smoke --grep "rapid same-author messages never overlap"`