### PR TITLE
fix(desktop): apply Claude models and run Windows installers natively

### DIFF
--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -536,21 +536,36 @@ fn persist_last_error_on_install(
     save_managed_agents(app, &records)
 }
 
-/// Build a login-shell `Command` for `command` with hermit env vars stripped,
-/// Buzz-managed npm locations set, and the user's PATH set. This is the
-/// single source of truth for
-/// the shell selection and environment cleanup shared by `run_install_command`
-/// and managed npm install path — keeping them in sync so the hermit-strip list
-/// can't drift between command execution paths.
+/// Build an install `Command` for `command` with hermit env vars stripped,
+/// Buzz-managed npm locations set, and the user's PATH set. This is the single
+/// source of truth for the shell selection and environment cleanup shared by
+/// `run_install_command` and managed npm install paths — keeping them in sync
+/// so the hermit-strip list can't drift between command execution paths.
 ///
-/// On Windows, resolves Git Bash via `resolve_bash_path` (skips `BUZZ_SHELL`
-/// since install commands require bash syntax). Returns `Err` when no shell
-/// can be found.
+/// On Windows, known PowerShell install commands run directly in PowerShell.
+/// Sending them through Git Bash enables MSYS path conversion, which corrupts
+/// paths consumed by native installers (for example, `C:` passed to `tar`).
+/// Other install commands use Git Bash via `resolve_bash_path`.
 fn install_shell_command(command: &str) -> Result<std::process::Command, String> {
-    let shell: std::path::PathBuf = resolve_install_shell()?;
+    #[cfg(windows)]
+    let mut cmd = if let Some(script) = powershell_install_script(command) {
+        let mut cmd = std::process::Command::new("powershell.exe");
+        cmd.args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script]);
+        cmd
+    } else {
+        let shell = resolve_install_shell()?;
+        let mut cmd = std::process::Command::new(shell);
+        cmd.args(["-l", "-c", command]);
+        cmd
+    };
 
-    let mut cmd = std::process::Command::new(&shell);
-    cmd.args(["-l", "-c", command]);
+    #[cfg(not(windows))]
+    let mut cmd = {
+        let shell = resolve_install_shell()?;
+        let mut cmd = std::process::Command::new(shell);
+        cmd.args(["-l", "-c", command]);
+        cmd
+    };
 
     // Strip hermit env vars so npm/node use the user's normal registry rather
     // than the project-local hermit-managed paths, then give npm defaults for
@@ -623,6 +638,20 @@ fn install_shell_command(command: &str) -> Result<std::process::Command, String>
     }
 
     Ok(cmd)
+}
+
+const POWERSHELL_INSTALL_PREFIX: &str = "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command ";
+
+/// Extract the script from a catalogued PowerShell installer command.
+///
+/// The catalog owns these command strings, so this deliberately recognizes
+/// only the quoted form used by the Windows runtime installers. All other
+/// commands retain the login-shell execution path.
+fn powershell_install_script(command: &str) -> Option<&str> {
+    command
+        .strip_prefix(POWERSHELL_INSTALL_PREFIX)?
+        .strip_prefix('"')?
+        .strip_suffix('"')
 }
 
 /// Resolve the shell binary for install commands.
@@ -1262,6 +1291,16 @@ mod tests {
         assert!(result.is_ok(), "install_shell_command must succeed on Unix");
     }
 
+    #[test]
+    fn test_powershell_install_script_extracts_catalogued_script() {
+        let command = "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://claude.ai/install.ps1 | iex\"";
+        assert_eq!(
+            super::powershell_install_script(command),
+            Some("irm https://claude.ai/install.ps1 | iex")
+        );
+        assert_eq!(super::powershell_install_script("echo test"), None);
+    }
+
     // ── Phase A: Windows install shell selection ───────────────────────────────
 
     /// On Windows (CI runner has Git pre-installed), resolve_install_shell succeeds.
