### PR TITLE
fix(desktop): use augmented PATH for model discovery subprocess

### DIFF
--- a/desktop/src-tauri/src/commands/agent_model_process.rs
+++ b/desktop/src-tauri/src/commands/agent_model_process.rs
@@ -27,7 +27,13 @@ pub(super) async fn run_agent_models_command(
         if let Some(home) = default_agent_workdir() {
             cmd.current_dir(home);
         }
-        if let Some(ref path) = crate::managed_agents::login_shell_path() {
+        // Inject the same augmented PATH used for launched agents and CLI
+        // probes: managed Node/npm dirs, exe-parent sidecars, login-shell
+        // PATH, and (Windows) the inherited process PATH. login_shell_path()
+        // alone is always None on Windows, which left this child with no
+        // managed Node dirs — the ACP adapter's `.cmd` shims then failed with
+        // `'node' is not recognized` and the model dropdown stayed empty.
+        if let Some(ref path) = crate::managed_agents::readiness::cli_probe::augmented_path() {
             cmd.env("PATH", path);
         }
         cmd.arg("models")

--- a/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
@@ -2,8 +2,10 @@ use std::path::Path;
 
 use crate::managed_agents::runtime::build_augmented_path;
 
-/// Build the augmented PATH for CLI probes, including nvm's default Node.js
-/// bin directory so `#!/usr/bin/env node` shims (e.g. codex-acp) resolve.
+/// Build the augmented PATH for CLI probes and other native child processes
+/// (auth commands, `buzz-acp models` discovery), including nvm's default
+/// Node.js bin directory so `#!/usr/bin/env node` shims (e.g. codex-acp)
+/// resolve.
 pub(crate) fn augmented_path() -> Option<String> {
     let home = dirs::home_dir();
     let nvm_bin = home


### PR DESCRIPTION
On Windows, the model dropdown never populates for CLI harnesses (Claude Code, Codex) while the same flow works on macOS.

Model discovery spawns `buzz-acp models` with `PATH` taken from `login_shell_path()` — which by design always returns `None` on Windows (Git Bash's POSIX-shaped PATH would poison native children). The discovery child therefore ran with only the raw inherited process PATH, missing the Buzz-managed Node/npm directories and exe-parent sidecar dir, so the ACP adapter's `.cmd` shims failed to resolve `node` and discovery returned nothing. macOS worked only because a login-shell PATH exists there.

The fix reuses the existing `augmented_path()` helper (already used by CLI login probes and auth commands, built on the same `build_augmented_path` kernel as the real agent spawn), so model discovery resolves the identical toolchain the agent will actually run with. `login_shell_path()` remains the login-shell component inside that composition — on macOS the composed PATH is a superset of the previous value.

Related: #2661 (managed Node fallback these entries point at), reported in the Windows install-issues follow-up.
