### PR TITLE
chore(desktop): fix stale LiveKit reference in audioWorklet comment

### DIFF
--- a/desktop/src/features/huddle/lib/audioWorklet.ts
+++ b/desktop/src/features/huddle/lib/audioWorklet.ts
@@ -45,7 +45,7 @@ export type AudioWorkletHandle = {
  *   and forwards them to the worklet via port.postMessage({ type: 'ptt', active }).
  *   The worklet discards audio frames when transmitting=false.
  *
- * @param audioTrack - Mic track from LiveKit
+ * @param audioTrack - Mic track from getUserMedia
  * @param initialTransmitting - Initial PTT state. true=open mic (VAD), false=muted until PTT press.
  */
 export async function setupAudioWorklet(


### PR DESCRIPTION
## What

One-line doc-comment fix in `desktop/src/features/huddle/lib/audioWorklet.ts`: `@param audioTrack - Mic track from LiveKit` → `Mic track from getUserMedia`.

## Why

LiveKit was replaced by the WebSocket Opus audio relay in #326; this comment is the last LiveKit reference in the tree. The track actually comes from `getUserMedia` in `HuddleContext.tsx`.

## Testing

Comment-only change; no behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)