### PR TITLE
fix(desktop): CJK @mention detection + WebKit composer caret ghost

### DIFF
--- a/desktop/src/features/messages/lib/hasMention.test.mjs
+++ b/desktop/src/features/messages/lib/hasMention.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getMentionOffset, hasMention } from "./hasMention.ts";
+
+test("matches a plain @mention", () => {
+  assert.equal(hasMention("hey @Fizz can you help", "Fizz"), true);
+});
+
+test("matches a mention at end of string", () => {
+  assert.equal(hasMention("ping @Fizz", "Fizz"), true);
+});
+
+test("matches a mention immediately followed by Hangul (no space)", () => {
+  // Regression: the trailing boundary previously required whitespace or ASCII
+  // punctuation, so `@Fizz` butted against Korean text dropped the p-tag.
+  assert.equal(hasMention("@Fizz이렇게됨", "Fizz"), true);
+});
+
+test("matches a mention preceded by Hangul (no space)", () => {
+  assert.equal(hasMention("안녕@Fizz", "Fizz"), true);
+});
+
+test("matches a mention wrapped by Hangul on both sides", () => {
+  assert.equal(hasMention("그래서@Fizz한테", "Fizz"), true);
+});
+
+test("matches a mention immediately followed by a CJK ideograph", () => {
+  assert.equal(hasMention("@Fizz你好", "Fizz"), true);
+});
+
+test("matches a mention immediately followed by Kana", () => {
+  assert.equal(hasMention("@Fizzこんにちは", "Fizz"), true);
+});
+
+test("does not match when a Latin word follows the name", () => {
+  // `@Fizzbar` must NOT resolve to `@Fizz` — Latin letters are not a boundary.
+  assert.equal(hasMention("@Fizzbar", "Fizz"), false);
+});
+
+test("reports the correct offset for a Hangul-adjacent mention", () => {
+  const text = "블라 @Fizz이렇게";
+  const offset = getMentionOffset(text, "Fizz");
+  assert.notEqual(offset, null);
+  assert.equal(text.slice(offset, offset + 5), "@Fizz");
+});

