### PR TITLE
docs(git-perms): document `**` recursive wildcard in RefPattern grammar

### DIFF
--- a/crates/buzz-core/src/git_perms.rs
+++ b/crates/buzz-core/src/git_perms.rs
@@ -24,10 +24,13 @@ pub const MAX_WILDCARDS_PER_PATTERN: usize = 3;
 
 /// A validated ref pattern for matching git refs.
 ///
-/// Grammar: `segment ("/" segment)*` where segment is either a literal
-/// `[a-zA-Z0-9._-]+` or `*` (matches exactly one path segment).
+/// Grammar: `segment ("/" segment)*` where each segment is a literal
+/// `[a-zA-Z0-9._-]+`, `*` (matches exactly one path segment), or `**`
+/// (matches one or more path segments; valid only as the final segment).
 ///
-/// Patterns MUST start with `refs/`. No `**`, `?`, `[...]`, or partial globs.
+/// Patterns MUST start with `refs/` and may contain at most
+/// [`MAX_WILDCARDS_PER_PATTERN`] wildcard segments. No `?`, `[...]`, or
+/// partial globs — a `*` or `**` must be a whole segment, so `v*` is invalid.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RefPattern {
     /// The original pattern string (e.g., "refs/heads/*").


### PR DESCRIPTION
## Problem

The `RefPattern` doc comment (`crates/buzz-core/src/git_perms.rs`) describes a grammar that omits the `**` recursive wildcard and explicitly lists it as unsupported:

> Grammar: `segment ("/" segment)*` where segment is either a literal `[a-zA-Z0-9._-]+` or `*` (matches exactly one path segment).
>
> Patterns MUST start with `refs/`. No `**`, `?`, `[...]`, or partial globs.

But `**` **is** a first-class supported segment:

- `PatternSegment::RecursiveWildcard` — "Matches one or more path segments (recursive). Must be the last segment."
- `RefPattern::parse` accepts `**` (and enforces last-segment-only + the `MAX_WILDCARDS_PER_PATTERN` limit)
- `RefPattern::matches` implements one-or-more-segment matching
- Covered by `pattern_recursive_wildcard_matches_nested`, `pattern_recursive_wildcard_must_be_last`, and `pattern_recursive_requires_at_least_one_segment`

Because this type backs `buzz-protect` git ref protection rules, the wrong contract has a concrete consequence: an operator who trusts the doc believes `refs/heads/**` is invalid and won't use it, leaving nested branches (`refs/heads/team/*`) unprotected when a recursive rule was the intent.

## Fix

Update the grammar to describe `*` and `**` accurately — including the last-segment-only rule and the wildcard-count limit — and remove the incorrect "No `**`". Documentation only; no behavior change, no code touched.

## Verification

- `cargo test -p buzz-core git_perms` → **34 passed, 0 failed** (behavior unchanged)
- `cargo clippy -p buzz-core --all-targets -- -D warnings` → clean
- `cargo fmt -p buzz-core -- --check` → clean
- `[MAX_WILDCARDS_PER_PATTERN]` intra-doc link resolves