### PR TITLE
fix(desktop): refine floating content surface

### DIFF
--- a/desktop/src/app/BuzzThemeSurfaces.tsx
+++ b/desktop/src/app/BuzzThemeSurfaces.tsx
@@ -22,7 +22,7 @@ export function GradientLayer() {
 export function ContentSurface({ children }: { children: ReactNode }) {
   return (
     <div
-      className="relative z-10 mb-2 ml-px mr-2 mt-px flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl bg-background shadow-content-edge"
+      className="relative z-10 mb-1 ml-px mr-1 mt-px flex min-h-0 flex-1 flex-col overflow-hidden rounded-content-surface bg-background shadow-content-edge"
       data-buzz-content-surface
     >
       {children}

--- a/desktop/src/features/settings/ui/SettingsView.tsx
+++ b/desktop/src/features/settings/ui/SettingsView.tsx
@@ -320,7 +320,7 @@ export function SettingsView({
           data-tauri-drag-region
         />
         <div
-          className="relative z-10 mb-2 ml-px mr-2 mt-px flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl bg-background shadow-content-edge"
+          className="relative z-10 mb-1 ml-px mr-1 mt-px flex min-h-0 flex-1 flex-col overflow-hidden rounded-content-surface bg-background shadow-content-edge"
           data-buzz-content-surface
           data-testid="settings-content-surface"
         >

--- a/desktop/tailwind.config.js
+++ b/desktop/tailwind.config.js
@@ -30,6 +30,10 @@ export default {
           "-1px 0 0 0 hsl(var(--border) / 0.8), -16px 0 32px -12px rgb(0 0 0 / 0.18)",
       },
       borderRadius: {
+        // Keep the floating content surface visually aligned with the native
+        // macOS window while preserving the 0.25rem (4px) inset. An 8px
+        // optical radius avoids the sharper appearance of a literal 6px arc.
+        "content-surface": "8px",
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",

--- a/desktop/tests/e2e/buzz-theme-screenshots.spec.ts
+++ b/desktop/tests/e2e/buzz-theme-screenshots.spec.ts
@@ -534,6 +534,7 @@ test("settings content uses the same inset surface as the main app", async ({
     .getByTestId("settings-back-to-app")
     .boundingBox();
   await expect(contentSurface).toBeVisible({ timeout: 10_000 });
+  await expect(contentSurface).toHaveCSS("border-radius", "8px");
   await expect(page.getByTestId("settings-content-scroll")).toHaveCSS(
     "padding-top",
     "24px",
@@ -552,12 +553,12 @@ test("settings content uses the same inset surface as the main app", async ({
   expect(Math.abs(backToAppBox.y - searchBox.y)).toBeLessThanOrEqual(0.5);
 
   // Match the normal app shell: a fixed 40px top chrome strip, then a 1px
-  // top/left inset and 8px right/bottom inset around the rounded content card.
+  // top/left inset and 4px right/bottom inset around the rounded content card.
   expect(surfaceBox.y - viewBox.y).toBe(41);
   expect(surfaceBox.x - viewBox.x).toBe(1);
-  expect(viewBox.x + viewBox.width - (surfaceBox.x + surfaceBox.width)).toBe(8);
+  expect(viewBox.x + viewBox.width - (surfaceBox.x + surfaceBox.width)).toBe(4);
   expect(viewBox.y + viewBox.height - (surfaceBox.y + surfaceBox.height)).toBe(
-    8,
+    4,
   );
 
   await waitForAnimations(page);


### PR DESCRIPTION
## Summary

- reduce the floating desktop content surface right and bottom inset from 8px to 4px
- introduce an 8px optical radius so the inner surface better follows the native macOS window contour
- apply the same treatment to Settings and cover the geometry in the existing screenshot test

## Why

The previous 16px surface radius and 8px inset made the inner page corner feel disconnected from the surrounding macOS window. The smaller inset and dedicated optical radius create a tighter, more coherent frame while retaining a visible strip of the Buzz gradient.

## Testing

- `just ci`
- `just desktop-check`
- `just desktop-test`
- `pnpm -C desktop build:e2e`
- `pnpm -C desktop exec playwright test tests/e2e/buzz-theme-screenshots.spec.ts --project=smoke --grep "settings content uses the same inset surface as the main app"`
- repository pre-push suite (desktop, Rust, Tauri, and mobile)

## Manual verification

- verified the main channel surface and Settings surface in the macOS desktop app
- checked the bottom-right corner at Retina scale