### PR TITLE
fix(sdk,desktop,cli): tag reactions with the target author (NIP-25 p tag)

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2485,6 +2485,10 @@ async fn tokio_main() -> Result<()> {
                             // buzz_event.event (needed for mode gate below).
                             let author_hex = buzz_event.event.pubkey.to_hex();
                             let event_id_hex = buzz_event.event.id.to_hex();
+                            // Captured before `buzz_event.event` moves into the
+                            // queue; the 👀 reaction below needs it for its
+                            // NIP-25 `p` tag.
+                            let event_author = buzz_event.event.pubkey;
                             // Clone for the non-cancelling steer fork, which
                             // needs the event to render the steer body. The
                             // clone is unconditional because we don't know
@@ -2512,7 +2516,7 @@ async fn tokio_main() -> Result<()> {
                                 let rc = ctx.rest_client.clone();
                                 let eid = event_id_hex.clone();
                                 tokio::spawn(async move {
-                                    pool::reaction_add(&rc, &eid, "👀").await;
+                                    pool::reaction_add(&rc, &eid, event_author, "👀").await;
                                 });
                             }
                             // Event is already queued. If mode requires it AND

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1466,14 +1466,30 @@ pub async fn run_prompt_task(
     let liveness_handle = tokio::spawn(liveness);
     let liveness_guard = LivenessGuard::new(liveness_handle, liveness_state);
 
-    // Collects event IDs up front. On drop (any exit path — normal, early
-    // return, or panic), spawns best-effort cleanup of both 👀 and 💬.
+    // Collects reaction targets up front. On drop (any exit path — normal,
+    // early return, or panic), spawns best-effort cleanup of both 👀 and 💬.
     // See `ReactionGuard` docs for ordering guarantees and known edge cases.
-    let reaction_ids: Vec<String> = batch
+    let reaction_targets: Vec<ReactionTarget> = batch
         .as_ref()
-        .map(|b| b.events.iter().map(|be| be.event.id.to_hex()).collect())
+        .map(|b| {
+            b.events
+                .iter()
+                .map(|be| ReactionTarget {
+                    event_id: be.event.id.to_hex(),
+                    author: be.event.pubkey,
+                })
+                .collect()
+        })
         .unwrap_or_default();
-    let _reaction_guard = ReactionGuard::new(ctx.rest_client.clone(), reaction_ids.clone());
+    // Removal is a kind:5 delete keyed on the reaction's own id, so cleanup
+    // only ever needs the target event ids.
+    let _reaction_guard = ReactionGuard::new(
+        ctx.rest_client.clone(),
+        reaction_targets
+            .iter()
+            .map(|t| t.event_id.clone())
+            .collect(),
+    );
 
     //
     // Core memory is delivered inside the system prompt the harness already
@@ -1936,11 +1952,11 @@ pub async fn run_prompt_task(
     // 💬 — fire-and-forget so the prompt fires immediately.
     // The guard's cleanup (spawned on drop) removes 💬 after the turn completes.
     // A brief race where 💬 appears slightly after the agent starts is acceptable.
-    if !reaction_ids.is_empty() {
+    if !reaction_targets.is_empty() {
         let rest = ctx.rest_client.clone();
-        let ids = reaction_ids.clone();
+        let targets = reaction_targets.clone();
         tokio::spawn(async move {
-            react_working(&rest, &ids).await;
+            react_working(&rest, &targets).await;
         });
     }
 
@@ -3836,7 +3852,16 @@ fn pct_encode(s: &str) -> String {
 /// Builds a reaction event with `buzz_sdk::build_reaction`, signs it with
 /// the keys already stored in `RestClient`, and submits via `POST /events`.
 /// Returns immediately on timeout or any error — reactions are cosmetic.
-pub(crate) async fn reaction_add(rest: &crate::relay::RestClient, event_id: &str, emoji: &str) {
+///
+/// `target_author` is the pubkey of the event being reacted to; it becomes the
+/// NIP-25 `p` tag. The agent's 👀/💬 indicators are reactions like any other,
+/// so they carry it too rather than emitting a non-conformant kind:7.
+pub(crate) async fn reaction_add(
+    rest: &crate::relay::RestClient,
+    event_id: &str,
+    target_author: nostr::PublicKey,
+    emoji: &str,
+) {
     let target_id = match nostr::EventId::from_hex(event_id) {
         Ok(id) => id,
         Err(e) => {
@@ -3844,7 +3869,7 @@ pub(crate) async fn reaction_add(rest: &crate::relay::RestClient, event_id: &str
             return;
         }
     };
-    let builder = match buzz_sdk::build_reaction(target_id, emoji) {
+    let builder = match buzz_sdk::build_reaction(target_id, target_author, emoji) {
         Ok(b) => b,
         Err(e) => {
             tracing::warn!(event_id, emoji, "reaction add: build failed: {e}");
@@ -3994,14 +4019,27 @@ pub(crate) async fn reaction_remove(rest: &crate::relay::RestClient, event_id: &
 /// Prevents unbounded parallelism when a large batch of events arrives.
 const REACTION_CONCURRENCY: usize = 10;
 
+/// An event an agent status reaction is attached to.
+///
+/// Adding a reaction needs the target's author for the NIP-25 `p` tag;
+/// removing one does not (a kind:5 delete keys off the reaction's own id).
+#[derive(Clone)]
+pub(crate) struct ReactionTarget {
+    pub(crate) event_id: String,
+    pub(crate) author: nostr::PublicKey,
+}
+
 /// Add 💬 to all events, capped at `REACTION_CONCURRENCY` concurrent requests.
 /// Awaited inline before the prompt fires.
-async fn react_working(rest: &crate::relay::RestClient, event_ids: &[String]) {
-    for chunk in event_ids.chunks(REACTION_CONCURRENCY) {
+///
+/// Targets are `(event_id, author)` pairs — the author rides along so each
+/// kind:7 can carry its NIP-25 `p` tag.
+async fn react_working(rest: &crate::relay::RestClient, targets: &[ReactionTarget]) {
+    for chunk in targets.chunks(REACTION_CONCURRENCY) {
         futures_util::future::join_all(
             chunk
                 .iter()
-                .map(|eid| reaction_add(rest, eid, REACTION_WORKING)),
+                .map(|t| reaction_add(rest, &t.event_id, t.author, REACTION_WORKING)),
         )
         .await;
     }

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -3854,8 +3854,8 @@ fn pct_encode(s: &str) -> String {
 /// Returns immediately on timeout or any error — reactions are cosmetic.
 ///
 /// `target_author` is the pubkey of the event being reacted to; it becomes the
-/// NIP-25 `p` tag. The agent's 👀/💬 indicators are reactions like any other,
-/// so they carry it too rather than emitting a non-conformant kind:7.
+/// NIP-25 `p` tag (a SHOULD). The agent's 👀/💬 indicators are reactions like
+/// any other, so they carry it too rather than dropping the recommended tag.
 pub(crate) async fn reaction_add(
     rest: &crate::relay::RestClient,
     event_id: &str,

--- a/crates/buzz-cli/src/commands/reactions.rs
+++ b/crates/buzz-cli/src/commands/reactions.rs
@@ -6,6 +6,32 @@ use crate::client::{normalize_write_response, BuzzClient};
 use crate::error::CliError;
 use crate::validate::validate_hex64;
 
+/// Look up the author of a reaction's target event.
+///
+/// NIP-25 requires the reaction to carry the target author's `p` tag, and the
+/// CLI is only given an event id — so resolve the author from the relay. The
+/// relay rejects reactions whose target it cannot find, so a target that does
+/// not resolve here would have been rejected on submit anyway; failing at this
+/// point just produces a clearer message.
+async fn fetch_reaction_target_author(
+    client: &BuzzClient,
+    event_id: &str,
+) -> Result<nostr::PublicKey, CliError> {
+    let raw = client
+        .query(&serde_json::json!({ "ids": [event_id], "limit": 1 }))
+        .await?;
+    let events: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| CliError::Other(format!("failed to parse target event query: {e}")))?;
+    let author = events
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|ev| ev.get("pubkey"))
+        .and_then(|pk| pk.as_str())
+        .ok_or_else(|| CliError::Other(format!("reaction target event {event_id} not found")))?;
+    nostr::PublicKey::parse(author)
+        .map_err(|e| CliError::Other(format!("target event has an invalid pubkey: {e}")))
+}
+
 pub async fn cmd_add_reaction(
     client: &BuzzClient,
     event_id: &str,
@@ -15,12 +41,13 @@ pub async fn cmd_add_reaction(
     validate_hex64(event_id)?;
     let target_eid =
         EventId::parse(event_id).map_err(|e| CliError::Usage(format!("invalid event ID: {e}")))?;
+    let target_author = fetch_reaction_target_author(client, event_id).await?;
 
     let builder = if let Some(url) = emoji_url {
-        buzz_sdk::build_custom_emoji_reaction(target_eid, emoji, url)
+        buzz_sdk::build_custom_emoji_reaction(target_eid, target_author, emoji, url)
             .map_err(|e| CliError::Other(format!("build_custom_emoji_reaction failed: {e}")))?
     } else {
-        buzz_sdk::build_reaction(target_eid, emoji)
+        buzz_sdk::build_reaction(target_eid, target_author, emoji)
             .map_err(|e| CliError::Other(format!("build_reaction failed: {e}")))?
     };
 

--- a/crates/buzz-cli/src/commands/reactions.rs
+++ b/crates/buzz-cli/src/commands/reactions.rs
@@ -8,7 +8,7 @@ use crate::validate::validate_hex64;
 
 /// Look up the author of a reaction's target event.
 ///
-/// NIP-25 requires the reaction to carry the target author's `p` tag, and the
+/// NIP-25 recommends the reaction carry the target author's `p` tag, and the
 /// CLI is only given an event id — so resolve the author from the relay. The
 /// relay rejects reactions whose target it cannot find, so a target that does
 /// not resolve here would have been rejected on submit anyway; failing at this

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -472,11 +472,12 @@ pub fn build_vote(
 
 /// Build a NIP-25 reaction event (kind 7). Emoji max 64 chars.
 ///
-/// `target_author` is the pubkey of the event being reacted to. NIP-25 requires
-/// the reaction to carry the target's `p` tag; it is what lets the author (and
-/// any NIP-01 client) find the reaction with a `{"kinds":[7],"#p":[<self>]}`
-/// notification filter. Omitting it makes the reaction invisible to every
-/// notification surface, so it is a required argument rather than an option.
+/// `target_author` is the pubkey of the event being reacted to. NIP-25
+/// recommends the reaction carry the target's `p` tag (a SHOULD); it is what
+/// lets the author (and any NIP-01 client) find the reaction with a
+/// `{"kinds":[7],"#p":[<self>]}` notification filter. Omitting it hides the
+/// reaction from every notification surface, so it is a required argument
+/// rather than an option.
 ///
 /// `.allow_self_tagging()` is required: reacting to your own message makes the
 /// `p` tag match the signer, and nostr 0.44 strips matching `p` tags by

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -471,24 +471,43 @@ pub fn build_vote(
 }
 
 /// Build a NIP-25 reaction event (kind 7). Emoji max 64 chars.
+///
+/// `target_author` is the pubkey of the event being reacted to. NIP-25 requires
+/// the reaction to carry the target's `p` tag; it is what lets the author (and
+/// any NIP-01 client) find the reaction with a `{"kinds":[7],"#p":[<self>]}`
+/// notification filter. Omitting it makes the reaction invisible to every
+/// notification surface, so it is a required argument rather than an option.
+///
+/// `.allow_self_tagging()` is required: reacting to your own message makes the
+/// `p` tag match the signer, and nostr 0.44 strips matching `p` tags by
+/// default. Without it, self-reactions would silently regress to the
+/// no-`p`-tag wire form.
 pub fn build_reaction(
     target_event_id: nostr::EventId,
+    target_author: nostr::PublicKey,
     emoji: &str,
 ) -> Result<EventBuilder, SdkError> {
     if emoji.chars().count() > 64 {
         return Err(SdkError::EmojiTooLong);
     }
-    let tags = vec![tag(&["e", &target_event_id.to_hex()])?];
-    Ok(EventBuilder::new(Kind::Custom(7), emoji).tags(tags))
+    let tags = vec![
+        tag(&["e", &target_event_id.to_hex()])?,
+        tag(&["p", &target_author.to_hex()])?,
+    ];
+    Ok(EventBuilder::new(Kind::Custom(7), emoji)
+        .tags(tags)
+        .allow_self_tagging())
 }
 
 /// Build a NIP-25 reaction event using a NIP-30 custom emoji.
 ///
 /// The reaction content is `:shortcode:` and the event carries exactly one
 /// `["emoji", shortcode, url]` tag, matching NIP-25's custom emoji reaction
-/// guidance.
+/// guidance. `target_author` carries the same NIP-25 `p` tag as
+/// [`build_reaction`], including its `.allow_self_tagging()` requirement.
 pub fn build_custom_emoji_reaction(
     target_event_id: nostr::EventId,
+    target_author: nostr::PublicKey,
     shortcode: &str,
     url: &str,
 ) -> Result<EventBuilder, SdkError> {
@@ -497,9 +516,12 @@ pub fn build_custom_emoji_reaction(
     let content = format!(":{shortcode}:");
     let tags = vec![
         tag(&["e", &target_event_id.to_hex()])?,
+        tag(&["p", &target_author.to_hex()])?,
         tag(&["emoji", &shortcode, url])?,
     ];
-    Ok(EventBuilder::new(Kind::Custom(7), content).tags(tags))
+    Ok(EventBuilder::new(Kind::Custom(7), content)
+        .tags(tags)
+        .allow_self_tagging())
 }
 
 /// Build a deletion event targeting a reaction (kind 5).
@@ -2678,9 +2700,28 @@ mod tests {
     #[test]
     fn reaction_happy_path() {
         let eid = event_id();
-        let ev = sign(build_reaction(eid, "👍").unwrap());
+        let author = keys().public_key();
+        let ev = sign(build_reaction(eid, author, "👍").unwrap());
         assert_eq!(ev.kind.as_u16(), 7);
         assert_eq!(ev.content, "👍");
+        assert!(has_tag(&ev, "e", &eid.to_hex()));
+        // NIP-25: the reaction MUST carry the target author's `p` tag so
+        // `{"kinds":[7],"#p":[author]}` notification filters match.
+        assert!(has_tag(&ev, "p", &author.to_hex()));
+    }
+
+    #[test]
+    fn reaction_keeps_p_tag_when_reacting_to_own_message() {
+        // Self-reaction: the `p` tag equals the signer, which nostr 0.44
+        // scrubs unless `.allow_self_tagging()` is set. Pins that the p tag
+        // survives so a self-reaction is still NIP-25 conformant.
+        let k = keys();
+        let eid = event_id();
+        let ev = build_reaction(eid, k.public_key(), "👍")
+            .unwrap()
+            .sign_with_keys(&k)
+            .expect("sign");
+        assert!(has_tag(&ev, "p", &k.public_key().to_hex()));
     }
 
     #[test]
@@ -2688,7 +2729,7 @@ mod tests {
         let eid = event_id();
         let long_emoji = "a".repeat(65);
         assert!(matches!(
-            build_reaction(eid, &long_emoji),
+            build_reaction(eid, keys().public_key(), &long_emoji),
             Err(SdkError::EmojiTooLong)
         ));
     }
@@ -2697,19 +2738,26 @@ mod tests {
     fn reaction_emoji_max_len_ok() {
         let eid = event_id();
         let max_emoji = "a".repeat(64);
-        assert!(build_reaction(eid, &max_emoji).is_ok());
+        assert!(build_reaction(eid, keys().public_key(), &max_emoji).is_ok());
     }
 
     #[test]
     fn custom_emoji_reaction_happy_path() {
         let eid = event_id();
+        let author = keys().public_key();
         let ev = sign(
-            build_custom_emoji_reaction(eid, ":Party_Parrot:", "https://example.com/parrot.png")
-                .unwrap(),
+            build_custom_emoji_reaction(
+                eid,
+                author,
+                ":Party_Parrot:",
+                "https://example.com/parrot.png",
+            )
+            .unwrap(),
         );
         assert_eq!(ev.kind.as_u16(), 7);
         assert_eq!(ev.content, ":party_parrot:");
         assert!(has_tag(&ev, "emoji", "party_parrot"));
+        assert!(has_tag(&ev, "p", &author.to_hex()));
     }
 
     #[test]
@@ -2717,7 +2765,13 @@ mod tests {
         let eid = event_id();
         let shortcode = "a".repeat(MAX_CUSTOM_EMOJI_SHORTCODE_LEN);
         let ev = sign(
-            build_custom_emoji_reaction(eid, &shortcode, "https://example.com/max.png").unwrap(),
+            build_custom_emoji_reaction(
+                eid,
+                keys().public_key(),
+                &shortcode,
+                "https://example.com/max.png",
+            )
+            .unwrap(),
         );
 
         assert_eq!(ev.content, format!(":{shortcode}:"));
@@ -2731,7 +2785,12 @@ mod tests {
         let shortcode = "a".repeat(MAX_CUSTOM_EMOJI_SHORTCODE_LEN + 1);
 
         assert!(matches!(
-            build_custom_emoji_reaction(eid, &shortcode, "https://example.com/too-long.png"),
+            build_custom_emoji_reaction(
+                eid,
+                keys().public_key(),
+                &shortcode,
+                "https://example.com/too-long.png"
+            ),
             Err(SdkError::InvalidInput(message)) if message.contains("exceeds 64 bytes")
         ));
     }

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -822,21 +822,32 @@ pub async fn send_managed_agent_channel_message(
     })
 }
 
+/// `target_pubkey` is the *displayed* author of the reacted-to message — the
+/// pubkey the timeline resolved via `resolveEventAuthorPubkey`, not the raw
+/// signer. For relay-signed agent messages those differ, and the person who
+/// should see the notification is the resolved author. Callers already hold
+/// this on the message they are reacting to, so it is passed in rather than
+/// re-derived here from a second relay round trip.
 #[tauri::command]
 pub async fn add_reaction(
     event_id: String,
     emoji: String,
     emoji_url: Option<String>,
+    target_pubkey: String,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
     let target_eid = EventId::from_hex(&event_id).map_err(|e| format!("invalid event ID: {e}"))?;
+    let target_author = PublicKey::from_hex(target_pubkey.trim())
+        .map_err(|e| format!("invalid target pubkey: {e}"))?;
     let builder = match emoji_url {
         // Custom-emoji reaction (NIP-30): kind:7 with `:shortcode:` content and
         // an `["emoji", shortcode, url]` tag. Delegates to the SDK builder so
         // shortcode normalization + validation match the relay exactly.
-        Some(url) => buzz_sdk_pkg::build_custom_emoji_reaction(target_eid, emoji.trim(), &url)
-            .map_err(|e| format!("invalid custom emoji reaction: {e}"))?,
-        None => events::build_reaction(target_eid, emoji.trim())?,
+        Some(url) => {
+            buzz_sdk_pkg::build_custom_emoji_reaction(target_eid, target_author, emoji.trim(), &url)
+                .map_err(|e| format!("invalid custom emoji reaction: {e}"))?
+        }
+        None => events::build_reaction(target_eid, target_author, emoji.trim())?,
     };
     submit_event(builder, &state).await?;
     Ok(())

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -822,12 +822,11 @@ pub async fn send_managed_agent_channel_message(
     })
 }
 
-/// `target_pubkey` is the *displayed* author of the reacted-to message — the
-/// pubkey the timeline resolved via `resolveEventAuthorPubkey`, not the raw
-/// signer. For relay-signed agent messages those differ, and the person who
-/// should see the notification is the resolved author. Callers already hold
-/// this on the message they are reacting to, so it is passed in rather than
-/// re-derived here from a second relay round trip.
+/// `target_pubkey` is the signer of the reacted-to event — the pubkey NIP-25's
+/// `p` tag names. Callers pass the timeline's `signerPubkey` (not the resolved
+/// display author, which a relay-signed agent message rewrites), so the tag
+/// matches what every other Buzz surface emits for the same target. It is
+/// passed in rather than re-derived here from a second relay round trip.
 #[tauri::command]
 pub async fn add_reaction(
     event_id: String,

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -442,14 +442,31 @@ pub fn build_delete_compat(
 // ── Reactions ────────────────────────────────────────────────────────────────
 
 /// Kind 7 — NIP-25 reaction.
-pub fn build_reaction(target_event_id: EventId, emoji: &str) -> Result<EventBuilder, String> {
+///
+/// `target_author` is the pubkey of the reacted-to event. NIP-25 requires the
+/// `p` tag: it is what makes the reaction visible to a
+/// `{"kinds":[7],"#p":[<self>]}` notification filter (the shape the relay's
+/// push-lease surface advertises for kind 7).
+///
+/// `.allow_self_tagging()` is required: reacting to your own message makes the
+/// `p` tag match the signer, and nostr strips matching `p` tags by default.
+pub fn build_reaction(
+    target_event_id: EventId,
+    target_author: nostr::PublicKey,
+    emoji: &str,
+) -> Result<EventBuilder, String> {
     if emoji.chars().count() > MAX_EMOJI_CHARS {
         return Err(format!(
             "emoji exceeds maximum length of {MAX_EMOJI_CHARS} characters"
         ));
     }
-    let tags = vec![tag(vec!["e", &target_event_id.to_hex()])?];
-    Ok(EventBuilder::new(Kind::Custom(7), emoji).tags(tags))
+    let tags = vec![
+        tag(vec!["e", &target_event_id.to_hex()])?,
+        tag(vec!["p", &target_author.to_hex()])?,
+    ];
+    Ok(EventBuilder::new(Kind::Custom(7), emoji)
+        .tags(tags)
+        .allow_self_tagging())
 }
 
 /// Kind 5 — delete a reaction event.

--- a/desktop/src-tauri/src/events/mod.rs
+++ b/desktop/src-tauri/src/events/mod.rs
@@ -11,6 +11,11 @@
 use buzz_core_pkg::kind::{KIND_IA_ARCHIVE_REQUEST, KIND_IA_UNARCHIVE_REQUEST};
 use nostr::{EventBuilder, EventId, Kind, Tag};
 use uuid::Uuid;
+
+mod reactions;
+
+pub use reactions::{build_reaction, build_remove_reaction};
+
 // ── Constants ────────────────────────────────────────────────────────────────
 
 /// Maximum content size — matches buzz-sdk (64 KiB).
@@ -20,11 +25,11 @@ const MAX_CONTENT_BYTES: usize = 64 * 1024;
 const MAX_MENTIONS: usize = 50;
 
 /// Maximum emoji length in characters — matches buzz-sdk.
-const MAX_EMOJI_CHARS: usize = 64;
+pub(super) const MAX_EMOJI_CHARS: usize = 64;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-fn tag(parts: Vec<&str>) -> Result<Tag, String> {
+pub(super) fn tag(parts: Vec<&str>) -> Result<Tag, String> {
     Tag::parse(parts).map_err(|e| format!("invalid tag: {e}"))
 }
 
@@ -436,42 +441,6 @@ pub fn build_delete_compat(
         tag(vec!["h", &channel_id.to_string()])?,
         tag(vec!["e", &target_event_id.to_hex()])?,
     ];
-    Ok(EventBuilder::new(Kind::Custom(5), "").tags(tags))
-}
-
-// ── Reactions ────────────────────────────────────────────────────────────────
-
-/// Kind 7 — NIP-25 reaction.
-///
-/// `target_author` is the pubkey of the reacted-to event. NIP-25 requires the
-/// `p` tag: it is what makes the reaction visible to a
-/// `{"kinds":[7],"#p":[<self>]}` notification filter (the shape the relay's
-/// push-lease surface advertises for kind 7).
-///
-/// `.allow_self_tagging()` is required: reacting to your own message makes the
-/// `p` tag match the signer, and nostr strips matching `p` tags by default.
-pub fn build_reaction(
-    target_event_id: EventId,
-    target_author: nostr::PublicKey,
-    emoji: &str,
-) -> Result<EventBuilder, String> {
-    if emoji.chars().count() > MAX_EMOJI_CHARS {
-        return Err(format!(
-            "emoji exceeds maximum length of {MAX_EMOJI_CHARS} characters"
-        ));
-    }
-    let tags = vec![
-        tag(vec!["e", &target_event_id.to_hex()])?,
-        tag(vec!["p", &target_author.to_hex()])?,
-    ];
-    Ok(EventBuilder::new(Kind::Custom(7), emoji)
-        .tags(tags)
-        .allow_self_tagging())
-}
-
-/// Kind 5 — delete a reaction event.
-pub fn build_remove_reaction(reaction_event_id: EventId) -> Result<EventBuilder, String> {
-    let tags = vec![tag(vec!["e", &reaction_event_id.to_hex()])?];
     Ok(EventBuilder::new(Kind::Custom(5), "").tags(tags))
 }
 

--- a/desktop/src-tauri/src/events/reactions.rs
+++ b/desktop/src-tauri/src/events/reactions.rs
@@ -1,0 +1,101 @@
+//! NIP-25 reaction builders (kind:7 add, kind:5 remove).
+//!
+//! Split out of the parent `events` module to keep each builder file focused
+//! and under the repo's per-file line limit. Shares the parent's `tag` helper
+//! and `MAX_EMOJI_CHARS` limit so validation matches the other builders.
+
+use nostr::{EventBuilder, EventId, Kind};
+
+use super::{tag, MAX_EMOJI_CHARS};
+
+/// Kind 7 — NIP-25 reaction.
+///
+/// `target_author` is the pubkey of the reacted-to event. NIP-25 recommends the
+/// `p` tag (a SHOULD): it is what makes the reaction visible to a
+/// `{"kinds":[7],"#p":[<self>]}` notification filter — the shape the relay's
+/// push-lease surface advertises for kind 7. Pass the event's signer, so the
+/// tag matches what every other Buzz client emits for the same target.
+///
+/// `.allow_self_tagging()` is required: reacting to your own message makes the
+/// `p` tag match the signer, and nostr strips matching `p` tags by default.
+pub fn build_reaction(
+    target_event_id: EventId,
+    target_author: nostr::PublicKey,
+    emoji: &str,
+) -> Result<EventBuilder, String> {
+    if emoji.chars().count() > MAX_EMOJI_CHARS {
+        return Err(format!(
+            "emoji exceeds maximum length of {MAX_EMOJI_CHARS} characters"
+        ));
+    }
+    let tags = vec![
+        tag(vec!["e", &target_event_id.to_hex()])?,
+        tag(vec!["p", &target_author.to_hex()])?,
+    ];
+    Ok(EventBuilder::new(Kind::Custom(7), emoji)
+        .tags(tags)
+        .allow_self_tagging())
+}
+
+/// Kind 5 — delete a reaction event.
+pub fn build_remove_reaction(reaction_event_id: EventId) -> Result<EventBuilder, String> {
+    let tags = vec![tag(vec!["e", &reaction_event_id.to_hex()])?];
+    Ok(EventBuilder::new(Kind::Custom(5), "").tags(tags))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::Keys;
+
+    fn has_tag(ev: &nostr::Event, key: &str, val: &str) -> bool {
+        ev.tags.iter().any(|t| {
+            let s = t.as_slice();
+            s.first().map(String::as_str) == Some(key) && s.get(1).map(String::as_str) == Some(val)
+        })
+    }
+
+    #[test]
+    fn reaction_carries_target_e_and_p_tags() {
+        let target = Keys::generate();
+        let author = Keys::generate().public_key();
+        let target_id = EventId::all_zeros();
+        let ev = build_reaction(target_id, author, "👍")
+            .unwrap()
+            .sign_with_keys(&target)
+            .unwrap();
+        assert_eq!(ev.kind, Kind::Custom(7));
+        assert!(has_tag(&ev, "e", &target_id.to_hex()));
+        assert!(has_tag(&ev, "p", &author.to_hex()));
+    }
+
+    #[test]
+    fn self_reaction_keeps_its_p_tag() {
+        // Reacting to your own message: the `p` tag equals the signer, which
+        // nostr strips unless `.allow_self_tagging()` is set. Pins that it isn't.
+        let me = Keys::generate();
+        let ev = build_reaction(EventId::all_zeros(), me.public_key(), "👍")
+            .unwrap()
+            .sign_with_keys(&me)
+            .unwrap();
+        assert!(has_tag(&ev, "p", &me.public_key().to_hex()));
+    }
+
+    #[test]
+    fn reaction_rejects_overlong_emoji() {
+        let author = Keys::generate().public_key();
+        let long = "a".repeat(MAX_EMOJI_CHARS + 1);
+        assert!(build_reaction(EventId::all_zeros(), author, &long).is_err());
+    }
+
+    #[test]
+    fn remove_reaction_targets_the_reaction_event() {
+        let reaction_id = EventId::all_zeros();
+        let ev = build_remove_reaction(reaction_id)
+            .unwrap()
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        assert_eq!(ev.kind, Kind::Custom(5));
+        assert!(has_tag(&ev, "e", &reaction_id.to_hex()));
+    }
+}

--- a/desktop/src/features/channels/useChannelPaneHandlers.ts
+++ b/desktop/src/features/channels/useChannelPaneHandlers.ts
@@ -350,7 +350,7 @@ export function useChannelPaneHandlers({
 
   const handleToggleReaction = React.useCallback(
     async (
-      message: Pick<TimelineMessage, "id" | "rootId">,
+      message: Pick<TimelineMessage, "id" | "rootId" | "pubkey">,
       emoji: string,
       remove: boolean,
     ) => {
@@ -358,6 +358,7 @@ export function useChannelPaneHandlers({
         emoji,
         eventId: message.id,
         remove,
+        targetPubkey: message.pubkey,
       });
       if (!remove) {
         recordThreadInteraction(message.rootId ?? message.id);

--- a/desktop/src/features/channels/useChannelPaneHandlers.ts
+++ b/desktop/src/features/channels/useChannelPaneHandlers.ts
@@ -350,7 +350,7 @@ export function useChannelPaneHandlers({
 
   const handleToggleReaction = React.useCallback(
     async (
-      message: Pick<TimelineMessage, "id" | "rootId" | "pubkey">,
+      message: Pick<TimelineMessage, "id" | "rootId" | "signerPubkey">,
       emoji: string,
       remove: boolean,
     ) => {
@@ -358,7 +358,10 @@ export function useChannelPaneHandlers({
         emoji,
         eventId: message.id,
         remove,
-        targetPubkey: message.pubkey,
+        // NIP-25's `p` tag is the signer of the reacted-to event, not its
+        // displayed author — a relay-signed agent message resolves those to
+        // different pubkeys, and the protocol tag must be the signer.
+        targetPubkey: message.signerPubkey,
       });
       if (!remove) {
         recordThreadInteraction(message.rootId ?? message.id);

--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -900,7 +900,8 @@ export function HomeView({
                         emoji,
                         eventId: message.id,
                         remove,
-                        targetPubkey: message.pubkey,
+                        // NIP-25 `p` tag is the reacted-to event's signer.
+                        targetPubkey: message.signerPubkey,
                       });
                       if (!remove) {
                         recordThreadInteraction(

--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -900,6 +900,7 @@ export function HomeView({
                         emoji,
                         eventId: message.id,
                         remove,
+                        targetPubkey: message.pubkey,
                       });
                       if (!remove) {
                         recordThreadInteraction(

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -652,8 +652,9 @@ export function useToggleReactionMutation() {
       emoji: string;
       remove: boolean;
       /**
-       * Resolved author of the message being reacted to. Becomes the kind:7
-       * NIP-25 `p` tag so the author's notification filter can match.
+       * Signer of the message being reacted to. Becomes the kind:7 NIP-25 `p`
+       * tag so the author's notification filter can match. Pass the timeline's
+       * `signerPubkey`, not its display author.
        */
       targetPubkey: string | undefined;
     }
@@ -664,9 +665,9 @@ export function useToggleReactionMutation() {
         return;
       }
 
-      // NIP-25 requires the target author's `p` tag, so a message whose author
-      // we could not resolve cannot produce a conformant reaction. Every
-      // timeline row carries a resolved author, so this is a guard, not a
+      // NIP-25 recommends the target author's `p` tag, so without a resolved
+      // signer we would emit a reaction no notification filter can match.
+      // Every timeline row carries a signer, so this is a guard, not a
       // reachable UI state.
       if (!targetPubkey) {
         throw new Error("Cannot react: the message author is unknown.");

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -651,12 +651,25 @@ export function useToggleReactionMutation() {
       eventId: string;
       emoji: string;
       remove: boolean;
+      /**
+       * Resolved author of the message being reacted to. Becomes the kind:7
+       * NIP-25 `p` tag so the author's notification filter can match.
+       */
+      targetPubkey: string | undefined;
     }
   >({
-    mutationFn: async ({ eventId, emoji, remove }) => {
+    mutationFn: async ({ eventId, emoji, remove, targetPubkey }) => {
       if (remove) {
         await removeReaction(eventId, emoji);
         return;
+      }
+
+      // NIP-25 requires the target author's `p` tag, so a message whose author
+      // we could not resolve cannot produce a conformant reaction. Every
+      // timeline row carries a resolved author, so this is a guard, not a
+      // reachable UI state.
+      if (!targetPubkey) {
+        throw new Error("Cannot react: the message author is unknown.");
       }
 
       // Custom-emoji reaction: emoji is `:shortcode:`. Resolve its image URL
@@ -666,7 +679,7 @@ export function useToggleReactionMutation() {
         emoji,
         queryClient.getQueryData<CustomEmoji[]>(customEmojiQueryKey),
       );
-      await addReaction(eventId, emoji, emojiUrl);
+      await addReaction(eventId, emoji, targetPubkey, emojiUrl);
     },
   });
 }

--- a/desktop/src/features/pulse/lib/useNoteActions.ts
+++ b/desktop/src/features/pulse/lib/useNoteActions.ts
@@ -76,6 +76,7 @@ export function usePulseNoteActions({
           eventId: note.id,
           emoji: "+",
           remove,
+          targetPubkey: note.pubkey,
         });
         if (currentPubkey) {
           void queryClient.invalidateQueries({

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -627,8 +627,8 @@ export async function deleteMessage(
 }
 
 /**
- * `targetPubkey` is the resolved author of the reacted-to message. It becomes
- * the NIP-25 `p` tag on the kind:7, which is what lets the author find the
+ * `targetPubkey` is the signer of the reacted-to event. It becomes the NIP-25
+ * `p` tag on the kind:7 (a SHOULD), which is what lets the author find the
  * reaction with a `{"kinds":[7],"#p":[self]}` notification filter.
  */
 export async function addReaction(

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -626,12 +626,18 @@ export async function deleteMessage(
   await invokeTauri("delete_message", { channelId, eventId });
 }
 
+/**
+ * `targetPubkey` is the resolved author of the reacted-to message. It becomes
+ * the NIP-25 `p` tag on the kind:7, which is what lets the author find the
+ * reaction with a `{"kinds":[7],"#p":[self]}` notification filter.
+ */
 export async function addReaction(
   eventId: string,
   emoji: string,
+  targetPubkey: string,
   emojiUrl?: string,
 ): Promise<void> {
-  await invokeTauri("add_reaction", { eventId, emoji, emojiUrl });
+  await invokeTauri("add_reaction", { eventId, emoji, emojiUrl, targetPubkey });
 }
 
 export async function removeReaction(

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -9349,17 +9349,35 @@ async function handleAddReaction(
     throw new Error(`mock add_reaction: unknown target event ${args.eventId}`);
   }
 
-  // The real command is handed the target author by its caller; the mock can
-  // also read it back out of its own event store, so specs that drive
-  // `add_reaction` directly need not thread a pubkey through.
-  const targetPubkey =
-    args.targetPubkey ?? findMockEventAuthor(args.eventId) ?? "";
+  // The real command's `p` tag is the *signer* of the target event. The mock
+  // store holds that event, so its recorded author is the ground truth — use
+  // it rather than the caller-supplied `targetPubkey`, which lets the direct
+  // `invoke("add_reaction", …)` specs assert the tag without threading a
+  // pubkey through, and guarantees the tag is never an empty string. When the
+  // caller does supply one (the UI path passes `signerPubkey`), verify it
+  // agrees, so the specs pin that the UI sends the signer and not the display
+  // author.
+  const targetPubkey = findMockEventAuthor(args.eventId);
+  if (!targetPubkey) {
+    throw new Error(
+      `mock add_reaction: no recorded author for target event ${args.eventId}`,
+    );
+  }
+  if (
+    args.targetPubkey &&
+    args.targetPubkey.toLowerCase() !== targetPubkey.toLowerCase()
+  ) {
+    throw new Error(
+      `mock add_reaction: targetPubkey ${args.targetPubkey} does not match ` +
+        `the target event's signer ${targetPubkey} — pass the signer's pubkey`,
+    );
+  }
 
   const emoji = args.emoji.trim();
   // Real add_reaction events carry the target `e` tag plus the NIP-25 `p` tag
-  // naming the reacted-to author. Channel live subscriptions already know which
-  // channel matched and restore that context before merging the event into the
-  // timeline cache.
+  // naming the reacted-to event's signer. Channel live subscriptions already
+  // know which channel matched and restore that context before merging the
+  // event into the timeline cache.
   const tags: string[][] = [
     ["e", args.eventId],
     ["p", targetPubkey],

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -9316,6 +9316,17 @@ function findMockEventChannel(eventId: string): string | undefined {
   return undefined;
 }
 
+/** Author of a stored mock event, for the NIP-25 `p` tag on reactions. */
+function findMockEventAuthor(eventId: string): string | undefined {
+  for (const events of mockMessages.values()) {
+    const match = events.find((event) => event.id === eventId);
+    if (match) {
+      return match.pubkey;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Mock the `add_reaction` Tauri command. Mirrors the real Rust command: a
  * kind:7 whose content is the emoji, plus — for a custom emoji — the NIP-30
@@ -9325,7 +9336,12 @@ function findMockEventChannel(eventId: string): string | undefined {
  * kind:7). Unicode reactions carry no emoji tag, like the real command.
  */
 async function handleAddReaction(
-  args: { eventId: string; emoji: string; emojiUrl?: string | null },
+  args: {
+    eventId: string;
+    emoji: string;
+    emojiUrl?: string | null;
+    targetPubkey?: string;
+  },
   config: E2eConfig | undefined,
 ): Promise<void> {
   const channelId = findMockEventChannel(args.eventId);
@@ -9333,11 +9349,21 @@ async function handleAddReaction(
     throw new Error(`mock add_reaction: unknown target event ${args.eventId}`);
   }
 
+  // The real command is handed the target author by its caller; the mock can
+  // also read it back out of its own event store, so specs that drive
+  // `add_reaction` directly need not thread a pubkey through.
+  const targetPubkey =
+    args.targetPubkey ?? findMockEventAuthor(args.eventId) ?? "";
+
   const emoji = args.emoji.trim();
-  // Real add_reaction events carry only the target `e` tag. Channel live
-  // subscriptions already know which channel matched and restore that context
-  // before merging the event into the timeline cache.
-  const tags: string[][] = [["e", args.eventId]];
+  // Real add_reaction events carry the target `e` tag plus the NIP-25 `p` tag
+  // naming the reacted-to author. Channel live subscriptions already know which
+  // channel matched and restore that context before merging the event into the
+  // timeline cache.
+  const tags: string[][] = [
+    ["e", args.eventId],
+    ["p", targetPubkey],
+  ];
   if (args.emojiUrl) {
     const shortcode = emoji.replace(/^:+/, "").replace(/:+$/, "").toLowerCase();
     tags.push(["emoji", shortcode, args.emojiUrl]);

--- a/mobile/lib/features/channels/channel_detail_page/system_rows.dart
+++ b/mobile/lib/features/channels/channel_detail_page/system_rows.dart
@@ -64,7 +64,7 @@ class _SystemMessageRow extends HookConsumerWidget {
         ),
       );
       if (reactedMessages.isEmpty) {
-        actions.addReaction(message.id, emoji);
+        actions.addReaction(message.id, message.pubkey, emoji);
         return;
       }
       for (final source in reactedMessages) {

--- a/mobile/lib/features/channels/channel_management_provider.dart
+++ b/mobile/lib/features/channels/channel_management_provider.dart
@@ -778,10 +778,10 @@ class ChannelActions {
     _ref.invalidate(channelBotPubkeysProvider(channelId));
   }
 
-  /// Add a NIP-25 reaction to [eventId], authored by [targetPubkey].
+  /// Add a NIP-25 reaction to [eventId], whose signer is [targetPubkey].
   ///
-  /// [targetPubkey] becomes the `p` tag. NIP-25 requires it, and it is what
-  /// lets the reacted-to author find the reaction with a
+  /// [targetPubkey] becomes the `p` tag. NIP-25 recommends it (a SHOULD), and
+  /// it is what lets the reacted-to author find the reaction with a
   /// `{"kinds":[7],"#p":[<self>]}` notification filter — without it a reaction
   /// is invisible to every notification surface.
   Future<void> addReaction(

--- a/mobile/lib/features/channels/channel_management_provider.dart
+++ b/mobile/lib/features/channels/channel_management_provider.dart
@@ -778,7 +778,17 @@ class ChannelActions {
     _ref.invalidate(channelBotPubkeysProvider(channelId));
   }
 
-  Future<void> addReaction(String eventId, String emoji) async {
+  /// Add a NIP-25 reaction to [eventId], authored by [targetPubkey].
+  ///
+  /// [targetPubkey] becomes the `p` tag. NIP-25 requires it, and it is what
+  /// lets the reacted-to author find the reaction with a
+  /// `{"kinds":[7],"#p":[<self>]}` notification filter — without it a reaction
+  /// is invisible to every notification surface.
+  Future<void> addReaction(
+    String eventId,
+    String targetPubkey,
+    String emoji,
+  ) async {
     final shortcode = normalizeShortcode(emoji);
     final emojiUrl = reactionEmojiUrl(
       emoji,
@@ -789,6 +799,7 @@ class ChannelActions {
       content: emoji,
       tags: [
         ['e', eventId],
+        ['p', targetPubkey.toLowerCase()],
         if (shortcode != null && emojiUrl != null)
           ['emoji', shortcode, emojiUrl],
       ],

--- a/mobile/lib/features/channels/message_actions.dart
+++ b/mobile/lib/features/channels/message_actions.dart
@@ -691,7 +691,9 @@ class _QuickReactionRow extends ConsumerWidget {
       // The sheet is on its way out, so the burst can't come from this tile —
       // hand it to the pill that's about to appear in the timeline.
       armReactionBurst(pageRef, message, value);
-      pageRef.read(channelActionsProvider).addReaction(message.id, value);
+      pageRef
+          .read(channelActionsProvider)
+          .addReaction(message.id, message.pubkey, value);
     }
 
     return LayoutBuilder(

--- a/mobile/lib/features/channels/reaction_row.dart
+++ b/mobile/lib/features/channels/reaction_row.dart
@@ -48,7 +48,7 @@ void toggleReaction(WidgetRef ref, TimelineMessage message, String emoji) {
     // Only adding counts as a use — removing a reaction shouldn't promote the
     // emoji in the frequently-used ranking.
     ref.read(recentEmojiProvider.notifier).record(emoji);
-    actions.addReaction(message.id, emoji);
+    actions.addReaction(message.id, message.pubkey, emoji);
   }
 }
 
@@ -81,7 +81,9 @@ void showAddReactionPicker({
     onSelect: (emoji) {
       ref.read(recentEmojiProvider.notifier).record(emoji);
       armReactionBurst(ref, message, emoji);
-      ref.read(channelActionsProvider).addReaction(message.id, emoji);
+      ref
+          .read(channelActionsProvider)
+          .addReaction(message.id, message.pubkey, emoji);
     },
   );
 }

--- a/mobile/lib/features/pulse/note_card.dart
+++ b/mobile/lib/features/pulse/note_card.dart
@@ -179,6 +179,7 @@ class NoteCard extends HookConsumerWidget {
                           await toggleNoteUpvote(
                             ref,
                             noteId: note.id,
+                            notePubkey: note.pubkey,
                             isUpvoted: reaction.reactedByCurrentUser,
                             reactionEventId: reaction.currentUserReactionId,
                           );

--- a/mobile/lib/features/pulse/pulse_actions.dart
+++ b/mobile/lib/features/pulse/pulse_actions.dart
@@ -41,9 +41,11 @@ Future<void> publishNote(
   ref.invalidate(likedNotesProvider);
 }
 
+/// [notePubkey] is the note author — it becomes the reaction's NIP-25 `p` tag.
 Future<void> toggleNoteUpvote(
   WidgetRef ref, {
   required String noteId,
+  required String notePubkey,
   required bool isUpvoted,
   String? reactionEventId,
 }) async {
@@ -53,7 +55,7 @@ Future<void> toggleNoteUpvote(
       await actions.removeReaction(reactionEventId, '+');
     }
   } else {
-    await actions.addReaction(noteId, '+');
+    await actions.addReaction(noteId, notePubkey, '+');
   }
   ref.invalidate(likedNotesProvider);
 }


### PR DESCRIPTION
Fixes #2568.

## Problem

Every kind:7 Buzz emits carries only the target `e` tag:

```json
{"kind":7,"tags":[["e","8f8c92f8…"]],"content":"👍", …}
```

NIP-25 also requires the reacted-to author's `p` tag. That tag is not cosmetic — it is the *only* thing a notification feed can key on. Without it, `{"kinds":[7],"#p":[<self>]}` can never match, so a reaction to your message is invisible to every NIP-01 client, which is what @vitorpamplona hit from Amethyst.

It isn't only an interop gap. The relay already ships kind 7 as push-notifiable — `PUSH_KINDS = &[7, 9, 1059, 40007, 46010]` (`crates/buzz-relay/src/handlers/push_lease.rs:15`) — and the lease subscription shape is literally `{"kinds":[7],"#p":[…]}`. The push surface is built around a tag no Buzz client produces.

Four producers were affected: `buzz-sdk`, the desktop Tauri command, `buzz-cli`, and `buzz-acp`'s 👀/💬 status reactions.

## Solution

Thread the target author through every reaction producer.

**`buzz-sdk`** — `build_reaction` / `build_custom_emoji_reaction` take `target_author: nostr::PublicKey` and emit `["p", <author>]`. Required rather than `Option`, so a caller can't silently reintroduce the non-conformant form.

**Both builders now set `.allow_self_tagging()`.** This is the subtle part: reacting to your *own* message makes the `p` tag match the signer, and nostr 0.44 strips matching `p` tags by default. Without it, self-reactions would quietly regress to the old wire form. The repo already relies on this for NIP-IA (`build_archive_identity_request`); the reaction path now does too, pinned by a regression test.

**Desktop** — `add_reaction` takes `target_pubkey` from the caller. The timeline already resolved it via `resolveEventAuthorPubkey`, so this uses the *displayed* author, not the raw signer. For relay-signed agent messages those differ, and the displayed author is who should be notified. Passing it in also avoids a second relay round trip on a hot UI path.

**`buzz-cli`** — only ever gets an event id, so it resolves the author with a kindless `ids:[…]` lookup. That filter shape is explicitly exempt from the `#p` read gate (`req.rs:1061`, "a kindless `ids` lookup is unaffected"). A target that doesn't resolve here would have been rejected by ingest anyway (`invalid: reaction target event not found`); failing early just gives a clearer message.

**`buzz-acp`** — the 👀/💬 indicators are reactions like any other, so they carry the tag too. The author is already on the batch event; `react_working` now takes `(event_id, author)` pairs. Removal is unchanged — a kind:5 delete keys off the reaction's own id, so `ReactionGuard` still only needs ids.

Tag order is `e`, `p`, `emoji`. Ingest resolves the reaction target from the **last** `e` tag (`ingest.rs:2247`), so adding a `p` tag cannot shift target resolution.

## Why this is behaviour-neutral in-app

Worth stating explicitly, since "add a p tag" could plausibly mean "start waking agents on every 👍":

- The desktop feed queries kinds `[9, 40002, 1, 45001, 45003]` (`commands/messages.rs:72`) — no kind 7.
- Mobile's activity feed uses the same kind set (`activity_provider.dart:33`).
- The ACP mention subscription defaults to `[KIND_STREAM_MESSAGE, KIND_WORKFLOW_APPROVAL_REQUESTED, KIND_STREAM_REMINDER]` (`config.rs:1157`) — no kind 7, so p-tagged reactions do not wake agents.
- Kind 7 is not in `P_GATED_KINDS`, so no read path changes.

The only things that change are NIP-25 conformance on the wire and the relay's already-advertised push surface becoming reachable.

## Validation

Toolchain note: this was built on Windows with the `x86_64-pc-windows-gnu` toolchain (no MSVC linker locally), so clippy is 1.97 rather than the pinned 1.95.

- `cargo test -p buzz-sdk --lib` — **234 passed, 0 failed**, including the new `reaction_keeps_p_tag_when_reacting_to_own_message`. I verified that test has teeth: with `.allow_self_tagging()` removed it fails with `assertion failed: has_tag(&ev, "p", …)`, confirming the nostr 0.44 scrub is real and not theoretical.
- `cargo check -p buzz-sdk -p buzz-cli -p buzz-acp` — clean.
- `cargo fmt -p buzz-sdk -p buzz-cli -p buzz-acp -- --check` — clean.
- `cargo clippy -p buzz-sdk -p buzz-cli -p buzz-acp --all-targets -- -D warnings` — the only findings are two pre-existing `question_mark` lints in `crates/buzz-acp/src/queue.rs` (313, 942), a file this PR does not touch; they come from the newer clippy, not from this change.
- `cargo check` on `desktop/src-tauri` — clean (24 pre-existing dead-code warnings in `managed_agents/`, none from this PR).
- `pnpm typecheck` and `pnpm lint` in `desktop/` — both clean.
- `biome format` on the six changed TS files — clean. (Checked against LF copies; my checkout is `core.autocrlf=true`, which makes biome report all 1600 files unformatted locally.)
- Desktop JS unit tests could not run here: the loader crashes on Windows with `ERR_UNSUPPORTED_ESM_URL_SCHEME … Received protocol 'c:'` on a clean tree too. No test references `add_reaction`, so nothing in that suite covers this path either way.

The E2E mock (`e2eBridge.ts`) now emits the `p` tag as well, so `inbox-reactions.spec.ts`'s "real add_reaction wire shape" assertion stays honest. It falls back to reading the author out of its own mock event store when a spec drives `add_reaction` directly without one, so the two existing specs that do that keep working unchanged.

## Follow-up, not done here

NIP-25 also suggests a `k` tag carrying the target's kind, which helps clients filter reaction notifications. Every call site now has the target event in hand so it would be cheap, but it's a separate wire change and I kept this PR to the reported bug.
