### PR TITLE
fix(desktop): wake local agents before sending messages

### DIFF
--- a/desktop/src/features/agents/managedAgentRuntimeReadiness.test.mjs
+++ b/desktop/src/features/agents/managedAgentRuntimeReadiness.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  runtimeCanReceiveMessages,
+  startManagedAgentRuntimeAndWait,
+} from "./managedAgentRuntimeReadiness.ts";
+
+const pubkey = "a".repeat(64);
+const relayUrl = "wss://relay.example.com";
+
+function runtime(lifecycle, error = null) {
+  return {
+    pubkey,
+    relayUrl,
+    localSetup: true,
+    lifecycle,
+    pid: lifecycle === "stopped" ? null : 42,
+    error,
+    logPath: null,
+  };
+}
+
+test("receive-ready lifecycle excludes a merely spawned process", () => {
+  assert.equal(runtimeCanReceiveMessages("starting"), false);
+  assert.equal(runtimeCanReceiveMessages("listening"), true);
+  assert.equal(runtimeCanReceiveMessages("waking"), true);
+  assert.equal(runtimeCanReceiveMessages("ready"), true);
+});
+
+test("message-triggered start waits until the runtime is listening", async () => {
+  let now = 0;
+  let listCalls = 0;
+  const result = await startManagedAgentRuntimeAndWait({
+    agentName: "Fizz",
+    pubkey,
+    relayUrl,
+    pollIntervalMs: 10,
+    timeoutMs: 100,
+    dependencies: {
+      startRuntime: async () => runtime("starting"),
+      listRuntimes: async () => {
+        listCalls += 1;
+        return [runtime(listCalls === 1 ? "starting" : "listening")];
+      },
+      now: () => now,
+      sleep: async (milliseconds) => {
+        now += milliseconds;
+      },
+    },
+  });
+
+  assert.equal(result.lifecycle, "listening");
+  assert.equal(listCalls, 2);
+});
+
+test("message-triggered start surfaces a runtime failure", async () => {
+  await assert.rejects(
+    startManagedAgentRuntimeAndWait({
+      agentName: "Fizz",
+      pubkey,
+      relayUrl,
+      dependencies: {
+        startRuntime: async () => runtime("failed", "relay auth rejected"),
+        listRuntimes: async () => [],
+        now: () => 0,
+        sleep: async () => {},
+      },
+    }),
+    /Fizz could not start: relay auth rejected/,
+  );
+});
+
+test("message-triggered start times out instead of sending silently", async () => {
+  let now = 0;
+  await assert.rejects(
+    startManagedAgentRuntimeAndWait({
+      agentName: "Fizz",
+      pubkey,
+      relayUrl,
+      pollIntervalMs: 10,
+      timeoutMs: 20,
+      dependencies: {
+        startRuntime: async () => runtime("starting"),
+        listRuntimes: async () => [runtime("starting")],
+        now: () => now,
+        sleep: async (milliseconds) => {
+          now += milliseconds;
+        },
+      },
+    }),
+    /Fizz did not become ready within 1 seconds/,
+  );
+});