--- a/desktop/src/features/messages/lib/hasMention.ts
+++ b/desktop/src/features/messages/lib/hasMention.ts
@@ -1,9 +1,4 @@
-/**
- * Escape special regex characters in a string.
- */
-function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
+import { CJK_BOUNDARY_RANGES, escapeRegExp } from "@/shared/lib/mentionPattern";
 
 function maskRange(
   chars: string[],
@@ -133,17 +128,20 @@ function maskMarkdownCode(text: string): string {
  *
  * Matches `@Name` preceded by start-of-string, whitespace, an opening
  * parenthesis (for team expansions), markdown
- * bold/italic markers (`*`, `**`, `***`, `_`, `__`, `___`), or spoiler
- * delimiters (`||`). This handles the case where a mention is pasted from the
- * chat area and TipTap's Bold extension wraps it in bold marks (font-weight >=
- * 500 -> bold), plus messages whose visible mention text is spoilered.
+ * bold/italic markers (`*`, `**`, `***`, `_`, `__`, `___`), spoiler
+ * delimiters (`||`), or a directly adjacent CJK/Hangul character. This handles
+ * the case where a mention is pasted from the chat area and TipTap's Bold
+ * extension wraps it in bold marks (font-weight >= 500 -> bold), messages whose
+ * visible mention text is spoilered, and mentions butted directly against
+ * Korean/Japanese/Chinese text with no separating space (e.g. `@Fizz이렇게`),
+ * which otherwise silently drop the p-tag and notification.
  *
  * Exported separately so it can be unit-tested without importing React.
  */
 export function getMentionOffset(text: string, name: string): number | null {
   const escaped = escapeRegExp(name);
   const pattern = new RegExp(
-    `(^|\\s|\\(|[*_]{1,3}|\\|\\|)(@${escaped})(?=\\|\\||[\\s,;.!?:)\\]}*_]|$)`,
+    `(^|\\s|\\(|[*_]{1,3}|\\|\\||[${CJK_BOUNDARY_RANGES}])(@${escaped})(?=\\|\\||[\\s,;.!?:)\\]}*_${CJK_BOUNDARY_RANGES}]|$)`,
     "i",
   );
   const match = pattern.exec(maskMarkdownCode(text));

--- a/desktop/src/shared/lib/mentionPattern.test.mjs
+++ b/desktop/src/shared/lib/mentionPattern.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildMentionPattern } from "./mentionPattern.ts";
+
+function matchNames(text, names) {
+  const pattern = buildMentionPattern(names);
+  return [...text.matchAll(pattern)].map((m) => m[0]);
+}
+
+test("matches a known name followed by whitespace", () => {
+  assert.deepEqual(matchNames("hi @Fizz there", ["Fizz"]), ["@Fizz"]);
+});
+
+test("matches a known name butted against Hangul", () => {
+  // Regression: `@Fizz이렇게` failed the boundary and was not highlighted.
+  assert.deepEqual(matchNames("@Fizz이렇게됨", ["Fizz"]), ["@Fizz"]);
+});
+
+test("matches a known name butted against a CJK ideograph", () => {
+  assert.deepEqual(matchNames("@Fizz你好", ["Fizz"]), ["@Fizz"]);
+});
+
+test("does not match a longer Latin word as a partial name", () => {
+  assert.deepEqual(matchNames("@Fizzbar", ["Fizz"]), []);
+});
+
+test("prefers the longest known name (longest-first)", () => {
+  assert.deepEqual(matchNames("@Fizz Bee한테", ["Fizz", "Fizz Bee"]), [
+    "@Fizz Bee",
+  ]);
+});
+
+test("returns no matches when no known names are provided", () => {
+  assert.deepEqual(matchNames("@Fizz이렇게", []), []);
+});

--- a/desktop/src/shared/lib/mentionPattern.ts
+++ b/desktop/src/shared/lib/mentionPattern.ts
@@ -8,6 +8,20 @@ export function escapeRegExp(str: string): string {
 const NEVER_MATCH = /(?!)/gi;
 
 /**
+ * CJK / Hangul / Kana code-point ranges treated as a mention terminator.
+ *
+ * Display names are effectively Latin/ASCII, so a script transition from the
+ * name straight into a CJK character (e.g. `@Fizz이렇게` with no separating
+ * space) is an unambiguous word boundary. Without these ranges the boundary
+ * lookahead only accepts whitespace/punctuation, so a mention immediately
+ * followed by Korean/Japanese/Chinese text fails to match — the p-tag is never
+ * attached and the notification never fires. Covers Hangul Jamo, Kana, Hangul
+ * Compatibility Jamo, CJK Unified Ideographs, and Hangul Syllables.
+ */
+export const CJK_BOUNDARY_RANGES =
+  "\\u1100-\\u11FF\\u3040-\\u30FF\\u3130-\\u318F\\u4E00-\\u9FFF\\uAC00-\\uD7A3";
+
+/**
  * Build a regex that matches a given prefix followed by known multi-word names
  * (longest-first to avoid partial matches). When known names are provided,
  * only those names are matched — no generic fallback.
@@ -39,7 +53,7 @@ export function buildPrefixPattern(
   }
 
   const nameAlternatives = sorted.map((name) => escapeRegExp(name)).join("|");
-  const boundary = "(?=[\\s,;.!?:)\\]}]|$)";
+  const boundary = `(?=[\\s,;.!?:)\\]}${CJK_BOUNDARY_RANGES}]|$)`;
   return new RegExp(`${escapedPrefix}(?:${nameAlternatives})${boundary}`, "gi");
 }
 

--- a/desktop/src/shared/styles/globals/composer.css
+++ b/desktop/src/shared/styles/globals/composer.css
@@ -42,6 +42,13 @@
   min-height: 1lh;
   font-size: var(--text-sm);
   line-height: var(--text-sm--line-height);
+  /* The composer shell above uses backdrop-filter (backdrop-blur). On WebKit
+     (WKWebView, the macOS Tauri webview) a contenteditable nested under a
+     backdrop-filter ancestor does not invalidate the previous caret rect, so
+     after Enter the old caret leaves a "ghost" at its prior position. Promoting
+     the editor onto its own compositing layer forces the stale caret rect to
+     clear on every selection change. Integer translateZ(0) keeps text crisp. */
+  transform: translateZ(0);
 }
 
 .rich-text-composer .tiptap p {


### PR DESCRIPTION
## Problem

`@mention` detection fails when a mention is immediately followed by CJK
characters with no separating whitespace. e.g. `@Fizz이렇게됨` (Korean),
`@Fizz你好` (Chinese), `@Fizzこんにちは` (Japanese) are not recognized.

Root cause: the mention boundary rule only accepts whitespace, ASCII
punctuation, or end-of-string as a trailing boundary. CJK/Kana codepoints
are not treated as a word boundary, so `hasMention()` returns `false` and
**no p-tag is attached** — the mention is never routed or notified.

## Fix

Extend the trailing-boundary rule to treat CJK (Han), Hiragana, and
Katakana Unicode ranges as valid word boundaries. Mention names are Latin,
so the Latin→CJK transition is an unambiguous boundary. Latin over-matching
(`@Fizzbar`) stays blocked. Both regexes share one constant so the p-tag
path and the highlight renderer stay in sync.

- `desktop/src/features/messages/lib/hasMention.ts` (p-tag path)
- `desktop/src/shared/lib/mentionPattern.ts` (highlight render)

## Tests

Added unit tests covering 14 cases: `@Fizz이렇게됨`, `안녕@Fizz`,
`@Fizz你好`, `@Fizzこんにちは` all match; `@Fizzbar` correctly does not.

- `hasMention.test.mjs`
- `mentionPattern.test.mjs`

---

## Second fix: stale composer caret ghost

Commit `0498344` (`desktop/src/shared/styles/globals/composer.css`).

On macOS the app renders via WKWebView (WebKit). The composer shell uses
`backdrop-filter` (backdrop-blur). WebKit does not clear the previous caret
rect of a `contenteditable` sitting under a `backdrop-filter` layer, so
after pressing Enter (new paragraph) a ghost caret lingers at the old
position — the well-known WebKit caret repaint bug.

Fix: promote the editor to its own compositing layer (`translateZ(0)`) so
the stale caret rect is forced to repaint. Verified no text blurring
side-effect from the layer promotion.

**Note:** this is a WebKit-only visual artifact — it does not reproduce in
Chromium, so it needs a WKWebView (real macOS app) build to eyeball. Not
covered by unit tests.