### PR TITLE
Make agent personality easy to edit

### DIFF
--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -68,6 +68,11 @@ with a TypeScript lookup table or an id comparison in a component.
    sole onboarding surface that chooses and persists `preferred_runtime`.
    `onboarding-agent-defaults.spec.ts` is the acceptance gate for anything
    touching this flow or the shared renderer.
+8. **Personality is the existing system prompt, not a second config layer.**
+   Definition and standalone-instance editors render it as a first-class
+   `Personality` field and persist through `systemPrompt`. Do not add a
+   personality env key or parallel prompt field; every runtime must keep using
+   the established system-prompt resolution path.
 
 ## The tests that enforce this
 
@@ -82,6 +87,8 @@ with a TypeScript lookup table or an id comparison in a component.
 - `desktop/tests/e2e/onboarding-agent-defaults.spec.ts` — onboarding behavior
   acceptance coverage for readiness, failure states, defaults, navigation, and
   persistence races.
+- `desktop/tests/e2e/edit-agent.spec.ts` — first-class personality editing and
+  persistence for standalone managed agents.
 - Rust: `runtime_metadata_env_vars` tests pin spawn-time key application.
 
 ## Keep this file true

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -12,8 +12,8 @@ import { Button } from "@/shared/ui/button";
 import { ChooserDialogContent } from "@/shared/ui/chooser-dialog-content";
 import { Dialog } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
-import { Textarea } from "@/shared/ui/textarea";
 import { AgentCreationPreview } from "./AgentCreationPreview";
+import { AgentPersonalityField } from "./AgentPersonalityField";
 import { PersonaDropdownField } from "./PersonaDropdownField";
 import type { EnvVarsValue } from "./EnvVarsEditor";
 import { PersonaAdvancedFields } from "./PersonaAdvancedFields";
