### PR TITLE
Select Rustls provider in Buzz CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "nostr",
  "rand 0.10.1",
  "reqwest 0.13.4",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/buzz-cli/Cargo.toml
+++ b/crates/buzz-cli/Cargo.toml
@@ -76,6 +76,10 @@ dirs = "6"
 # WebSocket client — ephemeral event publish (kind:20001 is WS-only on the relay)
 buzz-ws-client = { path = "../buzz-ws-client" }
 
+# The release build can enable both rustls providers through other sidecars, so
+# the CLI selects ring explicitly before opening any wss:// connection.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+
 # Random number generation — full jitter for exponential backoff in with_retry
 rand = { workspace = true }
 

--- a/crates/buzz-cli/src/main.rs
+++ b/crates/buzz-cli/src/main.rs
@@ -1,4 +1,21 @@
 #[tokio::main]
 async fn main() {
+    install_rustls_crypto_provider();
     std::process::exit(buzz_cli::run_from_args(std::env::args()).await);
+}
+
+fn install_rustls_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn installs_rustls_crypto_provider_before_websocket_setup() {
+        assert!(rustls::crypto::CryptoProvider::get_default().is_none());
+
+        super::install_rustls_crypto_provider();
+
+        assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+    }
 }


### PR DESCRIPTION
## Why
When `buzz-cli` is built alongside workspace crates that enable Rustls's other crypto backend, both providers are compiled and Rustls panics before the first secure WebSocket connection because it cannot select one automatically.

## What
- Select the `ring` CryptoProvider explicitly at CLI startup
- Add a startup regression test that verifies a provider is installed before WebSocket setup

## Risk Assessment
Low — this only makes the CLI's TLS provider selection deterministic and matches the provider already selected by other Buzz binaries.

## References
- `cargo test -p buzz-cli` — 251 tests passed
- `CMAKE_POLICY_VERSION_MINIMUM=3.5 cargo build --release -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli` — exact combined sidecar build passed

Generated with Codex