### PR TITLE
fix: reduce default parallelism to 1, use lazy pool on manual start

### DIFF
--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -2127,7 +2127,11 @@ pub fn start_managed_agent_process(
     // Scalar PIDs are migration-only and never establish pair liveness.
     record.runtime_pid = None;
 
-    let mut process = spawn_agent_child(app, record, &key.relay_url, false, owner_hex)?;
+    // Use lazy-pool startup for manual starts, matching launch-time restore.
+    // Eager startup (false) would immediately initialize the full worker pool,
+    // consuming large amounts of RAM and creating visible idle Codex sessions
+    // before any work arrives. See restore.rs F1 comment for the same rationale.
+    let mut process = spawn_agent_child(app, record, &key.relay_url, true, owner_hex)?;
     let now = now_iso();
     let receipt = super::ManagedAgentRuntimeReceipt {
         key: key.clone(),

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -728,7 +728,7 @@ pub struct UpdateTeamRequest {
 pub const DEFAULT_ACP_COMMAND: &str = "buzz-acp";
 /// ~5 min (320s) — matches the CLI harness default (BUZZ_ACP_IDLE_TIMEOUT).
 pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 320;
-pub const DEFAULT_AGENT_PARALLELISM: u32 = 24;
+pub const DEFAULT_AGENT_PARALLELISM: u32 = 1;
 
 fn default_agent_parallelism() -> u32 {
     DEFAULT_AGENT_PARALLELISM

--- a/desktop/src-tauri/src/managed_agents/types/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/tests.rs
@@ -649,3 +649,47 @@ fn mint_rejects_out_of_range_input_parallelism() {
         "input-branch error must not blame the definition: {err}"
     );
 }
+
+/// Regression test for issue #2631: the default parallelism must be 1 so that
+/// desktop agents do not eagerly spawn large ACP pools on startup, consuming
+/// double-digit GiB of RAM and creating idle Codex sessions.
+#[test]
+fn default_agent_parallelism_is_one() {
+    assert_eq!(
+        super::DEFAULT_AGENT_PARALLELISM,
+        1,
+        "default parallelism must be 1 to avoid eagerly spawning large ACP pools; \
+         see issue #2631"
+    );
+}
+
+/// Records created before explicit parallelism was stored must deserialize to
+/// the safe default of 1, not the old default of 24.
+#[test]
+fn managed_agent_record_without_parallelism_defaults_to_one() {
+    let record: ManagedAgentRecord = serde_json::from_str(
+        r#"{
+            "pubkey": "abcd1234",
+            "name": "legacy-agent",
+            "private_key_nsec": "nsec1fake",
+            "relay_url": "wss://localhost:3000",
+            "acp_command": "buzz-acp",
+            "agent_command": "goose",
+            "agent_args": [],
+            "mcp_command": "",
+            "turn_timeout_seconds": 320,
+            "system_prompt": null,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "last_started_at": null,
+            "last_stopped_at": null,
+            "last_exit_code": null,
+            "last_error": null
+        }"#,
+    )
+    .expect("legacy record without parallelism field should deserialize");
+    assert_eq!(
+        record.parallelism, 1,
+        "legacy records must default to parallelism 1, not the old value of 24"
+    );
+}


### PR DESCRIPTION
## Summary

- Change `DEFAULT_AGENT_PARALLELISM` from 24 to 1 in `types.rs`
- Use lazy-pool startup (`lazy: true`) in `start_managed_agent_process` to match launch-time restore behavior

## Problem

With the default parallelism of 24, starting agents eagerly initializes the full worker pool via `spawn_agent_child(..., false, ...)`. With Codex ACP backends, each worker spawns multiple processes (adapter + app-server chain), resulting in ~220 idle processes and ~14 GB RSS for just four agents -- before any work arrives.

The launch-time restore path already uses `lazy: true` with an explicit comment ("eager restore... silently reintroduces N idle brains on every launch"). The manual-start path lacked the same protection.

## Changes

- `types.rs`: `DEFAULT_AGENT_PARALLELISM` 24 → 1. Desktop installations should default to a single worker; higher parallelism remains available as an explicit setting.
- `runtime.rs`: `start_managed_agent_process` now passes `lazy: true` to `spawn_agent_child`, deferring pool initialization until the first event arrives.
- `types/tests.rs`: two regression tests pinning `DEFAULT_AGENT_PARALLELISM == 1` and verifying legacy records without an explicit parallelism field deserialize to 1.

## Test plan

- [x] `default_agent_parallelism_is_one` -- asserts `DEFAULT_AGENT_PARALLELISM == 1`
- [x] `managed_agent_record_without_parallelism_defaults_to_one` -- legacy JSON without a `parallelism` key deserializes to 1
- [x] Verified `BUZZ_ACP_LAZY_POOL=true` is already used by `spawn_agent_child` when `lazy=true` (runtime.rs line 1722), so the env-var path is covered by the existing harness

Fixes #2631