### PR TITLE
feat(composer): surface live agent activity in status pills

### DIFF
--- a/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
+++ b/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
@@ -54,6 +54,20 @@ describe("activeAgentTurnsStore", () => {
     resetActiveAgentTurnsStore();
   });
 
+  describe("active turn summaries", () => {
+    it("retains every concurrent turn id in one channel deterministically", () => {
+      syncAgentTurnsFromEvents(AGENT, [
+        makeEvent({ seq: 1, turnId: "turn-z", channelId: "c1" }),
+        makeEvent({ seq: 2, turnId: "turn-a", channelId: "c1" }),
+      ]);
+
+      assert.deepEqual(getActiveTurnsForAgent(AGENT)[0].turnIds, [
+        "turn-a",
+        "turn-z",
+      ]);
+    });
+  });
+
   describe("seq filtering", () => {
     it("processes events with increasing seq", () => {
       syncAgentTurnsFromEvents(AGENT, [

--- a/desktop/src/features/agents/activeAgentTurnsStore.ts
+++ b/desktop/src/features/agents/activeAgentTurnsStore.ts
@@ -62,6 +62,8 @@ type ActiveTurn = {
 export type ActiveTurnSummary = {
   channelId: string;
   anchorAt: number;
+  /** Live turn ids in this channel, used to scope current observer activity. */
+  turnIds: string[];
 };
 
 /** One channel with active agent work, aggregated across agents. */
@@ -505,21 +507,30 @@ export function getActiveTurnsForAgent(
 
   const offset = clockOffsetByAgent.get(key) ?? 0;
 
-  // Collapse multiple turns in one channel to the earliest start — the badge
-  // should count from when the channel's oldest live turn began. Anchors are
-  // derived here (startedAt + offset) so the latest skew estimate applies.
-  const earliestByChannel = new Map<string, number>();
+  // Collapse multiple turns in one channel to the earliest start while
+  // retaining every live turn id. The badge counts from the oldest live turn;
+  // current observer headlines need the ids to reject prior-turn transcript.
+  const byChannel = new Map<string, { startedAt: number; turnIds: string[] }>();
   for (const turn of agentTurns.values()) {
-    const prior = earliestByChannel.get(turn.channelId);
-    if (prior === undefined || turn.startedAt < prior) {
-      earliestByChannel.set(turn.channelId, turn.startedAt);
+    const summary = byChannel.get(turn.channelId);
+    if (!summary) {
+      byChannel.set(turn.channelId, {
+        startedAt: turn.startedAt,
+        turnIds: [turn.turnId],
+      });
+      continue;
+    }
+    summary.turnIds.push(turn.turnId);
+    if (turn.startedAt < summary.startedAt) {
+      summary.startedAt = turn.startedAt;
     }
   }
 
-  const result = [...earliestByChannel.entries()]
-    .map(([channelId, startedAt]) => ({
+  const result = [...byChannel.entries()]
+    .map(([channelId, { startedAt, turnIds }]) => ({
       channelId,
       anchorAt: startedAt + offset,
+      turnIds: turnIds.sort(),
     }))
     .sort((a, b) => a.channelId.localeCompare(b.channelId));
   cachedTurnSummaries.set(key, result);

--- a/desktop/src/features/agents/agentWorkingSignal.test.mjs
+++ b/desktop/src/features/agents/agentWorkingSignal.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { beforeEach, describe, it } from "node:test";
 
 import {
+  getAgentChannelTypingSince,
   getAgentWorkingState,
   getWorkingAgentPubkeysForChannel,
   getWorkingChannels,
@@ -113,6 +114,32 @@ describe("getAgentWorkingState", () => {
     reportChannelBotTyping("chan-1", [AGENT, AGENT_2]);
     const again = getAgentWorkingState(AGENT).channels[0].anchorAt;
     assert.equal(again, first);
+  });
+});
+
+describe("getAgentChannelTypingSince", () => {
+  it("returns null when the agent is not typing in the channel", () => {
+    assert.equal(getAgentChannelTypingSince(AGENT, "chan-1"), null);
+    reportChannelBotTyping("chan-1", [AGENT_2]);
+    assert.equal(getAgentChannelTypingSince(AGENT, "chan-1"), null);
+    assert.equal(getAgentChannelTypingSince(AGENT_2, "chan-2"), null);
+    assert.equal(getAgentChannelTypingSince(null, "chan-1"), null);
+    assert.equal(getAgentChannelTypingSince(AGENT, null), null);
+  });
+
+  it("returns the first-seen anchor while typing", () => {
+    reportChannelBotTyping("chan-1", [AGENT]);
+    const since = getAgentChannelTypingSince(AGENT, "chan-1");
+    assert.ok(since !== null && since <= Date.now());
+    reportChannelBotTyping("chan-1", []);
+    assert.equal(getAgentChannelTypingSince(AGENT, "chan-1"), null);
+  });
+
+  it("is NOT folded under observer precedence (unlike getAgentWorkingState)", () => {
+    startTurn(AGENT, "chan-1");
+    reportChannelBotTyping("chan-1", [AGENT]);
+    assert.equal(getAgentWorkingState(AGENT, "chan-1").source, "observer");
+    assert.notEqual(getAgentChannelTypingSince(AGENT, "chan-1"), null);
   });
 });
 

--- a/desktop/src/features/agents/agentWorkingSignal.ts
+++ b/desktop/src/features/agents/agentWorkingSignal.ts
@@ -35,6 +35,8 @@ export type AgentWorkingChannel = {
   /** Desktop-clock anchor for elapsed displays (turn start / first typing). */
   anchorAt: number;
   source: Exclude<AgentWorkingSource, "none">;
+  /** Live observer turn ids; empty for typing-backed fallback channels. */
+  turnIds: string[];
 };
 
 export type AgentWorkingState = {
@@ -162,6 +164,7 @@ function computeAgentWorkingState(
     channelId: turn.channelId,
     anchorAt: turn.anchorAt,
     source: "observer" as const,
+    turnIds: turn.turnIds,
   }));
   const observerChannelIds = new Set(turns.map((turn) => turn.channelId));
 
@@ -175,6 +178,7 @@ function computeAgentWorkingState(
         channelId: typingChannelId,
         anchorAt: since,
         source: "typing",
+        turnIds: [],
       });
     }
   }

--- a/desktop/src/features/agents/agentWorkingSignal.ts
+++ b/desktop/src/features/agents/agentWorkingSignal.ts
@@ -135,10 +135,9 @@ export function reportChannelBotTyping(
  * null when the agent is not typing there.
  *
  * Raw registry read: unlike `getAgentWorkingState`, this does NOT fold
- * typing under observer precedence — an observer-backed surface (the
- * composer activity pill) uses it to relabel IN PLACE to "is typing…" while
- * a turn is in flight, instead of the agent spawning a second, separate
- * typing-group item.
+ * typing under observer precedence. The composer activity pill uses it as a
+ * fallback before observer telemetry arrives and after an observer turn ends,
+ * without spawning a second, separate typing-group item.
  */
 export function getAgentChannelTypingSince(
   agentPubkey: string | null | undefined,

--- a/desktop/src/features/agents/agentWorkingSignal.ts
+++ b/desktop/src/features/agents/agentWorkingSignal.ts
@@ -130,6 +130,28 @@ export function reportChannelBotTyping(
   notify();
 }
 
+/**
+ * First-seen timestamp (ms) of the agent's channel-scoped typing entry, or
+ * null when the agent is not typing there.
+ *
+ * Raw registry read: unlike `getAgentWorkingState`, this does NOT fold
+ * typing under observer precedence — an observer-backed surface (the
+ * composer activity pill) uses it to relabel IN PLACE to "is typing…" while
+ * a turn is in flight, instead of the agent spawning a second, separate
+ * typing-group item.
+ */
+export function getAgentChannelTypingSince(
+  agentPubkey: string | null | undefined,
+  channelId: string | null | undefined,
+): number | null {
+  if (!agentPubkey || !channelId) {
+    return null;
+  }
+  return (
+    typingByChannel.get(channelId)?.get(normalizePubkey(agentPubkey)) ?? null
+  );
+}
+
 function computeAgentWorkingState(
   agentPubkey: string,
   channelId: string | null,

--- a/desktop/src/features/agents/ui/agentSessionFileEditDiff.ts
+++ b/desktop/src/features/agents/ui/agentSessionFileEditDiff.ts
@@ -197,7 +197,8 @@ function getDiffStats(
   return null;
 }
 
-function basename(path: string) {
+/** Final path segment (cross-platform); returns the input when empty. */
+export function basename(path: string) {
   const parts = path.replace(/\\/g, "/").split("/");
   return parts[parts.length - 1] || path;
 }

--- a/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.test.mjs
@@ -94,6 +94,57 @@ test("getActivityHeadline basenames path-like tool objects", () => {
   );
 });
 
+test("getActivityHeadline renders plan and thought items in past tense", () => {
+  // Bare "Plan" / "Thinking" titles must not headline next to the past-tense
+  // tool verbs ("Read foo.ts", "Ran …").
+  assert.equal(
+    getActivityHeadline({
+      id: "plan:1",
+      type: "plan",
+      renderClass: "plan",
+      title: "Plan",
+      text: "1. Do the thing",
+      timestamp: baseTimestamp,
+    }),
+    "Created plan",
+  );
+  assert.equal(
+    getActivityHeadline({
+      id: "plan:1:update:x",
+      type: "plan",
+      renderClass: "plan",
+      title: "Plan updated",
+      text: "Now doing step 2",
+      timestamp: baseTimestamp,
+      isUpdate: true,
+      targetId: "plan:1",
+    }),
+    "Updated plan",
+  );
+  assert.equal(
+    getActivityHeadline({
+      id: "thought:1",
+      type: "thought",
+      renderClass: "thought",
+      title: "Thinking",
+      text: "hmm",
+      timestamp: baseTimestamp,
+    }),
+    "Thought",
+  );
+  assert.equal(
+    getActivityHeadline({
+      id: "thought:2",
+      type: "thought",
+      renderClass: "thought",
+      title: "Plan",
+      text: "plan-shaped thought",
+      timestamp: baseTimestamp,
+    }),
+    "Planned",
+  );
+});
+
 test("getActivityHeadline keeps shell commands whole (no basenaming)", () => {
   assert.equal(
     getActivityHeadline(

--- a/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.test.mjs
@@ -40,13 +40,80 @@ function makeMessage(overrides = {}) {
   };
 }
 
-test("getActivityHeadline formats tool titles and assistant text", () => {
-  assert.equal(getActivityHeadline(makeTool()), "Send Message · abc");
+test("getActivityHeadline formats tool actions tersely and assistant text", () => {
+  // Tool items use the terse action tier (verb + object), not label · preview.
+  assert.equal(getActivityHeadline(makeTool()), "Sent abc");
   assert.equal(
     getActivityHeadline(makeMessage({ text: "First line\nSecond line" })),
     "First line",
   );
   assert.equal(getActivityHeadline(makeMessage({ text: "   " })), "Responding");
+});
+
+test("getActivityHeadline basenames path-like tool objects", () => {
+  assert.equal(
+    getActivityHeadline(
+      makeTool({
+        title: "Read file",
+        toolName: "dev__read_file",
+        buzzToolName: null,
+        args: { path: "src/agents/ui/foo.ts" },
+        descriptor: {
+          renderClass: "file-read",
+          label: "Read file",
+          preview: "src/agents/ui/foo.ts",
+          action: { verb: "Read", object: "src/agents/ui/foo.ts" },
+          source: "harness",
+          groupKey: "read_file",
+        },
+      }),
+    ),
+    "Read foo.ts",
+  );
+  assert.equal(
+    getActivityHeadline(
+      makeTool({
+        title: "Edit file",
+        toolName: "dev__str_replace",
+        buzzToolName: null,
+        args: { path: "desktop/src/features/channels/ui/ChannelPane.tsx" },
+        descriptor: {
+          renderClass: "file-edit",
+          label: "Edited file",
+          preview: "desktop/src/features/channels/ui/ChannelPane.tsx",
+          action: {
+            verb: "Edited",
+            object: "desktop/src/features/channels/ui/ChannelPane.tsx",
+          },
+          source: "harness",
+          groupKey: "file-edit:str_replace",
+        },
+      }),
+    ),
+    "Edited ChannelPane.tsx",
+  );
+});
+
+test("getActivityHeadline keeps shell commands whole (no basenaming)", () => {
+  assert.equal(
+    getActivityHeadline(
+      makeTool({
+        title: "Shell",
+        toolName: "dev__shell",
+        buzzToolName: null,
+        args: { command: "cat src/agents/ui/foo.ts" },
+        descriptor: {
+          renderClass: "shell",
+          label: "Ran command",
+          preview: "cat src/agents/ui/foo.ts",
+          action: { verb: "Ran", object: "cat src/agents/ui/foo.ts" },
+          source: "harness",
+          groupKey: "shell:command",
+        },
+      }),
+    ),
+    "Ran cat src/agents/ui/foo.ts",
+  );
 });
 
 test("isMeaningfulItem ignores lifecycle noise and raw JSON-RPC metadata", () => {
@@ -111,7 +178,7 @@ test("isMeaningfulItem ignores lifecycle noise and raw JSON-RPC metadata", () =>
   );
 });
 
-test("getActivityHeadline uses semantic tool descriptors", () => {
+test("getActivityHeadline falls back to label · preview when a descriptor has no action", () => {
   assert.equal(
     getActivityHeadline(
       makeTool({
@@ -225,7 +292,7 @@ test("two-tier headline: metadata excluded when spine work is present", () => {
     "System prompt should not headline when spine work exists",
   );
   assert.ok(
-    headlines.some((h) => h?.includes("Send Message")),
+    headlines.some((h) => h?.includes("Sent")),
     "Tool headline should appear",
   );
 });

--- a/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.ts
@@ -64,6 +64,11 @@ function terseActionObject(summary: CompactToolSummary): string | null {
  * reduced to their basename), e.g. "Read foo.ts" rather than
  * "Read file · src/agents/ui/foo.ts" — so the composer pill's 200px cap
  * shows the informative part instead of ellipsizing a long preview.
+ *
+ * Action headlines are past-tense verb phrases throughout ("Read foo.ts",
+ * "Thought", "Updated plan") — plan and thought items are normalized here
+ * so no bare noun ("Plan") or present participle ("Thinking") leaks into
+ * the pill next to the past-tense tool verbs.
  */
 export function getActivityHeadline(item: TranscriptItem): string | null {
   if (item.type === "tool") {
@@ -93,7 +98,14 @@ export function getActivityHeadline(item: TranscriptItem): string | null {
   }
 
   if (item.type === "thought") {
-    return item.title === "Plan" ? "Planning" : item.title;
+    if (item.title === "Plan") {
+      return "Planned";
+    }
+    return item.title === "Thinking" ? "Thought" : item.title;
+  }
+
+  if (item.type === "plan") {
+    return item.isUpdate ? "Updated plan" : "Created plan";
   }
 
   if (item.type === "metadata") {

--- a/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.ts
@@ -1,5 +1,9 @@
 import type { TranscriptItem } from "./agentSessionTypes";
-import { buildCompactToolSummary } from "./agentSessionToolSummary";
+import { basename } from "./agentSessionFileEditDiff";
+import {
+  buildCompactToolSummary,
+  type CompactToolSummary,
+} from "./agentSessionToolSummary";
 
 /**
  * Whether a polished activity row should render the opt-in timestamp footer.
@@ -26,10 +30,49 @@ const LIFECYCLE_NOISE = new Set([
   "wire parse error",
 ]);
 
-/** Human-readable headline for a single transcript item. */
+/**
+ * Render classes whose action object is a filesystem path — compact to the
+ * basename for terse headlines. Shell commands are deliberately excluded:
+ * they legitimately contain "/" (e.g. `cat src/foo.ts`) and must not be
+ * reduced to their last path segment.
+ */
+const PATHLIKE_RENDER_CLASSES = new Set([
+  "file-read",
+  "file-edit",
+  "skill-read",
+]);
+
+function terseActionObject(summary: CompactToolSummary): string | null {
+  if (summary.fileEditSummary) {
+    return summary.fileEditSummary.filename;
+  }
+  const object = summary.action?.object ?? null;
+  if (
+    object &&
+    PATHLIKE_RENDER_CLASSES.has(summary.kind) &&
+    /[\\/]/.test(object)
+  ) {
+    return basename(object);
+  }
+  return object;
+}
+
+/**
+ * Human-readable headline for a single transcript item.
+ *
+ * Tool items use the terse action tier — verb + compact object (file paths
+ * reduced to their basename), e.g. "Read foo.ts" rather than
+ * "Read file · src/agents/ui/foo.ts" — so the composer pill's 200px cap
+ * shows the informative part instead of ellipsizing a long preview.
+ */
 export function getActivityHeadline(item: TranscriptItem): string | null {
   if (item.type === "tool") {
     const summary = buildCompactToolSummary(item);
+    if (summary.action) {
+      return [summary.action.verb, terseActionObject(summary)]
+        .filter(Boolean)
+        .join(" ");
+    }
     return [summary.label, summary.preview].filter(Boolean).join(" · ");
   }
 

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -20,6 +20,11 @@ import { Shimmer } from "@/shared/ui/Shimmer";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import { ComposerLiveActivityFeed } from "./ComposerLiveActivityFeed";
 import {
+  COMPOSER_STRIP_AVATAR_MORPH_TRANSITION,
+  ComposerStripAvatarScopeContext,
+  useComposerStripAvatarLayoutId,
+} from "./composerStripAvatarLayout";
+import {
   deriveActivityPillLabel,
   deriveAgentWorkingOrder,
 } from "./composerLiveActivity";
@@ -255,6 +260,7 @@ function BotActivityAgentPill({
   const pillKey = agent.pubkey.toLowerCase();
   const open = hover.activePubkey === pillKey;
   const shouldReduceMotion = useReducedMotion();
+  const avatarMorphLayoutId = useComposerStripAvatarLayoutId(agent.pubkey);
   const transcript = useAgentTranscript(true, agent.pubkey);
   const headline = React.useMemo(
     () => deriveActivityPillLabel({ channelId, transcript }),
@@ -325,12 +331,22 @@ function BotActivityAgentPill({
 
   const pillContent = (
     <>
-      <UserAvatar
-        avatarUrl={avatarUrl}
-        className="!h-5 !w-5 shrink-0 text-3xs"
-        displayName={agent.name}
-        size="xs"
-      />
+      {/* Shared-element home: matches the typing group's avatar layoutId so
+          a group→pill promotion morphs the avatar across (see
+          composerStripAvatarLayout). Under reduced motion the id is dropped
+          and the avatar mounts in place. */}
+      <motion.div
+        className="shrink-0"
+        layoutId={shouldReduceMotion ? undefined : avatarMorphLayoutId}
+        transition={COMPOSER_STRIP_AVATAR_MORPH_TRANSITION}
+      >
+        <UserAvatar
+          avatarUrl={avatarUrl}
+          className="!h-5 !w-5 text-3xs"
+          displayName={agent.name}
+          size="xs"
+        />
+      </motion.div>
       {/* Ticker viewport: 16px tall with a matching 16px line box (leading-4
           overrides the button's leading-none). Inter's ascent+descent ink is
           ~1.21em (~14.5px at text-xs) — taller than a leading-none line box —
@@ -557,7 +573,9 @@ function AnimatedPillSlot({
  * compressing every pill into an unreadable sliver or wrapping the
  * fixed-height row. The scroll viewport bleeds across the mounting row's
  * gutter so the clip line and its fades sit at the container's visual
- * edges, never mid-row on a pill.
+ * edges, never mid-row on a pill. The strip provides a per-instance avatar
+ * shared-element scope (composerStripAvatarLayout) so an agent's avatar
+ * morphs between the typing group and a pill on partition flips.
  */
 export function BotActivityComposerAction({
   agents,
@@ -569,6 +587,10 @@ export function BotActivityComposerAction({
 }: BotActivityBarProps) {
   const shouldReduceMotion = useReducedMotion();
   const hover = useStripHoverPopover();
+  // Namespaces the avatar shared-element ids to THIS strip: the channel
+  // composer strip and the thread panel strip can be mounted at once, and a
+  // morph must never travel between them (see composerStripAvatarLayout).
+  const avatarScopeId = React.useId();
   // The MEMBERSHIP freeze engages as soon as the cursor is anywhere over the
   // bar — not only once a card opens — so pills can't enter/exit and slide
   // the strip under a cursor that is still traveling toward one. It also
@@ -670,132 +692,134 @@ export function BotActivityComposerAction({
   const itemCount = orderedAgents.length + (typingIndicator == null ? 0 : 1);
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: hover-only hold — keyboard focus drives the same hold via the pill triggers.
-    <div
-      // Full-bleed scroll viewport: -mx-5 cancels the mounting row's px-5
-      // gutter (ChannelComposerActivityRow and the thread panel's
-      // THREAD_PANEL_COMPOSER_GUTTER_CLASS — change together) and the
-      // scroller re-adds it as internal padding. Overflowing pills then clip
-      // at the CONTAINER's visual edge — where the edge fades sit — instead
-      // of getting cut at the padded content box, 20px shy of the edge with
-      // a dead gutter after the fade. At rest nothing changes: the padding
-      // keeps the first pill aligned to the gutter.
-      className="relative -mx-5 min-w-0 flex-1"
-      // Exposes the membership hold to the e2e suite: width pins no longer
-      // engage on bar hover alone, so tests need this to know the hold is
-      // armed before mutating membership.
-      data-hold={holdActive ? "true" : undefined}
-      data-testid="bot-activity-strip"
-      onMouseEnter={() => setBarHovered(true)}
-      onMouseLeave={() => setBarHovered(false)}
-    >
-      {/* layoutScroll keeps the slot layout animations correct while the
+    <ComposerStripAvatarScopeContext.Provider value={avatarScopeId}>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: hover-only hold — keyboard focus drives the same hold via the pill triggers. */}
+      <div
+        // Full-bleed scroll viewport: -mx-5 cancels the mounting row's px-5
+        // gutter (ChannelComposerActivityRow and the thread panel's
+        // THREAD_PANEL_COMPOSER_GUTTER_CLASS — change together) and the
+        // scroller re-adds it as internal padding. Overflowing pills then clip
+        // at the CONTAINER's visual edge — where the edge fades sit — instead
+        // of getting cut at the padded content box, 20px shy of the edge with
+        // a dead gutter after the fade. At rest nothing changes: the padding
+        // keeps the first pill aligned to the gutter.
+        className="relative -mx-5 min-w-0 flex-1"
+        // Exposes the membership hold to the e2e suite: width pins no longer
+        // engage on bar hover alone, so tests need this to know the hold is
+        // armed before mutating membership.
+        data-hold={holdActive ? "true" : undefined}
+        data-testid="bot-activity-strip"
+        onMouseEnter={() => setBarHovered(true)}
+        onMouseLeave={() => setBarHovered(false)}
+      >
+        {/* layoutScroll keeps the slot layout animations correct while the
           strip is scrolled — motion measures positions relative to the
           scroll offset instead of jumping. The negative-margin/padding pair
           gives focus rings and pill shadows room inside the clip box
           without changing the row's height. px-5 restores the row gutter
           inside the full-bleed viewport (see the wrapper above). */}
-      <motion.div
-        className="-my-1 flex items-center overflow-x-auto overscroll-x-contain px-5 py-1 scrollbar-none [&::-webkit-scrollbar]:hidden"
-        data-testid="bot-activity-strip-scroller"
-        layoutScroll
-        onScroll={updateFades}
-        ref={scrollerRef}
-      >
-        <div
-          // The overflow-fade hook resize-observes this wrapper as its proxy
-          // for content size. min-w-max keeps it from collapsing to the
-          // scroller's width (it is a shrinkable flex item), so late content
-          // growth — label tickers swap AFTER a resize settles — still
-          // changes an observed box and refreshes the fades. A lone item
-          // instead gets min-w-0 so it can shrink with the container
-          // (shrinkToFit) rather than overflow into scroll.
-          className={cn(
-            "flex items-center gap-3",
-            itemCount === 1 ? "min-w-0" : "min-w-max",
-          )}
+        <motion.div
+          className="-my-1 flex items-center overflow-x-auto overscroll-x-contain px-5 py-1 scrollbar-none [&::-webkit-scrollbar]:hidden"
+          data-testid="bot-activity-strip-scroller"
+          layoutScroll
+          onScroll={updateFades}
+          ref={scrollerRef}
         >
-          <AnimatePresence initial={false}>
-            {orderedAgents.map((agent, index) => {
-              const guardsOpenCard =
-                activeCardIndex !== -1 && index <= activeCardIndex;
-              return (
+          <div
+            // The overflow-fade hook resize-observes this wrapper as its proxy
+            // for content size. min-w-max keeps it from collapsing to the
+            // scroller's width (it is a shrinkable flex item), so late content
+            // growth — label tickers swap AFTER a resize settles — still
+            // changes an observed box and refreshes the fades. A lone item
+            // instead gets min-w-0 so it can shrink with the container
+            // (shrinkToFit) rather than overflow into scroll.
+            className={cn(
+              "flex items-center gap-3",
+              itemCount === 1 ? "min-w-0" : "min-w-max",
+            )}
+          >
+            <AnimatePresence initial={false}>
+              {orderedAgents.map((agent, index) => {
+                const guardsOpenCard =
+                  activeCardIndex !== -1 && index <= activeCardIndex;
+                return (
+                  <AnimatedPillSlot
+                    freezeLayout={guardsOpenCard}
+                    key={agent.pubkey}
+                    shouldReduceMotion={Boolean(shouldReduceMotion)}
+                    shrinkToFit={itemCount === 1}
+                  >
+                    {(isMoving) => (
+                      <BotActivityAgentPill
+                        agent={agent}
+                        avatarUrl={
+                          profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ??
+                          null
+                        }
+                        channelId={channelId}
+                        holdLabelSwap={isMoving}
+                        hover={hover}
+                        onOpenAgentSession={onOpenAgentSession}
+                        pinWidth={guardsOpenCard}
+                        profiles={profiles}
+                      />
+                    )}
+                  </AnimatedPillSlot>
+                );
+              })}
+              {typingIndicator == null ? null : (
                 <AnimatedPillSlot
-                  freezeLayout={guardsOpenCard}
-                  key={agent.pubkey}
+                  // The typing group trails every pill, so its movement can
+                  // never displace an open card (anchored at or left of it).
+                  freezeLayout={false}
+                  key="typing"
                   shouldReduceMotion={Boolean(shouldReduceMotion)}
                   shrinkToFit={itemCount === 1}
                 >
-                  {(isMoving) => (
-                    <BotActivityAgentPill
-                      agent={agent}
-                      avatarUrl={
-                        profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ??
-                        null
-                      }
-                      channelId={channelId}
-                      holdLabelSwap={isMoving}
-                      hover={hover}
-                      onOpenAgentSession={onOpenAgentSession}
-                      pinWidth={guardsOpenCard}
-                      profiles={profiles}
-                    />
+                  {() => (
+                    <div
+                      className={cn(
+                        // Cap like the pills (which use max-w-50 each) so a
+                        // long "X, Y, and N more are typing" label truncates
+                        // instead of inflating the scroll extent.
+                        "flex h-7 min-w-0 max-w-64 items-center",
+                        // Composer-edge alignment when the typing group leads
+                        // the strip (no pills): 0.75rem/1rem composer padding
+                        // + 1px border. Mirrors the standalone row's old
+                        // inset, and now animates via the slot's layout spring
+                        // when pills come and go.
+                        orderedAgents.length === 0 && "pl-3.25 sm:pl-4.25",
+                      )}
+                      data-testid="bot-activity-typing-slot"
+                    >
+                      {typingIndicator}
+                    </div>
                   )}
                 </AnimatedPillSlot>
-              );
-            })}
-            {typingIndicator == null ? null : (
-              <AnimatedPillSlot
-                // The typing group trails every pill, so its movement can
-                // never displace an open card (anchored at or left of it).
-                freezeLayout={false}
-                key="typing"
-                shouldReduceMotion={Boolean(shouldReduceMotion)}
-                shrinkToFit={itemCount === 1}
-              >
-                {() => (
-                  <div
-                    className={cn(
-                      // Cap like the pills (which use max-w-50 each) so a
-                      // long "X, Y, and N more are typing" label truncates
-                      // instead of inflating the scroll extent.
-                      "flex h-7 min-w-0 max-w-64 items-center",
-                      // Composer-edge alignment when the typing group leads
-                      // the strip (no pills): 0.75rem/1rem composer padding
-                      // + 1px border. Mirrors the standalone row's old
-                      // inset, and now animates via the slot's layout spring
-                      // when pills come and go.
-                      orderedAgents.length === 0 && "pl-3.25 sm:pl-4.25",
-                    )}
-                    data-testid="bot-activity-typing-slot"
-                  >
-                    {typingIndicator}
-                  </div>
-                )}
-              </AnimatedPillSlot>
-            )}
-          </AnimatePresence>
-        </div>
-      </motion.div>
-      {/* Edge fades: obvious "more pills off view" affordance. Rendered only
+              )}
+            </AnimatePresence>
+          </div>
+        </motion.div>
+        {/* Edge fades: obvious "more pills off view" affordance. Rendered only
           for a side that actually has clipped content, so they never dim a
           fully visible strip. They sit at the full-bleed viewport's edges —
           the container's visual edges — and w-12 spans the 20px gutter plus
           a soft zone over the pills scrolling under it. */}
-      {fades.start ? (
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-12 bg-linear-to-r from-background via-background/60 to-transparent"
-          data-testid="bot-activity-strip-fade-start"
-        />
-      ) : null}
-      {fades.end ? (
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-12 bg-linear-to-l from-background via-background/60 to-transparent"
-          data-testid="bot-activity-strip-fade-end"
-        />
-      ) : null}
-    </div>
+        {fades.start ? (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-y-0 left-0 z-10 w-12 bg-linear-to-r from-background via-background/60 to-transparent"
+            data-testid="bot-activity-strip-fade-start"
+          />
+        ) : null}
+        {fades.end ? (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-y-0 right-0 z-10 w-12 bg-linear-to-l from-background via-background/60 to-transparent"
+            data-testid="bot-activity-strip-fade-end"
+          />
+        ) : null}
+      </div>
+    </ComposerStripAvatarScopeContext.Provider>
   );
 }

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -339,7 +339,7 @@ function BotActivityAgentPill({
       <PopoverTrigger asChild>
         <button
           aria-label={`${agent.name} is working. View activity.`}
-          className="inline-flex h-7 min-w-0 max-w-50 items-center gap-2 rounded-full text-xs font-medium leading-none text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:text-primary"
+          className="inline-flex h-7 min-w-0 max-w-50 items-center gap-1.5 rounded-full text-xs font-medium leading-none text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:text-primary"
           data-testid="bot-activity-composer-trigger"
           onBlur={hover.scheduleClose}
           onClick={(event) => {
@@ -619,7 +619,7 @@ export function BotActivityComposerAction({
           // instead gets min-w-0 so it can shrink with the container
           // (shrinkToFit) rather than overflow into scroll.
           className={cn(
-            "flex items-center gap-1.5",
+            "flex items-center gap-3",
             itemCount === 1 ? "min-w-0" : "min-w-max",
           )}
         >

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -2,16 +2,11 @@ import * as React from "react";
 import { Loader2 } from "lucide-react";
 
 import { useAgentTranscript } from "@/features/agents/ui/useObserverEvents";
-import {
-  getActivityHeadline,
-  isMeaningfulItem,
-  isSpineItem,
-} from "@/features/agents/ui/agentSessionTranscriptPresentation";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ManagedAgent } from "@/shared/api/types";
 import { useFeatureEnabled } from "@/shared/features";
 import { cn } from "@/shared/lib/cn";
-import { Button } from "@/shared/ui/button";
+import { useNow } from "@/shared/lib/useNow";
 import {
   DEFAULT_POPOVER_HOVER_OPEN_DELAY_MS,
   Popover,
@@ -21,7 +16,7 @@ import {
 import { Shimmer } from "@/shared/ui/Shimmer";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import { ComposerLiveActivityFeed } from "./ComposerLiveActivityFeed";
-import { resolveSelectedActivityAgent } from "./composerLiveActivity";
+import { deriveActivityPillLabel } from "./composerLiveActivity";
 
 export type BotActivityAgent = Pick<ManagedAgent, "pubkey" | "name" | "status">;
 
@@ -32,99 +27,20 @@ type BotActivityBarProps = {
   openAgentSessionPubkey: string | null;
   profiles?: UserProfileLookup;
   workingBotPubkeys: string[];
-  variant?: "toolbar" | "inline";
 };
 
 const HOVER_CLOSE_DELAY_MS = 180;
-const HEADLINE_ROTATION_MS = 2200;
+/** Re-render cadence for the pill label's staleness check. */
+const PILL_LABEL_TICK_MS = 5_000;
+/** Shown when no fresh action headline exists (see deriveActivityPillLabel). */
+const GENERIC_WORKING_LABEL = "Working…";
 
-export function BotActivityComposerAction({
-  agents,
-  channelId = null,
-  onOpenAgentSession,
-  openAgentSessionPubkey,
-  profiles,
-  workingBotPubkeys,
-  variant = "toolbar",
-}: BotActivityBarProps) {
+/** Hover-intent popover state shared by every activity pill. */
+function useHoverPopover() {
   const [open, setOpen] = React.useState(false);
-  const liveActivityEnabled = useFeatureEnabled("composerLiveActivity");
-  // Which working agent's feed the live-activity preview shows. Explicit tab
-  // selection first; falls back to the open session pane, then the first
-  // working agent (see resolveSelectedActivityAgent).
-  const [selectedActivityPubkey, setSelectedActivityPubkey] = React.useState<
-    string | null
-  >(null);
   const hoverTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-
-  const workingAgents = React.useMemo(() => {
-    const workingSet = new Set(
-      workingBotPubkeys.map((pubkey) => pubkey.toLowerCase()),
-    );
-
-    return agents.filter((agent) => workingSet.has(agent.pubkey.toLowerCase()));
-  }, [agents, workingBotPubkeys]);
-  const singleWorkingAgent =
-    workingAgents.length === 1 ? (workingAgents[0] ?? null) : null;
-  const selectedActivityAgent = React.useMemo(
-    () =>
-      liveActivityEnabled
-        ? resolveSelectedActivityAgent({
-            openAgentSessionPubkey,
-            selectedPubkey: selectedActivityPubkey,
-            workingAgents,
-          })
-        : null,
-    [
-      liveActivityEnabled,
-      openAgentSessionPubkey,
-      selectedActivityPubkey,
-      workingAgents,
-    ],
-  );
-  const transcript = useAgentTranscript(
-    Boolean(singleWorkingAgent),
-    singleWorkingAgent?.pubkey,
-  );
-  const activityHeadlines = React.useMemo(() => {
-    if (!singleWorkingAgent) {
-      return [];
-    }
-
-    const seen = new Set<string>();
-    const headlines: string[] = [];
-    const scopedTranscript = channelId
-      ? transcript.filter((item) => item.channelId === channelId)
-      : transcript;
-
-    // Two-tier scan: spine items first (reads recede when real work is present).
-    // If no spine headlines are found (session start / idle), fall back to all
-    // meaningful items so the bar isn't left empty.
-    const passFilter: (item: (typeof scopedTranscript)[number]) => boolean =
-      scopedTranscript.some(isSpineItem) ? isSpineItem : isMeaningfulItem;
-
-    for (let i = scopedTranscript.length - 1; i >= 0; i--) {
-      const item = scopedTranscript[i];
-      if (!passFilter(item)) {
-        continue;
-      }
-      const headline = getActivityHeadline(item);
-      if (!headline || seen.has(headline)) {
-        continue;
-      }
-
-      seen.add(headline);
-      headlines.unshift(headline);
-      if (headlines.length >= 5) {
-        break;
-      }
-    }
-
-    return headlines;
-  }, [channelId, singleWorkingAgent, transcript]);
-  const [headlineIndex, setHeadlineIndex] = React.useState(0);
 
   const clearHoverTimer = React.useCallback(() => {
     if (hoverTimerRef.current !== null) {
@@ -147,217 +63,177 @@ export function BotActivityComposerAction({
     }, HOVER_CLOSE_DELAY_MS);
   }, [clearHoverTimer]);
 
-  const keepOpen = React.useCallback(() => {
-    clearHoverTimer();
-  }, [clearHoverTimer]);
-
   React.useEffect(() => {
     return () => clearHoverTimer();
   }, [clearHoverTimer]);
 
-  React.useEffect(() => {
-    if (activityHeadlines.length <= 1) {
-      return;
-    }
+  return { clearHoverTimer, closeWithDelay, open, openWithDelay, setOpen };
+}
 
-    const interval = window.setInterval(() => {
-      setHeadlineIndex((current) => (current + 1) % activityHeadlines.length);
-    }, HEADLINE_ROTATION_MS);
+/**
+ * One working agent's status pill: avatar + the agent's latest action summary
+ * (decaying to a generic working label when activity goes quiet). Hovering
+ * shows the agent's live activity feed as the popover surface itself — flat,
+ * no inset box, no tab strip — while clicking the pill opens the agent's full
+ * runtime in the auxiliary panel. With the `composerLiveActivity` preview
+ * flag off, the hover popover keeps the legacy "View activity" item instead.
+ */
+function BotActivityAgentPill({
+  agent,
+  avatarUrl,
+  channelId,
+  liveActivityEnabled,
+  onOpenAgentSession,
+  openAgentSessionPubkey,
+  profiles,
+}: {
+  agent: BotActivityAgent;
+  avatarUrl: string | null;
+  channelId: string | null;
+  liveActivityEnabled: boolean;
+  onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
+  openAgentSessionPubkey: string | null;
+  profiles?: UserProfileLookup;
+}) {
+  const { clearHoverTimer, closeWithDelay, open, openWithDelay, setOpen } =
+    useHoverPopover();
+  const transcript = useAgentTranscript(true, agent.pubkey);
+  const now = useNow(PILL_LABEL_TICK_MS);
+  const headline = React.useMemo(
+    () => deriveActivityPillLabel({ channelId, now, transcript }),
+    [channelId, now, transcript],
+  );
+  const label = headline ?? GENERIC_WORKING_LABEL;
+  const isSessionOpen =
+    openAgentSessionPubkey?.toLowerCase() === agent.pubkey.toLowerCase();
 
-    return () => window.clearInterval(interval);
-  }, [activityHeadlines.length]);
-
-  if (workingAgents.length === 0) {
-    return null;
-  }
-
-  const agentAvatarUrl = (agent: BotActivityAgent) =>
-    profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ?? null;
-  const selectedPubkey = openAgentSessionPubkey?.toLowerCase() ?? null;
-  const triggerLabel =
-    workingAgents.length === 1
-      ? `${workingAgents[0]?.name ?? "Agent"} is working`
-      : `${workingAgents.length} agents working`;
-  const isInline = variant === "inline";
-  const visibleStatusLabel =
-    workingAgents.length === 1
-      ? `${workingAgents[0]?.name ?? "Agent"}: ${
-          activityHeadlines[headlineIndex % activityHeadlines.length] ??
-          "Working"
-        }`
-      : `${workingAgents[0]?.name ?? "Agent"} +${workingAgents.length - 1}`;
+  const openSession = () => {
+    clearHoverTimer();
+    setOpen(false);
+    onOpenAgentSession(agent.pubkey, channelId);
+  };
 
   return (
     <Popover onOpenChange={setOpen} open={open}>
       <PopoverTrigger asChild>
         <button
-          aria-label={`${triggerLabel}. View activity.`}
-          className={cn(
-            "inline-flex items-center justify-center rounded-full border border-border/60 bg-background font-medium text-muted-foreground transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary",
-            isInline
-              ? "min-w-0 gap-1.5 overflow-visible border-transparent bg-transparent px-0 text-xs font-normal leading-normal shadow-none hover:border-transparent hover:bg-transparent data-[state=open]:border-transparent data-[state=open]:bg-transparent"
-              : "h-9 min-w-9 gap-1.5 px-2 text-xs",
-          )}
+          aria-label={`${agent.name} is working. View activity.`}
+          className="inline-flex h-7 min-w-0 max-w-30 items-center gap-1.5 rounded-full border border-border/60 bg-background px-2 text-xs font-semibold leading-none text-muted-foreground shadow-xs transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary"
           data-testid="bot-activity-composer-trigger"
           onBlur={closeWithDelay}
-          onClick={() => {
-            clearHoverTimer();
-            setOpen((current) => !current);
+          onClick={(event) => {
+            // The popover is a hover preview; clicking goes straight to the
+            // agent's runtime in the aux panel. preventDefault stops Radix's
+            // composed trigger toggle from fighting over the popover state.
+            event.preventDefault();
+            openSession();
           }}
           onFocus={() => setOpen(true)}
           onMouseEnter={openWithDelay}
           onMouseLeave={closeWithDelay}
           type="button"
         >
-          <span className="flex h-4.5 items-center overflow-visible -space-x-1">
-            {workingAgents.slice(0, 2).map((agent) => (
-              <UserAvatar
-                avatarUrl={agentAvatarUrl(agent)}
-                className={cn(
-                  "border border-background",
-                  isInline ? "!h-4.5 !w-4.5 text-3xs" : "shrink-0",
-                )}
-                displayName={agent.name}
-                fallbackDelayMs={isInline ? 0 : undefined}
-                key={agent.pubkey}
-                size="xs"
-              />
-            ))}
+          <UserAvatar
+            avatarUrl={avatarUrl}
+            className="!h-[18px] !w-[18px] shrink-0 text-3xs"
+            displayName={agent.name}
+            size="xs"
+          />
+          <span className="min-w-0 flex-1 overflow-hidden">
+            <Shimmer className="block truncate">{label}</Shimmer>
           </span>
-          {workingAgents.length > 2 ? (
-            <span className="text-2xs leading-none">
-              +{workingAgents.length - 2}
-            </span>
-          ) : null}
-          <span
-            className={cn(
-              isInline
-                ? "flex h-4.5 min-w-0 flex-1 items-center overflow-visible leading-none"
-                : "sr-only",
-            )}
-          >
-            {isInline ? (
-              <Shimmer className="-my-px truncate py-px">
-                {visibleStatusLabel}
-              </Shimmer>
-            ) : (
-              "working"
-            )}
-          </span>
-          {isInline ? null : (
-            <Loader2 className="h-4 w-4 shrink-0 animate-spin opacity-70" />
-          )}
         </button>
       </PopoverTrigger>
       <PopoverContent
-        align={isInline ? "start" : "end"}
+        align="start"
         className={cn(
-          liveActivityEnabled ? "flex w-80 flex-col gap-1.5 p-2" : "w-64 p-1",
+          liveActivityEnabled ? "w-80 overflow-hidden p-0" : "w-64 p-1",
         )}
-        onMouseEnter={keepOpen}
+        onMouseEnter={clearHoverTimer}
         onMouseLeave={closeWithDelay}
         onOpenAutoFocus={(event) => event.preventDefault()}
         side="top"
         sideOffset={8}
       >
         {liveActivityEnabled ? (
-          <>
-            {selectedActivityAgent ? (
-              <ComposerLiveActivityFeed
-                agent={selectedActivityAgent}
-                channelId={channelId}
-                className="h-48 rounded-lg border border-border/60 bg-background"
-                onOpenAgentSession={(pubkey) => {
-                  clearHoverTimer();
-                  setOpen(false);
-                  onOpenAgentSession(pubkey, channelId);
-                }}
-                profiles={profiles}
-              />
-            ) : null}
-            <div
-              aria-label="Working agents"
-              className="flex w-full flex-wrap items-center justify-start gap-1.5"
-              role="tablist"
-            >
-              {workingAgents.map((agent) => {
-                const isSelected =
-                  selectedActivityAgent?.pubkey.toLowerCase() ===
-                  agent.pubkey.toLowerCase();
-
-                return (
-                  <Button
-                    aria-selected={isSelected}
-                    className="max-w-full shrink-0 rounded-full px-2"
-                    data-testid={`bot-activity-composer-item-${agent.pubkey}`}
-                    key={agent.pubkey}
-                    onClick={() =>
-                      setSelectedActivityPubkey(agent.pubkey.toLowerCase())
-                    }
-                    role="tab"
-                    size="sm"
-                    type="button"
-                    variant={isSelected ? "secondary" : "ghost"}
-                  >
-                    <UserAvatar
-                      avatarUrl={agentAvatarUrl(agent)}
-                      className="!h-[18px] !w-[18px] shrink-0 text-3xs"
-                      displayName={agent.name}
-                      size="xs"
-                    />
-                    <span className="max-w-28 truncate">{agent.name}</span>
-                  </Button>
-                );
-              })}
-            </div>
-          </>
+          <ComposerLiveActivityFeed
+            agent={agent}
+            channelId={channelId}
+            className="h-48 rounded-[inherit]"
+            onOpenAgentSession={() => openSession()}
+            profiles={profiles}
+          />
         ) : (
-          <>
-            <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
-              Agents working
-            </div>
-            <div className="mt-1 flex flex-col gap-1">
-              {workingAgents.map((agent) => {
-                const isSelected =
-                  selectedPubkey === agent.pubkey.toLowerCase();
-
-                return (
-                  <button
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors",
-                      isSelected
-                        ? "bg-primary/10 text-primary"
-                        : "text-foreground hover:bg-accent hover:text-accent-foreground",
-                    )}
-                    data-testid={`bot-activity-composer-item-${agent.pubkey}`}
-                    key={agent.pubkey}
-                    onClick={() => {
-                      clearHoverTimer();
-                      setOpen(false);
-                      onOpenAgentSession(agent.pubkey, channelId);
-                    }}
-                    type="button"
-                  >
-                    <UserAvatar
-                      avatarUrl={agentAvatarUrl(agent)}
-                      className="shrink-0"
-                      displayName={agent.name}
-                      size="sm"
-                    />
-                    <span className="min-w-0 flex-1 truncate">
-                      {agent.name}
-                    </span>
-                    <span className="shrink-0 whitespace-nowrap text-xs font-medium opacity-80">
-                      View activity
-                    </span>
-                    <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground/70" />
-                  </button>
-                );
-              })}
-            </div>
-          </>
+          <button
+            className={cn(
+              "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors",
+              isSessionOpen
+                ? "bg-primary/10 text-primary"
+                : "text-foreground hover:bg-accent hover:text-accent-foreground",
+            )}
+            data-testid={`bot-activity-composer-item-${agent.pubkey}`}
+            onClick={openSession}
+            type="button"
+          >
+            <UserAvatar
+              avatarUrl={avatarUrl}
+              className="shrink-0"
+              displayName={agent.name}
+              size="sm"
+            />
+            <span className="min-w-0 flex-1 truncate">{agent.name}</span>
+            <span className="shrink-0 whitespace-nowrap text-xs font-medium opacity-80">
+              View activity
+            </span>
+            <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground/70" />
+          </button>
         )}
       </PopoverContent>
     </Popover>
+  );
+}
+
+/**
+ * Composer status strip for working agents: one pill per working agent, each
+ * owning its hover popover. Pills shrink and truncate their labels when
+ * several agents work at once so the strip never wraps the fixed-height row.
+ */
+export function BotActivityComposerAction({
+  agents,
+  channelId = null,
+  onOpenAgentSession,
+  openAgentSessionPubkey,
+  profiles,
+  workingBotPubkeys,
+}: BotActivityBarProps) {
+  const liveActivityEnabled = useFeatureEnabled("composerLiveActivity");
+
+  const workingAgents = React.useMemo(() => {
+    const workingSet = new Set(
+      workingBotPubkeys.map((pubkey) => pubkey.toLowerCase()),
+    );
+
+    return agents.filter((agent) => workingSet.has(agent.pubkey.toLowerCase()));
+  }, [agents, workingBotPubkeys]);
+
+  if (workingAgents.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-visible">
+      {workingAgents.map((agent) => (
+        <BotActivityAgentPill
+          agent={agent}
+          avatarUrl={profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ?? null}
+          channelId={channelId}
+          key={agent.pubkey}
+          liveActivityEnabled={liveActivityEnabled}
+          onOpenAgentSession={onOpenAgentSession}
+          openAgentSessionPubkey={openAgentSessionPubkey}
+          profiles={profiles}
+        />
+      ))}
+    </div>
   );
 }

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -295,7 +295,12 @@ function BotActivityAgentPill({
         displayName={agent.name}
         size="xs"
       />
-      <span className="relative block h-3.5 min-w-0 flex-1 overflow-hidden">
+      {/* Ticker viewport: 16px tall with a matching 16px line box (leading-4
+          overrides the button's leading-none). Inter's ascent+descent ink is
+          ~1.21em (~14.5px at text-xs) — taller than a leading-none line box —
+          and BOTH this span and the truncate span clip to their boxes, which
+          sheared descenders ("g", "y") off the label. */}
+      <span className="relative block h-4 min-w-0 flex-1 overflow-hidden leading-4">
         <AnimatePresence initial={false} mode="popLayout">
           <motion.span
             animate={{ y: 0 }}
@@ -470,7 +475,9 @@ function AnimatedPillSlot({
  * toolbars especially) the strip scrolls horizontally — scrollbar hidden,
  * with edge gradient fades signalling the pills off view — instead of
  * compressing every pill into an unreadable sliver or wrapping the
- * fixed-height row.
+ * fixed-height row. The scroll viewport bleeds across the mounting row's
+ * gutter so the clip line and its fades sit at the container's visual
+ * edges, never mid-row on a pill.
  */
 export function BotActivityComposerAction({
   agents,
@@ -559,7 +566,15 @@ export function BotActivityComposerAction({
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: hover-only hold — keyboard focus drives the same hold via the pill triggers.
     <div
-      className="relative min-w-0 flex-1"
+      // Full-bleed scroll viewport: -mx-5 cancels the mounting row's px-5
+      // gutter (ChannelComposerActivityRow and the thread panel's
+      // THREAD_PANEL_COMPOSER_GUTTER_CLASS — change together) and the
+      // scroller re-adds it as internal padding. Overflowing pills then clip
+      // at the CONTAINER's visual edge — where the edge fades sit — instead
+      // of getting cut at the padded content box, 20px shy of the edge with
+      // a dead gutter after the fade. At rest nothing changes: the padding
+      // keeps the first pill aligned to the gutter.
+      className="relative -mx-5 min-w-0 flex-1"
       data-testid="bot-activity-strip"
       onMouseEnter={() => setBarHovered(true)}
       onMouseLeave={() => setBarHovered(false)}
@@ -568,9 +583,10 @@ export function BotActivityComposerAction({
           strip is scrolled — motion measures positions relative to the
           scroll offset instead of jumping. The negative-margin/padding pair
           gives focus rings and pill shadows room inside the clip box
-          without changing the row's height. */}
+          without changing the row's height. px-5 restores the row gutter
+          inside the full-bleed viewport (see the wrapper above). */}
       <motion.div
-        className="-my-1 flex items-center overflow-x-auto overscroll-x-contain py-1 scrollbar-none [&::-webkit-scrollbar]:hidden"
+        className="-my-1 flex items-center overflow-x-auto overscroll-x-contain px-5 py-1 scrollbar-none [&::-webkit-scrollbar]:hidden"
         data-testid="bot-activity-strip-scroller"
         layoutScroll
         onScroll={updateFades}
@@ -606,18 +622,20 @@ export function BotActivityComposerAction({
       </motion.div>
       {/* Edge fades: obvious "more pills off view" affordance. Rendered only
           for a side that actually has clipped content, so they never dim a
-          fully visible strip. */}
+          fully visible strip. They sit at the full-bleed viewport's edges —
+          the container's visual edges — and w-12 spans the 20px gutter plus
+          a soft zone over the pills scrolling under it. */}
       {fades.start ? (
         <div
           aria-hidden
-          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-linear-to-r from-background via-background/60 to-transparent"
+          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-12 bg-linear-to-r from-background via-background/60 to-transparent"
           data-testid="bot-activity-strip-fade-start"
         />
       ) : null}
       {fades.end ? (
         <div
           aria-hidden
-          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-linear-to-l from-background via-background/60 to-transparent"
+          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-12 bg-linear-to-l from-background via-background/60 to-transparent"
           data-testid="bot-activity-strip-fade-end"
         />
       ) : null}

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -26,6 +26,7 @@ import {
 } from "./composerStripAvatarLayout";
 import {
   deriveActivityPillLabel,
+  deriveActivityPillPresentation,
   deriveAgentWorkingOrder,
 } from "./composerLiveActivity";
 
@@ -39,8 +40,8 @@ type BotActivityBarProps = {
   /**
    * Agent pubkeys known to be typing in this strip's scope. Thread-only
    * typing is intentionally absent from the channel-wide working registry,
-   * so callers pass it here to relabel an already pill-worthy agent without
-   * leaking thread activity into channel-level surfaces.
+   * so callers pass it here to retain the typing fallback without leaking
+   * thread activity into channel-level surfaces.
    */
   typingBotPubkeys?: string[];
   /** Combined human + typing-fallback agent indicator. */
@@ -49,10 +50,6 @@ type BotActivityBarProps = {
 };
 
 const HOVER_CLOSE_DELAY_MS = 180;
-/** Ticker key for the generic label shown before the first action lands. */
-const GENERIC_LABEL_ID = "generic-working";
-/** Ticker key for the typing override label (see BotActivityAgentPill). */
-const TYPING_LABEL_ID = "typing-override";
 /**
  * Perceptual duration shared by the pill reorder spring and the opacity dip
  * keyframes so the fade lands together with the layout switch.
@@ -230,9 +227,9 @@ function useStripHoverPopover(): StripHoverPopover {
  * partitionComposerWorkingAgents): typing agents with nothing to hover or
  * open are diverted into the combined typing indicator group by
  * ChannelComposerActivityRow before the strip renders. An agent that is
- * typing — mid-turn or across the turn-end gap — keeps its pill, with the
- * label relabeled in place to "is typing…" for the duration (see the
- * typing override below).
+ * typing across the turn-end gap keeps its pill and relabels in place to
+ * "is typing…"; during an active observer turn, the current action remains
+ * authoritative despite concurrent typing refreshes.
  */
 function BotActivityAgentPill({
   agent,
@@ -271,27 +268,28 @@ function BotActivityAgentPill({
     () => deriveActivityPillLabel({ channelId, transcript }),
     [channelId, transcript],
   );
-  // Typing overrides the action headline IN PLACE: when this observer-backed
-  // agent's typing signal is also on for the channel (it starts composing its
-  // reply mid-turn), the pill's ticker swaps to "is typing…" — same slot,
-  // avatar, and hover feed — instead of the stale last action persisting or a
-  // second typing-group item appearing. Raw registry read, because
-  // getAgentWorkingState folds typing away under observer precedence.
+  const workingState = React.useSyncExternalStore(
+    subscribeAgentWorkingSignal,
+    () => getAgentWorkingState(agent.pubkey, channelId),
+  );
+  // Raw typing remains available even when getAgentWorkingState folds it under
+  // observer precedence. It supplies the fallback before observer telemetry
+  // arrives and after the observer turn completes; it must not hide live
+  // observer activity while that turn is active.
   const typingSince = React.useSyncExternalStore(
     subscribeAgentWorkingSignal,
     () => getAgentChannelTypingSince(agent.pubkey, channelId),
   );
   const isTyping =
     typingBotPubkeys?.has(pillKey) === true || typingSince !== null;
-  const activeId = isTyping
-    ? TYPING_LABEL_ID
-    : (headline?.id ?? GENERIC_LABEL_ID);
-  // No action headline yet (see deriveActivityPillLabel) — show the
-  // agent-named generic working label until the first action lands. When
-  // typing ends, the ticker swaps back to the last action headline.
-  const activeLabel = isTyping
-    ? `${agent.name} is typing…`
-    : (headline?.label ?? `${agent.name} is working…`);
+  const presentation = deriveActivityPillPresentation({
+    agentName: agent.name,
+    headline,
+    isTyping,
+    workingSource: workingState.source,
+  });
+  const activeId = presentation.id;
+  const activeLabel = presentation.label;
   // The rendered label lags the derived one while the pill is moving: the
   // push-up ticker plays after the slot settles (or immediately when idle).
   // Keyed by transcript item id, not label text — a NEW action swaps, while

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Loader2 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
+import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
 import {
   getAgentTranscript,
   subscribeAgentObserverStore,
@@ -38,10 +39,11 @@ type BotActivityBarProps = {
 };
 
 const HOVER_CLOSE_DELAY_MS = 180;
-/** Re-render cadence for the pill label's staleness check. */
-const PILL_LABEL_TICK_MS = 5_000;
-/** Shown when no fresh action headline exists (see deriveActivityPillLabel). */
-const GENERIC_WORKING_LABEL = "Working…";
+/**
+ * Re-render cadence for the pill label's staleness check. One second so the
+ * decay to the generic label lands promptly after the stale window elapses.
+ */
+const PILL_LABEL_TICK_MS = 1_000;
 /** Ticker key for the generic label so decay/recovery animate as one swap. */
 const GENERIC_LABEL_ID = "generic-working";
 /**
@@ -55,39 +57,103 @@ const PILL_REORDER_DURATION_S = 0.9;
 const subscribeToObserverStore = (onStoreChange: () => void) =>
   subscribeAgentObserverStore(onStoreChange);
 
-/** Hover-intent popover state shared by every activity pill. */
-function useHoverPopover() {
-  const [open, setOpen] = React.useState(false);
-  const hoverTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
+/**
+ * Strip-level hover popover state: ONE active pill and ONE timer for the
+ * whole composer strip.
+ *
+ * Hover state used to live per pill, which raced N independent open/close
+ * timers against each other: traveling pill A → pill B opened B's card at
+ * +150ms while A's close fired at +180ms (brief double-open), and a cursor
+ * that clipped A's open card on the way cancelled A's close entirely,
+ * leaving the card stuck. Centralizing means at most one card can ever be
+ * open and pill-to-pill travel is a single deterministic switch.
+ */
+type StripHoverPopover = {
+  /** Pill key (lowercased pubkey) whose hover card is open, or null. */
+  activePubkey: string | null;
+  /** Cancel any pending open/close without touching the current card. */
+  cancelPending: () => void;
+  /** Close immediately (click-through to the session, Radix dismiss). */
+  closeNow: () => void;
+  /** Pointer entered a pill trigger. */
+  enterTrigger: (pubkey: string) => void;
+  /** Open a pill's card immediately (keyboard focus). */
+  openNow: (pubkey: string) => void;
+  /** Pointer left a trigger or the open card: close after the grace delay. */
+  scheduleClose: () => void;
+};
 
-  const clearHoverTimer = React.useCallback(() => {
-    if (hoverTimerRef.current !== null) {
-      clearTimeout(hoverTimerRef.current);
-      hoverTimerRef.current = null;
+function useStripHoverPopover(): StripHoverPopover {
+  const [activePubkey, setActivePubkey] = React.useState<string | null>(null);
+  // Ref mirror so pointer handlers can branch on open-vs-closed synchronously.
+  const activeRef = React.useRef<string | null>(null);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelPending = React.useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
     }
   }, []);
 
-  const openWithDelay = React.useCallback(() => {
-    clearHoverTimer();
-    hoverTimerRef.current = setTimeout(() => {
-      setOpen(true);
-    }, DEFAULT_POPOVER_HOVER_OPEN_DELAY_MS);
-  }, [clearHoverTimer]);
+  const setActive = React.useCallback(
+    (pubkey: string | null) => {
+      cancelPending();
+      activeRef.current = pubkey;
+      setActivePubkey(pubkey);
+    },
+    [cancelPending],
+  );
 
-  const closeWithDelay = React.useCallback(() => {
-    clearHoverTimer();
-    hoverTimerRef.current = setTimeout(() => {
-      setOpen(false);
+  const enterTrigger = React.useCallback(
+    (pubkey: string) => {
+      // With a card up (or in its close grace period), reaching another pill
+      // switches the card right away — re-arming the intent delay here is
+      // what raced the per-pill timers. From a fully closed strip, keep the
+      // hover-intent delay; the single timer means the pending target simply
+      // follows the cursor.
+      if (activeRef.current !== null) {
+        setActive(pubkey);
+        return;
+      }
+      cancelPending();
+      timerRef.current = setTimeout(() => {
+        setActive(pubkey);
+      }, HOVER_OPEN_DELAY_MS);
+    },
+    [cancelPending, setActive],
+  );
+
+  const scheduleClose = React.useCallback(() => {
+    cancelPending();
+    if (activeRef.current === null) {
+      // Nothing open — leaving just abandons the pending hover intent.
+      return;
+    }
+    timerRef.current = setTimeout(() => {
+      setActive(null);
     }, HOVER_CLOSE_DELAY_MS);
-  }, [clearHoverTimer]);
+  }, [cancelPending, setActive]);
+
+  const openNow = React.useCallback(
+    (pubkey: string) => setActive(pubkey),
+    [setActive],
+  );
+
+  const closeNow = React.useCallback(() => setActive(null), [setActive]);
 
   React.useEffect(() => {
-    return () => clearHoverTimer();
-  }, [clearHoverTimer]);
+    return () => cancelPending();
+  }, [cancelPending]);
 
-  return { clearHoverTimer, closeWithDelay, open, openWithDelay, setOpen };
+  return {
+    activePubkey,
+    cancelPending,
+    closeNow,
+    enterTrigger,
+    openNow,
+    scheduleClose,
+  };
 }
 
 /**
@@ -100,15 +166,22 @@ function useHoverPopover() {
  * the agent's full runtime in the auxiliary panel. With the
  * `composerLiveActivity` preview flag off, the hover popover keeps the
  * legacy "View activity" item instead.
+ *
+ * Typing-fallback-only agents (working source "typing", no observer turn)
+ * render a passive, borderless, width-uncapped status instead: no hover
+ * card, no click-through, not focusable — there is no transcript or session
+ * behind the signal to open.
  */
 function BotActivityAgentPill({
   agent,
   avatarUrl,
   channelId,
   holdLabelSwap,
+  hover,
   liveActivityEnabled,
   onOpenAgentSession,
   openAgentSessionPubkey,
+  pinWidth,
   profiles,
 }: {
   agent: BotActivityAgent;
@@ -116,14 +189,22 @@ function BotActivityAgentPill({
   channelId: string | null;
   /** Defer label swaps while the pill's slot is mid layout animation. */
   holdLabelSwap: boolean;
+  /** Strip-level hover popover state shared by every pill. */
+  hover: StripHoverPopover;
   liveActivityEnabled: boolean;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
   openAgentSessionPubkey: string | null;
+  /** Freeze the pill's rendered width (a hover card is showing). */
+  pinWidth: boolean;
   profiles?: UserProfileLookup;
 }) {
-  const { clearHoverTimer, closeWithDelay, open, openWithDelay, setOpen } =
-    useHoverPopover();
+  const pillKey = agent.pubkey.toLowerCase();
+  const open = hover.activePubkey === pillKey;
   const shouldReduceMotion = useReducedMotion();
+  // Typing-fallback-only agents (no observer turn) render borderless and
+  // uncapped — the basic "is typing" presentation.
+  const typingOnly =
+    useAgentWorking(agent.pubkey, channelId).source === "typing";
   const transcript = useAgentTranscript(true, agent.pubkey);
   const now = useNow(PILL_LABEL_TICK_MS);
   const headline = React.useMemo(
@@ -131,7 +212,9 @@ function BotActivityAgentPill({
     [channelId, now, transcript],
   );
   const activeId = headline?.id ?? GENERIC_LABEL_ID;
-  const activeLabel = headline?.label ?? GENERIC_WORKING_LABEL;
+  // No fresh action headline (see deriveActivityPillLabel) — decay to the
+  // agent-named generic working label.
+  const activeLabel = headline?.label ?? `${agent.name} is working…`;
   // The rendered label lags the derived one while the pill is moving: the
   // push-up ticker plays after the slot settles (or immediately when idle).
   // Keyed by transcript item id, not label text — a NEW action swaps, while
@@ -153,20 +236,90 @@ function BotActivityAgentPill({
   const isSessionOpen =
     openAgentSessionPubkey?.toLowerCase() === agent.pubkey.toLowerCase();
 
+  // While a hover card is showing, the pill must not resize: label swaps
+  // keep animating, but a longer/shorter label truncating inside a FROZEN
+  // width can no longer shift the neighboring pills under the cursor. The
+  // width is measured once when the hold starts and dropped on release.
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null);
+  const [pinnedWidth, setPinnedWidth] = React.useState<number | null>(null);
+  React.useLayoutEffect(() => {
+    if (!pinWidth) {
+      setPinnedWidth(null);
+      return;
+    }
+    const node = triggerRef.current;
+    if (node !== null) {
+      setPinnedWidth(node.getBoundingClientRect().width);
+    }
+  }, [pinWidth]);
+
   const openSession = () => {
-    clearHoverTimer();
-    setOpen(false);
+    hover.closeNow();
     onOpenAgentSession(agent.pubkey, channelId);
   };
 
+  const pillContent = (
+    <>
+      <UserAvatar
+        avatarUrl={avatarUrl}
+        className="!h-[18px] !w-[18px] shrink-0 text-3xs"
+        displayName={agent.name}
+        size="xs"
+      />
+      <span className="relative block h-3.5 min-w-0 flex-1 overflow-hidden">
+        <AnimatePresence initial={false} mode="popLayout">
+          <motion.span
+            animate={{ y: 0 }}
+            className="flex h-full items-center"
+            exit={{ y: "-110%" }}
+            initial={shouldReduceMotion ? false : { y: "110%" }}
+            key={display.id}
+            transition={
+              shouldReduceMotion
+                ? { duration: 0 }
+                : { type: "tween", duration: 0.28, ease: "easeOut" }
+            }
+          >
+            <Shimmer className="block min-w-0 truncate">
+              {display.label}
+            </Shimmer>
+          </motion.span>
+        </AnimatePresence>
+      </span>
+    </>
+  );
+
+  // Typing-fallback-only: a passive status readout — no hover card, no
+  // click-through, not focusable. There is no observer turn (and so no
+  // transcript or session) behind it to open.
+  if (typingOnly) {
+    return (
+      <div
+        className="inline-flex h-7 min-w-0 items-center gap-1.5 rounded-full bg-background px-2 text-xs font-semibold leading-none text-muted-foreground"
+        data-testid="bot-activity-composer-typing"
+      >
+        {pillContent}
+      </div>
+    );
+  }
+
   return (
-    <Popover onOpenChange={setOpen} open={open}>
+    <Popover
+      onOpenChange={(nextOpen) => {
+        // Radix only drives closes here (escape / outside dismiss) — trigger
+        // clicks are preventDefault'ed and hover opens are controlled.
+        if (!nextOpen) {
+          hover.closeNow();
+        }
+      }}
+      open={open}
+    >
       <PopoverTrigger asChild>
         <button
           aria-label={`${agent.name} is working. View activity.`}
-          className="inline-flex h-7 min-w-0 max-w-36 items-center gap-1.5 rounded-full border border-border/60 bg-background px-2 text-xs font-semibold leading-none text-muted-foreground shadow-xs transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary"
+          className="inline-flex h-7 min-w-0 max-w-49 items-center gap-1.5 rounded-full border border-border/60 bg-background px-2 text-xs font-semibold leading-none text-muted-foreground shadow-xs transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary"
           data-testid="bot-activity-composer-trigger"
-          onBlur={closeWithDelay}
+          onBlur={hover.scheduleClose}
           onClick={(event) => {
             // The popover is a hover preview; clicking goes straight to the
             // agent's runtime in the aux panel. preventDefault stops Radix's
@@ -174,37 +327,21 @@ function BotActivityAgentPill({
             event.preventDefault();
             openSession();
           }}
-          onFocus={() => setOpen(true)}
-          onMouseEnter={openWithDelay}
-          onMouseLeave={closeWithDelay}
+          onFocus={(event) => {
+            // Keyboard focus only (:focus-visible). Plain focus also lands
+            // here when Radix returns focus to the trigger as the card
+            // closes — opening on that re-opened the card in a loop.
+            if (event.currentTarget.matches(":focus-visible")) {
+              hover.openNow(pillKey);
+            }
+          }}
+          onMouseEnter={() => hover.enterTrigger(pillKey)}
+          onMouseLeave={hover.scheduleClose}
+          ref={triggerRef}
+          style={pinnedWidth === null ? undefined : { width: pinnedWidth }}
           type="button"
         >
-          <UserAvatar
-            avatarUrl={avatarUrl}
-            className="!h-[18px] !w-[18px] shrink-0 text-3xs"
-            displayName={agent.name}
-            size="xs"
-          />
-          <span className="relative block h-3.5 min-w-0 flex-1 overflow-hidden">
-            <AnimatePresence initial={false} mode="popLayout">
-              <motion.span
-                animate={{ y: 0 }}
-                className="flex h-full items-center"
-                exit={{ y: "-110%" }}
-                initial={shouldReduceMotion ? false : { y: "110%" }}
-                key={display.id}
-                transition={
-                  shouldReduceMotion
-                    ? { duration: 0 }
-                    : { type: "tween", duration: 0.28, ease: "easeOut" }
-                }
-              >
-                <Shimmer className="block min-w-0 truncate">
-                  {display.label}
-                </Shimmer>
-              </motion.span>
-            </AnimatePresence>
-          </span>
+          {pillContent}
         </button>
       </PopoverTrigger>
       <PopoverContent
@@ -212,8 +349,13 @@ function BotActivityAgentPill({
         className={cn(
           liveActivityEnabled ? "w-80 overflow-hidden p-0" : "w-64 p-1",
         )}
-        onMouseEnter={clearHoverTimer}
-        onMouseLeave={closeWithDelay}
+        onCloseAutoFocus={(event) => {
+          // A hover preview must not yank focus back to the trigger on
+          // close: the trigger's focus handler would re-open the card.
+          event.preventDefault();
+        }}
+        onMouseEnter={hover.cancelPending}
+        onMouseLeave={hover.scheduleClose}
         onOpenAutoFocus={(event) => event.preventDefault()}
         side="top"
         sideOffset={8}
@@ -261,17 +403,31 @@ function BotActivityAgentPill({
  * new slot (layout animation) its opacity dips and recovers via keyframes
  * that run for the same duration as the slot spring, so the fade and the
  * move finish together and reorders read as a shuffle instead of a hard
- * swap. Enter/exit use the same scale+fade treatment.
+ * swap. Enter/exit use the same scale+fade treatment. While a hover card is
+ * showing (`freezeLayout`), layout animation is disabled entirely so nothing
+ * can slide under the cursor.
  */
 function AnimatedPillSlot({
   children,
+  freezeLayout,
   shouldReduceMotion,
 }: {
   /** Render prop so the pill can defer label swaps while its slot moves. */
   children: (isMoving: boolean) => React.ReactNode;
+  /** Disable slot layout animation while a hover card is showing. */
+  freezeLayout: boolean;
   shouldReduceMotion: boolean;
 }) {
   const [isMoving, setIsMoving] = React.useState(false);
+
+  // Freezing mid-flight cuts the layout animation short, and
+  // onLayoutAnimationComplete never fires for a cancelled run — clear the
+  // moving flag here so the pill's label-swap hold can't get stuck.
+  React.useEffect(() => {
+    if (freezeLayout) {
+      setIsMoving(false);
+    }
+  }, [freezeLayout]);
 
   return (
     <motion.div
@@ -279,7 +435,7 @@ function AnimatedPillSlot({
       className="flex min-w-0"
       exit={{ opacity: 0, scale: 0.9 }}
       initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.9 }}
-      layout={!shouldReduceMotion}
+      layout={!shouldReduceMotion && !freezeLayout}
       onLayoutAnimationComplete={() => setIsMoving(false)}
       onLayoutAnimationStart={() => setIsMoving(true)}
       transition={
@@ -303,11 +459,14 @@ function AnimatedPillSlot({
 }
 
 /**
- * Composer status strip for working agents: one pill per working agent, each
- * owning its hover popover. Pills are ordered most-recently-active first
- * (left-most) and animate to their new slot as the order changes. Pills
- * shrink and truncate their labels when several agents work at once so the
- * strip never wraps the fixed-height row.
+ * Composer status strip for working agents: one pill per working agent,
+ * sharing one strip-level hover popover (at most one card open). Pills are
+ * ordered most-recently-active first (left-most) and animate to their new
+ * slot as the order changes — except while the cursor is over the bar or a
+ * hover card is showing, when order, membership, layout animation, and pill
+ * widths are all frozen so nothing can move out from under (or slide under)
+ * the cursor. Pills shrink and truncate their labels when several agents
+ * work at once so the strip never wraps the fixed-height row.
  */
 export function BotActivityComposerAction({
   agents,
@@ -319,6 +478,14 @@ export function BotActivityComposerAction({
 }: BotActivityBarProps) {
   const liveActivityEnabled = useFeatureEnabled("composerLiveActivity");
   const shouldReduceMotion = useReducedMotion();
+  const hover = useStripHoverPopover();
+  // The freeze engages as soon as the cursor is anywhere over the bar — not
+  // only once a card opens — so pills can't move (or resize) under a cursor
+  // that is still traveling toward one. It also holds while a card is open
+  // with the cursor off the bar (over the card itself, or during the close
+  // grace period).
+  const [barHovered, setBarHovered] = React.useState(false);
+  const holdActive = barHovered || hover.activePubkey !== null;
 
   const workingAgents = React.useMemo(() => {
     const workingSet = new Set(
@@ -344,7 +511,7 @@ export function BotActivityComposerAction({
     subscribeToObserverStore,
     getOrderSnapshot,
   );
-  const orderedAgents = React.useMemo(() => {
+  const liveOrderedAgents = React.useMemo(() => {
     const byPubkey = new Map(
       workingAgents.map((agent) => [agent.pubkey.toLowerCase(), agent]),
     );
@@ -353,15 +520,49 @@ export function BotActivityComposerAction({
       : orderKey.split(",").flatMap((pubkey) => byPubkey.get(pubkey) ?? []);
   }, [orderKey, workingAgents]);
 
+  // While the hold is active, the strip must not move under the cursor:
+  // pill order AND membership are frozen at their last hold-free values.
+  // Reorders queue up behind the hold and apply when it releases; an agent
+  // that finishes mid-hold keeps its pill until then. Without this, a
+  // reorder slides the hovered pill away (firing a spurious mouseleave that
+  // closes the card) or slides a different pill under the cursor (opening
+  // the wrong one).
+  //
+  // The queued order is adopted in an effect (a commit AFTER the release
+  // render) on purpose: the release render still shows the frozen order but
+  // re-enables slot layout animation, so when the live order lands next
+  // commit the pills ANIMATE from their frozen slots into the new layout
+  // instead of snapping.
+  const [orderedAgents, setOrderedAgents] =
+    React.useState<BotActivityAgent[]>(liveOrderedAgents);
+  React.useEffect(() => {
+    if (holdActive) {
+      return;
+    }
+    setOrderedAgents((current) =>
+      current.length === liveOrderedAgents.length &&
+      current.every((agent, index) => agent === liveOrderedAgents[index])
+        ? current
+        : liveOrderedAgents,
+    );
+  }, [holdActive, liveOrderedAgents]);
+
   if (orderedAgents.length === 0) {
     return null;
   }
 
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-visible">
+    // biome-ignore lint/a11y/noStaticElementInteractions: hover-only hold — keyboard focus drives the same hold via the pill triggers.
+    <div
+      className="flex min-w-0 flex-1 items-center gap-1.5 overflow-visible"
+      data-testid="bot-activity-strip"
+      onMouseEnter={() => setBarHovered(true)}
+      onMouseLeave={() => setBarHovered(false)}
+    >
       <AnimatePresence initial={false}>
         {orderedAgents.map((agent) => (
           <AnimatedPillSlot
+            freezeLayout={holdActive}
             key={agent.pubkey}
             shouldReduceMotion={Boolean(shouldReduceMotion)}
           >
@@ -373,9 +574,11 @@ export function BotActivityComposerAction({
                 }
                 channelId={channelId}
                 holdLabelSwap={isMoving}
+                hover={hover}
                 liveActivityEnabled={liveActivityEnabled}
                 onOpenAgentSession={onOpenAgentSession}
                 openAgentSessionPubkey={openAgentSessionPubkey}
+                pinWidth={holdActive}
                 profiles={profiles}
               />
             )}

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import {
+  getAgentChannelTypingSince,
   getAgentWorkingState,
   subscribeAgentWorkingSignal,
 } from "@/features/agents/agentWorkingSignal";
@@ -42,6 +43,8 @@ type BotActivityBarProps = {
 const HOVER_CLOSE_DELAY_MS = 180;
 /** Ticker key for the generic label shown before the first action lands. */
 const GENERIC_LABEL_ID = "generic-working";
+/** Ticker key for the typing override label (see BotActivityAgentPill). */
+const TYPING_LABEL_ID = "typing-override";
 /**
  * Perceptual duration shared by the pill reorder spring and the opacity dip
  * keyframes so the fade lands together with the layout switch.
@@ -210,7 +213,9 @@ function useStripHoverPopover(): StripHoverPopover {
  *
  * Only observer-backed agents reach this pill: typing-fallback-only agents
  * are diverted into the combined typing indicator group by
- * ChannelComposerActivityRow before the strip renders.
+ * ChannelComposerActivityRow before the strip renders. An observer-backed
+ * agent that ALSO starts typing keeps its pill — the label relabels in
+ * place to "is typing…" for the duration (see the typing override below).
  */
 function BotActivityAgentPill({
   agent,
@@ -246,10 +251,26 @@ function BotActivityAgentPill({
     () => deriveActivityPillLabel({ channelId, transcript }),
     [channelId, transcript],
   );
-  const activeId = headline?.id ?? GENERIC_LABEL_ID;
+  // Typing overrides the action headline IN PLACE: when this observer-backed
+  // agent's typing signal is also on for the channel (it starts composing its
+  // reply mid-turn), the pill's ticker swaps to "is typing…" — same slot,
+  // avatar, and hover feed — instead of the stale last action persisting or a
+  // second typing-group item appearing. Raw registry read, because
+  // getAgentWorkingState folds typing away under observer precedence.
+  const typingSince = React.useSyncExternalStore(
+    subscribeAgentWorkingSignal,
+    () => getAgentChannelTypingSince(agent.pubkey, channelId),
+  );
+  const isTyping = typingSince !== null;
+  const activeId = isTyping
+    ? TYPING_LABEL_ID
+    : (headline?.id ?? GENERIC_LABEL_ID);
   // No action headline yet (see deriveActivityPillLabel) — show the
-  // agent-named generic working label until the first action lands.
-  const activeLabel = headline?.label ?? `${agent.name} is working…`;
+  // agent-named generic working label until the first action lands. When
+  // typing ends, the ticker swaps back to the last action headline.
+  const activeLabel = isTyping
+    ? `${agent.name} is typing…`
+    : (headline?.label ?? `${agent.name} is working…`);
   // The rendered label lags the derived one while the pill is moving: the
   // push-up ticker plays after the slot settles (or immediately when idle).
   // Keyed by transcript item id, not label text — a NEW action swaps, while

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -9,7 +9,9 @@ import {
 } from "@/features/agents/ui/agentSessionTranscriptPresentation";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ManagedAgent } from "@/shared/api/types";
+import { useFeatureEnabled } from "@/shared/features";
 import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
 import {
   DEFAULT_POPOVER_HOVER_OPEN_DELAY_MS,
   Popover,
@@ -18,8 +20,10 @@ import {
 } from "@/shared/ui/popover";
 import { Shimmer } from "@/shared/ui/Shimmer";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
+import { ComposerLiveActivityFeed } from "./ComposerLiveActivityFeed";
+import { resolveSelectedActivityAgent } from "./composerLiveActivity";
 
-export type BotActivityAgent = Pick<ManagedAgent, "pubkey" | "name">;
+export type BotActivityAgent = Pick<ManagedAgent, "pubkey" | "name" | "status">;
 
 type BotActivityBarProps = {
   agents: BotActivityAgent[];
@@ -44,6 +48,13 @@ export function BotActivityComposerAction({
   variant = "toolbar",
 }: BotActivityBarProps) {
   const [open, setOpen] = React.useState(false);
+  const liveActivityEnabled = useFeatureEnabled("composerLiveActivity");
+  // Which working agent's feed the live-activity preview shows. Explicit tab
+  // selection first; falls back to the open session pane, then the first
+  // working agent (see resolveSelectedActivityAgent).
+  const [selectedActivityPubkey, setSelectedActivityPubkey] = React.useState<
+    string | null
+  >(null);
   const hoverTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -57,6 +68,22 @@ export function BotActivityComposerAction({
   }, [agents, workingBotPubkeys]);
   const singleWorkingAgent =
     workingAgents.length === 1 ? (workingAgents[0] ?? null) : null;
+  const selectedActivityAgent = React.useMemo(
+    () =>
+      liveActivityEnabled
+        ? resolveSelectedActivityAgent({
+            openAgentSessionPubkey,
+            selectedPubkey: selectedActivityPubkey,
+            workingAgents,
+          })
+        : null,
+    [
+      liveActivityEnabled,
+      openAgentSessionPubkey,
+      selectedActivityPubkey,
+      workingAgents,
+    ],
+  );
   const transcript = useAgentTranscript(
     Boolean(singleWorkingAgent),
     singleWorkingAgent?.pubkey,
@@ -224,52 +251,112 @@ export function BotActivityComposerAction({
       </PopoverTrigger>
       <PopoverContent
         align={isInline ? "start" : "end"}
-        className="w-64 p-1"
+        className={cn(
+          liveActivityEnabled ? "flex w-80 flex-col gap-1.5 p-2" : "w-64 p-1",
+        )}
         onMouseEnter={keepOpen}
         onMouseLeave={closeWithDelay}
         onOpenAutoFocus={(event) => event.preventDefault()}
         side="top"
         sideOffset={8}
       >
-        <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
-          Agents working
-        </div>
-        <div className="mt-1 flex flex-col gap-1">
-          {workingAgents.map((agent) => {
-            const isSelected = selectedPubkey === agent.pubkey.toLowerCase();
-
-            return (
-              <button
-                className={cn(
-                  "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors",
-                  isSelected
-                    ? "bg-primary/10 text-primary"
-                    : "text-foreground hover:bg-accent hover:text-accent-foreground",
-                )}
-                data-testid={`bot-activity-composer-item-${agent.pubkey}`}
-                key={agent.pubkey}
-                onClick={() => {
+        {liveActivityEnabled ? (
+          <>
+            {selectedActivityAgent ? (
+              <ComposerLiveActivityFeed
+                agent={selectedActivityAgent}
+                channelId={channelId}
+                className="h-48 rounded-lg border border-border/60 bg-background"
+                onOpenAgentSession={(pubkey) => {
                   clearHoverTimer();
                   setOpen(false);
-                  onOpenAgentSession(agent.pubkey, channelId);
+                  onOpenAgentSession(pubkey, channelId);
                 }}
-                type="button"
-              >
-                <UserAvatar
-                  avatarUrl={agentAvatarUrl(agent)}
-                  className="shrink-0"
-                  displayName={agent.name}
-                  size="sm"
-                />
-                <span className="min-w-0 flex-1 truncate">{agent.name}</span>
-                <span className="shrink-0 whitespace-nowrap text-xs font-medium opacity-80">
-                  View activity
-                </span>
-                <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground/70" />
-              </button>
-            );
-          })}
-        </div>
+                profiles={profiles}
+              />
+            ) : null}
+            <div
+              aria-label="Working agents"
+              className="flex w-full flex-wrap items-center justify-start gap-1.5"
+              role="tablist"
+            >
+              {workingAgents.map((agent) => {
+                const isSelected =
+                  selectedActivityAgent?.pubkey.toLowerCase() ===
+                  agent.pubkey.toLowerCase();
+
+                return (
+                  <Button
+                    aria-selected={isSelected}
+                    className="max-w-full shrink-0 rounded-full px-2"
+                    data-testid={`bot-activity-composer-item-${agent.pubkey}`}
+                    key={agent.pubkey}
+                    onClick={() =>
+                      setSelectedActivityPubkey(agent.pubkey.toLowerCase())
+                    }
+                    role="tab"
+                    size="sm"
+                    type="button"
+                    variant={isSelected ? "secondary" : "ghost"}
+                  >
+                    <UserAvatar
+                      avatarUrl={agentAvatarUrl(agent)}
+                      className="!h-[18px] !w-[18px] shrink-0 text-3xs"
+                      displayName={agent.name}
+                      size="xs"
+                    />
+                    <span className="max-w-28 truncate">{agent.name}</span>
+                  </Button>
+                );
+              })}
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
+              Agents working
+            </div>
+            <div className="mt-1 flex flex-col gap-1">
+              {workingAgents.map((agent) => {
+                const isSelected =
+                  selectedPubkey === agent.pubkey.toLowerCase();
+
+                return (
+                  <button
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors",
+                      isSelected
+                        ? "bg-primary/10 text-primary"
+                        : "text-foreground hover:bg-accent hover:text-accent-foreground",
+                    )}
+                    data-testid={`bot-activity-composer-item-${agent.pubkey}`}
+                    key={agent.pubkey}
+                    onClick={() => {
+                      clearHoverTimer();
+                      setOpen(false);
+                      onOpenAgentSession(agent.pubkey, channelId);
+                    }}
+                    type="button"
+                  >
+                    <UserAvatar
+                      avatarUrl={agentAvatarUrl(agent)}
+                      className="shrink-0"
+                      displayName={agent.name}
+                      size="sm"
+                    />
+                    <span className="min-w-0 flex-1 truncate">
+                      {agent.name}
+                    </span>
+                    <span className="shrink-0 whitespace-nowrap text-xs font-medium opacity-80">
+                      View activity
+                    </span>
+                    <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground/70" />
+                  </button>
+                );
+              })}
+            </div>
+          </>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -49,7 +49,7 @@ const TYPING_LABEL_ID = "typing-override";
  * Perceptual duration shared by the pill reorder spring and the opacity dip
  * keyframes so the fade lands together with the layout switch.
  */
-const PILL_REORDER_DURATION_S = 0.9;
+const PILL_REORDER_DURATION_S = 0.45;
 /**
  * Enter/exit fade+scale for a pill slot. Deliberately much quicker than the
  * reorder spring — the slow reorder pacing must not bleed into membership
@@ -217,11 +217,14 @@ function useStripHoverPopover(): StripHoverPopover {
  * itself — flat, no inset box, no tab strip — while clicking the pill opens
  * the agent's full runtime in the auxiliary panel.
  *
- * Only observer-backed agents reach this pill: typing-fallback-only agents
- * are diverted into the combined typing indicator group by
- * ChannelComposerActivityRow before the strip renders. An observer-backed
- * agent that ALSO starts typing keeps its pill — the label relabels in
- * place to "is typing…" for the duration (see the typing override below).
+ * Only pill-worthy agents reach this pill (an active observer turn, or a
+ * headline-able transcript left by a prior turn — see
+ * partitionComposerWorkingAgents): typing agents with nothing to hover or
+ * open are diverted into the combined typing indicator group by
+ * ChannelComposerActivityRow before the strip renders. An agent that is
+ * typing — mid-turn or across the turn-end gap — keeps its pill, with the
+ * label relabeled in place to "is typing…" for the duration (see the
+ * typing override below).
  */
 function BotActivityAgentPill({
   agent,
@@ -476,7 +479,16 @@ function AnimatedPillSlot({
       // instead of compressing every pill into an unreadable sliver. A lone
       // pill instead shrinks to fit (min-w-0) so it never scrolls.
       className={cn("flex", shrinkToFit ? "min-w-0" : "shrink-0")}
-      exit={{ opacity: 0, scale: 0.9 }}
+      // Inline exit transition: a slot removed mid-travel would otherwise
+      // inherit the slow isMoving opacity tween and fade out sluggishly.
+      exit={{
+        opacity: 0,
+        scale: 0.9,
+        transition: {
+          duration: PILL_ENTER_EXIT_DURATION_S,
+          ease: "easeOut",
+        },
+      }}
       initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.9 }}
       layout={!shouldReduceMotion && !freezeLayout}
       onLayoutAnimationComplete={() => setIsMoving(false)}

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -779,10 +779,16 @@ export function BotActivityComposerAction({
                   {() => (
                     <div
                       className={cn(
-                        // Cap like the pills (which use max-w-50 each) so a
-                        // long "X, Y, and N more are typing" label truncates
-                        // instead of inflating the scroll extent.
-                        "flex h-7 min-w-0 max-w-64 items-center",
+                        "flex h-7 min-w-0 items-center",
+                        // Only when sharing the strip with pills does the
+                        // group need a width cap (like the pills' max-w-50
+                        // each) so a long "X, Y, and N more are typing" label
+                        // truncates instead of inflating the scroll extent.
+                        // As the strip's lone item it shrinks with the
+                        // container instead (min-w-0 through the slot chain),
+                        // so a cap would only cut the label off in a row that
+                        // has room to spare.
+                        orderedAgents.length > 0 && "max-w-64",
                         // Composer-edge alignment when the typing group leads
                         // the strip (no pills): 0.75rem/1rem composer padding
                         // + 1px border. Mirrors the standalone row's old

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -230,7 +230,11 @@ function BotActivityAgentPill({
   /** Strip-level hover popover state shared by every pill. */
   hover: StripHoverPopover;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
-  /** Freeze the pill's rendered width (a hover card is showing). */
+  /**
+   * Freeze the pill's rendered width — set only while a hover card is open
+   * AND this pill's resize would move it (the pill anchors the card or sits
+   * left of the anchor).
+   */
   pinWidth: boolean;
   profiles?: UserProfileLookup;
 }) {
@@ -265,10 +269,12 @@ function BotActivityAgentPill({
     );
   }, [holdLabelSwap, activeId, activeLabel]);
 
-  // While a hover card is showing, the pill must not resize: label swaps
+  // While this pill's resize could move the open hover card (it is the
+  // card's anchor, or sits left of it), it must not resize: label swaps
   // keep animating, but a longer/shorter label truncating inside a FROZEN
-  // width can no longer shift the neighboring pills under the cursor. The
-  // width is measured once when the hold starts and dropped on release.
+  // width can no longer shift the card's anchor edge or slide the trigger
+  // out from under the cursor. The width is measured once when the pin
+  // starts and dropped on release.
   const triggerRef = React.useRef<HTMLButtonElement | null>(null);
   const [pinnedWidth, setPinnedWidth] = React.useState<number | null>(null);
   React.useLayoutEffect(() => {
@@ -398,8 +404,9 @@ function BotActivityAgentPill({
  * that run for the same duration as the slot spring, so the fade and the
  * move finish together and reorders read as a shuffle instead of a hard
  * swap. Enter/exit use the same scale+fade treatment. While a hover card is
- * showing (`freezeLayout`), layout animation is disabled entirely so nothing
- * can slide under the cursor.
+ * showing and this slot's movement would displace it (`freezeLayout` — the
+ * slot holds the card's anchor pill or one left of it), layout animation is
+ * disabled so nothing can shift the card or slide under the cursor.
  */
 function AnimatedPillSlot({
   children,
@@ -409,7 +416,10 @@ function AnimatedPillSlot({
 }: {
   /** Render prop so the pill can defer label swaps while its slot moves. */
   children: (isMoving: boolean) => React.ReactNode;
-  /** Disable slot layout animation while a hover card is showing. */
+  /**
+   * Disable slot layout animation while a hover card is open and this
+   * slot's movement would displace it (anchor pill or left of the anchor).
+   */
   freezeLayout: boolean;
   shouldReduceMotion: boolean;
   /**
@@ -474,10 +484,15 @@ function AnimatedPillSlot({
  * whole turn, so liveness is carried by each pill's label ticker while
  * positional motion is reserved for membership changes: a newly working
  * agent's pill enters on the right, a finished agent's pill exits and its
- * neighbors animate into the gap. No movement happens while the cursor is
- * over the bar or a hover card is showing, when order, membership, layout
- * animation, and pill widths are all frozen so nothing can move out from
- * under (or slide under) the cursor. Each pill truncates its label at its own max width. A lone
+ * neighbors animate into the gap. While the cursor is over the bar or a
+ * hover card is showing, order and membership are frozen so a pill can't
+ * exit (or enter) and slide the strip under the cursor. Width pinning and
+ * layout freezing are narrower — placement-aware: only while a card is OPEN,
+ * and only for the pills whose resize would actually move it (the card is
+ * side="top" align="start", anchored to its pill's left edge, so just the
+ * anchor pill and the pills left of it qualify). Pills right of the anchor —
+ * and every pill when no card is open — stay free to resize with their
+ * label swaps. Each pill truncates its label at its own max width. A lone
  * pill shrinks with a narrow container (its label ellipsizes) so it always
  * fits; when SEVERAL pills outgrow a narrow container (thread panel
  * toolbars especially) the strip scrolls horizontally — scrollbar hidden,
@@ -497,11 +512,13 @@ export function BotActivityComposerAction({
 }: BotActivityBarProps) {
   const shouldReduceMotion = useReducedMotion();
   const hover = useStripHoverPopover();
-  // The freeze engages as soon as the cursor is anywhere over the bar — not
-  // only once a card opens — so pills can't move (or resize) under a cursor
-  // that is still traveling toward one. It also holds while a card is open
-  // with the cursor off the bar (over the card itself, or during the close
-  // grace period).
+  // The MEMBERSHIP freeze engages as soon as the cursor is anywhere over the
+  // bar — not only once a card opens — so pills can't enter/exit and slide
+  // the strip under a cursor that is still traveling toward one. It also
+  // holds while a card is open with the cursor off the bar (over the card
+  // itself, or during the close grace period). Width pinning is NOT tied to
+  // this hold — it is placement-aware and applies per pill only while a
+  // card is open (see activeCardIndex below).
   const [barHovered, setBarHovered] = React.useState(false);
   const holdActive = barHovered || hover.activePubkey !== null;
 
@@ -572,6 +589,20 @@ export function BotActivityComposerAction({
     );
   }, [holdActive, liveOrderedAgents]);
 
+  // Placement-aware resize guard: index of the pill anchoring the open hover
+  // card, or -1 with no card up. The card is side="top" align="start" —
+  // anchored to its pill's LEFT edge — so only a resize of the anchor pill
+  // itself (which could also slide the trigger out from under the cursor)
+  // or of a pill left of it can move the card. Those pills pin their width
+  // and freeze their slot's layout animation; pills right of the anchor —
+  // and every pill when no card is open — resize freely with label swaps.
+  const activeCardIndex =
+    hover.activePubkey === null
+      ? -1
+      : orderedAgents.findIndex(
+          (agent) => agent.pubkey.toLowerCase() === hover.activePubkey,
+        );
+
   if (orderedAgents.length === 0 && typingIndicator == null) {
     return null;
   }
@@ -593,6 +624,10 @@ export function BotActivityComposerAction({
       // a dead gutter after the fade. At rest nothing changes: the padding
       // keeps the first pill aligned to the gutter.
       className="relative -mx-5 min-w-0 flex-1"
+      // Exposes the membership hold to the e2e suite: width pins no longer
+      // engage on bar hover alone, so tests need this to know the hold is
+      // armed before mutating membership.
+      data-hold={holdActive ? "true" : undefined}
       data-testid="bot-activity-strip"
       onMouseEnter={() => setBarHovered(true)}
       onMouseLeave={() => setBarHovered(false)}
@@ -624,32 +659,39 @@ export function BotActivityComposerAction({
           )}
         >
           <AnimatePresence initial={false}>
-            {orderedAgents.map((agent) => (
-              <AnimatedPillSlot
-                freezeLayout={holdActive}
-                key={agent.pubkey}
-                shouldReduceMotion={Boolean(shouldReduceMotion)}
-                shrinkToFit={itemCount === 1}
-              >
-                {(isMoving) => (
-                  <BotActivityAgentPill
-                    agent={agent}
-                    avatarUrl={
-                      profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ?? null
-                    }
-                    channelId={channelId}
-                    holdLabelSwap={isMoving}
-                    hover={hover}
-                    onOpenAgentSession={onOpenAgentSession}
-                    pinWidth={holdActive}
-                    profiles={profiles}
-                  />
-                )}
-              </AnimatedPillSlot>
-            ))}
+            {orderedAgents.map((agent, index) => {
+              const guardsOpenCard =
+                activeCardIndex !== -1 && index <= activeCardIndex;
+              return (
+                <AnimatedPillSlot
+                  freezeLayout={guardsOpenCard}
+                  key={agent.pubkey}
+                  shouldReduceMotion={Boolean(shouldReduceMotion)}
+                  shrinkToFit={itemCount === 1}
+                >
+                  {(isMoving) => (
+                    <BotActivityAgentPill
+                      agent={agent}
+                      avatarUrl={
+                        profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ??
+                        null
+                      }
+                      channelId={channelId}
+                      holdLabelSwap={isMoving}
+                      hover={hover}
+                      onOpenAgentSession={onOpenAgentSession}
+                      pinWidth={guardsOpenCard}
+                      profiles={profiles}
+                    />
+                  )}
+                </AnimatedPillSlot>
+              );
+            })}
             {typingIndicator == null ? null : (
               <AnimatedPillSlot
-                freezeLayout={holdActive}
+                // The typing group trails every pill, so its movement can
+                // never displace an open card (anchored at or left of it).
+                freezeLayout={false}
                 key="typing"
                 shouldReduceMotion={Boolean(shouldReduceMotion)}
                 shrinkToFit={itemCount === 1}

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -174,7 +174,7 @@ function useStripHoverPopover(): StripHoverPopover {
       cancelPending();
       timerRef.current = setTimeout(() => {
         setActive(pubkey);
-      }, HOVER_OPEN_DELAY_MS);
+      }, DEFAULT_POPOVER_HOVER_OPEN_DELAY_MS);
     },
     [cancelPending, setActive],
   );

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -264,13 +264,22 @@ function BotActivityAgentPill({
   const shouldReduceMotion = useReducedMotion();
   const avatarMorphLayoutId = useComposerStripAvatarLayoutId(agent.pubkey);
   const transcript = useAgentTranscript(true, agent.pubkey);
-  const headline = React.useMemo(
-    () => deriveActivityPillLabel({ channelId, transcript }),
-    [channelId, transcript],
-  );
   const workingState = React.useSyncExternalStore(
     subscribeAgentWorkingSignal,
     () => getAgentWorkingState(agent.pubkey, channelId),
+  );
+  const activeTurnIds = React.useMemo(() => {
+    if (workingState.source !== "observer") return undefined;
+    const scoped = workingState.channels.find(
+      (workingChannel) =>
+        workingChannel.source === "observer" &&
+        workingChannel.channelId === channelId,
+    );
+    return new Set(scoped?.turnIds ?? []);
+  }, [channelId, workingState]);
+  const headline = React.useMemo(
+    () => deriveActivityPillLabel({ activeTurnIds, channelId, transcript }),
+    [activeTurnIds, channelId, transcript],
   );
   // Raw typing remains available even when getAgentWorkingState folds it under
   // observer precedence. It supplies the fallback before observer telemetry

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -37,10 +37,13 @@ type BotActivityBarProps = {
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
   profiles?: UserProfileLookup;
   /**
-   * Combined typing indicator (humans + typing-fallback agents), rendered as
-   * the strip's trailing item — a sibling of the working pills, so it shares
-   * the scroller, edge fades, and layout/enter/exit animations.
+   * Agent pubkeys known to be typing in this strip's scope. Thread-only
+   * typing is intentionally absent from the channel-wide working registry,
+   * so callers pass it here to relabel an already pill-worthy agent without
+   * leaking thread activity into channel-level surfaces.
    */
+  typingBotPubkeys?: string[];
+  /** Combined human + typing-fallback agent indicator. */
   typingIndicator?: React.ReactNode;
   workingBotPubkeys: string[];
 };
@@ -240,6 +243,7 @@ function BotActivityAgentPill({
   onOpenAgentSession,
   pinWidth,
   profiles,
+  typingBotPubkeys,
 }: {
   agent: BotActivityAgent;
   avatarUrl: string | null;
@@ -256,6 +260,7 @@ function BotActivityAgentPill({
    */
   pinWidth: boolean;
   profiles?: UserProfileLookup;
+  typingBotPubkeys?: ReadonlySet<string>;
 }) {
   const pillKey = agent.pubkey.toLowerCase();
   const open = hover.activePubkey === pillKey;
@@ -276,7 +281,8 @@ function BotActivityAgentPill({
     subscribeAgentWorkingSignal,
     () => getAgentChannelTypingSince(agent.pubkey, channelId),
   );
-  const isTyping = typingSince !== null;
+  const isTyping =
+    typingBotPubkeys?.has(pillKey) === true || typingSince !== null;
   const activeId = isTyping
     ? TYPING_LABEL_ID
     : (headline?.id ?? GENERIC_LABEL_ID);
@@ -582,6 +588,7 @@ export function BotActivityComposerAction({
   channelId = null,
   onOpenAgentSession,
   profiles,
+  typingBotPubkeys = [],
   typingIndicator,
   workingBotPubkeys,
 }: BotActivityBarProps) {
@@ -611,6 +618,10 @@ export function BotActivityComposerAction({
 
     return agents.filter((agent) => workingSet.has(agent.pubkey.toLowerCase()));
   }, [agents, workingBotPubkeys]);
+  const typingBotSet = React.useMemo(
+    () => new Set(typingBotPubkeys.map((pubkey) => pubkey.toLowerCase())),
+    [typingBotPubkeys],
+  );
 
   // Turn-start pill order (earliest worker left-most, new agents append on
   // the right). Anchored to when each agent STARTED working — stable for the
@@ -762,6 +773,7 @@ export function BotActivityComposerAction({
                         onOpenAgentSession={onOpenAgentSession}
                         pinWidth={guardsOpenCard}
                         profiles={profiles}
+                        typingBotPubkeys={typingBotSet}
                       />
                     )}
                   </AnimatedPillSlot>

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -109,7 +109,11 @@ function useStripOverflowFades(
     const observer = new ResizeObserver(updateFades);
     observer.observe(node);
     // The content wrapper is the scroller's only child; observing it catches
-    // overflow changes that don't touch the scroller's own box.
+    // overflow changes that don't touch the scroller's own box. This relies
+    // on the wrapper being min-w-max (multi-item strip): if it could
+    // collapse to the scroller's width, content growing INSIDE it (label
+    // tickers swap after a resize settles) would change scrollWidth without
+    // resizing any observed element, leaving the fades stale.
     const content = node.firstElementChild;
     if (content !== null) {
       observer.observe(content);
@@ -606,7 +610,19 @@ export function BotActivityComposerAction({
         onScroll={updateFades}
         ref={scrollerRef}
       >
-        <div className="flex min-w-0 items-center gap-1.5">
+        <div
+          // The overflow-fade hook resize-observes this wrapper as its proxy
+          // for content size. min-w-max keeps it from collapsing to the
+          // scroller's width (it is a shrinkable flex item), so late content
+          // growth — label tickers swap AFTER a resize settles — still
+          // changes an observed box and refreshes the fades. A lone item
+          // instead gets min-w-0 so it can shrink with the container
+          // (shrinkToFit) rather than overflow into scroll.
+          className={cn(
+            "flex items-center gap-1.5",
+            itemCount === 1 ? "min-w-0" : "min-w-max",
+          )}
+        >
           <AnimatePresence initial={false}>
             {orderedAgents.map((agent) => (
               <AnimatedPillSlot

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -213,8 +213,11 @@ function BotActivityAgentPill({
   );
   const activeId = headline?.id ?? GENERIC_LABEL_ID;
   // No fresh action headline (see deriveActivityPillLabel) — decay to the
-  // agent-named generic working label.
-  const activeLabel = headline?.label ?? `${agent.name} is working…`;
+  // agent-named generic label. Typing-fallback-only agents read
+  // "is typing…" (matching the human indicator's vocabulary); observer-backed
+  // agents read "is working…".
+  const activeLabel =
+    headline?.label ?? `${agent.name} is ${typingOnly ? "typing" : "working"}…`;
   // The rendered label lags the derived one while the pill is moving: the
   // push-up ticker plays after the slot settles (or immediately when idle).
   // Keyed by transcript item id, not label text — a NEW action swaps, while
@@ -317,7 +320,7 @@ function BotActivityAgentPill({
       <PopoverTrigger asChild>
         <button
           aria-label={`${agent.name} is working. View activity.`}
-          className="inline-flex h-7 min-w-0 max-w-49 items-center gap-1.5 rounded-full border border-border/60 bg-background px-2 text-xs font-semibold leading-none text-muted-foreground shadow-xs transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary"
+          className="inline-flex h-7 min-w-0 max-w-50 items-center gap-1.5 rounded-full border border-border/60 bg-background px-2 text-xs font-semibold leading-none text-muted-foreground shadow-xs transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary"
           data-testid="bot-activity-composer-trigger"
           onBlur={hover.scheduleClose}
           onClick={(event) => {

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { Loader2 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
-import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
 import {
   getAgentTranscript,
   subscribeAgentObserverStore,
@@ -167,10 +166,9 @@ function useStripHoverPopover(): StripHoverPopover {
  * `composerLiveActivity` preview flag off, the hover popover keeps the
  * legacy "View activity" item instead.
  *
- * Typing-fallback-only agents (working source "typing", no observer turn)
- * render a passive, borderless, width-uncapped status instead: no hover
- * card, no click-through, not focusable — there is no transcript or session
- * behind the signal to open.
+ * Only observer-backed agents reach this pill: typing-fallback-only agents
+ * are diverted into the combined typing indicator group by
+ * ChannelComposerActivityRow before the strip renders.
  */
 function BotActivityAgentPill({
   agent,
@@ -201,10 +199,6 @@ function BotActivityAgentPill({
   const pillKey = agent.pubkey.toLowerCase();
   const open = hover.activePubkey === pillKey;
   const shouldReduceMotion = useReducedMotion();
-  // Typing-fallback-only agents (no observer turn) render borderless and
-  // uncapped — the basic "is typing" presentation.
-  const typingOnly =
-    useAgentWorking(agent.pubkey, channelId).source === "typing";
   const transcript = useAgentTranscript(true, agent.pubkey);
   const now = useNow(PILL_LABEL_TICK_MS);
   const headline = React.useMemo(
@@ -213,11 +207,8 @@ function BotActivityAgentPill({
   );
   const activeId = headline?.id ?? GENERIC_LABEL_ID;
   // No fresh action headline (see deriveActivityPillLabel) — decay to the
-  // agent-named generic label. Typing-fallback-only agents read
-  // "is typing…" (matching the human indicator's vocabulary); observer-backed
-  // agents read "is working…".
-  const activeLabel =
-    headline?.label ?? `${agent.name} is ${typingOnly ? "typing" : "working"}…`;
+  // agent-named generic working label.
+  const activeLabel = headline?.label ?? `${agent.name} is working…`;
   // The rendered label lags the derived one while the pill is moving: the
   // push-up ticker plays after the slot settles (or immediately when idle).
   // Keyed by transcript item id, not label text — a NEW action swaps, while
@@ -265,7 +256,7 @@ function BotActivityAgentPill({
     <>
       <UserAvatar
         avatarUrl={avatarUrl}
-        className="!h-[18px] !w-[18px] shrink-0 text-3xs"
+        className="!h-5 !w-5 shrink-0 text-3xs"
         displayName={agent.name}
         size="xs"
       />
@@ -292,20 +283,6 @@ function BotActivityAgentPill({
     </>
   );
 
-  // Typing-fallback-only: a passive status readout — no hover card, no
-  // click-through, not focusable. There is no observer turn (and so no
-  // transcript or session) behind it to open.
-  if (typingOnly) {
-    return (
-      <div
-        className="inline-flex h-7 min-w-0 items-center gap-1.5 rounded-full bg-background px-2 text-xs font-semibold leading-none text-muted-foreground"
-        data-testid="bot-activity-composer-typing"
-      >
-        {pillContent}
-      </div>
-    );
-  }
-
   return (
     <Popover
       onOpenChange={(nextOpen) => {
@@ -320,7 +297,7 @@ function BotActivityAgentPill({
       <PopoverTrigger asChild>
         <button
           aria-label={`${agent.name} is working. View activity.`}
-          className="inline-flex h-7 min-w-0 max-w-50 items-center gap-1.5 rounded-full border border-border/60 bg-background px-2 text-xs font-semibold leading-none text-muted-foreground shadow-xs transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary"
+          className="inline-flex h-7 min-w-0 max-w-50 items-center gap-1.5 rounded-full border border-border/60 bg-background pl-0.75 pr-2 text-xs font-semibold leading-none text-muted-foreground shadow-xs transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary"
           data-testid="bot-activity-composer-trigger"
           onBlur={hover.scheduleClose}
           onClick={(event) => {

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -30,6 +30,12 @@ type BotActivityBarProps = {
   channelId?: string | null;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
   profiles?: UserProfileLookup;
+  /**
+   * Combined typing indicator (humans + typing-fallback agents), rendered as
+   * the strip's trailing item — a sibling of the working pills, so it shares
+   * the scroller, edge fades, and layout/enter/exit animations.
+   */
+  typingIndicator?: React.ReactNode;
   workingBotPubkeys: string[];
 };
 
@@ -289,8 +295,10 @@ function BotActivityAgentPill({
           overrides the button's leading-none). Inter's ascent+descent ink is
           ~1.21em (~14.5px at text-xs) — taller than a leading-none line box —
           and BOTH this span and the truncate span clip to their boxes, which
-          sheared descenders ("g", "y") off the label. */}
-      <span className="relative block h-4 min-w-0 flex-1 overflow-hidden leading-4">
+          sheared descenders
+          ("g", "y") off the label. translate-y-px mirrors the typing
+          indicator label's optical nudge so both baselines line up. */}
+      <span className="relative block h-4 min-w-0 flex-1 translate-y-px overflow-hidden leading-4">
         <AnimatePresence initial={false} mode="popLayout">
           <motion.span
             animate={{ y: 0 }}
@@ -327,7 +335,7 @@ function BotActivityAgentPill({
       <PopoverTrigger asChild>
         <button
           aria-label={`${agent.name} is working. View activity.`}
-          className="inline-flex h-7 min-w-0 max-w-50 items-center gap-1.5 rounded-full border border-border/60 bg-background pl-0.75 pr-2 text-xs font-semibold leading-none text-muted-foreground shadow-xs transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary"
+          className="inline-flex h-7 min-w-0 max-w-50 items-center gap-2 rounded-full text-xs font-medium leading-none text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:text-primary"
           data-testid="bot-activity-composer-trigger"
           onBlur={hover.scheduleClose}
           onClick={(event) => {
@@ -454,7 +462,10 @@ function AnimatedPillSlot({
 
 /**
  * Composer status strip for working agents: one pill per working agent,
- * sharing one strip-level hover popover (at most one card open). Pills are
+ * sharing one strip-level hover popover (at most one card open), plus the
+ * combined typing indicator as the strip's trailing item — a slot sibling of
+ * the pills, so it scrolls with them, clips under the same edge fades, and
+ * enters/exits/moves with the same slot animations. Pills are
  * ordered by turn start (earliest worker left-most) — a stable slot for the
  * whole turn, so liveness is carried by each pill's label ticker while
  * positional motion is reserved for membership changes: a newly working
@@ -477,6 +488,7 @@ export function BotActivityComposerAction({
   channelId = null,
   onOpenAgentSession,
   profiles,
+  typingIndicator,
   workingBotPubkeys,
 }: BotActivityBarProps) {
   const shouldReduceMotion = useReducedMotion();
@@ -556,9 +568,14 @@ export function BotActivityComposerAction({
     );
   }, [holdActive, liveOrderedAgents]);
 
-  if (orderedAgents.length === 0) {
+  if (orderedAgents.length === 0 && typingIndicator == null) {
     return null;
   }
+
+  // A slot only shrinks with the container when it is the strip's LONE item;
+  // otherwise items keep their natural width and the strip scrolls under the
+  // edge fades.
+  const itemCount = orderedAgents.length + (typingIndicator == null ? 0 : 1);
 
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: hover-only hold — keyboard focus drives the same hold via the pill triggers.
@@ -596,7 +613,7 @@ export function BotActivityComposerAction({
                 freezeLayout={holdActive}
                 key={agent.pubkey}
                 shouldReduceMotion={Boolean(shouldReduceMotion)}
-                shrinkToFit={orderedAgents.length === 1}
+                shrinkToFit={itemCount === 1}
               >
                 {(isMoving) => (
                   <BotActivityAgentPill
@@ -614,6 +631,34 @@ export function BotActivityComposerAction({
                 )}
               </AnimatedPillSlot>
             ))}
+            {typingIndicator == null ? null : (
+              <AnimatedPillSlot
+                freezeLayout={holdActive}
+                key="typing"
+                shouldReduceMotion={Boolean(shouldReduceMotion)}
+                shrinkToFit={itemCount === 1}
+              >
+                {() => (
+                  <div
+                    className={cn(
+                      // Cap like the pills (which use max-w-50 each) so a
+                      // long "X, Y, and N more are typing" label truncates
+                      // instead of inflating the scroll extent.
+                      "flex h-7 min-w-0 max-w-64 items-center",
+                      // Composer-edge alignment when the typing group leads
+                      // the strip (no pills): 0.75rem/1rem composer padding
+                      // + 1px border. Mirrors the standalone row's old
+                      // inset, and now animates via the slot's layout spring
+                      // when pills come and go.
+                      orderedAgents.length === 0 && "pl-3.25 sm:pl-4.25",
+                    )}
+                    data-testid="bot-activity-typing-slot"
+                  >
+                    {typingIndicator}
+                  </div>
+                )}
+              </AnimatedPillSlot>
+            )}
           </AnimatePresence>
         </div>
       </motion.div>

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 import { Loader2 } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
+import {
+  getAgentTranscript,
+  subscribeAgentObserverStore,
+} from "@/features/agents/observerRelayStore";
 import { useAgentTranscript } from "@/features/agents/ui/useObserverEvents";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ManagedAgent } from "@/shared/api/types";
@@ -16,7 +21,10 @@ import {
 import { Shimmer } from "@/shared/ui/Shimmer";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import { ComposerLiveActivityFeed } from "./ComposerLiveActivityFeed";
-import { deriveActivityPillLabel } from "./composerLiveActivity";
+import {
+  deriveActivityPillLabel,
+  deriveAgentActivityOrder,
+} from "./composerLiveActivity";
 
 export type BotActivityAgent = Pick<ManagedAgent, "pubkey" | "name" | "status">;
 
@@ -34,6 +42,18 @@ const HOVER_CLOSE_DELAY_MS = 180;
 const PILL_LABEL_TICK_MS = 5_000;
 /** Shown when no fresh action headline exists (see deriveActivityPillLabel). */
 const GENERIC_WORKING_LABEL = "Working…";
+/** Ticker key for the generic label so decay/recovery animate as one swap. */
+const GENERIC_LABEL_ID = "generic-working";
+/**
+ * Perceptual duration shared by the pill reorder spring and the opacity dip
+ * keyframes so the fade lands together with the layout switch.
+ */
+const PILL_REORDER_DURATION_S = 0.9;
+
+// Stable subscribe reference for useSyncExternalStore (same pattern as
+// useObserverEvents).
+const subscribeToObserverStore = (onStoreChange: () => void) =>
+  subscribeAgentObserverStore(onStoreChange);
 
 /** Hover-intent popover state shared by every activity pill. */
 function useHoverPopover() {
@@ -72,16 +92,20 @@ function useHoverPopover() {
 
 /**
  * One working agent's status pill: avatar + the agent's latest action summary
- * (decaying to a generic working label when activity goes quiet). Hovering
- * shows the agent's live activity feed as the popover surface itself — flat,
- * no inset box, no tab strip — while clicking the pill opens the agent's full
- * runtime in the auxiliary panel. With the `composerLiveActivity` preview
- * flag off, the hover popover keeps the legacy "View activity" item instead.
+ * (decaying to a generic working label when activity goes quiet). Label
+ * updates play as a clipped ticker — the new text pushes the old text up and
+ * out — deferred until the pill's slot settles when a reorder is in flight.
+ * Hovering shows the agent's live activity feed as the popover surface
+ * itself — flat, no inset box, no tab strip — while clicking the pill opens
+ * the agent's full runtime in the auxiliary panel. With the
+ * `composerLiveActivity` preview flag off, the hover popover keeps the
+ * legacy "View activity" item instead.
  */
 function BotActivityAgentPill({
   agent,
   avatarUrl,
   channelId,
+  holdLabelSwap,
   liveActivityEnabled,
   onOpenAgentSession,
   openAgentSessionPubkey,
@@ -90,6 +114,8 @@ function BotActivityAgentPill({
   agent: BotActivityAgent;
   avatarUrl: string | null;
   channelId: string | null;
+  /** Defer label swaps while the pill's slot is mid layout animation. */
+  holdLabelSwap: boolean;
   liveActivityEnabled: boolean;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
   openAgentSessionPubkey: string | null;
@@ -97,13 +123,33 @@ function BotActivityAgentPill({
 }) {
   const { clearHoverTimer, closeWithDelay, open, openWithDelay, setOpen } =
     useHoverPopover();
+  const shouldReduceMotion = useReducedMotion();
   const transcript = useAgentTranscript(true, agent.pubkey);
   const now = useNow(PILL_LABEL_TICK_MS);
   const headline = React.useMemo(
     () => deriveActivityPillLabel({ channelId, now, transcript }),
     [channelId, now, transcript],
   );
-  const label = headline ?? GENERIC_WORKING_LABEL;
+  const activeId = headline?.id ?? GENERIC_LABEL_ID;
+  const activeLabel = headline?.label ?? GENERIC_WORKING_LABEL;
+  // The rendered label lags the derived one while the pill is moving: the
+  // push-up ticker plays after the slot settles (or immediately when idle).
+  // Keyed by transcript item id, not label text — a NEW action swaps, while
+  // streamed chunks growing the same item update text in place.
+  const [display, setDisplay] = React.useState({
+    id: activeId,
+    label: activeLabel,
+  });
+  React.useEffect(() => {
+    if (holdLabelSwap) {
+      return;
+    }
+    setDisplay((current) =>
+      current.id === activeId && current.label === activeLabel
+        ? current
+        : { id: activeId, label: activeLabel },
+    );
+  }, [holdLabelSwap, activeId, activeLabel]);
   const isSessionOpen =
     openAgentSessionPubkey?.toLowerCase() === agent.pubkey.toLowerCase();
 
@@ -118,7 +164,7 @@ function BotActivityAgentPill({
       <PopoverTrigger asChild>
         <button
           aria-label={`${agent.name} is working. View activity.`}
-          className="inline-flex h-7 min-w-0 max-w-30 items-center gap-1.5 rounded-full border border-border/60 bg-background px-2 text-xs font-semibold leading-none text-muted-foreground shadow-xs transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary"
+          className="inline-flex h-7 min-w-0 max-w-36 items-center gap-1.5 rounded-full border border-border/60 bg-background px-2 text-xs font-semibold leading-none text-muted-foreground shadow-xs transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:border-primary/40 data-[state=open]:bg-primary/10 data-[state=open]:text-primary"
           data-testid="bot-activity-composer-trigger"
           onBlur={closeWithDelay}
           onClick={(event) => {
@@ -139,8 +185,25 @@ function BotActivityAgentPill({
             displayName={agent.name}
             size="xs"
           />
-          <span className="min-w-0 flex-1 overflow-hidden">
-            <Shimmer className="block truncate">{label}</Shimmer>
+          <span className="relative block h-3.5 min-w-0 flex-1 overflow-hidden">
+            <AnimatePresence initial={false} mode="popLayout">
+              <motion.span
+                animate={{ y: 0 }}
+                className="flex h-full items-center"
+                exit={{ y: "-110%" }}
+                initial={shouldReduceMotion ? false : { y: "110%" }}
+                key={display.id}
+                transition={
+                  shouldReduceMotion
+                    ? { duration: 0 }
+                    : { type: "tween", duration: 0.28, ease: "easeOut" }
+                }
+              >
+                <Shimmer className="block min-w-0 truncate">
+                  {display.label}
+                </Shimmer>
+              </motion.span>
+            </AnimatePresence>
           </span>
         </button>
       </PopoverTrigger>
@@ -194,9 +257,57 @@ function BotActivityAgentPill({
 }
 
 /**
+ * Layout slot for one pill in the composer strip. While a pill travels to a
+ * new slot (layout animation) its opacity dips and recovers via keyframes
+ * that run for the same duration as the slot spring, so the fade and the
+ * move finish together and reorders read as a shuffle instead of a hard
+ * swap. Enter/exit use the same scale+fade treatment.
+ */
+function AnimatedPillSlot({
+  children,
+  shouldReduceMotion,
+}: {
+  /** Render prop so the pill can defer label swaps while its slot moves. */
+  children: (isMoving: boolean) => React.ReactNode;
+  shouldReduceMotion: boolean;
+}) {
+  const [isMoving, setIsMoving] = React.useState(false);
+
+  return (
+    <motion.div
+      animate={{ opacity: isMoving ? [1, 0.35, 1] : 1, scale: 1 }}
+      className="flex min-w-0"
+      exit={{ opacity: 0, scale: 0.9 }}
+      initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.9 }}
+      layout={!shouldReduceMotion}
+      onLayoutAnimationComplete={() => setIsMoving(false)}
+      onLayoutAnimationStart={() => setIsMoving(true)}
+      transition={
+        shouldReduceMotion
+          ? { duration: 0 }
+          : {
+              type: "spring",
+              duration: PILL_REORDER_DURATION_S,
+              bounce: 0.15,
+              opacity: {
+                type: "tween",
+                duration: PILL_REORDER_DURATION_S,
+                ease: "linear",
+              },
+            }
+      }
+    >
+      {children(isMoving)}
+    </motion.div>
+  );
+}
+
+/**
  * Composer status strip for working agents: one pill per working agent, each
- * owning its hover popover. Pills shrink and truncate their labels when
- * several agents work at once so the strip never wraps the fixed-height row.
+ * owning its hover popover. Pills are ordered most-recently-active first
+ * (left-most) and animate to their new slot as the order changes. Pills
+ * shrink and truncate their labels when several agents work at once so the
+ * strip never wraps the fixed-height row.
  */
 export function BotActivityComposerAction({
   agents,
@@ -207,6 +318,7 @@ export function BotActivityComposerAction({
   workingBotPubkeys,
 }: BotActivityBarProps) {
   const liveActivityEnabled = useFeatureEnabled("composerLiveActivity");
+  const shouldReduceMotion = useReducedMotion();
 
   const workingAgents = React.useMemo(() => {
     const workingSet = new Set(
@@ -216,24 +328,60 @@ export function BotActivityComposerAction({
     return agents.filter((agent) => workingSet.has(agent.pubkey.toLowerCase()));
   }, [agents, workingBotPubkeys]);
 
-  if (workingAgents.length === 0) {
+  // Most-recent-first pill order. The snapshot is a joined string so
+  // useSyncExternalStore only re-renders this strip when the ORDER actually
+  // changes, not on every observer store write.
+  const getOrderSnapshot = React.useCallback(
+    () =>
+      deriveAgentActivityOrder({
+        channelId,
+        getTranscript: (pubkey) => getAgentTranscript(pubkey, true),
+        pubkeys: workingAgents.map((agent) => agent.pubkey.toLowerCase()),
+      }).join(","),
+    [channelId, workingAgents],
+  );
+  const orderKey = React.useSyncExternalStore(
+    subscribeToObserverStore,
+    getOrderSnapshot,
+  );
+  const orderedAgents = React.useMemo(() => {
+    const byPubkey = new Map(
+      workingAgents.map((agent) => [agent.pubkey.toLowerCase(), agent]),
+    );
+    return orderKey === ""
+      ? []
+      : orderKey.split(",").flatMap((pubkey) => byPubkey.get(pubkey) ?? []);
+  }, [orderKey, workingAgents]);
+
+  if (orderedAgents.length === 0) {
     return null;
   }
 
   return (
     <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-visible">
-      {workingAgents.map((agent) => (
-        <BotActivityAgentPill
-          agent={agent}
-          avatarUrl={profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ?? null}
-          channelId={channelId}
-          key={agent.pubkey}
-          liveActivityEnabled={liveActivityEnabled}
-          onOpenAgentSession={onOpenAgentSession}
-          openAgentSessionPubkey={openAgentSessionPubkey}
-          profiles={profiles}
-        />
-      ))}
+      <AnimatePresence initial={false}>
+        {orderedAgents.map((agent) => (
+          <AnimatedPillSlot
+            key={agent.pubkey}
+            shouldReduceMotion={Boolean(shouldReduceMotion)}
+          >
+            {(isMoving) => (
+              <BotActivityAgentPill
+                agent={agent}
+                avatarUrl={
+                  profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ?? null
+                }
+                channelId={channelId}
+                holdLabelSwap={isMoving}
+                liveActivityEnabled={liveActivityEnabled}
+                onOpenAgentSession={onOpenAgentSession}
+                openAgentSessionPubkey={openAgentSessionPubkey}
+                profiles={profiles}
+              />
+            )}
+          </AnimatedPillSlot>
+        ))}
+      </AnimatePresence>
     </div>
   );
 }

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -50,6 +50,12 @@ const TYPING_LABEL_ID = "typing-override";
  * keyframes so the fade lands together with the layout switch.
  */
 const PILL_REORDER_DURATION_S = 0.9;
+/**
+ * Enter/exit fade+scale for a pill slot. Deliberately much quicker than the
+ * reorder spring — the slow reorder pacing must not bleed into membership
+ * changes, which should feel snappy.
+ */
+const PILL_ENTER_EXIT_DURATION_S = 0.18;
 
 /**
  * Strip-level hover popover state: ONE active pill and ONE timer for the
@@ -479,13 +485,31 @@ function AnimatedPillSlot({
         shouldReduceMotion
           ? { duration: 0 }
           : {
-              type: "spring",
-              duration: PILL_REORDER_DURATION_S,
-              bounce: 0.15,
-              opacity: {
-                type: "tween",
+              // Only the slot's travel gets the slow reorder pacing; the
+              // enter/exit fade+scale runs on its own fast tween below.
+              layout: {
+                type: "spring",
                 duration: PILL_REORDER_DURATION_S,
-                ease: "linear",
+                bounce: 0.15,
+              },
+              // While the slot travels, opacity plays the dip keyframes and
+              // must land together with the layout spring; otherwise it is
+              // an enter/exit fade and should be quick.
+              opacity: isMoving
+                ? {
+                    type: "tween",
+                    duration: PILL_REORDER_DURATION_S,
+                    ease: "linear",
+                  }
+                : {
+                    type: "tween",
+                    duration: PILL_ENTER_EXIT_DURATION_S,
+                    ease: "easeOut",
+                  },
+              scale: {
+                type: "tween",
+                duration: PILL_ENTER_EXIT_DURATION_S,
+                ease: "easeOut",
               },
             }
       }

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -2,14 +2,13 @@ import * as React from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import {
-  getAgentTranscript,
-  subscribeAgentObserverStore,
-} from "@/features/agents/observerRelayStore";
+  getAgentWorkingState,
+  subscribeAgentWorkingSignal,
+} from "@/features/agents/agentWorkingSignal";
 import { useAgentTranscript } from "@/features/agents/ui/useObserverEvents";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ManagedAgent } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
-import { useNow } from "@/shared/lib/useNow";
 import {
   DEFAULT_POPOVER_HOVER_OPEN_DELAY_MS,
   Popover,
@@ -21,7 +20,7 @@ import { UserAvatar } from "@/shared/ui/UserAvatar";
 import { ComposerLiveActivityFeed } from "./ComposerLiveActivityFeed";
 import {
   deriveActivityPillLabel,
-  deriveAgentActivityOrder,
+  deriveAgentWorkingOrder,
 } from "./composerLiveActivity";
 
 export type BotActivityAgent = Pick<ManagedAgent, "pubkey" | "name" | "status">;
@@ -35,23 +34,13 @@ type BotActivityBarProps = {
 };
 
 const HOVER_CLOSE_DELAY_MS = 180;
-/**
- * Re-render cadence for the pill label's staleness check. One second so the
- * decay to the generic label lands promptly after the stale window elapses.
- */
-const PILL_LABEL_TICK_MS = 1_000;
-/** Ticker key for the generic label so decay/recovery animate as one swap. */
+/** Ticker key for the generic label shown before the first action lands. */
 const GENERIC_LABEL_ID = "generic-working";
 /**
  * Perceptual duration shared by the pill reorder spring and the opacity dip
  * keyframes so the fade lands together with the layout switch.
  */
 const PILL_REORDER_DURATION_S = 0.9;
-
-// Stable subscribe reference for useSyncExternalStore (same pattern as
-// useObserverEvents).
-const subscribeToObserverStore = (onStoreChange: () => void) =>
-  subscribeAgentObserverStore(onStoreChange);
 
 /**
  * Strip-level hover popover state: ONE active pill and ONE timer for the
@@ -200,9 +189,11 @@ function useStripHoverPopover(): StripHoverPopover {
 
 /**
  * One working agent's status pill: avatar + the agent's latest action summary
- * (decaying to a generic working label when activity goes quiet). Label
- * updates play as a clipped ticker — the new text pushes the old text up and
- * out — deferred until the pill's slot settles when a reorder is in flight.
+ * (a generic working label until the first action lands; after that the last
+ * action persists — during a quiet stretch, what the agent last did is more
+ * informative than a generic placeholder). Label updates play as a clipped
+ * ticker — the new text pushes the old text up and out — deferred until the
+ * pill's slot settles when a reorder is in flight.
  * Hovering shows the agent's live activity feed as the popover surface
  * itself — flat, no inset box, no tab strip — while clicking the pill opens
  * the agent's full runtime in the auxiliary panel.
@@ -237,14 +228,13 @@ function BotActivityAgentPill({
   const open = hover.activePubkey === pillKey;
   const shouldReduceMotion = useReducedMotion();
   const transcript = useAgentTranscript(true, agent.pubkey);
-  const now = useNow(PILL_LABEL_TICK_MS);
   const headline = React.useMemo(
-    () => deriveActivityPillLabel({ channelId, now, transcript }),
-    [channelId, now, transcript],
+    () => deriveActivityPillLabel({ channelId, transcript }),
+    [channelId, transcript],
   );
   const activeId = headline?.id ?? GENERIC_LABEL_ID;
-  // No fresh action headline (see deriveActivityPillLabel) — decay to the
-  // agent-named generic working label.
+  // No action headline yet (see deriveActivityPillLabel) — show the
+  // agent-named generic working label until the first action lands.
   const activeLabel = headline?.label ?? `${agent.name} is working…`;
   // The rendered label lags the derived one while the pill is moving: the
   // push-up ticker plays after the slot settles (or immediately when idle).
@@ -465,11 +455,14 @@ function AnimatedPillSlot({
 /**
  * Composer status strip for working agents: one pill per working agent,
  * sharing one strip-level hover popover (at most one card open). Pills are
- * ordered most-recently-active first (left-most) and animate to their new
- * slot as the order changes — except while the cursor is over the bar or a
- * hover card is showing, when order, membership, layout animation, and pill
- * widths are all frozen so nothing can move out from under (or slide under)
- * the cursor. Each pill truncates its label at its own max width. A lone
+ * ordered by turn start (earliest worker left-most) — a stable slot for the
+ * whole turn, so liveness is carried by each pill's label ticker while
+ * positional motion is reserved for membership changes: a newly working
+ * agent's pill enters on the right, a finished agent's pill exits and its
+ * neighbors animate into the gap. No movement happens while the cursor is
+ * over the bar or a hover card is showing, when order, membership, layout
+ * animation, and pill widths are all frozen so nothing can move out from
+ * under (or slide under) the cursor. Each pill truncates its label at its own max width. A lone
  * pill shrinks with a narrow container (its label ellipsizes) so it always
  * fits; when SEVERAL pills outgrow a narrow container (thread panel
  * toolbars especially) the strip scrolls horizontally — scrollbar hidden,
@@ -507,20 +500,23 @@ export function BotActivityComposerAction({
     return agents.filter((agent) => workingSet.has(agent.pubkey.toLowerCase()));
   }, [agents, workingBotPubkeys]);
 
-  // Most-recent-first pill order. The snapshot is a joined string so
+  // Turn-start pill order (earliest worker left-most, new agents append on
+  // the right). Anchored to when each agent STARTED working — stable for the
+  // whole turn — so pills never shuffle on transcript activity; only
+  // membership changes move slots. The snapshot is a joined string so
   // useSyncExternalStore only re-renders this strip when the ORDER actually
-  // changes, not on every observer store write.
+  // changes, not on every working-signal write.
   const getOrderSnapshot = React.useCallback(
     () =>
-      deriveAgentActivityOrder({
+      deriveAgentWorkingOrder({
         channelId,
-        getTranscript: (pubkey) => getAgentTranscript(pubkey, true),
+        getWorkingState: (pubkey) => getAgentWorkingState(pubkey, channelId),
         pubkeys: workingAgents.map((agent) => agent.pubkey.toLowerCase()),
       }).join(","),
     [channelId, workingAgents],
   );
   const orderKey = React.useSyncExternalStore(
-    subscribeToObserverStore,
+    subscribeAgentWorkingSignal,
     getOrderSnapshot,
   );
   const liveOrderedAgents = React.useMemo(() => {
@@ -534,9 +530,10 @@ export function BotActivityComposerAction({
 
   // While the hold is active, the strip must not move under the cursor:
   // pill order AND membership are frozen at their last hold-free values.
-  // Reorders queue up behind the hold and apply when it releases; an agent
-  // that finishes mid-hold keeps its pill until then. Without this, a
-  // reorder slides the hovered pill away (firing a spurious mouseleave that
+  // Membership changes (the only source of slot movement under turn-start
+  // ordering) queue up behind the hold and apply when it releases; an agent
+  // that finishes mid-hold keeps its pill until then. Without this, a pill
+  // exiting slides the hovered pill away (firing a spurious mouseleave that
   // closes the card) or slides a different pill under the cursor (opening
   // the wrong one).
   //

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { Loader2 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 
 import {
@@ -9,7 +8,6 @@ import {
 import { useAgentTranscript } from "@/features/agents/ui/useObserverEvents";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ManagedAgent } from "@/shared/api/types";
-import { useFeatureEnabled } from "@/shared/features";
 import { cn } from "@/shared/lib/cn";
 import { useNow } from "@/shared/lib/useNow";
 import {
@@ -32,7 +30,6 @@ type BotActivityBarProps = {
   agents: BotActivityAgent[];
   channelId?: string | null;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
-  openAgentSessionPubkey: string | null;
   profiles?: UserProfileLookup;
   workingBotPubkeys: string[];
 };
@@ -81,6 +78,52 @@ type StripHoverPopover = {
   /** Pointer left a trigger or the open card: close after the grace delay. */
   scheduleClose: () => void;
 };
+
+/**
+ * Edge-fade state for the horizontally scrollable pill strip: which sides
+ * currently have pills clipped out of view. Tracks the scroller's scroll
+ * position plus size changes of both the scroller (container narrows —
+ * thread panel resize) and its content wrapper (pills entering, leaving, or
+ * relabeling to a different width), so the fades appear and disappear
+ * without a re-render triggering event.
+ */
+function useStripOverflowFades(
+  scrollerRef: React.RefObject<HTMLDivElement | null>,
+) {
+  const [fades, setFades] = React.useState({ end: false, start: false });
+
+  const updateFades = React.useCallback(() => {
+    const node = scrollerRef.current;
+    if (node === null) {
+      return;
+    }
+    // 1px slack absorbs sub-pixel rounding in scrollWidth/clientWidth.
+    const start = node.scrollLeft > 1;
+    const end = node.scrollLeft + node.clientWidth < node.scrollWidth - 1;
+    setFades((current) =>
+      current.start === start && current.end === end ? current : { end, start },
+    );
+  }, [scrollerRef]);
+
+  React.useEffect(() => {
+    const node = scrollerRef.current;
+    if (node === null) {
+      return;
+    }
+    updateFades();
+    const observer = new ResizeObserver(updateFades);
+    observer.observe(node);
+    // The content wrapper is the scroller's only child; observing it catches
+    // overflow changes that don't touch the scroller's own box.
+    const content = node.firstElementChild;
+    if (content !== null) {
+      observer.observe(content);
+    }
+    return () => observer.disconnect();
+  }, [scrollerRef, updateFades]);
+
+  return { fades, updateFades };
+}
 
 function useStripHoverPopover(): StripHoverPopover {
   const [activePubkey, setActivePubkey] = React.useState<string | null>(null);
@@ -162,9 +205,7 @@ function useStripHoverPopover(): StripHoverPopover {
  * out — deferred until the pill's slot settles when a reorder is in flight.
  * Hovering shows the agent's live activity feed as the popover surface
  * itself — flat, no inset box, no tab strip — while clicking the pill opens
- * the agent's full runtime in the auxiliary panel. With the
- * `composerLiveActivity` preview flag off, the hover popover keeps the
- * legacy "View activity" item instead.
+ * the agent's full runtime in the auxiliary panel.
  *
  * Only observer-backed agents reach this pill: typing-fallback-only agents
  * are diverted into the combined typing indicator group by
@@ -176,9 +217,7 @@ function BotActivityAgentPill({
   channelId,
   holdLabelSwap,
   hover,
-  liveActivityEnabled,
   onOpenAgentSession,
-  openAgentSessionPubkey,
   pinWidth,
   profiles,
 }: {
@@ -189,9 +228,7 @@ function BotActivityAgentPill({
   holdLabelSwap: boolean;
   /** Strip-level hover popover state shared by every pill. */
   hover: StripHoverPopover;
-  liveActivityEnabled: boolean;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
-  openAgentSessionPubkey: string | null;
   /** Freeze the pill's rendered width (a hover card is showing). */
   pinWidth: boolean;
   profiles?: UserProfileLookup;
@@ -227,8 +264,6 @@ function BotActivityAgentPill({
         : { id: activeId, label: activeLabel },
     );
   }, [holdLabelSwap, activeId, activeLabel]);
-  const isSessionOpen =
-    openAgentSessionPubkey?.toLowerCase() === agent.pubkey.toLowerCase();
 
   // While a hover card is showing, the pill must not resize: label swaps
   // keep animating, but a longer/shorter label truncating inside a FROZEN
@@ -326,9 +361,7 @@ function BotActivityAgentPill({
       </PopoverTrigger>
       <PopoverContent
         align="start"
-        className={cn(
-          liveActivityEnabled ? "w-80 overflow-hidden p-0" : "w-64 p-1",
-        )}
+        className="w-80 overflow-hidden p-0"
         onCloseAutoFocus={(event) => {
           // A hover preview must not yank focus back to the trigger on
           // close: the trigger's focus handler would re-open the card.
@@ -340,39 +373,13 @@ function BotActivityAgentPill({
         side="top"
         sideOffset={8}
       >
-        {liveActivityEnabled ? (
-          <ComposerLiveActivityFeed
-            agent={agent}
-            channelId={channelId}
-            className="h-48 rounded-[inherit]"
-            onOpenAgentSession={() => openSession()}
-            profiles={profiles}
-          />
-        ) : (
-          <button
-            className={cn(
-              "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors",
-              isSessionOpen
-                ? "bg-primary/10 text-primary"
-                : "text-foreground hover:bg-accent hover:text-accent-foreground",
-            )}
-            data-testid={`bot-activity-composer-item-${agent.pubkey}`}
-            onClick={openSession}
-            type="button"
-          >
-            <UserAvatar
-              avatarUrl={avatarUrl}
-              className="shrink-0"
-              displayName={agent.name}
-              size="sm"
-            />
-            <span className="min-w-0 flex-1 truncate">{agent.name}</span>
-            <span className="shrink-0 whitespace-nowrap text-xs font-medium opacity-80">
-              View activity
-            </span>
-            <Loader2 className="h-4 w-4 shrink-0 animate-spin text-muted-foreground/70" />
-          </button>
-        )}
+        <ComposerLiveActivityFeed
+          agent={agent}
+          channelId={channelId}
+          className="h-48 rounded-[inherit]"
+          onOpenAgentSession={() => openSession()}
+          profiles={profiles}
+        />
       </PopoverContent>
     </Popover>
   );
@@ -391,12 +398,19 @@ function AnimatedPillSlot({
   children,
   freezeLayout,
   shouldReduceMotion,
+  shrinkToFit,
 }: {
   /** Render prop so the pill can defer label swaps while its slot moves. */
   children: (isMoving: boolean) => React.ReactNode;
   /** Disable slot layout animation while a hover card is showing. */
   freezeLayout: boolean;
   shouldReduceMotion: boolean;
+  /**
+   * Lone pill: shrink with the container (label ellipsizes) instead of
+   * overflowing into scroll — an edge fade over a single pill reads as a
+   * cut-off bug, not an affordance.
+   */
+  shrinkToFit: boolean;
 }) {
   const [isMoving, setIsMoving] = React.useState(false);
 
@@ -412,7 +426,12 @@ function AnimatedPillSlot({
   return (
     <motion.div
       animate={{ opacity: isMoving ? [1, 0.35, 1] : 1, scale: 1 }}
-      className="flex min-w-0"
+      // With several pills, shrink-0 keeps each at its natural
+      // (label-truncated) width so a strip that outgrows a narrow container
+      // scrolls — with the edge fade signalling the pills off view —
+      // instead of compressing every pill into an unreadable sliver. A lone
+      // pill instead shrinks to fit (min-w-0) so it never scrolls.
+      className={cn("flex", shrinkToFit ? "min-w-0" : "shrink-0")}
       exit={{ opacity: 0, scale: 0.9 }}
       initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.9 }}
       layout={!shouldReduceMotion && !freezeLayout}
@@ -445,18 +464,21 @@ function AnimatedPillSlot({
  * slot as the order changes — except while the cursor is over the bar or a
  * hover card is showing, when order, membership, layout animation, and pill
  * widths are all frozen so nothing can move out from under (or slide under)
- * the cursor. Pills shrink and truncate their labels when several agents
- * work at once so the strip never wraps the fixed-height row.
+ * the cursor. Each pill truncates its label at its own max width. A lone
+ * pill shrinks with a narrow container (its label ellipsizes) so it always
+ * fits; when SEVERAL pills outgrow a narrow container (thread panel
+ * toolbars especially) the strip scrolls horizontally — scrollbar hidden,
+ * with edge gradient fades signalling the pills off view — instead of
+ * compressing every pill into an unreadable sliver or wrapping the
+ * fixed-height row.
  */
 export function BotActivityComposerAction({
   agents,
   channelId = null,
   onOpenAgentSession,
-  openAgentSessionPubkey,
   profiles,
   workingBotPubkeys,
 }: BotActivityBarProps) {
-  const liveActivityEnabled = useFeatureEnabled("composerLiveActivity");
   const shouldReduceMotion = useReducedMotion();
   const hover = useStripHoverPopover();
   // The freeze engages as soon as the cursor is anywhere over the bar — not
@@ -466,6 +488,9 @@ export function BotActivityComposerAction({
   // grace period).
   const [barHovered, setBarHovered] = React.useState(false);
   const holdActive = barHovered || hover.activePubkey !== null;
+
+  const scrollerRef = React.useRef<HTMLDivElement | null>(null);
+  const { fades, updateFades } = useStripOverflowFades(scrollerRef);
 
   const workingAgents = React.useMemo(() => {
     const workingSet = new Set(
@@ -534,37 +559,68 @@ export function BotActivityComposerAction({
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: hover-only hold — keyboard focus drives the same hold via the pill triggers.
     <div
-      className="flex min-w-0 flex-1 items-center gap-1.5 overflow-visible"
+      className="relative min-w-0 flex-1"
       data-testid="bot-activity-strip"
       onMouseEnter={() => setBarHovered(true)}
       onMouseLeave={() => setBarHovered(false)}
     >
-      <AnimatePresence initial={false}>
-        {orderedAgents.map((agent) => (
-          <AnimatedPillSlot
-            freezeLayout={holdActive}
-            key={agent.pubkey}
-            shouldReduceMotion={Boolean(shouldReduceMotion)}
-          >
-            {(isMoving) => (
-              <BotActivityAgentPill
-                agent={agent}
-                avatarUrl={
-                  profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ?? null
-                }
-                channelId={channelId}
-                holdLabelSwap={isMoving}
-                hover={hover}
-                liveActivityEnabled={liveActivityEnabled}
-                onOpenAgentSession={onOpenAgentSession}
-                openAgentSessionPubkey={openAgentSessionPubkey}
-                pinWidth={holdActive}
-                profiles={profiles}
-              />
-            )}
-          </AnimatedPillSlot>
-        ))}
-      </AnimatePresence>
+      {/* layoutScroll keeps the slot layout animations correct while the
+          strip is scrolled — motion measures positions relative to the
+          scroll offset instead of jumping. The negative-margin/padding pair
+          gives focus rings and pill shadows room inside the clip box
+          without changing the row's height. */}
+      <motion.div
+        className="-my-1 flex items-center overflow-x-auto overscroll-x-contain py-1 scrollbar-none [&::-webkit-scrollbar]:hidden"
+        data-testid="bot-activity-strip-scroller"
+        layoutScroll
+        onScroll={updateFades}
+        ref={scrollerRef}
+      >
+        <div className="flex min-w-0 items-center gap-1.5">
+          <AnimatePresence initial={false}>
+            {orderedAgents.map((agent) => (
+              <AnimatedPillSlot
+                freezeLayout={holdActive}
+                key={agent.pubkey}
+                shouldReduceMotion={Boolean(shouldReduceMotion)}
+                shrinkToFit={orderedAgents.length === 1}
+              >
+                {(isMoving) => (
+                  <BotActivityAgentPill
+                    agent={agent}
+                    avatarUrl={
+                      profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ?? null
+                    }
+                    channelId={channelId}
+                    holdLabelSwap={isMoving}
+                    hover={hover}
+                    onOpenAgentSession={onOpenAgentSession}
+                    pinWidth={holdActive}
+                    profiles={profiles}
+                  />
+                )}
+              </AnimatedPillSlot>
+            ))}
+          </AnimatePresence>
+        </div>
+      </motion.div>
+      {/* Edge fades: obvious "more pills off view" affordance. Rendered only
+          for a side that actually has clipped content, so they never dim a
+          fully visible strip. */}
+      {fades.start ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-linear-to-r from-background via-background/60 to-transparent"
+          data-testid="bot-activity-strip-fade-start"
+        />
+      ) : null}
+      {fades.end ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-linear-to-l from-background via-background/60 to-transparent"
+          data-testid="bot-activity-strip-fade-end"
+        />
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/features/channels/ui/ChannelComposerActivityAccessory.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityAccessory.tsx
@@ -1,69 +1,52 @@
 import type { ComponentProps } from "react";
 
-import { CardMintComposerChip } from "@/features/agents/ui/CardMintComposerChip";
 import { useCardMintJobs } from "@/features/agents/cardMintStore";
-import { BotActivityComposerAction } from "@/features/channels/ui/BotActivityBar";
+import { CardMintComposerChip } from "@/features/agents/ui/CardMintComposerChip";
+import { ChannelComposerActivityRow } from "@/features/channels/ui/ChannelComposerActivityRow";
 import { ComposerActivityAccessory } from "@/features/messages/ui/ComposerActivityAccessory";
-import { TypingIndicatorRow } from "@/features/messages/ui/TypingIndicatorRow";
 
 type ChannelComposerActivityAccessoryProps = {
-  agents: ComponentProps<typeof BotActivityComposerAction>["agents"];
-  channel: ComponentProps<typeof TypingIndicatorRow>["channel"];
-  currentPubkey: ComponentProps<typeof TypingIndicatorRow>["currentPubkey"];
+  agents: ComponentProps<typeof ChannelComposerActivityRow>["agents"];
+  channel: ComponentProps<typeof ChannelComposerActivityRow>["channel"];
+  currentPubkey: ComponentProps<
+    typeof ChannelComposerActivityRow
+  >["currentPubkey"];
   onOpenAgentSession: ComponentProps<
-    typeof BotActivityComposerAction
+    typeof ChannelComposerActivityRow
   >["onOpenAgentSession"];
-  openAgentSessionPubkey: ComponentProps<
-    typeof BotActivityComposerAction
-  >["openAgentSessionPubkey"];
-  profiles: ComponentProps<typeof BotActivityComposerAction>["profiles"];
+  profiles: ComponentProps<typeof ChannelComposerActivityRow>["profiles"];
   typingPubkeys: string[];
   visible: boolean;
-  workingBotPubkeys: string[];
 };
 
+/** Main's shared channel activity host with the unified live-activity strip. */
 export function ChannelComposerActivityAccessory({
   agents,
   channel,
   currentPubkey,
   onOpenAgentSession,
-  openAgentSessionPubkey,
   profiles,
   typingPubkeys,
   visible,
-  workingBotPubkeys,
 }: ChannelComposerActivityAccessoryProps) {
   const cardMintJobs = useCardMintJobs();
+
   return (
     <ComposerActivityAccessory
       className="px-5"
       testId="channel-composer-activity-row"
       visible={visible}
     >
-      <div className="flex w-full items-center gap-2 overflow-visible pl-2">
+      <div className="flex h-8.5 w-full items-center gap-2 overflow-visible pb-1.5 pl-2">
         {cardMintJobs.length > 0 ? <CardMintComposerChip /> : null}
-        {workingBotPubkeys.length > 0 ? (
-          <div className="flex min-w-0 flex-1 overflow-visible">
-            <BotActivityComposerAction
-              agents={agents}
-              channelId={channel?.id ?? null}
-              onOpenAgentSession={onOpenAgentSession}
-              openAgentSessionPubkey={openAgentSessionPubkey}
-              profiles={profiles}
-              workingBotPubkeys={workingBotPubkeys}
-              variant="inline"
-            />
-          </div>
-        ) : null}
-        {typingPubkeys.length > 0 ? (
-          <TypingIndicatorRow
-            channel={channel}
-            className="min-w-0 flex-1 py-0 pl-[calc(0.75rem+1px)] pr-0 sm:pl-[calc(1rem+1px)]"
-            currentPubkey={currentPubkey}
-            profiles={profiles}
-            typingPubkeys={typingPubkeys}
-          />
-        ) : null}
+        <ChannelComposerActivityRow
+          agents={agents}
+          channel={channel}
+          currentPubkey={currentPubkey}
+          onOpenAgentSession={onOpenAgentSession}
+          profiles={profiles}
+          typingPubkeys={typingPubkeys}
+        />
       </div>
     </ComposerActivityAccessory>
   );

--- a/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
@@ -12,11 +12,12 @@ import {
 import { TypingIndicatorRow } from "@/features/messages/ui/TypingIndicatorRow";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { Channel } from "@/shared/api/types";
-import { cn } from "@/shared/lib/cn";
 
 /**
- * Status strip anchored directly below the message composer: the inline
- * "agents working" trigger plus the typing indicator.
+ * Status strip anchored directly below the message composer: the working
+ * agent pills plus the typing indicator, rendered as slot siblings inside
+ * ONE strip (BotActivityComposerAction) so both share the scroller, edge
+ * fades, and layout/enter/exit animations.
  *
  * The working set splits by signal source: observer-backed agents get the
  * interactive activity pills, while typing-fallback-only agents (no observer
@@ -110,42 +111,34 @@ export function ChannelComposerActivityRow({
       className="h-8.5 overflow-visible bg-background px-5 pb-1.5 pt-0"
       data-testid="channel-composer-activity-row"
     >
-      <div className="flex h-full w-full items-center gap-3 overflow-visible">
-        {/* The pill strip sizes to its content; when the row gets tight it
-            scrolls horizontally (edge fades signal clipped pills) rather
-            than compressing. The typing group takes whatever is left so it
-            sits directly after the pills instead of splitting the row
-            50/50. */}
-        {observerWorkingPubkeys.length > 0 ? (
-          <div className="flex min-w-0 overflow-visible">
-            <BotActivityComposerAction
-              agents={agents}
-              channelId={channelId}
-              onOpenAgentSession={onOpenAgentSession}
-              profiles={profiles}
-              workingBotPubkeys={observerWorkingPubkeys}
-            />
-          </div>
-        ) : null}
-        {combinedTypingPubkeys.length > 0 ? (
-          <TypingIndicatorRow
-            channel={channel}
-            className={cn(
-              "min-w-0 flex-1 py-0 pr-0",
-              // Composer-edge alignment only when the typing group leads the
-              // row; next to pills the row's gap is the whole spacing (the
-              // base variant's px-4/sm:px-6 must be zeroed, not just left
-              // unoverridden).
-              observerWorkingPubkeys.length === 0
-                ? "pl-[calc(0.75rem+1px)] sm:pl-[calc(1rem+1px)]"
-                : "pl-0 sm:pl-0",
-            )}
-            currentPubkey={currentPubkey}
-            // Match the activity pills' label weight so the two read as one
-            // strip.
-            labelClassName="font-semibold"
-            profiles={typingProfiles}
-            typingPubkeys={combinedTypingPubkeys}
+      <div className="flex h-full w-full items-center overflow-visible">
+        {/* One strip hosts both groups: working pills plus the typing group
+            as the strip's trailing slot sibling, so they share the scroller,
+            edge fades, and layout/enter/exit animations. When the row gets
+            tight the strip scrolls horizontally (edge fades signal clipped
+            items) rather than compressing. */}
+        {observerWorkingPubkeys.length > 0 ||
+        combinedTypingPubkeys.length > 0 ? (
+          <BotActivityComposerAction
+            agents={agents}
+            channelId={channelId}
+            onOpenAgentSession={onOpenAgentSession}
+            profiles={profiles}
+            typingIndicator={
+              combinedTypingPubkeys.length > 0 ? (
+                <TypingIndicatorRow
+                  channel={channel}
+                  // The strip's slot owns spacing and the typing-only inset;
+                  // zero the base paddings and let the row shrink so the
+                  // lone-item slot can ellipsize the label.
+                  className="min-w-0 shrink px-0 py-0 sm:px-0"
+                  currentPubkey={currentPubkey}
+                  profiles={typingProfiles}
+                  typingPubkeys={combinedTypingPubkeys}
+                />
+              ) : null
+            }
+            workingBotPubkeys={observerWorkingPubkeys}
           />
         ) : null}
       </div>

--- a/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
@@ -6,9 +6,14 @@ import {
   useChannelWorkingAgentPubkeys,
 } from "@/features/agents/agentWorkingSignal";
 import {
+  getAgentTranscript,
+  subscribeAgentObserverStore,
+} from "@/features/agents/observerRelayStore";
+import {
   BotActivityComposerAction,
   type BotActivityAgent,
 } from "@/features/channels/ui/BotActivityBar";
+import { partitionComposerWorkingAgents } from "@/features/channels/ui/composerLiveActivity";
 import { TypingIndicatorRow } from "@/features/messages/ui/TypingIndicatorRow";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { Channel } from "@/shared/api/types";
@@ -19,11 +24,15 @@ import type { Channel } from "@/shared/api/types";
  * ONE strip (BotActivityComposerAction) so both share the scroller, edge
  * fades, and layout/enter/exit animations.
  *
- * The working set splits by signal source: observer-backed agents get the
- * interactive activity pills, while typing-fallback-only agents (no observer
- * turn — nothing to hover or open) merge with the human typers into ONE
- * combined typing indicator group ("X and Y are typing…") with an
- * overlapping avatar set.
+ * The working set splits by pill-worthiness (capability, not signal
+ * source — see partitionComposerWorkingAgents): agents with a session worth
+ * hovering/opening (an active observer turn, or a headline-able transcript
+ * left by a prior turn) get the interactive activity pills, while
+ * typing-fallback agents with nothing to show merge with the human typers
+ * into ONE combined typing indicator group ("X and Y are typing…") with an
+ * overlapping avatar set. An agent whose turn just ended but who is still
+ * typing therefore keeps its pill (relabeled "is typing…") instead of
+ * demoting to the group.
  *
  * The row has a FIXED height (not min-h): it must not grow when the inline
  * bot-activity button (h-7) mounts, or the bottom-anchored composer above it
@@ -53,28 +62,44 @@ export function ChannelComposerActivityRow({
   // whose typing signal never arrives — and vice versa.
   const workingBotPubkeys = useChannelWorkingAgentPubkeys(channelId);
 
-  // Typing-fallback-only pubkeys (channel-scoped working source "typing").
+  // Typing-group pubkeys: typing-fallback agents with NO headline-able
+  // transcript for this channel (see partitionComposerWorkingAgents).
+  // The partition reads two stores — the working signal (source) and the
+  // observer store (transcripts) — so the snapshot subscribes to both:
+  // a transcript landing must be able to promote a typing agent to a pill.
   // Snapshot is a joined string so useSyncExternalStore only re-renders when
-  // the partition actually changes, not on every signal write.
+  // the partition actually changes, not on every store write.
+  const subscribeToPartitionSources = React.useCallback(
+    (onChange: () => void) => {
+      const unsubscribeWorking = subscribeAgentWorkingSignal(onChange);
+      const unsubscribeObserver = subscribeAgentObserverStore(onChange);
+      return () => {
+        unsubscribeWorking();
+        unsubscribeObserver();
+      };
+    },
+    [],
+  );
   const getAgentTypingSnapshot = React.useCallback(
     () =>
-      workingBotPubkeys
-        .filter(
-          (pubkey) =>
-            getAgentWorkingState(pubkey, channelId).source === "typing",
-        )
-        .join(","),
+      partitionComposerWorkingAgents({
+        channelId,
+        getTranscript: (pubkey) => getAgentTranscript(pubkey),
+        getWorkingSource: (pubkey) =>
+          getAgentWorkingState(pubkey, channelId).source,
+        pubkeys: workingBotPubkeys,
+      }).typingGroupPubkeys.join(","),
     [channelId, workingBotPubkeys],
   );
   const agentTypingKey = React.useSyncExternalStore(
-    subscribeAgentWorkingSignal,
+    subscribeToPartitionSources,
     getAgentTypingSnapshot,
   );
   const agentTypingPubkeys = React.useMemo(
     () => (agentTypingKey === "" ? [] : agentTypingKey.split(",")),
     [agentTypingKey],
   );
-  const observerWorkingPubkeys = React.useMemo(() => {
+  const pillBotPubkeys = React.useMemo(() => {
     const typingSet = new Set(agentTypingPubkeys);
     return workingBotPubkeys.filter((pubkey) => !typingSet.has(pubkey));
   }, [agentTypingPubkeys, workingBotPubkeys]);
@@ -117,8 +142,7 @@ export function ChannelComposerActivityRow({
             edge fades, and layout/enter/exit animations. When the row gets
             tight the strip scrolls horizontally (edge fades signal clipped
             items) rather than compressing. */}
-        {observerWorkingPubkeys.length > 0 ||
-        combinedTypingPubkeys.length > 0 ? (
+        {pillBotPubkeys.length > 0 || combinedTypingPubkeys.length > 0 ? (
           <BotActivityComposerAction
             agents={agents}
             channelId={channelId}
@@ -138,7 +162,7 @@ export function ChannelComposerActivityRow({
                 />
               ) : null
             }
-            workingBotPubkeys={observerWorkingPubkeys}
+            workingBotPubkeys={pillBotPubkeys}
           />
         ) : null}
       </div>

--- a/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
@@ -54,7 +54,6 @@ export function ChannelComposerActivityRow({
               onOpenAgentSession={onOpenAgentSession}
               openAgentSessionPubkey={openAgentSessionPubkey}
               profiles={profiles}
-              variant="inline"
               workingBotPubkeys={workingBotPubkeys}
             />
           </div>

--- a/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
@@ -1,0 +1,74 @@
+import { useChannelWorkingAgentPubkeys } from "@/features/agents/agentWorkingSignal";
+import {
+  BotActivityComposerAction,
+  type BotActivityAgent,
+} from "@/features/channels/ui/BotActivityBar";
+import { TypingIndicatorRow } from "@/features/messages/ui/TypingIndicatorRow";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import type { Channel } from "@/shared/api/types";
+
+/**
+ * Status strip anchored directly below the message composer: the inline
+ * "agents working" trigger plus the typing indicator.
+ *
+ * The row has a FIXED height (not min-h): it must not grow when the inline
+ * bot-activity button (h-7) mounts, or the bottom-anchored composer above it
+ * visibly bumps up. 34px (h-8.5) = 28px button + 6px bottom padding, the
+ * row's rendered height while a trigger is present. Guarded by the "composer
+ * does not shift when the activity row mounts and clears" e2e test.
+ */
+export function ChannelComposerActivityRow({
+  agents,
+  channel,
+  currentPubkey,
+  onOpenAgentSession,
+  openAgentSessionPubkey,
+  profiles,
+  typingPubkeys,
+}: {
+  agents: BotActivityAgent[];
+  channel: Channel | null;
+  currentPubkey?: string;
+  onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
+  openAgentSessionPubkey: string | null;
+  profiles?: UserProfileLookup;
+  typingPubkeys: string[];
+}) {
+  // Unified working set for the composer bar: observer-derived turns primary,
+  // bot typing fallback (both folded together by agentWorkingSignal). This is
+  // what makes the bar show for an agent whose observer stream is live but
+  // whose typing signal never arrives — and vice versa.
+  const workingBotPubkeys = useChannelWorkingAgentPubkeys(channel?.id ?? null);
+
+  return (
+    <div
+      className="h-8.5 overflow-visible bg-background px-5 pb-1.5 pt-0"
+      data-testid="channel-composer-activity-row"
+    >
+      <div className="flex h-full w-full items-center gap-2 overflow-visible">
+        {workingBotPubkeys.length > 0 ? (
+          <div className="flex min-w-0 flex-1 overflow-visible">
+            <BotActivityComposerAction
+              agents={agents}
+              channelId={channel?.id ?? null}
+              onOpenAgentSession={onOpenAgentSession}
+              openAgentSessionPubkey={openAgentSessionPubkey}
+              profiles={profiles}
+              variant="inline"
+              workingBotPubkeys={workingBotPubkeys}
+            />
+          </div>
+        ) : null}
+        {typingPubkeys.length > 0 ? (
+          <TypingIndicatorRow
+            channel={channel}
+            className="min-w-0 flex-1 py-0 pl-[calc(0.75rem+1px)] pr-0 sm:pl-[calc(1rem+1px)]"
+            currentPubkey={currentPubkey}
+            profiles={profiles}
+            typingPubkeys={typingPubkeys}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
@@ -32,7 +32,8 @@ import type { Channel } from "@/shared/api/types";
  * into ONE combined typing indicator group ("X and Y are typing…") with an
  * overlapping avatar set. An agent whose turn just ended but who is still
  * typing therefore keeps its pill (relabeled "is typing…") instead of
- * demoting to the group.
+ * demoting to the group. While an observer turn is active, its latest action
+ * remains the pill label even if the harness continues refreshing typing.
  *
  * The row has a FIXED height (not min-h): it must not grow when the inline
  * bot-activity button (h-7) mounts, or the bottom-anchored composer above it

--- a/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
@@ -132,11 +132,7 @@ export function ChannelComposerActivityRow({
   }, [agentTypingPubkeys.length, agents, profiles]);
 
   return (
-    <div
-      className="h-8.5 overflow-visible bg-background px-5 pb-1.5 pt-0"
-      data-testid="channel-composer-activity-row"
-    >
-      <div className="flex h-full w-full items-center overflow-visible">
+    <div className="flex min-w-0 flex-1 items-center overflow-visible">
         {/* One strip hosts both groups: working pills plus the typing group
             as the strip's trailing slot sibling, so they share the scroller,
             edge fades, and layout/enter/exit animations. When the row gets
@@ -165,7 +161,6 @@ export function ChannelComposerActivityRow({
             workingBotPubkeys={pillBotPubkeys}
           />
         ) : null}
-      </div>
     </div>
   );
 }

--- a/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
@@ -134,34 +134,34 @@ export function ChannelComposerActivityRow({
 
   return (
     <div className="flex min-w-0 flex-1 items-center overflow-visible">
-        {/* One strip hosts both groups: working pills plus the typing group
+      {/* One strip hosts both groups: working pills plus the typing group
             as the strip's trailing slot sibling, so they share the scroller,
             edge fades, and layout/enter/exit animations. When the row gets
             tight the strip scrolls horizontally (edge fades signal clipped
             items) rather than compressing. */}
-        {pillBotPubkeys.length > 0 || combinedTypingPubkeys.length > 0 ? (
-          <BotActivityComposerAction
-            agents={agents}
-            channelId={channelId}
-            onOpenAgentSession={onOpenAgentSession}
-            profiles={profiles}
-            typingIndicator={
-              combinedTypingPubkeys.length > 0 ? (
-                <TypingIndicatorRow
-                  channel={channel}
-                  // The strip's slot owns spacing and the typing-only inset;
-                  // zero the base paddings and let the row shrink so the
-                  // lone-item slot can ellipsize the label.
-                  className="min-w-0 shrink px-0 py-0 sm:px-0"
-                  currentPubkey={currentPubkey}
-                  profiles={typingProfiles}
-                  typingPubkeys={combinedTypingPubkeys}
-                />
-              ) : null
-            }
-            workingBotPubkeys={pillBotPubkeys}
-          />
-        ) : null}
+      {pillBotPubkeys.length > 0 || combinedTypingPubkeys.length > 0 ? (
+        <BotActivityComposerAction
+          agents={agents}
+          channelId={channelId}
+          onOpenAgentSession={onOpenAgentSession}
+          profiles={profiles}
+          typingIndicator={
+            combinedTypingPubkeys.length > 0 ? (
+              <TypingIndicatorRow
+                channel={channel}
+                // The strip's slot owns spacing and the typing-only inset;
+                // zero the base paddings and let the row shrink so the
+                // lone-item slot can ellipsize the label.
+                className="min-w-0 shrink px-0 py-0 sm:px-0"
+                currentPubkey={currentPubkey}
+                profiles={typingProfiles}
+                typingPubkeys={combinedTypingPubkeys}
+              />
+            ) : null
+          }
+          workingBotPubkeys={pillBotPubkeys}
+        />
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
@@ -35,7 +35,6 @@ export function ChannelComposerActivityRow({
   channel,
   currentPubkey,
   onOpenAgentSession,
-  openAgentSessionPubkey,
   profiles,
   typingPubkeys,
 }: {
@@ -43,7 +42,6 @@ export function ChannelComposerActivityRow({
   channel: Channel | null;
   currentPubkey?: string;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
-  openAgentSessionPubkey: string | null;
   profiles?: UserProfileLookup;
   typingPubkeys: string[];
 }) {
@@ -113,16 +111,17 @@ export function ChannelComposerActivityRow({
       data-testid="channel-composer-activity-row"
     >
       <div className="flex h-full w-full items-center gap-3 overflow-visible">
-        {/* The pill strip sizes to its content (shrinkable when the row gets
-            tight); the typing group takes whatever is left so it sits
-            directly after the pills instead of splitting the row 50/50. */}
+        {/* The pill strip sizes to its content; when the row gets tight it
+            scrolls horizontally (edge fades signal clipped pills) rather
+            than compressing. The typing group takes whatever is left so it
+            sits directly after the pills instead of splitting the row
+            50/50. */}
         {observerWorkingPubkeys.length > 0 ? (
           <div className="flex min-w-0 overflow-visible">
             <BotActivityComposerAction
               agents={agents}
               channelId={channelId}
               onOpenAgentSession={onOpenAgentSession}
-              openAgentSessionPubkey={openAgentSessionPubkey}
               profiles={profiles}
               workingBotPubkeys={observerWorkingPubkeys}
             />

--- a/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityRow.tsx
@@ -1,4 +1,10 @@
-import { useChannelWorkingAgentPubkeys } from "@/features/agents/agentWorkingSignal";
+import * as React from "react";
+
+import {
+  getAgentWorkingState,
+  subscribeAgentWorkingSignal,
+  useChannelWorkingAgentPubkeys,
+} from "@/features/agents/agentWorkingSignal";
 import {
   BotActivityComposerAction,
   type BotActivityAgent,
@@ -6,10 +12,17 @@ import {
 import { TypingIndicatorRow } from "@/features/messages/ui/TypingIndicatorRow";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { Channel } from "@/shared/api/types";
+import { cn } from "@/shared/lib/cn";
 
 /**
  * Status strip anchored directly below the message composer: the inline
  * "agents working" trigger plus the typing indicator.
+ *
+ * The working set splits by signal source: observer-backed agents get the
+ * interactive activity pills, while typing-fallback-only agents (no observer
+ * turn — nothing to hover or open) merge with the human typers into ONE
+ * combined typing indicator group ("X and Y are typing…") with an
+ * overlapping avatar set.
  *
  * The row has a FIXED height (not min-h): it must not grow when the inline
  * bot-activity button (h-7) mounts, or the bottom-anchored composer above it
@@ -34,37 +47,106 @@ export function ChannelComposerActivityRow({
   profiles?: UserProfileLookup;
   typingPubkeys: string[];
 }) {
+  const channelId = channel?.id ?? null;
   // Unified working set for the composer bar: observer-derived turns primary,
   // bot typing fallback (both folded together by agentWorkingSignal). This is
   // what makes the bar show for an agent whose observer stream is live but
   // whose typing signal never arrives — and vice versa.
-  const workingBotPubkeys = useChannelWorkingAgentPubkeys(channel?.id ?? null);
+  const workingBotPubkeys = useChannelWorkingAgentPubkeys(channelId);
+
+  // Typing-fallback-only pubkeys (channel-scoped working source "typing").
+  // Snapshot is a joined string so useSyncExternalStore only re-renders when
+  // the partition actually changes, not on every signal write.
+  const getAgentTypingSnapshot = React.useCallback(
+    () =>
+      workingBotPubkeys
+        .filter(
+          (pubkey) =>
+            getAgentWorkingState(pubkey, channelId).source === "typing",
+        )
+        .join(","),
+    [channelId, workingBotPubkeys],
+  );
+  const agentTypingKey = React.useSyncExternalStore(
+    subscribeAgentWorkingSignal,
+    getAgentTypingSnapshot,
+  );
+  const agentTypingPubkeys = React.useMemo(
+    () => (agentTypingKey === "" ? [] : agentTypingKey.split(",")),
+    [agentTypingKey],
+  );
+  const observerWorkingPubkeys = React.useMemo(() => {
+    const typingSet = new Set(agentTypingPubkeys);
+    return workingBotPubkeys.filter((pubkey) => !typingSet.has(pubkey));
+  }, [agentTypingPubkeys, workingBotPubkeys]);
+
+  // Humans and typing-fallback agents share one indicator group.
+  const combinedTypingPubkeys = React.useMemo(
+    () => [...typingPubkeys, ...agentTypingPubkeys],
+    [agentTypingPubkeys, typingPubkeys],
+  );
+
+  // The channel-agent roster carries names for agents that have no profile
+  // entry (e.g. relay-roster-only agents); overlay them so the typing label
+  // never falls back to a truncated pubkey.
+  const typingProfiles = React.useMemo(() => {
+    if (agentTypingPubkeys.length === 0 || agents.length === 0) {
+      return profiles;
+    }
+    const merged: UserProfileLookup = { ...profiles };
+    for (const agent of agents) {
+      const key = agent.pubkey.toLowerCase();
+      merged[key] = {
+        ...merged[key],
+        displayName: merged[key]?.displayName || agent.name,
+        avatarUrl: merged[key]?.avatarUrl ?? null,
+        nip05Handle: merged[key]?.nip05Handle ?? null,
+        isAgent: true,
+      };
+    }
+    return merged;
+  }, [agentTypingPubkeys.length, agents, profiles]);
 
   return (
     <div
       className="h-8.5 overflow-visible bg-background px-5 pb-1.5 pt-0"
       data-testid="channel-composer-activity-row"
     >
-      <div className="flex h-full w-full items-center gap-2 overflow-visible">
-        {workingBotPubkeys.length > 0 ? (
-          <div className="flex min-w-0 flex-1 overflow-visible">
+      <div className="flex h-full w-full items-center gap-3 overflow-visible">
+        {/* The pill strip sizes to its content (shrinkable when the row gets
+            tight); the typing group takes whatever is left so it sits
+            directly after the pills instead of splitting the row 50/50. */}
+        {observerWorkingPubkeys.length > 0 ? (
+          <div className="flex min-w-0 overflow-visible">
             <BotActivityComposerAction
               agents={agents}
-              channelId={channel?.id ?? null}
+              channelId={channelId}
               onOpenAgentSession={onOpenAgentSession}
               openAgentSessionPubkey={openAgentSessionPubkey}
               profiles={profiles}
-              workingBotPubkeys={workingBotPubkeys}
+              workingBotPubkeys={observerWorkingPubkeys}
             />
           </div>
         ) : null}
-        {typingPubkeys.length > 0 ? (
+        {combinedTypingPubkeys.length > 0 ? (
           <TypingIndicatorRow
             channel={channel}
-            className="min-w-0 flex-1 py-0 pl-[calc(0.75rem+1px)] pr-0 sm:pl-[calc(1rem+1px)]"
+            className={cn(
+              "min-w-0 flex-1 py-0 pr-0",
+              // Composer-edge alignment only when the typing group leads the
+              // row; next to pills the row's gap is the whole spacing (the
+              // base variant's px-4/sm:px-6 must be zeroed, not just left
+              // unoverridden).
+              observerWorkingPubkeys.length === 0
+                ? "pl-[calc(0.75rem+1px)] sm:pl-[calc(1rem+1px)]"
+                : "pl-0 sm:pl-0",
+            )}
             currentPubkey={currentPubkey}
-            profiles={profiles}
-            typingPubkeys={typingPubkeys}
+            // Match the activity pills' label weight so the two read as one
+            // strip.
+            labelClassName="font-semibold"
+            profiles={typingProfiles}
+            typingPubkeys={combinedTypingPubkeys}
           />
         ) : null}
       </div>

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -38,7 +38,8 @@ import { useFocusDrawerPresence } from "@/features/channels/ui/useFocusDrawerPre
 import { useChannelWorkingAgentPubkeys } from "@/features/agents/agentWorkingSignal";
 import { useCardMintJobs } from "@/features/agents/cardMintStore";
 import { BotActivityComposerAction } from "@/features/channels/ui/BotActivityBar";
-import { ChannelComposerActivityAccessory } from "@/features/channels/ui/ChannelComposerActivityAccessory";
+import { ChannelComposerActivityRow } from "@/features/channels/ui/ChannelComposerActivityRow";
+import { ComposerActivityAccessory } from "@/features/messages/ui/ComposerActivityAccessory";
 import {
   containsWelcomePersonaMention,
   WelcomeComposerGuidanceLayer,
@@ -738,17 +739,17 @@ export const ChannelPane = React.memo(function ChannelPane({
                     bottom rail, so fading it cannot change the observed
                     overlay height or move the conversation. Its natural
                     content height remains responsive. */}
-                  <ChannelComposerActivityAccessory
-                    agents={activityAgents}
-                    channel={activeChannel}
-                    currentPubkey={currentPubkey}
-                    onOpenAgentSession={onOpenAgentSession}
-                    openAgentSessionPubkey={openAgentSessionPubkey}
-                    profiles={profiles}
-                    typingPubkeys={typingPubkeys}
-                    visible={hasComposerBottomActivity}
-                    workingBotPubkeys={composerWorkingBotPubkeys}
-                  />
+                  <ComposerActivityAccessory visible={hasComposerBottomActivity}>
+                    <ChannelComposerActivityRow
+                      agents={activityAgents}
+                      channel={activeChannel}
+                      currentPubkey={currentPubkey}
+                      onOpenAgentSession={onOpenAgentSession}
+                      openAgentSessionPubkey={openAgentSessionPubkey}
+                      profiles={profiles}
+                      typingPubkeys={typingPubkeys}
+                    />
+                  </ComposerActivityAccessory>
                 </div>
               </div>
             )}

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -745,7 +745,6 @@ export const ChannelPane = React.memo(function ChannelPane({
                       channel={activeChannel}
                       currentPubkey={currentPubkey}
                       onOpenAgentSession={onOpenAgentSession}
-                      openAgentSessionPubkey={openAgentSessionPubkey}
                       profiles={profiles}
                       typingPubkeys={typingPubkeys}
                     />
@@ -846,7 +845,6 @@ export const ChannelPane = React.memo(function ChannelPane({
                       agents={activityAgents}
                       channelId={activeChannel?.id ?? null}
                       onOpenAgentSession={onOpenAgentSession}
-                      openAgentSessionPubkey={openAgentSessionPubkey}
                       profiles={profiles}
                       workingBotPubkeys={threadComposerBotTypingPubkeys}
                     />

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -40,6 +40,7 @@ import { useCardMintJobs } from "@/features/agents/cardMintStore";
 import { BotActivityComposerAction } from "@/features/channels/ui/BotActivityBar";
 import { ChannelComposerActivityRow } from "@/features/channels/ui/ChannelComposerActivityRow";
 import { ComposerActivityAccessory } from "@/features/messages/ui/ComposerActivityAccessory";
+import { TypingIndicatorRow } from "@/features/messages/ui/TypingIndicatorRow";
 import {
   containsWelcomePersonaMention,
   WelcomeComposerGuidanceLayer,
@@ -837,15 +838,33 @@ export const ChannelPane = React.memo(function ChannelPane({
                   threadHeadMessage.id,
                 )}
                 threadReplyUnreadCounts={threadReplyUnreadCounts}
-                threadTypingPubkeys={threadTypingPubkeys}
-                activityAccessoryVisible={hasThreadComposerBotActivity}
+                activityAccessoryVisible={
+                  hasThreadComposerBotActivity ||
+                  threadTypingPubkeys.length > 0
+                }
                 activityAccessoryContent={
-                  hasThreadComposerBotActivity ? (
+                  hasThreadComposerBotActivity ||
+                  threadTypingPubkeys.length > 0 ? (
                     <BotActivityComposerAction
                       agents={activityAgents}
                       channelId={activeChannel?.id ?? null}
                       onOpenAgentSession={onOpenAgentSession}
                       profiles={profiles}
+                      typingIndicator={
+                        threadTypingPubkeys.length > 0 ? (
+                          <TypingIndicatorRow
+                            channel={activeChannel}
+                            // The strip's slot owns spacing and the
+                            // typing-only inset; zero the base paddings and
+                            // let the row shrink so the lone-item slot can
+                            // ellipsize the label.
+                            className="min-w-0 shrink px-0 py-0 sm:px-0"
+                            currentPubkey={currentPubkey}
+                            profiles={profiles}
+                            typingPubkeys={threadTypingPubkeys}
+                          />
+                        ) : null
+                      }
                       workingBotPubkeys={threadComposerBotTypingPubkeys}
                     />
                   ) : null

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -38,8 +38,7 @@ import { useFocusDrawerPresence } from "@/features/channels/ui/useFocusDrawerPre
 import { useChannelWorkingAgentPubkeys } from "@/features/agents/agentWorkingSignal";
 import { useCardMintJobs } from "@/features/agents/cardMintStore";
 import { BotActivityComposerAction } from "@/features/channels/ui/BotActivityBar";
-import { ChannelComposerActivityRow } from "@/features/channels/ui/ChannelComposerActivityRow";
-import { ComposerActivityAccessory } from "@/features/messages/ui/ComposerActivityAccessory";
+import { ChannelComposerActivityAccessory } from "@/features/channels/ui/ChannelComposerActivityAccessory";
 import { TypingIndicatorRow } from "@/features/messages/ui/TypingIndicatorRow";
 import {
   containsWelcomePersonaMention,
@@ -740,16 +739,15 @@ export const ChannelPane = React.memo(function ChannelPane({
                     bottom rail, so fading it cannot change the observed
                     overlay height or move the conversation. Its natural
                     content height remains responsive. */}
-                  <ComposerActivityAccessory visible={hasComposerBottomActivity}>
-                    <ChannelComposerActivityRow
-                      agents={activityAgents}
-                      channel={activeChannel}
-                      currentPubkey={currentPubkey}
-                      onOpenAgentSession={onOpenAgentSession}
-                      profiles={profiles}
-                      typingPubkeys={typingPubkeys}
-                    />
-                  </ComposerActivityAccessory>
+                  <ChannelComposerActivityAccessory
+                    agents={activityAgents}
+                    channel={activeChannel}
+                    currentPubkey={currentPubkey}
+                    onOpenAgentSession={onOpenAgentSession}
+                    profiles={profiles}
+                    typingPubkeys={typingPubkeys}
+                    visible={hasComposerBottomActivity}
+                  />
                 </div>
               </div>
             )}

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -849,7 +849,6 @@ export const ChannelPane = React.memo(function ChannelPane({
                       openAgentSessionPubkey={openAgentSessionPubkey}
                       profiles={profiles}
                       workingBotPubkeys={threadComposerBotTypingPubkeys}
-                      variant="inline"
                     />
                   ) : null
                 }

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -39,6 +39,7 @@ import { useChannelWorkingAgentPubkeys } from "@/features/agents/agentWorkingSig
 import { useCardMintJobs } from "@/features/agents/cardMintStore";
 import { BotActivityComposerAction } from "@/features/channels/ui/BotActivityBar";
 import { ChannelComposerActivityAccessory } from "@/features/channels/ui/ChannelComposerActivityAccessory";
+import { useThreadComposerActivity } from "@/features/channels/ui/useThreadComposerActivity";
 import { TypingIndicatorRow } from "@/features/messages/ui/TypingIndicatorRow";
 import {
   containsWelcomePersonaMention,
@@ -364,20 +365,16 @@ export const ChannelPane = React.memo(function ChannelPane({
   const hasCardMintActivity = useCardMintJobs().length > 0;
   const hasComposerBottomActivity =
     hasComposerBotActivity || hasTypingActivity || hasCardMintActivity;
-  const threadComposerBotTypingPubkeys = React.useMemo(() => {
-    if (!openThreadHeadId) return [];
-    return botTypingEntries
-      .filter((entry) => entry.threadHeadId === openThreadHeadId)
-      .map((entry) => entry.pubkey)
-      .filter(
-        (pubkey, index, all) =>
-          all.findIndex(
-            (candidate) => candidate.toLowerCase() === pubkey.toLowerCase(),
-          ) === index,
-      );
-  }, [botTypingEntries, openThreadHeadId]);
-  const hasThreadComposerBotActivity =
-    threadComposerBotTypingPubkeys.length > 0;
+  const {
+    combinedTypingPubkeys: combinedThreadTypingPubkeys,
+    hasActivity: hasThreadComposerActivity,
+    pillBotPubkeys: threadPillBotPubkeys,
+  } = useThreadComposerActivity({
+    botTypingEntries,
+    channelId: activeChannel?.id ?? null,
+    threadHeadId: openThreadHeadId,
+    typingPubkeys: threadTypingPubkeys,
+  });
   const directMessageIntro = React.useMemo(
     () =>
       buildDirectMessageIntro({
@@ -836,34 +833,27 @@ export const ChannelPane = React.memo(function ChannelPane({
                   threadHeadMessage.id,
                 )}
                 threadReplyUnreadCounts={threadReplyUnreadCounts}
-                activityAccessoryVisible={
-                  hasThreadComposerBotActivity ||
-                  threadTypingPubkeys.length > 0
-                }
+                activityAccessoryVisible={hasThreadComposerActivity}
                 activityAccessoryContent={
-                  hasThreadComposerBotActivity ||
-                  threadTypingPubkeys.length > 0 ? (
+                  hasThreadComposerActivity ? (
                     <BotActivityComposerAction
                       agents={activityAgents}
                       channelId={activeChannel?.id ?? null}
                       onOpenAgentSession={onOpenAgentSession}
                       profiles={profiles}
+                      typingBotPubkeys={threadPillBotPubkeys}
                       typingIndicator={
-                        threadTypingPubkeys.length > 0 ? (
+                        combinedThreadTypingPubkeys.length > 0 ? (
                           <TypingIndicatorRow
                             channel={activeChannel}
-                            // The strip's slot owns spacing and the
-                            // typing-only inset; zero the base paddings and
-                            // let the row shrink so the lone-item slot can
-                            // ellipsize the label.
                             className="min-w-0 shrink px-0 py-0 sm:px-0"
                             currentPubkey={currentPubkey}
                             profiles={profiles}
-                            typingPubkeys={threadTypingPubkeys}
+                            typingPubkeys={combinedThreadTypingPubkeys}
                           />
                         ) : null
                       }
-                      workingBotPubkeys={threadComposerBotTypingPubkeys}
+                      workingBotPubkeys={threadPillBotPubkeys}
                     />
                   ) : null
                 }

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -280,6 +280,7 @@ export function ChannelScreen({
     currentPubkey,
     latestMessageEvent,
     relaySelfPubkey,
+    threadReplyEvents,
   );
   const activeDmParticipantPubkeys = React.useMemo(
     () =>

--- a/desktop/src/features/channels/ui/ComposerLiveActivityFeed.tsx
+++ b/desktop/src/features/channels/ui/ComposerLiveActivityFeed.tsx
@@ -1,0 +1,112 @@
+import * as React from "react";
+
+import { useActiveAgentTurns } from "@/features/agents/activeAgentTurnsStore";
+import { scopeByChannel } from "@/features/agents/ui/agentSessionPanelLayout";
+import { isMeaningfulItem } from "@/features/agents/ui/agentSessionTranscriptPresentation";
+import { ManagedAgentSessionPanel } from "@/features/agents/ui/ManagedAgentSessionPanel";
+import { useAgentTranscript } from "@/features/agents/ui/useObserverEvents";
+import { formatLastLiveLabel } from "@/features/profile/lib/lastLiveLabel";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import { cn } from "@/shared/lib/cn";
+import { useNow } from "@/shared/lib/useNow";
+import { Button } from "@/shared/ui/button";
+import type { BotActivityAgent } from "./BotActivityBar";
+
+/**
+ * Single-agent live activity preview for the composer "agents working"
+ * popover. Preview-gated behind the `composerLiveActivity` feature.
+ *
+ * Renders the selected working agent's channel-scoped transcript with the
+ * same compact primitive as the profile activity embed
+ * (`ManagedAgentSessionPanel` + `compactPreview`), so projection, live/archive
+ * merging, scrolling, and idle handling stay owned by that surface.
+ *
+ * The whole preview is ONE click target: an overlay button opens the agent's
+ * full activity view, and transcript rows underneath are made inert. This
+ * avoids nesting interactive transcript controls inside a clickable shell.
+ */
+export function ComposerLiveActivityFeed({
+  agent,
+  channelId,
+  className,
+  onOpenAgentSession,
+  profiles,
+}: {
+  agent: BotActivityAgent;
+  channelId: string | null;
+  className?: string;
+  onOpenAgentSession: (pubkey: string) => void;
+  profiles?: UserProfileLookup;
+}) {
+  const activeTurns = useActiveAgentTurns(agent.pubkey);
+  const transcript = useAgentTranscript(true, agent.pubkey);
+  const lastLiveAt = React.useMemo(() => {
+    const scoped = scopeByChannel(transcript, channelId).filter(
+      isMeaningfulItem,
+    );
+    for (let index = scoped.length - 1; index >= 0; index -= 1) {
+      const item = scoped[index];
+      if (!item) {
+        continue;
+      }
+      const millis = Date.parse(item.timestamp);
+      if (!Number.isNaN(millis)) {
+        return millis;
+      }
+    }
+
+    const channelTurn = channelId
+      ? activeTurns.find((turn) => turn.channelId === channelId)
+      : activeTurns[0];
+    return channelTurn?.anchorAt ?? null;
+  }, [activeTurns, channelId, transcript]);
+
+  const now = useNow(15_000);
+  const lastLiveLabel = formatLastLiveLabel(lastLiveAt, now);
+  const openLabel = `Open ${agent.name}'s full activity. Last live ${lastLiveLabel}.`;
+  const avatarUrl = profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ?? null;
+
+  return (
+    <div
+      className={cn("relative overflow-hidden", className)}
+      data-testid="composer-live-activity-feed"
+    >
+      <button
+        aria-label={openLabel}
+        className="absolute inset-0 z-10 cursor-pointer rounded-lg transition-colors hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        data-testid="composer-live-activity-open"
+        onClick={() => onOpenAgentSession(agent.pubkey)}
+        type="button"
+      />
+      <Button
+        aria-label={openLabel}
+        className="absolute right-2 top-2 z-20 rounded-full bg-primary px-2.5 text-xs font-semibold text-primary-foreground hover:bg-primary/90"
+        data-testid="composer-live-activity-last-live"
+        onClick={(event) => {
+          event.stopPropagation();
+          onOpenAgentSession(agent.pubkey);
+        }}
+        size="xs"
+        title={`Last live ${lastLiveLabel}`}
+        type="button"
+      >
+        {lastLiveLabel}
+      </Button>
+      <ManagedAgentSessionPanel
+        agent={{ ...agent, avatarUrl }}
+        autoTail={true}
+        channelId={channelId}
+        className="relative z-0 h-full min-h-0 border-0 bg-transparent px-3 text-xs shadow-none **:data-message-id:pointer-events-none"
+        emptyDescription="Live activity will appear here."
+        emptyState="loading"
+        panelPadding={false}
+        profiles={profiles}
+        rawLayout="responsive"
+        showHeader={false}
+        showRaw={false}
+        transcriptContentClassName="py-2"
+        transcriptVariant="compactPreview"
+      />
+    </div>
+  );
+}

--- a/desktop/src/features/channels/ui/ComposerLiveActivityFeed.tsx
+++ b/desktop/src/features/channels/ui/ComposerLiveActivityFeed.tsx
@@ -1,16 +1,18 @@
 import * as React from "react";
 
 import { useActiveAgentTurns } from "@/features/agents/activeAgentTurnsStore";
-import { scopeByChannel } from "@/features/agents/ui/agentSessionPanelLayout";
-import { isMeaningfulItem } from "@/features/agents/ui/agentSessionTranscriptPresentation";
 import { ManagedAgentSessionPanel } from "@/features/agents/ui/ManagedAgentSessionPanel";
-import { useAgentTranscript } from "@/features/agents/ui/useObserverEvents";
+import {
+  useAgentTranscript,
+  useArchivedChannelEvents,
+} from "@/features/agents/ui/useObserverEvents";
 import { formatLastLiveLabel } from "@/features/profile/lib/lastLiveLabel";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { cn } from "@/shared/lib/cn";
 import { useNow } from "@/shared/lib/useNow";
 import { Button } from "@/shared/ui/button";
 import type { BotActivityAgent } from "./BotActivityBar";
+import { deriveLastLiveAt } from "./composerLiveActivity";
 
 /**
  * Single-agent live activity preview for the composer "agents working"
@@ -22,8 +24,10 @@ import type { BotActivityAgent } from "./BotActivityBar";
  * merging, scrolling, and idle handling stay owned by that surface.
  *
  * The whole preview is ONE click target: an overlay button opens the agent's
- * full activity view, and transcript rows underneath are made inert. This
- * avoids nesting interactive transcript controls inside a clickable shell.
+ * full activity view. The panel subtree is wrapped in a native `inert`
+ * container so its rows (which can include keyboard-focusable message links)
+ * are removed from pointer, keyboard-tab, AND assistive-tech interaction —
+ * CSS pointer-events alone would leave them tabbable behind the overlay.
  */
 export function ComposerLiveActivityFeed({
   agent,
@@ -40,26 +44,12 @@ export function ComposerLiveActivityFeed({
 }) {
   const activeTurns = useActiveAgentTurns(agent.pubkey);
   const transcript = useAgentTranscript(true, agent.pubkey);
-  const lastLiveAt = React.useMemo(() => {
-    const scoped = scopeByChannel(transcript, channelId).filter(
-      isMeaningfulItem,
-    );
-    for (let index = scoped.length - 1; index >= 0; index -= 1) {
-      const item = scoped[index];
-      if (!item) {
-        continue;
-      }
-      const millis = Date.parse(item.timestamp);
-      if (!Number.isNaN(millis)) {
-        return millis;
-      }
-    }
-
-    const channelTurn = channelId
-      ? activeTurns.find((turn) => turn.channelId === channelId)
-      : activeTurns[0];
-    return channelTurn?.anchorAt ?? null;
-  }, [activeTurns, channelId, transcript]);
+  const archivedEvents = useArchivedChannelEvents(agent.pubkey, channelId);
+  const lastLiveAt = React.useMemo(
+    () =>
+      deriveLastLiveAt({ activeTurns, archivedEvents, channelId, transcript }),
+    [activeTurns, archivedEvents, channelId, transcript],
+  );
 
   const now = useNow(15_000);
   const lastLiveLabel = formatLastLiveLabel(lastLiveAt, now);
@@ -92,21 +82,27 @@ export function ComposerLiveActivityFeed({
       >
         {lastLiveLabel}
       </Button>
-      <ManagedAgentSessionPanel
-        agent={{ ...agent, avatarUrl }}
-        autoTail={true}
-        channelId={channelId}
-        className="relative z-0 h-full min-h-0 border-0 bg-transparent px-3 text-xs shadow-none **:data-message-id:pointer-events-none"
-        emptyDescription="Live activity will appear here."
-        emptyState="loading"
-        panelPadding={false}
-        profiles={profiles}
-        rawLayout="responsive"
-        showHeader={false}
-        showRaw={false}
-        transcriptContentClassName="py-2"
-        transcriptVariant="compactPreview"
-      />
+      <div
+        className="h-full min-h-0"
+        data-testid="composer-live-activity-inert"
+        inert={true}
+      >
+        <ManagedAgentSessionPanel
+          agent={{ ...agent, avatarUrl }}
+          autoTail={true}
+          channelId={channelId}
+          className="relative z-0 h-full min-h-0 border-0 bg-transparent px-3 text-xs shadow-none"
+          emptyDescription="Live activity will appear here."
+          emptyState="loading"
+          panelPadding={false}
+          profiles={profiles}
+          rawLayout="responsive"
+          showHeader={false}
+          showRaw={false}
+          transcriptContentClassName="py-2"
+          transcriptVariant="compactPreview"
+        />
+      </div>
     </div>
   );
 }

--- a/desktop/src/features/channels/ui/ComposerLiveActivityFeed.tsx
+++ b/desktop/src/features/channels/ui/ComposerLiveActivityFeed.tsx
@@ -16,7 +16,7 @@ import { deriveLastLiveAt } from "./composerLiveActivity";
 
 /**
  * Single-agent live activity preview for the composer "agents working"
- * popover. Preview-gated behind the `composerLiveActivity` feature.
+ * popover.
  *
  * Renders the selected working agent's channel-scoped transcript with the
  * same compact primitive as the profile activity embed

--- a/desktop/src/features/channels/ui/ComposerLiveActivityFeed.tsx
+++ b/desktop/src/features/channels/ui/ComposerLiveActivityFeed.tsx
@@ -63,7 +63,7 @@ export function ComposerLiveActivityFeed({
     >
       <button
         aria-label={openLabel}
-        className="absolute inset-0 z-10 cursor-pointer rounded-lg transition-colors hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        className="absolute inset-0 z-10 cursor-pointer rounded-[inherit] transition-colors hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
         data-testid="composer-live-activity-open"
         onClick={() => onOpenAgentSession(agent.pubkey)}
         type="button"

--- a/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
+++ b/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { resolveSelectedActivityAgent } from "./composerLiveActivity.ts";
+import {
+  deriveLastLiveAt,
+  resolveSelectedActivityAgent,
+} from "./composerLiveActivity.ts";
 
 const alice = { pubkey: "ALICE-pubkey", name: "Alice" };
 const bob = { pubkey: "bob-pubkey", name: "Bob" };
@@ -49,4 +52,66 @@ test("returns null with no working agents", () => {
     workingAgents: [],
   });
   assert.equal(agent, null);
+});
+
+const CHANNEL = "channel-1";
+const OTHER_CHANNEL = "channel-2";
+
+test("deriveLastLiveAt prefers the newest channel-scoped transcript item", () => {
+  const lastLiveAt = deriveLastLiveAt({
+    activeTurns: [],
+    archivedEvents: [],
+    channelId: CHANNEL,
+    transcript: [
+      { channelId: CHANNEL, timestamp: "2026-07-23T00:00:01.000Z" },
+      { channelId: OTHER_CHANNEL, timestamp: "2026-07-23T00:00:09.000Z" },
+      { channelId: CHANNEL, timestamp: "2026-07-23T00:00:05.000Z" },
+    ],
+  });
+  assert.equal(lastLiveAt, Date.parse("2026-07-23T00:00:05.000Z"));
+});
+
+test("deriveLastLiveAt sees archived content the panel renders", () => {
+  // Regression: archived rows are visible in the preview even when the live
+  // transcript window is empty — the pill must not say "No activity yet".
+  const lastLiveAt = deriveLastLiveAt({
+    activeTurns: [],
+    archivedEvents: [{ timestamp: "2026-07-20T10:00:00.000Z" }],
+    channelId: CHANNEL,
+    transcript: [],
+  });
+  assert.equal(lastLiveAt, Date.parse("2026-07-20T10:00:00.000Z"));
+});
+
+test("deriveLastLiveAt takes the newest across live, archive, and turn anchor", () => {
+  const lastLiveAt = deriveLastLiveAt({
+    activeTurns: [
+      { anchorAt: Date.parse("2026-07-23T00:00:30.000Z"), channelId: CHANNEL },
+    ],
+    archivedEvents: [{ timestamp: "2026-07-23T00:00:10.000Z" }],
+    channelId: CHANNEL,
+    transcript: [{ channelId: CHANNEL, timestamp: "2026-07-23T00:00:20.000Z" }],
+  });
+  assert.equal(lastLiveAt, Date.parse("2026-07-23T00:00:30.000Z"));
+});
+
+test("deriveLastLiveAt falls back to the active-turn anchor with no items", () => {
+  const anchorAt = Date.parse("2026-07-23T00:01:00.000Z");
+  const lastLiveAt = deriveLastLiveAt({
+    activeTurns: [{ anchorAt, channelId: CHANNEL }],
+    archivedEvents: [],
+    channelId: CHANNEL,
+    transcript: [],
+  });
+  assert.equal(lastLiveAt, anchorAt);
+});
+
+test("deriveLastLiveAt ignores other-channel turns and returns null when idle", () => {
+  const lastLiveAt = deriveLastLiveAt({
+    activeTurns: [{ anchorAt: 1, channelId: OTHER_CHANNEL }],
+    archivedEvents: [],
+    channelId: CHANNEL,
+    transcript: [],
+  });
+  assert.equal(lastLiveAt, null);
 });

--- a/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
+++ b/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveSelectedActivityAgent } from "./composerLiveActivity.ts";
+
+const alice = { pubkey: "ALICE-pubkey", name: "Alice" };
+const bob = { pubkey: "bob-pubkey", name: "Bob" };
+
+test("explicit selection wins, case-insensitively", () => {
+  const agent = resolveSelectedActivityAgent({
+    openAgentSessionPubkey: "bob-pubkey",
+    selectedPubkey: "alice-PUBKEY",
+    workingAgents: [alice, bob],
+  });
+  assert.equal(agent, alice);
+});
+
+test("falls back to the open session agent", () => {
+  const agent = resolveSelectedActivityAgent({
+    openAgentSessionPubkey: "bob-pubkey",
+    selectedPubkey: null,
+    workingAgents: [alice, bob],
+  });
+  assert.equal(agent, bob);
+});
+
+test("falls back to the first working agent", () => {
+  const agent = resolveSelectedActivityAgent({
+    openAgentSessionPubkey: "gone-pubkey",
+    selectedPubkey: "also-gone",
+    workingAgents: [alice, bob],
+  });
+  assert.equal(agent, alice);
+});
+
+test("selection that stopped working falls through", () => {
+  const agent = resolveSelectedActivityAgent({
+    openAgentSessionPubkey: null,
+    selectedPubkey: "bob-pubkey",
+    workingAgents: [alice],
+  });
+  assert.equal(agent, alice);
+});
+
+test("returns null with no working agents", () => {
+  const agent = resolveSelectedActivityAgent({
+    openAgentSessionPubkey: null,
+    selectedPubkey: null,
+    workingAgents: [],
+  });
+  assert.equal(agent, null);
+});

--- a/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
+++ b/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
@@ -2,60 +2,114 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  deriveActivityPillLabel,
   deriveLastLiveAt,
-  resolveSelectedActivityAgent,
 } from "./composerLiveActivity.ts";
-
-const alice = { pubkey: "ALICE-pubkey", name: "Alice" };
-const bob = { pubkey: "bob-pubkey", name: "Bob" };
-
-test("explicit selection wins, case-insensitively", () => {
-  const agent = resolveSelectedActivityAgent({
-    openAgentSessionPubkey: "bob-pubkey",
-    selectedPubkey: "alice-PUBKEY",
-    workingAgents: [alice, bob],
-  });
-  assert.equal(agent, alice);
-});
-
-test("falls back to the open session agent", () => {
-  const agent = resolveSelectedActivityAgent({
-    openAgentSessionPubkey: "bob-pubkey",
-    selectedPubkey: null,
-    workingAgents: [alice, bob],
-  });
-  assert.equal(agent, bob);
-});
-
-test("falls back to the first working agent", () => {
-  const agent = resolveSelectedActivityAgent({
-    openAgentSessionPubkey: "gone-pubkey",
-    selectedPubkey: "also-gone",
-    workingAgents: [alice, bob],
-  });
-  assert.equal(agent, alice);
-});
-
-test("selection that stopped working falls through", () => {
-  const agent = resolveSelectedActivityAgent({
-    openAgentSessionPubkey: null,
-    selectedPubkey: "bob-pubkey",
-    workingAgents: [alice],
-  });
-  assert.equal(agent, alice);
-});
-
-test("returns null with no working agents", () => {
-  const agent = resolveSelectedActivityAgent({
-    openAgentSessionPubkey: null,
-    selectedPubkey: null,
-    workingAgents: [],
-  });
-  assert.equal(agent, null);
-});
 
 const CHANNEL = "channel-1";
 const OTHER_CHANNEL = "channel-2";
+
+const NOW = Date.parse("2026-07-23T00:01:00.000Z");
+
+/** Thought item: spine, headlined by its title. */
+const thought = (title, timestamp, channelId = CHANNEL) => ({
+  id: `thought-${title}-${timestamp}`,
+  type: "thought",
+  renderClass: "thought",
+  title,
+  text: "",
+  timestamp,
+  channelId,
+});
+
+/** Metadata item: meaningful but NOT spine — recedes when real work exists. */
+const metadata = (title, timestamp, channelId = CHANNEL) => ({
+  id: `metadata-${title}-${timestamp}`,
+  type: "metadata",
+  renderClass: "raw-rail",
+  title,
+  sections: [],
+  timestamp,
+  acpSource: "prompt_context",
+  channelId,
+});
+
+const secondsBeforeNow = (seconds) =>
+  new Date(NOW - seconds * 1000).toISOString();
+
+test("deriveActivityPillLabel returns the newest fresh headline, no rotation", () => {
+  const label = deriveActivityPillLabel({
+    channelId: CHANNEL,
+    now: NOW,
+    transcript: [
+      thought("Reading files", secondsBeforeNow(8)),
+      thought("Editing ChannelPane", secondsBeforeNow(2)),
+    ],
+  });
+  assert.equal(label, "Editing ChannelPane");
+});
+
+test("deriveActivityPillLabel decays to null once the newest headline is stale", () => {
+  const label = deriveActivityPillLabel({
+    channelId: CHANNEL,
+    now: NOW,
+    transcript: [thought("Editing ChannelPane", secondsBeforeNow(30))],
+  });
+  assert.equal(label, null);
+});
+
+test("deriveActivityPillLabel honors a custom staleness window", () => {
+  const transcript = [thought("Editing ChannelPane", secondsBeforeNow(30))];
+  const label = deriveActivityPillLabel({
+    channelId: CHANNEL,
+    now: NOW,
+    staleAfterMs: 60_000,
+    transcript,
+  });
+  assert.equal(label, "Editing ChannelPane");
+});
+
+test("deriveActivityPillLabel ignores other-channel items", () => {
+  const label = deriveActivityPillLabel({
+    channelId: CHANNEL,
+    now: NOW,
+    transcript: [
+      thought("In-channel work", secondsBeforeNow(10)),
+      thought("Other-channel work", secondsBeforeNow(1), OTHER_CHANNEL),
+    ],
+  });
+  assert.equal(label, "In-channel work");
+});
+
+test("deriveActivityPillLabel lets spine work headline over fresher metadata reads", () => {
+  const label = deriveActivityPillLabel({
+    channelId: CHANNEL,
+    now: NOW,
+    transcript: [
+      thought("Real work", secondsBeforeNow(10)),
+      metadata("Prompt context", secondsBeforeNow(1)),
+    ],
+  });
+  assert.equal(label, "Real work");
+});
+
+test("deriveActivityPillLabel falls back to metadata when no spine items exist", () => {
+  const label = deriveActivityPillLabel({
+    channelId: CHANNEL,
+    now: NOW,
+    transcript: [metadata("Prompt context", secondsBeforeNow(5))],
+  });
+  assert.equal(label, "Prompt context");
+});
+
+test("deriveActivityPillLabel returns null for an empty transcript", () => {
+  const label = deriveActivityPillLabel({
+    channelId: CHANNEL,
+    now: NOW,
+    transcript: [],
+  });
+  assert.equal(label, null);
+});
 
 test("deriveLastLiveAt prefers the newest channel-scoped transcript item", () => {
   const lastLiveAt = deriveLastLiveAt({

--- a/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
+++ b/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
@@ -48,6 +48,32 @@ const lifecycleMeta = (acpSource, timestamp, channelId = CHANNEL) => ({
   channelId,
 });
 
+/** Tool item with a classifier descriptor: headlines tersely (verb + object). */
+const fileReadTool = (path, timestamp, channelId = CHANNEL) => ({
+  id: `tool-${path}-${timestamp}`,
+  type: "tool",
+  renderClass: "file-read",
+  title: "Read file",
+  toolName: "dev__read_file",
+  buzzToolName: null,
+  status: "completed",
+  args: { path },
+  result: "",
+  isError: false,
+  timestamp,
+  startedAt: timestamp,
+  completedAt: timestamp,
+  descriptor: {
+    renderClass: "file-read",
+    label: "Read file",
+    preview: path,
+    action: { verb: "Read", object: path },
+    source: "harness",
+    groupKey: "read_file",
+  },
+  channelId,
+});
+
 /** Streaming assistant message: headline is the (growing) first line. */
 const assistantMessage = (id, text, timestamp, channelId = CHANNEL) => ({
   id,
@@ -69,6 +95,17 @@ test("deriveActivityPillLabel returns the newest headline, no rotation", () => {
     transcript: [thought("Reading files", secondsBeforeNow(4)), editing],
   });
   assert.deepEqual(headline, { id: editing.id, label: "Editing ChannelPane" });
+});
+
+test("deriveActivityPillLabel headlines tool items tersely (verb + basename)", () => {
+  const read = fileReadTool("src/agents/ui/foo.ts", secondsBeforeNow(2));
+  const headline = deriveActivityPillLabel({
+    channelId: CHANNEL,
+    transcript: [read],
+  });
+  // Terse action tier, not "Read file · src/agents/ui/foo.ts" — the pill's
+  // narrow cap must show the informative part of the action.
+  assert.deepEqual(headline, { id: read.id, label: "Read foo.ts" });
 });
 
 test("deriveActivityPillLabel keeps the last action headline regardless of age", () => {

--- a/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
+++ b/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
@@ -67,7 +67,7 @@ test("deriveActivityPillLabel returns the newest fresh headline, no rotation", (
   const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
     now: NOW,
-    transcript: [thought("Reading files", secondsBeforeNow(8)), editing],
+    transcript: [thought("Reading files", secondsBeforeNow(4)), editing],
   });
   assert.deepEqual(headline, { id: editing.id, label: "Editing ChannelPane" });
 });
@@ -93,7 +93,7 @@ test("deriveActivityPillLabel honors a custom staleness window", () => {
 });
 
 test("deriveActivityPillLabel ignores other-channel items", () => {
-  const inChannel = thought("In-channel work", secondsBeforeNow(10));
+  const inChannel = thought("In-channel work", secondsBeforeNow(3));
   const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
     now: NOW,
@@ -106,7 +106,7 @@ test("deriveActivityPillLabel ignores other-channel items", () => {
 });
 
 test("deriveActivityPillLabel lets spine work headline over fresher metadata reads", () => {
-  const realWork = thought("Real work", secondsBeforeNow(10));
+  const realWork = thought("Real work", secondsBeforeNow(4));
   const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
     now: NOW,
@@ -135,7 +135,7 @@ test("deriveActivityPillLabel returns null for an empty transcript", () => {
 });
 
 test("deriveActivityPillLabel never headlines usage/commands meta frames", () => {
-  const realWork = thought("Real work", secondsBeforeNow(10));
+  const realWork = thought("Real work", secondsBeforeNow(4));
   const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
     now: NOW,

--- a/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
+++ b/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import {
   deriveActivityPillLabel,
-  deriveAgentActivityOrder,
+  deriveAgentWorkingOrder,
   deriveLastLiveAt,
 } from "./composerLiveActivity.ts";
 
@@ -62,31 +62,21 @@ const assistantMessage = (id, text, timestamp, channelId = CHANNEL) => ({
 const secondsBeforeNow = (seconds) =>
   new Date(NOW - seconds * 1000).toISOString();
 
-test("deriveActivityPillLabel returns the newest fresh headline, no rotation", () => {
+test("deriveActivityPillLabel returns the newest headline, no rotation", () => {
   const editing = thought("Editing ChannelPane", secondsBeforeNow(2));
   const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
-    now: NOW,
     transcript: [thought("Reading files", secondsBeforeNow(4)), editing],
   });
   assert.deepEqual(headline, { id: editing.id, label: "Editing ChannelPane" });
 });
 
-test("deriveActivityPillLabel decays to null once the newest headline is stale", () => {
+test("deriveActivityPillLabel keeps the last action headline regardless of age", () => {
+  // A quiet stretch (long tool call, thinking gap) must NOT decay the label
+  // to the generic placeholder — the last real action stays informative.
+  const editing = thought("Editing ChannelPane", secondsBeforeNow(300));
   const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
-    now: NOW,
-    transcript: [thought("Editing ChannelPane", secondsBeforeNow(30))],
-  });
-  assert.equal(headline, null);
-});
-
-test("deriveActivityPillLabel honors a custom staleness window", () => {
-  const editing = thought("Editing ChannelPane", secondsBeforeNow(30));
-  const headline = deriveActivityPillLabel({
-    channelId: CHANNEL,
-    now: NOW,
-    staleAfterMs: 60_000,
     transcript: [editing],
   });
   assert.deepEqual(headline, { id: editing.id, label: "Editing ChannelPane" });
@@ -96,7 +86,6 @@ test("deriveActivityPillLabel ignores other-channel items", () => {
   const inChannel = thought("In-channel work", secondsBeforeNow(3));
   const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
-    now: NOW,
     transcript: [
       inChannel,
       thought("Other-channel work", secondsBeforeNow(1), OTHER_CHANNEL),
@@ -109,7 +98,6 @@ test("deriveActivityPillLabel lets spine work headline over fresher metadata rea
   const realWork = thought("Real work", secondsBeforeNow(4));
   const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
-    now: NOW,
     transcript: [realWork, metadata("Prompt context", secondsBeforeNow(1))],
   });
   assert.deepEqual(headline, { id: realWork.id, label: "Real work" });
@@ -119,7 +107,6 @@ test("deriveActivityPillLabel falls back to metadata when no spine items exist",
   const context = metadata("Prompt context", secondsBeforeNow(5));
   const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
-    now: NOW,
     transcript: [context],
   });
   assert.deepEqual(headline, { id: context.id, label: "Prompt context" });
@@ -128,7 +115,6 @@ test("deriveActivityPillLabel falls back to metadata when no spine items exist",
 test("deriveActivityPillLabel returns null for an empty transcript", () => {
   const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
-    now: NOW,
     transcript: [],
   });
   assert.equal(headline, null);
@@ -138,7 +124,6 @@ test("deriveActivityPillLabel never headlines usage/commands meta frames", () =>
   const realWork = thought("Real work", secondsBeforeNow(4));
   const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
-    now: NOW,
     transcript: [
       realWork,
       lifecycleMeta("usage_update", secondsBeforeNow(2)),
@@ -149,10 +134,9 @@ test("deriveActivityPillLabel never headlines usage/commands meta frames", () =>
   assert.deepEqual(headline, { id: realWork.id, label: "Real work" });
 });
 
-test("deriveActivityPillLabel returns null when only meta frames are fresh", () => {
+test("deriveActivityPillLabel returns null when only meta frames exist", () => {
   const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
-    now: NOW,
     transcript: [lifecycleMeta("usage_update", secondsBeforeNow(1))],
   });
   assert.equal(headline, null);
@@ -161,12 +145,10 @@ test("deriveActivityPillLabel returns null when only meta frames are fresh", () 
 test("deriveActivityPillLabel keeps a stable id while a message streams", () => {
   const first = deriveActivityPillLabel({
     channelId: CHANNEL,
-    now: NOW,
     transcript: [assistantMessage("msg-1", "Pass 1: reading", NOW_ISO)],
   });
   const extended = deriveActivityPillLabel({
     channelId: CHANNEL,
-    now: NOW,
     transcript: [
       assistantMessage("msg-1", "Pass 1: reading the composer wiring", NOW_ISO),
     ],
@@ -177,56 +159,114 @@ test("deriveActivityPillLabel keeps a stable id while a message streams", () => 
   assert.equal(extended.label, "Pass 1: reading the composer wiring");
 });
 
-test("deriveAgentActivityOrder puts the most recently active agent first", () => {
-  const transcripts = new Map([
-    ["alpha", [thought("Older work", secondsBeforeNow(20))]],
-    ["beta", [thought("Newer work", secondsBeforeNow(2))]],
+/** Fake working-state reader over pubkey → [{channelId, anchorAt}] entries. */
+const workingStates = (entries) => (pubkey) => ({
+  channels: entries.get(pubkey) ?? [],
+});
+
+test("deriveAgentWorkingOrder puts the earliest-started agent first", () => {
+  const states = new Map([
+    ["alpha", [{ channelId: CHANNEL, anchorAt: NOW - 20_000 }]],
+    ["beta", [{ channelId: CHANNEL, anchorAt: NOW - 90_000 }]],
   ]);
-  const order = deriveAgentActivityOrder({
+  const order = deriveAgentWorkingOrder({
     channelId: CHANNEL,
-    getTranscript: (pubkey) => transcripts.get(pubkey) ?? [],
+    getWorkingState: workingStates(states),
     pubkeys: ["alpha", "beta"],
   });
   assert.deepEqual(order, ["beta", "alpha"]);
 });
 
-test("deriveAgentActivityOrder keeps roster order for agents with no activity", () => {
-  const transcripts = new Map([
-    ["gamma", [thought("Only worker", secondsBeforeNow(5))]],
+test("deriveAgentWorkingOrder appends a later starter after existing workers", () => {
+  const states = new Map([
+    ["alpha", [{ channelId: CHANNEL, anchorAt: NOW - 60_000 }]],
+    ["beta", [{ channelId: CHANNEL, anchorAt: NOW - 30_000 }]],
+    ["gamma", [{ channelId: CHANNEL, anchorAt: NOW - 2_000 }]],
   ]);
-  const order = deriveAgentActivityOrder({
+  const order = deriveAgentWorkingOrder({
     channelId: CHANNEL,
-    getTranscript: (pubkey) => transcripts.get(pubkey) ?? [],
+    getWorkingState: workingStates(states),
+    // Roster order deliberately differs from start order.
+    pubkeys: ["gamma", "beta", "alpha"],
+  });
+  assert.deepEqual(order, ["alpha", "beta", "gamma"]);
+});
+
+test("deriveAgentWorkingOrder ignores other-channel anchors", () => {
+  const states = new Map([
+    ["alpha", [{ channelId: CHANNEL, anchorAt: NOW - 5_000 }]],
+    // Beta started much earlier — but in another channel, so it has no
+    // anchor for this scope and sorts to the end.
+    ["beta", [{ channelId: OTHER_CHANNEL, anchorAt: NOW - 300_000 }]],
+  ]);
+  const order = deriveAgentWorkingOrder({
+    channelId: CHANNEL,
+    getWorkingState: workingStates(states),
+    pubkeys: ["beta", "alpha"],
+  });
+  assert.deepEqual(order, ["alpha", "beta"]);
+});
+
+test("deriveAgentWorkingOrder uses the earliest anchor across channels when unscoped", () => {
+  const states = new Map([
+    [
+      "alpha",
+      [
+        { channelId: CHANNEL, anchorAt: NOW - 10_000 },
+        { channelId: OTHER_CHANNEL, anchorAt: NOW - 120_000 },
+      ],
+    ],
+    ["beta", [{ channelId: CHANNEL, anchorAt: NOW - 60_000 }]],
+  ]);
+  const order = deriveAgentWorkingOrder({
+    channelId: null,
+    getWorkingState: workingStates(states),
+    pubkeys: ["beta", "alpha"],
+  });
+  assert.deepEqual(order, ["alpha", "beta"]);
+});
+
+test("deriveAgentWorkingOrder keeps roster order for agents with no anchor", () => {
+  const states = new Map([
+    ["gamma", [{ channelId: CHANNEL, anchorAt: NOW - 5_000 }]],
+  ]);
+  const order = deriveAgentWorkingOrder({
+    channelId: CHANNEL,
+    getWorkingState: workingStates(states),
     pubkeys: ["alpha", "beta", "gamma"],
   });
   assert.deepEqual(order, ["gamma", "alpha", "beta"]);
 });
 
-test("deriveAgentActivityOrder ignores other-channel activity", () => {
-  const transcripts = new Map([
-    ["alpha", [thought("In-channel", secondsBeforeNow(30))]],
-    ["beta", [thought("Elsewhere", secondsBeforeNow(1), OTHER_CHANNEL)]],
-  ]);
-  const order = deriveAgentActivityOrder({
+test("deriveAgentWorkingOrder quantizes anchors to seconds so sub-second shifts never reorder", () => {
+  // Same wall-clock second; beta's anchor is a few hundred ms earlier (the
+  // shape of a retroactive clock-offset refinement). Order must follow the
+  // roster, and must not flip when the sub-second part changes.
+  const base = Math.floor((NOW - 10_000) / 1000) * 1000;
+  const order = deriveAgentWorkingOrder({
     channelId: CHANNEL,
-    getTranscript: (pubkey) => transcripts.get(pubkey) ?? [],
+    getWorkingState: workingStates(
+      new Map([
+        ["alpha", [{ channelId: CHANNEL, anchorAt: base + 700 }]],
+        ["beta", [{ channelId: CHANNEL, anchorAt: base + 100 }]],
+      ]),
+    ),
     pubkeys: ["alpha", "beta"],
   });
   assert.deepEqual(order, ["alpha", "beta"]);
-});
 
-test("deriveAgentActivityOrder is stable for identical timestamps", () => {
-  const sameTime = secondsBeforeNow(3);
-  const transcripts = new Map([
-    ["alpha", [thought("Tied A", sameTime)]],
-    ["beta", [thought("Tied B", sameTime)]],
-  ]);
-  const order = deriveAgentActivityOrder({
+  const afterRefinement = deriveAgentWorkingOrder({
     channelId: CHANNEL,
-    getTranscript: (pubkey) => transcripts.get(pubkey) ?? [],
+    getWorkingState: workingStates(
+      new Map([
+        // Alpha's offset estimate tightened: anchor slid 400ms earlier.
+        ["alpha", [{ channelId: CHANNEL, anchorAt: base + 300 }]],
+        ["beta", [{ channelId: CHANNEL, anchorAt: base + 100 }]],
+      ]),
+    ),
     pubkeys: ["alpha", "beta"],
   });
-  assert.deepEqual(order, ["alpha", "beta"]);
+  assert.deepEqual(afterRefinement, order);
 });
 
 test("deriveLastLiveAt prefers the newest channel-scoped transcript item", () => {

--- a/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
+++ b/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   deriveActivityPillLabel,
+  deriveAgentActivityOrder,
   deriveLastLiveAt,
 } from "./composerLiveActivity.ts";
 
@@ -10,6 +11,7 @@ const CHANNEL = "channel-1";
 const OTHER_CHANNEL = "channel-2";
 
 const NOW = Date.parse("2026-07-23T00:01:00.000Z");
+const NOW_ISO = new Date(NOW).toISOString();
 
 /** Thought item: spine, headlined by its title. */
 const thought = (title, timestamp, channelId = CHANNEL) => ({
@@ -34,81 +36,197 @@ const metadata = (title, timestamp, channelId = CHANNEL) => ({
   channelId,
 });
 
+/** Lifecycle meta-frame (usage tick / commands): spine, but never a headline. */
+const lifecycleMeta = (acpSource, timestamp, channelId = CHANNEL) => ({
+  id: `lifecycle-${acpSource}-${timestamp}`,
+  type: "lifecycle",
+  renderClass: "status",
+  title: acpSource === "usage_update" ? "Usage" : "Commands",
+  text: "Tokens: 1200/8192",
+  timestamp,
+  acpSource,
+  channelId,
+});
+
+/** Streaming assistant message: headline is the (growing) first line. */
+const assistantMessage = (id, text, timestamp, channelId = CHANNEL) => ({
+  id,
+  type: "message",
+  role: "assistant",
+  title: "",
+  text,
+  timestamp,
+  channelId,
+});
+
 const secondsBeforeNow = (seconds) =>
   new Date(NOW - seconds * 1000).toISOString();
 
 test("deriveActivityPillLabel returns the newest fresh headline, no rotation", () => {
-  const label = deriveActivityPillLabel({
+  const editing = thought("Editing ChannelPane", secondsBeforeNow(2));
+  const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
     now: NOW,
-    transcript: [
-      thought("Reading files", secondsBeforeNow(8)),
-      thought("Editing ChannelPane", secondsBeforeNow(2)),
-    ],
+    transcript: [thought("Reading files", secondsBeforeNow(8)), editing],
   });
-  assert.equal(label, "Editing ChannelPane");
+  assert.deepEqual(headline, { id: editing.id, label: "Editing ChannelPane" });
 });
 
 test("deriveActivityPillLabel decays to null once the newest headline is stale", () => {
-  const label = deriveActivityPillLabel({
+  const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
     now: NOW,
     transcript: [thought("Editing ChannelPane", secondsBeforeNow(30))],
   });
-  assert.equal(label, null);
+  assert.equal(headline, null);
 });
 
 test("deriveActivityPillLabel honors a custom staleness window", () => {
-  const transcript = [thought("Editing ChannelPane", secondsBeforeNow(30))];
-  const label = deriveActivityPillLabel({
+  const editing = thought("Editing ChannelPane", secondsBeforeNow(30));
+  const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
     now: NOW,
     staleAfterMs: 60_000,
-    transcript,
+    transcript: [editing],
   });
-  assert.equal(label, "Editing ChannelPane");
+  assert.deepEqual(headline, { id: editing.id, label: "Editing ChannelPane" });
 });
 
 test("deriveActivityPillLabel ignores other-channel items", () => {
-  const label = deriveActivityPillLabel({
+  const inChannel = thought("In-channel work", secondsBeforeNow(10));
+  const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
     now: NOW,
     transcript: [
-      thought("In-channel work", secondsBeforeNow(10)),
+      inChannel,
       thought("Other-channel work", secondsBeforeNow(1), OTHER_CHANNEL),
     ],
   });
-  assert.equal(label, "In-channel work");
+  assert.deepEqual(headline, { id: inChannel.id, label: "In-channel work" });
 });
 
 test("deriveActivityPillLabel lets spine work headline over fresher metadata reads", () => {
-  const label = deriveActivityPillLabel({
+  const realWork = thought("Real work", secondsBeforeNow(10));
+  const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
     now: NOW,
-    transcript: [
-      thought("Real work", secondsBeforeNow(10)),
-      metadata("Prompt context", secondsBeforeNow(1)),
-    ],
+    transcript: [realWork, metadata("Prompt context", secondsBeforeNow(1))],
   });
-  assert.equal(label, "Real work");
+  assert.deepEqual(headline, { id: realWork.id, label: "Real work" });
 });
 
 test("deriveActivityPillLabel falls back to metadata when no spine items exist", () => {
-  const label = deriveActivityPillLabel({
+  const context = metadata("Prompt context", secondsBeforeNow(5));
+  const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
     now: NOW,
-    transcript: [metadata("Prompt context", secondsBeforeNow(5))],
+    transcript: [context],
   });
-  assert.equal(label, "Prompt context");
+  assert.deepEqual(headline, { id: context.id, label: "Prompt context" });
 });
 
 test("deriveActivityPillLabel returns null for an empty transcript", () => {
-  const label = deriveActivityPillLabel({
+  const headline = deriveActivityPillLabel({
     channelId: CHANNEL,
     now: NOW,
     transcript: [],
   });
-  assert.equal(label, null);
+  assert.equal(headline, null);
+});
+
+test("deriveActivityPillLabel never headlines usage/commands meta frames", () => {
+  const realWork = thought("Real work", secondsBeforeNow(10));
+  const headline = deriveActivityPillLabel({
+    channelId: CHANNEL,
+    now: NOW,
+    transcript: [
+      realWork,
+      lifecycleMeta("usage_update", secondsBeforeNow(2)),
+      lifecycleMeta("available_commands_update", secondsBeforeNow(1)),
+    ],
+  });
+  // Meta frames are skipped entirely — the older real action still headlines.
+  assert.deepEqual(headline, { id: realWork.id, label: "Real work" });
+});
+
+test("deriveActivityPillLabel returns null when only meta frames are fresh", () => {
+  const headline = deriveActivityPillLabel({
+    channelId: CHANNEL,
+    now: NOW,
+    transcript: [lifecycleMeta("usage_update", secondsBeforeNow(1))],
+  });
+  assert.equal(headline, null);
+});
+
+test("deriveActivityPillLabel keeps a stable id while a message streams", () => {
+  const first = deriveActivityPillLabel({
+    channelId: CHANNEL,
+    now: NOW,
+    transcript: [assistantMessage("msg-1", "Pass 1: reading", NOW_ISO)],
+  });
+  const extended = deriveActivityPillLabel({
+    channelId: CHANNEL,
+    now: NOW,
+    transcript: [
+      assistantMessage("msg-1", "Pass 1: reading the composer wiring", NOW_ISO),
+    ],
+  });
+  // Same item id: the pill updates text in place instead of re-animating.
+  assert.equal(first.id, "msg-1");
+  assert.equal(extended.id, "msg-1");
+  assert.equal(extended.label, "Pass 1: reading the composer wiring");
+});
+
+test("deriveAgentActivityOrder puts the most recently active agent first", () => {
+  const transcripts = new Map([
+    ["alpha", [thought("Older work", secondsBeforeNow(20))]],
+    ["beta", [thought("Newer work", secondsBeforeNow(2))]],
+  ]);
+  const order = deriveAgentActivityOrder({
+    channelId: CHANNEL,
+    getTranscript: (pubkey) => transcripts.get(pubkey) ?? [],
+    pubkeys: ["alpha", "beta"],
+  });
+  assert.deepEqual(order, ["beta", "alpha"]);
+});
+
+test("deriveAgentActivityOrder keeps roster order for agents with no activity", () => {
+  const transcripts = new Map([
+    ["gamma", [thought("Only worker", secondsBeforeNow(5))]],
+  ]);
+  const order = deriveAgentActivityOrder({
+    channelId: CHANNEL,
+    getTranscript: (pubkey) => transcripts.get(pubkey) ?? [],
+    pubkeys: ["alpha", "beta", "gamma"],
+  });
+  assert.deepEqual(order, ["gamma", "alpha", "beta"]);
+});
+
+test("deriveAgentActivityOrder ignores other-channel activity", () => {
+  const transcripts = new Map([
+    ["alpha", [thought("In-channel", secondsBeforeNow(30))]],
+    ["beta", [thought("Elsewhere", secondsBeforeNow(1), OTHER_CHANNEL)]],
+  ]);
+  const order = deriveAgentActivityOrder({
+    channelId: CHANNEL,
+    getTranscript: (pubkey) => transcripts.get(pubkey) ?? [],
+    pubkeys: ["alpha", "beta"],
+  });
+  assert.deepEqual(order, ["alpha", "beta"]);
+});
+
+test("deriveAgentActivityOrder is stable for identical timestamps", () => {
+  const sameTime = secondsBeforeNow(3);
+  const transcripts = new Map([
+    ["alpha", [thought("Tied A", sameTime)]],
+    ["beta", [thought("Tied B", sameTime)]],
+  ]);
+  const order = deriveAgentActivityOrder({
+    channelId: CHANNEL,
+    getTranscript: (pubkey) => transcripts.get(pubkey) ?? [],
+    pubkeys: ["alpha", "beta"],
+  });
+  assert.deepEqual(order, ["alpha", "beta"]);
 });
 
 test("deriveLastLiveAt prefers the newest channel-scoped transcript item", () => {

--- a/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
+++ b/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   deriveActivityPillLabel,
+  deriveActivityPillPresentation,
   deriveAgentWorkingOrder,
   deriveLastLiveAt,
   partitionComposerWorkingAgents,
@@ -195,6 +196,55 @@ test("deriveActivityPillLabel keeps a stable id while a message streams", () => 
   assert.equal(first.id, "msg-1");
   assert.equal(extended.id, "msg-1");
   assert.equal(extended.label, "Pass 1: reading the composer wiring");
+});
+
+test("deriveActivityPillPresentation keeps observer activity authoritative over typing", () => {
+  const headline = { id: "action-1", label: "Inspect composer state" };
+  const presentation = deriveActivityPillPresentation({
+    agentName: "Alice",
+    headline,
+    isTyping: true,
+    workingSource: "observer",
+  });
+
+  assert.deepEqual(presentation, headline);
+});
+
+test("deriveActivityPillPresentation uses working copy before the first observer action", () => {
+  const presentation = deriveActivityPillPresentation({
+    agentName: "Alice",
+    headline: null,
+    isTyping: true,
+    workingSource: "observer",
+  });
+
+  assert.deepEqual(presentation, {
+    id: "generic-working",
+    label: "Alice is working…",
+  });
+});
+
+test("deriveActivityPillPresentation uses typing before observer startup and after completion", () => {
+  const headline = { id: "action-1", label: "Inspect composer state" };
+
+  assert.deepEqual(
+    deriveActivityPillPresentation({
+      agentName: "Alice",
+      headline: null,
+      isTyping: true,
+      workingSource: "none",
+    }),
+    { id: "typing-override", label: "Alice is typing…" },
+  );
+  assert.deepEqual(
+    deriveActivityPillPresentation({
+      agentName: "Alice",
+      headline,
+      isTyping: true,
+      workingSource: "typing",
+    }),
+    { id: "typing-override", label: "Alice is typing…" },
+  );
 });
 
 /** Lifecycle noise item ("Turn started") — meaningful:false, never headlines. */

--- a/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
+++ b/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
@@ -5,6 +5,7 @@ import {
   deriveActivityPillLabel,
   deriveAgentWorkingOrder,
   deriveLastLiveAt,
+  partitionComposerWorkingAgents,
 } from "./composerLiveActivity.ts";
 
 const CHANNEL = "channel-1";
@@ -194,6 +195,122 @@ test("deriveActivityPillLabel keeps a stable id while a message streams", () => 
   assert.equal(first.id, "msg-1");
   assert.equal(extended.id, "msg-1");
   assert.equal(extended.label, "Pass 1: reading the composer wiring");
+});
+
+/** Lifecycle noise item ("Turn started") — meaningful:false, never headlines. */
+const turnStartedLifecycle = (timestamp, channelId = CHANNEL) => ({
+  id: `lifecycle-turn-${timestamp}`,
+  type: "lifecycle",
+  renderClass: "status",
+  title: "Turn started",
+  text: "",
+  timestamp,
+  channelId,
+});
+
+/** Fake partition readers over pubkey → source / transcript maps. */
+const partitionReaders = (sources, transcripts) => ({
+  getTranscript: (pubkey) => transcripts.get(pubkey) ?? [],
+  getWorkingSource: (pubkey) => sources.get(pubkey) ?? "none",
+});
+
+test("partitionComposerWorkingAgents pills observer-backed agents regardless of transcript", () => {
+  const partition = partitionComposerWorkingAgents({
+    channelId: CHANNEL,
+    ...partitionReaders(new Map([["alpha", "observer"]]), new Map()),
+    pubkeys: ["alpha"],
+  });
+  assert.deepEqual(partition, {
+    pillPubkeys: ["alpha"],
+    typingGroupPubkeys: [],
+  });
+});
+
+test("partitionComposerWorkingAgents groups typing agents with nothing to show", () => {
+  // First-ever activity in the channel: no transcript at all.
+  const partition = partitionComposerWorkingAgents({
+    channelId: CHANNEL,
+    ...partitionReaders(new Map([["alpha", "typing"]]), new Map()),
+    pubkeys: ["alpha"],
+  });
+  assert.deepEqual(partition, {
+    pillPubkeys: [],
+    typingGroupPubkeys: ["alpha"],
+  });
+});
+
+test("partitionComposerWorkingAgents keeps a typing agent's pill across the turn-end gap", () => {
+  // Turn completed but the agent is still typing: the prior turn's real
+  // action keeps the agent pill-worthy — the pill relabels instead of
+  // demoting to the typing group.
+  const partition = partitionComposerWorkingAgents({
+    channelId: CHANNEL,
+    ...partitionReaders(
+      new Map([["alpha", "typing"]]),
+      new Map([
+        ["alpha", [thought("Editing ChannelPane", secondsBeforeNow(9))]],
+      ]),
+    ),
+    pubkeys: ["alpha"],
+  });
+  assert.deepEqual(partition, {
+    pillPubkeys: ["alpha"],
+    typingGroupPubkeys: [],
+  });
+});
+
+test("partitionComposerWorkingAgents ignores lifecycle-noise-only transcripts", () => {
+  // A transcript holding only "Turn started" noise (seeded turns, no content
+  // frames) is NOT pill-worthy — nothing would render in the hover feed.
+  const partition = partitionComposerWorkingAgents({
+    channelId: CHANNEL,
+    ...partitionReaders(
+      new Map([["alpha", "typing"]]),
+      new Map([["alpha", [turnStartedLifecycle(secondsBeforeNow(5))]]]),
+    ),
+    pubkeys: ["alpha"],
+  });
+  assert.deepEqual(partition, {
+    pillPubkeys: [],
+    typingGroupPubkeys: ["alpha"],
+  });
+});
+
+test("partitionComposerWorkingAgents scopes pill-worthiness to the channel", () => {
+  // Real work in ANOTHER channel must not promote this channel's typing.
+  const partition = partitionComposerWorkingAgents({
+    channelId: CHANNEL,
+    ...partitionReaders(
+      new Map([["alpha", "typing"]]),
+      new Map([
+        ["alpha", [thought("Other work", secondsBeforeNow(3), OTHER_CHANNEL)]],
+      ]),
+    ),
+    pubkeys: ["alpha"],
+  });
+  assert.deepEqual(partition, {
+    pillPubkeys: [],
+    typingGroupPubkeys: ["alpha"],
+  });
+});
+
+test("partitionComposerWorkingAgents splits a mixed roster preserving order", () => {
+  const partition = partitionComposerWorkingAgents({
+    channelId: CHANNEL,
+    ...partitionReaders(
+      new Map([
+        ["alpha", "observer"],
+        ["beta", "typing"],
+        ["gamma", "typing"],
+      ]),
+      new Map([["gamma", [thought("Prior work", secondsBeforeNow(30))]]]),
+    ),
+    pubkeys: ["alpha", "beta", "gamma"],
+  });
+  assert.deepEqual(partition, {
+    pillPubkeys: ["alpha", "gamma"],
+    typingGroupPubkeys: ["beta"],
+  });
 });
 
 /** Fake working-state reader over pubkey → [{channelId, anchorAt}] entries. */

--- a/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
+++ b/desktop/src/features/channels/ui/composerLiveActivity.test.mjs
@@ -16,7 +16,12 @@ const NOW = Date.parse("2026-07-23T00:01:00.000Z");
 const NOW_ISO = new Date(NOW).toISOString();
 
 /** Thought item: spine, headlined by its title. */
-const thought = (title, timestamp, channelId = CHANNEL) => ({
+const thought = (
+  title,
+  timestamp,
+  channelId = CHANNEL,
+  turnId = undefined,
+) => ({
   id: `thought-${title}-${timestamp}`,
   type: "thought",
   renderClass: "thought",
@@ -24,6 +29,7 @@ const thought = (title, timestamp, channelId = CHANNEL) => ({
   text: "",
   timestamp,
   channelId,
+  turnId,
 });
 
 /** Metadata item: meaningful but NOT spine — recedes when real work exists. */
@@ -196,6 +202,35 @@ test("deriveActivityPillLabel keeps a stable id while a message streams", () => 
   assert.equal(first.id, "msg-1");
   assert.equal(extended.id, "msg-1");
   assert.equal(extended.label, "Pass 1: reading the composer wiring");
+});
+
+test("deriveActivityPillLabel scopes observer headlines to every live turn", () => {
+  const turnTwo = thought(
+    "Current turn work",
+    secondsBeforeNow(1),
+    CHANNEL,
+    "turn-2",
+  );
+  const headline = deriveActivityPillLabel({
+    activeTurnIds: new Set(["turn-2", "turn-3"]),
+    channelId: CHANNEL,
+    transcript: [
+      thought("Previous turn work", secondsBeforeNow(2), CHANNEL, "turn-1"),
+      turnTwo,
+    ],
+  });
+  assert.deepEqual(headline, { id: turnTwo.id, label: "Current turn work" });
+
+  assert.equal(
+    deriveActivityPillLabel({
+      activeTurnIds: new Set(["turn-3"]),
+      channelId: CHANNEL,
+      transcript: [
+        thought("Previous turn work", secondsBeforeNow(2), CHANNEL, "turn-1"),
+      ],
+    }),
+    null,
+  );
 });
 
 test("deriveActivityPillPresentation keeps observer activity authoritative over typing", () => {

--- a/desktop/src/features/channels/ui/composerLiveActivity.ts
+++ b/desktop/src/features/channels/ui/composerLiveActivity.ts
@@ -30,3 +30,67 @@ export function resolveSelectedActivityAgent<T extends { pubkey: string }>({
     null
   );
 }
+
+/**
+ * Latest activity timestamp (ms) for the composer preview's "Last live" pill.
+ *
+ * Reads the same sources the preview panel renders — the live transcript
+ * window AND the channel-scoped archive — so the pill can never claim
+ * "No activity yet" while archived rows are visible underneath. Falls back
+ * to the active-turn anchor when a turn is running but no items exist yet.
+ */
+export function deriveLastLiveAt({
+  activeTurns,
+  archivedEvents,
+  channelId,
+  transcript,
+}: {
+  activeTurns: readonly { anchorAt: number; channelId: string }[];
+  archivedEvents: readonly { timestamp: string }[];
+  channelId: string | null;
+  transcript: readonly {
+    channelId?: string | null;
+    timestamp: string;
+  }[];
+}): number | null {
+  let latest: number | null = null;
+  const record = (timestamp: number) => {
+    if (latest === null || timestamp > latest) {
+      latest = timestamp;
+    }
+  };
+
+  for (let index = transcript.length - 1; index >= 0; index -= 1) {
+    const item = transcript[index];
+    if (!item || (channelId && item.channelId !== channelId)) {
+      continue;
+    }
+    const millis = Date.parse(item.timestamp);
+    if (!Number.isNaN(millis)) {
+      record(millis);
+      break;
+    }
+  }
+
+  // Archived events are already channel-scoped by the store, sorted ascending.
+  for (let index = archivedEvents.length - 1; index >= 0; index -= 1) {
+    const event = archivedEvents[index];
+    if (!event) {
+      continue;
+    }
+    const millis = Date.parse(event.timestamp);
+    if (!Number.isNaN(millis)) {
+      record(millis);
+      break;
+    }
+  }
+
+  const channelTurn = channelId
+    ? activeTurns.find((turn) => turn.channelId === channelId)
+    : activeTurns[0];
+  if (channelTurn) {
+    record(channelTurn.anchorAt);
+  }
+
+  return latest;
+}

--- a/desktop/src/features/channels/ui/composerLiveActivity.ts
+++ b/desktop/src/features/channels/ui/composerLiveActivity.ts
@@ -1,0 +1,32 @@
+/**
+ * Selection logic for the composer live-activity preview.
+ *
+ * The popover shows ONE working agent's feed at a time. Resolution order:
+ * explicit tab selection, then the agent whose session pane is already open,
+ * then the first working agent. A selection that stops working (its agent
+ * leaves the list) silently falls through to the next candidate rather than
+ * pinning a dead tab.
+ */
+export function resolveSelectedActivityAgent<T extends { pubkey: string }>({
+  openAgentSessionPubkey,
+  selectedPubkey,
+  workingAgents,
+}: {
+  openAgentSessionPubkey: string | null;
+  selectedPubkey: string | null;
+  workingAgents: readonly T[];
+}): T | null {
+  const findByPubkey = (pubkey: string | null) =>
+    pubkey
+      ? (workingAgents.find(
+          (agent) => agent.pubkey.toLowerCase() === pubkey.toLowerCase(),
+        ) ?? null)
+      : null;
+
+  return (
+    findByPubkey(selectedPubkey) ??
+    findByPubkey(openAgentSessionPubkey) ??
+    workingAgents[0] ??
+    null
+  );
+}

--- a/desktop/src/features/channels/ui/composerLiveActivity.ts
+++ b/desktop/src/features/channels/ui/composerLiveActivity.ts
@@ -6,14 +6,6 @@ import {
 import type { TranscriptItem } from "@/features/agents/ui/agentSessionTypes";
 
 /**
- * How long the latest action headline stays on a working agent's composer
- * pill before the label decays to the generic working state. Kept short so
- * any pause in the event stream (a long tool call, a thinking gap) cycles
- * the pill back to "<name> is working…" until the next action lands.
- */
-export const ACTIVITY_PILL_STALE_MS = 6_000;
-
-/**
  * Lifecycle meta-frames that must never headline the pill. They pass the
  * spine filter (meaningful lifecycle items) but would surface as bare
  * "Usage" / "Commands" labels that read like phantom activity.
@@ -34,23 +26,21 @@ export type ActivityPillHeadline = {
 };
 
 /**
- * Latest fresh action headline for a working agent's composer pill.
+ * Latest action headline for a working agent's composer pill.
  *
  * Channel-scoped, two-tier scan (spine items headline over metadata reads,
- * mirroring the session transcript's noise gate), newest wins. Returns null
- * when there is no headline or the newest one is older than `staleAfterMs`;
- * the pill then falls back to its generic "<name> is working…" label.
- * Deliberately no rotation through recent actions: one headline, then decay.
+ * mirroring the session transcript's noise gate), newest wins. The headline
+ * PERSISTS regardless of age — while a turn is in progress, the last real
+ * action is more informative than a generic placeholder, so there is
+ * deliberately no staleness decay (and no rotation through recent actions).
+ * Returns null only when the transcript has nothing headline-able yet; the
+ * pill then falls back to its generic "<name> is working…" label.
  */
 export function deriveActivityPillLabel({
   channelId,
-  now,
-  staleAfterMs = ACTIVITY_PILL_STALE_MS,
   transcript,
 }: {
   channelId: string | null;
-  now: number;
-  staleAfterMs?: number;
   transcript: readonly TranscriptItem[];
 }): ActivityPillHeadline | null {
   const scoped = channelId
@@ -74,55 +64,69 @@ export function deriveActivityPillLabel({
     if (!headline) {
       continue;
     }
-    const millis = Date.parse(item.timestamp);
-    if (!Number.isNaN(millis) && now - millis > staleAfterMs) {
-      return null;
-    }
     return { id: item.id, label: headline };
   }
 
   return null;
 }
 
+/** Minimal working-state shape the ordering needs (see agentWorkingSignal). */
+export type AgentWorkingChannelAnchor = {
+  channelId: string;
+  /** Desktop-clock anchor for when the agent started working there. */
+  anchorAt: number;
+};
+
 /**
- * Working-agent pill order for the composer strip: agents with the newest
- * channel-scoped transcript activity first (left-most). Agents with no
- * recorded activity keep their incoming (roster) order at the end — the
- * sort is stable, so ties never reshuffle.
+ * Working-agent pill order for the composer strip: agents ordered by when
+ * they STARTED working in this channel (turn anchor), earliest first —
+ * new agents append on the right. Deliberately not transcript recency:
+ * a start anchor is stable for the whole turn, so pills hold their slot
+ * while agents stream instead of shuffling on every event, and positional
+ * motion is reserved for membership changes (an agent starting/finishing).
  *
- * `getTranscript` is injected so the helper stays pure and unit-testable;
- * callers pass the observer store's cached reader.
+ * Anchors are quantized to whole seconds — clock-offset refinement can
+ * retroactively shift an anchor by the sub-second network delay it just
+ * measured out, and such a shift must not reorder the strip. Ties (same
+ * second, or no anchor for the requested scope) keep the incoming roster
+ * order — the sort is stable, so they never reshuffle. Agents with no
+ * anchor sort to the end.
+ *
+ * `getWorkingState` is injected so the helper stays pure and unit-testable;
+ * callers pass the working signal's cached reader.
  */
-export function deriveAgentActivityOrder({
+export function deriveAgentWorkingOrder({
   channelId,
-  getTranscript,
+  getWorkingState,
   pubkeys,
 }: {
   channelId: string | null;
-  getTranscript: (pubkey: string) => readonly TranscriptItem[];
+  getWorkingState: (pubkey: string) => {
+    channels: readonly AgentWorkingChannelAnchor[];
+  };
   pubkeys: readonly string[];
 }): string[] {
-  const lastActivityAt = new Map<string, number>();
+  const startSecond = new Map<string, number>();
 
   for (const pubkey of pubkeys) {
-    const transcript = getTranscript(pubkey);
-    for (let index = transcript.length - 1; index >= 0; index -= 1) {
-      const item = transcript[index];
-      if (!item || (channelId && item.channelId !== channelId)) {
+    let earliest: number | null = null;
+    for (const channel of getWorkingState(pubkey).channels) {
+      if (channelId !== null && channel.channelId !== channelId) {
         continue;
       }
-      const millis = Date.parse(item.timestamp);
-      if (!Number.isNaN(millis)) {
-        lastActivityAt.set(pubkey, millis);
-        break;
+      if (earliest === null || channel.anchorAt < earliest) {
+        earliest = channel.anchorAt;
       }
+    }
+    if (earliest !== null) {
+      startSecond.set(pubkey, Math.floor(earliest / 1000));
     }
   }
 
   return [...pubkeys].sort(
     (a, b) =>
-      (lastActivityAt.get(b) ?? Number.NEGATIVE_INFINITY) -
-      (lastActivityAt.get(a) ?? Number.NEGATIVE_INFINITY),
+      (startSecond.get(a) ?? Number.POSITIVE_INFINITY) -
+      (startSecond.get(b) ?? Number.POSITIVE_INFINITY),
   );
 }
 

--- a/desktop/src/features/channels/ui/composerLiveActivity.ts
+++ b/desktop/src/features/channels/ui/composerLiveActivity.ts
@@ -89,15 +89,22 @@ export function deriveActivityPillPresentation({
  * pill then falls back to its generic "<name> is working…" label.
  */
 export function deriveActivityPillLabel({
+  activeTurnIds,
   channelId,
   transcript,
 }: {
+  activeTurnIds?: ReadonlySet<string>;
   channelId: string | null;
   transcript: readonly TranscriptItem[];
 }): ActivityPillHeadline | null {
-  const scoped = channelId
-    ? transcript.filter((item) => item.channelId === channelId)
-    : transcript;
+  const scoped = transcript.filter(
+    (item) =>
+      (!channelId || item.channelId === channelId) &&
+      (!activeTurnIds ||
+        (item.turnId !== null &&
+          item.turnId !== undefined &&
+          activeTurnIds.has(item.turnId))),
+  );
   const passFilter = scoped.some(isSpineItem) ? isSpineItem : isMeaningfulItem;
 
   for (let index = scoped.length - 1; index >= 0; index -= 1) {

--- a/desktop/src/features/channels/ui/composerLiveActivity.ts
+++ b/desktop/src/features/channels/ui/composerLiveActivity.ts
@@ -74,6 +74,60 @@ export function deriveActivityPillLabel({
   return null;
 }
 
+/**
+ * Partition a channel's working agents into pill-rendered agents and the
+ * combined typing-indicator group.
+ *
+ * Pill-worthiness is capability-based, not source-based: an agent renders as
+ * a pill when there is an agent session worth hovering and opening — an
+ * active observer turn, or a transcript with a headline-able item for this
+ * channel left behind by a prior turn. Typing agents with nothing to show
+ * fold into the combined typing group with the human typers.
+ *
+ * This is what keeps a pill stable across the turn-end gap: an agent whose
+ * observer turn just completed but who is still typing keeps its pill (the
+ * label swaps to "is typing…" in place) instead of demoting to the group,
+ * and re-typing after a finished turn relights the pill rather than
+ * mounting a group item. Only an agent's FIRST-ever activity in the channel
+ * can start in the typing group.
+ *
+ * `getWorkingSource` / `getTranscript` are injected so the helper stays pure
+ * and unit-testable; callers pass the working signal's and observer store's
+ * cached readers.
+ */
+export function partitionComposerWorkingAgents({
+  channelId,
+  getTranscript,
+  getWorkingSource,
+  pubkeys,
+}: {
+  channelId: string | null;
+  getTranscript: (pubkey: string) => readonly TranscriptItem[];
+  getWorkingSource: (pubkey: string) => "observer" | "typing" | "none";
+  pubkeys: readonly string[];
+}): { pillPubkeys: string[]; typingGroupPubkeys: string[] } {
+  const pillPubkeys: string[] = [];
+  const typingGroupPubkeys: string[] = [];
+
+  for (const pubkey of pubkeys) {
+    if (getWorkingSource(pubkey) !== "typing") {
+      pillPubkeys.push(pubkey);
+      continue;
+    }
+    const headline = deriveActivityPillLabel({
+      channelId,
+      transcript: getTranscript(pubkey),
+    });
+    if (headline !== null) {
+      pillPubkeys.push(pubkey);
+    } else {
+      typingGroupPubkeys.push(pubkey);
+    }
+  }
+
+  return { pillPubkeys, typingGroupPubkeys };
+}
+
 /** Minimal working-state shape the ordering needs (see agentWorkingSignal). */
 export type AgentWorkingChannelAnchor = {
   channelId: string;

--- a/desktop/src/features/channels/ui/composerLiveActivity.ts
+++ b/desktop/src/features/channels/ui/composerLiveActivity.ts
@@ -1,34 +1,58 @@
-/**
- * Selection logic for the composer live-activity preview.
- *
- * The popover shows ONE working agent's feed at a time. Resolution order:
- * explicit tab selection, then the agent whose session pane is already open,
- * then the first working agent. A selection that stops working (its agent
- * leaves the list) silently falls through to the next candidate rather than
- * pinning a dead tab.
- */
-export function resolveSelectedActivityAgent<T extends { pubkey: string }>({
-  openAgentSessionPubkey,
-  selectedPubkey,
-  workingAgents,
-}: {
-  openAgentSessionPubkey: string | null;
-  selectedPubkey: string | null;
-  workingAgents: readonly T[];
-}): T | null {
-  const findByPubkey = (pubkey: string | null) =>
-    pubkey
-      ? (workingAgents.find(
-          (agent) => agent.pubkey.toLowerCase() === pubkey.toLowerCase(),
-        ) ?? null)
-      : null;
+import {
+  getActivityHeadline,
+  isMeaningfulItem,
+  isSpineItem,
+} from "@/features/agents/ui/agentSessionTranscriptPresentation";
+import type { TranscriptItem } from "@/features/agents/ui/agentSessionTypes";
 
-  return (
-    findByPubkey(selectedPubkey) ??
-    findByPubkey(openAgentSessionPubkey) ??
-    workingAgents[0] ??
-    null
-  );
+/**
+ * How long the latest action headline stays on a working agent's composer
+ * pill before the label decays to the generic working state.
+ */
+export const ACTIVITY_PILL_STALE_MS = 15_000;
+
+/**
+ * Latest fresh action headline for a working agent's composer pill.
+ *
+ * Channel-scoped, two-tier scan (spine items headline over metadata reads,
+ * mirroring the session transcript's noise gate), newest wins. Returns null
+ * when there is no headline or the newest one is older than `staleAfterMs`;
+ * the pill then falls back to its generic "Working…" label. Deliberately no
+ * rotation through recent actions: one headline, then decay.
+ */
+export function deriveActivityPillLabel({
+  channelId,
+  now,
+  staleAfterMs = ACTIVITY_PILL_STALE_MS,
+  transcript,
+}: {
+  channelId: string | null;
+  now: number;
+  staleAfterMs?: number;
+  transcript: readonly TranscriptItem[];
+}): string | null {
+  const scoped = channelId
+    ? transcript.filter((item) => item.channelId === channelId)
+    : transcript;
+  const passFilter = scoped.some(isSpineItem) ? isSpineItem : isMeaningfulItem;
+
+  for (let index = scoped.length - 1; index >= 0; index -= 1) {
+    const item = scoped[index];
+    if (!item || !passFilter(item)) {
+      continue;
+    }
+    const headline = getActivityHeadline(item);
+    if (!headline) {
+      continue;
+    }
+    const millis = Date.parse(item.timestamp);
+    if (!Number.isNaN(millis) && now - millis > staleAfterMs) {
+      return null;
+    }
+    return headline;
+  }
+
+  return null;
 }
 
 /**

--- a/desktop/src/features/channels/ui/composerLiveActivity.ts
+++ b/desktop/src/features/channels/ui/composerLiveActivity.ts
@@ -7,9 +7,11 @@ import type { TranscriptItem } from "@/features/agents/ui/agentSessionTypes";
 
 /**
  * How long the latest action headline stays on a working agent's composer
- * pill before the label decays to the generic working state.
+ * pill before the label decays to the generic working state. Kept short so
+ * any pause in the event stream (a long tool call, a thinking gap) cycles
+ * the pill back to "<name> is working…" until the next action lands.
  */
-export const ACTIVITY_PILL_STALE_MS = 15_000;
+export const ACTIVITY_PILL_STALE_MS = 6_000;
 
 /**
  * Lifecycle meta-frames that must never headline the pill. They pass the
@@ -37,8 +39,8 @@ export type ActivityPillHeadline = {
  * Channel-scoped, two-tier scan (spine items headline over metadata reads,
  * mirroring the session transcript's noise gate), newest wins. Returns null
  * when there is no headline or the newest one is older than `staleAfterMs`;
- * the pill then falls back to its generic "Working…" label. Deliberately no
- * rotation through recent actions: one headline, then decay.
+ * the pill then falls back to its generic "<name> is working…" label.
+ * Deliberately no rotation through recent actions: one headline, then decay.
  */
 export function deriveActivityPillLabel({
   channelId,

--- a/desktop/src/features/channels/ui/composerLiveActivity.ts
+++ b/desktop/src/features/channels/ui/composerLiveActivity.ts
@@ -12,6 +12,26 @@ import type { TranscriptItem } from "@/features/agents/ui/agentSessionTypes";
 export const ACTIVITY_PILL_STALE_MS = 15_000;
 
 /**
+ * Lifecycle meta-frames that must never headline the pill. They pass the
+ * spine filter (meaningful lifecycle items) but would surface as bare
+ * "Usage" / "Commands" labels that read like phantom activity.
+ */
+const PILL_HEADLINE_EXCLUDED_SOURCES = new Set([
+  "usage_update",
+  "available_commands_update",
+]);
+
+export type ActivityPillHeadline = {
+  /**
+   * Transcript item id backing the headline. The pill keys its ticker swap
+   * on this id, so a NEW action animates while streamed chunks that grow the
+   * same item (message first line, thought text) update text in place.
+   */
+  id: string;
+  label: string;
+};
+
+/**
  * Latest fresh action headline for a working agent's composer pill.
  *
  * Channel-scoped, two-tier scan (spine items headline over metadata reads,
@@ -30,7 +50,7 @@ export function deriveActivityPillLabel({
   now: number;
   staleAfterMs?: number;
   transcript: readonly TranscriptItem[];
-}): string | null {
+}): ActivityPillHeadline | null {
   const scoped = channelId
     ? transcript.filter((item) => item.channelId === channelId)
     : transcript;
@@ -41,6 +61,13 @@ export function deriveActivityPillLabel({
     if (!item || !passFilter(item)) {
       continue;
     }
+    if (
+      item.type === "lifecycle" &&
+      item.acpSource !== undefined &&
+      PILL_HEADLINE_EXCLUDED_SOURCES.has(item.acpSource)
+    ) {
+      continue;
+    }
     const headline = getActivityHeadline(item);
     if (!headline) {
       continue;
@@ -49,10 +76,52 @@ export function deriveActivityPillLabel({
     if (!Number.isNaN(millis) && now - millis > staleAfterMs) {
       return null;
     }
-    return headline;
+    return { id: item.id, label: headline };
   }
 
   return null;
+}
+
+/**
+ * Working-agent pill order for the composer strip: agents with the newest
+ * channel-scoped transcript activity first (left-most). Agents with no
+ * recorded activity keep their incoming (roster) order at the end — the
+ * sort is stable, so ties never reshuffle.
+ *
+ * `getTranscript` is injected so the helper stays pure and unit-testable;
+ * callers pass the observer store's cached reader.
+ */
+export function deriveAgentActivityOrder({
+  channelId,
+  getTranscript,
+  pubkeys,
+}: {
+  channelId: string | null;
+  getTranscript: (pubkey: string) => readonly TranscriptItem[];
+  pubkeys: readonly string[];
+}): string[] {
+  const lastActivityAt = new Map<string, number>();
+
+  for (const pubkey of pubkeys) {
+    const transcript = getTranscript(pubkey);
+    for (let index = transcript.length - 1; index >= 0; index -= 1) {
+      const item = transcript[index];
+      if (!item || (channelId && item.channelId !== channelId)) {
+        continue;
+      }
+      const millis = Date.parse(item.timestamp);
+      if (!Number.isNaN(millis)) {
+        lastActivityAt.set(pubkey, millis);
+        break;
+      }
+    }
+  }
+
+  return [...pubkeys].sort(
+    (a, b) =>
+      (lastActivityAt.get(b) ?? Number.NEGATIVE_INFINITY) -
+      (lastActivityAt.get(a) ?? Number.NEGATIVE_INFINITY),
+  );
 }
 
 /**

--- a/desktop/src/features/channels/ui/composerLiveActivity.ts
+++ b/desktop/src/features/channels/ui/composerLiveActivity.ts
@@ -25,6 +25,54 @@ export type ActivityPillHeadline = {
   label: string;
 };
 
+export type ActivityPillPresentation = {
+  id: string;
+  label: string;
+};
+
+/**
+ * Choose the label shown by an agent's composer pill.
+ *
+ * Observer activity is authoritative while a turn is active, even though the
+ * ACP harness continues refreshing its public typing signal throughout that
+ * turn. Raw typing remains a fallback before observer telemetry arrives and
+ * after the observer turn completes.
+ */
+export function deriveActivityPillPresentation({
+  agentName,
+  headline,
+  isTyping,
+  workingSource,
+}: {
+  agentName: string;
+  headline: ActivityPillHeadline | null;
+  isTyping: boolean;
+  workingSource: "observer" | "typing" | "none";
+}): ActivityPillPresentation {
+  if (workingSource === "observer") {
+    return (
+      headline ?? {
+        id: "generic-working",
+        label: `${agentName} is working…`,
+      }
+    );
+  }
+
+  if (isTyping) {
+    return {
+      id: "typing-override",
+      label: `${agentName} is typing…`,
+    };
+  }
+
+  return (
+    headline ?? {
+      id: "generic-working",
+      label: `${agentName} is working…`,
+    }
+  );
+}
+
 /**
  * Latest action headline for a working agent's composer pill.
  *

--- a/desktop/src/features/channels/ui/composerLiveActivity.ts
+++ b/desktop/src/features/channels/ui/composerLiveActivity.ts
@@ -28,6 +28,10 @@ export type ActivityPillHeadline = {
 /**
  * Latest action headline for a working agent's composer pill.
  *
+ * Tool items headline in the terse action format from getActivityHeadline —
+ * verb + compact object ("Read foo.ts"), not "label · full preview" — so the
+ * pill's narrow cap shows the informative part of the action.
+ *
  * Channel-scoped, two-tier scan (spine items headline over metadata reads,
  * mirroring the session transcript's noise gate), newest wins. The headline
  * PERSISTS regardless of age — while a turn is in progress, the last real

--- a/desktop/src/features/channels/ui/composerStripAvatarLayout.ts
+++ b/desktop/src/features/channels/ui/composerStripAvatarLayout.ts
@@ -1,0 +1,61 @@
+import * as React from "react";
+
+/**
+ * Per-strip namespace for the composer strip's avatar shared-element ids.
+ *
+ * The same agent avatar has two possible homes inside a strip — the merged
+ * typing group and a status pill — and a partition flip (typing agent
+ * promoted to a pill) should MORPH the avatar between them via a matching
+ * motion `layoutId` instead of exiting one and entering the other.
+ *
+ * layoutIds are app-global, and the channel composer strip and the thread
+ * panel strip can be mounted at once, so the ids must be namespaced per
+ * strip instance — two simultaneously mounted elements sharing a layoutId
+ * would fight over the "lead" and a morph could travel between strips.
+ * Motion's own namespacing tool (LayoutGroup id) is deliberately NOT used:
+ * LayoutGroup re-measures every layout-animating member whenever any member
+ * updates, which turns each pill label ticker resize into a group-wide
+ * onLayoutAnimationStart storm that permanently holds the pills' deferred
+ * label swaps. A per-strip scope string baked into the id gives the
+ * isolation without the group re-measurement semantics.
+ *
+ * BotActivityComposerAction provides the scope (its React.useId());
+ * the pill and TypingIndicatorRow read it through
+ * useComposerStripAvatarLayoutId. Outside a strip the context is null and
+ * avatars render without a layoutId.
+ */
+export const ComposerStripAvatarScopeContext = React.createContext<
+  string | null
+>(null);
+
+/**
+ * Shared-element layout id for an agent's avatar within one strip scope.
+ * Exposed for tests; components should prefer the hook below.
+ */
+export function composerStripAvatarLayoutId(scope: string, pubkey: string) {
+  return `bot-activity-avatar-${scope}-${pubkey.toLowerCase()}`;
+}
+
+/**
+ * The avatar's shared-element layout id in the enclosing composer strip, or
+ * undefined when rendered outside a strip (no morph counterpart exists).
+ */
+export function useComposerStripAvatarLayoutId(
+  pubkey: string,
+): string | undefined {
+  const scope = React.useContext(ComposerStripAvatarScopeContext);
+  return scope === null
+    ? undefined
+    : composerStripAvatarLayoutId(scope, pubkey);
+}
+
+/**
+ * Layout spring for the avatar morph, shared by both morph endpoints
+ * (whichever end MOUNTS drives the transition). Quicker than the strip's
+ * slot reorder spring — the morph travels the short hop between the
+ * trailing typing group and the adjacent new pill and should read as one
+ * quick slide.
+ */
+export const COMPOSER_STRIP_AVATAR_MORPH_TRANSITION = {
+  layout: { type: "spring", duration: 0.45, bounce: 0.2 },
+} as const;

--- a/desktop/src/features/channels/ui/useThreadComposerActivity.ts
+++ b/desktop/src/features/channels/ui/useThreadComposerActivity.ts
@@ -1,0 +1,71 @@
+import * as React from "react";
+import {
+  getAgentTranscript,
+  subscribeAgentObserverStore,
+} from "@/features/agents/observerRelayStore";
+import { partitionComposerWorkingAgents } from "@/features/channels/ui/composerLiveActivity";
+import type { TypingIndicatorEntry } from "@/features/messages/useChannelTyping";
+
+/** Partitions thread-scoped bot typers without leaking them into channel state. */
+export function useThreadComposerActivity({
+  botTypingEntries,
+  channelId,
+  threadHeadId,
+  typingPubkeys,
+}: {
+  botTypingEntries: readonly TypingIndicatorEntry[];
+  channelId: string | null;
+  threadHeadId: string | null;
+  typingPubkeys: readonly string[];
+}): {
+  combinedTypingPubkeys: string[];
+  hasActivity: boolean;
+  pillBotPubkeys: string[];
+} {
+  const botPubkeys = React.useMemo(() => {
+    if (!threadHeadId) return [];
+    return botTypingEntries
+      .filter((entry) => entry.threadHeadId === threadHeadId)
+      .map((entry) => entry.pubkey)
+      .filter(
+        (pubkey, index, all) =>
+          all.findIndex(
+            (candidate) => candidate.toLowerCase() === pubkey.toLowerCase(),
+          ) === index,
+      );
+  }, [botTypingEntries, threadHeadId]);
+  const subscribe = React.useCallback(
+    (onChange: () => void) => subscribeAgentObserverStore(onChange),
+    [],
+  );
+  const getSnapshot = React.useCallback(() => {
+    const partition = partitionComposerWorkingAgents({
+      channelId,
+      getTranscript: getAgentTranscript,
+      // Thread typing stays out of the channel-wide working registry. A
+      // channel-scoped transcript alone decides whether a real preview exists.
+      getWorkingSource: () => "typing",
+      pubkeys: botPubkeys,
+    });
+    return `${partition.pillPubkeys.join(",")}\n${partition.typingGroupPubkeys.join(",")}`;
+  }, [botPubkeys, channelId]);
+  const partitionKey = React.useSyncExternalStore(subscribe, getSnapshot);
+  const [pillKey = "", typingKey = ""] = partitionKey.split("\n");
+  const pillBotPubkeys = React.useMemo(
+    () => (pillKey === "" ? [] : pillKey.split(",")),
+    [pillKey],
+  );
+  const typingBotPubkeys = React.useMemo(
+    () => (typingKey === "" ? [] : typingKey.split(",")),
+    [typingKey],
+  );
+  const combinedTypingPubkeys = React.useMemo(
+    () => [...typingPubkeys, ...typingBotPubkeys],
+    [typingBotPubkeys, typingPubkeys],
+  );
+  return {
+    combinedTypingPubkeys,
+    hasActivity: pillBotPubkeys.length > 0 || combinedTypingPubkeys.length > 0,
+    pillBotPubkeys,
+  };
+}

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -41,7 +41,6 @@ import {
 import type { ThreadDepthGuideAction } from "./MessageRow";
 import { MessageThreadRow } from "./MessageThreadRow";
 import { MessageThreadSummaryRow } from "./MessageThreadSummaryRow";
-import { TypingIndicatorRow } from "./TypingIndicatorRow";
 import { UnreadDivider } from "./UnreadDivider";
 import { useComposerHeightPadding } from "./useComposerHeightPadding";
 import { useStableSendToChannel } from "./useStableSendToChannel";
@@ -108,7 +107,6 @@ type MessageThreadPanelProps = ThreadPanelLayoutProps & {
   threadRepliesPending?: boolean;
   threadUnreadCount?: number;
   threadReplyUnreadCounts?: ReadonlyMap<string, number>;
-  threadTypingPubkeys: string[];
   videoReviewPresentation?: VideoReviewPresentation;
   activityAccessoryContent?: React.ReactNode;
   activityAccessoryVisible: boolean;
@@ -235,7 +233,6 @@ export function MessageThreadPanel({
   threadRepliesPending = false,
   threadUnreadCount,
   threadReplyUnreadCounts,
-  threadTypingPubkeys,
   activityAccessoryContent,
   activityAccessoryVisible,
   canResetWidth,
@@ -264,9 +261,9 @@ export function MessageThreadPanel({
   );
   const hasConstrainedColumn = columnMaxWidthPx != null;
   // Whether the composer dock trades its quiet-state spacer for the
-  // conditional activity accessory (agent working and/or someone typing).
-  const hasComposerBottomActivity =
-    activityAccessoryVisible || threadTypingPubkeys.length > 0;
+  // conditional activity accessory (agent working and/or someone typing —
+  // ChannelPane folds thread typers into the strip and its visibility).
+  const hasComposerBottomActivity = activityAccessoryVisible;
 
   // Live ref so onCaptureSendContext can read reply state at submit time
   // (before any async mention-flow awaits change navigation state).
@@ -907,33 +904,11 @@ export function MessageThreadPanel({
               {/* No mx-auto/max-w column here: the composer above spans the
                   full pane width, so the activity row must too or the typing
                   group floats toward the pane's center. Mirrors
-                  ChannelComposerActivityRow: the pill strip sizes to its
-                  content and the typing group takes the remainder, instead of
-                  splitting the row 50/50. */}
-              <div className="flex w-full items-center gap-3 overflow-visible">
-                {activityAccessoryVisible && activityAccessoryContent ? (
-                  <div className="flex min-w-0 overflow-visible">
-                    {activityAccessoryContent}
-                  </div>
-                ) : null}
-                {threadTypingPubkeys.length > 0 ? (
-                  <TypingIndicatorRow
-                    channel={channel}
-                    className={cn(
-                      "min-w-0 flex-1 py-0 pr-0",
-                      // Composer-edge alignment only when the typing group
-                      // leads the row; next to pills the row's gap is the
-                      // whole spacing.
-                      activityAccessoryVisible && activityAccessoryContent
-                        ? "pl-0 sm:pl-0"
-                        : "pl-[calc(0.75rem+1px)] sm:pl-[calc(1rem+1px)]",
-                    )}
-                    currentPubkey={currentPubkey}
-                    profiles={profiles}
-                    typingPubkeys={threadTypingPubkeys}
-                    variant="activity"
-                  />
-                ) : null}
+                  ChannelComposerActivityRow: ONE strip hosts the pills and the
+                  typing group as slot siblings (the strip is built by
+                  ChannelPane, thread typers included). */}
+              <div className="flex w-full items-center overflow-visible">
+                {activityAccessoryContent}
               </div>
             </ComposerActivityAccessory>
           </div>

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -904,16 +904,30 @@ export function MessageThreadPanel({
               className={THREAD_PANEL_COMPOSER_GUTTER_CLASS}
               visible={hasComposerBottomActivity}
             >
-              <div className="mx-auto flex w-full max-w-4xl items-center gap-2 overflow-visible pl-2">
+              {/* No mx-auto/max-w column here: the composer above spans the
+                  full pane width, so the activity row must too or the typing
+                  group floats toward the pane's center. Mirrors
+                  ChannelComposerActivityRow: the pill strip sizes to its
+                  content and the typing group takes the remainder, instead of
+                  splitting the row 50/50. */}
+              <div className="flex w-full items-center gap-3 overflow-visible">
                 {activityAccessoryVisible && activityAccessoryContent ? (
-                  <div className="flex min-w-0 flex-1 overflow-visible">
+                  <div className="flex min-w-0 overflow-visible">
                     {activityAccessoryContent}
                   </div>
                 ) : null}
                 {threadTypingPubkeys.length > 0 ? (
                   <TypingIndicatorRow
                     channel={channel}
-                    className="min-w-0 flex-1 py-0 pl-[calc(0.75rem+1px)] pr-0 sm:pl-[calc(1rem+1px)]"
+                    className={cn(
+                      "min-w-0 flex-1 py-0 pr-0",
+                      // Composer-edge alignment only when the typing group
+                      // leads the row; next to pills the row's gap is the
+                      // whole spacing.
+                      activityAccessoryVisible && activityAccessoryContent
+                        ? "pl-0 sm:pl-0"
+                        : "pl-[calc(0.75rem+1px)] sm:pl-[calc(1rem+1px)]",
+                    )}
                     currentPubkey={currentPubkey}
                     profiles={profiles}
                     typingPubkeys={threadTypingPubkeys}

--- a/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
+++ b/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
+import { motion, useReducedMotion } from "motion/react";
 
+import {
+  COMPOSER_STRIP_AVATAR_MORPH_TRANSITION,
+  useComposerStripAvatarLayoutId,
+} from "@/features/channels/ui/composerStripAvatarLayout";
 import {
   resolveUserLabel,
   type UserProfileLookup,
@@ -52,6 +57,47 @@ function formatTypingLabel(names: string[]) {
   return `${names[0]}, ${names[1]}, and ${names.length - 2} more are typing...`;
 }
 
+/**
+ * One typer's avatar in the overlapping set. Inside a composer activity
+ * strip, the avatar carries that strip's shared-element layout id (see
+ * composerStripAvatarLayout) so an agent's avatar MORPHS between the merged
+ * typing group and its status pill on partition flips instead of exiting
+ * one and entering the other. Outside a strip (context null) or under
+ * reduced motion the id is dropped and the avatar mounts in place.
+ */
+function TypingAvatar({
+  avatarUrl,
+  label,
+  overlap,
+  pubkey,
+}: {
+  avatarUrl: string | null;
+  label: string;
+  overlap: boolean;
+  pubkey: string;
+}) {
+  const shouldReduceMotion = useReducedMotion();
+  const morphLayoutId = useComposerStripAvatarLayoutId(pubkey);
+  return (
+    <motion.div
+      className={cn(
+        "relative h-5 w-5 shrink-0 rounded-lg ring-1 ring-background",
+        overlap && "-ml-1.5",
+      )}
+      data-testid="message-typing-avatar"
+      layoutId={shouldReduceMotion ? undefined : morphLayoutId}
+      transition={COMPOSER_STRIP_AVATAR_MORPH_TRANSITION}
+    >
+      <ProfileAvatar
+        avatarUrl={avatarUrl}
+        label={label}
+        className="h-5 w-5 text-3xs"
+        iconClassName="h-4 w-4"
+      />
+    </motion.div>
+  );
+}
+
 export function TypingIndicatorRow({
   channel,
   className,
@@ -85,27 +131,15 @@ export function TypingIndicatorRow({
       {labels.length > 0 && (
         <div className="flex min-w-0 w-full items-center gap-2">
           <div className="flex shrink-0 items-center">
-            {typingPubkeys.map((pubkey, index) => {
-              const profile = profiles?.[pubkey.toLowerCase()];
-              const label = labels[index] ?? truncatePubkey(pubkey);
-              return (
-                <div
-                  key={pubkey}
-                  className={cn(
-                    "relative h-5 w-5 shrink-0 rounded-lg ring-1 ring-background",
-                    index > 0 && "-ml-1.5",
-                  )}
-                  data-testid="message-typing-avatar"
-                >
-                  <ProfileAvatar
-                    avatarUrl={profile?.avatarUrl ?? null}
-                    label={label}
-                    className="h-5 w-5 text-3xs"
-                    iconClassName="h-4 w-4"
-                  />
-                </div>
-              );
-            })}
+            {typingPubkeys.map((pubkey, index) => (
+              <TypingAvatar
+                key={pubkey}
+                avatarUrl={profiles?.[pubkey.toLowerCase()]?.avatarUrl ?? null}
+                label={labels[index] ?? truncatePubkey(pubkey)}
+                overlap={index > 0}
+                pubkey={pubkey}
+              />
+            ))}
           </div>
           <p
             className={cn(

--- a/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
+++ b/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
@@ -14,6 +14,8 @@ type TypingIndicatorRowProps = {
   channel: Channel | null;
   className?: string;
   currentPubkey?: string;
+  /** Extra classes for the "… is typing" label (e.g. weight overrides). */
+  labelClassName?: string;
   profiles?: UserProfileLookup;
   typingPubkeys: string[];
   variant?: "default" | "activity";
@@ -48,13 +50,14 @@ function formatTypingLabel(names: string[]) {
     return `${names[0]}, ${names[1]}, and ${names[2]} are typing...`;
   }
 
-  return `${names[0]}, ${names[1]}, and ${names.length - 2} others are typing...`;
+  return `${names[0]}, ${names[1]}, and ${names.length - 2} more are typing...`;
 }
 
 export function TypingIndicatorRow({
   channel,
   className,
   currentPubkey,
+  labelClassName,
   profiles,
   typingPubkeys,
   variant = "default",
@@ -129,6 +132,7 @@ export function TypingIndicatorRow({
               isActivityVariant
                 ? "text-2xs font-medium leading-3"
                 : "text-xs font-medium leading-4",
+              labelClassName,
             )}
             data-testid="message-typing-indicator-label"
           >

--- a/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
+++ b/desktop/src/features/messages/ui/TypingIndicatorRow.tsx
@@ -18,7 +18,6 @@ type TypingIndicatorRowProps = {
   labelClassName?: string;
   profiles?: UserProfileLookup;
   typingPubkeys: string[];
-  variant?: "default" | "activity";
 };
 
 function resolveFallbackName(channel: Channel | null, pubkey: string) {
@@ -60,9 +59,7 @@ export function TypingIndicatorRow({
   labelClassName,
   profiles,
   typingPubkeys,
-  variant = "default",
 }: TypingIndicatorRowProps) {
-  const isActivityVariant = variant === "activity";
   const labels = React.useMemo(
     () =>
       typingPubkeys.map((pubkey) =>
@@ -80,22 +77,13 @@ export function TypingIndicatorRow({
   return (
     <div
       aria-live="polite"
-      className={cn(
-        "shrink-0 bg-transparent",
-        isActivityVariant ? "flex items-center px-0 py-0" : "px-4 py-2 sm:px-6",
-        className,
-      )}
+      className={cn("shrink-0 bg-transparent px-4 py-2 sm:px-6", className)}
       {...(labels.length > 0
         ? { "data-testid": "message-typing-indicator" }
         : {})}
     >
       {labels.length > 0 && (
-        <div
-          className={cn(
-            "flex min-w-0 w-full items-center",
-            isActivityVariant ? "h-full gap-1.5" : "gap-2",
-          )}
-        >
+        <div className="flex min-w-0 w-full items-center gap-2">
           <div className="flex shrink-0 items-center">
             {typingPubkeys.map((pubkey, index) => {
               const profile = profiles?.[pubkey.toLowerCase()];
@@ -104,8 +92,7 @@ export function TypingIndicatorRow({
                 <div
                   key={pubkey}
                   className={cn(
-                    "relative shrink-0 rounded-lg ring-1 ring-background",
-                    isActivityVariant ? "h-4 w-4" : "h-5 w-5",
+                    "relative h-5 w-5 shrink-0 rounded-lg ring-1 ring-background",
                     index > 0 && "-ml-1.5",
                   )}
                   data-testid="message-typing-avatar"
@@ -113,14 +100,8 @@ export function TypingIndicatorRow({
                   <ProfileAvatar
                     avatarUrl={profile?.avatarUrl ?? null}
                     label={label}
-                    className={cn(
-                      isActivityVariant
-                        ? "h-4 w-4 text-3xs"
-                        : "h-5 w-5 text-3xs",
-                    )}
-                    iconClassName={
-                      isActivityVariant ? "h-2.5 w-2.5" : "h-4 w-4"
-                    }
+                    className="h-5 w-5 text-3xs"
+                    iconClassName="h-4 w-4"
                   />
                 </div>
               );
@@ -128,10 +109,7 @@ export function TypingIndicatorRow({
           </div>
           <p
             className={cn(
-              "min-w-0 translate-y-px truncate text-muted-foreground",
-              isActivityVariant
-                ? "text-2xs font-medium leading-3"
-                : "text-xs font-medium leading-4",
+              "min-w-0 translate-y-px truncate text-xs font-medium leading-4 text-muted-foreground",
               labelClassName,
             )}
             data-testid="message-typing-indicator-label"

--- a/desktop/src/features/messages/useChannelTyping.test.mjs
+++ b/desktop/src/features/messages/useChannelTyping.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { recordTypingCompletion } from "./useChannelTyping.ts";
+import {
+  clearTypingStateForCompletion,
+  recordTypingCompletion,
+} from "./useChannelTyping.ts";
 
 const TYPING_KEY = "agent:thread";
 const NOW = 2_000_000_000_000;
@@ -14,17 +17,12 @@ function makeState() {
   };
 }
 
-function record(
-  state,
-  createdAt,
-  { hasActiveTyping = true, now = NOW, typingCreatedAt = createdAt } = {},
-) {
+function record(state, createdAt, { now = NOW } = {}) {
   return recordTypingCompletion({
     createdAt,
     latestMessageCreatedAtByPubkey: state.latestMessageCreatedAtByPubkey,
     now,
     suppressUntilByPubkey: state.suppressUntilByPubkey,
-    typingCreatedAt: hasActiveTyping ? typingCreatedAt : undefined,
     typingKey: TYPING_KEY,
   });
 }
@@ -33,7 +31,7 @@ test("duplicate full-array replay does not reprocess completion events", () => {
   const state = makeState();
 
   assert.equal(record(state, NOW_SECONDS), true);
-  assert.equal(record(state, NOW_SECONDS), false);
+  assert.equal(record(state, NOW_SECONDS, { now: NOW + 1_000 }), false);
   assert.deepEqual(state.latestMessageCreatedAtByPubkey, {
     [TYPING_KEY]: { createdAt: NOW_SECONDS, observedAt: NOW },
   });
@@ -66,17 +64,18 @@ test("older-then-newer completion arrival advances the watermark", () => {
   assert.equal(state.suppressUntilByPubkey[TYPING_KEY], NOW + 2_000);
 });
 
-test("historical thread load records ordering but creates no fresh suppression", () => {
+test("historical first observation arms one bounded suppression for trailing ticks", () => {
   const state = makeState();
+  const historicalCreatedAt = NOW_SECONDS - 60;
 
-  assert.equal(
-    record(state, NOW_SECONDS - 60, { hasActiveTyping: false }),
-    false,
-  );
+  assert.equal(record(state, historicalCreatedAt), true);
+  assert.equal(record(state, historicalCreatedAt, { now: NOW + 1_000 }), false);
   assert.deepEqual(state.latestMessageCreatedAtByPubkey, {
-    [TYPING_KEY]: { createdAt: NOW_SECONDS - 60, observedAt: NOW },
+    [TYPING_KEY]: { createdAt: historicalCreatedAt, observedAt: NOW },
   });
-  assert.deepEqual(state.suppressUntilByPubkey, {});
+  assert.deepEqual(state.suppressUntilByPubkey, {
+    [TYPING_KEY]: NOW + 2_000,
+  });
 });
 
 test("lagging agent completion clears typing for a matching agent-clock event", () => {
@@ -99,14 +98,43 @@ test("ahead agent completion keeps suppression desktop-local", () => {
   });
 });
 
-test("message older than active typing advances ordering without clearing", () => {
-  const state = makeState();
+test("queued newer typing survives an older completion clear", () => {
+  const typingStateAfterQueuedTick = {
+    [TYPING_KEY]: {
+      createdAt: NOW_SECONDS + 1,
+      expiresAt: NOW + 8_000,
+      firstSeenAt: NOW,
+      pubkey: "agent",
+      threadHeadId: "thread",
+    },
+  };
 
   assert.equal(
-    record(state, NOW_SECONDS - 60, { typingCreatedAt: NOW_SECONDS }),
-    false,
+    clearTypingStateForCompletion(
+      typingStateAfterQueuedTick,
+      TYPING_KEY,
+      NOW_SECONDS,
+      NOW,
+    ),
+    typingStateAfterQueuedTick,
   );
-  assert.deepEqual(state.suppressUntilByPubkey, {});
+});
+
+test("completion clears matching or older typing state", () => {
+  const typingState = {
+    [TYPING_KEY]: {
+      createdAt: NOW_SECONDS,
+      expiresAt: NOW + 8_000,
+      firstSeenAt: NOW,
+      pubkey: "agent",
+      threadHeadId: "thread",
+    },
+  };
+
+  assert.deepEqual(
+    clearTypingStateForCompletion(typingState, TYPING_KEY, NOW_SECONDS, NOW),
+    {},
+  );
 });
 
 test("watermarks expire by desktop observation time, not agent clock", () => {

--- a/desktop/src/features/messages/useChannelTyping.test.mjs
+++ b/desktop/src/features/messages/useChannelTyping.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { recordTypingCompletion } from "./useChannelTyping.ts";
+
+const TYPING_KEY = "agent:thread";
+const NOW = 2_000_000_000_000;
+const NOW_SECONDS = NOW / 1_000;
+
+function makeState() {
+  return {
+    latestMessageCreatedAtByPubkey: {},
+    suppressUntilByPubkey: {},
+  };
+}
+
+function record(state, createdAt) {
+  return recordTypingCompletion({
+    createdAt,
+    latestMessageCreatedAtByPubkey: state.latestMessageCreatedAtByPubkey,
+    now: NOW,
+    suppressUntilByPubkey: state.suppressUntilByPubkey,
+    typingKey: TYPING_KEY,
+  });
+}
+
+test("duplicate full-array replay does not reprocess completion events", () => {
+  const state = makeState();
+
+  assert.equal(record(state, NOW_SECONDS), true);
+  assert.equal(record(state, NOW_SECONDS), false);
+  assert.deepEqual(state.latestMessageCreatedAtByPubkey, {
+    [TYPING_KEY]: NOW_SECONDS,
+  });
+  assert.deepEqual(state.suppressUntilByPubkey, {
+    [TYPING_KEY]: NOW + 2_000,
+  });
+});
+
+test("newer-then-older completion arrival keeps the newer watermark", () => {
+  const state = makeState();
+
+  assert.equal(record(state, NOW_SECONDS), true);
+  assert.equal(record(state, NOW_SECONDS - 1), false);
+  assert.equal(state.latestMessageCreatedAtByPubkey[TYPING_KEY], NOW_SECONDS);
+  assert.equal(state.suppressUntilByPubkey[TYPING_KEY], NOW + 2_000);
+});
+
+test("older-then-newer completion arrival advances the watermark", () => {
+  const state = makeState();
+
+  assert.equal(record(state, NOW_SECONDS - 1), true);
+  assert.equal(record(state, NOW_SECONDS), true);
+  assert.equal(state.latestMessageCreatedAtByPubkey[TYPING_KEY], NOW_SECONDS);
+  assert.equal(state.suppressUntilByPubkey[TYPING_KEY], NOW + 2_000);
+});
+
+test("historical thread load creates neither a watermark nor fresh suppression", () => {
+  const state = makeState();
+
+  assert.equal(record(state, NOW_SECONDS - 60), false);
+  assert.deepEqual(state.latestMessageCreatedAtByPubkey, {});
+  assert.deepEqual(state.suppressUntilByPubkey, {});
+});

--- a/desktop/src/features/messages/useChannelTyping.test.mjs
+++ b/desktop/src/features/messages/useChannelTyping.test.mjs
@@ -14,12 +14,17 @@ function makeState() {
   };
 }
 
-function record(state, createdAt) {
+function record(
+  state,
+  createdAt,
+  { hasActiveTyping = true, now = NOW, typingCreatedAt = createdAt } = {},
+) {
   return recordTypingCompletion({
     createdAt,
     latestMessageCreatedAtByPubkey: state.latestMessageCreatedAtByPubkey,
-    now: NOW,
+    now,
     suppressUntilByPubkey: state.suppressUntilByPubkey,
+    typingCreatedAt: hasActiveTyping ? typingCreatedAt : undefined,
     typingKey: TYPING_KEY,
   });
 }
@@ -30,7 +35,7 @@ test("duplicate full-array replay does not reprocess completion events", () => {
   assert.equal(record(state, NOW_SECONDS), true);
   assert.equal(record(state, NOW_SECONDS), false);
   assert.deepEqual(state.latestMessageCreatedAtByPubkey, {
-    [TYPING_KEY]: NOW_SECONDS,
+    [TYPING_KEY]: { createdAt: NOW_SECONDS, observedAt: NOW },
   });
   assert.deepEqual(state.suppressUntilByPubkey, {
     [TYPING_KEY]: NOW + 2_000,
@@ -42,7 +47,10 @@ test("newer-then-older completion arrival keeps the newer watermark", () => {
 
   assert.equal(record(state, NOW_SECONDS), true);
   assert.equal(record(state, NOW_SECONDS - 1), false);
-  assert.equal(state.latestMessageCreatedAtByPubkey[TYPING_KEY], NOW_SECONDS);
+  assert.equal(
+    state.latestMessageCreatedAtByPubkey[TYPING_KEY].createdAt,
+    NOW_SECONDS,
+  );
   assert.equal(state.suppressUntilByPubkey[TYPING_KEY], NOW + 2_000);
 });
 
@@ -51,14 +59,62 @@ test("older-then-newer completion arrival advances the watermark", () => {
 
   assert.equal(record(state, NOW_SECONDS - 1), true);
   assert.equal(record(state, NOW_SECONDS), true);
-  assert.equal(state.latestMessageCreatedAtByPubkey[TYPING_KEY], NOW_SECONDS);
+  assert.equal(
+    state.latestMessageCreatedAtByPubkey[TYPING_KEY].createdAt,
+    NOW_SECONDS,
+  );
   assert.equal(state.suppressUntilByPubkey[TYPING_KEY], NOW + 2_000);
 });
 
-test("historical thread load creates neither a watermark nor fresh suppression", () => {
+test("historical thread load records ordering but creates no fresh suppression", () => {
   const state = makeState();
 
-  assert.equal(record(state, NOW_SECONDS - 60), false);
-  assert.deepEqual(state.latestMessageCreatedAtByPubkey, {});
+  assert.equal(
+    record(state, NOW_SECONDS - 60, { hasActiveTyping: false }),
+    false,
+  );
+  assert.deepEqual(state.latestMessageCreatedAtByPubkey, {
+    [TYPING_KEY]: { createdAt: NOW_SECONDS - 60, observedAt: NOW },
+  });
   assert.deepEqual(state.suppressUntilByPubkey, {});
+});
+
+test("lagging agent completion clears typing for a matching agent-clock event", () => {
+  const state = makeState();
+  const laggingCreatedAt = NOW_SECONDS - 60;
+
+  assert.equal(record(state, laggingCreatedAt), true);
+  assert.deepEqual(state.suppressUntilByPubkey, {
+    [TYPING_KEY]: NOW + 2_000,
+  });
+});
+
+test("ahead agent completion keeps suppression desktop-local", () => {
+  const state = makeState();
+  const aheadCreatedAt = NOW_SECONDS + 60;
+
+  assert.equal(record(state, aheadCreatedAt), true);
+  assert.deepEqual(state.suppressUntilByPubkey, {
+    [TYPING_KEY]: NOW + 2_000,
+  });
+});
+
+test("message older than active typing advances ordering without clearing", () => {
+  const state = makeState();
+
+  assert.equal(
+    record(state, NOW_SECONDS - 60, { typingCreatedAt: NOW_SECONDS }),
+    false,
+  );
+  assert.deepEqual(state.suppressUntilByPubkey, {});
+});
+
+test("watermarks expire by desktop observation time, not agent clock", () => {
+  const state = makeState();
+  record(state, NOW_SECONDS + 60);
+
+  assert.equal(record(state, NOW_SECONDS + 61, { now: NOW + 8_000 }), true);
+  assert.deepEqual(state.latestMessageCreatedAtByPubkey, {
+    [TYPING_KEY]: { createdAt: NOW_SECONDS + 61, observedAt: NOW + 8_000 },
+  });
 });

--- a/desktop/src/features/messages/useChannelTyping.ts
+++ b/desktop/src/features/messages/useChannelTyping.ts
@@ -25,10 +25,62 @@ type TypingEntry = {
   threadHeadId: string | null;
 };
 type TypingState = Record<string, TypingEntry>;
+type TypingCompletionWatermarks = Record<string, number>;
+type TypingSuppressionDeadlines = Record<string, number>;
 
 const TYPING_INDICATOR_TTL_MS = 8_000;
 const TYPING_PRUNE_INTERVAL_MS = 1_000;
 const TYPING_POST_MESSAGE_SUPPRESS_MS = 2_000;
+
+/**
+ * Advance one author + thread completion watermark when it can still affect
+ * an acceptable typing indicator. Returns whether matching typing state should
+ * be cleared. Exported so replay and out-of-order behavior stays unit-tested.
+ */
+export function recordTypingCompletion({
+  createdAt,
+  latestMessageCreatedAtByPubkey,
+  now = Date.now(),
+  suppressUntilByPubkey,
+  typingKey,
+}: {
+  createdAt: number;
+  latestMessageCreatedAtByPubkey: TypingCompletionWatermarks;
+  now?: number;
+  suppressUntilByPubkey: TypingSuppressionDeadlines;
+  typingKey: string;
+}) {
+  for (const [key, watermark] of Object.entries(
+    latestMessageCreatedAtByPubkey,
+  )) {
+    if (watermark * 1_000 + TYPING_INDICATOR_TTL_MS <= now) {
+      delete latestMessageCreatedAtByPubkey[key];
+    }
+  }
+  for (const [key, suppressUntil] of Object.entries(suppressUntilByPubkey)) {
+    if (suppressUntil <= now) {
+      delete suppressUntilByPubkey[key];
+    }
+  }
+
+  if (createdAt * 1_000 + TYPING_INDICATOR_TTL_MS <= now) {
+    return false;
+  }
+
+  const latestMessageCreatedAt = latestMessageCreatedAtByPubkey[typingKey] ?? 0;
+  if (createdAt <= latestMessageCreatedAt) {
+    return false;
+  }
+  latestMessageCreatedAtByPubkey[typingKey] = createdAt;
+
+  const suppressUntil = createdAt * 1_000 + TYPING_POST_MESSAGE_SUPPRESS_MS;
+  if (suppressUntil > now) {
+    suppressUntilByPubkey[typingKey] = suppressUntil;
+  } else {
+    delete suppressUntilByPubkey[typingKey];
+  }
+  return true;
+}
 
 function pruneTypingState(state: TypingState, now = Date.now()) {
   let changed = false;
@@ -78,7 +130,6 @@ export function useChannelTyping(
   const normalizedCurrentPubkey = currentPubkey?.toLowerCase();
   const typingSuppressUntilByPubkeyRef = useRef<Record<string, number>>({});
   const latestMessageCreatedAtByPubkeyRef = useRef<Record<string, number>>({});
-  const processedCompletionEventIdsRef = useRef<Set<string>>(new Set());
 
   const registerTyping = useEffectEvent((event: RelayEvent) => {
     if (!channelId || event.kind !== KIND_TYPING_INDICATOR) {
@@ -137,7 +188,6 @@ export function useChannelTyping(
     setTypingByPubkey({});
     typingSuppressUntilByPubkeyRef.current = {};
     latestMessageCreatedAtByPubkeyRef.current = {};
-    processedCompletionEventIdsRef.current = new Set();
   }, [channelId]);
 
   const clearTypingForMessage = useEffectEvent((event: RelayEvent) => {
@@ -149,11 +199,6 @@ export function useChannelTyping(
       return;
     }
 
-    if (processedCompletionEventIdsRef.current.has(event.id)) {
-      return;
-    }
-    processedCompletionEventIdsRef.current.add(event.id);
-
     const authorPubkey = resolveEventAuthorPubkey({
       event,
       preferActorTag: true,
@@ -162,12 +207,16 @@ export function useChannelTyping(
     }).toLowerCase();
     const threadHeadId = getTypingScopeId(event);
     const typingKey = getTypingStateKey(authorPubkey, threadHeadId);
-    latestMessageCreatedAtByPubkeyRef.current[typingKey] = Math.max(
-      latestMessageCreatedAtByPubkeyRef.current[typingKey] ?? 0,
-      event.created_at,
-    );
-    typingSuppressUntilByPubkeyRef.current[typingKey] =
-      Date.now() + TYPING_POST_MESSAGE_SUPPRESS_MS;
+    const shouldClearTyping = recordTypingCompletion({
+      createdAt: event.created_at,
+      latestMessageCreatedAtByPubkey: latestMessageCreatedAtByPubkeyRef.current,
+      suppressUntilByPubkey: typingSuppressUntilByPubkeyRef.current,
+      typingKey,
+    });
+    if (!shouldClearTyping) {
+      return;
+    }
+
     setTypingByPubkey((current) => {
       const next = pruneTypingState(current);
       if (!(typingKey in next)) {

--- a/desktop/src/features/messages/useChannelTyping.ts
+++ b/desktop/src/features/messages/useChannelTyping.ts
@@ -43,22 +43,20 @@ const TYPING_POST_MESSAGE_SUPPRESS_MS = 2_000;
  * agent's clock domain; retention and suppression use the observing desktop's
  * clock so host skew cannot disable or stretch typing cleanup.
  *
- * Returns whether matching typing state should be cleared. Exported so replay,
- * out-of-order, and clock-skew behavior stays unit-tested.
+ * Returns whether this completion newly advanced the scope watermark. Exported so
+ * replay, out-of-order, and clock-skew behavior stays unit-tested.
  */
 export function recordTypingCompletion({
   createdAt,
   latestMessageCreatedAtByPubkey,
   now = Date.now(),
   suppressUntilByPubkey,
-  typingCreatedAt,
   typingKey,
 }: {
   createdAt: number;
   latestMessageCreatedAtByPubkey: TypingCompletionWatermarks;
   now?: number;
   suppressUntilByPubkey: TypingSuppressionDeadlines;
-  typingCreatedAt?: number;
   typingKey: string;
 }) {
   for (const [key, watermark] of Object.entries(
@@ -80,9 +78,8 @@ export function recordTypingCompletion({
     return false;
   }
   latestMessageCreatedAtByPubkey[typingKey] = { createdAt, observedAt: now };
-  if (typingCreatedAt === undefined || createdAt < typingCreatedAt) {
-    return false;
-  }
+  // Arm even without visible typing: the harness can publish a trailing tick
+  // after its reply, and that tick must not resurrect a completed-turn pill.
   suppressUntilByPubkey[typingKey] = now + TYPING_POST_MESSAGE_SUPPRESS_MS;
   return true;
 }
@@ -101,6 +98,23 @@ function pruneTypingState(state: TypingState, now = Date.now()) {
   }
 
   return changed ? next : state;
+}
+
+export function clearTypingStateForCompletion(
+  state: TypingState,
+  typingKey: string,
+  completionCreatedAt: number,
+  now = Date.now(),
+) {
+  const next = pruneTypingState(state, now);
+  const typingEntry = next[typingKey];
+  if (!typingEntry || completionCreatedAt < typingEntry.createdAt) {
+    return next;
+  }
+
+  const updated = { ...next };
+  delete updated[typingKey];
+  return updated;
 }
 
 function isTypingCompletionEvent(event: RelayEvent | null | undefined) {
@@ -222,27 +236,19 @@ export function useChannelTyping(
     }).toLowerCase();
     const threadHeadId = getTypingScopeId(event);
     const typingKey = getTypingStateKey(authorPubkey, threadHeadId);
-    const shouldClearTyping = recordTypingCompletion({
+    const isNewCompletion = recordTypingCompletion({
       createdAt: event.created_at,
       latestMessageCreatedAtByPubkey: latestMessageCreatedAtByPubkeyRef.current,
       suppressUntilByPubkey: typingSuppressUntilByPubkeyRef.current,
-      typingCreatedAt: typingByPubkey[typingKey]?.createdAt,
       typingKey,
     });
-    if (!shouldClearTyping) {
+    if (!isNewCompletion) {
       return;
     }
 
-    setTypingByPubkey((current) => {
-      const next = pruneTypingState(current);
-      if (!(typingKey in next)) {
-        return next;
-      }
-
-      const updated = { ...next };
-      delete updated[typingKey];
-      return updated;
-    });
+    setTypingByPubkey((current) =>
+      clearTypingStateForCompletion(current, typingKey, event.created_at),
+    );
   });
 
   useEffect(() => {

--- a/desktop/src/features/messages/useChannelTyping.ts
+++ b/desktop/src/features/messages/useChannelTyping.ts
@@ -19,13 +19,18 @@ export type TypingIndicatorEntry = {
 };
 
 type TypingEntry = {
+  createdAt: number;
   expiresAt: number;
   firstSeenAt: number;
   pubkey: string;
   threadHeadId: string | null;
 };
 type TypingState = Record<string, TypingEntry>;
-type TypingCompletionWatermarks = Record<string, number>;
+type TypingCompletionWatermark = {
+  createdAt: number;
+  observedAt: number;
+};
+type TypingCompletionWatermarks = Record<string, TypingCompletionWatermark>;
 type TypingSuppressionDeadlines = Record<string, number>;
 
 const TYPING_INDICATOR_TTL_MS = 8_000;
@@ -33,27 +38,33 @@ const TYPING_PRUNE_INTERVAL_MS = 1_000;
 const TYPING_POST_MESSAGE_SUPPRESS_MS = 2_000;
 
 /**
- * Advance one author + thread completion watermark when it can still affect
- * an acceptable typing indicator. Returns whether matching typing state should
- * be cleared. Exported so replay and out-of-order behavior stays unit-tested.
+ * Advance one author + thread completion watermark and start a desktop-local
+ * suppression window. Event timestamps are used only for ordering within the
+ * agent's clock domain; retention and suppression use the observing desktop's
+ * clock so host skew cannot disable or stretch typing cleanup.
+ *
+ * Returns whether matching typing state should be cleared. Exported so replay,
+ * out-of-order, and clock-skew behavior stays unit-tested.
  */
 export function recordTypingCompletion({
   createdAt,
   latestMessageCreatedAtByPubkey,
   now = Date.now(),
   suppressUntilByPubkey,
+  typingCreatedAt,
   typingKey,
 }: {
   createdAt: number;
   latestMessageCreatedAtByPubkey: TypingCompletionWatermarks;
   now?: number;
   suppressUntilByPubkey: TypingSuppressionDeadlines;
+  typingCreatedAt?: number;
   typingKey: string;
 }) {
   for (const [key, watermark] of Object.entries(
     latestMessageCreatedAtByPubkey,
   )) {
-    if (watermark * 1_000 + TYPING_INDICATOR_TTL_MS <= now) {
+    if (watermark.observedAt + TYPING_INDICATOR_TTL_MS <= now) {
       delete latestMessageCreatedAtByPubkey[key];
     }
   }
@@ -63,22 +74,16 @@ export function recordTypingCompletion({
     }
   }
 
-  if (createdAt * 1_000 + TYPING_INDICATOR_TTL_MS <= now) {
-    return false;
-  }
-
-  const latestMessageCreatedAt = latestMessageCreatedAtByPubkey[typingKey] ?? 0;
+  const latestMessageCreatedAt =
+    latestMessageCreatedAtByPubkey[typingKey]?.createdAt ?? 0;
   if (createdAt <= latestMessageCreatedAt) {
     return false;
   }
-  latestMessageCreatedAtByPubkey[typingKey] = createdAt;
-
-  const suppressUntil = createdAt * 1_000 + TYPING_POST_MESSAGE_SUPPRESS_MS;
-  if (suppressUntil > now) {
-    suppressUntilByPubkey[typingKey] = suppressUntil;
-  } else {
-    delete suppressUntilByPubkey[typingKey];
+  latestMessageCreatedAtByPubkey[typingKey] = { createdAt, observedAt: now };
+  if (typingCreatedAt === undefined || createdAt < typingCreatedAt) {
+    return false;
   }
+  suppressUntilByPubkey[typingKey] = now + TYPING_POST_MESSAGE_SUPPRESS_MS;
   return true;
 }
 
@@ -129,7 +134,9 @@ export function useChannelTyping(
   const [typingByPubkey, setTypingByPubkey] = useState<TypingState>({});
   const normalizedCurrentPubkey = currentPubkey?.toLowerCase();
   const typingSuppressUntilByPubkeyRef = useRef<Record<string, number>>({});
-  const latestMessageCreatedAtByPubkeyRef = useRef<Record<string, number>>({});
+  const latestMessageCreatedAtByPubkeyRef = useRef<TypingCompletionWatermarks>(
+    {},
+  );
 
   const registerTyping = useEffectEvent((event: RelayEvent) => {
     if (!channelId || event.kind !== KIND_TYPING_INDICATOR) {
@@ -162,8 +169,15 @@ export function useChannelTyping(
       delete typingSuppressUntilByPubkeyRef.current[typingKey];
     }
 
+    const watermark = latestMessageCreatedAtByPubkeyRef.current[typingKey];
+    if (
+      watermark?.observedAt &&
+      watermark.observedAt + TYPING_INDICATOR_TTL_MS <= now
+    ) {
+      delete latestMessageCreatedAtByPubkeyRef.current[typingKey];
+    }
     const latestMessageCreatedAt =
-      latestMessageCreatedAtByPubkeyRef.current[typingKey] ?? 0;
+      latestMessageCreatedAtByPubkeyRef.current[typingKey]?.createdAt ?? 0;
     if (event.created_at <= latestMessageCreatedAt) {
       return;
     }
@@ -174,6 +188,7 @@ export function useChannelTyping(
       return {
         ...pruned,
         [typingKey]: {
+          createdAt: event.created_at,
           expiresAt: Math.min(now + TYPING_INDICATOR_TTL_MS, eventExpiresAt),
           firstSeenAt: existing?.firstSeenAt ?? now,
           pubkey: typingPubkey,
@@ -211,6 +226,7 @@ export function useChannelTyping(
       createdAt: event.created_at,
       latestMessageCreatedAtByPubkey: latestMessageCreatedAtByPubkeyRef.current,
       suppressUntilByPubkey: typingSuppressUntilByPubkeyRef.current,
+      typingCreatedAt: typingByPubkey[typingKey]?.createdAt,
       typingKey,
     });
     if (!shouldClearTyping) {

--- a/desktop/src/features/messages/useChannelTyping.ts
+++ b/desktop/src/features/messages/useChannelTyping.ts
@@ -70,6 +70,7 @@ export function useChannelTyping(
   currentPubkey?: string,
   latestMessageEvent?: RelayEvent | null,
   relaySelfPubkey?: string | null,
+  threadReplyEvents: readonly RelayEvent[] = [],
 ) {
   const channelId = channel?.id ?? null;
   const channelType = channel?.channelType ?? null;
@@ -77,6 +78,7 @@ export function useChannelTyping(
   const normalizedCurrentPubkey = currentPubkey?.toLowerCase();
   const typingSuppressUntilByPubkeyRef = useRef<Record<string, number>>({});
   const latestMessageCreatedAtByPubkeyRef = useRef<Record<string, number>>({});
+  const processedCompletionEventIdsRef = useRef<Set<string>>(new Set());
 
   const registerTyping = useEffectEvent((event: RelayEvent) => {
     if (!channelId || event.kind !== KIND_TYPING_INDICATOR) {
@@ -135,32 +137,34 @@ export function useChannelTyping(
     setTypingByPubkey({});
     typingSuppressUntilByPubkeyRef.current = {};
     latestMessageCreatedAtByPubkeyRef.current = {};
+    processedCompletionEventIdsRef.current = new Set();
   }, [channelId]);
 
-  useEffect(() => {
-    if (
-      !channelId ||
-      !latestMessageEvent ||
-      !isTypingCompletionEvent(latestMessageEvent)
-    ) {
+  const clearTypingForMessage = useEffectEvent((event: RelayEvent) => {
+    if (!channelId || !isTypingCompletionEvent(event)) {
       return;
     }
 
-    if (getChannelIdFromTags(latestMessageEvent.tags) !== channelId) {
+    if (getChannelIdFromTags(event.tags) !== channelId) {
       return;
     }
+
+    if (processedCompletionEventIdsRef.current.has(event.id)) {
+      return;
+    }
+    processedCompletionEventIdsRef.current.add(event.id);
 
     const authorPubkey = resolveEventAuthorPubkey({
-      event: latestMessageEvent,
+      event,
       preferActorTag: true,
       relaySelfPubkey,
       requireChannelTagForPTags: true,
     }).toLowerCase();
-    const threadHeadId = getTypingScopeId(latestMessageEvent);
+    const threadHeadId = getTypingScopeId(event);
     const typingKey = getTypingStateKey(authorPubkey, threadHeadId);
     latestMessageCreatedAtByPubkeyRef.current[typingKey] = Math.max(
       latestMessageCreatedAtByPubkeyRef.current[typingKey] ?? 0,
-      latestMessageEvent.created_at,
+      event.created_at,
     );
     typingSuppressUntilByPubkeyRef.current[typingKey] =
       Date.now() + TYPING_POST_MESSAGE_SUPPRESS_MS;
@@ -174,7 +178,19 @@ export function useChannelTyping(
       delete updated[typingKey];
       return updated;
     });
-  }, [channelId, latestMessageEvent, relaySelfPubkey]);
+  });
+
+  useEffect(() => {
+    if (latestMessageEvent) {
+      clearTypingForMessage(latestMessageEvent);
+    }
+  }, [latestMessageEvent]);
+
+  useEffect(() => {
+    for (const event of threadReplyEvents) {
+      clearTypingForMessage(event);
+    }
+  }, [threadReplyEvents]);
 
   useEffect(() => {
     if (!channelId || channelType === "forum") {

--- a/desktop/src/features/profile/lib/lastLiveLabel.test.mjs
+++ b/desktop/src/features/profile/lib/lastLiveLabel.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatLastLiveLabel } from "./lastLiveLabel.ts";
+
+const NOW = Date.parse("2026-07-23T12:00:00.000Z");
+
+test("formatLastLiveLabel reports missing activity", () => {
+  assert.equal(formatLastLiveLabel(null, NOW), "No activity yet");
+});
+
+test("formatLastLiveLabel clamps future timestamps to Just now", () => {
+  assert.equal(formatLastLiveLabel(NOW + 5_000, NOW), "Just now");
+});
+
+test("formatLastLiveLabel buckets by elapsed time", () => {
+  assert.equal(formatLastLiveLabel(NOW - 30 * 1000, NOW), "Just now");
+  assert.equal(formatLastLiveLabel(NOW - 5 * 60 * 1000, NOW), "5m ago");
+  assert.equal(formatLastLiveLabel(NOW - 3 * 60 * 60 * 1000, NOW), "3h ago");
+  assert.equal(
+    formatLastLiveLabel(NOW - 2 * 24 * 60 * 60 * 1000, NOW),
+    "2d ago",
+  );
+  assert.equal(
+    formatLastLiveLabel(NOW - 3 * 7 * 24 * 60 * 60 * 1000, NOW),
+    "3w ago",
+  );
+});

--- a/desktop/src/features/profile/lib/lastLiveLabel.ts
+++ b/desktop/src/features/profile/lib/lastLiveLabel.ts
@@ -1,0 +1,36 @@
+/**
+ * Human-readable recency label for an activity surface's "Last live" pill.
+ * `null` means the agent has never produced observable activity.
+ */
+export function formatLastLiveLabel(
+  timestamp: number | null,
+  now: number,
+): string {
+  if (timestamp === null) {
+    return "No activity yet";
+  }
+
+  const elapsedMs = Math.max(0, now - timestamp);
+  const totalSeconds = Math.floor(elapsedMs / 1000);
+  if (totalSeconds < 60) {
+    return "Just now";
+  }
+
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) {
+    return `${totalMinutes}m ago`;
+  }
+
+  const totalHours = Math.floor(totalMinutes / 60);
+  if (totalHours < 24) {
+    return `${totalHours}h ago`;
+  }
+
+  const totalDays = Math.floor(totalHours / 24);
+  if (totalDays < 7) {
+    return `${totalDays}d ago`;
+  }
+
+  const totalWeeks = Math.floor(totalDays / 7);
+  return `${totalWeeks}w ago`;
+}

--- a/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
@@ -20,6 +20,7 @@ import {
 import type { ActiveTurnSummary } from "@/features/agents/activeAgentTurnsStore";
 import { ManagedAgentSessionPanel } from "@/features/agents/ui/ManagedAgentSessionPanel";
 import type { ProfileActivityAgent } from "@/features/profile/lib/profileActivityAgent";
+import { formatLastLiveLabel } from "@/features/profile/lib/lastLiveLabel";
 import { resolveActivityChannelId } from "@/features/profile/lib/profileActivityCarousel";
 import {
   type ProfileActivityFeedScope,
@@ -649,36 +650,6 @@ function LiveActivityOpenButton({
       {label}
     </Button>
   );
-}
-
-function formatLastLiveLabel(timestamp: number | null, now: number): string {
-  if (timestamp === null) {
-    return "No activity yet";
-  }
-
-  const elapsedMs = Math.max(0, now - timestamp);
-  const totalSeconds = Math.floor(elapsedMs / 1000);
-  if (totalSeconds < 60) {
-    return "Just now";
-  }
-
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  if (totalMinutes < 60) {
-    return `${totalMinutes}m ago`;
-  }
-
-  const totalHours = Math.floor(totalMinutes / 60);
-  if (totalHours < 24) {
-    return `${totalHours}h ago`;
-  }
-
-  const totalDays = Math.floor(totalHours / 24);
-  if (totalDays < 7) {
-    return `${totalDays}d ago`;
-  }
-
-  const totalWeeks = Math.floor(totalDays / 7);
-  return `${totalWeeks}w ago`;
 }
 
 function ArchiveStatusTooltip() {

--- a/desktop/src/features/projects/ui/ProjectConversationPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectConversationPanel.tsx
@@ -280,7 +280,6 @@ export function ProjectConversationPanel({
         threadHead={panelData.threadHead}
         threadReplies={panelData.visibleReplies}
         threadRepliesPending={false}
-        threadTypingPubkeys={[]}
         widthPx={widthPx}
       />,
       {

--- a/desktop/src/shared/styles/globals/animations.css
+++ b/desktop/src/shared/styles/globals/animations.css
@@ -238,6 +238,15 @@
   -webkit-text-fill-color: transparent;
 }
 
+/* Truncated hosts (Tailwind `truncate`): ellipsize the overlay copy the same
+   way as the base text so the highlight sweeps the ellipsis, instead of
+   revealing the clipped characters at the right edge. `white-space: nowrap`
+   is inherited from the host; overflow rules are not, so restate them. */
+.buzz-shimmer.truncate::before {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 @keyframes buzz-shimmer {
   0%,
   100% {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1356,6 +1356,12 @@ declare global {
       channelId: string;
       turnId: string;
       kind?: "turn_started" | "turn_completed";
+      /**
+       * Explicit event timestamp (epoch ms). The composer strip orders pills
+       * by turn START anchor, so tests seed well-separated starts to make
+       * the order deterministic. Defaults to now.
+       */
+      atMs?: number;
     }) => void;
     __BUZZ_E2E_SEED_OBSERVER_EVENTS__?: (input: {
       agentPubkey: string;
@@ -11038,11 +11044,12 @@ export function maybeInstallE2eTauriMocks() {
     channelId,
     turnId,
     kind = "turn_started",
+    atMs,
   }) => {
     seedTurnSeq += 1;
     const event = {
       seq: seedTurnSeq,
-      timestamp: new Date().toISOString(),
+      timestamp: new Date(atMs ?? Date.now()).toISOString(),
       kind,
       agentIndex: 0,
       channelId,

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2160,6 +2160,80 @@ test("shows and clears activity indicators for active channel agents", async ({
   await expect(page.getByTestId("bot-activity-composer-trigger")).toBeVisible();
 });
 
+test("thread agent typing promotes only when activity exists", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
+  await waitForMockLiveSubscription(page, "agents", KIND_TYPING_INDICATOR);
+  await page.waitForFunction(
+    () =>
+      typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function" &&
+      typeof window.__BUZZ_E2E_SEED_OBSERVER_EVENTS__ === "function",
+  );
+
+  const threadHeadId = await page.evaluate(() => {
+    const root = window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "agents",
+      content: "Thread activity partition root",
+    });
+    if (!root) throw new Error("Failed to seed thread root");
+    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "agents",
+      content: "Thread activity partition reply",
+      parentEventId: root.id,
+    });
+    return root.id;
+  });
+  const summary = page.locator(
+    `[data-testid="message-thread-summary"][data-thread-head-id="${threadHeadId}"]`,
+  );
+  await expect(summary).toBeVisible();
+  await summary.click();
+
+  const threadPanel = page.getByTestId("message-thread-panel");
+  await expect(threadPanel).toBeVisible();
+  await page.evaluate(
+    ({ pubkey, threadHeadId }) => {
+      window.__BUZZ_E2E_EMIT_MOCK_TYPING__?.({
+        channelName: "agents",
+        pubkey,
+        threadHeadId,
+      });
+    },
+    { pubkey: TEST_IDENTITIES.alice.pubkey, threadHeadId },
+  );
+
+  // Thread-only typing has no observer-backed session to preview, so it joins
+  // the thread typing group and must not manufacture an interactive pill.
+  await expect(
+    threadPanel.getByTestId("message-typing-indicator-label"),
+  ).toContainText("alice");
+  await expect(
+    threadPanel.getByTestId("bot-activity-composer-trigger"),
+  ).toHaveCount(0);
+
+  // Once channel-scoped observer activity exists, the same thread typer earns
+  // a pill and leaves the combined typing group. The explicit thread typing
+  // set keeps the promoted pill truthfully labeled "is typing…" even though
+  // thread typing is intentionally absent from the channel-wide registry.
+  await seedPillActivityMessage(page, {
+    agentPubkey: TEST_IDENTITIES.alice.pubkey,
+    atMs: Date.now(),
+    seq: Date.now(),
+    text: "Alice: inspecting the thread context",
+    turnId: "thread-indicator-turn",
+  });
+  const pill = threadPanel.getByTestId("bot-activity-composer-trigger");
+  await expect(pill).toBeVisible();
+  await expect(pill).toContainText("alice is typing");
+  await expect(threadPanel.getByTestId("message-typing-indicator")).toHaveCount(
+    0,
+  );
+});
+
 test("composer does not shift when the activity row mounts and clears", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -3158,6 +3158,52 @@ test("typing indicator shows avatars and maintains stable name order", async ({
   ).toContainText("alice and bob are typing");
 });
 
+test("lone typing group uses the full row width instead of truncating at the strip cap", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByTestId("channel-random").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("random");
+  await waitForMockLiveSubscription(page, "random", KIND_TYPING_INDICATOR);
+
+  // Three typers push the label past the strip's shared-slot cap (max-w-64,
+  // 256px): with no pills the typing group is the strip's LONE item and must
+  // consume the row's free width instead of cutting the label off mid-name.
+  for (const identity of [
+    TEST_IDENTITIES.alice,
+    TEST_IDENTITIES.bob,
+    TEST_IDENTITIES.charlie,
+  ]) {
+    await page.evaluate((pubkey) => {
+      window.__BUZZ_E2E_EMIT_MOCK_TYPING__?.({
+        channelName: "random",
+        pubkey,
+      });
+    }, identity.pubkey);
+  }
+
+  const label = page.getByTestId("message-typing-indicator-label");
+  await expect(label).toContainText("alice, bob, and charlie are typing");
+
+  // No truncation with room to spare: the label's content fits its box.
+  await expect
+    .poll(() => label.evaluate((el) => el.scrollWidth - el.clientWidth))
+    .toBeLessThanOrEqual(0);
+
+  // Genuinely narrow, the lone group still shrinks with the container and
+  // ellipsizes (rather than overflowing into scroll under an edge fade).
+  await page
+    .getByTestId("channel-composer-activity-row")
+    .evaluate((element) => {
+      element.style.width = "200px";
+    });
+  await expect
+    .poll(() => label.evaluate((el) => el.scrollWidth - el.clientWidth))
+    .toBeGreaterThan(0);
+  await expect(page.getByTestId("bot-activity-strip-fade-end")).toHaveCount(0);
+});
+
 test("sidebar shows unread indicator for newly active channels", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2115,6 +2115,51 @@ test("shows and clears activity indicators for active channel agents", async ({
   );
 });
 
+test("composer does not shift when the activity row mounts and clears", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
+  await waitForMockLiveSubscription(page, "agents", KIND_TYPING_INDICATOR);
+
+  // The activity row below the composer has a fixed height (h-8.5 in
+  // ChannelComposerActivityRow) so the bottom-anchored composer must not move
+  // when the bot-activity trigger mounts into it or clears from it.
+  const composerBox = async () => {
+    const box = await page.getByTestId("message-composer").boundingBox();
+    if (!box) {
+      throw new Error("Composer is not visible.");
+    }
+    return box;
+  };
+  const idleComposerTop = (await composerBox()).y;
+
+  await page.evaluate((pubkey) => {
+    window.__BUZZ_E2E_EMIT_MOCK_TYPING__?.({
+      channelName: "agents",
+      pubkey,
+    });
+  }, TEST_IDENTITIES.alice.pubkey);
+
+  await expect(page.getByTestId("bot-activity-composer-trigger")).toBeVisible();
+  expect((await composerBox()).y).toBeCloseTo(idleComposerTop, 0);
+
+  await page.evaluate((pubkey) => {
+    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+      channelName: "agents",
+      content: "Done.",
+      pubkey,
+    });
+  }, TEST_IDENTITIES.alice.pubkey);
+
+  await expect(page.getByTestId("bot-activity-composer-trigger")).toHaveCount(
+    0,
+  );
+  expect((await composerBox()).y).toBeCloseTo(idleComposerTop, 0);
+});
+
 test("members sidebar exposes view-activity for a viewer-owned relay agent", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2093,12 +2093,22 @@ test("shows and clears activity indicators for active channel agents", async ({
     atMs: Date.now(),
     seq: Date.now(),
     text: "Alice: indexing the channel history",
+    turnId: "indicator-turn",
   });
 
   const activityPill = page.getByTestId("bot-activity-composer-trigger");
   await expect(activityPill).toBeVisible();
-  await expect(activityPill).not.toContainText("View activity");
+  await expect(activityPill).toContainText("indexing the channel history");
   await expect(page.getByTestId("message-typing-indicator")).toHaveCount(0);
+  // The harness refreshes typing throughout the turn. Observer activity must
+  // remain authoritative instead of regressing the pill to "is typing…".
+  await page.evaluate((pubkey) => {
+    window.__BUZZ_E2E_EMIT_MOCK_TYPING__?.({
+      channelName: "agents",
+      pubkey,
+    });
+  }, TEST_IDENTITIES.alice.pubkey);
+  await expect(activityPill).toContainText("indexing the channel history");
   // Hovering the pill opens the live-activity preview.
   await activityPill.hover();
   await expect(page.getByTestId("composer-live-activity-feed")).toBeVisible();
@@ -2122,8 +2132,8 @@ test("shows and clears activity indicators for active channel agents", async ({
   await page.keyboard.press("Escape");
   await expect(page.getByTestId("message-typing-indicator")).toHaveCount(0);
 
-  // Completing the turn clears the pill; the agent's finished message lands
-  // in the timeline as usual.
+  // Completion makes raw typing the fallback again until the final message
+  // clears it.
   await page.evaluate(
     ({ channelId, pubkey }) => {
       window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
@@ -2132,13 +2142,20 @@ test("shows and clears activity indicators for active channel agents", async ({
         turnId: "indicator-turn",
         kind: "turn_completed",
       });
+    },
+    { channelId: AGENTS_CHANNEL_ID, pubkey: TEST_IDENTITIES.alice.pubkey },
+  );
+  await expect(activityPill).toContainText("alice is typing");
+
+  await page.evaluate(
+    ({ pubkey }) => {
       window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
         channelName: "agents",
         content: "Done.",
         pubkey,
       });
     },
-    { channelId: AGENTS_CHANNEL_ID, pubkey: TEST_IDENTITIES.alice.pubkey },
+    { pubkey: TEST_IDENTITIES.alice.pubkey },
   );
 
   await expect(page.getByTestId("message-timeline")).toContainText("Done.");
@@ -2171,7 +2188,8 @@ test("thread agent typing promotes only when activity exists", async ({
   await page.waitForFunction(
     () =>
       typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function" &&
-      typeof window.__BUZZ_E2E_SEED_OBSERVER_EVENTS__ === "function",
+      typeof window.__BUZZ_E2E_SEED_OBSERVER_EVENTS__ === "function" &&
+      typeof window.__BUZZ_E2E_SEED_ACTIVE_TURNS__ === "function",
   );
 
   const threadHeadId = await page.evaluate(() => {
@@ -2216,9 +2234,18 @@ test("thread agent typing promotes only when activity exists", async ({
   ).toHaveCount(0);
 
   // Once channel-scoped observer activity exists, the same thread typer earns
-  // a pill and leaves the combined typing group. The explicit thread typing
-  // set keeps the promoted pill truthfully labeled "is typing…" even though
-  // thread typing is intentionally absent from the channel-wide registry.
+  // a pill and leaves the combined typing group. Active observer work remains
+  // authoritative over the concurrent thread typing signal.
+  await page.evaluate(
+    ({ channelId, pubkey }) => {
+      window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+        agentPubkey: pubkey,
+        channelId,
+        turnId: "thread-indicator-turn",
+      });
+    },
+    { channelId: AGENTS_CHANNEL_ID, pubkey: TEST_IDENTITIES.alice.pubkey },
+  );
   await seedPillActivityMessage(page, {
     agentPubkey: TEST_IDENTITIES.alice.pubkey,
     atMs: Date.now(),
@@ -2228,10 +2255,51 @@ test("thread agent typing promotes only when activity exists", async ({
   });
   const pill = threadPanel.getByTestId("bot-activity-composer-trigger");
   await expect(pill).toBeVisible();
-  await expect(pill).toContainText("alice is typing");
+  await expect(pill).toContainText("inspecting the thread context");
   await expect(threadPanel.getByTestId("message-typing-indicator")).toHaveCount(
     0,
   );
+  // A later typing refresh still cannot mask the live action.
+  await page.evaluate(
+    ({ pubkey, threadHeadId }) => {
+      window.__BUZZ_E2E_EMIT_MOCK_TYPING__?.({
+        channelName: "agents",
+        pubkey,
+        threadHeadId,
+      });
+    },
+    { pubkey: TEST_IDENTITIES.alice.pubkey, threadHeadId },
+  );
+  await expect(pill).toContainText("inspecting the thread context");
+
+  // Once the observer turn completes, thread typing becomes the fallback and
+  // the eventual reply clears the pill in the same scope.
+  await page.evaluate(
+    ({ channelId, pubkey }) => {
+      window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+        agentPubkey: pubkey,
+        channelId,
+        turnId: "thread-indicator-turn",
+        kind: "turn_completed",
+      });
+    },
+    { channelId: AGENTS_CHANNEL_ID, pubkey: TEST_IDENTITIES.alice.pubkey },
+  );
+  await expect(pill).toContainText("alice is typing");
+  await page.evaluate(
+    ({ pubkey, threadHeadId }) => {
+      window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "agents",
+        content: "Thread done.",
+        parentEventId: threadHeadId,
+        pubkey,
+      });
+    },
+    { pubkey: TEST_IDENTITIES.alice.pubkey, threadHeadId },
+  );
+  await expect(
+    threadPanel.getByTestId("bot-activity-composer-trigger"),
+  ).toHaveCount(0);
 });
 
 test("composer does not shift when the activity row mounts and clears", async ({

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2158,6 +2158,261 @@ test("composer does not shift when the activity row mounts and clears", async ({
   expect((await composerBox()).y).toBeCloseTo(idleComposerTop, 0);
 });
 
+// ── Composer pill hover freeze ───────────────────────────────────────────────
+// Working pills reorder most-recently-active-first. While the cursor is
+// anywhere over the activity bar OR a hover card is showing, the strip must
+// not move under the cursor: pill order, membership, and widths are frozen,
+// and the queued reorder applies (animated) only after the hold releases
+// (BotActivityBar strip-level hover popover + bar-hover freeze).
+
+const PILL_AGENT_NOVA = "cc".repeat(32);
+const PILL_AGENT_ASTRA = "dd".repeat(32);
+const PILL_AGENT_SEEDS = [
+  {
+    pubkey: PILL_AGENT_NOVA,
+    name: "nova",
+    status: "running" as const,
+    channelNames: ["agents"],
+  },
+  {
+    pubkey: PILL_AGENT_ASTRA,
+    name: "astra",
+    status: "running" as const,
+    channelNames: ["agents"],
+  },
+];
+
+/**
+ * Seed one channel-scoped assistant-message observer event. Its transcript
+ * timestamp drives the strip's most-recent-first pill order, so tests pass
+ * explicit future `atMs` stamps to make the order deterministic.
+ */
+async function seedPillActivityMessage(
+  page: import("@playwright/test").Page,
+  input: { agentPubkey: string; atMs: number; seq: number; text: string },
+) {
+  await page.evaluate(
+    ({ agentPubkey, atMs, channelId, seq, text }) => {
+      const sessionId = `seed-session-${agentPubkey.slice(0, 6)}`;
+      window.__BUZZ_E2E_SEED_OBSERVER_EVENTS__?.({
+        agentPubkey,
+        events: [
+          {
+            seq,
+            timestamp: new Date(atMs).toISOString(),
+            kind: "acp_read",
+            agentIndex: 0,
+            channelId,
+            sessionId,
+            turnId: `seed-turn-${agentPubkey.slice(0, 6)}`,
+            payload: {
+              jsonrpc: "2.0",
+              method: "session/update",
+              params: {
+                sessionId,
+                update: {
+                  sessionUpdate: "agent_message_chunk",
+                  messageId: `seed-msg-${agentPubkey.slice(0, 6)}-${seq}`,
+                  content: { type: "text", text },
+                },
+              },
+            },
+          },
+        ],
+      });
+    },
+    { ...input, channelId: AGENTS_CHANNEL_ID },
+  );
+}
+
+/**
+ * Open #agents with two seeded working agents. Activity messages stamp nova
+ * as most recent, so the strip renders [nova, astra]. Returns the shared
+ * trigger locator and the timestamp base used for the seeds.
+ */
+async function openAgentsChannelWithTwoWorkingPills(
+  page: import("@playwright/test").Page,
+) {
+  await page.goto("/");
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_SEED_ACTIVE_TURNS__ === "function",
+    null,
+    { timeout: 10_000 },
+  );
+
+  const baseMs = Date.now();
+  await page.evaluate(
+    ({ agents, channelId }) => {
+      for (const [index, agentPubkey] of agents.entries()) {
+        window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+          agentPubkey,
+          channelId,
+          turnId: `pill-turn-${index}`,
+        });
+      }
+    },
+    {
+      agents: [PILL_AGENT_ASTRA, PILL_AGENT_NOVA],
+      channelId: AGENTS_CHANNEL_ID,
+    },
+  );
+  // Future-stamped messages outrank the just-seeded turn events regardless
+  // of turn-seed timing: nova (+2s) newest, astra (+1s) second.
+  await seedPillActivityMessage(page, {
+    agentPubkey: PILL_AGENT_ASTRA,
+    atMs: baseMs + 1_000,
+    seq: baseMs + 10_001,
+    text: "Astra: reviewing the composer wiring",
+  });
+  await seedPillActivityMessage(page, {
+    agentPubkey: PILL_AGENT_NOVA,
+    atMs: baseMs + 2_000,
+    seq: baseMs + 10_002,
+    text: "Nova: tracing the observer store",
+  });
+
+  const triggers = page.getByTestId("bot-activity-composer-trigger");
+  await expect(triggers).toHaveCount(2);
+  await expect(triggers.first()).toHaveAttribute(
+    "aria-label",
+    "nova is working. View activity.",
+  );
+  return { baseMs, triggers };
+}
+
+test("hover card freezes pill order; queued reorder applies on close", async ({
+  page,
+}) => {
+  await installMockBridge(page, { managedAgents: PILL_AGENT_SEEDS });
+  const { baseMs, triggers } = await openAgentsChannelWithTwoWorkingPills(page);
+
+  const astraPill = page.getByRole("button", {
+    name: "astra is working. View activity.",
+  });
+  await astraPill.hover();
+  const feed = page.getByTestId("composer-live-activity-feed");
+  await expect(feed).toBeVisible();
+  await expect(page.getByTestId("composer-live-activity-open")).toHaveAttribute(
+    "aria-label",
+    /^Open astra's full activity/,
+  );
+  const heldBox = await astraPill.boundingBox();
+  if (!heldBox) {
+    throw new Error("Hovered pill is not visible.");
+  }
+
+  // Newest activity for astra would move her pill to the front — but a hover
+  // card is showing, so the strip must not move. The dwell covers the close
+  // grace (180ms) plus the reorder spring (0.9s) that would have played.
+  await seedPillActivityMessage(page, {
+    agentPubkey: PILL_AGENT_ASTRA,
+    atMs: baseMs + 5_000,
+    seq: baseMs + 10_003,
+    text: "Astra: verifying the turn-resurrection path",
+  });
+  await page.waitForTimeout(1_200);
+  await expect(feed).toBeVisible();
+  await expect(triggers.first()).toHaveAttribute(
+    "aria-label",
+    "nova is working. View activity.",
+  );
+  const stillHeldBox = await astraPill.boundingBox();
+  if (!stillHeldBox) {
+    throw new Error("Hovered pill is not visible after the reorder attempt.");
+  }
+  // Frozen order + pinned width: the hovered pill's slot and size held even
+  // though its label swapped to the new (longer) message text.
+  expect(stillHeldBox.x).toBeCloseTo(heldBox.x, 0);
+  expect(stillHeldBox.width).toBeCloseTo(heldBox.width, 0);
+
+  // Release the hover: the card closes and the queued reorder applies.
+  await page.getByTestId("chat-title").hover();
+  await expect(feed).toBeHidden();
+  await expect(triggers.first()).toHaveAttribute(
+    "aria-label",
+    "astra is working. View activity.",
+  );
+});
+
+test("hovering the bar itself freezes pill order without opening a card", async ({
+  page,
+}) => {
+  await installMockBridge(page, { managedAgents: PILL_AGENT_SEEDS });
+  const { baseMs, triggers } = await openAgentsChannelWithTwoWorkingPills(page);
+
+  // Park the cursor on the bar's empty right side — over the strip, not a
+  // pill. This alone must engage the freeze; no card opens.
+  const strip = page.getByTestId("bot-activity-strip");
+  const stripBox = await strip.boundingBox();
+  if (!stripBox) {
+    throw new Error("Activity strip is not visible.");
+  }
+  await strip.hover({
+    position: { x: stripBox.width - 8, y: stripBox.height / 2 },
+  });
+  await page.waitForTimeout(400);
+  await expect(page.getByTestId("composer-live-activity-feed")).toBeHidden();
+
+  // Newest activity for astra would move her pill to the front — but the
+  // cursor is over the bar, so the order stays frozen.
+  await seedPillActivityMessage(page, {
+    agentPubkey: PILL_AGENT_ASTRA,
+    atMs: baseMs + 5_000,
+    seq: baseMs + 10_003,
+    text: "Astra: verifying the turn-resurrection path",
+  });
+  await page.waitForTimeout(1_200);
+  await expect(triggers.first()).toHaveAttribute(
+    "aria-label",
+    "nova is working. View activity.",
+  );
+
+  // Leaving the bar releases the hold: the queued reorder applies.
+  await page.getByTestId("chat-title").hover();
+  await expect(triggers.first()).toHaveAttribute(
+    "aria-label",
+    "astra is working. View activity.",
+  );
+});
+
+test("hovering across pills switches a single live-activity card", async ({
+  page,
+}) => {
+  await installMockBridge(page, { managedAgents: PILL_AGENT_SEEDS });
+  await openAgentsChannelWithTwoWorkingPills(page);
+
+  const novaPill = page.getByRole("button", {
+    name: "nova is working. View activity.",
+  });
+  const astraPill = page.getByRole("button", {
+    name: "astra is working. View activity.",
+  });
+  const feed = page.getByTestId("composer-live-activity-feed");
+  const openOverlay = page.getByTestId("composer-live-activity-open");
+
+  await novaPill.hover();
+  await expect(feed).toBeVisible();
+  await expect(openOverlay).toHaveAttribute(
+    "aria-label",
+    /^Open nova's full activity/,
+  );
+
+  // Traveling to the other pill swaps the card immediately — one card, no
+  // double-open, no stuck card from the old pill's close timer. Wait for the
+  // old card's ~150ms exit animation with retrying count assertions first;
+  // attribute assertions would hit a non-retrying strict-mode violation
+  // while both cards are briefly mounted.
+  await astraPill.hover();
+  await expect(openOverlay).toHaveCount(1);
+  await expect(feed).toHaveCount(1);
+  await expect(openOverlay).toHaveAttribute(
+    "aria-label",
+    /^Open astra's full activity/,
+  );
+});
+
 test("members sidebar exposes view-activity for a viewer-owned relay agent", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2063,8 +2063,7 @@ test("shows and clears activity indicators for active channel agents", async ({
   const activityPill = page.getByTestId("bot-activity-composer-trigger");
   await expect(activityPill).toBeVisible();
   await expect(activityPill).not.toContainText("View activity");
-  // E2E seeds every preview feature on, so the composerLiveActivity path is
-  // what renders here: hovering the pill opens the live-activity preview.
+  // Hovering the pill opens the live-activity preview.
   await activityPill.hover();
   await expect(page.getByTestId("composer-live-activity-feed")).toBeVisible();
   // Clicking the pill promotes the agent's runtime into the aux panel.
@@ -2410,6 +2409,98 @@ test("hovering across pills switches a single live-activity card", async ({
   await expect(openOverlay).toHaveAttribute(
     "aria-label",
     /^Open astra's full activity/,
+  );
+});
+
+test("narrow strip scrolls horizontally with edge fades instead of compressing pills", async ({
+  page,
+}) => {
+  await installMockBridge(page, { managedAgents: PILL_AGENT_SEEDS });
+  await openAgentsChannelWithTwoWorkingPills(page);
+
+  // Constrain the activity row directly (instead of resizing the whole
+  // window) so the overflow condition is deterministic regardless of the
+  // app's responsive layout — this mirrors a narrow thread panel, where the
+  // same strip renders in the thread composer toolbar.
+  await page
+    .getByTestId("channel-composer-activity-row")
+    .evaluate((element) => {
+      element.style.width = "300px";
+    });
+
+  const scroller = page.getByTestId("bot-activity-strip-scroller");
+  await expect
+    .poll(() => scroller.evaluate((el) => el.scrollWidth - el.clientWidth))
+    .toBeGreaterThan(0);
+
+  // Pills keep a readable natural width instead of compressing into
+  // slivers to fit.
+  const triggers = page.getByTestId("bot-activity-composer-trigger");
+  const firstBox = await triggers.first().boundingBox();
+  expect(firstBox?.width ?? 0).toBeGreaterThan(120);
+
+  // At rest the strip is pinned to the start: clipped content (and its
+  // fade affordance) on the trailing side only.
+  await expect(page.getByTestId("bot-activity-strip-fade-end")).toBeVisible();
+  await expect(page.getByTestId("bot-activity-strip-fade-start")).toHaveCount(
+    0,
+  );
+
+  // Scrolling to the far end swaps the fades to the leading side.
+  await scroller.evaluate((el) => {
+    el.scrollLeft = el.scrollWidth;
+  });
+  await expect(page.getByTestId("bot-activity-strip-fade-start")).toBeVisible();
+  await expect(page.getByTestId("bot-activity-strip-fade-end")).toHaveCount(0);
+});
+
+test("lone pill shrinks to fit a narrow container without scroll fades", async ({
+  page,
+}) => {
+  await installMockBridge(page, { managedAgents: PILL_AGENT_SEEDS });
+  await page.goto("/");
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_SEED_ACTIVE_TURNS__ === "function",
+    null,
+    { timeout: 10_000 },
+  );
+  await page.evaluate(
+    ({ agentPubkey, channelId }) => {
+      window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+        agentPubkey,
+        channelId,
+        turnId: "lone-pill-turn",
+      });
+    },
+    { agentPubkey: PILL_AGENT_NOVA, channelId: AGENTS_CHANNEL_ID },
+  );
+
+  const trigger = page.getByTestId("bot-activity-composer-trigger");
+  await expect(trigger).toHaveCount(1);
+
+  // Narrower than the pill's natural width: a lone pill must shrink and
+  // ellipsize rather than overflow into scroll — an edge fade over a single
+  // pill reads as a cut-off bug, not a "more pills off view" affordance.
+  const row = page.getByTestId("channel-composer-activity-row");
+  await row.evaluate((element) => {
+    element.style.width = "160px";
+  });
+
+  const scroller = page.getByTestId("bot-activity-strip-scroller");
+  await expect
+    .poll(() => scroller.evaluate((el) => el.scrollWidth - el.clientWidth))
+    .toBe(0);
+  await expect(page.getByTestId("bot-activity-strip-fade-end")).toHaveCount(0);
+  await expect(page.getByTestId("bot-activity-strip-fade-start")).toHaveCount(
+    0,
+  );
+
+  const pillBox = await trigger.boundingBox();
+  const rowBox = await row.boundingBox();
+  expect(pillBox?.width ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(
+    rowBox?.width ?? 0,
   );
 });
 

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2895,21 +2895,24 @@ test("narrow strip scrolls horizontally with edge fades instead of compressing p
     0,
   );
 
-  // The fade sits at the CONTAINER's visual edge, not at the row's padded
-  // content box: the full-bleed viewport cancels the row's px-5 gutter, so
-  // pills scroll all the way under a gradient pinned to the row's border
-  // box instead of getting cut mid-row with a dead gutter after the fade.
+  // The fade sits at the STRIP's visual edge, not at its padded content box:
+  // the full-bleed viewport cancels the strip's px-5 gutter, so pills scroll
+  // under the gradient instead of getting cut mid-strip with a dead gutter.
+  // Main's shared channel accessory intentionally adds a separate pl-2 host
+  // inset, so the strip's leading edge is not the outer row's leading edge.
   const rowBox = await page
     .getByTestId("channel-composer-activity-row")
     .boundingBox();
+  const stripBox = await page.getByTestId("bot-activity-strip").boundingBox();
   const fadeEndBox = await page
     .getByTestId("bot-activity-strip-fade-end")
     .boundingBox();
   expect(fadeEndBox).not.toBeNull();
   expect(rowBox).not.toBeNull();
-  if (fadeEndBox && rowBox) {
+  expect(stripBox).not.toBeNull();
+  if (fadeEndBox && stripBox) {
     expect(
-      Math.abs(fadeEndBox.x + fadeEndBox.width - (rowBox.x + rowBox.width)),
+      Math.abs(fadeEndBox.x + fadeEndBox.width - (stripBox.x + stripBox.width)),
     ).toBeLessThanOrEqual(1);
   }
 
@@ -2920,13 +2923,13 @@ test("narrow strip scrolls horizontally with edge fades instead of compressing p
   await expect(page.getByTestId("bot-activity-strip-fade-start")).toBeVisible();
   await expect(page.getByTestId("bot-activity-strip-fade-end")).toHaveCount(0);
 
-  // Same pinning on the leading edge once scrolled.
+  // Same pinning on the strip's leading edge once scrolled.
   const fadeStartBox = await page
     .getByTestId("bot-activity-strip-fade-start")
     .boundingBox();
   expect(fadeStartBox).not.toBeNull();
-  if (fadeStartBox && rowBox) {
-    expect(Math.abs(fadeStartBox.x - rowBox.x)).toBeLessThanOrEqual(1);
+  if (fadeStartBox && stripBox) {
+    expect(Math.abs(fadeStartBox.x - stripBox.x)).toBeLessThanOrEqual(1);
   }
 });
 

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2060,19 +2060,15 @@ test("shows and clears activity indicators for active channel agents", async ({
     });
   }, TEST_IDENTITIES.alice.pubkey);
 
-  await expect(page.getByTestId("bot-activity-composer-trigger")).toBeVisible();
-  await expect(
-    page.getByTestId("bot-activity-composer-trigger"),
-  ).not.toContainText("View activity");
-  // Hovering the pill opens the preview popover with the activity item.
-  await page.getByTestId("bot-activity-composer-trigger").hover();
-  const aliceActivityItem = page.getByTestId(
-    `bot-activity-composer-item-${TEST_IDENTITIES.alice.pubkey}`,
-  );
-  await expect(aliceActivityItem).toBeVisible();
-  await expect(aliceActivityItem).toContainText("View activity");
-  // Clicking the pill itself opens the agent's runtime in the aux panel.
-  await page.getByTestId("bot-activity-composer-trigger").click();
+  const activityPill = page.getByTestId("bot-activity-composer-trigger");
+  await expect(activityPill).toBeVisible();
+  await expect(activityPill).not.toContainText("View activity");
+  // E2E seeds every preview feature on, so the composerLiveActivity path is
+  // what renders here: hovering the pill opens the live-activity preview.
+  await activityPill.hover();
+  await expect(page.getByTestId("composer-live-activity-feed")).toBeVisible();
+  // Clicking the pill promotes the agent's runtime into the aux panel.
+  await activityPill.click();
   await expect(page.getByTestId("agent-session-thread-panel")).toBeVisible();
   await expect(page.getByTestId("agent-session-thread-panel")).toContainText(
     "alice",

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2064,13 +2064,15 @@ test("shows and clears activity indicators for active channel agents", async ({
   await expect(
     page.getByTestId("bot-activity-composer-trigger"),
   ).not.toContainText("View activity");
-  await page.getByTestId("bot-activity-composer-trigger").click();
+  // Hovering the pill opens the preview popover with the activity item.
+  await page.getByTestId("bot-activity-composer-trigger").hover();
   const aliceActivityItem = page.getByTestId(
     `bot-activity-composer-item-${TEST_IDENTITIES.alice.pubkey}`,
   );
   await expect(aliceActivityItem).toBeVisible();
   await expect(aliceActivityItem).toContainText("View activity");
-  await aliceActivityItem.click({ force: true });
+  // Clicking the pill itself opens the agent's runtime in the aux panel.
+  await page.getByTestId("bot-activity-composer-trigger").click();
   await expect(page.getByTestId("agent-session-thread-panel")).toBeVisible();
   await expect(page.getByTestId("agent-session-thread-panel")).toContainText(
     "alice",

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2233,11 +2233,15 @@ test("composer does not shift when the activity row mounts and clears", async ({
 // Working pills hold a stable turn-start order (earliest worker left-most);
 // slots only change when MEMBERSHIP does — an agent starting work appends a
 // pill on the right, a finishing agent's pill exits. While the cursor is
-// anywhere over the activity bar OR a hover card is showing, even those
-// changes must not move the strip under the cursor: pill order, membership,
-// and widths are frozen, and the queued membership change applies (animated)
-// only after the hold releases (BotActivityBar strip-level hover popover +
-// bar-hover freeze).
+// anywhere over the activity bar OR a hover card is showing, membership is
+// frozen so an exit/enter can't slide the strip under the cursor; the queued
+// membership change applies (animated) only after the hold releases. Width
+// pinning is narrower — placement-aware: the hover card is anchored to its
+// pill's LEFT edge (side="top" align="start"), so only the anchor pill and
+// the pills left of it pin their widths, and only while a card is open.
+// Pills right of the anchor — and every pill when no card is open — resize
+// freely with their label swaps (BotActivityBar strip-level hover popover +
+// bar-hover membership hold).
 
 const PILL_AGENT_NOVA = "cc".repeat(32);
 const PILL_AGENT_ASTRA = "dd".repeat(32);
@@ -2318,6 +2322,30 @@ async function seedPillActivityMessage(
 }
 
 /**
+ * Wait until every pill trigger's box holds still across a 150ms window.
+ * Label swaps resize the pills (widths are no longer pinned on bar hover)
+ * and the growth animates via the slot layout spring, so tests must not
+ * measure geometry — or park the cursor relative to it — mid-animation.
+ */
+async function waitForSettledPillBoxes(
+  page: import("@playwright/test").Page,
+  triggers: import("@playwright/test").Locator,
+) {
+  await expect(async () => {
+    const count = await triggers.count();
+    const measure = () =>
+      Promise.all(
+        Array.from({ length: count }, (_, index) =>
+          triggers.nth(index).boundingBox(),
+        ),
+      );
+    const before = await measure();
+    await page.waitForTimeout(150);
+    expect(await measure()).toEqual(before);
+  }).toPass();
+}
+
+/**
  * Open #agents with two seeded working agents. Pill order follows turn
  * START anchors (earliest worker left-most): nova's turn starts 60s before
  * base and astra's 30s before, so the strip renders [nova, astra] — well
@@ -2384,6 +2412,17 @@ async function openAgentsChannelWithTwoWorkingPills(
     "aria-label",
     "nova is working. View activity.",
   );
+  // The pills mount with the generic "<name> is working…" label and GROW
+  // when the seeded headlines tick in. Wait for the swap and for the boxes
+  // to settle so callers measure — and park the cursor against — final
+  // geometry, not a strip that is still expanding rightward.
+  await expect(triggers.first()).toContainText(
+    "Nova: tracing the observer store",
+  );
+  await expect(triggers.nth(1)).toContainText(
+    "Astra: reviewing the composer wiring",
+  );
+  await waitForSettledPillBoxes(page, triggers);
   return { baseMs, triggers };
 }
 
@@ -2476,22 +2515,32 @@ test("hovering the bar itself freezes pill membership without opening a card", a
   await installMockBridge(page, { managedAgents: PILL_AGENT_SEEDS });
   const { baseMs, triggers } = await openAgentsChannelWithTwoWorkingPills(page);
 
-  // Park the cursor in the gap between the two pills — over the strip, not a
-  // pill trigger. The strip sizes to its content, so there is no reliable
-  // "empty right side"; the inter-pill gap is the one spot guaranteed to be
-  // strip-not-pill. This alone must engage the freeze; no card opens.
+  // Park the cursor on the strip past the last pill — over the bar, not a
+  // pill trigger. The strip root is a flex-1 row item, so the space right of
+  // the pills is strip-not-pill. Widths are no longer pinned on bar hover,
+  // so the inter-pill gap is unsafe: a label swap growing the left pill
+  // would push the trigger under a cursor parked there and open a card.
+  // This alone must engage the membership freeze; no card opens.
   const novaBox = await triggers.first().boundingBox();
   const astraBox = await triggers.nth(1).boundingBox();
   if (!novaBox || !astraBox) {
     throw new Error("Both pills must be visible.");
   }
   await page.mouse.move(
-    (novaBox.x + novaBox.width + astraBox.x) / 2,
+    astraBox.x + astraBox.width + 60,
     novaBox.y + novaBox.height / 2,
   );
-  // The bar hold pins every pill's width via an inline style — waiting for
-  // it proves the freeze is engaged before the membership change below.
-  await expect(triggers.first()).toHaveAttribute("style", /width/);
+  // Bar hover alone no longer pins pill widths (the pin is placement-aware
+  // and engages only for pills at/left of an OPEN card's anchor) — the strip
+  // exposes the membership hold via data-hold; waiting for it proves the
+  // freeze is engaged before the membership change below.
+  await expect(page.getByTestId("bot-activity-strip")).toHaveAttribute(
+    "data-hold",
+    "true",
+  );
+  // No card is open, so no pill is width-pinned.
+  await expect(triggers.first()).not.toHaveAttribute("style", /width/);
+  await expect(triggers.nth(1)).not.toHaveAttribute("style", /width/);
   await expect(page.getByTestId("composer-live-activity-feed")).toHaveCount(0);
 
   // Astra's turn completes — her pill would exit, sliding the strip under
@@ -2539,6 +2588,99 @@ test("hovering the bar itself freezes pill membership without opening a card", a
     "aria-label",
     "nova is working. View activity.",
   );
+});
+
+test("open card pins only its anchor pill and the pills left of it", async ({
+  page,
+}) => {
+  await installMockBridge(page, { managedAgents: PILL_AGENT_SEEDS });
+  const { baseMs, triggers } = await openAgentsChannelWithTwoWorkingPills(page);
+
+  const novaPill = page.getByRole("button", {
+    name: "nova is working. View activity.",
+  });
+  const astraPill = page.getByRole("button", {
+    name: "astra is working. View activity.",
+  });
+  const feed = page.getByTestId("composer-live-activity-feed");
+
+  // Give astra a SHORT label first so the long label seeded mid-hover below
+  // grows her pill by a measurable amount (the helper's default label may
+  // already sit near the pill's max-width cap).
+  await seedPillActivityMessage(page, {
+    agentPubkey: PILL_AGENT_ASTRA,
+    atMs: baseMs + 3_000,
+    seq: baseMs + 10_003,
+    text: "Astra: ok",
+    turnId: "pill-turn-astra",
+  });
+  await expect(astraPill).toContainText("Astra: ok");
+  // The shrink animates via the slot layout spring — settle before
+  // measuring baseline geometry.
+  await waitForSettledPillBoxes(page, triggers);
+
+  // Card on the FIRST pill: the card anchors to nova's left edge, so astra
+  // (right of the anchor) stays free to resize — her growth cannot move it.
+  await novaPill.hover();
+  await expect(feed).toBeVisible();
+  // Only the anchor pill carries the inline width pin.
+  await expect(novaPill).toHaveAttribute("style", /width/);
+  await expect(astraPill).not.toHaveAttribute("style", /width/);
+  const novaBox = await novaPill.boundingBox();
+  const astraBox = await astraPill.boundingBox();
+  const feedBox = await feed.boundingBox();
+  if (!novaBox || !astraBox || !feedBox) {
+    throw new Error("Both pills and the card must be visible.");
+  }
+
+  await seedPillActivityMessage(page, {
+    agentPubkey: PILL_AGENT_ASTRA,
+    atMs: baseMs + 4_000,
+    seq: baseMs + 10_004,
+    text: "Astra: expanding into a much longer running action label",
+    turnId: "pill-turn-astra",
+  });
+  await expect(astraPill).toContainText("much longer running action");
+  // Astra's pill grew with the label swap (no pin right of the anchor)...
+  await expect
+    .poll(async () => (await astraPill.boundingBox())?.width ?? 0)
+    .toBeGreaterThan(astraBox.width + 4);
+  // ...while the anchor pill and its open card never moved. The card gets a
+  // 2px tolerance: Radix's popper re-measures on content changes and lands
+  // with sub-pixel rounding jitter that toBeCloseTo(…, 0) would flag.
+  const novaAfter = await novaPill.boundingBox();
+  const feedAfter = await feed.boundingBox();
+  expect(novaAfter?.x).toBeCloseTo(novaBox.x, 0);
+  expect(novaAfter?.width).toBeCloseTo(novaBox.width, 0);
+  expect(Math.abs((feedAfter?.x ?? Number.NaN) - feedBox.x)).toBeLessThan(2);
+  expect(Math.abs((feedAfter?.y ?? Number.NaN) - feedBox.y)).toBeLessThan(2);
+
+  // Inverse: a card on the SECOND pill pins the pill left of the anchor —
+  // nova resizing would shift astra's left edge and drag the card with it.
+  await page.getByTestId("chat-title").hover();
+  await expect(feed).toBeHidden();
+  await astraPill.hover();
+  await expect(feed).toBeVisible();
+  await expect(novaPill).toHaveAttribute("style", /width/);
+  await expect(astraPill).toHaveAttribute("style", /width/);
+  const novaPinned = await novaPill.boundingBox();
+  if (!novaPinned) {
+    throw new Error("Nova's pill must be visible.");
+  }
+  await seedPillActivityMessage(page, {
+    agentPubkey: PILL_AGENT_NOVA,
+    atMs: baseMs + 5_000,
+    seq: baseMs + 10_005,
+    text: "Nova: ok",
+    turnId: "pill-turn-nova",
+  });
+  await expect(novaPill).toContainText("Nova: ok");
+  // The shorter label swapped in but truncates inside the FROZEN width —
+  // the pill can't shrink and shift the card's anchor.
+  const novaHeld = await novaPill.boundingBox();
+  expect(novaHeld?.x).toBeCloseTo(novaPinned.x, 0);
+  expect(novaHeld?.width).toBeCloseTo(novaPinned.width, 0);
+  await expect(feed).toBeVisible();
 });
 
 test("hovering across pills switches a single live-activity card", async ({

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2531,12 +2531,39 @@ test("narrow strip scrolls horizontally with edge fades instead of compressing p
     0,
   );
 
+  // The fade sits at the CONTAINER's visual edge, not at the row's padded
+  // content box: the full-bleed viewport cancels the row's px-5 gutter, so
+  // pills scroll all the way under a gradient pinned to the row's border
+  // box instead of getting cut mid-row with a dead gutter after the fade.
+  const rowBox = await page
+    .getByTestId("channel-composer-activity-row")
+    .boundingBox();
+  const fadeEndBox = await page
+    .getByTestId("bot-activity-strip-fade-end")
+    .boundingBox();
+  expect(fadeEndBox).not.toBeNull();
+  expect(rowBox).not.toBeNull();
+  if (fadeEndBox && rowBox) {
+    expect(
+      Math.abs(fadeEndBox.x + fadeEndBox.width - (rowBox.x + rowBox.width)),
+    ).toBeLessThanOrEqual(1);
+  }
+
   // Scrolling to the far end swaps the fades to the leading side.
   await scroller.evaluate((el) => {
     el.scrollLeft = el.scrollWidth;
   });
   await expect(page.getByTestId("bot-activity-strip-fade-start")).toBeVisible();
   await expect(page.getByTestId("bot-activity-strip-fade-end")).toHaveCount(0);
+
+  // Same pinning on the leading edge once scrolled.
+  const fadeStartBox = await page
+    .getByTestId("bot-activity-strip-fade-start")
+    .boundingBox();
+  expect(fadeStartBox).not.toBeNull();
+  if (fadeStartBox && rowBox) {
+    expect(Math.abs(fadeStartBox.x - rowBox.x)).toBeLessThanOrEqual(1);
+  }
 });
 
 test("lone pill shrinks to fit a narrow container without scroll fades", async ({

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2052,64 +2052,112 @@ test("shows and clears activity indicators for active channel agents", async ({
   await page.getByTestId("channel-agents").click();
   await expect(page.getByTestId("chat-title")).toHaveText("agents");
   await waitForMockLiveSubscription(page, "agents", KIND_TYPING_INDICATOR);
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_SEED_ACTIVE_TURNS__ === "function",
+    null,
+    { timeout: 10_000 },
+  );
 
+  // A typing-only agent folds into the combined typing indicator group with
+  // the humans — status pills are observer-backed only, so no pill mounts
+  // (ChannelComposerActivityRow's source partition).
   await page.evaluate((pubkey) => {
     window.__BUZZ_E2E_EMIT_MOCK_TYPING__?.({
       channelName: "agents",
       pubkey,
     });
   }, TEST_IDENTITIES.alice.pubkey);
+  await expect(page.getByTestId("message-typing-indicator")).toBeVisible();
+  await expect(
+    page.getByTestId("message-typing-indicator-label"),
+  ).toContainText("alice");
+  await expect(page.getByTestId("bot-activity-composer-trigger")).toHaveCount(
+    0,
+  );
+
+  // An observer-backed turn promotes the agent into a status pill; the
+  // observer signal outranks the typing fallback for the same channel, so
+  // the agent leaves the typing group at the same time.
+  await page.evaluate(
+    ({ channelId, pubkey }) => {
+      window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+        agentPubkey: pubkey,
+        channelId,
+        turnId: "indicator-turn",
+      });
+    },
+    { channelId: AGENTS_CHANNEL_ID, pubkey: TEST_IDENTITIES.alice.pubkey },
+  );
+  await seedPillActivityMessage(page, {
+    agentPubkey: TEST_IDENTITIES.alice.pubkey,
+    atMs: Date.now(),
+    seq: Date.now(),
+    text: "Alice: indexing the channel history",
+  });
 
   const activityPill = page.getByTestId("bot-activity-composer-trigger");
   await expect(activityPill).toBeVisible();
   await expect(activityPill).not.toContainText("View activity");
+  await expect(page.getByTestId("message-typing-indicator")).toHaveCount(0);
   // Hovering the pill opens the live-activity preview.
   await activityPill.hover();
   await expect(page.getByTestId("composer-live-activity-feed")).toBeVisible();
-  // Clicking the pill promotes the agent's runtime into the aux panel.
+  // Clicking the pill promotes the agent's runtime into the aux panel,
+  // scoped to this channel and showing the agent's live transcript.
   await activityPill.click();
   await expect(page.getByTestId("agent-session-thread-panel")).toBeVisible();
+  await expect(page.getByTestId("agent-session-scope-label")).toContainText(
+    "#agents",
+  );
   await expect(page.getByTestId("agent-session-thread-panel")).toContainText(
-    "alice",
+    "Alice: indexing the channel history",
   );
   // Opened from the composer with no prior pane: there is nowhere to go
   // "back" to, so the header shows only the close affordance.
   await expect(page.getByTestId("agent-session-back")).toHaveCount(0);
   await expect(page.getByTestId("auxiliary-panel-close")).toBeVisible();
-  await expect(page.getByTestId("agent-transcript-now-summary")).toHaveCount(0);
   await page.getByTestId("agent-session-settings-menu-trigger").click();
   await expect(page.getByTestId("agent-session-stop-turn")).toBeVisible();
   await expect(page.getByTestId("agent-session-stop-turn")).toBeDisabled();
   await page.keyboard.press("Escape");
-  await expect(page.getByTestId("agent-session-thread-panel")).toContainText(
-    "No ACP activity yet",
-  );
   await expect(page.getByTestId("message-typing-indicator")).toHaveCount(0);
 
-  await page.evaluate((pubkey) => {
-    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
-      channelName: "agents",
-      content: "Done.",
-      pubkey,
-    });
-  }, TEST_IDENTITIES.alice.pubkey);
+  // Completing the turn clears the pill; the agent's finished message lands
+  // in the timeline as usual.
+  await page.evaluate(
+    ({ channelId, pubkey }) => {
+      window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+        agentPubkey: pubkey,
+        channelId,
+        turnId: "indicator-turn",
+        kind: "turn_completed",
+      });
+      window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "agents",
+        content: "Done.",
+        pubkey,
+      });
+    },
+    { channelId: AGENTS_CHANNEL_ID, pubkey: TEST_IDENTITIES.alice.pubkey },
+  );
 
   await expect(page.getByTestId("message-timeline")).toContainText("Done.");
   await expect(page.getByTestId("bot-activity-composer-trigger")).toHaveCount(
     0,
   );
 
-  await page.waitForTimeout(1_200);
-  await page.evaluate((pubkey) => {
-    window.__BUZZ_E2E_EMIT_MOCK_TYPING__?.({
-      channelName: "agents",
-      pubkey,
-    });
-  }, TEST_IDENTITIES.alice.pubkey);
-
-  await expect(page.getByTestId("bot-activity-composer-trigger")).toHaveCount(
-    0,
+  // A fresh turn re-mounts the pill — the cleared state is not sticky.
+  await page.evaluate(
+    ({ channelId, pubkey }) => {
+      window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+        agentPubkey: pubkey,
+        channelId,
+        turnId: "indicator-turn-2",
+      });
+    },
+    { channelId: AGENTS_CHANNEL_ID, pubkey: TEST_IDENTITIES.alice.pubkey },
   );
+  await expect(page.getByTestId("bot-activity-composer-trigger")).toBeVisible();
 });
 
 test("composer does not shift when the activity row mounts and clears", async ({
@@ -2119,7 +2167,11 @@ test("composer does not shift when the activity row mounts and clears", async ({
 
   await page.getByTestId("channel-agents").click();
   await expect(page.getByTestId("chat-title")).toHaveText("agents");
-  await waitForMockLiveSubscription(page, "agents", KIND_TYPING_INDICATOR);
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_SEED_ACTIVE_TURNS__ === "function",
+    null,
+    { timeout: 10_000 },
+  );
 
   // The activity row below the composer has a fixed height (h-8.5 in
   // ChannelComposerActivityRow) so the bottom-anchored composer must not move
@@ -2133,27 +2185,47 @@ test("composer does not shift when the activity row mounts and clears", async ({
   };
   const idleComposerTop = (await composerBox()).y;
 
+  await page.evaluate(
+    ({ channelId, pubkey }) => {
+      window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+        agentPubkey: pubkey,
+        channelId,
+        turnId: "no-shift-turn",
+      });
+    },
+    { channelId: AGENTS_CHANNEL_ID, pubkey: TEST_IDENTITIES.alice.pubkey },
+  );
+
+  await expect(page.getByTestId("bot-activity-composer-trigger")).toBeVisible();
+  expect((await composerBox()).y).toBeCloseTo(idleComposerTop, 0);
+
+  await page.evaluate(
+    ({ channelId, pubkey }) => {
+      window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+        agentPubkey: pubkey,
+        channelId,
+        turnId: "no-shift-turn",
+        kind: "turn_completed",
+      });
+    },
+    { channelId: AGENTS_CHANNEL_ID, pubkey: TEST_IDENTITIES.alice.pubkey },
+  );
+
+  await expect(page.getByTestId("bot-activity-composer-trigger")).toHaveCount(
+    0,
+  );
+  expect((await composerBox()).y).toBeCloseTo(idleComposerTop, 0);
+
+  // The combined typing group mounts into the same fixed row — it must not
+  // move the composer either.
+  await waitForMockLiveSubscription(page, "agents", KIND_TYPING_INDICATOR);
   await page.evaluate((pubkey) => {
     window.__BUZZ_E2E_EMIT_MOCK_TYPING__?.({
       channelName: "agents",
       pubkey,
     });
   }, TEST_IDENTITIES.alice.pubkey);
-
-  await expect(page.getByTestId("bot-activity-composer-trigger")).toBeVisible();
-  expect((await composerBox()).y).toBeCloseTo(idleComposerTop, 0);
-
-  await page.evaluate((pubkey) => {
-    window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
-      channelName: "agents",
-      content: "Done.",
-      pubkey,
-    });
-  }, TEST_IDENTITIES.alice.pubkey);
-
-  await expect(page.getByTestId("bot-activity-composer-trigger")).toHaveCount(
-    0,
-  );
+  await expect(page.getByTestId("message-typing-indicator")).toBeVisible();
   expect((await composerBox()).y).toBeCloseTo(idleComposerTop, 0);
 });
 
@@ -2303,15 +2375,19 @@ test("hover card freezes pill order; queued reorder applies on close", async ({
   }
 
   // Newest activity for astra would move her pill to the front — but a hover
-  // card is showing, so the strip must not move. The dwell covers the close
-  // grace (180ms) plus the reorder spring (0.9s) that would have played.
+  // card is showing, so the strip must not move. Waiting on the pill's label
+  // to swap to the new message text proves the store update reached this
+  // strip's render; a broken freeze would have flipped the DOM order in that
+  // same commit, so no blind animation-length sleep is needed.
   await seedPillActivityMessage(page, {
     agentPubkey: PILL_AGENT_ASTRA,
     atMs: baseMs + 5_000,
     seq: baseMs + 10_003,
     text: "Astra: verifying the turn-resurrection path",
   });
-  await page.waitForTimeout(1_200);
+  await expect(astraPill).toContainText(
+    "Astra: verifying the turn-resurrection path",
+  );
   await expect(feed).toBeVisible();
   await expect(triggers.first()).toHaveAttribute(
     "aria-label",
@@ -2341,28 +2417,37 @@ test("hovering the bar itself freezes pill order without opening a card", async 
   await installMockBridge(page, { managedAgents: PILL_AGENT_SEEDS });
   const { baseMs, triggers } = await openAgentsChannelWithTwoWorkingPills(page);
 
-  // Park the cursor on the bar's empty right side — over the strip, not a
-  // pill. This alone must engage the freeze; no card opens.
-  const strip = page.getByTestId("bot-activity-strip");
-  const stripBox = await strip.boundingBox();
-  if (!stripBox) {
-    throw new Error("Activity strip is not visible.");
+  // Park the cursor in the gap between the two pills — over the strip, not a
+  // pill trigger. The strip sizes to its content, so there is no reliable
+  // "empty right side"; the inter-pill gap is the one spot guaranteed to be
+  // strip-not-pill. This alone must engage the freeze; no card opens.
+  const novaBox = await triggers.first().boundingBox();
+  const astraBox = await triggers.nth(1).boundingBox();
+  if (!novaBox || !astraBox) {
+    throw new Error("Both pills must be visible.");
   }
-  await strip.hover({
-    position: { x: stripBox.width - 8, y: stripBox.height / 2 },
-  });
-  await page.waitForTimeout(400);
-  await expect(page.getByTestId("composer-live-activity-feed")).toBeHidden();
+  await page.mouse.move(
+    (novaBox.x + novaBox.width + astraBox.x) / 2,
+    novaBox.y + novaBox.height / 2,
+  );
+  // The bar hold pins every pill's width via an inline style — waiting for
+  // it proves the freeze is engaged before the reorder attempt below.
+  await expect(triggers.first()).toHaveAttribute("style", /width/);
+  await expect(page.getByTestId("composer-live-activity-feed")).toHaveCount(0);
 
   // Newest activity for astra would move her pill to the front — but the
-  // cursor is over the bar, so the order stays frozen.
+  // cursor is over the bar, so the order stays frozen. The label swap
+  // confirms the store update reached the strip without a blind sleep.
   await seedPillActivityMessage(page, {
     agentPubkey: PILL_AGENT_ASTRA,
     atMs: baseMs + 5_000,
     seq: baseMs + 10_003,
     text: "Astra: verifying the turn-resurrection path",
   });
-  await page.waitForTimeout(1_200);
+  await expect(triggers.nth(1)).toContainText(
+    "Astra: verifying the turn-resurrection path",
+  );
+  await expect(page.getByTestId("composer-live-activity-feed")).toHaveCount(0);
   await expect(triggers.first()).toHaveAttribute(
     "aria-label",
     "nova is working. View activity.",

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2646,6 +2646,76 @@ test("narrow strip scrolls horizontally with edge fades instead of compressing p
   }
 });
 
+test("typing group renders inside the pill strip and scrolls under the edge fades", async ({
+  page,
+}) => {
+  await installMockBridge(page, { managedAgents: PILL_AGENT_SEEDS });
+  await openAgentsChannelWithTwoWorkingPills(page);
+  await waitForMockLiveSubscription(page, "agents", KIND_TYPING_INDICATOR);
+
+  // A human typer joins the strip as the trailing slot sibling of the
+  // pills — same scroller, same edge fades, same slot animations — instead
+  // of a separate row sibling outside the scroll viewport.
+  await page.evaluate((pubkey) => {
+    window.__BUZZ_E2E_EMIT_MOCK_TYPING__?.({
+      channelName: "agents",
+      pubkey,
+    });
+  }, TEST_IDENTITIES.alice.pubkey);
+
+  const scroller = page.getByTestId("bot-activity-strip-scroller");
+  const typingIndicator = scroller.getByTestId("message-typing-indicator");
+  await expect(typingIndicator).toBeVisible();
+  await expect(
+    scroller.getByTestId("message-typing-indicator-label"),
+  ).toContainText("alice is typing");
+
+  // Trailing slot: the typing group sits after the last pill.
+  const lastPillBox = await page
+    .getByTestId("bot-activity-composer-trigger")
+    .last()
+    .boundingBox();
+  const typingBox = await typingIndicator.boundingBox();
+  expect(typingBox).not.toBeNull();
+  expect(lastPillBox).not.toBeNull();
+  if (typingBox && lastPillBox) {
+    expect(typingBox.x).toBeGreaterThanOrEqual(
+      lastPillBox.x + lastPillBox.width,
+    );
+  }
+
+  // Constrained, the strip overflows into scroll with the trailing fade:
+  // the typing group is part of the scrollable content and clips under the
+  // fade rather than holding a reserved spot outside the scroller.
+  await page
+    .getByTestId("channel-composer-activity-row")
+    .evaluate((element) => {
+      element.style.width = "300px";
+    });
+  await expect
+    .poll(() => scroller.evaluate((el) => el.scrollWidth - el.clientWidth))
+    .toBeGreaterThan(0);
+  await expect(page.getByTestId("bot-activity-strip-fade-end")).toBeVisible();
+
+  // Scrolled to the far end, the typing group's right edge lands inside the
+  // row — it scrolled WITH the pills.
+  await scroller.evaluate((el) => {
+    el.scrollLeft = el.scrollWidth;
+  });
+  await expect(page.getByTestId("bot-activity-strip-fade-start")).toBeVisible();
+  const constrainedRowBox = await page
+    .getByTestId("channel-composer-activity-row")
+    .boundingBox();
+  const scrolledTypingBox = await typingIndicator.boundingBox();
+  expect(scrolledTypingBox).not.toBeNull();
+  expect(constrainedRowBox).not.toBeNull();
+  if (scrolledTypingBox && constrainedRowBox) {
+    expect(scrolledTypingBox.x + scrolledTypingBox.width).toBeLessThanOrEqual(
+      constrainedRowBox.x + constrainedRowBox.width + 1,
+    );
+  }
+});
+
 test("lone pill shrinks to fit a narrow container without scroll fades", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2230,14 +2230,18 @@ test("composer does not shift when the activity row mounts and clears", async ({
 });
 
 // ── Composer pill hover freeze ───────────────────────────────────────────────
-// Working pills reorder most-recently-active-first. While the cursor is
-// anywhere over the activity bar OR a hover card is showing, the strip must
-// not move under the cursor: pill order, membership, and widths are frozen,
-// and the queued reorder applies (animated) only after the hold releases
-// (BotActivityBar strip-level hover popover + bar-hover freeze).
+// Working pills hold a stable turn-start order (earliest worker left-most);
+// slots only change when MEMBERSHIP does — an agent starting work appends a
+// pill on the right, a finishing agent's pill exits. While the cursor is
+// anywhere over the activity bar OR a hover card is showing, even those
+// changes must not move the strip under the cursor: pill order, membership,
+// and widths are frozen, and the queued membership change applies (animated)
+// only after the hold releases (BotActivityBar strip-level hover popover +
+// bar-hover freeze).
 
 const PILL_AGENT_NOVA = "cc".repeat(32);
 const PILL_AGENT_ASTRA = "dd".repeat(32);
+const PILL_AGENT_LYRA = "ee".repeat(32);
 const PILL_AGENT_SEEDS = [
   {
     pubkey: PILL_AGENT_NOVA,
@@ -2251,19 +2255,36 @@ const PILL_AGENT_SEEDS = [
     status: "running" as const,
     channelNames: ["agents"],
   },
+  // Not seeded as working by the shared helper — the membership-freeze test
+  // starts lyra's turn mid-hover to prove a queued pill append.
+  {
+    pubkey: PILL_AGENT_LYRA,
+    name: "lyra",
+    status: "running" as const,
+    channelNames: ["agents"],
+  },
 ];
 
 /**
- * Seed one channel-scoped assistant-message observer event. Its transcript
- * timestamp drives the strip's most-recent-first pill order, so tests pass
- * explicit future `atMs` stamps to make the order deterministic.
+ * Seed one channel-scoped assistant-message observer event. The message
+ * drives the pill's LABEL (the newest headline-able transcript item wins) —
+ * pill ORDER is anchored to turn start and does not move on messages.
+ * `turnId` must match the agent's seeded active turn so the event refreshes
+ * that turn's liveness instead of resurrecting a phantom sibling turn
+ * (which would keep the agent "working" after its real turn completes).
  */
 async function seedPillActivityMessage(
   page: import("@playwright/test").Page,
-  input: { agentPubkey: string; atMs: number; seq: number; text: string },
+  input: {
+    agentPubkey: string;
+    atMs: number;
+    seq: number;
+    text: string;
+    turnId: string;
+  },
 ) {
   await page.evaluate(
-    ({ agentPubkey, atMs, channelId, seq, text }) => {
+    ({ agentPubkey, atMs, channelId, seq, text, turnId }) => {
       const sessionId = `seed-session-${agentPubkey.slice(0, 6)}`;
       window.__BUZZ_E2E_SEED_OBSERVER_EVENTS__?.({
         agentPubkey,
@@ -2275,7 +2296,7 @@ async function seedPillActivityMessage(
             agentIndex: 0,
             channelId,
             sessionId,
-            turnId: `seed-turn-${agentPubkey.slice(0, 6)}`,
+            turnId,
             payload: {
               jsonrpc: "2.0",
               method: "session/update",
@@ -2297,9 +2318,12 @@ async function seedPillActivityMessage(
 }
 
 /**
- * Open #agents with two seeded working agents. Activity messages stamp nova
- * as most recent, so the strip renders [nova, astra]. Returns the shared
- * trigger locator and the timestamp base used for the seeds.
+ * Open #agents with two seeded working agents. Pill order follows turn
+ * START anchors (earliest worker left-most): nova's turn starts 60s before
+ * base and astra's 30s before, so the strip renders [nova, astra] — well
+ * clear of the ordering's whole-second anchor quantization, and unaffected
+ * by later message activity. Returns the shared trigger locator and the
+ * timestamp base used for the seeds.
  */
 async function openAgentsChannelWithTwoWorkingPills(
   page: import("@playwright/test").Page,
@@ -2315,33 +2339,43 @@ async function openAgentsChannelWithTwoWorkingPills(
 
   const baseMs = Date.now();
   await page.evaluate(
-    ({ agents, channelId }) => {
-      for (const [index, agentPubkey] of agents.entries()) {
-        window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
-          agentPubkey,
-          channelId,
-          turnId: `pill-turn-${index}`,
-        });
+    ({ channelId, turns }) => {
+      for (const turn of turns) {
+        window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({ channelId, ...turn });
       }
     },
     {
-      agents: [PILL_AGENT_ASTRA, PILL_AGENT_NOVA],
       channelId: AGENTS_CHANNEL_ID,
+      turns: [
+        {
+          agentPubkey: PILL_AGENT_NOVA,
+          turnId: "pill-turn-nova",
+          atMs: baseMs - 60_000,
+        },
+        {
+          agentPubkey: PILL_AGENT_ASTRA,
+          turnId: "pill-turn-astra",
+          atMs: baseMs - 30_000,
+        },
+      ],
     },
   );
-  // Future-stamped messages outrank the just-seeded turn events regardless
-  // of turn-seed timing: nova (+2s) newest, astra (+1s) second.
+  // Seeded messages give each pill a distinctive action headline (labels
+  // hold the newest headline-able item) without touching the turn-start
+  // order.
   await seedPillActivityMessage(page, {
     agentPubkey: PILL_AGENT_ASTRA,
     atMs: baseMs + 1_000,
     seq: baseMs + 10_001,
     text: "Astra: reviewing the composer wiring",
+    turnId: "pill-turn-astra",
   });
   await seedPillActivityMessage(page, {
     agentPubkey: PILL_AGENT_NOVA,
     atMs: baseMs + 2_000,
     seq: baseMs + 10_002,
     text: "Nova: tracing the observer store",
+    turnId: "pill-turn-nova",
   });
 
   const triggers = page.getByTestId("bot-activity-composer-trigger");
@@ -2353,7 +2387,7 @@ async function openAgentsChannelWithTwoWorkingPills(
   return { baseMs, triggers };
 }
 
-test("hover card freezes pill order; queued reorder applies on close", async ({
+test("hover card freezes pill membership; queued pill append applies on close", async ({
   page,
 }) => {
   await installMockBridge(page, { managedAgents: PILL_AGENT_SEEDS });
@@ -2374,44 +2408,69 @@ test("hover card freezes pill order; queued reorder applies on close", async ({
     throw new Error("Hovered pill is not visible.");
   }
 
-  // Newest activity for astra would move her pill to the front — but a hover
-  // card is showing, so the strip must not move. Waiting on the pill's label
-  // to swap to the new message text proves the store update reached this
-  // strip's render; a broken freeze would have flipped the DOM order in that
-  // same commit, so no blind animation-length sleep is needed.
+  // Lyra starting a turn would append her pill on the right — but a hover
+  // card is showing, so the strip's membership must not change. Waiting on
+  // the hovered pill's label to swap to the new message text proves the
+  // store updates reached this strip's render; a broken freeze would have
+  // mounted lyra's pill in that same commit, so no blind animation-length
+  // sleep is needed.
+  await page.evaluate(
+    ({ agentPubkey, atMs, channelId }) => {
+      window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+        agentPubkey,
+        channelId,
+        turnId: "pill-turn-lyra",
+        atMs,
+      });
+    },
+    {
+      agentPubkey: PILL_AGENT_LYRA,
+      atMs: baseMs + 4_000,
+      channelId: AGENTS_CHANNEL_ID,
+    },
+  );
   await seedPillActivityMessage(page, {
     agentPubkey: PILL_AGENT_ASTRA,
     atMs: baseMs + 5_000,
     seq: baseMs + 10_003,
     text: "Astra: verifying the turn-resurrection path",
+    turnId: "pill-turn-astra",
   });
   await expect(astraPill).toContainText(
     "Astra: verifying the turn-resurrection path",
   );
   await expect(feed).toBeVisible();
+  await expect(triggers).toHaveCount(2);
   await expect(triggers.first()).toHaveAttribute(
     "aria-label",
     "nova is working. View activity.",
   );
   const stillHeldBox = await astraPill.boundingBox();
   if (!stillHeldBox) {
-    throw new Error("Hovered pill is not visible after the reorder attempt.");
+    throw new Error("Hovered pill is not visible after the membership change.");
   }
-  // Frozen order + pinned width: the hovered pill's slot and size held even
-  // though its label swapped to the new (longer) message text.
+  // Frozen membership + pinned width: the hovered pill's slot and size held
+  // even though its label swapped to the new (longer) message text.
   expect(stillHeldBox.x).toBeCloseTo(heldBox.x, 0);
   expect(stillHeldBox.width).toBeCloseTo(heldBox.width, 0);
 
-  // Release the hover: the card closes and the queued reorder applies.
+  // Release the hover: the card closes and the queued append applies —
+  // lyra's pill enters at the END (turn-start order: newest starter last),
+  // leaving the existing pills' slots untouched.
   await page.getByTestId("chat-title").hover();
   await expect(feed).toBeHidden();
+  await expect(triggers).toHaveCount(3);
   await expect(triggers.first()).toHaveAttribute(
     "aria-label",
-    "astra is working. View activity.",
+    "nova is working. View activity.",
+  );
+  await expect(triggers.nth(2)).toHaveAttribute(
+    "aria-label",
+    "lyra is working. View activity.",
   );
 });
 
-test("hovering the bar itself freezes pill order without opening a card", async ({
+test("hovering the bar itself freezes pill membership without opening a card", async ({
   page,
 }) => {
   await installMockBridge(page, { managedAgents: PILL_AGENT_SEEDS });
@@ -2431,33 +2490,54 @@ test("hovering the bar itself freezes pill order without opening a card", async 
     novaBox.y + novaBox.height / 2,
   );
   // The bar hold pins every pill's width via an inline style — waiting for
-  // it proves the freeze is engaged before the reorder attempt below.
+  // it proves the freeze is engaged before the membership change below.
   await expect(triggers.first()).toHaveAttribute("style", /width/);
   await expect(page.getByTestId("composer-live-activity-feed")).toHaveCount(0);
 
-  // Newest activity for astra would move her pill to the front — but the
-  // cursor is over the bar, so the order stays frozen. The label swap
-  // confirms the store update reached the strip without a blind sleep.
+  // Astra's turn completes — her pill would exit, sliding the strip under
+  // the parked cursor. The cursor is over the bar, so membership stays
+  // frozen and the pill holds. Nova's label swap confirms the store updates
+  // reached the strip without a blind sleep.
+  await page.evaluate(
+    ({ agentPubkey, atMs, channelId }) => {
+      window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
+        agentPubkey,
+        channelId,
+        turnId: "pill-turn-astra",
+        kind: "turn_completed",
+        atMs,
+      });
+    },
+    {
+      agentPubkey: PILL_AGENT_ASTRA,
+      atMs: baseMs + 4_000,
+      channelId: AGENTS_CHANNEL_ID,
+    },
+  );
   await seedPillActivityMessage(page, {
-    agentPubkey: PILL_AGENT_ASTRA,
+    agentPubkey: PILL_AGENT_NOVA,
     atMs: baseMs + 5_000,
     seq: baseMs + 10_003,
-    text: "Astra: verifying the turn-resurrection path",
+    text: "Nova: confirming the frozen strip",
+    turnId: "pill-turn-nova",
   });
-  await expect(triggers.nth(1)).toContainText(
-    "Astra: verifying the turn-resurrection path",
+  await expect(triggers.first()).toContainText(
+    "Nova: confirming the frozen strip",
   );
   await expect(page.getByTestId("composer-live-activity-feed")).toHaveCount(0);
+  await expect(triggers).toHaveCount(2);
+  await expect(triggers.nth(1)).toHaveAttribute(
+    "aria-label",
+    "astra is working. View activity.",
+  );
+
+  // Leaving the bar releases the hold: the queued exit applies and astra's
+  // pill leaves the strip.
+  await page.getByTestId("chat-title").hover();
+  await expect(triggers).toHaveCount(1);
   await expect(triggers.first()).toHaveAttribute(
     "aria-label",
     "nova is working. View activity.",
-  );
-
-  // Leaving the bar releases the hold: the queued reorder applies.
-  await page.getByTestId("chat-title").hover();
-  await expect(triggers.first()).toHaveAttribute(
-    "aria-label",
-    "astra is working. View activity.",
   );
 });
 

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2163,7 +2163,8 @@ test("shows and clears activity indicators for active channel agents", async ({
     0,
   );
 
-  // A fresh turn re-mounts the pill — the cleared state is not sticky.
+  // A fresh turn re-mounts the pill without presenting the prior turn's last
+  // action as current work.
   await page.evaluate(
     ({ channelId, pubkey }) => {
       window.__BUZZ_E2E_SEED_ACTIVE_TURNS__?.({
@@ -2174,7 +2175,9 @@ test("shows and clears activity indicators for active channel agents", async ({
     },
     { channelId: AGENTS_CHANNEL_ID, pubkey: TEST_IDENTITIES.alice.pubkey },
   );
-  await expect(page.getByTestId("bot-activity-composer-trigger")).toBeVisible();
+  await expect(page.getByTestId("bot-activity-composer-trigger")).toContainText(
+    "alice is working",
+  );
 });
 
 test("thread agent typing promotes only when activity exists", async ({

--- a/preview-features.json
+++ b/preview-features.json
@@ -30,6 +30,12 @@
       "name": "Agent-managed profiles",
       "description": "Let agents manage their own relay name and avatar instead of restoring the desktop copy",
       "platforms": ["desktop"]
+    },
+    {
+      "id": "composerLiveActivity",
+      "name": "Composer live activity",
+      "description": "Live activity preview for the selected working agent in the agents-working popover below the chat composer",
+      "platforms": ["desktop"]
     }
   ]
 }

--- a/preview-features.json
+++ b/preview-features.json
@@ -30,12 +30,6 @@
       "name": "Agent-managed profiles",
       "description": "Let agents manage their own relay name and avatar instead of restoring the desktop copy",
       "platforms": ["desktop"]
-    },
-    {
-      "id": "composerLiveActivity",
-      "name": "Composer live activity",
-      "description": "Live activity preview for the selected working agent in the agents-working popover below the chat composer",
-      "platforms": ["desktop"]
     }
   ]
 }


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Working agents now appear as compact composer status pills that show their latest action, preview live activity on hover, and open the full session on click.

**Problem:** The combined “agents working” control hid which agent was doing what, shifted the composer when it mounted, and required an extra interaction to understand recent activity. Human typing and agent activity also competed for space without a clear signal hierarchy, while crowded thread composers could compress activity labels until they were unreadable.

**Solution:** Replace the combined control with a fixed-height pill strip for observer-backed agents, while grouping typing-only agents with human typers. Pills preserve turn-start ordering, retain the latest meaningful channel-scoped headline for the life of the turn, freeze safely while hovered, preview the shared compact activity feed, and open the full agent session on click. Thread-only bot typers stay in the combined typing group until channel-scoped observer activity provides a real session to preview, then promote to a pill while retaining the truthful “is typing…” label.

<details>
<summary>File changes</summary>

- **Agent working state:** Adds channel-scoped observer/typing signals and pure helpers for capability partitioning, persistent headlines, turn-start ordering, and archive-aware recency.
- **Composer UI:** Replaces the combined trigger with animated per-agent pills, shared hover-card control, responsive overflow affordances, and a fixed-height activity row shared by the main composer.
- **Thread composer:** Applies the same capability partition without leaking thread typing into channel-wide working state; transcript-less agent typers remain non-interactive until observer activity exists.
- **Activity preview:** Reuses the managed agent transcript presentation in an inert compact hover preview and shares Last-live formatting with the profile panel.
- **Typing presentation:** Combines typing-only agents with human typers and supports composer-specific styling.
- **Tests:** Covers label selection, filtering, ordering, hover stability, click-through, overflow geometry, focus-mode anchoring, and thread typing-group-to-pill promotion.

</details>

## Reproduction steps

1. Open a channel where one observer-backed agent is working; confirm a fixed-height pill appears with the latest meaningful action.
2. Emit more actions; confirm the headline updates in place and remains visible without freshness decay while the turn is active.
3. Hover the pill; confirm its order and width freeze while the compact transcript preview is open.
4. Click the pill; confirm the full agent session opens.
5. Start multiple agents; confirm turn-start order is stable, and narrow the composer to verify horizontal overflow fades.
6. Start a first-ever typing-only agent; confirm it joins the combined typing group rather than exposing an empty activity preview.
7. In a thread, start a transcript-less agent typer; confirm it remains in the typing group. Add channel-scoped observer activity and confirm it promotes to a pill labeled “is typing…”.
8. Enable reduced motion; confirm label and pill transitions become immediate.

## Screenshots / demos

### Narrow composer strip
![Narrow composer strip](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/2646/01-narrow-strip-1d4356b.png)

### Hover activity preview
![Hover activity preview](https://d24qwcpro867f5.cloudfront.net/repos/buzz/prs/2646/02-hover-preview-1d4356b.png)

## Validation

Validated at `a5be90af587a9c68865c1eb6b199ee988fd887c8`, rebased onto `origin/main` at `0720f5380ce8a6c050afac159f8462c06cd51ab5`:

- `pnpm build:e2e`
- Full desktop unit suite: **5,436/5,436 passed**
- Desktop check suite, including Biome, px-text, and pubkey-truncation guards (only four pre-existing warnings/info outside this PR's files)
- Focused Playwright activity regression set: **5/5 passed**, including thread reply typing clear, fixed-height composer behavior, horizontal overflow fades, shared typing-strip overflow, and lone-pill shrink behavior
- Pre-push gates: org guard, branch skew, file-size guard, desktop check, TypeScript typecheck, and full desktop unit suite
- `git diff --check`
- `git merge-tree --write-tree origin/main HEAD`
- DCO check passed on the pushed head
