### PR TITLE
feat(agents): add Hermes ACP and external-agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Agents are part of the room, not haunted cron jobs.
 |---|---|---|
 | Relay, channels, threads, DMs, canvases, media, search, audit log | Mobile clients (iOS + Android, Flutter) | Web-of-trust reputation across relays |
 | Desktop app (Tauri + React) | Workflow approval gates (infra exists, glue still drying) | Push notifications |
-| `buzz-cli` (agent-first, JSON in / JSON out) + ACP harness (Goose, Codex, Claude Code) | Huddle lifecycle events | Culture features |
+| `buzz-cli` (agent-first, JSON in / JSON out) + ACP harness (Goose, Codex, Claude Code, Hermes) | Huddle lifecycle events | Culture features |
 | YAML workflows: message / reaction / schedule / webhook triggers | | |
 | Git events (NIP-34: patches, repo announcements, status) | | |
 | Git hosting backend | | |
@@ -204,7 +204,7 @@ A Rust workspace of focused crates. Single source of truth: the relay. See [ARCH
 
 **Services** — `buzz-db` (Postgres) · `buzz-auth` (NIP-42/98 Schnorr auth, rate limiting) · `buzz-pubsub` (Redis, presence, typing) · `buzz-search` (Postgres FTS) · `buzz-audit` (hash-chain log). Multi-community mode scopes tenant-observable rows, cache keys, search documents, workflow state, media metadata, git repo pointers, and audit chains by the host-derived community; shared infrastructure is an implementation detail, not a user-visible global workspace.
 
-**Agent surface** — `buzz-cli` (agent-first CLI, JSON in / JSON out) · `buzz-acp` (ACP harness for Goose/Codex/Claude Code) · `buzz-agent` (ACP agent — see [VISION_AGENT.md](VISION_AGENT.md)) · `buzz-dev-mcp` (shell + file-edit tools) · `buzz-workflow` (YAML automation) · `buzz-persona` (agent persona packs)
+**Agent surface** — `buzz-cli` (agent-first CLI, JSON in / JSON out) · `buzz-acp` (ACP harness for Goose/Codex/Claude Code/Hermes) · `buzz-agent` (ACP agent — see [VISION_AGENT.md](VISION_AGENT.md)) · `buzz-dev-mcp` (shell + file-edit tools) · `buzz-workflow` (YAML automation) · `buzz-persona` (agent persona packs)
 
 **Git & pairing** — `git-sign-nostr` / `git-credential-nostr` (nostr-signed git) · `buzz-pair-relay` / `buzz-pairing-cli` (relay pairing)
 

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -61,6 +61,9 @@ and inbound author gate. This makes an externally hosted agent discoverable on
 the Desktop Agents page and eligible for the `@` picker without creating a
 duplicate Desktop-managed process. `buzz channels set-add-policy` preserves
 these directory fields when it updates the profile's addition policy.
+Desktop ignores policy-only kind `10100` records for directory cards and uses
+the harness's ephemeral kind `20001` heartbeat for the card's live presence,
+so the Agents page matches DMs and profile surfaces.
 
 ## Running with Codex
 

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -108,6 +108,7 @@ skills as the Hermes CLI.
 
 export BUZZ_ACP_AGENT_COMMAND="hermes"
 export BUZZ_ACP_AGENT_ARGS="acp"
+export BUZZ_ACP_RELAY_OBSERVER="true"
 
 buzz-acp
 ```
@@ -119,6 +120,12 @@ arguments instead. Buzz Desktop discovers that entrypoint as the first-class
 For dedicated identities, channel membership, secret storage, a persistent
 `systemd` service, end-to-end verification, and troubleshooting, see
 [Run a Hermes Agent in Buzz](../../docs/hermes-agent-acp.md).
+
+With `BUZZ_ACP_RELAY_OBSERVER=true`, the bridge encrypts ACP activity to the
+verified owner as kind `24200` frames. Buzz Desktop renders those frames in the
+same Activity panel used for locally managed agents. The relay does not retain
+these ephemeral frames, so keep Desktop online for live capture and enable its
+local observer archive when history must survive a restart.
 
 ## Configuration
 
@@ -136,6 +143,7 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
+| `BUZZ_ACP_RELAY_OBSERVER` | no | `false` | Publish encrypted kind `24200` ACP activity frames addressed to the verified owner for Desktop Activity. |
 
 **Note:** `BUZZ_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
 

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -109,6 +109,10 @@ If `hermes-acp` is on `PATH`, it can be launched directly with empty agent
 arguments instead. Buzz Desktop discovers that entrypoint as the first-class
 `Hermes Agent` runtime.
 
+For dedicated identities, channel membership, secret storage, a persistent
+`systemd` service, end-to-end verification, and troubleshooting, see
+[Run a Hermes Agent in Buzz](../../docs/hermes-agent-acp.md).
+
 ## Configuration
 
 All configuration is via environment variables (or CLI flags — every env var has a matching flag).

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -89,6 +89,26 @@ buzz-acp
 Older installs that still expose `claude-code-acp` are also supported. `buzz-acp`
 treats both Claude ACP command names as the same zero-arg runtime.
 
+## Running with Hermes Agent
+
+[Hermes Agent](https://github.com/NousResearch/hermes-agent) includes a native
+ACP server that uses the same personal configuration, credentials, memory, and
+skills as the Hermes CLI.
+
+```bash
+# Install Hermes, configure the personal agent, and add its optional ACP extra.
+# See https://hermes-agent.nousresearch.com/docs/user-guide/features/acp/
+
+export BUZZ_ACP_AGENT_COMMAND="hermes"
+export BUZZ_ACP_AGENT_ARGS="acp"
+
+buzz-acp
+```
+
+If `hermes-acp` is on `PATH`, it can be launched directly with empty agent
+arguments instead. Buzz Desktop discovers that entrypoint as the first-class
+`Hermes Agent` runtime.
+
 ## Configuration
 
 All configuration is via environment variables (or CLI flags — every env var has a matching flag).

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -55,6 +55,13 @@ buzz-acp
 
 That's it. The harness spawns `goose acp`, connects to the relay, discovers channels, and starts listening. When someone @mentions the agent, goose receives the message and can reply using the Buzz CLI that the harness configures automatically.
 
+At startup the harness also publishes a complete kind `10100` relay-directory
+profile using the identity's kind `0` display name, discovered channels, owner,
+and inbound author gate. This makes an externally hosted agent discoverable on
+the Desktop Agents page and eligible for the `@` picker without creating a
+duplicate Desktop-managed process. `buzz channels set-add-policy` preserves
+these directory fields when it updates the profile's addition policy.
+
 ## Running with Codex
 
 [codex-acp](https://github.com/agentclientprotocol/codex-acp) wraps OpenAI Codex in an ACP interface.

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -21,8 +21,8 @@ use std::time::Duration;
 use acp::{AcpClient, EnvVar, McpServer};
 use anyhow::Result;
 use buzz_core::kind::{
-    KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
+    KIND_AGENT_PROFILE, KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION,
+    KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::observer::{
     decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
@@ -87,6 +87,248 @@ async fn publish_presence(
         .sign_with_keys(keys)
         .map_err(|e| relay::RelayError::Http(format!("presence sign error: {e}")))?;
     publisher.publish_event(event).await?;
+    Ok(())
+}
+
+fn directory_profile_content(
+    existing: Option<serde_json::Value>,
+    display_name: &str,
+    channel_info: &HashMap<Uuid, relay::ChannelInfo>,
+    respond_to: &RespondTo,
+    respond_to_allowlist: &HashSet<String>,
+    owner_pubkey: Option<&str>,
+) -> serde_json::Value {
+    let mut profile = existing
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+
+    let mut channels: Vec<(String, String)> = channel_info
+        .iter()
+        .map(|(id, info)| (id.to_string(), info.name.clone()))
+        .collect();
+    channels.sort_by(|left, right| left.0.cmp(&right.0));
+
+    profile.insert("name".into(), serde_json::json!(display_name));
+    profile.insert("display_name".into(), serde_json::json!(display_name));
+    profile.insert("agent_type".into(), serde_json::json!("agent"));
+    profile.insert(
+        "channels".into(),
+        serde_json::json!(channels.iter().map(|(_, name)| name).collect::<Vec<_>>()),
+    );
+    profile.insert(
+        "channel_ids".into(),
+        serde_json::json!(channels.iter().map(|(id, _)| id).collect::<Vec<_>>()),
+    );
+    profile
+        .entry("capabilities")
+        .or_insert_with(|| serde_json::json!([]));
+    profile
+        .entry("channel_add_policy")
+        .or_insert_with(|| serde_json::json!("owner_only"));
+
+    if *respond_to == RespondTo::Nobody {
+        profile.remove("respond_to");
+    } else {
+        profile.insert(
+            "respond_to".into(),
+            serde_json::json!(respond_to.to_string()),
+        );
+    }
+    let mut allowlist: Vec<&String> = respond_to_allowlist.iter().collect();
+    allowlist.sort();
+    profile.insert("respond_to_allowlist".into(), serde_json::json!(allowlist));
+    if let Some(owner) = owner_pubkey {
+        profile.insert("owner_pubkey".into(), serde_json::json!(owner));
+    } else {
+        profile.remove("owner_pubkey");
+    }
+
+    serde_json::Value::Object(profile)
+}
+
+#[cfg(test)]
+mod directory_profile_tests {
+    use super::*;
+
+    #[test]
+    fn profile_preserves_policy_and_publishes_invocation_metadata() {
+        let channel_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let channels = HashMap::from([(
+            channel_id,
+            relay::ChannelInfo {
+                name: "identity".into(),
+                channel_type: "stream".into(),
+            },
+        )]);
+        let content = directory_profile_content(
+            Some(serde_json::json!({
+                "channel_add_policy": "nobody",
+                "custom": "preserved"
+            })),
+            "Alice",
+            &channels,
+            &RespondTo::OwnerOnly,
+            &HashSet::new(),
+            Some(&"a".repeat(64)),
+        );
+
+        assert_eq!(content["name"], "Alice");
+        assert_eq!(content["channels"], serde_json::json!(["identity"]));
+        assert_eq!(
+            content["channel_ids"],
+            serde_json::json!(["11111111-1111-1111-1111-111111111111"])
+        );
+        assert_eq!(content["respond_to"], "owner-only");
+        assert_eq!(content["owner_pubkey"], "a".repeat(64));
+        assert_eq!(content["channel_add_policy"], "nobody");
+        assert_eq!(content["custom"], "preserved");
+    }
+
+    #[test]
+    fn nobody_mode_is_not_advertised_as_invocable() {
+        let content = directory_profile_content(
+            None,
+            "Silent",
+            &HashMap::new(),
+            &RespondTo::Nobody,
+            &HashSet::new(),
+            None,
+        );
+
+        assert!(content.get("respond_to").is_none());
+        assert!(content.get("owner_pubkey").is_none());
+    }
+
+    #[test]
+    fn fresh_membership_snapshot_replaces_stale_directory_channels() {
+        let current_channel = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+        let channels = HashMap::from([(
+            current_channel,
+            relay::ChannelInfo {
+                name: "current".into(),
+                channel_type: "stream".into(),
+            },
+        )]);
+        let content = directory_profile_content(
+            Some(serde_json::json!({
+                "channels": ["removed"],
+                "channel_ids": ["11111111-1111-1111-1111-111111111111"]
+            })),
+            "Alice",
+            &channels,
+            &RespondTo::OwnerOnly,
+            &HashSet::new(),
+            Some(&"a".repeat(64)),
+        );
+
+        assert_eq!(content["channels"], serde_json::json!(["current"]));
+        assert_eq!(
+            content["channel_ids"],
+            serde_json::json!(["22222222-2222-2222-2222-222222222222"])
+        );
+    }
+}
+
+async fn publish_directory_profile(
+    relay: &HarnessRelay,
+    config: &Config,
+    channel_info: &HashMap<Uuid, relay::ChannelInfo>,
+    fallback_name: Option<&str>,
+    owner_pubkey: Option<&str>,
+) -> Result<(), relay::RelayError> {
+    use nostr::{EventBuilder, Filter, Kind};
+
+    let author = config.keys.public_key();
+    let rest = relay.rest_client();
+    let events = rest
+        .query(&[
+            Filter::new().author(author).kind(Kind::Metadata).limit(1),
+            Filter::new()
+                .author(author)
+                .kind(Kind::Custom(KIND_AGENT_PROFILE as u16))
+                .limit(1),
+        ])
+        .await?;
+
+    let events = events.as_array().ok_or_else(|| {
+        relay::RelayError::Http("expected JSON array from /query (profile)".into())
+    })?;
+    let mut display_name = None;
+    let mut existing_profile = None;
+    for event in events {
+        match event.get("kind").and_then(serde_json::Value::as_u64) {
+            Some(0) => {
+                let metadata = event
+                    .get("content")
+                    .and_then(serde_json::Value::as_str)
+                    .and_then(|content| serde_json::from_str::<serde_json::Value>(content).ok());
+                display_name = metadata.as_ref().and_then(|value| {
+                    value
+                        .get("display_name")
+                        .or_else(|| value.get("name"))
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::trim)
+                        .filter(|name| !name.is_empty())
+                        .map(str::to_string)
+                });
+            }
+            Some(kind) if kind == KIND_AGENT_PROFILE as u64 => {
+                let content = event
+                    .get("content")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| {
+                        relay::RelayError::Http(
+                            "existing agent profile is missing string content".into(),
+                        )
+                    })?;
+                let parsed: serde_json::Value = serde_json::from_str(content).map_err(|error| {
+                    relay::RelayError::Http(format!(
+                        "failed to parse existing agent profile content: {error}"
+                    ))
+                })?;
+                if !parsed.is_object() {
+                    return Err(relay::RelayError::Http(
+                        "existing agent profile content is not a JSON object".into(),
+                    ));
+                }
+                existing_profile = Some(parsed);
+            }
+            _ => {}
+        }
+    }
+
+    let existing_display_name = existing_profile.as_ref().and_then(|value| {
+        value
+            .get("display_name")
+            .or_else(|| value.get("name"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_string)
+    });
+    let display_name = display_name
+        .or(existing_display_name)
+        .or_else(|| fallback_name.map(str::to_string))
+        .unwrap_or_else(|| config.keys.public_key().to_bech32().unwrap_or_default());
+    let content = directory_profile_content(
+        existing_profile,
+        &display_name,
+        channel_info,
+        &config.respond_to,
+        &config.respond_to_allowlist,
+        owner_pubkey,
+    );
+    let mut tags = Vec::new();
+    if let Ok(raw_auth_tag) = std::env::var("BUZZ_AUTH_TAG") {
+        if let Ok(auth_tag) = buzz_sdk::nip_oa::parse_auth_tag(&raw_auth_tag) {
+            tags.push(auth_tag);
+        }
+    }
+    let event = EventBuilder::new(Kind::Custom(KIND_AGENT_PROFILE as u16), content.to_string())
+        .tags(tags)
+        .sign_with_keys(&config.keys)
+        .map_err(|error| relay::RelayError::Http(format!("agent profile sign error: {error}")))?;
+    rest.submit_event(&event).await?;
     Ok(())
 }
 
@@ -1387,6 +1629,21 @@ async fn tokio_main() -> Result<()> {
 
     tracing::info!("discovered {} channel(s)", channel_info_map.len());
     let channel_ids: Vec<Uuid> = channel_info_map.keys().copied().collect();
+    let directory_fallback_name = pool.initialized_agent_name().map(str::to_string);
+
+    if let Err(error) = publish_directory_profile(
+        &relay,
+        &config,
+        &channel_info_map,
+        directory_fallback_name.as_deref(),
+        startup_owner.as_deref(),
+    )
+    .await
+    {
+        tracing::warn!("failed to publish agent directory profile: {error}");
+    } else {
+        tracing::info!("published agent directory profile");
+    }
 
     let rules: Vec<SubscriptionRule> = match config.subscribe_mode {
         SubscribeMode::Mentions => {
@@ -1970,6 +2227,36 @@ async fn tokio_main() -> Result<()> {
                                             drained = drained_ids.len(),
                                             invalidated,
                                             "cleaned up after membership removal"
+                                        );
+                                    }
+                                }
+                                match relay.discover_channels().await {
+                                    Ok(fresh_channel_info) => {
+                                        if let Err(error) = publish_directory_profile(
+                                            &relay,
+                                            &config,
+                                            &fresh_channel_info,
+                                            directory_fallback_name.as_deref(),
+                                            startup_owner.as_deref(),
+                                        )
+                                        .await
+                                        {
+                                            tracing::warn!(
+                                                channel_id = %ch,
+                                                "failed to refresh agent directory profile after membership change: {error}"
+                                            );
+                                        } else {
+                                            tracing::info!(
+                                                channel_id = %ch,
+                                                channels = fresh_channel_info.len(),
+                                                "refreshed agent directory profile after membership change"
+                                            );
+                                        }
+                                    }
+                                    Err(error) => {
+                                        tracing::warn!(
+                                            channel_id = %ch,
+                                            "failed to rediscover channels after membership change: {error}"
                                         );
                                     }
                                 }

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -542,6 +542,18 @@ impl AgentPool {
         self.agents.iter().any(|slot| slot.is_some())
     }
 
+    /// Name reported by the first initialized ACP agent, when the pool is eager.
+    ///
+    /// The harness uses this as a fallback for its relay-directory profile when
+    /// the identity has not published kind:0 metadata yet.
+    pub fn initialized_agent_name(&self) -> Option<&str> {
+        self.agents
+            .iter()
+            .flatten()
+            .map(|agent| agent.agent_name.as_str())
+            .find(|name| !name.trim().is_empty() && *name != "unknown")
+    }
+
     /// Whether any idle agent already has a session for `channel_id`.
     /// Used to compute `affinity_hit` before calling `try_claim`.
     pub fn has_session_for(&self, channel_id: Uuid) -> bool {

--- a/crates/buzz-cli/src/commands/channels.rs
+++ b/crates/buzz-cli/src/commands/channels.rs
@@ -1032,7 +1032,17 @@ pub async fn cmd_set_add_policy(client: &BuzzClient, policy: &str) -> Result<(),
         }
     }
 
-    let content = serde_json::json!({ "channel_add_policy": policy }).to_string();
+    // Kind 10100 is the complete replaceable agent-directory profile. Preserve
+    // fields published by buzz-acp (name, channels, audience) when changing
+    // only the channel-add policy.
+    let profile_filter = serde_json::json!({
+        "authors": [client.keys().public_key().to_hex()],
+        "kinds": [buzz_sdk::kind::KIND_AGENT_PROFILE],
+        "limit": 1
+    });
+    let raw_profile = client.query(&profile_filter).await?;
+    let existing_content = parse_agent_profile_query_response(&raw_profile)?;
+    let content = set_channel_add_policy_content(existing_content, policy)?.to_string();
     use nostr::{EventBuilder, Kind};
     let builder = EventBuilder::new(
         Kind::Custom(buzz_sdk::kind::KIND_AGENT_PROFILE as u16),
@@ -1044,6 +1054,45 @@ pub async fn cmd_set_add_policy(client: &BuzzClient, policy: &str) -> Result<(),
     let resp = client.submit_event(event).await?;
     println!("{}", normalize_write_response(&resp));
     Ok(())
+}
+
+fn set_channel_add_policy_content(
+    existing: Option<serde_json::Value>,
+    policy: &str,
+) -> Result<serde_json::Value, CliError> {
+    let mut content = match existing {
+        Some(value) => value.as_object().cloned().ok_or_else(|| {
+            CliError::Other("existing agent profile content is not a JSON object".into())
+        })?,
+        None => serde_json::Map::new(),
+    };
+    content.insert("channel_add_policy".to_string(), serde_json::json!(policy));
+    Ok(serde_json::Value::Object(content))
+}
+
+fn parse_agent_profile_query_response(raw: &str) -> Result<Option<serde_json::Value>, CliError> {
+    let events: serde_json::Value = serde_json::from_str(raw).map_err(|error| {
+        CliError::Other(format!("failed to parse agent profile query: {error}"))
+    })?;
+    let events = events
+        .as_array()
+        .ok_or_else(|| CliError::Other("agent profile query response is not an array".into()))?;
+    let Some(event) = events.first() else {
+        return Ok(None);
+    };
+    let content = event
+        .get("content")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| CliError::Other("agent profile event is missing string content".into()))?;
+    let content: serde_json::Value = serde_json::from_str(content).map_err(|error| {
+        CliError::Other(format!("failed to parse agent profile content: {error}"))
+    })?;
+    if !content.is_object() {
+        return Err(CliError::Other(
+            "existing agent profile content is not a JSON object".into(),
+        ));
+    }
+    Ok(Some(content))
 }
 
 pub async fn cmd_set_canvas(
@@ -1177,9 +1226,9 @@ pub async fn dispatch_canvas(cmd: crate::CanvasCmd, client: &BuzzClient) -> Resu
 mod tests {
     use super::{
         apply_cardinality_rule, build_template_report, cmd_set_add_policy,
-        finalize_roster_resolution, name_matches, resolve_roster_with_archive_filter,
-        validate_ttl_seconds, ArchivedExclusion, ChannelSummary, ResolvedAgent, RosterResolution,
-        SkippedSlug,
+        finalize_roster_resolution, name_matches, parse_agent_profile_query_response,
+        resolve_roster_with_archive_filter, set_channel_add_policy_content, validate_ttl_seconds,
+        ArchivedExclusion, ChannelSummary, ResolvedAgent, RosterResolution, SkippedSlug,
     };
     use crate::client::BuzzClient;
     use crate::CliError;
@@ -1339,6 +1388,47 @@ mod tests {
         assert!(
             result.is_ok(),
             "empty allowed list should permit any policy: {result:?}"
+        );
+    }
+
+    #[test]
+    fn set_add_policy_preserves_complete_directory_profile() {
+        let updated = set_channel_add_policy_content(
+            Some(json!({
+                "name": "Alice",
+                "channel_ids": ["identity"],
+                "respond_to": "owner-only",
+                "owner_pubkey": "a".repeat(64),
+            })),
+            "nobody",
+        )
+        .expect("valid object profile");
+
+        assert_eq!(updated["name"], "Alice");
+        assert_eq!(updated["channel_ids"], json!(["identity"]));
+        assert_eq!(updated["respond_to"], "owner-only");
+        assert_eq!(updated["owner_pubkey"], "a".repeat(64));
+        assert_eq!(updated["channel_add_policy"], "nobody");
+    }
+
+    #[test]
+    fn set_add_policy_allows_successful_empty_profile_query() {
+        let existing =
+            parse_agent_profile_query_response("[]").expect("empty query response is valid");
+        let updated =
+            set_channel_add_policy_content(existing, "owner_only").expect("new profile content");
+
+        assert_eq!(updated, json!({ "channel_add_policy": "owner_only" }));
+    }
+
+    #[test]
+    fn set_add_policy_fails_closed_on_malformed_profile_query() {
+        assert!(parse_agent_profile_query_response("not-json").is_err());
+        assert!(parse_agent_profile_query_response("{}").is_err());
+        assert!(parse_agent_profile_query_response(r#"[{"content":"not-json"}]"#).is_err());
+        assert!(
+            parse_agent_profile_query_response(r#"[{"content":"[]"}]"#).is_err(),
+            "non-object profile content must not be replaced by a policy-only record"
         );
     }
 

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -162,8 +162,8 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
     KnownAcpRuntime {
         id: "hermes",
         label: "Hermes Agent",
-        commands: &["hermes-acp"],
-        aliases: &["hermes"],
+        commands: &["hermes", "hermes-acp"],
+        aliases: &[],
         avatar_url: HERMES_AVATAR_URL,
         mcp_command: None,
         mcp_hooks: false,
@@ -175,7 +175,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
             "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp/",
         cli_install_hint: "Install and configure Hermes Agent.",
         adapter_install_hint:
-            "Install Hermes's optional ACP support so `hermes-acp` is available.",
+            "Install Hermes's optional ACP support so `hermes acp --check` succeeds.",
         skill_dir: None,
         supports_acp_model_switching: false,
         model_env_var: None,
@@ -380,6 +380,14 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
         "goose" | "hermes" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "hermes-acp" | "buzz-agent" => Some(Vec::new()),
+        _ => None,
+    }
+}
+
+fn hermes_readiness_probe_args(command: &str) -> Option<&'static [&'static str]> {
+    match normalize_command_identity(command).as_str() {
+        "hermes" => Some(&["hermes", "acp", "--check"]),
+        "hermes-acp" => Some(&["hermes-acp", "--check"]),
         _ => None,
     }
 }
@@ -1202,7 +1210,7 @@ pub fn discover_acp_runtimes() -> Vec<AcpRuntimeCatalogEntry> {
                 .underlying_cli
                 .map(|cli| find_command(cli).is_some())
                 .unwrap_or(false);
-            let (mut availability, command, binary_path) =
+            let (mut availability, mut command, mut binary_path) =
                 classify_runtime(adapter_result, runtime.underlying_cli, underlying_cli_found);
 
             // For codex-acp: when the adapter resolves as Available, probe the
@@ -1214,6 +1222,30 @@ pub fn discover_acp_runtimes() -> Vec<AcpRuntimeCatalogEntry> {
             {
                 if let Some(path_str) = &binary_path {
                     availability = codex_adapter_availability(&PathBuf::from(path_str));
+                }
+            }
+
+            // Hermes's official installer exposes the native `hermes` binary
+            // even when the optional ACP dependencies are absent. A successful
+            // path lookup therefore is not enough to call the runtime ready.
+            // Probe the selected entrypoint with its command-specific `--check`
+            // invocation and surface a failure as AdapterMissing, not as an
+            // authentication problem.
+            if runtime.id == "hermes" && availability == AcpAvailabilityStatus::Available {
+                let readiness = command
+                    .as_deref()
+                    .and_then(hermes_readiness_probe_args)
+                    .zip(binary_path.as_deref())
+                    .map(|(args, path)| {
+                        matches!(
+                            probe_auth_status(Path::new(path), args),
+                            AuthStatus::LoggedIn
+                        )
+                    });
+                if readiness == Some(false) {
+                    availability = AcpAvailabilityStatus::AdapterMissing;
+                    command = None;
+                    binary_path = None;
                 }
             }
 

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -16,6 +16,8 @@ pub(crate) use runtime_metadata::KnownAcpRuntime;
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
+const HERMES_AVATAR_URL: &str =
+    "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/acp_registry/icon.svg";
 const BUZZ_AGENT_AVATAR_URL: &str =
     "https://raw.githubusercontent.com/block/buzz/refs/heads/main/crates/buzz-agent/buzz-agent.png";
 
@@ -156,6 +158,39 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         login_hint: Some("Run `codex login` to authenticate."),
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
         auth_probe_args: Some(&["codex", "login", "status"]),
+    },
+    KnownAcpRuntime {
+        id: "hermes",
+        label: "Hermes Agent",
+        commands: &["hermes-acp"],
+        aliases: &["hermes"],
+        avatar_url: HERMES_AVATAR_URL,
+        mcp_command: None,
+        mcp_hooks: false,
+        underlying_cli: Some("hermes"),
+        cli_install_commands: &[],
+        cli_install_commands_windows: &[],
+        adapter_install_commands: &[],
+        install_instructions_url:
+            "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp/",
+        cli_install_hint: "Install and configure Hermes Agent.",
+        adapter_install_hint:
+            "Install Hermes's optional ACP support so `hermes-acp` is available.",
+        skill_dir: None,
+        supports_acp_model_switching: false,
+        model_env_var: None,
+        provider_env_var: None,
+        provider_locked: false,
+        default_env: &[],
+        config_file_path: Some("~/.hermes/config.yaml"),
+        config_file_format: Some("yaml"),
+        supports_acp_native_config: false,
+        thinking_env_var: None,
+        max_tokens_env_var: None,
+        context_limit_env_var: None,
+        required_normalized_fields: &[],
+        login_hint: None,
+        auth_probe_args: None,
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -342,9 +377,9 @@ pub use overrides::{apply_agent_command_update, create_time_agent_command_overri
 
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
-        "goose" => Some(vec!["acp".to_string()]),
+        "goose" | "hermes" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        | "claudecode" | "hermes-acp" | "buzz-agent" => Some(Vec::new()),
         _ => None,
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -384,7 +384,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     }
 }
 
-fn hermes_readiness_probe_args(command: &str) -> Option<&'static [&'static str]> {
+pub(crate) fn hermes_readiness_probe_args(command: &str) -> Option<&'static [&'static str]> {
     match normalize_command_identity(command).as_str() {
         "hermes" => Some(&["hermes", "acp", "--check"]),
         "hermes-acp" => Some(&["hermes-acp", "--check"]),

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -5,10 +5,11 @@ use super::{
     apply_agent_command_update, classify_runtime, codex_adapter_availability,
     codex_adapter_is_outdated, create_time_agent_command_override, default_agent_command,
     effective_agent_command, find_nvm_default_bin, find_via_login_shell,
-    is_login_shell_path_uninit, is_safe_nvm_tag, managed_agent_avatar_url, normalize_agent_args,
-    parse_semver_tag, probe_codex_acp_major_version, record_agent_command,
-    refresh_login_shell_path, BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL,
-    GOOSE_AVATAR_URL, HERMES_AVATAR_URL,
+    hermes_readiness_probe_args, is_login_shell_path_uninit, is_safe_nvm_tag,
+    managed_agent_avatar_url, normalize_agent_args, parse_semver_tag,
+    probe_codex_acp_major_version, record_agent_command, refresh_login_shell_path,
+    BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL, GOOSE_AVATAR_URL,
+    HERMES_AVATAR_URL,
 };
 use crate::managed_agents::AcpAvailabilityStatus;
 
@@ -89,6 +90,29 @@ fn normalizes_hermes_entrypoints() {
     assert_eq!(
         normalize_agent_args("hermes-acp", vec!["acp".into()]),
         Vec::<String>::new()
+    );
+}
+
+#[test]
+fn hermes_prefers_native_entrypoint_and_probes_acp_readiness() {
+    let runtime = super::known_acp_runtime("hermes").expect("Hermes runtime should resolve");
+
+    assert_eq!(runtime.commands, &["hermes", "hermes-acp"]);
+    assert_eq!(
+        hermes_readiness_probe_args("hermes"),
+        Some(&["hermes", "acp", "--check"][..])
+    );
+    assert_eq!(
+        hermes_readiness_probe_args("hermes-acp"),
+        Some(&["hermes-acp", "--check"][..])
+    );
+    assert_eq!(runtime.auth_probe_args, None);
+
+    let record = record_with(Some("hermes"), None, None);
+    assert_eq!(record_agent_command(&record, &[]), "hermes");
+    assert_eq!(
+        normalize_agent_args(&record_agent_command(&record, &[]), Vec::new()),
+        vec!["acp".to_string()]
     );
 }
 

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -8,7 +8,7 @@ use super::{
     is_login_shell_path_uninit, is_safe_nvm_tag, managed_agent_avatar_url, normalize_agent_args,
     parse_semver_tag, probe_codex_acp_major_version, record_agent_command,
     refresh_login_shell_path, BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL,
-    GOOSE_AVATAR_URL,
+    GOOSE_AVATAR_URL, HERMES_AVATAR_URL,
 };
 use crate::managed_agents::AcpAvailabilityStatus;
 
@@ -36,6 +36,14 @@ fn resolves_known_avatar_for_command_paths_and_aliases() {
     assert_eq!(
         managed_agent_avatar_url("/usr/local/bin/claude-code-acp"),
         Some(CLAUDE_CODE_AVATAR_URL.to_string())
+    );
+    assert_eq!(
+        managed_agent_avatar_url("/home/alice/.local/bin/hermes-acp"),
+        Some(HERMES_AVATAR_URL.to_string())
+    );
+    assert_eq!(
+        managed_agent_avatar_url("hermes"),
+        Some(HERMES_AVATAR_URL.to_string())
     );
 }
 
@@ -68,6 +76,18 @@ fn normalizes_claude_and_codex_args_to_empty() {
     );
     assert_eq!(
         normalize_agent_args("codex-acp", vec!["acp".into()]),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
+fn normalizes_hermes_entrypoints() {
+    assert_eq!(
+        normalize_agent_args("hermes", Vec::new()),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("hermes-acp", vec!["acp".into()]),
         Vec::<String>::new()
     );
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -5,11 +5,10 @@ use super::{
     apply_agent_command_update, classify_runtime, codex_adapter_availability,
     codex_adapter_is_outdated, create_time_agent_command_override, default_agent_command,
     effective_agent_command, find_nvm_default_bin, find_via_login_shell,
-    hermes_readiness_probe_args, is_login_shell_path_uninit, is_safe_nvm_tag,
-    managed_agent_avatar_url, normalize_agent_args, parse_semver_tag,
-    probe_codex_acp_major_version, record_agent_command, refresh_login_shell_path,
-    BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL, GOOSE_AVATAR_URL,
-    HERMES_AVATAR_URL,
+    is_login_shell_path_uninit, is_safe_nvm_tag, managed_agent_avatar_url, normalize_agent_args,
+    parse_semver_tag, probe_codex_acp_major_version, record_agent_command,
+    refresh_login_shell_path, BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL,
+    GOOSE_AVATAR_URL, HERMES_AVATAR_URL,
 };
 use crate::managed_agents::AcpAvailabilityStatus;
 
@@ -90,29 +89,6 @@ fn normalizes_hermes_entrypoints() {
     assert_eq!(
         normalize_agent_args("hermes-acp", vec!["acp".into()]),
         Vec::<String>::new()
-    );
-}
-
-#[test]
-fn hermes_prefers_native_entrypoint_and_probes_acp_readiness() {
-    let runtime = super::known_acp_runtime("hermes").expect("Hermes runtime should resolve");
-
-    assert_eq!(runtime.commands, &["hermes", "hermes-acp"]);
-    assert_eq!(
-        hermes_readiness_probe_args("hermes"),
-        Some(&["hermes", "acp", "--check"][..])
-    );
-    assert_eq!(
-        hermes_readiness_probe_args("hermes-acp"),
-        Some(&["hermes-acp", "--check"][..])
-    );
-    assert_eq!(runtime.auth_probe_args, None);
-
-    let record = record_with(Some("hermes"), None, None);
-    assert_eq!(record_agent_command(&record, &[]), "hermes");
-    assert_eq!(
-        normalize_agent_args(&record_agent_command(&record, &[]), Vec::new()),
-        vec!["acp".to_string()]
     );
 }
 

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -43,6 +43,9 @@ pub(crate) const KNOWN_AGENT_BINARIES: &[&str] = &[
     "codex-acp",
     "codex_acp",
     "goose",
+    "hermes",
+    "hermes-acp",
+    "hermes_acp",
     // buzz-dev-mcp's multicall personalities (rg, tree, buzz,
     // git-credential-nostr, git-sign-nostr) are short-lived per-tool-call
     // invocations — not listed here.

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -56,8 +56,9 @@ pub(crate) const KNOWN_AGENT_BINARIES: &[&str] = &[
 /// Script interpreters that may host managed agent wrappers (e.g. npm shims).
 /// A process whose name matches here is NOT immediately claimed — it must also
 /// carry `BUZZ_MANAGED_AGENT` in its environment (checked by the caller via
-/// `process_has_buzz_marker()`). This avoids sweeping unrelated node processes.
-pub(crate) const KNOWN_SCRIPT_INTERPRETERS: &[&str] = &["node"];
+/// `process_has_buzz_marker()`). This avoids sweeping unrelated Node or Python
+/// processes.
+pub(crate) const KNOWN_SCRIPT_INTERPRETERS: &[&str] = &["node", "python", "python3"];
 
 /// Check if a process name matches any of our known agent binaries.
 /// Uses exact match or prefix-with-separator to avoid false positives

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -106,6 +106,22 @@ fn goose_has_no_mcp_hooks() {
 }
 
 #[test]
+fn hermes_uses_its_native_tools_and_personal_config() {
+    let runtime = known_acp_runtime("hermes-acp").expect("should resolve");
+    assert_eq!(runtime.id, "hermes");
+    assert!(!runtime.mcp_hooks);
+    assert_eq!(runtime.mcp_command, None);
+    assert_eq!(runtime.config_file_path, Some("~/.hermes/config.yaml"));
+}
+
+#[test]
+fn hermes_process_names_are_owned_runtime_candidates() {
+    assert!(super::name_matches_known_binary("hermes"));
+    assert!(super::name_matches_known_binary("hermes-acp"));
+    assert!(super::name_matches_known_binary("hermes_acp"));
+}
+
+#[test]
 fn unknown_command_returns_none() {
     assert!(known_acp_runtime("custom-agent").is_none());
 }

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -573,26 +573,31 @@ fn name_matches_known_binary_rejects_node() {
 }
 
 #[test]
-fn name_matches_interpreter_accepts_node() {
-    // `node` IS a known script interpreter and must be recognized.
+fn name_matches_interpreter_accepts_exact_known_names() {
+    // Script interpreters are candidates only when the separate
+    // BUZZ_MANAGED_AGENT marker check proves ownership.
     assert!(super::name_matches_interpreter("node"));
+    assert!(super::name_matches_interpreter("python"));
+    assert!(super::name_matches_interpreter("python3"));
 }
 
 #[test]
 fn name_matches_interpreter_rejects_unknown() {
     // Interpreters not in KNOWN_SCRIPT_INTERPRETERS must not match.
-    assert!(!super::name_matches_interpreter("python3"));
     assert!(!super::name_matches_interpreter("deno"));
     assert!(!super::name_matches_interpreter("bun"));
 }
 
 #[test]
-fn name_matches_interpreter_rejects_node_prefix() {
-    // A name that starts with "node" but is longer must not match —
+fn name_matches_interpreter_rejects_interpreter_prefixes() {
+    // A name that starts with a known interpreter but is longer must not match —
     // exact equality is required to avoid false positives.
     assert!(!super::name_matches_interpreter("node_modules"));
     assert!(!super::name_matches_interpreter("nodejs"));
     assert!(!super::name_matches_interpreter("node-gyp"));
+    assert!(!super::name_matches_interpreter("python3.12"));
+    assert!(!super::name_matches_interpreter("python3-config"));
+    assert!(!super::name_matches_interpreter("pythonw"));
 }
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -1,4 +1,4 @@
-use crate::managed_agents::known_acp_runtime;
+use crate::managed_agents::{hermes_readiness_probe_args, known_acp_runtime, normalize_agent_args};
 
 // ── buffer_contains_identifier tests ────────────────────────────────────
 
@@ -107,11 +107,25 @@ fn goose_has_no_mcp_hooks() {
 
 #[test]
 fn hermes_uses_its_native_tools_and_personal_config() {
-    let runtime = known_acp_runtime("hermes-acp").expect("should resolve");
+    let runtime = known_acp_runtime("hermes").expect("should resolve");
     assert_eq!(runtime.id, "hermes");
+    assert_eq!(runtime.commands, &["hermes", "hermes-acp"]);
     assert!(!runtime.mcp_hooks);
     assert_eq!(runtime.mcp_command, None);
     assert_eq!(runtime.config_file_path, Some("~/.hermes/config.yaml"));
+    assert_eq!(runtime.auth_probe_args, None);
+    assert_eq!(
+        normalize_agent_args(runtime.commands[0], Vec::new()),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        hermes_readiness_probe_args("hermes"),
+        Some(&["hermes", "acp", "--check"][..])
+    );
+    assert_eq!(
+        hermes_readiness_probe_args("hermes-acp"),
+        Some(&["hermes-acp", "--check"][..])
+    );
 }
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -178,6 +178,8 @@ pub struct RelayAgentInfo {
     pub pubkey: String,
     pub name: String,
     #[serde(default)]
+    pub avatar_url: Option<String>,
+    #[serde(default)]
     pub owner_pubkey: Option<String>,
     pub agent_type: String,
     pub channels: Vec<String>,

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -177,6 +177,8 @@ impl ManagedAgentRecord {
 pub struct RelayAgentInfo {
     pub pubkey: String,
     pub name: String,
+    #[serde(default)]
+    pub owner_pubkey: Option<String>,
     pub agent_type: String,
     pub channels: Vec<String>,
     #[serde(default)]

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -55,13 +55,13 @@ fn tags_named<'a>(event: &'a Event, name: &'a str) -> impl Iterator<Item = &'a [
     })
 }
 
-/// Return the owner pubkey from a valid NIP-OA owner tag on a kind:0 profile.
+/// Return the owner pubkey from a valid NIP-OA owner tag on an agent-authored
+/// event.
 ///
-/// NIP-OA marks an agent identity by having the owner sign an `auth` tag for
-/// the agent pubkey. We verify the tag against the profile event author, not
-/// against the owner, so a forged or stale marker does not turn a person into
-/// an agent in mention search.
-pub(crate) fn profile_valid_oa_owner_pubkey(event: &Event) -> Option<String> {
+/// The owner signs an `auth` tag for the agent pubkey. We verify the tag
+/// against the event author, not against a self-claimed content field, so a
+/// forged or stale marker cannot establish ownership.
+fn valid_oa_owner_pubkey(event: &Event) -> Option<String> {
     let target_hex = event.pubkey.to_hex();
     let Ok(target_pubkey) = nostr::PublicKey::from_hex(&target_hex) else {
         return None;
@@ -81,6 +81,10 @@ pub(crate) fn profile_valid_oa_owner_pubkey(event: &Event) -> Option<String> {
     }
 
     None
+}
+
+pub(crate) fn profile_valid_oa_owner_pubkey(event: &Event) -> Option<String> {
+    valid_oa_owner_pubkey(event)
 }
 
 pub(crate) fn profile_has_valid_oa_owner(event: &Event) -> bool {
@@ -448,12 +452,25 @@ pub fn agents_from_events(events: &[Event]) -> Value {
         .map(|ev| {
             let mut v: Value = serde_json::from_str(&ev.content).unwrap_or_else(|_| json!({}));
             let pubkey = ev.pubkey.to_hex();
+            let verified_owner_pubkey = valid_oa_owner_pubkey(ev);
             // Full npub fallback — truncated prefixes are grindable (see pubkey-display).
             let npub = ev.pubkey.to_bech32().unwrap_or_else(|_| pubkey.clone());
             // Always overwrite the pubkey with the event author — it's the
             // authoritative source even if the content claims otherwise.
             if let Some(obj) = v.as_object_mut() {
                 obj.insert("pubkey".to_string(), json!(pubkey.clone()));
+                // Never trust the self-claimed directory JSON for ownership.
+                // NIP-OA binds the owner signature to this event author's
+                // pubkey, so only the verified auth tag may populate this
+                // security-sensitive field.
+                match verified_owner_pubkey {
+                    Some(owner_pubkey) => {
+                        obj.insert("owner_pubkey".to_string(), json!(owner_pubkey));
+                    }
+                    None => {
+                        obj.remove("owner_pubkey");
+                    }
+                }
                 let fallback_name = obj
                     .get("display_name")
                     .and_then(Value::as_str)
@@ -597,6 +614,11 @@ mod tests {
 
     /// Build a kind:0 profile with a valid NIP-OA auth tag.
     fn oa_profile_event(content: &str) -> (Event, String) {
+        oa_event(Kind::Metadata, content)
+    }
+
+    /// Build an event with a valid NIP-OA auth tag for its author.
+    fn oa_event(kind: Kind, content: &str) -> (Event, String) {
         let agent_keys = Keys::generate();
         let owner_keys = Keys::generate();
         let agent_pubkey = agent_keys.public_key();
@@ -605,7 +627,7 @@ mod tests {
         let tag_values: Vec<String> = serde_json::from_str(&tag_json).expect("parse auth tag json");
         let auth_tag = Tag::parse(tag_values).expect("parse auth tag");
 
-        let event = EventBuilder::new(Kind::Metadata, content)
+        let event = EventBuilder::new(kind, content)
             .tags(vec![auth_tag])
             .sign_with_keys(&agent_keys)
             .expect("sign");
@@ -893,6 +915,34 @@ mod tests {
             e.pubkey.to_hex()
         );
         assert_eq!(arr[0].get("name").and_then(Value::as_str), Some("agent-1"));
+    }
+
+    #[test]
+    fn agents_derives_owner_from_valid_nip_oa_auth_tag() {
+        let (e, owner_pubkey) = oa_event(
+            Kind::from_u16(10100),
+            r#"{"name":"Alice","owner_pubkey":"forged"}"#,
+        );
+        let v = agents_from_events(std::slice::from_ref(&e));
+        let arr = v.get("agents").and_then(Value::as_array).unwrap();
+
+        assert_eq!(
+            arr[0].get("owner_pubkey").and_then(Value::as_str),
+            Some(owner_pubkey.as_str())
+        );
+    }
+
+    #[test]
+    fn agents_rejects_self_claimed_owner_without_valid_nip_oa_auth_tag() {
+        let e = ev(
+            10100,
+            r#"{"name":"Mallory","owner_pubkey":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#,
+            vec![],
+        );
+        let v = agents_from_events(std::slice::from_ref(&e));
+        let arr = v.get("agents").and_then(Value::as_array).unwrap();
+
+        assert!(arr[0].get("owner_pubkey").is_none());
     }
 
     #[test]

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -9,7 +9,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-use nostr::{Event, ToBech32};
+use nostr::Event;
 use serde_json::{json, Value};
 
 use crate::models::*;
@@ -449,73 +449,66 @@ pub fn search_response_from_events(events: &[Event]) -> SearchResponse {
 pub fn agents_from_events(events: &[Event]) -> Value {
     let arr: Vec<Value> = events
         .iter()
-        .map(|ev| {
-            let mut v: Value = serde_json::from_str(&ev.content).unwrap_or_else(|_| json!({}));
+        .filter_map(|ev| {
+            let mut v: Value = serde_json::from_str(&ev.content).ok()?;
+            let obj = v.as_object_mut()?;
+            // kind:10100 is also used to persist channel-add policy. A
+            // policy-only record is not a complete directory declaration and
+            // must not become a key-only "external agent" card.
+            let directory_name = ["name", "display_name"]
+                .iter()
+                .filter_map(|key| obj.get(*key).and_then(Value::as_str))
+                .find(|value| !value.trim().is_empty())
+                .map(str::to_string)?;
+
             let pubkey = ev.pubkey.to_hex();
             let verified_owner_pubkey = valid_oa_owner_pubkey(ev);
-            // Full npub fallback — truncated prefixes are grindable (see pubkey-display).
-            let npub = ev.pubkey.to_bech32().unwrap_or_else(|_| pubkey.clone());
             // Always overwrite the pubkey with the event author — it's the
             // authoritative source even if the content claims otherwise.
-            if let Some(obj) = v.as_object_mut() {
-                obj.insert("pubkey".to_string(), json!(pubkey.clone()));
-                // Never trust the self-claimed directory JSON for ownership.
-                // NIP-OA binds the owner signature to this event author's
-                // pubkey, so only the verified auth tag may populate this
-                // security-sensitive field.
-                match verified_owner_pubkey {
-                    Some(owner_pubkey) => {
-                        obj.insert("owner_pubkey".to_string(), json!(owner_pubkey));
-                    }
-                    None => {
-                        obj.remove("owner_pubkey");
-                    }
+            obj.insert("pubkey".to_string(), json!(pubkey.clone()));
+            // Never trust the self-claimed directory JSON for ownership.
+            // NIP-OA binds the owner signature to this event author's
+            // pubkey, so only the verified auth tag may populate this
+            // security-sensitive field.
+            match verified_owner_pubkey {
+                Some(owner_pubkey) => {
+                    obj.insert("owner_pubkey".to_string(), json!(owner_pubkey));
                 }
-                let fallback_name = obj
-                    .get("display_name")
+                None => {
+                    obj.remove("owner_pubkey");
+                }
+            }
+            if obj
+                .get("name")
+                .and_then(Value::as_str)
+                .is_none_or(|value| value.trim().is_empty())
+            {
+                obj.insert("name".to_string(), json!(directory_name));
+            }
+            if !obj.get("agent_type").is_some_and(Value::is_string) {
+                obj.insert("agent_type".to_string(), json!("agent"));
+            }
+            if !obj.get("avatar_url").is_some_and(Value::is_string) {
+                let avatar_url = obj
+                    .get("picture")
                     .and_then(Value::as_str)
                     .filter(|value| !value.trim().is_empty())
-                    .map(str::to_string)
-                    .unwrap_or_else(|| npub.clone());
-                if !obj.get("name").is_some_and(Value::is_string) {
-                    obj.insert("name".to_string(), json!(fallback_name));
-                }
-                if !obj.get("agent_type").is_some_and(Value::is_string) {
-                    obj.insert("agent_type".to_string(), json!("agent"));
-                }
-                if !obj.get("avatar_url").is_some_and(Value::is_string) {
-                    let avatar_url = obj
-                        .get("picture")
-                        .and_then(Value::as_str)
-                        .filter(|value| !value.trim().is_empty())
-                        .map(str::to_string);
-                    obj.insert("avatar_url".to_string(), json!(avatar_url));
-                }
-                if !obj.get("channels").is_some_and(Value::is_array) {
-                    obj.insert("channels".to_string(), json!([]));
-                }
-                if !obj.get("channel_ids").is_some_and(Value::is_array) {
-                    obj.insert("channel_ids".to_string(), json!([]));
-                }
-                if !obj.get("capabilities").is_some_and(Value::is_array) {
-                    obj.insert("capabilities".to_string(), json!([]));
-                }
-                if !obj.get("status").is_some_and(Value::is_string) {
-                    obj.insert("status".to_string(), json!("offline"));
-                }
-            } else {
-                v = json!({
-                    "pubkey": pubkey,
-                    "name": npub,
-                    "avatar_url": null,
-                    "agent_type": "agent",
-                    "channels": [],
-                    "channel_ids": [],
-                    "capabilities": [],
-                    "status": "offline",
-                });
+                    .map(str::to_string);
+                obj.insert("avatar_url".to_string(), json!(avatar_url));
             }
-            v
+            if !obj.get("channels").is_some_and(Value::is_array) {
+                obj.insert("channels".to_string(), json!([]));
+            }
+            if !obj.get("channel_ids").is_some_and(Value::is_array) {
+                obj.insert("channel_ids".to_string(), json!([]));
+            }
+            if !obj.get("capabilities").is_some_and(Value::is_array) {
+                obj.insert("capabilities".to_string(), json!([]));
+            }
+            if !obj.get("status").is_some_and(Value::is_string) {
+                obj.insert("status".to_string(), json!("offline"));
+            }
+            Some(v)
         })
         .collect();
     json!({ "agents": arr })
@@ -959,10 +952,23 @@ mod tests {
         let e = ev(10100, "not-json", vec![]);
         let v = agents_from_events(std::slice::from_ref(&e));
         let arr = v.get("agents").and_then(Value::as_array).unwrap();
-        assert_eq!(
-            arr[0].get("pubkey").and_then(Value::as_str).unwrap(),
-            e.pubkey.to_hex()
-        );
+        assert!(arr.is_empty());
+    }
+
+    #[test]
+    fn agents_ignores_policy_only_profiles() {
+        let e = ev(10100, r#"{"channel_add_policy":"owner_only"}"#, vec![]);
+        let v = agents_from_events(std::slice::from_ref(&e));
+        let arr = v.get("agents").and_then(Value::as_array).unwrap();
+        assert!(arr.is_empty());
+    }
+
+    #[test]
+    fn agents_accepts_display_name_when_name_is_empty() {
+        let e = ev(10100, r#"{"name":"","display_name":"Alice"}"#, vec![]);
+        let v = agents_from_events(std::slice::from_ref(&e));
+        let arr = v.get("agents").and_then(Value::as_array).unwrap();
+        assert_eq!(arr[0].get("name").and_then(Value::as_str), Some("Alice"));
     }
 
     #[test]

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -483,6 +483,14 @@ pub fn agents_from_events(events: &[Event]) -> Value {
                 if !obj.get("agent_type").is_some_and(Value::is_string) {
                     obj.insert("agent_type".to_string(), json!("agent"));
                 }
+                if !obj.get("avatar_url").is_some_and(Value::is_string) {
+                    let avatar_url = obj
+                        .get("picture")
+                        .and_then(Value::as_str)
+                        .filter(|value| !value.trim().is_empty())
+                        .map(str::to_string);
+                    obj.insert("avatar_url".to_string(), json!(avatar_url));
+                }
                 if !obj.get("channels").is_some_and(Value::is_array) {
                     obj.insert("channels".to_string(), json!([]));
                 }
@@ -499,6 +507,7 @@ pub fn agents_from_events(events: &[Event]) -> Value {
                 v = json!({
                     "pubkey": pubkey,
                     "name": npub,
+                    "avatar_url": null,
                     "agent_type": "agent",
                     "channels": [],
                     "channel_ids": [],
@@ -960,7 +969,7 @@ mod tests {
     fn agents_default_sparse_agent_profiles_for_directory_parse() {
         let e = ev(
             10100,
-            r#"{"channel_add_policy":"owner-only","display_name":"Scout"}"#,
+            r#"{"channel_add_policy":"owner-only","display_name":"Scout","picture":"https://example.com/scout.png"}"#,
             vec![],
         );
         let v = agents_from_events(std::slice::from_ref(&e));
@@ -971,6 +980,10 @@ mod tests {
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].pubkey, e.pubkey.to_hex());
         assert_eq!(parsed[0].name, "Scout");
+        assert_eq!(
+            parsed[0].avatar_url.as_deref(),
+            Some("https://example.com/scout.png")
+        );
         assert_eq!(parsed[0].agent_type, "agent");
         assert_eq!(parsed[0].channels, Vec::<String>::new());
         assert_eq!(parsed[0].capabilities, Vec::<String>::new());

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -78,7 +78,11 @@ without a parallel TypeScript runtime list.
    host. Desktop may persist an owner-scoped presentation name/avatar, but that
    presentation must flow through the shared profile query layer so cards,
    profiles, messages, mentions, DMs, and sidebars agree. Never write the
-   presentation back to kind `0` or external runtime files.
+   presentation back to kind `0` or external runtime files. A policy-only kind
+   `10100` record is not a directory declaration and must not become a key-only
+   external card; directory entries require a non-empty `name` or
+   `display_name`. Card liveness comes from live kind `20001` presence, never a
+   persisted `status` field in kind `10100`.
 9. **Owner-declared relay agents participate in observer ingestion.** An
    external agent with a verified NIP-OA owner belongs in the app-global
    kind-`24200` ingestion list as `deployed`; non-owned and owner-unknown relay

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -22,6 +22,11 @@ X" flag): add it to `KnownAcpRuntime` first, expose it on
 `AcpRuntimeCatalogEntry`, then project it through the core. Do not shortcut
 with a TypeScript lookup table or an id comparison in a component.
 
+Adding a runtime follows the same rule: declare its command aliases, default
+arguments, install/readiness metadata, and configuration capabilities in the
+Rust catalog. Catalog-driven setup and selection surfaces should pick it up
+without a parallel TypeScript runtime list.
+
 ## Rules
 
 1. **No hardcoded harness-ID checks in render code.** `runtime.id === "claude"`

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -73,6 +73,18 @@ without a parallel TypeScript runtime list.
    sole onboarding surface that chooses and persists `preferred_runtime`.
    `onboarding-agent-defaults.spec.ts` is the acceptance gate for anything
    touching this flow or the shared renderer.
+8. **External agents are relay identities, not shadow managed agents.** Their
+   runtime, prompts, memory, provider, skills, and identity stay on the external
+   host. Desktop may persist an owner-scoped presentation name/avatar, but that
+   presentation must flow through the shared profile query layer so cards,
+   profiles, messages, mentions, DMs, and sidebars agree. Never write the
+   presentation back to kind `0` or external runtime files.
+9. **Owner-declared relay agents participate in observer ingestion.** An
+   external agent with a verified NIP-OA owner belongs in the app-global
+   kind-`24200` ingestion list as `deployed`; non-owned and owner-unknown relay
+   agents stay excluded. Activity UI must use the combined managed + eligible
+   relay-agent candidate list, while interrupt/runtime controls remain local
+   only.
 
 ## The tests that enforce this
 
@@ -87,6 +99,11 @@ without a parallel TypeScript runtime list.
 - `desktop/tests/e2e/onboarding-agent-defaults.spec.ts` — onboarding behavior
   acceptance coverage for readiness, failure states, defaults, navigation, and
   persistence races.
+- `externalAgentPresentation.test.mjs` and
+  `desktop/tests/e2e/agents.spec.ts` — owner presentation propagation across
+  profile-backed surfaces and external-agent Activity ingress.
+- `useAgentObserverIngestion.test.mjs` — verified-owner relay agents join
+  global observer ingestion without admitting unrelated relay identities.
 - Rust: `runtime_metadata_env_vars` tests pin spawn-time key application.
 
 ## Keep this file true

--- a/desktop/src/features/agents/externalAgentPresentation.test.mjs
+++ b/desktop/src/features/agents/externalAgentPresentation.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { applyExternalAgentPresentations } from "./externalAgentPresentation.ts";
+
+const alice = {
+  pubkey: "A".repeat(64),
+  name: "Alice",
+  avatarUrl: null,
+  ownerPubkey: "b".repeat(64),
+  agentType: "hermes",
+  channels: ["identity"],
+  channelIds: ["identity-id"],
+  capabilities: [],
+  status: "online",
+  respondTo: "anyone",
+  respondToAllowlist: [],
+};
+
+test("applies owner presentation name and avatar without changing runtime data", () => {
+  const [presented] = applyExternalAgentPresentations([alice], {
+    ["a".repeat(64)]: {
+      displayName: "ALICE",
+      avatarUrl: "https://example.com/alice.png",
+    },
+  });
+
+  assert.equal(presented.name, "ALICE");
+  assert.equal(presented.avatarUrl, "https://example.com/alice.png");
+  assert.equal(presented.agentType, "hermes");
+  assert.deepEqual(presented.channels, ["identity"]);
+  assert.equal(presented.ownerPubkey, alice.ownerPubkey);
+});
+
+test("leaves agents unchanged when no presentation exists", () => {
+  const [presented] = applyExternalAgentPresentations([alice], {});
+  assert.equal(presented, alice);
+});

--- a/desktop/src/features/agents/externalAgentPresentation.test.mjs
+++ b/desktop/src/features/agents/externalAgentPresentation.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { applyExternalAgentPresentations } from "./externalAgentPresentation.ts";
+import {
+  applyExternalAgentPresentations,
+  applyExternalAgentPresentationsToUsersBatch,
+} from "./externalAgentPresentation.ts";
 
 const alice = {
   pubkey: "A".repeat(64),
@@ -35,4 +38,33 @@ test("applies owner presentation name and avatar without changing runtime data",
 test("leaves agents unchanged when no presentation exists", () => {
   const [presented] = applyExternalAgentPresentations([alice], {});
   assert.equal(presented, alice);
+});
+
+test("applies the same presentation to profile-backed app surfaces", () => {
+  const response = {
+    profiles: {
+      ["a".repeat(64)]: {
+        displayName: "Alice",
+        avatarUrl: null,
+        nip05Handle: null,
+        ownerPubkey: "b".repeat(64),
+        isAgent: true,
+      },
+    },
+    missing: [],
+  };
+
+  const presented = applyExternalAgentPresentationsToUsersBatch(response, {
+    ["a".repeat(64)]: {
+      displayName: "ALICE",
+      avatarUrl: "https://example.com/alice.png",
+    },
+  });
+
+  assert.equal(
+    presented.profiles["a".repeat(64)].avatarUrl,
+    "https://example.com/alice.png",
+  );
+  assert.equal(presented.profiles["a".repeat(64)].displayName, "ALICE");
+  assert.equal(presented.profiles["a".repeat(64)].ownerPubkey, "b".repeat(64));
 });

--- a/desktop/src/features/agents/externalAgentPresentation.ts
+++ b/desktop/src/features/agents/externalAgentPresentation.ts
@@ -1,0 +1,163 @@
+import * as React from "react";
+
+import type { RelayAgent } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+const STORAGE_PREFIX = "buzz.external-agent-presentations.v1";
+const CHANGE_EVENT = "buzz-external-agent-presentations-changed";
+
+export type ExternalAgentPresentation = {
+  displayName: string | null;
+  avatarUrl: string | null;
+};
+
+export type ExternalAgentPresentations = Record<
+  string,
+  ExternalAgentPresentation
+>;
+
+const EMPTY_PRESENTATIONS: ExternalAgentPresentations = Object.freeze({});
+let cachedStorageKey = "";
+let cachedRawValue: string | null = null;
+let cachedPresentations = EMPTY_PRESENTATIONS;
+
+export function externalAgentPresentationScope({
+  identityPubkey,
+  relayUrl,
+}: {
+  identityPubkey: string | null | undefined;
+  relayUrl: string | null | undefined;
+}): string | null {
+  const owner = identityPubkey?.trim().toLowerCase();
+  const relay = relayUrl?.trim().toLowerCase();
+  return owner && relay ? `${owner}:${relay}` : null;
+}
+
+function storageKey(scope: string) {
+  return `${STORAGE_PREFIX}:${scope}`;
+}
+
+function parsePresentations(raw: string | null): ExternalAgentPresentations {
+  if (!raw) return EMPTY_PRESENTATIONS;
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return EMPTY_PRESENTATIONS;
+    }
+
+    const presentations: ExternalAgentPresentations = {};
+    for (const [pubkey, value] of Object.entries(parsed)) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+      const record = value as Record<string, unknown>;
+      presentations[normalizePubkey(pubkey)] = {
+        displayName:
+          typeof record.displayName === "string"
+            ? record.displayName.trim() || null
+            : null,
+        avatarUrl:
+          typeof record.avatarUrl === "string"
+            ? record.avatarUrl.trim() || null
+            : null,
+      };
+    }
+    return presentations;
+  } catch {
+    return EMPTY_PRESENTATIONS;
+  }
+}
+
+export function readExternalAgentPresentations(
+  scope: string | null,
+): ExternalAgentPresentations {
+  if (!scope || typeof window === "undefined") return EMPTY_PRESENTATIONS;
+
+  const key = storageKey(scope);
+  const raw = window.localStorage.getItem(key);
+  if (key === cachedStorageKey && raw === cachedRawValue) {
+    return cachedPresentations;
+  }
+
+  cachedStorageKey = key;
+  cachedRawValue = raw;
+  cachedPresentations = parsePresentations(raw);
+  return cachedPresentations;
+}
+
+export function saveExternalAgentPresentation(
+  scope: string,
+  pubkey: string,
+  presentation: ExternalAgentPresentation | null,
+) {
+  if (typeof window === "undefined") return;
+
+  const key = storageKey(scope);
+  const current = { ...readExternalAgentPresentations(scope) };
+  const normalizedPubkey = normalizePubkey(pubkey);
+  if (presentation) {
+    current[normalizedPubkey] = {
+      displayName: presentation.displayName?.trim() || null,
+      avatarUrl: presentation.avatarUrl?.trim() || null,
+    };
+  } else {
+    delete current[normalizedPubkey];
+  }
+
+  const raw = Object.keys(current).length > 0 ? JSON.stringify(current) : null;
+  if (raw === null) window.localStorage.removeItem(key);
+  else window.localStorage.setItem(key, raw);
+
+  cachedStorageKey = key;
+  cachedRawValue = raw;
+  cachedPresentations =
+    Object.keys(current).length > 0 ? current : EMPTY_PRESENTATIONS;
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT, { detail: { scope } }));
+}
+
+function subscribe(scope: string | null, onStoreChange: () => void) {
+  if (!scope || typeof window === "undefined") return () => {};
+  const key = storageKey(scope);
+  const handleChange = (event: Event) => {
+    if (event instanceof StorageEvent && event.key !== key) return;
+    if (
+      event instanceof CustomEvent &&
+      (event.detail as { scope?: unknown } | null)?.scope !== scope
+    ) {
+      return;
+    }
+    cachedStorageKey = "";
+    onStoreChange();
+  };
+  window.addEventListener("storage", handleChange);
+  window.addEventListener(CHANGE_EVENT, handleChange);
+  return () => {
+    window.removeEventListener("storage", handleChange);
+    window.removeEventListener(CHANGE_EVENT, handleChange);
+  };
+}
+
+export function useExternalAgentPresentations(scope: string | null) {
+  return React.useSyncExternalStore(
+    React.useCallback(
+      (onStoreChange) => subscribe(scope, onStoreChange),
+      [scope],
+    ),
+    React.useCallback(() => readExternalAgentPresentations(scope), [scope]),
+    () => EMPTY_PRESENTATIONS,
+  );
+}
+
+export function applyExternalAgentPresentations(
+  agents: readonly RelayAgent[],
+  presentations: ExternalAgentPresentations,
+): RelayAgent[] {
+  return agents.map((agent) => {
+    const presentation = presentations[normalizePubkey(agent.pubkey)];
+    if (!presentation) return agent;
+    return {
+      ...agent,
+      name: presentation.displayName ?? agent.name,
+      avatarUrl: presentation.avatarUrl ?? agent.avatarUrl,
+    };
+  });
+}

--- a/desktop/src/features/agents/externalAgentPresentation.ts
+++ b/desktop/src/features/agents/externalAgentPresentation.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
-import type { RelayAgent } from "@/shared/api/types";
+import type {
+  RelayAgent,
+  UserProfileSummary,
+  UsersBatchResponse,
+} from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 const STORAGE_PREFIX = "buzz.external-agent-presentations.v1";
@@ -160,4 +164,35 @@ export function applyExternalAgentPresentations(
       avatarUrl: presentation.avatarUrl ?? agent.avatarUrl,
     };
   });
+}
+
+export function applyExternalAgentPresentationToProfile<
+  T extends Pick<UserProfileSummary, "displayName" | "avatarUrl">,
+>(pubkey: string, profile: T, presentations: ExternalAgentPresentations): T {
+  const presentation = presentations[normalizePubkey(pubkey)];
+  if (!presentation) return profile;
+  return {
+    ...profile,
+    displayName: presentation.displayName ?? profile.displayName,
+    avatarUrl: presentation.avatarUrl ?? profile.avatarUrl,
+  };
+}
+
+export function applyExternalAgentPresentationsToUsersBatch(
+  response: UsersBatchResponse,
+  presentations: ExternalAgentPresentations,
+): UsersBatchResponse {
+  let changed = false;
+  const profiles = Object.fromEntries(
+    Object.entries(response.profiles).map(([pubkey, profile]) => {
+      const presented = applyExternalAgentPresentationToProfile(
+        pubkey,
+        profile,
+        presentations,
+      );
+      changed ||= presented !== profile;
+      return [pubkey, presented];
+    }),
+  );
+  return changed ? { ...response, profiles } : response;
 }

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -294,7 +294,7 @@ export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: relayAgentsQueryKey,
     queryFn: listRelayAgents,
-    staleTime: 30_000,
+    staleTime: 15_000,
     // Relay agent profiles (kind:10100) are near-static and the backing
     // `list_relay_agents` command is an unfiltered relay query for the whole
     // profile set — mounted on ~13 always-live surfaces (channel screen,
@@ -302,9 +302,13 @@ export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
     // re-pulls the full set app-wide. This poll is also the ONLY refresh path:
     // the `agents-data-changed` event fires only for local persona/team/managed
     // reconcile (kinds PERSONA/TEAM/MANAGED_AGENT), never for kind:10100. So we
-    // keep polling but at a relaxed cadence and pause it while backgrounded.
-    refetchInterval: 5 * 60_000,
+    // External agents publish this profile from another process, so there is
+    // no local Tauri event to invalidate the cache. Poll often enough for a
+    // newly started agent to appear without requiring an app restart, and
+    // always refresh when the user returns to Buzz.
+    refetchInterval: 30_000,
     refetchIntervalInBackground: false,
+    refetchOnWindowFocus: "always",
     enabled: options?.enabled,
   });
 }

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -2,6 +2,13 @@ import * as React from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
+  applyExternalAgentPresentations,
+  externalAgentPresentationScope,
+  useExternalAgentPresentations,
+} from "@/features/agents/externalAgentPresentation";
+import { useCommunities } from "@/features/communities/useCommunities";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import {
   connectAcpRuntime,
   discoverAcpAuthMethods,
 } from "@/shared/api/tauriAgentAuth";
@@ -68,6 +75,7 @@ import type {
   CreateManagedAgentInput,
   CreatePersonaInput,
   ManagedAgent,
+  RelayAgent,
   UpdateManagedAgentInput,
   UpdatePersonaInput,
 } from "@/shared/api/types";
@@ -291,9 +299,22 @@ export function useManagedAgentPrereqsQuery(
 }
 
 export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
+  const identityQuery = useIdentityQuery();
+  const { activeCommunity } = useCommunities();
+  const presentationScope = externalAgentPresentationScope({
+    identityPubkey: identityQuery.data?.pubkey,
+    relayUrl: activeCommunity?.relayUrl,
+  });
+  const presentations = useExternalAgentPresentations(presentationScope);
+
   return useQuery({
     queryKey: relayAgentsQueryKey,
     queryFn: listRelayAgents,
+    select: React.useCallback(
+      (agents: RelayAgent[]) =>
+        applyExternalAgentPresentations(agents, presentations),
+      [presentations],
+    ),
     staleTime: 15_000,
     // Relay agent profiles (kind:10100) are near-static and the backing
     // `list_relay_agents` command is an unfiltered relay query for the whole

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -52,7 +52,12 @@ test("relayAgentIsSharedWithUser: accepts shared anyone agents and rejects unsha
 
   assert.equal(
     relayAgentIsSharedWithUser(
-      { respondTo: "anyone", respondToAllowlist: [], channelIds: ["general"] },
+      {
+        ownerPubkey: null,
+        respondTo: "anyone",
+        respondToAllowlist: [],
+        channelIds: ["general"],
+      },
       sharedChannelIds,
     ),
     true,
@@ -60,6 +65,7 @@ test("relayAgentIsSharedWithUser: accepts shared anyone agents and rejects unsha
   assert.equal(
     relayAgentIsSharedWithUser(
       {
+        ownerPubkey: null,
         respondTo: "owner-only",
         respondToAllowlist: [],
         channelIds: ["general"],
@@ -70,7 +76,12 @@ test("relayAgentIsSharedWithUser: accepts shared anyone agents and rejects unsha
   );
   assert.equal(
     relayAgentIsSharedWithUser(
-      { respondTo: "anyone", respondToAllowlist: [], channelIds: ["other"] },
+      {
+        ownerPubkey: null,
+        respondTo: "anyone",
+        respondToAllowlist: [],
+        channelIds: ["other"],
+      },
       sharedChannelIds,
     ),
     false,
@@ -83,6 +94,7 @@ test("relayAgentIsSharedWithUser: accepts allowlist agents for the current user"
   assert.equal(
     relayAgentIsSharedWithUser(
       {
+        ownerPubkey: null,
         respondTo: "allowlist",
         respondToAllowlist: [OTHER_OWNER_PUBKEY, CURRENT_PUBKEY.toUpperCase()],
         channelIds: ["other"],
@@ -95,11 +107,41 @@ test("relayAgentIsSharedWithUser: accepts allowlist agents for the current user"
   assert.equal(
     relayAgentIsSharedWithUser(
       {
+        ownerPubkey: null,
         respondTo: "allowlist",
         respondToAllowlist: [OTHER_OWNER_PUBKEY],
         channelIds: ["general"],
       },
       sharedChannelIds,
+      CURRENT_PUBKEY,
+    ),
+    false,
+  );
+});
+
+test("relayAgentIsSharedWithUser: accepts owner-only agents for their owner", () => {
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      {
+        ownerPubkey: CURRENT_PUBKEY.toUpperCase(),
+        respondTo: "owner-only",
+        respondToAllowlist: [],
+        channelIds: [],
+      },
+      new Set(),
+      CURRENT_PUBKEY,
+    ),
+    true,
+  );
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      {
+        ownerPubkey: OTHER_OWNER_PUBKEY,
+        respondTo: "owner-only",
+        respondToAllowlist: [],
+        channelIds: ["general"],
+      },
+      new Set(["general"]),
       CURRENT_PUBKEY,
     ),
     false,
@@ -113,18 +155,21 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
     relayAgents: [
       {
         pubkey: PUB_B,
+        ownerPubkey: null,
         respondTo: "anyone",
         respondToAllowlist: [],
         channelIds: ["general"],
       },
       {
         pubkey: PUB_C,
+        ownerPubkey: null,
         respondTo: "allowlist",
         respondToAllowlist: [CURRENT_PUBKEY],
         channelIds: ["other"],
       },
       {
         pubkey: PUB_D,
+        ownerPubkey: null,
         respondTo: "anyone",
         respondToAllowlist: [],
         channelIds: ["other"],

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -10,7 +10,10 @@ export function getSharedChannelIds(channels: readonly Channel[] | undefined) {
 }
 
 export function relayAgentIsSharedWithUser(
-  agent: Pick<RelayAgent, "channelIds" | "respondTo" | "respondToAllowlist">,
+  agent: Pick<
+    RelayAgent,
+    "channelIds" | "ownerPubkey" | "respondTo" | "respondToAllowlist"
+  >,
   sharedChannelIds: ReadonlySet<string>,
   currentPubkey?: string | null,
 ) {
@@ -22,6 +25,14 @@ export function relayAgentIsSharedWithUser(
     return agent.respondToAllowlist
       .map((pubkey) => normalizePubkey(pubkey))
       .includes(normalizedCurrentPubkey);
+  }
+
+  if (
+    agent.respondTo === "owner-only" &&
+    normalizedCurrentPubkey &&
+    agent.ownerPubkey
+  ) {
+    return normalizePubkey(agent.ownerPubkey) === normalizedCurrentPubkey;
   }
 
   return (

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -235,6 +235,9 @@ export function AgentsView() {
               }
               isLoading={agents.relayAgentsQuery.isLoading}
               managedPubkeys={agents.managedPubkeys}
+              onOpenAgentProfile={(pubkey) => {
+                openProfilePanel?.(pubkey);
+              }}
               relayAgents={agents.relayAgentsQuery.data ?? []}
             />
           </div>

--- a/desktop/src/features/agents/ui/ExternalAgentPresentationDialog.tsx
+++ b/desktop/src/features/agents/ui/ExternalAgentPresentationDialog.tsx
@@ -1,0 +1,124 @@
+import * as React from "react";
+
+import {
+  saveExternalAgentPresentation,
+  type ExternalAgentPresentation,
+} from "@/features/agents/externalAgentPresentation";
+import { ProfileAvatarEditor } from "@/features/profile/ui/ProfileAvatarEditor";
+import type { RelayAgent } from "@/shared/api/types";
+import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+import { Input } from "@/shared/ui/input";
+
+export function ExternalAgentPresentationDialog({
+  agent,
+  onOpenChange,
+  open,
+  scope,
+}: {
+  agent: RelayAgent | null;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  scope: string | null;
+}) {
+  const [displayName, setDisplayName] = React.useState("");
+  const [avatarUrl, setAvatarUrl] = React.useState("");
+  const [isUploading, setIsUploading] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!open || !agent) return;
+    setDisplayName(agent.name);
+    setAvatarUrl(agent.avatarUrl ?? "");
+    setIsUploading(false);
+  }, [agent, open]);
+
+  if (!agent) return null;
+
+  const save = (presentation: ExternalAgentPresentation | null) => {
+    if (!scope) return;
+    saveExternalAgentPresentation(scope, agent.pubkey, presentation);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent
+        aria-describedby="external-agent-presentation-description"
+        className="max-h-[calc(100vh-2rem)] overflow-y-auto"
+        data-testid="external-agent-presentation-dialog"
+      >
+        <DialogHeader>
+          <DialogTitle>Customize external agent</DialogTitle>
+          <DialogDescription id="external-agent-presentation-description">
+            This changes how the agent appears in your Buzz Desktop. It never
+            edits the external runtime, Soul, prompts, memory, or provider
+            files.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-5">
+          <label
+            className="grid gap-2 text-sm font-medium"
+            htmlFor="external-agent-display-name"
+          >
+            Display name
+            <Input
+              autoFocus
+              data-testid="external-agent-display-name"
+              id="external-agent-display-name"
+              maxLength={80}
+              onChange={(event) => setDisplayName(event.target.value)}
+              placeholder={agent.name}
+              value={displayName}
+            />
+          </label>
+
+          <div className="grid gap-2">
+            <p className="text-sm font-medium">Icon / avatar</p>
+            <ProfileAvatarEditor
+              avatarUrl={avatarUrl}
+              disabled={isUploading}
+              onUploadedAvatarChange={(url) => {
+                if (url) setAvatarUrl(url);
+              }}
+              onUploadingChange={setIsUploading}
+              onUrlChange={setAvatarUrl}
+              previewName={displayName.trim() || agent.name}
+              testIdPrefix="external-agent-avatar"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            disabled={isUploading}
+            onClick={() => save(null)}
+            type="button"
+            variant="ghost"
+          >
+            Reset
+          </Button>
+          <Button
+            disabled={isUploading || !displayName.trim()}
+            onClick={() =>
+              save({
+                displayName: displayName.trim(),
+                avatarUrl: avatarUrl.trim() || null,
+              })
+            }
+            type="button"
+          >
+            Save appearance
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentSessionPanel.tsx
@@ -369,9 +369,9 @@ function EmptyObserverState() {
   return (
     <div className="mt-4 flex min-h-48 flex-col items-center justify-center px-6 py-8 text-center">
       <TerminalSquare className="mx-auto h-4 w-4 text-muted-foreground" />
-      <p className="mt-3 text-sm font-medium">Observer not attached</p>
+      <p className="mt-3 text-sm font-medium">No observer activity yet</p>
       <p className="mt-1 text-sm text-muted-foreground">
-        The live feed is available for local agents started after this update.
+        Activity appears here when this agent starts its next observed turn.
       </p>
     </div>
   );

--- a/desktop/src/features/agents/ui/RelayDirectorySection.tsx
+++ b/desktop/src/features/agents/ui/RelayDirectorySection.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, Pencil, Search } from "lucide-react";
 
 import { externalAgentPresentationScope } from "@/features/agents/externalAgentPresentation";
 import { useCommunities } from "@/features/communities/useCommunities";
+import { usePresenceQuery } from "@/features/presence/hooks";
 import { useIdentityQuery } from "@/shared/api/hooks";
 import type { RelayAgent } from "@/shared/api/types";
 import { PresenceBadge } from "@/features/presence/ui/PresenceBadge";
@@ -44,6 +45,13 @@ export function RelayDirectorySection({
     () => relayAgents.filter((agent) => !managedPubkeys.has(agent.pubkey)),
     [relayAgents, managedPubkeys],
   );
+  const otherAgentPubkeys = React.useMemo(
+    () => otherAgents.map((agent) => normalizePubkey(agent.pubkey)),
+    [otherAgents],
+  );
+  const presenceQuery = usePresenceQuery(otherAgentPubkeys, {
+    enabled: otherAgentPubkeys.length > 0,
+  });
 
   const filteredAgents = React.useMemo(() => {
     if (!searchQuery.trim()) return otherAgents;
@@ -119,6 +127,12 @@ export function RelayDirectorySection({
                 const canCustomize =
                   presentationScope !== null &&
                   normalizePubkey(agent.ownerPubkey ?? "") === currentPubkey;
+                // kind:10100 is persistent directory metadata, not liveness.
+                // External hosts publish live status as ephemeral kind:20001,
+                // which is also the source used by DMs and profile surfaces.
+                const liveStatus =
+                  presenceQuery.data?.[normalizePubkey(agent.pubkey)] ??
+                  "offline";
                 return (
                   <AgentIdentityCard
                     actions={
@@ -147,7 +161,7 @@ export function RelayDirectorySection({
                         <Badge variant="info">External</Badge>
                         <PresenceBadge
                           className="border-0 bg-transparent px-0 py-0 text-2xs"
-                          status={agent.status}
+                          status={liveStatus}
                         />
                       </span>
                     }

--- a/desktop/src/features/agents/ui/RelayDirectorySection.tsx
+++ b/desktop/src/features/agents/ui/RelayDirectorySection.tsx
@@ -1,25 +1,42 @@
 import * as React from "react";
-import { ChevronDown, ChevronRight, Search } from "lucide-react";
+import { ChevronDown, ChevronRight, Pencil, Search } from "lucide-react";
 
+import { externalAgentPresentationScope } from "@/features/agents/externalAgentPresentation";
+import { useCommunities } from "@/features/communities/useCommunities";
+import { useIdentityQuery } from "@/shared/api/hooks";
 import type { RelayAgent } from "@/shared/api/types";
 import { PresenceBadge } from "@/features/presence/ui/PresenceBadge";
-import { Card } from "@/shared/ui/card";
+import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
-import { truncatePubkey } from "@/shared/lib/pubkey";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import { AgentIdentityCard } from "./AgentIdentityCard";
+import { ExternalAgentPresentationDialog } from "./ExternalAgentPresentationDialog";
 
 export function RelayDirectorySection({
   error,
   isLoading,
   managedPubkeys,
+  onOpenAgentProfile,
   relayAgents,
 }: {
   error: Error | null;
   isLoading: boolean;
   managedPubkeys: Set<string>;
+  onOpenAgentProfile: (pubkey: string) => void;
   relayAgents: RelayAgent[];
 }) {
+  const identityQuery = useIdentityQuery();
+  const { activeCommunity } = useCommunities();
   const [isExpanded, setIsExpanded] = React.useState(true);
   const [searchQuery, setSearchQuery] = React.useState("");
+  const [agentToCustomize, setAgentToCustomize] =
+    React.useState<RelayAgent | null>(null);
+  const currentPubkey = normalizePubkey(identityQuery.data?.pubkey ?? "");
+  const presentationScope = externalAgentPresentationScope({
+    identityPubkey: identityQuery.data?.pubkey,
+    relayUrl: activeCommunity?.relayUrl,
+  });
 
   // Only show agents that are NOT managed locally — those are already in the
   // managed agents section above.
@@ -94,58 +111,50 @@ export function RelayDirectorySection({
                 : "No other agents in this community."}
             </p>
           ) : (
-            <Card className="overflow-hidden">
-              <div className="overflow-x-auto">
-                <table
-                  className="w-full border-collapse text-left text-sm"
-                  data-testid="relay-directory-table"
-                >
-                  <thead className="bg-muted/35 text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    <tr>
-                      <th className="px-4 py-3">Agent</th>
-                      <th className="px-4 py-3">Status</th>
-                      <th className="px-4 py-3">Type</th>
-                      <th className="px-4 py-3">Channels</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedAgents.map((agent) => (
-                      <tr
-                        className="border-b border-border/60 last:border-b-0"
-                        key={agent.pubkey}
-                      >
-                        <td className="min-w-[16rem] px-4 py-3 align-top">
-                          <div className="min-w-0">
-                            <p className="truncate font-medium text-foreground">
-                              {agent.name}
-                            </p>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              {truncatePubkey(agent.pubkey)}
-                            </p>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 align-top">
-                          <PresenceBadge
-                            className="px-2.5 py-0.5 text-2xs"
-                            status={agent.status}
-                          />
-                        </td>
-                        <td className="px-4 py-3 align-top text-muted-foreground">
-                          {agent.agentType || "Unknown"}
-                        </td>
-                        <td className="max-w-[20rem] px-4 py-3 align-top text-muted-foreground">
-                          <span className="block truncate">
-                            {agent.channels.length > 0
-                              ? agent.channels.join(", ")
-                              : "No visible channel memberships"}
-                          </span>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </Card>
+            <div
+              className="grid w-full grid-cols-[repeat(auto-fill,minmax(220px,240px))] justify-start gap-3"
+              data-testid="relay-directory-cards"
+            >
+              {sortedAgents.map((agent) => {
+                const canCustomize =
+                  presentationScope !== null &&
+                  normalizePubkey(agent.ownerPubkey ?? "") === currentPubkey;
+                return (
+                  <AgentIdentityCard
+                    actions={
+                      canCustomize ? (
+                        <Button
+                          aria-label={`Customize ${agent.name}`}
+                          className="h-8 w-8 rounded-full"
+                          data-testid={`customize-external-agent-${agent.pubkey}`}
+                          onClick={() => setAgentToCustomize(agent)}
+                          size="icon"
+                          variant="secondary"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                      ) : null
+                    }
+                    ariaLabel={`${agent.name} external agent profile`}
+                    avatarUrl={agent.avatarUrl}
+                    dataTestId={`external-agent-card-${agent.pubkey}`}
+                    key={agent.pubkey}
+                    label={agent.name}
+                    modelLabel={agent.agentType || "External runtime"}
+                    onClick={() => onOpenAgentProfile(agent.pubkey)}
+                    statusBadge={
+                      <span className="mt-1 flex flex-wrap items-center gap-1.5">
+                        <Badge variant="info">External</Badge>
+                        <PresenceBadge
+                          className="border-0 bg-transparent px-0 py-0 text-2xs"
+                          status={agent.status}
+                        />
+                      </span>
+                    }
+                  />
+                );
+              })}
+            </div>
           )}
         </>
       ) : null}
@@ -155,6 +164,15 @@ export function RelayDirectorySection({
           {error.message}
         </p>
       ) : null}
+
+      <ExternalAgentPresentationDialog
+        agent={agentToCustomize}
+        onOpenChange={(open) => {
+          if (!open) setAgentToCustomize(null);
+        }}
+        open={agentToCustomize !== null}
+        scope={presentationScope}
+      />
     </section>
   );
 }

--- a/desktop/src/features/agents/ui/RelayDirectorySection.tsx
+++ b/desktop/src/features/agents/ui/RelayDirectorySection.tsx
@@ -18,7 +18,7 @@ export function RelayDirectorySection({
   managedPubkeys: Set<string>;
   relayAgents: RelayAgent[];
 }) {
-  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [isExpanded, setIsExpanded] = React.useState(true);
   const [searchQuery, setSearchQuery] = React.useState("");
 
   // Only show agents that are NOT managed locally — those are already in the
@@ -63,14 +63,15 @@ export function RelayDirectorySection({
             <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
           )}
           <h2 className="text-lg font-semibold tracking-tight">
-            Agent directory
+            External agents
           </h2>
           <span className="text-sm text-muted-foreground">
             ({otherAgents.length})
           </span>
         </button>
         <p className="pl-6 text-sm text-muted-foreground">
-          View agents other members have shared in this community.
+          Agents hosted outside this Desktop. You can mention them, but runtime
+          controls stay with their host.
         </p>
       </div>
 

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -326,7 +326,7 @@ export function MembersSidebar({
         displayName: agent.name,
         avatarUrl: null,
         nip05Handle: null,
-        ownerPubkey: null,
+        ownerPubkey: agent.ownerPubkey,
         isAgent: true,
       });
     }

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -324,7 +324,7 @@ export function MembersSidebar({
       addCandidate({
         pubkey: agent.pubkey,
         displayName: agent.name,
-        avatarUrl: null,
+        avatarUrl: agent.avatarUrl,
         nip05Handle: null,
         ownerPubkey: agent.ownerPubkey,
         isAgent: true,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -341,7 +341,7 @@ export function useMentions(
         personaId:
           managedAgentPersonaIdsByPubkey.get(pubkey) ??
           (activePersonaById.has(pubkey) ? pubkey : undefined),
-        ownerPubkey: null,
+        ownerPubkey: agent.ownerPubkey,
         isAgent: true,
       });
     }

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -246,7 +246,10 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (
+        !mentionableAgentPubkeys.has(pubkey) &&
+        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+      ) {
         return;
       }
       if (

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -179,6 +179,16 @@ export function useMentions(
       ),
     [relayAgentsQuery.data],
   );
+  const relayAgentAvatarsByPubkey = React.useMemo(
+    () =>
+      new Map(
+        (relayAgentsQuery.data ?? []).map((agent) => [
+          normalizePubkey(agent.pubkey),
+          agent.avatarUrl,
+        ]),
+      ),
+    [relayAgentsQuery.data],
+  );
   const directoryAgentPubkeys = React.useMemo(
     () =>
       new Set(
@@ -314,7 +324,8 @@ export function useMentions(
           profile?.displayName?.trim() ||
           profile?.nip05Handle?.trim() ||
           null,
-        avatarUrl: profile?.avatarUrl ?? null,
+        avatarUrl:
+          relayAgentAvatarsByPubkey.get(pubkey) ?? profile?.avatarUrl ?? null,
         isMember: true,
         personaId:
           managedAgentPersonaIdsByPubkey.get(pubkey) ?? linkedPersonaId,
@@ -340,6 +351,7 @@ export function useMentions(
         kind: "identity",
         pubkey,
         displayName: agent.name,
+        avatarUrl: agent.avatarUrl,
         isMember: false,
         personaId:
           managedAgentPersonaIdsByPubkey.get(pubkey) ??
@@ -430,6 +442,7 @@ export function useMentions(
     mentionableAgentPubkeys,
     personaNameByPubkey,
     profiles,
+    relayAgentAvatarsByPubkey,
     relayAgentNamesByPubkey,
     relayAgentsQuery.data,
   ]);

--- a/desktop/src/features/messages/ui/useNewMessageRecipients.ts
+++ b/desktop/src/features/messages/ui/useNewMessageRecipients.ts
@@ -177,7 +177,7 @@ export function useNewMessageRecipients({
           displayName: agent.name,
           avatarUrl: null,
           nip05Handle: null,
-          ownerPubkey: null,
+          ownerPubkey: agent.ownerPubkey,
           isAgent: true,
         },
         { includeSelected: deferredSearchQuery.length > 0 },

--- a/desktop/src/features/messages/ui/useNewMessageRecipients.ts
+++ b/desktop/src/features/messages/ui/useNewMessageRecipients.ts
@@ -175,7 +175,7 @@ export function useNewMessageRecipients({
         {
           pubkey: agent.pubkey,
           displayName: agent.name,
-          avatarUrl: null,
+          avatarUrl: agent.avatarUrl,
           nip05Handle: null,
           ownerPubkey: agent.ownerPubkey,
           isAgent: true,

--- a/desktop/src/features/profile/hooks.ts
+++ b/desktop/src/features/profile/hooks.ts
@@ -43,6 +43,12 @@ import {
 } from "@/features/profile/lib/selfProfileStorage";
 import { useCommunities } from "@/features/communities/useCommunities";
 import { updateCachedChannelMemberDisplayName } from "@/features/channels/channelMemberProfileCache";
+import {
+  applyExternalAgentPresentationToProfile,
+  applyExternalAgentPresentationsToUsersBatch,
+  externalAgentPresentationScope,
+  useExternalAgentPresentations,
+} from "@/features/agents/externalAgentPresentation";
 
 export const profileQueryKey = ["profile"] as const;
 export const contactListQueryKey = (pubkey: string) =>
@@ -271,10 +277,29 @@ export function useUnfollowMutation(currentPubkey?: string) {
 }
 
 export function useUserProfileQuery(pubkey?: string) {
+  const identityQuery = useIdentityQuery();
+  const { activeCommunity } = useCommunities();
+  const presentationScope = externalAgentPresentationScope({
+    identityPubkey: identityQuery.data?.pubkey,
+    relayUrl: activeCommunity?.relayUrl,
+  });
+  const presentations = useExternalAgentPresentations(presentationScope);
+
   return useQuery({
     enabled: typeof pubkey === "string" && pubkey.length > 0,
     queryKey: ["user-profile", pubkey?.toLowerCase() ?? ""],
     queryFn: () => getUserProfile(pubkey),
+    select: React.useCallback(
+      (profile: Profile) =>
+        pubkey
+          ? applyExternalAgentPresentationToProfile(
+              pubkey,
+              profile,
+              presentations,
+            )
+          : profile,
+      [presentations, pubkey],
+    ),
     staleTime: 60_000,
   });
 }
@@ -317,6 +342,13 @@ export function useUsersBatchQuery(
   },
 ) {
   const queryClient = useQueryClient();
+  const identityQuery = useIdentityQuery();
+  const { activeCommunity } = useCommunities();
+  const presentationScope = externalAgentPresentationScope({
+    identityPubkey: identityQuery.data?.pubkey,
+    relayUrl: activeCommunity?.relayUrl,
+  });
+  const presentations = useExternalAgentPresentations(presentationScope);
   const normalizedPubkeys = [
     ...new Set(pubkeys.map((pubkey) => pubkey.toLowerCase())),
   ]
@@ -364,6 +396,11 @@ export function useUsersBatchQuery(
       }
       return { profiles, missing };
     },
+    select: React.useCallback(
+      (response: UsersBatchResponse) =>
+        applyExternalAgentPresentationsToUsersBatch(response, presentations),
+      [presentations],
+    ),
     // Loading older messages grows the pubkey set, which changes this query's
     // key entirely. Without this, already-resolved authors would flash back
     // to their raw pubkey while the larger batch refetches.

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -266,11 +266,25 @@ export function UserProfilePanel({
   const unfollowMutation = useUnfollowMutation(currentPubkey);
   const { canOpenAgentActivity, openAgentActivity } = useOpenAgentActivity();
   const { goChannel } = useAppNavigation();
-  const profile = resolvePanelProfile({
+  const relayAgent = relayAgentsQuery.data?.find(
+    (agent) => agent.pubkey.toLowerCase() === pubkeyLower,
+  );
+  const baseProfile = resolvePanelProfile({
     managedAgent,
     persona: resolvedPersona,
     profile: profileQuery.data,
   });
+  const profile = relayAgent
+    ? {
+        pubkey: effectivePubkey ?? relayAgent.pubkey,
+        displayName: relayAgent.name || baseProfile?.displayName || null,
+        avatarUrl: relayAgent.avatarUrl ?? baseProfile?.avatarUrl ?? null,
+        about: baseProfile?.about ?? null,
+        nip05Handle: baseProfile?.nip05Handle ?? null,
+        ownerPubkey: relayAgent.ownerPubkey ?? baseProfile?.ownerPubkey ?? null,
+        hasProfileEvent: baseProfile?.hasProfileEvent ?? false,
+      }
+    : baseProfile;
   const ownerPubkey = profile?.ownerPubkey ?? null;
   const ownerProfileQuery = useUserProfileQuery(ownerPubkey ?? undefined);
   const presenceStatus = pubkeyLower
@@ -280,9 +294,6 @@ export function UserProfilePanel({
     ? userStatusQuery.data?.[pubkeyLower]
     : undefined;
 
-  const relayAgent = relayAgentsQuery.data?.find(
-    (agent) => agent.pubkey.toLowerCase() === pubkeyLower,
-  );
   const managedAgentLogQuery = useManagedAgentLogQuery(
     (view === "diagnostics" || view === "logs") &&
       managedAgent?.backend.type === "local"

--- a/desktop/src/features/pulse/ui/PulseView.tsx
+++ b/desktop/src/features/pulse/ui/PulseView.tsx
@@ -103,6 +103,7 @@ export function PulseView({ currentPubkey }: PulseViewProps) {
         agentsByPubkey.set(agent.pubkey, {
           pubkey: agent.pubkey,
           name: agent.name,
+          avatarUrl: null,
           ownerPubkey: null,
           agentType: agent.agentCommand,
           channels: [],

--- a/desktop/src/features/pulse/ui/PulseView.tsx
+++ b/desktop/src/features/pulse/ui/PulseView.tsx
@@ -103,6 +103,7 @@ export function PulseView({ currentPubkey }: PulseViewProps) {
         agentsByPubkey.set(agent.pubkey, {
           pubkey: agent.pubkey,
           name: agent.name,
+          ownerPubkey: null,
           agentType: agent.agentCommand,
           channels: [],
           channelIds: [],

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -106,6 +106,7 @@ type RawSendChannelMessageResult = {
 type RawRelayAgent = {
   pubkey: string;
   name: string;
+  owner_pubkey?: string | null;
   agent_type: string;
   channels: string[];
   channel_ids: string[];
@@ -666,6 +667,7 @@ function fromRawRelayAgent(agent: RawRelayAgent): RelayAgent {
   return {
     pubkey: agent.pubkey,
     name: agent.name,
+    ownerPubkey: agent.owner_pubkey ?? null,
     agentType: agent.agent_type,
     channels: agent.channels,
     channelIds: agent.channel_ids ?? [],

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -106,6 +106,7 @@ type RawSendChannelMessageResult = {
 type RawRelayAgent = {
   pubkey: string;
   name: string;
+  avatar_url?: string | null;
   owner_pubkey?: string | null;
   agent_type: string;
   channels: string[];
@@ -667,6 +668,7 @@ function fromRawRelayAgent(agent: RawRelayAgent): RelayAgent {
   return {
     pubkey: agent.pubkey,
     name: agent.name,
+    avatarUrl: agent.avatar_url ?? null,
     ownerPubkey: agent.owner_pubkey ?? null,
     agentType: agent.agent_type,
     channels: agent.channels,

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -305,6 +305,7 @@ export type RelayMember = {
 export type RelayAgent = {
   pubkey: string;
   name: string;
+  ownerPubkey: string | null;
   agentType: string;
   channels: string[];
   channelIds: string[];

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -305,6 +305,7 @@ export type RelayMember = {
 export type RelayAgent = {
   pubkey: string;
   name: string;
+  avatarUrl: string | null;
   ownerPubkey: string | null;
   agentType: string;
   channels: string[];

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -90,6 +90,8 @@ type MockManagedAgentRuntimeSeed = {
 type MockRelayAgentSeed = {
   pubkey: string;
   name: string;
+  avatarUrl?: string | null;
+  ownerPubkey?: string | null;
   agentType?: string;
   capabilities?: string[];
   respondTo?: RawRelayAgent["respond_to"];
@@ -648,6 +650,8 @@ type RawSendChannelMessageResponse = {
 type RawRelayAgent = {
   pubkey: string;
   name: string;
+  avatar_url?: string | null;
+  owner_pubkey?: string | null;
   agent_type: string;
   channels: string[];
   channel_ids: string[];
@@ -1981,6 +1985,8 @@ function resetMockRelayAgents(config?: E2eConfig) {
     mockRelayAgents.push({
       pubkey: seed.pubkey,
       name: seed.name,
+      avatar_url: seed.avatarUrl ?? null,
+      owner_pubkey: seed.ownerPubkey ?? null,
       agent_type: seed.agentType ?? "goose",
       channels: channels.map((channel) => channel.name),
       channel_ids: channels.map((channel) => channel.id),
@@ -3103,6 +3109,8 @@ function syncMockRelayAgentsFromManagedAgents() {
       return {
         pubkey: agent.pubkey,
         name: agent.name,
+        avatar_url: agent.avatar_url,
+        owner_pubkey: MOCK_IDENTITY_PUBKEY,
         agent_type: agent.agent_command,
         channels: memberships.channels,
         channel_ids: memberships.channelIds,

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1976,6 +1976,9 @@ function resetMockRelayAgents(config?: E2eConfig) {
   }));
 
   for (const seed of config?.mock?.relayAgents ?? []) {
+    mockRelayAgents = mockRelayAgents.filter(
+      (agent) => agent.pubkey.toLowerCase() !== seed.pubkey.toLowerCase(),
+    );
     const channels = mockChannels.filter((channel) => {
       return (
         seed.channelIds?.includes(channel.id) ||

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -177,7 +177,9 @@ test("owned external agents are first-class, labeled, and presentation-customiza
         agentType: "hermes",
         channelNames: ["general", "agents"],
         respondTo: "anyone",
-        status: "online",
+        // Directory metadata is intentionally stale. The card must use the
+        // independent live-presence source, which seeds Alice as online.
+        status: "offline",
       },
     ],
     searchProfiles: [

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -157,7 +157,7 @@ async function invokeTauriExpectError(
 test("owned external agents are first-class, labeled, and presentation-customizable", async ({
   page,
 }) => {
-  const externalPubkey = "a0456f86".repeat(8);
+  const externalPubkey = TEST_IDENTITIES.alice.pubkey;
   await page.route("https://example.com/alice.png", async (route) => {
     await route.fulfill({
       body: Buffer.from(
@@ -175,9 +175,18 @@ test("owned external agents are first-class, labeled, and presentation-customiza
         name: "Alice",
         ownerPubkey: "deadbeef".repeat(8),
         agentType: "hermes",
-        channelNames: ["agents"],
+        channelNames: ["general", "agents"],
         respondTo: "anyone",
         status: "online",
+      },
+    ],
+    searchProfiles: [
+      {
+        pubkey: externalPubkey,
+        displayName: "Alice",
+        avatarUrl: null,
+        ownerPubkey: "deadbeef".repeat(8),
+        isAgent: true,
       },
     ],
   });
@@ -210,6 +219,19 @@ test("owned external agents are first-class, labeled, and presentation-customiza
   await expect(panel).toContainText("ALICE");
   await expect(
     panel.locator('img[src="https://example.com/alice.png"]'),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Close panel" }).click();
+
+  const aliceDm = page.getByTestId("channel-alice-tyler");
+  await expect(
+    aliceDm.locator('img[src="https://example.com/alice.png"]'),
+  ).toBeVisible();
+  await page.getByTestId("channel-general").click();
+  const alicePost = page
+    .getByTestId("message-row")
+    .filter({ hasText: "Hey team — checking in." });
+  await expect(
+    alicePost.locator('img[src="https://example.com/alice.png"]'),
   ).toBeVisible();
 
   await page.reload();

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -154,6 +154,71 @@ async function invokeTauriExpectError(
   );
 }
 
+test("owned external agents are first-class, labeled, and presentation-customizable", async ({
+  page,
+}) => {
+  const externalPubkey = "a0456f86".repeat(8);
+  await page.route("https://example.com/alice.png", async (route) => {
+    await route.fulfill({
+      body: Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+        "base64",
+      ),
+      contentType: "image/png",
+      status: 200,
+    });
+  });
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: externalPubkey,
+        name: "Alice",
+        ownerPubkey: "deadbeef".repeat(8),
+        agentType: "hermes",
+        channelNames: ["agents"],
+        respondTo: "anyone",
+        status: "online",
+      },
+    ],
+  });
+  await gotoApp(page);
+  await page.getByTestId("open-agents-view").click();
+
+  const card = page.getByTestId(`external-agent-card-${externalPubkey}`);
+  await expect(card).toBeVisible();
+  await expect(card).toContainText("Alice");
+  await expect(card).toContainText("External");
+  await expect(card).toContainText("Online");
+
+  await page.getByTestId(`customize-external-agent-${externalPubkey}`).click();
+  const dialog = page.getByTestId("external-agent-presentation-dialog");
+  await expect(dialog).toContainText(
+    "never edits the external runtime, Soul, prompts, memory, or provider files",
+  );
+  await dialog.getByTestId("external-agent-display-name").fill("ALICE");
+  await dialog
+    .getByTestId("external-agent-avatar-url")
+    .fill("https://example.com/alice.png");
+  await dialog.getByTestId("external-agent-display-name").click();
+  await dialog.getByRole("button", { name: "Save appearance" }).click();
+
+  await expect(card).toContainText("ALICE");
+  await card
+    .getByRole("button", { name: "ALICE external agent profile" })
+    .click();
+  const panel = page.getByTestId("user-profile-panel");
+  await expect(panel).toContainText("ALICE");
+  await expect(
+    panel.locator('img[src="https://example.com/alice.png"]'),
+  ).toBeVisible();
+
+  await page.reload();
+  await page.getByTestId("open-agents-view").click();
+  await expect(
+    page.getByTestId(`external-agent-card-${externalPubkey}`),
+  ).toContainText("ALICE");
+});
+
 test("built-in personas are used from the catalog dialog", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 420 });
   await gotoApp(page);

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -187,7 +187,7 @@ async function expectAgentProfileActionsHidden(
   ).toHaveCount(0);
 }
 
-test("@ trigger prioritizes channel members before runnable personas and other managed agents", async ({
+test("@ trigger prioritizes channel members before runnable personas and other agents", async ({
   page,
 }) => {
   await installMockBridge(page, {
@@ -209,7 +209,7 @@ test("@ trigger prioritizes channel members before runnable personas and other m
 
   const dropdown = autocomplete(page);
   await expect(dropdown).toBeVisible();
-  await expect(dropdown.getByText("alice")).toHaveCount(0);
+  await expect(dropdown.getByText("alice")).toBeVisible();
   await expect(dropdown.getByText("bob")).toBeVisible();
   await expect(dropdown.getByText("Fizz")).toBeVisible();
   await expect(dropdown.getByText("charlie")).toBeVisible();
@@ -225,6 +225,7 @@ test("@ trigger prioritizes channel members before runnable personas and other m
 
   const suggestions = dropdown.locator("button");
   const suggestionText = await suggestions.allInnerTexts();
+  const aliceIndex = suggestionText.findIndex((text) => text.includes("alice"));
   const fizzIndex = suggestionText.findIndex((text) => text.includes("Fizz"));
   const bobIndex = suggestionText.findIndex((text) => text.includes("bob"));
   const charlieIndex = suggestionText.findIndex((text) =>
@@ -233,10 +234,12 @@ test("@ trigger prioritizes channel members before runnable personas and other m
   const outsiderIndex = suggestionText.findIndex((text) =>
     text.includes("outsider"),
   );
+  expect(aliceIndex).toBeGreaterThanOrEqual(0);
   expect(fizzIndex).toBeGreaterThanOrEqual(0);
   expect(bobIndex).toBeGreaterThanOrEqual(0);
   expect(charlieIndex).toBeGreaterThanOrEqual(0);
   expect(outsiderIndex).toEqual(-1);
+  expect(aliceIndex).toBeLessThan(fizzIndex);
   expect(bobIndex).toBeLessThan(fizzIndex);
   expect(fizzIndex).toBeLessThan(charlieIndex);
 });
@@ -826,7 +829,7 @@ test("managed relay agents are visible in channel mentions regardless of relay p
   await expect(dropdown.getByText("agent")).toBeVisible();
 });
 
-test("relay-only agents stay hidden from channel mentions even when allowlisted", async ({
+test("relay-only agents are visible in channel mentions when allowlisted", async ({
   page,
 }) => {
   await installMockBridge(page, {
@@ -846,7 +849,9 @@ test("relay-only agents stay hidden from channel mentions even when allowlisted"
   const input = page.getByTestId("message-input");
   await input.fill("@quinn");
 
-  await expect(autocomplete(page)).toHaveCount(0);
+  const dropdown = autocomplete(page);
+  await expect(dropdown.getByText("quinn")).toBeVisible();
+  await expect(dropdown.getByText("agent")).toBeVisible();
 });
 
 test("mentioning an in-channel stopped managed agent starts it before sending", async ({

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -73,6 +73,8 @@ type MockSearchProfileSeed = {
 type MockRelayAgentSeed = {
   pubkey: string;
   name: string;
+  avatarUrl?: string | null;
+  ownerPubkey?: string | null;
   agentType?: string;
   capabilities?: string[];
   respondTo?: "owner-only" | "allowlist" | "anyone";

--- a/docs/hermes-agent-acp.md
+++ b/docs/hermes-agent-acp.md
@@ -86,6 +86,13 @@ every channel where the agent is a member. It also subscribes automatically
 when the agent is added to another channel, so the service does not need a
 restart for ordinary membership changes.
 
+After discovery, the harness publishes the identity's complete kind `10100`
+agent-directory profile. Buzz Desktop uses that record to show externally
+hosted agents under **Agents → External agents** and to decide whether they
+belong in the `@` mention picker. The profile carries the identity's kind `0`
+display name, channel list, verified NIP-OA owner, and inbound author gate; it
+contains no credentials.
+
 ## Configure the bridge
 
 Create a credential file readable only by the service account. The values
@@ -182,13 +189,16 @@ The startup log should show:
 - a successful ACP adapter start;
 - the expected Hermes tools and memory mode;
 - at least one discovered channel.
+- `published agent directory profile`.
 
 Then run a real round trip:
 
-1. Mention the agent in a channel where it has the `bot` role.
-2. Ask it to identify its runtime and reply in the same thread.
-3. Confirm the reply is authored by the dedicated agent public key.
-4. Confirm the reply event is accepted by the relay.
+1. Open **Agents → External agents** and confirm the identity appears by name.
+2. Type `@<agent-name>` in a channel where it has the `bot` role and select it
+   from the composer picker.
+3. Ask it to identify its runtime and reply in the same thread.
+4. Confirm the reply is authored by the dedicated agent public key.
+5. Confirm the reply event is accepted by the relay.
 
 This validates the entire path, not just process health:
 

--- a/docs/hermes-agent-acp.md
+++ b/docs/hermes-agent-acp.md
@@ -1,0 +1,263 @@
+# Run a Hermes Agent in Buzz
+
+Buzz can host an existing [Hermes Agent](https://github.com/NousResearch/hermes-agent)
+through Agent Client Protocol (ACP). Hermes remains the agent runtime and keeps
+its provider configuration, credentials, memory, skills, and tools. `buzz-acp`
+owns the Buzz connection, channel subscriptions, and message delivery.
+
+```text
+Buzz relay <-- WebSocket --> buzz-acp <-- ACP over stdio --> Hermes Agent
+                                |
+                                +-- injects Buzz context and CLI environment
+```
+
+This guide covers a persistent Linux deployment. For a local desktop setup,
+choose **Hermes Agent** in Buzz Desktop after it detects `hermes-acp`. A custom
+command with `hermes` and the argument `acp` is equivalent.
+
+## Prerequisites
+
+- A configured Hermes Agent installation on the host.
+- The Hermes ACP extra and either `hermes acp` or `hermes-acp` on `PATH`.
+- A `buzz-acp` binary built from this repository.
+- A dedicated Buzz/Nostr identity for the agent.
+- Membership for that identity in at least one Buzz channel.
+
+Verify both runtimes before adding credentials:
+
+```bash
+hermes acp --version
+hermes acp --check
+buzz-acp --version
+```
+
+If Hermes ACP is not installed:
+
+```bash
+cd ~/.hermes/hermes-agent
+uv pip install -e '.[acp]'
+```
+
+See the
+[Hermes ACP guide](https://hermes-agent.nousresearch.com/docs/user-guide/features/acp/)
+for the supported installation and provider setup.
+
+Build the Buzz harness:
+
+```bash
+git clone https://github.com/block/buzz.git
+cd buzz
+. ./bin/activate-hermit
+cargo build --release -p buzz-acp -p buzz-cli
+```
+
+Install `target/release/buzz-acp` and `target/release/buzz` somewhere on the
+service account's `PATH`.
+
+## Provision a dedicated Buzz identity
+
+Do not reuse a human identity or another agent's private key. Each agent should
+have its own public identity so membership, attribution, and revocation remain
+independent.
+
+For a self-hosted relay, mint credentials with:
+
+```bash
+cargo run -p buzz-admin -- mint-token \
+  --name "hermes-agent" \
+  --scopes "messages:read,messages:write,channels:read"
+```
+
+For a hosted community, ask the community owner to provision the agent
+identity. Keep the returned private key and API token on the agent host. Share
+only the public key when adding the agent to channels.
+
+Add the public key to each intended channel with the `bot` role:
+
+```bash
+buzz channels add-member \
+  --channel <channel-uuid> \
+  --pubkey <agent-public-key-hex> \
+  --role bot
+```
+
+Channel membership is the access boundary. On startup, `buzz-acp` discovers
+every channel where the agent is a member. It also subscribes automatically
+when the agent is added to another channel, so the service does not need a
+restart for ordinary membership changes.
+
+## Configure the bridge
+
+Create a credential file readable only by the service account. The values
+below are examples; do not commit the real file.
+
+```bash
+BUZZ_RELAY_URL=wss://community.example.com
+BUZZ_PRIVATE_KEY=nsec1...
+BUZZ_API_TOKEN=...
+BUZZ_AUTH_TAG=...
+
+BUZZ_ACP_AGENT_COMMAND=/home/hermes/.local/bin/hermes
+BUZZ_ACP_AGENT_ARGS=acp
+BUZZ_ACP_RESPOND_TO=allowlist
+BUZZ_ACP_RESPOND_TO_ALLOWLIST=<trusted-user-pubkey-hex>
+```
+
+`BUZZ_API_TOKEN` is needed only when the relay enforces token authentication.
+`BUZZ_AUTH_TAG` is needed for owner-authorized operations such as opening
+agent drafts; normal channel messaging does not require it.
+
+Choose the inbound author gate deliberately:
+
+| Value | Behavior |
+|---|---|
+| `owner-only` | Only the registered owner can prompt the agent. This is the default. |
+| `allowlist` | The owner and the listed public keys can prompt the agent. |
+| `anyone` | Any channel member can prompt the agent. Use only for a deliberately open agent. |
+| `nobody` | Ignore inbound prompts; useful only with proactive heartbeat work. |
+
+The default ACP permission mode is `bypassPermissions` because a headless
+message bridge cannot stop at an editor approval dialog. This gives Hermes the
+same host capabilities it has when run non-interactively. Use a dedicated
+operating-system account, limit its filesystem permissions, and restrict the
+inbound author gate. Set `BUZZ_ACP_PERMISSION_MODE=default` only when the ACP
+client and your operational workflow can service permission requests.
+
+## Run under systemd
+
+The service must run as the same operating-system user that owns the intended
+Hermes home. Otherwise Hermes will load a different configuration and memory.
+
+Create `/etc/systemd/system/buzz-hermes.service`:
+
+```ini
+[Unit]
+Description=Buzz ACP bridge for Hermes Agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=hermes
+Group=hermes
+Environment=HOME=/home/hermes
+EnvironmentFile=/etc/buzz-hermes/bridge.env
+ExecStart=/usr/local/bin/buzz-acp
+Restart=always
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Protect the environment file and start the service:
+
+```bash
+sudo install -d -o root -g hermes -m 0750 /etc/buzz-hermes
+sudo chown root:hermes /etc/buzz-hermes/bridge.env
+sudo chmod 0640 /etc/buzz-hermes/bridge.env
+sudo systemctl daemon-reload
+sudo systemctl enable --now buzz-hermes.service
+```
+
+Use `0600` instead when the service itself runs as `root`. Running Hermes as a
+dedicated unprivileged user is preferred.
+
+## Verify the live integration
+
+Check local health without printing secrets:
+
+```bash
+systemctl is-enabled buzz-hermes.service
+systemctl is-active buzz-hermes.service
+systemctl show buzz-hermes.service -p Restart -p User -p EnvironmentFiles
+journalctl -u buzz-hermes.service -n 100 --no-pager
+```
+
+The startup log should show:
+
+- the expected relay URL and Hermes command;
+- a successful ACP adapter start;
+- the expected Hermes tools and memory mode;
+- at least one discovered channel.
+
+Then run a real round trip:
+
+1. Mention the agent in a channel where it has the `bot` role.
+2. Ask it to identify its runtime and reply in the same thread.
+3. Confirm the reply is authored by the dedicated agent public key.
+4. Confirm the reply event is accepted by the relay.
+
+This validates the entire path, not just process health:
+
+```text
+Buzz event -> relay subscription -> buzz-acp -> Hermes ACP turn
+          -> Buzz CLI reply -> signed relay event -> channel thread
+```
+
+## Operational behavior
+
+- Hermes continues to read its normal home, including `config.yaml`, `.env`,
+  skills, memory, and state database.
+- `buzz-acp` injects the Buzz base instructions and authenticated `buzz` CLI
+  environment into the ACP subprocess.
+- One Hermes ACP session is maintained per Buzz channel.
+- New mentions are queued per channel; separate channels can run concurrently
+  when `BUZZ_ACP_AGENTS` is greater than one.
+- Relay disconnects are retried, and channel subscriptions resume with replay
+  protection.
+- `Restart=always` restarts the bridge after a process or host failure.
+
+## Troubleshooting
+
+### Hermes exits during ACP initialization
+
+Run the same command as the service account:
+
+```bash
+sudo -u hermes -H /home/hermes/.local/bin/hermes acp --check
+```
+
+If that fails, fix the Hermes ACP installation or provider configuration before
+debugging Buzz.
+
+### The service is active but the agent does not respond
+
+Check:
+
+- the agent public key has the `bot` role in the channel;
+- the message mentions the agent's exact Buzz identity;
+- the author passes `BUZZ_ACP_RESPOND_TO`;
+- the service account loads the intended Hermes home;
+- the relay URL uses `ws://` or `wss://`, not `http://` or `https://`.
+
+### Hermes can answer but cannot post
+
+Confirm `buzz` is on the service `PATH` and the private key, API token, and
+optional owner authorization belong to the same agent identity.
+
+### A new channel is not discovered
+
+Verify membership from an owner account:
+
+```bash
+buzz channels members --channel <channel-uuid>
+```
+
+The agent should appear with role `bot`. Membership notifications normally add
+the subscription without a restart; restart once if the bridge was offline
+when the membership event was issued.
+
+## Security checklist
+
+- Use one dedicated Buzz identity per agent.
+- Never paste or log `BUZZ_PRIVATE_KEY`, `BUZZ_API_TOKEN`, or `BUZZ_AUTH_TAG`.
+- Store credentials outside the repository with restrictive permissions.
+- Run Hermes under a dedicated unprivileged operating-system account.
+- Prefer `owner-only` or `allowlist` over `anyone`.
+- Grant channel membership only where the agent is expected to work.
+- Review Hermes tool access before using `bypassPermissions`.
+- Rotate and revoke the dedicated identity independently if the host is
+  compromised.

--- a/docs/hermes-agent-acp.md
+++ b/docs/hermes-agent-acp.md
@@ -96,6 +96,13 @@ belong in the `@` mention picker. The profile carries the identity's kind `0`
 display name, channel list, verified NIP-OA owner, and inbound author gate; it
 contains no credentials.
 
+Desktop only treats records with a non-empty `name` or `display_name` as
+directory declarations. A policy-only kind `10100` record therefore remains
+valid for channel-add enforcement without creating a key-only external-agent
+card. The card's Online/Away/Offline indicator comes from the harness's live,
+ephemeral kind `20001` presence heartbeat, matching DMs and profile surfaces;
+kind `10100` is not used as a liveness source.
+
 The verified owner can customize an external agent's display name and avatar
 from that card. This is a Buzz presentation layer: the selected name and avatar
 are applied consistently to the Agents card, profiles, messages, mentions, and

--- a/docs/hermes-agent-acp.md
+++ b/docs/hermes-agent-acp.md
@@ -12,8 +12,11 @@ Buzz relay <-- WebSocket --> buzz-acp <-- ACP over stdio --> Hermes Agent
 ```
 
 This guide covers a persistent Linux deployment. For a local desktop setup,
-choose **Hermes Agent** in Buzz Desktop after it detects `hermes-acp`. A custom
+choose **Hermes Agent** in Buzz Desktop after it detects the official `hermes`
+entrypoint or the direct `hermes-acp` executable. A custom
 command with `hermes` and the argument `acp` is equivalent.
+Desktop prefers the native entrypoint and verifies its optional ACP dependencies
+with `hermes acp --check`.
 
 ## Prerequisites
 

--- a/docs/hermes-agent-acp.md
+++ b/docs/hermes-agent-acp.md
@@ -93,6 +93,12 @@ belong in the `@` mention picker. The profile carries the identity's kind `0`
 display name, channel list, verified NIP-OA owner, and inbound author gate; it
 contains no credentials.
 
+The verified owner can customize an external agent's display name and avatar
+from that card. This is a Buzz presentation layer: the selected name and avatar
+are applied consistently to the Agents card, profiles, messages, mentions, and
+sidebar surfaces without writing to the external runtime, Hermes configuration,
+Soul, prompts, memory, provider, skills, or identity.
+
 ## Configure the bridge
 
 Create a credential file readable only by the service account. The values
@@ -108,6 +114,7 @@ BUZZ_ACP_AGENT_COMMAND=/home/hermes/.local/bin/hermes
 BUZZ_ACP_AGENT_ARGS=acp
 BUZZ_ACP_RESPOND_TO=allowlist
 BUZZ_ACP_RESPOND_TO_ALLOWLIST=<trusted-user-pubkey-hex>
+BUZZ_ACP_RELAY_OBSERVER=true
 ```
 
 `BUZZ_API_TOKEN` is needed only when the relay enforces token authentication.
@@ -129,6 +136,12 @@ same host capabilities it has when run non-interactively. Use a dedicated
 operating-system account, limit its filesystem permissions, and restrict the
 inbound author gate. Set `BUZZ_ACP_PERMISSION_MODE=default` only when the ACP
 client and your operational workflow can service permission requests.
+
+`BUZZ_ACP_RELAY_OBSERVER=true` publishes encrypted kind `24200` ACP telemetry
+frames addressed only to the verified owner. A signed-in owner Desktop can
+decrypt and render the same live Activity transcript used for locally managed
+agents. Observer frames are ephemeral at the relay; Desktop must be online to
+receive them, and local archiving is the durable owner-side record.
 
 ## Run under systemd
 
@@ -188,8 +201,9 @@ The startup log should show:
 - the expected relay URL and Hermes command;
 - a successful ACP adapter start;
 - the expected Hermes tools and memory mode;
-- at least one discovered channel.
-- `published agent directory profile`.
+- at least one discovered channel;
+- `published agent directory profile`;
+- `relay observer enabled` when `BUZZ_ACP_RELAY_OBSERVER=true`.
 
 Then run a real round trip:
 
@@ -199,6 +213,10 @@ Then run a real round trip:
 3. Ask it to identify its runtime and reply in the same thread.
 4. Confirm the reply is authored by the dedicated agent public key.
 5. Confirm the reply event is accepted by the relay.
+6. Customize the external agent's avatar, then verify the same avatar appears
+   on its card, profile, channel messages, and sidebar entry.
+7. Open **Activity log**, trigger a fresh turn while Desktop is online, and
+   confirm the owner can see the live ACP transcript.
 
 This validates the entire path, not just process health:
 
@@ -218,6 +236,8 @@ Buzz event -> relay subscription -> buzz-acp -> Hermes ACP turn
   when `BUZZ_ACP_AGENTS` is greater than one.
 - Relay disconnects are retried, and channel subscriptions resume with replay
   protection.
+- With relay observation enabled, ACP lifecycle, tool, response, and usage
+  frames are encrypted to the owner and appear in Desktop Activity.
 - `Restart=always` restarts the bridge after a process or host failure.
 
 ## Troubleshooting
@@ -259,6 +279,26 @@ buzz channels members --channel <channel-uuid>
 The agent should appear with role `bot`. Membership notifications normally add
 the subscription without a restart; restart once if the bridge was offline
 when the membership event was issued.
+
+### The custom avatar appears only on the Agents card
+
+Use a Desktop build that includes external-agent presentation propagation, then
+refresh the app. The owner presentation must win in profile-backed surfaces;
+Hermes kind `0` and runtime files are intentionally unchanged.
+
+### Activity says there are no observer updates
+
+Check that:
+
+- `BUZZ_ACP_RELAY_OBSERVER=true` is present in the bridge environment;
+- startup logs contain `relay observer enabled`;
+- the Desktop is signed in as the verified agent owner and was online before
+  the test turn started;
+- the test opens Activity for the same agent and channel that received the
+  prompt.
+
+Kind `24200` frames are not queryable from relay history. Trigger a new turn
+after fixing the subscription instead of expecting an old turn to replay.
 
 ## Security checklist
 


### PR DESCRIPTION
## Summary

- add Hermes Agent to the Desktop runtime catalog and document local/VPS deployment
- prefer the official `hermes acp` entrypoint, retain direct `hermes-acp` fallback, and verify optional ACP dependencies with the matching `--check` command
- recognize exact `python` and `python3` interpreter names for marker-owned managed-process cleanup without admitting versioned prefixes or unrelated Python jobs
- publish complete kind `10100` directory profiles from externally hosted `buzz-acp` agents and refresh them after membership changes
- derive external-agent ownership only from a verified NIP-OA auth tag
- show eligible externally hosted agents under **External agents** without local runtime controls
- use live kind `20001` presence for external cards and ignore policy-only kind `10100` records as directory entries
- let verified owners customize an external agent's Buzz display name and avatar without changing its runtime-owned state
- resolve that owner presentation consistently across cards, profiles, messages, mentions, DMs, and sidebars
- ingest encrypted kind `24200` ACP activity from verified owner-declared relay agents into the same Desktop Activity surface used by managed agents
- document the complete external-agent deployment, presentation, observer, and troubleshooting path

## Root cause

Externally hosted agents could have valid identity, ownership, and channel membership while remaining absent from Desktop mention surfaces. Their replaceable kind `10100` record was incomplete, policy changes could clobber it, and Desktop did not carry verified owner identity into eligibility checks.

After directory discovery was fixed, three additional gaps remained: owner-selected external-agent presentation did not win in profile-backed message/sidebar surfaces, observer ingestion only considered locally managed agents, and the Agents card incorrectly treated persistent directory metadata as live presence. Policy-only kind `10100` records could also appear as raw-key cards even though they were not complete agent declarations.

The new path remains fail-closed. Desktop ignores self-claimed owner fields, trusts only a cryptographically valid NIP-OA auth tag, admits only verified owner-declared relay agents to observer ingestion, requires a non-empty `name` or `display_name` for a directory card, and keeps interrupt/runtime controls local-only. Card liveness comes from the same ephemeral kind `20001` heartbeat used by DMs and profile surfaces.

## Hermes runtime design

Hermes exposes ACP over stdio through both `hermes acp` and `hermes-acp`. Desktop now discovers the official `hermes` entrypoint first, supplies its command-specific `acp` default, and runs `hermes acp --check`; the direct executable remains a fallback and is verified with `hermes-acp --check`. A base install without the optional ACP dependencies is therefore reported as adapter-missing rather than authenticated or ready.

Hermes console scripts may run as a virtual-environment Python interpreter. Marker-owned process recognition accepts exact `python` and `python3` names only after the existing `BUZZ_MANAGED_AGENT` ownership check. Versioned names such as `python3.12` and unrelated Python processes remain excluded.

Automatic installation remains disabled because the official ACP-extra install path differs across managed source installs and platforms; Doctor links to Hermes's official setup instructions instead.

Hermes keeps its own model/provider selection and existing `~/.hermes/config.yaml` state. Buzz does not inject parallel provider configuration or replace Hermes memory, skills, tools, prompts, Soul, provider, or identity. Owner customization is stored only as Buzz presentation.

## Live end-to-end proof

The integration is running against an existing Hermes Agent on a supervised Linux VPS:

- `hermes acp --check` returned `OK`
- `buzz-acp` initialized Hermes with its existing memory and native tools
- the dedicated identity appeared in the real owner canary under **External agents**
- an owner-selected avatar appeared on the Agents card, profile, channel post, DM sidebar, and related identity surfaces
- the Agents card now derives Alice's Online state from her live kind `20001` heartbeat, matching the DM sidebar
- a policy-only kind `10100` record for another active identity remains valid for channel-add enforcement but no longer creates a raw-key external-agent card
- `BUZZ_ACP_RELAY_OBSERVER=true` enabled the encrypted owner observer lane
- a fresh Hermes turn produced a complete owner-decrypted Activity transcript in Desktop, including lifecycle, tool, response, timestamp, and usage frames
- the owner-side archive captured 11 signed kind `24200` frames for that live turn
- Hermes-owned runtime state was not modified

No private key, API token, owner authorization, private relay endpoint, or owner-addressed event identifier is included in this PR.

## Validation

External-card presence and directory filtering at head `74e6d5a9127d296446657fe54046ac49b9c222c2`:

- full Desktop Tauri package: 1,567 passed, 13 ignored
- mixer diagnostics: 3 passed
- full Desktop unit suite: 3,405 passed
- full Agents E2E: 20 passed
- TypeScript and production E2E build
- Biome, Rust fmt, Rust clippy with warnings denied, px-text, public-key truncation, and `git diff --check`
- regression coverage proves stale directory status cannot override live presence and policy-only kind `10100` records do not render
- DCO, Semgrep, and zizmor are green on the PR
- required `Co-authored-by` and `Signed-off-by` trailers are present

Reviewer follow-up validation at ancestor `6cf8384fea8959036add7ad48041391e1cb0bad6`:

- exact-match regression coverage for `python`, `python3`, `python3.12`, `python3-config`, and `pythonw`
- native/direct Hermes command defaults and readiness-probe coverage

The file-size gate remains at its existing two baseline failures; this change adds no new violation:

- `desktop/src-tauri/src/managed_agents/discovery/tests.rs`
- `desktop/src/features/messages/lib/useMentions.ts`

## Companion Hermes documentation

- https://github.com/NousResearch/hermes-agent/pull/69915
