### PR TITLE
feat: adjust order of agent status and text box

### DIFF
--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -322,7 +322,6 @@ export const ChannelPane = React.memo(function ChannelPane({
     isSending;
   const knownAgentPubkeys = React.useMemo(() => {
     const pubkeys = new Set<string>();
-
     for (const pubkey of agentPubkeys ?? []) {
       pubkeys.add(pubkey.toLowerCase());
     }
@@ -332,14 +331,12 @@ export const ChannelPane = React.memo(function ChannelPane({
     for (const agent of activityAgents) {
       pubkeys.add(agent.pubkey.toLowerCase());
     }
-
     return pubkeys;
   }, [activityAgents, agentPubkeys, agentSessionAgents]);
   const completeWelcomeComposerBanner = React.useCallback(() => {
     if (!activeChannelId || !isActiveWelcomeChannel) {
       return;
     }
-
     clearWelcomeComposerDismissTimer();
     completedWelcomeBannerChannelIdsRef.current.add(activeChannelId);
     setWelcomeComposerBannerState("complete");
@@ -748,11 +745,42 @@ export const ChannelPane = React.memo(function ChannelPane({
                     />
                   </div>
                 ) : null}
+                {hasComposerBotActivity || hasTypingActivity ? (
+                  <div
+                    className="min-h-8 overflow-visible bg-background px-5 pb-0 pt-1.5"
+                    data-testid="channel-composer-activity-row"
+                  >
+                    <div className="flex h-full w-full items-center gap-2 overflow-visible">
+                      {hasComposerBotActivity ? (
+                        <div className="flex min-w-0 flex-1 overflow-visible">
+                          <BotActivityComposerAction
+                            agents={activityAgents}
+                            channelId={activeChannel?.id ?? null}
+                            onOpenAgentSession={onOpenAgentSession}
+                            openAgentSessionPubkey={openAgentSessionPubkey}
+                            profiles={profiles}
+                            workingBotPubkeys={composerWorkingBotPubkeys}
+                            variant="inline"
+                          />
+                        </div>
+                      ) : null}
+                      {hasTypingActivity ? (
+                        <TypingIndicatorRow
+                          channel={activeChannel}
+                          className="min-w-0 flex-1 py-0 pl-[calc(0.75rem+1px)] pr-0 sm:pl-[calc(1rem+1px)]"
+                          currentPubkey={currentPubkey}
+                          profiles={profiles}
+                          typingPubkeys={typingPubkeys}
+                        />
+                      ) : null}
+                    </div>
+                  </div>
+                ) : null}
                 <MessageComposer
                   channelId={activeChannel?.id ?? null}
                   channelName={activeChannel?.name ?? "channel"}
                   channelType={activeChannel?.channelType ?? null}
-                  containerClassName="px-5"
+                  containerClassName="px-5 pb-5"
                   disabled={isComposerDisabled}
                   editTarget={mainEditTarget}
                   autoSubmitDraftKey={autoSendDraftKey}
@@ -787,35 +815,6 @@ export const ChannelPane = React.memo(function ChannelPane({
                   }
                   showTopBorder={false}
                 />
-                <div
-                  className="min-h-8 overflow-visible bg-background px-5 pb-1.5 pt-0"
-                  data-testid="channel-composer-activity-row"
-                >
-                  <div className="flex h-full w-full items-center gap-2 overflow-visible">
-                    {hasComposerBotActivity ? (
-                      <div className="flex min-w-0 flex-1 overflow-visible">
-                        <BotActivityComposerAction
-                          agents={activityAgents}
-                          channelId={activeChannel?.id ?? null}
-                          onOpenAgentSession={onOpenAgentSession}
-                          openAgentSessionPubkey={openAgentSessionPubkey}
-                          profiles={profiles}
-                          workingBotPubkeys={composerWorkingBotPubkeys}
-                          variant="inline"
-                        />
-                      </div>
-                    ) : null}
-                    {hasTypingActivity ? (
-                      <TypingIndicatorRow
-                        channel={activeChannel}
-                        className="min-w-0 flex-1 py-0 pl-[calc(0.75rem+1px)] pr-0 sm:pl-[calc(1rem+1px)]"
-                        currentPubkey={currentPubkey}
-                        profiles={profiles}
-                        typingPubkeys={typingPubkeys}
-                      />
-                    ) : null}
-                  </div>
-                </div>
               </div>
             </div>
           )}

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -823,6 +823,32 @@ export function MessageThreadPanel({
             hasConstrainedColumn ? { maxWidth: columnMaxWidthPx } : undefined
           }
         >
+          {toolbarExtraActions || threadTypingPubkeys.length > 0 ? (
+            <div
+              className={cn(
+                "min-h-8 bg-background pb-0 pt-1.5",
+                THREAD_PANEL_COMPOSER_GUTTER_CLASS,
+              )}
+            >
+              <div className="mx-auto flex h-full w-full max-w-4xl items-center gap-2 overflow-visible">
+                {toolbarExtraActions ? (
+                  <div className="flex min-w-0 flex-1 overflow-visible">
+                    {toolbarExtraActions}
+                  </div>
+                ) : null}
+                {threadTypingPubkeys.length > 0 ? (
+                  <TypingIndicatorRow
+                    channel={channel}
+                    className="min-w-0 flex-1 py-0 pl-[calc(0.75rem+1px)] pr-0 sm:pl-[calc(1rem+1px)]"
+                    currentPubkey={currentPubkey}
+                    profiles={profiles}
+                    typingPubkeys={threadTypingPubkeys}
+                    variant="activity"
+                  />
+                ) : null}
+              </div>
+            </div>
+          ) : null}
           <MessageComposer
             audienceContext={{
               type: "thread",
@@ -832,7 +858,7 @@ export function MessageThreadPanel({
             channelId={channelId}
             channelName={channelName}
             channelType={channel?.channelType ?? null}
-            containerClassName={THREAD_PANEL_COMPOSER_GUTTER_CLASS}
+            containerClassName={cn(THREAD_PANEL_COMPOSER_GUTTER_CLASS, "pb-5")}
             disabled={disabled || isSending || !channelId}
             draftKey={`thread:${threadHead.id}`}
             autoSubmitDraftKey={autoSendDraftKey}
@@ -851,30 +877,6 @@ export function MessageThreadPanel({
             typingParentEventId={threadHead.id}
             typingRootEventId={threadHead.rootId}
           />
-          <div
-            className={cn(
-              "min-h-8 bg-background pb-1.5 pt-0",
-              THREAD_PANEL_COMPOSER_GUTTER_CLASS,
-            )}
-          >
-            <div className="mx-auto flex h-full w-full max-w-4xl items-center gap-2 overflow-visible">
-              {toolbarExtraActions ? (
-                <div className="flex min-w-0 flex-1 overflow-visible">
-                  {toolbarExtraActions}
-                </div>
-              ) : null}
-              {threadTypingPubkeys.length > 0 ? (
-                <TypingIndicatorRow
-                  channel={channel}
-                  className="min-w-0 flex-1 py-0 pl-[calc(0.75rem+1px)] pr-0 sm:pl-[calc(1rem+1px)]"
-                  currentPubkey={currentPubkey}
-                  profiles={profiles}
-                  typingPubkeys={threadTypingPubkeys}
-                  variant="activity"
-                />
-              ) : null}
-            </div>
-          </div>
         </div>
       </div>
     </>

--- a/desktop/src/shared/styles/globals/composer.css
+++ b/desktop/src/shared/styles/globals/composer.css
@@ -1,7 +1,7 @@
 .composer-overlay-corner-masks::before,
 .composer-overlay-corner-masks::after {
   position: absolute;
-  bottom: 2.5rem;
+  bottom: 1.25rem;
   z-index: 0;
   width: 1rem;
   height: 1rem;

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1740,14 +1740,6 @@ test("channel date divider keeps the date sticky while the separator rule scroll
     "backdrop-filter",
     "none",
   );
-  const composerActivityRow = composerOverlay.getByTestId(
-    "channel-composer-activity-row",
-  );
-  await expect(composerActivityRow).toHaveCSS("backdrop-filter", "none");
-  await expect(composerActivityRow).not.toHaveCSS(
-    "background-color",
-    "rgba(0, 0, 0, 0)",
-  );
   await expect
     .poll(async () => {
       const composerOverlayZIndex = await page


### PR DESCRIPTION
I noticed a UI issue where the text entry box doesn't have consistent padding vertically and horizontally because the agent status bar (which is only active sometimes) sits below it. This makes the text box further away from the bottom than it is from the sides when the agent isn't doing anything and looked a bit off to me.

This change flips it so the agent status bar is _above_ the text entry box, and the text entry box can sit in a more natural spot. It also subtly moves the messages up when the agent status bar is there so that they don't run under the status bar.

**Before**

<img width="1840" height="1120" alt="Screenshot 2026-07-22 at 8 43 25 PM" src="https://github.com/user-attachments/assets/9616a3d8-940b-46a8-a3be-d3f6dd57b91a" />

**After**

<img width="1840" height="1122" alt="Screenshot 2026-07-22 at 8 49 38 PM" src="https://github.com/user-attachments/assets/0ca1c8b7-56c2-412b-ba15-67e418789f59" />

**Agent Active State**

<img width="1840" height="1122" alt="Screenshot 2026-07-22 at 8 49 48 PM" src="https://github.com/user-attachments/assets/8319894a-03d3-43e3-9924-5e3107f72be5" />