### PR TITLE
fix(acp): restrict DM turns to owner and verified siblings

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -220,13 +220,32 @@ async fn is_owner_or_sibling(
 /// Coarse security policy applied before subscription rules. Both `OwnerOnly`
 /// and `Allowlist` accept the owner and same-owner siblings; `Allowlist`
 /// additionally accepts the explicit external pubkey list.
+///
+/// # DM hardening (`is_dm`)
+///
+/// Clients auto-p-tag every DM participant, so in a DM *any* participant's
+/// message looks like a mention and would fire a turn. Combined with
+/// agent-initiated DMs (the agent can be asked to DM a third party), that
+/// turns `anyone`/`allowlist` modes into transitive access grants: whoever
+/// lands in a DM with the agent can prompt it. To close that hole, when
+/// `is_dm` is true only the owner and cryptographically verified same-owner
+/// siblings may fire a turn — the explicit allowlist and `anyone` mode do
+/// NOT apply inside DMs. `Nobody` still drops everything. Callers must
+/// resolve `is_dm` fail-closed: unknown channel type ⇒ treat as DM.
 async fn author_allowed(
     respond_to: &RespondTo,
     allowlist: &HashSet<String>,
     author: &str,
+    is_dm: bool,
     owner_cache: &OwnerCache,
     rest_client: &relay::RestClient,
 ) -> bool {
+    if is_dm {
+        return match respond_to {
+            RespondTo::Nobody => false,
+            _ => is_owner_or_sibling(author, owner_cache, rest_client).await,
+        };
+    }
     match respond_to {
         RespondTo::Anyone => true,
         RespondTo::Nobody => false,
@@ -234,6 +253,47 @@ async fn author_allowed(
         RespondTo::Allowlist => {
             allowlist.contains(author)
                 || is_owner_or_sibling(author, owner_cache, rest_client).await
+        }
+    }
+}
+
+/// Resolve whether `channel_id` is a DM, for the inbound author gate.
+///
+/// Resolution order:
+/// 1. Startup discovery metadata (`startup_info`) — covers channels known at
+///    process start.
+/// 2. Per-loop resolution cache (`cache`) — covers channels resolved since.
+/// 3. Lazy REST fetch of the channel's kind:39000 metadata — covers channels
+///    the agent was added to *after* startup (the exploit path: an
+///    agent-initiated DM is exactly such a channel).
+///
+/// Fail-closed: if the fetch fails or times out, the channel is treated as a
+/// DM for this event and the result is NOT cached, so a later event retries
+/// the fetch instead of pinning a mis-classification.
+pub(crate) async fn is_dm_channel(
+    channel_id: Uuid,
+    startup_info: &HashMap<Uuid, relay::ChannelInfo>,
+    cache: &mut HashMap<Uuid, bool>,
+    rest_client: &relay::RestClient,
+) -> bool {
+    if let Some(ci) = startup_info.get(&channel_id) {
+        return ci.channel_type == "dm";
+    }
+    if let Some(&cached) = cache.get(&channel_id) {
+        return cached;
+    }
+    match pool::fetch_channel_info(channel_id, rest_client).await {
+        Some(ci) => {
+            let is_dm = ci.channel_type == "dm";
+            cache.insert(channel_id, is_dm);
+            is_dm
+        }
+        None => {
+            tracing::warn!(
+                channel_id = %channel_id,
+                "channel type unresolved — treating as DM for author gate (fail closed)"
+            );
+            true
         }
     }
 }
@@ -1609,6 +1669,10 @@ async fn tokio_main() -> Result<()> {
     // second are both processed. The seen_membership_ids set handles exact
     // replays that share the same timestamp.
     let mut membership_newest_ts: HashMap<Uuid, u64> = HashMap::new();
+    // Resolved channel-type cache for the inbound author gate's DM check.
+    // Covers channels joined after startup (not in ctx.channel_info). Only
+    // successful lookups are cached — failures fail closed per-event and retry.
+    let mut dm_channel_cache: HashMap<Uuid, bool> = HashMap::new();
     // Two-generation dedup for membership event replays (bounded, no amnesia).
     // Rotates at 1000 entries instead of clearing the entire set at 2000.
     let mut seen_membership_current: HashSet<String> = HashSet::new();
@@ -2097,10 +2161,21 @@ async fn tokio_main() -> Result<()> {
                             // it never revokes same-owner team bots.
                             {
                                 let author = buzz_event.event.pubkey.to_hex();
+                                // DM hardening: resolve channel type (fail-closed
+                                // to DM) so allowlist/anyone modes cannot be
+                                // exercised by non-owner authors inside DMs.
+                                let is_dm = is_dm_channel(
+                                    buzz_event.channel_id,
+                                    &ctx.channel_info,
+                                    &mut dm_channel_cache,
+                                    &ctx.rest_client,
+                                )
+                                .await;
                                 let allowed = author_allowed(
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
                                     &author,
+                                    is_dm,
                                     &owner_cache,
                                     &ctx.rest_client,
                                 )
@@ -2110,6 +2185,7 @@ async fn tokio_main() -> Result<()> {
                                         channel_id = %buzz_event.channel_id,
                                         author = %buzz_event.event.pubkey.to_hex(),
                                         mode = %config.respond_to,
+                                        is_dm,
                                         "inbound author gate — dropping event"
                                     );
                                     continue;
@@ -4293,6 +4369,7 @@ mod author_gate_tests {
         let cache = OwnerCache::new(Some(OWNER.into()));
         cache.cache_sibling(SIBLING.into(), true);
         cache.cache_sibling(STRANGER.into(), false);
+        cache.cache_sibling(EXTERNAL.into(), false);
         cache
     }
 
@@ -4305,6 +4382,7 @@ mod author_gate_tests {
                 &RespondTo::Allowlist,
                 &allowlist,
                 SIBLING,
+                false,
                 &cache,
                 &dummy_rest_client()
             )
@@ -4322,6 +4400,7 @@ mod author_gate_tests {
                 &RespondTo::Allowlist,
                 &allowlist,
                 EXTERNAL,
+                false,
                 &cache,
                 &dummy_rest_client()
             )
@@ -4339,6 +4418,7 @@ mod author_gate_tests {
                 &RespondTo::Allowlist,
                 &allowlist,
                 STRANGER,
+                false,
                 &cache,
                 &dummy_rest_client()
             )
@@ -4356,6 +4436,7 @@ mod author_gate_tests {
                 &RespondTo::Allowlist,
                 &allowlist,
                 OWNER,
+                false,
                 &cache,
                 &dummy_rest_client()
             )
@@ -4376,6 +4457,7 @@ mod author_gate_tests {
                 &RespondTo::OwnerOnly,
                 &HashSet::new(),
                 STRANGER,
+                false,
                 &cache,
                 &dummy_rest_client()
             )
@@ -4393,6 +4475,7 @@ mod author_gate_tests {
                     &RespondTo::OwnerOnly,
                     &HashSet::new(),
                     who,
+                    false,
                     &cache,
                     &dummy_rest_client()
                 )
@@ -4400,6 +4483,153 @@ mod author_gate_tests {
                 "under default OwnerOnly, the {label} must be admitted so steering can fire"
             );
         }
+    }
+
+    // ── DM hardening ──────────────────────────────────────────────────────
+    //
+    // In a DM, clients auto-p-tag every participant, and an agent can be
+    // asked to open a DM with a third party. The gate must therefore ignore
+    // the allowlist and `anyone` mode inside DMs: only owner + verified
+    // siblings fire turns.
+
+    #[tokio::test]
+    async fn test_dm_rejects_allowlisted_external_pubkey() {
+        let cache = cache_with_sibling();
+        let allowlist = HashSet::from([EXTERNAL.to_string()]);
+        assert!(
+            !author_allowed(
+                &RespondTo::Allowlist,
+                &allowlist,
+                EXTERNAL,
+                true,
+                &cache,
+                &dummy_rest_client()
+            )
+            .await,
+            "an allowlisted external pubkey must NOT fire a turn inside a DM"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dm_rejects_stranger_under_anyone() {
+        let cache = cache_with_sibling();
+        assert!(
+            !author_allowed(
+                &RespondTo::Anyone,
+                &HashSet::new(),
+                STRANGER,
+                true,
+                &cache,
+                &dummy_rest_client()
+            )
+            .await,
+            "respond_to=anyone must still drop non-owner authors inside a DM"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dm_admits_owner_and_sibling_in_every_responding_mode() {
+        let cache = cache_with_sibling();
+        for mode in [
+            RespondTo::OwnerOnly,
+            RespondTo::Allowlist,
+            RespondTo::Anyone,
+        ] {
+            for (who, label) in [(OWNER, "owner"), (SIBLING, "sibling")] {
+                assert!(
+                    author_allowed(
+                        &mode,
+                        &HashSet::new(),
+                        who,
+                        true,
+                        &cache,
+                        &dummy_rest_client()
+                    )
+                    .await,
+                    "in a DM under {mode}, the {label} must still be admitted"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dm_nobody_rejects_even_owner() {
+        let cache = cache_with_sibling();
+        assert!(
+            !author_allowed(
+                &RespondTo::Nobody,
+                &HashSet::new(),
+                OWNER,
+                true,
+                &cache,
+                &dummy_rest_client()
+            )
+            .await,
+            "respond_to=nobody must drop everything, DMs included"
+        );
+    }
+
+    // ── is_dm_channel resolution ──────────────────────────────────────────
+
+    fn startup_info(id: Uuid, channel_type: &str) -> HashMap<Uuid, relay::ChannelInfo> {
+        HashMap::from([(
+            id,
+            relay::ChannelInfo {
+                name: "test".into(),
+                channel_type: channel_type.into(),
+            },
+        )])
+    }
+
+    #[tokio::test]
+    async fn test_is_dm_channel_uses_startup_metadata() {
+        let id = Uuid::new_v4();
+        let mut cache = HashMap::new();
+        assert!(
+            is_dm_channel(
+                id,
+                &startup_info(id, "dm"),
+                &mut cache,
+                &dummy_rest_client()
+            )
+            .await
+        );
+        assert!(
+            !is_dm_channel(
+                id,
+                &startup_info(id, "stream"),
+                &mut cache,
+                &dummy_rest_client()
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_dm_channel_uses_resolution_cache() {
+        let id = Uuid::new_v4();
+        let empty = HashMap::new();
+        let mut cache = HashMap::from([(id, false)]);
+        assert!(
+            !is_dm_channel(id, &empty, &mut cache, &dummy_rest_client()).await,
+            "a cached non-DM resolution must be honored without a fetch"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_dm_channel_fails_closed_and_does_not_cache_failure() {
+        // dummy_rest_client points at localhost:0 — the lazy fetch fails.
+        let id = Uuid::new_v4();
+        let empty = HashMap::new();
+        let mut cache = HashMap::new();
+        assert!(
+            is_dm_channel(id, &empty, &mut cache, &dummy_rest_client()).await,
+            "an unresolvable channel type must be treated as a DM (fail closed)"
+        );
+        assert!(
+            !cache.contains_key(&id),
+            "a failed resolution must not be cached — later events must retry"
+        );
     }
 }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -272,22 +272,10 @@ async fn author_allowed(
 /// the fetch instead of pinning a mis-classification.
 pub(crate) async fn is_dm_channel(
     channel_id: Uuid,
-    startup_info: &HashMap<Uuid, relay::ChannelInfo>,
-    cache: &mut HashMap<Uuid, bool>,
-    rest_client: &relay::RestClient,
+    channel_info: &pool::ChannelInfoResolver,
 ) -> bool {
-    if let Some(ci) = startup_info.get(&channel_id) {
-        return ci.channel_type == "dm";
-    }
-    if let Some(&cached) = cache.get(&channel_id) {
-        return cached;
-    }
-    match pool::fetch_channel_info(channel_id, rest_client).await {
-        Some(ci) => {
-            let is_dm = ci.channel_type == "dm";
-            cache.insert(channel_id, is_dm);
-            is_dm
-        }
+    match channel_info.resolve(channel_id).await {
+        Some(info) => info.channel_type == "dm",
         None => {
             tracing::warn!(
                 channel_id = %channel_id,
@@ -1561,7 +1549,7 @@ async fn tokio_main() -> Result<()> {
             .to_string_lossy()
             .to_string(),
         rest_client: relay.rest_client(),
-        channel_info: channel_info_map,
+        channel_info: pool::ChannelInfoResolver::new(channel_info_map, relay.rest_client()),
         context_message_limit: config.context_message_limit,
         max_turns_per_session: config.max_turns_per_session,
         permission_mode: config.permission_mode,
@@ -1669,10 +1657,6 @@ async fn tokio_main() -> Result<()> {
     // second are both processed. The seen_membership_ids set handles exact
     // replays that share the same timestamp.
     let mut membership_newest_ts: HashMap<Uuid, u64> = HashMap::new();
-    // Resolved channel-type cache for the inbound author gate's DM check.
-    // Covers channels joined after startup (not in ctx.channel_info). Only
-    // successful lookups are cached — failures fail closed per-event and retry.
-    let mut dm_channel_cache: HashMap<Uuid, bool> = HashMap::new();
     // Two-generation dedup for membership event replays (bounded, no amnesia).
     // Rotates at 1000 entries instead of clearing the entire set at 2000.
     let mut seen_membership_current: HashSet<String> = HashSet::new();
@@ -2164,13 +2148,8 @@ async fn tokio_main() -> Result<()> {
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
-                                let is_dm = is_dm_channel(
-                                    buzz_event.channel_id,
-                                    &ctx.channel_info,
-                                    &mut dm_channel_cache,
-                                    &ctx.rest_client,
-                                )
-                                .await;
+                                let is_dm =
+                                    is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                                 let allowed = author_allowed(
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
@@ -4571,64 +4550,146 @@ mod author_gate_tests {
 
     // ── is_dm_channel resolution ──────────────────────────────────────────
 
-    fn startup_info(id: Uuid, channel_type: &str) -> HashMap<Uuid, relay::ChannelInfo> {
-        HashMap::from([(
+    fn resolver(startup: HashMap<Uuid, relay::ChannelInfo>) -> pool::ChannelInfoResolver {
+        pool::ChannelInfoResolver::new(startup, dummy_rest_client())
+    }
+
+    #[tokio::test]
+    async fn test_is_dm_channel_uses_definitive_startup_metadata() {
+        let dm_id = Uuid::new_v4();
+        let stream_id = Uuid::new_v4();
+        let startup = HashMap::from([
+            (
+                dm_id,
+                relay::ChannelInfo {
+                    name: "dm".into(),
+                    channel_type: "dm".into(),
+                },
+            ),
+            (
+                stream_id,
+                relay::ChannelInfo {
+                    name: "stream".into(),
+                    channel_type: "stream".into(),
+                },
+            ),
+        ]);
+        let resolver = resolver(startup);
+        assert!(is_dm_channel(dm_id, &resolver).await);
+        assert!(!is_dm_channel(stream_id, &resolver).await);
+    }
+
+    #[tokio::test]
+    async fn test_is_dm_channel_fails_closed_for_unknown_startup_metadata() {
+        let id = Uuid::new_v4();
+        let startup = HashMap::from([(
             id,
             relay::ChannelInfo {
-                name: "test".into(),
-                channel_type: channel_type.into(),
+                name: "unknown".into(),
+                channel_type: "unknown".into(),
             },
-        )])
+        )]);
+        assert!(
+            is_dm_channel(id, &resolver(startup)).await,
+            "missing startup metadata must not be trusted as a stream"
+        );
     }
 
-    #[tokio::test]
-    async fn test_is_dm_channel_uses_startup_metadata() {
-        let id = Uuid::new_v4();
-        let mut cache = HashMap::new();
-        assert!(
-            is_dm_channel(
-                id,
-                &startup_info(id, "dm"),
-                &mut cache,
-                &dummy_rest_client()
-            )
+    async fn lazy_resolver_with_response(
+        response: serde_json::Value,
+    ) -> (
+        pool::ChannelInfoResolver,
+        std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
+            .expect("bind test HTTP server");
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let requests = std::sync::Arc::new(AtomicUsize::new(0));
+        let server_requests = requests.clone();
+        let body = response.to_string();
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let mut request = vec![0; 8192];
+                let _ = socket.read(&mut request).await;
+                server_requests.fetch_add(1, Ordering::SeqCst);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+        let rest = relay::RestClient {
+            http: reqwest::Client::new(),
+            base_url,
+            keys: nostr::Keys::generate(),
+            auth_tag_json: None,
+        };
+        (
+            pool::ChannelInfoResolver::new(HashMap::new(), rest),
+            requests,
+            server,
+        )
+    }
+
+    #[tokio::test]
+    async fn test_is_dm_channel_lazy_resolves_declared_dm_and_caches_it() {
+        use std::sync::atomic::Ordering;
+
+        let id = Uuid::new_v4();
+        let response = serde_json::json!([{
+            "tags": [["d", id.to_string()], ["name", "DM"], ["t", "dm"]]
+        }]);
+        let (resolver, requests, server) = lazy_resolver_with_response(response).await;
+
+        assert!(is_dm_channel(id, &resolver).await);
+        assert!(is_dm_channel(id, &resolver).await);
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            1,
+            "second resolution uses cache"
         );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_discovery_without_metadata_stays_fail_closed_at_author_gate() {
+        let id = Uuid::new_v4();
+        let discovered = relay::merge_discovered_channels(vec![id], &serde_json::json!([]));
+        let channel_info = resolver(discovered);
+        let owner_cache = cache_with_sibling();
+        let allowlist = HashSet::from([EXTERNAL.to_string()]);
+
+        let is_dm = is_dm_channel(id, &channel_info).await;
+        assert!(is_dm, "unknown startup metadata must fail closed as DM");
         assert!(
-            !is_dm_channel(
-                id,
-                &startup_info(id, "stream"),
-                &mut cache,
-                &dummy_rest_client()
+            !author_allowed(
+                &RespondTo::Allowlist,
+                &allowlist,
+                EXTERNAL,
+                is_dm,
+                &owner_cache,
+                &dummy_rest_client(),
             )
-            .await
+            .await,
+            "an external author must not pass when startup discovery omitted metadata"
         );
     }
 
     #[tokio::test]
-    async fn test_is_dm_channel_uses_resolution_cache() {
-        let id = Uuid::new_v4();
-        let empty = HashMap::new();
-        let mut cache = HashMap::from([(id, false)]);
+    async fn test_is_dm_channel_fails_closed_when_lazy_resolution_fails() {
         assert!(
-            !is_dm_channel(id, &empty, &mut cache, &dummy_rest_client()).await,
-            "a cached non-DM resolution must be honored without a fetch"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_is_dm_channel_fails_closed_and_does_not_cache_failure() {
-        // dummy_rest_client points at localhost:0 — the lazy fetch fails.
-        let id = Uuid::new_v4();
-        let empty = HashMap::new();
-        let mut cache = HashMap::new();
-        assert!(
-            is_dm_channel(id, &empty, &mut cache, &dummy_rest_client()).await,
-            "an unresolvable channel type must be treated as a DM (fail closed)"
-        );
-        assert!(
-            !cache.contains_key(&id),
-            "a failed resolution must not be cached — later events must retry"
+            is_dm_channel(Uuid::new_v4(), &resolver(HashMap::new())).await,
+            "an unresolvable channel type must be treated as a DM"
         );
     }
 }

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -2189,7 +2189,10 @@ where
 /// Uses `CONTEXT_FETCH_TIMEOUT` with one retry on failure. Returns `None` on
 /// persistent failure (graceful degradation — prompt will lack channel name and
 /// DM detection).
-async fn fetch_channel_info(channel_id: Uuid, rest: &RestClient) -> Option<PromptChannelInfo> {
+pub(crate) async fn fetch_channel_info(
+    channel_id: Uuid,
+    rest: &RestClient,
+) -> Option<PromptChannelInfo> {
     use nostr::{Alphabet, SingleLetterTag};
 
     let d_tag = SingleLetterTag::lowercase(Alphabet::D);

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -427,6 +427,58 @@ pub enum PromptOutcome {
 ///
 /// Built once from `Config` at startup. Avoids cloning the full config
 /// into every task.
+/// Shared channel-metadata resolver for startup-known and dynamically joined channels.
+///
+/// Successful lazy lookups are cached for every consumer (author gate, prompt
+/// context, canvas, and setup mode). Unknown metadata is never cached as a
+/// non-DM: callers can fail closed and a later event retries resolution.
+#[derive(Debug, Clone)]
+pub struct ChannelInfoResolver {
+    cache: std::sync::Arc<std::sync::RwLock<std::collections::HashMap<Uuid, PromptChannelInfo>>>,
+    rest_client: RestClient,
+}
+
+impl ChannelInfoResolver {
+    pub fn new(
+        startup: std::collections::HashMap<Uuid, ChannelInfo>,
+        rest_client: RestClient,
+    ) -> Self {
+        let cache = startup
+            .into_iter()
+            .filter_map(|(id, info)| {
+                (info.channel_type != "unknown").then_some((
+                    id,
+                    PromptChannelInfo {
+                        name: info.name,
+                        channel_type: info.channel_type,
+                    },
+                ))
+            })
+            .collect();
+        Self {
+            cache: std::sync::Arc::new(std::sync::RwLock::new(cache)),
+            rest_client,
+        }
+    }
+
+    pub async fn resolve(&self, channel_id: Uuid) -> Option<PromptChannelInfo> {
+        if let Some(info) = self
+            .cache
+            .read()
+            .ok()
+            .and_then(|cache| cache.get(&channel_id).cloned())
+        {
+            return Some(info);
+        }
+
+        let info = fetch_channel_info(channel_id, &self.rest_client).await?;
+        if let Ok(mut cache) = self.cache.write() {
+            cache.insert(channel_id, info.clone());
+        }
+        Some(info)
+    }
+}
+
 pub struct PromptContext {
     pub mcp_servers: Vec<McpServer>,
     pub initial_message: Option<String>,
@@ -450,8 +502,8 @@ pub struct PromptContext {
     pub cwd: String,
     /// REST client for pre-prompt context fetches (thread/DM history).
     pub rest_client: RestClient,
-    /// Channel metadata from discovery (name, type). Read-only after startup.
-    pub channel_info: std::collections::HashMap<Uuid, ChannelInfo>,
+    /// Shared channel metadata for startup-known and dynamically joined channels.
+    pub channel_info: ChannelInfoResolver,
     /// Max messages to include in thread/DM context. 0 = disabled.
     pub context_message_limit: u32,
     /// Max turns per session before proactive rotation. 0 = disabled.
@@ -1380,13 +1432,12 @@ pub async fn run_prompt_task(
         if is_new_channel_session && !agent.state.canvas_sections.contains_key(cid) {
             // Resolve DM status: prefer the startup cache, lazy-fetch as fallback.
             // Unknown → treat as DM (fail-closed).
-            let is_dm = match ctx.channel_info.get(cid) {
-                Some(ci) => ci.channel_type == "dm",
-                None => fetch_channel_info(*cid, &ctx.rest_client)
-                    .await
-                    .map(|ci| ci.channel_type == "dm")
-                    .unwrap_or(true),
-            };
+            let is_dm = ctx
+                .channel_info
+                .resolve(*cid)
+                .await
+                .map(|ci| ci.channel_type == "dm")
+                .unwrap_or(true);
             if !is_dm {
                 if let Some(section) = fetch_canvas_section(*cid, &ctx.rest_client).await {
                     pending_canvas = Some((*cid, section));
@@ -1690,13 +1741,7 @@ pub async fn run_prompt_task(
     } else if let Some(ref b) = batch {
         // Build prompt from batch with context enrichment.
         // Try startup cache first; lazy-fetch via REST for dynamic channels.
-        let channel_info = match ctx.channel_info.get(&b.channel_id) {
-            Some(ci) => Some(PromptChannelInfo {
-                name: ci.name.clone(),
-                channel_type: ci.channel_type.clone(),
-            }),
-            None => fetch_channel_info(b.channel_id, &ctx.rest_client).await,
-        };
+        let channel_info = ctx.channel_info.resolve(b.channel_id).await;
 
         let conversation_context = if ctx.context_message_limit > 0 {
             fetch_conversation_context(b, &channel_info, &ctx).await
@@ -2214,25 +2259,14 @@ pub(crate) async fn fetch_channel_info(
                 let ev = events.first()?;
                 let tags = ev.get("tags")?.as_array()?;
                 let mut name = None;
-                let mut is_hidden = false;
-                let mut is_private = false;
                 for tag in tags {
                     if let Some(arr) = tag.as_array() {
-                        match arr.first().and_then(|v| v.as_str()) {
-                            Some("name") => name = arr.get(1).and_then(|v| v.as_str()),
-                            Some("hidden") => is_hidden = true,
-                            Some("private") => is_private = true,
-                            _ => {}
+                        if arr.first().and_then(|v| v.as_str()) == Some("name") {
+                            name = arr.get(1).and_then(|v| v.as_str());
                         }
                     }
                 }
-                let channel_type = if is_hidden {
-                    "dm".to_string()
-                } else if is_private {
-                    "private".to_string()
-                } else {
-                    "stream".to_string()
-                };
+                let channel_type = crate::relay::channel_type_from_tags(tags);
                 Some(PromptChannelInfo {
                     name: name.unwrap_or("unknown").to_string(),
                     channel_type,
@@ -5256,7 +5290,15 @@ mod tests {
                 keys: agent_keys.clone(),
                 auth_tag_json: None,
             },
-            channel_info: std::collections::HashMap::new(),
+            channel_info: ChannelInfoResolver::new(
+                std::collections::HashMap::new(),
+                RestClient {
+                    http: reqwest::Client::new(),
+                    base_url: "http://127.0.0.1:0".to_string(),
+                    keys: agent_keys.clone(),
+                    auth_tag_json: None,
+                },
+            ),
             context_message_limit: 0,
             max_turns_per_session: 0,
             permission_mode: PermissionMode::Default,

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -135,6 +135,29 @@ pub struct ChannelInfo {
     pub channel_type: String,
 }
 
+pub(crate) fn channel_type_from_tags(tags: &[serde_json::Value]) -> String {
+    let mut is_hidden = false;
+    let mut is_private = false;
+    let mut declared_type = None;
+    for tag in tags {
+        if let Some(arr) = tag.as_array() {
+            match arr.first().and_then(|v| v.as_str()) {
+                Some("hidden") => is_hidden = true,
+                Some("private") => is_private = true,
+                Some("t") => declared_type = arr.get(1).and_then(|v| v.as_str()),
+                _ => {}
+            }
+        }
+    }
+    if declared_type == Some("dm") || is_hidden {
+        "dm".to_string()
+    } else if declared_type == Some("private") || is_private {
+        "private".to_string()
+    } else {
+        "stream".to_string()
+    }
+}
+
 /// Build the discovered-channel subscribe set from the membership UUIDs and the
 /// kind:39000 metadata events, **skipping any channel flagged `archived=true`**.
 ///
@@ -143,9 +166,9 @@ pub struct ChannelInfo {
 /// re-form the reconnect loop. Dropping them here is the defense-in-depth
 /// backstop to the relay-side live-subscription eviction — it covers a client
 /// that was offline when the channel was reaped and so missed the CLOSED.
-/// A channel with no metadata event defaults to a `stream` named `unknown`,
-/// preserving prior behavior for non-archived channels.
-fn merge_discovered_channels(
+/// A channel with no metadata event is preserved as `unknown`; security
+/// consumers must lazy-resolve it or fail closed rather than assuming stream.
+pub(crate) fn merge_discovered_channels(
     channel_uuids: Vec<Uuid>,
     meta_events: &serde_json::Value,
 ) -> HashMap<Uuid, ChannelInfo> {
@@ -159,16 +182,12 @@ fn merge_discovered_channels(
             };
             let mut d_val = None;
             let mut name = None;
-            let mut is_hidden = false;
-            let mut is_private = false;
             let mut is_archived = false;
             for tag in tags {
                 if let Some(arr) = tag.as_array() {
                     match arr.first().and_then(|v| v.as_str()) {
                         Some("d") => d_val = arr.get(1).and_then(|v| v.as_str()),
                         Some("name") => name = arr.get(1).and_then(|v| v.as_str()),
-                        Some("hidden") => is_hidden = true,
-                        Some("private") => is_private = true,
                         Some("archived") => {
                             is_archived = arr.get(1).and_then(|v| v.as_str()) == Some("true")
                         }
@@ -183,14 +202,7 @@ fn merge_discovered_channels(
                         continue;
                     }
                     let ch_name = name.unwrap_or("unknown").to_string();
-                    // DMs have the "hidden" tag; private channels have "private".
-                    let ch_type = if is_hidden {
-                        "dm".to_string()
-                    } else if is_private {
-                        "private".to_string()
-                    } else {
-                        "stream".to_string()
-                    };
+                    let ch_type = channel_type_from_tags(tags);
                     meta_map.insert(uuid, (ch_name, ch_type));
                 }
             }
@@ -204,7 +216,7 @@ fn merge_discovered_channels(
         }
         let (name, channel_type) = meta_map
             .remove(&uuid)
-            .unwrap_or_else(|| ("unknown".to_string(), "stream".to_string()));
+            .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
         map.insert(uuid, ChannelInfo { name, channel_type });
     }
     map
@@ -4069,6 +4081,21 @@ mod tests {
             }
         }
         serde_json::json!({ "tags": tags })
+    }
+
+    #[test]
+    fn merge_discovered_channels_preserves_missing_metadata_as_unknown() {
+        let channel = Uuid::new_v4();
+        let map = merge_discovered_channels(vec![channel], &serde_json::json!([]));
+        assert_eq!(map[&channel].channel_type, "unknown");
+    }
+
+    #[test]
+    fn merge_discovered_channels_uses_declared_dm_type_without_hidden_hint() {
+        let channel = Uuid::new_v4();
+        let meta = serde_json::json!([meta_event(channel, "dm", &["t", "dm"])]);
+        let map = merge_discovered_channels(vec![channel], &meta);
+        assert_eq!(map[&channel].channel_type, "dm");
     }
 
     #[test]

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -383,11 +383,10 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
     let publisher = relay.event_publisher();
     let rest_client = relay.rest_client();
 
+    let channel_info = crate::pool::ChannelInfoResolver::new(channel_info_map, rest_client.clone());
+
     // Deduplicate by event-id so reconnect replay cannot double-nudge.
     let mut nudged_event_ids: HashSet<EventId> = HashSet::new();
-    // Resolved channel-type cache for the DM author-gate check (see normal mode).
-    let mut dm_channel_cache: std::collections::HashMap<Uuid, bool> =
-        std::collections::HashMap::new();
 
     loop {
         let Some(buzz_event) = relay.next_event().await else {
@@ -430,13 +429,7 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         // to authors the real agent would have answered. Same DM hardening:
         // in DMs only owner/siblings get a nudge (fail-closed on unknown type).
         let author_hex = buzz_event.event.pubkey.to_hex();
-        let is_dm = crate::is_dm_channel(
-            buzz_event.channel_id,
-            &channel_info_map,
-            &mut dm_channel_cache,
-            &rest_client,
-        )
-        .await;
+        let is_dm = crate::is_dm_channel(buzz_event.channel_id, &channel_info).await;
         let allowed = author_allowed(
             &config.respond_to,
             &config.respond_to_allowlist,

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -385,6 +385,9 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
 
     // Deduplicate by event-id so reconnect replay cannot double-nudge.
     let mut nudged_event_ids: HashSet<EventId> = HashSet::new();
+    // Resolved channel-type cache for the DM author-gate check (see normal mode).
+    let mut dm_channel_cache: std::collections::HashMap<Uuid, bool> =
+        std::collections::HashMap::new();
 
     loop {
         let Some(buzz_event) = relay.next_event().await else {
@@ -424,12 +427,21 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         }
 
         // Apply the same author gate as normal mode so the nudge only goes
-        // to authors the real agent would have answered.
+        // to authors the real agent would have answered. Same DM hardening:
+        // in DMs only owner/siblings get a nudge (fail-closed on unknown type).
         let author_hex = buzz_event.event.pubkey.to_hex();
+        let is_dm = crate::is_dm_channel(
+            buzz_event.channel_id,
+            &channel_info_map,
+            &mut dm_channel_cache,
+            &rest_client,
+        )
+        .await;
         let allowed = author_allowed(
             &config.respond_to,
             &config.respond_to_allowlist,
             &author_hex,
+            is_dm,
             &owner_cache,
             &rest_client,
         )


### PR DESCRIPTION
## Security fix — transitive DM access to shared agents

Reported by colbya via baxen (buzz-team thread): José allowlisted Colby on his agent. Colby asked the agent to DM Nick. From then on Nick — never allowlisted — could prompt the agent and extract private host info. Revoking Colby didn't stop his access either (separate stale-process issue; see Fizz's notes).

### Root cause (this PR's half)

Clients auto-p-tag every DM participant (`messageMentionPubkeys`: a DM addresses all members/participants), so in a DM **any** participant's message satisfies the harness's `require_mention` rule and fires a turn. Combined with agent-initiated DMs — an allowlisted user can ask the agent to open a DM with a third party, which makes that third party a channel member — `respond_to=allowlist`/`anyone` become transitive access grants: whoever lands in a DM with the agent can prompt it.

### Fix

At the inbound author gate (`author_allowed`), when the event's channel is a DM only the **owner and cryptographically verified same-owner siblings** (NIP-OA) fire a turn, regardless of `respond_to` mode:

- allowlist entries do **not** apply inside DMs
- `anyone` does **not** apply inside DMs
- `nobody` still drops everything

Channel type resolution (`is_dm_channel`) is layered: startup discovery metadata → per-loop resolution cache → lazy kind:39000 REST fetch. The lazy fetch is what covers the exploit path — the DM is created **after** harness startup, so it's absent from startup discovery. Unresolvable channel types are treated as DM for that event and **not cached** (fail closed, retry later). The same gate applies to setup-mode nudges.

### Not covered here (follow-ups)

- **Stale-allowlist revocation**: access edits only take effect after the agent child process restarts (env-var snapshot). Needs auto-restart or hot reload on policy save.
- Product question: whether allowlisted users should be able to converse with the agent in group (non-DM) channels remains as-is — allowlist still applies there.

### Verification

- `cargo test -p buzz-acp`: 588 passed / 0 failed (full package suite) at this head
- New tests: DM rejects allowlisted external + stranger-under-anyone; DM admits owner/sibling in all responding modes; nobody rejects owner; `is_dm_channel` startup/cache/fail-closed-no-cache behavior
- fmt + clippy clean

Incident thread: buzz-team 2a929e60.