### PR TITLE
feat(agent): add OpenAI service-tier configuration

### DIFF
--- a/crates/buzz-agent/README.md
+++ b/crates/buzz-agent/README.md
@@ -138,6 +138,7 @@ Everything is environment variables. No flags, no config files. (We are a subpro
 | `OPENAI_COMPAT_MODEL` | — | Required when provider=openai. |
 | `OPENAI_COMPAT_BASE_URL` | `https://api.openai.com/v1` | Point at vLLM, llama.cpp, OpenRouter, Ollama, etc. |
 | `OPENAI_COMPAT_API` | `auto` | `auto` \| `chat` \| `responses`. `auto` picks Responses for `*.openai.com`, Chat Completions everywhere else. |
+| `BUZZ_AGENT_SERVICE_TIER` | — | Optional OpenAI processing tier: `auto`, `default`, `flex`, or `priority`. |
 | `DATABRICKS_HOST` | — | Required when provider=databricks or provider=databricks_v2. |
 | `DATABRICKS_MODEL` | — | Required when provider=databricks or provider=databricks_v2. |
 | `DATABRICKS_TOKEN` | — | Optional static bearer escape hatch. If unset, Databricks uses browser OAuth + refresh cache. |

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -683,6 +683,27 @@ pub enum OpenAiApi {
     Auto,
 }
 
+/// OpenAI request processing tier. `None` leaves the provider default intact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenAiServiceTier {
+    Auto,
+    Default,
+    Flex,
+    Priority,
+}
+
+impl OpenAiServiceTier {
+    /// Return the wire-format value expected by OpenAI APIs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Default => "default",
+            Self::Flex => "flex",
+            Self::Priority => "priority",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub provider: Provider,
@@ -730,6 +751,8 @@ pub struct Config {
     /// Thinking/reasoning effort level. `None` = use provider default (no
     /// thinking config sent). Set via `BUZZ_AGENT_THINKING_EFFORT`.
     pub thinking_effort: Option<ThinkingEffort>,
+    /// OpenAI processing tier. Set via `BUZZ_AGENT_SERVICE_TIER`.
+    pub service_tier: Option<OpenAiServiceTier>,
 }
 
 impl Config {
@@ -824,6 +847,7 @@ impl Config {
             hook_servers: parse_hook_servers_env("MCP_HOOK_SERVERS"),
             hints_enabled: parse_env("BUZZ_AGENT_NO_HINTS", 0u8)? == 0,
             thinking_effort: parse_thinking_effort(env("BUZZ_AGENT_THINKING_EFFORT").as_deref())?,
+            service_tier: parse_service_tier(env("BUZZ_AGENT_SERVICE_TIER").as_deref())?,
         };
         cfg.validate()?;
         Ok(cfg)
@@ -864,6 +888,7 @@ impl Config {
             hook_servers: HookServers::None,
             hints_enabled: false,
             thinking_effort: None,
+            service_tier: None,
         }
     }
 
@@ -948,6 +973,22 @@ impl Config {
             }
         }
         Ok(())
+    }
+}
+
+/// Parse the optional OpenAI service tier. Empty values preserve provider defaults.
+pub fn parse_service_tier(raw: Option<&str>) -> Result<Option<OpenAiServiceTier>, String> {
+    match raw.map(str::trim).filter(|value| !value.is_empty()) {
+        None => Ok(None),
+        Some(value) => match value.to_ascii_lowercase().as_str() {
+            "auto" => Ok(Some(OpenAiServiceTier::Auto)),
+            "default" => Ok(Some(OpenAiServiceTier::Default)),
+            "flex" => Ok(Some(OpenAiServiceTier::Flex)),
+            "priority" => Ok(Some(OpenAiServiceTier::Priority)),
+            other => Err(format!(
+                "config: BUZZ_AGENT_SERVICE_TIER={other} not supported (use auto|default|flex|priority)"
+            )),
+        },
     }
 }
 
