### PR TITLE
docs(contributing): drop stale MCP-tool ToC entry, align `just ci` docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,8 +90,10 @@ See CONTRIBUTING.md for full setup details and dependency requirements.
 
 ## Quality Gates
 
-Run `just ci` before every PR — it runs `fmt` + `clippy` + desktop lint +
-unit tests + builds. Clippy passing does not mean fmt passes; run both.
+Run `just ci` before every PR — it runs `check` (fmt + lints across Rust,
+desktop, Tauri, web, and mobile), unit tests (Rust, desktop, Tauri, mobile),
+and the desktop and web builds. Clippy passing does not mean fmt passes; run
+both.
 
 Run `just test` for integration tests if you touched `buzz-relay`,
 `buzz-db`, or `buzz-auth` — these require a running Postgres and Redis.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,8 @@ reach out in the community channels.
 6. [Architecture Overview](#architecture-overview)
 7. [Ecosystem](#ecosystem)
 8. [How to Add a New Event Kind](#how-to-add-a-new-event-kind)
-9. [How to Add a New MCP Tool](#how-to-add-a-new-mcp-tool)
-10. [How to Add a New API Endpoint](#how-to-add-a-new-api-endpoint)
-11. [License and CLA](#license-and-cla)
+9. [How to Add a New API Endpoint](#how-to-add-a-new-api-endpoint)
+10. [License and CLA](#license-and-cla)
 
 ---
 
@@ -167,7 +166,8 @@ Before opening a PR, run the full CI gate locally:
 
 ```bash
 just ci
-# Runs: check + unit tests + desktop build + Tauri check + mobile tests
+# Runs: check (fmt + lints across Rust, desktop, Tauri, web, and mobile),
+# unit tests (Rust, desktop, Tauri, mobile), and the desktop and web builds
 ```
 
 This is the same check that runs in CI. PRs that fail `just ci` will not be
@@ -278,7 +278,7 @@ required. The scope (in parentheses) is optional but encouraged.
 ### PR Checklist
 
 ```
-- [ ] `just ci` passes (fmt + clippy + unit tests + mobile)
+- [ ] `just ci` passes (fmt + lints, unit tests, and desktop/web builds)
 - [ ] Integration tests pass (`just test`)
 - [ ] New public APIs / tools / endpoints are documented
 - [ ] No new `unwrap()` in production code paths

--- a/TESTING.md
+++ b/TESTING.md
@@ -308,4 +308,4 @@ CLI-side, only two matter for testing:
 | ACP agent ignores all events | `BUZZ_ACP_RESPOND_TO=owner-only` (default) with no owner configured | Set `BUZZ_ACP_RESPOND_TO=anyone` for testing |
 | ACP logs `discovered 0 channel(s)` / `no channel subscriptions resolved` | Agent identity isn't a member of any channel | `buzz channels add-member --channel "$CHANNEL" --pubkey "$AGENT_PUBKEY" --role member` from another identity |
 | `GOOSE_MODE` warning, agent hangs | Not set | `export GOOSE_MODE=auto` |
-| Tests pass locally but CI fails | Forgot to run `just ci` | `just ci` runs the gate (fmt, clippy, unit tests, desktop/web builds) |
+| Tests pass locally but CI fails | Forgot to run `just ci` | `just ci` runs the gate (fmt + lints, unit tests across Rust/desktop/Tauri/mobile, desktop/web builds) |


### PR DESCRIPTION

## Problem

Two verified pieces of contributor-docs drift:

1. **Dead ToC entry.** The CONTRIBUTING.md Table of Contents lists
   "How to Add a New MCP Tool" (`#how-to-add-a-new-mcp-tool`), but no such
   section exists in the body — the body jumps from "How to Add a New Event
   Kind" straight to "How to Add a New API Endpoint". The section was
   deliberately removed in #850 ("chore: deprecate sprout-mcp — fill CLI
   gaps, remove crate and all references"); the ToC entry was left behind
   and now links to a dead anchor.

2. **`just ci` described inconsistently everywhere it is enumerated.** The
   Justfile recipe (line 258) actually runs:
   `ci: check test-unit desktop-test desktop-build desktop-tauri-check
   desktop-tauri-test web-build mobile-test`
   (where `check` = fmt-check + clippy + desktop/Tauri/web/mobile lint
   checks). Four prose descriptions each claimed a different, incomplete
   subset:
   - CONTRIBUTING.md "CI Gate" comment: "check + unit tests + desktop build
     + Tauri check + mobile tests" (omits desktop/Tauri tests, web build)
   - CONTRIBUTING.md PR checklist: "fmt + clippy + unit tests + mobile"
     (omits desktop, Tauri, and web entirely)
   - TESTING.md troubleshooting table: "fmt, clippy, unit tests,
     desktop/web builds" (omits mobile and desktop/Tauri tests)
   - AGENTS.md Quality Gates: "fmt + clippy + desktop lint + unit tests +
     builds" (omits web and mobile)

   Since "PRs that fail `just ci` will not be merged", contributors deserve
   an accurate description of what the gate covers.

## Fix

- Remove the stale ToC entry and renumber the two entries after it.
  Restoring the section was considered and rejected: the current
  `crates/buzz-dev-mcp` crate is a local dev-tools shim (rg / read_file /
  shell / str_replace), unrelated to the removed sprout-mcp agent API
  surface that section documented, and it has no README to source a
  replacement from. Removal matches the intent of #850.
- Rewrite all four `just ci` descriptions to match the recipe: check
  (fmt + lints across Rust, desktop, Tauri, web, and mobile), unit tests
  (Rust, desktop, Tauri, mobile), and the desktop and web builds.

## Test evidence

Docs-only change — no code paths touched, no build required per
CONTRIBUTING's own guidance.

- Verified no section heading nor anchor reference to "How to Add a New MCP
  Tool" remains anywhere in the repo's markdown after the change
  (`grep -rn 'how-to-add-a-new-mcp-tool\|How to Add a New MCP Tool'
  --include='*.md' .` → no matches).
- Verified every remaining `just ci` enumeration against the Justfile
  recipe at line 258 and its sub-recipes (`check` line 94, `test-unit`,
  `desktop-test`, `desktop-build`, `desktop-tauri-check`,
  `desktop-tauri-test`, `web-build`, `mobile-test`).
- All other ToC entries were checked against body headings; no other dead
  anchors exist.

## Links

- #850 — the commit (f1c672fe) that removed the sprout-mcp crate and the
  "How to Add a New MCP Tool" section but missed the ToC entry.
- Related but non-overlapping: open PR #2228 repoints the CONTRIBUTING.md
  "GitHub Discussion" pointer to Issues (the repo has Discussions
  disabled). This PR deliberately does not touch that line to avoid
  duplicating #2228.
