### PR TITLE
fix(desktop): shared relay agents are un-mentionable/un-addable — let directory eligibility run

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -6,6 +6,7 @@ import {
   getMentionableAgentPubkeys,
   getSharedChannelIds,
   isAgentIdentityInManagedList,
+  relayAgentIsInvocableByUser,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
@@ -305,4 +306,65 @@ test("coalesceAgentAutocompleteCandidates: leaves non-agents alone", () => {
   const second = makeAgent({ pubkey: PUB_B, isAgent: false });
 
   assert.deepEqual(coalesce([first, second]), [first, second]);
+});
+
+test("relayAgentIsInvocableByUser: anyone responds regardless of channel overlap", () => {
+  assert.equal(
+    relayAgentIsInvocableByUser(
+      { respondTo: "anyone", respondToAllowlist: [] },
+      CURRENT_PUBKEY,
+    ),
+    true,
+  );
+});
+
+test("relayAgentIsInvocableByUser: allowlist honors membership", () => {
+  const agent = { respondTo: "allowlist", respondToAllowlist: [CURRENT_PUBKEY] };
+  assert.equal(relayAgentIsInvocableByUser(agent, CURRENT_PUBKEY), true);
+  assert.equal(relayAgentIsInvocableByUser(agent, OTHER_OWNER_PUBKEY), false);
+});
+
+test("relayAgentIsInvocableByUser: owner-only and unknown modes are not invocable", () => {
+  assert.equal(
+    relayAgentIsInvocableByUser(
+      { respondTo: "owner-only", respondToAllowlist: [] },
+      CURRENT_PUBKEY,
+    ),
+    false,
+  );
+  assert.equal(
+    relayAgentIsInvocableByUser({ respondTo: null, respondToAllowlist: [] }, CURRENT_PUBKEY),
+    false,
+  );
+});
+
+test("shouldHideAgentFromMentions: relay-shared agent shows without local managed entry", () => {
+  // Regression: a shared agent owned by another member (directory-eligible,
+  // respond_to=anyone, shared channel) must be mentionable even though it is
+  // not in this device's managed-agents list.
+  const sharedChannelIds = new Set(["chan-1"]);
+  const relayAgents = [
+    {
+      pubkey: PUB_D,
+      respondTo: "anyone",
+      respondToAllowlist: [],
+      channelIds: ["chan-1"],
+    },
+  ];
+  const mentionable = getMentionableAgentPubkeys({
+    currentPubkey: CURRENT_PUBKEY,
+    managedAgentPubkeys: [],
+    relayAgents,
+    sharedChannelIds,
+  });
+  assert.equal(
+    shouldHideAgentFromMentions({
+      isAgent: true,
+      isMember: true,
+      pubkey: PUB_D,
+      mentionableAgentPubkeys: mentionable,
+      directoryAgentPubkeys: new Set([PUB_D]),
+    }),
+    false,
+  );
 });

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -9,9 +9,12 @@ export function getSharedChannelIds(channels: readonly Channel[] | undefined) {
   );
 }
 
