### PR TITLE
fix(desktop): add create CTA to the projects empty state

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -95,6 +95,7 @@ export default defineConfig({
         "**/send-channel-binding.spec.ts",
         "**/project-commit-detail.spec.ts",
         "**/project-pr-review.spec.ts",
+        "**/projects-empty-state.spec.ts",
         "**/persona-model-combobox-screenshots.spec.ts",
         "**/drafts-screenshots.spec.ts",
         "**/buzz-theme-screenshots.spec.ts",

--- a/desktop/src/features/projects/ui/ProjectCards.tsx
+++ b/desktop/src/features/projects/ui/ProjectCards.tsx
@@ -3,6 +3,7 @@ import {
   FolderGit2,
   GitCommit,
   GitPullRequest,
+  Plus,
   TerminalSquare,
   Trash2,
 } from "lucide-react";
@@ -263,16 +264,34 @@ function StatusPill({ status }: { status: string }) {
   );
 }
 
-export function EmptyState() {
+export function EmptyState({
+  onCreateProject,
+}: {
+  /** When provided, render a CTA that opens the create-project dialog. */
+  onCreateProject?: () => void;
+}) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-3 px-4 py-16 text-center">
       <FolderGit2 className="h-10 w-10 text-muted-foreground/40" />
       <div className="space-y-1">
         <p className="text-sm font-medium text-foreground">No projects yet</p>
         <p className="text-sm text-muted-foreground">
-          Projects published to this relay will appear here.
+          Create the first project, or it will appear here once published to
+          this relay.
         </p>
       </div>
+      {onCreateProject ? (
+        <Button
+          className="mt-1"
+          data-testid="projects-empty-create"
+          onClick={onCreateProject}
+          size="sm"
+          type="button"
+        >
+          <Plus className="h-4 w-4" />
+          Create project
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -428,6 +428,24 @@ export function ProjectsView() {
     [deleteProjectMutation],
   );
 
+  // Shared across the empty-state and populated views so the first project
+  // can be created from the empty state without duplicating the create flow.
+  const createProjectDialog = (
+    <CreateProjectDialog
+      isCreating={createProjectMutation.isPending}
+      onCreate={async (input) => {
+        const project = await createProjectMutation.mutateAsync(input);
+        toast.success(`Project "${project.name}" created.`);
+        // Land on the list that actually shows the new project — the
+        // Overview only surfaces the top few most-active repositories.
+        handleRepositoryScopeChange("all");
+        handleFilterChange("repositories");
+      }}
+      onOpenChange={setCreateProjectOpen}
+      open={createProjectOpen}
+    />
+  );
+
   if (projectsQuery.isLoading) {
     return null;
   }
@@ -448,7 +466,12 @@ export function ProjectsView() {
   }
 
   if (projects.length === 0) {
-    return <EmptyState />;
+    return (
+      <>
+        {createProjectDialog}
+        <EmptyState onCreateProject={() => setCreateProjectOpen(true)} />
+      </>
+    );
   }
 
   const repositoryItems =
@@ -599,19 +622,7 @@ export function ProjectsView() {
         className="pointer-events-none absolute right-[3px] top-0 z-50 w-1 rounded-full bg-border/80 opacity-0 transition-opacity duration-200"
         ref={scrollIndicatorRef}
       />
-      <CreateProjectDialog
-        isCreating={createProjectMutation.isPending}
-        onCreate={async (input) => {
-          const project = await createProjectMutation.mutateAsync(input);
-          toast.success(`Project "${project.name}" created.`);
-          // Land on the list that actually shows the new project — the
-          // Overview only surfaces the top few most-active repositories.
-          handleRepositoryScopeChange("all");
-          handleFilterChange("repositories");
-        }}
-        onOpenChange={setCreateProjectOpen}
-        open={createProjectOpen}
-      />
+      {createProjectDialog}
       {createPullRequestOpen ? (
         <CreatePullRequestDialog
           onCreated={async (createdProject, pullRequestId) => {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -135,6 +135,8 @@ type E2eConfig = {
   mock?: {
     /** Advertised HEAD for the first mock project without adding that branch. */
     projectHeadBranch?: string;
+    /** Serve zero projects so the Projects empty state can be exercised. */
+    emptyProjects?: boolean;
     /** Builderlab account returned by hosted-community onboarding. Null/omitted = signed out. */
     builderlabAuth?: {
       email?: string;
@@ -4947,6 +4949,7 @@ function buildMockProjectEvents(): RelayEvent[] {
 }
 
 function getMockProjectEventStore(): RelayEvent[] {
+  if (getConfig()?.mock?.emptyProjects) return [];
   mockProjectEventStore ??= buildMockProjectEvents();
   return mockProjectEventStore;
 }

--- a/desktop/tests/e2e/projects-empty-state.spec.ts
+++ b/desktop/tests/e2e/projects-empty-state.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+// The projects surface is a preview feature — opt in before the app mounts.
+// Must run before installMockBridge so React reads the override on mount.
+async function enableProjectsFeature(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "buzz-feature-overrides-v1",
+      JSON.stringify({ projects: true }),
+    );
+  });
+}
+
+// Regression for the projects empty state: when there are zero projects the
+// only entry point to create one (the "+" menu in the toolbar) is not
+// rendered, so the empty state itself must offer a create CTA. Otherwise the
+// first project can only be created from the CLI.
+test("empty projects state offers a create-project CTA", async ({ page }) => {
+  await enableProjectsFeature(page);
+  await installMockBridge(page, { emptyProjects: true });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  await page.getByTestId("open-projects-view").click();
+
+  await expect(page.getByText("No projects yet")).toBeVisible();
+
+  const createCta = page.getByTestId("projects-empty-create");
+  await expect(createCta).toBeVisible();
+
+  await createCta.click();
+
+  // The CTA opens the same create-project dialog as the toolbar "+" menu.
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+  await expect(page.getByTestId("create-project-name")).toBeVisible();
+});

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -129,6 +129,8 @@ export type MockAgentMemoryListing = {
 type MockBridgeOptions = {
   /** Advertised HEAD for the first mock project without adding that branch. */
   projectHeadBranch?: string;
+  /** Serve zero projects so the Projects empty state can be exercised. */
+  emptyProjects?: boolean;
   /** Relay NIP-11 identity used to sign authoritative repository state. */
   relaySelf?: string | null;
   /** Builderlab account returned by hosted-community onboarding. Null/omitted = signed out. */


### PR DESCRIPTION
## Summary

When the **Projects** view has zero projects, `ProjectsView` early-returns the `EmptyState` *before* rendering the projects navigation bar — which is where the only create entry point (`ProjectsCreateMenu`, the round "+") lives. So with no projects there was no UI affordance to create one, and the first project could only be created from the CLI (`buzz repos create`) or another NIP-34 client.

This adds a **Create project** CTA to the empty state. It reuses the exact same internal flow as the toolbar "+":

- The `CreateProjectDialog` JSX is hoisted into a single `createProjectDialog` const rendered by **both** the empty-state and populated views — no create logic is duplicated.
- The CTA calls the existing `setCreateProjectOpen(true)` and the dialog uses the existing `createProjectMutation` and post-create `handleRepositoryScopeChange`/`handleFilterChange` handlers verbatim.

Blast radius is intentionally minimal: one new optional prop on `EmptyState`, a hoisted const, and the empty-state branch now renders the shared dialog.

Closes #2585

## Changes

- `desktop/src/features/projects/ui/ProjectCards.tsx` — `EmptyState` gains an optional `onCreateProject` prop that renders a "Create project" button (`data-testid="projects-empty-create"`); copy updated to reflect that the first project can be created here.
- `desktop/src/features/projects/ui/ProjectsView.tsx` — hoist `CreateProjectDialog` into a shared const; render it + the CTA in the empty-state branch; reuse it in the populated view.
- `desktop/src/testing/e2eBridge.ts` + `desktop/tests/helpers/bridge.ts` — additive `emptyProjects` mock flag serving zero projects.
- `desktop/tests/e2e/projects-empty-state.spec.ts` (+ `playwright.config.ts`) — regression spec: empty state shows the CTA and clicking it opens the create dialog.

## Testing

- `pnpm typecheck` ✅
- `pnpm check` (biome + file-size + px-text + pubkey guards) ✅
- `pnpm exec playwright test --project=smoke projects-empty-state` ✅ (1 passed)

## How to verify manually

Open Projects against a relay with no `30617` announcements → the empty state now shows a **Create project** button that opens the same dialog as the toolbar "+".

---
Authored by an AI agent (Claude) under human direction and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
