### PR TITLE
fix(desktop): dial managed agents on the configured relay URL, not the canonical runtime key

### DIFF
--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -323,7 +323,7 @@ pub async fn restore_managed_agents_on_launch(
                                             spawn_agent_child(
                                                 app,
                                                 record,
-                                                &key.relay_url,
+                                                &relay_url,
                                                 true,
                                                 owner_hex_ref,
                                             )

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1673,9 +1673,13 @@ pub fn spawn_agent_child(
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| effective_command.clone());
 
-    // The caller supplies the explicit canonical pair relay. This is the only
-    // relay this child may connect to, regardless of the record/workspace default.
-    let effective_relay_url = runtime_key.relay_url.clone();
+    // The caller supplies the explicit pair relay. This is the only relay this
+    // child may connect to, regardless of the record/workspace default. Dial it
+    // as configured, not via `runtime_key.relay_url`: the canonical form is
+    // identity-only, and its loopback folding (`localhost` -> `127.0.0.1`)
+    // changes the Host the relay derives the community boundary from, silently
+    // parking the child in a different (empty) community than the UI.
+    let effective_relay_url = relay_url.to_string();
 
     // Augment PATH for DMG launches so child processes can find:
     //   - bundled CLI via ~/.local/bin symlink
@@ -2115,7 +2119,7 @@ pub fn start_managed_agent_process(
     // Scalar PIDs are migration-only and never establish pair liveness.
     record.runtime_pid = None;
 
-    let mut process = spawn_agent_child(app, record, &key.relay_url, false, owner_hex)?;
+    let mut process = spawn_agent_child(app, record, &relay_url, false, owner_hex)?;
     let now = now_iso();
     let receipt = super::ManagedAgentRuntimeReceipt {
         key: key.clone(),

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -272,7 +272,13 @@ fn start_pair(
         .get_mut(&key)
         .is_some_and(|runtime| runtime.child.try_wait().ok().flatten().is_none())
     {
-        let status = status_for(&app, record, &key, runtimes.get(&key), None);
+        let status = status_for(
+            &app,
+            record,
+            &key,
+            runtimes.get(&key),
+            Some(relay_url.clone()),
+        );
         return Ok(status);
     }
     runtimes.remove(&key);
@@ -283,7 +289,7 @@ fn start_pair(
         .lock()
         .ok()
         .map(|keys| keys.public_key().to_hex());
-    let mut process = spawn_agent_child(&app, record, &key.relay_url, lazy, owner.as_deref())?;
+    let mut process = spawn_agent_child(&app, record, &relay_url, lazy, owner.as_deref())?;
     let now = crate::util::now_iso();
     let receipt = ManagedAgentRuntimeReceipt {
         key: key.clone(),
@@ -302,7 +308,13 @@ fn start_pair(
     record.last_stopped_at = None;
     record.last_error = None;
     runtimes.insert(key.clone(), ManagedAgentPairRuntime::starting(process));
-    let status = status_for(&app, record, &key, runtimes.get(&key), None);
+    let status = status_for(
+        &app,
+        record,
+        &key,
+        runtimes.get(&key),
+        Some(relay_url.clone()),
+    );
     drop(runtimes);
     save_managed_agents(&app, &records)?;
     emit_status(&app, &status);
@@ -403,7 +415,7 @@ async fn probe_agent_relay_access(
     let key = ManagedAgentRuntimeKey::new(record.pubkey.clone(), &requested_relay_url)?;
     let keys = nostr::Keys::parse(record.private_key_nsec.trim())
         .map_err(|error| format!("invalid managed-agent key: {error}"))?;
-    let api_base = crate::relay::relay_http_base_url(&key.relay_url);
+    let api_base = crate::relay::relay_http_base_url(&requested_relay_url);
     tokio::time::timeout(
         std::time::Duration::from_secs(10),
         crate::relay::query_relay_at_with_keys(
@@ -504,7 +516,7 @@ pub async fn reconcile_managed_agent_runtimes(
                 Ok((record, key, requested)) => {
                     match start_pair(
                         record.pubkey.clone(),
-                        key.relay_url.clone(),
+                        requested.clone(),
                         true,
                         Some(&record.updated_at),
                         app.clone(),

--- a/desktop/src/features/settings/ui/ActiveAgentCommunitiesSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ActiveAgentCommunitiesSettingsCard.tsx
@@ -50,7 +50,7 @@ export function ActiveAgentCommunitiesSettingsCard() {
               ? "start"
               : "restart",
         pubkey: runtime.pubkey,
-        relayUrl: runtime.relayUrl,
+        relayUrl: runtime.requestedRelayUrl ?? runtime.relayUrl,
       });
     } finally {
       setPendingRuntimeKey(null);


### PR DESCRIPTION
Fixes #2444

## Problem

Since #2122 (shipped in desktop v0.4.23), every managed-agent spawn path passes `ManagedAgentRuntimeKey.relay_url` - the canonical identity form - to the child as `BUZZ_RELAY_URL`. The canonicalizer folds every loopback spelling to `127.0.0.1`, but the relay derives the community boundary from the Host header. So with a community configured as `ws://localhost:3000`:

- the UI posts messages into the `localhost:3000` community
- every agent connects to the `127.0.0.1:3000` community, which is empty

Each agent logs `discovered 0 channel(s)` and `no channel subscriptions resolved - agent will sit idle`, shows as online, and silently never answers a mention. Full diagnosis with DB evidence is in #2444.

This also contradicts the contract documented on `buzz_core::relay::normalize_relay_url` itself:

> Connection code may retain the configured URL; this canonical form is for identity, receipts, status and deduplication.

## Fix

Keep the canonical key for identity, receipts, and log paths. Dial the caller-supplied requested URL:

- `spawn_agent_child` dials its `relay_url` parameter verbatim; `runtime_key` stays identity-only
- `start_managed_agent_process`, `start_pair`, and the launch restore path pass their already-resolved requested URL instead of `key.relay_url`
- `reconcile_managed_agent_runtimes` forwards the requested community URL to `start_pair` instead of the canonical echo
- `probe_agent_relay_access` probes over the requested URL, so the spawn-eligibility probe hits the same community the child will join
- `start_pair` now fills `requested_relay_url` in its status rows, and the Active Communities settings card prefers `requestedRelayUrl` for start/stop/restart, so a manual restart re-dials the configured URL

## Testing

- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib`: 1560 passed
- `cargo clippy --all-targets` and `cargo fmt --check` on the Tauri crate: clean
- `tsc --noEmit` and `biome check` on the changed frontend file: clean
- Honest gap: no new automated test covers the spawn wiring itself, since `spawn_agent_child` forks a real child process. Verified the failure mode end to end on the affected machine (v0.4.23, local relay): before the fix, children spawn with `BUZZ_RELAY_URL=ws://127.0.0.1:3000` (checked via `ps eww`) and discover 0 channels; the configured community URL is `ws://localhost:3000`.

A relay-side follow-up worth discussing separately (also in #2444): folding loopback spellings into one community key on the relay, and surfacing the agent-idle state in the UI instead of only in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
