### PR TITLE
feat(onboarding): add private key download

### DIFF
--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -1,8 +1,11 @@
 use nostr::{
     nips::nip44, Event, EventBuilder, JsonUtil, Keys, Kind, PublicKey, Tag, Timestamp, ToBech32,
 };
+use std::io::Write;
 use tauri::Manager;
 use tauri::State;
+use tauri_plugin_dialog::DialogExt;
+use zeroize::Zeroizing;
 
 use crate::{
     app_state::AppState,
@@ -186,6 +189,66 @@ pub fn get_nsec(state: State<'_, AppState>) -> Result<String, String> {
     keys.secret_key()
         .to_bech32()
         .map_err(|error| format!("encode nsec: {error}"))
+}
+
+fn write_identity_backup(path: &std::path::Path, nsec: &str) -> Result<(), String> {
+    use atomic_write_file::AtomicWriteFile;
+
+    let mut file = AtomicWriteFile::open(path)
+        .map_err(|error| format!("open identity backup for atomic write: {error}"))?;
+
+    // Apply owner-only permissions before any secret bytes reach disk.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .map_err(|error| format!("set identity backup permissions: {error}"))?;
+    }
+
+    file.write_all(nsec.as_bytes())
+        .map_err(|error| format!("write identity backup: {error}"))?;
+    file.write_all(b"\n")
+        .map_err(|error| format!("write identity backup: {error}"))?;
+    file.commit()
+        .map_err(|error| format!("commit identity backup: {error}"))
+}
+
+/// Save the current identity key through the native file picker.
+///
+/// The frontend never supplies the key: it is read from trusted app state only
+/// after the user chooses a destination. The plaintext string is zeroized when
+/// this command returns, and Unix backups are written owner-only (`0o600`).
+#[tauri::command]
+pub async fn save_identity_backup(app: tauri::AppHandle) -> Result<bool, String> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.dialog()
+        .file()
+        .add_filter("Text file", &["txt"])
+        .set_file_name("buzz-identity-key.txt")
+        .save_file(move |path| {
+            let _ = tx.send(path);
+        });
+
+    let selected = rx
+        .await
+        .map_err(|_| "identity backup dialog closed unexpectedly".to_string())?;
+    let Some(selected) = selected else {
+        return Ok(false);
+    };
+    let destination = selected
+        .as_path()
+        .ok_or_else(|| "Save dialog returned an invalid path".to_string())?;
+
+    let state = app.state::<AppState>();
+    let keys = state.signing_keys()?;
+    let nsec = Zeroizing::new(
+        keys.secret_key()
+            .to_bech32()
+            .map_err(|error| format!("encode nsec: {error}"))?,
+    );
+    write_identity_backup(destination, &nsec)?;
+
+    Ok(true)
 }
 
 #[tauri::command]
