### PR TITLE
fix(desktop): allow cross-machine agent mentions

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -6,6 +6,7 @@ import {
   getMentionableAgentPubkeys,
   getSharedChannelIds,
   isAgentIdentityInManagedList,
+  isAgentMentionReachable,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
@@ -156,6 +157,39 @@ test("isAgentIdentityInManagedList: keeps people and only current managed agent 
   assert.equal(
     isAgentIdentityInManagedList(
       { isAgent: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+    ),
+    false,
+  );
+});
+
+test("isAgentMentionReachable: keeps remote channel agents without restoring stale non-members", () => {
+  const managedAgentPubkeys = new Set([PUB_A]);
+
+  assert.equal(
+    isAgentMentionReachable(
+      { isAgent: false, isMember: false, pubkey: PUB_D },
+      managedAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentMentionReachable(
+      { isAgent: true, isMember: false, pubkey: PUB_A },
+      managedAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentMentionReachable(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentMentionReachable(
+      { isAgent: true, isMember: false, pubkey: PUB_C },
       managedAgentPubkeys,
     ),
     false,

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -68,23 +68,17 @@ export function isAgentIdentityInManagedList(
  * Keep agent identities that this client can actually address.
  *
  * Channel members must reach the policy-aware gate below even when their
- * process is managed on another machine. Non-members stay limited to local
- * managed agents or relay agents whose shared-channel/respond-to policy makes
- * them invocable by the current user.
+ * process is managed on another machine. Non-members stay limited to agents
+ * managed by this client.
  */
-export function isAgentIdentityReachableForMentions(
+export function isAgentMentionReachable(
   candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
-  mentionableAgentPubkeys: ReadonlySet<string>,
 ) {
   if (candidate.isAgent !== true) return true;
 
   const normalized = normalizePubkey(candidate.pubkey);
-  return (
-    candidate.isMember === true ||
-    managedAgentPubkeys.has(normalized) ||
-    mentionableAgentPubkeys.has(normalized)
-  );
+  return candidate.isMember === true || managedAgentPubkeys.has(normalized);
 }
 
 export function shouldHideAgentFromMentions({

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -64,6 +64,29 @@ export function isAgentIdentityInManagedList(
   );
 }
 
+/**
+ * Keep agent identities that this client can actually address.
+ *
+ * Channel members must reach the policy-aware gate below even when their
+ * process is managed on another machine. Non-members stay limited to local
+ * managed agents or relay agents whose shared-channel/respond-to policy makes
+ * them invocable by the current user.
+ */
+export function isAgentIdentityReachableForMentions(
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
+  managedAgentPubkeys: ReadonlySet<string>,
+  mentionableAgentPubkeys: ReadonlySet<string>,
+) {
+  if (candidate.isAgent !== true) return true;
+
+  const normalized = normalizePubkey(candidate.pubkey);
+  return (
+    candidate.isMember === true ||
+    managedAgentPubkeys.has(normalized) ||
+    mentionableAgentPubkeys.has(normalized)
+  );
+}
+
 export function shouldHideAgentFromMentions({
   isAgent,
   isMember,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,7 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityReachableForMentions,
+  isAgentMentionReachable,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,13 +246,7 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (
-        !isAgentIdentityReachableForMentions(
-          candidate,
-          managedAgentPubkeys,
-          mentionableAgentPubkeys,
-        )
-      ) {
+      if (!isAgentMentionReachable(candidate, managedAgentPubkeys)) {
         return;
       }
       if (

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,7 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isAgentIdentityReachableForMentions,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,7 +246,13 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (
+        !isAgentIdentityReachableForMentions(
+          candidate,
+          managedAgentPubkeys,
+          mentionableAgentPubkeys,
+        )
+      ) {
         return;
       }
       if (

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -187,7 +187,7 @@ async function expectAgentProfileActionsHidden(
   ).toHaveCount(0);
 }
 
-test("@ trigger prioritizes channel members before runnable personas and other managed agents", async ({
+test("@ trigger prioritizes remote channel agents before runnable personas and other managed agents", async ({
   page,
 }) => {
   await installMockBridge(page, {
@@ -209,7 +209,7 @@ test("@ trigger prioritizes channel members before runnable personas and other m
 
   const dropdown = autocomplete(page);
   await expect(dropdown).toBeVisible();
-  await expect(dropdown.getByText("alice")).toHaveCount(0);
+  await expect(dropdown.getByText("alice")).toBeVisible();
   await expect(dropdown.getByText("bob")).toBeVisible();
   await expect(dropdown.getByText("Fizz")).toBeVisible();
   await expect(dropdown.getByText("charlie")).toBeVisible();
@@ -226,6 +226,7 @@ test("@ trigger prioritizes channel members before runnable personas and other m
   const suggestions = dropdown.locator("button");
   const suggestionText = await suggestions.allInnerTexts();
   const fizzIndex = suggestionText.findIndex((text) => text.includes("Fizz"));
+  const aliceIndex = suggestionText.findIndex((text) => text.includes("alice"));
   const bobIndex = suggestionText.findIndex((text) => text.includes("bob"));
   const charlieIndex = suggestionText.findIndex((text) =>
     text.includes("charlie"),
@@ -234,11 +235,57 @@ test("@ trigger prioritizes channel members before runnable personas and other m
     text.includes("outsider"),
   );
   expect(fizzIndex).toBeGreaterThanOrEqual(0);
+  expect(aliceIndex).toBeGreaterThanOrEqual(0);
   expect(bobIndex).toBeGreaterThanOrEqual(0);
   expect(charlieIndex).toBeGreaterThanOrEqual(0);
   expect(outsiderIndex).toEqual(-1);
+  expect(aliceIndex).toBeLessThan(fizzIndex);
   expect(bobIndex).toBeLessThan(fizzIndex);
   expect(fizzIndex).toBeLessThan(charlieIndex);
+});
+
+test("mentioning a remote channel agent routes its pubkey without starting it locally", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@alice");
+
+  const dropdown = autocomplete(page);
+  await expect(dropdown.getByText("alice")).toBeVisible();
+  await input.press("Enter");
+  await page.keyboard.type(" can you help?");
+
+  const baselineStartCount = commandCount(
+    await readCommandLog(page),
+    "start_managed_agent",
+  );
+  await page.getByTestId("send-message").click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const events = (
+          window as Window & {
+            __BUZZ_E2E_SIGNED_EVENTS__?: Array<{
+              content: string;
+              tags: string[][];
+            }>;
+          }
+        ).__BUZZ_E2E_SIGNED_EVENTS__;
+        return (
+          events?.find((event) => event.content.includes("can you help?"))
+            ?.tags ?? []
+        );
+      }),
+    )
+    .toContainEqual(["p", TEST_IDENTITIES.alice.pubkey]);
+  expect(commandCount(await readCommandLog(page), "start_managed_agent")).toBe(
+    baselineStartCount,
+  );
 });
 
 test("thread autocomplete keeps multiple long names readable in a narrow panel", async ({


### PR DESCRIPTION
## Summary

- allow agents managed on another machine to appear in `@` autocomplete when they are members of the current channel
- preserve the existing `respond-to` policy check and keep non-member remote agents hidden
- route the selected agent pubkey as a Nostr `p` tag without trying to start the remote process locally
- add unit and desktop E2E regression coverage

## Root cause

The mention pipeline correctly identified shared relay agents as invocable, but then applied a local-managed-agent filter before the policy-aware eligibility check. That removed every agent not managed by the current desktop, including valid members running on another machine. Manually typing the name did not restore the missing pubkey tag, so the remote ACP process never received the mention.

## User impact

Users connected to the same community can now discover and invoke an in-channel agent from another machine, subject to that agent's existing `respond-to` policy.

## Manual test

1. Started an agent on Machine A and set **Respond-to** to **Anyone**.
2. Added the agent and the Machine B user to the same channel.
3. Ran this branch on Machine B with `just desktop-standalone`.
4. Confirmed the remote agent appeared in `@` autocomplete and responded after selection.

## Validation

- [x] `just ci`
- [x] focused unit regression test
- [x] focused Playwright smoke tests for remote-agent visibility, Nostr `p`-tag routing, and no local process start
- [x] no new `unwrap()` or `unsafe` code
- [x] no public API, event kind, endpoint, or configuration documentation required
- [ ] `just test` not run; this is a desktop-only change and does not modify relay, database, or auth behavior

Fixes #2508