@@ -1345,6 +1386,25 @@ mod tests {
             err.contains("none|minimal|low|medium|high|xhigh|max"),
             "{err}"
         );
+    }
+
+    #[test]
+    fn parse_service_tier_accepts_openai_values_case_insensitively() {
+        assert_eq!(
+            parse_service_tier(Some(" FLEX ")).unwrap(),
+            Some(OpenAiServiceTier::Flex)
+        );
+        assert_eq!(
+            parse_service_tier(Some("priority")).unwrap(),
+            Some(OpenAiServiceTier::Priority)
+        );
+        assert_eq!(parse_service_tier(Some(" ")).unwrap(), None);
+    }
+
+    #[test]
+    fn parse_service_tier_rejects_unknown_value() {
+        let err = parse_service_tier(Some("economy")).unwrap_err();
+        assert!(err.contains("BUZZ_AGENT_SERVICE_TIER=economy"), "{err}");
     }
 
     #[test]

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -847,7 +847,10 @@ impl Config {
             hook_servers: parse_hook_servers_env("MCP_HOOK_SERVERS"),
             hints_enabled: parse_env("BUZZ_AGENT_NO_HINTS", 0u8)? == 0,
             thinking_effort: parse_thinking_effort(env("BUZZ_AGENT_THINKING_EFFORT").as_deref())?,
-            service_tier: parse_service_tier(env("BUZZ_AGENT_SERVICE_TIER").as_deref())?,
+            service_tier: parse_service_tier_for_provider(
+                provider,
+                env("BUZZ_AGENT_SERVICE_TIER").as_deref(),
+            )?,
         };
         cfg.validate()?;
         Ok(cfg)
@@ -989,6 +992,17 @@ pub fn parse_service_tier(raw: Option<&str>) -> Result<Option<OpenAiServiceTier>
                 "config: BUZZ_AGENT_SERVICE_TIER={other} not supported (use auto|default|flex|priority)"
             )),
         },
+    }
+}
+
+fn parse_service_tier_for_provider(
+    provider: Provider,
+    raw: Option<&str>,
+) -> Result<Option<OpenAiServiceTier>, String> {
+    if matches!(provider, Provider::OpenAi) {
+        parse_service_tier(raw)
+    } else {
+        Ok(None)
     }
 }
 
@@ -1399,6 +1413,14 @@ mod tests {
             Some(OpenAiServiceTier::Priority)
         );
         assert_eq!(parse_service_tier(Some(" ")).unwrap(), None);