--- a/desktop/src/features/agents/managedAgentRuntimeReadiness.ts
+++ b/desktop/src/features/agents/managedAgentRuntimeReadiness.ts
@@ -1,0 +1,93 @@
+import {
+  listManagedAgentRuntimes,
+  startManagedAgentRuntime,
+} from "@/shared/api/tauriManagedAgents";
+import type {
+  ManagedAgentRuntimeLifecycle,
+  ManagedAgentRuntimeStatus,
+} from "@/shared/api/types";
+import { findManagedAgentRuntime } from "./managedAgentRuntimeStatus";
+
+const DEFAULT_READY_TIMEOUT_MS = 60_000;
+const DEFAULT_POLL_INTERVAL_MS = 500;
+
+type RuntimeReadinessDependencies = {
+  listRuntimes: () => Promise<ManagedAgentRuntimeStatus[]>;
+  now: () => number;
+  sleep: (milliseconds: number) => Promise<void>;
+  startRuntime: (
+    pubkey: string,
+    relayUrl: string,
+  ) => Promise<ManagedAgentRuntimeStatus>;
+};
+
+const defaultDependencies: RuntimeReadinessDependencies = {
+  listRuntimes: listManagedAgentRuntimes,
+  now: Date.now,
+  sleep: (milliseconds) =>
+    new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  startRuntime: startManagedAgentRuntime,
+};
+
+export function runtimeCanReceiveMessages(
+  lifecycle: ManagedAgentRuntimeLifecycle,
+): boolean {
+  return (
+    lifecycle === "listening" || lifecycle === "waking" || lifecycle === "ready"
+  );
+}
+
+function runtimeFailureMessage(
+  agentName: string,
+  runtime: ManagedAgentRuntimeStatus,
+): string {
+  return runtime.error
+    ? `${agentName} could not start: ${runtime.error}`
+    : `${agentName} could not start.`;
+}
+
+export async function startManagedAgentRuntimeAndWait({
+  agentName,
+  dependencies = defaultDependencies,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  pubkey,
+  relayUrl,
+  timeoutMs = DEFAULT_READY_TIMEOUT_MS,
+}: {
+  agentName: string;
+  dependencies?: RuntimeReadinessDependencies;
+  pollIntervalMs?: number;
+  pubkey: string;
+  relayUrl: string;
+  timeoutMs?: number;
+}): Promise<ManagedAgentRuntimeStatus> {
+  let runtime = await dependencies.startRuntime(pubkey, relayUrl);
+  if (runtimeCanReceiveMessages(runtime.lifecycle)) {
+    return runtime;
+  }
+  if (runtime.lifecycle === "failed") {
+    throw new Error(runtimeFailureMessage(agentName, runtime));
+  }
+
+  const deadline = dependencies.now() + timeoutMs;
+  while (dependencies.now() < deadline) {
+    await dependencies.sleep(pollIntervalMs);
+    runtime =
+      findManagedAgentRuntime(
+        await dependencies.listRuntimes(),
+        pubkey,
+        relayUrl,
+      ) ?? runtime;
+
+    if (runtimeCanReceiveMessages(runtime.lifecycle)) {
+      return runtime;
+    }
+    if (runtime.lifecycle === "failed" || runtime.lifecycle === "stopped") {
+      throw new Error(runtimeFailureMessage(agentName, runtime));
+    }
+  }
+
+  throw new Error(
+    `${agentName} did not become ready within ${Math.ceil(timeoutMs / 1000)} seconds.`,
+  );
+}

--- a/desktop/src/features/messages/lib/managedAgentSendAudience.test.mjs
+++ b/desktop/src/features/messages/lib/managedAgentSendAudience.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveManagedAgentSendAudience } from "./managedAgentSendAudience.ts";
+
+const agentA = "a".repeat(64);
+const agentB = "b".repeat(64);
+const person = "c".repeat(64);
+
+test("DM messages wake managed-agent participants without an explicit mention", () => {
+  assert.deepEqual(
+    resolveManagedAgentSendAudience({
+      channelType: "dm",
+      dmParticipantPubkeys: [person, agentA],
+      explicitMentionPubkeys: [],
+      managedAgentPubkeys: [agentA],
+    }),
+    [agentA],
+  );
+});
+
+test("channel messages wake only explicitly mentioned managed agents", () => {
+  assert.deepEqual(
+    resolveManagedAgentSendAudience({
+      channelType: "private",
+      dmParticipantPubkeys: [agentA],
+      explicitMentionPubkeys: [person, agentB],
+      managedAgentPubkeys: [agentA, agentB],
+    }),
+    [agentB],
+  );
+});
+
+test("managed-agent audience is normalized and deduplicated", () => {
+  assert.deepEqual(
+    resolveManagedAgentSendAudience({
+      channelType: "dm",
+      dmParticipantPubkeys: [agentA.toUpperCase(), agentA],
+      explicitMentionPubkeys: [agentA],
+      managedAgentPubkeys: [agentA],
+    }),
+    [agentA],
+  );
+});