@@ -581,5 +644,36 @@ mod nostr_identity_binding_tests {
         .unwrap_err();
 
         assert_eq!(error, "expires_at is expired");
+    }
+}
+
+#[cfg(test)]
+mod identity_backup_tests {
+    use super::write_identity_backup;
+
+    #[test]
+    fn identity_backup_is_plain_text_with_a_trailing_newline() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("buzz-identity-key.txt");
+
+        write_identity_backup(&path, "nsec1example").unwrap();
+
+        assert_eq!(std::fs::read_to_string(path).unwrap(), "nsec1example\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identity_backup_replaces_permissive_files_with_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("buzz-identity-key.txt");
+        std::fs::write(&path, "old contents").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_identity_backup(&path, "nsec1example").unwrap();
+
+        let mode = std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
     }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -663,6 +663,7 @@ pub fn run() {
             title_bar_double_click,
             get_identity,
             get_nsec,
+            save_identity_backup,
             import_identity,
             persist_current_identity,
             get_profile,

--- a/desktop/src/features/onboarding/ui/BackupStep.tsx
+++ b/desktop/src/features/onboarding/ui/BackupStep.tsx
@@ -1,7 +1,8 @@
 import { AlertTriangle, Info, RefreshCw } from "lucide-react";
 import * as React from "react";
+import { toast } from "sonner";
 
-import { getNsec } from "@/shared/api/tauriIdentity";
+import { getNsec, saveIdentityBackup } from "@/shared/api/tauriIdentity";
 import { Button } from "@/shared/ui/button";
 import { Card } from "@/shared/ui/card";
 import { Spinner } from "@/shared/ui/spinner";
@@ -43,7 +44,9 @@ export function BackupStep({ direction, onBack, onNext }: BackupStepProps) {
   const [nsec, setNsec] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
   const [loadError, setLoadError] = React.useState<string | null>(null);
+  const [isDownloading, setIsDownloading] = React.useState(false);
   const cancelledRef = React.useRef(false);
+  const downloadInFlightRef = React.useRef(false);
 
   const loadNsec = React.useCallback(async () => {
     setIsLoading(true);
@@ -73,6 +76,24 @@ export function BackupStep({ direction, onBack, onNext }: BackupStepProps) {
       setNsec(null);
     };
   }, [loadNsec]);
+
+  async function handleDownload() {
+    if (downloadInFlightRef.current) return;
+    downloadInFlightRef.current = true;
+    setIsDownloading(true);
+    try {
+      const saved = await saveIdentityBackup();
+      if (saved) toast.success("Private key saved");
+    } catch (error) {
+      toast.error("Failed to save private key", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+      });
+    } finally {
+      downloadInFlightRef.current = false;
+      if (!cancelledRef.current) setIsDownloading(false);
+    }
+  }
 
   return (
     <OnboardingSlideTransition
@@ -124,8 +145,13 @@ export function BackupStep({ direction, onBack, onNext }: BackupStepProps) {
           </div>
         ) : nsec ? (
           <Card className="w-full px-8 py-6" variant="textured">
-            <div className="mx-auto w-full max-w-[832px]">
-              <NsecMaskedDisplay nsec={nsec} variant="bare" />
+            <div className="mx-auto w-full max-w-[896px]">
+              <NsecMaskedDisplay
+                isDownloading={isDownloading}
+                nsec={nsec}
+                onDownload={() => void handleDownload()}
+                variant="bare"
+              />
             </div>
           </Card>
         ) : (

--- a/desktop/src/features/onboarding/ui/NsecMaskedDisplay.tsx
+++ b/desktop/src/features/onboarding/ui/NsecMaskedDisplay.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, Eye, EyeOff } from "lucide-react";
+import { Check, Copy, Download, Eye, EyeOff, LoaderCircle } from "lucide-react";
 import * as React from "react";
 import { Button } from "@/shared/ui/button";
 import { writeTextToClipboard } from "@/shared/lib/clipboard";
@@ -12,6 +12,9 @@ type NsecMaskedDisplayProps = {
    * a backup (e.g. sign-out) gate on actual interaction with the key.
    */
   onKeyInteraction?: () => void;
+  /** Optional native backup action, shown beside reveal and copy. */
+  onDownload?: () => void;
+  isDownloading?: boolean;
 };
 
 export const ONBOARDING_KEY_FRAME_CLASS =
@@ -31,6 +34,8 @@ export function NsecMaskedDisplay({
   nsec,
   variant = "boxed",
   onKeyInteraction,
+  onDownload,
+  isDownloading = false,
 }: NsecMaskedDisplayProps) {
   const [isRevealed, setIsRevealed] = React.useState(false);
   const [isCopied, setIsCopied] = React.useState(false);
@@ -139,6 +144,27 @@ export function NsecMaskedDisplay({
               <Copy className={iconSize} aria-hidden="true" />
             )}
           </Button>
+          {onDownload ? (
+            <Button
+              aria-label="Download private key"
+              className={`${isBare ? "h-10 w-10" : "h-7 w-7"} text-muted-foreground hover:text-foreground`}
+              data-testid="nsec-download"
+              disabled={isDownloading}
+              onClick={onDownload}
+              size="icon"
+              type="button"
+              variant="ghost"
+            >
+              {isDownloading ? (
+                <LoaderCircle
+                  className={`${iconSize} animate-spin`}
+                  aria-hidden="true"
+                />
+              ) : (
+                <Download className={iconSize} aria-hidden="true" />
+              )}
+            </Button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/desktop/src/shared/api/tauriIdentity.ts
+++ b/desktop/src/shared/api/tauriIdentity.ts
@@ -27,6 +27,10 @@ export async function getNsec(): Promise<string> {
   return invokeTauri<string>("get_nsec");
 }
 
+export async function saveIdentityBackup(): Promise<boolean> {
+  return invokeTauri<boolean>("save_identity_backup");
+}
+
 export async function importIdentity(nsec: string): Promise<Identity> {
   return fromRawIdentity(
     await invokeTauri<RawIdentity>("import_identity", { nsec }),

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -9309,6 +9309,10 @@ export function maybeInstallE2eTauriMocks() {
         }
         return "nsec1mock000000000000000000000000000000000000000000000000000000";
       }
+      case "save_identity_backup":
+        // The browser harness cannot open a native save dialog. Returning true
+        // lets onboarding specs assert the command and success feedback.
+        return true;
       case "persist_current_identity": {
         // Persist the ephemeral key: clears only the lost flag. The locked flag
         // is cleared only by import_identity; production rejects

--- a/desktop/tests/e2e/onboarding-backup.spec.ts
+++ b/desktop/tests/e2e/onboarding-backup.spec.ts
@@ -57,6 +57,30 @@ test("backup step shows masked nsec from mock bridge", async ({ page }) => {
   });
 });
 
+test("backup step downloads the private key through the native save command", async ({
+  page,
+}) => {
+  await enterMachineBackup(page);
+
+  const download = page.getByRole("button", {
+    name: "Download private key",
+  });
+  await expect(download).toBeVisible();
+  await download.click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          window.__BUZZ_E2E_COMMANDS__?.filter(
+            (command) => command === "save_identity_backup",
+          ).length ?? 0,
+      ),
+    )
+    .toBe(1);
+  await expect(page.getByText("Private key saved")).toBeVisible();
+});
+
 test("backup step Next is enabled once the key is shown", async ({ page }) => {
   await enterMachineBackup(page);
 


### PR DESCRIPTION
## Summary

- add a Download action beside Reveal and Copy on the fresh-identity backup step
- save `buzz-identity-key.txt` through the native file picker
- write key backups atomically and owner-only on Unix
- keep private-key bytes out of browser download URLs, filenames, and IPC payloads

## Why

The onboarding copy asks users to save the key somewhere safe, but the only available action was copying it to the clipboard. A native save action removes the manual copy-and-create-file step while keeping the destination explicit.

## Security

- the native command reads the key from trusted app state after the destination is selected
- the encoded key is zeroized when the command returns
- Unix backups are written with `0600` permissions before secret bytes reach disk
- cancellation creates no file and shows no success state

## Validation

- `just ci`
- `pnpm --dir desktop exec playwright test --project=smoke tests/e2e/onboarding-backup.spec.ts`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml identity_backup_tests`
