### PR TITLE
feat(managed-agents): add Oh My Pi as a native ACP runtime

### DIFF
--- a/desktop/src-tauri/src/commands/agent_config.rs
+++ b/desktop/src-tauri/src/commands/agent_config.rs
@@ -631,6 +631,7 @@ mod tests {
             required_normalized_fields: &["model", "provider"],
             login_hint: None,
             auth_probe_args: None,
+            auth_probe_requires_positive_integer_stdout: false,
         }
     }
 

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -59,6 +59,7 @@ fn test_runtime() -> &'static KnownAcpRuntime {
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_probe_requires_positive_integer_stdout: false,
     }
 }
 
@@ -635,6 +636,7 @@ fn buzz_agent_runtime() -> &'static KnownAcpRuntime {
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_probe_requires_positive_integer_stdout: false,
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -14,6 +14,8 @@ mod runtime_metadata;
 pub(crate) use runtime_metadata::KnownAcpRuntime;
 
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
+const OMP_AVATAR_URL: &str =
+    "https://raw.githubusercontent.com/can1357/oh-my-pi/refs/heads/main/assets/icon.svg";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
 const BUZZ_AGENT_AVATAR_URL: &str =
@@ -49,8 +51,10 @@ fn common_binary_paths() -> &'static [PathBuf] {
                 paths.push(PathBuf::from(appdata).join("npm"));
             }
             if let Some(local) = std::env::var_os("LOCALAPPDATA") {
+                let local = PathBuf::from(local);
+                paths.push(local.join("omp"));
                 paths.push(
-                    PathBuf::from(local)
+                    local
                         .join("Programs")
                         .join("OpenAI")
                         .join("Codex")
@@ -96,6 +100,40 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_probe_requires_positive_integer_stdout: false,
+    },
+    KnownAcpRuntime {
+        id: "omp",
+        label: "Oh My Pi",
+        commands: &["omp"],
+        aliases: &["oh-my-pi"],
+        avatar_url: OMP_AVATAR_URL,
+        mcp_command: None,
+        mcp_hooks: false,
+        underlying_cli: Some("omp"),
+        cli_install_commands: &["curl -fsSL https://omp.sh/install | sh"],
+        cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://omp.sh/install.ps1 | iex\""],
+        adapter_install_commands: &[],
+        cli_install_instructions_url: "https://github.com/can1357/oh-my-pi",
+        adapter_install_instructions_url: "",
+        cli_install_hint: "Install Oh My Pi via the official install script, then run `omp setup`.",
+        adapter_install_hint: "",
+        skill_dir: Some(".omp/skills"),
+        supports_acp_model_switching: false,
+        model_env_var: None,
+        provider_env_var: None,
+        provider_locked: true,
+        default_env: &[],
+        config_file_path: Some("~/.omp/agent/config.yml"),
+        config_file_format: Some("yaml"),
+        supports_acp_native_config: false,
+        thinking_env_var: None,
+        max_tokens_env_var: None,
+        context_limit_env_var: None,
+        required_normalized_fields: &[],
+        login_hint: Some("Run `omp setup` to choose a model and authenticate."),
+        auth_probe_args: Some(&["omp", "config", "get", "setupVersion"]),
+        auth_probe_requires_positive_integer_stdout: true,
     },
     KnownAcpRuntime {
         id: "claude",
@@ -128,6 +166,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         required_normalized_fields: &[],
         login_hint: Some("Run the Claude CLI to complete authentication."),
         auth_probe_args: Some(&["claude", "auth", "status"]),
+        auth_probe_requires_positive_integer_stdout: false,
     },
     KnownAcpRuntime {
         id: "codex",
@@ -161,6 +200,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         login_hint: Some("Run `codex login` to authenticate."),
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
         auth_probe_args: Some(&["codex", "login", "status"]),
+        auth_probe_requires_positive_integer_stdout: false,
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -193,6 +233,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
         auth_probe_args: None,
+        auth_probe_requires_positive_integer_stdout: false,
     },
 ];
 
