### PR TITLE
fix(desktop): make starter channels best-effort for community joiners

### DIFF
--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -674,8 +674,21 @@ pub async fn ensure_starter_channels(
         existing_channels = get_channels(state.clone()).await?;
     }
 
+    // Best-effort from here: a spec that still has no match is normal
+    // community evolution, not a failure. In an established community the
+    // starter channels may have been renamed, made private (their kind:39000
+    // is then invisible to a non-member joiner), archived, or converted to a
+    // forum — none of which should block a new member's onboarding.
+    // The freshly-created case needs no rescue either: the relay grants the
+    // creator owner membership at create time, so a slow kind:39000 only
+    // delays sidebar visibility. `ensure_starter_channel_memberships` skips
+    // unmatched specs, joining only the starter channels that are actually
+    // observable.
     if !has_all_starter_channels(&existing_channels) {
-        return Err("starter channels created but metadata not yet available".to_string());
+        eprintln!(
+            "buzz-desktop: ensure_starter_channels: proceeding without full starter set \
+             (metadata missing or channels customized)"
+        );
     }
 
     ensure_starter_channel_memberships(&state, &creator_keys, &mut existing_channels).await?;

--- a/desktop/src/features/onboarding/welcome.test.mjs
+++ b/desktop/src/features/onboarding/welcome.test.mjs
@@ -332,6 +332,31 @@ test("ensureStarterChannels resumes when one starter channel is missing", async 
   assert.equal(ensureCalls, 1);
 });
 
