### PR TITLE
test(ws-client): cover relay message parsing, NIP-42 auth flow, and connection state machine

### DIFF
--- a/crates/buzz-ws-client/src/connection.rs
+++ b/crates/buzz-ws-client/src/connection.rs
@@ -297,6 +297,9 @@ pub async fn publish_event(
 mod tests {
     use super::*;
 
+    use nostr::{EventBuilder, Kind};
+    use tokio_tungstenite::accept_async;
+
     #[test]
     fn auth_challenge_timeout_meets_floor() {
         const { assert!(AUTH_CHALLENGE_TIMEOUT_SECS >= 20) };
@@ -310,5 +313,325 @@ mod tests {
     #[test]
     fn publish_ok_timeout_meets_floor() {
         const { assert!(PUBLISH_OK_TIMEOUT_SECS >= 30) };
+    }
+
+    type ServerStream = WebSocketStream<tokio::net::TcpStream>;
+
+    /// Bind an in-process WebSocket server and return its `ws://` URL plus a
+    /// handle that resolves to the server side of the stream once a client
+    /// completes the handshake.
+    async fn spawn_test_relay() -> (String, tokio::task::JoinHandle<ServerStream>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test websocket");
+        let address = listener.local_addr().expect("read test address");
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept test websocket");
+            accept_async(stream)
+                .await
+                .expect("complete server websocket handshake")
+        });
+        (format!("ws://{address}"), server)
+    }
+
+    async fn next_test_frame(server: &mut ServerStream) -> Value {
+        let message = timeout(Duration::from_secs(5), server.next())
+            .await
+            .expect("timed out waiting for websocket frame")
+            .expect("test websocket closed")
+            .expect("read test websocket frame");
+        serde_json::from_str(message.to_text().expect("expected text frame"))
+            .expect("parse test websocket frame")
+    }
+
+    async fn send_frame(server: &mut ServerStream, value: Value) {
+        server
+            .send(Message::Text(value.to_string().into()))
+            .await
+            .expect("send test frame");
+    }
+
+    /// Build a real signed Nostr event for publish tests.
+    fn make_test_event(keys: &Keys) -> Event {
+        EventBuilder::new(Kind::TextNote, "test")
+            .sign_with_keys(keys)
+            .expect("signing should succeed")
+    }
+
+    async fn connect_test_pair() -> (NostrWsConnection, ServerStream) {
+        let (url, accept) = spawn_test_relay().await;
+        let conn = NostrWsConnection::connect(&url)
+            .await
+            .expect("connect test client");
+        let server = accept.await.expect("join test websocket server");
+        (conn, server)
+    }
+
+    #[tokio::test]
+    async fn connect_rejects_invalid_url() {
+        let result = NostrWsConnection::connect("not a url").await;
+        assert!(matches!(result, Err(WsClientError::Url(_))));
+    }
+
+    #[tokio::test]
+    async fn authenticate_signs_challenge_and_accepts_ok() {
+        let (mut conn, server) = connect_test_pair().await;
+        let keys = Keys::generate();
+        let pubkey = keys.public_key();
+
+        let server_task = tokio::spawn(async move {
+            let mut server = server;
+            send_frame(&mut server, json!(["AUTH", "test-challenge"])).await;
+            let frame = next_test_frame(&mut server).await;
+            assert_eq!(frame[0], "AUTH");
+            let auth_event: Event =
+                serde_json::from_value(frame[1].clone()).expect("deserialize AUTH event");
+            let event_id = auth_event.id.to_hex();
+            send_frame(&mut server, json!(["OK", event_id, true, ""])).await;
+            auth_event
+        });
+
+        conn.authenticate(&keys, None).await.expect("authenticate");
+
+        let auth_event = server_task.await.expect("join server task");
+        assert_eq!(auth_event.kind, Kind::Authentication);
+        assert_eq!(auth_event.pubkey, pubkey);
+        auth_event.verify().expect("valid signature");
+        let tags = serde_json::to_value(&auth_event).expect("serialize AUTH event")["tags"]
+            .as_array()
+            .cloned()
+            .expect("tags array");
+        assert!(
+            tags.contains(&json!(["challenge", "test-challenge"])),
+            "missing challenge tag in {tags:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn authenticate_rejected_by_relay_fails_with_reason() {
+        let (mut conn, server) = connect_test_pair().await;
+        let keys = Keys::generate();
+
+        let server_task = tokio::spawn(async move {
+            let mut server = server;
+            send_frame(&mut server, json!(["AUTH", "test-challenge"])).await;
+            let frame = next_test_frame(&mut server).await;
+            let event_id = frame[1]["id"].as_str().expect("auth event id").to_string();
+            send_frame(
+                &mut server,
+                json!(["OK", event_id, false, "auth-required: bad"]),
+            )
+            .await;
+        });
+
+        let result = conn.authenticate(&keys, None).await;
+        server_task.await.expect("join server task");
+        match result {
+            Err(WsClientError::AuthFailed(message)) => {
+                assert_eq!(message, "auth-required: bad");
+            }
+            other => panic!("expected AuthFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn authenticate_buffers_earlier_messages_for_later_delivery() {
+        let (mut conn, server) = connect_test_pair().await;
+        let keys = Keys::generate();
+
+        let server_task = tokio::spawn(async move {
+            let mut server = server;
+            send_frame(&mut server, json!(["NOTICE", "welcome"])).await;
+            send_frame(&mut server, json!(["EOSE", "sub-1"])).await;
+            send_frame(&mut server, json!(["AUTH", "test-challenge"])).await;
+            let frame = next_test_frame(&mut server).await;
+            let event_id = frame[1]["id"].as_str().expect("auth event id").to_string();
+            send_frame(&mut server, json!(["OK", event_id, true, ""])).await;
+            server
+        });
+
+        conn.authenticate(&keys, None).await.expect("authenticate");
+        let _server = server_task.await.expect("join server task");
+
+        match conn.next_event(Duration::from_secs(1)).await {
+            Ok(RelayMessage::Notice { message }) => assert_eq!(message, "welcome"),
+            other => panic!("expected buffered Notice first, got {other:?}"),
+        }
+        match conn.next_event(Duration::from_secs(1)).await {
+            Ok(RelayMessage::Eose { subscription_id }) => assert_eq!(subscription_id, "sub-1"),
+            other => panic!("expected buffered Eose second, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn authenticate_rejects_oversized_challenge() {
+        let (mut conn, server) = connect_test_pair().await;
+        let keys = Keys::generate();
+
+        let server_task = tokio::spawn(async move {
+            let mut server = server;
+            send_frame(&mut server, json!(["AUTH", "x".repeat(1025)])).await;
+            server
+        });
+
+        let result = conn.authenticate(&keys, None).await;
+        let _server = server_task.await.expect("join server task");
+        match result {
+            Err(WsClientError::AuthFailed(message)) => {
+                assert_eq!(message, "challenge exceeds 1024 bytes");
+            }
+            other => panic!("expected AuthFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_event_returns_matching_ok_and_buffers_interleaved_messages() {
+        let (mut conn, server) = connect_test_pair().await;
+        let keys = Keys::generate();
+        let event = make_test_event(&keys);
+        let event_id = event.id.to_hex();
+
+        let server_task = tokio::spawn(async move {
+            let mut server = server;
+            let frame = next_test_frame(&mut server).await;
+            assert_eq!(frame[0], "EVENT");
+            let published_id = frame[1]["id"].as_str().expect("event id").to_string();
+            send_frame(&mut server, json!(["EOSE", "sub-1"])).await;
+            send_frame(&mut server, json!(["OK", "deadbeef", false, "other event"])).await;
+            send_frame(&mut server, json!(["OK", published_id, true, "stored"])).await;
+            server
+        });
+
+        let ok = conn.send_event(event).await.expect("send event");
+        let _server = server_task.await.expect("join server task");
+        assert!(ok.accepted);
+        assert_eq!(ok.event_id, event_id);
+        assert_eq!(ok.message, "stored");
+
+        match conn.next_event(Duration::from_secs(1)).await {
+            Ok(RelayMessage::Eose { subscription_id }) => assert_eq!(subscription_id, "sub-1"),
+            other => panic!("expected buffered Eose first, got {other:?}"),
+        }
+        match conn.next_event(Duration::from_secs(1)).await {
+            Ok(RelayMessage::Ok(other_ok)) => assert_eq!(other_ok.event_id, "deadbeef"),
+            other => panic!("expected buffered Ok second, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_event_answers_ping_while_waiting_for_ok() {
+        let (mut conn, server) = connect_test_pair().await;
+        let keys = Keys::generate();
+        let event = make_test_event(&keys);
+
+        let server_task = tokio::spawn(async move {
+            let mut server = server;
+            let frame = next_test_frame(&mut server).await;
+            let published_id = frame[1]["id"].as_str().expect("event id").to_string();
+            server
+                .send(Message::Ping(b"heartbeat".to_vec().into()))
+                .await
+                .expect("send ping");
+            let reply = timeout(Duration::from_secs(5), server.next())
+                .await
+                .expect("timed out waiting for pong")
+                .expect("test websocket closed")
+                .expect("read pong frame");
+            match reply {
+                Message::Pong(data) => assert_eq!(data.as_ref(), b"heartbeat"),
+                other => panic!("expected Pong, got {other:?}"),
+            }
+            send_frame(&mut server, json!(["OK", published_id, true, ""])).await;
+            server
+        });
+
+        let ok = conn.send_event(event).await.expect("send event");
+        let _server = server_task.await.expect("join server task");
+        assert!(ok.accepted);
+    }
+
+    #[tokio::test]
+    async fn auth_challenge_received_while_publishing_is_reused_by_authenticate() {
+        let (mut conn, server) = connect_test_pair().await;
+        let keys = Keys::generate();
+        let event = make_test_event(&keys);
+
+        let server_task = tokio::spawn(async move {
+            let mut server = server;
+            let frame = next_test_frame(&mut server).await;
+            let published_id = frame[1]["id"].as_str().expect("event id").to_string();
+            send_frame(&mut server, json!(["AUTH", "late-challenge"])).await;
+            send_frame(&mut server, json!(["OK", published_id, true, ""])).await;
+            // The client must now authenticate against the stored challenge
+            // without waiting for another AUTH frame from the relay.
+            let auth_frame = next_test_frame(&mut server).await;
+            assert_eq!(auth_frame[0], "AUTH");
+            let tags = auth_frame[1]["tags"].as_array().cloned().expect("tags");
+            assert!(
+                tags.contains(&json!(["challenge", "late-challenge"])),
+                "missing challenge tag in {tags:?}"
+            );
+            let auth_id = auth_frame[1]["id"].as_str().expect("auth id").to_string();
+            send_frame(&mut server, json!(["OK", auth_id, true, ""])).await;
+            server
+        });
+
+        let ok = conn.send_event(event).await.expect("send event");
+        assert!(ok.accepted);
+        conn.authenticate(&keys, None)
+            .await
+            .expect("authenticate with stored challenge");
+        let _server = server_task.await.expect("join server task");
+
+        match conn.next_event(Duration::from_secs(1)).await {
+            Ok(RelayMessage::Auth { challenge }) => assert_eq!(challenge, "late-challenge"),
+            other => panic!("expected buffered Auth, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn next_event_times_out_when_relay_is_silent() {
+        let (mut conn, _server) = connect_test_pair().await;
+        let result = conn.next_event(Duration::from_millis(50)).await;
+        assert!(matches!(result, Err(WsClientError::Timeout)));
+    }
+
+    #[tokio::test]
+    async fn next_event_surfaces_connection_close() {
+        let (mut conn, mut server) = connect_test_pair().await;
+        server.close(None).await.expect("close server side");
+        let result = conn.next_event(Duration::from_secs(5)).await;
+        assert!(matches!(result, Err(WsClientError::ConnectionClosed)));
+    }
+
+    #[tokio::test]
+    async fn publish_event_helper_completes_full_auth_and_publish_flow() {
+        let (url, accept) = spawn_test_relay().await;
+        let keys = Keys::generate();
+        let event = make_test_event(&keys);
+        let expected_id = event.id.to_hex();
+
+        let server_task = tokio::spawn(async move {
+            let mut server = accept.await.expect("join test websocket server");
+            send_frame(&mut server, json!(["AUTH", "publish-challenge"])).await;
+            let auth_frame = next_test_frame(&mut server).await;
+            assert_eq!(auth_frame[0], "AUTH");
+            let auth_id = auth_frame[1]["id"].as_str().expect("auth id").to_string();
+            send_frame(&mut server, json!(["OK", auth_id, true, ""])).await;
+            let event_frame = next_test_frame(&mut server).await;
+            assert_eq!(event_frame[0], "EVENT");
+            let event_id = event_frame[1]["id"].as_str().expect("event id").to_string();
+            send_frame(&mut server, json!(["OK", event_id, true, "stored"])).await;
+            event_id
+        });
+
+        let ok = publish_event(&url, event, &keys, None, 10)
+            .await
+            .expect("publish event");
+        let published_id = server_task.await.expect("join server task");
+        assert!(ok.accepted);
+        assert_eq!(ok.event_id, expected_id);
+        assert_eq!(published_id, expected_id);
+        assert_eq!(ok.message, "stored");
     }
 }

--- a/crates/buzz-ws-client/src/message.rs
+++ b/crates/buzz-ws-client/src/message.rs
@@ -165,3 +165,220 @@ pub fn build_auth_event(
         .sign_with_keys(keys)
         .map_err(|e| WsClientError::EventBuilder(e.to_string()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::Kind;
+    use serde_json::json;
+
+    fn test_keys() -> Keys {
+        Keys::generate()
+    }
+
+    /// Build a real signed Nostr event so EVENT frames carry a valid payload.
+    fn make_signed_event(keys: &Keys) -> Event {
+        EventBuilder::new(Kind::TextNote, "test")
+            .sign_with_keys(keys)
+            .expect("signing should succeed")
+    }
+
+    #[test]
+    fn event_frame_parses_subscription_and_payload() {
+        let keys = test_keys();
+        let event = make_signed_event(&keys);
+        let expected_id = event.id;
+        let frame = json!(["EVENT", "sub-1", event]).to_string();
+
+        match parse_relay_message(&frame).expect("parse EVENT frame") {
+            RelayMessage::Event {
+                subscription_id,
+                event,
+            } => {
+                assert_eq!(subscription_id, "sub-1");
+                assert_eq!(event.id, expected_id);
+            }
+            other => panic!("expected Event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn event_frame_without_payload_is_rejected() {
+        let result = parse_relay_message(r#"["EVENT","sub-1"]"#);
+        assert!(matches!(result, Err(WsClientError::UnexpectedMessage(_))));
+    }
+
+    #[test]
+    fn event_frame_with_malformed_payload_is_json_error() {
+        let result = parse_relay_message(r#"["EVENT","sub-1",{"garbage":true}]"#);
+        assert!(matches!(result, Err(WsClientError::Json(_))));
+    }
+
+    #[test]
+    fn ok_frame_parses_all_fields() {
+        match parse_relay_message(r#"["OK","abc123",true,"duplicate: already stored"]"#)
+            .expect("parse OK frame")
+        {
+            RelayMessage::Ok(ok) => {
+                assert_eq!(ok.event_id, "abc123");
+                assert!(ok.accepted);
+                assert_eq!(ok.message, "duplicate: already stored");
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ok_frame_without_flags_defaults_to_rejected_with_empty_message() {
+        match parse_relay_message(r#"["OK","abc123"]"#).expect("parse short OK frame") {
+            RelayMessage::Ok(ok) => {
+                assert_eq!(ok.event_id, "abc123");
+                assert!(!ok.accepted);
+                assert_eq!(ok.message, "");
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn eose_frame_parses_subscription() {
+        match parse_relay_message(r#"["EOSE","sub-1"]"#).expect("parse EOSE frame") {
+            RelayMessage::Eose { subscription_id } => assert_eq!(subscription_id, "sub-1"),
+            other => panic!("expected Eose, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn eose_frame_without_subscription_is_rejected() {
+        let result = parse_relay_message(r#"["EOSE"]"#);
+        assert!(matches!(result, Err(WsClientError::UnexpectedMessage(_))));
+    }
+
+    #[test]
+    fn closed_frame_parses_reason() {
+        match parse_relay_message(r#"["CLOSED","sub-1","error: shutting down"]"#)
+            .expect("parse CLOSED frame")
+        {
+            RelayMessage::Closed {
+                subscription_id,
+                message,
+            } => {
+                assert_eq!(subscription_id, "sub-1");
+                assert_eq!(message, "error: shutting down");
+            }
+            other => panic!("expected Closed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn closed_frame_without_reason_defaults_to_empty() {
+        match parse_relay_message(r#"["CLOSED","sub-1"]"#).expect("parse short CLOSED frame") {
+            RelayMessage::Closed { message, .. } => assert_eq!(message, ""),
+            other => panic!("expected Closed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn notice_frame_parses_message() {
+        match parse_relay_message(r#"["NOTICE","rate limited"]"#).expect("parse NOTICE frame") {
+            RelayMessage::Notice { message } => assert_eq!(message, "rate limited"),
+            other => panic!("expected Notice, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn auth_frame_parses_challenge() {
+        match parse_relay_message(r#"["AUTH","challenge-string"]"#).expect("parse AUTH frame") {
+            RelayMessage::Auth { challenge } => assert_eq!(challenge, "challenge-string"),
+            other => panic!("expected Auth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn auth_frame_without_challenge_is_rejected() {
+        let result = parse_relay_message(r#"["AUTH"]"#);
+        assert!(matches!(result, Err(WsClientError::UnexpectedMessage(_))));
+    }
+
+    #[test]
+    fn unknown_message_type_is_rejected() {
+        match parse_relay_message(r#"["REQ","sub-1",{}]"#) {
+            Err(WsClientError::UnexpectedMessage(msg)) => {
+                assert!(msg.contains("unknown message type: REQ"));
+            }
+            other => panic!("expected UnexpectedMessage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_json_input_is_json_error() {
+        let result = parse_relay_message("not json at all");
+        assert!(matches!(result, Err(WsClientError::Json(_))));
+    }
+
+    #[test]
+    fn json_object_input_is_json_error() {
+        let result = parse_relay_message(r#"{"type":"EVENT"}"#);
+        assert!(matches!(result, Err(WsClientError::Json(_))));
+    }
+
+    #[test]
+    fn empty_array_is_rejected() {
+        let result = parse_relay_message("[]");
+        assert!(matches!(result, Err(WsClientError::UnexpectedMessage(_))));
+    }
+
+    #[test]
+    fn non_string_message_type_is_rejected() {
+        let result = parse_relay_message("[42]");
+        assert!(matches!(result, Err(WsClientError::UnexpectedMessage(_))));
+    }
+
+    #[test]
+    fn auth_event_is_signed_authentication_kind_with_nip42_tags() {
+        let keys = test_keys();
+        let event = build_auth_event("test-challenge", "wss://relay.example.com", &keys, None)
+            .expect("build auth event");
+
+        assert_eq!(event.kind, Kind::Authentication);
+        event.verify().expect("valid signature");
+
+        let value = serde_json::to_value(&event).expect("serialize auth event");
+        let tags = value["tags"].as_array().expect("tags array");
+        assert!(
+            tags.contains(&json!(["challenge", "test-challenge"])),
+            "missing challenge tag in {tags:?}"
+        );
+        assert!(
+            tags.iter().any(|t| t[0] == "relay"),
+            "missing relay tag in {tags:?}"
+        );
+    }
+
+    #[test]
+    fn auth_event_includes_optional_auth_tag() {
+        let keys = test_keys();
+        let auth_tag = Tag::parse(["auth", "token-123"]).expect("parse auth tag");
+        let event = build_auth_event(
+            "test-challenge",
+            "wss://relay.example.com",
+            &keys,
+            Some(&auth_tag),
+        )
+        .expect("build auth event");
+
+        let value = serde_json::to_value(&event).expect("serialize auth event");
+        let tags = value["tags"].as_array().expect("tags array");
+        assert!(
+            tags.contains(&json!(["auth", "token-123"])),
+            "missing auth tag in {tags:?}"
+        );
+    }
+
+    #[test]
+    fn auth_event_rejects_invalid_relay_url() {
+        let keys = test_keys();
+        let result = build_auth_event("test-challenge", "not a url", &keys, None);
+        assert!(matches!(result, Err(WsClientError::Url(_))));
+    }
+}


### PR DESCRIPTION

## Problem

`crates/buzz-ws-client` is the NIP-42 WebSocket client that buzz-cli and
buzz-test-client use to talk to relays, but it currently has almost no test
coverage: the only tests are three const assertions on timeout floors. The
crate's actual behavior — NIP-01 frame parsing, NIP-42 AUTH event
construction, challenge handling, OK-response matching, out-of-order message
buffering, ping/pong keepalive, and close/timeout error paths — is entirely
unexercised, so regressions in any of it would only surface as live relay
failures.

## Fix

Pure test addition — no production code changes, no new dependencies (dev or
otherwise).

`src/message.rs` (+217): unit tests for `parse_relay_message` and
`build_auth_event`:
- every frame type parses (EVENT with a real signed event, OK, EOSE, CLOSED,
  NOTICE, AUTH), including the NIP-01 defaulting rules (short OK defaults to
  rejected/empty message, CLOSED without reason defaults to empty);
- every rejection path (missing fields, non-array JSON, non-string type tag,
  unknown message type, malformed event payload) maps to the right
  `WsClientError` variant;
- AUTH events are signed `Kind::Authentication` events carrying the NIP-42
  challenge/relay tags, the optional NIP-OA auth tag is injected when
  provided, and invalid relay URLs are rejected.

`src/connection.rs` (+323): integration-style tests for `NostrWsConnection`
and `publish_event` against an in-process scripted relay (bind
`127.0.0.1:0` + `tokio_tungstenite::accept_async` — same idiom as the
existing `test_ws_pair` helper in `buzz-acp/src/relay.rs`; no network, no
mock frameworks):
- full authenticate handshake: client signs the relay's challenge and the
  sent AUTH event verifies (kind/pubkey/signature/challenge tag);
- relay-rejected auth surfaces `AuthFailed` with the relay's reason;
- messages arriving before the AUTH challenge are buffered and delivered
  in order by `next_event` afterwards;
- oversized (>1024 byte) challenges are rejected;
- `send_event` matches the OK for its own event id, buffering interleaved
  EOSE/foreign-OK frames for later delivery;
- pings received mid-wait are answered with payload-matching pongs without
  disrupting the OK wait;
- an AUTH challenge received while waiting for a publish OK is stored and
  reused by a later `authenticate()` call (no second challenge needed);
- silent relay → `Timeout`; server-initiated close → `ConnectionClosed`;
  invalid URL → `Url` error;
- `publish_event` one-shot helper: connect → auth → publish → OK end to end.

All server-side reads are bounded by 5s timeouts so failures are fast, and
ephemeral ports keep the tests parallel-safe under nextest.

## Test evidence

Against the pinned toolchain (Rust 1.95.0, per `rust-toolchain.toml`):

```
cargo clippy -p buzz-ws-client --all-targets -- -D warnings   # clean
cargo nextest run -p buzz-ws-client                           # 34 tests run: 34 passed, 0 skipped
```

## Links

- Crate: `crates/buzz-ws-client` (used by `crates/buzz-cli`, `crates/buzz-test-client`)
- Test-server idiom precedent: `crates/buzz-acp/src/relay.rs` tests