--- a/desktop/src/features/messages/lib/managedAgentSendAudience.ts
+++ b/desktop/src/features/messages/lib/managedAgentSendAudience.ts
@@ -1,0 +1,28 @@
+import type { ChannelType } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+export function resolveManagedAgentSendAudience({
+  channelType,
+  dmParticipantPubkeys,
+  explicitMentionPubkeys,
+  managedAgentPubkeys,
+}: {
+  channelType: ChannelType | null;
+  dmParticipantPubkeys: Iterable<string>;
+  explicitMentionPubkeys: Iterable<string>;
+  managedAgentPubkeys: Iterable<string>;
+}): string[] {
+  const managed = new Set([...managedAgentPubkeys].map(normalizePubkey));
+  const candidates = [
+    ...explicitMentionPubkeys,
+    ...(channelType === "dm" ? dmParticipantPubkeys : []),
+  ];
+
+  return [
+    ...new Set(
+      candidates
+        .map(normalizePubkey)
+        .filter((pubkey) => pubkey && managed.has(pubkey)),
+    ),
+  ];
+}

--- a/desktop/src/features/messages/ui/NewMessageScreen.tsx
+++ b/desktop/src/features/messages/ui/NewMessageScreen.tsx
@@ -2,11 +2,18 @@ import * as React from "react";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
 import {
+  useManagedAgentsQuery,
+  useStartManagedAgentMutation,
+} from "@/features/agents/hooks";
+import { startManagedAgentRuntimeAndWait } from "@/features/agents/managedAgentRuntimeReadiness";
+import {
   useOpenDmMutation,
   useUpsertCachedChannel,
 } from "@/features/channels/hooks";
+import { useCommunities } from "@/features/communities/useCommunities";
 import type { Channel } from "@/shared/api/types";
 import { useSendMessageMutation } from "@/features/messages/hooks";
+import { resolveManagedAgentSendAudience } from "@/features/messages/lib/managedAgentSendAudience";
 import { getKeyboardSearchSelection } from "@/features/profile/lib/userCandidateSearch";
 import { SelectedRecipientChip } from "@/features/profile/ui/SelectedRecipientChip";
 import { useIdentityQuery } from "@/shared/api/hooks";
