### PR TITLE
fix(ws-client): install rustls CryptoProvider before wss connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,7 @@ version = "0.1.0"
 dependencies = [
  "futures-util",
  "nostr",
+ "rustls",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/buzz-ws-client/Cargo.toml
+++ b/crates/buzz-ws-client/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 nostr = { workspace = true }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 tokio = { workspace = true }
 tokio-tungstenite = { workspace = true }
 futures-util = { workspace = true }

--- a/crates/buzz-ws-client/src/connection.rs
+++ b/crates/buzz-ws-client/src/connection.rs
@@ -46,6 +46,16 @@ impl NostrWsConnection {
 
     /// Connects to the relay at `url` without performing authentication.
     pub async fn connect(url: &str) -> Result<Self, WsClientError> {
+        // tokio-tungstenite resolves the process-level rustls CryptoProvider
+        // from crate features when it builds the TLS config for wss:// URLs.
+        // Workspace builds enable both `ring` (relay-side crates) and
+        // `aws-lc-rs` (via reqwest), which makes that resolution ambiguous
+        // and panics on the first secure connection. Pin ring at this shared
+        // chokepoint so every consumer works without its own entrypoint
+        // install_default() call; the install is idempotent and the Err from
+        // a provider already being set is intentionally discarded.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         let parsed = url
             .parse::<url::Url>()
             .map_err(|e| WsClientError::Url(e.to_string()))?;


### PR DESCRIPTION
## Problem

Fixes #2457.

Workspace builds enable **both** rustls crypto providers: the relay-side crates (`buzz-relay`, `buzz-acp`, `buzz-admin`, `buzz-dev-mcp`) pin `ring`, while `reqwest` in `buzz-cli` pulls in `aws-lc-rs`. Feature unification leaves tokio-tungstenite's feature-based `CryptoProvider` resolution ambiguous, so the first `wss://` connection panics with the reported `Could not automatically determine the process-level CryptoProvider` error.

Every other binary touching the WS path already works around this with an entrypoint `install_default()` call — `buzz-cli` is the one that doesn't, so any command publishing over WebSocket against a secure relay aborts (`buzz agents draft-create`, `buzz users set-presence`, …). A standalone `cargo build -p buzz-cli` doesn't reproduce it (only `aws-lc-rs` lands), which is presumably why it slipped through.

## Fix

Install the ring provider at `NostrWsConnection::connect` — the chokepoint every consumer of the shared WS client goes through (including the one-shot `publish_event` helper in the panic's backtrace) — instead of adding one more per-binary call to forget. The install is idempotent; a provider already being set is discarded intentionally. Existing entrypoint installs in sibling binaries are left in place since they also guard non-WS TLS paths (e.g. redis).

## Testing

No regression test: the panic only manifests under multi-provider feature unification, and a `buzz-ws-client` unit-test binary builds with only this crate's features (`ring` alone), so the ambiguous state can't be constructed inside the test harness. Verified manually instead, with a full-workspace build (the shipped configuration):

- Before: `buzz users set-presence` against a `wss://` URL aborts with the reported CryptoProvider panic.
- After: the same command proceeds into the TLS handshake and fails gracefully with a WebSocket error when the endpoint isn't actually TLS, and succeeds end-to-end against a plain `ws://` dev relay (event accepted) — no regression on the non-TLS path.

`cargo fmt` / `clippy --all-targets --all-features` clean.
