### PR TITLE
chore: finish sprout->buzz rename in relay env vars and public-facing strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,7 +483,7 @@ jobs:
             BUZZ_RATE_LIMIT_HUMAN_API_CALLS_PER_MIN=100000 \
             BUZZ_RATE_LIMIT_HUMAN_WS_EVENTS_PER_SEC=10000 \
             BUZZ_GIT_PROBE_WRITERS=8 \
-            SPROUT_REMINDER_SCHEDULER_INTERVAL_SECS=1 \
+            BUZZ_REMINDER_SCHEDULER_INTERVAL_SECS=1 \
             ./target/ci/buzz-relay > /tmp/buzz-relay.log 2>&1 &
           echo $! > /tmp/buzz-relay.pid
           for attempt in $(seq 1 60); do
@@ -640,7 +640,7 @@ jobs:
             BUZZ_REQUIRE_AUTH_TOKEN=false \
             BUZZ_RECONCILE_CHANNELS=true \
             BUZZ_GIT_PROBE_WRITERS=8 \
-            SPROUT_REMINDER_SCHEDULER_INTERVAL_SECS=1 \
+            BUZZ_REMINDER_SCHEDULER_INTERVAL_SECS=1 \
             ./target/ci/buzz-relay > /tmp/buzz-relay.log 2>&1 &
           echo $! > /tmp/buzz-relay.pid
           for attempt in $(seq 1 60); do

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -1536,7 +1536,7 @@ mod tests {
 
     #[test]
     fn codex_network_env_wss_url() {
-        let result = codex_network_env("codex-acp", "wss://sprout-oss.stage.blox.sqprod.co");
+        let result = codex_network_env("codex-acp", "wss://relay.example.com");
         assert_eq!(
             result,
             Some(("CODEX_CONFIG".to_string(), CODEX_CONFIG_JSON.to_string()))

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -644,7 +644,7 @@ pub const MAX_TOOL_RESULT_BYTES: usize = 8 * 1024 * 1024;
 /// Default cap on the *text* portion of a single tool result. Oversized text
 /// is middle-elided before it enters history; without this, one fat `cat`
 /// burns the context window and forces a lossy handoff. 50 KiB matches the
-/// shell-output caps in sprout-dev-mcp, goose, and pi; codex defaults to
+/// shell-output caps in buzz-dev-mcp, goose, and pi; codex defaults to
 /// 10 KB. Tunable via `BUZZ_AGENT_MAX_TOOL_RESULT_TEXT_BYTES`.
 pub const DEFAULT_TOOL_RESULT_TEXT_BYTES: usize = 50 * 1024;
 pub const MAX_TOOL_CALLS_PER_TURN: usize = 64;

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -1295,8 +1295,10 @@ fn validate_event_reminder(event: &Event) -> Result<(), &'static str> {
     // omit it. The ordering check only applies when both are present.
     if let Some(nb) = not_before {
         // Reject reminders scheduled beyond the configured horizon. The same
-        // SPROUT_MAX_NOT_BEFORE_DELTA env var is advertised in NIP-11.
-        let max_delta: u64 = std::env::var("SPROUT_MAX_NOT_BEFORE_DELTA")
+        // BUZZ_MAX_NOT_BEFORE_DELTA env var is advertised in NIP-11 (legacy
+        // SPROUT_-prefixed name still accepted, matching nip11.rs).
+        let max_delta: u64 = std::env::var("BUZZ_MAX_NOT_BEFORE_DELTA")
+            .or_else(|_| std::env::var("SPROUT_MAX_NOT_BEFORE_DELTA"))
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(31_536_000); // 1 year default

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -2058,7 +2058,7 @@ async fn handle_a_tag_deletion(
         // separate concern) takes precedence. For every other addressable
         // kind, including kind:30023 (NIP-23 long-form), we soft-delete the
         // live row matching `(kind, pubkey, d_tag)` so REQs stop returning it.
-        // See https://github.com/block/sprout/issues/714.
+        // See https://github.com/block/buzz/issues/714.
         k if is_parameterized_replaceable(k) => {
             let pubkey_bytes = match hex::decode(pubkey_hex) {
                 Ok(b) => b,

--- a/crates/buzz-relay/src/main.rs
+++ b/crates/buzz-relay/src/main.rs
@@ -698,11 +698,16 @@ async fn main() -> anyhow::Result<()> {
     // column: only the pod that wins the atomic claim publishes.
     {
         let scheduler_state = Arc::clone(&state);
-        let scheduler_interval_secs: u64 = std::env::var("SPROUT_REMINDER_SCHEDULER_INTERVAL_SECS")
+        // Legacy SPROUT_-prefixed names still accepted so existing
+        // deployments keep their scheduler tuning across the sprout→buzz
+        // rename.
+        let scheduler_interval_secs: u64 = std::env::var("BUZZ_REMINDER_SCHEDULER_INTERVAL_SECS")
+            .or_else(|_| std::env::var("SPROUT_REMINDER_SCHEDULER_INTERVAL_SECS"))
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(10);
-        let scheduler_batch_limit: i64 = std::env::var("SPROUT_REMINDER_SCHEDULER_BATCH_LIMIT")
+        let scheduler_batch_limit: i64 = std::env::var("BUZZ_REMINDER_SCHEDULER_BATCH_LIMIT")
+            .or_else(|_| std::env::var("SPROUT_REMINDER_SCHEDULER_BATCH_LIMIT"))
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(100);

--- a/crates/buzz-relay/src/nip11.rs
+++ b/crates/buzz-relay/src/nip11.rs
@@ -94,7 +94,10 @@ pub struct RelayLimitation {
 /// `AuthState::Authenticated`. This is independent of the REST API token
 /// toggle (`config.require_auth_token`).
 fn relay_limitation(max_message_length: usize) -> RelayLimitation {
-    let max_not_before_delta: u64 = std::env::var("SPROUT_MAX_NOT_BEFORE_DELTA")
+    // Legacy SPROUT_-prefixed name still accepted so existing deployments
+    // keep their configured horizon across the sprout→buzz rename.
+    let max_not_before_delta: u64 = std::env::var("BUZZ_MAX_NOT_BEFORE_DELTA")
+        .or_else(|_| std::env::var("SPROUT_MAX_NOT_BEFORE_DELTA"))
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(31_536_000); // 1 year default

--- a/crates/buzz-test-client/tests/e2e_event_reminder.rs
+++ b/crates/buzz-test-client/tests/e2e_event_reminder.rs
@@ -1137,7 +1137,7 @@ async fn await_scheduler_push(
 /// fan-out.
 ///
 /// Requires a low scheduler interval; run the relay with
-/// `SPROUT_REMINDER_SCHEDULER_INTERVAL_SECS=1`.
+/// `BUZZ_REMINDER_SCHEDULER_INTERVAL_SECS=1`.
 #[tokio::test]
 #[ignore]
 async fn test_scheduler_delivers_due_reminder_to_author_subscription() {

--- a/docs/nips/NIP-AO.md
+++ b/docs/nips/NIP-AO.md
@@ -297,4 +297,4 @@ of decrypted payloads and MUST NOT log it at INFO level or above.
 
 ## Reference Implementation
 
-[block/sprout PR #421](https://github.com/block/sprout/pull/421)
+[block/buzz PR #421](https://github.com/block/buzz/pull/421)


### PR DESCRIPTION

## Problem

The block/sprout -> block/buzz rename left residue in public-facing strings and, more importantly, in three relay environment variables that still use the old `SPROUT_` prefix while every other relay knob is `BUZZ_`-prefixed:

- `SPROUT_MAX_NOT_BEFORE_DELTA` — read in two places (`crates/buzz-relay/src/nip11.rs` and `crates/buzz-relay/src/handlers/ingest.rs`); it is both advertised in the NIP-11 relay information document (`limitation.max_not_before_delta`) and enforced on NIP-ER reminder ingest, so the relay literally self-identifies with a stale config surface.
- `SPROUT_REMINDER_SCHEDULER_INTERVAL_SECS` / `SPROUT_REMINDER_SCHEDULER_BATCH_LIMIT` — read in `crates/buzz-relay/src/main.rs` for the NIP-ER push scheduler.

Plus cosmetic residue: the NIP-AO reference-implementation link and a source comment still point at `github.com/block/sprout`, a doc comment names the pre-rename `sprout-dev-mcp` crate, and one buzz-acp test uses an internal pre-rename staging hostname as its example URL.

## Fix

- Env vars are read as `BUZZ_*` first with a fallback to the legacy `SPROUT_*` name, so existing deployments that persisted the old names keep their configured horizon/scheduler tuning — no behavior change for anyone. Comments at each read site note the legacy fallback. A follow-up can drop the fallback once deployments have migrated.
- `.github/workflows/ci.yml` now sets `BUZZ_REMINDER_SCHEDULER_INTERVAL_SECS=1` (2 lines), so CI's e2e relay jobs exercise the new name end-to-end.
- `docs/nips/NIP-AO.md` reference-implementation link and a `handlers/side_effects.rs` comment updated to `github.com/block/buzz` (GitHub redirects the old URLs, but the text no longer names the dead repo).
- `crates/buzz-agent/src/config.rs` doc comment: `sprout-dev-mcp` -> `buzz-dev-mcp` (the crate's actual name).
- `crates/buzz-acp/src/config.rs` test: `wss://sprout-oss.stage.blox.sqprod.co` -> `wss://relay.example.com`, matching the sibling tests' example hosts and removing an internal hostname from the public repo.
- `crates/buzz-test-client/tests/e2e_event_reminder.rs` doc comment updated to the new scheduler var name.

Deliberately NOT touched (intentional references): `squareup/sprout-*` internal-repo references in AGENTS.md/CONTRIBUTING.md; legacy-migration/cleanup code in `scripts/dev-setup.sh`, `scripts/instance-env.sh`, `scripts/reset-desktop-dev-state.sh` (they migrate/clean old sprout-named state by design); `scripts/check-pr-image-urls.sh` (its pattern intentionally matches the old internal media host); the `sprout_ref` Buildkite input in RELEASING.md and workflows (an internal pipeline's real input name); the `SPROUT_UPDATER_PUBLIC_KEY` secret fallback in release.yml (already a deliberate compat fallback); the historical `crates/sprout-relay/...` pre-rewrite reference in `conformance_multitenant.rs`; Cargo.toml repository URLs (covered by PR #2519) and the `sprout-cli` skill dirs (covered by PR #2525); CHANGELOG/git history.

## Test evidence

- `cargo fmt -p buzz-relay -p buzz-acp -p buzz-agent -p buzz-test-client --check` — clean.
- `cargo check -p buzz-relay -p buzz-acp -p buzz-agent` — clean.
- `cargo clippy -p buzz-relay -p buzz-acp -p buzz-agent -- -D warnings` — clean.
- No `unwrap()`/`expect()` introduced; env reads keep the existing `.ok().and_then(...).unwrap_or(default)` shape.

## Links

- Related prior renames: #971 (desktop SPROUT_ env vars), #958, #1012.
- Complementary open PRs (no overlap): #2519 (Cargo repository URLs), #2525 (sprout-cli skill dirs).
