### PR TITLE
fix(mentions): resolve emphasis/spoiler-wrapped @mentions in CLI (#2526)

### DIFF
--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -187,8 +187,12 @@ async fn resolve_content_mentions(
     }
 
     // 4. Two-pass extraction: known multi-word names first, single-word fallback.
+    //    Strip code blocks/spans first so an `@name` inside a code sample does
+    //    not fire a notification — matching both the NIP-27 URI path below and
+    //    Desktop's `hasMention.ts`.
+    let scan = strip_code_regions(content);
     let known_refs: Vec<&str> = display_names.iter().map(|s| s.as_str()).collect();
-    let names = extract_at_mentions_with_known(content, &known_refs);
+    let names = extract_at_mentions_with_known(&scan, &known_refs);
 
     // 5. Look up matched names → pubkeys via the map we already built.
     names
@@ -878,7 +882,8 @@ pub async fn dispatch(
 mod tests {
     use super::{find_root_from_tags, match_profiles_by_name, parse_member_pubkeys};
     use buzz_sdk::mentions::{
-        extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
+        extract_at_mentions_with_known, extract_at_names, match_names_to_profiles,
+        strip_code_regions, MentionProfile,
     };
     use serde_json::json;
 
@@ -1054,6 +1059,44 @@ mod tests {
             .cloned()
             .collect();
         assert_eq!(resolved, vec![PK_VALID_A, PK_VALID_B]);
+    }
+
+    #[test]
+    fn cli_pipeline_resolves_emphasis_wrapped_mentions() {
+        // #2526: **@Name** from an agent must resolve to a p-tag exactly like
+        // @Name. Runs the full resolve_content_mentions chain: known-name
+        // extraction → display-name → pubkey, proving a p-tag is emitted.
+        let mut name_to_pubkeys: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        name_to_pubkeys.insert("atlas".into(), vec![PK_VALID_A.into()]);
+        name_to_pubkeys.insert("will pfleger".into(), vec![PK_VALID_B.into()]);
+        let known = ["Atlas", "Will Pfleger"];
+
+        for (content, expected) in [
+            ("**@Atlas** your fix is aimed", vec![PK_VALID_A]),
+            ("cc **@Will Pfleger**", vec![PK_VALID_B]),
+            ("_@Atlas_ and (@Will Pfleger)", vec![PK_VALID_A, PK_VALID_B]),
+        ] {
+            let names = extract_at_mentions_with_known(content, &known);
+            let pubkeys: Vec<String> = names
+                .iter()
+                .flat_map(|n| name_to_pubkeys.get(n).into_iter().flatten())
+                .cloned()
+                .collect();
+            assert_eq!(pubkeys, expected, "content: {content}");
+        }
+    }
+
+    #[test]
+    fn cli_pipeline_ignores_mentions_inside_code() {
+        // #2526: an @name inside a code span/block must NOT fire a notification.
+        // Mirrors resolve_content_mentions: strip_code_regions then extract.
+        let known = ["Atlas"];
+        let scan = strip_code_regions("run `buzz send --to @Atlas` like so");
+        assert!(extract_at_mentions_with_known(&scan, &known).is_empty());
+
+        let fenced = strip_code_regions("before\n```\n@Atlas\n```\nafter");
+        assert!(extract_at_mentions_with_known(&fenced, &known).is_empty());
     }
 
     #[test]

--- a/crates/buzz-sdk/src/mentions.rs
+++ b/crates/buzz-sdk/src/mentions.rs
@@ -57,7 +57,9 @@ pub struct MentionProfile<'a> {
 ///
 /// Returns lowercased names found after `@` tokens. An `@name` only matches
 /// when the `@` is at start-of-string or preceded by an ASCII whitespace
-/// character — this excludes things like email addresses (`user@host`).
+/// character or a mention delimiter (`*`, `_`, `(`, `|` — markdown emphasis,
+/// spoiler bars, or an opening paren; see `is_mention_lead`). This admits
+/// `**@name**`/`_@name_` while still excluding email addresses (`user@host`).
 ///
 /// Allowed name characters: ASCII alphanumerics, `.`, `-`, `_`.
 /// Duplicates are removed; first-seen order is preserved.
@@ -72,7 +74,7 @@ pub fn extract_at_names(content: &str) -> Vec<String> {
     let mut i = 0;
     while i < len {
         if chars[i] == '@' {
-            let preceded_by_ws = i == 0 || chars[i - 1].is_ascii_whitespace();
+            let preceded_by_ws = i == 0 || is_mention_lead(chars[i - 1]);
             if preceded_by_ws && i + 1 < len {
                 let start = i + 1;
                 let mut end = start;
@@ -100,7 +102,8 @@ pub fn extract_at_names(content: &str) -> Vec<String> {
 
 /// Extract `@mention` names from message content using known member names.
 ///
-/// At each `@` preceded by whitespace or start-of-string, tries known names
+/// At each `@` at start-of-string or preceded by whitespace or a mention
+/// delimiter (`*`, `_`, `(`, `|`; see `is_mention_lead`), tries known names
 /// longest-first (case-insensitive, word-boundary-checked), then falls back
 /// to single-word tokenization. Returns lowercased names in first-seen order,
 /// deduplicated. Empty/whitespace-only entries in `known_names` are ignored.
@@ -120,7 +123,11 @@ pub fn extract_at_mentions_with_known(content: &str, known_names: &[&str]) -> Ve
     let mut seen = HashSet::new();
 
     for (i, _) in content.match_indices('@') {
-        let preceded = i == 0 || content.as_bytes()[i - 1].is_ascii_whitespace();
+        let preceded = i == 0
+            || content[..i]
+                .chars()
+                .next_back()
+                .is_some_and(is_mention_lead);
         if !preceded {
             continue;
         }
@@ -151,9 +158,29 @@ pub fn extract_at_mentions_with_known(content: &str, known_names: &[&str]) -> Ve
     names
 }
 
+/// Characters that may immediately precede an `@` and still begin a mention.
+///
+/// Covers markdown emphasis (`*`, `_`), NIP-style spoiler bars (`|`), and an
+/// opening paren — matching Desktop's `hasMention.ts`. Start-of-string and
+/// whitespace are the base cases; this widens the set so `**@name**`,
+/// `_@name_`, `(@name)` and `||@name||` resolve like a bare `@name`. An email
+/// local part (`user@host`) is still excluded: `r` is none of these.
+fn is_mention_lead(prev: char) -> bool {
+    prev.is_ascii_whitespace() || matches!(prev, '*' | '_' | '(' | '|')
+}
+
+/// Trailing delimiters that terminate a known-name match.
+///
+/// Widened past plain punctuation to admit markdown emphasis (`*`, `_`) and
+/// spoiler bars (`|`) so a name wrapped as `@Will Pfleger**` still matches the
+/// full known name instead of falling through to the single-word tokenizer.
 fn is_word_boundary(s: &str) -> bool {
     s.chars().next().is_none_or(|c| {
-        c.is_ascii_whitespace() || matches!(c, ',' | ';' | '.' | '!' | '?' | ':' | ')' | ']' | '}')
+        c.is_ascii_whitespace()
+            || matches!(
+                c,
+                ',' | ';' | '.' | '!' | '?' | ':' | ')' | ']' | '}' | '*' | '_' | '|'
+            )
     })
 }
 
@@ -540,6 +567,71 @@ mod tests {
         // Reverse case: multi-byte known name against ASCII content.
         let result = extract_at_mentions_with_known("@alice hello", &["日本語"]);
         assert_eq!(result, vec!["alice"]);
+    }
+
+    // --- #2526: markdown emphasis / spoiler / paren delimiters around @mentions ---
+    // Parity with Desktop's hasMention.ts, which admits *, _, (, || as delimiters.
+
+    #[test]
+    fn extract_at_names_bold_and_italic_wrapped() {
+        // The core repro: **@Atlas** was silently dropped (preceding byte '*').
+        assert_eq!(extract_at_names("**@atlas** your fix"), vec!["atlas"]);
+        assert_eq!(extract_at_names("*@bob* hi"), vec!["bob"]);
+    }
+
+    #[test]
+    fn extract_at_names_paren_and_spoiler_lead() {
+        assert_eq!(extract_at_names("(@alice)"), vec!["alice"]);
+        assert_eq!(extract_at_names("||@bob|| spoiler"), vec!["bob"]);
+    }
+
+    #[test]
+    fn extract_at_names_still_rejects_email() {
+        // Widening the lead delimiter must NOT start matching email locals.
+        assert!(extract_at_names("user@example.com").is_empty());
+    }
+
+    #[test]
+    fn known_name_bold_wrapped_matches() {
+        // The exact production failure from the issue.
+        assert_eq!(
+            extract_at_mentions_with_known("**@Atlas** your fix is aimed", &["Atlas"]),
+            vec!["atlas"]
+        );
+    }
+
+    #[test]
+    fn known_name_italic_spoiler_paren_wrapped_match() {
+        assert_eq!(
+            extract_at_mentions_with_known("_@Atlas_", &["Atlas"]),
+            vec!["atlas"]
+        );
+        assert_eq!(
+            extract_at_mentions_with_known("||@Atlas||", &["Atlas"]),
+            vec!["atlas"]
+        );
+        assert_eq!(
+            extract_at_mentions_with_known("(@Atlas)", &["Atlas"]),
+            vec!["atlas"]
+        );
+    }
+
+    #[test]
+    fn trailing_emphasis_multiword_name_matches() {
+        // @Will Pfleger** must resolve the full name, not tokenize to "will".
+        assert_eq!(
+            extract_at_mentions_with_known("**@Will Pfleger** ping", &["Will Pfleger"]),
+            vec!["will pfleger"]
+        );
+        assert_eq!(
+            extract_at_mentions_with_known("cc @Will Pfleger_", &["Will Pfleger"]),
+            vec!["will pfleger"]
+        );
+    }
+
+    #[test]
+    fn known_name_email_still_rejected() {
+        assert!(extract_at_mentions_with_known("user@example.com", &["example.com"]).is_empty());
     }
 
     fn profile<'a>(pk: &'a str, json: &'a str) -> MentionProfile<'a> {


### PR DESCRIPTION
Fixes #2526.

## Problem

The Rust mention parser (`buzz-sdk/src/mentions.rs`) only accepted an `@` at start-of-string or after ASCII whitespace. Any `@mention` wrapped in markdown emphasis — `**@Name**`, `*@Name*`, `_@Name_`, `(@Name)`, `||@Name||` — was silently dropped: `buzz messages send` exited 0 with **zero `p` tags**, so nobody was notified and no `buzz-acp` agent woke.

Agents post exclusively through `buzz messages send`, so this broke agent handoffs with no signal to anyone — a handoff would stall until a human noticed. Desktop's `hasMention.ts` fixed the same class of bug months ago (#328); the Rust parser never got parity. This is parser divergence: two implementations of "is this an `@mention`" giving different answers on the two surfaces that have to agree.

## Fix

Bring `mentions.rs` to behavioural parity with `hasMention.ts` by widening the two existing predicates against one shared delimiter definition — rather than porting the TS regex, which would create a second hand-maintained list that drifts exactly as the first one did.

- **`is_mention_lead`** — accept `*`, `_`, `(`, `|` as leading delimiters, used at both `extract_at_names` and `extract_at_mentions_with_known`. Email locals (`user@host`) stay excluded.
- **`is_word_boundary`** — accept trailing `*`, `_`, `|` so `@Will Pfleger**` matches the full known name instead of falling through to the single-word tokenizer and yielding `will`.
- **CLI** — strip code regions before `@name` extraction in `resolve_content_mentions`, mirroring the existing NIP-27 URI path, so an `@name` inside a code sample no longer fires a false notification.

## Tests

The gap that let this ship: of 69 existing mention tests, not one had an emphasis character next to an `@`. Added:

- **buzz-sdk** (+7): bold/italic/spoiler/paren leading delimiters, trailing emphasis on multi-word names, and email-still-rejected regression guards.
- **buzz-cli** (+2): full resolution chain (`**@Atlas**` / `_@Atlas_` / `(@Will Pfleger)` → resolved pubkeys, proving a `p` tag is emitted) and the code-region exclusion.

## Verification

- `cargo test -p buzz-sdk -p buzz-cli` — 492 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo build --release -p buzz-cli` — clean
- `just test-unit` — passed

## Scope

Fixes the three parser divergences the issue prescribes. Deliberately out of scope: the optional stderr "zero mentions resolved" warning (better as a focused follow-up — a naive version would spam on every email) and the longer-term unification of the Rust and TS parsers.
