### PR TITLE
feat(desktop): add native glass themes

### DIFF
--- a/desktop/src/app/BuzzThemeSurfaces.tsx
+++ b/desktop/src/app/BuzzThemeSurfaces.tsx
@@ -22,7 +22,7 @@ export function GradientLayer() {
 export function ContentSurface({ children }: { children: ReactNode }) {
   return (
     <div
-      className="relative z-10 mb-2 ml-px mr-2 mt-px flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl bg-background shadow-content-edge"
+      className="relative z-10 mb-1 ml-px mr-1 mt-px flex min-h-0 flex-1 flex-col overflow-hidden rounded-content-surface bg-background shadow-content-edge"
       data-buzz-content-surface
     >
       {children}

--- a/desktop/src/features/settings/ui/SettingsPanels.tsx
+++ b/desktop/src/features/settings/ui/SettingsPanels.tsx
@@ -48,6 +48,7 @@ import {
 import {
   ACCENT_COLORS,
   isBuzzTheme,
+  isGlassTheme,
   NEUTRAL_ACCENT,
   useTheme,
 } from "@/shared/theme/ThemeProvider";
@@ -421,10 +422,9 @@ function ThemeSettingsCard() {
     setFollowSystem,
   } = useTheme();
 
-  // Buzz themes pin a neutral accent (GitHub black in light, white in dark),
-  // so the accent picker is hidden while a Buzz theme is active. `themeName` is
-  // the effective theme, so this also covers System mode resolving to Buzz.
-  const accentPickerHidden = isBuzzTheme(themeName);
+  // First-party Buzz and Glass themes pin a neutral accent, so their selected
+  // state stays consistent with their custom sidebar treatments.
+  const accentPickerHidden = isBuzzTheme(themeName) || isGlassTheme(themeName);
   const shouldReduceMotion = useReducedMotion();
 
   const previewVarsByTheme = useThemePreviewVars();

--- a/desktop/src/features/settings/ui/SettingsView.tsx
+++ b/desktop/src/features/settings/ui/SettingsView.tsx
@@ -320,7 +320,7 @@ export function SettingsView({
           data-tauri-drag-region
         />
         <div
-          className="relative z-10 mb-2 ml-px mr-2 mt-px flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl bg-background shadow-content-edge"
+          className="relative z-10 mb-1 ml-px mr-1 mt-px flex min-h-0 flex-1 flex-col overflow-hidden rounded-content-surface bg-background shadow-content-edge"
           data-buzz-content-surface
           data-testid="settings-content-surface"
         >

--- a/desktop/src/shared/styles/globals/theme.css
+++ b/desktop/src/shared/styles/globals/theme.css
@@ -562,19 +562,40 @@
 }
 
 /*
- * Translucency (Buzz theme).
+ * Translucency (Glass theme).
  *
- * ThemeProvider toggles `data-buzz-translucent` for Buzz themes. Keep the
+ * ThemeProvider toggles `data-buzz-translucent` only for Glass themes. Keep the
  * frosted layer on the outer canvases only; nested sidebar/header/footer
  * surfaces pass through so the nav reads as one continuous pane.
  */
 :root[data-buzz-translucent] {
-  --buzz-translucency-gradient-alpha: 70%;
-  --buzz-translucency-wash-alpha: 2.4%;
+  --buzz-translucency-gradient-alpha: 0%;
+  --buzz-translucency-wash-alpha: 25%;
+}
+
+/*
+ * Glass Dark must remain a dark surface independently of the macOS appearance.
+ * Layer a smoked neutral over a restrained Buzz tint while preserving enough
+ * transparency for the desktop and native frost to remain visible.
+ */
+:root[data-buzz-translucent].dark {
+  --buzz-translucency-gradient-alpha: 25%;
+  --buzz-translucency-wash-alpha: 90%;
+}
+
+/*
+ * The content surface normally has a top/left inset plus a highlight shadow.
+ * Against translucent chrome those combine into a bright rim, so both Glass
+ * variants remove the highlight and sit flush on those two edges.
+ */
+:root[data-buzz-sidebar][data-buzz-translucent] [data-buzz-content-surface] {
+  box-shadow: none;
+  margin-left: 0;
+  margin-top: 0;
 }
 
 :root[data-buzz-translucent] .buzz-theme-gradient-layer-light {
-  /* Buzz color wash above a neutral frost wash. */
+  /* Optional Buzz color wash above the native frost. */
   background-image:
     linear-gradient(
       to bottom,

--- a/desktop/src/shared/theme/ThemePreviewFrame.tsx
+++ b/desktop/src/shared/theme/ThemePreviewFrame.tsx
@@ -20,6 +20,16 @@ export const BUZZ_GRADIENT_STOPS: Record<
     top: "var(--buzz-gradient-dark-top)",
     bottom: "var(--buzz-gradient-dark-bottom)",
   },
+  // Theme previews cannot sample the desktop behind the native window, so the
+  // light preview shows the same subtle white wash layered over native frost.
+  glass: {
+    top: "rgb(255 255 255 / 25%)",
+    bottom: "rgb(255 255 255 / 25%)",
+  },
+  "glass-dark": {
+    top: "rgb(18 22 29 / 93%)",
+    bottom: "rgb(10 20 35 / 93%)",
+  },
 };
 
 export const LIGHT_PREVIEW_VARS: ThemePreviewVars = {

--- a/desktop/src/shared/theme/ThemeProvider.tsx
+++ b/desktop/src/shared/theme/ThemeProvider.tsx
@@ -30,7 +30,7 @@ const VIDEO_REVIEW_NEUTRAL_ACCENT = "0 0% 98%";
 const VIDEO_REVIEW_CHIP_SURFACE = "#161616";
 const VIDEO_REVIEW_TEXT_CONTRAST = 4.5;
 const VIDEO_REVIEW_CHIP_BACKGROUND_ALPHAS = [0.15, 0.3] as const;
-const BUZZ_VIBRANCY_MATERIAL = "sidebar";
+const GLASS_VIBRANCY_MATERIAL = "sidebar";
 
 export const ACCENT_COLORS = [
   { name: "Neutral", value: NEUTRAL_ACCENT },
@@ -212,51 +212,66 @@ function applyAccentColor(value: string) {
 }
 
 /**
- * The Buzz themes ship with a fixed neutral accent (the GitHub black/white
- * foreground) rather than a user-selectable accent color. When a Buzz theme is
- * active we force `NEUTRAL_ACCENT` regardless of the stored preference, and the
- * appearance panel hides the accent picker. The user's chosen accent is left
- * untouched in storage so it returns when they switch back to another theme.
+ * The Buzz and Glass themes ship with a fixed neutral accent (the GitHub
+ * black/white foreground) rather than a user-selectable accent color. When one
+ * is active we force `NEUTRAL_ACCENT` regardless of the stored preference and
+ * hide the accent picker. The user's chosen accent stays in storage so it
+ * returns when they switch back to another theme.
  */
 export function isBuzzTheme(themeName: string): boolean {
   return themeName === "buzz" || themeName === "buzz-dark";
 }
 
+/** Whether the selected theme uses native translucent window chrome. */
+export function isGlassTheme(themeName: string): boolean {
+  return themeName === "glass" || themeName === "glass-dark";
+}
+
+function isBuzzSurfaceTheme(themeName: string): boolean {
+  return isBuzzTheme(themeName) || isGlassTheme(themeName);
+}
+
 /**
- * Resolve the accent to actually apply for a theme: Buzz themes are pinned to
- * the neutral accent; every other theme uses the stored/selected accent.
+ * Resolve the accent to actually apply for a first-party surface theme: Buzz
+ * and Glass are pinned to neutral; every other theme uses the selected accent.
  */
 function resolveEffectiveAccent(
   themeName: string,
   accentColor: string,
 ): string {
-  return isBuzzTheme(themeName) ? NEUTRAL_ACCENT : accentColor;
+  return isBuzzSurfaceTheme(themeName) ? NEUTRAL_ACCENT : accentColor;
 }
 
 /**
  * Toggle the opaque Buzz sidebar-gradient marker. This is always safe to apply
  * synchronously: `data-buzz-sidebar` paints solid gradient colors, so it never
  * makes the window see-through. The *translucent* treatment (transparent
- * root/body) is handled separately via {@link setBuzzTranslucent} because it
+ * root/body) is handled separately via {@link setGlassTranslucent} because it
  * must be sequenced against the native vibrancy layer — see
- * {@link applyBuzzVibrancy}.
+ * {@link applyGlassVibrancy}.
  */
 function applyBuzzSidebar(themeName: string) {
   const root = document.documentElement;
-  if (isBuzzTheme(themeName)) {
+  if (isBuzzSurfaceTheme(themeName)) {
     root.setAttribute("data-buzz-sidebar", "");
     // Keep the concrete Buzz variant on the root as well as the generic
     // marker. The gradient stylesheet matches this attribute directly, which
     // makes WKWebView invalidate the painted background when light/dark mode
     // changes instead of relying only on a custom-property dependency update.
     root.setAttribute("data-buzz-theme", themeName);
+    if (!isGlassTheme(themeName)) {
+      // Buzz keeps its original opaque branded gradient. Glass owns the
+      // see-through treatment and must relinquish it immediately when the
+      // user switches back to Buzz.
+      setGlassTranslucent(false);
+    }
   } else {
     root.removeAttribute("data-buzz-sidebar");
     root.removeAttribute("data-buzz-theme");
-    // Leaving Buzz: drop translucency synchronously here too. Going *opaque*
+    // Leaving branded chrome: drop translucency synchronously. Going *opaque*
     // never shows desktop/prior content through, so there's no ordering risk
     // on the way out — only on the way in.
-    setBuzzTranslucent(false);
+    setGlassTranslucent(false);
   }
 }
 
@@ -270,11 +285,16 @@ function applyBuzzSidebar(themeName: string) {
  * behind the webview. Only enable it once the native `NSVisualEffectView`
  * vibrancy layer is confirmed installed, otherwise there's a frame where the
  * transparent webview reveals the content behind it (the "main app nav
- * underneath" flicker). {@link applyBuzzVibrancy} owns that sequencing.
+ * underneath" flicker). {@link applyGlassVibrancy} owns that sequencing.
  */
-function setBuzzTranslucent(enabled: boolean) {
+function setGlassTranslucent(enabled: boolean) {
   const root = document.documentElement;
   if (enabled) {
+    // index.html seeds an inline background color before the app bundle loads
+    // to prevent a cold-boot flash. Once native vibrancy is ready that boot
+    // canvas must be removed, otherwise transparent app surfaces reveal the
+    // stale inline white/black color instead of the desktop behind the window.
+    root.style.removeProperty("background-color");
     root.setAttribute("data-buzz-translucent", "");
   } else {
     root.removeAttribute("data-buzz-translucent");
@@ -283,48 +303,48 @@ function setBuzzTranslucent(enabled: boolean) {
 
 /**
  * Monotonic token identifying the most recent vibrancy request. Because
- * {@link applyBuzzVibrancy} awaits the native `set_window_vibrancy` IPC, a rapid
- * Buzz → non-Buzz toggle can fire two overlapping calls whose awaits resolve out
+ * {@link applyGlassVibrancy} awaits the native `set_window_vibrancy` IPC, a rapid
+ * Glass → non-Glass toggle can fire overlapping calls whose awaits resolve out
  * of order. Each call captures the token before awaiting and re-checks it after;
  * a stale continuation (superseded by a newer request) bails without touching
- * translucency — otherwise the earlier Buzz call could re-add
+ * translucency — otherwise the earlier Glass call could re-add
  * `data-buzz-translucent` after the later non-Buzz call already cleared it,
  * leaving the window transparent under a non-Buzz theme.
  */
-let buzzVibrancyRequest = 0;
+let glassVibrancyRequest = 0;
 
 /**
- * Whether the native vibrancy layer is confirmed installed for a Buzz theme.
+ * Whether the native vibrancy layer is confirmed installed for a Glass theme.
  * Set true only after `set_window_vibrancy(true)` resolves; cleared as soon as a
  * new vibrancy request is issued (its outcome is not yet known).
  */
-let buzzVibrancyReady = false;
+let glassVibrancyReady = false;
 
-/** The native layer does not need rebuilding when Buzz only changes mode. */
-let buzzVibrancyEnabled = false;
+/** The native layer does not need rebuilding when Glass only changes mode. */
+let glassVibrancyEnabled = false;
 
 /**
  * Enable the CSS translucency treatment, but only once BOTH prerequisites for
  * the current request are in place:
  *
- *  1. the native vibrancy layer is installed ({@link buzzVibrancyReady}), and
+ *  1. the native vibrancy layer is installed ({@link glassVibrancyReady}), and
  *  2. the Buzz sidebar marker + gradient vars are applied (`data-buzz-sidebar`,
  *     set synchronously by {@link applyBuzzSidebar} inside {@link applyTheme}).
  *
  * Translucency clears the body/sidebar surfaces so the vibrancy layer shows
  * through; enabling it before the Buzz gradient vars are installed would flash a
  * transparent/unstyled sidebar. `applyTheme` (theme vars) and
- * `applyBuzzVibrancy` (native layer) are independent async effects that can win
+ * `applyGlassVibrancy` (native layer) are independent async effects that can win
  * their race in either order, so each calls this after its own step completes —
  * whichever lands last flips translucency on. The token check drops stale
  * continuations superseded by a newer theme switch.
  */
-function maybeEnableBuzzTranslucent(themeName: string, requestToken: number) {
-  if (requestToken !== buzzVibrancyRequest) return;
-  if (!isBuzzTheme(themeName) || !isMacPlatform()) return;
-  if (!buzzVibrancyReady) return;
+function maybeEnableGlassTranslucent(themeName: string, requestToken: number) {
+  if (requestToken !== glassVibrancyRequest) return;
+  if (!isGlassTheme(themeName) || !isMacPlatform()) return;
+  if (!glassVibrancyReady) return;
   if (!document.documentElement.hasAttribute("data-buzz-sidebar")) return;
-  setBuzzTranslucent(true);
+  setGlassTranslucent(true);
 }
 
 /**
@@ -332,66 +352,66 @@ function maybeEnableBuzzTranslucent(themeName: string, requestToken: number) {
  * the right order and never leave a transparent webview with nothing painted
  * behind it:
  *
- * - Entering Buzz (macOS): install the vibrancy layer first (await the IPC),
+ * - Entering Glass (macOS): install the vibrancy layer first (await the IPC),
  *   *then* flip on translucency. This closes the frame-gap where the root was
  *   transparent before the vibrancy view existed — the flicker.
- * - Leaving Buzz: translucency was already removed synchronously in
+ * - Leaving Glass: translucency was already removed synchronously in
  *   `applyBuzzSidebar` (safe — opaque never shows through), so here we just
  *   clear the native layer.
  *
  * On non-macOS `set_window_vibrancy` is a no-op and translucency stays off, so
  * these platforms fall back to the opaque Buzz gradient.
  *
- * Overlapping calls are guarded by {@link buzzVibrancyRequest} so a stale async
+ * Overlapping calls are guarded by {@link glassVibrancyRequest} so a stale async
  * continuation can't re-enable translucency after a newer theme superseded it.
  */
-async function applyBuzzVibrancy(themeName: string) {
-  const buzz = isBuzzTheme(themeName);
-  const requestToken = ++buzzVibrancyRequest;
+async function applyGlassVibrancy(themeName: string) {
+  const glass = isGlassTheme(themeName);
+  const requestToken = ++glassVibrancyRequest;
 
-  // Buzz Light and Buzz Dark use the same native material. Rebuilding the
+  // Glass Light and Glass Dark use the same native material. Rebuilding the
   // NSVisualEffectView on every mode change briefly clears the layer behind
   // the webview and makes the new CSS theme appear late. Keep the installed
   // layer and let applyTheme swap only the color tokens.
-  if (buzz && buzzVibrancyEnabled && buzzVibrancyReady) {
-    maybeEnableBuzzTranslucent(themeName, requestToken);
+  if (glass && glassVibrancyEnabled && glassVibrancyReady) {
+    maybeEnableGlassTranslucent(themeName, requestToken);
     return;
   }
 
   // A new request is in flight — the vibrancy layer's readiness for it is not
   // yet known, so any stale "ready" from a prior request must not gate this one.
-  buzzVibrancyReady = false;
+  glassVibrancyReady = false;
 
   if (!isTauri()) {
     // Web/dev preview: no native vibrancy layer exists, so translucency would
     // show raw page background. Keep it off; the opaque gradient stands in.
-    setBuzzTranslucent(false);
+    setGlassTranslucent(false);
     return;
   }
 
   try {
     await invokeTauri<void>("set_window_vibrancy", {
-      enabled: buzz,
-      material: BUZZ_VIBRANCY_MATERIAL,
+      enabled: glass,
+      material: GLASS_VIBRANCY_MATERIAL,
     });
     // A newer theme change superseded this request while the IPC was in flight;
     // that later call owns the current translucency state, so don't clobber it.
-    if (requestToken !== buzzVibrancyRequest) return;
-    buzzVibrancyEnabled = buzz;
+    if (requestToken !== glassVibrancyRequest) return;
+    glassVibrancyEnabled = glass;
     // Native layer is installed. Record readiness and try to enable translucency
     // — but only if `applyBuzzSidebar` has already installed the Buzz gradient
     // vars. If that effect hasn't landed yet (the IPC won the race), it will
-    // call maybeEnableBuzzTranslucent itself once the marker is applied.
-    if (buzz && isMacPlatform()) {
-      buzzVibrancyReady = true;
-      maybeEnableBuzzTranslucent(themeName, requestToken);
+    // call maybeEnableGlassTranslucent itself once the marker is applied.
+    if (glass && isMacPlatform()) {
+      glassVibrancyReady = true;
+      maybeEnableGlassTranslucent(themeName, requestToken);
     }
   } catch (error) {
     console.warn("set_window_vibrancy failed", error);
-    if (requestToken !== buzzVibrancyRequest) return;
+    if (requestToken !== glassVibrancyRequest) return;
     // Vibrancy failed — don't go transparent or we'd show through to nothing.
-    buzzVibrancyEnabled = false;
-    setBuzzTranslucent(false);
+    glassVibrancyEnabled = false;
+    setGlassTranslucent(false);
   }
 }
 
@@ -411,7 +431,7 @@ function applyCachedVars(): string | null {
 
     const accent =
       window.localStorage.getItem(ACCENT_STORAGE_KEY) ?? DEFAULT_ACCENT;
-    // Pin Buzz themes to the neutral accent here too, matching applyTheme.
+    // Pin first-party surface themes to neutral here too, matching applyTheme.
     // Otherwise a cached Buzz theme + non-neutral stored accent flashes the
     // old accent on reload until the async applyTheme effect runs.
     applyAccentColor(resolveEffectiveAccent(themeName, accent));
@@ -450,10 +470,10 @@ async function applyTheme(
   applyBuzzSidebar(name);
   // The Buzz gradient vars are now installed. If the vibrancy layer already
   // resolved for the current request (the IPC won the race against this theme
-  // load), enable translucency now — otherwise applyBuzzVibrancy does it. This
+  // load), enable translucency now — otherwise applyGlassVibrancy does it. This
   // is the second half of the two-effect handshake; the token guards against a
   // superseding theme switch.
-  maybeEnableBuzzTranslucent(name, buzzVibrancyRequest);
+  maybeEnableGlassTranslucent(name, glassVibrancyRequest);
 
   // Apply the accent synchronously in the same batch as the theme vars so the
   // browser paints the new theme + accent together. Doing this in a later
@@ -542,7 +562,7 @@ export function ThemeProvider({
 
   useEffect(() => {
     if (!isValidThemeName(effectiveTheme)) return;
-    void applyBuzzVibrancy(effectiveTheme);
+    void applyGlassVibrancy(effectiveTheme);
   }, [effectiveTheme]);
 
   // Listen for system color scheme changes when followSystem is enabled

--- a/desktop/src/shared/theme/theme-loader.ts
+++ b/desktop/src/shared/theme/theme-loader.ts
@@ -31,6 +31,12 @@ export const BUZZ_THEME_NAME = "buzz";
  */
 export const BUZZ_DARK_THEME_NAME = "buzz-dark";
 
+/** Glass light theme: GitHub-based Buzz chrome with native macOS vibrancy. */
+export const GLASS_THEME_NAME = "glass";
+
+/** Dark-mode counterpart to {@link GLASS_THEME_NAME}. */
+export const GLASS_DARK_THEME_NAME = "glass-dark";
+
 /** The Shiki bundle Buzz borrows its base palette from. */
 export const BUZZ_BASE_THEME: SyntaxThemeName = "github-light";
 
@@ -40,17 +46,17 @@ export const BUZZ_DARK_BASE_THEME: SyntaxThemeName = "github-dark";
 /**
  * Resolve a theme name to the real Shiki bundled theme it maps to.
  *
- * Most themes map to themselves, but the Buzz aliases (`buzz` / `buzz-dark`)
- * are not bundled Shiki themes — they reuse the GitHub Light / GitHub Dark
- * palettes. The Shiki highlighter engine (used for fenced code blocks in
- * `CodeBlock.tsx`) only understands bundled names, so callers that hand a
- * theme name to `loadTheme` / `codeToTokens` must resolve it through here
- * first; passing a raw Buzz alias makes Shiki throw and code blocks fall
- * back to unhighlighted plain text.
+ * Most themes map to themselves, but the Buzz and Glass aliases are not
+ * bundled Shiki themes — they reuse the GitHub Light / GitHub Dark palettes.
+ * The Shiki highlighter engine (used for fenced code blocks in `CodeBlock.tsx`)
+ * only understands bundled names, so callers must resolve first; passing a raw
+ * first-party alias makes Shiki throw and code blocks fall back to plain text.
  */
 export function resolveShikiThemeName(name: string): SyntaxThemeName {
   if (name === BUZZ_THEME_NAME) return BUZZ_BASE_THEME;
   if (name === BUZZ_DARK_THEME_NAME) return BUZZ_DARK_BASE_THEME;
+  if (name === GLASS_THEME_NAME) return BUZZ_BASE_THEME;
+  if (name === GLASS_DARK_THEME_NAME) return BUZZ_DARK_BASE_THEME;
   return name as SyntaxThemeName;
 }
 
@@ -60,6 +66,8 @@ export function resolveShikiThemeName(name: string): SyntaxThemeName {
 export const SYNTAX_THEMES = [
   "buzz",
   "buzz-dark",
+  "glass",
+  "glass-dark",
   "andromeeda",
   "aurora-x",
   "ayu-dark",
@@ -128,6 +136,7 @@ export type SyntaxThemeName = (typeof SYNTAX_THEMES)[number];
 // for themes that haven't been loaded yet.
 export const LIGHT_THEMES: ReadonlySet<SyntaxThemeName> = new Set([
   "buzz",
+  "glass",
   "catppuccin-latte",
   "everforest-light",
   "github-light",
@@ -157,6 +166,10 @@ const themeImports: Record<
   buzz: () => import("shiki/themes/github-light.mjs"),
   // Buzz Dark reuses the github-dark palette; dark gradient applied separately.
   "buzz-dark": () => import("shiki/themes/github-dark.mjs"),
+  // Glass uses the same content palettes; its translucent chrome is applied
+  // separately by ThemeProvider and the Buzz surface stylesheet.
+  glass: () => import("shiki/themes/github-light.mjs"),
+  "glass-dark": () => import("shiki/themes/github-dark.mjs"),
   andromeeda: () => import("shiki/themes/andromeeda.mjs"),
   "aurora-x": () => import("shiki/themes/aurora-x.mjs"),
   "ayu-dark": () => import("shiki/themes/ayu-dark.mjs"),
@@ -237,6 +250,7 @@ export const THEME_PAIRS: ReadonlyMap<SyntaxThemeName, SyntaxThemeName> =
     // Light → Dark
     // Buzz is the first-party pair; keep it first so it leads every category.
     ["buzz", "buzz-dark"],
+    ["glass", "glass-dark"],
     ["catppuccin-latte", "catppuccin-mocha"],
     ["everforest-light", "everforest-dark"],
     ["github-light", "github-dark"],
@@ -256,6 +270,7 @@ export const THEME_PAIRS: ReadonlyMap<SyntaxThemeName, SyntaxThemeName> =
     ["vitesse-light", "vitesse-dark"],
     // Dark → Light (reverse mappings)
     ["buzz-dark", "buzz"],
+    ["glass-dark", "glass"],
     ["catppuccin-mocha", "catppuccin-latte"],
     ["everforest-dark", "everforest-light"],
     ["github-dark", "github-light"],

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -10922,6 +10922,8 @@ export function maybeInstallE2eTauriMocks() {
         return activeConfig?.mock?.agentMetricArchiveDefaultEnabled ?? false;
       case "set_prevent_sleep_active":
         return null;
+      case "set_window_vibrancy":
+        return null;
       case "plugin:window|is_fullscreen":
         return false;
       case "merge_save_subscription_kinds": {

--- a/desktop/tailwind.config.js
+++ b/desktop/tailwind.config.js
@@ -30,6 +30,10 @@ export default {
           "-1px 0 0 0 hsl(var(--border) / 0.8), -16px 0 32px -12px rgb(0 0 0 / 0.18)",
       },
       borderRadius: {
+        // Keep the floating content surface visually aligned with the native
+        // macOS window while preserving the 0.25rem (4px) inset. An 8px
+        // optical radius avoids the sharper appearance of a literal 6px arc.
+        "content-surface": "8px",
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",

--- a/desktop/tests/e2e/buzz-theme-screenshots.spec.ts
+++ b/desktop/tests/e2e/buzz-theme-screenshots.spec.ts
@@ -534,6 +534,7 @@ test("settings content uses the same inset surface as the main app", async ({
     .getByTestId("settings-back-to-app")
     .boundingBox();
   await expect(contentSurface).toBeVisible({ timeout: 10_000 });
+  await expect(contentSurface).toHaveCSS("border-radius", "8px");
   await expect(page.getByTestId("settings-content-scroll")).toHaveCSS(
     "padding-top",
     "24px",
@@ -552,12 +553,12 @@ test("settings content uses the same inset surface as the main app", async ({
   expect(Math.abs(backToAppBox.y - searchBox.y)).toBeLessThanOrEqual(0.5);
 
   // Match the normal app shell: a fixed 40px top chrome strip, then a 1px
-  // top/left inset and 8px right/bottom inset around the rounded content card.
+  // top/left inset and 4px right/bottom inset around the rounded content card.
   expect(surfaceBox.y - viewBox.y).toBe(41);
   expect(surfaceBox.x - viewBox.x).toBe(1);
-  expect(viewBox.x + viewBox.width - (surfaceBox.x + surfaceBox.width)).toBe(8);
+  expect(viewBox.x + viewBox.width - (surfaceBox.x + surfaceBox.width)).toBe(4);
   expect(viewBox.y + viewBox.height - (surfaceBox.y + surfaceBox.height)).toBe(
-    8,
+    4,
   );
 
   await waitForAnimations(page);

--- a/desktop/tests/e2e/buzz-theme-screenshots.spec.ts
+++ b/desktop/tests/e2e/buzz-theme-screenshots.spec.ts
@@ -466,6 +466,39 @@ test("appearance picker — dark tab (Buzz Dark)", async ({ page }) => {
   await panel.screenshot({ path: `${SHOTS}/05-picker-dark.png` });
 });
 
+test("Glass is a separate selectable theme", async ({ page }) => {
+  await seedTheme(page, "glass");
+  await installMockBridge(page);
+  const panel = await openAppearance(page, "light");
+
+  await expect(page.getByTestId("theme-option-glass")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect(page.getByTestId("theme-option-buzz")).toHaveAttribute(
+    "aria-pressed",
+    "false",
+  );
+  await expect(page.locator("html")).toHaveAttribute(
+    "data-buzz-theme",
+    "glass",
+  );
+  await expect(page.getByTestId("accent-color-neutral")).toHaveCount(0);
+  await panel.screenshot({ path: `${SHOTS}/06-picker-glass-light.png` });
+
+  await page.getByTestId("appearance-mode-dark").click();
+  await expect(page.getByTestId("theme-option-glass-dark")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect(page.locator("html")).toHaveAttribute(
+    "data-buzz-theme",
+    "glass-dark",
+  );
+  await waitForAnimations(page);
+  await panel.screenshot({ path: `${SHOTS}/07-picker-glass-dark.png` });
+});
+
 test("settings nav uses Buzz active pill + hover (light)", async ({ page }) => {
   await seedTheme(page, "buzz");
   await installMockBridge(page);


### PR DESCRIPTION
## Depends on

- #2683 — the Glass surfaces build on the refined floating content surface geometry

## Summary

- add separate Glass Light and Glass Dark themes without changing the existing Buzz themes
- enable native macOS vibrancy only while a Glass theme is active
- layer a 25% white frost over Glass Light and a substantially darker smoked layer over Glass Dark
- keep Glass content surfaces shadowless and remove the bright top/left inset seam
- add matching theme-picker previews and hide accent controls for the neutral Glass palette
- cover Glass selection, light/dark pairing, and the vibrancy command in the desktop E2E bridge

## Why

Glass gives the desktop app a native translucent appearance while preserving Buzz as its existing opaque branded option. Keeping Glass as a separate theme lets users opt into desktop-through-window styling without changing the appearance for people who prefer Buzz.

## Testing

- `just desktop-check`
- `just desktop-test` — 3,472 passed
- `pnpm -C desktop run build:e2e`
- `pnpm -C desktop exec playwright test tests/e2e/buzz-theme-screenshots.spec.ts --project=smoke --grep "Glass is a separate selectable theme"`
- repository pre-push suite:
  - Rust unit suites passed
  - desktop checks and 3,472 desktop tests passed
  - 541 mobile tests passed, 1 skipped
  - 1,614 Tauri tests passed, 14 ignored

## Manual verification

- verified Glass Light and Glass Dark in the native macOS desktop app
- confirmed that desktop content is visible through the native vibrancy layer
- confirmed the 25% light frost, dark smoke layer, and shadowless content edge