@@ -1309,6 +1348,34 @@ mod tests {
             result.is_ok(),
             "install_shell_command must succeed on Windows with Git; got: {:?}",
             result.err()
+        );
+    }
+
+    /// Catalogued PowerShell installers must bypass Git Bash so MSYS path
+    /// conversion cannot corrupt paths passed to native Windows tools.
+    #[cfg(windows)]
+    #[test]
+    fn test_powershell_installer_runs_natively_on_windows() {
+        let command = "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://claude.ai/install.ps1 | iex\"";
+        let cmd = super::install_shell_command(command)
+            .expect("PowerShell installer must not require Git Bash");
+
+        assert_eq!(
+            cmd.get_program(),
+            std::ffi::OsStr::new("powershell.exe"),
+            "catalogued PowerShell installers must run in PowerShell"
+        );
+        assert_eq!(
+            cmd.get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec![
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                "irm https://claude.ai/install.ps1 | iex",
+            ]
         );
     }
 

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -111,7 +111,10 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         adapter_install_hint: "Install the Claude Code ACP adapter via npm.",
         skill_dir: Some(".claude/skills"),
         supports_acp_model_switching: false,
-        model_env_var: None,
+        // Claude Code reads the selected model from ANTHROPIC_MODEL at process
+        // startup. Keep this in the runtime catalog so the structured picker
+        // remains the source of truth for every spawn.
+        model_env_var: Some("ANTHROPIC_MODEL"),
         provider_env_var: None,
         provider_locked: true,
         default_env: &[],

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -25,6 +25,7 @@ use std::collections::BTreeMap;
 /// Non-structured knobs (`GOOSE_TEMPERATURE`, `GOOSE_CONTEXT_LIMIT`) are NOT
 /// in this list — they have no structured counterpart and must be preserved.
 pub(crate) const DERIVED_PROVIDER_MODEL_ENV_KEYS: &[&str] = &[
+    "ANTHROPIC_MODEL",
     "GOOSE_MODEL",
     "GOOSE_PROVIDER",
     "BUZZ_AGENT_MODEL",

--- a/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
@@ -435,6 +435,7 @@ fn is_derived_key_matches_all_known_keys() {
 
 #[test]
 fn is_derived_key_is_case_insensitive() {
+    assert!(is_derived_provider_model_key("anthropic_model"));
     assert!(is_derived_provider_model_key("goose_model"));
     assert!(is_derived_provider_model_key("Goose_Provider"));
     assert!(is_derived_provider_model_key("buzz_agent_model"));

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -518,13 +518,13 @@ fn runtime_metadata_env_vars_injects_model_and_provider() {
 #[test]
 fn runtime_metadata_env_vars_skips_provider_when_locked() {
     let vars = runtime_metadata_env_vars(
-        None, // claude has no model_env_var
+        Some("ANTHROPIC_MODEL"), // Claude reads its selected model from this key
         None, // claude has no provider_env_var
         true, // provider_locked = true
         Some("claude-opus-4-7"),
         Some("anthropic"),
     );
-    assert!(vars.is_empty());
+    assert_eq!(vars, vec![("ANTHROPIC_MODEL", "claude-opus-4-7")]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- inject `ANTHROPIC_MODEL` from the structured Claude Code model picker at spawn time
- treat `ANTHROPIC_MODEL` as derived configuration so stale custom environment values cannot override later picker changes
- run catalogued Windows PowerShell installers directly instead of routing them through Git Bash, preventing MSYS path conversion from corrupting native installer paths
- add regression coverage for model injection and native PowerShell command construction

## Root cause

Claude Code's runtime catalog had no model environment variable, so the picker value was saved but never reached the spawned Claude process. On Windows, Claude and Codex installer scripts were invoked through Git Bash; MSYS path conversion could turn `C:` paths into invalid arguments for native tools such as `tar`.

Closes #2692
Closes #2688

Issue #2690 is intentionally not duplicated here: upstream PR #2694 already addresses the macOS artifact-name collision.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- verified upstream comparison: one commit ahead of `block/buzz:main`, with only the five intended files
- targeted Rust tests could not link in this Linux workspace because `pkg-config` and the required GLib/GObject development libraries are unavailable; CI should run the full platform matrix.