### PR TITLE
Lock internal local agents to approved relays

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -122,7 +122,10 @@ const overrides = new Map([
   // runtime log path. Load-bearing crash-recovery surface; queued to split.
   // internal-owner-only: persistence choke point normalizes local agent access.
   // internal-local-relay-lockdown: load/save rejects legacy disallowed pins.
-  ["src-tauri/src/managed_agents/storage.rs", 1390],
+  // internal-local-relay-lockdown round 2: remediation-safe changed-pin checks and tests.
+  ["src-tauri/src/managed_agents/storage.rs", 1464],
+  // internal-local-relay-lockdown round 2: guard initial and incremental huddle enrollment.
+  ["src-tauri/src/huddle/mod.rs", 1006],
   // harness-persona-sync: persona-runtime resolution threaded into the spawn
   // path here. Load-bearing feature growth; queued to split in the resolver
   // unify refactor followup. +26 for resolve_effective_prompt_model_provider

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -468,7 +468,8 @@ const overrides = new Map([
   // (if let Some(provider_update) = input.provider { record.provider = provider_update; }).
   // +8: harness_override thread-through in update_managed_agent so a deliberate
   // Custom pin routes to update_time_agent_command_override (comment + call).
-  ["src-tauri/src/commands/agent_models.rs", 1079],
+  // +4: internal relay lockdown validates effective relay before update/profile sync.
+  ["src-tauri/src/commands/agent_models.rs", 1083],
   // global-agent-config: get_agent_config_surface / write_agent_config_field /
   // put_agent_session_config commands + GlobalAgentConfig serde types. New file
   // in this PR; queued to split with the command module refactor.

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -122,10 +122,10 @@ const overrides = new Map([
   // runtime log path. Load-bearing crash-recovery surface; queued to split.
   // internal-owner-only: persistence choke point normalizes local agent access.
   // internal-local-relay-lockdown: load/save rejects legacy disallowed pins.
-  // internal-local-relay-lockdown round 2: remediation-safe changed-pin checks and tests.
-  ["src-tauri/src/managed_agents/storage.rs", 1464],
-  // internal-local-relay-lockdown round 2: guard initial and incremental huddle enrollment.
-  ["src-tauri/src/huddle/mod.rs", 1006],
+  // internal-local-relay-lockdown round 3: fail-loud save baselines and regressions.
+  ["src-tauri/src/managed_agents/storage.rs", 1496],
+  // internal-local-relay-lockdown rounds 2-3: guarded enrollment; OSS fast-path.
+  ["src-tauri/src/huddle/mod.rs", 1007],
   // harness-persona-sync: persona-runtime resolution threaded into the spawn
   // path here. Load-bearing feature growth; queued to split in the resolver
   // unify refactor followup. +26 for resolve_effective_prompt_model_provider

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -121,7 +121,8 @@ const overrides = new Map([
   // helpers) replace the pubkey-keyed PID file, plus the hashed pair-scoped
   // runtime log path. Load-bearing crash-recovery surface; queued to split.
   // internal-owner-only: persistence choke point normalizes local agent access.
-  ["src-tauri/src/managed_agents/storage.rs", 1386],
+  // internal-local-relay-lockdown: load/save rejects legacy disallowed pins.
+  ["src-tauri/src/managed_agents/storage.rs", 1390],
   // harness-persona-sync: persona-runtime resolution threaded into the spawn
   // path here. Load-bearing feature growth; queued to split in the resolver
   // unify refactor followup. +26 for resolve_effective_prompt_model_provider
@@ -136,7 +137,8 @@ const overrides = new Map([
   // lowest env layer (+8 lines). Queued to split.
   // internal-owner-only: runtime authorization normalization protects stale
   // or hand-edited records before spawning an internal managed agent.
-  ["src-tauri/src/managed_agents/runtime.rs", 2228],
+  // internal-local-relay-lockdown: final spawn validates the effective relay.
+  ["src-tauri/src/managed_agents/runtime.rs", 2229],
   // config-bridge setup-payload env-boundary fix adds readiness wiring in
   // spawn_agent_child; load-bearing security fix, queued to split.
   ["src-tauri/src/managed_agents/config_bridge/reader.rs", 1016],

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -87,7 +87,8 @@ const overrides = new Map([
   // 3-phase (stage/stop/commit) + commit_cascade_agents injectable helper for
   // retry-safety. Load-bearing reviewer-required change; queued to split.
   // Consolidation removed the legacy persona-card import/export codecs.
-  ["src-tauri/src/commands/personas/mod.rs", 984],
+  // internal-local-relay-lockdown round 5: preflight linked-agent profile updates.
+  ["src-tauri/src/commands/personas/mod.rs", 1018],
   // #1418 read-path fix: get_thread_replies' blocker fix (shared TIMELINE_KINDS
   // const + build_thread_replies_filter helper, mirroring the channel sibling so
   // the two p-gate filters can't drift) plus two guard unit tests. The file was

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -16,12 +16,22 @@ fn main() {
     println!("cargo:rerun-if-env-changed=BUZZ_BUILD_OBSERVER_ARCHIVE_DEFAULT");
     println!("cargo:rerun-if-env-changed=BUZZ_BUILD_AGENT_METRIC_ARCHIVE_DEFAULT");
     println!("cargo:rerun-if-env-changed=BUZZ_BUILD_INTERNAL");
+    println!("cargo:rerun-if-env-changed=BUZZ_BUILD_LOCAL_AGENT_RELAY_ALLOWLIST");
     println!("cargo:rustc-check-cfg=cfg(buzz_updater_enabled)");
 
     // Explicit distribution identity. Internal packaging sets this presence-only
     // marker; OSS/custom builds remain public regardless of baked defaults.
     if std::env::var("BUZZ_BUILD_INTERNAL").is_ok() {
         println!("cargo:rustc-env=BUZZ_DESKTOP_BUILD_INTERNAL=1");
+    }
+
+    // Newline-delimited exact relay URLs. Runtime parsing canonicalizes every
+    // entry with buzz-core before comparing an effective local-agent relay.
+    // Preserve malformed or empty input so internal builds fail loudly at the
+    // policy boundary instead of silently compiling to an empty allowlist.
+    if let Ok(raw) = std::env::var("BUZZ_BUILD_LOCAL_AGENT_RELAY_ALLOWLIST") {
+        let encoded = base64::engine::general_purpose::STANDARD.encode(raw.as_bytes());
+        println!("cargo:rustc-env=BUZZ_DESKTOP_BUILD_LOCAL_AGENT_RELAY_ALLOWLIST={encoded}");
     }
 
     if let Ok(relay_url) = std::env::var("BUZZ_RELAY_URL") {

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -801,6 +801,7 @@ pub async fn update_managed_agent(
     state: State<'_, AppState>,
 ) -> Result<UpdateManagedAgentResponse, String> {
     // Phase 1: local save (synchronous, under lock)
+    let workspace_relay_url = relay_ws_url_with_override(&state);
     let (summary, sync_params, rollback) = {
         let _store_guard = state
             .managed_agents_store_lock
@@ -848,9 +849,11 @@ pub async fn update_managed_agent(
         // read-time. A name-only edit (relay_url == None) leaves the pin intact.
         if let Some(relay_url) = input.relay_url {
             let relay_url = relay_url.trim().to_string();
-            if !relay_url.is_empty() {
-                crate::managed_agents::validate_local_agent_relay(&record.backend, &relay_url)?;
-            }
+            crate::managed_agents::validate_effective_local_agent_relay(
+                &record.backend,
+                &relay_url,
+                &workspace_relay_url,
+            )?;
             record.relay_url = relay_url;
         }
         if let Some(acp_command) = input.acp_command {
@@ -908,6 +911,13 @@ pub async fn update_managed_agent(
 
         record.updated_at = now_iso();
 
+        if name_changed {
+            crate::managed_agents::validate_effective_local_agent_relay(
+                &record.backend,
+                &record.relay_url,
+                &workspace_relay_url,
+            )?;
+        }
         save_managed_agents(&app, &records)?;
 
         let record = records

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -773,6 +773,22 @@ pub fn agent_access_owner_only() -> bool {
     crate::managed_agents::internal_build()
 }
 
+/// Return whether local agents may attach to the active workspace relay.
+#[tauri::command]
+pub fn local_agent_relay_allowed(
+    state: tauri::State<'_, crate::app_state::AppState>,
+) -> Result<bool, String> {
+    if !crate::managed_agents::internal_build() {
+        return Ok(true);
+    }
+    let relay_url = crate::relay::relay_ws_url_with_override(&state);
+    crate::managed_agents::validate_local_agent_relay(
+        &crate::managed_agents::BackendKind::Local,
+        &relay_url,
+    )?;
+    Ok(true)
+}
+
 /// Update mutable fields on an existing managed agent record.
 ///
 /// Does NOT auto-restart the agent. Runtime config changes (system prompt,
@@ -831,7 +847,11 @@ pub async fn update_managed_agent(
         // value pins the agent; empty falls back to the workspace relay at
         // read-time. A name-only edit (relay_url == None) leaves the pin intact.
         if let Some(relay_url) = input.relay_url {
-            record.relay_url = relay_url.trim().to_string();
+            let relay_url = relay_url.trim().to_string();
+            if !relay_url.is_empty() {
+                crate::managed_agents::validate_local_agent_relay(&record.backend, &relay_url)?;
+            }
+            record.relay_url = relay_url;
         }
         if let Some(acp_command) = input.acp_command {
             record.acp_command = acp_command;

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -588,6 +588,7 @@ pub async fn create_managed_agent(
     // Snapshot the workspace owner pubkey for the legacy-record auth_tag
     // fallback. Computed outside the records lock to keep lock ordering simple.
     let owner_hex = workspace_owner_hex(&state)?;
+    let workspace_relay_url = relay_ws_url_with_override(&state);
 
     // ── Phase 1: generate keys (sync lock) ────────────────────────────────────
     let (agent_keys, private_key_nsec, pubkey, resolved_relay_url, input) = {
@@ -632,9 +633,11 @@ pub async fn create_managed_agent(
             .map(str::trim)
             .unwrap_or("")
             .to_string();
-        if !resolved_relay_url.is_empty() {
-            crate::managed_agents::validate_local_agent_relay(&input.backend, &resolved_relay_url)?;
-        }
+        crate::managed_agents::validate_effective_local_agent_relay(
+            &input.backend,
+            &resolved_relay_url,
+            &workspace_relay_url,
+        )?;
 
         (keys, private_key_nsec, pubkey, resolved_relay_url, input)
     };

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -1083,6 +1083,7 @@ pub async fn start_managed_agent(
 
         let reconcile = ProfileReconcileData {
             private_key_nsec: record.private_key_nsec.clone(),
+            backend: record.backend.clone(),
             name: record.name.clone(),
             relay_url: record.relay_url.clone(),
             avatar_url: record.avatar_url.clone(),
@@ -1325,7 +1326,7 @@ pub(crate) use deploy::resolve_deploy_model_provider;
 #[path = "agents_profile.rs"]
 mod profile;
 #[cfg(test)]
-use profile::{profile_needs_sync, resolve_legacy_avatar};
+use profile::{profile_needs_sync, resolve_legacy_avatar, validate_profile_reconcile_relay_with};
 pub(crate) use profile::{reconcile_agent_profile, ProfileReconcileData};
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -632,6 +632,9 @@ pub async fn create_managed_agent(
             .map(str::trim)
             .unwrap_or("")
             .to_string();
+        if !resolved_relay_url.is_empty() {
+            crate::managed_agents::validate_local_agent_relay(&input.backend, &resolved_relay_url)?;
+        }
 
         (keys, private_key_nsec, pubkey, resolved_relay_url, input)
     };

--- a/desktop/src-tauri/src/commands/agents_profile.rs
+++ b/desktop/src-tauri/src/commands/agents_profile.rs
@@ -11,6 +11,7 @@ use super::*;
 
 pub(crate) struct ProfileReconcileData {
     pub(crate) private_key_nsec: String,
+    pub(crate) backend: BackendKind,
     pub(crate) name: String,
     pub(crate) relay_url: String,
     /// Expected avatar URL for the published profile. `None` for legacy records
@@ -49,6 +50,17 @@ pub(super) fn resolve_legacy_avatar(
         .unwrap_or_default()
 }
 
+pub(super) fn validate_profile_reconcile_relay_with<F>(
+    data: &ProfileReconcileData,
+    workspace_relay_url: &str,
+    validate: F,
+) -> Result<(), String>
+where
+    F: FnOnce(&BackendKind, &str, &str) -> Result<(), String>,
+{
+    validate(&data.backend, &data.relay_url, workspace_relay_url)
+}
+
 /// Reconcile an agent's kind:0 profile on the relay.
 ///
 /// Queries the relay for the agent's existing profile and re-publishes if missing
@@ -74,19 +86,25 @@ pub(crate) async fn reconcile_agent_profile(
 ) -> Result<(), String> {
     use crate::relay::{query_agent_profile, sync_managed_agent_profile};
 
-    // An explicit per-agent relay wins; an empty one falls back to the active
-    // workspace relay. Resolved once and used for both the read and write-back.
-    let relay_url = crate::relay::effective_agent_relay_url(
-        &data.relay_url,
-        &relay_ws_url_with_override(state),
-    );
-
     if !state
         .managed_agent_profile_reconcile_enabled
         .load(std::sync::atomic::Ordering::Acquire)
     {
         return Ok(());
     }
+
+    let workspace_relay_url = relay_ws_url_with_override(state);
+    validate_profile_reconcile_relay_with(
+        data,
+        &workspace_relay_url,
+        |backend, pin, workspace| {
+            crate::managed_agents::validate_effective_local_agent_relay(backend, pin, workspace)
+        },
+    )?;
+
+    // An explicit per-agent relay wins; an empty one falls back to the active
+    // workspace relay. Resolved once and used for both the read and write-back.
+    let relay_url = crate::relay::effective_agent_relay_url(&data.relay_url, &workspace_relay_url);
 
     // Query the relay for the agent's existing kind:0 profile.
     let existing = query_agent_profile(state, &relay_url, agent_pubkey).await?;

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -414,3 +414,32 @@ fn deploy_payload_carries_the_full_behavioral_quad() {
     assert_eq!(payload["provider"], "openai");
     assert_eq!(payload["relay_url"], "wss://relay.example");
 }
+
+#[test]
+fn profile_reconcile_preflights_legacy_empty_pin_before_relay_io() {
+    let data = ProfileReconcileData {
+        private_key_nsec: String::new(),
+        backend: BackendKind::Local,
+        name: "legacy".into(),
+        relay_url: String::new(),
+        avatar_url: None,
+        auth_tag: None,
+        pubkey: "pubkey".into(),
+        agent_command: "goose".into(),
+        persona_id: None,
+    };
+    let calls = std::cell::Cell::new(0);
+    let result = validate_profile_reconcile_relay_with(
+        &data,
+        "wss://public.example",
+        |backend, pin, workspace| {
+            calls.set(calls.get() + 1);
+            assert_eq!(backend, &BackendKind::Local);
+            assert!(pin.is_empty());
+            assert_eq!(workspace, "wss://public.example");
+            Err("blocked before query".into())
+        },
+    );
+    assert_eq!(result.unwrap_err(), "blocked before query");
+    assert_eq!(calls.get(), 1);
+}

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -1,4 +1,4 @@
-use tauri::State;
+use tauri::{AppHandle, State};
 
 use crate::{
     app_state::AppState,
@@ -785,9 +785,20 @@ pub async fn add_channel_members(
     channel_id: String,
     pubkeys: Vec<String>,
     role: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<serde_json::Value, String> {
     let uuid = parse_channel_uuid(&channel_id)?;
+    let relay_url = crate::relay::relay_ws_url_with_override(&state);
+    let local_agents = crate::managed_agents::load_managed_agents(&app)?;
+    for pubkey in &pubkeys {
+        if let Some(record) = local_agents.iter().find(|record| {
+            record.pubkey.eq_ignore_ascii_case(pubkey)
+                && record.backend == crate::managed_agents::BackendKind::Local
+        }) {
+            crate::managed_agents::validate_local_agent_relay(&record.backend, &relay_url)?;
+        }
+    }
     let role_str = match role.as_deref() {
         Some("admin") => Some("admin"),
         Some("bot") => Some("bot"),

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -791,14 +791,7 @@ pub async fn add_channel_members(
     let uuid = parse_channel_uuid(&channel_id)?;
     let relay_url = crate::relay::relay_ws_url_with_override(&state);
     let local_agents = crate::managed_agents::load_managed_agents(&app)?;
-    for pubkey in &pubkeys {
-        if let Some(record) = local_agents.iter().find(|record| {
-            record.pubkey.eq_ignore_ascii_case(pubkey)
-                && record.backend == crate::managed_agents::BackendKind::Local
-        }) {
-            crate::managed_agents::validate_local_agent_relay(&record.backend, &relay_url)?;
-        }
-    }
+    crate::managed_agents::validate_local_agent_members(&local_agents, &pubkeys, &relay_url)?;
     let role_str = match role.as_deref() {
         Some("admin") => Some("admin"),
         Some("bot") => Some("bot"),

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -790,8 +790,9 @@ pub async fn add_channel_members(
 ) -> Result<serde_json::Value, String> {
     let uuid = parse_channel_uuid(&channel_id)?;
     let relay_url = crate::relay::relay_ws_url_with_override(&state);
-    let local_agents = crate::managed_agents::load_managed_agents(&app)?;
-    crate::managed_agents::validate_local_agent_members(&local_agents, &pubkeys, &relay_url)?;
+    crate::managed_agents::validate_local_agent_members_from_store(&pubkeys, &relay_url, || {
+        crate::managed_agents::load_managed_agents(&app)
+    })?;
     let role_str = match role.as_deref() {
         Some("admin") => Some("admin"),
         Some("bot") => Some("bot"),

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -838,6 +838,7 @@ pub async fn change_channel_member_role(
     channel_id: String,
     pubkey: String,
     role: String,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     let uuid = parse_channel_uuid(&channel_id)?;
@@ -848,6 +849,12 @@ pub async fn change_channel_member_role(
         "owner" => return Err("cannot assign owner role — use transfer ownership".into()),
         other => return Err(format!("invalid role: {other}")),
     };
+    let relay_url = crate::relay::relay_ws_url_with_override(&state);
+    crate::managed_agents::validate_local_agent_members_from_store(
+        std::slice::from_ref(&pubkey),
+        &relay_url,
+        || crate::managed_agents::load_managed_agents(&app),
+    )?;
     let builder = events::build_add_member(uuid, &pubkey, Some(role_str))?;
     submit_event(builder, &state).await?;
     Ok(())

--- a/desktop/src-tauri/src/commands/personas/mod.rs
+++ b/desktop/src-tauri/src/commands/personas/mod.rs
@@ -144,6 +144,24 @@ fn propagate_persona_name_rename(
     renamed
 }
 
+fn validate_persona_profile_updates_with<F>(
+    records: &[ManagedAgentRecord],
+    persona_id: &str,
+    old_display_name: &str,
+    name_changed: bool,
+    avatar_changed: bool,
+    mut validate: F,
+) -> Result<(), String>
+where
+    F: FnMut(&ManagedAgentRecord) -> Result<(), String>,
+{
+    records
+        .iter()
+        .filter(|record| record.persona_id.as_deref() == Some(persona_id))
+        .filter(|record| avatar_changed || (name_changed && record.name == old_display_name))
+        .try_for_each(&mut validate)
+}
+
 #[tauri::command]
 pub async fn update_persona(
     input: UpdatePersonaRequest,
@@ -176,10 +194,32 @@ pub async fn update_persona(
                 .find(|record| record.id == input.id)
                 .ok_or_else(|| format!("agent {} not found", input.id))?;
 
-            // Track what changed so we can propagate to linked agent records.
+            // Track what changed so we can preflight every linked agent before
+            // mutating either store or enqueueing agent-keyed profile I/O.
             let avatar_changed = persona.avatar_url != avatar_url;
             let name_changed = persona.display_name != display_name;
             let old_display_name = persona.display_name.clone();
+            let workspace_relay = crate::relay::relay_ws_url_with_override(&state);
+            let mut linked_records = if avatar_changed || name_changed {
+                let records = load_managed_agents(&app)?;
+                validate_persona_profile_updates_with(
+                    &records,
+                    &persona.id,
+                    &old_display_name,
+                    name_changed,
+                    avatar_changed,
+                    |record| {
+                        crate::managed_agents::validate_effective_local_agent_relay(
+                            &record.backend,
+                            &record.relay_url,
+                            &workspace_relay,
+                        )
+                    },
+                )?;
+                Some(records)
+            } else {
+                None
+            };
 
             persona.display_name = display_name;
             persona.avatar_url = avatar_url;
@@ -209,11 +249,9 @@ pub async fn update_persona(
 
             // If the avatar or display_name changed, propagate to linked agent
             // records and collect relay profile sync params for the async phase.
-            let sync_params: ProfileSyncParams = if avatar_changed || name_changed {
-                let mut records = load_managed_agents(&app)?;
+            let sync_params: ProfileSyncParams = if let Some(mut records) = linked_records.take() {
                 let mut params: ProfileSyncParams = Vec::new();
                 let mut agents_modified = false;
-                let workspace_relay = crate::relay::relay_ws_url_with_override(&state);
 
                 // Propagate the display_name rename to instances that still
                 // carry the old definition display_name (pool-named instances

--- a/desktop/src-tauri/src/commands/personas/name_propagation_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/name_propagation_tests.rs
@@ -156,3 +156,44 @@ fn test_rename_renames_all_matching_instances_in_one_pass() {
     assert_eq!(records[1].name, "Duncan Idaho");
     assert_eq!(records[2].name, "Birch", "pool-named instance untouched");
 }
+
+#[test]
+fn persona_profile_updates_preflight_only_records_that_would_mutate_or_publish() {
+    let mut records = vec![
+        agent("persona-1", "Paul", Some("Paul")),
+        agent("persona-1", "Birch", Some("Birch")),
+        agent("persona-2", "Paul", Some("Paul")),
+    ];
+    records[0].backend = crate::managed_agents::BackendKind::Local;
+    records[1].backend = crate::managed_agents::BackendKind::Provider {
+        id: "provider".into(),
+        config: serde_json::json!({}),
+    };
+    let visited = std::cell::RefCell::new(Vec::new());
+
+    validate_persona_profile_updates_with(&records, "persona-1", "Paul", true, false, |record| {
+        visited.borrow_mut().push(record.pubkey.clone());
+        Ok(())
+    })
+    .unwrap();
+    assert_eq!(*visited.borrow(), vec!["pubkey-Paul"]);
+
+    visited.borrow_mut().clear();
+    validate_persona_profile_updates_with(&records, "persona-1", "Paul", false, true, |record| {
+        visited.borrow_mut().push(record.pubkey.clone());
+        Ok(())
+    })
+    .unwrap();
+    assert_eq!(*visited.borrow(), vec!["pubkey-Paul", "pubkey-Birch"]);
+}
+
+#[test]
+fn persona_profile_preflight_failure_happens_before_name_mutation() {
+    let records = vec![agent("persona-1", "Paul", Some("Paul"))];
+    let result =
+        validate_persona_profile_updates_with(&records, "persona-1", "Paul", true, false, |_| {
+            Err("blocked".into())
+        });
+    assert_eq!(result.unwrap_err(), "blocked");
+    assert_eq!(records[0].name, "Paul");
+}

--- a/desktop/src-tauri/src/commands/personas/snapshot/import.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/import.rs
@@ -288,18 +288,21 @@ pub async fn preview_agent_snapshot_import(
     .map_err(|e| format!("spawn_blocking failed: {e}"))?
 }
 
-pub(super) fn validate_snapshot_import_relay_with<F>(
-    workspace_relay_url: &str,
+pub(super) fn validated_snapshot_import_relay_with<R, F>(
+    read_workspace_relay: R,
     validate: F,
-) -> Result<(), String>
+) -> Result<String, String>
 where
+    R: FnOnce() -> String,
     F: FnOnce(&crate::managed_agents::BackendKind, &str, &str) -> Result<(), String>,
 {
+    let workspace_relay_url = read_workspace_relay();
     validate(
         &crate::managed_agents::BackendKind::Local,
         "",
-        workspace_relay_url,
-    )
+        &workspace_relay_url,
+    )?;
+    Ok(workspace_relay_url)
 }
 
 // ── `confirm_agent_snapshot_import` ──────────────────────────────────────────
@@ -337,10 +340,12 @@ pub async fn confirm_agent_snapshot_import(
 
     // Snapshot imports always mint a local agent with an empty relay pin. Reject
     // a disallowed effective workspace relay before key generation or store I/O.
-    let workspace_relay_url = relay_ws_url_with_override(&state);
-    validate_snapshot_import_relay_with(&workspace_relay_url, |backend, pin, workspace| {
-        crate::managed_agents::validate_effective_local_agent_relay(backend, pin, workspace)
-    })?;
+    let workspace_relay_url = validated_snapshot_import_relay_with(
+        || relay_ws_url_with_override(&state),
+        |backend, pin, workspace| {
+            crate::managed_agents::validate_effective_local_agent_relay(backend, pin, workspace)
+        },
+    )?;
 
     // ── Resolve behavioral defaults ──────────────────────────────────────────
     let minted = resolve_snapshot_import_behavior(
@@ -527,8 +532,7 @@ pub async fn confirm_agent_snapshot_import(
     };
 
     // ── Phase 3b: publish kind:0 profile (async, outside lock) ───────────────
-    let relay_url =
-        effective_agent_relay_url(&record.relay_url, &relay_ws_url_with_override(&state));
+    let relay_url = effective_agent_relay_url(&record.relay_url, &workspace_relay_url);
     let profile_sync_error = sync_managed_agent_profile(
         &state,
         &relay_url,

--- a/desktop/src-tauri/src/commands/personas/snapshot/import.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/import.rs
@@ -288,6 +288,20 @@ pub async fn preview_agent_snapshot_import(
     .map_err(|e| format!("spawn_blocking failed: {e}"))?
 }
 
+pub(super) fn validate_snapshot_import_relay_with<F>(
+    workspace_relay_url: &str,
+    validate: F,
+) -> Result<(), String>
+where
+    F: FnOnce(&crate::managed_agents::BackendKind, &str, &str) -> Result<(), String>,
+{
+    validate(
+        &crate::managed_agents::BackendKind::Local,
+        "",
+        workspace_relay_url,
+    )
+}
+
 // ── `confirm_agent_snapshot_import` ──────────────────────────────────────────
 
 /// Import a `buzz-agent-snapshot v1` file as a brand-new agent.
@@ -320,6 +334,13 @@ pub async fn confirm_agent_snapshot_import(
     if display_name.is_empty() {
         return Err("Snapshot display name is empty.".to_string());
     }
+
+    // Snapshot imports always mint a local agent with an empty relay pin. Reject
+    // a disallowed effective workspace relay before key generation or store I/O.
+    let workspace_relay_url = relay_ws_url_with_override(&state);
+    validate_snapshot_import_relay_with(&workspace_relay_url, |backend, pin, workspace| {
+        crate::managed_agents::validate_effective_local_agent_relay(backend, pin, workspace)
+    })?;
 
     // ── Resolve behavioral defaults ──────────────────────────────────────────
     let minted = resolve_snapshot_import_behavior(

--- a/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
@@ -1,6 +1,7 @@
 use super::import::{
     decode_snapshot_from_bytes, reject_legacy_persona_filename, resolve_snapshot_import_behavior,
-    AgentSnapshotImportResult, MAX_SNAPSHOT_JSON_BYTES, MAX_SNAPSHOT_PNG_BYTES,
+    validate_snapshot_import_relay_with, AgentSnapshotImportResult, MAX_SNAPSHOT_JSON_BYTES,
+    MAX_SNAPSHOT_PNG_BYTES,
 };
 use super::*;
 use crate::managed_agents::{
@@ -968,4 +969,19 @@ fn validate_encode_size_png_over_boundary_is_rejected() {
         err.contains("size limit"),
         "error must mention size limit, got: {err}"
     );
+}
+
+#[test]
+fn individual_snapshot_import_preflights_empty_pin_before_mint_or_store() {
+    let calls = std::cell::Cell::new(0);
+    let result =
+        validate_snapshot_import_relay_with("wss://public.example", |backend, pin, relay| {
+            calls.set(calls.get() + 1);
+            assert_eq!(backend, &BackendKind::Local);
+            assert!(pin.is_empty());
+            assert_eq!(relay, "wss://public.example");
+            Err("blocked before mutation".into())
+        });
+    assert_eq!(result.unwrap_err(), "blocked before mutation");
+    assert_eq!(calls.get(), 1);
 }

--- a/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
@@ -1,6 +1,6 @@
 use super::import::{
     decode_snapshot_from_bytes, reject_legacy_persona_filename, resolve_snapshot_import_behavior,
-    validate_snapshot_import_relay_with, AgentSnapshotImportResult, MAX_SNAPSHOT_JSON_BYTES,
+    validated_snapshot_import_relay_with, AgentSnapshotImportResult, MAX_SNAPSHOT_JSON_BYTES,
     MAX_SNAPSHOT_PNG_BYTES,
 };
 use super::*;
@@ -972,16 +972,27 @@ fn validate_encode_size_png_over_boundary_is_rejected() {
 }
 
 #[test]
-fn individual_snapshot_import_preflights_empty_pin_before_mint_or_store() {
-    let calls = std::cell::Cell::new(0);
-    let result =
-        validate_snapshot_import_relay_with("wss://public.example", |backend, pin, relay| {
-            calls.set(calls.get() + 1);
+fn individual_snapshot_import_carries_the_validated_relay_snapshot_to_io() {
+    let reads = std::cell::Cell::new(0);
+    let relay = validated_snapshot_import_relay_with(
+        || {
+            reads.set(reads.get() + 1);
+            "wss://allowed.example".into()
+        },
+        |backend, pin, relay| {
             assert_eq!(backend, &BackendKind::Local);
             assert!(pin.is_empty());
-            assert_eq!(relay, "wss://public.example");
-            Err("blocked before mutation".into())
-        });
-    assert_eq!(result.unwrap_err(), "blocked before mutation");
-    assert_eq!(calls.get(), 1);
+            assert_eq!(relay, "wss://allowed.example");
+            Ok(())
+        },
+    )
+    .unwrap();
+    assert_eq!(relay, "wss://allowed.example");
+    assert_eq!(reads.get(), 1);
+
+    let blocked = validated_snapshot_import_relay_with(
+        || "wss://public.example".into(),
+        |_, _, _| Err("blocked before mutation".into()),
+    );
+    assert_eq!(blocked.unwrap_err(), "blocked before mutation");
 }

--- a/desktop/src-tauri/src/commands/team_snapshot.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot.rs
@@ -483,12 +483,12 @@ pub async fn preview_team_snapshot_import(
 ///      If ANY generation fails, return immediately — zero writes.
 ///   3. Store — inside `managed_agents_store_lock`: write all `AgentDefinition`s
 ///      + all `ManagedAgentRecord`s (with `team_id` set) + `TeamRecord`.
-///      Both store files are snapshotted (or noted absent) before the first
-///      write. On any write error the pre-import state is restored — including
-///      deleting a file that was absent, cleaning minted keyring entries, and
-///      surfacing rollback failures alongside the original error. This makes
-///      the store phase all-or-none for ordinary application errors; a process
-///      crash between atomic file commits is NOT covered.
+///        Both store files are snapshotted (or noted absent) before the first
+///        write. On any write error the pre-import state is restored — including
+///        deleting a file that was absent, cleaning minted keyring entries, and
+///        surfacing rollback failures alongside the original error. This makes
+///        the store phase all-or-none for ordinary application errors; a process
+///        crash between atomic file commits is NOT covered.
 ///   4. Profile sync — for each member, call `sync_managed_agent_profile`.
 ///      Best-effort; errors are collected per member.
 ///   5. Memory restore — for each member with non-empty snapshot memory,

--- a/desktop/src-tauri/src/commands/team_snapshot.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot.rs
@@ -496,18 +496,21 @@ pub async fn preview_team_snapshot_import(
 ///
 /// Importing the same file twice yields two distinct teams with different
 /// agent keypairs (same as individual agent import).
-fn validate_team_snapshot_import_relay_with<F>(
-    workspace_relay_url: &str,
+fn validated_team_snapshot_import_relay_with<R, F>(
+    read_workspace_relay: R,
     validate: F,
-) -> Result<(), String>
+) -> Result<String, String>
 where
+    R: FnOnce() -> String,
     F: FnOnce(&crate::managed_agents::BackendKind, &str, &str) -> Result<(), String>,
 {
+    let workspace_relay_url = read_workspace_relay();
     validate(
         &crate::managed_agents::BackendKind::Local,
         "",
-        workspace_relay_url,
-    )
+        &workspace_relay_url,
+    )?;
+    Ok(workspace_relay_url)
 }
 
 #[tauri::command]
@@ -522,10 +525,12 @@ pub async fn confirm_team_snapshot_import(
 
     // Team snapshots mint only empty-pin local agents. Preflight the workspace
     // relay once before generating any member key or mutating any store.
-    let workspace_relay_url = relay_ws_url_with_override(&state);
-    validate_team_snapshot_import_relay_with(&workspace_relay_url, |backend, pin, workspace| {
-        crate::managed_agents::validate_effective_local_agent_relay(backend, pin, workspace)
-    })?;
+    let workspace_relay_url = validated_team_snapshot_import_relay_with(
+        || relay_ws_url_with_override(&state),
+        |backend, pin, workspace| {
+            crate::managed_agents::validate_effective_local_agent_relay(backend, pin, workspace)
+        },
+    )?;
 
     // Resolve behavioral defaults for every member before any key generation.
     let definitions = build_import_definitions(&snapshot, input.keep_allowlist, &now)?;
@@ -775,7 +780,8 @@ pub async fn confirm_team_snapshot_import(
     };
 
     // ── Phase 4 & 5: profile sync + memory restore (async, outside lock) ────
-    let relay_ws = relay_ws_url_with_override(&state);
+    // Use the relay snapshot validated before mint/store for all agent-keyed I/O.
+    let relay_ws = workspace_relay_url;
     let mut member_results: Vec<TeamSnapshotImportMemberResult> = Vec::with_capacity(minted.len());
 
     for (m, snap_member) in minted.iter().zip(snapshot.members.iter()) {

--- a/desktop/src-tauri/src/commands/team_snapshot.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot.rs
@@ -496,6 +496,20 @@ pub async fn preview_team_snapshot_import(
 ///
 /// Importing the same file twice yields two distinct teams with different
 /// agent keypairs (same as individual agent import).
+fn validate_team_snapshot_import_relay_with<F>(
+    workspace_relay_url: &str,
+    validate: F,
+) -> Result<(), String>
+where
+    F: FnOnce(&crate::managed_agents::BackendKind, &str, &str) -> Result<(), String>,
+{
+    validate(
+        &crate::managed_agents::BackendKind::Local,
+        "",
+        workspace_relay_url,
+    )
+}
+
 #[tauri::command]
 pub async fn confirm_team_snapshot_import(
     input: TeamSnapshotImportConfirm,
@@ -505,6 +519,13 @@ pub async fn confirm_team_snapshot_import(
     // ── Phase 1: validate (no I/O) ───────────────────────────────────────────
     let snapshot = decode_team_snapshot_from_bytes(&input.file_bytes)?;
     let now = now_iso();
+
+    // Team snapshots mint only empty-pin local agents. Preflight the workspace
+    // relay once before generating any member key or mutating any store.
+    let workspace_relay_url = relay_ws_url_with_override(&state);
+    validate_team_snapshot_import_relay_with(&workspace_relay_url, |backend, pin, workspace| {
+        crate::managed_agents::validate_effective_local_agent_relay(backend, pin, workspace)
+    })?;
 
     // Resolve behavioral defaults for every member before any key generation.
     let definitions = build_import_definitions(&snapshot, input.keep_allowlist, &now)?;

--- a/desktop/src-tauri/src/commands/team_snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot/tests.rs
@@ -724,3 +724,18 @@ fn full_rollback_at_teams_boundary_absent_agents_store() {
     assert!(!teams_path.exists());
     assert_eq!(errors.len(), 1, "only the teams-write error");
 }
+
+#[test]
+fn team_snapshot_import_preflights_empty_pin_once_before_mint_or_store() {
+    let calls = std::cell::Cell::new(0);
+    let result =
+        validate_team_snapshot_import_relay_with("wss://public.example", |backend, pin, relay| {
+            calls.set(calls.get() + 1);
+            assert_eq!(backend, &crate::managed_agents::BackendKind::Local);
+            assert!(pin.is_empty());
+            assert_eq!(relay, "wss://public.example");
+            Err("blocked before mutation".into())
+        });
+    assert_eq!(result.unwrap_err(), "blocked before mutation");
+    assert_eq!(calls.get(), 1);
+}

--- a/desktop/src-tauri/src/commands/team_snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot/tests.rs
@@ -726,16 +726,39 @@ fn full_rollback_at_teams_boundary_absent_agents_store() {
 }
 
 #[test]
+fn team_snapshot_import_carries_the_validated_relay_snapshot_to_io() {
+    let workspace_reads = std::cell::Cell::new(0);
+    let validated_relay = validated_team_snapshot_import_relay_with(
+        || {
+            workspace_reads.set(workspace_reads.get() + 1);
+            "wss://allowed.example".to_string()
+        },
+        |backend, pin, relay| {
+            assert_eq!(backend, &crate::managed_agents::BackendKind::Local);
+            assert!(pin.is_empty());
+            assert_eq!(relay, "wss://allowed.example");
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(validated_relay, "wss://allowed.example");
+    assert_eq!(workspace_reads.get(), 1);
+}
+
+#[test]
 fn team_snapshot_import_preflights_empty_pin_once_before_mint_or_store() {
     let calls = std::cell::Cell::new(0);
-    let result =
-        validate_team_snapshot_import_relay_with("wss://public.example", |backend, pin, relay| {
+    let result = validated_team_snapshot_import_relay_with(
+        || "wss://public.example".to_string(),
+        |backend, pin, relay| {
             calls.set(calls.get() + 1);
             assert_eq!(backend, &crate::managed_agents::BackendKind::Local);
             assert!(pin.is_empty());
             assert_eq!(relay, "wss://public.example");
             Err("blocked before mutation".into())
-        });
+        },
+    );
     assert_eq!(result.unwrap_err(), "blocked before mutation");
     assert_eq!(calls.get(), 1);
 }

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -99,9 +99,10 @@ fn validate_huddle_agent_enrollment(
     state: &AppState,
     pubkeys: &[String],
 ) -> Result<(), String> {
-    let records = crate::managed_agents::load_managed_agents(app)?;
     let relay_url = crate::relay::relay_ws_url_with_override(state);
-    crate::managed_agents::validate_local_agent_members(&records, pubkeys, &relay_url)
+    crate::managed_agents::validate_local_agent_members_from_store(pubkeys, &relay_url, || {
+        crate::managed_agents::load_managed_agents(app)
+    })
 }
 
 // ── Tauri commands ────────────────────────────────────────────────────────────

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -67,7 +67,7 @@ pub use transcription::{set_huddle_transcription_enabled, start_stt_pipeline};
 // ── Imports ───────────────────────────────────────────────────────────────────
 
 use std::sync::{atomic::Ordering, Arc};
-use tauri::State;
+use tauri::{AppHandle, State};
 use uuid::Uuid;
 
 use crate::{app_state::AppState, events, relay::submit_event};
@@ -92,6 +92,16 @@ fn normalize_huddle_channel_name(candidate: Option<String>, fallback: &str) -> S
     };
 
     name.chars().take(80).collect()
+}
+
+fn validate_huddle_agent_enrollment(
+    app: &AppHandle,
+    state: &AppState,
+    pubkeys: &[String],
+) -> Result<(), String> {
+    let records = crate::managed_agents::load_managed_agents(app)?;
+    let relay_url = crate::relay::relay_ws_url_with_override(state);
+    crate::managed_agents::validate_local_agent_members(&records, pubkeys, &relay_url)
 }
 
 // ── Tauri commands ────────────────────────────────────────────────────────────
@@ -162,6 +172,7 @@ pub async fn start_huddle(
     parent_channel_id: String,
     member_pubkeys: Vec<String>,
     channel_name: Option<String>,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<HuddleJoinInfo, String> {
     // Validate inputs at the Tauri boundary.
@@ -184,6 +195,7 @@ pub async fn start_huddle(
         }
         deduped
     };
+    validate_huddle_agent_enrollment(&app, &state, &member_pubkeys)?;
 
     // Transition to Creating.
     {
@@ -925,9 +937,11 @@ pub async fn speak_agent_message(text: String, state: State<'_, AppState>) -> Re
 #[tauri::command]
 pub async fn add_agent_to_huddle(
     agent_pubkey: String,
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<agents::AgentAddResult, String> {
     validate_pubkey_hex(&agent_pubkey)?;
+    validate_huddle_agent_enrollment(&app, &state, std::slice::from_ref(&agent_pubkey))?;
 
     let (eph_id, parent_id) = {
         let hs = state.huddle()?;

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -788,6 +788,7 @@ pub fn run() {
             get_agent_models,
             discover_agent_models,
             agent_access_owner_only,
+            local_agent_relay_allowed,
             get_agent_config_surface,
             get_runtime_file_config,
             get_baked_build_env_keys,

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod access_policy;
 mod agent_env;
 pub(crate) mod agent_events;
 pub(crate) mod agent_snapshot;
+pub(crate) mod relay_policy;
 pub(crate) mod team_snapshot;
 pub(crate) use access_policy::{
     apply_update_access, internal_build, normalize_definition_access,
@@ -10,6 +11,7 @@ pub(crate) use access_policy::{
 pub(crate) use agent_env::{
     baked_build_env, build_buzz_agent_provider_defaults, discovery_env_with_baked_floor,
 };
+pub(crate) use relay_policy::{validate_local_agent_relay, validate_managed_agent_relay_pin};
 mod backend;
 pub(crate) mod config_bridge;
 mod discovery;

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -11,7 +11,9 @@ pub(crate) use access_policy::{
 pub(crate) use agent_env::{
     baked_build_env, build_buzz_agent_provider_defaults, discovery_env_with_baked_floor,
 };
-pub(crate) use relay_policy::{validate_local_agent_relay, validate_managed_agent_relay_pin};
+pub(crate) use relay_policy::{
+    validate_local_agent_members, validate_local_agent_relay, validate_managed_agent_relay_pin,
+};
 mod backend;
 pub(crate) mod config_bridge;
 mod discovery;

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -12,7 +12,8 @@ pub(crate) use agent_env::{
     baked_build_env, build_buzz_agent_provider_defaults, discovery_env_with_baked_floor,
 };
 pub(crate) use relay_policy::{
-    validate_local_agent_members, validate_local_agent_relay, validate_managed_agent_relay_pin,
+    validate_local_agent_members_from_store, validate_local_agent_relay,
+    validate_managed_agent_relay_pin,
 };
 mod backend;
 pub(crate) mod config_bridge;

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -12,8 +12,8 @@ pub(crate) use agent_env::{
     baked_build_env, build_buzz_agent_provider_defaults, discovery_env_with_baked_floor,
 };
 pub(crate) use relay_policy::{
-    validate_local_agent_members_from_store, validate_local_agent_relay,
-    validate_managed_agent_relay_pin,
+    validate_effective_local_agent_relay, validate_local_agent_members_from_store,
+    validate_local_agent_relay, validate_managed_agent_relay_pin,
 };
 mod backend;
 pub(crate) mod config_bridge;

--- a/desktop/src-tauri/src/managed_agents/relay_policy.rs
+++ b/desktop/src-tauri/src/managed_agents/relay_policy.rs
@@ -89,12 +89,60 @@ pub(crate) fn validate_managed_agent_relay_pin(record: &ManagedAgentRecord) -> R
     validate_local_agent_relay(&record.backend, &record.relay_url)
 }
 
+/// Reject attachment of locally managed agents to a disallowed effective relay.
+/// Unknown pubkeys and provider-backed records are outside this policy.
+pub(crate) fn validate_local_agent_members(
+    records: &[ManagedAgentRecord],
+    pubkeys: &[String],
+    relay_url: &str,
+) -> Result<(), String> {
+    validate_local_agent_members_with(records, pubkeys, |backend| {
+        validate_local_agent_relay(backend, relay_url)
+    })
+}
+
+fn validate_local_agent_members_with<F>(
+    records: &[ManagedAgentRecord],
+    pubkeys: &[String],
+    validate: F,
+) -> Result<(), String>
+where
+    F: Fn(&BackendKind) -> Result<(), String>,
+{
+    for pubkey in pubkeys {
+        if let Some(record) = records.iter().find(|record| {
+            record.pubkey.eq_ignore_ascii_case(pubkey) && record.backend == BackendKind::Local
+        }) {
+            validate(&record.backend)?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn allowlist() -> Result<Vec<String>, String> {
         parse_allowlist(" WSS://Buzz.Block.Builderlab.XYZ:443/\n")
+    }
+
+    fn record(pubkey: &str, backend: BackendKind) -> ManagedAgentRecord {
+        let mut record: ManagedAgentRecord = serde_json::from_value(serde_json::json!({
+            "pubkey": pubkey,
+            "name": "test-agent",
+            "relay_url": "",
+            "acp_command": "buzz-acp",
+            "agent_command": "goose",
+            "agent_args": [],
+            "mcp_command": "",
+            "turn_timeout_seconds": 320,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z"
+        }))
+        .expect("sample record");
+        record.backend = backend;
+        record
     }
 
     #[test]
@@ -136,6 +184,38 @@ mod tests {
             unavailable,
         )
         .is_ok());
+    }
+
+    #[test]
+    fn member_enrollment_validates_only_matching_local_agents() {
+        let provider = BackendKind::Provider {
+            id: "provider".into(),
+            config: serde_json::json!({}),
+        };
+        let records = vec![
+            record("local", BackendKind::Local),
+            record("provider", provider),
+        ];
+        let calls = std::cell::Cell::new(0);
+
+        assert!(
+            validate_local_agent_members_with(&records, &["LOCAL".into()], |_| {
+                calls.set(calls.get() + 1);
+                Err("blocked".to_string())
+            })
+            .is_err()
+        );
+        assert_eq!(calls.get(), 1);
+        assert!(validate_local_agent_members_with(
+            &records,
+            &["provider".into(), "unknown".into()],
+            |_| {
+                calls.set(calls.get() + 1);
+                Err("blocked".to_string())
+            },
+        )
+        .is_ok());
+        assert_eq!(calls.get(), 1);
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/relay_policy.rs
+++ b/desktop/src-tauri/src/managed_agents/relay_policy.rs
@@ -1,0 +1,157 @@
+//! Distribution policy for relays used by local managed agents.
+
+use base64::Engine as _;
+
+use super::{BackendKind, ManagedAgentRecord};
+
+const MISSING_ALLOWLIST_ERROR: &str =
+    "internal build has no valid local-agent relay allowlist; contact your Buzz administrator";
+
+fn normalized_origin(raw: &str) -> Result<String, String> {
+    let normalized =
+        buzz_core_pkg::relay::normalize_relay_url(raw).map_err(|error| error.to_string())?;
+    let url =
+        url::Url::parse(&normalized).map_err(|error| format!("invalid relay URL: {error}"))?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| "relay URL must contain a host".to_string())?;
+    let mut origin = format!("{}://{host}", url.scheme());
+    if let Some(port) = url.port() {
+        origin.push(':');
+        origin.push_str(&port.to_string());
+    }
+    Ok(origin)
+}
+
+fn baked_allowlist() -> Result<Vec<String>, String> {
+    let encoded = option_env!("BUZZ_DESKTOP_BUILD_LOCAL_AGENT_RELAY_ALLOWLIST")
+        .ok_or_else(|| MISSING_ALLOWLIST_ERROR.to_string())?;
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|_| MISSING_ALLOWLIST_ERROR.to_string())?;
+    let raw = String::from_utf8(decoded).map_err(|_| MISSING_ALLOWLIST_ERROR.to_string())?;
+    parse_allowlist(&raw)
+}
+
+fn parse_allowlist(raw: &str) -> Result<Vec<String>, String> {
+    let entries: Vec<_> = raw
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(normalized_origin)
+        .collect::<Result<_, _>>()?;
+    if entries.is_empty() {
+        return Err(MISSING_ALLOWLIST_ERROR.to_string());
+    }
+    Ok(entries)
+}
+
+pub(crate) fn validate_local_agent_relay(
+    backend: &BackendKind,
+    relay_url: &str,
+) -> Result<(), String> {
+    validate_local_agent_relay_with_policy(
+        backend,
+        relay_url,
+        super::internal_build(),
+        baked_allowlist,
+    )
+}
+
+fn validate_local_agent_relay_with_policy<F>(
+    backend: &BackendKind,
+    relay_url: &str,
+    internal: bool,
+    allowlist: F,
+) -> Result<(), String>
+where
+    F: FnOnce() -> Result<Vec<String>, String>,
+{
+    if !internal || *backend != BackendKind::Local {
+        return Ok(());
+    }
+    let requested = normalized_origin(relay_url)
+        .map_err(|error| format!("local agent relay is invalid: {error}"))?;
+    if allowlist()?.iter().any(|allowed| allowed == &requested) {
+        return Ok(());
+    }
+    Err(format!(
+        "local agents in this internal build cannot use relay {requested}"
+    ))
+}
+
+/// Validate a legacy explicit record pin at persistence boundaries. Empty pins
+/// are workspace-relative and are checked when their effective relay is known.
+pub(crate) fn validate_managed_agent_relay_pin(record: &ManagedAgentRecord) -> Result<(), String> {
+    if record.relay_url.trim().is_empty() {
+        return Ok(());
+    }
+    validate_local_agent_relay(&record.backend, &record.relay_url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allowlist() -> Result<Vec<String>, String> {
+        parse_allowlist(" WSS://Buzz.Block.Builderlab.XYZ:443/\n")
+    }
+
+    #[test]
+    fn internal_local_policy_matches_exact_normalized_origin() {
+        assert!(validate_local_agent_relay_with_policy(
+            &BackendKind::Local,
+            "wss://buzz.block.builderlab.xyz/channels",
+            true,
+            allowlist,
+        )
+        .is_ok());
+        assert!(validate_local_agent_relay_with_policy(
+            &BackendKind::Local,
+            "wss://public.example",
+            true,
+            allowlist,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn provider_and_oss_relays_remain_configurable() {
+        let provider = BackendKind::Provider {
+            id: "provider".into(),
+            config: serde_json::json!({}),
+        };
+        let unavailable = || Err("allowlist must not be read".into());
+        assert!(validate_local_agent_relay_with_policy(
+            &BackendKind::Local,
+            "wss://public.example",
+            false,
+            unavailable,
+        )
+        .is_ok());
+        assert!(validate_local_agent_relay_with_policy(
+            &provider,
+            "wss://public.example",
+            true,
+            unavailable,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn internal_policy_fails_closed_on_missing_empty_or_malformed_allowlist() {
+        for allowlist in [
+            || Err(MISSING_ALLOWLIST_ERROR.into()),
+            || parse_allowlist(" \n"),
+            || parse_allowlist("https://not-a-relay.example"),
+        ] {
+            assert!(validate_local_agent_relay_with_policy(
+                &BackendKind::Local,
+                "wss://buzz.block.builderlab.xyz",
+                true,
+                allowlist,
+            )
+            .is_err());
+        }
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/relay_policy.rs
+++ b/desktop/src-tauri/src/managed_agents/relay_policy.rs
@@ -80,6 +80,34 @@ where
     ))
 }
 
+pub(crate) fn validate_effective_local_agent_relay(
+    backend: &BackendKind,
+    relay_pin: &str,
+    workspace_relay_url: &str,
+) -> Result<(), String> {
+    validate_effective_local_agent_relay_with_policy(
+        backend,
+        relay_pin,
+        workspace_relay_url,
+        super::internal_build(),
+        baked_allowlist,
+    )
+}
+
+fn validate_effective_local_agent_relay_with_policy<F>(
+    backend: &BackendKind,
+    relay_pin: &str,
+    workspace_relay_url: &str,
+    internal: bool,
+    allowlist: F,
+) -> Result<(), String>
+where
+    F: FnOnce() -> Result<Vec<String>, String>,
+{
+    let effective = crate::relay::effective_agent_relay_url(relay_pin, workspace_relay_url);
+    validate_local_agent_relay_with_policy(backend, &effective, internal, allowlist)
+}
+
 /// Validate a legacy explicit record pin at persistence boundaries. Empty pins
 /// are workspace-relative and are checked when their effective relay is known.
 pub(crate) fn validate_managed_agent_relay_pin(record: &ManagedAgentRecord) -> Result<(), String> {
@@ -220,6 +248,44 @@ mod tests {
     }
 
     #[test]
+    fn empty_pin_validates_the_effective_workspace_relay() {
+        assert!(validate_effective_local_agent_relay_with_policy(
+            &BackendKind::Local,
+            "",
+            "wss://public.example",
+            true,
+            allowlist,
+        )
+        .is_err());
+        assert!(validate_effective_local_agent_relay_with_policy(
+            &BackendKind::Local,
+            "",
+            "wss://buzz.block.builderlab.xyz",
+            true,
+            allowlist,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn effective_relay_validation_skips_oss_and_provider_backends() {
+        let provider = BackendKind::Provider {
+            id: "provider".into(),
+            config: serde_json::json!({}),
+        };
+        for (backend, internal) in [(&BackendKind::Local, false), (&provider, true)] {
+            assert!(validate_effective_local_agent_relay_with_policy(
+                backend,
+                "",
+                "not-even-a-relay",
+                internal,
+                || Err("allowlist must not load".into()),
+            )
+            .is_ok());
+        }
+    }
+
+    #[test]
     fn member_enrollment_validates_only_matching_local_agents() {
         let provider = BackendKind::Provider {
             id: "provider".into(),
@@ -249,6 +315,15 @@ mod tests {
         )
         .is_ok());
         assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn role_change_rejects_matching_local_agent_before_membership_emit() {
+        let records = vec![record("local", BackendKind::Local)];
+        let result = validate_local_agent_members_with(&records, &["LOCAL".into()], |backend| {
+            validate_local_agent_relay_with_policy(backend, "wss://public.example", true, allowlist)
+        });
+        assert!(result.is_err());
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/relay_policy.rs
+++ b/desktop/src-tauri/src/managed_agents/relay_policy.rs
@@ -89,6 +89,39 @@ pub(crate) fn validate_managed_agent_relay_pin(record: &ManagedAgentRecord) -> R
     validate_local_agent_relay(&record.backend, &record.relay_url)
 }
 
+/// Load and validate local members only when the internal-build policy applies.
+/// OSS builds must not make ordinary membership depend on managed-agent store health.
+pub(crate) fn validate_local_agent_members_from_store<F>(
+    pubkeys: &[String],
+    relay_url: &str,
+    load: F,
+) -> Result<(), String>
+where
+    F: FnOnce() -> Result<Vec<ManagedAgentRecord>, String>,
+{
+    validate_local_agent_members_from_store_with_policy(
+        pubkeys,
+        relay_url,
+        super::internal_build(),
+        load,
+    )
+}
+
+fn validate_local_agent_members_from_store_with_policy<F>(
+    pubkeys: &[String],
+    relay_url: &str,
+    internal: bool,
+    load: F,
+) -> Result<(), String>
+where
+    F: FnOnce() -> Result<Vec<ManagedAgentRecord>, String>,
+{
+    if !internal {
+        return Ok(());
+    }
+    validate_local_agent_members(&load()?, pubkeys, relay_url)
+}
+
 /// Reject attachment of locally managed agents to a disallowed effective relay.
 /// Unknown pubkeys and provider-backed records are outside this policy.
 pub(crate) fn validate_local_agent_members(
@@ -216,6 +249,33 @@ mod tests {
         )
         .is_ok());
         assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn oss_member_enrollment_does_not_load_the_agent_store() {
+        let loads = std::cell::Cell::new(0);
+        assert!(validate_local_agent_members_from_store_with_policy(
+            &["human".into()],
+            "not-even-a-relay",
+            false,
+            || {
+                loads.set(loads.get() + 1);
+                Err("broken store".into())
+            },
+        )
+        .is_ok());
+        assert_eq!(loads.get(), 0);
+    }
+
+    #[test]
+    fn internal_member_enrollment_fails_loudly_on_broken_store() {
+        assert!(validate_local_agent_members_from_store_with_policy(
+            &["human".into()],
+            "wss://buzz.block.builderlab.xyz",
+            true,
+            || Err("broken store".into()),
+        )
+        .is_err());
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -422,6 +422,7 @@ pub async fn restore_managed_agents_on_launch(
                     pubkey.clone(),
                     crate::commands::ProfileReconcileData {
                         private_key_nsec: record.private_key_nsec.clone(),
+                        backend: record.backend.clone(),
                         name: record.name.clone(),
                         relay_url: record.relay_url.clone(),
                         avatar_url: record.avatar_url.clone(),

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1649,6 +1649,7 @@ pub fn spawn_agent_child(
     if let Some(error) = spawn_key_refusal(record) {
         return Err(error);
     }
+    super::validate_local_agent_relay(&record.backend, relay_url)?;
     let runtime_key = ManagedAgentRuntimeKey::new(record.pubkey.clone(), relay_url)?;
     let log_path = super::managed_agent_runtime_log_path(app, &runtime_key)?;
     append_log_marker(

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -260,6 +260,7 @@ fn start_pair(
     if record.backend != BackendKind::Local {
         return Err("managed runtime pairs require a local agent".into());
     }
+    super::validate_local_agent_relay(&record.backend, &relay_url)?;
     if expected_updated_at.is_some_and(|expected| record.updated_at != expected) {
         return Err("managed agent changed while runtime reconciliation was in flight".into());
     }
@@ -400,6 +401,7 @@ async fn probe_agent_relay_access(
     record: super::ManagedAgentRecord,
     requested_relay_url: String,
 ) -> Result<(super::ManagedAgentRecord, ManagedAgentRuntimeKey, String), String> {
+    super::validate_local_agent_relay(&record.backend, &requested_relay_url)?;
     let key = ManagedAgentRuntimeKey::new(record.pubkey.clone(), &requested_relay_url)?;
     let keys = nostr::Keys::parse(record.private_key_nsec.trim())
         .map_err(|error| format!("invalid managed-agent key: {error}"))?;

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -199,6 +199,9 @@ fn load_agent_store(app: &AppHandle) -> Result<Vec<ManagedAgentRecord>, String> 
 pub fn load_managed_agents(app: &AppHandle) -> Result<Vec<ManagedAgentRecord>, String> {
     let mut records = load_agent_store(app)?;
     records.retain(|record| !record.pubkey.is_empty());
+    records
+        .iter()
+        .try_for_each(super::validate_managed_agent_relay_pin)?;
     hydrate_keys(&mut records);
     Ok(records)
 }
@@ -302,6 +305,7 @@ pub fn save_managed_agents(app: &AppHandle, records: &[ManagedAgentRecord]) -> R
     let mut sorted = records.to_vec();
     for record in &mut sorted {
         super::normalize_managed_agent_access(record);
+        super::validate_managed_agent_relay_pin(record)?;
     }
     // A caller-supplied key-less record would collide with the definition
     // half re-read below; instances always carry a pubkey.

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -193,15 +193,18 @@ fn load_agent_store(app: &AppHandle) -> Result<Vec<ManagedAgentRecord>, String> 
     })
 }
 
+fn retain_managed_agent_instances(records: &mut Vec<ManagedAgentRecord>) {
+    records.retain(|record| !record.pubkey.is_empty());
+}
+
 /// Load the keyed agent *instances*. Key-less definitions (former personas,
 /// folded into the same store) are filtered out so every pre-fold call site
-/// keeps seeing exactly the records it always did.
+/// keeps seeing exactly the records it always did. Relay-policy violations are
+/// enforced at save/attach/start boundaries, not here, so a bad legacy pin can
+/// still be listed, fixed, or deleted.
 pub fn load_managed_agents(app: &AppHandle) -> Result<Vec<ManagedAgentRecord>, String> {
     let mut records = load_agent_store(app)?;
-    records.retain(|record| !record.pubkey.is_empty());
-    records
-        .iter()
-        .try_for_each(super::validate_managed_agent_relay_pin)?;
+    retain_managed_agent_instances(&mut records);
     hydrate_keys(&mut records);
     Ok(records)
 }
@@ -295,17 +298,49 @@ fn hydrate_keys_with(store: &impl KeyStore, records: &mut [ManagedAgentRecord]) 
     }
 }
 
+fn validate_changed_relay_pins_with<F>(
+    records: &[ManagedAgentRecord],
+    previous: &[ManagedAgentRecord],
+    validate: F,
+) -> Result<(), String>
+where
+    F: Fn(&ManagedAgentRecord) -> Result<(), String>,
+{
+    for record in records {
+        let unchanged = previous.iter().any(|old| {
+            old.pubkey == record.pubkey
+                && old.backend == record.backend
+                && old.relay_url == record.relay_url
+        });
+        if !unchanged {
+            validate(record)?;
+        }
+    }
+    Ok(())
+}
+
 /// Save the keyed agent *instances*, preserving the key-less definitions that
 /// share the unified store: callers pass exactly the records they loaded via
 /// [`load_managed_agents`], and this re-reads the definition half from disk
 /// before the wholesale rewrite so a definition is never dropped by an
 /// instance-side save (and vice versa via [`save_agent_definitions`]).
 pub fn save_managed_agents(app: &AppHandle, records: &[ManagedAgentRecord]) -> Result<(), String> {
-    let definitions = load_agent_definitions(app).unwrap_or_default();
+    let stored = load_agent_store(app).unwrap_or_default();
+    let definitions = stored
+        .iter()
+        .filter(|record| record.pubkey.is_empty())
+        .cloned()
+        .collect();
+    let previous_instances: Vec<_> = stored
+        .into_iter()
+        .filter(|record| !record.pubkey.is_empty())
+        .collect();
+    validate_changed_relay_pins_with(records, &previous_instances, |record| {
+        super::validate_managed_agent_relay_pin(record)
+    })?;
     let mut sorted = records.to_vec();
     for record in &mut sorted {
         super::normalize_managed_agent_access(record);
-        super::validate_managed_agent_relay_pin(record)?;
     }
     // A caller-supplied key-less record would collide with the definition
     // half re-read below; instances always carry a pubkey.
@@ -802,7 +837,8 @@ mod tests {
 
     use super::{
         agent_keyring_name, hydrate_keys_with, migrate_inline_key, persist_agent_keys_with,
-        KeyMigration, KeyStore, KeyringProbe, ManagedAgentRecord,
+        retain_managed_agent_instances, validate_changed_relay_pins_with, KeyMigration, KeyStore,
+        KeyringProbe, ManagedAgentRecord,
     };
 
     /// In-memory [`KeyStore`] for testing the migrate decision without the OS
@@ -930,6 +966,44 @@ mod tests {
             }}"#
         ))
         .expect("sample record")
+    }
+
+    #[test]
+    fn instance_filter_keeps_legacy_pins_available_for_remediation() {
+        let mut pinned = record_with_key("nsec1realkey");
+        pinned.relay_url = "wss://public.example".into();
+        let mut definition = pinned.clone();
+        definition.pubkey.clear();
+        let mut records = vec![pinned.clone(), definition];
+
+        retain_managed_agent_instances(&mut records);
+
+        assert_eq!(records, vec![pinned]);
+    }
+
+    #[test]
+    fn legacy_bad_pin_allows_unrelated_save_but_changed_pin_is_validated() {
+        let mut pinned = record_with_key("nsec1realkey");
+        pinned.relay_url = "wss://public.example".into();
+        let previous = vec![pinned.clone()];
+        let calls = std::cell::Cell::new(0);
+
+        assert!(
+            validate_changed_relay_pins_with(&[pinned.clone()], &previous, |_| {
+                calls.set(calls.get() + 1);
+                Err("blocked".into())
+            })
+            .is_ok()
+        );
+        assert_eq!(calls.get(), 0);
+
+        pinned.relay_url = "wss://other.example".into();
+        assert!(validate_changed_relay_pins_with(&[pinned], &previous, |_| {
+            calls.set(calls.get() + 1);
+            Err("blocked".into())
+        })
+        .is_err());
+        assert_eq!(calls.get(), 1);
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -319,22 +319,33 @@ where
     Ok(())
 }
 
+fn load_managed_agent_save_baseline_with<F>(
+    load: F,
+) -> Result<(Vec<ManagedAgentRecord>, Vec<ManagedAgentRecord>), String>
+where
+    F: FnOnce() -> Result<Vec<ManagedAgentRecord>, String>,
+{
+    let stored = load()?;
+    let definitions = stored
+        .iter()
+        .filter(|record| record.pubkey.is_empty())
+        .cloned()
+        .collect();
+    let instances = stored
+        .into_iter()
+        .filter(|record| !record.pubkey.is_empty())
+        .collect();
+    Ok((definitions, instances))
+}
+
 /// Save the keyed agent *instances*, preserving the key-less definitions that
 /// share the unified store: callers pass exactly the records they loaded via
 /// [`load_managed_agents`], and this re-reads the definition half from disk
 /// before the wholesale rewrite so a definition is never dropped by an
 /// instance-side save (and vice versa via [`save_agent_definitions`]).
 pub fn save_managed_agents(app: &AppHandle, records: &[ManagedAgentRecord]) -> Result<(), String> {
-    let stored = load_agent_store(app).unwrap_or_default();
-    let definitions = stored
-        .iter()
-        .filter(|record| record.pubkey.is_empty())
-        .cloned()
-        .collect();
-    let previous_instances: Vec<_> = stored
-        .into_iter()
-        .filter(|record| !record.pubkey.is_empty())
-        .collect();
+    let (definitions, previous_instances) =
+        load_managed_agent_save_baseline_with(|| load_agent_store(app))?;
     validate_changed_relay_pins_with(records, &previous_instances, |record| {
         super::validate_managed_agent_relay_pin(record)
     })?;
@@ -836,9 +847,9 @@ mod tests {
     use tempfile::NamedTempFile;
 
     use super::{
-        agent_keyring_name, hydrate_keys_with, migrate_inline_key, persist_agent_keys_with,
-        retain_managed_agent_instances, validate_changed_relay_pins_with, KeyMigration, KeyStore,
-        KeyringProbe, ManagedAgentRecord,
+        agent_keyring_name, hydrate_keys_with, load_managed_agent_save_baseline_with,
+        migrate_inline_key, persist_agent_keys_with, retain_managed_agent_instances,
+        validate_changed_relay_pins_with, KeyMigration, KeyStore, KeyringProbe, ManagedAgentRecord,
     };
 
     /// In-memory [`KeyStore`] for testing the migrate decision without the OS
@@ -966,6 +977,27 @@ mod tests {
             }}"#
         ))
         .expect("sample record")
+    }
+
+    #[test]
+    fn save_baseline_propagates_store_errors_without_rewriting_from_empty() {
+        let result = load_managed_agent_save_baseline_with(|| Err("broken store".into()));
+        assert_eq!(result.unwrap_err(), "broken store");
+    }
+
+    #[test]
+    fn save_baseline_preserves_definitions_and_instances() {
+        let instance = record_with_key("nsec1realkey");
+        let mut definition = instance.clone();
+        definition.pubkey.clear();
+
+        let (definitions, instances) = load_managed_agent_save_baseline_with(|| {
+            Ok(vec![definition.clone(), instance.clone()])
+        })
+        .expect("baseline");
+
+        assert_eq!(definitions, vec![definition]);
+        assert_eq!(instances, vec![instance]);
     }
 
     #[test]

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -27,6 +27,7 @@ import {
   discoverManagedAgentPrereqs,
   getAgentConfigSurface,
   getAgentAccessOwnerOnly,
+  getLocalAgentRelayAllowed,
   getBakedBuildEnv,
   getBakedBuildEnvKeys,
   getChannelMembers,
@@ -910,9 +911,25 @@ export function useRuntimeFileConfigQuery(
 
 export const bakedBuildEnvKeysQueryKey = ["baked-build-env-keys"] as const;
 export const bakedBuildEnvQueryKey = ["baked-build-env"] as const;
+export const localAgentRelayAllowedQueryKey = [
+  "local-agent-relay-allowed",
+] as const;
 export const agentAccessOwnerOnlyQueryKey = [
   "agent-access-owner-only",
 ] as const;
+
+export function useLocalAgentRelayAllowedQuery(options?: {
+  enabled?: boolean;
+}) {
+  return useQuery({
+    queryKey: localAgentRelayAllowedQueryKey,
+    queryFn: () => getLocalAgentRelayAllowed(),
+    enabled: options?.enabled ?? true,
+    staleTime: 30_000,
+    refetchInterval: false,
+    retry: false,
+  });
+}
 
 export function useAgentAccessOwnerOnlyQuery(options?: { enabled?: boolean }) {
   return useQuery({

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -11,6 +11,7 @@ import {
   ensureChannelAgentPresetInChannel,
   provisionChannelManagedAgent,
 } from "@/features/agents/channelAgents";
+import { localAgentRelayAllowedQueryKey } from "@/features/agents/localAgentRelayPolicyQuery";
 import { resolveSnapshotAvatarPng } from "@/features/agents/ui/snapshotAvatarPng";
 import {
   channelsQueryKey,
@@ -911,18 +912,16 @@ export function useRuntimeFileConfigQuery(
 
 export const bakedBuildEnvKeysQueryKey = ["baked-build-env-keys"] as const;
 export const bakedBuildEnvQueryKey = ["baked-build-env"] as const;
-export const localAgentRelayAllowedQueryKey = [
-  "local-agent-relay-allowed",
-] as const;
 export const agentAccessOwnerOnlyQueryKey = [
   "agent-access-owner-only",
 ] as const;
 
-export function useLocalAgentRelayAllowedQuery(options?: {
-  enabled?: boolean;
-}) {
+export function useLocalAgentRelayAllowedQuery(
+  communityId: string | null,
+  options?: { enabled?: boolean },
+) {
   return useQuery({
-    queryKey: localAgentRelayAllowedQueryKey,
+    queryKey: localAgentRelayAllowedQueryKey(communityId),
     queryFn: () => getLocalAgentRelayAllowed(),
     enabled: options?.enabled ?? true,
     staleTime: 30_000,

--- a/desktop/src/features/agents/localAgentRelayPolicyQuery.test.mjs
+++ b/desktop/src/features/agents/localAgentRelayPolicyQuery.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { localAgentRelayAllowedQueryKey } from "./localAgentRelayPolicyQuery.ts";
+
+test("local agent relay policy cache is scoped by community", () => {
+  assert.notDeepEqual(
+    localAgentRelayAllowedQueryKey("community-a"),
+    localAgentRelayAllowedQueryKey("community-b"),
+  );
+  assert.deepEqual(localAgentRelayAllowedQueryKey(null), [
+    "local-agent-relay-allowed",
+    "none",
+  ]);
+});

--- a/desktop/src/features/agents/localAgentRelayPolicyQuery.ts
+++ b/desktop/src/features/agents/localAgentRelayPolicyQuery.ts
@@ -1,0 +1,2 @@
+export const localAgentRelayAllowedQueryKey = (communityId: string | null) =>
+  ["local-agent-relay-allowed", communityId ?? "none"] as const;

--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 
 import {
   useCreateChannelManagedAgentsMutation,
+  useLocalAgentRelayAllowedQuery,
   usePersonasQuery,
   useTeamsQuery,
   type CreateChannelManagedAgentResult,
@@ -63,6 +64,7 @@ export function AddChannelBotDialog({
   onOpenChange,
 }: AddChannelBotDialogProps) {
   const personasQuery = usePersonasQuery();
+  const localRelayPolicy = useLocalAgentRelayAllowedQuery({ enabled: open });
   const teamsQuery = useTeamsQuery();
   const inChannelPersonaIds = useInChannelPersonaIds(
     channelId,
@@ -191,6 +193,7 @@ export function AddChannelBotDialog({
 
   const canSubmit =
     providers.length > 0 &&
+    localRelayPolicy.data === true &&
     selectedPersonas.length > 0 &&
     !providersLoading &&
     !createBotsMutation.isPending;
@@ -259,6 +262,19 @@ export function AddChannelBotDialog({
             selectedPersonaIds={selectedPersonaIds}
             teams={teams}
           />
+        ) : null}
+
+        {localRelayPolicy.isError ? (
+          <div
+            className="flex gap-3 rounded-lg border border-warning/30 bg-warning-bg px-4 py-3"
+            data-testid="local-agent-relay-blocked"
+          >
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+            <p className="text-sm text-warning">
+              Local agents cannot be added to this community on this managed
+              build.
+            </p>
+          </div>
         ) : null}
 
         {providers.length === 0 && !providersLoading ? (

--- a/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
+++ b/desktop/src/features/channels/ui/AddChannelBotDialog.tsx
@@ -11,6 +11,7 @@ import {
 import { getActivePersonas } from "@/features/agents/lib/catalog";
 import { resolvePersonaRuntime } from "@/features/agents/lib/resolvePersonaRuntime";
 import { getUsableTeams } from "@/features/agents/lib/teamPersonas";
+import { useCommunities } from "@/features/communities/useCommunities";
 import { AddChannelBotPersonasSection } from "@/features/channels/ui/AddChannelBotPersonasSection";
 import { AddChannelBotTeamsSection } from "@/features/channels/ui/AddChannelBotTeamsSection";
 import { useInChannelPersonaIds } from "@/features/channels/ui/useInChannelPersonaIds";
@@ -64,7 +65,11 @@ export function AddChannelBotDialog({
   onOpenChange,
 }: AddChannelBotDialogProps) {
   const personasQuery = usePersonasQuery();
-  const localRelayPolicy = useLocalAgentRelayAllowedQuery({ enabled: open });
+  const { activeCommunity } = useCommunities();
+  const localRelayPolicy = useLocalAgentRelayAllowedQuery(
+    activeCommunity?.id ?? null,
+    { enabled: open },
+  );
   const teamsQuery = useTeamsQuery();
   const inChannelPersonaIds = useInChannelPersonaIds(
     channelId,

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -1014,6 +1014,11 @@ export async function getBakedBuildEnvKeys(): Promise<string[]> {
   return invokeTauri<string[]>("get_baked_build_env_keys");
 }
 
+/** Return whether local agents may attach to the active workspace relay. */
+export async function getLocalAgentRelayAllowed(): Promise<boolean> {
+  return invokeTauri<boolean>("local_agent_relay_allowed");
+}
+
 /** Return whether this build forces managed-agent access to owner-only. */
 export async function getAgentAccessOwnerOnly(): Promise<boolean> {
   return invokeTauri<boolean>("agent_access_owner_only");

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -353,6 +353,8 @@ type E2eConfig = {
     };
     /** Explicit internal-distribution marker; independent of baked defaults. */
     internalBuild?: boolean;
+    /** Whether local agents may attach to the active mocked community. */
+    localAgentRelayAllowed?: boolean;
     /** Baked build env returned by the display and key-name Tauri commands. */
     bakedBuildEnv?: Array<{
       key: string;
@@ -10289,6 +10291,13 @@ export function maybeInstallE2eTauriMocks() {
         return (config?.mock?.bakedBuildEnv ?? []).map((entry) => entry.key);
       case "agent_access_owner_only":
         return config?.mock?.internalBuild ?? false;
+      case "local_agent_relay_allowed":
+        if (config?.mock?.localAgentRelayAllowed === false) {
+          throw new Error(
+            "local agents in this internal build cannot use the active relay",
+          );
+        }
+        return true;
       case "update_managed_agent":
         return handleUpdateManagedAgent(
           payload as Parameters<typeof handleUpdateManagedAgent>[0],

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1541,6 +1541,7 @@ test("internal build blocks local agents on a non-allowlisted community", async 
   await page.getByTestId("channel-intro-action-create-agent").click();
 
   await expect(page.getByTestId("local-agent-relay-blocked")).toBeVisible();
+  await page.getByRole("button", { name: "Fizz" }).click();
   await expect(page.getByRole("button", { name: "Add agent" })).toBeDisabled();
 });
 

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1528,6 +1528,36 @@ test("empty channel shows intro actions", async ({ page }) => {
   );
 });
 
+test("internal build blocks local agents on a non-allowlisted community", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    internalBuild: true,
+    localAgentRelayAllowed: false,
+    activePersonaIds: ["builtin:fizz"],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-random").click();
+  await page.getByTestId("channel-intro-action-create-agent").click();
+
+  await expect(page.getByTestId("local-agent-relay-blocked")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Add agent" })).toBeDisabled();
+});
+
+test("OSS build keeps local agent attachment available", async ({ page }) => {
+  await installMockBridge(page, {
+    internalBuild: false,
+    activePersonaIds: ["builtin:fizz"],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-random").click();
+  await page.getByTestId("channel-intro-action-create-agent").click();
+
+  await expect(page.getByTestId("local-agent-relay-blocked")).toHaveCount(0);
+  await page.getByRole("button", { name: "Fizz" }).click();
+  await expect(page.getByRole("button", { name: "Add agent" })).toBeEnabled();
+});
+
 test("short channel with messages shows intro actions on open", async ({
   page,
 }) => {

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -394,6 +394,7 @@ type MockBridgeOptions = {
     preferred_runtime?: string | null;
   };
   internalBuild?: boolean;
+  localAgentRelayAllowed?: boolean;
   bakedBuildEnv?: Array<{
     key: string;
     masked: boolean;


### PR DESCRIPTION
### Summary

Internal (managed) builds now lock `BackendKind::Local` agents to a baked-in relay allowlist. OSS builds and provider-backed agents keep unrestricted relay configuration.

- [Bake a newline-delimited local-agent relay-origin allowlist into managed builds](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/build.rs#L18-L35) through `BUZZ_BUILD_LOCAL_AGENT_RELAY_ALLOWLIST` at compile time.
- [Require exact canonical WebSocket origin matches for local agents](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/managed_agents/relay_policy.rs#L10-L23), with [exact equality instead of wildcard or hostname-suffix trust](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/managed_agents/relay_policy.rs#L61-L80).
- [Fail closed in internal builds](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/managed_agents/relay_policy.rs#L26-L46) when the allowlist is missing, empty, or malformed, or when the effective relay is not allowed. [OSS builds and provider-backed agents bypass this policy](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/managed_agents/relay_policy.rs#L61-L72).
- [Enforce the policy at every path that can put a local agent on a relay](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/managed_agents/relay_policy.rs#L83-L108):
  - [saving a new or changed legacy relay pin](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/managed_agents/storage.rs#L301-L351)
  - [creating an agent, including an agent with no explicit relay pin](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/commands/agents.rs#L590-L640)
  - [updating an agent's relay or name](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/commands/agent_models.rs#L798-L920)
  - [adding an agent to a channel](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/commands/channels.rs#L783-L795) or [changing its channel role](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/commands/channels.rs#L836-L860)
  - [starting a huddle with agents](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/huddle/mod.rs#L172-L200) or [adding an agent to an active huddle](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/huddle/mod.rs#L938-L946)
  - [probing relay access](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/managed_agents/runtime_commands.rs#L390-L405) and [starting or restarting a runtime pair](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/managed_agents/runtime_commands.rs#L239-L267)
  - [reconciling an agent profile after start or restore](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/commands/agents_profile.rs#L88-L110)
  - [publishing linked agent profiles after a persona name or avatar change](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/commands/personas/mod.rs#L197-L218)
  - [importing one agent from a backup](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/commands/personas/snapshot/import.rs#L310-L348) or [importing a team from a backup](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/commands/team_snapshot.rs#L499-L533)
  - [the final child-process spawn boundary](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/managed_agents/runtime.rs#L1642-L1653)

  The spawn check is the final backstop. The earlier checks are still needed so users get a clear error at the action they took, before data is changed or relay work begins.
- [Importing an agent or team from a backup file creates fresh local agent identities, so the import checks the workspace relay before creating them](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/commands/personas/snapshot/import.rs#L291-L348). The import then [keeps using that checked relay for the new agent's profile and memory](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/commands/personas/snapshot/import.rs#L534-L545), and [does the same for every member of an imported team](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/commands/team_snapshot.rs#L782-L790). This prevents a race where the relay setting changes mid-import.
- [A corrupted agent store is now preserved and reported as an error](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/managed_agents/storage.rs#L185-L193), and [saving no longer treats a failed read as an empty store](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/src/managed_agents/storage.rs#L322-L351). Previously, a later save could silently replace the corrupted store from an empty starting point.
- [Show a warning and disable local-agent attachment when the active community's relay is blocked](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src/features/channels/ui/AddChannelBotDialog.tsx#L199-L204), with [the relay-policy query keyed to the active community](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src/features/agents/hooks.ts#L919-L930).

This PR is stacked on [#2537](https://github.com/block/buzz/pull/2537). The two build variables serve different purposes: [`BUZZ_BUILD_INTERNAL` marks the distribution as an internal build](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/build.rs#L22-L26), while [`BUZZ_BUILD_LOCAL_AGENT_RELAY_ALLOWLIST` supplies the relay origins approved for that deployment](https://github.com/block/buzz/blob/eb7354dd80e0a3205a1c52b4fcbfe48e6ddd6654/desktop/src-tauri/build.rs#L28-L35).

### Packaging contract

Internal packaging must set both:

```sh
BUZZ_BUILD_INTERNAL=1
BUZZ_BUILD_LOCAL_AGENT_RELAY_ALLOWLIST=wss://buzz.block.builderlab.xyz
```

Future internal or staging origins must be explicit newline-delimited entries in [`buzz-releases`](https://github.com/squareup/buzz-releases/pull/75) (Block-internal packaging configuration).

### Screenshots

| Before: base behavior | After: managed-build warning |
|---|---|
| ![Before: Add agents dialog without relay warning](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/2582/local-relay-before.png) | ![After: Add agents dialog with blocked-relay warning](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/2582/local-relay-after.png) |

Both screenshots are cropped to the same 576 x 398 dialog canvas.

### Validation

At [source commit `931865f0478b25e3566637dc824f7cc3a3e387a1`](https://github.com/block/buzz/commit/931865f0478b25e3566637dc824f7cc3a3e387a1), whose code was reapplied as `eb7354dd`, the full desktop Rust suite passed with 1,582 tests and 13 ignored tests, plus 3 diagnostic integration tests. TypeScript typechecking passed, all 3,402 JavaScript unit tests passed, and 2 focused browser tests passed for the blocked internal-build case and unaffected OSS case. Formatting, static checks, file checks, and commit hooks also passed.

A separate internal-build test run confirmed the relay-policy behavior. Six existing tests from #2537 still encode OSS access expectations and fail when internal mode intentionally forces owner-only access.
