### PR TITLE
fix(desktop): stage real sidecar binaries in _ensure-sidecar-stubs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -154,9 +154,22 @@ _ensure-sidecar-stubs:
     #!/usr/bin/env bash
     set -euo pipefail
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
+    TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).target_directory")
     mkdir -p desktop/src-tauri/binaries
     for bin in buzz-acp buzz-agent buzz-dev-mcp git-credential-nostr buzz; do
-        touch "desktop/src-tauri/binaries/${bin}-${TARGET}"
+        stub="desktop/src-tauri/binaries/${bin}-${TARGET}"
+        real="${TARGET_DIR}/debug/${bin}"
+        # Copy the real binary when it's been built (e.g. after `just build`),
+        # so `just dev` stages a working sidecar instead of a 0-byte stub that
+        # the app later tries to exec (-> os error 13). Fall back to an empty
+        # stub only when the binary isn't built yet, preserving the prior
+        # tauri-config-validation behavior.
+        if [ -s "$real" ]; then
+            cp "$real" "$stub"
+            chmod +x "$stub"
+        else
+            touch "$stub"
+        fi
     done
 
 # Ensure Docker dev services (Postgres, Redis, etc.) are running and healthy


### PR DESCRIPTION
## What this fixes

On the documented dev flow (`just setup && just build && just dev`), the desktop app fails to launch its agent auth helper on macOS:

```
Couldn't load sign-in options: failed to run buzz-acp auth helper: Permission denied (os error 13)
```

This blocks Claude Code / Codex harness sign-in during onboarding (the "Set up your agent harnesses" step) and in Settings → Agents.

## Root cause

`_ensure-sidecar-stubs` unconditionally `touch`es 0-byte placeholder files in `desktop/src-tauri/binaries/`. They exist only to satisfy the tauri `externalBin` config at build time and are never filled. On the documented flow the real binaries are already compiled by `just build` (to the workspace target dir), but the stubs stay empty — so `tauri dev` stages a **0-byte `buzz-acp` next to the app binary**, and the app execs an empty file → `os error 13`.

## Fix

Copy the compiled binary into the stub when it exists (with `chmod +x`), matching the `cp` + `chmod` pattern that `desktop-standalone` and `desktop-release-build` already use. Fall back to `touch` only when the binary isn't built yet, so flows that haven't run `just build` keep the existing config-validation behavior.

## Reproduction (macOS, aarch64)

1. Fresh clone
2. `. ./bin/activate-hermit && just setup && just build && just dev`
3. Onboarding → "Set up your agent harnesses" → Claude Code shows "Sign-in unavailable"; Settings → Agents shows the `os error 13` above.

- **Before:** `desktop/src-tauri/binaries/buzz-acp-aarch64-apple-darwin` is 0 bytes; the real 40 MB binary is in `target/debug/`.
- **After:** the stub is the real executable; `buzz-acp --help` runs; the harness loads.

## Testing

Verified manually via the reproduction above. This is a build-tooling recipe and there is no automated test harness for justfile recipes in the repo — happy to add one if there's a preferred pattern.

## Related

Distinct from #2492 / #2496, which fix the **Windows** `.exe` stub suffix. This is the macOS empty-fill case; the two are complementary.
