### PR TITLE
fix(deploy): bundle buzz-pair-relay sidecar so mobile pairing works out of the box

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -42,6 +42,17 @@ BUZZ_HTTP_PORT=3000
 CADDY_HTTP_PORT=80
 CADDY_HTTPS_PORT=443
 
+# Device pairing (mobile QR). The stack always runs the buzz-pair-relay sidecar.
+# - TLS mode (compose.caddy.yml): Caddy routes /pair on your main domain to the
+#   sidecar, so the desktop's NIP-43 legacy fallback works with no config here.
+# - Split-domain or your own proxy: advertise a dedicated URL so the desktop
+#   uses it directly instead of the /pair fallback. Must be ws:// or wss://.
+#     BUZZ_PAIRING_RELAY_URL=wss://pair.buzz.example.com
+# - Non-TLS / direct: publish the pair service's port 5000 and point clients at
+#   it, e.g. BUZZ_PAIRING_RELAY_URL=ws://buzz.example.com:5000 — otherwise use
+#   TLS mode. See README.md § Device pairing.
+# BUZZ_PAIRING_RELAY_URL=
+
 # Dev override ports. Only used with compose.dev.yml.
 POSTGRES_PORT=5432
 REDIS_PORT=6379

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -35,8 +35,11 @@ BUZZ_S3_ACCESS_KEY=CHANGE_ME_RANDOM_ACCESS_KEY
 BUZZ_S3_SECRET_KEY=CHANGE_ME_RANDOM_SECRET_KEY
 BUZZ_S3_BUCKET=buzz-media
 
-# Optional host ports. Base compose publishes the relay directly on BUZZ_HTTP_PORT.
+# Optional host ports. Base compose publishes the relay directly on
+# BUZZ_HTTP_PORT and the pairing sidecar on BUZZ_PAIR_RELAY_PORT;
+# compose.caddy.yml unpublishes both and fronts them with Caddy.
 BUZZ_HTTP_PORT=3000
+BUZZ_PAIR_RELAY_PORT=5000
 
 # Caddy host ports. Only used with compose.caddy.yml.
 CADDY_HTTP_PORT=80
@@ -48,8 +51,9 @@ CADDY_HTTPS_PORT=443
 # - Split-domain or your own proxy: advertise a dedicated URL so the desktop
 #   uses it directly instead of the /pair fallback. Must be ws:// or wss://.
 #     BUZZ_PAIRING_RELAY_URL=wss://pair.buzz.example.com
-# - Non-TLS / direct: publish the pair service's port 5000 and point clients at
-#   it, e.g. BUZZ_PAIRING_RELAY_URL=ws://buzz.example.com:5000 — otherwise use
+# - Non-TLS / direct: the pair service is already published on
+#   BUZZ_PAIR_RELAY_PORT, so just point clients at it, e.g.
+#   BUZZ_PAIRING_RELAY_URL=ws://buzz.example.com:5000 — otherwise use
 #   TLS mode. See README.md § Device pairing.
 # BUZZ_PAIRING_RELAY_URL=
 

