### PR TITLE
fix(desktop): dedupe transcript turn-block keys across session runs

### DIFF
--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.test.mjs
@@ -1718,9 +1718,14 @@ test("getDisplayBlockKey_single_returnsItemId", () => {
   assert.equal(getDisplayBlockKey(block), "item-42");
 });
 
-test("getDisplayBlockKey_turn_returnsPrefixedTurnId", () => {
-  const block = { kind: "turn", turnId: "t-99", segments: [] };
-  assert.equal(getDisplayBlockKey(block), "turn:t-99");
+test("getDisplayBlockKey_turn_returnsPrefixedTurnIdAndFirstItemId", () => {
+  const block = {
+    kind: "turn",
+    turnId: "t-99",
+    firstItemId: "item-1",
+    segments: [],
+  };
+  assert.equal(getDisplayBlockKey(block), "turn:t-99:item-1");
 });
 
 test("getDisplayBlockKey_sessionBoundary_usesFirstItemIdNotRunIndex", () => {
@@ -1807,6 +1812,35 @@ test("getDisplayBlockKey_parity_matchesBuildTranscriptDisplayBlocksOutput", () =
 
   // No duplicates.
   assert.equal(new Set(keys).size, keys.length, "all keys must be unique");
+});
+
+test("getDisplayBlockKey_turnSplitAcrossSessionRuns_keysUnique", () => {
+  // A session restart mid-turn splits one turn's items across two session
+  // runs. Each run emits its own turn block for the same turnId — their React
+  // keys must still be distinct (regression: duplicate `turn:<id>` keys).
+  const items = [
+    sessionItem("a", "sess-1", "2026-07-08T00:00:00.000Z"),
+    sessionItem("b", "sess-1", "2026-07-08T00:00:01.000Z"),
+    sessionItem("c", "sess-2", "2026-07-08T00:00:02.000Z"),
+  ];
+  for (const item of items) {
+    item.turnId = "turn-split";
+  }
+
+  const blocks = buildTranscriptDisplayBlocks(items, null);
+  const turnBlocks = blocks.filter((b) => b.kind === "turn");
+  assert.equal(
+    turnBlocks.length,
+    2,
+    "turn split across two runs emits two turn blocks (test setup sanity)",
+  );
+
+  const keys = blocks.map(getDisplayBlockKey);
+  assert.equal(
+    new Set(keys).size,
+    keys.length,
+    `all keys must be unique, got: ${keys.join(", ")}`,
+  );
 });
 
 // ── Key-parity invariant: transient [turn, single] → [single, turn] reorder ──

--- a/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptGrouping.ts
@@ -15,7 +15,20 @@ export type TranscriptTurnSegment =
 
 export type TranscriptDisplayBlock =
   | { kind: "single"; item: TranscriptItem }
-  | { kind: "turn"; turnId: string; segments: TranscriptTurnSegment[] }
+  | {
+      kind: "turn";
+      turnId: string;
+      /**
+       * The `id` of the first turn-bound `TranscriptItem` in this block.
+       * A turn's items can be split across session runs (e.g. a session
+       * restart mid-turn), producing multiple turn blocks with the same
+       * `turnId` — this field keeps their React keys distinct. Stable while
+       * a live turn streams (segments append after the first item) and
+       * across archive prepends (older runs don't reorder this run's items).
+       */
+      firstItemId: string;
+      segments: TranscriptTurnSegment[];
+    }
   | {
       /**
        * Session boundary divider injected between consecutive session runs.
@@ -689,6 +702,7 @@ function buildBlocksForRun(
       blocks.push({
         kind: "turn",
         turnId: entry.turnId,
+        firstItemId: bucket.items[0].id,
         segments,
       });
     }
@@ -760,7 +774,9 @@ export function getDisplayBlockKey(block: TranscriptDisplayBlock): string {
     // older sessions are prepended, causing unnecessary boundary remounts).
     return `session-boundary:${block.sessionId}:${block.firstItemId}`;
   }
-  return `turn:${block.turnId}`;
+  // firstItemId disambiguates fragments of a turn split across session runs
+  // (same turnId, different runs) — see the field doc on the turn block type.
+  return `turn:${block.turnId}:${block.firstItemId}`;
 }
 
 /**


### PR DESCRIPTION
## Problem

The agent-session transcript logs a stream of React warnings when a session restarts mid-turn:

```
Encountered two children with the same key, `turn:<turn-uuid>`.
Keys should be unique so that components maintain their identity across updates.
```

`buildTranscriptDisplayBlocks` splits transcript items into session runs, then builds turn blocks **per run**. When a session restart lands mid-turn, items sharing one `turnId` end up in two different session runs, so two turn blocks are emitted with the same React key `turn:<turnId>`. Beyond the console spam, React may duplicate or drop those rows, and the duplicated `data-message-id` breaks the 1:1 contract `useAnchoredScroll` relies on.

## Fix

Turn blocks now carry a `firstItemId` (the id of the block's first turn-bound transcript item), and `getDisplayBlockKey` returns `turn:<turnId>:<firstItemId>` — the same tiebreaker session-boundary blocks already use for this exact problem. The key stays stable while a live turn streams (segments append after the first item) and across archive prepends (older runs don't reorder this run's items), so no spurious remounts or scroll-anchor churn.

## Testing

- New regression test `getDisplayBlockKey_turnSplitAcrossSessionRuns_keysUnique`: builds a turn split across two session runs and asserts all block keys are unique. Verified it fails against the previous key derivation and passes with the fix.
- Updated `getDisplayBlockKey_turn_returnsPrefixedTurnIdAndFirstItemId` for the new key shape.
- Full desktop unit suite: 3402 pass. `tsc --noEmit` and biome clean.
- Reproduced the original warning in a live `tauri dev` session; it no longer occurs with this change.
