### PR TITLE
Add goose and Ollama as first-class onboarding providers

### DIFF
--- a/desktop/src/features/agents/ui/agentConfigOptions.tsx
+++ b/desktop/src/features/agents/ui/agentConfigOptions.tsx
@@ -40,6 +40,7 @@ const KNOWN_LLM_PROVIDER_IDS = [
   "anthropic",
   "databricks",
   "databricks_v2",
+  "ollama",
   "openai",
   "openai-compat",
 ] as const;
@@ -109,6 +110,11 @@ const PROVIDER_CREDENTIAL_CONFIG: Partial<
   "databricks-v2": {
     requiredEnvKeys: ["DATABRICKS_HOST"],
   },
+  ollama: {
+    // Ollama runs locally — no API key or host required (defaults to
+    // http://localhost:11434). Set OLLAMA_BASE_URL only for non-default hosts.
+    requiredEnvKeys: [],
+  },
 };
 
 const DEFAULT_MODEL_OPTION: PersonaModelOption = {
@@ -120,6 +126,7 @@ export const PERSONA_LLM_PROVIDER_OPTIONS: readonly PersonaModelOption[] = [
   { id: "anthropic", label: "Anthropic" },
   { id: "openai", label: "OpenAI" },
   { id: "openai-compat", label: "OpenAI-compatible" },
+  { id: "ollama", label: "Ollama (local)" },
   { id: "relay-mesh", label: "Buzz shared compute" },
   { id: "databricks", label: "Databricks" },
   { id: "databricks_v2", label: "Databricks v2" },

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
@@ -15,7 +15,7 @@ function runtime(id, availability, status) {
 test("only Claude Code and Codex are visible in onboarding", () => {
   assert.equal(runtimeIsVisibleInOnboarding("claude"), true);
   assert.equal(runtimeIsVisibleInOnboarding("codex"), true);
-  assert.equal(runtimeIsVisibleInOnboarding("goose"), false);
+  assert.equal(runtimeIsVisibleInOnboarding("goose"), true);
   assert.equal(runtimeIsVisibleInOnboarding("buzz-agent"), false);
   assert.equal(runtimeIsVisibleInOnboarding("custom"), false);
 });
@@ -30,7 +30,7 @@ test("visible onboarding runtimes use the product order", () => {
 
   assert.deepEqual(
     getVisibleOnboardingRuntimes(runtimes).map(({ id }) => id),
-    ["claude", "codex"],
+    ["goose", "claude", "codex"],
   );
 });
 
@@ -65,6 +65,6 @@ test("ready onboarding runtimes exclude hidden ready harnesses", () => {
 
   assert.deepEqual(
     getReadyOnboardingRuntimes(runtimes).map(({ id }) => id),
-    ["claude"],
+    ["goose", "claude"],
   );
 });

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
@@ -1,6 +1,6 @@
 import type { AcpRuntimeCatalogEntry } from "@/shared/api/types";
 
-export const ONBOARDING_RUNTIME_ORDER = ["claude", "codex"];
+export const ONBOARDING_RUNTIME_ORDER = ["goose", "claude", "codex"];
 
 const VISIBLE_ONBOARDING_RUNTIME_IDS = new Set<string>(
   ONBOARDING_RUNTIME_ORDER,


### PR DESCRIPTION
## Summary

Goose was intentionally hidden from the desktop onboarding screen — only Claude Code and Codex were listed as visible runtimes (`ONBOARDING_RUNTIME_ORDER = ["claude", "codex"]`). This excluded the most popular open-source agent harness from the setup flow.

This PR adds goose as a first-class onboarding runtime and adds Ollama as a first-class LLM provider option.

## Changes

**Goose onboarding visibility** (`onboardingRuntimeSelection.ts`):
- Add `"goose"` to `ONBOARDING_RUNTIME_ORDER` so it appears in the harness selection and default-config steps alongside Claude Code and Codex

**Ollama LLM provider** (`agentConfigOptions.tsx`):
- Add `"ollama"` to `KNOWN_LLM_PROVIDER_IDS`
- Add `{ id: "ollama", label: "Ollama (local)" }` to `PERSONA_LLM_PROVIDER_OPTIONS`
- Add `ollama` entry to `PROVIDER_CREDENTIAL_CONFIG` with no required env keys (Ollama runs locally at `localhost:11434` by default, no API key needed)
- No Rust backend changes needed — the `goose_requirements` readiness function already handles unknown providers via a catch-all `_ => {}` branch, and goose's file config tier (`~/.config/goose/config.yaml`) silences provider/model requirements

**Tests** (`onboardingRuntimeSelection.test.mjs`):
- Updated visibility, ordering, and readiness tests to reflect goose inclusion

## Tests run

- `pnpm check` (biome + file-sizes + px-text + pubkey-truncation): **pass**
- `node --test onboardingRuntimeSelection.test.mjs` (4 tests): **pass**

## Manual validation

Built and ran the desktop app from source (`just desktop-standalone`) against a local relay:
- Goose appears as "READY" in the harness selection step
- Ollama appears as a provider option in the default model config step
- Goose correctly reads provider/model from `~/.config/goose/config.yaml` — no credentials needed for Ollama
- Agent (goose + Ollama) successfully connects to relay, discovers channels, and responds to @mentions via the ACP harness

## Docs updated

No docs changes needed — this is a UI visibility/config change, not a feature behavior change.

## Risks / assumptions

- Goose was intentionally excluded from onboarding. The original test explicitly asserted `runtimeIsVisibleInOnboarding("goose") === false`. There may be a product reason for this (e.g. goose onboarding UX is incomplete, or Block wants to promote Claude Code/Codex first). If so, this PR can be scoped to just the Ollama provider addition and goose visibility can be revisited separately.
- Ollama provider has no credential requirements. If the relay or agent harness needs to validate provider credentials for Ollama in the future, the readiness function would need updating.

## Plan reference

No plan file — this is a small, well-scoped change (11 lines across 3 files).