### PR TITLE
fix(desktop): apply the configured model to Claude Code agents via ANTHROPIC_MODEL

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -111,7 +111,11 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         adapter_install_hint: "Install the Claude Code ACP adapter via npm.",
         skill_dir: Some(".claude/skills"),
         supports_acp_model_switching: false,
-        model_env_var: None,
+        // The Claude CLI honors this env var as a session model override,
+        // and the adapter's child `claude` process inherits the spawn env —
+        // without this, the model picked in the UI is persisted but never
+        // applied (#2692).
+        model_env_var: Some(crate::managed_agents::ANTHROPIC_MODEL_ENV_KEY),
         provider_env_var: None,
         provider_locked: true,
         default_env: &[],

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -1270,3 +1270,25 @@ fn test_install_shell_from_some_returns_path() {
         "install_shell_from(Some) must return the path as Ok"
     );
 }
+
+/// The claude runtime must declare a model env channel — without one, the
+/// model picked in the UI is persisted but never applied at spawn (#2692).
+/// ANTHROPIC_MODEL is the override the Claude CLI honors, and the same key
+/// readiness uses for the anthropic provider.
+#[test]
+fn claude_runtime_declares_anthropic_model_env_var() {
+    let claude = super::known_acp_runtime_exact("claude").expect("claude runtime registered");
+    assert_eq!(claude.model_env_var, Some("ANTHROPIC_MODEL"));
+    // Provider stays locked: only the model is injectable for this harness.
+    assert!(claude.provider_locked);
+    assert_eq!(claude.provider_env_var, None);
+}
+
+/// A stale persisted ANTHROPIC_MODEL must not shadow the structured model
+/// field after a UI edit — same treatment as GOOSE_MODEL / BUZZ_AGENT_MODEL.
+#[test]
+fn anthropic_model_is_a_derived_env_key() {
+    use crate::managed_agents::is_derived_provider_model_key;
+    assert!(is_derived_provider_model_key("ANTHROPIC_MODEL"));
+    assert!(is_derived_provider_model_key("anthropic_model"));
+}

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -24,11 +24,18 @@ use std::collections::BTreeMap;
 ///
 /// Non-structured knobs (`GOOSE_TEMPERATURE`, `GOOSE_CONTEXT_LIMIT`) are NOT
 /// in this list — they have no structured counterpart and must be preserved.
+/// Env var the Claude CLI honors as a session model override. Single source
+/// of truth for the key — referenced by the claude runtime entry
+/// (`discovery.rs`), the derived-key list below, and the readiness
+/// provider-model mapping, so the three cannot drift apart.
+pub(crate) const ANTHROPIC_MODEL_ENV_KEY: &str = "ANTHROPIC_MODEL";
+
 pub(crate) const DERIVED_PROVIDER_MODEL_ENV_KEYS: &[&str] = &[
     "GOOSE_MODEL",
     "GOOSE_PROVIDER",
     "BUZZ_AGENT_MODEL",
     "BUZZ_AGENT_PROVIDER",
+    ANTHROPIC_MODEL_ENV_KEY,
 ];
 
 /// Returns `true` if `key` is a derived provider/model env key that should be

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -327,7 +327,7 @@ fn buzz_agent_requirements(effective: &EffectiveAgentEnv) -> Vec<Requirement> {
         Some("databricks") | Some("databricks_v2") | Some("databricks-v2") => {
             Some("DATABRICKS_MODEL")
         }
-        Some("anthropic") => Some("ANTHROPIC_MODEL"),
+        Some("anthropic") => Some(super::ANTHROPIC_MODEL_ENV_KEY),
         Some("openai") | Some("openai-compat") => Some("OPENAI_COMPAT_MODEL"),
         _ => None,
     };

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -517,13 +517,21 @@ fn runtime_metadata_env_vars_injects_model_and_provider() {
 
 #[test]
 fn runtime_metadata_env_vars_skips_provider_when_locked() {
+    // The claude runtime shape: model injectable via ANTHROPIC_MODEL (#2692),
+    // provider locked to Anthropic so no provider env is written.
     let vars = runtime_metadata_env_vars(
-        None, // claude has no model_env_var
+        Some("ANTHROPIC_MODEL"),
         None, // claude has no provider_env_var
         true, // provider_locked = true
-        Some("claude-opus-4-7"),
+        Some("claude-sonnet-5"),
         Some("anthropic"),
     );
+    assert_eq!(vars, vec![("ANTHROPIC_MODEL", "claude-sonnet-5")]);
+}
+
+#[test]
+fn runtime_metadata_env_vars_empty_without_env_channels() {
+    let vars = runtime_metadata_env_vars(None, None, true, Some("some-model"), Some("anthropic"));
     assert!(vars.is_empty());
 }
 


### PR DESCRIPTION
Fixes #2692

## Problem

Picking a model for a **Claude Code** agent in the desktop UI persists the selection but never applies it. The `claude` entry in `KNOWN_ACP_RUNTIMES` declares `model_env_var: None` and `supports_acp_model_switching: false`, so `runtime_metadata_env_vars` has no channel to carry the saved model into the spawned session — the agent silently runs on the user's global Claude Code default. Goose (`GOOSE_MODEL`) and Buzz Agent (`BUZZ_AGENT_MODEL`) both have this channel; claude was the only harness with a model picker but no application path behind it.

Observed in the wild: a stock agent set to Sonnet answering as `claude-fable-5`, across restarts, with no error anywhere.

## Changes

- **`discovery.rs`**: the claude runtime declares `model_env_var: Some(ANTHROPIC_MODEL_ENV_KEY)`. The Claude CLI honors `ANTHROPIC_MODEL` as a session model override (verified: `ANTHROPIC_MODEL=claude-sonnet-5 claude --print "<model id?>"` → `claude-sonnet-5`), and the ACP adapter's child `claude` process inherits the spawn env. `provider_locked` stays `true`, so only the model is injected — no provider env is written for this harness.
- **`env_vars.rs`**: new `ANTHROPIC_MODEL_ENV_KEY` const as the single source of truth for the key — referenced by the runtime entry, the `DERIVED_PROVIDER_MODEL_ENV_KEYS` list (so a stale persisted copy can't shadow the structured model field after a UI edit, same treatment as the other derived keys), and the readiness provider-model mapping in `readiness.rs`, which already used the literal `"ANTHROPIC_MODEL"` for the anthropic provider. Three call sites, one definition, no drift.
- **Tests**: pin the claude runtime shape (model env declared, provider locked), the derived-key classification (including case-insensitivity), and the claude-shaped `runtime_metadata_env_vars` injection. The tests intentionally assert the literal string so the const's value itself is pinned.

## Notes for reviewers

- Users who worked around this by setting `ANTHROPIC_MODEL` manually in the agent's env vars: on the next provider/model edit the derived-key rule strips the manual copy, and the structured field takes over — which is the intended convergence.
- Local `cargo test` for `desktop/src-tauri` could not be run on my machine (Intel mac — `sherpa-onnx-sys` has no usable static lib here, unrelated to this change); CI's Desktop Core job is the authoritative check for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqMxL1inNtU7icywZxbrGY
