### PR TITLE
feat(desktop): register Cursor as native ACP runtime + onboarding harness

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -9,7 +9,7 @@ Buzz Relay ──WS──→ buzz-acp ──stdio──→ Your Agent
                                        (send_message, etc.)
 ```
 
-Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/agentclientprotocol/codex-acp)), and **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)).
+Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **cursor** (native `agent acp`), **codex** (via [codex-acp](https://github.com/agentclientprotocol/codex-acp)), and **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)).
 
 ## Prerequisites
 
@@ -98,6 +98,26 @@ buzz-acp
 Older installs that still expose `claude-code-acp` are also supported. `buzz-acp`
 treats both Claude ACP command names as the same zero-arg runtime.
 
+## Running with Cursor
+
+Cursor's Agent CLI speaks ACP natively — no separate `*-acp` adapter.
+
+```bash
+# Install: https://cursor.com/docs/cli (binary lands as `agent` / `cursor-agent`)
+agent login   # or export CURSOR_API_KEY=...
+
+export BUZZ_ACP_AGENT_COMMAND="agent"
+export BUZZ_ACP_AGENT_ARGS="acp"
+
+buzz-acp
+```
+
+> **Harness note:** Cursor ACP can emit blocking extension methods
+> (`cursor/ask_question`, `cursor/create_plan`). Headless `buzz-acp` needs an
+> explicit client policy for those (auto-allow vs reject-with-reason) so turns
+> neither hang nor over-permit. That policy is a separate design item from
+> registering the runtime in Desktop's `KNOWN_ACP_RUNTIMES`.
+
 ## Configuration
 
 All configuration is via environment variables (or CLI flags — every env var has a matching flag).
@@ -178,7 +198,27 @@ buzz-acp --respond-to anyone
 buzz-acp --respond-to nobody --heartbeat-interval 300
 ```
 
-### Configuration Examples
+### Running with Cursor
+
+Cursor's Agent CLI speaks ACP natively — no separate `*-acp` adapter.
+
+```bash
+# Install: https://cursor.com/docs/cli (binary lands as `agent` / `cursor-agent`)
+agent login   # or export CURSOR_API_KEY=...
+
+export BUZZ_ACP_AGENT_COMMAND="agent"
+export BUZZ_ACP_AGENT_ARGS="acp"
+
+buzz-acp
+```
+
+> **Harness note:** Cursor ACP can emit blocking extension methods
+> (`cursor/ask_question`, `cursor/create_plan`). Headless `buzz-acp` needs an
+> explicit client policy for those (auto-allow vs reject-with-reason) so turns
+> neither hang nor over-permit. That policy is a separate design item from
+> registering the runtime in Desktop's `KNOWN_ACP_RUNTIMES`.
+
+## Configuration Examples
 
 **Single agent, no heartbeat (default):**
 ```bash

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -103,10 +103,11 @@ treats both Claude ACP command names as the same zero-arg runtime.
 Cursor's Agent CLI speaks ACP natively — no separate `*-acp` adapter.
 
 ```bash
-# Install: https://cursor.com/docs/cli (binary lands as `agent` / `cursor-agent`)
-agent login   # or export CURSOR_API_KEY=...
+# Install: https://cursor.com/docs/cli (binary lands as `cursor-agent` (+ optional `agent` shim))
+cursor-agent login   # or export CURSOR_API_KEY=...
+# Prefer cursor-agent — bare `agent` collides with Grok Build PATH shim.
 
-export BUZZ_ACP_AGENT_COMMAND="agent"
+export BUZZ_ACP_AGENT_COMMAND="cursor-agent"
 export BUZZ_ACP_AGENT_ARGS="acp"
 
 buzz-acp
