### PR TITLE
docs: document BUZZ_CORS_ORIGINS and Tauri webview origins in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,13 @@ RELAY_URL=ws://localhost:3000
 # the web frontend at / for browser requests. Leave unset for local dev
 # (use `just web` for Vite HMR instead).
 # BUZZ_WEB_DIR=./web/dist
+# Allowed CORS origins (comma-separated). Unset = permissive (dev mode).
+# When set, MUST include the desktop app's webview origins or its HTTP API
+# calls (invites, moderation) fail with a network error while WebSocket
+# traffic still works: `tauri://localhost` (macOS/Linux) and
+# `http://tauri.localhost` (Windows). Invalid values are rejected, not
+# treated as permissive.
+# BUZZ_CORS_ORIGINS=https://your-relay.example.com,tauri://localhost,http://tauri.localhost
 
 # Shared Redis-backed admission limits. Defaults shown below; each value must
 # be a positive integer.


### PR DESCRIPTION
## Summary

Documents the `BUZZ_CORS_ORIGINS` relay setting in `.env.example`, including the Tauri desktop webview origins that must be allowlisted for the desktop app's HTTP API calls to work.

## Motivation

Self-hosting Buzz behind a reverse proxy, we set `BUZZ_CORS_ORIGINS=https://<our-domain>` and the desktop app's invite minting failed with WebKit's "Load failed", while WebSocket chat kept working. Root cause: the desktop webview's origin (`tauri://localhost`) was not in the allowlist, so the browser engine blocked the HTTP endpoints (`/api/invites`, moderation) at preflight.

The relay code already notes this in a doc comment (`crates/buzz-relay/src/config.rs`), but `.env.example`, the file operators actually copy, has no mention of `BUZZ_CORS_ORIGINS` at all. This fills that gap where operators will actually see it.

## What changed

**`.env.example`**: 7 comment lines in the Relay section documenting `BUZZ_CORS_ORIGINS`:

- comma-separated format
- permissive default when unset (dev mode)
- the desktop webview origins that must be included: `tauri://localhost` (macOS/Linux) and `http://tauri.localhost` (Windows)
- invalid values are rejected rather than treated as permissive

## Verification

Docs-only change; no code paths touched.

- Reproduced live on our deployment: `OPTIONS /api/invites` preflight with `Origin: tauri://localhost` returned no `access-control-allow-origin` until the origin was added to `BUZZ_CORS_ORIGINS`; the desktop invite flow then worked.
- Claims cross-checked against code: `build_cors_layer` in `crates/buzz-relay/src/router.rs` (permissive when unset; empty non-permissive layer when values fail to parse), `crates/buzz-relay/src/config.rs` (comma-separated parsing), `desktop/src-tauri/src/media_proxy.rs` (accepted webview origins `tauri://localhost` and `http://tauri.localhost`).
- The Windows origin is derived from `media_proxy.rs` and Tauri v2's default (`useHttpsScheme` unset = `http://tauri.localhost`), not live-verified on Windows. It would be `https://tauri.localhost` only if `useHttpsScheme: true` were set, which this app does not do.

## Notes

- Related but distinct: #2444 tracks a loopback-host mismatch on the WebSocket side (`ws://127.0.0.1` vs `ws://localhost`). This PR only documents the HTTP CORS requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