+test("ensureStarterChannels succeeds without a full starter set (customized community)", async () => {
+  // An established community renamed/privatized its starter channels: the
+  // ensure command returns whatever this member can see, and a partial (or
+  // empty) starter match must not throw — joiner onboarding is best-effort.
+  const renamedGeneral = makeChannel({
+    id: "general-channel",
+    name: "town-square",
+    visibility: "open",
+  });
+  let ensureCalls = 0;
+
+  const result = await ensureStarterChannels({
+    getChannels: async () => [renamedGeneral],
+    ensureStarterChannels: async () => {
+      ensureCalls += 1;
+      return [renamedGeneral];
+    },
+  });
+
+  assert.equal(result.generalChannel, null);
+  assert.equal(result.welcomeChannel, null);
+  assert.deepEqual(result.channels, [renamedGeneral]);
+  assert.equal(ensureCalls, 1);
+});
+
 test("isWelcomeExperienceChannel matches legacy Welcome and starter welcome-everyone", () => {
   assert.equal(isWelcomeExperienceChannel(makeChannel()), true);
   assert.equal(

--- a/desktop/src/features/onboarding/welcome.ts
+++ b/desktop/src/features/onboarding/welcome.ts
@@ -41,8 +41,13 @@ type StarterChannelsClient = {
 
 export type StarterChannelsResult = {
   channels: Channel[];
-  generalChannel: Channel;
-  welcomeChannel: Channel;
+  /**
+   * Null when the community's starter channel no longer matches the spec
+   * (renamed, private, archived, or forum). Starter channels are best-effort
+   * for joiners of established communities — a missing match is not an error.
+   */
+  generalChannel: Channel | null;
+  welcomeChannel: Channel | null;
 };
 
 type WelcomeChannelOptions = {
@@ -86,21 +91,17 @@ function findStarterChannel(channels: Channel[], name: string) {
 
 export function findStarterChannels(
   channels: Channel[],
-): Omit<StarterChannelsResult, "channels"> | null {
-  const generalChannel = findStarterChannel(
-    channels,
-    STARTER_GENERAL_CHANNEL_NAME,
-  );
-  const welcomeChannel = findStarterChannel(
-    channels,
-    STARTER_WELCOME_CHANNEL_NAME,
-  );
+): Omit<StarterChannelsResult, "channels"> {
+  return {
+    generalChannel: findStarterChannel(channels, STARTER_GENERAL_CHANNEL_NAME),
+    welcomeChannel: findStarterChannel(channels, STARTER_WELCOME_CHANNEL_NAME),
+  };
+}
 
-  if (!generalChannel || !welcomeChannel) {
-    return null;
-  }
-
-  return { generalChannel, welcomeChannel };
+function hasAllStarterChannels(
+  starters: Omit<StarterChannelsResult, "channels">,
+) {
+  return starters.generalChannel !== null && starters.welcomeChannel !== null;
 }
 
 function hasOnlyCurrentOrAllowedMembers(
@@ -262,22 +263,22 @@ export async function ensureStarterChannels(
 ): Promise<StarterChannelsResult> {
   const existingChannels = await client.getChannels();
   const existingStarters = findStarterChannels(existingChannels);
-  if (existingStarters) {
+  if (hasAllStarterChannels(existingStarters)) {
     return {
       channels: existingChannels,
       ...existingStarters,
     };
   }
 
+  // Best-effort: in an established community the starter channels may have
+  // been renamed, made private, archived, or converted — the ensure command
+  // creates whatever is genuinely missing and returns what this member can
+  // see. A partial (or empty) starter set is fine; it must not fail a
+  // joiner's onboarding.
   const ensuredChannels = await client.ensureStarterChannels();
-  const ensuredStarters = findStarterChannels(ensuredChannels);
-  if (!ensuredStarters) {
-    throw new Error("Starter channels were not available after setup");
-  }
-
   return {
     channels: ensuredChannels,
-    ...ensuredStarters,
+    ...findStarterChannels(ensuredChannels),
   };
 }
 


### PR DESCRIPTION
## Problem

Joining an established community fails onboarding on the "Meet your starter team" screen with:

> starter channels created but metadata not yet available Try again.

Reported for the meshllm community — reproduced by multiple joiners ([#buzz-bugs thread](buzz://message?channel=d14cd131-6084-4c9c-ba4d-24fb6bfc4263&id=3cd62139cbec3f3da327a7b9e5679e46f5c2779e75607d9b75bc9c430e8c8c12)).

`ensure_starter_channels` requires that **every** member — not just the community founder — can observe two channels matching the pristine starter spec (`general` / `welcome-everyone`, open, stream, unarchived). In an established community those channels may have been renamed, made private (their kind:39000 metadata is then invisible to a non-member joiner — channel-scoped storage), archived, or converted to a forum. Any of these makes every subsequent joiner hit the error deterministically. The failure was already effectively non-fatal ("Take me to Buzz" → "Skip for now" after 2 failures), so the error only scared users without protecting anything.

## Fix

Starter-channel setup is a real requirement only for the founder creating them; for a joiner, a customized starter set is normal community evolution. Downgrade both layers to best-effort:

- **`ensure_starter_channels` (Rust, `channels.rs`)** — log and proceed instead of returning `Err` when the full starter set is not observable after create + metadata polling. `ensure_starter_channel_memberships` already skips unmatched specs, so membership joins still happen for whatever starter channels do match. The freshly-created case needs no rescue: the relay grants the creator owner membership at create time, so slow kind:39000 propagation only delays sidebar visibility.
- **`ensureStarterChannels` (TS, `welcome.ts`)** — `StarterChannelsResult.generalChannel` / `welcomeChannel` become nullable instead of throwing `"Starter channels were not available after setup"`. No callers consumed those fields outside tests (verified by grep — only `result.channels` is used in `hooks.ts`).

The private Welcome channel flow is unchanged and was already independent of this failure.

## Testing

- New TS test: `ensureStarterChannels succeeds without a full starter set (customized community)` — renamed `general`, no `welcome-everyone`; asserts no throw, null fields.
- Full desktop JS suite: 3402 pass (includes the new test). Full Tauri Rust suite: 1560 pass. clippy + fmt + tsc + biome clean.
- Pre-push hooks (including relay integration tests) green.
