### PR TITLE
fix(desktop): fast-track relay restart reconnects

### DIFF
--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -534,8 +534,6 @@ export class RelayClient {
   }
 
   private async connect() {
-    // Clear any pending stability timer from a previous connection — a new
-    // connect attempt resets the clock and must re-arm the timer on success.
     if (this.stabilityTimer !== null) {
       window.clearTimeout(this.stabilityTimer);
       this.stabilityTimer = null;
@@ -545,51 +543,66 @@ export class RelayClient {
       this.hasConnectedOnce ? "reconnecting" : "connecting",
     );
 
-    if (!this.relayUrl) {
-      this.relayUrl = await getRelayWsUrl();
-    }
-
     const generation = ++this.connectionGeneration;
     this.onMessageChannel = new Channel<unknown>((message) => {
-      void this.handleWsMessage(message, generation);
-    });
-
-    this.wsId = await invoke<number>("plugin:websocket|connect", {
-      url: this.relayUrl,
-      onMessage: this.onMessageChannel,
-      config: {},
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      const timeout = window.setTimeout(() => {
-        this.authRequest = null;
+      void this.handleWsMessage(message, generation).catch((error) => {
+        if (generation !== this.connectionGeneration) return;
         this.resetConnection(
-          new Error("Timed out while waiting for relay authentication."),
+          this.normalizeRelayError(error, "Relay connection errored."),
         );
-        reject(new Error("Timed out while waiting for relay authentication."));
-      }, AUTH_TIMEOUT_MS);
-
-      this.authRequest = {
-        pendingEventId: "",
-        resolve,
-        reject,
-        timeout,
-      };
+      });
     });
 
-    // Start a stability timer instead of resetting backoff immediately.
-    // The backoff resets to its base value only after BACKOFF_RESET_STABLE_MS
-    // of uninterrupted uptime, preventing fast reconnect loops from erasing
-    // the exponential backoff that throttles them.
-    this.stabilityTimer = window.setTimeout(() => {
-      this.stabilityTimer = null;
-      this.reconnectDelayMs = RECONNECT_BASE_DELAY_MS;
-    }, BACKOFF_RESET_STABLE_MS);
+    try {
+      if (!this.relayUrl) {
+        this.relayUrl = await getRelayWsUrl();
+      }
+      const wsId = await invoke<number>("plugin:websocket|connect", {
+        url: this.relayUrl,
+        onMessage: this.onMessageChannel,
+        config: {},
+      });
+      if (generation !== this.connectionGeneration) {
+        void closeWebSocket(wsId, "stale connection attempt");
+        throw new Error("Relay connection attempt was superseded.");
+      }
+      this.wsId = wsId;
 
-    await this.replayLiveSubscriptions();
-    this.connectionStateEmitter.set("connected");
-    this.stallWatchdog.start();
-    this.emitReconnectIfNeeded();
+      await new Promise<void>((resolve, reject) => {
+        const timeout = window.setTimeout(() => {
+          const error = new Error("Relay authentication timed out.");
+          this.authRequest = null;
+          this.resetConnection(error);
+          reject(error);
+        }, AUTH_TIMEOUT_MS);
+
+        this.authRequest = {
+          pendingEventId: "",
+          resolve,
+          reject,
+          timeout,
+        };
+      });
+
+      this.stabilityTimer = window.setTimeout(() => {
+        this.stabilityTimer = null;
+        this.reconnectDelayMs = RECONNECT_BASE_DELAY_MS;
+      }, BACKOFF_RESET_STABLE_MS);
+
+      await this.replayLiveSubscriptions();
+      this.connectionStateEmitter.set("connected");
+      this.stallWatchdog.start();
+      this.emitReconnectIfNeeded();
+    } catch (error) {
+      const connectionError = this.normalizeRelayError(
+        error,
+        "Failed to connect to relay.",
+      );
+      if (generation === this.connectionGeneration) {
+        this.resetConnection(connectionError);
+      }
+      throw connectionError;
+    }
   }
 
   private async subscribe(

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -43,6 +43,8 @@ import {
 import { requestHistoryGated } from "@/shared/api/relayGateBoundary";
 import { RelayConnectionStateEmitter } from "@/shared/api/relayConnectionStateEmitter";
 import {
+  isServiceRestartClose,
+  isWebSocketClose,
   shouldRefuseConnect,
   shouldScheduleReconnect,
 } from "@/shared/api/relayReconnectPolicy";
@@ -767,16 +769,12 @@ export class RelayClient {
     if (generation !== this.connectionGeneration) return;
     this.stallWatchdog.recordInbound();
 
-    if (
-      typeof message === "object" &&
-      message !== null &&
-      "type" in message &&
-      message.type === "Close"
-    ) {
+    if (isWebSocketClose(message)) {
+      if (isServiceRestartClose(message))
+        this.reconnectDelayMs = RECONNECT_BASE_DELAY_MS;
       this.resetConnection(new Error("Relay connection closed."));
       return;
     }
-
     if (
       typeof message === "object" &&
       message !== null &&

--- a/desktop/src/shared/api/relayReconnectPolicy.test.mjs
+++ b/desktop/src/shared/api/relayReconnectPolicy.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  isServiceRestartClose,
+  isWebSocketClose,
   shouldRefuseConnect,
   shouldScheduleReconnect,
 } from "./relayReconnectPolicy.ts";
@@ -80,4 +82,26 @@ test("keep-alive alone is enough to schedule", () => {
 test("shouldRefuseConnect mirrors terminal", () => {
   assert.equal(shouldRefuseConnect({ terminal: false }), false);
   assert.equal(shouldRefuseConnect({ terminal: true }), true);
+});
+
+test("only a close frame with code 1012 is a service restart", () => {
+  assert.equal(isWebSocketClose({ type: "Close" }), true);
+  assert.equal(isWebSocketClose({ type: "Error" }), false);
+  assert.equal(
+    isServiceRestartClose({
+      type: "Close",
+      data: { code: 1012, reason: "relay restarting" },
+    }),
+    true,
+  );
+  assert.equal(
+    isServiceRestartClose({ type: "Close", data: { code: 1000 } }),
+    false,
+  );
+  assert.equal(isServiceRestartClose({ type: "Close" }), false);
+  assert.equal(
+    isServiceRestartClose({ type: "Error", data: { code: 1012 } }),
+    false,
+  );
+  assert.equal(isServiceRestartClose(null), false);
 });

--- a/desktop/src/shared/api/relayReconnectPolicy.ts
+++ b/desktop/src/shared/api/relayReconnectPolicy.ts
@@ -41,3 +41,26 @@ export function shouldScheduleReconnect(inputs: RelayReconnectInputs): boolean {
 export function shouldRefuseConnect(inputs: { terminal: boolean }): boolean {
   return inputs.terminal;
 }
+
+export function isWebSocketClose(
+  message: unknown,
+): message is { type: "Close"; data?: unknown } {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    message.type === "Close"
+  );
+}
+
+export function isServiceRestartClose(message: unknown): boolean {
+  if (!isWebSocketClose(message)) return false;
+  if (!("data" in message)) return false;
+  const data = message.data;
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "code" in data &&
+    data.code === 1012
+  );
+}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -250,6 +250,8 @@ type E2eConfig = {
     openerError?: string;
     /** Delay binding signatures so specs can exercise request supersession. */
     nostrBindSignDelayMs?: number;
+    /** Reject successive mock WebSocket connect attempts, then resume. */
+    websocketConnectErrors?: string[];
     stallWebsocketSends?: boolean;
     userSearchDelayMs?: number;
     // NIP-IA gate inputs — see tests/helpers/bridge.ts:MockBridgeOptions for
@@ -8498,6 +8500,11 @@ async function connectRealSocket(args: { url?: string; onMessage: unknown }) {
 }
 
 async function connectMockSocket(args: { onMessage: unknown }) {
+  const connectError = getConfig()?.mock?.websocketConnectErrors?.shift();
+  if (connectError) {
+    throw new Error(connectError);
+  }
+
   if (mockWebsocketSendMutexWedged) {
     return new Promise<number>(() => {});
   }

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1038,6 +1038,7 @@ declare global {
     __BUZZ_E2E_GET_RELAY_CONNECTION_STATE__?: () => ConnectionState;
     __BUZZ_E2E_SET_STALL_WEBSOCKET_SENDS__?: (stall: boolean) => void;
     __BUZZ_E2E_DISCONNECT_MOCK_WEBSOCKETS__?: () => number;
+    __BUZZ_E2E_RESTART_MOCK_WEBSOCKETS__?: () => number;
     __BUZZ_E2E_SET_MESH__?: (mesh: {
       admitted?: boolean;
       models?: Array<{ id: string; name: string | null }>;
@@ -3326,9 +3327,10 @@ function sendWsText(handler: WsHandler, payload: unknown[]) {
   });
 }
 
-function sendWsClose(handler: WsHandler) {
+function sendWsClose(handler: WsHandler, code?: number, reason?: string) {
   handler({
     type: "Close",
+    data: code === undefined ? undefined : { code, reason: reason ?? "" },
   });
 }
 
@@ -9084,6 +9086,14 @@ export function maybeInstallE2eTauriMocks() {
     const socketIds = [...mockSockets.keys()];
     for (const socketId of socketIds) disconnectMockSocket(socketId);
     return socketIds.length;
+  };
+  window.__BUZZ_E2E_RESTART_MOCK_WEBSOCKETS__ = () => {
+    const sockets = [...mockSockets.values()];
+    mockSockets.clear();
+    for (const socket of sockets) {
+      sendWsClose(socket.handler, 1012, "relay restarting");
+    }
+    return sockets.length;
   };
   // Tests vary mesh admission and models to exercise provider discovery and
   // the managed-agent start preflight.

--- a/desktop/tests/e2e/relay-reconnect.spec.ts
+++ b/desktop/tests/e2e/relay-reconnect.spec.ts
@@ -80,6 +80,33 @@ test.beforeEach(async ({ page }) => {
   await installMockBridge(page);
 });
 
+test("failed initial relay dial retries automatically", async ({ page }) => {
+  await installMockBridge(page, {
+    websocketConnectErrors: ["mock relay pod unavailable"],
+  });
+  await page.goto("/");
+
+  // App-shell preconnect owns a keep-alive request. The first native dial is
+  // rejected before a socket ID exists; the session must still enter its
+  // backoff loop and recover without a click, query, or reload.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const getState = (
+            window as Window & {
+              __BUZZ_E2E_GET_RELAY_CONNECTION_STATE__?: () => string;
+            }
+          ).__BUZZ_E2E_GET_RELAY_CONNECTION_STATE__;
+          if (!getState) throw new Error("Relay state seam is not installed.");
+          return getState();
+        }),
+      { timeout: 10_000 },
+    )
+    .toBe("connected");
+  await expect(page.getByTestId("channel-general")).toBeVisible();
+});
+
 test("passive relay watchdog does not write while the websocket is half-open", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/relay-reconnect.spec.ts
+++ b/desktop/tests/e2e/relay-reconnect.spec.ts
@@ -35,6 +35,20 @@ async function disconnectMockWebsockets(page: import("@playwright/test").Page) {
   expect(disconnected).toBeGreaterThan(0);
 }
 
+async function restartMockWebsockets(page: import("@playwright/test").Page) {
+  const restarted = await page.evaluate(() => {
+    const restart = (
+      window as Window & {
+        __BUZZ_E2E_RESTART_MOCK_WEBSOCKETS__?: () => number;
+      }
+    ).__BUZZ_E2E_RESTART_MOCK_WEBSOCKETS__;
+    if (!restart)
+      throw new Error("E2E websocket restart seam is not installed.");
+    return restart();
+  });
+  expect(restarted).toBeGreaterThan(0);
+}
+
 async function emitMockMessages(
   page: import("@playwright/test").Page,
   messages: Array<{ content: string; createdAt: number }>,
@@ -105,6 +119,27 @@ test("failed initial relay dial retries automatically", async ({ page }) => {
     )
     .toBe("connected");
   await expect(page.getByTestId("channel-general")).toBeVisible();
+});
+
+test("service restart close resets accumulated backoff", async ({ page }) => {
+  await installMockBridge(page, {
+    websocketConnectErrors: ["down 1", "down 2", "down 3"],
+  });
+  await page.goto("/");
+  await expect(page.getByTestId("channel-general")).toBeVisible({
+    timeout: 15_000,
+  });
+
+  const startedAt = Date.now();
+  await restartMockWebsockets(page);
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => window.__BUZZ_E2E_GET_RELAY_CONNECTION_STATE__?.()),
+      { timeout: 2_500 },
+    )
+    .toBe("connected");
+  expect(Date.now() - startedAt).toBeLessThan(2_500);
 });
 
 test("passive relay watchdog does not write while the websocket is half-open", async ({

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -261,6 +261,8 @@ type MockBridgeOptions = {
   openerError?: string;
   /** Delay binding signatures so specs can exercise request supersession. */
   nostrBindSignDelayMs?: number;
+  /** Reject successive mock WebSocket connect attempts, then resume. */
+  websocketConnectErrors?: string[];
   stallWebsocketSends?: boolean;
   userSearchDelayMs?: number;
   /**


### PR DESCRIPTION
## Summary

- recognize WebSocket close code 1012 (`Service Restart`) as an explicit relay-restart signal
- reset accumulated exponential reconnect backoff to the existing 1-second base before scheduling the retry
- extend the E2E bridge with a realistic 1012 close and prove a backed-off session reconnects within 2.5 seconds

Ordinary disconnects and errors keep the existing retry behavior. The 1-second base still includes jitter, avoiding a synchronized zero-delay reconnect storm.

Stacked on #2564. Complements #2575, which emits 1012 while draining relay connections.

## Validation

- `just desktop-test` — 3,424 passed
- relay reconnect E2E suite — 6 passed
- pre-push `branch-skew`, `desktop-check`, and `desktop-test` — passed at `92ee76d5f26bd11358d86913075d6adb6a88bd0f`