--- a/deploy/compose/Caddyfile
+++ b/deploy/compose/Caddyfile
@@ -1,5 +1,15 @@
 {$BUZZ_DOMAIN} {
   encode zstd gzip
 
-  reverse_proxy relay:3000
+  # Device-pairing sidecar. The desktop's NIP-43 legacy fallback resolves to
+  # wss://{$BUZZ_DOMAIN}/pair, so routing that path to buzz-pair-relay makes
+  # mobile pairing work with no extra DNS. The sidecar ignores the request path.
+  @pair path /pair /pair/*
+  handle @pair {
+    reverse_proxy pair:5000
+  }
+
+  handle {
+    reverse_proxy relay:3000
+  }
 }

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -41,6 +41,32 @@ keypair.
 
 Run `./run.sh backup-hint` for the backup checklist.
 
+## Device pairing
+
+Mobile pairing needs a dedicated pairing relay (`buzz-pair-relay`). The desktop
+generates the QR, then resolves where the phone should connect: it first reads
+the main relay's NIP-11 `pairing_relay_url`, and if that is unset it falls back
+to the legacy `/pair` path on the main relay. The base relay does **not** serve
+`/pair`, so the stack runs a `pair` sidecar (bundled in the same relay image)
+and the deployment just has to route traffic to it. Three cases:
+
+- **TLS (`compose.caddy.yml`) — works out of the box.** Caddy routes
+  `/pair` on your main domain to the sidecar, so the desktop's legacy fallback
+  (`wss://<domain>/pair`) Just Works with no extra DNS and nothing to set.
+- **Split domain or your own reverse proxy.** Expose the sidecar at its own
+  host name and advertise it so the desktop uses it directly:
+  set `BUZZ_PAIRING_RELAY_URL=wss://pair.<domain>` in `.env` and point that
+  name at the `pair` service (port 5000) in your proxy. The relay then
+  advertises it in NIP-11 and the desktop skips the `/pair` fallback.
+- **Non-TLS / direct (no Caddy).** The base stack keeps the sidecar on the
+  internal network only. Publish its port (add a `5000:5000` mapping to the
+  `pair` service) and set `BUZZ_PAIRING_RELAY_URL=ws://<host>:5000`, or run TLS
+  mode. Without one of these, the desktop QR points at a `/pair` endpoint the
+  relay 404s and pairing fails.
+
+`BUZZ_PAIRING_RELAY_URL` must be a `ws://` or `wss://` URL; the relay rejects
+anything else at startup.
+
 ## Validation
 
 Before sharing an install link publicly, verify a fresh install with:

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -52,17 +52,22 @@ and the deployment just has to route traffic to it. Three cases:
 
 - **TLS (`compose.caddy.yml`) — works out of the box.** Caddy routes
   `/pair` on your main domain to the sidecar, so the desktop's legacy fallback
-  (`wss://<domain>/pair`) Just Works with no extra DNS and nothing to set.
+  (`wss://<domain>/pair`) Just Works with no extra DNS and nothing to set. The
+  overlay unpublishes the sidecar's host port; Caddy is the only way in.
 - **Split domain or your own reverse proxy.** Expose the sidecar at its own
   host name and advertise it so the desktop uses it directly:
   set `BUZZ_PAIRING_RELAY_URL=wss://pair.<domain>` in `.env` and point that
-  name at the `pair` service (port 5000) in your proxy. The relay then
-  advertises it in NIP-11 and the desktop skips the `/pair` fallback.
-- **Non-TLS / direct (no Caddy).** The base stack keeps the sidecar on the
-  internal network only. Publish its port (add a `5000:5000` mapping to the
-  `pair` service) and set `BUZZ_PAIRING_RELAY_URL=ws://<host>:5000`, or run TLS
-  mode. Without one of these, the desktop QR points at a `/pair` endpoint the
-  relay 404s and pairing fails.
+  name at the sidecar in your proxy — the base stack publishes it on
+  `BUZZ_PAIR_RELAY_PORT` (default 5000). If your proxy runs *outside* this
+  compose project and you would rather not publish the port, attach the proxy
+  to the project's `buzz-net` network and target `pair:5000` directly. The
+  relay then advertises the URL in NIP-11 and the desktop skips the `/pair`
+  fallback.
+- **Non-TLS / direct (no Caddy).** The base stack publishes the sidecar on
+  `BUZZ_PAIR_RELAY_PORT` (default 5000); set
+  `BUZZ_PAIRING_RELAY_URL=ws://<host>:5000` so the QR points at it. Without
+  that, the desktop QR points at a `/pair` endpoint the relay 404s and pairing
+  fails.
 
 `BUZZ_PAIRING_RELAY_URL` must be a `ws://` or `wss://` URL; the relay rejects
 anything else at startup.

--- a/deploy/compose/compose.caddy.yml
+++ b/deploy/compose/compose.caddy.yml
@@ -7,6 +7,8 @@ services:
     depends_on:
       relay:
         condition: service_healthy
+      pair:
+        condition: service_healthy
     environment:
       BUZZ_DOMAIN: ${BUZZ_DOMAIN:?set BUZZ_DOMAIN}
     ports:

--- a/deploy/compose/compose.caddy.yml
+++ b/deploy/compose/compose.caddy.yml
@@ -2,6 +2,10 @@ services:
   relay:
     ports: !reset []
 
+  # Caddy routes /pair to the sidecar, so its direct host port goes away too.
+  pair:
+    ports: !reset []
+
   caddy:
     image: caddy:2-alpine
     depends_on:

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -46,6 +46,29 @@ services:
     networks:
       - buzz-net
 
+  # Ephemeral NIP-AB device-pairing sidecar. The relay image already ships the
+  # binary; without this service the desktop QR resolves to a /pair endpoint the
+  # relay itself does not serve and mobile pairing fails. The sidecar binds only
+  # inside the compose network — a reverse proxy terminates TLS and routes /pair
+  # here (see compose.caddy.yml). To expose it directly, publish port 5000 and
+  # set BUZZ_PAIRING_RELAY_URL (see .env.example and README.md).
+  pair:
+    image: ${BUZZ_IMAGE:-ghcr.io/block/buzz:main}
+    entrypoint: ["/usr/local/bin/buzz-pair-relay"]
+    environment:
+      BUZZ_PAIR_RELAY_BIND_ADDR: 0.0.0.0:5000
+    # The sidecar speaks only WebSocket upgrades and answers a plain GET with 400,
+    # so probe the raw TCP port over /dev/tcp rather than expecting an HTTP 200.
+    healthcheck:
+      test: ["CMD-SHELL", "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/5000'"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - buzz-net
+
   postgres:
     image: postgres:17-alpine
     environment:

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -48,15 +48,17 @@ services:
 
   # Ephemeral NIP-AB device-pairing sidecar. The relay image already ships the
   # binary; without this service the desktop QR resolves to a /pair endpoint the
-  # relay itself does not serve and mobile pairing fails. The sidecar binds only
-  # inside the compose network — a reverse proxy terminates TLS and routes /pair
-  # here (see compose.caddy.yml). To expose it directly, publish port 5000 and
-  # set BUZZ_PAIRING_RELAY_URL (see .env.example and README.md).
+  # relay itself does not serve and mobile pairing fails. Published directly on
+  # BUZZ_PAIR_RELAY_PORT, mirroring the relay's BUZZ_HTTP_PORT; compose.caddy.yml
+  # unpublishes it and routes /pair through Caddy instead (see README.md
+  # § Device pairing).
   pair:
     image: ${BUZZ_IMAGE:-ghcr.io/block/buzz:main}
     entrypoint: ["/usr/local/bin/buzz-pair-relay"]
     environment:
       BUZZ_PAIR_RELAY_BIND_ADDR: 0.0.0.0:5000
+    ports:
+      - "${BUZZ_PAIR_RELAY_PORT:-5000}:5000"
     # The sidecar speaks only WebSocket upgrades and answers a plain GET with 400,
     # so probe the raw TCP port over /dev/tcp rather than expecting an HTTP 200.
     healthcheck:


### PR DESCRIPTION
## Problem

Closes #2734.

On a self-hosted relay deployed from the official `deploy/compose` bundle,
mobile pairing is broken for every user out of the box: the desktop generates a
QR, the phone scans it, and the connection errors out.

Root cause is a missing sidecar plus dead-endpoint fallback:

1. `start_pairing` (desktop) probes the main relay's NIP-11 for
   `pairing_relay_url`. The compose bundle sets no `BUZZ_PAIRING_RELAY_URL`, so
   the field is absent (`crates/buzz-relay/src/config.rs:430` → `nip11.rs:243`).
2. Because the relay advertises NIP-43, `pairing_relay_from_nip11`
   (`desktop/src-tauri/src/commands/pairing.rs:469`) resolves to the **legacy
   `/pair` path** on the main relay:
   `resolve_pairing_relay_url` turns `wss://<domain>` into `wss://<domain>/pair`.
3. `buzz-relay` does not serve `/pair` — no such route — so the QR encodes a
   dead endpoint (`GET /pair → 404`, WS upgrade `/pair → 404`) and the phone
   fails to connect.

The relay image **already ships the fix**: `/usr/local/bin/buzz-pair-relay` is
present in `ghcr.io/block/buzz:main`; it simply was never wired into the bundle.

## Fix

Bundle- and docs-only. No relay/desktop source changes.

- **Add the `pair` service to `compose.yml`** using the same relay image with
  `entrypoint: ["/usr/local/bin/buzz-pair-relay"]` and
  `BUZZ_PAIR_RELAY_BIND_ADDR=0.0.0.0:5000`. The base bundle publishes it on
  `BUZZ_PAIR_RELAY_PORT` (default 5000) — the same convention as the relay's
  `BUZZ_HTTP_PORT` — and `compose.caddy.yml` resets the mapping
  (`ports: !reset []`) exactly as it already does for the relay, so in TLS mode
  Caddy's `/pair` route is the only way in.
  Healthcheck is a raw-TCP `/dev/tcp` probe: the sidecar speaks only WebSocket
  upgrades and answers a plain `GET` with `400` (`lib.rs:943`), so an HTTP
  healthcheck would never see a `200`.

- **Route `/pair` to the sidecar in the Caddy TLS overlay** (`Caddyfile`), via a
  named path matcher `@pair path /pair /pair/*` → `reverse_proxy pair:5000`,
  with everything else falling through to `relay:3000`. This is the key design
  decision: the desktop's NIP-43 legacy fallback already targets
  `wss://<domain>/pair`, so a path proxy on the **main domain** makes pairing
  work with **zero extra DNS** and nothing for the operator to set. Verified in
  the pair-relay source that the sidecar **ignores the request path** entirely
  (`http_service` only inspects the WS-upgrade headers — `lib.rs:913`), so a
  path proxy needs no prefix stripping. `compose.caddy.yml` also gains a
  `depends_on: pair` (service_healthy) so Caddy waits for the sidecar.

- **Document `BUZZ_PAIRING_RELAY_URL`** in `.env.example` (commented) and a new
  README "Device pairing" section, covering three operator cases:
  - **TLS (`compose.caddy.yml`)** — works out of the box via the `/pair` path
    proxy; nothing to set.
  - **Split-domain / own proxy** — set `BUZZ_PAIRING_RELAY_URL=wss://pair.<domain>`
    and route that name at the sidecar's published port (or, for a proxy running
    outside this compose project that keeps the port unpublished, attach it to
    the `buzz-net` network and target `pair:5000`); the relay then advertises it
    in NIP-11 and the desktop uses it directly, skipping the `/pair` fallback.
    Semantics match `config.rs:430`: must be `ws://` or `wss://`, else the relay
    rejects it at startup.
  - **Non-TLS / direct** — the sidecar is already published on
    `BUZZ_PAIR_RELAY_PORT`; set `BUZZ_PAIRING_RELAY_URL=ws://<host>:5000`.

  (The first revision of this PR kept the sidecar network-internal by default.
  Operator reports below showed that made the split-domain and direct paths
  un-followable without hand-editing `compose.yml`, so `7a933968` switched it
  to the relay's published-by-default posture, reset by the Caddy overlay.)

### Why path-proxy over a dedicated `pair.<domain>`

The dedicated-subdomain approach (what we ran in production tonight,
`wss://pair.<domain>` + `BUZZ_PAIRING_RELAY_URL`) works but forces every
operator to add a second DNS record and a cert. Routing `/pair` on the existing
domain reuses the NIP-43 legacy fallback the desktop already emits, so the
common single-domain deploy needs no extra config at all. The split-domain path
remains fully supported via the documented env var for operators who want it.

## Tests / Validation

Production-verified tonight (per #2734): the equivalent `pair` service +
`BUZZ_PAIRING_RELAY_URL=wss://pair.<domain>` made NIP-11 advertise
`pairing_relay_url`, the desktop QR encode the working endpoint, and pairing
proceed end to end on a live self-hosted relay.

Bundle validation with a stub `.env` (`.env.example` copied, CHANGE_MEs filled
with dummies):

**a. Base compose renders clean, sidecar present:**
```
$ docker compose --env-file .env -f compose.yml config
OK base rendered
  pair:
    entrypoint: [/usr/local/bin/buzz-pair-relay]
    environment: { BUZZ_PAIR_RELAY_BIND_ADDR: 0.0.0.0:5000 }
    healthcheck: test [CMD-SHELL, bash -ec 'exec 3<>/dev/tcp/127.0.0.1/5000']
    image: ghcr.io/block/buzz:main
    restart: unless-stopped
```

**b. Caddy overlay combo renders clean, ports reset + depends_on wired:**
```
$ docker compose --env-file .env -f compose.yml -f compose.caddy.yml config
OK caddy overlay rendered
  caddy.depends_on: { pair: service_healthy, relay: service_healthy }
  relay.ports: (reset to empty via !reset — OK)
```
Dev overlay (`-f compose.dev.yml`) and the full three-file combo also render clean.

**b2. (`7a933968`) port-publish follow-up:** base render shows
`pair.ports: 5000:5000` and honors a `BUZZ_PAIR_RELAY_PORT=6789` override;
the Caddy overlay render resets both `relay.ports` and `pair.ports` to empty.
Base, Caddy, and dev combos all re-rendered clean.

**c. Caddyfile validates and routes correctly (via `caddy:2-alpine`):**
```
$ caddy validate --config Caddyfile --adapter caddyfile
Valid configuration
$ caddy adapt ... | routes
  /pair, /pair/*  -> pair:5000
  (default)       -> relay:3000
```

**d. Pre-push gate (all green — the branch touches no Rust/TS, but hooks ran the
full suite anyway):**
```
✔️ branch-skew        ✔️ desktop-check   ✔️ desktop-test
✔️ rust-tests (1626 passed)             ✔️ desktop-tauri-test
```

## Follow-up (out of scope for this PR)

The Helm chart (`squareup/block-coder-tf-stacks`) has the same pairing gap — it
also ships no pair sidecar and sets no `BUZZ_PAIRING_RELAY_URL`. Worth a
separate change on the chart side; not bundled here to keep this diff surgical
(compose bundle + docs only).

## Checklist

- [x] Deploy-bundle + docs only — no relay/desktop source changed
- [x] `docker compose config` renders clean for base, Caddy overlay, and dev overlay
- [x] `caddy validate` passes; `/pair` routes to the sidecar, default to the relay
- [x] New config variable (`BUZZ_PAIRING_RELAY_URL`) documented in `.env.example` + README
- [x] Pre-push hooks pass (clippy + unit tests + desktop + tauri)
- [x] No new `unwrap()` / `unsafe` (no code changes)