@@ -348,7 +389,7 @@ pub use overrides::{apply_agent_command_update, create_time_agent_command_overri
 
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
-        "goose" => Some(vec!["acp".to_string()]),
+        "goose" | "omp" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,
@@ -905,13 +946,24 @@ pub(crate) fn is_npm_global_install(cmd: &str) -> bool {
         || t.starts_with("npm uninstall -g ")
 }
 
+fn stdout_is_positive_integer(stdout: &[u8]) -> bool {
+    String::from_utf8_lossy(stdout)
+        .trim()
+        .parse::<u64>()
+        .is_ok_and(|value| value > 0)
+}
+
 /// Run a CLI auth probe with a 10-second process-level timeout.
 ///
 /// Spawns the probe CLI as a child process. Stdout and stderr are drained on
 /// background threads to prevent pipe-buffer deadlock. On timeout the child is
 /// killed and `Unknown` is returned; no orphaned threads or processes are left
 /// behind. Returns `Unknown` on timeout.
-fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
+fn probe_auth_status(
+    binary_path: &Path,
+    probe_args: &[&str],
+    require_positive_integer_stdout: bool,
+) -> AuthStatus {
     use crate::managed_agents::readiness::cli_probe;
 
     let augmented_path = cli_probe::augmented_path();
@@ -941,6 +993,7 @@ fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
         if let Some(mut pipe) = stdout_pipe {
             let _ = pipe.read_to_end(&mut buf);
         }
+        buf
     });
     let stderr_thread = std::thread::spawn(move || {
         let mut buf = Vec::new();
@@ -992,8 +1045,15 @@ fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
     };
 
     let _ = wait_thread.join();
-    let _ = stdout_thread.join();
+    let stdout_bytes = stdout_thread.join().unwrap_or_default();
     let stderr_bytes = stderr_thread.join().unwrap_or_default();
+
+    if exit_status.success()
+        && require_positive_integer_stdout
+        && !stdout_is_positive_integer(&stdout_bytes)
+    {
+        return AuthStatus::LoggedOut;
+    }
 
     match cli_probe::classify_probe_output(&stderr_bytes, exit_status.success()) {
         cli_probe::ProbeOutcome::LoggedIn => AuthStatus::LoggedIn,
@@ -1320,10 +1380,12 @@ pub fn discover_acp_runtimes() -> Vec<AcpRuntimeCatalogEntry> {
             // Need the resolved binary path for the CLI (e.g. the actual `claude` binary).
             let binary_path = resolve_command(probe_args[0])?;
             let probe_args_owned: Vec<String> = probe_args.iter().map(|s| s.to_string()).collect();
+            let require_positive_integer_stdout =
+                partial.runtime.auth_probe_requires_positive_integer_stdout;
 
             let handle = std::thread::spawn(move || {
                 let refs: Vec<&str> = probe_args_owned.iter().map(String::as_str).collect();
-                probe_auth_status(&binary_path, &refs)
+                probe_auth_status(&binary_path, &refs, require_positive_integer_stdout)
             });
             Some((idx, handle))
         })

--- a/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
@@ -62,6 +62,9 @@ pub(crate) struct KnownAcpRuntime {
     /// CLI args for probing authentication status. `args[0]` is the binary name;
     /// the remainder are the subcommand. `None` for runtimes with no login step.
     pub auth_probe_args: Option<&'static [&'static str]>,
+    /// Require a successful auth probe's trimmed stdout to parse as a positive
+    /// integer. Used for versioned setup markers such as OMP's `setupVersion`.
+    pub auth_probe_requires_positive_integer_stdout: bool,
 }
 
 impl KnownAcpRuntime {

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -8,7 +8,7 @@ use super::{
     is_login_shell_path_uninit, is_safe_nvm_tag, managed_agent_avatar_url, normalize_agent_args,
     parse_semver_tag, probe_codex_acp_major_version, record_agent_command,
     refresh_login_shell_path, BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL,
-    GOOSE_AVATAR_URL,
+    GOOSE_AVATAR_URL, OMP_AVATAR_URL,
 };
 use crate::managed_agents::AcpAvailabilityStatus;
 
@@ -36,6 +36,10 @@ fn resolves_known_avatar_for_command_paths_and_aliases() {
     assert_eq!(
         managed_agent_avatar_url("/usr/local/bin/claude-code-acp"),
         Some(CLAUDE_CODE_AVATAR_URL.to_string())
+    );
+    assert_eq!(
+        managed_agent_avatar_url(r"C:\Tools\omp.exe"),
+        Some(OMP_AVATAR_URL.to_string())
     );
 }
 
@@ -70,6 +74,46 @@ fn normalizes_claude_and_codex_args_to_empty() {
         normalize_agent_args("codex-acp", vec!["acp".into()]),
         Vec::<String>::new()
     );
+}
+
+#[test]
+fn normalizes_omp_args_to_acp() {
+    assert_eq!(
+        normalize_agent_args("omp", Vec::new()),
+        vec!["acp".to_string()]
+    );
+}
+
+#[test]
+fn classifies_positive_integer_auth_probe_stdout() {
+    assert!(!super::stdout_is_positive_integer(b""));
+    assert!(!super::stdout_is_positive_integer(b"0\n"));
+    assert!(!super::stdout_is_positive_integer(b"not-a-number"));
+    assert!(super::stdout_is_positive_integer(b" 2\r\n"));
+}
+
+#[cfg(unix)]
+#[test]
+fn auth_probe_requires_positive_integer_stdout() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = std::env::temp_dir().join(format!("buzz-auth-probe-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let binary = dir.join("probe");
+    std::fs::write(&binary, "#!/bin/sh\nprintf '0\\n'\n").expect("write probe");
+    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755)).expect("chmod probe");
+
+    assert_eq!(
+        super::probe_auth_status(&binary, &["probe"], true),
+        crate::managed_agents::AuthStatus::LoggedOut
+    );
+    std::fs::write(&binary, "#!/bin/sh\nprintf '2\\n'\n").expect("update probe");
+    assert_eq!(
+        super::probe_auth_status(&binary, &["probe"], true),
+        crate::managed_agents::AuthStatus::LoggedIn
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
 }
 
 #[test]
