### PR TITLE
fix(desktop): allow WebKitGTK media permission requests so huddles work on Linux

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1085,6 +1085,7 @@ dependencies = [
  "url",
  "user-idle",
  "uuid",
+ "webkit2gtk",
  "window-vibrancy",
  "windows-sys 0.61.2",
  "zeroize",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -35,6 +35,10 @@ ctrlc = { version = "3", features = ["termination"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { version = "3.6.3", default-features = false, features = ["sync-secret-service", "vendored"], optional = true }
+# Same version tauri links. Needed to reach the native WebKitGTK webview and
+# approve UserMedia permission requests — WebKitGTK denies unhandled requests,
+# which made getUserMedia() (huddle mic) always fail on Linux.
+webkit2gtk = "2.0"
 # Used directly (alongside tauri-plugin-notification) so we can hold the posting
 # D-Bus connection open. GNOME 46+ dismisses a notification the moment that
 # connection is dropped, which the plugin does immediately. Default features

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -187,6 +187,42 @@ pub fn run() {
                 .build(),
         )
         .plugin(
+            tauri::plugin::Builder::<_, ()>::new("linux-media-permissions")
+                .on_webview_ready(|webview| {
+                    // WebKitGTK denies any permission request the embedder
+                    // doesn't handle, so without this getUserMedia() always
+                    // fails on Linux — the huddle mic never connects and the
+                    // huddle tears itself down right after starting. Allow
+                    // media-device requests; everything else keeps the
+                    // default deny.
+                    #[cfg(target_os = "linux")]
+                    {
+                        use webkit2gtk::glib::prelude::*;
+                        use webkit2gtk::{PermissionRequestExt, WebViewExt};
+
+                        let _ = webview.with_webview(|platform_webview| {
+                            platform_webview.inner().connect_permission_request(
+                                |_, request| {
+                                    if request
+                                        .is::<webkit2gtk::UserMediaPermissionRequest>()
+                                        || request
+                                            .is::<webkit2gtk::DeviceInfoPermissionRequest>()
+                                    {
+                                        request.allow();
+                                        true
+                                    } else {
+                                        false
+                                    }
+                                },
+                            );
+                        });
+                    }
+                    #[cfg(not(target_os = "linux"))]
+                    let _ = &webview;
+                })
+                .build(),
+        )
+        .plugin(
             tauri::plugin::Builder::<_, ()>::new("initial-window-reveal")
                 .on_webview_ready(|webview| {
                     if webview.label() != "main" {


### PR DESCRIPTION
## Problem

Huddles have never worked on the Linux desktop app: starting one tears itself down about a second later. The mic never connects.

Root cause: WebKitGTK **denies any permission request the embedder doesn't handle**, and wry's WebKitGTK backend registers no `permission-request` handler (it implements media permissions only on Android and macOS — verified against wry 0.55.1 sources). So `getUserMedia()` always rejects on Linux → `connectAndSetupMedia` throws → `cleanupFailedStart()` ends the huddle. The open dictation PR (#1511) adds UI copy for "mic permission denied" — that's this bug's symptom.

## Implementation

A small `linux-media-permissions` plugin in `desktop/src-tauri/src/lib.rs`: on webview ready, reach the native `webkit2gtk::WebView` via `with_webview` and connect `permission-request`, allowing exactly two request types:

- `UserMediaPermissionRequest` — mic/camera capture (huddles)
- `DeviceInfoPermissionRequest` — device labels for the input picker

Everything else returns `false`, keeping WebKitGTK's default deny — nothing beyond media devices is granted. Compiled out entirely on macOS/Windows.

`Cargo.toml` adds a Linux-only `webkit2gtk = "2.0"` dependency — the same crate + version Tauri already links (2.0.2 in the lockfile), needed only to name the types.

## Testing

An automated test is impractical here: the behavior lives in a native WebKitGTK signal handler that requires a live webview under a compositor. Verified manually on Arch Linux (Hyprland/Wayland, webkit2gtk-4.1 2.52.4):

- Before: start huddle → mic never connects → huddle drops after ~1s, every time.
- After: start huddle → mic connects, huddle stays up, audio works.

Manual test steps: on any Linux machine, build the desktop app, join a community, start a huddle in a channel. Without this patch it self-ends within ~2s; with it, it stays connected.

## Checklist

- `just ci`: all gates pass except `buzz-db` unit test `replica_fence::tests::fence_starts_closed_and_opens_on_advance`, which fails identically on pristine `main` (timestamp precision mismatch: `…237894Z` vs `…237894147Z`, last touched in #2084) — pre-existing and unrelated; happy to file a separate issue.
- Integration tests: N/A — no relay/db/auth changes.
- No new `unwrap()`/`expect()` in production paths; no `unsafe`.
- No new public API surface to document; behavior is documented in code comments.