### PR TITLE
fix(pairing): reject malformed protocol version in QR decode

### DIFF
--- a/crates/buzz-core/src/pairing/qr.rs
+++ b/crates/buzz-core/src/pairing/qr.rs
@@ -145,7 +145,12 @@ pub fn decode_qr(uri: &str) -> Result<QrPayload, PairingError> {
             match key {
                 "secret" => secret_hex = Some(value),
                 "relay" => relays.push(url_decode(value)),
-                "v" => version = value.parse::<u32>().ok(),
+                "v" => {
+                    let parsed = value.parse::<u32>().map_err(|_| {
+                        PairingError::InvalidQr(format!("invalid protocol version {value:?}"))
+                    })?;
+                    version = Some(parsed);
+                }
                 _ => {} // ignore unknown params
             }
         }
@@ -522,6 +527,28 @@ mod tests {
         assert!(
             matches!(err, PairingError::InvalidQr(ref msg) if msg.contains("unsupported protocol version 2")),
             "expected unsupported version error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn reject_out_of_range_version() {
+        let payload = make_payload(vec!["wss://relay.example.com".to_string()]);
+        let uri = encode_qr(&payload).replace("&v=1", "&v=99999999999");
+        let err = decode_qr(&uri).unwrap_err();
+        assert!(
+            matches!(err, PairingError::InvalidQr(ref msg) if msg.contains("invalid protocol version")),
+            "expected invalid version error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn reject_malformed_version() {
+        let payload = make_payload(vec!["wss://relay.example.com".to_string()]);
+        let uri = encode_qr(&payload).replace("&v=1", "&v=2x");
+        let err = decode_qr(&uri).unwrap_err();
+        assert!(
+            matches!(err, PairingError::InvalidQr(ref msg) if msg.contains("invalid protocol version")),
+            "expected invalid version error, got {err:?}"
         );
     }
 


### PR DESCRIPTION
## Problem

`decode_qr` (`crates/buzz-core/src/pairing/qr.rs`) parses the `v=` version parameter with:

```rust
"v" => version = value.parse::<u32>().ok(),
```

`.ok()` turns a **present-but-invalid** version into `None`, which is then indistinguishable from an **absent** `v` and defaults to version 1:

```rust
let version = version.unwrap_or(1);
if version != 1 { /* reject */ }
```

So a `nostrpair://` URI that explicitly declares a version that doesn't parse as `u32` decodes **successfully as version 1** instead of being rejected. Examples:

- `…&v=99999999999` — overflows `u32` → accepted as v1
- `…&v=2x` / `…&v=abc` — non-numeric → accepted as v1

This contradicts the documented contract on `QrPayload::version`:

> Absent in legacy URIs; defaults to `1` on decode for backward compatibility. **Values > 1 are rejected.**

Only an *absent* `v` should default to 1. A newer/garbage client that stamps a higher (or malformed) version is silently reinterpreted as v1 — a forward-compatibility and input-robustness gap on a security-adjacent pairing path.

## Fix

Parse the value and propagate the error on failure, so a present-but-malformed `v` is rejected rather than collapsed to `None`. Absent `v` still defaults to 1 (backward compat preserved); `v=2` is still rejected as before.

## Tests

Added two regression tests to the `qr` module:
- `reject_out_of_range_version` — `v=99999999999` (u32 overflow) → `Err`
- `reject_malformed_version` — `v=2x` → `Err`

Both would previously have decoded as version 1. Existing `default_version_when_absent`, `round_trip_with_version`, and `reject_unsupported_version` still pass.

## Verification

- `cargo test -p buzz-core pairing::qr` → **29 passed, 0 failed**
- `cargo clippy -p buzz-core --all-targets -- -D warnings` → clean
- `cargo fmt -p buzz-core -- --check` → clean

## PR Checklist

- [x] Regression tests for the new behavior
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] No new `unsafe`, no new `unwrap()`/`expect()` in production paths
- [x] Focused, single logical change