### PR TITLE
fix(desktop): keep astral-plane letters whole in avatar initials

### DIFF
--- a/desktop/src/shared/lib/initials.test.mjs
+++ b/desktop/src/shared/lib/initials.test.mjs
@@ -19,4 +19,20 @@ describe("getInitials", () => {
   it("returns empty for a symbol-only name", () => {
     assert.equal(getInitials("()"), "");
   });
+
+  it("derives whole-character initials from astral-plane letters", () => {
+    const initials = getInitials("𠮷野 太郎");
+    assert.equal(initials, "𠮷太");
+    for (const ch of initials) {
+      const cp = ch.codePointAt(0);
+      assert.ok(
+        cp < 0xd800 || cp > 0xdfff,
+        `unexpected lone surrogate U+${cp.toString(16)}`,
+      );
+    }
+  });
+
+  it("derives an initial from an astral-plane single word", () => {
+    assert.equal(getInitials("𝓐lice"), "𝓐");
+  });
 });

--- a/desktop/src/shared/lib/initials.ts
+++ b/desktop/src/shared/lib/initials.ts
@@ -4,8 +4,9 @@ export function getInitials(name: string): string {
     .replace(/[^\p{L}\p{N}\s]/gu, " ")
     .trim()
     .split(/\s+/)
-    .map((part) => part[0] ?? "")
-    .join("")
+    .map((part) => [...part][0] ?? "")
+    .filter(Boolean)
     .slice(0, 2)
+    .join("")
     .toUpperCase();
 }


### PR DESCRIPTION
## Problem

`getInitials` (`desktop/src/shared/lib/initials.ts`) derives up to two initials by taking the first character of each name part with `part[0]`. In JavaScript, string indexing returns a single **UTF-16 code unit**, so `part[0]` splits a surrogate pair when a word begins with an astral-plane (non-BMP) letter.

The resulting initial is a **lone surrogate**, which renders as the replacement character `�`. This affects real display names, e.g.:

| Name | before | after |
|------|--------|-------|
| `𠮷野 太郎` (CJK Ext-B surname 𠮷 = U+20BB7) | `\uD842太` → `�太` | `𠮷太` |
| `𝓐lice Smith` (math letter U+1D4D0) | `\uD835S` → `�S` | `𝓐S` |
| `𐐜ff Team` (Deseret U+10410) | `\uD801T` → `�T` | `𐐜T` |

The `replace(/[^\p{L}\p{N}\s]/gu, " ")` step already keeps astral **letters** (they match `\p{L}`), so they reach the buggy indexing intact and then get sliced apart.

## Fix

Iterate by code point using spread (`[...part][0]`) instead of the first UTF-16 unit, and take the first two **initials** (`.filter(Boolean).slice(0, 2)`) rather than the first two UTF-16 units — otherwise a name with two astral initials would be re-truncated at the join step.

Single-file, behavior-preserving for all existing (BMP) inputs.

## Tests

Added two regression tests to `initials.test.mjs`:
- an astral initial stays a whole character with no lone surrogate leaking through
- an astral-plane single word yields its full first letter

## Verification

- `pnpm test` (desktop unit suite): **3425 passed, 0 failed**
- `biome check` clean on both changed files

Scope is desktop TypeScript only; the Rust workspace / Tauri / mobile targets in `just ci` are untouched by this change.

## PR Checklist

- [x] New behavior has a regression test
- [x] Desktop unit tests pass (`pnpm test`)
- [x] Biome lint/format clean
- [x] No new `unsafe`, no new `unwrap()` (N/A — TypeScript)
- [x] Focused, single logical change