-export function relayAgentIsSharedWithUser(
-  agent: Pick<RelayAgent, "channelIds" | "respondTo" | "respondToAllowlist">,
-  sharedChannelIds: ReadonlySet<string>,
+/// Whether the relay directory says this agent would respond to the current
+/// user at all, ignoring channel overlap. Used where the user is about to
+/// CREATE the overlap (e.g. adding the agent to a channel), so requiring an
+/// existing shared channel would be circular.
+export function relayAgentIsInvocableByUser(
+  agent: Pick<RelayAgent, "respondTo" | "respondToAllowlist">,
   currentPubkey?: string | null,
 ) {
   const normalizedCurrentPubkey = currentPubkey
@@ -22,6 +25,18 @@ export function relayAgentIsSharedWithUser(
     return agent.respondToAllowlist
       .map((pubkey) => normalizePubkey(pubkey))
       .includes(normalizedCurrentPubkey);
+  }
+
+  return agent.respondTo === "anyone";
+}
+
+export function relayAgentIsSharedWithUser(
+  agent: Pick<RelayAgent, "channelIds" | "respondTo" | "respondToAllowlist">,
+  sharedChannelIds: ReadonlySet<string>,
+  currentPubkey?: string | null,
+) {
+  if (agent.respondTo === "allowlist") {
+    return relayAgentIsInvocableByUser(agent, currentPubkey);
   }
 
   return (
@@ -54,13 +69,18 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
+/// Non-agents always pass; agent identities pass when their pubkey is in the
+/// provided allow-set. Callers decide the set: the local managed list alone is
+/// NOT sufficient — relay-directory agents that would respond to this user
+/// (see `relayAgentIsInvocableByUser`) must be included, otherwise shared
+/// agents owned by other members are silently unreachable.
 export function isAgentIdentityInManagedList(
   candidate: { isAgent?: boolean; pubkey: string },
-  managedAgentPubkeys: ReadonlySet<string>,
+  allowedAgentPubkeys: ReadonlySet<string>,
 ) {
   return (
     candidate.isAgent !== true ||
-    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
+    allowedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
   );
 }
 

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -10,6 +10,7 @@ import { attachManagedAgentToChannel } from "@/features/agents/channelAgents";
 import {
   coalesceAgentAutocompleteCandidates,
   isAgentIdentityInManagedList,
+  relayAgentIsInvocableByUser,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
@@ -271,7 +272,15 @@ export function MembersSidebar({
         .map((member) => member.displayName?.trim().toLowerCase())
         .filter((label): label is string => Boolean(label)),
     );
-    const managedAgentPubkeys = new Set(managedAgentsByPubkey.keys());
+    // Agents addable to this channel: locally managed ones plus relay-directory
+    // agents that would respond to this user. Channel overlap is deliberately
+    // not required — adding the agent to this channel is what creates it.
+    const addableAgentPubkeys = new Set(managedAgentsByPubkey.keys());
+    for (const agent of relayAgentsQuery.data ?? []) {
+      if (relayAgentIsInvocableByUser(agent, currentPubkey)) {
+        addableAgentPubkeys.add(normalizePubkey(agent.pubkey));
+      }
+    }
 
     const addCandidate = (candidate: AddMemberSearchCandidate) => {
       const pubkey = normalizePubkey(candidate.pubkey);
@@ -282,7 +291,7 @@ export function MembersSidebar({
           )) ||
         memberPubkeys.has(pubkey) ||
         isArchivedDiscovery(pubkey) ||
-        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+        !isAgentIdentityInManagedList(candidate, addableAgentPubkeys)
       ) {
         return;
       }

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,6 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,9 +245,12 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
-        return;
-      }
+      // NOTE: no pre-emptive managed-list gate here. `shouldHideAgentFromMentions`
+      // is the single authority: it already shows invocable agents (local managed
+      // OR relay-directory-eligible via `mentionableAgentPubkeys`), hides
+      // non-member non-invocable ones, and applies the member/directory rules.
+      // An earlier managed-list-only gate made shared agents owned by other
+      // members unreachable from the composer.
       if (
         shouldHideAgentFromMentions({
           isAgent: candidate.isAgent === true,


### PR DESCRIPTION
Closes #2603

## Summary

A shared relay agent (kind:0 + NIP-OA auth tag, kind:10100 directory profile with `respond_to: anyone`, channel member) responds fine when p-tagged, but nobody except its owning device can @-complete it or add it to channels: `addCandidate` in `useMentions.ts` drops every agent-flagged identity that isn't in the **local** managed-agents list *before* `shouldHideAgentFromMentions` runs, making the directory-eligibility path (`mentionableAgentPubkeys`, and the "Invocable => always show" / member Option-B rules) unreachable for foreign agents. `MembersSidebar` applies the same managed-list-only gate to add-member search.

## Changes

- **`useMentions.ts`**: remove the pre-emptive `isAgentIdentityInManagedList` gate. `shouldHideAgentFromMentions` is the single authority — it already shows invocable agents (local managed ∪ relay-directory-eligible), hides non-member non-invocable ones, and applies the member/directory rules. Local managed agents are unaffected (they're seeded into `mentionableAgentPubkeys`), and other members' `owner-only` agents stay hidden (non-member + non-invocable, or member + directory-excluded).
- **`MembersSidebar.tsx`**: add-member candidates now pass when the agent is locally managed **or** relay-directory invocable by the current user (new `relayAgentIsInvocableByUser`: `respond_to: anyone`, or an allowlist containing them). Channel overlap is deliberately not required here — adding the agent to the channel is what creates the overlap.
- **`agentAutocompleteEligibility.ts`**: new `relayAgentIsInvocableByUser` helper; `relayAgentIsSharedWithUser` delegates its allowlist branch to it (behavior unchanged); doc comment on `isAgentIdentityInManagedList` clarifying the caller-supplied allow-set contract.

## Test plan

- `node --import ./test-loader.mjs --experimental-strip-types --test` on `agentAutocompleteEligibility.test.mjs`: 22/22 (4 new: invocable-by-user modes, and a regression test that a directory-eligible member agent is shown without a local managed entry).
- `biome check` and `tsc --noEmit` clean on touched files.
- Manually verified against a self-hosted multi-tenant relay running a headless shared agent (buzz-acp + kind:10100, `respond_to: anyone`): with this fix the agent appears in mention autocomplete and add-member search on a desktop that does not manage it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)