### PR TITLE
fix: expose community icon control on open relays

### DIFF
--- a/desktop/src/features/community-members/ui/CommunityMembersSettingsCard.tsx
+++ b/desktop/src/features/community-members/ui/CommunityMembersSettingsCard.tsx
@@ -12,12 +12,13 @@ import { nip19 } from "nostr-tools";
 import * as React from "react";
 import { toast } from "sonner";
 
+import { canEditCommunityProfile } from "@/shared/api/relayMembers";
 import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import {
   useAddRelayMemberMutation,
   useChangeRelayMemberRoleMutation,
-  useMyRelayMembershipQuery,
+  useMyRelayMembershipLookupQuery,
   useRelayMembersQuery,
   useRemoveRelayMemberMutation,
 } from "@/features/community-members/hooks";
@@ -275,9 +276,13 @@ export function CommunityMembersSettingsCard({
 }: {
   currentPubkey?: string;
 }) {
-  const myMembershipQuery = useMyRelayMembershipQuery();
-  const currentRole = myMembershipQuery.data?.role ?? null;
+  const myMembershipQuery = useMyRelayMembershipLookupQuery();
+  const currentRole = myMembershipQuery.data?.membership?.role ?? null;
   const canManageRelay = currentRole === "owner" || currentRole === "admin";
+  // Open relays do not advertise NIP-43, so they cannot expose an admin role
+  // snapshot. Keep the icon editor available there and let the relay enforce
+  // the authoritative owner/admin check on kind 9033.
+  const canEditIcon = canEditCommunityProfile(myMembershipQuery.data);
   const membersQuery = useRelayMembersQuery(canManageRelay);
   const members = React.useMemo(
     () => membersQuery.data ?? [],
@@ -323,8 +328,20 @@ export function CommunityMembersSettingsCard({
     );
   }
 
-  if (!canManageRelay || !currentRole) {
+  if (!canEditIcon) {
     return null;
+  }
+
+  if (!canManageRelay || !currentRole) {
+    return (
+      <section className="min-w-0" data-testid="settings-community-members">
+        <SettingsSectionHeader
+          title="Community access"
+          description="Manage how this community appears to members."
+        />
+        <CommunityIconSettingsCard />
+      </section>
+    );
   }
 
   const normalizedInput = normalizeRelayPubkeyInput(pubkeyInput);

--- a/desktop/src/features/settings/ui/SettingsView.tsx
+++ b/desktop/src/features/settings/ui/SettingsView.tsx
@@ -3,7 +3,10 @@ import { getVersion } from "@tauri-apps/api/app";
 import { AlertCircle, ArrowLeft, LoaderCircle, RefreshCw } from "lucide-react";
 
 import { useMyRelayMembershipLookupQuery } from "@/features/community-members/hooks";
-import { shouldWarnMissingMembershipSnapshot } from "@/shared/api/relayMembers";
+import {
+  canEditCommunityProfile,
+  shouldWarnMissingMembershipSnapshot,
+} from "@/shared/api/relayMembers";
 import { getFeature } from "@/shared/features/manifest";
 import {
   resolveEnabled,
@@ -126,8 +129,6 @@ export function SettingsView({
   const myMembershipQuery = useMyRelayMembershipLookupQuery();
   const featureState = useFeatureSnapshot();
   const visibleSections = React.useMemo(() => {
-    const membership = myMembershipQuery.data?.membership;
-
     return settingsSections.filter((s) => {
       // Feature gate check. Manifest is preview-only — if the gate id is in
       // the manifest, it's preview and needs an opt-in; if it's not, it's
@@ -138,12 +139,10 @@ export function SettingsView({
           return false;
         }
       }
-      // Community members requires admin/owner role
+      // Closed relays require a discovered admin/owner role. Open relays have
+      // no NIP-43 snapshot, so expose only the relay-authorized profile editor.
       if (s.value === "community-members") {
-        return (
-          membership != null &&
-          (membership.role === "owner" || membership.role === "admin")
-        );
+        return canEditCommunityProfile(myMembershipQuery.data);
       }
       return true;
     });

--- a/desktop/src/shared/api/relayMembers.test.mjs
+++ b/desktop/src/shared/api/relayMembers.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  canEditCommunityProfile,
   loadRelayMembershipLookup,
   shouldWarnMissingMembershipSnapshot,
 } from "./relayMembers.ts";
@@ -33,6 +34,50 @@ test("membership relays request their membership snapshot", async () => {
   assert.equal(lookup.snapshotFound, true);
   assert.equal(lookup.membershipRequired, true);
   assert.equal(lookup.membership?.role, "admin");
+});
+
+test("community profile editing is visible on open relays", () => {
+  assert.equal(
+    canEditCommunityProfile({
+      snapshotFound: false,
+      membershipRequired: false,
+      membership: null,
+    }),
+    true,
+  );
+});
+
+test("community profile editing is visible to closed-relay admins and owners", () => {
+  for (const role of ["admin", "owner"]) {
+    assert.equal(
+      canEditCommunityProfile({
+        snapshotFound: true,
+        membershipRequired: true,
+        membership: { pubkey: "a".repeat(64), role },
+      }),
+      true,
+    );
+  }
+});
+
+test("community profile editing stays hidden while loading and from closed-relay non-admins", () => {
+  assert.equal(canEditCommunityProfile(undefined), false);
+  assert.equal(
+    canEditCommunityProfile({
+      snapshotFound: true,
+      membershipRequired: true,
+      membership: { pubkey: "a".repeat(64), role: "member" },
+    }),
+    false,
+  );
+  assert.equal(
+    canEditCommunityProfile({
+      snapshotFound: true,
+      membershipRequired: true,
+      membership: null,
+    }),
+    false,
+  );
 });
 
 test("missing snapshot warns when the relay requires membership", () => {

--- a/desktop/src/shared/api/relayMembers.ts
+++ b/desktop/src/shared/api/relayMembers.ts
@@ -38,6 +38,15 @@ export type RelayMembershipLookup = {
   membership: RelayMember | null;
 };
 
+export function canEditCommunityProfile(
+  lookup: RelayMembershipLookup | undefined,
+): boolean {
+  const role = lookup?.membership?.role;
+  return (
+    lookup?.membershipRequired === false || role === "owner" || role === "admin"
+  );
+}
+
 export function shouldWarnMissingMembershipSnapshot(
   lookup: RelayMembershipLookup | undefined,
 ): boolean {


### PR DESCRIPTION
## Summary

- expose the existing community icon editor when the active relay does not advertise NIP-43 membership enforcement
- keep member-management controls gated to relay-reported owner/admin roles
- share one fail-closed capability predicate between settings navigation and the icon card
- rely on the existing kind `9033` relay authorization for the authoritative icon-write permission check

## Why

The Block production relay is intentionally open and does not advertise NIP-43, so Desktop skips the membership snapshot and currently hides the icon editor even though the relay supports owner-signed kind `9033` icon updates.

This does not enable membership management on open relays and does not change relay admission semantics.

## Verification

At commit `5ea82929cb28814c027c0640996870f9594d4722`:

- `pnpm exec biome lint src/shared/api/relayMembers.ts src/shared/api/relayMembers.test.mjs src/features/settings/ui/SettingsView.tsx src/features/community-members/ui/CommunityMembersSettingsCard.tsx`
- `pnpm typecheck`
- `pnpm test` — 3,462 passed before history-only rebase onto current `main`
- `git diff --check`
