### PR TITLE
fix(acp): name the hung RPC method in request timeout errors

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -967,6 +967,19 @@ impl AcpClient {
         method: &str,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, AcpError> {
+        self.send_request_with_timeout(method, params, Self::REQUEST_TIMEOUT)
+            .await
+    }
+
+    /// [`send_request`](Self::send_request) with an explicit timeout instead
+    /// of `REQUEST_TIMEOUT` — the seam that lets tests exercise the timeout
+    /// path without a 60s wait.
+    async fn send_request_with_timeout(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+        timeout: std::time::Duration,
+    ) -> Result<serde_json::Value, AcpError> {
         let id = self.next_id;
         self.next_id += 1;
 
@@ -982,7 +995,6 @@ impl AcpClient {
         // Wrap write + read in a single timeout so a hung agent can't block forever.
         // We cannot use an async block that borrows `self` mutably across two awaits
         // inside timeout(), so we sequence them with early-return on timeout.
-        let timeout = Self::REQUEST_TIMEOUT;
         match tokio::time::timeout(timeout, self.write_ndjson(&msg)).await {
             Ok(result) => result?,
             Err(_) => return Err(AcpError::Timeout(timeout)),
@@ -2808,6 +2820,30 @@ mod tests {
             .await;
         assert!(result.is_ok(), "expected Ok, got {result:?}");
         assert_eq!(result.unwrap()["worked"], serde_json::json!(true));
+    }
+
+    /// A hung non-prompt RPC must surface WHICH method timed out. When an
+    /// agent stalls during `session/new` (e.g. goose blocking on MCP
+    /// extension startup while the package index is unreachable), a bare
+    /// "agent did not respond within 60s" gives the operator nothing to
+    /// act on — the error must name the hung method.
+    #[tokio::test]
+    async fn request_timeout_error_names_the_hung_rpc_method() {
+        // Agent that reads the request but never responds.
+        let mut client = spawn_script("read -t 5 _req; sleep 5").await;
+        let err = client
+            .send_request_with_timeout(
+                "session/new",
+                serde_json::json!({}),
+                std::time::Duration::from_millis(100),
+            )
+            .await
+            .expect_err("request against a silent agent must time out");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("session/new"),
+            "timeout error must name the hung RPC method; got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -95,8 +95,11 @@ pub enum AcpError {
     #[error("Agent did not stop within {0:?} after cancellation")]
     CancelDrainTimeout(std::time::Duration),
 
-    #[error("Request timeout — agent did not respond within {0:?}")]
-    Timeout(std::time::Duration),
+    #[error("Request timeout — agent did not respond to {method} within {timeout:?}")]
+    Timeout {
+        method: String,
+        timeout: std::time::Duration,
+    },
 
     #[error("Write timeout — agent stopped reading stdin (blocked for {0:?})")]
     WriteTimeout(std::time::Duration),
@@ -997,12 +1000,20 @@ impl AcpClient {
         // inside timeout(), so we sequence them with early-return on timeout.
         match tokio::time::timeout(timeout, self.write_ndjson(&msg)).await {
             Ok(result) => result?,
-            Err(_) => return Err(AcpError::Timeout(timeout)),
+            Err(_) => {
+                return Err(AcpError::Timeout {
+                    method: method.to_string(),
+                    timeout,
+                })
+            }
         }
 
         match tokio::time::timeout(timeout, self.read_until_response(id)).await {
             Ok(result) => result,
-            Err(_) => Err(AcpError::Timeout(timeout)),
+            Err(_) => Err(AcpError::Timeout {
+                method: method.to_string(),
+                timeout,
+            }),
         }
     }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3029,7 +3029,7 @@ fn handle_prompt_result(
                 e,
                 acp::AcpError::Io(_)
                     | acp::AcpError::WriteTimeout(_)
-                    | acp::AcpError::Timeout(_)
+                    | acp::AcpError::Timeout { .. }
                     | acp::AcpError::Protocol(_)
             );
             let error_code = match &e {

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -911,7 +911,7 @@ async fn apply_model_switch(
         // so the caller can respawn the agent instead of reusing a poisoned one.
         Ok(Err(e @ AcpError::Io(_)))
         | Ok(Err(e @ AcpError::WriteTimeout(_)))
-        | Ok(Err(e @ AcpError::Timeout(_)))
+        | Ok(Err(e @ AcpError::Timeout { .. }))
         | Ok(Err(e @ AcpError::Protocol(_)))
         | Ok(Err(e @ AcpError::AgentExited)) => {
             tracing::error!(
@@ -934,7 +934,10 @@ async fn apply_model_switch(
                 target: "pool::model",
                 "model set via {method_label} timed out ({MODEL_SWITCH_TIMEOUT:?}) — treating as fatal"
             );
-            return Err(AcpError::Timeout(MODEL_SWITCH_TIMEOUT));
+            return Err(AcpError::Timeout {
+                method: method_label,
+                timeout: MODEL_SWITCH_TIMEOUT,
+            });
         }
     }
     Ok(())
@@ -987,7 +990,7 @@ async fn apply_permission_mode(
         // so the caller can respawn the agent.
         Ok(Err(e @ AcpError::Io(_)))
         | Ok(Err(e @ AcpError::WriteTimeout(_)))
-        | Ok(Err(e @ AcpError::Timeout(_)))
+        | Ok(Err(e @ AcpError::Timeout { .. }))
         | Ok(Err(e @ AcpError::Protocol(_)))
         | Ok(Err(e @ AcpError::AgentExited)) => {
             tracing::error!(
@@ -1009,7 +1012,10 @@ async fn apply_permission_mode(
                 target: "pool::permission",
                 "permission mode set timed out ({PERMISSION_MODE_TIMEOUT:?}) — treating as fatal"
             );
-            return Err(AcpError::Timeout(PERMISSION_MODE_TIMEOUT));
+            return Err(AcpError::Timeout {
+                method: "session/set_config_option".to_string(),
+                timeout: PERMISSION_MODE_TIMEOUT,
+            });
         }
     }
     Ok(())


### PR DESCRIPTION
## Why

When an agent stalls on a non-prompt RPC, the harness surfaces only `Request timeout — agent did not respond within 60s`. The method name is dropped, so the desktop Activity panel and the harness log give the operator nothing to act on.

This bit hard in practice: an agent hung during `session/new` because its MCP extension startup was blocked on an unreachable package index. Five identical generic timeouts later, diagnosing required correlating the harness log, the agent's own logs, and network state by hand. An error naming `session/new` would have pointed straight at agent startup.

It is not a one-off. #3729 reports OpenCode-backed agents hanging on every model, and the entire log evidence available to the reporter is three identical copies of the generic message:

```
ERROR buzz_acp: agent initialize failed: Request timeout — agent did not respond within 60s agent=1
ERROR buzz_acp: agent initialize failed: Request timeout — agent did not respond within 60s agent=2
```

The actual stall was `session/set_config_option` rejecting a permission-mode value — a different call than the `initialize` the log implies. Pinning down which RPC hung took a hand-run ACP round-trip outside of Buzz.

## Before / after

Every stall below produced a byte-identical message before this change:

| Stall point | Before | After |
| --- | --- | --- |
| Agent binary never came up | `Request timeout — agent did not respond within 60s` | `Request timeout — agent did not respond to initialize within 60s` |
| Stuck in startup / extension load | `Request timeout — agent did not respond within 60s` | `Request timeout — agent did not respond to session/new within 60s` |
| Auth handshake wedged | `Request timeout — agent did not respond within 60s` | `Request timeout — agent did not respond to authenticate within 60s` |
| Permission mode rejected or ignored (#3729) | `Request timeout — agent did not respond within 60s` | `Request timeout — agent did not respond to session/set_config_option within 5s` |
| Model switch wedged | `Request timeout — agent did not respond within 5s` | `Request timeout — agent did not respond to set_model within 5s` |
| Model switch via config option | `Request timeout — agent did not respond within 5s` | `Request timeout — agent did not respond to configOption (configId=model) within 5s` |

The operator reads the failing subsystem straight off the line instead of inferring it from which log lines happen to sit nearby.

## What

`AcpError::Timeout` now carries the RPC method:

```rust
#[error("Request timeout — agent did not respond to {method} within {timeout:?}")]
Timeout { method: String, timeout: std::time::Duration },
```

- `send_request` populates the method at both timeout sites (a `send_request_with_timeout` seam makes the path testable without a 60s wait)
- The model-switch and permission-mode timeouts in `pool.rs` report their operation the same way

## Test plan

- New unit test: a silent agent times out on `session/new` and the error message names the method — confirmed failing before the fix (message had no method), passing after
- Full `buzz-acp` suite green
- `cargo fmt --check`, `cargo clippy`, and workspace `cargo check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
