### PR TITLE
ci: add Windows and Linux canary workflows with caching

### DIFF
--- a/.github/workflows/linux-canary.yml
+++ b/.github/workflows/linux-canary.yml
@@ -1,36 +1,17 @@
 name: Linux Canary
 
-# Produces unsigned Linux .deb and .AppImage packages from any ref without
+# Produces unsigned Linux .deb and .AppImage packages from main without
 # creating a tag, GitHub Release, or auto-updater artifact. Artifacts are
 # available as a short-lived GitHub Actions artifact for explicit testing.
 #
 # Design notes vs. signed-macos-canary.yml:
-#   - Accepts a `ref` input (default: main) so pre-merge branches can be
-#     tested. The macOS canary requires main because it runs OIDC
-#     signing/notarization; this job is unsigned, contents: read only, and
-#     zero secrets — building arbitrary refs is safe and is the entire point.
-#   - No `Require main` guard for the same reason.
 #   - fix-appimage.sh is run without signing env vars; the script detects
 #     their absence and skips re-signing, repacking only (documented inline).
 #   - mold linker added (rui314/setup-mold) to reduce link time, matching
 #     the Linux Rust CI jobs in ci.yml.
 #   - pnpm store restore/save pattern mirrors ci.yml:149-196.
-#
-# Cache safety: workflow_dispatch executes on the dispatch ref (github.ref /
-# github.sha stay main-scoped even when inputs.ref points at a feature branch).
-# A cache write with the standard pnpm key from a non-main inputs.ref would
-# land in the main-scoped namespace and could be restored by CI later — a
-# cache-poisoning path. To close it:
-#   - Cache restores are unconditional (cold miss for untrusted refs is safe).
-#   - Cache saves (rust-cache save-if, pnpm actions/cache/save if:) only write
-#     when BOTH the dispatch ref and inputs.ref are trusted main.
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "Branch, tag, or SHA to build (default: main)"
-        required: false
-        default: main
 
 permissions:
   contents: read
@@ -52,6 +33,15 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Require main
+        env:
+          SOURCE_REF: ${{ github.ref }}
+        run: |
+          if [[ "$SOURCE_REF" != "refs/heads/main" ]]; then
+            echo "::error::Canary builds must run from main; got $SOURCE_REF"
+            exit 1
+          fi
+
       - name: Install system dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
@@ -86,18 +76,10 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.ref }}
           persist-credentials: false
 
       - name: Mark workspace safe for git (containerized job)
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      # Capture the checked-out commit SHA for artifact naming and log lines.
-      # github.sha stays the dispatch-ref (main) SHA regardless of inputs.ref;
-      # this step resolves the actual source SHA so artifacts are unambiguous.
-      - name: Capture source SHA
-        id: source
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
 
@@ -112,9 +94,6 @@ jobs:
             .
             desktop/src-tauri
           shared-key: linux-canary-release
-          # Save only when both the dispatch ref and the checked-out input are
-          # trusted main; restores are unconditional (a cold miss is safe).
-          save-if: ${{ github.ref == 'refs/heads/main' && inputs.ref == 'main' }}
 
       - name: Install appimagetool
         run: |
@@ -157,8 +136,6 @@ jobs:
 
       - name: Derive canary version
         id: version
-        env:
-          SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: |
           set -euo pipefail
           BASE_VERSION=$(node -p "require('./desktop/package.json').version")
@@ -168,7 +145,7 @@ jobs:
           fi
           VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))-test.${GITHUB_RUN_NUMBER}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Building canary version $VERSION from $SOURCE_SHA"
+          echo "Building canary version $VERSION from $GITHUB_SHA"
 
       - name: Patch canary version
         env:
@@ -214,9 +191,6 @@ jobs:
           bash desktop/scripts/fix-appimage.sh "${APPIMAGES[0]}"
 
       - name: Save pnpm store cache
