### PR TITLE
fix(cli): initialize Rustls crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "nostr",
  "rand 0.10.1",
  "reqwest 0.13.4",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/buzz-cli/Cargo.toml
+++ b/crates/buzz-cli/Cargo.toml
@@ -25,6 +25,10 @@ reqwest = { workspace = true, features = ["json"] }
 # Async runtime — tokio macros + multi-thread for reqwest
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
+# TLS crypto provider — required before reqwest or WebSocket clients create
+# rustls configurations. Both ring and aws-lc-rs are present transitively.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+
 # Serialization — JSON body building and response passthrough
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -25,6 +25,13 @@ where
     I: IntoIterator<Item = S>,
     S: Into<std::ffi::OsString> + Clone,
 {
+    // The CLI can use both reqwest and buzz-ws-client. Their transitive
+    // dependencies enable multiple Rustls crypto providers, so Rustls cannot
+    // select one automatically. Install ring before either client builds TLS
+    // configuration (including a plain ws:// connection). Ignore an already
+    // installed provider when the CLI is embedded in another process.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let cli = match Cli::try_parse_from(args) {
         Ok(cli) => cli,
         Err(e) => {
@@ -1786,6 +1793,29 @@ mod tests {
     #[test]
     fn cli_definition_is_valid() {
         Cli::command().debug_assert();
+    }
+
+    #[tokio::test]
+    async fn agent_draft_missing_auth_returns_error_without_crypto_panic() {
+        let exit_code = run_from_args([
+            "buzz",
+            "--private-key",
+            "0000000000000000000000000000000000000000000000000000000000000001",
+            "agents",
+            "draft-create",
+            "--channel",
+            "00000000-0000-0000-0000-000000000000",
+            "--display-name",
+            "Test Agent",
+            "--system-prompt",
+            "Follow the system instructions.",
+        ])
+        .await;
+
+        // Constructing BuzzClient occurs before draft authorization. This
+        // asserts it gets that far and returns the expected auth error rather
+        // than panicking because Rustls lacks a CryptoProvider.
+        assert_eq!(exit_code, 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Initializes the Ring Rustls crypto provider before the Buzz CLI creates HTTP or WebSocket clients, preventing agent-draft commands from panicking when multiple providers are compiled.
Adds a regression test that exercises `agents draft-create` through client initialization and verifies the expected missing-auth error.

## Validation

`just ci`
