### PR TITLE
feat(desktop): add local voice dictation to message composer

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
         "**/file-attachment.spec.ts",
         "**/image-attachment-gallery.spec.ts",
         "**/composer-image-draw.spec.ts",
+        "**/composer-dictation.spec.ts",
         "**/video-attachment.spec.ts",
         "**/spoiler.spec.ts",
         "**/composer-link-shortcut.spec.ts",

--- a/desktop/src-tauri/Info.plist
+++ b/desktop/src-tauri/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleName</key>
     <string>Buzz</string>
     <key>NSMicrophoneUsageDescription</key>
-    <string>Buzz needs microphone access for voice huddles.</string>
+    <string>Buzz needs microphone access for voice dictation and huddles.</string>
     <key>NSCameraUsageDescription</key>
     <string>Buzz needs camera access to record animated avatars.</string>
 </dict>

--- a/desktop/src-tauri/src/dictation.rs
+++ b/desktop/src-tauri/src/dictation.rs
@@ -1,0 +1,199 @@
+//! Standalone composer dictation backed by the local huddle STT engine.
+//!
+//! Dictation deliberately owns a separate pipeline and PCM command from
+//! huddles. Microphone audio captured for a draft must never be fanned out to
+//! the huddle relay, even when a huddle is active in the same process.
+
+use std::sync::{atomic::AtomicBool, Arc, LazyLock, Mutex, MutexGuard};
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+
+use crate::{
+    app_state::AppState,
+    huddle::{
+        models::{self, ModelStatus},
+        stt::SttPipeline,
+    },
+};
+
+const MAX_AUDIO_BATCH_BYTES: usize = 100 * 1024;
+
+/// Runtime state for the one process-wide composer dictation session.
+#[derive(Default)]
+struct DictationState {
+    pipeline: Option<Arc<SttPipeline>>,
+    generation: u64,
+}
+
+static DICTATION_STATE: LazyLock<Mutex<DictationState>> =
+    LazyLock::new(|| Mutex::new(DictationState::default()));
+
+fn dictation() -> Result<MutexGuard<'static, DictationState>, String> {
+    DICTATION_STATE.lock().map_err(|error| error.to_string())
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DictationTranscript {
+    session_id: u64,
+    text: String,
+}
+
+fn model_not_ready_message(status: ModelStatus) -> String {
+    match status {
+        ModelStatus::NotDownloaded => {
+            "Voice input is getting ready. The speech model download has started; try again shortly."
+                .to_string()
+        }
+        ModelStatus::Downloading { progress_percent } => format!(
+            "Voice input is getting ready ({progress_percent}% downloaded). Try again shortly."
+        ),
+        ModelStatus::Ready => "Speech model is not available yet.".to_string(),
+        ModelStatus::Error(error) => format!("Speech model download failed: {error}"),
+    }
+}
+
+/// Start an isolated, continuous-VAD dictation session.
+///
+/// Returns a monotonically increasing session id. Transcript events include
+/// the same id so composers can ignore results from replaced sessions.
+#[tauri::command]
+pub async fn start_dictation(app: AppHandle, state: State<'_, AppState>) -> Result<u64, String> {
+    let manager = models::global_model_manager()
+        .ok_or("model manager unavailable (home directory could not be resolved)")?;
+    manager.start_stt_download(state.http_client.clone());
+    let model_dir = manager
+        .stt_model_dir()
+        .ok_or_else(|| model_not_ready_message(manager.stt_status()))?;
+
+    let (session_id, old_pipeline) = {
+        let mut dictation = dictation()?;
+        dictation.generation = dictation.generation.wrapping_add(1);
+        let session_id = dictation.generation;
+        let old_pipeline = dictation.pipeline.take();
+        (session_id, old_pipeline)
+    };
+
+    if let Some(ref pipeline) = old_pipeline {
+        pipeline.shutdown();
+    }
+    // SttPipeline::drop joins its worker, so never drop it while holding state.
+    drop(old_pipeline);
+
+    let constructed = tokio::task::spawn_blocking(move || {
+        SttPipeline::new(model_dir, Arc::new(AtomicBool::new(false)), None, None)
+    })
+    .await;
+    let (pipeline, mut text_rx) = match constructed {
+        Ok(Ok(result)) => result,
+        Ok(Err(error)) => return Err(error),
+        Err(error) => return Err(format!("failed to start dictation worker: {error}")),
+    };
+    let pipeline = Arc::new(pipeline);
+
+    let installed = {
+        let mut dictation = dictation()?;
+        if dictation.generation != session_id {
+            false
+        } else {
+            dictation.pipeline = Some(Arc::clone(&pipeline));
+            true
+        }
+    };
+    if !installed {
+        pipeline.shutdown();
+        drop(pipeline);
+        return Err("dictation start was superseded".to_string());
+    }
+
+    tauri::async_runtime::spawn(async move {
+        while let Some(text) = text_rx.recv().await {
+            if text.trim().is_empty() {
+                continue;
+            }
+            let is_active = dictation()
+                .map(|dictation| dictation.generation == session_id && dictation.pipeline.is_some())
+                .unwrap_or(false);
+            if !is_active {
+                break;
+            }
+            let _ = app.emit(
+                "dictation-transcript",
+                DictationTranscript { session_id, text },
+            );
+        }
+    });
+
+    Ok(session_id)
+}
+
+/// Stop a dictation session if it is still current.
+///
+/// Stale callers are ignored so cleanup from an old composer cannot stop a
+/// newer session started in another channel or thread.
+#[tauri::command]
+pub fn stop_dictation(session_id: u64) -> Result<(), String> {
+    let old_pipeline = {
+        let mut dictation = dictation()?;
+        if dictation.generation != session_id {
+            return Ok(());
+        }
+        dictation.generation = dictation.generation.wrapping_add(1);
+        dictation.pipeline.take()
+    };
+
+    if let Some(ref pipeline) = old_pipeline {
+        pipeline.shutdown();
+    }
+    drop(old_pipeline);
+    Ok(())
+}
+
+/// Feed raw microphone PCM to composer dictation only.
+///
+/// Expects f32 little-endian samples at 48 kHz mono. This command intentionally
+/// does not touch huddle state or the huddle relay encoder.
+#[tauri::command]
+pub fn push_dictation_audio_pcm(request: tauri::ipc::Request<'_>) -> Result<(), String> {
+    match request.body() {
+        tauri::ipc::InvokeBody::Raw(bytes) => {
+            if bytes.len() > MAX_AUDIO_BATCH_BYTES {
+                return Err(format!(
+                    "audio batch too large: {} bytes (max {})",
+                    bytes.len(),
+                    MAX_AUDIO_BATCH_BYTES
+                ));
+            }
+            if let Some(ref pipeline) = dictation()?.pipeline {
+                pipeline.push_audio(bytes.to_vec())?;
+            }
+            Ok(())
+        }
+        _ => Err("expected raw binary body".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::model_not_ready_message;
+    use crate::huddle::models::ModelStatus;
+
+    #[test]
+    fn download_progress_is_actionable() {
+        assert_eq!(
+            model_not_ready_message(ModelStatus::Downloading {
+                progress_percent: 42
+            }),
+            "Voice input is getting ready (42% downloaded). Try again shortly."
+        );
+    }
+
+    #[test]
+    fn download_errors_are_preserved() {
+        assert_eq!(
+            model_not_ready_message(ModelStatus::Error("disk full".to_string())),
+            "Speech model download failed: disk full"
+        );
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod archive;
 mod builderlab;
 mod commands;
 mod deep_link;
+mod dictation;
 mod event_sync;
 mod events;
 mod huddle;
@@ -36,6 +37,7 @@ use deep_link::{
     acknowledge_pending_community_deep_link, handle_deep_link_url,
     take_pending_community_deep_link, PendingCommunityDeepLinks,
 };
+use dictation::{push_dictation_audio_pcm, start_dictation, stop_dictation};
 use huddle::audio_output::{
     get_audio_output_device, list_audio_output_devices, set_audio_output_device,
 };
@@ -848,6 +850,9 @@ pub fn run() {
             get_note,
             get_note_reactions,
             get_liked_notes,
+            start_dictation,
+            stop_dictation,
+            push_dictation_audio_pcm,
             start_huddle,
             join_huddle,
             leave_huddle,

--- a/desktop/src/features/huddle/lib/audioWorklet.ts
+++ b/desktop/src/features/huddle/lib/audioWorklet.ts
@@ -1,20 +1,5 @@
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-
-/**
- * Raw binary invoke — uses Tauri's internal IPC for zero-copy ArrayBuffer transfer.
- *
- * The typed @tauri-apps/api doesn't support raw binary payloads (InvokeBody::Raw).
- * This wrapper isolates the internal API dependency to a single call site.
- * Tested against Tauri v2. If this breaks on upgrade, only this function needs updating.
- */
-function invokeRawBinary(cmd: string, payload: Uint8Array): Promise<unknown> {
-  // biome-ignore lint/suspicious/noExplicitAny: Tauri internals have no public type definition
-  const internals = (window as any).__TAURI_INTERNALS__;
-  if (!internals?.invoke) {
-    return Promise.reject(new Error("Tauri internals not available"));
-  }
-  return internals.invoke(cmd, payload);
-}
+import { setupPcmCapture } from "@/shared/lib/pcmCapture";
 
 /** Return type for setupAudioWorklet — stop + mode control. */
 export type AudioWorkletHandle = {
@@ -52,49 +37,11 @@ export async function setupAudioWorklet(
   audioTrack: MediaStreamTrack,
   initialTransmitting = true,
 ): Promise<AudioWorkletHandle> {
-  const audioContext = new AudioContext({ sampleRate: 48000 });
-
-  // Resume after user gesture (required by autoplay policy)
-  if (audioContext.state === "suspended") {
-    await audioContext.resume();
-  }
-
-  // Load the worklet processor (must live in public/ for Vite to serve it)
-  await audioContext.audioWorklet.addModule("/worklet.js");
-
-  const source = audioContext.createMediaStreamSource(
-    new MediaStream([audioTrack]),
+  const capture = await setupPcmCapture(
+    audioTrack,
+    "push_audio_pcm",
+    initialTransmitting,
   );
-
-  const gainNode = audioContext.createGain();
-
-  const workletNode = new AudioWorkletNode(audioContext, "stt-tap-processor");
-
-  // Connect: mic → gain → worklet (tap only — no playback)
-  source.connect(gainNode);
-  gainNode.connect(workletNode);
-
-  // Set initial PTT state (worklet defaults to transmitting=true).
-  // In PTT mode, immediately gate audio until the user presses the key.
-  if (!initialTransmitting) {
-    workletNode.port.postMessage({ type: "ptt", active: false });
-  }
-
-  // Forward PCM batches to Rust via raw binary invoke.
-  // Direction: worklet→main (receives PCM data from worklet processor).
-  workletNode.port.onmessage = (event: MessageEvent<Float32Array>) => {
-    const float32 = event.data;
-    // Fire-and-forget — Rust side uses try_send which drops on backpressure.
-    // No await: prevents main-thread backpressure from slow Rust processing.
-    // Create a zero-copy Uint8Array view over the same underlying buffer.
-    // Rust reinterprets the bytes as f32 on the other side.
-    invokeRawBinary(
-      "push_audio_pcm",
-      new Uint8Array(float32.buffer, float32.byteOffset, float32.byteLength),
-    ).catch(() => {
-      /* silently drop — Rust handles backpressure */
-    });
-  };
 
   // Track the current mode so PTT events are only forwarded in PTT mode.
   // In VAD mode, the worklet stays in transmitting=true regardless of
@@ -111,7 +58,7 @@ export async function setupAudioWorklet(
       // Only forward PTT events to the worklet when in PTT mode.
       // In VAD mode, Ctrl+Space is ignored — the worklet stays open.
       if (currentMode === "push_to_talk") {
-        workletNode.port.postMessage({ type: "ptt", active: event.payload });
+        capture.setTransmitting(event.payload);
       }
     });
   } catch {
@@ -122,27 +69,20 @@ export async function setupAudioWorklet(
 
   return {
     stop: () => {
-      workletNode.port.onmessage = null;
       pttUnlisten?.();
-      source.disconnect();
-      gainNode.disconnect();
-      workletNode.disconnect();
-      void audioContext.close();
+      capture.stop();
     },
     setTransmitting: (active: boolean) => {
-      workletNode.port.postMessage({ type: "ptt", active });
+      capture.setTransmitting(active);
     },
     setMode: (mode: "push_to_talk" | "voice_activity") => {
       currentMode = mode;
       // When switching to VAD, immediately open the mic.
       // When switching to PTT, immediately gate until key press.
-      workletNode.port.postMessage({
-        type: "ptt",
-        active: mode === "voice_activity",
-      });
+      capture.setTransmitting(mode === "voice_activity");
     },
     setGain: (value: number) => {
-      gainNode.gain.value = value;
+      capture.setGain(value);
     },
   };
 }

--- a/desktop/src/features/messages/lib/dictationInsertion.test.mjs
+++ b/desktop/src/features/messages/lib/dictationInsertion.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildDictationInsertion } from "./dictationInsertion.ts";
+
+test("inserts the first transcript without a leading space", () => {
+  assert.equal(
+    buildDictationInsertion("", "  Hello from voice.  "),
+    "Hello from voice. ",
+  );
+});
+
+test("separates dictation from existing text", () => {
+  assert.equal(
+    buildDictationInsertion("d", "Continue this thought."),
+    " Continue this thought. ",
+  );
+});
+
+test("does not double-space at an existing boundary", () => {
+  assert.equal(
+    buildDictationInsertion(" ", "Continue this thought."),
+    "Continue this thought. ",
+  );
+});
+
+test("ignores an empty recognition result", () => {
+  assert.equal(buildDictationInsertion("x", " \n "), "");
+});

--- a/desktop/src/features/messages/lib/dictationInsertion.ts
+++ b/desktop/src/features/messages/lib/dictationInsertion.ts
@@ -1,0 +1,17 @@
+/**
+ * Normalize one finalized STT segment for insertion at the editor selection.
+ *
+ * Parakeet emits complete utterances without leading/trailing whitespace. Add
+ * a boundary when dictating after existing text and retain one trailing space
+ * so the next finalized segment joins naturally.
+ */
+export function buildDictationInsertion(
+  previousCharacter: string,
+  transcript: string,
+): string {
+  const normalized = transcript.trim();
+  if (!normalized) return "";
+  const prefix =
+    previousCharacter.length > 0 && !/\s/.test(previousCharacter) ? " " : "";
+  return `${prefix}${normalized} `;
+}

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -60,6 +60,7 @@ import { useMentionSendFlow } from "./useMentionSendFlow";
 import { usePersistentAgentMentionHydration } from "./usePersistentAgentMentionHydration";
 import { useComposerContentState } from "./useComposerContentState";
 import { useDraftPersistLifecycle } from "./useDraftPersistSnapshot";
+import { useComposerDictation } from "./useComposerDictation";
 
 type MessageComposerAudienceContext = {
   type: "thread";
@@ -358,8 +359,12 @@ function MessageComposerImpl({
       }
     },
   });
-
   const linkEditor = useLinkEditor(richText);
+  const dictation = useComposerDictation({
+    disabled,
+    editor: richText.editor,
+    sessionKey: effectiveDraftKey,
+  });
   syncContentRefFromEditorRef.current = () => {
     const markdown = richText.getMarkdown();
     contentRef.current = markdown;
@@ -598,6 +603,7 @@ function MessageComposerImpl({
 
   // ── Submit message ──────────────────────────────────────────────────
   const submitMessage = React.useCallback(async () => {
+    if (dictation.isActive) return;
     const trimmed = syncComposerContentFromEditor().trim();
 
     // Edit mode
@@ -712,6 +718,7 @@ function MessageComposerImpl({
     channelId,
     channelLinks.clearChannels,
     customEmoji,
+    dictation.isActive,
     drafts.loadDraft,
     emojiAutocomplete.clearEmojis,
     media.pendingImetaRef,
@@ -913,21 +920,12 @@ function MessageComposerImpl({
     });
   }, [media.setPendingImeta, richText.editor, scrollComposerToBottom]);
 
-  // ── Send button state ───────────────────────────────────────────────
-  const sendDisabled = React.useMemo(
-    () =>
-      disabled ||
-      media.isUploading ||
-      mentionSendFlow.isPreparingMentionSend ||
-      (isContentEmpty && media.pendingImeta.length === 0),
-    [
-      disabled,
-      media.isUploading,
-      mentionSendFlow.isPreparingMentionSend,
-      isContentEmpty,
-      media.pendingImeta.length,
-    ],
-  );
+  const sendDisabled =
+    disabled ||
+    dictation.isActive ||
+    media.isUploading ||
+    mentionSendFlow.isPreparingMentionSend ||
+    (isContentEmpty && media.pendingImeta.length === 0);
 
   const handleCaptureSelection = React.useCallback(() => {
     // No-op for Tiptap — selection is managed by ProseMirror.
@@ -1077,6 +1075,7 @@ function MessageComposerImpl({
               editor={richText.editor}
               extraActions={toolbarExtraActions}
               formattingDisabled={disabled}
+              dictationStatus={dictation.status}
               isEmojiPickerOpen={isEmojiPickerOpen}
               isFormattingOpen={isFormattingOpen}
               isSending={isSending}
@@ -1085,6 +1084,7 @@ function MessageComposerImpl({
               onEmojiPickerOpenChange={setIsEmojiPickerOpen}
               onEmojiSelect={insertEmoji}
               onFormattingToggle={handleFormattingToggle}
+              onDictationToggle={dictation.toggle}
               onLinkButton={linkEditor.openFromToolbar}
               onOpenMentionPicker={openMentionPicker}
               onPaperclip={handlePaperclipClick}

--- a/desktop/src/features/messages/ui/MessageComposerToolbar.tsx
+++ b/desktop/src/features/messages/ui/MessageComposerToolbar.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
 import type { Editor } from "@tiptap/react";
 import { AnimatePresence, motion } from "motion/react";
-import { ALargeSmall, ArrowUp, AtSign, Paperclip, X } from "lucide-react";
+import { ALargeSmall, ArrowUp, AtSign, Mic, Paperclip, X } from "lucide-react";
 
 import { Button } from "@/shared/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { ComposerEmojiPicker } from "./ComposerEmojiPicker";
 import { FormattingToolbar } from "./FormattingToolbar";
 import { SelectionFormattingTray } from "./SelectionFormattingTray";
+import type { ComposerDictationStatus } from "./useComposerDictation";
 
 /** Spring for enter/exit of button groups — all fire simultaneously. */
 const presenceSpring = {
@@ -22,6 +23,7 @@ export const MessageComposerToolbar = React.memo(
     editor,
     extraActions,
     formattingDisabled,
+    dictationStatus = "idle",
     isEmojiPickerOpen,
     isFormattingOpen,
     isSending,
@@ -30,6 +32,7 @@ export const MessageComposerToolbar = React.memo(
     onEmojiPickerOpenChange,
     onEmojiSelect,
     onFormattingToggle,
+    onDictationToggle,
     onLinkButton,
     onOpenMentionPicker,
     onPaperclip,
@@ -39,6 +42,7 @@ export const MessageComposerToolbar = React.memo(
     editor: Editor | null;
     extraActions?: React.ReactNode;
     formattingDisabled: boolean;
+    dictationStatus?: ComposerDictationStatus;
     isEmojiPickerOpen: boolean;
     isFormattingOpen: boolean;
     isSending: boolean;
@@ -47,6 +51,7 @@ export const MessageComposerToolbar = React.memo(
     onEmojiPickerOpenChange: (open: boolean) => void;
     onEmojiSelect: (emoji: string) => void;
     onFormattingToggle: (pressed: boolean) => void;
+    onDictationToggle?: () => void;
     onLinkButton: () => void;
     onOpenMentionPicker: () => void;
     onPaperclip: () => void;
@@ -231,6 +236,61 @@ export const MessageComposerToolbar = React.memo(
 
         <div className="flex items-center gap-2">
           {extraActions}
+          {onDictationToggle ? (
+            <Tooltip disableHoverableContent>
+              <TooltipTrigger asChild>
+                <Button
+                  aria-label={
+                    dictationStatus === "recording"
+                      ? "Stop dictation"
+                      : dictationStatus === "stopping"
+                        ? "Finishing dictation"
+                        : dictationStatus === "starting"
+                          ? "Starting dictation"
+                          : "Dictate message"
+                  }
+                  aria-pressed={dictationStatus === "recording"}
+                  data-testid="message-dictation"
+                  disabled={
+                    composerDisabled ||
+                    dictationStatus === "starting" ||
+                    dictationStatus === "stopping"
+                  }
+                  onClick={onDictationToggle}
+                  onMouseDown={onCaptureSelection}
+                  size="icon"
+                  type="button"
+                  variant={
+                    dictationStatus === "recording" ? "destructive" : "ghost"
+                  }
+                >
+                  {dictationStatus === "starting" ||
+                  dictationStatus === "stopping" ? (
+                    <span
+                      aria-hidden
+                      className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+                    />
+                  ) : (
+                    <Mic
+                      aria-hidden
+                      className={
+                        dictationStatus === "recording" ? "animate-pulse" : ""
+                      }
+                    />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {dictationStatus === "recording"
+                  ? "Stop dictation"
+                  : dictationStatus === "stopping"
+                    ? "Finishing dictation"
+                    : dictationStatus === "starting"
+                      ? "Starting dictation"
+                      : "Dictate message"}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
           <Button
             aria-label={isSending ? "Sending" : "Send message"}
             className="rounded-full"

--- a/desktop/src/features/messages/ui/useComposerDictation.ts
+++ b/desktop/src/features/messages/ui/useComposerDictation.ts
@@ -1,0 +1,264 @@
+import * as React from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { Editor } from "@tiptap/react";
+import { toast } from "sonner";
+
+import { buildDictationInsertion } from "@/features/messages/lib/dictationInsertion";
+import { invokeTauri } from "@/shared/api/tauri";
+import {
+  type PcmCaptureHandle,
+  setupPcmCapture,
+} from "@/shared/lib/pcmCapture";
+
+export type ComposerDictationStatus =
+  | "idle"
+  | "starting"
+  | "recording"
+  | "stopping";
+
+type DictationTranscript = {
+  sessionId: number;
+  text: string;
+};
+
+type ActiveOwner = {
+  id: symbol;
+  release: () => void;
+};
+
+let activeOwner: ActiveOwner | null = null;
+
+// The STT worker flushes after ~300 ms of silence. Keep capture open briefly
+// after Stop so clicking immediately after the last word does not drop it.
+const FINAL_TRANSCRIPT_GRACE_MS = 450;
+
+function stopNativeDictation(sessionId: number): void {
+  void invokeTauri("stop_dictation", { sessionId }).catch(() => {
+    // Session cleanup is best-effort; native generation guards prevent a stale
+    // session from writing into another composer.
+  });
+}
+
+function dictationErrorMessage(error: unknown): string {
+  if (error instanceof DOMException && error.name === "NotAllowedError") {
+    return "Microphone access was denied. Allow Buzz to use the microphone in system settings, then try again.";
+  }
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return "Voice input could not start.";
+}
+
+function insertTranscript(editor: Editor, transcript: string): boolean {
+  const { from, to } = editor.state.selection;
+  const previousCharacter =
+    from > 1 ? editor.state.doc.textBetween(from - 1, from, "\n", "\n") : "";
+  const insertion = buildDictationInsertion(previousCharacter, transcript);
+  if (!insertion) return false;
+  return editor
+    .chain()
+    .focus()
+    .insertContentAt({ from, to }, insertion)
+    .scrollIntoView()
+    .run();
+}
+
+export function useComposerDictation({
+  disabled,
+  editor,
+  sessionKey,
+}: {
+  disabled: boolean;
+  editor: Editor | null;
+  sessionKey?: string | null;
+}) {
+  const [status, setStatus] = React.useState<ComposerDictationStatus>("idle");
+  const activeSessionRef = React.useRef<number | null>(null);
+  const captureRef = React.useRef<PcmCaptureHandle | null>(null);
+  const streamRef = React.useRef<MediaStream | null>(null);
+  const operationRef = React.useRef(0);
+  const instanceIdRef = React.useRef(Symbol("composer-dictation"));
+  const sessionKeyRef = React.useRef(sessionKey);
+  const editorRef = React.useRef(editor);
+  editorRef.current = editor;
+
+  const stopCapture = React.useCallback(() => {
+    captureRef.current?.stop();
+    captureRef.current = null;
+    for (const track of streamRef.current?.getTracks() ?? []) {
+      track.stop();
+    }
+    streamRef.current = null;
+  }, []);
+
+  const releaseImmediately = React.useCallback(
+    (updateState: boolean) => {
+      operationRef.current += 1;
+      stopCapture();
+      const sessionId = activeSessionRef.current;
+      activeSessionRef.current = null;
+      if (sessionId !== null) {
+        stopNativeDictation(sessionId);
+      }
+      if (activeOwner?.id === instanceIdRef.current) {
+        activeOwner = null;
+      }
+      if (updateState) setStatus("idle");
+    },
+    [stopCapture],
+  );
+
+  React.useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+    void listen<DictationTranscript>("dictation-transcript", (event) => {
+      if (event.payload.sessionId !== activeSessionRef.current) return;
+      const activeEditor = editorRef.current;
+      if (activeEditor) insertTranscript(activeEditor, event.payload.text);
+    })
+      .then((dispose) => {
+        if (disposed) {
+          dispose();
+        } else {
+          unlisten = dispose;
+        }
+      })
+      .catch((error) => {
+        console.error("Failed to listen for dictation transcripts:", error);
+      });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (disabled) releaseImmediately(true);
+  }, [disabled, releaseImmediately]);
+
+  // A MessageComposer can survive channel/thread navigation. Never let a
+  // transcript started in one draft land in the next draft key.
+  React.useEffect(() => {
+    if (sessionKeyRef.current === sessionKey) return;
+    sessionKeyRef.current = sessionKey;
+    releaseImmediately(true);
+  }, [sessionKey, releaseImmediately]);
+
+  React.useEffect(
+    () => () => {
+      releaseImmediately(false);
+    },
+    [releaseImmediately],
+  );
+
+  const start = React.useCallback(async () => {
+    if (disabled || !editorRef.current) return;
+
+    if (activeOwner?.id !== instanceIdRef.current) {
+      activeOwner?.release();
+    }
+    releaseImmediately(false);
+    activeOwner = {
+      id: instanceIdRef.current,
+      release: () => releaseImmediately(true),
+    };
+    const operation = operationRef.current + 1;
+    operationRef.current = operation;
+    setStatus("starting");
+
+    let sessionId: number | null = null;
+    let stream: MediaStream | null = null;
+    try {
+      sessionId = await invokeTauri<number>("start_dictation");
+      if (operation !== operationRef.current) {
+        stopNativeDictation(sessionId);
+        return;
+      }
+      activeSessionRef.current = sessionId;
+
+      if (!navigator.mediaDevices?.getUserMedia) {
+        throw new Error("Microphone capture is unavailable on this system.");
+      }
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          autoGainControl: true,
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+          sampleRate: 48000,
+        },
+      });
+      const [audioTrack] = stream.getAudioTracks();
+      if (!audioTrack) {
+        throw new Error("No microphone input is available.");
+      }
+      const capture = await setupPcmCapture(
+        audioTrack,
+        "push_dictation_audio_pcm",
+      );
+      if (operation !== operationRef.current) {
+        capture.stop();
+        for (const track of stream.getTracks()) track.stop();
+        stopNativeDictation(sessionId);
+        return;
+      }
+      streamRef.current = stream;
+      captureRef.current = capture;
+      setStatus("recording");
+    } catch (error) {
+      for (const track of stream?.getTracks() ?? []) track.stop();
+      if (sessionId !== null) {
+        stopNativeDictation(sessionId);
+      }
+      if (operation === operationRef.current) {
+        activeSessionRef.current = null;
+        if (activeOwner?.id === instanceIdRef.current) activeOwner = null;
+        setStatus("idle");
+        toast.error(dictationErrorMessage(error));
+      }
+    }
+  }, [disabled, releaseImmediately]);
+
+  const stop = React.useCallback(async () => {
+    const sessionId = activeSessionRef.current;
+    if (sessionId === null) {
+      releaseImmediately(true);
+      return;
+    }
+
+    operationRef.current += 1;
+    setStatus("stopping");
+    await new Promise((resolve) =>
+      window.setTimeout(resolve, FINAL_TRANSCRIPT_GRACE_MS),
+    );
+    if (activeSessionRef.current !== sessionId) return;
+
+    stopCapture();
+    try {
+      await invokeTauri("stop_dictation", { sessionId });
+    } catch (error) {
+      console.error("Failed to stop dictation:", error);
+    } finally {
+      if (activeSessionRef.current === sessionId) {
+        activeSessionRef.current = null;
+        if (activeOwner?.id === instanceIdRef.current) activeOwner = null;
+        setStatus("idle");
+        editorRef.current?.commands.focus();
+      }
+    }
+  }, [releaseImmediately, stopCapture]);
+
+  const toggle = React.useCallback(() => {
+    if (status === "idle") {
+      void start();
+    } else if (status === "recording") {
+      void stop();
+    }
+  }, [start, status, stop]);
+
+  return {
+    isActive: status !== "idle",
+    status,
+    toggle,
+  };
+}

--- a/desktop/src/shared/lib/pcmCapture.ts
+++ b/desktop/src/shared/lib/pcmCapture.ts
@@ -1,0 +1,78 @@
+/**
+ * Raw binary invoke over Tauri's internal IPC.
+ *
+ * The public typed API does not support InvokeBody::Raw. Keeping the internal
+ * dependency here gives huddles and composer dictation one upgrade boundary.
+ */
+function invokeRawBinary(
+  command: string,
+  payload: Uint8Array,
+): Promise<unknown> {
+  // biome-ignore lint/suspicious/noExplicitAny: Tauri internals have no public type definition
+  const internals = (window as any).__TAURI_INTERNALS__;
+  if (!internals?.invoke) {
+    return Promise.reject(new Error("Tauri internals not available"));
+  }
+  return internals.invoke(command, payload);
+}
+
+export type PcmCaptureHandle = {
+  stop: () => void;
+  setGain: (value: number) => void;
+  setTransmitting: (active: boolean) => void;
+};
+
+/**
+ * Capture a microphone track as 48 kHz mono f32 PCM and forward it to a raw
+ * Tauri command. The command selects the isolated Rust consumer (huddle or
+ * composer dictation).
+ */
+export async function setupPcmCapture(
+  audioTrack: MediaStreamTrack,
+  command: "push_audio_pcm" | "push_dictation_audio_pcm",
+  initialTransmitting = true,
+): Promise<PcmCaptureHandle> {
+  const audioContext = new AudioContext({ sampleRate: 48000 });
+  if (audioContext.state === "suspended") {
+    await audioContext.resume();
+  }
+
+  await audioContext.audioWorklet.addModule("/worklet.js");
+  const source = audioContext.createMediaStreamSource(
+    new MediaStream([audioTrack]),
+  );
+  const gainNode = audioContext.createGain();
+  const workletNode = new AudioWorkletNode(audioContext, "stt-tap-processor");
+
+  source.connect(gainNode);
+  gainNode.connect(workletNode);
+  if (!initialTransmitting) {
+    workletNode.port.postMessage({ type: "ptt", active: false });
+  }
+
+  workletNode.port.onmessage = (event: MessageEvent<Float32Array>) => {
+    const float32 = event.data;
+    invokeRawBinary(
+      command,
+      new Uint8Array(float32.buffer, float32.byteOffset, float32.byteLength),
+    ).catch(() => {
+      // The Rust queues are deliberately lossy under backpressure.
+    });
+  };
+
+  return {
+    stop: () => {
+      workletNode.port.onmessage = null;
+      source.disconnect();
+      gainNode.disconnect();
+      workletNode.disconnect();
+      void audioContext.close();
+    },
+    setGain: (value: number) => {
+      gainNode.gain.value = value;
+    },
+    setTransmitting: (active: boolean) => {
+      workletNode.port.postMessage({ type: "ptt", active });
+    },
+  };
+}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -11060,6 +11060,11 @@ export function maybeInstallE2eTauriMocks() {
         }
         return null;
       }
+      case "start_dictation":
+        return 1;
+      case "stop_dictation":
+      case "push_dictation_audio_pcm":
+        return null;
       default:
         throw new Error(`Unsupported mocked Tauri command: ${command}`);
     }

--- a/desktop/tests/e2e/composer-dictation.spec.ts
+++ b/desktop/tests/e2e/composer-dictation.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+async function installAudioCaptureMock(page: Page) {
+  await page.addInitScript(() => {
+    class FakeAudioTrack {
+      stop() {}
+    }
+
+    class FakeMediaStream {
+      constructor(private readonly tracks = [new FakeAudioTrack()]) {}
+      getAudioTracks() {
+        return this.tracks;
+      }
+      getTracks() {
+        return this.tracks;
+      }
+    }
+
+    class FakeAudioNode {
+      connect() {
+        return this;
+      }
+      disconnect() {}
+    }
+
+    class FakeAudioContext {
+      state = "running";
+      audioWorklet = { addModule: async () => {} };
+      createGain() {
+        return Object.assign(new FakeAudioNode(), { gain: { value: 1 } });
+      }
+      createMediaStreamSource() {
+        return new FakeAudioNode();
+      }
+      async close() {}
+      async resume() {}
+    }
+
+    class FakeAudioWorkletNode extends FakeAudioNode {
+      port = {
+        onmessage: null,
+        postMessage() {},
+      };
+    }
+
+    Object.defineProperty(window, "MediaStream", {
+      configurable: true,
+      value: FakeMediaStream,
+    });
+    Object.defineProperty(window, "AudioContext", {
+      configurable: true,
+      value: FakeAudioContext,
+    });
+    Object.defineProperty(window, "AudioWorkletNode", {
+      configurable: true,
+      value: FakeAudioWorkletNode,
+    });
+    Object.defineProperty(navigator.mediaDevices, "getUserMedia", {
+      configurable: true,
+      value: async () => new FakeMediaStream(),
+    });
+  });
+}
+
+async function emitDictationTranscript(page: Page, text: string) {
+  await page.evaluate(async (transcript) => {
+    const internals = (
+      window as Window & {
+        __TAURI_INTERNALS__?: {
+          invoke: (command: string, payload: unknown) => Promise<unknown>;
+        };
+      }
+    ).__TAURI_INTERNALS__;
+    if (!internals) throw new Error("mock Tauri internals are unavailable");
+    await internals.invoke("plugin:event|emit", {
+      event: "dictation-transcript",
+      payload: { sessionId: 1, text: transcript },
+    });
+  }, text);
+}
+
+test("dictation inserts finalized speech and waits for Stop before sending", async ({
+  page,
+}) => {
+  await installAudioCaptureMock(page);
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.click();
+  await input.pressSequentially("Existing draft");
+
+  await page.getByRole("button", { name: "Dictate message" }).click();
+  await expect(
+    page.getByRole("button", { name: "Stop dictation" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("send-message")).toBeDisabled();
+
+  await emitDictationTranscript(page, "dictated continuation.");
+  await expect(input).toContainText("Existing draft dictated continuation.");
+
+  await page.getByRole("button", { name: "Stop dictation" }).click();
+  await expect(
+    page.getByRole("button", { name: "Finishing dictation" }),
+  ).toBeDisabled();
+  await expect(
+    page.getByRole("button", { name: "Dictate message" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("send-message")).toBeEnabled();
+});


### PR DESCRIPTION
## Summary

- add a microphone control to channel, DM, and thread message composers
- transcribe microphone audio with Buzz's existing local Parakeet STT model
- insert finalized speech at the current editor selection before sending through the normal message and ACP flow
- keep composer dictation on an isolated native PCM/STT path so microphone audio never enters the huddle relay
- expose accessible starting, recording, and finishing states and prevent sending until the final utterance has flushed
- share the low-level PCM capture plumbing with huddles without changing their push-to-talk behavior

## Why

ACP agents consume the text Buzz sends them, but the desktop composer had no voice-to-text input. Buzz already ships an on-device speech model for huddles, so composer dictation can reuse that local capability without adding a cloud transcription dependency or another API key.

## User impact

Users can dictate a draft, review or edit the resulting text, and then send it to people or connected agents through the existing message path. The first use may briefly wait for the local speech model download, and macOS will request microphone permission.

## Validation

- `pnpm -C desktop test` — 3,487 passed
- `pnpm -C desktop typecheck`
- `pnpm -C desktop build`
- `pnpm -C desktop check`
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml`
- focused dictation Rust tests — 2 passed
- pre-push desktop Tauri suite — 1,628 passed, 14 ignored
- Playwright dictation flow covering start, transcript insertion, stop/finalization, and send gating
- rendered desktop composer screenshot

## Manual validation

- [x] Confirmed physical-microphone transcription and the macOS permission prompt in the native Buzz Dev build