-        # Write only when both the dispatch ref and the checked-out input are
-        # trusted main; restores above are unconditional (a cold miss is safe).
-        if: ${{ github.ref == 'refs/heads/main' && inputs.ref == 'main' }}
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -245,7 +219,7 @@ jobs:
       - name: Upload Linux canary packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: buzz-linux-canary-${{ steps.source.outputs.sha }}
+          name: buzz-linux-canary-${{ github.sha }}
           path: |
             ${{ steps.artifacts.outputs.deb }}
             ${{ steps.artifacts.outputs.appimage }}

--- a/.github/workflows/linux-canary.yml
+++ b/.github/workflows/linux-canary.yml
@@ -15,6 +15,15 @@ name: Linux Canary
 #   - mold linker added (rui314/setup-mold) to reduce link time, matching
 #     the Linux Rust CI jobs in ci.yml.
 #   - pnpm store restore/save pattern mirrors ci.yml:149-196.
+#
+# Cache safety: workflow_dispatch executes on the dispatch ref (github.ref /
+# github.sha stay main-scoped even when inputs.ref points at a feature branch).
+# A cache write with the standard pnpm key from a non-main inputs.ref would
+# land in the main-scoped namespace and could be restored by CI later — a
+# cache-poisoning path. To close it:
+#   - Cache restores are unconditional (cold miss for untrusted refs is safe).
+#   - Cache saves (rust-cache save-if, pnpm actions/cache/save if:) only write
+#     when BOTH the dispatch ref and inputs.ref are trusted main.
 on:
   workflow_dispatch:
     inputs:
@@ -83,6 +92,13 @@ jobs:
       - name: Mark workspace safe for git (containerized job)
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      # Capture the checked-out commit SHA for artifact naming and log lines.
+      # github.sha stays the dispatch-ref (main) SHA regardless of inputs.ref;
+      # this step resolves the actual source SHA so artifacts are unambiguous.
+      - name: Capture source SHA
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
 
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
@@ -96,6 +112,9 @@ jobs:
             .
             desktop/src-tauri
           shared-key: linux-canary-release
+          # Save only when both the dispatch ref and the checked-out input are
+          # trusted main; restores are unconditional (a cold miss is safe).
+          save-if: ${{ github.ref == 'refs/heads/main' && inputs.ref == 'main' }}
 
       - name: Install appimagetool
         run: |
@@ -138,6 +157,8 @@ jobs:
 
       - name: Derive canary version
         id: version
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: |
           set -euo pipefail
           BASE_VERSION=$(node -p "require('./desktop/package.json').version")
@@ -147,7 +168,7 @@ jobs:
           fi
           VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))-test.${GITHUB_RUN_NUMBER}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Building canary version $VERSION from $GITHUB_SHA"
+          echo "Building canary version $VERSION from $SOURCE_SHA"
 
       - name: Patch canary version
         env:
@@ -193,6 +214,9 @@ jobs:
           bash desktop/scripts/fix-appimage.sh "${APPIMAGES[0]}"
 
       - name: Save pnpm store cache
+        # Write only when both the dispatch ref and the checked-out input are
+        # trusted main; restores above are unconditional (a cold miss is safe).
+        if: ${{ github.ref == 'refs/heads/main' && inputs.ref == 'main' }}
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -221,7 +245,7 @@ jobs:
       - name: Upload Linux canary packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: buzz-linux-canary-${{ github.sha }}
+          name: buzz-linux-canary-${{ steps.source.outputs.sha }}
           path: |
             ${{ steps.artifacts.outputs.deb }}
             ${{ steps.artifacts.outputs.appimage }}

--- a/.github/workflows/linux-canary.yml
+++ b/.github/workflows/linux-canary.yml
@@ -75,7 +75,7 @@ jobs:
             wget \
             xdg-utils
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false

