### PR TITLE
fix(mobile): invite join stuck on Connecting — URL scheme mismatch

### DIFF
--- a/mobile/lib/features/invites/invite_join_provider.dart
+++ b/mobile/lib/features/invites/invite_join_provider.dart
@@ -151,7 +151,7 @@ class InviteJoinNotifier extends Notifier<InviteJoinState> {
 
       final community = Community.create(
         name: _communityNameFromClaim(claim, invite.relayUrl),
-        relayUrl: invite.relayUrl,
+        relayUrl: _normalizeRelayUrlForStorage(invite.relayUrl),
         pubkey: keys.public,
         nsec: keys.nsec,
       );
@@ -273,4 +273,21 @@ String _friendlyInviteError(Object error) {
     return 'Could not reach the relay. Check your connection and try again.';
   }
   return 'Could not join this community: $message';
+}
+
+/// Normalize a relay URL from websocket scheme to HTTP scheme for storage.
+///
+/// The invite deep-link parser produces `wss://` or `ws://` URLs, but the
+/// [Community.relayUrl] convention (matching the pairing flow) is HTTP-scheme
+/// (`https://` / `http://`). [RelayConfig] then derives both `wsUrl` and
+/// `httpUrl` from the stored base URL, so storing the canonical HTTP form
+/// keeps all downstream derivations correct.
+String _normalizeRelayUrlForStorage(String relayUrl) {
+  final uri = Uri.parse(relayUrl);
+  final scheme = switch (uri.scheme) {
+    'wss' => 'https',
+    'ws' => 'http',
+    _ => uri.scheme, // already http/https — pass through
+  };
+  return uri.replace(scheme: scheme).toString();
 }