@@ -1074,9 +1118,10 @@ fn test_command_basenames_dotted_name_no_extra_candidates() {
 
 // ── Phase B: cli_install_commands_for_os ────────────────────────────────────
 
-/// Claude and Codex have non-empty default cli_install_commands (install.sh).
+/// Supported external runtimes have non-empty default CLI install commands.
 #[test]
-fn test_claude_and_codex_have_cli_install_commands() {
+fn test_external_runtimes_have_cli_install_commands() {
+    let omp = super::known_acp_runtime_exact("omp").unwrap();
     let claude = super::known_acp_runtime_exact("claude").unwrap();
     let codex = super::known_acp_runtime_exact("codex").unwrap();
     assert!(
@@ -1087,11 +1132,16 @@ fn test_claude_and_codex_have_cli_install_commands() {
         !codex.cli_install_commands.is_empty(),
         "codex must have cli install commands"
     );
+    assert!(
+        !omp.cli_install_commands.is_empty(),
+        "omp must have cli install commands"
+    );
 }
 
-/// cli_install_commands_for_os returns a non-empty slice for claude and codex.
+/// Install commands are available for each supported external runtime.
 #[test]
-fn test_cli_install_commands_for_os_non_empty_for_claude_codex() {
+fn test_cli_install_commands_for_os_non_empty_for_external_runtimes() {
+    let omp = super::known_acp_runtime_exact("omp").unwrap();
     let claude = super::known_acp_runtime_exact("claude").unwrap();
     let codex = super::known_acp_runtime_exact("codex").unwrap();
     assert!(
@@ -1102,12 +1152,17 @@ fn test_cli_install_commands_for_os_non_empty_for_claude_codex() {
         !codex.cli_install_commands_for_os().is_empty(),
         "codex must have install commands on every platform"
     );
+    assert!(
+        !omp.cli_install_commands_for_os().is_empty(),
+        "omp must have install commands on every platform"
+    );
 }
 
 /// On Windows, every vendor CLI selects its official PowerShell installer.
 #[cfg(windows)]
 #[test]
 fn test_cli_install_commands_for_os_selects_powershell_on_windows() {
+    let omp = super::known_acp_runtime_exact("omp").unwrap();
     let claude = super::known_acp_runtime_exact("claude").unwrap();
     let codex = super::known_acp_runtime_exact("codex").unwrap();
     let goose = super::known_acp_runtime_exact("goose").unwrap();
@@ -1116,6 +1171,7 @@ fn test_cli_install_commands_for_os_selects_powershell_on_windows() {
     let claude_cmds = claude.cli_install_commands_for_os();
     let codex_cmds = codex.cli_install_commands_for_os();
     let goose_cmds = goose.cli_install_commands_for_os();
+    let omp_cmds = omp.cli_install_commands_for_os();
 
     assert_ne!(
         claude_cmds, claude.cli_install_commands,
@@ -1126,6 +1182,10 @@ fn test_cli_install_commands_for_os_selects_powershell_on_windows() {
         "Windows must NOT use the default curl|bash commands for codex"
     );
     assert_eq!(goose_cmds, goose.cli_install_commands_windows);
+    assert_ne!(
+        omp_cmds, omp.cli_install_commands,
+        "Windows must NOT use the default curl|sh commands for omp"
+    );
 
     // Verify they are the PowerShell installers.
     assert!(
@@ -1135,6 +1195,10 @@ fn test_cli_install_commands_for_os_selects_powershell_on_windows() {
     assert!(
         codex_cmds.iter().any(|c| c.contains("powershell")),
         "codex Windows install must use powershell; got: {codex_cmds:?}"
+    );
+    assert!(
+        omp_cmds.iter().any(|c| c.contains("powershell")),
+        "omp Windows install must use powershell; got: {omp_cmds:?}"
     );
     assert!(
         goose_cmds.iter().any(|c| c.contains("download_cli.ps1")),

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -888,6 +888,7 @@ mod tests {
             required_normalized_fields: &[],
             login_hint: None,
             auth_probe_args: None,
+            auth_probe_requires_positive_integer_stdout: false,
         }
     }
 
@@ -1083,6 +1084,7 @@ mod tests {
             required_normalized_fields: &[],
             login_hint: None,
             auth_probe_args: None,
+            auth_probe_requires_positive_integer_stdout: false,
         }
     }
 

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
@@ -12,7 +12,8 @@ function runtime(id, availability, status) {
   return { id, availability, authStatus: { status } };
 }
 
-test("only Claude Code and Codex are visible in onboarding", () => {
+test("Oh My Pi, Claude Code, and Codex are visible in onboarding", () => {
+  assert.equal(runtimeIsVisibleInOnboarding("omp"), true);
   assert.equal(runtimeIsVisibleInOnboarding("claude"), true);
   assert.equal(runtimeIsVisibleInOnboarding("codex"), true);
   assert.equal(runtimeIsVisibleInOnboarding("goose"), false);
@@ -26,11 +27,12 @@ test("visible onboarding runtimes use the product order", () => {
     runtime("codex", "available", "logged_in"),
     runtime("goose", "available", "not_applicable"),
     runtime("claude", "available", "logged_in"),
+    runtime("omp", "available", "not_applicable"),
   ];
 
   assert.deepEqual(
     getVisibleOnboardingRuntimes(runtimes).map(({ id }) => id),
-    ["claude", "codex"],
+    ["omp", "claude", "codex"],
   );
 });
 
@@ -61,10 +63,11 @@ test("ready onboarding runtimes exclude hidden ready harnesses", () => {
     runtime("codex", "available", "logged_out"),
     runtime("buzz-agent", "available", "not_applicable"),
     runtime("claude", "available", "logged_in"),
+    runtime("omp", "available", "not_applicable"),
   ];
 
   assert.deepEqual(
     getReadyOnboardingRuntimes(runtimes).map(({ id }) => id),
-    ["claude"],
+    ["omp", "claude"],
   );
 });

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
@@ -1,6 +1,6 @@
 import type { AcpRuntimeCatalogEntry } from "@/shared/api/types";
 
-export const ONBOARDING_RUNTIME_ORDER = ["claude", "codex"];
+export const ONBOARDING_RUNTIME_ORDER = ["omp", "claude", "codex"];
 
 const VISIBLE_ONBOARDING_RUNTIME_IDS = new Set<string>(
   ONBOARDING_RUNTIME_ORDER,


### PR DESCRIPTION
## Summary
- add Oh My Pi to the ACP runtime catalog with native `omp acp` invocation
- support official macOS/Linux and Windows installers, including the Windows `%LOCALAPPDATA%\omp` path
- gate onboarding on OMP setup completion and expose OMP in the harness picker
- keep OMP first in onboarding so the newly supported native-ACP option is immediately discoverable during rollout; Claude Code and Codex remain available alongside it

### Related issue

None found.

### Testing

- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml managed_agents::discovery::tests:: --lib` (78 passed)
- `node --test --experimental-strip-types desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs` (4 passed)
