### PR TITLE
fix: push text box down closer to the bottom

### DIFF
--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -164,7 +164,7 @@ export function BotActivityComposerAction({
           className={cn(
             "inline-flex items-center justify-center rounded-full border border-border/60 bg-background font-medium text-muted-foreground transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary",
             isInline
-              ? "h-7 min-w-0 gap-2 overflow-visible border-transparent bg-transparent px-0 text-xs font-semibold leading-none shadow-none hover:border-transparent hover:bg-transparent data-[state=open]:border-transparent data-[state=open]:bg-transparent"
+              ? "h-5 min-w-0 gap-1.5 overflow-visible border-transparent bg-transparent px-0 text-2xs font-semibold leading-none shadow-none hover:border-transparent hover:bg-transparent data-[state=open]:border-transparent data-[state=open]:bg-transparent"
               : "h-9 min-w-9 gap-1.5 px-2 text-xs",
           )}
           data-testid="bot-activity-composer-trigger"
@@ -185,7 +185,7 @@ export function BotActivityComposerAction({
                 className={cn(
                   "border border-background",
                   isInline
-                    ? "!h-[18px] !w-[18px] shadow-xs ring-1 ring-primary/25 text-3xs"
+                    ? "!h-3.5 !w-3.5 shadow-xs ring-1 ring-primary/25 text-3xs"
                     : "shrink-0",
                 )}
                 displayName={agent.name}

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -752,7 +752,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                   channelId={activeChannel?.id ?? null}
                   channelName={activeChannel?.name ?? "channel"}
                   channelType={activeChannel?.channelType ?? null}
-                  containerClassName="px-5"
+                  containerClassName="px-5 pb-1"
                   disabled={isComposerDisabled}
                   editTarget={mainEditTarget}
                   autoSubmitDraftKey={autoSendDraftKey}
@@ -788,10 +788,10 @@ export const ChannelPane = React.memo(function ChannelPane({
                   showTopBorder={false}
                 />
                 <div
-                  className="min-h-8 overflow-visible bg-background px-5 pb-1.5 pt-0"
+                  className="-mt-1 min-h-5 overflow-visible bg-background px-5 pb-0 pt-0"
                   data-testid="channel-composer-activity-row"
                 >
-                  <div className="flex h-full w-full items-center gap-2 overflow-visible">
+                  <div className="flex h-full w-full items-center gap-2 overflow-visible pl-2">
                     {hasComposerBotActivity ? (
                       <div className="flex min-w-0 flex-1 overflow-visible">
                         <BotActivityComposerAction

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -832,7 +832,7 @@ export function MessageThreadPanel({
             channelId={channelId}
             channelName={channelName}
             channelType={channel?.channelType ?? null}
-            containerClassName={THREAD_PANEL_COMPOSER_GUTTER_CLASS}
+            containerClassName={cn(THREAD_PANEL_COMPOSER_GUTTER_CLASS, "pb-1")}
             disabled={disabled || isSending || !channelId}
             draftKey={`thread:${threadHead.id}`}
             autoSubmitDraftKey={autoSendDraftKey}
@@ -853,11 +853,11 @@ export function MessageThreadPanel({
           />
           <div
             className={cn(
-              "min-h-8 bg-background pb-1.5 pt-0",
+              "-mt-1 min-h-5 bg-background pb-0 pt-0",
               THREAD_PANEL_COMPOSER_GUTTER_CLASS,
             )}
           >
-            <div className="mx-auto flex h-full w-full max-w-4xl items-center gap-2 overflow-visible">
+            <div className="mx-auto flex h-full w-full max-w-4xl items-center gap-2 overflow-visible pl-2">
               {toolbarExtraActions ? (
                 <div className="flex min-w-0 flex-1 overflow-visible">
                   {toolbarExtraActions}

--- a/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
+++ b/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
@@ -80,7 +80,7 @@ export function TypingIndicatorRow({
       className={cn(
         "shrink-0 bg-transparent",
         isActivityVariant
-          ? "flex h-7 items-center px-0 py-0"
+          ? "flex h-5 items-center px-0 py-0"
           : "px-4 py-2 sm:px-6",
         className,
       )}

--- a/desktop/src/shared/styles/globals/composer.css
+++ b/desktop/src/shared/styles/globals/composer.css
@@ -1,7 +1,7 @@
 .composer-overlay-corner-masks::before,
 .composer-overlay-corner-masks::after {
   position: absolute;
-  bottom: 2.5rem;
+  bottom: 1.5rem;
   z-index: 0;
   width: 1rem;
   height: 1rem;


### PR DESCRIPTION
The text entry box currently sits a bit far away from the bottom. This makes the agent status reporting smaller so it can sit closer to the bottom and almost match the horizontal padding.

Replaces https://github.com/block/buzz/pull/2447

**Before**

<img width="2666" height="1239" alt="Screenshot 2026-07-23 at 3 55 31 PM" src="https://github.com/user-attachments/assets/63baa49d-a0a1-43ec-a65b-c505673c6b28" />

**After**

<img width="2666" height="1239" alt="Screenshot 2026-07-23 at 3 54 30 PM" src="https://github.com/user-attachments/assets/447d82bd-fedd-455e-ac75-6e703bce5aee" />