--- a/.github/workflows/linux-canary.yml
+++ b/.github/workflows/linux-canary.yml
@@ -1,0 +1,229 @@
+name: Linux Canary
+
+# Produces unsigned Linux .deb and .AppImage packages from any ref without
+# creating a tag, GitHub Release, or auto-updater artifact. Artifacts are
+# available as a short-lived GitHub Actions artifact for explicit testing.
+#
+# Design notes vs. signed-macos-canary.yml:
+#   - Accepts a `ref` input (default: main) so pre-merge branches can be
+#     tested. The macOS canary requires main because it runs OIDC
+#     signing/notarization; this job is unsigned, contents: read only, and
+#     zero secrets — building arbitrary refs is safe and is the entire point.
+#   - No `Require main` guard for the same reason.
+#   - fix-appimage.sh is run without signing env vars; the script detects
+#     their absence and skips re-signing, repacking only (documented inline).
+#   - mold linker added (rui314/setup-mold) to reduce link time, matching
+#     the Linux Rust CI jobs in ci.yml.
+#   - pnpm store restore/save pattern mirrors ci.yml:149-196.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to build (default: main)"
+        required: false
+        default: main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Linux canary
+    if: github.repository == 'block/buzz'
+    runs-on: ubuntu-latest
+    container: ubuntu:22.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    env:
+      # AppImage tools are themselves AppImages; containers lack FUSE so we
+      # must use the extract-and-run fallback.
+      APPIMAGE_EXTRACT_AND_RUN: "1"
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Install system dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30
+          apt-get install -y --no-install-recommends \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            -o DPkg::Lock::Timeout=120 \
+            build-essential \
+            ca-certificates \
+            curl \
+            desktop-file-utils \
+            file \
+            git \
+            libasound2-dev \
+            libayatana-appindicator3-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf \
+            pkg-config \
+            squashfs-tools \
+            wget \
+            xdg-utils
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Mark workspace safe for git (containerized job)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
+
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
+      # Rust cache covering both the workspace sidecar build and the Tauri
+      # crate build. shared-key scoped to linux-canary-release so canary runs
+      # warm each other without colliding with CI's debug-profile keys.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: |
+            .
+            desktop/src-tauri
+          shared-key: linux-canary-release
+
+      - name: Install appimagetool
+        run: |
+          case "$(uname -m)" in
+            x86_64)  ARCH_SUFFIX="x86_64" ;;
+            aarch64) ARCH_SUFFIX="aarch64" ;;
+            *)
+              echo "::error::Unsupported architecture: $(uname -m)"
+              exit 1
+              ;;
+          esac
+          wget -q --tries=3 --timeout=30 -O /tmp/appimagetool \
+            "https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-${ARCH_SUFFIX}.AppImage"
+          if [[ "$ARCH_SUFFIX" == "x86_64" ]]; then
+            echo "ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0  /tmp/appimagetool" | sha256sum -c
+          else
+            echo "::error::No pinned SHA256 for appimagetool-${ARCH_SUFFIX} — add it before enabling this architecture"
+            exit 1
+          fi
+          install -m 755 /tmp/appimagetool /usr/local/bin/appimagetool
+          wget -q --tries=3 --timeout=30 -O /tmp/appimage-runtime \
+            "https://github.com/AppImage/type2-runtime/releases/download/20251108/runtime-${ARCH_SUFFIX}"
+          echo "2fca8b443c92510f1483a883f60061ad09b46b978b2631c807cd873a47ec260d  /tmp/appimage-runtime" | sha256sum -c
+          install -D -m 644 /tmp/appimage-runtime /usr/local/lib/appimage-runtime
+          echo "APPIMAGETOOL_RUNTIME_FILE=/usr/local/lib/appimage-runtime" >> "$GITHUB_ENV"
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pnpm store cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-
+
+      - name: Install desktop dependencies
+        run: just desktop-install-ci
+
+      - name: Derive canary version
+        id: version
+        run: |
+          set -euo pipefail
+          BASE_VERSION=$(node -p "require('./desktop/package.json').version")
+          if ! [[ "$BASE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Desktop version '$BASE_VERSION' is not semver"
+            exit 1
+          fi
+          VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))-test.${GITHUB_RUN_NUMBER}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building canary version $VERSION from $GITHUB_SHA"
+
+      - name: Patch canary version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          cd desktop && node scripts/set-version-from-tag.mjs "$VERSION"
+          cd src-tauri && cargo update --workspace
+
+      - name: Generate non-updating bundle config
+        run: |
+          cat > desktop/src-tauri/tauri.canary.conf.json <<'JSON'
+          {
+            "bundle": {
+              "createUpdaterArtifacts": false
+            }
+          }
+          JSON
+
+      - name: Build sidecars
+        run: |
+          cargo build --release -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          ./scripts/bundle-sidecars.sh
+
+      - name: Build Linux Tauri app
+        run: cd desktop && pnpm tauri build --ci --bundles deb,appimage --config src-tauri/tauri.canary.conf.json
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+
+      - name: Fix AppImage (remove infra libs, symlink system GStreamer)
+        # fix-appimage.sh checks for TAURI_SIGNING_PRIVATE_KEY and skips
+        # re-signing when absent, so no signing env vars are needed here.
+        # Repacking still runs, removing the Mesa/GLib/GStreamer conflict libs.
+        run: |
+          mapfile -t APPIMAGES < <(find desktop/src-tauri/target/release/bundle/appimage -name '*.AppImage' -type f)
+          if [[ ${#APPIMAGES[@]} -eq 0 ]]; then
+            echo "::error::No AppImage found to post-process"
+            exit 1
+          fi
+          if [[ ${#APPIMAGES[@]} -gt 1 ]]; then
+            echo "::error::Expected exactly one AppImage, found ${#APPIMAGES[@]}: ${APPIMAGES[*]}"
+            exit 1
+          fi
+          bash desktop/scripts/fix-appimage.sh "${APPIMAGES[0]}"
+
+      - name: Save pnpm store cache
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Locate Linux build artifacts
+        id: artifacts
+        run: |
+          set -euo pipefail
+          BUNDLE_DIR="desktop/src-tauri/target/release/bundle"
+
+          DEB=$(find "$BUNDLE_DIR/deb" -name '*.deb' -type f | head -1)
+          if [[ -z "$DEB" ]]; then
+            echo "::error::No DEB found in $BUNDLE_DIR/deb"
+            exit 1
+          fi
+          echo "deb=$DEB" >> "$GITHUB_OUTPUT"
+
+          APPIMAGE=$(find "$BUNDLE_DIR/appimage" -name '*.AppImage' -type f | head -1)
+          if [[ -z "$APPIMAGE" ]]; then
+            echo "::error::No AppImage found in $BUNDLE_DIR/appimage"
+            exit 1
+          fi
+          echo "appimage=$APPIMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Linux canary packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: buzz-linux-canary-${{ github.sha }}
+          path: |
+            ${{ steps.artifacts.outputs.deb }}
+            ${{ steps.artifacts.outputs.appimage }}
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/signed-macos-canary.yml
+++ b/.github/workflows/signed-macos-canary.yml
@@ -34,6 +34,27 @@ jobs:
 
       - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
 
+      # Rust cache covering both the workspace sidecar build and the Tauri
+      # crate build. shared-key scoped to macos-canary-release so canary runs
+      # warm each other without colliding with CI's debug-profile keys.
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: |
+            .
+            desktop/src-tauri
+          shared-key: macos-canary-release
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pnpm store cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-
+
       - name: Install desktop dependencies
         run: just desktop-install-ci
 
@@ -188,3 +209,9 @@ jobs:
           path: ${{ steps.artifact.outputs.path }}
           if-no-files-found: error
           retention-days: 7
+
+      - name: Save pnpm store cache
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/signed-macos-canary.yml
+++ b/.github/workflows/signed-macos-canary.yml
@@ -28,7 +28,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/windows-canary.yml
+++ b/.github/workflows/windows-canary.yml
@@ -1,0 +1,161 @@
+name: Windows Canary
+
+# Produces an unsigned Windows NSIS installer from any ref without creating
+# a tag, GitHub Release, or auto-updater artifact. The installer is available
+# only as a short-lived GitHub Actions artifact for explicit testing.
+#
+# Design notes vs. signed-macos-canary.yml:
+#   - Accepts a `ref` input (default: main) so pre-merge branches can be
+#     tested. The macOS canary requires main because it runs OIDC
+#     signing/notarization; this job is unsigned, contents: read only, and
+#     zero secrets — building arbitrary refs is safe and is the entire point.
+#   - No `Require main` guard for the same reason.
+#   - No mesh-llm: release-windows doesn't build it.
+#   - pnpm store restore/save pattern mirrors ci.yml:149-196. This is safe
+#     because this job is contents:read and artifact-only (unsigned). The
+#     release.yml Windows job explicitly disables pnpm caching because that
+#     job is contents:write feeding a signed installer — a poisoning vector
+#     (see release.yml:747-750). GitHub cache scoping means PR-branch caches
+#     can never restore into the main-branch scope.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to build (default: main)"
+        required: false
+        default: main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Windows canary
+    if: github.repository == 'block/buzz'
+    runs-on: windows-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    env:
+      TARGET: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        with:
+          targets: ${{ env.TARGET }}
+
+      # Rust cache covering both the workspace sidecar build and the Tauri
+      # crate build. shared-key scoped to windows-canary-release so canary
+      # runs warm each other without colliding with CI's debug-profile key
+      # (CI windows job does clippy/check, not --release).
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: |
+            .
+            desktop/src-tauri
+          shared-key: windows-canary-release
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.14.1
+          # Disable setup-node's built-in cache: we manage the pnpm store cache
+          # explicitly below (restore before install, save after) to mirror the
+          # pattern used by ci.yml and to keep caching logic consistent across
+          # all three canary workflows.
+          package-manager-cache: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        with:
+          version: 11.4.0
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pnpm store cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-
+
+      - name: Install desktop dependencies
+        shell: bash
+        run: pnpm install --frozen-lockfile
+
+      - name: Derive canary version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE_VERSION=$(node -p "require('./desktop/package.json').version")
+          if ! [[ "$BASE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Desktop version '$BASE_VERSION' is not semver"
+            exit 1
+          fi
+          VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))-test.${GITHUB_RUN_NUMBER}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building canary version $VERSION from $GITHUB_SHA"
+
+      - name: Patch canary version
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          cd desktop && node scripts/set-version-from-tag.mjs "$VERSION"
+          cd src-tauri && cargo update --workspace
+
+      - name: Generate non-updating bundle config
+        shell: bash
+        run: |
+          cat > desktop/src-tauri/tauri.canary.conf.json <<'JSON'
+          {
+            "bundle": {
+              "createUpdaterArtifacts": false
+            }
+          }
+          JSON
+
+      - name: Build sidecars
+        shell: bash
+        run: |
+          cargo build --release --target "$TARGET" -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          ./scripts/bundle-sidecars.sh "$TARGET"
+
+      - name: Build Windows NSIS installer (unsigned)
+        shell: bash
+        run: cd desktop && pnpm tauri build --target "$TARGET" --bundles nsis --config src-tauri/tauri.canary.conf.json
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+
+      - name: Locate NSIS installer
+        id: artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          BUNDLE_DIR="desktop/src-tauri/target/${TARGET}/release/bundle"
+          EXE=$(find "$BUNDLE_DIR/nsis" -name '*.exe' -type f | head -1)
+          if [[ -z "$EXE" ]]; then
+            echo "::error::No NSIS installer found in $BUNDLE_DIR/nsis"
+            exit 1
+          fi
+          echo "exe=$EXE" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Windows canary installer
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: buzz-windows-canary-${{ github.sha }}
+          path: ${{ steps.artifact.outputs.exe }}
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Save pnpm store cache
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/windows-canary.yml
+++ b/.github/workflows/windows-canary.yml
@@ -11,12 +11,16 @@ name: Windows Canary
 #     zero secrets — building arbitrary refs is safe and is the entire point.
 #   - No `Require main` guard for the same reason.
 #   - No mesh-llm: release-windows doesn't build it.
-#   - pnpm store restore/save pattern mirrors ci.yml:149-196. This is safe
-#     because this job is contents:read and artifact-only (unsigned). The
-#     release.yml Windows job explicitly disables pnpm caching because that
-#     job is contents:write feeding a signed installer — a poisoning vector
-#     (see release.yml:747-750). GitHub cache scoping means PR-branch caches
-#     can never restore into the main-branch scope.
+#   - pnpm store restore/save pattern mirrors ci.yml:149-196.
+#
+# Cache safety: workflow_dispatch executes on the dispatch ref (github.ref /
+# github.sha stay main-scoped even when inputs.ref points at a feature branch).
+# A cache write with the standard pnpm key from a non-main inputs.ref would
+# land in the main-scoped namespace and could be restored by CI later — a
+# cache-poisoning path. To close it:
+#   - Cache restores are unconditional (cold miss for untrusted refs is safe).
+#   - Cache saves (rust-cache save-if, pnpm actions/cache/save if:) only write
+#     when BOTH the dispatch ref and inputs.ref are trusted main.
 on:
   workflow_dispatch:
     inputs:
@@ -44,6 +48,14 @@ jobs:
           ref: ${{ inputs.ref }}
           persist-credentials: false
 
+      # Capture the checked-out commit SHA for artifact naming and log lines.
+      # github.sha stays the dispatch-ref (main) SHA regardless of inputs.ref;
+      # this step resolves the actual source SHA so artifacts are unambiguous.
+      - name: Capture source SHA
+        id: source
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       # The Windows runner ships with rustup preinstalled; rust-toolchain.toml
       # in the repo root pins the channel (1.95.0) automatically. We only need
       # to ensure the cross-compile target is registered; on windows-latest the
@@ -62,6 +74,9 @@ jobs:
             .
             desktop/src-tauri
           shared-key: windows-canary-release
+          # Save only when both the dispatch ref and the checked-out input are
+          # trusted main; restores are unconditional (a cold miss is safe).
+          save-if: ${{ github.ref == 'refs/heads/main' && inputs.ref == 'main' }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -95,6 +110,8 @@ jobs:
       - name: Derive canary version
         id: version
         shell: bash
+        env:
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: |
           set -euo pipefail
           BASE_VERSION=$(node -p "require('./desktop/package.json').version")
@@ -104,7 +121,7 @@ jobs:
           fi
           VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))-test.${GITHUB_RUN_NUMBER}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Building canary version $VERSION from $GITHUB_SHA"
+          echo "Building canary version $VERSION from $SOURCE_SHA"
 
       - name: Patch canary version
         shell: bash
@@ -153,12 +170,15 @@ jobs:
       - name: Upload Windows canary installer
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: buzz-windows-canary-${{ github.sha }}
+          name: buzz-windows-canary-${{ steps.source.outputs.sha }}
           path: ${{ steps.artifact.outputs.exe }}
           if-no-files-found: error
           retention-days: 7
 
       - name: Save pnpm store cache
+        # Write only when both the dispatch ref and the checked-out input are
+        # trusted main; restores above are unconditional (a cold miss is safe).
+        if: ${{ github.ref == 'refs/heads/main' && inputs.ref == 'main' }}
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}

--- a/.github/workflows/windows-canary.yml
+++ b/.github/workflows/windows-canary.yml
@@ -39,7 +39,7 @@ jobs:
     env:
       TARGET: x86_64-pc-windows-msvc
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false

--- a/.github/workflows/windows-canary.yml
+++ b/.github/workflows/windows-canary.yml
@@ -44,9 +44,13 @@ jobs:
           ref: ${{ inputs.ref }}
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
-        with:
-          targets: ${{ env.TARGET }}
+      # The Windows runner ships with rustup preinstalled; rust-toolchain.toml
+      # in the repo root pins the channel (1.95.0) automatically. We only need
+      # to ensure the cross-compile target is registered; on windows-latest the
+      # host IS x86_64-pc-windows-msvc so this is typically a no-op.
+      - name: Add Rust target
+        shell: bash
+        run: rustup target add "$TARGET"
 
       # Rust cache covering both the workspace sidecar build and the Tauri
       # crate build. shared-key scoped to windows-canary-release so canary

--- a/.github/workflows/windows-canary.yml
+++ b/.github/workflows/windows-canary.yml
@@ -1,33 +1,14 @@
 name: Windows Canary
 
-# Produces an unsigned Windows NSIS installer from any ref without creating
+# Produces an unsigned Windows NSIS installer from main without creating
 # a tag, GitHub Release, or auto-updater artifact. The installer is available
 # only as a short-lived GitHub Actions artifact for explicit testing.
 #
 # Design notes vs. signed-macos-canary.yml:
-#   - Accepts a `ref` input (default: main) so pre-merge branches can be
-#     tested. The macOS canary requires main because it runs OIDC
-#     signing/notarization; this job is unsigned, contents: read only, and
-#     zero secrets — building arbitrary refs is safe and is the entire point.
-#   - No `Require main` guard for the same reason.
 #   - No mesh-llm: release-windows doesn't build it.
 #   - pnpm store restore/save pattern mirrors ci.yml:149-196.
-#
-# Cache safety: workflow_dispatch executes on the dispatch ref (github.ref /
-# github.sha stay main-scoped even when inputs.ref points at a feature branch).
-# A cache write with the standard pnpm key from a non-main inputs.ref would
-# land in the main-scoped namespace and could be restored by CI later — a
-# cache-poisoning path. To close it:
-#   - Cache restores are unconditional (cold miss for untrusted refs is safe).
-#   - Cache saves (rust-cache save-if, pnpm actions/cache/save if:) only write
-#     when BOTH the dispatch ref and inputs.ref are trusted main.
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "Branch, tag, or SHA to build (default: main)"
-        required: false
-        default: main
 
 permissions:
   contents: read
@@ -43,18 +24,19 @@ jobs:
     env:
       TARGET: x86_64-pc-windows-msvc
     steps:
+      - name: Require main
+        shell: bash
+        env:
+          SOURCE_REF: ${{ github.ref }}
+        run: |
+          if [[ "$SOURCE_REF" != "refs/heads/main" ]]; then
+            echo "::error::Canary builds must run from main; got $SOURCE_REF"
+            exit 1
+          fi
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.ref }}
           persist-credentials: false
-
-      # Capture the checked-out commit SHA for artifact naming and log lines.
-      # github.sha stays the dispatch-ref (main) SHA regardless of inputs.ref;
-      # this step resolves the actual source SHA so artifacts are unambiguous.
-      - name: Capture source SHA
-        id: source
-        shell: bash
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       # The Windows runner ships with rustup preinstalled; rust-toolchain.toml
       # in the repo root pins the channel (1.95.0) automatically. We only need
@@ -74,9 +56,6 @@ jobs:
             .
             desktop/src-tauri
           shared-key: windows-canary-release
-          # Save only when both the dispatch ref and the checked-out input are
-          # trusted main; restores are unconditional (a cold miss is safe).
-          save-if: ${{ github.ref == 'refs/heads/main' && inputs.ref == 'main' }}
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -110,8 +89,6 @@ jobs:
       - name: Derive canary version
         id: version
         shell: bash
-        env:
-          SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: |
           set -euo pipefail
           BASE_VERSION=$(node -p "require('./desktop/package.json').version")
@@ -121,7 +98,7 @@ jobs:
           fi
           VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))-test.${GITHUB_RUN_NUMBER}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Building canary version $VERSION from $SOURCE_SHA"
