### PR TITLE
fix(desktop): populate team instructions when opening the edit team dialog

### DIFF
--- a/desktop/src/features/agents/ui/useTeamActions.ts
+++ b/desktop/src/features/agents/ui/useTeamActions.ts
@@ -215,6 +215,7 @@ export function useTeamActions(
         id: team.id,
         name: team.name,
         description: team.description ?? "",
+        instructions: team.instructions ?? undefined,
         personaIds: [...team.personaIds],
       },
     });


### PR DESCRIPTION
## Summary

`openEditDialog()` in `useTeamActions.ts` omits `instructions` when building `initialValues` for the Edit Team dialog. This causes two problems:

- **Display bug:** The Team Instructions field always appears blank when editing a team, even when instructions are stored — `TeamDialog.tsx` initializes `instructions` state from `initialValues.instructions ?? ""`, which resolves to `""` when the property is absent.
- **Silent data loss:** Saving the dialog without re-pasting instructions submits `instructions: undefined`, which `update_team` persists as `None` and publishes via kind:30176 — permanently wiping the stored team instructions.

Bug has existed since #1846 introduced the `instructions` field. TypeScript never flagged it because `UpdateTeamInput.instructions` is optional.

## Fix

Add `instructions: team.instructions ?? undefined` to the `initialValues` object in `openEditDialog()`, so the dialog opens pre-populated with the stored instructions.