### PR TITLE
fix(desktop): allow channel member agents in mentions

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -77,6 +77,29 @@ test("relayAgentIsSharedWithUser: accepts shared anyone agents and rejects unsha
   );
 });
 
+test("relayAgentIsSharedWithUser: active channel must match the agent channel", () => {
+  const sharedChannelIds = new Set(["general", "ops"]);
+
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      { respondTo: "anyone", respondToAllowlist: [], channelIds: ["general"] },
+      sharedChannelIds,
+      CURRENT_PUBKEY,
+      "general",
+    ),
+    true,
+  );
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      { respondTo: "anyone", respondToAllowlist: [], channelIds: ["ops"] },
+      sharedChannelIds,
+      CURRENT_PUBKEY,
+      "general",
+    ),
+    false,
+  );
+});
+
 test("relayAgentIsSharedWithUser: accepts allowlist agents for the current user", () => {
   const sharedChannelIds = new Set(["general"]);
 
@@ -85,7 +108,7 @@ test("relayAgentIsSharedWithUser: accepts allowlist agents for the current user"
       {
         respondTo: "allowlist",
         respondToAllowlist: [OTHER_OWNER_PUBKEY, CURRENT_PUBKEY.toUpperCase()],
-        channelIds: ["other"],
+        channelIds: ["general"],
       },
       sharedChannelIds,
       CURRENT_PUBKEY,
@@ -98,6 +121,23 @@ test("relayAgentIsSharedWithUser: accepts allowlist agents for the current user"
         respondTo: "allowlist",
         respondToAllowlist: [OTHER_OWNER_PUBKEY],
         channelIds: ["general"],
+      },
+      sharedChannelIds,
+      CURRENT_PUBKEY,
+    ),
+    false,
+  );
+});
+
+test("relayAgentIsSharedWithUser: allowlist agents still require shared channel placement", () => {
+  const sharedChannelIds = new Set(["general"]);
+
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      {
+        respondTo: "allowlist",
+        respondToAllowlist: [CURRENT_PUBKEY],
+        channelIds: ["other"],
       },
       sharedChannelIds,
       CURRENT_PUBKEY,
@@ -121,7 +161,7 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
         pubkey: PUB_C,
         respondTo: "allowlist",
         respondToAllowlist: [CURRENT_PUBKEY],
-        channelIds: ["other"],
+        channelIds: ["general"],
       },
       {
         pubkey: PUB_D,
@@ -134,6 +174,31 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   });
 
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
+});
+
+test("getMentionableAgentPubkeys: scopes relay agents to the active channel", () => {
+  const result = getMentionableAgentPubkeys({
+    managedAgentPubkeys: [PUB_A],
+    currentPubkey: CURRENT_PUBKEY,
+    relayAgents: [
+      {
+        pubkey: PUB_B,
+        respondTo: "anyone",
+        respondToAllowlist: [],
+        channelIds: ["general"],
+      },
+      {
+        pubkey: PUB_C,
+        respondTo: "anyone",
+        respondToAllowlist: [],
+        channelIds: ["ops"],
+      },
+    ],
+    sharedChannelIds: new Set(["general", "ops"]),
+    activeChannelId: "general",
+  });
+
+  assert.deepEqual(result, new Set([PUB_A, PUB_B]));
 });
 
 test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
@@ -162,6 +227,17 @@ test("isAgentIdentityInManagedList: keeps people and only current managed agent 
   );
 });
 
+test("isAgentIdentityInManagedList: keeps remote agents explicitly allowed by the caller", () => {
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey: PUB_B.toUpperCase() },
+      new Set([PUB_A]),
+      new Set([PUB_B]),
+    ),
+    true,
+  );
+});
+
 test("shouldHideAgentFromMentions: never hides non-agents", () => {
   assert.equal(
     shouldHideAgentFromMentions({
@@ -169,7 +245,6 @@ test("shouldHideAgentFromMentions: never hides non-agents", () => {
       isMember: false,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set([PUB_A]),
     }),
     false,
   );
@@ -182,7 +257,6 @@ test("shouldHideAgentFromMentions: shows invocable agents even when non-member",
       isMember: false,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set([PUB_A]),
-      directoryAgentPubkeys: new Set([PUB_A]),
     }),
     false,
   );
@@ -195,22 +269,20 @@ test("shouldHideAgentFromMentions: hides non-member non-invocable agents", () =>
       isMember: false,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set(),
     }),
     true,
   );
 });
 
