### PR TITLE
docs: add one-click Railway deploy for a hosted relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ Grab a packaged build from the [latest release](https://github.com/block/buzz/re
 
 By default the app connects to `ws://localhost:3000`. To point it at a relay you're running or one someone shared with you, set `BUZZ_RELAY_URL` before launching, or switch the relay from inside the app. If you don't have a relay yet, follow **Build & run from source** below to stand one up locally.
 
+### I want my own hosted relay
+
+To run a relay for your team without managing servers, deploy one to Railway in a click:
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/buzz)
+
+It provisions the relay with Postgres, Redis, and media storage, migrates the database, and generates your owner identity on first boot — no configuration. The deploy logs print an `nsec1…` key; choose **Use an existing key** in the app, paste it, and point the app at `wss://<your-service>.up.railway.app`. One deployment can host several communities. (Community-maintained template; not an official Block build.)
+
 ### I work at Block
 
 Don't build from source, and don't use the OSS release — use the internal build. It comes pre-wired to the Block relay and agent provider, so it works out of the box with nothing to configure.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ By default the app connects to `ws://localhost:3000`. To point it at a relay you
 
 To run a relay for your team without managing servers, deploy one to Railway in a click:
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/buzz)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/buzz-relay-block)
 
 It provisions the relay with Postgres, Redis, and media storage, migrates the database, and generates your owner identity on first boot — no configuration. The deploy logs print an `nsec1…` key; choose **Use an existing key** in the app, paste it, and point the app at `wss://<your-service>.up.railway.app`. One deployment can host several communities. (Community-maintained template; not an official Block build.)
 

--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ By default the app connects to `ws://localhost:3000`. To point it at a relay you
 
 ### I want my own hosted relay
 
-To run a relay for your team without managing servers, deploy one to Railway in a click:
+To run a relay for your team without managing servers, you can deploy one to Railway in a click:
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/buzz-relay-block)
 
-It provisions the relay with Postgres, Redis, and media storage, migrates the database, and generates your owner identity on first boot — no configuration. The deploy logs print an `nsec1…` key; choose **Use an existing key** in the app, paste it, and point the app at `wss://<your-service>.up.railway.app`. One deployment can host several communities. (Community-maintained template; not an official Block build.)
+See [here](https://engineering.block.xyz/blog/run-your-own-buzz-relay) for details.
 
 ### I work at Block
 


### PR DESCRIPTION
Adds a **"I want my own hosted relay"** path to *Getting started* with a one-click Railway deploy button.

Buzz today asks anyone who wants a real relay to take the build-from-source route. This gives non-developers a hosted option: the template provisions the relay plus Postgres, Redis, and media storage, runs migrations, and generates the owner identity on first boot — no configuration.

The listing is flagged **community-maintained, not an official Block build**, so there's no implied ownership. Happy to adjust wording, placement, or drop the button and keep just a link if you'd prefer.

Template deploys green end-to-end; the owner key is surfaced as a paste-ready `nsec1…` in the deploy logs, and one deployment can host multiple communities by hostname.

_Note: this supersedes the stale #984 — that template modeled a since-removed Typesense service and didn't run migrations._


### Checklist

`README.md` only, +8 −0 — no source files touched, so the build/test items don't apply.

- [x] `just ci` passes (fmt + clippy + unit tests + mobile) — n/a, no code changed
- [x] Integration tests pass (`just test`) — n/a, no code changed
- [x] New public APIs / tools / endpoints are documented — none added
- [x] No new `unwrap()` in production code paths
- [x] No new `unsafe` blocks

### How to verify

Click the button in the rendered README. The template stands up the relay
with Postgres, Redis and media storage wired, runs migrations, and prints the
owner key once in the deploy logs. Walkthrough with screenshots:
https://hmseeb.github.io/buzz-railway
