### PR TITLE
fix(desktop): defer default agent pool startup

### DIFF
--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -2127,7 +2127,13 @@ pub fn start_managed_agent_process(
     // Scalar PIDs are migration-only and never establish pair liveness.
     record.runtime_pid = None;
 
-    let mut process = spawn_agent_child(app, record, &key.relay_url, false, owner_hex)?;
+    let mut process = spawn_agent_child(
+        app,
+        record,
+        &key.relay_url,
+        manual_start_uses_lazy_pool(),
+        owner_hex,
+    )?;
     let now = now_iso();
     let receipt = super::ManagedAgentRuntimeReceipt {
         key: key.clone(),
@@ -2150,6 +2156,10 @@ pub fn start_managed_agent_process(
 
     runtimes.insert(key, ManagedAgentPairRuntime::starting(process));
     Ok(())
+}
+
+fn manual_start_uses_lazy_pool() -> bool {
+    true
 }
 
 /// Returns the (key, value) env var pairs that should be forwarded to the

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -1,5 +1,10 @@
 use crate::managed_agents::known_acp_runtime;
 
+#[test]
+fn manual_start_defers_agent_pool_initialization() {
+    assert!(super::manual_start_uses_lazy_pool());
+}
+
 // ── buffer_contains_identifier tests ────────────────────────────────────
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -728,7 +728,7 @@ pub struct UpdateTeamRequest {
 pub const DEFAULT_ACP_COMMAND: &str = "buzz-acp";
 /// ~5 min (320s) — matches the CLI harness default (BUZZ_ACP_IDLE_TIMEOUT).
 pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 320;
-pub const DEFAULT_AGENT_PARALLELISM: u32 = 24;
+pub const DEFAULT_AGENT_PARALLELISM: u32 = 1;
 
 fn default_agent_parallelism() -> u32 {
     DEFAULT_AGENT_PARALLELISM

--- a/desktop/src-tauri/src/managed_agents/types/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/tests.rs
@@ -2,6 +2,29 @@ use super::{AgentDefinition, ManagedAgentRecord};
 use std::path::PathBuf;
 
 #[test]
+fn managed_agent_parallelism_defaults_to_one() {
+    let record: ManagedAgentRecord = serde_json::from_str(
+        r#"{
+            "pubkey": "abcd1234",
+            "name": "test-agent",
+            "private_key_nsec": "nsec1fake",
+            "relay_url": "wss://localhost:3000",
+            "acp_command": "buzz-acp",
+            "agent_command": "codex-acp",
+            "agent_args": [],
+            "mcp_command": "",
+            "turn_timeout_seconds": 320,
+            "system_prompt": null,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z"
+        }"#,
+    )
+    .expect("agent record should deserialize");
+
+    assert_eq!(record.parallelism, 1);
+}
+
+#[test]
 fn persona_record_defaults_active_when_field_is_missing() {
     let record: AgentDefinition = serde_json::from_str(
         r#"{


### PR DESCRIPTION
## Summary

- default new and legacy-deserialized managed agents to one worker instead of 24
- start manually launched managed agents with a lazy ACP pool
- add regressions for the default and manual-start policy

Closes #2631

## Validation

- `just ci`
- `just desktop-tauri-test`
- targeted regression tests after rebasing onto current `main`

## Risk / Notes

Existing agents that explicitly persist higher parallelism keep that value, but their workers are now created on demand after manual start.
