### PR TITLE
fix(relay): warn at startup when the IPv6 loopback port is squatted

### DIFF
--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -31,6 +31,16 @@ fn buzz_auto_migrate_enabled(value: Option<&str>) -> bool {
     })
 }
 
+/// Returns true when some other process is listening on the IPv6 loopback at
+/// `port`. Used to warn when the relay binds IPv4-only (the `0.0.0.0:3000`
+/// default): on macOS `localhost` resolves to `::1` first, so local clients
+/// silently reach the squatter instead of the relay — dev servers often answer
+/// GETs with 200 and writes with 404, which looks like a relay bug.
+fn ipv6_loopback_squatter(port: u16) -> bool {
+    let probe = std::net::SocketAddr::from((std::net::Ipv6Addr::LOCALHOST, port));
+    std::net::TcpStream::connect_timeout(&probe, std::time::Duration::from_millis(250)).is_ok()
+}
+
 /// Controls how many per-community gauge series the usage poller emits.
 ///
 /// Datadog cost is proportional to the number of unique time-series.  With ~25
@@ -1147,6 +1157,18 @@ async fn serve(
         .map_err(|e| anyhow::anyhow!("Failed to bind {}: {e}", config.bind_addr))?;
     info!(addr = %config.bind_addr, "buzz-relay TCP listening");
 
+    // Warn-only probe: an IPv4-only bind leaves [::1]:<port> free for another
+    // process, and `localhost` resolves IPv6-first on macOS, silently routing
+    // local clients away from the relay.
+    if config.bind_addr.is_ipv4() && ipv6_loopback_squatter(config.bind_addr.port()) {
+        warn!(
+            port = config.bind_addr.port(),
+            "another process is listening on the IPv6 loopback for this port; \
+             clients resolving `localhost` to ::1 will reach it instead of \
+             buzz-relay — set BUZZ_BIND_ADDR=[::]:<port> or free the port"
+        );
+    }
+
     #[cfg(unix)]
     if let Some(ref uds_path) = config.uds_path {
         use std::os::unix::fs::FileTypeExt as _;
@@ -1813,6 +1835,20 @@ mod tests {
         debugging::DebugValue,
         registry::{GenerationalAtomicStorage, Registry},
     };
+
+    #[test]
+    fn ipv6_loopback_squatter_detects_listener() {
+        // Skip silently when the environment has no IPv6 loopback.
+        let Ok(listener) = std::net::TcpListener::bind("[::1]:0") else {
+            return;
+        };
+        let Ok(addr) = listener.local_addr() else {
+            return;
+        };
+        assert!(super::ipv6_loopback_squatter(addr.port()));
+        drop(listener);
+        assert!(!super::ipv6_loopback_squatter(addr.port()));
+    }
 
     #[tokio::test(start_paused = true)]
     async fn periodic_loop_exits_immediately_on_cancellation() {


### PR DESCRIPTION
## What

Adds a warn-only startup probe to `buzz-relay`: after binding, if the relay is bound IPv4-only (the `0.0.0.0:3000` default) and another process is listening on `[::1]:<port>`, log a warning naming the fix (`BUZZ_BIND_ADDR=[::]:<port>` or freeing the port). No binding behavior changes.

## Why

On macOS, `localhost` resolves to `::1` first. With the IPv4-only default bind, any unrelated listener on `[::1]:3000` (a Vite dev server is the classic case, since 3000 is a popular default) silently intercepts local desktop traffic. Dev servers answer GETs with 200 (SPA fallback) and writes with 404 — during first-launch onboarding this presents as `relay returned 404 Not Found` on profile save while the relay logs show zero inbound traffic. We lost a debugging session to exactly this. The desktop's HTML-interception detection (`classify_intercepted_response`) softens the symptom client-side, and #1245 fixed a sibling v4/v6 localhost issue for media proxy URLs, but nothing warns at the source.

Changing the default bind to `[::]:3000` would fix it structurally but changes dual-stack behavior across platforms/containers — deliberately not done here; happy to discuss that as a follow-up if maintainers prefer it.

## How

- `ipv6_loopback_squatter(port)` — a 250ms `TcpStream::connect_timeout` probe against `[::1]:<port>`; runs once at startup, only when the bind address is IPv4 (an `[::]` bind would connect to itself).
- Warning logged right after the `buzz-relay TCP listening` line.
- No new `unwrap()`/`expect()`; probe failure can never affect binding.

## Testing

- Unit test `ipv6_loopback_squatter_detects_listener` (binds an ephemeral `[::1]` listener, asserts detection, then asserts clean after drop; skips silently on IPv6-less environments).
- `cargo fmt` clean; `cargo clippy -p buzz-relay --all-targets` clean; `cargo test -p buzz-relay ipv6_loopback_squatter` passes.
- Manual repro of the warning: bind anything on `[::1]:3000` (e.g. a Vite dev server), start the relay with defaults, observe the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)