@@ -203,10 +204,11 @@ buzz-acp --respond-to nobody --heartbeat-interval 300
 Cursor's Agent CLI speaks ACP natively — no separate `*-acp` adapter.
 
 ```bash
-# Install: https://cursor.com/docs/cli (binary lands as `agent` / `cursor-agent`)
-agent login   # or export CURSOR_API_KEY=...
+# Install: https://cursor.com/docs/cli (binary lands as `cursor-agent` (+ optional `agent` shim))
+cursor-agent login   # or export CURSOR_API_KEY=...
+# Prefer cursor-agent — bare `agent` collides with Grok Build PATH shim.
 
-export BUZZ_ACP_AGENT_COMMAND="agent"
+export BUZZ_ACP_AGENT_COMMAND="cursor-agent"
 export BUZZ_ACP_AGENT_ARGS="acp"
 
 buzz-acp

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -14,10 +14,11 @@ mod runtime_metadata;
 
 pub(crate) use runtime_metadata::KnownAcpRuntime;
 
-const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
-const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
-const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
-const BUZZ_AGENT_AVATAR_URL: &str =
+pub(crate) const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
+pub(crate) const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
+pub(crate) const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
+pub(crate) const CURSOR_AVATAR_URL: &str = "https://www.cursor.com/favicon.ico";
+pub(crate) const BUZZ_AGENT_AVATAR_URL: &str =
     "https://raw.githubusercontent.com/block/buzz/refs/heads/main/crates/buzz-agent/buzz-agent.png";
 
 fn common_binary_paths() -> &'static [PathBuf] {
@@ -39,6 +40,7 @@ fn common_binary_paths() -> &'static [PathBuf] {
             paths.extend([
                 home.join(".local/share/mise/shims"),
                 home.join(".local/bin"),
+                home.join(".cursor/bin"),
                 home.join(".volta/bin"),
                 home.join(".asdf/shims"),
             ]);
@@ -162,6 +164,42 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         login_hint: Some("Run `codex login` to authenticate."),
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
         auth_probe_args: Some(&["codex", "login", "status"]),
+    },
+
+    // Cursor Agent CLI speaks ACP natively (`agent acp` / `cursor-agent acp`) —
+    // no separate *-acp npm adapter (same class as Goose). Auth: `agent login`
+    // or CURSOR_API_KEY. Headless extension methods (ask_question / create_plan)
+    // need a separate buzz-acp client policy; not part of this registry entry.
+    KnownAcpRuntime {
+        id: "cursor",
+        label: "Cursor",
+        commands: &["agent", "cursor-agent"],
+        aliases: &["cursor"],
+        avatar_url: CURSOR_AVATAR_URL,
+        mcp_command: Some("buzz-dev-mcp"),
+        mcp_hooks: false,
+        underlying_cli: Some("agent"),
+        cli_install_commands: &["curl -fsSL https://cursor.com/install | bash"],
+        cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://cursor.com/install?win32=true | iex\""],
+        adapter_install_commands: &[],
+        install_instructions_url: "https://cursor.com/docs/cli/acp",
+        cli_install_hint: "Install the Cursor Agent CLI via the official install script.",
+        adapter_install_hint: "",
+        skill_dir: Some(".cursor/skills"),
+        supports_acp_model_switching: false,
+        model_env_var: None,
+        provider_env_var: None,
+        provider_locked: false,
+        default_env: &[],
+        config_file_path: Some("~/.cursor/cli-config.json"),
+        config_file_format: Some("json"),
+        supports_acp_native_config: false,
+        thinking_env_var: None,
+        max_tokens_env_var: None,
+        context_limit_env_var: None,
+        required_normalized_fields: &[],
+        login_hint: Some("Run `agent login` to authenticate (or set CURSOR_API_KEY)."),
+        auth_probe_args: Some(&["agent", "status"]),
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -456,7 +494,8 @@ pub fn try_record_agent_command(
 
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
-        "goose" => Some(vec!["acp".to_string()]),
+        // goose + Cursor speak ACP as a subcommand (`goose acp`, `agent acp`).
+        "goose" | "agent" | "cursor-agent" | "cursor" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -166,24 +166,30 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         auth_probe_args: Some(&["codex", "login", "status"]),
     },
 
-    // Cursor Agent CLI speaks ACP natively (`agent acp` / `cursor-agent acp`) —
-    // no separate *-acp npm adapter (same class as Goose). Auth: `agent login`
-    // or CURSOR_API_KEY. Headless extension methods (ask_question / create_plan)
-    // need a separate buzz-acp client policy; not part of this registry entry.
+    // Cursor Agent CLI speaks ACP natively (`cursor-agent acp` / `agent acp`).
+    // IMPORTANT: both Cursor and Grok Build install a PATH shim named `agent`
+    // (`~/.local/bin/agent`). Prefer the unambiguous `cursor-agent` binary and
+    // only accept bare `agent` when the resolved path is clearly Cursor's
+    // (see `is_cursor_agent_binary`). Never process-sweep bare `agent`.
+    // Auth: `cursor-agent login` / `agent login` or CURSOR_API_KEY.
+    // Headless extension methods (ask_question / create_plan) need a separate
+    // buzz-acp client policy; not part of this registry entry.
     KnownAcpRuntime {
         id: "cursor",
         label: "Cursor",
-        commands: &["agent", "cursor-agent"],
+        // Prefer the unambiguous name first so discovery does not bind Grok's
+        // `~/.local/bin/agent` shim when both are installed.
+        commands: &["cursor-agent"],
         aliases: &["cursor"],
         avatar_url: CURSOR_AVATAR_URL,
         mcp_command: Some("buzz-dev-mcp"),
         mcp_hooks: false,
-        underlying_cli: Some("agent"),
+        underlying_cli: Some("cursor-agent"),
         cli_install_commands: &["curl -fsSL https://cursor.com/install | bash"],
         cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://cursor.com/install?win32=true | iex\""],
         adapter_install_commands: &[],
         install_instructions_url: "https://cursor.com/docs/cli",
-        cli_install_hint: "Install the Cursor Agent CLI via the official install script.",
+        cli_install_hint: "Install the Cursor Agent CLI via the official install script (provides `cursor-agent` and an `agent` shim).",
         adapter_install_hint: "",
         skill_dir: Some(".cursor/skills"),
         supports_acp_model_switching: false,
@@ -198,9 +204,10 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         max_tokens_env_var: None,
         context_limit_env_var: None,
         required_normalized_fields: &[],
-        login_hint: Some("Run `agent login` to authenticate (or set CURSOR_API_KEY)."),
-        auth_probe_args: Some(&["agent", "status"]),
+        login_hint: Some("Run `cursor-agent login` to authenticate (or set CURSOR_API_KEY)."),
+        auth_probe_args: Some(&["cursor-agent", "status"]),
     },
+
     KnownAcpRuntime {
         id: "buzz-agent",
         label: "Buzz Agent",
@@ -287,8 +294,35 @@ fn normalize_command_identity(command: &str) -> String {
     lower
 }
 
+
+/// True when a resolved binary path is Cursor's Agent CLI (not Grok's `agent` shim).
+///
+/// Cursor installs:
+///   ~/.local/bin/cursor-agent -> ~/.local/share/cursor-agent/versions/.../cursor-agent
+///   ~/.local/bin/agent        -> same target (ambiguous name)
+/// Grok Build installs:
+///   ~/.grok/bin/agent -> grok binary
+///   ~/.local/bin/agent -> ~/.grok/bin/agent
+fn is_cursor_agent_binary(path: &Path) -> bool {
+    let s = path.to_string_lossy().replace('\\', "/").to_ascii_lowercase();
+    s.contains("cursor-agent")
+        || s.contains("/cursor-agent/")
+        || s.contains(".local/share/cursor-agent/")
+}
+
 pub(crate) fn known_acp_runtime(command: &str) -> Option<&'static KnownAcpRuntime> {
     let normalized = normalize_command_identity(command);
+
+    // Path-qualified bare `agent` that resolves to Cursor's install tree.
+    // Basename-only `agent` must NOT match Cursor — Grok uses the same name.
+    if normalized == "agent" {
+        let path = Path::new(command.trim());
+        if path.is_absolute() || command.contains('/') || command.contains('\\') {
+            if is_cursor_agent_binary(path) {
+                return known_acp_runtime_exact("cursor");
+            }
+        }
+    }
 
     KNOWN_ACP_RUNTIMES.iter().find(|runtime| {
         normalized == runtime.id
@@ -494,8 +528,9 @@ pub fn try_record_agent_command(
 
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
-        // goose + Cursor speak ACP as a subcommand (`goose acp`, `agent acp`).
-        "goose" | "agent" | "cursor-agent" | "cursor" => Some(vec!["acp".to_string()]),
+        // goose + Cursor speak ACP as a subcommand (`goose acp`, `cursor-agent acp`).
+        // Bare `agent` omitted: Grok Build also installs an `agent` PATH shim.
+        "goose" | "cursor-agent" | "cursor" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,
@@ -1333,6 +1368,21 @@ fn discover_acp_runtime_phase1(runtime: &'static KnownAcpRuntime) -> PartialEntr
         .commands
         .iter()
         .find_map(|command| find_command(command).map(|path| (*command, path)));
+
+    // Cursor: install also ships a PATH shim named `agent`. If
+    // `cursor-agent` is missing from PATH but the shim points at
+    // Cursor's tree, treat it as the adapter (never Grok's agent).
+    let adapter_result = if adapter_result.is_none() && runtime.id == "cursor" {
+        find_command("agent").and_then(|path| {
+            if is_cursor_agent_binary(&path) {
+                Some(("agent", path))
+            } else {
+                None
+            }
+        })
+    } else {
+        adapter_result
+    };
 
     let underlying_cli_found = runtime
         .underlying_cli

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -182,7 +182,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         cli_install_commands: &["curl -fsSL https://cursor.com/install | bash"],
         cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://cursor.com/install?win32=true | iex\""],
         adapter_install_commands: &[],
-        install_instructions_url: "https://cursor.com/docs/cli/acp",
+        install_instructions_url: "https://cursor.com/docs/cli",
         cli_install_hint: "Install the Cursor Agent CLI via the official install script.",
         adapter_install_hint: "",
         skill_dir: Some(".cursor/skills"),

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -73,13 +73,11 @@ fn normalizes_claude_and_codex_args_to_empty() {
 }
 
 
+
 #[test]
 fn normalizes_cursor_args_to_acp_subcommand() {
-    // Cursor speaks ACP natively as `agent acp` (same shape as goose).
-    assert_eq!(
-        normalize_agent_args("agent", Vec::new()),
-        vec!["acp".to_string()]
-    );
+    // Cursor speaks ACP natively as `cursor-agent acp` (same shape as goose).
+    // Bare `agent` must NOT get Cursor defaults — Grok owns that PATH name too.
     assert_eq!(
         normalize_agent_args("cursor-agent", Vec::new()),
         vec!["acp".to_string()]
@@ -89,30 +87,56 @@ fn normalizes_cursor_args_to_acp_subcommand() {
         vec!["acp".to_string()]
     );
     assert_eq!(
-        normalize_agent_args("agent", vec!["acp".into()]),
+        normalize_agent_args("cursor-agent", vec!["acp".into()]),
         vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("agent", Vec::new()),
+        Vec::<String>::new(),
+        "bare agent must not inherit Cursor acp defaults (Grok collision)"
     );
 }
 
 #[test]
 fn resolves_cursor_avatar() {
     assert_eq!(
-        managed_agent_avatar_url("agent"),
-        Some(CURSOR_AVATAR_URL.to_string())
-    );
-    assert_eq!(
         managed_agent_avatar_url("cursor-agent"),
         Some(CURSOR_AVATAR_URL.to_string())
     );
     assert_eq!(
-        managed_agent_avatar_url("/Users/me/.local/bin/agent"),
+        managed_agent_avatar_url("/Users/me/.local/bin/cursor-agent"),
         Some(CURSOR_AVATAR_URL.to_string())
     );
     assert_eq!(
         managed_agent_avatar_url("cursor"),
         Some(CURSOR_AVATAR_URL.to_string())
     );
+    // Basename-only `agent` is ambiguous (Grok) — no Cursor avatar.
+    assert_eq!(managed_agent_avatar_url("agent"), None);
 }
+
+#[test]
+fn path_qualified_cursor_agent_resolves_to_cursor_runtime() {
+    use super::known_acp_runtime;
+    let rt = known_acp_runtime(
+        "/Users/me/.local/share/cursor-agent/versions/1.0.0/cursor-agent",
+    )
+    .expect("path-qualified cursor-agent should resolve");
+    assert_eq!(rt.id, "cursor");
+
+    // Grok's agent path must not resolve as Cursor.
+    assert!(
+        known_acp_runtime("/Users/me/.grok/bin/agent").is_none()
+            || known_acp_runtime("/Users/me/.grok/bin/agent")
+                .is_some_and(|r| r.id != "cursor"),
+        "Grok agent path must not map to Cursor"
+    );
+    assert!(
+        known_acp_runtime("agent").is_none(),
+        "basename-only agent must not map to Cursor"
+    );
+}
+
 
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -8,7 +8,7 @@ use super::{
     is_login_shell_path_uninit, is_safe_nvm_tag, managed_agent_avatar_url, normalize_agent_args,
     parse_semver_tag, preset_catalog_entry, probe_codex_acp_major_version, record_agent_command,
     refresh_login_shell_path, try_record_agent_command, PresetHarness, BUZZ_AGENT_AVATAR_URL,
-    CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL, GOOSE_AVATAR_URL,
+    CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL, CURSOR_AVATAR_URL, GOOSE_AVATAR_URL,
 };
 use crate::managed_agents::AcpAvailabilityStatus;
 
@@ -71,6 +71,49 @@ fn normalizes_claude_and_codex_args_to_empty() {
         Vec::<String>::new()
     );
 }
+
+
+#[test]
+fn normalizes_cursor_args_to_acp_subcommand() {
+    // Cursor speaks ACP natively as `agent acp` (same shape as goose).
+    assert_eq!(
+        normalize_agent_args("agent", Vec::new()),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("cursor-agent", Vec::new()),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("cursor", Vec::new()),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("agent", vec!["acp".into()]),
+        vec!["acp".to_string()]
+    );
+}
+
+#[test]
+fn resolves_cursor_avatar() {
+    assert_eq!(
+        managed_agent_avatar_url("agent"),
+        Some(CURSOR_AVATAR_URL.to_string())
+    );
+    assert_eq!(
+        managed_agent_avatar_url("cursor-agent"),
+        Some(CURSOR_AVATAR_URL.to_string())
+    );
+    assert_eq!(
+        managed_agent_avatar_url("/Users/me/.local/bin/agent"),
+        Some(CURSOR_AVATAR_URL.to_string())
+    );
+    assert_eq!(
+        managed_agent_avatar_url("cursor"),
+        Some(CURSOR_AVATAR_URL.to_string())
+    );
+}
+
 
 #[test]
 fn resolves_buzz_agent_avatar() {

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -444,7 +444,11 @@ fn collect_missing_requirements(
         ),
         "codex" => cli_login::requirements(&["codex", "login", "status"], "run `codex login`", rt),
         "cursor" => {
-            cli_login::requirements(&["agent", "status"], "run `agent login`", rt)
+            cli_login::requirements(
+                &["cursor-agent", "status"],
+                "run `cursor-agent login`",
+                rt,
+            )
         }
         _ => vec![],
     }

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -393,6 +393,8 @@ impl AgentReadiness {
 /// * **claude**: a successful `claude auth status` probe.
 /// * **codex**: a successful `codex login status` probe (checks the codex
 ///   credential store — NOT `OPENAI_API_KEY`).
+/// * **cursor**: a successful `agent status` probe (`agent login` / `CURSOR_API_KEY`).
+/// * **grok**: a successful `grok auth status` probe when available, else env `XAI_API_KEY`.
 /// * **unknown / custom command**: always `Ready` (no requirements known).
 ///
 /// Databricks note: `DATABRICKS_TOKEN` is `.unwrap_or_default()` in

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -441,6 +441,9 @@ fn collect_missing_requirements(
             rt,
         ),
         "codex" => cli_login::requirements(&["codex", "login", "status"], "run `codex login`", rt),
+        "cursor" => {
+            cli_login::requirements(&["agent", "status"], "run `agent login`", rt)
+        }
         _ => vec![],
     }
 }

--- a/desktop/src-tauri/src/managed_agents/runtime/process.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/process.rs
@@ -17,6 +17,10 @@ pub(crate) const KNOWN_AGENT_BINARIES: &[&str] = &[
     "codex-acp",
     "codex_acp",
     "goose",
+    // Cursor Agent CLI (native ACP via `cursor-agent acp`).
+    // Do NOT list bare "agent" — Grok Build installs the same process name.
+    "cursor-agent",
+    "cursor_agent",
     // buzz-dev-mcp's multicall personalities (rg, tree, buzz,
     // git-credential-nostr, git-sign-nostr) are short-lived per-tool-call
     // invocations — not listed here.

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -107,21 +107,27 @@ fn codex_has_mcp_command() {
 
 #[test]
 fn cursor_runtime_resolves_native_acp() {
-    use crate::managed_agents::discovery::known_acp_runtime;
-    let p = known_acp_runtime("agent").expect("cursor agent should resolve");
+    use crate::managed_agents::discovery::{known_acp_runtime, normalize_agent_args};
+    let p = known_acp_runtime("cursor-agent").expect("cursor-agent should resolve");
     assert_eq!(p.id, "cursor");
     assert!(!p.mcp_hooks);
     assert_eq!(p.skill_dir, Some(".cursor/skills"));
     assert_eq!(p.mcp_command, Some("buzz-dev-mcp"));
     assert!(
-        known_acp_runtime("cursor-agent").is_some_and(|r| r.id == "cursor"),
-        "cursor-agent alias should resolve"
-    );
-    assert!(
         known_acp_runtime("cursor").is_some_and(|r| r.id == "cursor"),
         "cursor id/alias should resolve"
     );
+    // Bare agent is NOT Cursor (Grok collision).
+    assert!(
+        known_acp_runtime("agent").is_none(),
+        "bare agent must not resolve as Cursor"
+    );
+    assert_eq!(
+        normalize_agent_args("cursor-agent", Vec::new()),
+        vec!["acp".to_string()]
+    );
 }
+
 
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -106,6 +106,25 @@ fn codex_has_mcp_command() {
 }
 
 #[test]
+fn cursor_runtime_resolves_native_acp() {
+    use crate::managed_agents::discovery::known_acp_runtime;
+    let p = known_acp_runtime("agent").expect("cursor agent should resolve");
+    assert_eq!(p.id, "cursor");
+    assert!(!p.mcp_hooks);
+    assert_eq!(p.skill_dir, Some(".cursor/skills"));
+    assert_eq!(p.mcp_command, Some("buzz-dev-mcp"));
+    assert!(
+        known_acp_runtime("cursor-agent").is_some_and(|r| r.id == "cursor"),
+        "cursor-agent alias should resolve"
+    );
+    assert!(
+        known_acp_runtime("cursor").is_some_and(|r| r.id == "cursor"),
+        "cursor id/alias should resolve"
+    );
+}
+
+
+#[test]
 fn goose_has_no_mcp_hooks() {
     let p = known_acp_runtime("goose").expect("should resolve");
     assert!(!p.mcp_hooks);

--- a/desktop/src/features/onboarding/ui/agentReadiness.ts
+++ b/desktop/src/features/onboarding/ui/agentReadiness.ts
@@ -47,7 +47,9 @@ export function resolveAgentReadiness(
   }
 
   if (
-    (preferredRuntime.id === "claude" || preferredRuntime.id === "codex") &&
+    (preferredRuntime.id === "claude" ||
+      preferredRuntime.id === "codex" ||
+      preferredRuntime.id === "cursor") &&
     (preferredRuntime.authStatus.status === "logged_in" ||
       preferredRuntime.authStatus.status === "not_applicable")
   ) {

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
@@ -12,17 +12,19 @@ function runtime(id, availability, status) {
   return { id, availability, authStatus: { status } };
 }
 
-test("all bundled harnesses are visible in onboarding", () => {
+test("all bundled harnesses plus Cursor are visible in onboarding", () => {
   assert.equal(runtimeIsVisibleInOnboarding("claude"), true);
   assert.equal(runtimeIsVisibleInOnboarding("codex"), true);
   assert.equal(runtimeIsVisibleInOnboarding("goose"), true);
   assert.equal(runtimeIsVisibleInOnboarding("buzz-agent"), true);
+  assert.equal(runtimeIsVisibleInOnboarding("cursor"), true);
   assert.equal(runtimeIsVisibleInOnboarding("custom"), false);
 });
 
 test("visible onboarding runtimes use the product order", () => {
   const runtimes = [
     runtime("buzz-agent", "available", "not_applicable"),
+    runtime("cursor", "available", "logged_in"),
     runtime("codex", "available", "logged_in"),
     runtime("goose", "available", "not_applicable"),
     runtime("claude", "available", "logged_in"),
@@ -30,7 +32,7 @@ test("visible onboarding runtimes use the product order", () => {
 
   assert.deepEqual(
     getVisibleOnboardingRuntimes(runtimes).map(({ id }) => id),
-    ["claude", "codex", "goose", "buzz-agent"],
+    ["claude", "codex", "goose", "buzz-agent", "cursor"],
   );
 });
 

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
@@ -5,6 +5,7 @@ export const ONBOARDING_RUNTIME_ORDER = [
   "codex",
   "goose",
   "buzz-agent",
+  "cursor",
 ];
 
 const VISIBLE_ONBOARDING_RUNTIME_IDS = new Set<string>(


### PR DESCRIPTION
## Summary

Register **Cursor** as a first-class ACP harness and show it on **Set up your agent harnesses** next to Claude Code and Codex.

Closes #2535. Related: #1683 (prior Cursor PR), #2347 / #2546 (Grok Build companion).

## Why this PR exists

Onboarding currently hard-filters visible harnesses to `claude` + `codex` only (`ONBOARDING_RUNTIME_ORDER`). Cursor users cannot Install/sign-in on that page even though Cursor speaks ACP natively:

```bash
cursor-agent acp
```

## Critical design note (Grok collision)

**Both Cursor and Grok Build install `~/.local/bin/agent`.** This PR deliberately:

- Uses **`cursor-agent`** as the catalog command (not bare `agent`)
- Only treats path-qualified `agent` as Cursor when the binary path is under Cursor’s install tree
- Does **not** process-sweep bare `agent` (would claim Grok workers)

## What changed

- `KNOWN_ACP_RUNTIMES`: `cursor` entry (`cursor-agent`, default args `acp`, install script, `cursor-agent status` auth probe, `.cursor/skills`, `~/.cursor/bin` on PATH)
- Readiness + process-sweep binary names (`cursor-agent` only)
- Onboarding visibility order: `claude`, `codex`, **`cursor`**
- `agentReadiness` treats Cursor like other CLI harnesses
- Unit tests for arg normalization, avatar, path disambiguation vs Grok
- `buzz-acp` README: Cursor path + extension-method follow-up note

## Non-claims

- Does **not** implement auto-allow policy for Cursor blocking extension methods (follow-up).
- Does **not** implement Grok Build (see #2546 / #2347).

## Test plan

- [x] `cargo test --lib normalizes_cursor`
- [x] `cargo test --lib resolves_cursor`
- [x] `cargo test --lib path_qualified_cursor`
- [x] `cargo test --lib cursor_runtime`
- [x] `node --test onboardingRuntimeSelection.test.mjs`
- [ ] Desktop: harness page shows Cursor Install; after `cursor-agent login`, Next enables
- [ ] Machine with Grok installed: Cursor still resolves via `cursor-agent`, not Grok’s `agent` shim

Signed-off-by: Bartok9 <danielrpike9@gmail.com>