### PR TITLE
Gate default relay auto-connect behind release flag

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -211,12 +211,19 @@ desktop-tauri-test-compiled-flags: _ensure-sidecar-stubs
     cd desktop/src-tauri
     echo "=== Clean build (no flag) → expect false ==="
     env -u BUZZ_BUILD_OBSERVER_ARCHIVE_DEFAULT \
+      -u BUZZ_BUILD_AUTO_CONNECT_DEFAULT_RELAY \
       BUZZ_TEST_EXPECTED_OBSERVER_ARCHIVE_DEFAULT=false \
       cargo test observer_archive_default_enabled_matches_expected -- --ignored --nocapture
-    echo "=== Internal build (flag set) → expect true ==="
+    env -u BUZZ_BUILD_AUTO_CONNECT_DEFAULT_RELAY \
+      BUZZ_TEST_EXPECTED_AUTO_CONNECT_DEFAULT_RELAY=false \
+      cargo test compiled_flag_matches_expected -- --ignored --nocapture
+    echo "=== Internal build (flags set) → expect true ==="
     BUZZ_BUILD_OBSERVER_ARCHIVE_DEFAULT=1 \
       BUZZ_TEST_EXPECTED_OBSERVER_ARCHIVE_DEFAULT=true \
       cargo test observer_archive_default_enabled_matches_expected -- --ignored --nocapture
+    BUZZ_BUILD_AUTO_CONNECT_DEFAULT_RELAY=1 \
+      BUZZ_TEST_EXPECTED_AUTO_CONNECT_DEFAULT_RELAY=true \
+      cargo test compiled_flag_matches_expected -- --ignored --nocapture
     echo "Both compiled states verified."
 
 # Build the full desktop Tauri app locally (unsigned, for testing)

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -15,6 +15,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=BUZZ_BUILD_RELAY_RECONNECT_CMD");
     println!("cargo:rerun-if-env-changed=BUZZ_BUILD_OBSERVER_ARCHIVE_DEFAULT");
     println!("cargo:rerun-if-env-changed=BUZZ_BUILD_AGENT_METRIC_ARCHIVE_DEFAULT");