--- a/mobile/lib/shared/community/community_storage.dart
+++ b/mobile/lib/shared/community/community_storage.dart
@@ -22,10 +22,15 @@ class CommunityStorage {
     : _secure = secure ?? const FlutterSecureStorage();
 
   /// Load all communities. On first call, migrates legacy single-community
-  /// credentials if present.
+  /// credentials if present. Also canonicalizes any stored `wss://`/`ws://`
+  /// relay URLs to `https://`/`http://` (invite-created communities before
+  /// the normalization fix stored websocket-scheme URLs directly).
   Future<List<Community>> loadAll() async {
     final raw = await _secure.read(key: _keyCommunities);
-    if (raw != null) return _decodeList(raw);
+    if (raw != null) {
+      final communities = _decodeList(raw);
+      return _migrateRelaySchemes(communities);
+    }
 
     final legacyCommunities = await _secure.read(key: _legacyCommunities);
     if (legacyCommunities != null) {
@@ -107,5 +112,35 @@ class CommunityStorage {
   Future<void> _saveList(List<Community> communities) async {
     final json = jsonEncode(communities.map((item) => item.toJson()).toList());
     await _secure.write(key: _keyCommunities, value: json);
+  }
+
+  /// Rewrite stored `wss://`/`ws://` relay URLs to `https://`/`http://`.
+  ///
+  /// Communities created via the invite deep-link flow before the
+  /// normalization fix stored the raw websocket-scheme URL. This migration
+  /// canonicalizes them on first load so [RelayConfig.httpUrl] and
+  /// downstream HTTP consumers (media upload, `/query`) work correctly.
+  Future<List<Community>> _migrateRelaySchemes(
+    List<Community> communities,
+  ) async {
+    var dirty = false;
+    final migrated = communities.map((community) {
+      final uri = Uri.tryParse(community.relayUrl);
+      if (uri == null) return community;
+      final scheme = uri.scheme;
+      if (scheme == 'wss' || scheme == 'ws') {
+        dirty = true;
+        final httpScheme = scheme == 'wss' ? 'https' : 'http';
+        return community.copyWith(
+          relayUrl: uri.replace(scheme: httpScheme).toString(),
+        );
+      }
+      return community;
+    }).toList();
+
+    if (dirty) {
+      await _saveList(migrated);
+    }
+    return migrated;
   }
 }

--- a/mobile/lib/shared/relay/media_auth.dart
+++ b/mobile/lib/shared/relay/media_auth.dart
@@ -121,7 +121,7 @@ class MediaGetAuthService {
 
 final mediaGetAuthServiceProvider = Provider<MediaGetAuthService>((ref) {
   final config = ref.watch(relayConfigProvider);
-  return MediaGetAuthService(baseUrl: config.baseUrl, nsec: config.nsec);
+  return MediaGetAuthService(baseUrl: config.httpUrl, nsec: config.nsec);
 });
 
 Map<String, String> mediaGetHeadersFor(WidgetRef ref, String url) {

--- a/mobile/lib/shared/relay/media_upload.dart
+++ b/mobile/lib/shared/relay/media_upload.dart
@@ -680,7 +680,7 @@ final mediaUploadServiceProvider = Provider<MediaUploadService>((ref) {
   final config = ref.watch(relayConfigProvider);
   final picker = ImagePicker();
   final service = MediaUploadService(
-    baseUrl: config.baseUrl,
+    baseUrl: config.httpUrl,
     nsec: config.nsec,
     pickGalleryImage: () => picker.pickImage(
       source: ImageSource.gallery,

--- a/mobile/lib/shared/relay/relay_provider.dart
+++ b/mobile/lib/shared/relay/relay_provider.dart
@@ -17,10 +17,31 @@ class RelayConfig {
 
   const RelayConfig({required this.baseUrl, this.nsec});
 
-  /// Derive the websocket URL from the HTTP base URL.
+  /// Derive the websocket URL from the base URL.
+  ///
+  /// Handles both HTTP-scheme (`https` → `wss`, `http` → `ws`) and
+  /// already-websocket URLs (`wss`/`ws` passed through unchanged). The invite
+  /// join flow stores `wss://` relay URLs directly from the parsed deep link;
+  /// without this, those URLs were incorrectly downgraded to `ws://`.
   String get wsUrl {
     final uri = Uri.parse(baseUrl);
-    final scheme = uri.scheme == 'https' ? 'wss' : 'ws';
+    final scheme = switch (uri.scheme) {
+      'https' || 'wss' => 'wss',
+      _ => 'ws',
+    };
+    return uri.replace(scheme: scheme).toString();
+  }
+
+  /// Derive the HTTP base URL for REST endpoints (`/query`, `/upload`, etc.).
+  ///
+  /// Handles both HTTP-scheme (passed through) and websocket-scheme URLs
+  /// (`wss` → `https`, `ws` → `http`).
+  String get httpUrl {
+    final uri = Uri.parse(baseUrl);
+    final scheme = switch (uri.scheme) {
+      'wss' || 'https' => 'https',
+      _ => 'http',
+    };
     return uri.replace(scheme: scheme).toString();
   }
 }
@@ -86,7 +107,7 @@ final myPubkeyProvider = Provider<String?>((ref) {
 /// through the relay WebSocket session.
 final relayClientProvider = Provider<RelayClient>((ref) {
   final config = ref.watch(relayConfigProvider);
-  final client = RelayClient(baseUrl: config.baseUrl);
+  final client = RelayClient(baseUrl: config.httpUrl);
   ref.onDispose(client.dispose);
   return client;
 });

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -133,7 +133,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     Duration timeout = const Duration(seconds: 8),
   }) async {
     final config = ref.read(relayConfigProvider);
-    final url = Uri.parse(config.baseUrl).resolve('/query').toString();
+    final url = Uri.parse(config.httpUrl).resolve('/query').toString();
     final bodyBytes = utf8.encode(
       jsonEncode(filters.map((filter) => filter.toJson()).toList()),
     );

--- a/mobile/test/features/invites/invite_join_provider_test.dart
+++ b/mobile/test/features/invites/invite_join_provider_test.dart
@@ -65,7 +65,11 @@ void main() {
         final stored = (await storage.loadAll()).single;
         expect(state.status, InviteJoinStatus.switchedExisting);
         expect(await storage.loadActiveId(), existing.id);
-        expect(stored.relayUrl, existingRelayUrl);
+        // After loading, wss:// URLs are migrated to https:// by storage.
+        final expectedStoredUrl = existingRelayUrl.startsWith('wss://')
+            ? existingRelayUrl.replaceFirst('wss://', 'https://')
+            : existingRelayUrl;
+        expect(stored.relayUrl, expectedStoredUrl);
         expect(stored.pubkey, 'old-pubkey');
         expect(stored.nsec, 'old-nsec');
         expect(generatedKeys, 0);
@@ -132,12 +136,57 @@ void main() {
       expect(auth.authenticatedCommunities, hasLength(1));
       expect(
         auth.authenticatedCommunities.single.relayUrl,
-        'wss://relay.example.com',
+        'https://relay.example.com',
       );
       expect(auth.authenticatedCommunities.single.pubkey, keys.public);
       expect(auth.authenticatedCommunities.single.nsec, keys.nsec);
     },
   );
+
+  for (final entry in [
+    ('wss://relay.example.com', 'https://relay.example.com'),
+    ('ws://local.dev:3000', 'http://local.dev:3000'),
+  ]) {
+    test(
+      'confirmJoin normalizes ${entry.$1} to ${entry.$2} for storage',
+      () async {
+        final keys = nostr.Keys.generate();
+        final storage = CommunityStorage(secure: FakeSecureStorage());
+        final auth = _RecordingAuthNotifier();
+        final container = ProviderContainer(
+          overrides: [
+            communityStorageProvider.overrideWithValue(storage),
+            authProvider.overrideWith(() => auth),
+            inviteKeyGeneratorProvider.overrideWithValue(() => keys),
+            inviteJoinHttpClientProvider.overrideWithValue(
+              http_testing.MockClient((request) async {
+                return http.Response(
+                  jsonEncode({
+                    'status': 'joined',
+                    'host': 'relay.example.com',
+                    'role': 'member',
+                  }),
+                  200,
+                );
+              }),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container
+            .read(inviteJoinProvider.notifier)
+            .prepare(InviteDeepLink(relayUrl: entry.$1, code: 'code'));
+        await container.read(inviteJoinProvider.notifier).confirmJoin();
+
+        expect(
+          container.read(inviteJoinProvider).status,
+          InviteJoinStatus.success,
+        );
+        expect(auth.authenticatedCommunities.single.relayUrl, entry.$2);
+      },
+    );
+  }
 
   test('join_policy_required requires a fresh link and cannot retry', () async {
     final keys = nostr.Keys.generate();

--- a/mobile/test/shared/community/community_storage_test.dart
+++ b/mobile/test/shared/community/community_storage_test.dart
@@ -232,6 +232,48 @@ void main() {
         final loaded = await storage.loadAll();
         expect(loaded.first.name, 'Local Dev');
       });
+
+      test('migrates wss:// relay URLs to https:// on load', () async {
+        final community = Community.create(
+          name: 'Invite Community',
+          relayUrl: 'wss://hosted.relay.example',
+          pubkey: 'pub1',
+          nsec: 'nsec1',
+        );
+        fakeSecure['buzz_communities'] = jsonEncode([community.toJson()]);
+
+        final loaded = await storage.loadAll();
+
+        expect(loaded.single.relayUrl, 'https://hosted.relay.example');
+        // Verify persisted so re-load doesn't re-migrate.
+        final reloaded = await storage.loadAll();
+        expect(reloaded.single.relayUrl, 'https://hosted.relay.example');
+      });
+
+      test('migrates ws:// relay URLs to http:// on load', () async {
+        final community = Community.create(
+          name: 'Dev Community',
+          relayUrl: 'ws://localhost:3000',
+          pubkey: 'pub2',
+        );
+        fakeSecure['buzz_communities'] = jsonEncode([community.toJson()]);
+
+        final loaded = await storage.loadAll();
+
+        expect(loaded.single.relayUrl, 'http://localhost:3000');
+      });
+
+      test('does not rewrite already-https communities', () async {
+        final community = Community.create(
+          name: 'Normal',
+          relayUrl: 'https://relay.example.com',
+        );
+        fakeSecure['buzz_communities'] = jsonEncode([community.toJson()]);
+
+        final loaded = await storage.loadAll();
+
+        expect(loaded.single.relayUrl, 'https://relay.example.com');
+      });
     });
   });
 }

--- a/mobile/test/shared/relay/relay_config_test.dart
+++ b/mobile/test/shared/relay/relay_config_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:buzz/shared/relay/relay_provider.dart';
+
+void main() {
+  group('RelayConfig.wsUrl', () {
+    test('converts https to wss', () {
+      const config = RelayConfig(baseUrl: 'https://relay.example');
+      expect(config.wsUrl, 'wss://relay.example');
+    });
+
+    test('converts http to ws', () {
+      const config = RelayConfig(baseUrl: 'http://relay.example');
+      expect(config.wsUrl, 'ws://relay.example');
+    });
+
+    test('preserves wss unchanged', () {
+      const config = RelayConfig(baseUrl: 'wss://relay.example');
+      expect(config.wsUrl, 'wss://relay.example');
+    });
+
+    test('preserves ws unchanged', () {
+      const config = RelayConfig(baseUrl: 'ws://relay.example');
+      expect(config.wsUrl, 'ws://relay.example');
+    });
+
+    test('preserves port with https', () {
+      const config = RelayConfig(baseUrl: 'https://relay.example:8443');
+      expect(config.wsUrl, 'wss://relay.example:8443');
+    });
+
+    test('preserves port with wss', () {
+      const config = RelayConfig(baseUrl: 'wss://relay.example:8443');
+      expect(config.wsUrl, 'wss://relay.example:8443');
+    });
+
+    test('preserves path with http', () {
+      const config = RelayConfig(baseUrl: 'http://relay.example:3000/base');
+      expect(config.wsUrl, 'ws://relay.example:3000/base');
+    });
+  });
+
+  group('RelayConfig.httpUrl', () {
+    test('preserves https unchanged', () {
+      const config = RelayConfig(baseUrl: 'https://relay.example');
+      expect(config.httpUrl, 'https://relay.example');
+    });
+
+    test('preserves http unchanged', () {
+      const config = RelayConfig(baseUrl: 'http://relay.example');
+      expect(config.httpUrl, 'http://relay.example');
+    });
+
+    test('converts wss to https', () {
+      const config = RelayConfig(baseUrl: 'wss://relay.example');
+      expect(config.httpUrl, 'https://relay.example');
+    });
+
+    test('converts ws to http', () {
+      const config = RelayConfig(baseUrl: 'ws://relay.example');
+      expect(config.httpUrl, 'http://relay.example');
+    });
+
+    test('preserves port with wss', () {
+      const config = RelayConfig(baseUrl: 'wss://relay.example:8443');
+      expect(config.httpUrl, 'https://relay.example:8443');
+    });
+
+    test('preserves path with ws', () {
+      const config = RelayConfig(baseUrl: 'ws://relay.example:3000/base');
+      expect(config.httpUrl, 'http://relay.example:3000/base');
+    });
+  });
+
+  group('existing wss:// community HTTP derivation', () {
+    // Exercises the scenario where a community was stored with a wss:// URL
+    // (invite-created before migration). Even without the migration running,
+    // httpUrl should produce a valid HTTPS URL for REST endpoints.
+    test('httpUrl converts stored wss:// community URL to https', () {
+      // Simulates a RelayConfig built from an un-migrated community.
+      const config = RelayConfig(
+        baseUrl: 'wss://hosted.communities.buzz.xyz',
+        nsec: 'nsec1test',
+      );
+      expect(config.httpUrl, 'https://hosted.communities.buzz.xyz');
+      expect(config.wsUrl, 'wss://hosted.communities.buzz.xyz');
+    });
+
+    test('httpUrl converts stored ws:// community URL to http', () {
+      const config = RelayConfig(baseUrl: 'ws://localhost:3000');
+      expect(config.httpUrl, 'http://localhost:3000');
+      expect(config.wsUrl, 'ws://localhost:3000');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the iOS invite join flow getting permanently stuck on "Connecting…" when opening a hosted-community invite link.

## Root Cause

The invite deep-link parser produces `wss://` relay URLs (correct for the WebSocket scheme). These are stored directly as `Community.relayUrl`. However, `RelayConfig.wsUrl` assumed `baseUrl` was always HTTP-scheme:

```dart
// Before: only recognized https → wss
final scheme = uri.scheme == 'https' ? 'wss' : 'ws';
```

When `baseUrl` was `wss://`, this incorrectly downgraded it to `ws://` (plaintext). A hosted relay at `*.communities.buzz.xyz` only accepts TLS connections, so the `ws://` connect attempt hangs forever — no timeout on `WebSocketChannel.connect`.

The pairing flow works because it validates and stores URLs as `https://`, which the old getter handled correctly.

## Fix

1. **`RelayConfig.wsUrl`** — switch expression that passes `wss`/`ws` through unchanged and converts `https` → `wss`, `http` → `ws`.
2. **`RelayConfig.httpUrl`** (new) — inverse getter for REST endpoints. Converts `wss` → `https`, `ws` → `http`.
3. **`queryRelay` + `relayClientProvider`** — use `httpUrl` instead of raw `baseUrl` for HTTP calls (media upload, `/query` bridge).
4. **`InviteJoinNotifier.confirmJoin`** — normalize URL at storage time (`wss` → `https`, `ws` → `http`) so `Community.relayUrl` matches the pairing convention.

## Testing

- 13 new unit tests for `RelayConfig.wsUrl`/`httpUrl` scheme handling
- 2 new parameterized tests for invite URL normalization
- All 20 existing + new invite tests pass
- `flutter analyze` — no issues
- `dart format` — no changes needed

Closes #2662