### PR TITLE
fix(desktop): edit the selected agent instance

### DIFF
--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -402,12 +402,14 @@ export function UserProfilePanel({
   });
 
   const handleEditAgent = React.useCallback(() => {
-    if (resolvedPersona) {
-      setPersonaDialogState(editPersonaDialogState(resolvedPersona));
+    if (managedAgent) {
+      setEditAgentOpen(true);
       return;
     }
-    setEditAgentOpen(true);
-  }, [resolvedPersona]);
+    if (resolvedPersona) {
+      setPersonaDialogState(editPersonaDialogState(resolvedPersona));
+    }
+  }, [managedAgent, resolvedPersona]);
 
   const { deleteManagedAgentRecord, deleteManagedAgentsForPersona } =
     useProfileAgentDeletion({

--- a/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelTabs.tsx
@@ -406,8 +406,13 @@ function ProfileInstancesSection({
                 onClick={() => onOpenInstance(instance.pubkey)}
                 type="button"
               >
-                <span className="min-w-0 flex-1 truncate text-sm font-medium">
-                  {instance.name}
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium">
+                    {instance.name}
+                  </span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {instance.relayUrl}
+                  </span>
                 </span>
                 <span className="text-xs capitalize text-muted-foreground">
                   {isCurrent ? "Current" : instance.status.replace("_", " ")}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -78,6 +78,7 @@ type MockCommandAvailability = {
 export type MockManagedAgentSeed = {
   pubkey: string;
   name: string;
+  relayUrl?: string;
   avatarUrl?: string | null;
   personaId?: string | null;
   /** Harness/runtime id pin; `null` = inherit from persona (native default). */
@@ -2182,7 +2183,7 @@ function buildSeededManagedAgent(seed: MockManagedAgentSeed): MockManagedAgent {
     // Native serde always emits this key (`null` when unpinned) — the bridge
     // must mirror the wire shape, not omit the key.
     runtime: seed.runtime ?? null,
-    relay_url: DEFAULT_RELAY_WS_URL,
+    relay_url: seed.relayUrl ?? DEFAULT_RELAY_WS_URL,
     acp_command: "buzz-acp",
     agent_command: agentCommand,
     agent_args: agentArgs,
@@ -2215,7 +2216,7 @@ function buildSeededManagedAgent(seed: MockManagedAgentSeed): MockManagedAgent {
     respond_to_allowlist: seed.respondToAllowlist ?? [],
     private_key_nsec: `nsec1mock${seed.pubkey.slice(0, 20)}`,
     log_lines: [
-      `buzz-acp starting: relay=${DEFAULT_RELAY_WS_URL} agent_pubkey=${seed.pubkey} parallelism=1`,
+      `buzz-acp starting: relay=${seed.relayUrl ?? DEFAULT_RELAY_WS_URL} agent_pubkey=${seed.pubkey} parallelism=1`,
       "profile created; harness not started",
     ],
   };

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -2537,6 +2537,8 @@ test("duplicate instances move from the agents gallery into the agent profile", 
   const personaId = "custom:duplicate-auditor";
   const primaryPubkey = TEST_IDENTITIES.alice.pubkey;
   const additionalPubkey = TEST_IDENTITIES.charlie.pubkey;
+  const primaryRelayUrl = "wss://primary.example.com";
+  const additionalRelayUrl = "wss://secondary.example.com";
   await installMockBridge(page, {
     personas: [
       {
@@ -2549,12 +2551,14 @@ test("duplicate instances move from the agents gallery into the agent profile", 
       {
         pubkey: primaryPubkey,
         name: "Duplicate Auditor",
+        relayUrl: primaryRelayUrl,
         personaId,
         status: "running",
       },
       {
         pubkey: additionalPubkey,
         name: "Duplicate Auditor",
+        relayUrl: additionalRelayUrl,
         personaId,
         status: "stopped",
       },
@@ -2570,11 +2574,33 @@ test("duplicate instances move from the agents gallery into the agent profile", 
 
   await page.getByTestId(`persona-agent-row-${personaId}`).click();
   await page.getByTestId("user-profile-instances").click();
+  await expect(page.getByText(primaryRelayUrl, { exact: true })).toBeVisible();
+  await expect(
+    page.getByText(additionalRelayUrl, { exact: true }),
+  ).toBeVisible();
   await page.getByTestId(`user-profile-instance-${additionalPubkey}`).click();
 
   await expect(page.getByTestId("user-profile-panel")).toBeVisible();
-  await page.getByTestId("user-profile-settings-menu-trigger").click();
-  await expect(
-    page.getByTestId(`user-profile-agent-delete-${additionalPubkey}`),
-  ).toBeVisible();
+  await page.getByTestId("user-profile-edit-agent").click();
+  const dialog = page.getByTestId("edit-agent-dialog");
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Advanced", exact: true }).click();
+  await dialog.getByTestId("env-vars-add").click();
+  await dialog.getByTestId("env-vars-key").fill("CLAUDE_CONFIG_DIR");
+  await dialog.getByTestId("env-vars-value").fill("C:\\buzz-secondary");
+  await dialog.getByTestId("edit-agent-dialog-submit").click();
+  await expect(dialog).not.toBeVisible();
+
+  const agents = await invokeTauri<
+    Array<{
+      pubkey: string;
+      env_vars: Record<string, string>;
+    }>
+  >(page, "list_managed_agents");
+  expect(
+    agents.find((agent) => agent.pubkey === primaryPubkey)?.env_vars,
+  ).toEqual({});
+  expect(
+    agents.find((agent) => agent.pubkey === additionalPubkey)?.env_vars,
+  ).toEqual({ CLAUDE_CONFIG_DIR: "C:\\buzz-secondary" });
 });

--- a/desktop/tests/e2e/edit-agent.spec.ts
+++ b/desktop/tests/e2e/edit-agent.spec.ts
@@ -353,16 +353,9 @@ test.describe("edit agent dialog", () => {
     ).toBeVisible();
   });
 
-  test("profile Edit routes persona-linked agents to the definition editor", async ({
+  test("profile Edit routes persona-linked agents to the instance editor", async ({
     page,
   }) => {
-    // Routing pin for handleEditAgent (UserProfilePanel): when the agent has
-    // a resolvable non-built-in persona, the Edit quick action opens the
-    // DEFINITION editor (persona dialog), not EditAgentDialog. The instance
-    // editor (and its inherit-runtime toggle) is reachable for persona-linked
-    // agents only via the requestOpenEditAgent event (ConfigNudgeCard) — no
-    // plain UI path — so its inherit-toggle behavior is covered by B3b's
-    // component-level pinning test, not e2e.
     await installMockBridge(page, {
       managedAgents: [
         {
@@ -397,14 +390,10 @@ test.describe("edit agent dialog", () => {
     });
     await page.getByTestId("user-profile-edit-agent").click();
 
-    // Definition editor opens; the instance editor does not.
-    await expect(page.getByTestId("persona-dialog")).toBeVisible({
+    await expect(page.getByTestId("edit-agent-dialog")).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByTestId("edit-agent-dialog")).not.toBeVisible();
-    // And it is the persona's record that's being edited.
-    await expect(page.locator("#persona-display-name")).toHaveValue(
-      "Edit E2E Persona",
-    );
+    await expect(page.getByTestId("persona-dialog")).not.toBeVisible();
+    await expect(page.locator("#edit-agent-name")).toHaveValue(AGENT_NAME);
   });
 });


### PR DESCRIPTION
## Summary

- route Edit on an agent profile to the selected managed-agent instance instead of the shared persona
- show each instance's relay URL so same-persona deployments can be distinguished
- add regression coverage proving an environment-variable update targets only the selected pubkey

Fixes #2717

## Root cause

`UserProfilePanel.handleEditAgent` preferred `resolvedPersona` whenever one existed. Because managed agents are persona-backed, Edit always opened the persona-definition dialog and never reached the instance editor.

Persona definitions remain editable through the existing actions on the Agents card.

## Validation

- `pnpm typecheck`
- `pnpm build:e2e`
- focused integration E2E for two same-persona instances on different relays — 1 passed
- focused smoke E2E for persona-linked profile editing — 1 passed