@@ -814,27 +814,12 @@ export function AgentDefinitionDialog({
               </div>
             </div>
 
-            <div className="space-y-1.5">
-              <label
-                className="text-sm font-medium text-foreground"
-                htmlFor="persona-system-prompt"
-              >
-                Agent instructions
-              </label>
-              <div className={PERSONA_FIELD_SHELL_CLASS}>
-                <Textarea
-                  className={cn(
-                    "min-h-40 resize-y px-3 py-3 leading-5",
-                    PERSONA_FIELD_CONTROL_CLASS,
-                  )}
-                  disabled={isPending}
-                  id="persona-system-prompt"
-                  onChange={(event) => setSystemPrompt(event.target.value)}
-                  placeholder="Describe what this agent should do."
-                  value={systemPrompt}
-                />
-              </div>
-            </div>
+            <AgentPersonalityField
+              disabled={isPending}
+              id="persona-system-prompt"
+              onChange={setSystemPrompt}
+              value={systemPrompt}
+            />
 
             <div className="space-y-1.5">
               <label

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -63,6 +63,7 @@ import {
   type RuntimeModelProviderSelection,
 } from "./runtimeModelProviderSelection";
 import { AgentCreationPreview } from "./AgentCreationPreview";
+import { AgentPersonalityField } from "./AgentPersonalityField";
 import type { EnvVarsValue } from "./EnvVarsEditor";
 import { useRequiredCredentialState } from "./useRequiredCredentialState";
 import { CreateAgentRespondToField } from "./RespondToField";
@@ -920,6 +921,13 @@ export function AgentInstanceEditDialog({
               </div>
             </div>
 
+            <AgentPersonalityField
+              disabled={updateMutation.isPending}
+              id="edit-agent-system-prompt"
+              onChange={setSystemPrompt}
+              value={systemPrompt}
+            />
+
             {/* Who can talk to this agent */}
             <CreateAgentRespondToField
               allowlist={respondToAllowlist}
@@ -1151,7 +1159,6 @@ export function AgentInstanceEditDialog({
                       provider={effectiveProvider}
                       requiredEnvKeys={advancedRequiredEnvKeys}
                       selectedRuntimeId={selectedRuntimeId}
-                      systemPrompt={systemPrompt}
                       onAcpCommandChange={setAcpCommand}
                       onAgentArgsChange={setAgentArgs}
                       onAgentCommandChange={setAgentCommand}
@@ -1159,7 +1166,6 @@ export function AgentInstanceEditDialog({
                       onEnvVarsChange={setEnvVars}
                       onInheritHarnessChange={setInheritHarness}
                       onParallelismChange={setParallelism}
-                      onSystemPromptChange={setSystemPrompt}
                     />
                   </motion.div>
                 ) : null}

--- a/desktop/src/features/agents/ui/AgentPersonalityField.tsx
+++ b/desktop/src/features/agents/ui/AgentPersonalityField.tsx
@@ -1,0 +1,45 @@
+import { cn } from "@/shared/lib/cn";
+import { Textarea } from "@/shared/ui/textarea";
+import {
+  PERSONA_FIELD_CONTROL_CLASS,
+  PERSONA_FIELD_SHELL_CLASS,
+  PERSONA_LABEL_OPTIONAL_CLASS,
+} from "./agentConfigOptions";
+
+export function AgentPersonalityField({
+  disabled,
+  id,
+  onChange,
+  value,
+}: {
+  disabled: boolean;
+  id: string;
+  onChange: (value: string) => void;
+  value: string;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label className="text-sm font-medium text-foreground" htmlFor={id}>
+        Personality
+        <span className={PERSONA_LABEL_OPTIONAL_CLASS}>Optional</span>
+      </label>
+      <div className={PERSONA_FIELD_SHELL_CLASS}>
+        <Textarea
+          className={cn(
+            "min-h-32 resize-y px-3 py-3 leading-5",
+            PERSONA_FIELD_CONTROL_CLASS,
+          )}
+          disabled={disabled}
+          id={id}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder="Warm, curious, candid, and concise. Ask before making assumptions."
+          value={value}
+        />
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Describe how this agent thinks, speaks, and behaves. This guides every
+        conversation.
+      </p>
+    </div>
+  );
+}

--- a/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
+++ b/desktop/src/features/agents/ui/EditAgentAdvancedFields.tsx
@@ -1,6 +1,5 @@
 import { cn } from "@/shared/lib/cn";
 import { Input } from "@/shared/ui/input";
-import { Textarea } from "@/shared/ui/textarea";
 import { EnvVarsEditor, type EnvVarsValue } from "./EnvVarsEditor";
 import {
   PERSONA_FIELD_CONTROL_CLASS,
@@ -30,7 +29,6 @@ export function EditAgentAdvancedFields({
   provider,
   requiredEnvKeys,
   selectedRuntimeId,
-  systemPrompt,
   onAcpCommandChange,
   onAgentArgsChange,
   onAgentCommandChange,
@@ -38,7 +36,6 @@ export function EditAgentAdvancedFields({
   onInheritHarnessChange,
   onParallelismChange,
   onAutoRestartChange,
-  onSystemPromptChange,
 }: {
   acpCommand: string;
   agentArgs: string;
@@ -66,7 +63,6 @@ export function EditAgentAdvancedFields({
   provider?: string;
   requiredEnvKeys: readonly string[];
   selectedRuntimeId: string;
-  systemPrompt: string;
   onAcpCommandChange: (value: string) => void;
   onAgentArgsChange: (value: string) => void;
   onAgentCommandChange: (value: string) => void;
@@ -74,7 +70,6 @@ export function EditAgentAdvancedFields({
   onInheritHarnessChange: (value: boolean) => void;
   onParallelismChange: (value: string) => void;
   onAutoRestartChange: (value: boolean) => void;
-  onSystemPromptChange: (value: string) => void;
 }) {
   return (
     <div className="space-y-5 pt-2">
@@ -244,30 +239,6 @@ export function EditAgentAdvancedFields({
             id="edit-agent-acp-command"
             onChange={(event) => onAcpCommandChange(event.target.value)}
             value={acpCommand}
-          />
-        </div>
-      </div>
-
-      {/* System prompt override */}
-      <div className="space-y-1.5">
-        <label
-          className="text-sm font-medium text-foreground"
-          htmlFor="edit-agent-system-prompt"
-        >
-          System prompt override
-          <span className={PERSONA_LABEL_OPTIONAL_CLASS}>Optional</span>
-        </label>
-        <div className={PERSONA_FIELD_SHELL_CLASS}>
-          <Textarea
-            className={cn(
-              "min-h-24 resize-y px-3 py-3 leading-5",
-              PERSONA_FIELD_CONTROL_CLASS,
-            )}
-            disabled={disabled}
-            id="edit-agent-system-prompt"
-            onChange={(event) => onSystemPromptChange(event.target.value)}
-            placeholder="Leave blank to send no ACP system prompt"
-            value={systemPrompt}
           />
         </div>
       </div>

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -67,6 +67,7 @@ type MockCommandAvailability = {
 type MockManagedAgentSeed = {
   pubkey: string;
   name: string;
+  systemPrompt?: string | null;
   avatarUrl?: string | null;
   personaId?: string | null;
   status?: RawManagedAgent["status"];
@@ -1933,7 +1934,7 @@ function buildSeededManagedAgent(seed: MockManagedAgentSeed): MockManagedAgent {
     idle_timeout_seconds: null,
     max_turn_duration_seconds: null,
     parallelism: 1,
-    system_prompt: null,
+    system_prompt: seed.systemPrompt ?? null,
     avatar_url: seed.avatarUrl ?? null,
     model: null,
     env_vars: {},

--- a/desktop/tests/e2e/edit-agent.spec.ts
+++ b/desktop/tests/e2e/edit-agent.spec.ts
@@ -113,6 +113,42 @@ test.describe("edit agent dialog", () => {
     );
   });
 
+  test("edits personality without opening advanced settings", async ({
+    page,
+  }) => {
+    await installMockBridge(page, {
+      managedAgents: [
+        {
+          pubkey: AGENT_PUBKEY,
+          name: AGENT_NAME,
+          status: "stopped",
+          channelNames: ["agents"],
+          systemPrompt: "Be formal and reserved.",
+        },
+      ],
+    });
+
+    await openEditDialog(page);
+
+    const personality = page.locator("#edit-agent-system-prompt");
+    await expect(personality).toBeVisible();
+    await expect(personality).toHaveValue("Be formal and reserved.");
+    await expect(
+      page.getByRole("button", { name: "Advanced", exact: true }),
+    ).toHaveAttribute("aria-expanded", "false");
+
+    await personality.fill(
+      "Be warm, candid, and concise. Ask before making assumptions.",
+    );
+    await page.getByTestId("edit-agent-dialog-submit").click();
+    await expect(page.getByTestId("edit-agent-dialog")).not.toBeVisible();
+
+    await page.getByTestId("user-profile-edit-agent").click();
+    await expect(page.locator("#edit-agent-system-prompt")).toHaveValue(
+      "Be warm, candid, and concise. Ask before making assumptions.",
+    );
+  });
+
   test("changes the model via custom entry and persists it", async ({
     page,
   }) => {

--- a/desktop/tests/e2e/smoke.spec.ts
+++ b/desktop/tests/e2e/smoke.spec.ts
@@ -206,9 +206,7 @@ test("create agent persists Buzz shared compute with auto model", async ({
   });
 });
 
-test("create agent supports parallelism and system prompt overrides", async ({
-  page,
-}) => {
+test("create agent supports personality and parallelism", async ({ page }) => {
   const agentName = `Parallel agent ${Date.now()}`;
 
   await page.goto("/");
@@ -217,6 +215,7 @@ test("create agent supports parallelism and system prompt overrides", async ({
   await page.getByRole("menuitem", { name: "Create from scratch" }).click();
 
   await page.locator("#persona-display-name").fill(agentName);
+  await expect(page.getByLabel("Personality")).toBeVisible();
   await page
     .locator("#persona-system-prompt")
     .fill("You are concise and parallelize independent work.");

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -45,6 +45,7 @@ type MockCommandAvailability = {
 type MockManagedAgentSeed = {
   pubkey: string;
   name: string;
+  systemPrompt?: string | null;
   personaId?: string | null;
   status?: "running" | "stopped" | "deployed" | "not_deployed";
   channelNames?: string[];


### PR DESCRIPTION
## Summary

- add a shared, first-class **Personality** field to agent definition and standalone-agent editors
- keep personality on the existing `systemPrompt` persistence and runtime path
- move the standalone system prompt out of Advanced settings and add create/edit round-trip coverage

## Why

Agent behavior was already controlled by `systemPrompt`, but the UI exposed it inconsistently: definitions called it **Agent instructions**, while standalone agents buried it as **System prompt override** under Advanced. That made personality customization hard to discover, especially across built-in and custom agents.

## Impact

Users can now describe how an agent thinks, speaks, and behaves from the main create/edit form. Existing prompt resolution, save behavior, and runtime restart semantics remain unchanged; this does not introduce a second personality configuration layer.

## Validation

- `pnpm --dir desktop check`
- `pnpm --dir desktop build:e2e`
- `pnpm --dir desktop exec playwright test tests/e2e/edit-agent.spec.ts tests/e2e/smoke.spec.ts --project=smoke --grep "edits personality without opening advanced settings|create agent supports personality and parallelism"`
- `node --import ./test-loader.mjs --experimental-strip-types --test --test-reporter=dot "src/**/*.test.mjs"` (from `desktop/`)