-test("shouldHideAgentFromMentions: hides member agents with an explicit not-invocable directory entry (Fizz)", () => {
+test("shouldHideAgentFromMentions: shows member agents even with a non-invocable directory entry", () => {
   assert.equal(
     shouldHideAgentFromMentions({
       isAgent: true,
       isMember: true,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set([PUB_A]),
     }),
-    true,
+    false,
   );
 });
 
@@ -221,25 +293,8 @@ test("shouldHideAgentFromMentions: shows member agents with unknown invocability
       isMember: true,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set(),
     }),
     false,
-  );
-});
-
-test("shouldHideAgentFromMentions: normalizes the pubkey before lookup", () => {
-  const mixedCase = "Ab".repeat(32);
-  const normalized = mixedCase.toLowerCase();
-
-  assert.equal(
-    shouldHideAgentFromMentions({
-      isAgent: true,
-      isMember: true,
-      pubkey: mixedCase,
-      mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set([normalized]),
-    }),
-    true,
   );
 });
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -13,10 +13,23 @@ export function relayAgentIsSharedWithUser(
   agent: Pick<RelayAgent, "channelIds" | "respondTo" | "respondToAllowlist">,
   sharedChannelIds: ReadonlySet<string>,
   currentPubkey?: string | null,
+  activeChannelId?: string | null,
 ) {
   const normalizedCurrentPubkey = currentPubkey
     ? normalizePubkey(currentPubkey)
     : null;
+  const sharesActiveChannel =
+    activeChannelId == null || agent.channelIds.includes(activeChannelId);
+  if (!sharesActiveChannel) {
+    return false;
+  }
+
+  const sharesAnyJoinedChannel = agent.channelIds.some((channelId) =>
+    sharedChannelIds.has(channelId),
+  );
+  if (!sharesAnyJoinedChannel) {
+    return false;
+  }
 
   if (agent.respondTo === "allowlist" && normalizedCurrentPubkey) {
     return agent.respondToAllowlist
@@ -24,10 +37,7 @@ export function relayAgentIsSharedWithUser(
       .includes(normalizedCurrentPubkey);
   }
 
-  return (
-    agent.respondTo === "anyone" &&
-    agent.channelIds.some((channelId) => sharedChannelIds.has(channelId))
-  );
+  return agent.respondTo === "anyone";
 }
 
 export function getMentionableAgentPubkeys({
@@ -35,18 +45,27 @@ export function getMentionableAgentPubkeys({
   managedAgentPubkeys,
   relayAgents,
   sharedChannelIds,
+  activeChannelId,
 }: {
   currentPubkey?: string | null;
   managedAgentPubkeys: Iterable<string>;
   relayAgents: readonly RelayAgent[] | undefined;
   sharedChannelIds: ReadonlySet<string>;
+  activeChannelId?: string | null;
 }) {
   const pubkeys = new Set(
     [...managedAgentPubkeys].map((pubkey) => normalizePubkey(pubkey)),
   );
 
   for (const agent of relayAgents ?? []) {
-    if (relayAgentIsSharedWithUser(agent, sharedChannelIds, currentPubkey)) {
+    if (
+      relayAgentIsSharedWithUser(
+        agent,
+        sharedChannelIds,
+        currentPubkey,
+        activeChannelId,
+      )
+    ) {
       pubkeys.add(normalizePubkey(agent.pubkey));
     }
   }
@@ -57,10 +76,13 @@ export function getMentionableAgentPubkeys({
 export function isAgentIdentityInManagedList(
   candidate: { isAgent?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
+  allowedAgentPubkeys: ReadonlySet<string> = new Set(),
 ) {
+  const normalizedPubkey = normalizePubkey(candidate.pubkey);
   return (
     candidate.isAgent !== true ||
-    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
+    managedAgentPubkeys.has(normalizedPubkey) ||
+    allowedAgentPubkeys.has(normalizedPubkey)
   );
 }
 
@@ -69,32 +91,21 @@ export function shouldHideAgentFromMentions({
   isMember,
   pubkey,
   mentionableAgentPubkeys,
-  directoryAgentPubkeys,
 }: {
   isAgent: boolean;
   isMember: boolean;
   pubkey: string;
   mentionableAgentPubkeys: ReadonlySet<string>;
-  directoryAgentPubkeys: ReadonlySet<string>;
 }) {
   if (!isAgent) return false;
   const normalized = normalizePubkey(pubkey);
   // Invocable => always show.
   if (mentionableAgentPubkeys.has(normalized)) return false;
+  // Channel membership is enough to expose the identity as mentionable. The
+  // receiving agent still enforces whether it will respond.
+  if (isMember) return false;
   // Non-member, non-invocable => hide (preserves prior behavior).
-  if (!isMember) return true;
-  // Member (Option B): hide only when we have an explicit not-invocable
-  // signal — a relay directory (kind:10100) entry that excludes us.
-  // Unknown invocability (not in directory) => show.
-  //
-  // NOTE: this assumes `directoryAgentPubkeys` and `mentionableAgentPubkeys`
-  // share the same source query (`relayAgentsQuery.data`), so directory
-  // presence without membership in `mentionableAgentPubkeys` is a real
-  // explicit-exclusion signal. If a future change sources the directory set
-  // from a different query, an agent that's directory-present but whose
-  // mentionability is still loading could be hidden prematurely — keep the
-  // two sets derived from the same query.
-  return directoryAgentPubkeys.has(normalized);
+  return true;
 }
 
 type AgentAutocompleteCandidate = {

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -179,15 +179,6 @@ export function useMentions(
       ),
     [relayAgentsQuery.data],
   );
-  const directoryAgentPubkeys = React.useMemo(
-    () =>
-      new Set(
-        (relayAgentsQuery.data ?? []).map((agent) =>
-          normalizePubkey(agent.pubkey),
-        ),
-      ),
-    [relayAgentsQuery.data],
-  );
   const sharedChannelIds = React.useMemo(
     () => getSharedChannelIds(channelsQuery.data),
     [channelsQuery.data],
@@ -199,8 +190,10 @@ export function useMentions(
         managedAgentPubkeys,
         relayAgents: relayAgentsQuery.data,
         sharedChannelIds,
+        activeChannelId: channelId,
       }),
     [
+      channelId,
       currentPubkey,
       managedAgentPubkeys,
       relayAgentsQuery.data,
@@ -220,7 +213,6 @@ export function useMentions(
     }
     return lookup;
   }, [managedAgentsQuery.data, personasQuery.data]);
-  const knownAgentPubkeys = mentionableAgentPubkeys;
   const activePersonas = React.useMemo(
     () => (personasQuery.data ?? []).filter((persona) => persona.isActive),
     [personasQuery.data],
@@ -238,6 +230,25 @@ export function useMentions(
       new Set((members ?? []).map((member) => normalizePubkey(member.pubkey))),
     [members],
   );
+  const memberAgentPubkeys = React.useMemo(
+    () =>
+      new Set(
+        (members ?? [])
+          .filter(
+            (member) => member.isAgent === true || member.role === "bot",
+          )
+          .map((member) => normalizePubkey(member.pubkey)),
+      ),
+    [members],
+  );
+  const knownAgentPubkeys = React.useMemo(
+    () => new Set([...mentionableAgentPubkeys, ...memberAgentPubkeys]),
+    [memberAgentPubkeys, mentionableAgentPubkeys],
+  );
+  const allowedAgentIdentityPubkeys = React.useMemo(
+    () => new Set([...memberPubkeys, ...mentionableAgentPubkeys]),
+    [memberPubkeys, mentionableAgentPubkeys],
+  );
   const mentionCandidates = React.useMemo<MentionCandidate[]>(() => {
     const candidatesByPubkey = new Map<string, MentionCandidate>();
 
@@ -246,7 +257,13 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (
+        !isAgentIdentityInManagedList(
+          candidate,
+          managedAgentPubkeys,
+          allowedAgentIdentityPubkeys,
+        )
+      ) {
         return;
       }
       if (
@@ -255,7 +272,6 @@ export function useMentions(
           isMember: candidate.isMember === true,
           pubkey,
           mentionableAgentPubkeys,
-          directoryAgentPubkeys,
         })
       ) {
         return;
@@ -412,10 +428,10 @@ export function useMentions(
   }, [
     activePersonaById,
     activePersonas,
+    allowedAgentIdentityPubkeys,
     userSearchResults,
     canSearchGlobalUsers,
     currentPubkey,
-    directoryAgentPubkeys,
     isArchivedDiscovery,
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,


### PR DESCRIPTION
## Summary

Fixes Desktop mention resolution for remote/shared managed agents that are already channel members but are not owned by the local Desktop.

The verified user-facing failure was: Satsdisco could see a remote managed agent, Fizz, as a channel member, but typing `@Fizz` did not produce the agent `p` tag. Another user's `@Fizz` message did include Fizz's `p` tag, which narrowed the issue to local Desktop mention candidate filtering/resolution rather than relay delivery.

## Root Cause

Desktop mention autocomplete had two related assumptions that broke for remote managed agents:

- Agent identities from search/autocomplete were filtered unless they were in the local managed-agent list.
- Channel-member agents could still be hidden when relay-directory invocability data made them look non-invocable/owner-only.

That is too strict for shared channel usage. Channel membership is the concrete signal that the identity can be mentioned in that channel. Whether the remote agent actually responds is still enforced by the receiving agent/relay policy.

## Changes

- Keeps channel-member bots/agents visible in mention autocomplete even when they are remote managed agents.
- Counts channel-member bots as known agent pubkeys during message mention resolution, so selected mentions emit the correct agent `p` tag.
- Scopes relay-directory mentionability to the active channel so shared relay agents from other channels do not leak into the current channel's autocomplete.
- Adds coverage for active-channel scoping, allowlist channel placement, remote allowed agent identities, and channel-member agents with non-invocable directory entries.

## Validation

Validated at commit `cff618911b0c26d810055cb1b787f3cc487ffed5`:

- `corepack pnpm --dir desktop test` - 3,374 passed, 0 failed
- `corepack pnpm --dir desktop typecheck`
- `corepack pnpm --dir desktop build`

Also validated manually via the replacement DMG: typing `@Fizz` from Satsdisco now works and emits the intended mention behavior.