### PR TITLE
feat(desktop): add copy raw event JSON action to message menu

### DIFF
--- a/desktop/src/features/messages/ui/MessageActionBar.tsx
+++ b/desktop/src/features/messages/ui/MessageActionBar.tsx
@@ -2,6 +2,7 @@ import {
   BellOff,
   BellRing,
   Clock,
+  Code,
   Copy,
   CornerUpLeft,
   EllipsisVertical,
@@ -208,6 +209,29 @@ function MoreActionsMenu({
             >
               <Copy className="h-4 w-4" />
               Copy message
+            </DropdownMenuItem>
+          ) : null}
+
+          {hasCopyActions ? (
+            <DropdownMenuItem
+              data-testid={`copy-raw-event-${message.id}`}
+              onClick={() => {
+                const rawEvent = {
+                  id: message.id,
+                  pubkey: message.signerPubkey ?? message.pubkey ?? "",
+                  created_at: message.createdAt,
+                  kind: message.kind ?? 9,
+                  tags: message.tags ?? [],
+                  content: message.body,
+                };
+                copyTextToClipboard(
+                  JSON.stringify(rawEvent, null, 2),
+                  "Raw event JSON copied to clipboard",
+                );
+              }}
+            >
+              <Code className="h-4 w-4" />
+              Copy raw event JSON
             </DropdownMenuItem>
           ) : null}
 


### PR DESCRIPTION
## Summary

Add a **"Copy raw event JSON"** action to the Desktop message action bar (`MessageActionBar`) dropdown menu, allowing users to copy formatted Nostr Event JSON payloads for debugging.

## How to Test

1. Launch Desktop app (`just dev`).
2. Hover over a message in `#general` and click **`...`** (*More actions*).
3. Click **"Copy raw event JSON"** and paste to verify the copied JSON structure.

## Checklist

- [x] `just ci` & `pnpm check` pass
- [x] Unit tests pass (`pnpm desktop test`: 3,455 passed, `just test-unit`)
- [x] No `unwrap()` / `unsafe` added
- [x] Zoom-safe rem typography used
