### PR TITLE
fix(cli): install rustls crypto provider to unbreak WSS publishes in release builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "nostr",
  "rand 0.10.1",
  "reqwest 0.13.4",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/buzz-cli/Cargo.toml
+++ b/crates/buzz-cli/Cargo.toml
@@ -76,6 +76,13 @@ dirs = "6"
 # WebSocket client — ephemeral event publish (kind:20001 is WS-only on the relay)
 buzz-ws-client = { path = "../buzz-ws-client" }
 
+# Explicit rustls dep with ring provider — required to install the process-level
+# CryptoProvider at startup. Without this the standalone `buzz` binary panics when
+# a multi-package release build (buzz-acp + buzz-dev-mcp + buzz-cli in one cargo
+# invocation) unifies both ring and aws-lc-rs features, leaving rustls unable to
+# auto-select a provider. See crates/buzz-acp/Cargo.toml for the same dependency.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+
 # Random number generation — full jitter for exponential backoff in with_retry
 rand = { workspace = true }
 

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -25,6 +25,18 @@ where
     I: IntoIterator<Item = S>,
     S: Into<std::ffi::OsString> + Clone,
 {
+    // Install ring as the process-level rustls CryptoProvider. Required because the
+    // release workflow builds all binaries in one cargo invocation, which unifies
+    // features across the workspace and enables *both* ring (from buzz-acp/buzz-dev-mcp)
+    // and aws-lc-rs (from reqwest's rustls feature via hyper-rustls). With both on,
+    // rustls cannot auto-select a provider, and any code that reaches
+    // ClientConfig::builder() — specifically the WSS path in publish_ephemeral_event
+    // used by `agents draft-create`, `agents draft-update`, and `users set-presence`
+    // — panics at rustls crypto/mod.rs. The `let _ =` swallow is intentional: when
+    // buzz-dev-mcp delegates to run_from_args, it has already installed ring; the
+    // double-install returns Err and is harmless.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let cli = match Cli::try_parse_from(args) {
         Ok(cli) => cli,
         Err(e) => {


### PR DESCRIPTION
## Problem

The standalone `buzz` binary panicked at `rustls crypto/mod.rs:249` on any command that opens a raw WSS connection: `agents draft-create`, `agents draft-update`, and `users set-presence`. The panic message:

```
thread 'main' panicked at .../rustls-0.23.42/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually,
or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
```

## Root Cause

The release workflow builds all five binaries in one `cargo` invocation, which unifies crate features across the workspace. This enables **both** `ring` (from `buzz-acp`/`buzz-dev-mcp`) and `aws-lc-rs` (from `reqwest`'s `rustls` feature via `hyper-rustls`). When both are active, rustls cannot auto-select a process-level `CryptoProvider`, and any code reaching `ClientConfig::builder()` panics instead of returning an error.

Most subcommands are unaffected because they use the `reqwest` HTTP bridge, which constructs its TLS config with an explicit provider. Only the WSS path in `publish_ephemeral_event` (`buzz-ws-client` → `tokio-tungstenite` → rustls) hits the process-default provider lookup and panics.

The bundled Desktop CLI is unaffected because `buzz-dev-mcp` installs the ring provider before delegating to `run_from_args`. Only the standalone native binary is exposed.

## Fix

Call `rustls::crypto::ring::default_provider().install_default()` at the top of `run_from_args` in `crates/buzz-cli/src/lib.rs`, and add the explicit `rustls` dep to `crates/buzz-cli/Cargo.toml`. This mirrors the established pattern in `buzz-acp`, `buzz-dev-mcp`, `buzz-relay`, and `buzz-admin`. The `let _ =` discard is intentional — when `buzz-dev-mcp` delegates to `run_from_args` it has already installed ring; the second install returns `Err` and is harmless.

## Repro Evidence

**Before fix** — multi-package build (release workflow shape) panics:

```
$ cargo build -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
$ BUZZ_PRIVATE_KEY=<key> BUZZ_RELAY_URL=wss://buzz.block.builderlab.xyz ./target/debug/buzz users set-presence --status online

thread 'main' (4762635) panicked at .../rustls-0.23.42/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
...
   6: builder_with_protocol_versions (rustls-0.23.42/src/client/client_conn.rs:339)
   8: {async_fn#0} (tokio-tungstenite-0.29.0/src/tls.rs:126)
```

**After fix** — both build paths succeed:

```
# Multi-package build (release workflow shape)
$ cargo build -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
$ BUZZ_PRIVATE_KEY=<key> BUZZ_RELAY_URL=wss://buzz.block.builderlab.xyz ./target/debug/buzz users set-presence --status online
{"accepted":true,"event_id":"2e3634e1d87eeed8870afe66e74fc2023f4a6c428b72491edadf2c77baaed19d","message":""}

# Solo build
$ cargo build -p buzz-cli
$ BUZZ_PRIVATE_KEY=<key> BUZZ_RELAY_URL=wss://buzz.block.builderlab.xyz ./target/debug/buzz users set-presence --status online
{"accepted":true,"event_id":"15a0e942061dc0430f80e84109912fb80f5260562dd134ad2760758080dbf020","message":""}
```

`cargo test -p buzz-cli`: 250 passed, 0 failed. `cargo clippy -p buzz-cli`: clean.