+    }
+
+    #[test]
+    fn parse_service_tier_is_ignored_for_non_openai_providers() {
+        assert_eq!(
+            parse_service_tier_for_provider(Provider::Anthropic, Some("invalid")).unwrap(),
+            None
+        );
     }
 
     #[test]

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -672,10 +672,8 @@ fn responses_body(
 }
 
 fn apply_openai_service_tier(cfg: &Config, body: &mut Value) {
-    if matches!(cfg.provider, Provider::OpenAi) {
-        if let Some(tier) = cfg.service_tier {
-            body["service_tier"] = json!(tier.as_str());
-        }
+    if let (Provider::OpenAi, Some(tier)) = (cfg.provider, cfg.service_tier) {
+        body["service_tier"] = json!(tier.as_str());
     }
 }
 

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -183,28 +183,26 @@ impl Llm {
                 let r = self
                     .openai_request(cfg, effective_model, |use_responses| {
                         if use_responses {
-                            (
-                                json!({
-                                    "model": effective_model,
-                                    "max_output_tokens": max_output_tokens,
-                                    "instructions": system_prompt,
-                                    "input": user_prompt,
-                                }),
-                                parse_responses as OpenAiParse,
-                            )
+                            let mut body = json!({
+                                "model": effective_model,
+                                "max_output_tokens": max_output_tokens,
+                                "instructions": system_prompt,
+                                "input": user_prompt,
+                            });
+                            apply_openai_service_tier(cfg, &mut body);
+                            (body, parse_responses as OpenAiParse)
                         } else {
-                            (
-                                json!({
-                                    "model": effective_model,
-                                    "stream": false,
-                                    "max_completion_tokens": max_output_tokens,
-                                    "messages": [
-                                        { "role": "system", "content": system_prompt },
-                                        { "role": "user", "content": user_prompt },
-                                    ],
-                                }),
-                                parse_openai as OpenAiParse,
-                            )
+                            let mut body = json!({
+                                "model": effective_model,
+                                "stream": false,
+                                "max_completion_tokens": max_output_tokens,
+                                "messages": [
+                                    { "role": "system", "content": system_prompt },
+                                    { "role": "user", "content": user_prompt },
+                                ],
+                            });
+                            apply_openai_service_tier(cfg, &mut body);
+                            (body, parse_openai as OpenAiParse)
                         }
                     })
                     .await?;
@@ -545,6 +543,7 @@ fn openai_body(
     if let Some(e) = effort {
         body["reasoning_effort"] = json!(e.openai_effort_str());
     }
+    apply_openai_service_tier(cfg, &mut body);
     if !tools_json.is_empty() {
         body["tools"] = Value::Array(tools_json);
         body["tool_choice"] = json!("auto");
@@ -664,11 +663,20 @@ fn responses_body(
     if let Some(e) = effort {
         body["reasoning"] = json!({ "effort": e.openai_effort_str() });
     }
+    apply_openai_service_tier(cfg, &mut body);
     if !tools_json.is_empty() {
         body["tools"] = Value::Array(tools_json);
         body["tool_choice"] = json!("auto");
     }
     body
+}
+
+fn apply_openai_service_tier(cfg: &Config, body: &mut Value) {
+    if matches!(cfg.provider, Provider::OpenAi) {
+        if let Some(tier) = cfg.service_tier {
+            body["service_tier"] = json!(tier.as_str());
+        }
+    }
 }
 
 /// Narrow matcher for "you should be on the Responses API" provider errors,
@@ -1251,6 +1259,7 @@ mod tests {
             openai_api: OpenAiApi::Chat,
             hints_enabled: true,
             thinking_effort: None,
+            service_tier: None,
         }
     }
 
@@ -1844,6 +1853,22 @@ mod tests {
             body.get("reasoning_effort").is_none(),
             "reasoning_effort must be absent when effort is None"
         );
+    }
+
+    #[test]
+    fn openai_body_emits_service_tier_when_configured() {
+        let mut cfg = cfg(Provider::OpenAi);
+        cfg.service_tier = Some(crate::config::OpenAiServiceTier::Flex);
+        let body = openai_body(&cfg, "system", &[], &[], "model", None);
+        assert_eq!(body["service_tier"], "flex");
+    }
+
+    #[test]
+    fn responses_body_emits_service_tier_when_configured() {
+        let mut cfg = cfg(Provider::OpenAi);
+        cfg.service_tier = Some(crate::config::OpenAiServiceTier::Priority);
+        let body = responses_body(&cfg, "system", &[], &[], "model", None);
+        assert_eq!(body["service_tier"], "priority");
     }
 
     #[test]

--- a/desktop/src/features/agents/ui/buzzAgentConfig.test.mjs
+++ b/desktop/src/features/agents/ui/buzzAgentConfig.test.mjs
@@ -5,6 +5,8 @@ import {
   BUZZ_AGENT_MAX_CONTEXT_TOKENS,
   BUZZ_AGENT_MAX_OUTPUT_TOKENS,
   BUZZ_AGENT_MAX_ROUNDS,
+  BUZZ_AGENT_SERVICE_TIER,
+  BUZZ_AGENT_SERVICE_TIER_VALUES,
   BUZZ_AGENT_THINKING_EFFORT,
   BUZZ_AGENT_THINKING_EFFORT_VALUES,
   getProviderEffortConfig,
@@ -36,6 +38,16 @@ test("env var key constants match expected BUZZ_AGENT_* names", () => {
   assert.equal(BUZZ_AGENT_MAX_OUTPUT_TOKENS, "BUZZ_AGENT_MAX_OUTPUT_TOKENS");
   assert.equal(BUZZ_AGENT_MAX_CONTEXT_TOKENS, "BUZZ_AGENT_MAX_CONTEXT_TOKENS");
   assert.equal(BUZZ_AGENT_MAX_ROUNDS, "BUZZ_AGENT_MAX_ROUNDS");
+  assert.equal(BUZZ_AGENT_SERVICE_TIER, "BUZZ_AGENT_SERVICE_TIER");
+});
+
+test("BUZZ_AGENT_SERVICE_TIER_VALUES contains the OpenAI service tiers", () => {
+  assert.deepEqual([...BUZZ_AGENT_SERVICE_TIER_VALUES], [
+    "auto",
+    "default",
+    "flex",
+    "priority",
+  ]);
 });
 
 // ---------------------------------------------------------------------------
@@ -127,6 +139,14 @@ test("clearing max rounds removes the key", () => {
   const initial = { [BUZZ_AGENT_MAX_ROUNDS]: "50" };
   const result = applyEnvVarChange(initial, BUZZ_AGENT_MAX_ROUNDS, "");
   assert.equal(Object.hasOwn(result, BUZZ_AGENT_MAX_ROUNDS), false);
+});
+
+test("setting and clearing service tier uses the inheritable env-var shape", () => {
+  const set = applyEnvVarChange({}, BUZZ_AGENT_SERVICE_TIER, "flex");
+  assert.equal(set[BUZZ_AGENT_SERVICE_TIER], "flex");
+
+  const cleared = applyEnvVarChange(set, BUZZ_AGENT_SERVICE_TIER, "");
+  assert.equal(Object.hasOwn(cleared, BUZZ_AGENT_SERVICE_TIER), false);
 });
 
 test("changing one field does not disturb other env vars", () => {

--- a/desktop/src/features/agents/ui/buzzAgentConfig.ts
+++ b/desktop/src/features/agents/ui/buzzAgentConfig.ts
@@ -17,6 +17,19 @@ export const BUZZ_AGENT_MAX_CONTEXT_TOKENS = "BUZZ_AGENT_MAX_CONTEXT_TOKENS";
 /** Env var key for the maximum number of LLM/tool rounds per turn. */
 export const BUZZ_AGENT_MAX_ROUNDS = "BUZZ_AGENT_MAX_ROUNDS";
 
+/** Env var key for the OpenAI request processing tier. */
+export const BUZZ_AGENT_SERVICE_TIER = "BUZZ_AGENT_SERVICE_TIER";
+
+/** OpenAI service tiers accepted by buzz-agent. */
+export const BUZZ_AGENT_SERVICE_TIER_VALUES = [
+  "auto",
+  "default",
+  "flex",
+  "priority",
+] as const;
+
+export type ServiceTierValue = (typeof BUZZ_AGENT_SERVICE_TIER_VALUES)[number];
+
 /**
  * Ordered set of valid thinking-effort values accepted by buzz-agent.
  * Mirrors `parse_thinking_effort` in `crates/buzz-agent/src/config.rs`.

--- a/desktop/src/features/agents/ui/buzzAgentConfig.ts
+++ b/desktop/src/features/agents/ui/buzzAgentConfig.ts
@@ -28,8 +28,6 @@ export const BUZZ_AGENT_SERVICE_TIER_VALUES = [
   "priority",
 ] as const;
 
-export type ServiceTierValue = (typeof BUZZ_AGENT_SERVICE_TIER_VALUES)[number];
-
 /**
  * Ordered set of valid thinking-effort values accepted by buzz-agent.
  * Mirrors `parse_thinking_effort` in `crates/buzz-agent/src/config.rs`.

--- a/desktop/src/features/agents/ui/buzzAgentModelTuningFields.tsx
+++ b/desktop/src/features/agents/ui/buzzAgentModelTuningFields.tsx
@@ -17,6 +17,8 @@ import {
   BUZZ_AGENT_MAX_CONTEXT_TOKENS,
   BUZZ_AGENT_MAX_OUTPUT_TOKENS,
   BUZZ_AGENT_MAX_ROUNDS,
+  BUZZ_AGENT_SERVICE_TIER,
+  BUZZ_AGENT_SERVICE_TIER_VALUES,
   BUZZ_AGENT_THINKING_EFFORT,
   BUZZ_AGENT_THINKING_EFFORT_VALUES,
   getProviderEffortConfig,
@@ -221,6 +223,7 @@ export function BuzzAgentModelTuningFields({
     effortConfig;
 
   const currentEffort = envVars[BUZZ_AGENT_THINKING_EFFORT] ?? "";
+  const isOpenAi = provider?.trim().toLowerCase() === "openai";
   useEffortAutoClear({
     currentEffort,
     effortValid,
@@ -257,6 +260,38 @@ export function BuzzAgentModelTuningFields({
             blank to inherit from the global or persona default.
           </p>
         </div>
+
+        {isOpenAi && (
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium" htmlFor="ba-service-tier">
+              Service tier
+            </label>
+            <select
+              className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs"
+              data-testid="ba-service-tier-select"
+              id="ba-service-tier"
+              onChange={(event) =>
+                onEnvVarChange(BUZZ_AGENT_SERVICE_TIER, event.target.value)
+              }
+              value={envVars[BUZZ_AGENT_SERVICE_TIER] ?? ""}
+            >
+              <option value="">
+                {inheritedEnvVars[BUZZ_AGENT_SERVICE_TIER]
+                  ? `Inherit (${inheritedEnvVars[BUZZ_AGENT_SERVICE_TIER]})`
+                  : "Inherit (agent default)"}
+              </option>
+              {BUZZ_AGENT_SERVICE_TIER_VALUES.map((tier) => (
+                <option key={tier} value={tier}>
+                  {tier}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-muted-foreground" id="help-ba-service-tier">
+              Controls OpenAI request processing priority. Leave blank to use
+              the project default.
+            </p>
+          </div>
+        )}
 
         {/* Max Rounds */}
         <div className="space-y-1.5">

--- a/desktop/src/features/agents/ui/buzzAgentModelTuningFields.tsx
+++ b/desktop/src/features/agents/ui/buzzAgentModelTuningFields.tsx
@@ -223,7 +223,7 @@ export function BuzzAgentModelTuningFields({
     effortConfig;
 
   const currentEffort = envVars[BUZZ_AGENT_THINKING_EFFORT] ?? "";
-  const isOpenAi = provider?.trim().toLowerCase() === "openai";
+  const isOpenAi = provider === "openai";
   useEffortAutoClear({
     currentEffort,
     effortValid,
@@ -286,7 +286,10 @@ export function BuzzAgentModelTuningFields({
                 </option>
               ))}
             </select>
-            <p className="text-xs text-muted-foreground" id="help-ba-service-tier">
+            <p
+              className="text-xs text-muted-foreground"
+              id="help-ba-service-tier"
+            >
               Controls OpenAI request processing priority. Leave blank to use
               the project default.
             </p>


### PR DESCRIPTION
Adds OpenAI service-tier configuration to Buzz agents.

## Changes
- Adds a Service tier selector to Buzz agent model tuning.
- Supports:
  - `auto`
  - `default`
  - `flex`
  - `priority`
- Persists the setting through `BUZZ_AGENT_SERVICE_TIER`.
- Sends `service_tier` on OpenAI Chat Completions and Responses requests.
- Applies the setting to OpenAI summary requests as well.
- Keeps the setting out of Anthropic and Databricks request paths.
- Adds parsing, request-body, UI, and configuration tests.
- Documents the new environment variable.

<img width="875" height="912" alt="Screenshot 2026-07-24 at 7 18 12 PM" src="https://github.com/user-attachments/assets/6d462f30-9dc6-49dc-aa17-e84fdd56c0a1" />

