### PR TITLE
fix(desktop): give Windows agent children a usable PATH and start dev

### DIFF
--- a/desktop/src-tauri/src/managed_agents/runtime/path.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/path.rs
@@ -11,6 +11,8 @@ use std::path::PathBuf;
 ///   4. `nvm_bin` — nvm's default Node.js bin dir (if the user uses nvm)
 ///   5. exe parent dir — DMG sidecars under `Contents/MacOS/`
 ///   6. user's login-shell `PATH` — runtimes like node/python from other managers
+///   7. Windows only: the current process `PATH`, since step 6 is always empty
+///      there and callers replace rather than extend the child's `PATH`
 ///
 /// `shell_path` is the raw colon-delimited string from a login shell, so it is
 /// split into individual entries before joining. Pushing it as a single segment
@@ -46,9 +48,30 @@ pub(in crate::managed_agents) fn build_augmented_path(
     if let Some(parent) = exe_parent {
         parts.push(parent);
     }
+    #[cfg_attr(not(windows), allow(unused_variables))]
+    let had_shell_path = shell_path.is_some();
     if let Some(shell_path) = shell_path {
         parts.extend(std::env::split_paths(&shell_path));
     }
+
+    // Windows never supplies a login-shell PATH: `login_shell_path()` returns
+    // None there because Git Bash reports POSIX colon-delimited entries that
+    // would poison a native child. Nothing above contributes the user's real
+    // PATH, and the child does not fall back to its inherited one either —
+    // callers pass this value to `Command::env("PATH", ..)`, which replaces
+    // rather than extends. Without the process PATH the child loses node, npm
+    // and git, and every npm `.cmd` shim dies with
+    // `'"node"' is not recognized as an internal or external command`.
+    // Gated on local context for the same reason the managed dirs above are:
+    // callers that pass nothing must still get `None` back rather than a PATH
+    // manufactured out of ambient process state.
+    #[cfg(windows)]
+    if !had_shell_path && !parts.is_empty() {
+        parts.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+    }
+
     if parts.is_empty() {
         return None;
     }
@@ -133,5 +156,38 @@ mod tests {
         let result = result.expect("path");
         assert!(result.starts_with("/home/user/.local/bin:"), "{result}");
         assert!(result.ends_with(":/usr/local/bin"), "{result}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn appends_process_path_when_no_shell_path() {
+        // Regression: `login_shell_path()` is always None on Windows, and
+        // callers overwrite the child's PATH rather than extending it, so
+        // without this the child loses node/npm/git and every npm `.cmd` shim
+        // fails with `'"node"' is not recognized`.
+        let _guard = crate::managed_agents::lock_path_mutex();
+        let previous = std::env::var_os("PATH");
+        std::env::set_var("PATH", r"C:\Program Files\nodejs");
+
+        let result = build_augmented_path(Some(PathBuf::from(r"C:\Users\agent")), None, None, None);
+
+        match previous {
+            Some(value) => std::env::set_var("PATH", value),
+            None => std::env::remove_var("PATH"),
+        }
+
+        let result = result.expect("path");
+        assert!(
+            result.starts_with(r"C:\Users\agent\.local\bin;"),
+            "{result}"
+        );
+        assert!(result.ends_with(r";C:\Program Files\nodejs"), "{result}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn process_path_not_manufactured_without_local_context() {
+        let _guard = crate::managed_agents::lock_path_mutex();
+        assert_eq!(build_augmented_path(None, None, None, None), None);
     }
 }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "xyz.block.buzz.app",
   "build": {
     "beforeDevCommand": {
-      "script": "exec ./node_modules/.bin/vite",
+      "script": "node ./node_modules/vite/bin/vite.js",
       "cwd": "..",
       "wait": false
     },


### PR DESCRIPTION
Two separate things stop Buzz working on Windows. Both are small, but together they make the desktop app unusable there.

## Agents can't find node

Every managed agent dies the moment it starts. From `%APPDATA%\xyz.block.buzz.app\agents\logs\`:

```
'"node"' is not recognized as an internal or external command,
ERROR buzz_acp: agent initialize failed: Agent process exited unexpectedly
Error: all 24 agents failed to start — cannot continue
```

`build_augmented_path` assembles the child's PATH from Buzz's managed directories plus the user's login-shell PATH. On Windows the latter is always `None` — `fetch_login_shell_path_inner` returns early there, correctly, since Git Bash reports POSIX colon-delimited entries (`/c/Users/...`) that a native child can't use.

The comment says children "inherit the real Windows PATH instead." They don't. `runtime.rs` does `command.env("PATH", path)`, which replaces the inherited value rather than extending it, so the agent ends up with Buzz's managed directories and nothing else. No node, no npm, no git. The npm `.cmd` shims fail on their first line.

This appends the process PATH on Windows when no shell PATH was supplied. It's gated on `!parts.is_empty()` so callers that pass no local context still get `None` back, matching the existing rule about not manufacturing a PATH out of ambient state.

## `tauri dev` doesn't start

```
'exec' is not recognized as an internal or external command
The "beforeDevCommand" terminated with a non-zero status code.
```

`beforeDevCommand` is `exec ./node_modules/.bin/vite`. `exec` is a POSIX shell builtin, and Tauri runs the script through `cmd.exe` on Windows. Calling Vite through node works everywhere.

One caveat worth a review from someone on the macOS dev loop: `exec` was presumably there to avoid an intermediate shell process so signals reach Vite directly. This change gives that up on Unix. If that matters more than I think, the alternative is a platform-specific config file, which is uglier but keeps the current behaviour.

## Testing

Windows 11 (26100). Two new unit tests cover the PATH change: one asserts the process PATH is appended after the managed directories, the other that no PATH is manufactured without local context. `cargo test -p buzz-desktop --lib managed_agents::runtime::path` passes, and the existing Unix tests are untouched.

For the dev command, `pnpm exec tauri dev` now starts cleanly with no platform-specific config override:

```
Running BeforeDevCommand (`node ./node_modules/vite/bin/vite.js`)
VITE v8.0.16  ready in 984 ms
```

Neither change affects macOS or Linux behaviour: the PATH addition is behind `#[cfg(windows)]`, and on Unix `shell_path` is always `Some`, so the new branch can't be reached even if the cfg were removed.
