### PR TITLE
chore: update Cargo repository URLs from block/sprout to block/buzz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.88.0"
 license = "Apache-2.0"
-repository = "https://github.com/block/sprout"
+repository = "https://github.com/block/buzz"
 
 [workspace.dependencies]
 # Runtime

--- a/crates/buzz-persona/Cargo.toml
+++ b/crates/buzz-persona/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Parser and loader for Buzz persona pack files (.persona.md)"
 license = "Apache-2.0"
-repository = "https://github.com/block/sprout"
+repository = "https://github.com/block/buzz"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## What

The workspace `Cargo.toml` and `crates/buzz-persona/Cargo.toml` still set `repository = "https://github.com/block/sprout"` — the pre-rename URL. This updates both to `https://github.com/block/buzz`.

## Why

The release tooling's repository-name check was already migrated in #1012, but the Cargo package metadata was missed. The old URL still redirects, but published crate metadata and tooling that reads `repository` (docs.rs links, cargo-generated pages, SBOM tooling) should point at the canonical name.

## Testing

Metadata-only change — no code paths affected. `cargo metadata --no-deps` passes, confirming the manifests parse and resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)