+    println!("cargo:rerun-if-env-changed=BUZZ_BUILD_AUTO_CONNECT_DEFAULT_RELAY");
     println!("cargo:rustc-check-cfg=cfg(buzz_updater_enabled)");
 
     if let Ok(relay_url) = std::env::var("BUZZ_RELAY_URL") {
@@ -87,6 +88,13 @@ fn main() {
     // leave this unset → default OFF.
     if std::env::var("BUZZ_BUILD_AGENT_METRIC_ARCHIVE_DEFAULT").is_ok() {
         println!("cargo:rustc-env=BUZZ_DESKTOP_BUILD_AGENT_METRIC_ARCHIVE_DEFAULT=1");
+    }
+
+    // Presence-only release capability: internal desktop builds opt into
+    // auto-connecting their configured default relay on first run. OSS builds
+    // leave this unset and retain explicit community selection.
+    if std::env::var("BUZZ_BUILD_AUTO_CONNECT_DEFAULT_RELAY").is_ok() {
+        println!("cargo:rustc-env=BUZZ_DESKTOP_BUILD_AUTO_CONNECT_DEFAULT_RELAY=1");
     }
 
     let updater_public_key = std::env::var("BUZZ_UPDATER_PUBLIC_KEY")

--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -55,6 +55,27 @@ pub fn get_default_relay_url() -> String {
 }
 
 #[tauri::command]
+pub fn auto_connect_default_relay_enabled() -> bool {
+    option_env!("BUZZ_DESKTOP_BUILD_AUTO_CONNECT_DEFAULT_RELAY").is_some()
+}
+
+#[cfg(test)]
+mod auto_connect_default_relay_tests {
+    use super::auto_connect_default_relay_enabled;
+
+    #[test]
+    #[ignore]
+    fn compiled_flag_matches_expected() {
+        let expected = std::env::var("BUZZ_TEST_EXPECTED_AUTO_CONNECT_DEFAULT_RELAY")
+            .expect("compiled-flag test requires an expected value");
+        assert_eq!(
+            auto_connect_default_relay_enabled(),
+            expected == "true" || expected == "1"
+        );
+    }
+}
+
+#[tauri::command]
 pub fn is_shared_identity() -> bool {
     std::env::var("BUZZ_SHARE_IDENTITY")
         .map(|v| v == "1")

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -691,6 +691,7 @@ pub fn run() {
             get_presence,
             get_os_idle_seconds,
             get_default_relay_url,
+            auto_connect_default_relay_enabled,
             get_legacy_workspace_storage,
             is_shared_identity,
             get_relay_ws_url,

--- a/desktop/src/features/communities/communityStorage.test.mjs
+++ b/desktop/src/features/communities/communityStorage.test.mjs
@@ -58,6 +58,12 @@ test("signed-build relay defaults auto-connect during first-run onboarding", () 
   assert.equal(shouldAutoConnectDefaultRelay("ws://127.0.0.1:3000"), false);
   assert.equal(shouldAutoConnectDefaultRelay("ws://[::1]:3000"), false);
   assert.equal(shouldAutoConnectDefaultRelay("ws://0.0.0.0:3000"), false);
+  assert.equal(shouldAutoConnectDefaultRelay("http://localhost:3000"), false);
+  assert.equal(
+    shouldAutoConnectDefaultRelay("https://relay.example.com"),
+    false,
+  );
+  assert.equal(shouldAutoConnectDefaultRelay("relay.example.com"), false);
   assert.equal(shouldAutoConnectDefaultRelay("not a valid relay"), false);
 });
 

--- a/desktop/src/features/communities/communityStorage.test.mjs
+++ b/desktop/src/features/communities/communityStorage.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   clearCommunityStorage,
   migrateLegacyCommunityStorage,
+  shouldAutoConnectDefaultRelay,
 } from "./communityStorage.ts";
 
 function createMemoryStorage(initial = {}) {
@@ -44,6 +45,16 @@ test("migrateLegacyCommunityStorage does not overwrite new community state", () 
 
   assert.equal(storage.getItem("buzz-communities"), '[{"id":"new"}]');
   assert.equal(storage.getItem("buzz-active-community-id"), "new");
+});
+
+test("signed-build relay defaults auto-connect during first-run onboarding", () => {
+  assert.equal(
+    shouldAutoConnectDefaultRelay("wss://buzz.block.builderlab.xyz"),
+    true,
+  );
+  assert.equal(shouldAutoConnectDefaultRelay("ws://localhost:3000"), false);
+  assert.equal(shouldAutoConnectDefaultRelay("ws://127.0.0.1:3000"), false);
+  assert.equal(shouldAutoConnectDefaultRelay("not a valid relay"), false);
 });
 
 test("clearCommunityStorage removes new and legacy state", () => {

--- a/desktop/src/features/communities/communityStorage.test.mjs
+++ b/desktop/src/features/communities/communityStorage.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   clearCommunityStorage,
+  initFirstCommunity,
   migrateLegacyCommunityStorage,
   shouldAutoConnectDefaultRelay,
 } from "./communityStorage.ts";
@@ -10,6 +11,7 @@ import {
 function createMemoryStorage(initial = {}) {
   const values = new Map(Object.entries(initial));
   return {
+    values,
     getItem: (key) => values.get(key) ?? null,
     setItem: (key, value) => values.set(key, String(value)),
     removeItem: (key) => values.delete(key),
@@ -57,6 +59,28 @@ test("signed-build relay defaults auto-connect during first-run onboarding", () 
   assert.equal(shouldAutoConnectDefaultRelay("ws://[::1]:3000"), false);
   assert.equal(shouldAutoConnectDefaultRelay("ws://0.0.0.0:3000"), false);
   assert.equal(shouldAutoConnectDefaultRelay("not a valid relay"), false);
+});
+
+test("failed first-community write preserves existing community data", () => {
+  const storage = createMemoryStorage({
+    "buzz-communities": '[{"id":"existing"}]',
+    "buzz-workspaces": '[{"id":"legacy"}]',
+    "buzz-active-workspace-id": "legacy",
+  });
+  storage.setItem = (key, value) => {
+    if (key === "buzz-communities") {
+      throw new Error("QuotaExceededError");
+    }
+    storage.values.set(key, String(value));
+  };
+  globalThis.localStorage = storage;
+  globalThis.window = { localStorage: storage };
+
+  assert.equal(initFirstCommunity("wss://relay.example.com", "pubkey"), null);
+  assert.equal(storage.getItem("buzz-communities"), '[{"id":"existing"}]');
+  assert.equal(storage.getItem("buzz-active-community-id"), null);
+  assert.equal(storage.getItem("buzz-workspaces"), '[{"id":"legacy"}]');
+  assert.equal(storage.getItem("buzz-active-workspace-id"), "legacy");
 });
 
 test("clearCommunityStorage removes new and legacy state", () => {

--- a/desktop/src/features/communities/communityStorage.test.mjs
+++ b/desktop/src/features/communities/communityStorage.test.mjs
@@ -54,6 +54,8 @@ test("signed-build relay defaults auto-connect during first-run onboarding", () 
   );
   assert.equal(shouldAutoConnectDefaultRelay("ws://localhost:3000"), false);
   assert.equal(shouldAutoConnectDefaultRelay("ws://127.0.0.1:3000"), false);
+  assert.equal(shouldAutoConnectDefaultRelay("ws://[::1]:3000"), false);
+  assert.equal(shouldAutoConnectDefaultRelay("ws://0.0.0.0:3000"), false);
   assert.equal(shouldAutoConnectDefaultRelay("not a valid relay"), false);
 });
 

--- a/desktop/src/features/communities/communityStorage.ts
+++ b/desktop/src/features/communities/communityStorage.ts
@@ -81,8 +81,11 @@ export function loadCommunities(): Community[] {
   }
 }
 
-export function saveCommunities(communities: Community[]): void {
-  setLocalStorageItemWithRecovery(COMMUNITIES_KEY, JSON.stringify(communities));
+export function saveCommunities(communities: Community[]): boolean {
+  return setLocalStorageItemWithRecovery(
+    COMMUNITIES_KEY,
+    JSON.stringify(communities),
+  );
 }
 
 export function clearCommunityStorage(storage: Storage = localStorage): void {
@@ -97,8 +100,8 @@ export function loadActiveCommunityId(): string | null {
   return localStorage.getItem(ACTIVE_COMMUNITY_KEY);
 }
 
-export function saveActiveCommunityId(id: string): void {
-  setLocalStorageItemWithRecovery(ACTIVE_COMMUNITY_KEY, id);
+export function saveActiveCommunityId(id: string): boolean {
+  return setLocalStorageItemWithRecovery(ACTIVE_COMMUNITY_KEY, id);
 }
 
 export function normalizeRelayUrl(url: string): string {
@@ -111,7 +114,9 @@ export function normalizeRelayUrl(url: string): string {
 export function shouldAutoConnectDefaultRelay(relayUrl: string): boolean {
   try {
     const parsed = new URL(normalizeRelayUrl(relayUrl));
-    return parsed.hostname !== "localhost" && parsed.hostname !== "127.0.0.1";
+    return !["localhost", "127.0.0.1", "[::1]", "0.0.0.0"].includes(
+      parsed.hostname,
+    );
   } catch {
     return false;
   }
@@ -145,7 +150,7 @@ export function initFirstCommunity(
   relayUrl: string,
   pubkey: string,
   name?: string,
-): Community {
+): Community | null {
   const normalizedUrl = normalizeRelayUrl(relayUrl);
   const trimmedName = name?.trim();
   const community: Community = {
@@ -155,7 +160,16 @@ export function initFirstCommunity(
     pubkey,
     addedAt: new Date().toISOString(),
   };
-  saveCommunities([community]);
-  saveActiveCommunityId(community.id);
+  const didSaveCommunities = saveCommunities([community]);
+  const didSaveActiveCommunity =
+    didSaveCommunities && saveActiveCommunityId(community.id);
+
+  // The quota-recovery helper reports failure instead of throwing. Do not let
+  // callers reload unless both writes landed; otherwise first launch can loop.
+  if (!didSaveCommunities || !didSaveActiveCommunity) {
+    clearCommunityStorage();
+    return null;
+  }
+
   return community;
 }

--- a/desktop/src/features/communities/communityStorage.ts
+++ b/desktop/src/features/communities/communityStorage.ts
@@ -160,14 +160,26 @@ export function initFirstCommunity(
     pubkey,
     addedAt: new Date().toISOString(),
   };
-  const didSaveCommunities = saveCommunities([community]);
-  const didSaveActiveCommunity =
-    didSaveCommunities && saveActiveCommunityId(community.id);
+  const previousActiveCommunityId = localStorage.getItem(ACTIVE_COMMUNITY_KEY);
+  const didSaveActiveCommunity = saveActiveCommunityId(community.id);
+  if (!didSaveActiveCommunity) {
+    return null;
+  }
 
-  // The quota-recovery helper reports failure instead of throwing. Do not let
-  // callers reload unless both writes landed; otherwise first launch can loop.
-  if (!didSaveCommunities || !didSaveActiveCommunity) {
-    clearCommunityStorage();
+  if (!saveCommunities([community])) {
+    // A failed setItem leaves the existing communities value untouched. Roll
+    // back only the active-ID write so inconsistent pre-existing data is never
+    // destroyed while recovering from a quota failure.
+    try {
+      if (previousActiveCommunityId === null) {
+        localStorage.removeItem(ACTIVE_COMMUNITY_KEY);
+      } else {
+        localStorage.setItem(ACTIVE_COMMUNITY_KEY, previousActiveCommunityId);
+      }
+    } catch {
+      // Best effort: persistence is already unavailable, and callers will stay
+      // on setup instead of reloading.
+    }
     return null;
   }
 

--- a/desktop/src/features/communities/communityStorage.ts
+++ b/desktop/src/features/communities/communityStorage.ts
@@ -108,6 +108,15 @@ export function normalizeRelayUrl(url: string): string {
   return url;
 }
 
+export function shouldAutoConnectDefaultRelay(relayUrl: string): boolean {
+  try {
+    const parsed = new URL(normalizeRelayUrl(relayUrl));
+    return parsed.hostname !== "localhost" && parsed.hostname !== "127.0.0.1";
+  } catch {
+    return false;
+  }
+}
+
 export function deriveCommunityName(relayUrl: string): string {
   try {
     const url = new URL(

--- a/desktop/src/features/communities/communityStorage.ts
+++ b/desktop/src/features/communities/communityStorage.ts
@@ -111,11 +111,16 @@ export function normalizeRelayUrl(url: string): string {
   return url;
 }
 
+function isLocalRelayHost(hostname: string): boolean {
+  return ["localhost", "127.0.0.1", "[::1]", "0.0.0.0"].includes(hostname);
+}
+
 export function shouldAutoConnectDefaultRelay(relayUrl: string): boolean {
   try {
-    const parsed = new URL(normalizeRelayUrl(relayUrl));
-    return !["localhost", "127.0.0.1", "[::1]", "0.0.0.0"].includes(
-      parsed.hostname,
+    const parsed = new URL(relayUrl);
+    return (
+      (parsed.protocol === "ws:" || parsed.protocol === "wss:") &&
+      !isLocalRelayHost(parsed.hostname)
     );
   } catch {
     return false;
@@ -128,7 +133,7 @@ export function deriveCommunityName(relayUrl: string): string {
       relayUrl.replace("ws://", "http://").replace("wss://", "https://"),
     );
     const host = url.hostname;
-    if (host === "localhost" || host === "127.0.0.1") {
+    if (isLocalRelayHost(host)) {
       return "Local Dev";
     }
     const parts = host.split(".");
@@ -157,6 +162,8 @@ export function initFirstCommunity(
     id: crypto.randomUUID(),
     name: trimmedName || deriveCommunityName(normalizedUrl),
     relayUrl: normalizedUrl,
+    // Compiled default relays must admit the first token-less connection; there
+    // is no invite-token prompt on this auto-connect path.
     pubkey,
     addedAt: new Date().toISOString(),
   };

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -23,7 +23,10 @@ import { resetSidebarRelayConnectionCardState } from "@/features/sidebar/ui/useS
 import { clearMarkdownNodeCache } from "@/shared/ui/markdown/nodeCache";
 import { resetVideoPlayerState } from "@/shared/ui/videoPlayerState";
 
-import { initFirstCommunity } from "./communityStorage";
+import {
+  initFirstCommunity,
+  shouldAutoConnectDefaultRelay,
+} from "./communityStorage";
 import type { Community } from "./types";
 
 /**
@@ -94,7 +97,14 @@ export function useCommunityInit(
         try {
           const defaultRelayUrl = await getDefaultRelayUrl();
 
-          if (isSharedIdentity) {
+          // Signed builds carry a reviewed production relay. Treat that as the
+          // user's first community so first-run onboarding proceeds directly
+          // from machine setup into profile/team setup. Local development keeps
+          // the explicit add-a-community flow for ws://localhost defaults.
+          if (
+            isSharedIdentity ||
+            shouldAutoConnectDefaultRelay(defaultRelayUrl)
+          ) {
             const identity = await getIdentity();
             if (cancelled) return;
             initFirstCommunity(defaultRelayUrl, identity.pubkey);

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -107,9 +107,20 @@ export function useCommunityInit(
           ) {
             const identity = await getIdentity();
             if (cancelled) return;
-            initFirstCommunity(defaultRelayUrl, identity.pubkey);
-            if (!cancelled) {
+            const community = initFirstCommunity(
+              defaultRelayUrl,
+              identity.pubkey,
+            );
+            if (community && !cancelled) {
               window.location.reload();
+              return;
+            }
+            if (!cancelled) {
+              setResult({
+                isReady: false,
+                needsSetup: true,
+                defaultRelayUrl,
+              });
             }
             return;
           }

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -2,7 +2,11 @@ import { useEffect, useRef, useState } from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
 import { resetRateLimitGate } from "@/shared/api/relayRateLimitGate";
-import { applyCommunity, getDefaultRelayUrl } from "@/shared/api/tauri";
+import {
+  applyCommunity,
+  autoConnectDefaultRelayEnabled,
+  getDefaultRelayUrl,
+} from "@/shared/api/tauri";
 import { getIdentity } from "@/shared/api/tauriIdentity";
 import { getOverrides } from "@/shared/features";
 import { resetMediaCaches } from "@/shared/lib/mediaUrl";
@@ -96,14 +100,16 @@ export function useCommunityInit(
       if (!activeCommunity) {
         try {
           const defaultRelayUrl = await getDefaultRelayUrl();
+          const autoConnectDefaultRelay =
+            await autoConnectDefaultRelayEnabled();
 
-          // Signed builds carry a reviewed production relay. Treat that as the
-          // user's first community so first-run onboarding proceeds directly
-          // from machine setup into profile/team setup. Local development keeps
-          // the explicit add-a-community flow for ws://localhost defaults.
+          // Internal builds explicitly opt into treating their reviewed default
+          // relay as the first community. Public builds retain community
+          // selection even when BUZZ_RELAY_URL is overridden at runtime.
           if (
             isSharedIdentity ||
-            shouldAutoConnectDefaultRelay(defaultRelayUrl)
+            (autoConnectDefaultRelay &&
+              shouldAutoConnectDefaultRelay(defaultRelayUrl))
           ) {
             const identity = await getIdentity();
             if (cancelled) return;

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -359,6 +359,10 @@ export function getDefaultRelayUrl(): Promise<string> {
   return invokeTauri<string>("get_default_relay_url");
 }
 
+export function autoConnectDefaultRelayEnabled(): Promise<boolean> {
+  return invokeTauri<boolean>("auto_connect_default_relay_enabled");
+}
+
 export function isSharedIdentity(): Promise<boolean> {
   return invokeTauri<boolean>("is_shared_identity");
 }

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -415,6 +415,7 @@ type E2eConfig = {
   };
   relayHttpUrl?: string;
   relayWsUrl?: string;
+  autoConnectDefaultRelay?: boolean;
   identity?: TestIdentity;
 };
 
@@ -9792,6 +9793,8 @@ export function maybeInstallE2eTauriMocks() {
         return getRelayWsUrl(activeConfig);
       case "get_default_relay_url":
         return getRelayWsUrl(activeConfig);
+      case "auto_connect_default_relay_enabled":
+        return activeConfig?.autoConnectDefaultRelay ?? false;
       case "get_legacy_workspace_storage":
         return {
           workspaces: null,

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -560,6 +560,46 @@ test("first-launch key import continues to machine setup", async ({ page }) => {
   await expect(page.getByTestId("app-loading-gate")).toHaveCount(0);
 });
 
+test("non-local default auto-connects the first community", async ({
+  page,
+}) => {
+  await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
+  await page.addInitScript((pubkey) => {
+    window.localStorage.setItem(
+      `buzz-machine-onboarding-complete.v2:${pubkey}`,
+      "true",
+    );
+  }, BLANK_TYLER_IDENTITY.pubkey);
+  await installMockBridge(page, undefined, {
+    relayWsUrl: "wss://default.example.com",
+    skipOnboardingSeed: true,
+    skipCommunitySeed: true,
+  });
+  await page.goto("/");
+
+  await expectIncompleteOnboarding(page);
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const raw = window.localStorage.getItem("buzz-communities");
+        const communities = raw
+          ? (JSON.parse(raw) as Array<{ id: string; relayUrl: string }>)
+          : [];
+        return {
+          activeMatchesCommunity:
+            communities.length === 1 &&
+            window.localStorage.getItem("buzz-active-community-id") ===
+              communities[0]?.id,
+          relayUrl: communities[0]?.relayUrl ?? null,
+        };
+      }),
+    )
+    .toEqual({
+      activeMatchesCommunity: true,
+      relayUrl: "wss://default.example.com",
+    });
+});
+
 test("first-community choices route join, create, owner, and member intents", async ({
   page,
 }) => {
@@ -1298,7 +1338,7 @@ test("connected first-community profile step offers equal-width Next and Back co
           id: "txn-profile-step",
           source: "first-community",
           stage: "profile",
-          relayUrl: "wss://default.example.com",
+          relayUrl: "ws://localhost:3000",
           communityName: "Default",
           communityId: "e2e-default-community",
           addedCommunity: true,
@@ -1346,7 +1386,7 @@ test("connected first-community profile step offers equal-width Next and Back co
       ],
     },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
     },
   );

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -560,7 +560,32 @@ test("first-launch key import continues to machine setup", async ({ page }) => {
   await expect(page.getByTestId("app-loading-gate")).toHaveCount(0);
 });
 
-test("non-local default auto-connects the first community", async ({
+test("non-local runtime override keeps community selection without release flag", async ({
+  page,
+}) => {
+  await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
+  await page.addInitScript((pubkey) => {
+    window.localStorage.setItem(
+      `buzz-machine-onboarding-complete.v2:${pubkey}`,
+      "true",
+    );
+  }, BLANK_TYLER_IDENTITY.pubkey);
+  await installMockBridge(page, undefined, {
+    relayWsUrl: "wss://override.example.com",
+    skipOnboardingSeed: true,
+    skipCommunitySeed: true,
+  });
+  await page.goto("/");
+
+  await expect(
+    page.getByRole("button", { name: /Join a community/ }),
+  ).toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("buzz-communities")))
+    .toBeNull();
+});
+
+test("non-local default auto-connects when the release flag is enabled", async ({
   page,
 }) => {
   await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
@@ -572,6 +597,7 @@ test("non-local default auto-connects the first community", async ({
   }, BLANK_TYLER_IDENTITY.pubkey);
   await installMockBridge(page, undefined, {
     relayWsUrl: "wss://default.example.com",
+    autoConnectDefaultRelay: true,
     skipOnboardingSeed: true,
     skipCommunitySeed: true,
   });

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -571,7 +571,7 @@ test("first-community choices route join, create, owner, and member intents", as
     );
   }, BLANK_TYLER_IDENTITY.pubkey);
   await installMockBridge(page, undefined, {
-    relayWsUrl: "wss://default.example.com",
+    relayWsUrl: "ws://localhost:3000",
     skipOnboardingSeed: true,
     skipCommunitySeed: true,
   });
@@ -657,7 +657,7 @@ test("first-community owner can connect an existing hosted community", async ({
       ],
     },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -715,7 +715,7 @@ test("first-community owner can create and connect a hosted community", async ({
     page,
     {},
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -789,7 +789,7 @@ test("hosted community address line stays within the card for a long name", asyn
     page,
     {},
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -860,7 +860,7 @@ test("first-community reports a created community without a relay address", asyn
       },
     },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -891,7 +891,7 @@ test("first-community X cancels a pending sign-in", async ({ page }) => {
     page,
     { builderlabLoginDelayMs: 5_000 },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -933,7 +933,7 @@ test("first-community owner can replace a mismatched account identity", async ({
       builderlabIdentity: { pubkey_hex: "f".repeat(64) },
     },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -983,7 +983,7 @@ test("first-community explains when the local identity belongs to another accoun
       builderlabBindError: { code: "pubkey_already_bound" },
     },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -1024,7 +1024,7 @@ test("back clears Builderlab auth before returning to first-community choices", 
       builderlabIdentity: { pubkey_hex: BLANK_TYLER_IDENTITY.pubkey },
     },
     {
-      relayWsUrl: "wss://default.example.com",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },
@@ -1112,7 +1112,7 @@ test("first-community direct join reaches profile", async ({ page }) => {
     );
   }, BLANK_TYLER_IDENTITY.pubkey);
   await installMockBridge(page, undefined, {
-    relayWsUrl: "wss://onboarding.communities.buzz.xyz",
+    relayWsUrl: "ws://localhost:3000",
     skipOnboardingSeed: true,
     skipCommunitySeed: true,
   });
@@ -1167,7 +1167,7 @@ test("first-community direct join cancel returns to request access", async ({
     page,
     { applyCommunityDelayMs: 5_000 },
     {
-      relayWsUrl: "wss://onboarding.communities.buzz.xyz",
+      relayWsUrl: "ws://localhost:3000",
       skipOnboardingSeed: true,
       skipCommunitySeed: true,
     },

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -459,6 +459,7 @@ type BridgeOptions = {
   mock?: MockBridgeOptions;
   relayHttpUrl?: string;
   relayWsUrl?: string;
+  autoConnectDefaultRelay?: boolean;
   skipOnboardingSeed?: boolean;
   skipCommunitySeed?: boolean;
   /**
@@ -710,7 +711,14 @@ export async function installBridge(page: Page, options: BridgeOptions) {
   }
 
   await page.addInitScript(
-    ({ identity: bridgeIdentity, mock, mode, relayHttpUrl, relayWsUrl }) => {
+    ({
+      identity: bridgeIdentity,
+      mock,
+      mode,
+      relayHttpUrl,
+      relayWsUrl,
+      autoConnectDefaultRelay,
+    }) => {
       const notificationLog: Array<{
         body: string | null;
         title: string;
@@ -767,6 +775,8 @@ export async function installBridge(page: Page, options: BridgeOptions) {
         mode,
         relayHttpUrl: relayHttpUrl ?? currentConfig.relayHttpUrl,
         relayWsUrl: relayWsUrl ?? currentConfig.relayWsUrl,
+        autoConnectDefaultRelay:
+          autoConnectDefaultRelay ?? currentConfig.autoConnectDefaultRelay,
       };
       testWindow.__BUZZ_E2E_APP_BADGE_COUNT__ = 0;
       testWindow.__BUZZ_E2E_APP_BADGE_STATE__ = "none";
@@ -789,6 +799,7 @@ export async function installBridge(page: Page, options: BridgeOptions) {
       mode: options.mode,
       relayHttpUrl: options.relayHttpUrl,
       relayWsUrl: options.relayWsUrl,
+      autoConnectDefaultRelay: options.autoConnectDefaultRelay,
     },
   );
 }
@@ -798,6 +809,7 @@ export async function installMockBridge(
   mock?: MockBridgeOptions,
   options?: {
     relayWsUrl?: string;
+    autoConnectDefaultRelay?: boolean;
     skipOnboardingSeed?: boolean;
     skipCommunitySeed?: boolean;
     seedPreviewFeatures?: boolean;
@@ -807,6 +819,7 @@ export async function installMockBridge(
     mode: "mock",
     mock,
     relayWsUrl: options?.relayWsUrl,
+    autoConnectDefaultRelay: options?.autoConnectDefaultRelay,
     skipOnboardingSeed: options?.skipOnboardingSeed,
     skipCommunitySeed: options?.skipCommunitySeed,
     seedPreviewFeatures: options?.seedPreviewFeatures,


### PR DESCRIPTION
## Why

Internal desktop releases need to enter their reviewed default relay on first run without changing public-build behavior. Relay URL inference alone is too broad: a runtime `BUZZ_RELAY_URL` override must not silently bypass community selection.

This replaces and supersedes #2411 with an explicit release capability.

## What

- add the presence-only build-time capability `BUZZ_BUILD_AUTO_CONNECT_DEFAULT_RELAY`
- bake it into the desktop binary as `BUZZ_DESKTOP_BUILD_AUTO_CONNECT_DEFAULT_RELAY` and expose it through a Tauri command
- auto-create the first community only when both conditions hold:
  - the compiled capability is present
  - the configured default relay is a valid, non-local `ws:` or `wss:` URL
- bypass only first-community selection; machine/profile onboarding remains intact
- keep shared-identity behavior independent
- preserve existing community data and stay in setup if persistence fails
- add dual compile-state Rust coverage plus E2E bridge/cases for public and flagged behavior

## Release contract

Companion release PR: https://github.com/squareup/buzz-releases/pull/76

That PR sets `BUZZ_BUILD_AUTO_CONNECT_DEFAULT_RELAY=1` only for the internal desktop release build and forwards it to `pnpm tauri build`. Public/unprivileged and iOS build paths leave it unset. Runtime relay overrides cannot enable this feature.

Merge this consumer before enabling the release-side flag (or select a desktop tag containing this change).

## Risk Assessment

Medium, narrowly scoped to fresh installs with no community. Existing users are unchanged. Public builds fail closed. Invalid/local relay defaults retain explicit community selection, as does any persistence failure.

## Verification

At `8c86c8e622aab3e27ff68a06fdbddd78690add9c`:

- `git diff --check origin/main...HEAD`
- Biome check on all changed frontend/test files
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --check`
- commit trailer audit across all five commits

Per review policy, local unit/Playwright suites were not duplicated; CI is authoritative.
