### PR TITLE
fix(desktop): read pair-scoped agent logs

### DIFF
--- a/desktop/src-tauri/src/commands/agent_logs.rs
+++ b/desktop/src-tauri/src/commands/agent_logs.rs
@@ -1,12 +1,20 @@
+use std::path::PathBuf;
+
 use tauri::{AppHandle, Manager};
 
 use crate::{
     app_state::AppState,
     managed_agents::{
-        load_managed_agents, managed_agent_log_path, read_log_tail, BackendKind,
-        ManagedAgentLogResponse,
+        load_managed_agents, managed_agent_log_path, managed_agent_runtime_log_path, read_log_tail,
+        workspace_pair_key, BackendKind, ManagedAgentLogResponse,
     },
 };
+
+fn select_log_path(pair_log_path: Option<PathBuf>, legacy_log_path: PathBuf) -> PathBuf {
+    pair_log_path
+        .filter(|path| path.exists())
+        .unwrap_or(legacy_log_path)
+}
 
 #[tauri::command]
 pub async fn get_managed_agent_log(
@@ -29,7 +37,10 @@ pub async fn get_managed_agent_log(
             return Err("logs are not available for remote agents".to_string());
         }
 
-        let log_path = managed_agent_log_path(&app, &pubkey)?;
+        let pair_log_path = workspace_pair_key(&app, record)
+            .map(|key| managed_agent_runtime_log_path(&app, &key))
+            .transpose()?;
+        let log_path = select_log_path(pair_log_path, managed_agent_log_path(&app, &pubkey)?);
         Ok(ManagedAgentLogResponse {
             content: read_log_tail(&log_path, line_count.unwrap_or(120) as usize)?,
             log_path: log_path.display().to_string(),
@@ -37,4 +48,21 @@ pub async fn get_managed_agent_log(
     })
     .await
     .map_err(|e| format!("spawn_blocking failed: {e}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_existing_pair_log_and_falls_back_to_legacy_log() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let legacy = dir.path().join("agent.log");
+        let pair = dir.path().join("agent-relay.log");
+
+        assert_eq!(select_log_path(Some(pair.clone()), legacy.clone()), legacy);
+
+        std::fs::write(&pair, "pair log").expect("write pair log");
+        assert_eq!(select_log_path(Some(pair.clone()), legacy), pair);
+    }
 }


### PR DESCRIPTION
## Summary

- read managed-agent logs from the active community's pair-scoped path
- fall back to the legacy pubkey-only path

Fixes the empty Harness Log regression from #2122, where writers became pair-scoped but the reader remained pubkey-scoped.

Part of #2641.

## Testing

- `cargo test --manifest-path desktop/src-tauri/Cargo.toml selects_existing_pair_log_and_falls_back_to_legacy_log --lib`
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`
