### PR TITLE
Show replies inside nested threads on mobile

### DIFF
--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -53,9 +53,12 @@ class ThreadDetailPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // The relay's thread query is root-scoped. Nested thread heads retain the
+    // original root ID, while top-level thread heads use their own ID.
+    final effectiveRootId = threadHead.rootId ?? threadHead.id;
     final repliesState = ref.watch(
       threadRepliesProvider(
-        ThreadRepliesArgs(channelId: channelId, rootId: threadHead.id),
+        ThreadRepliesArgs(channelId: channelId, rootId: effectiveRootId),
       ),
     );
     final replyMessages = repliesState.whenData((events) {
@@ -131,10 +134,6 @@ class ThreadDetailPage extends HookConsumerWidget {
     // Resolve thread head from live data (reactions/edits may have changed).
     final liveHead =
         allMsgs.where((m) => m.id == threadHead.id).firstOrNull ?? threadHead;
-
-    // The root of the entire thread chain. If the current thread head is
-    // itself a root message its rootId is null, so fall back to its own id.
-    final effectiveRootId = threadHead.rootId ?? threadHead.id;
 
     // Channel names for message content rendering.
     final channelsAsync = ref.watch(channelsProvider);

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -142,6 +142,7 @@ Widget _buildTestable({
   ChannelActions Function(Ref ref)? createChannelActions,
   ReadStateNotifier? readStateNotifier,
   _FakeMessagesNotifier? messagesNotifier,
+  _NestedThreadRelaySession? relaySession,
   String? canvasContent,
   List<NostrEvent>? threadReplies,
 }) {
@@ -182,6 +183,8 @@ Widget _buildTestable({
         threadRepliesProvider(
           const ThreadRepliesArgs(channelId: _channelId, rootId: 'thread-root'),
         ).overrideWith((ref) async => threadReplies),
+      if (relaySession != null)
+        relaySessionProvider.overrideWith(() => relaySession),
       // Stub the relay client provider so preloadMembers doesn't crash.
       relayClientProvider.overrideWithValue(
         RelayClient(baseUrl: 'http://localhost:3000'),
@@ -1591,6 +1594,69 @@ void main() {
       expect(find.text(formatDayHeading(rootCreatedAt)), findsOneWidget);
       expect(find.text(formatDayHeading(nextDayCreatedAt)), findsOneWidget);
     });
+
+    testWidgets(
+      'nested thread queries the true root and renders its direct reply',
+      (tester) async {
+        final root = _textMsg(
+          id: 'root',
+          pubkey: 'alice',
+          content: 'Root message',
+          createdAt: 1000,
+        );
+        final nestedHead = _textMsg(
+          id: 'nested-head',
+          pubkey: 'bob',
+          content: 'Nested head',
+          createdAt: 1100,
+          extraTags: const [
+            ['e', 'root', '', 'root'],
+            ['e', 'root', '', 'reply'],
+          ],
+        );
+        final nestedReply = _textMsg(
+          id: 'nested-reply',
+          pubkey: 'carol',
+          content: 'Nested child',
+          createdAt: 1200,
+          extraTags: const [
+            ['e', 'root', '', 'root'],
+            ['e', 'nested-head', '', 'reply'],
+          ],
+        );
+        final relaySession = _NestedThreadRelaySession(
+          expectedRootId: root.id,
+          replies: [nestedHead, nestedReply],
+        );
+
+        await tester.pumpWidget(
+          _buildTestable(
+            messages: [root, nestedHead],
+            relaySession: relaySession,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final threadMessages = formatTimeline([root, nestedHead]);
+        Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+          MaterialPageRoute<void>(
+            builder: (_) => ThreadDetailPage(
+              threadHead: threadMessages.last,
+              allMessages: threadMessages,
+              channelId: _channelId,
+              currentPubkey: 'self',
+              isMember: true,
+              isArchived: false,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(relaySession.queryFilters, hasLength(1));
+        expect(relaySession.queryFilters.single.tags['#e'], [root.id]);
+        expect(findRichText('Nested child'), findsOneWidget);
+      },
+    );
   });
 }
 
@@ -1631,6 +1697,38 @@ class _ErrorMessagesNotifier extends ChannelMessagesNotifier {
   @override
   AsyncValue<List<NostrEvent>> build() =>
       AsyncError('Connection failed', StackTrace.current);
+}
+
+class _NestedThreadRelaySession extends RelaySessionNotifier {
+  final String expectedRootId;
+  final List<NostrEvent> replies;
+  final List<NostrFilter> queryFilters = [];
+
+  _NestedThreadRelaySession({
+    required this.expectedRootId,
+    required this.replies,
+  });
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<List<NostrEvent>> queryRelay(
+    List<NostrFilter> filters, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    queryFilters.addAll(filters);
+    if (filters.single.tags['#e']?.single == expectedRootId) {
+      return replies;
+    }
+    return const [];
+  }
+
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async => const [];
 }
 
 class _FakeTypingNotifier extends ChannelTypingNotifier {


### PR DESCRIPTION
Fixes #2415.

## What mobile users saw

Opening a reply as the head of a nested thread showed no direct replies, even when those replies existed on the relay.

## Why it happened

`ThreadDetailPage` asked `threadRepliesProvider` for relay history using the nested head ID. Relay thread history is keyed by the original root event, so the query returned no history for that nested head.

The page already knew the effective root later in the build and already filtered the result down to direct children. The history query was using the wrong ID.

## What changed

- Query root-scoped history with the original thread root.
- Keep the existing direct-child filter so the nested view still shows only replies to the selected head.
- Add a Flutter widget regression for root `R` → nested head `M` → direct reply `C`.

## How this was tested

The test needed to distinguish two separate identities: relay history is scoped to the original root, while the nested screen must still render only direct children of the selected nested head. Testing only the rendered reply would not prove the relay query used the correct event ID.

### Focused regression coverage

The Flutter widget regression constructs root `R`, nested head `M`, and direct reply `C`. Before the production fix, it expected the relay filter `#e == [R]` and received `[M]`. With the fix, the provider queries history using `R`, the existing child filter selects replies to `M`, and `C` renders in the nested view.

The focused proof is a widget-level relay-history regression. It validates the query and render contract without claiming a live-relay or physical-device end-to-end test.

### Current rebased head

Verified at exact PR head `cc429baa8be179d44d35cb40579e79f3e80f323d`, rebased onto `origin/main` at `dd222a509b156ba52ed3219e895d7bf1cf322c92`:

- `just mobile-check` — formatting unchanged, analyzer clean, and mobile file-size checks passed.
- `just mobile-test` — 656 passed, one skipped.
- `just ci` — Rust formatting and workspace Clippy passed; Desktop dependency-policy and Biome checks passed. The aggregate gate then stopped on an unchanged upstream baseline: `desktop/src-tauri/src/managed_agents/runtime.rs` is 2,220 lines against its 2,216-line ratchet. This PR does not modify that file.

The rebase conflict was limited to the shared mobile test helper after a newer day-divider regression landed. The resolution preserves both the upstream day-divider coverage and this nested-thread regression.
