### PR TITLE
fix(desktop): explain open agent access

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -121,6 +121,7 @@ export default defineConfig({
         "**/signout-confirmation.spec.ts",
         "**/agent-provider-dropdowns.spec.ts",
         "**/agent-lifecycle-feedback.spec.ts",
+        "**/agent-access-warning.spec.ts",
         "**/inbox-live-update.spec.ts",
         "**/mesh-compute.spec.ts",
         "**/observer-archive-policy.spec.ts",

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -114,6 +114,13 @@ with a TypeScript lookup table or an id comparison in a component.
     published or removed. A queued update must stay visibly queued, and the
     catalog itself must render only relay-confirmed publications — never an
     optimistic local persona.
+11. **Open agent access names the consequence where it is selected.** The shared
+   respond-to field shows a persistent warning whenever `anyone` is selected,
+   including persona-backed create and edit surfaces. Keep that disclosure in
+   the shared field instead of adding surface-specific flags. Describe the
+   audience and their ability to use the agent to access the computer or server
+   where it runs in plain language; don't expose `respond-to`, `allowlist`,
+   Nostr, or harness jargon in primary UI copy.
 
 ## The tests that enforce this
 
@@ -128,6 +135,8 @@ with a TypeScript lookup table or an id comparison in a component.
   `isCacheableDiscoveryResponse`, `deriveModelDiscoveryPending`,
   `isSuccessfulEmptyDiscovery`. If the "reopen to retry" copy becomes inert
   again, these tests will catch it.
+- `ui/respondToFieldContract.test.mjs` — plain-language mode labels and the
+  persistent warning contract for open agent access.
 - `desktop/tests/e2e/onboarding-agent-defaults.spec.ts` — onboarding behavior
   acceptance coverage for readiness, failure states, defaults, navigation,
   successful-empty vs failed optional-model discovery, and persistence races.

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -114,13 +114,39 @@ with a TypeScript lookup table or an id comparison in a component.
     published or removed. A queued update must stay visibly queued, and the
     catalog itself must render only relay-confirmed publications — never an
     optimistic local persona.
-11. **Open agent access names the consequence where it is selected.** The shared
-   respond-to field shows a persistent warning whenever `anyone` is selected,
-   including persona-backed create and edit surfaces. Keep that disclosure in
-   the shared field instead of adding surface-specific flags. Describe the
-   audience and their ability to use the agent to access the computer or server
-   where it runs in plain language; don't expose `respond-to`, `allowlist`,
-   Nostr, or harness jargon in primary UI copy.
+11. **Shared agent access names the consequence where it is selected.** The
+   shared respond-to field shows a persistent warning whenever `anyone` **or**
+   `allowlist` is selected — both hand the host's access to someone other than
+   the owner, so both disclose it and only the audience phrase differs. This
+   covers persona-backed create and edit surfaces. Keep that disclosure in
+   the shared field instead of adding surface-specific flags. It renders
+   directly below the selector for `anyone` but *after* the people picker for
+   `allowlist`, so it never sits between the user and the selection they came
+   to make. The copy leads with the audience ("Anyone can use this agent to
+   access…") so it reads as a warning rather than an explanation, and stays one
+   sentence — don't split the mechanism into a second sentence. Both the machine
+   and the stakes it names come from `lib/agentAccessWarning.ts`, keyed on an
+   optional `runLocation`: instance surfaces resolve it from
+   `ManagedAgent.backend` via `runLocationForBackend`, and the create flow from
+   `WhereToRunDraft.runOn` via `runLocationForRunOn`. `AgentDialog` is the one
+   place that resolves it for dialog surfaces and publishes it through
+   `ui/AgentRunLocationContext.tsx`; the field reads that context and lets an
+   explicit `runLocation` prop win. Do **not** thread the value as a prop
+   through `AgentDefinitionDialog` / `AgentInstanceEditDialog` — both are
+   already over the 1000-line ceiling, and neither uses the value itself.
+   Surfaces rendered outside `AgentDialog` (e.g. `EditRespondToDialog`) pass the
+   prop directly. Local names "your
+   computer, including files, accounts, and connected tools"; remote names "the
+   server it runs on, including any accounts and tools available there" —
+   deliberately *not* the owner's files, which aren't theirs to describe on a
+   host they don't own. **An unknown location falls back to the local wording —
+   never hedge with "computer or server".** A remote host requires an
+   installed `buzz-backend-*` provider, and without one `WhereToRunSection`
+   never renders, so "server" would name a concept the owner has never been
+   shown; when it *is* remote they picked that host from the selector
+   themselves. Never synthesize a run location a surface doesn't have. Don't
+   expose `respond-to`, `allowlist`, Nostr, or harness jargon in primary UI
+   copy.
 
 ## The tests that enforce this
 
@@ -135,8 +161,12 @@ with a TypeScript lookup table or an id comparison in a component.
   `isCacheableDiscoveryResponse`, `deriveModelDiscoveryPending`,
   `isSuccessfulEmptyDiscovery`. If the "reopen to retry" copy becomes inert
   again, these tests will catch it.
-- `ui/respondToFieldContract.test.mjs` — plain-language mode labels and the
-  persistent warning contract for open agent access.
+- `ui/respondToFieldContract.test.mjs` — plain-language mode labels, the
+  persistent warning contract for shared agent access, and its two render
+  positions (after the people picker for `allowlist`).
+- `lib/agentAccessWarning.test.mjs` — every mode × run-location copy variant
+  plus both resolvers, including unknown-reads-as-local and
+  blank-`runOn`-is-not-a-provider.
 - `desktop/tests/e2e/onboarding-agent-defaults.spec.ts` — onboarding behavior
   acceptance coverage for readiness, failure states, defaults, navigation,
   successful-empty vs failed optional-model discovery, and persistence races.

--- a/desktop/src/features/agents/lib/agentAccessWarning.test.mjs
+++ b/desktop/src/features/agents/lib/agentAccessWarning.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  agentAccessWarningText,
+  runLocationForBackend,
+  runLocationForRunOn,
+} from "./agentAccessWarning.ts";
+
+test("only the modes that share access warn", () => {
+  assert.equal(agentAccessWarningText("owner-only", "local"), null);
+  assert.ok(agentAccessWarningText("anyone", "local"));
+  assert.ok(agentAccessWarningText("allowlist", "local"));
+});
+
+test("a local agent names this computer and what is reachable on it", () => {
+  assert.equal(
+    agentAccessWarningText("anyone", "local"),
+    "Anyone can use this agent to access your computer, including files, accounts, and connected tools.",
+  );
+  assert.equal(
+    agentAccessWarningText("allowlist", "local"),
+    "Selected people can use this agent to access your computer, including files, accounts, and connected tools.",
+  );
+});
+
+test("a provider-backed agent names the server, and not the owner's files", () => {
+  // A remote host's files aren't the owner's to describe, so the tail narrows
+  // to the accounts and tools provisioned there.
+  assert.equal(
+    agentAccessWarningText("anyone", "remote"),
+    "Anyone can use this agent to access the server it runs on, including any accounts and tools available there.",
+  );
+  assert.equal(
+    agentAccessWarningText("allowlist", "remote"),
+    "Selected people can use this agent to access the server it runs on, including any accounts and tools available there.",
+  );
+  assert.doesNotMatch(
+    agentAccessWarningText("anyone", "remote"),
+    /your computer/,
+  );
+});
+
+test("an unknown run location reads as local, not as a hedge", () => {
+  // "computer or server" names a concept most owners have never been shown:
+  // the Run on selector only renders when a buzz-backend-* provider exists.
+  for (const unknown of [undefined, null]) {
+    assert.equal(
+      agentAccessWarningText("anyone", unknown),
+      "Anyone can use this agent to access your computer, including files, accounts, and connected tools.",
+    );
+  }
+});
+
+test("every variant leads with the audience and stays jargon-free", () => {
+  for (const mode of ["anyone", "allowlist"]) {
+    for (const runLocation of [null, "local", "remote"]) {
+      const text = agentAccessWarningText(mode, runLocation);
+      assert.match(
+        text,
+        /^(Anyone|Selected people) can use this agent to access/,
+      );
+      assert.doesNotMatch(text, /respond-to|allowlist|pubkey|Nostr|harness/i);
+    }
+  }
+});
+
+test("runLocationForBackend maps the backend union", () => {
+  assert.equal(runLocationForBackend({ type: "local" }), "local");
+  assert.equal(
+    runLocationForBackend({ type: "provider", id: "blox", config: {} }),
+    "remote",
+  );
+  assert.equal(runLocationForBackend(null), null);
+  assert.equal(runLocationForBackend(undefined), null);
+});
+
+test("runLocationForRunOn treats a provider id as remote", () => {
+  assert.equal(runLocationForRunOn("local"), "local");
+  assert.equal(runLocationForRunOn("blox"), "remote");
+});
+
+test("runLocationForRunOn treats a blank value as unknown", () => {
+  // `runOn` is typed `"local" | string`, so a blank must not read as a
+  // provider id and produce the server wording.
+  assert.equal(runLocationForRunOn(""), null);
+  assert.equal(runLocationForRunOn(null), null);
+  assert.equal(runLocationForRunOn(undefined), null);
+});

--- a/desktop/src/features/agents/lib/agentAccessWarning.ts
+++ b/desktop/src/features/agents/lib/agentAccessWarning.ts
@@ -1,0 +1,63 @@
+import type { ManagedAgentBackend, RespondToMode } from "@/shared/api/types";
+
+/**
+ * Where an agent's process runs, as far as the calling surface can tell.
+ *
+ * Deliberately coarser than `ManagedAgentBackend`: the warning copy only needs
+ * to know "this machine" vs "somewhere else", so surfaces resolve their own
+ * backend shape down to this before handing it over. `null` means the surface
+ * genuinely cannot tell — see `agentAccessWarningText` for how that is
+ * treated.
+ */
+export type AgentRunLocation = "local" | "remote";
+
+/** Resolve a running agent's backend record. `null` when the backend is unknown. */
+export function runLocationForBackend(
+  backend: ManagedAgentBackend | null | undefined,
+): AgentRunLocation | null {
+  if (!backend) return null;
+  return backend.type === "local" ? "local" : "remote";
+}
+
+/**
+ * Resolve the create flow's `WhereToRunDraft.runOn`, which is `"local"` or a
+ * discovered provider id. An empty string is treated as unknown rather than as
+ * a provider, since `runOn` is typed `"local" | string`.
+ */
+export function runLocationForRunOn(
+  runOn: string | null | undefined,
+): AgentRunLocation | null {
+  if (!runOn) return null;
+  return runOn === "local" ? "local" : "remote";
+}
+
+/**
+ * Copy for the shared-access warning in the respond-to field, or `null` for
+ * modes that share nothing.
+ *
+ * Both `anyone` and `allowlist` hand the host's access to someone other than
+ * the owner, so both warn; only the audience phrase differs.
+ *
+ * An unknown run location falls back to the same "your computer" wording as
+ * `local` rather than hedging with "computer or server". A remote host is only
+ * reachable when a `buzz-backend-*` provider binary is installed — without one
+ * `WhereToRunSection`'s "Run on" selector never renders and every agent is
+ * local — so hedging would name a concept most owners have never been shown.
+ * When it *is* remote the owner picked that host from the selector
+ * deliberately, so naming a server is meaningful there.
+ */
+export function agentAccessWarningText(
+  mode: RespondToMode,
+  runLocation?: AgentRunLocation | null,
+): string | null {
+  if (mode !== "anyone" && mode !== "allowlist") return null;
+  const audience = mode === "anyone" ? "Anyone" : "Selected people";
+  // The two locations differ in more than the noun: a local agent reaches the
+  // owner's own files, while a remote host's files aren't theirs to describe —
+  // only the accounts and tools provisioned there.
+  const target =
+    runLocation === "remote"
+      ? "the server it runs on, including any accounts and tools available there"
+      : "your computer, including files, accounts, and connected tools";
+  return `${audience} can use this agent to access ${target}.`;
+}

--- a/desktop/src/features/agents/ui/AgentDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDialog.tsx
@@ -6,6 +6,11 @@ import type {
   ManagedAgent,
   UpdatePersonaInput,
 } from "@/shared/api/types";
+import {
+  runLocationForBackend,
+  runLocationForRunOn,
+} from "../lib/agentAccessWarning";
+import { AgentRunLocationProvider } from "./AgentRunLocationContext";
 import type { BackendIntent } from "../lib/instanceInputForDefinition";
 import type { AgentCreateIntent } from "./agentCreateIntent";
 import type { EditAgentFocusTarget } from "@/features/agents/openEditAgentEvent";
@@ -89,17 +94,25 @@ type AgentDialogProps =
 export function AgentDialog(props: AgentDialogProps) {
   if (props.mode === "instance-edit") {
     return (
-      <AgentInstanceEditDialog
-        agent={props.agent}
-        onEditLinkedPersona={props.onEditLinkedPersona}
-        onOpenChange={props.onOpenChange}
-        onUpdated={props.onUpdated}
-        open={props.open}
-        initialFocus={props.initialFocus}
-      />
+      // A running instance knows its own backend, so the respond-to warning can
+      // name the machine it will actually run on.
+      <AgentRunLocationProvider
+        runLocation={runLocationForBackend(props.agent.backend)}
+      >
+        <AgentInstanceEditDialog
+          agent={props.agent}
+          onEditLinkedPersona={props.onEditLinkedPersona}
+          onOpenChange={props.onOpenChange}
+          onUpdated={props.onUpdated}
+          open={props.open}
+          initialFocus={props.initialFocus}
+        />
+      </AgentRunLocationProvider>
     );
   }
   if (props.mode === "definition-edit") {
+    // A definition has no instance and no run draft, so the run location stays
+    // unknown and the warning uses its local-wording fallback.
     const { mode: _mode, ...definitionProps } = props;
     return <AgentDefinitionDialog {...definitionProps} />;
   }
@@ -124,35 +137,39 @@ function AgentCreateDialogRouter({
   const copy = createPersonaDialogState();
 
   return (
-    <AgentDefinitionDialog
-      createRunSection={
-        <WhereToRunSection
-          draft={runDraft}
-          isPending={isDefinitionPending}
-          onDraftChange={setRunDraft}
-        />
-      }
-      createSubmitBlocked={!canSubmitWhereToRun(runDraft)}
-      description={copy.description}
-      error={definitionError}
-      initialValues={initialValues}
-      isPending={isDefinitionPending}
-      onOpenChange={onOpenChange}
-      onSubmit={async (input) => {
-        const submitted = await onSubmitDefinition(
-          input,
-          "definition_start",
-          resolveBackendIntent(runDraft),
-        );
-        if (submitted) {
-          onOpenChange(false);
+    // The create flow is the one surface that knows where the agent will run,
+    // because it owns the "Run on" draft.
+    <AgentRunLocationProvider runLocation={runLocationForRunOn(runDraft.runOn)}>
+      <AgentDefinitionDialog
+        createRunSection={
+          <WhereToRunSection
+            draft={runDraft}
+            isPending={isDefinitionPending}
+            onDraftChange={setRunDraft}
+          />
         }
-      }}
-      open
-      runtimes={runtimes}
-      runtimesLoading={runtimesLoading}
-      submitLabel={copy.submitLabel}
-      title={copy.title}
-    />
+        createSubmitBlocked={!canSubmitWhereToRun(runDraft)}
+        description={copy.description}
+        error={definitionError}
+        initialValues={initialValues}
+        isPending={isDefinitionPending}
+        onOpenChange={onOpenChange}
+        onSubmit={async (input) => {
+          const submitted = await onSubmitDefinition(
+            input,
+            "definition_start",
+            resolveBackendIntent(runDraft),
+          );
+          if (submitted) {
+            onOpenChange(false);
+          }
+        }}
+        open
+        runtimes={runtimes}
+        runtimesLoading={runtimesLoading}
+        submitLabel={copy.submitLabel}
+        title={copy.title}
+      />
+    </AgentRunLocationProvider>
   );
 }

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -936,7 +936,7 @@ export function AgentInstanceEditDialog({
               </div>
             </div>
 
-            {/* Who can talk to this agent */}
+            {/* Who can send instructions */}
             <CreateAgentRespondToField
               allowlist={respondToAllowlist}
               disabled={updateMutation.isPending}

--- a/desktop/src/features/agents/ui/AgentRunLocationContext.tsx
+++ b/desktop/src/features/agents/ui/AgentRunLocationContext.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+import type { AgentRunLocation } from "../lib/agentAccessWarning";
+
+/**
+ * Where the agent a dialog subtree is editing will run.
+ *
+ * Context rather than a prop on purpose: the only consumer is the respond-to
+ * warning, buried several levels inside `AgentDefinitionDialog` (1000+ lines)
+ * and `AgentInstanceEditDialog` (1200+ lines). Threading a prop through them
+ * would grow two files that are already over the 1000-line ceiling enforced by
+ * `desktop/scripts/check-file-sizes.mjs`, for a value neither of them uses.
+ *
+ * `AgentDialog` is the single entry point for all three dialog modes, so it is
+ * the one place that provides this. Surfaces that render the respond-to field
+ * outside that tree (e.g. `EditRespondToDialog`) pass the `runLocation` prop
+ * directly instead.
+ *
+ * The default is `null` — unknown. Never provide a guessed value; the copy
+ * falls back to the local wording, which is correct for any owner who has not
+ * installed a `buzz-backend-*` provider.
+ */
+const AgentRunLocationContext = React.createContext<AgentRunLocation | null>(
+  null,
+);
+
+export function AgentRunLocationProvider({
+  children,
+  runLocation,
+}: {
+  children: React.ReactNode;
+  runLocation: AgentRunLocation | null;
+}) {
+  return (
+    <AgentRunLocationContext.Provider value={runLocation}>
+      {children}
+    </AgentRunLocationContext.Provider>
+  );
+}
+
+export function useAgentRunLocation(): AgentRunLocation | null {
+  return React.useContext(AgentRunLocationContext);
+}

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ChevronDown, Search, X } from "lucide-react";
+import { AlertTriangle, ChevronDown, Search, X } from "lucide-react";
 import {
   mergeAllowlist,
   parsePubkeyInput,
@@ -20,10 +20,10 @@ import type { PersonaDropdownOption } from "./agentConfigOptions";
  * Inbound author gate UI for create/edit agent dialogs.
  *
  * Dropdown:
- *   - Owner only  (default; matches `buzz-acp --respond-to=owner-only`)
- *   - Anyone      (`--respond-to=anyone` — fully open bot)
- *   - Allowlist   (`--respond-to=allowlist`, plus the chip list as
- *                  `--respond-to-allowlist`)
+ *   - Only me        (default; maps to `buzz-acp --respond-to=owner-only`)
+ *   - Anyone         (`--respond-to=anyone` — fully open agent)
+ *   - Selected people (`--respond-to=allowlist`, plus the selected pubkeys as
+ *                     `--respond-to-allowlist`)
  *
  * `nobody` is intentionally not surfaced — it pairs with a heartbeat-only
  * setup that has no meaningful GUI use case.
@@ -53,7 +53,7 @@ function formatSearchUserSecondary(user: UserSearchResult) {
 const RESPOND_TO_OPTIONS: PersonaDropdownOption[] = [
   { label: "Only me (default)", value: "owner-only" },
   { label: "Anyone", value: "anyone" },
-  { label: "Allowlist", value: "allowlist" },
+  { label: "Selected people", value: "allowlist" },
 ];
 
 export function CreateAgentRespondToField({
@@ -142,7 +142,7 @@ export function CreateAgentRespondToField({
         }
         htmlFor="agent-respond-to"
       >
-        Who can talk to this agent
+        Who can send instructions
       </label>
       {isPersonaVariant ? (
         <PersonaDropdownField
@@ -162,18 +162,35 @@ export function CreateAgentRespondToField({
           onChange={(e) => onModeChange(e.target.value as RespondToMode)}
           value={mode}
         >
-          <option value="owner-only">Owner only (default)</option>
-          <option value="anyone">Anyone</option>
-          <option value="allowlist">Allowlist</option>
+          {RESPOND_TO_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
         </select>
       )}
-      {!isPersonaVariant ? (
+      {mode === "anyone" ? (
+        <div
+          className="flex items-start gap-2 rounded-xl border border-warning/30 bg-warning-bg px-3 py-2.5"
+          data-testid="agent-access-warning"
+        >
+          <AlertTriangle
+            aria-hidden="true"
+            className="mt-0.5 h-4 w-4 shrink-0 text-warning"
+          />
+          <p aria-live="polite" className="text-xs leading-5 text-warning">
+            Anyone can send instructions to this agent and use it to access the
+            computer or server where it runs. This includes files, accounts, and
+            tools available to the agent.
+          </p>
+        </div>
+      ) : (
         <p className="text-xs text-muted-foreground">
-          Controls which Nostr authors the agent listens to (@mentions, DMs,
-          thread replies). The agent&apos;s owner can always shut it down with
-          <span className="font-mono"> !shutdown</span>.
+          {mode === "allowlist"
+            ? "Only you and the people you choose can send instructions."
+            : "Only you can send instructions."}
         </p>
-      ) : null}
+      )}
       {mode === "allowlist" ? (
         <AllowlistPicker
           allowlist={allowlist}
@@ -269,7 +286,7 @@ function AllowlistPicker({
     >
       {!isPersona ? (
         <div className="flex items-center justify-between gap-2">
-          <span className="text-sm font-medium">Allowed pubkeys</span>
+          <span className="text-sm font-medium">Selected people</span>
           <span className="rounded-full bg-background px-2 py-1 text-2xs font-medium leading-none text-muted-foreground">
             {allowlist.length} selected
           </span>
@@ -277,13 +294,13 @@ function AllowlistPicker({
       ) : null}
       {!isPersona && ownerPubkey ? (
         <p className="text-xs text-muted-foreground">
-          Owner (
-          <PubKey pubkey={ownerPubkey} />) is always implicitly allowed by the
-          harness — no need to add it here.
+          You (
+          <PubKey pubkey={ownerPubkey} />) can always use this agent. You
+          don&apos;t need to add yourself.
         </p>
       ) : !isPersona ? (
         <p className="text-xs text-muted-foreground">
-          The agent&apos;s owner is always implicitly allowed.
+          You can always use this agent.
         </p>
       ) : null}
       <div className="rounded-lg border border-border/80 bg-background">
@@ -452,7 +469,7 @@ function AllowlistPicker({
                   onClick={onAddFromPaste}
                   type="button"
                 >
-                  Add to allowlist
+                  Add people
                 </button>
               </div>
             </div>

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -179,8 +179,8 @@ export function CreateAgentRespondToField({
             className="mt-0.5 h-4 w-4 shrink-0 text-warning"
           />
           <p aria-live="polite" className="text-xs leading-5 text-warning">
-            Anyone can use this agent to access files, accounts, and tools on
-            the computer or server where it runs.
+            Anyone can use this agent to access the computer or server where it
+            runs, including files, accounts, and tools available to the agent.
           </p>
         </div>
       ) : (

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -179,9 +179,8 @@ export function CreateAgentRespondToField({
             className="mt-0.5 h-4 w-4 shrink-0 text-warning"
           />
           <p aria-live="polite" className="text-xs leading-5 text-warning">
-            Anyone can use this agent to access the computer or server where it
-            runs. They can access files, accounts, and tools available to the
-            agent.
+            Anyone can use this agent to access files, accounts, and tools on
+            the computer or server where it runs.
           </p>
         </div>
       ) : (

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -179,9 +179,9 @@ export function CreateAgentRespondToField({
             className="mt-0.5 h-4 w-4 shrink-0 text-warning"
           />
           <p aria-live="polite" className="text-xs leading-5 text-warning">
-            Anyone can send instructions to this agent and use it to access the
-            computer or server where it runs. This includes files, accounts, and
-            tools available to the agent.
+            Anyone can use this agent to access the computer or server where it
+            runs. They can access files, accounts, and tools available to the
+            agent.
           </p>
         </div>
       ) : (

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -179,8 +179,8 @@ export function CreateAgentRespondToField({
             className="mt-0.5 h-4 w-4 shrink-0 text-warning"
           />
           <p aria-live="polite" className="text-xs leading-5 text-warning">
-            Anyone can use this agent to access the computer or server where it
-            runs, including files, accounts, and tools available to the agent.
+            Anyone will be able to access the computer or server running this
+            agent.
           </p>
         </div>
       ) : (

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -13,6 +13,11 @@ import { cn } from "@/shared/lib/cn";
 import { Input } from "@/shared/ui/input";
 import { Textarea } from "@/shared/ui/textarea";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
+import {
+  type AgentRunLocation,
+  agentAccessWarningText,
+} from "@/features/agents/lib/agentAccessWarning";
+import { useAgentRunLocation } from "./AgentRunLocationContext";
 import { PersonaDropdownField } from "./PersonaDropdownField";
 import type { PersonaDropdownOption } from "./agentConfigOptions";
 
@@ -27,6 +32,17 @@ import type { PersonaDropdownOption } from "./agentConfigOptions";
  *
  * `nobody` is intentionally not surfaced — it pairs with a heartbeat-only
  * setup that has no meaningful GUI use case.
+ *
+ * Anyone and Selected people both share the host's access with someone other
+ * than the owner, so both render the persistent warning; only the audience
+ * phrase differs. It leads with the audience so it reads as a warning rather
+ * than an explanation, and stays one sentence — Only me already owns the line
+ * below the control.
+ *
+ * Which machine and stakes it names follow the optional `runLocation` prop, and
+ * an unknown location falls back to the local wording rather than hedging with
+ * "computer or server" — see `lib/agentAccessWarning.ts` for the copy and the
+ * reasoning.
  *
  * Validation is duplicated lightly here for inline UX feedback only; the
  * authoritative validator is `validate_respond_to_allowlist` in
@@ -64,6 +80,7 @@ export function CreateAgentRespondToField({
   ownerPubkey,
   disabled,
   variant,
+  runLocation,
 }: {
   mode: RespondToMode;
   allowlist: string[];
@@ -78,6 +95,12 @@ export function CreateAgentRespondToField({
   disabled?: boolean;
   /** When "persona", uses PersonaDropdownField styling to match the persona dialog. */
   variant?: "default" | "persona";
+  /**
+   * Where the agent's process runs, when the surface can tell. Omit or pass
+   * `null` when it can't — the warning then uses the same "your computer"
+   * wording as a local agent rather than hedging. Never synthesize a value.
+   */
+  runLocation?: AgentRunLocation | null;
 }) {
   const [query, setQuery] = React.useState("");
   const [isDirectEntryOpen, setIsDirectEntryOpen] = React.useState(false);
@@ -132,6 +155,33 @@ export function CreateAgentRespondToField({
 
   const isPersonaVariant = variant === "persona";
 
+  // An explicit prop wins; otherwise inherit from the dialog subtree. Surfaces
+  // inside AgentDialog get it from context (see AgentRunLocationContext for
+  // why), standalone ones like EditRespondToDialog pass the prop.
+  const inheritedRunLocation = useAgentRunLocation();
+  const warningText = agentAccessWarningText(
+    mode,
+    runLocation ?? inheritedRunLocation,
+  );
+
+  // Rendered in two positions: directly below the selector for Anyone, but
+  // after the people picker for Selected people, so it never sits between the
+  // user and the selection they came here to make.
+  const accessWarning = warningText ? (
+    <div
+      className="flex items-start gap-2 rounded-xl border border-warning/30 bg-warning-bg px-3 py-2.5"
+      data-testid="agent-access-warning"
+    >
+      <AlertTriangle
+        aria-hidden="true"
+        className="mt-0.5 h-4 w-4 shrink-0 text-warning"
+      />
+      <p aria-live="polite" className="text-xs leading-5 text-warning">
+        {warningText}
+      </p>
+    </div>
+  ) : null;
+
   return (
     <div className="space-y-2" data-testid="agent-respond-to">
       <label
@@ -169,27 +219,12 @@ export function CreateAgentRespondToField({
           ))}
         </select>
       )}
-      {mode === "anyone" ? (
-        <div
-          className="flex items-start gap-2 rounded-xl border border-warning/30 bg-warning-bg px-3 py-2.5"
-          data-testid="agent-access-warning"
-        >
-          <AlertTriangle
-            aria-hidden="true"
-            className="mt-0.5 h-4 w-4 shrink-0 text-warning"
-          />
-          <p aria-live="polite" className="text-xs leading-5 text-warning">
-            Anyone will be able to access the computer or server running this
-            agent.
-          </p>
-        </div>
-      ) : (
+      {mode === "anyone" ? accessWarning : null}
+      {mode === "owner-only" ? (
         <p className="text-xs text-muted-foreground">
-          {mode === "allowlist"
-            ? "Only you and the people you choose can send instructions."
-            : "Only you can send instructions."}
+          Only you can send instructions.
         </p>
-      )}
+      ) : null}
       {mode === "allowlist" ? (
         <AllowlistPicker
           allowlist={allowlist}
@@ -218,6 +253,7 @@ export function CreateAgentRespondToField({
           variant={isPersonaVariant ? "persona" : "default"}
         />
       ) : null}
+      {mode === "allowlist" ? accessWarning : null}
     </div>
   );
 }

--- a/desktop/src/features/agents/ui/agentDialogRouting.test.mjs
+++ b/desktop/src/features/agents/ui/agentDialogRouting.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import { AgentDialog } from "./AgentDialog.tsx";
 import { AgentDefinitionDialog } from "./AgentDefinitionDialog.tsx";
 import { AgentInstanceEditDialog } from "./AgentInstanceEditDialog.tsx";
+import { AgentRunLocationProvider } from "./AgentRunLocationContext.tsx";
 
 // ── Phase 1B.3c routing pinning ─────────────────────────────────────────────
 //
@@ -54,8 +55,13 @@ test("instance-edit routes to AgentInstanceEditDialog with its contract props", 
     open: true,
   });
 
-  assert.equal(element.type, AgentInstanceEditDialog);
-  assert.deepEqual(element.props, {
+  // The arm wraps the form in the run-location provider so the respond-to
+  // warning can name the machine without the value being threaded as a prop
+  // through AgentInstanceEditDialog (see AgentRunLocationContext for why).
+  assert.equal(element.type, AgentRunLocationProvider);
+  const form = element.props.children;
+  assert.equal(form.type, AgentInstanceEditDialog);
+  assert.deepEqual(form.props, {
     agent,
     onEditLinkedPersona: undefined,
     onOpenChange,
@@ -63,6 +69,25 @@ test("instance-edit routes to AgentInstanceEditDialog with its contract props", 
     open: true,
     initialFocus: undefined,
   });
+});
+
+test("instance-edit publishes the run location resolved from the agent backend", () => {
+  const routeWithBackend = (backend) =>
+    AgentDialog({
+      mode: "instance-edit",
+      agent: { pubkey: "abc", name: "test-agent", backend },
+      onOpenChange: noop,
+      onUpdated: noop,
+      open: true,
+    }).props.runLocation;
+
+  assert.equal(routeWithBackend({ type: "local" }), "local");
+  assert.equal(
+    routeWithBackend({ type: "provider", id: "blox", config: {} }),
+    "remote",
+  );
+  // An agent with no backend record has an unknown location — never a guess.
+  assert.equal(routeWithBackend(undefined), null);
 });
 
 test("create mode routes to the internal create router, not a form directly", () => {

--- a/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
+++ b/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
@@ -27,11 +27,7 @@ test("open agent access always renders a persistent warning", () => {
   );
   assert.match(
     respondToFieldSource,
-    /Anyone can use this agent to access the[\s\S]*computer or server where it[\s\S]*runs\./,
-  );
-  assert.match(
-    respondToFieldSource,
-    /They can access files,[\s\S]*accounts, and tools available to the[\s\S]*agent\./,
+    /Anyone can use this agent to access files,[\s\S]*accounts, and tools on[\s\S]*the computer or server where it runs\./,
   );
 });
 

--- a/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
+++ b/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
@@ -27,7 +27,7 @@ test("open agent access always renders a persistent warning", () => {
   );
   assert.match(
     respondToFieldSource,
-    /Anyone can use this agent to access the computer or server where it[\s\S]*runs, including files,[\s\S]*accounts, and tools available to the agent\./,
+    /Anyone will be able to access the computer or server running this[\s\S]*agent\./,
   );
 });
 

--- a/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
+++ b/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
@@ -27,11 +27,11 @@ test("open agent access always renders a persistent warning", () => {
   );
   assert.match(
     respondToFieldSource,
-    /Anyone can send instructions to this agent and use it to access the[\s\S]*computer or server where it runs\./,
+    /Anyone can use this agent to access the[\s\S]*computer or server where it[\s\S]*runs\./,
   );
   assert.match(
     respondToFieldSource,
-    /This includes files,[\s\S]*accounts, and[\s\S]*tools available to the agent\./,
+    /They can access files,[\s\S]*accounts, and tools available to the[\s\S]*agent\./,
   );
 });
 

--- a/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
+++ b/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
@@ -27,7 +27,7 @@ test("open agent access always renders a persistent warning", () => {
   );
   assert.match(
     respondToFieldSource,
-    /Anyone can use this agent to access files,[\s\S]*accounts, and tools on[\s\S]*the computer or server where it runs\./,
+    /Anyone can use this agent to access the computer or server where it[\s\S]*runs, including files,[\s\S]*accounts, and tools available to the agent\./,
   );
 });
 

--- a/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
+++ b/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const respondToFieldSource = await readFile(
+  new URL("./RespondToField.tsx", import.meta.url),
+  "utf8",
+);
+
+for (const label of ["Only me (default)", "Selected people", "Anyone"]) {
+  test(`respond-to control uses the plain-language label: ${label}`, () => {
+    assert.ok(respondToFieldSource.includes(`label: "${label}"`));
+  });
+}
+
+test("native and persona controls share one option list", () => {
+  assert.match(
+    respondToFieldSource,
+    /<select[\s\S]*RESPOND_TO_OPTIONS\.map\(\(option\) => \([\s\S]*<option/,
+  );
+});
+
+test("open agent access always renders a persistent warning", () => {
+  assert.match(
+    respondToFieldSource,
+    /mode === "anyone"[\s\S]*data-testid="agent-access-warning"/,
+  );
+  assert.match(
+    respondToFieldSource,
+    /Anyone can send instructions to this agent and use it to access the[\s\S]*computer or server where it runs\./,
+  );
+  assert.match(
+    respondToFieldSource,
+    /This includes files,[\s\S]*accounts, and[\s\S]*tools available to the agent\./,
+  );
+});
+
+test("primary respond-to copy does not expose implementation jargon", () => {
+  const primaryFieldSource = respondToFieldSource.slice(
+    respondToFieldSource.indexOf('data-testid="agent-respond-to"'),
+    respondToFieldSource.indexOf("const HEX_64_RE"),
+  );
+
+  for (const jargon of ["Nostr authors", "!shutdown"]) {
+    assert.doesNotMatch(primaryFieldSource, new RegExp(jargon));
+  }
+});

--- a/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
+++ b/desktop/src/features/agents/ui/respondToFieldContract.test.mjs
@@ -7,6 +7,13 @@ const respondToFieldSource = await readFile(
   "utf8",
 );
 
+/**
+ * Copy assertions run against this rather than the raw source: JSX text wraps
+ * wherever the formatter decides, and a sentence split across lines should not
+ * fail a copy test.
+ */
+const collapsedSource = respondToFieldSource.replace(/\s+/g, " ");
+
 for (const label of ["Only me (default)", "Selected people", "Anyone"]) {
   test(`respond-to control uses the plain-language label: ${label}`, () => {
     assert.ok(respondToFieldSource.includes(`label: "${label}"`));
@@ -20,15 +27,32 @@ test("native and persona controls share one option list", () => {
   );
 });
 
-test("open agent access always renders a persistent warning", () => {
-  assert.match(
-    respondToFieldSource,
-    /mode === "anyone"[\s\S]*data-testid="agent-access-warning"/,
+test("every shared-access mode renders a persistent warning", () => {
+  // Anyone and Selected people both hand host access to someone other than the
+  // owner, so both warn; only the audience phrase differs.
+  assert.match(respondToFieldSource, /mode === "anyone" \? accessWarning/);
+  assert.match(respondToFieldSource, /mode === "allowlist" \? accessWarning/);
+});
+
+test("the Selected people warning sits after the people picker", () => {
+  // It must not sit between the user and the selection they came here to make.
+  const pickerAt = respondToFieldSource.indexOf("<AllowlistPicker");
+  const warningAt = respondToFieldSource.indexOf(
+    'mode === "allowlist" ? accessWarning',
   );
+  assert.ok(pickerAt > 0 && warningAt > pickerAt);
+});
+
+test("the warning copy comes from the shared helper, not inline text", () => {
+  // Guards against a surface hand-rolling its own wording, which is how the
+  // machine name drifts out of sync with the actual run location.
+  // An explicit prop wins over the AgentRunLocationContext fallback, so the
+  // call site must keep that precedence rather than reading only one source.
   assert.match(
-    respondToFieldSource,
-    /Anyone will be able to access the computer or server running this[\s\S]*agent\./,
+    collapsedSource,
+    /agentAccessWarningText\( mode, runLocation \?\? inheritedRunLocation, \)/,
   );
+  assert.match(collapsedSource, /<p aria-live="polite"[^>]*> \{warningText\}/);
 });
 
 test("primary respond-to copy does not expose implementation jargon", () => {

--- a/desktop/src/features/channels/ui/EditRespondToDialog.tsx
+++ b/desktop/src/features/channels/ui/EditRespondToDialog.tsx
@@ -54,9 +54,9 @@ export function EditRespondToDialog({
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>Edit respond-to</DialogTitle>
+          <DialogTitle>Manage agent access</DialogTitle>
           <DialogDescription>
-            Choose who {agent?.name ?? "this agent"} responds to.
+            Choose who can send instructions to {agent?.name ?? "this agent"}.
           </DialogDescription>
         </DialogHeader>
         <CreateAgentRespondToField
@@ -87,7 +87,7 @@ export function EditRespondToDialog({
             size="sm"
             type="button"
           >
-            {updateMutation.isPending ? "Saving..." : "Save"}
+            {updateMutation.isPending ? "Saving..." : "Save access"}
           </Button>
         </div>
       </DialogContent>

--- a/desktop/src/features/channels/ui/EditRespondToDialog.tsx
+++ b/desktop/src/features/channels/ui/EditRespondToDialog.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { useUpdateManagedAgentMutation } from "@/features/agents/hooks";
+import { runLocationForBackend } from "@/features/agents/lib/agentAccessWarning";
 import { CreateAgentRespondToField } from "@/features/agents/ui/RespondToField";
 import type { ManagedAgent, RespondToMode } from "@/shared/api/types";
 import { Button } from "@/shared/ui/button";
@@ -66,6 +67,7 @@ export function EditRespondToDialog({
           onAllowlistChange={setRespondToAllowlist}
           onModeChange={setRespondTo}
           ownerPubkey={currentPubkey}
+          runLocation={runLocationForBackend(agent?.backend)}
         />
         {updateMutation.error instanceof Error ? (
           <p className="text-sm text-destructive">

--- a/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebarMemberCard.tsx
@@ -109,9 +109,9 @@ function formatRespondToLabel(agent: ManagedAgent) {
     case "anyone":
       return "Anyone";
     case "allowlist":
-      return `Allowlist (${agent.respondToAllowlist.length})`;
+      return `Selected people (${agent.respondToAllowlist.length})`;
     default:
-      return "Owner only";
+      return "Only me";
   }
 }
 
@@ -379,7 +379,7 @@ function MemberActionsMenu({
                 onClick={() => onEditRespondTo(managedAgent)}
               >
                 <Pencil className="h-4 w-4" />
-                Edit respond-to...
+                Manage agent access...
               </DropdownMenuItem>
             ) : null}
             {canRemoveMember || showChangeRole ? (

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { AlertTriangle } from "lucide-react";
 
 import {
   depthGuideActionsEqual,
@@ -383,12 +384,8 @@ export const MessageRow = React.memo(
     const guideBleedRem = isThreadReplyLayout ? 0.25 : 0;
     const avatarButtonRadiusClass = "rounded-full";
 
-    const respondToDotColor =
-      message.respondTo === "anyone"
-        ? "bg-emerald-500"
-        : message.respondTo === "allowlist"
-          ? "bg-amber-500"
-          : null;
+    const showRespondToIndicator =
+      message.respondTo === "anyone" || message.respondTo === "allowlist";
 
     const avatarNode = (
       <div className="relative shrink-0">
@@ -399,18 +396,31 @@ export const MessageRow = React.memo(
           displayName={message.author}
           testId="message-avatar"
         />
-        {respondToDotColor && !isThreadReplyLayout ? (
+        {showRespondToIndicator && !isThreadReplyLayout ? (
           <span
             className={cn(
               "absolute -bottom-0.5 -right-0.5 flex h-3 w-3 items-center justify-center rounded-full bg-background",
             )}
+            role="img"
+            aria-label={
+              message.respondTo === "anyone"
+                ? "Anyone can send instructions to this agent"
+                : "Selected people can send instructions to this agent"
+            }
             title={
               message.respondTo === "anyone"
-                ? "Responds to anyone"
-                : "Responds to allowlist"
+                ? "Anyone can send instructions to this agent"
+                : "Selected people can send instructions to this agent"
             }
           >
-            <span className={cn("h-2 w-2 rounded-full", respondToDotColor)} />
+            {message.respondTo === "anyone" ? (
+              <AlertTriangle
+                aria-hidden="true"
+                className="h-2.5 w-2.5 fill-background text-amber-500"
+              />
+            ) : (
+              <span className="h-2 w-2 rounded-full bg-blue-500" />
+            )}
           </span>
         ) : null}
       </div>

--- a/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
@@ -56,7 +56,7 @@ const AGENT_INFO_LABELS = new Set([
 const AGENT_SETTINGS_LABELS = new Set([
   "Runtime",
   "Agent profile",
-  "Respond to",
+  "Who can send instructions",
   "ACP command",
   "MCP command",
   "Start on launch",
@@ -246,9 +246,13 @@ export function buildOwnerFields({
   const fields: ProfileField[] = [];
   const respondTo = managedAgent?.respondTo ?? relayAgent?.respondTo ?? null;
   const respondToDisplayValue = respondTo
-    ? respondTo === "owner-only" && ownerDisplayName
+    ? respondTo === "owner-only"
       ? ownerDisplayName
-      : respondTo.replace(/-/g, " ")
+        ? `Only ${ownerDisplayName} (owner)`
+        : "Only the owner"
+      : respondTo === "allowlist"
+        ? "Selected people"
+        : "Anyone"
     : null;
 
   const ownerClickable = Boolean(onOpenProfile && ownerProfilePubkey);
@@ -386,7 +390,7 @@ export function buildOwnerFields({
     fields.push({
       displayValue: respondToDisplayValue,
       icon: Ear,
-      label: "Respond to",
+      label: "Who can send instructions",
       testId: "user-profile-respond-to",
     });
   }

--- a/desktop/src/features/settings/ui/SendFeedbackDialog.tsx
+++ b/desktop/src/features/settings/ui/SendFeedbackDialog.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 
 import { cn } from "@/shared/lib/cn";
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
+import { useMediaProxyPort } from "@/shared/lib/useMediaProxyPort";
 import { Button } from "@/shared/ui/button";
 import { Checkbox } from "@/shared/ui/checkbox";
 import {
@@ -83,6 +84,7 @@ export function SendFeedbackDialog({
   open: boolean;
 }) {
   const { burstEmoji } = useEmojiBurst();
+  useMediaProxyPort();
   const resolvedAttachedImageUrl = attachedImageUrl
     ? rewriteRelayUrl(attachedImageUrl)
     : null;

--- a/desktop/src/shared/lib/mediaUrl.test.mjs
+++ b/desktop/src/shared/lib/mediaUrl.test.mjs
@@ -27,6 +27,42 @@ test("mediaProxyUrl: uses the IPv4 loopback literal for the localhost proxy", ()
   );
 });
 
+test("media-proxy port store: resolved port publishes and reset notifies subscribers", async () => {
+  const previousWindow = globalThis.window;
+  let notifications = 0;
+
+  globalThis.window = {
+    __TAURI_INTERNALS__: {
+      invoke(command) {
+        if (command === "get_media_proxy_port") return Promise.resolve(54321);
+        if (command === "get_relay_http_url") {
+          return Promise.resolve("https://relay.example");
+        }
+        return Promise.reject(new Error(`Unexpected command: ${command}`));
+      },
+    },
+  };
+
+  try {
+    const mediaUrl = await import(`./mediaUrl.ts?portStore=${Date.now()}`);
+    const unsubscribe = mediaUrl.subscribeMediaProxyPort(() => notifications++);
+
+    mediaUrl.rewriteRelayUrl(`https://relay.example/media/${HASH}.png`);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.equal(mediaUrl.getCachedMediaProxyPort(), 54321);
+    assert.equal(notifications, 1);
+
+    mediaUrl.resetMediaCaches();
+    assert.equal(mediaUrl.getCachedMediaProxyPort(), null);
+    assert.equal(notifications, 2);
+
+    unsubscribe();
+  } finally {
+    globalThis.window = previousWindow;
+  }
+});
+
 test("relay-origin store: publishes are canonicalized at the store boundary", () => {
   // The store must hold the invariant that `cachedRelayOrigin` is always a
   // canonical URL origin — consumers compare `new URL(src).origin` against it

--- a/desktop/src/shared/lib/mediaUrl.ts
+++ b/desktop/src/shared/lib/mediaUrl.ts
@@ -63,8 +63,15 @@ let cacheGeneration = 0;
 /** `useSyncExternalStore` listeners for relay-origin changes. */
 const relayOriginListeners = new Set<() => void>();
 
+/** `useSyncExternalStore` listeners for media-proxy port changes. */
+const mediaProxyPortListeners = new Set<() => void>();
+
 function notifyRelayOriginListeners(): void {
   for (const listener of relayOriginListeners) listener();
+}
+
+function notifyMediaProxyPortListeners(): void {
+  for (const listener of mediaProxyPortListeners) listener();
 }
 
 /**
@@ -105,6 +112,18 @@ export function subscribeRelayOrigin(listener: () => void): () => void {
   relayOriginListeners.add(listener);
   return () => {
     relayOriginListeners.delete(listener);
+  };
+}
+
+/**
+ * Subscribe to media-proxy port changes. Returns a stable unsubscribe function
+ * for `useSyncExternalStore` consumers that need to re-run `rewriteRelayUrl`
+ * once the async Tauri proxy lookup has resolved.
+ */
+export function subscribeMediaProxyPort(listener: () => void): () => void {
+  mediaProxyPortListeners.add(listener);
+  return () => {
+    mediaProxyPortListeners.delete(listener);
   };
 }
 
@@ -188,7 +207,10 @@ async function fetchProxyPort(): Promise<number | null> {
           deadline,
         );
         if (port !== null && port > 0 && generation === cacheGeneration) {
-          cachedPort = port;
+          if (cachedPort !== port) {
+            cachedPort = port;
+            notifyMediaProxyPortListeners();
+          }
         }
       } catch {
         // invoke failed (e.g. Tauri IPC not ready yet) — keep retrying
@@ -227,8 +249,12 @@ if (typeof window !== "undefined") {
  */
 export function resetMediaCaches(): void {
   cacheGeneration += 1;
+  const hadCachedPort = cachedPort !== null;
   cachedPort = null;
   portPromise = null;
+  if (hadCachedPort) {
+    notifyMediaProxyPortListeners();
+  }
   if (cachedRelayOrigin !== null) {
     cachedRelayOrigin = null;
     notifyRelayOriginListeners();
@@ -244,6 +270,14 @@ export function resetMediaCaches(): void {
  */
 export function getCachedRelayOrigin(): string | null {
   return cachedRelayOrigin;
+}
+
+/**
+ * The localhost proxy port if it has been resolved, else `null`. Synchronous
+ * best-effort read of the same cache `rewriteRelayUrl` uses.
+ */
+export function getCachedMediaProxyPort(): number | null {
+  return cachedPort;
 }
 
 /**

--- a/desktop/src/shared/lib/useMediaProxyPort.ts
+++ b/desktop/src/shared/lib/useMediaProxyPort.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+import { getCachedMediaProxyPort, subscribeMediaProxyPort } from "./mediaUrl";
+
+/**
+ * The resolved localhost media-proxy port, re-rendering when it resolves or
+ * changes. Components that call `rewriteRelayUrl` during render can subscribe
+ * to this so an initial `buzz-media://` fallback is replaced by the loopback
+ * proxy URL as soon as the Tauri backend reports the port.
+ */
+export function useMediaProxyPort(): number | null {
+  return React.useSyncExternalStore(
+    subscribeMediaProxyPort,
+    getCachedMediaProxyPort,
+    () => null,
+  );
+}

--- a/desktop/tests/e2e/agent-access-warning.spec.ts
+++ b/desktop/tests/e2e/agent-access-warning.spec.ts
@@ -66,10 +66,7 @@ test("open agent access explains the available access before save", async ({
   const warning = page.getByTestId("agent-access-warning");
   await expect(warning).toBeVisible();
   await expect(warning).toContainText(
-    "Anyone can use this agent to access the computer or server where it runs.",
-  );
-  await expect(warning).toContainText(
-    "They can access files, accounts, and tools available to the agent.",
+    "Anyone can use this agent to access files, accounts, and tools on the computer or server where it runs.",
   );
 
   await waitForAnimations(page);
@@ -135,7 +132,7 @@ test("persona-backed edit warns before saving open access", async ({
   );
   await choosePersonaAccess(page, "Anyone");
   await expect(dialog.getByTestId("agent-access-warning")).toContainText(
-    "Anyone can use this agent to access the computer or server where it runs",
+    "Anyone can use this agent to access files, accounts, and tools on the computer or server where it runs",
   );
 
   const commandsBeforeSave = await page.evaluate(

--- a/desktop/tests/e2e/agent-access-warning.spec.ts
+++ b/desktop/tests/e2e/agent-access-warning.spec.ts
@@ -66,10 +66,10 @@ test("open agent access explains the available access before save", async ({
   const warning = page.getByTestId("agent-access-warning");
   await expect(warning).toBeVisible();
   await expect(warning).toContainText(
-    "Anyone can send instructions to this agent and use it to access the computer or server where it runs.",
+    "Anyone can use this agent to access the computer or server where it runs.",
   );
   await expect(warning).toContainText(
-    "This includes files, accounts, and tools available to the agent.",
+    "They can access files, accounts, and tools available to the agent.",
   );
 
   await waitForAnimations(page);
@@ -135,7 +135,7 @@ test("persona-backed edit warns before saving open access", async ({
   );
   await choosePersonaAccess(page, "Anyone");
   await expect(dialog.getByTestId("agent-access-warning")).toContainText(
-    "use it to access the computer or server where it runs",
+    "Anyone can use this agent to access the computer or server where it runs",
   );
 
   const commandsBeforeSave = await page.evaluate(

--- a/desktop/tests/e2e/agent-access-warning.spec.ts
+++ b/desktop/tests/e2e/agent-access-warning.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const SHOTS = "test-results/agent-access-warning";
+
+async function choosePersonaAccess(
+  page: import("@playwright/test").Page,
+  optionName: string,
+) {
+  await page.locator("#agent-respond-to").click();
+  await page.getByRole("menuitemradio", { name: optionName }).click();
+}
+
+async function openAgentAccessDialog(
+  page: import("@playwright/test").Page,
+  agentPubkey: string,
+) {
+  if (!(await page.getByTestId("members-sidebar").isVisible())) {
+    await page.getByTestId("channel-general").click();
+    await page.getByTestId("channel-members-trigger").click();
+    await expect(page.getByTestId("members-sidebar")).toBeVisible();
+  }
+
+  const row = page.getByTestId(`sidebar-member-${agentPubkey}`);
+  const menu = page.getByTestId(`sidebar-member-menu-${agentPubkey}`);
+  await row.hover();
+  await menu.focus();
+  await menu.press("Enter");
+  await page.getByTestId(`sidebar-edit-respond-to-${agentPubkey}`).click();
+
+  await expect(
+    page.getByRole("dialog", { name: "Manage agent access" }),
+  ).toBeVisible();
+}
+
+test("open agent access explains the available access before save", async ({
+  page,
+}) => {
+  const agent = TEST_IDENTITIES.charlie;
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: agent.pubkey,
+        name: "Hack Day Helper",
+        status: "running",
+        channelNames: ["general"],
+        respondTo: "owner-only",
+      },
+    ],
+  });
+  await page.goto("/");
+  await openAgentAccessDialog(page, agent.pubkey);
+
+  const accessSelect = page.getByTestId("agent-respond-to-select");
+  await expect(accessSelect).toHaveValue("owner-only");
+  await expect(page.getByTestId("agent-access-warning")).toHaveCount(0);
+  const saveAccess = page.getByRole("button", { name: "Save access" });
+  await expect(saveAccess).toBeVisible();
+
+  const commandsBeforeSave = await page.evaluate(
+    () => window.__BUZZ_E2E_COMMAND_LOG__?.length ?? 0,
+  );
+  await accessSelect.selectOption("anyone");
+  const warning = page.getByTestId("agent-access-warning");
+  await expect(warning).toBeVisible();
+  await expect(warning).toContainText(
+    "Anyone can send instructions to this agent and use it to access the computer or server where it runs.",
+  );
+  await expect(warning).toContainText(
+    "This includes files, accounts, and tools available to the agent.",
+  );
+
+  await waitForAnimations(page);
+  await page
+    .getByRole("dialog", { name: "Manage agent access" })
+    .screenshot({ path: `${SHOTS}/open-access-warning.png` });
+
+  await saveAccess.click();
+  await expect(
+    page.getByRole("dialog", { name: "Manage agent access" }),
+  ).not.toBeVisible();
+  await expect
+    .poll(async () =>
+      page.evaluate((start) => {
+        const commands = window.__BUZZ_E2E_COMMAND_LOG__ ?? [];
+        return commands
+          .slice(start)
+          .some(
+            (entry) =>
+              entry.command === "update_managed_agent" &&
+              (entry.payload as { input?: { respondTo?: string } })?.input
+                ?.respondTo === "anyone",
+          );
+      }, commandsBeforeSave),
+    )
+    .toBe(true);
+
+  await openAgentAccessDialog(page, agent.pubkey);
+  await expect(accessSelect).toHaveValue("anyone");
+  await accessSelect.selectOption("allowlist");
+  await expect(warning).toHaveCount(0);
+  await expect(
+    page
+      .getByTestId("agent-respond-to-allowlist")
+      .getByText("Selected people", { exact: true }),
+  ).toBeVisible();
+});
+
+test("persona-backed edit warns before saving open access", async ({
+  page,
+}) => {
+  const agent = TEST_IDENTITIES.tyler;
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: agent.pubkey,
+        name: "Tyler Agent",
+        status: "stopped",
+        channelNames: ["agents"],
+        respondTo: "owner-only",
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("open-agents-view").click();
+  await page.getByRole("button", { name: "Tyler Agent agent profile" }).click();
+  await page.getByTestId("user-profile-edit-agent").click();
+
+  const dialog = page.getByTestId("edit-agent-dialog");
+  await expect(dialog).toBeVisible();
+  await expect(page.locator("#agent-respond-to")).toHaveText(
+    "Only me (default)",
+  );
+  await choosePersonaAccess(page, "Anyone");
+  await expect(dialog.getByTestId("agent-access-warning")).toContainText(
+    "use it to access the computer or server where it runs",
+  );
+
+  const commandsBeforeSave = await page.evaluate(
+    () => window.__BUZZ_E2E_COMMAND_LOG__?.length ?? 0,
+  );
+  await page.getByTestId("edit-agent-dialog-submit").click();
+  await expect(dialog).not.toBeVisible();
+  await expect
+    .poll(async () =>
+      page.evaluate((start) => {
+        const commands = window.__BUZZ_E2E_COMMAND_LOG__ ?? [];
+        return commands
+          .slice(start)
+          .some(
+            (entry) =>
+              entry.command === "update_managed_agent" &&
+              (entry.payload as { input?: { respondTo?: string } })?.input
+                ?.respondTo === "anyone",
+          );
+      }, commandsBeforeSave),
+    )
+    .toBe(true);
+});

--- a/desktop/tests/e2e/agent-access-warning.spec.ts
+++ b/desktop/tests/e2e/agent-access-warning.spec.ts
@@ -66,7 +66,7 @@ test("open agent access explains the available access before save", async ({
   const warning = page.getByTestId("agent-access-warning");
   await expect(warning).toBeVisible();
   await expect(warning).toContainText(
-    "Anyone can use this agent to access the computer or server where it runs, including files, accounts, and tools available to the agent.",
+    "Anyone will be able to access the computer or server running this agent.",
   );
 
   await waitForAnimations(page);
@@ -132,7 +132,7 @@ test("persona-backed edit warns before saving open access", async ({
   );
   await choosePersonaAccess(page, "Anyone");
   await expect(dialog.getByTestId("agent-access-warning")).toContainText(
-    "Anyone can use this agent to access the computer or server where it runs, including files, accounts, and tools available to the agent",
+    "Anyone will be able to access the computer or server running this agent",
   );
 
   const commandsBeforeSave = await page.evaluate(

--- a/desktop/tests/e2e/agent-access-warning.spec.ts
+++ b/desktop/tests/e2e/agent-access-warning.spec.ts
@@ -66,7 +66,7 @@ test("open agent access explains the available access before save", async ({
   const warning = page.getByTestId("agent-access-warning");
   await expect(warning).toBeVisible();
   await expect(warning).toContainText(
-    "Anyone can use this agent to access files, accounts, and tools on the computer or server where it runs.",
+    "Anyone can use this agent to access the computer or server where it runs, including files, accounts, and tools available to the agent.",
   );
 
   await waitForAnimations(page);
@@ -132,7 +132,7 @@ test("persona-backed edit warns before saving open access", async ({
   );
   await choosePersonaAccess(page, "Anyone");
   await expect(dialog.getByTestId("agent-access-warning")).toContainText(
-    "Anyone can use this agent to access files, accounts, and tools on the computer or server where it runs",
+    "Anyone can use this agent to access the computer or server where it runs, including files, accounts, and tools available to the agent",
   );
 
   const commandsBeforeSave = await page.evaluate(

--- a/desktop/tests/e2e/agent-access-warning.spec.ts
+++ b/desktop/tests/e2e/agent-access-warning.spec.ts
@@ -66,7 +66,7 @@ test("open agent access explains the available access before save", async ({
   const warning = page.getByTestId("agent-access-warning");
   await expect(warning).toBeVisible();
   await expect(warning).toContainText(
-    "Anyone will be able to access the computer or server running this agent.",
+    "Anyone can use this agent to access your computer, including files, accounts, and connected tools.",
   );
 
   await waitForAnimations(page);
@@ -96,13 +96,60 @@ test("open agent access explains the available access before save", async ({
 
   await openAgentAccessDialog(page, agent.pubkey);
   await expect(accessSelect).toHaveValue("anyone");
+  // Selected people narrows the audience but not the access, so the warning
+  // persists with its own audience phrase.
   await accessSelect.selectOption("allowlist");
-  await expect(warning).toHaveCount(0);
+  await expect(warning).toBeVisible();
+  await expect(warning).toContainText(
+    "Selected people can use this agent to access your computer, including files, accounts, and connected tools.",
+  );
+  const picker = page.getByTestId("agent-respond-to-allowlist");
   await expect(
-    page
-      .getByTestId("agent-respond-to-allowlist")
-      .getByText("Selected people", { exact: true }),
+    picker.getByText("Selected people", { exact: true }),
   ).toBeVisible();
+
+  // The warning sits below the picker so it never blocks the selection the
+  // user came here to make.
+  await waitForAnimations(page);
+  const pickerBox = await picker.boundingBox();
+  const warningBox = await warning.boundingBox();
+  expect(pickerBox?.y).toBeDefined();
+  expect(warningBox?.y).toBeGreaterThan(pickerBox?.y ?? 0);
+  await page
+    .getByRole("dialog", { name: "Manage agent access" })
+    .screenshot({ path: `${SHOTS}/selected-people-warning.png` });
+
+  // Only me shares nothing, so the warning goes away entirely.
+  await accessSelect.selectOption("owner-only");
+  await expect(warning).toHaveCount(0);
+});
+
+test("a provider-backed agent's warning names the server, not this computer", async ({
+  page,
+}) => {
+  const agent = TEST_IDENTITIES.charlie;
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: agent.pubkey,
+        name: "Remote Helper",
+        status: "running",
+        channelNames: ["general"],
+        respondTo: "owner-only",
+        backend: { type: "provider", id: "blox", config: {} },
+      },
+    ],
+  });
+  await page.goto("/");
+  await openAgentAccessDialog(page, agent.pubkey);
+
+  await page.getByTestId("agent-respond-to-select").selectOption("anyone");
+  const warning = page.getByTestId("agent-access-warning");
+  await expect(warning).toContainText(
+    "Anyone can use this agent to access the server it runs on, including any accounts and tools available there.",
+  );
+  // The local wording must not leak into a remote-backed agent.
+  await expect(warning).not.toContainText("your computer");
 });
 
 test("persona-backed edit warns before saving open access", async ({
@@ -132,7 +179,7 @@ test("persona-backed edit warns before saving open access", async ({
   );
   await choosePersonaAccess(page, "Anyone");
   await expect(dialog.getByTestId("agent-access-warning")).toContainText(
-    "Anyone will be able to access the computer or server running this agent",
+    "Anyone can use this agent to access your computer, including files, accounts, and connected tools.",
   );
 
   const commandsBeforeSave = await page.evaluate(

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -1021,7 +1021,7 @@ test("declared owner sees runtime tab for a remote relay agent", async ({
     "Goose",
   );
   await expect(panel.getByTestId("user-profile-respond-to")).toContainText(
-    "anyone",
+    "Anyone",
   );
 
   // Declared ownership grants read visibility only; local-management write UI


### PR DESCRIPTION
## Why

Hack-day feedback exposed a dangerous mismatch between the UI and the underlying access model. The `Anyone` respond-to mode appeared as a neutral dropdown choice, while a Buzz agent may act with the files, accounts, and tools available on the machine where it runs.

People reasonably read this as sharing a bot in a channel. The current UI did not explain that it can also share the agent's available access.

## What

- Reframes `respond-to` as **agent access** in user-facing UI.
- Uses plain audience labels: **Only me**, **Anyone**, and **Selected people**.
- Warns for **both** sharing modes, not just `Anyone` — `Selected people` also hands host access to someone other than the owner, so only the audience phrase differs:
  > Anyone can use this agent to access your computer, including files, accounts, and connected tools.

  > Selected people can use this agent to access your computer, including files, accounts, and connected tools.
- Names the machine the agent actually runs on. A provider-backed (remote) agent reads:
  > Anyone can use this agent to access the server it runs on, including any accounts and tools available there.

  The remote wording deliberately omits the owner's files — those aren't theirs to describe on a host they don't own.
- Places the warning below the selector for `Anyone`, but **after** the people picker for `Selected people`, so it never sits between the user and the selection they came to make.
- Removes Nostr, harness, pubkey, and `!shutdown` jargon from the primary decision copy. Direct pubkey entry remains available as an advanced path.
- Replaces the green open-access avatar dot with an amber warning marker and accessible text. Selected access uses a separate blue status.
- Aligns the sidebar action and profile field with the same language.
- Records the shared-field disclosure contract in `desktop/src/features/agents/AGENTS.md` so future surfaces do not silently omit it.

## Design decisions

**Persistent inline warning, not a confirmation modal.** The setting does not autosave; the consequence remains visible beside the selection until the person chooses **Save access**. This gives the information before commitment without adding a dismiss-and-confirm ritual that would repeat in every create/edit surface.

**An unknown run location falls back to the local wording.** It does not hedge with "computer or server". A remote host requires an installed `buzz-backend-*` provider, and without one `WhereToRunSection` never renders — so "server" would name a concept the owner has never been shown. When it *is* remote, they picked that host from the selector themselves. Surfaces never synthesize a run location they don't have.

**One resolution site, published through context.** `AgentDialog` resolves the run location (`runLocationForBackend` from `ManagedAgent.backend`, `runLocationForRunOn` from the create flow's `WhereToRunDraft`) and publishes it via `AgentRunLocationContext`. It is not threaded as a prop through `AgentDefinitionDialog` (1047 lines) or `AgentInstanceEditDialog` (1228 lines) — neither uses the value, and both are already over the file-size ceiling. Surfaces outside that tree (`EditRespondToDialog`) pass the prop directly.

The copy follows the writing system's guidance for high-sensitivity decisions: lead with the material consequence, use plain actor/action language, keep helper text adjacent and persistent, and never rely on color alone.

## Scope

Desktop only. The web and mobile clients do not currently expose this setting. No protocol, gate, runtime, persistence, or backend behavior changes.

This does not add team-scoped remote agents. It makes the current local-or-remote access model honest while that product work remains separate.

## Validation

- `pnpm exec biome check` and `pnpm exec tsc --noEmit` — clean
- `lib/agentAccessWarning.test.mjs` (8/8) — every mode × run-location copy variant, both resolvers, unknown-reads-as-local, blank `runOn` is not a provider
- `ui/respondToFieldContract.test.mjs` (8/8) — plain labels, both warning positions, source-order guard that the `allowlist` warning follows the picker, helper-not-inline-copy guard
- `agent-access-warning.spec.ts` (3/3) — native local, provider-backed remote (asserts the server sentence and *not* "your computer"), persona-backed edit; includes a bounding-box check that the `Selected people` warning renders below the picker
