### PR TITLE
chore(mobile): relax release check

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -221,8 +221,9 @@ release App because strict tag protection denies direct human creation. The App
 must be installed on `block/buzz`, have Contents write and Metadata read, and
 retain an `always` bypass on the immutable `mobile-v*` tag rules. It does not
 require GitHub Releases permissions, repository Administration permission, or a
-mobile release-branch ruleset. The publisher validates both the App token's
-effective `current_user_can_bypass` value and the exact ruleset bypass actor set.
+mobile release-branch ruleset. The publisher validates the App token's effective
+`current_user_can_bypass` value rather than reading the ruleset's hidden bypass
+actor list.
 
 ---
 

--- a/scripts/release-rulesets.sh
+++ b/scripts/release-rulesets.sh
@@ -22,7 +22,7 @@ require_canonical_repository() {
 }
 
 require_release_tag_ruleset() {
-  local ruleset_endpoint state can_bypass bypass_actors rule_types includes excludes
+  local ruleset_endpoint state can_bypass rule_types includes excludes
 
   command -v gh >/dev/null 2>&1 || fail_release_ruleset "gh is required" || return 1
   ruleset_endpoint="repos/block/buzz/rulesets/$RELEASE_TAG_RULESET_ID"
@@ -36,11 +36,6 @@ require_release_tag_ruleset() {
     fail_release_ruleset "could not verify the release App's tag-ruleset bypass" || return 1
   [[ "$can_bypass" == "always" ]] || \
     fail_release_ruleset "release App cannot always bypass Release tag ruleset $RELEASE_TAG_RULESET_ID (reported '$can_bypass')" || return 1
-
-  bypass_actors="$(gh api "$ruleset_endpoint" --jq '[.bypass_actors[] | [.actor_type, (.actor_id | tostring), .bypass_mode] | join(":")] | sort | join(",")')" || \
-    fail_release_ruleset "could not verify Release tag ruleset $RELEASE_TAG_RULESET_ID bypass actors" || return 1
-  [[ "$bypass_actors" == "Integration:4349119:always" ]] || \
-    fail_release_ruleset "Release tag ruleset $RELEASE_TAG_RULESET_ID has unexpected bypass actors: '$bypass_actors'" || return 1
 
   rule_types="$(gh api "$ruleset_endpoint" --jq '[.rules[].type] | sort | join(",")')" || \
     fail_release_ruleset "could not verify Release tag ruleset $RELEASE_TAG_RULESET_ID rules" || return 1

--- a/scripts/test-mobile-release-candidate-publisher.sh
+++ b/scripts/test-mobile-release-candidate-publisher.sh
@@ -21,7 +21,6 @@ case "${1:-}:${2:-}" in
     case "$*" in
       *'.enforcement'*) printf '%s\n' "${GH_TAG_RULESET_STATE:-active}" ;;
       *'.current_user_can_bypass'*) printf '%s\n' "${GH_CURRENT_USER_CAN_BYPASS-always}" ;;
-      *'.bypass_actors[]'*) printf '%s\n' "${GH_BYPASS_ACTORS:-Integration:4349119:always}" ;;
       *'[.rules[].type]'*) printf '%s\n' "${GH_TAG_RULE_TYPES:-creation,deletion,non_fast_forward,update}" ;;
       *'.conditions.ref_name.include[]'*) printf '%s\n' "${GH_TAG_INCLUDES:-refs/tags/mobile-v*}" ;;
       *'.conditions.ref_name.exclude[]'*) printf '%s\n' "${GH_TAG_EXCLUDES:-}" ;;
@@ -89,21 +88,6 @@ if GH_CURRENT_USER_CAN_BYPASS=never "$publisher" 1.2.3 1 "$GH_TARGET_SHA" >/dev/
 fi
 if GH_CURRENT_USER_CAN_BYPASS='' "$publisher" 1.2.3 1 "$GH_TARGET_SHA" >/dev/null 2>&1; then
   echo "publisher accepted a ruleset response without an effective bypass" >&2
-  exit 1
-fi
-if GH_BYPASS_ACTORS='Integration:4349119:always,Integration:9876543:always' \
-    "$publisher" 1.2.3 1 "$GH_TARGET_SHA" >/dev/null 2>&1; then
-  echo "publisher accepted an extra ruleset bypass actor" >&2
-  exit 1
-fi
-if GH_BYPASS_ACTORS='Integration:9876543:always' \
-    "$publisher" 1.2.3 1 "$GH_TARGET_SHA" >/dev/null 2>&1; then
-  echo "publisher accepted a substituted ruleset bypass actor" >&2
-  exit 1
-fi
-if GH_BYPASS_ACTORS='Integration:4349119:pull_request' \
-    "$publisher" 1.2.3 1 "$GH_TARGET_SHA" >/dev/null 2>&1; then
-  echo "publisher accepted a ruleset bypass actor with the wrong mode" >&2
   exit 1
 fi
 if GH_TAG_RULESET_STATE=disabled "$publisher" 1.2.3 1 "$GH_TARGET_SHA" >/dev/null 2>&1; then


### PR DESCRIPTION
### What changed?

Reverts commit [169d3e43f](https://github.com/block/buzz/commit/169d3e43f83fc151aef98ea3ef5ce6543163a484) that was added to #2144 during review.

`require_release_tag_ruleset` returns to validating the App token's effective `current_user_can_bypass` value.

### Why?

The exact bypass-actor assertion added in #2144's final review round cannot work with the release App's permissions.

GitHub returns a ruleset's `bypass_actors` list only to admin-capable tokens; everyone else gets `null`. The release App deliberately has only Contents write and Metadata read, so the assertion fails on every candidate publication and blocks all mobile releases. Verified in production: [run 30048723817](https://github.com/block/buzz/actions/runs/30048723817) failed with `could not verify Release tag ruleset 14378754 bypass actors`.

The only way to make it work would be granting the release App Administration read, and that is the wrong trade. It widens what a compromised release credential can see across repository administration solely to power a self-check, on a credential whose value comes from being narrow.

Relying on `current_user_can_bypass` instead was the original deliberate design, not an oversight: [RELEASING.md](https://github.com/block/buzz/blob/eda53c382389070cadad463b211b55f9986bb509/RELEASING.md#L196-L200) documented that the App "does not require GitHub Releases permissions, repository Administration permission, or a mobile release-branch ruleset" and that "the publisher validates the App token's effective `current_user_can_bypass` value rather than reading the ruleset's hidden bypass actor list."

What we give up is the drift check requested in [review](https://github.com/block/buzz/pull/2144#pullrequestreview-4767999381): a second bypass actor quietly added to the ruleset would no longer be caught at publication time. That remains a known, accepted gap.

The retained check still fails closed if the release App itself loses its `always` bypass. If we want drift detection back, the right home is an out-of-band audit running with admin credentials (for example a scheduled check), not the release path.

### How is it tested?

`scripts/test-mobile-release-candidate-publisher.sh` and `scripts/test-mobile-release-contract.sh` pass at this head.
