### PR TITLE
fix(cli): install rustls ring CryptoProvider before WSS connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "nostr",
  "rand 0.10.1",
  "reqwest 0.13.4",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/buzz-cli/Cargo.toml
+++ b/crates/buzz-cli/Cargo.toml
@@ -76,6 +76,12 @@ dirs = "6"
 # WebSocket client — ephemeral event publish (kind:20001 is WS-only on the relay)
 buzz-ws-client = { path = "../buzz-ws-client" }
 
+# rustls — WSS connections (via tokio-tungstenite's rustls-tls backend) require a
+# process-level CryptoProvider to be installed before the first TLS handshake.
+# Pin the ring provider so `install_default` is unambiguous even though both ring
+# and aws-lc-rs are present elsewhere in the workspace tree.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+
 # Random number generation — full jitter for exponential backoff in with_retry
 rand = { workspace = true }
 

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -25,6 +25,15 @@ where
     I: IntoIterator<Item = S>,
     S: Into<std::ffi::OsString> + Clone,
 {
+    // WSS connections (ephemeral-event publish goes over tokio-tungstenite's
+    // rustls backend) require a process-level CryptoProvider before the first
+    // TLS handshake. With both ring and aws-lc-rs present in the workspace,
+    // rustls cannot auto-select one and otherwise panics inside
+    // `publish_ephemeral_event`. Install the ring provider explicitly; ignore
+    // the error so a repeat call (e.g. when embedded) is a no-op rather than a
+    // panic.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let cli = match Cli::try_parse_from(args) {
         Ok(cli) => cli,
         Err(e) => {


### PR DESCRIPTION
## Summary
- add the rustls ring provider dependency for `buzz-cli`
- install the process-level rustls ring `CryptoProvider` before CLI command dispatch
- make agent draft creation over WSS deterministic on installs where rustls cannot auto-select a provider

## Context
Agent creation publishes a WS-only ephemeral event (`kind:20001`) through `buzz-ws-client`, which connects via `tokio-tungstenite` using rustls. rustls 0.23 requires a process-level `CryptoProvider` to be installed before the first TLS handshake.

In this workspace, both `ring` and `aws-lc-rs` are present in the dependency tree, so rustls cannot safely auto-pick a provider in all builds. On affected installs, the CLI panics during the agent draft publish path before the ephemeral event can be sent. The crash path from the original report was `publish_ephemeral_event -> agents::dispatch -> buzz::main`.

Other Buzz binaries already install the ring provider explicitly at startup, including `buzz-acp`, `buzz-relay`, `buzz-admin`, and test clients. `buzz-cli` was the missing entrypoint. This PR closes that gap by installing the same ring provider at the top of `run_from_args`.

The install call intentionally ignores the return value:

```rust
let _ = rustls::crypto::ring::default_provider().install_default();
```

That makes repeated calls harmless when the CLI is embedded or a provider has already been installed, matching the existing test-client idiom.

## Why this can be machine-dependent
This panic depends on the built feature/provider ambiguity. Some installs happen to resolve provider selection without crashing; others do not. Explicit provider installation makes the behavior deterministic instead of letting TLS startup depend on dependency graph luck, which is an unkind thing to ask of a command-line tool.

## Tests
- `cargo check -p buzz-cli`
- `cargo test -p buzz-cli`
- built the CLI and exercised `agents draft-create` against a live WSS relay: accepted, exit 0, no rustls panic