@@ -32,6 +39,9 @@ export function NewMessageScreen() {
   const openDmMutation = useOpenDmMutation();
   const upsertCachedChannel = useUpsertCachedChannel();
   const sendMessageMutation = useSendMessageMutation(null, identityQuery.data);
+  const managedAgentsQuery = useManagedAgentsQuery();
+  const startAgentMutation = useStartManagedAgentMutation();
+  const { activeCommunity } = useCommunities();
   const { goChannel } = useAppNavigation();
 
   const [isRecipientPickerOpen, setIsRecipientPickerOpen] =
@@ -262,6 +272,38 @@ export function NewMessageScreen() {
       }
 
       try {
+        const managedAgents =
+          managedAgentsQuery.data ??
+          (await managedAgentsQuery.refetch()).data ??
+          [];
+        const managedAgentsByPubkey = new Map(
+          managedAgents.map((agent) => [normalizePubkey(agent.pubkey), agent]),
+        );
+        const managedAudience = resolveManagedAgentSendAudience({
+          channelType: "dm",
+          dmParticipantPubkeys: directMessage.participantPubkeys,
+          explicitMentionPubkeys: mentionPubkeys,
+          managedAgentPubkeys: managedAgentsByPubkey.keys(),
+        });
+        for (const pubkey of managedAudience) {
+          const agent = managedAgentsByPubkey.get(pubkey);
+          if (!agent) continue;
+          if (agent.backend.type === "provider") {
+            if (agent.status !== "deployed") {
+              await startAgentMutation.mutateAsync(agent.pubkey);
+            }
+          } else if (agent.status !== "running") {
+            const relayUrl = activeCommunity?.relayUrl;
+            if (!relayUrl) {
+              throw new Error("No active community relay is available.");
+            }
+            await startManagedAgentRuntimeAndWait({
+              agentName: agent.name,
+              pubkey: agent.pubkey,
+              relayUrl,
+            });
+          }
+        }
         await sendMessageMutation.mutateAsync({
           targetChannel: directMessage,
           content,
@@ -288,8 +330,12 @@ export function NewMessageScreen() {
     },
     [
       goChannel,
+      activeCommunity?.relayUrl,
+      managedAgentsQuery.data,
+      managedAgentsQuery.refetch,
       openDirectMessage,
       sendMessageMutation,
+      startAgentMutation,
       submitErrorMessage,
       upsertCachedChannel,
     ],

--- a/desktop/src/features/messages/ui/useMentionSendFlow.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.ts
@@ -10,9 +10,12 @@ import {
   useProvisionChannelManagedAgentMutation,
   useStartManagedAgentMutation,
 } from "@/features/agents/hooks";
+import { startManagedAgentRuntimeAndWait } from "@/features/agents/managedAgentRuntimeReadiness";
 import { resolvePersonaRuntime } from "@/features/agents/lib/resolvePersonaRuntime";
+import { useCommunities } from "@/features/communities/useCommunities";
 import { useAddChannelMembersMutation } from "@/features/channels/hooks";
 import { filterEffectiveExplicitAgentPubkeys } from "@/features/messages/lib/effectiveExplicitAgentPubkeys";
+import { resolveManagedAgentSendAudience } from "@/features/messages/lib/managedAgentSendAudience";
 import type { UseChannelLinksResult } from "@/features/messages/lib/useChannelLinks";
 import type { UseEmojiAutocompleteResult } from "@/features/messages/lib/useEmojiAutocomplete";
 import {
@@ -197,6 +200,7 @@ export function useMentionSendFlow({
   const availableRuntimesQuery = useAvailableAcpRuntimes();
   const managedAgentsQuery = useManagedAgentsQuery();
   const startAgentMutation = useStartManagedAgentMutation();
+  const { activeCommunity } = useCommunities();
 
   const getManagedAgentsByPubkey = React.useCallback(async () => {
     const agents =
@@ -230,14 +234,14 @@ export function useMentionSendFlow({
     availableRuntimesQuery.refetch,
   ]);
 
-  const ensureManagedAgentMentionsReady = React.useCallback(
+  const ensureManagedAgentsReady = React.useCallback(
     async (
-      mentionPubkeys: string[],
+      audiencePubkeys: string[],
       capturedChannelId: string,
       preparedParticipantPubkeys: string[] = [],
       preparedManagedAgents: ManagedAgent[] = [],
     ) => {
-      if (!capturedChannelId || mentionPubkeys.length === 0) {
+      if (!capturedChannelId || audiencePubkeys.length === 0) {
         return {
           errors: [] as string[],
           pubkeys: [] as string[],
@@ -255,7 +259,7 @@ export function useMentionSendFlow({
       const errors: string[] = [];
       const pubkeys: string[] = [];
 
-      for (const pubkey of uniqueNormalizedPubkeys(mentionPubkeys)) {
+      for (const pubkey of uniqueNormalizedPubkeys(audiencePubkeys)) {
         const agent = managedAgentsByPubkey.get(pubkey);
         if (!agent) {
           continue;
@@ -268,7 +272,15 @@ export function useMentionSendFlow({
                 await startAgentMutation.mutateAsync(agent.pubkey);
               }
             } else if (!isManagedAgentRunning(agent)) {
-              await startAgentMutation.mutateAsync(agent.pubkey);
+              const relayUrl = activeCommunity?.relayUrl;
+              if (!relayUrl) {
+                throw new Error("No active community relay is available.");
+              }
+              await startManagedAgentRuntimeAndWait({
+                agentName: agent.name,
+                pubkey: agent.pubkey,
+                relayUrl,
+              });
             }
           } else {
             await attachAgentMutation.mutateAsync({
@@ -295,6 +307,7 @@ export function useMentionSendFlow({
     },
     [
       attachAgentMutation,
+      activeCommunity?.relayUrl,
       getManagedAgentsByPubkey,
       mentions.memberPubkeys,
       startAgentMutation,
@@ -457,6 +470,12 @@ export function useMentionSendFlow({
         const managedMentionPubkeys = normalizedMentionPubkeys.filter(
           (pubkey) => managedAgentsByPubkey.has(pubkey),
         );
+        const managedAudiencePubkeys = resolveManagedAgentSendAudience({
+          channelType,
+          dmParticipantPubkeys: mentions.memberPubkeys,
+          explicitMentionPubkeys: managedMentionPubkeys,
+          managedAgentPubkeys: managedAgentsByPubkey.keys(),
+        });
         const agentMentionPubkeys = uniqueNormalizedPubkeys([
           ...managedMentionPubkeys,
           ...normalizedMentionPubkeys.filter(mentions.isAgentPubkey),
@@ -476,8 +495,8 @@ export function useMentionSendFlow({
           }
         }
 
-        const agentReadiness = await ensureManagedAgentMentionsReady(
-          managedMentionPubkeys.filter(
+        const agentReadiness = await ensureManagedAgentsReady(
+          managedAudiencePubkeys.filter(
             (pubkey) => !readyAgentPubkeys.has(normalizePubkey(pubkey)),
           ),
           sendChannelId ?? "",
@@ -490,10 +509,8 @@ export function useMentionSendFlow({
         if (agentReadiness.errors.length > 0) {
           const message =
             agentReadiness.errors.length === 1
-              ? `Could not start agent mention: ${agentReadiness.errors[0]}`
-              : `Could not start agent mentions: ${agentReadiness.errors.join(
-                  "; ",
-                )}`;
+              ? `Could not prepare agent: ${agentReadiness.errors[0]}`
+              : `Could not prepare agents: ${agentReadiness.errors.join("; ")}`;
           setNonMemberPromptError(message);
           toast.error(message);
           return;
@@ -564,10 +581,12 @@ export function useMentionSendFlow({
     },
     [
       clearComposer,
+      channelType,
       contentRef,
       drafts,
-      ensureManagedAgentMentionsReady,
+      ensureManagedAgentsReady,
       getManagedAgentsByPubkey,
+      mentions.memberPubkeys,
       mentions.isAgentPubkey,
       onPrepareSendChannel,
       onSendRef,

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -324,6 +324,28 @@ async function readCommandPayloadLog(page: import("@playwright/test").Page) {
   });
 }
 
+function outgoingEventIndex(
+  commands: Array<{ command: string; payload: unknown }>,
+  content: string,
+) {
+  return commands.findIndex((entry) => {
+    if (entry.command !== "plugin:websocket|send") {
+      return false;
+    }
+    const data = (entry.payload as { message?: { data?: string } } | undefined)
+      ?.message?.data;
+    if (!data) {
+      return false;
+    }
+    try {
+      const frame = JSON.parse(data) as [string, { content?: string }];
+      return frame[0] === "EVENT" && frame[1]?.content === content;
+    } catch {
+      return false;
+    }
+  });
+}
+
 async function invokeMockCommand<T>(
   page: import("@playwright/test").Page,
   command: string,
@@ -649,6 +671,83 @@ test("sends the first message from the new direct message composer", async ({
 
   await expect(page.getByTestId("chat-title")).toHaveText("charlie");
   await expect(page.getByTestId("message-timeline")).toContainText(message);
+});
+
+test("wakes a stopped local agent before sending the first DM without a mention", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.charlie.pubkey,
+        name: "charlie",
+        status: "stopped",
+      },
+    ],
+  });
+  await page.goto("/");
+  await openNewMessagePage(page);
+
+  await page.getByTestId("new-dm-search").fill("charlie");
+  await page
+    .getByTestId(`new-dm-result-${TEST_IDENTITIES.charlie.pubkey}`)
+    .click();
+
+  const message = "Wake for this first direct message";
+  await page.getByTestId("message-input").fill(message);
+  const baselineCommands = await readCommandPayloadLog(page);
+  await page.getByTestId("send-message").click();
+
+  await expect(page.getByTestId("message-timeline")).toContainText(message);
+  const sendCommands = (await readCommandPayloadLog(page)).slice(
+    baselineCommands.length,
+  );
+  const startIndex = sendCommands.findIndex(
+    (entry) => entry.command === "start_managed_agent_runtime",
+  );
+  const sendIndex = outgoingEventIndex(sendCommands, message);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(sendIndex).toBeGreaterThan(startIndex);
+  expect(sendCommands.map((entry) => entry.command)).not.toContain(
+    "start_managed_agent",
+  );
+});
+
+test("wakes a stopped local agent before sending in an existing DM without a mention", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.alice.pubkey,
+        name: "alice",
+        status: "stopped",
+        channelNames: ["alice-tyler"],
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-alice-tyler").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("alice-tyler");
+
+  const message = "Wake for this existing direct message";
+  await page.getByTestId("message-input").fill(message);
+  const baselineCommands = await readCommandPayloadLog(page);
+  await page.getByTestId("send-message").click();
+
+  await expect(page.getByTestId("message-timeline")).toContainText(message);
+  const sendCommands = (await readCommandPayloadLog(page)).slice(
+    baselineCommands.length,
+  );
+  const startIndex = sendCommands.findIndex(
+    (entry) => entry.command === "start_managed_agent_runtime",
+  );
+  const sendIndex = outgoingEventIndex(sendCommands, message);
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+  expect(sendIndex).toBeGreaterThan(startIndex);
+  expect(sendCommands.map((entry) => entry.command)).not.toContain(
+    "start_managed_agent",
+  );
 });
 
 test("creates the DM before preparing a persona mention", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Wake local managed-agent runtimes before publishing messages intended for them.
- Treat managed participants in new and existing DMs as recipients without requiring an explicit `@mention`.
- Wait for the active community pair runtime to become receive-ready, and preserve the draft if startup fails or times out.
- Keep channel wakeups mention-scoped and leave provider-backed agent startup behavior unchanged.

## Problem

The relay can accept a DM while its local managed-agent runtime is stopped and has no active subscription. The sender then sees a delivered message, but the agent never receives it and does not respond.

The Desktop send flow previously derived its agent startup audience from explicit mentions only. That misses ordinary DMs, where the selected or existing conversation participant already expresses the recipient intent. The local startup path also did not wait for the pair-scoped runtime to reach a receive-ready state before publishing.

This change derives the wake audience from DM participants, starts the local pair runtime on demand, and waits until it reports `listening`, `waking`, or `ready` before sending.

## Scope

This is a Desktop-side fix for locally managed agents. It does not add relay delivery receipts, durable offline replay, or wake agents owned by another client.

Partially addresses #1743.

## Validation

- `just ci`
- `cd desktop && pnpm build:e2e`
- `cd desktop && pnpm exec playwright test tests/e2e/channels.spec.ts --project=smoke --grep "wakes a stopped local agent"`

The focused E2E coverage verifies both a first DM and an existing DM without an explicit mention, including that runtime startup happens before the outgoing WebSocket event.
