### PR TITLE
feat(relay): make Redis pool size configurable, default 16

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ PGDATABASE=buzz
 # Redis 7
 # -----------------------------------------------------------------------------
 REDIS_URL=redis://localhost:6379
+# Max connections in the relay's shared Redis pool (default 16).
+# BUZZ_REDIS_POOL_SIZE=16
 
 # -----------------------------------------------------------------------------
 # Typesense (search)

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -58,6 +58,12 @@ pub struct Config {
     pub read_database_url: Option<String>,
     /// Redis connection URL used by the pub/sub manager.
     pub redis_url: String,
+    /// Maximum connections in the shared Redis pool. Defaults to 16.
+    ///
+    /// deadpool's own default is `CPU_COUNT * 2`, which on a 2-vCPU relay
+    /// pod is only 4 — small enough that rate-limit checks, presence, and
+    /// pub/sub publishes queue behind each other under load.
+    pub redis_pool_size: usize,
     /// Public WebSocket URL of this relay, advertised in NIP-11.
     pub relay_url: String,
     /// Public WebSocket URL of the dedicated device-pairing relay, when configured.
@@ -411,6 +417,12 @@ impl Config {
 
         let redis_url =
             std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+
+        let redis_pool_size = std::env::var("BUZZ_REDIS_POOL_SIZE")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&v| v > 0)
+            .unwrap_or(16);
 
         let relay_url =
             std::env::var("RELAY_URL").unwrap_or_else(|_| "ws://localhost:3000".to_string());
@@ -862,6 +874,7 @@ impl Config {
             database_url,
             read_database_url,
             redis_url,
+            redis_pool_size,
             relay_url,
             pairing_relay_url,
             max_connections,
@@ -928,6 +941,7 @@ mod tests {
         assert!(config.bind_addr.port() > 0);
         assert!(!config.database_url.is_empty());
         assert!(!config.redis_url.is_empty());
+        assert_eq!(config.redis_pool_size, 16);
         assert!(config.max_connections > 0);
         assert!(config.send_buffer_size > 0);
         assert_eq!(config.max_frame_bytes, DEFAULT_MAX_FRAME_BYTES);
@@ -968,6 +982,31 @@ mod tests {
             config.huddle_audio_available,
             "huddle_audio_available should default to true so single-pod (N=1) keeps today's huddle behavior"
         );
+    }
+
+    #[test]
+    fn redis_pool_size_env_override_and_invalid_fallback() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let previous = std::env::var_os("BUZZ_REDIS_POOL_SIZE");
+
+        std::env::set_var("BUZZ_REDIS_POOL_SIZE", "32");
+        let overridden = Config::from_env().expect("config").redis_pool_size;
+
+        std::env::set_var("BUZZ_REDIS_POOL_SIZE", "0");
+        let zero = Config::from_env().expect("config").redis_pool_size;
+
+        std::env::set_var("BUZZ_REDIS_POOL_SIZE", "not-a-number");
+        let junk = Config::from_env().expect("config").redis_pool_size;
+
+        if let Some(value) = previous {
+            std::env::set_var("BUZZ_REDIS_POOL_SIZE", value);
+        } else {
+            std::env::remove_var("BUZZ_REDIS_POOL_SIZE");
+        }
+
+        assert_eq!(overridden, 32);
+        assert_eq!(zero, 16, "zero must fall back to the default");
+        assert_eq!(junk, 16, "unparsable value must fall back to the default");
     }
 
     #[test]

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -334,7 +334,8 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let redis_pool = {
-        let cfg = deadpool_redis::Config::from_url(&config.redis_url);
+        let mut cfg = deadpool_redis::Config::from_url(&config.redis_url);
+        cfg.pool = Some(deadpool_redis::PoolConfig::new(config.redis_pool_size));
         cfg.create_pool(Some(deadpool_redis::Runtime::Tokio1))
             .map_err(|e| anyhow::anyhow!("Redis pool creation failed: {e}"))?
     };


### PR DESCRIPTION
## Why

bb-public relay pods started showing Redis pool waiters today (`buzz_redis_pool_waiting` peaked at 2, `buzz_redis_pool_available` min 1) at ~190 events/s — first waiters since launch day.

Root cause: we never configure the deadpool-redis pool size, so it uses deadpool's default of `CPU_COUNT * 2`. On a 2-vCPU relay pod that's **4 connections**, shared by rate-limit checks, presence, pub/sub publishes, NIP-98 replay guard, and cache invalidation. Confirmed live: every bb-public pod reports `buzz_redis_pool_max = 4`.

## What

- New `BUZZ_REDIS_POOL_SIZE` env var (relay), default **16** when unset; zero/unparsable values fall back to the default.
- Wired into the single shared pool built in `main.rs` (the only production pool construction; test-only pools untouched).
- `.env.example` documents it.

Minimal by design: 16 per pod × 5 pods = 80 Redis connections vs ElastiCache's 65k ceiling — noise for the server, but 4× more headroom where the waiters showed up. No chart change needed; ops can tune per-deploy via env.

## Testing

- New config test: env override (32), zero → fallback, junk → fallback; `defaults_are_valid` asserts the 16 default.
- `cargo test -p buzz-relay`: 735 passed, 1 failed — `api::mesh_demo::tests::demo_join_forwarded_arm_round_trips_echo`, which fails identically on clean `origin/main` at the same SHA (pre-existing, known flake).
- `cargo clippy -p buzz-relay --all-targets` clean, `cargo fmt` clean.

## Observability

Watch `block.buzz_relay.buzz_redis_pool_max` flip 4 → 16 on rollout, and `buzz_redis_pool_waiting` stay at 0.