+          echo "Building canary version $VERSION from $GITHUB_SHA"
 
       - name: Patch canary version
         shell: bash
@@ -170,15 +147,12 @@ jobs:
       - name: Upload Windows canary installer
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: buzz-windows-canary-${{ steps.source.outputs.sha }}
+          name: buzz-windows-canary-${{ github.sha }}
           path: ${{ steps.artifact.outputs.exe }}
           if-no-files-found: error
           retention-days: 7
 
       - name: Save pnpm store cache
-        # Write only when both the dispatch ref and the checked-out input are
-        # trusted main; restores above are unconditional (a cold miss is safe).
-        if: ${{ github.ref == 'refs/heads/main' && inputs.ref == 'main' }}
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}


### PR DESCRIPTION
Adds `windows-canary.yml` and `linux-canary.yml` — `workflow_dispatch` jobs that produce unsigned installable artifacts (.exe NSIS installer, .deb + .AppImage) from main without touching the release pipeline. Also retrofits `signed-macos-canary.yml` with Rust and pnpm caching so all three canary builds warm quickly on repeat dispatches.

## What this adds

**`windows-canary.yml`** — `windows-latest` runner, `rust-toolchain.toml` in the repo root pins the toolchain via preinstalled rustup (`rustup target add` to register the MSVC target), `pnpm install --frozen-lockfile`, sidecars `cargo build --release`, `pnpm tauri build --bundles nsis` with `createUpdaterArtifacts:false`. Uploads the NSIS `.exe` as artifact `buzz-windows-canary-<sha>`, 7-day retention. No mesh-llm (release-windows doesn't build it).

**`linux-canary.yml`** — same `ubuntu:22.04` container as the release job, same apt deps block, pinned `appimagetool 1.9.1` + `type2-runtime 20251108`, hermit, mold, `just desktop-install-ci`, sidecars, `pnpm tauri build --bundles deb,appimage`. Runs `fix-appimage.sh` without signing env vars (the script detects their absence and skips re-signing; repacking still removes the Mesa/GLib/GStreamer conflict libs). Uploads `.deb` + `.AppImage` as `buzz-linux-canary-<sha>`, 7-day retention.

**`signed-macos-canary.yml`** — adds `Swatinem/rust-cache` (workspace root + `desktop/src-tauri`) and the pnpm store restore/save pattern. The existing mesh-llama cache is unchanged.

## Design decisions

All three canary workflows share the same structure: `workflow_dispatch` with no inputs, a `Require main` guard that fails the job if dispatched from a non-main ref, and `github.sha` for artifact naming. This keeps them consistent and avoids the cache-safety complexity that arbitrary-ref builds would require.

## Caching rationale

- **Rust**: `Swatinem/rust-cache` with `workspaces: . \n desktop/src-tauri` covering both the sidecar `--release` build and the Tauri build. `shared-key` scoped to `<platform>-canary-release` — canary runs warm each other without colliding with CI's debug-profile keys (CI Windows runs clippy/check, not `--release`).
- **pnpm**: explicit store restore/save pattern from `ci.yml:149-196`. The main-only guard makes all cache saves trusted unconditionally.
- **mold**: `rui314/setup-mold` on Linux to reduce link time, matching the Linux Rust CI jobs.
- `timeout-minutes: 60` on all three — generous enough for the cold path.

## Zizmor hygiene

All three workflows: every action pinned by full commit SHA (matching `ci.yml`/`release.yml` pins), `persist-credentials: false` on checkouts, top-level `permissions: contents: read`, no `${{ }}` interpolation directly in `run:` bodies (env-var indirection throughout), `if: github.repository == 'block/buzz'` on jobs.