### PR TITLE
fix(desktop): show shared relay agents

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -5,7 +5,7 @@ import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isAgentAddableByCurrentUser,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
@@ -136,27 +136,27 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
-test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
-  const managedAgentPubkeys = new Set([PUB_A]);
+test("isAgentAddableByCurrentUser: keeps people and only invocable agent identities", () => {
+  const mentionableAgentPubkeys = new Set([PUB_A]);
 
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentAddableByCurrentUser(
       { isAgent: false, pubkey: PUB_B },
-      managedAgentPubkeys,
+      mentionableAgentPubkeys,
     ),
     true,
   );
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentAddableByCurrentUser(
       { isAgent: true, pubkey: PUB_A.toUpperCase() },
-      managedAgentPubkeys,
+      mentionableAgentPubkeys,
     ),
     true,
   );
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentAddableByCurrentUser(
       { isAgent: true, pubkey: PUB_B },
-      managedAgentPubkeys,
+      mentionableAgentPubkeys,
     ),
     false,
   );

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -54,13 +54,13 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
-export function isAgentIdentityInManagedList(
+export function isAgentAddableByCurrentUser(
   candidate: { isAgent?: boolean; pubkey: string },
-  managedAgentPubkeys: ReadonlySet<string>,
+  mentionableAgentPubkeys: ReadonlySet<string>,
 ) {
   return (
     candidate.isAgent !== true ||
-    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
+    mentionableAgentPubkeys.has(normalizePubkey(candidate.pubkey))
   );
 }
 

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -5,11 +5,14 @@ import {
   invalidateChannelState,
   useAddChannelMembersMutation,
   useChannelMembersQuery,
+  useChannelsQuery,
 } from "@/features/channels/hooks";
 import { attachManagedAgentToChannel } from "@/features/agents/channelAgents";
 import {
   coalesceAgentAutocompleteCandidates,
-  isAgentIdentityInManagedList,
+  getMentionableAgentPubkeys,
+  getSharedChannelIds,
+  isAgentAddableByCurrentUser,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
@@ -240,6 +243,35 @@ export function MembersSidebar({
     () => new Set(rawMembers.map((member) => normalizePubkey(member.pubkey))),
     [rawMembers],
   );
+  const managedAgentPubkeys = React.useMemo(
+    () =>
+      new Set(
+        (managedAgentsQuery.data ?? []).map((agent) =>
+          normalizePubkey(agent.pubkey),
+        ),
+      ),
+    [managedAgentsQuery.data],
+  );
+  const channelsQuery = useChannelsQuery();
+  const sharedChannelIds = React.useMemo(
+    () => getSharedChannelIds(channelsQuery.data),
+    [channelsQuery.data],
+  );
+  const mentionableAgentPubkeys = React.useMemo(
+    () =>
+      getMentionableAgentPubkeys({
+        currentPubkey,
+        managedAgentPubkeys,
+        relayAgents: relayAgentsQuery.data,
+        sharedChannelIds,
+      }),
+    [
+      currentPubkey,
+      managedAgentPubkeys,
+      relayAgentsQuery.data,
+      sharedChannelIds,
+    ],
+  );
   const canAddMembers =
     (selfMember !== null || channel?.visibility === "open") &&
     channel?.channelType !== "dm";
@@ -271,8 +303,6 @@ export function MembersSidebar({
         .map((member) => member.displayName?.trim().toLowerCase())
         .filter((label): label is string => Boolean(label)),
     );
-    const managedAgentPubkeys = new Set(managedAgentsByPubkey.keys());
-
     const addCandidate = (candidate: AddMemberSearchCandidate) => {
       const pubkey = normalizePubkey(candidate.pubkey);
       if (
@@ -282,7 +312,7 @@ export function MembersSidebar({
           )) ||
         memberPubkeys.has(pubkey) ||
         isArchivedDiscovery(pubkey) ||
-        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+        !isAgentAddableByCurrentUser(candidate, mentionableAgentPubkeys)
       ) {
         return;
       }
@@ -363,6 +393,7 @@ export function MembersSidebar({
     canAddMembers,
     isArchivedDiscovery,
     currentPubkey,
+    mentionableAgentPubkeys,
     managedAgentsQuery.data,
     memberPubkeys,
     normalizedDeferredSearchQuery,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,6 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,9 +245,6 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
-        return;
-      }
       if (
         shouldHideAgentFromMentions({
           isAgent: candidate.isAgent === true,
@@ -420,7 +416,6 @@ export function useMentions(
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,
     managedAgentPersonaIdsByPubkey,
-    managedAgentPubkeys,
     managedAgentsQuery.data,
     memberPubkeys,
     members,


### PR DESCRIPTION
## Summary

- allow eligible shared relay agents to appear in message mention suggestions
- allow those same agents to appear in the channel member picker
- derive eligibility from the relay agent directory, the current user, and shared joined channels
- retain existing behavior for people and locally managed agents

## Root cause

The mention and member-search paths applied a locally-managed-agent gate before the shared relay-agent eligibility policy. That excluded agents owned by other members even when their `respondTo` policy allowed the current user to invoke them.

## Validation

- `just ci`
- `just test-integration`
- pre-push `desktop-check`
- pre-push `desktop-test` (3,455 tests)

Fixes #2603
