### PR TITLE
feat(transport): pluggable Transport trait — relay, remote bridge, and in-memory implementations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ crates/
   # Tooling + shared
   buzz-cli            # Agent-first CLI
   buzz-sdk            # Typed Nostr event builders
+  buzz-transport      # Pluggable Transport seam — signed-event streams (relay, remote bridge, in-memory)
   buzz-admin          # Operator CLI for relay administration
   buzz-ws-client      # Shared NIP-42 WebSocket client (connect, auth, publish)
   buzz-test-client    # Integration test client and E2E test suite

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,6 +87,7 @@ buzz-core    (zero I/O — types, verification, filter matching, kind registry)
          └── buzz-relay       (ties everything together — the server)
 
 buzz-acp            (agent harness — bridges relay @mentions → AI agents via ACP/JSON-RPC)
+buzz-transport      (pluggable Transport seam — signed-event streams; used by buzz-acp)
 buzz-sdk            (typed Nostr event builders — used by buzz-acp and buzz-cli)
 buzz-media          (Blossom/S3 media storage)
 buzz-cli            (agent-first CLI)
@@ -672,6 +673,58 @@ Buzz Relay ──WS──→ buzz-acp ──stdio (ACP/JSON-RPC)──→ Agent 
 - Depends on `buzz-core` (kind constants) and `buzz-sdk` (relay/REST utilities).
 
 **Does NOT:** persist state.
+
+---
+
+### buzz-transport — Pluggable Event-Transport Seam
+
+Captures what the relay connection *provides* as one small trait — a
+bidirectional stream of signed events — so the network under a Buzz consumer
+becomes swappable.
+
+**Key types:**
+
+```rust
+pub trait Transport: Send {
+    fn subscribe(&mut self, subscription: Subscription) -> …;
+    fn unsubscribe(&mut self, channel_id: Uuid) -> …;
+    fn next_event(&mut self) -> …;   // None = connection lost → reconnect()
+    fn publish(&self, event: SignedEvent) -> …;
+    fn try_publish(&self, event: SignedEvent) -> Result<(), TransportError>;
+    fn reconnect(&mut self) -> …;
+    fn shutdown(self: Box<Self>) -> …;
+}
+
+pub struct SignedEvent { id, pubkey, created_at, kind, tags, content, sig }
+```
+
+`SignedEvent` is crate-owned plain data — structurally the NIP-01 event Buzz
+already speaks (lossless conversion, Schnorr verification), but implementors
+never need a Nostr library. The trait has no side-channel API: membership,
+discovery, presence, and typing already *are* events in Buzz, so they ride
+the same stream.
+
+**Implementations:**
+
+| Implementation | Where | Purpose |
+|----------------|-------|---------|
+| `HarnessRelay` | `buzz-acp` | The NIP-42 relay WebSocket — the default |
+| `RemoteTransport` | `buzz-transport` | Dials an operator-run bridge speaking the JSON protocol in `PROTOCOL.md` — bridge Buzz onto any network (Slack, a private mesh) in any language |
+| `InMemoryHub` | `buzz-transport` | Reference implementation: in-process fan-out between participants, used by integration tests |
+
+`RemoteTransport` carriers are selected by URL scheme: `wss://`/`ws://`
+(WebSocket) or `unix:///path.sock` (newline-delimited JSON over a Unix
+socket), optionally tunneled through a SOCKS5 proxy. Security policy:
+`wss://` always; plaintext `ws://` only to loopback, to `.onion` through a
+loopback proxy, or with an explicit insecure opt-in. Inbound events are
+signature-verified and dropped on failure. `buzz-acp` ships a
+`connect_transport` factory selecting the implementation from
+`BUZZ_TRANSPORT` env vars (see the harness README); the harness event loop
+still constructs the relay client directly — converting it to consume
+`Box<dyn Transport>` is the tracked follow-up.
+
+**Does NOT:** persist events, implement channel membership, or expose any
+API beyond the event stream.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,6 +769,7 @@ dependencies = [
  "buzz-core",
  "buzz-persona",
  "buzz-sdk",
+ "buzz-transport",
  "chrono",
  "clap",
  "evalexpr",
@@ -1256,6 +1257,23 @@ dependencies = [
  "tokio-tungstenite 0.29.0",
  "tracing",
  "tracing-subscriber",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "buzz-transport"
+version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "nostr",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.29.0",
+ "tokio-util",
+ "tracing",
  "url",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/buzz-agent",
     "crates/sprig",
     "crates/buzz-test-client",
+    "crates/buzz-transport",
     "crates/buzz-ws-client",
     "crates/buzz-admin",
     "crates/buzz-workflow",
@@ -131,6 +132,7 @@ buzz-audit = { path = "crates/buzz-audit" }
 buzz-workflow = { path = "crates/buzz-workflow" }
 buzz-media = { path = "crates/buzz-media" }
 buzz-sdk = { path = "crates/buzz-sdk" }
+buzz-transport = { path = "crates/buzz-transport" }
 buzz-ws-client = { path = "crates/buzz-ws-client" }
 buzz-relay-mesh = { path = "crates/buzz-relay-mesh" }
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ A Rust workspace of focused crates. Single source of truth: the relay. See [ARCH
 
 **Git & pairing** — `git-sign-nostr` / `git-credential-nostr` (nostr-signed git) · `buzz-pair-relay` / `buzz-pairing-cli` (relay pairing)
 
-**Shared** — `buzz-sdk` (typed event builders) · `buzz-media` (Blossom/S3)
+**Shared** — `buzz-sdk` (typed event builders) · `buzz-transport` (pluggable event-transport seam: relay, remote bridge, in-memory) · `buzz-media` (Blossom/S3)
 
 **Tooling** — `buzz-admin` (admin CLI) · `buzz-test-client` (E2E)
 

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 # Internal
 buzz-core = { workspace = true }
 buzz-sdk = { workspace = true }
+buzz-transport = { workspace = true }
 buzz-persona = { path = "../buzz-persona" }
 
 # Nostr

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -110,6 +110,24 @@ All configuration is via environment variables (or CLI flags — every env var h
 
 **Legacy env vars:** `BUZZ_ACP_PRIVATE_KEY`, `BUZZ_ACP_API_TOKEN`, and `BUZZ_ACP_TURN_TIMEOUT` (replaced by `BUZZ_ACP_IDLE_TIMEOUT`) are still accepted as fallbacks.
 
+### Transport
+
+The transport seam ([`buzz-transport`](../buzz-transport) and its
+[bridge protocol](../buzz-transport/PROTOCOL.md)) lets a Buzz consumer carry
+its events over an operator-run bridge instead of the Buzz relay.
+`buzz_acp::transport::connect_transport` selects an implementation from the
+variables below. **Status:** the harness's own event loop does not consume
+the seam yet — it still connects to the relay directly, and these variables
+take effect once that conversion lands (tracked follow-up).
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `BUZZ_TRANSPORT` | no | `nostr` | Which transport carries events: `nostr` (the relay) or `remote` (an operator-run bridge). |
+| `BUZZ_TRANSPORT_URL` | with `remote` | — | Bridge endpoint: `wss://…` (WebSocket) or `unix:///path.sock` (line-framed Unix socket). |
+| `BUZZ_TRANSPORT_TOKEN` | no | — | Bearer token sent in the `hello` frame and, on WebSocket, the upgrade `Authorization` header. |
+| `BUZZ_TRANSPORT_SOCKS_PROXY` | no | — | Tunnel WebSocket carriers through a SOCKS5 proxy: `socks5://[user:pass@]host:port`. |
+| `BUZZ_TRANSPORT_ALLOW_INSECURE` | no | `false` | Permit plaintext `ws://` to non-loopback hosts (trusted private networks only). |
+
 ### Parallel Agents & Heartbeat
 
 | Flag | Env Var | Default | Description |

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -10,6 +10,7 @@ mod pool_lifecycle;
 mod queue;
 mod relay;
 mod setup_mode;
+pub mod transport;
 mod usage;
 
 pub use usage::TurnUsage;

--- a/crates/buzz-acp/src/transport.rs
+++ b/crates/buzz-acp/src/transport.rs
@@ -1,0 +1,268 @@
+//! Transport seam wiring — the Nostr relay as one [`Transport`] among many.
+//!
+//! [`HarnessRelay`] (the NIP-42 relay WebSocket client) implements
+//! [`buzz_transport::Transport`] here, making the relay connection just one
+//! implementation of the seam. [`connect_transport`] selects an
+//! implementation from the environment. The harness's main event loop does
+//! not call it yet — it still constructs [`HarnessRelay`] directly, and
+//! converting it to run on `Box<dyn Transport>` is the tracked follow-up
+//! that makes these variables take effect:
+//!
+//! | Variable | Values | Meaning |
+//! |---|---|---|
+//! | `BUZZ_TRANSPORT` | `nostr` (default) \| `remote` | Which transport carries events |
+//! | `BUZZ_TRANSPORT_URL` | `wss://…` \| `unix:///…` | Remote bridge endpoint (required for `remote`) |
+//! | `BUZZ_TRANSPORT_TOKEN` | any string | Optional bearer token for the bridge |
+//! | `BUZZ_TRANSPORT_SOCKS_PROXY` | `socks5://[user:pass@]host:port` | Optional SOCKS5 tunnel to the bridge |
+//! | `BUZZ_TRANSPORT_ALLOW_INSECURE` | `true`/`1` | Permit `ws://` to non-loopback hosts |
+//!
+//! The remote protocol is documented in `crates/buzz-transport/PROTOCOL.md`.
+
+use buzz_transport::remote::{RemoteTransport, RemoteTransportConfig};
+use buzz_transport::{
+    BoxFuture, SignedEvent, Subscription, Transport, TransportError, TransportEvent,
+};
+use nostr::Keys;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::config::ChannelFilter;
+use crate::relay::{HarnessRelay, RelayError};
+
+/// Which [`Transport`] implementation carries events for this process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TransportKind {
+    /// Buzz relay over a NIP-42-authenticated WebSocket (the default).
+    #[default]
+    Nostr,
+    /// Operator-supplied bridge speaking the buzz-transport wire protocol.
+    Remote,
+}
+
+impl std::str::FromStr for TransportKind {
+    type Err = TransportSetupError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "" | "nostr" => Ok(Self::Nostr),
+            "remote" => Ok(Self::Remote),
+            other => Err(TransportSetupError::UnknownKind(other.to_string())),
+        }
+    }
+}
+
+impl TransportKind {
+    /// Read `BUZZ_TRANSPORT` from the environment (absent = `Nostr`).
+    pub fn from_env() -> Result<Self, TransportSetupError> {
+        match std::env::var("BUZZ_TRANSPORT") {
+            Ok(value) => value.parse(),
+            Err(_) => Ok(Self::default()),
+        }
+    }
+}
+
+/// Errors selecting or establishing a transport.
+#[derive(Debug, thiserror::Error)]
+pub enum TransportSetupError {
+    /// `BUZZ_TRANSPORT` is set to a value this build does not know.
+    #[error("unknown BUZZ_TRANSPORT value {0:?} (expected \"nostr\" or \"remote\")")]
+    UnknownKind(String),
+    /// `BUZZ_TRANSPORT=remote` without `BUZZ_TRANSPORT_URL`.
+    #[error("BUZZ_TRANSPORT=remote requires BUZZ_TRANSPORT_URL")]
+    MissingUrl,
+    /// The selected transport failed to connect.
+    #[error(transparent)]
+    Transport(#[from] TransportError),
+    /// The Nostr relay connection failed.
+    #[error("relay connection failed: {0}")]
+    Relay(#[from] RelayError),
+}
+
+/// Connect the transport selected by the environment (see module docs).
+///
+/// `relay_url`, `keys`, and `auth_tag` are the same values
+/// [`HarnessRelay::connect`] takes; the remote transport reuses `keys` for
+/// its `hello` identity and reads its endpoint configuration from
+/// `BUZZ_TRANSPORT_URL` / `BUZZ_TRANSPORT_TOKEN` /
+/// `BUZZ_TRANSPORT_ALLOW_INSECURE`.
+pub async fn connect_transport(
+    kind: TransportKind,
+    relay_url: &str,
+    keys: &Keys,
+    auth_tag: Option<nostr::Tag>,
+) -> Result<Box<dyn Transport>, TransportSetupError> {
+    match kind {
+        TransportKind::Nostr => {
+            let pubkey_hex = keys.public_key().to_hex();
+            let relay = HarnessRelay::connect(relay_url, keys, &pubkey_hex, auth_tag).await?;
+            Ok(Box::new(relay))
+        }
+        TransportKind::Remote => {
+            let url =
+                std::env::var("BUZZ_TRANSPORT_URL").map_err(|_| TransportSetupError::MissingUrl)?;
+            let config = RemoteTransportConfig {
+                url,
+                pubkey: keys.public_key().to_hex(),
+                token: std::env::var("BUZZ_TRANSPORT_TOKEN").ok(),
+                allow_insecure: env_flag("BUZZ_TRANSPORT_ALLOW_INSECURE"),
+                socks_proxy: std::env::var("BUZZ_TRANSPORT_SOCKS_PROXY").ok(),
+            };
+            Ok(Box::new(RemoteTransport::connect(config).await?))
+        }
+    }
+}
+
+/// True when the env var is set to a truthy value (`true`/`1`/`yes`/`on`).
+fn env_flag(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+/// Map a [`Subscription`] onto the relay client's [`ChannelFilter`].
+fn to_channel_filter(subscription: &Subscription) -> ChannelFilter {
+    ChannelFilter {
+        kinds: subscription.kinds.clone(),
+        require_mention: subscription.require_mention,
+    }
+}
+
+fn relay_error(e: RelayError) -> TransportError {
+    match e {
+        RelayError::ConnectionClosed => TransportError::Closed,
+        RelayError::Json(e) => TransportError::Codec(e.to_string()),
+        other => TransportError::Connection(other.to_string()),
+    }
+}
+
+/// The Buzz relay connection is one [`Transport`]: subscriptions become
+/// NIP-01 `REQ` filters, published events go out on the relay socket, and
+/// inbound channel events arrive through the same background task that has
+/// always fed the harness.
+impl Transport for HarnessRelay {
+    fn subscribe(
+        &mut self,
+        subscription: Subscription,
+    ) -> BoxFuture<'_, Result<(), TransportError>> {
+        Box::pin(async move {
+            let filter = to_channel_filter(&subscription);
+            self.subscribe_channel_from(subscription.channel_id, filter, subscription.replay_since)
+                .await
+                .map_err(relay_error)
+        })
+    }
+
+    fn unsubscribe(&mut self, channel_id: Uuid) -> BoxFuture<'_, Result<(), TransportError>> {
+        Box::pin(async move {
+            self.unsubscribe_channel(channel_id)
+                .await
+                .map_err(relay_error)
+        })
+    }
+
+    fn next_event(&mut self) -> BoxFuture<'_, Option<TransportEvent>> {
+        Box::pin(async move {
+            // Skip (never terminate on) events that fail conversion — the
+            // relay only delivers verified NIP-01 events, so a conversion
+            // failure is a bug worth logging, not a stream-ending condition.
+            loop {
+                let buzz_event = HarnessRelay::next_event(self).await?;
+                match SignedEvent::from_nostr(&buzz_event.event) {
+                    Ok(event) => {
+                        return Some(TransportEvent {
+                            channel_id: buzz_event.channel_id,
+                            event,
+                        });
+                    }
+                    Err(e) => {
+                        warn!(event_id = %buzz_event.event.id, "skipping unconvertible event: {e}");
+                    }
+                }
+            }
+        })
+    }
+
+    fn publish(&self, event: SignedEvent) -> BoxFuture<'_, Result<(), TransportError>> {
+        Box::pin(async move {
+            let event = event.to_nostr()?;
+            self.publish_event(event).await.map_err(relay_error)
+        })
+    }
+
+    fn try_publish(&self, event: SignedEvent) -> Result<(), TransportError> {
+        let event = event.to_nostr()?;
+        self.try_publish_event(event).map_err(relay_error)
+    }
+
+    fn reconnect(&mut self) -> BoxFuture<'_, Result<(), TransportError>> {
+        Box::pin(async move { HarnessRelay::reconnect(self).await.map_err(relay_error) })
+    }
+
+    fn shutdown(self: Box<Self>) -> BoxFuture<'static, ()> {
+        Box::pin(async move { HarnessRelay::shutdown(*self).await })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transport_kind_parses_known_values() {
+        assert_eq!(
+            "nostr".parse::<TransportKind>().unwrap(),
+            TransportKind::Nostr
+        );
+        assert_eq!(
+            "NOSTR".parse::<TransportKind>().unwrap(),
+            TransportKind::Nostr
+        );
+        assert_eq!("".parse::<TransportKind>().unwrap(), TransportKind::Nostr);
+        assert_eq!(
+            "remote".parse::<TransportKind>().unwrap(),
+            TransportKind::Remote
+        );
+        assert_eq!(
+            " Remote ".parse::<TransportKind>().unwrap(),
+            TransportKind::Remote
+        );
+        assert!(matches!(
+            "slack".parse::<TransportKind>(),
+            Err(TransportSetupError::UnknownKind(_))
+        ));
+    }
+
+    #[test]
+    fn default_transport_is_nostr() {
+        assert_eq!(TransportKind::default(), TransportKind::Nostr);
+    }
+
+    #[test]
+    fn subscription_maps_onto_channel_filter() {
+        let sub = Subscription {
+            channel_id: Uuid::new_v4(),
+            kinds: Some(vec![9, 40002]),
+            require_mention: true,
+            replay_since: Some(1_700_000_000),
+        };
+        let filter = to_channel_filter(&sub);
+        assert_eq!(filter.kinds, Some(vec![9, 40002]));
+        assert!(filter.require_mention);
+
+        let wildcard = to_channel_filter(&Subscription::all(Uuid::new_v4()));
+        assert_eq!(wildcard.kinds, None);
+        assert!(!wildcard.require_mention);
+    }
+
+    #[test]
+    fn relay_errors_map_to_transport_errors() {
+        assert!(matches!(
+            relay_error(RelayError::ConnectionClosed),
+            TransportError::Closed
+        ));
+        assert!(matches!(
+            relay_error(RelayError::Timeout),
+            TransportError::Connection(_)
+        ));
+    }
+}

--- a/crates/buzz-transport/Cargo.toml
+++ b/crates/buzz-transport/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "buzz-transport"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Pluggable event-transport seam: bidirectional streams of signed Nostr events"
+
+[features]
+# In-memory MockTransport for harness/integration tests in dependent crates.
+test-utils = []
+
+[dependencies]
+# Nostr event types (the payload of every frame)
+nostr = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true }
+
+# Remote bridge carriers: WebSocket + line-framed Unix socket
+tokio-tungstenite = { workspace = true }
+tokio-util = { workspace = true }
+futures-util = { workspace = true }
+url = { workspace = true }
+
+# Frame serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# IDs
+uuid = { workspace = true }
+
+# Errors + logging
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/buzz-transport/PROTOCOL.md
+++ b/crates/buzz-transport/PROTOCOL.md
@@ -1,0 +1,186 @@
+# Buzz Bridge Protocol v1
+
+The bridge protocol lets you carry Buzz events over **your own network**.
+You run an endpoint — in any language — and a Buzz consumer (the ACP
+harness, a bot) connects to it with `RemoteTransport` instead of a Buzz
+relay. From the consumer's point of view nothing changes: it publishes
+signed events and receives channel-tagged signed events. What your endpoint
+does with them — forwards them to Slack, fans them out over a private mesh,
+stores them — is entirely up to you.
+
+The design premise: **the same events, transferred through a bidirectional
+stream.** Every frame is a small JSON object, and the payload of the `event`
+frames is the unmodified signed-event JSON that Buzz speaks natively. There
+is no REST surface and no second protocol — even channel discovery and
+membership ride the stream, because in Buzz those are events too.
+
+## Carriers
+
+The frames are carrier-agnostic; the client's bridge URL scheme selects how
+they travel:
+
+| Scheme | Carrier | Framing |
+|---|---|---|
+| `wss://` (or opted-in `ws://`) | WebSocket | One JSON object per text message |
+| `unix:///path/to/bridge.sock` | Unix domain socket | One JSON object per LF-terminated line |
+
+A Unix-socket bridge is the lightest way to run a local sidecar (or a test
+harness): listen on a socket, read lines, write lines. A WebSocket bridge is
+the right shape for anything remote.
+
+WebSocket carriers can additionally be tunneled through a **SOCKS5 proxy**
+(`BUZZ_TRANSPORT_SOCKS_PROXY=socks5://[user:pass@]host:port`) — Tor, an SSH
+`-D` tunnel, or a private-overlay entry point. This is invisible to the
+bridge: hostnames are resolved at the proxy, so overlay-only names
+(`.onion`, mesh-internal DNS) work.
+
+## Transport requirements
+
+- **TLS for remote endpoints.** Clients require `wss://`. Plaintext `ws://`
+  is accepted only for loopback hosts, for `.onion` destinations through a
+  **loopback** SOCKS5 proxy (Tor's encryption starts at the proxy, so the
+  proxy must be on the same machine for no plaintext to cross the network),
+  or when the operator explicitly opts in (`allow_insecure` /
+  `BUZZ_TRANSPORT_ALLOW_INSECURE=true`) for a trusted private network.
+  `unix://` sockets are local by construction — filesystem permissions are
+  the access control.
+- **Authentication.** If the operator configured a token, it arrives in the
+  `hello` frame's `token` field on every carrier, and *additionally* as an
+  `Authorization: Bearer <token>` header on the WebSocket upgrade request
+  (useful for rejecting early, before any frame). Reject the connection if
+  it is missing or wrong. The client also announces its public key in the
+  `hello` frame; use it to scope what you deliver.
+- **Text frames only**, one JSON object per frame, at most **524,288 bytes**
+  (the Buzz relay's default frame cap, so any event the relay accepts fits).
+- **Keepalive** is WebSocket-level ping/pong where the carrier has it. The
+  client answers pings; it does not send protocol-level heartbeats.
+
+## The signed event
+
+The payload of every `event` frame is a signed event — plain JSON, seven
+fields:
+
+```json
+{
+  "id":         "<64-char hex — SHA-256 of the canonical serialization>",
+  "pubkey":     "<64-char hex — author public key (secp256k1, x-only)>",
+  "created_at": 1700000000,
+  "kind":       9,
+  "tags":       [["h", "0b1f…-uuid"], ["p", "deadbeef…"]],
+  "content":    "hello",
+  "sig":        "<128-char hex — Schnorr signature over id>"
+}
+```
+
+This is structurally a [Nostr NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md)
+event — Buzz's native form — so events pass through a bridge losslessly. You
+do not need a Nostr library to build a bridge: treat events as opaque signed
+JSON and route them. If your bridge *originates* events (e.g. mirroring
+Slack messages into Buzz), it must sign them with its own key; any NIP-01
+library, or ~50 lines of SHA-256 + BIP-340 Schnorr, does the job.
+
+Clients verify the `id` hash and `sig` of every inbound event and silently
+drop events that fail. An unsigned or tampered event will never reach the
+consumer.
+
+## Handshake
+
+The first frame in each direction negotiates the protocol:
+
+1. Client → bridge: `{"type":"hello","version":1,"pubkey":"<64-char hex>","token":"<optional>"}`
+2. Bridge → client: `{"type":"hello_ack","version":1}`
+
+The versions must match; the client disconnects otherwise. The bridge may
+send `notice` frames before the `hello_ack` (they are logged), but the
+`hello_ack` must arrive within 20 seconds. After a reconnect the client
+repeats the handshake and re-sends all of its subscriptions **exactly as
+first issued** — including any `replay_since` watermark — so a reconnecting
+client may receive events it has already seen. Treat replay as advisory and
+deduplicate by event `id` where overlap matters.
+
+## Frames: client → bridge
+
+| `type` | Fields | Meaning |
+|---|---|---|
+| `hello` | `version`, `pubkey`, `token?` | Handshake, first frame on every connection |
+| `subscribe` | `channel_id`, `kinds?`, `require_mention?`, `replay_since?` | Declare interest in a channel's events |
+| `unsubscribe` | `channel_id` | Withdraw interest |
+| `event` | `event` | A signed event published by the consumer |
+
+`subscribe` fields:
+
+- `channel_id` — UUID string identifying the channel. Your bridge chooses
+  the mapping (e.g. one UUID per Slack conversation) and must use it
+  consistently in both directions.
+- `kinds` — optional array of kind integers to deliver. Absent = all kinds;
+  an explicit empty array matches nothing (the NIP-01 edge case).
+- `require_mention` — optional boolean (default `false`). When true, only
+  deliver events that `p`-tag the `hello` pubkey.
+- `replay_since` — optional Unix timestamp. If your bridge stores history,
+  replay stored events created at/after it (oldest first), then send `eose`.
+  Bridges without history may ignore it.
+
+Subscriptions are **advisory**: a bridge that already knows which
+conversations the agent belongs to may push events for them regardless.
+Re-subscribing a channel replaces the previous subscription.
+
+## Frames: bridge → client
+
+| `type` | Fields | Meaning |
+|---|---|---|
+| `hello_ack` | `version` | Handshake acknowledgment, first frame |
+| `event` | `channel_id`, `event` | A signed event, tagged with its channel |
+| `ok` | `event_id`, `accepted`, `message?` | Optional ack of a client-published event |
+| `eose` | `channel_id` | Optional end-of-replay marker |
+| `notice` | `message` | Human-readable diagnostic (logged by the client) |
+
+`ok` and `eose` are optional — the stream is fire-and-forget, like the relay
+socket it mirrors. Send `ok` with `accepted:false` and a `message` when you
+reject a publish; the client logs it.
+
+## Forward compatibility
+
+- Receivers **ignore frames** whose `type` they do not recognize.
+- Receivers **ignore unknown fields** inside known frames.
+- Breaking changes bump `version` in the handshake.
+
+This means a v1 bridge keeps working against newer clients until the major
+version actually changes.
+
+## Delivering the workspace over the stream
+
+Everything a consumer learns about its workspace arrives as events, so a
+bridge controls the whole experience with the one `event` frame:
+
+- **Messages**: kind `9` / `40002` stream messages, with the channel UUID in
+  an `h` tag and the `channel_id` field.
+- **Membership / discovery**: kind `39002` (channel members) and `39000`
+  (channel metadata) events announce which channels exist and who is in
+  them.
+- **Ephemeral signals**: typing (`20002`) and presence (`20001`) kinds pass
+  through like any other event.
+
+Kind numbers live in `crates/buzz-core/src/kind.rs`.
+
+## Sketch: a Slack bridge
+
+A minimal Slack bridge is a single process that:
+
+1. Serves `wss://bridge.internal/buzz` and checks the bearer token on
+   upgrade.
+2. Answers `hello` with `hello_ack`, remembering the client's pubkey.
+3. Maintains a table `slack_channel_id ⇄ channel_uuid` (any stable mapping —
+   e.g. UUIDv5 of the Slack channel ID).
+4. On Slack message (Events API / Socket Mode): build a kind-`9` event with
+   the text as `content`, an `h` tag carrying the channel UUID, and — when
+   the Slack message @-mentions the agent's Slack user — a `p` tag carrying
+   the client pubkey. Sign it with the bridge's key and send it as an
+   `event` frame (respecting `require_mention` if the subscription set it).
+5. On client `event` frame: verify the signature, extract the channel UUID
+   from the `h` tag, look up the Slack channel, and post the `content` via
+   `chat.postMessage`. Optionally answer with an `ok` frame.
+6. On `subscribe`: start forwarding that conversation (and, optionally,
+   replay history via `replay_since` + `eose`).
+
+Steps 4–5 are the whole data plane. Threading, reactions, and richer kinds
+can be layered on incrementally — unknown kinds simply flow through.

--- a/crates/buzz-transport/src/lib.rs
+++ b/crates/buzz-transport/src/lib.rs
@@ -1,0 +1,307 @@
+//! buzz-transport — the pluggable event-transport seam.
+//!
+//! Buzz's native wire is signed events over a relay WebSocket. This crate
+//! captures what that layer *provides* as one small trait — a bidirectional
+//! stream of the same signed events — so the relay connection becomes one
+//! implementation among many:
+//!
+//! - [`Transport`] — the seam. Outbound: signed events published into the
+//!   stream. Inbound: channel-tagged events delivered by the other side.
+//! - [`remote::RemoteTransport`] — dials an operator-supplied bridge
+//!   endpoint (WebSocket or Unix socket, optionally through a SOCKS5
+//!   proxy) speaking the small JSON protocol documented in
+//!   [`PROTOCOL.md`](https://github.com/block/buzz/blob/main/crates/buzz-transport/PROTOCOL.md),
+//!   so anyone can bridge Buzz onto their own network (Slack, a private
+//!   mesh, …) in any language that can serve a socket.
+//! - [`memory::InMemoryHub`] — the reference implementation: a working
+//!   in-process hub fanning signed events out between participants.
+//! - `MockTransport` (feature `test-utils`) — scripted test double for
+//!   call-log assertions in tests of transport consumers.
+//!
+//! The unit that flows through the seam is [`SignedEvent`]: plain data owned
+//! by this crate, deliberately not a Nostr-library type. It is structurally
+//! the NIP-01 event Buzz already speaks (so the relay path converts
+//! losslessly), but a transport or bridge implementor only ever sees six
+//! JSON fields and a signature — no Nostr dependency required.
+//!
+//! Everything above raw delivery — channel membership, discovery, presence,
+//! typing — already *is* events in Buzz (kind 39000/39002 metadata, the
+//! ephemeral kinds), so it rides the same stream. The trait deliberately has
+//! no side-channel API: if a bridge wants the agent to see a channel, it
+//! delivers that channel's events; if it wants to announce membership, it
+//! delivers the membership event.
+
+#![deny(unsafe_code)]
+
+pub mod memory;
+pub mod protocol;
+pub mod remote;
+mod socks;
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod mock;
+
+use std::future::Future;
+use std::pin::Pin;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Boxed future used across the seam trait. Public because [`Transport`]
+/// implementors outside this crate must name it.
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Errors from transport operations.
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    /// Dial, TLS, handshake, or socket-level failure.
+    #[error("connection: {0}")]
+    Connection(String),
+
+    /// The transport (or its background task) has shut down.
+    #[error("transport closed")]
+    Closed,
+
+    /// The remote endpoint violated the bridge protocol.
+    #[error("protocol: {0}")]
+    Protocol(String),
+
+    /// A frame or event failed to encode or decode.
+    #[error("codec: {0}")]
+    Codec(String),
+
+    /// An event's signature or ID failed verification.
+    #[error("invalid event: {0}")]
+    InvalidEvent(String),
+
+    /// Plaintext `ws://` to a non-loopback host without the explicit opt-in.
+    #[error("insecure transport rejected: {0}")]
+    Insecure(String),
+}
+
+/// A signed event — the unit that flows through every transport.
+///
+/// Plain data: six fields plus the ID, all JSON-friendly. Structurally this
+/// is the [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md)
+/// event Buzz already speaks — `id` is the SHA-256 of the canonical
+/// serialization, `sig` a Schnorr signature over it — so events convert
+/// losslessly to and from the Nostr wire form ([`SignedEvent::from_nostr`],
+/// [`SignedEvent::to_nostr`]). Transports and bridges, however, only ever
+/// need this struct and its JSON: no Nostr library required.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedEvent {
+    /// Event ID: SHA-256 of the canonical serialization, hex-encoded.
+    pub id: String,
+    /// Author public key (secp256k1 x-only), hex-encoded.
+    pub pubkey: String,
+    /// Creation time, Unix seconds.
+    pub created_at: u64,
+    /// Event kind — the only dispatch switch in Buzz.
+    pub kind: u32,
+    /// Structured metadata: an array of string arrays.
+    pub tags: Vec<Vec<String>>,
+    /// Payload: plain text or JSON, depending on `kind`.
+    pub content: String,
+    /// Schnorr signature over `id`, hex-encoded.
+    pub sig: String,
+}
+
+impl SignedEvent {
+    /// Convert from the Nostr wire type. Lossless: both serialize to the
+    /// same NIP-01 JSON.
+    pub fn from_nostr(event: &nostr::Event) -> Result<Self, TransportError> {
+        serde_json::to_value(event)
+            .and_then(serde_json::from_value)
+            .map_err(|e| TransportError::Codec(format!("event conversion failed: {e}")))
+    }
+
+    /// Convert to the Nostr wire type. Fails only if a field is out of the
+    /// Nostr type's domain (e.g. a malformed hex ID).
+    pub fn to_nostr(&self) -> Result<nostr::Event, TransportError> {
+        serde_json::to_value(self)
+            .and_then(serde_json::from_value)
+            .map_err(|e| TransportError::Codec(format!("event conversion failed: {e}")))
+    }
+
+    /// Verify the event ID hash and Schnorr signature.
+    pub fn verify(&self) -> Result<(), TransportError> {
+        self.to_nostr()?
+            .verify()
+            .map_err(|e| TransportError::InvalidEvent(e.to_string()))
+    }
+}
+
+/// A subscription: which events the consumer wants delivered for a channel.
+///
+/// Subscriptions are *advisory* for transports whose far side decides what to
+/// push (a Slack bridge already knows which conversations the agent is in);
+/// the Nostr relay transport translates them into NIP-01 `REQ` filters
+/// verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Subscription {
+    /// The channel whose events should be delivered.
+    pub channel_id: Uuid,
+    /// Event kinds to deliver. `None` = all kinds. Per the NIP-01 edge
+    /// case, an explicit empty list matches nothing.
+    pub kinds: Option<Vec<u32>>,
+    /// Only deliver events that mention (`p`-tag) the transport's own
+    /// identity — the pubkey the transport connected as.
+    pub require_mention: bool,
+    /// Replay stored events created at or after this Unix timestamp before
+    /// switching to live delivery. `None` = live events only.
+    pub replay_since: Option<u64>,
+}
+
+impl Subscription {
+    /// Subscription for all kinds, live-only, without a mention gate.
+    pub fn all(channel_id: Uuid) -> Self {
+        Self {
+            channel_id,
+            kinds: None,
+            require_mention: false,
+            replay_since: None,
+        }
+    }
+}
+
+/// An inbound event, tagged with the channel it belongs to.
+#[derive(Debug, Clone)]
+pub struct TransportEvent {
+    /// Which channel this event belongs to.
+    pub channel_id: Uuid,
+    /// The underlying signed event.
+    pub event: SignedEvent,
+}
+
+/// A bidirectional stream of signed events.
+///
+/// This is the seam between Buzz consumers (the ACP harness, custom bots)
+/// and whatever network carries their events. The contract is deliberately
+/// the same shape in both directions: signed events, tagged with a channel.
+/// The relay WebSocket is one implementation; a remote bridge to a private
+/// network is another.
+///
+/// Methods return [`BoxFuture`] for dyn-compatibility — consumers hold a
+/// `Box<dyn Transport>` chosen at startup.
+///
+/// # Delivery contract
+///
+/// - [`next_event`](Transport::next_event) returning `None` signals
+///   connection loss; the caller should invoke
+///   [`reconnect`](Transport::reconnect) and continue polling.
+/// - [`publish`](Transport::publish) resolves when the event is accepted for
+///   sending (queued on the connection), not when the far side acknowledges
+///   it. Rejections are surfaced by implementations through logging; the
+///   stream stays fire-and-forget like the underlying relay socket.
+/// - Implementations must not deliver events that fail
+///   [`SignedEvent::verify`] — either by verifying inbound events
+///   themselves (the remote bridge and in-memory transports do) or by
+///   relying on an upstream that already verified them (the relay verifies
+///   every event on ingest).
+pub trait Transport: Send {
+    /// Declare interest in a channel's events.
+    ///
+    /// Re-subscribing an already-subscribed channel replaces the previous
+    /// subscription. Implementations re-establish active subscriptions after
+    /// [`reconnect`](Transport::reconnect).
+    fn subscribe(
+        &mut self,
+        subscription: Subscription,
+    ) -> BoxFuture<'_, Result<(), TransportError>>;
+
+    /// Withdraw interest in a channel's events.
+    fn unsubscribe(&mut self, channel_id: Uuid) -> BoxFuture<'_, Result<(), TransportError>>;
+
+    /// Wait for the next inbound event from any subscribed channel.
+    ///
+    /// Returns `None` on connection loss — the caller should call
+    /// [`reconnect`](Transport::reconnect).
+    fn next_event(&mut self) -> BoxFuture<'_, Option<TransportEvent>>;
+
+    /// Publish a signed event into the stream.
+    ///
+    /// Waits for queue capacity; use [`try_publish`](Transport::try_publish)
+    /// for ephemeral events that may be dropped instead.
+    fn publish(&self, event: SignedEvent) -> BoxFuture<'_, Result<(), TransportError>>;
+
+    /// Fire-and-forget publish — never blocks the caller.
+    ///
+    /// Suitable for ephemeral events (typing indicators, presence) where
+    /// dropping on a full queue is acceptable.
+    fn try_publish(&self, event: SignedEvent) -> Result<(), TransportError>;
+
+    /// Re-establish the stream after connection loss, restoring active
+    /// subscriptions.
+    fn reconnect(&mut self) -> BoxFuture<'_, Result<(), TransportError>>;
+
+    /// Gracefully shut the transport down.
+    fn shutdown(self: Box<Self>) -> BoxFuture<'static, ()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr::{EventBuilder, Keys, Kind};
+
+    use super::*;
+
+    // Compile-time proof that the trait stays dyn-compatible: consumers hold
+    // a `Box<dyn Transport>` chosen at startup.
+    fn _assert_dyn_compatible(_: Box<dyn Transport>) {}
+
+    #[test]
+    fn subscription_all_is_wildcard_live_only() {
+        let id = Uuid::new_v4();
+        let sub = Subscription::all(id);
+        assert_eq!(sub.channel_id, id);
+        assert_eq!(sub.kinds, None);
+        assert!(!sub.require_mention);
+        assert_eq!(sub.replay_since, None);
+    }
+
+    #[test]
+    fn signed_event_round_trips_through_nostr() {
+        let keys = Keys::generate();
+        let nostr_event = EventBuilder::new(Kind::Custom(9), "hello transport")
+            .sign_with_keys(&keys)
+            .unwrap();
+
+        let event = SignedEvent::from_nostr(&nostr_event).unwrap();
+        // Same JSON both ways — the seam type is the wire form, verbatim.
+        assert_eq!(
+            serde_json::to_value(&event).unwrap(),
+            serde_json::to_value(&nostr_event).unwrap()
+        );
+        assert_eq!(event.to_nostr().unwrap(), nostr_event);
+        assert_eq!(event.kind, 9);
+        assert_eq!(event.content, "hello transport");
+        event.verify().unwrap();
+    }
+
+    #[test]
+    fn tampered_event_fails_verification() {
+        let keys = Keys::generate();
+        let nostr_event = EventBuilder::new(Kind::Custom(9), "original")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let mut event = SignedEvent::from_nostr(&nostr_event).unwrap();
+        event.content = "tampered".to_string();
+        assert!(matches!(
+            event.verify(),
+            Err(TransportError::InvalidEvent(_))
+        ));
+    }
+
+    #[test]
+    fn malformed_event_fails_conversion() {
+        let event = SignedEvent {
+            id: "not-hex".into(),
+            pubkey: "also-not-hex".into(),
+            created_at: 0,
+            kind: 9,
+            tags: vec![],
+            content: String::new(),
+            sig: "nope".into(),
+        };
+        assert!(matches!(event.verify(), Err(TransportError::Codec(_))));
+    }
+}

--- a/crates/buzz-transport/src/memory.rs
+++ b/crates/buzz-transport/src/memory.rs
@@ -1,0 +1,240 @@
+//! In-process [`Transport`]: a hub fanning signed events out between
+//! participants, entirely in memory.
+//!
+//! This is the reference implementation of the seam — every contract rule
+//! ([`SignedEvent`] verification, `h`-tag channel scoping, subscription
+//! matching, replace-on-resubscribe) in a few dozen lines with no I/O. Use
+//! it to integration-test transport consumers against a *working* stream
+//! (several participants exchanging events through `Box<dyn Transport>`),
+//! or to wire co-located components together without a relay. For scripted
+//! inputs and call-log assertions use `MockTransport` (feature `test-utils`)
+//! instead.
+//!
+//! Semantics:
+//!
+//! - Publishing verifies the event and routes it by its `h` tag; events
+//!   without a channel UUID in an `h` tag are rejected.
+//! - Delivery requires a matching subscription (channel, `kinds`,
+//!   `require_mention` against the participant's pubkey).
+//! - A participant's own publishes are not echoed back to it.
+//! - There is no history: `replay_since` is advisory (see
+//!   [`Subscription`]) and ignored here, like a bridge without storage.
+//! - There is no connection to lose: `next_event` pends until an event
+//!   matches, and `reconnect` is a no-op that never fails.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::{BoxFuture, SignedEvent, Subscription, Transport, TransportError, TransportEvent};
+
+/// Buffered deliveries per participant. A participant that stops polling
+/// `next_event` skips the oldest events past this depth (with a warning)
+/// rather than blocking publishers.
+const HUB_CAPACITY: usize = 256;
+
+/// One published event in flight inside the hub.
+#[derive(Debug, Clone)]
+struct Delivery {
+    origin: u64,
+    channel_id: Uuid,
+    event: SignedEvent,
+}
+
+/// An in-memory event hub that participants [`connect`](InMemoryHub::connect)
+/// to. Cloning the hub yields another handle to the same hub.
+#[derive(Debug, Clone)]
+pub struct InMemoryHub {
+    tx: broadcast::Sender<Delivery>,
+    next_id: Arc<AtomicU64>,
+}
+
+impl InMemoryHub {
+    /// Create an empty hub.
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(HUB_CAPACITY);
+        Self {
+            tx,
+            next_id: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Connect a participant. `pubkey` is the identity `require_mention`
+    /// subscriptions are matched against — the same role the `hello` pubkey
+    /// plays on the remote bridge.
+    pub fn connect(&self, pubkey: impl Into<String>) -> InMemoryTransport {
+        InMemoryTransport {
+            id: self.next_id.fetch_add(1, Ordering::Relaxed),
+            pubkey: pubkey.into(),
+            rx: self.tx.subscribe(),
+            tx: self.tx.clone(),
+            subscriptions: HashMap::new(),
+        }
+    }
+}
+
+impl Default for InMemoryHub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// One participant's [`Transport`] onto an [`InMemoryHub`].
+#[derive(Debug)]
+pub struct InMemoryTransport {
+    id: u64,
+    pubkey: String,
+    rx: broadcast::Receiver<Delivery>,
+    tx: broadcast::Sender<Delivery>,
+    subscriptions: HashMap<Uuid, Subscription>,
+}
+
+impl InMemoryTransport {
+    /// Verify and route an event into the hub (shared by both publish paths).
+    fn send(&self, event: SignedEvent) -> Result<(), TransportError> {
+        event.verify()?;
+        let channel_id = channel_of(&event).ok_or_else(|| {
+            TransportError::InvalidEvent("event has no channel UUID in an `h` tag".into())
+        })?;
+        // Send fails only with zero receivers; `self.rx` alone guarantees one.
+        self.tx
+            .send(Delivery {
+                origin: self.id,
+                channel_id,
+                event,
+            })
+            .map_err(|_| TransportError::Closed)?;
+        Ok(())
+    }
+
+    /// Does this delivery match one of our subscriptions?
+    fn wants(&self, delivery: &Delivery) -> bool {
+        if delivery.origin == self.id {
+            return false;
+        }
+        let Some(sub) = self.subscriptions.get(&delivery.channel_id) else {
+            return false;
+        };
+        // NIP-01 edge: an explicit empty `kinds` list matches nothing.
+        if let Some(kinds) = &sub.kinds {
+            if !kinds.contains(&delivery.event.kind) {
+                return false;
+            }
+        }
+        if sub.require_mention {
+            let mentioned = delivery
+                .event
+                .tags
+                .iter()
+                .any(|t| t.len() >= 2 && t[0] == "p" && t[1] == self.pubkey);
+            if !mentioned {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// The channel an event belongs to: the first `h` tag holding a UUID.
+fn channel_of(event: &SignedEvent) -> Option<Uuid> {
+    event
+        .tags
+        .iter()
+        .filter(|t| t.len() >= 2 && t[0] == "h")
+        .find_map(|t| Uuid::parse_str(&t[1]).ok())
+}
+
+impl Transport for InMemoryTransport {
+    fn subscribe(
+        &mut self,
+        subscription: Subscription,
+    ) -> BoxFuture<'_, Result<(), TransportError>> {
+        // Replace-on-resubscribe, per the seam contract.
+        self.subscriptions
+            .insert(subscription.channel_id, subscription);
+        Box::pin(async { Ok(()) })
+    }
+
+    fn unsubscribe(&mut self, channel_id: Uuid) -> BoxFuture<'_, Result<(), TransportError>> {
+        self.subscriptions.remove(&channel_id);
+        Box::pin(async { Ok(()) })
+    }
+
+    fn next_event(&mut self) -> BoxFuture<'_, Option<TransportEvent>> {
+        Box::pin(async move {
+            loop {
+                match self.rx.recv().await {
+                    Ok(delivery) if self.wants(&delivery) => {
+                        return Some(TransportEvent {
+                            channel_id: delivery.channel_id,
+                            event: delivery.event,
+                        });
+                    }
+                    Ok(_) => {}
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        warn!(skipped, "in-memory transport lagged; events skipped");
+                    }
+                    // All senders gone — unreachable while `self.tx` lives,
+                    // but the honest mapping is end-of-stream.
+                    Err(broadcast::error::RecvError::Closed) => return None,
+                }
+            }
+        })
+    }
+
+    fn publish(&self, event: SignedEvent) -> BoxFuture<'_, Result<(), TransportError>> {
+        let result = self.send(event);
+        Box::pin(async move { result })
+    }
+
+    fn try_publish(&self, event: SignedEvent) -> Result<(), TransportError> {
+        self.send(event)
+    }
+
+    fn reconnect(&mut self) -> BoxFuture<'_, Result<(), TransportError>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn shutdown(self: Box<Self>) -> BoxFuture<'static, ()> {
+        Box::pin(async {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event_with_tags(tags: Vec<Vec<String>>) -> SignedEvent {
+        SignedEvent {
+            id: "00".repeat(32),
+            pubkey: "11".repeat(32),
+            created_at: 1_700_000_000,
+            kind: 9,
+            tags,
+            content: "x".into(),
+            sig: "22".repeat(64),
+        }
+    }
+
+    #[test]
+    fn channel_of_takes_the_first_uuid_h_tag() {
+        let channel = Uuid::new_v4();
+        let event = event_with_tags(vec![
+            vec!["p".into(), "aa".repeat(32)],
+            vec!["h".into(), "not-a-uuid".into()],
+            vec!["h".into(), channel.to_string()],
+        ]);
+        assert_eq!(channel_of(&event), Some(channel));
+
+        assert_eq!(channel_of(&event_with_tags(vec![])), None);
+        assert_eq!(
+            channel_of(&event_with_tags(vec![vec!["h".into()]])),
+            None,
+            "a bare h tag with no value must not match"
+        );
+    }
+}

--- a/crates/buzz-transport/src/mock.rs
+++ b/crates/buzz-transport/src/mock.rs
@@ -1,0 +1,181 @@
+//! In-memory [`Transport`] for tests of transport consumers.
+//!
+//! Gated behind `#[cfg(any(test, feature = "test-utils"))]` — enable the
+//! `test-utils` feature from a dependent crate's dev-dependencies to drive a
+//! consumer with scripted inbound events and observe everything it publishes.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::{BoxFuture, SignedEvent, Subscription, Transport, TransportError, TransportEvent};
+
+/// Shared observation log between [`MockTransport`] and [`MockTransportHandle`].
+#[derive(Default)]
+struct MockLog {
+    subscriptions: Mutex<Vec<Subscription>>,
+    unsubscribed: Mutex<Vec<Uuid>>,
+    published: Mutex<VecDeque<SignedEvent>>,
+    reconnects: AtomicUsize,
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    // A poisoned lock only means a panicking test thread — the data is
+    // plain Vec/VecDeque state and safe to keep using.
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Test-side controller for a [`MockTransport`].
+pub struct MockTransportHandle {
+    event_tx: mpsc::Sender<Option<TransportEvent>>,
+    log: Arc<MockLog>,
+}
+
+impl MockTransportHandle {
+    /// Deliver an inbound event to the consumer.
+    pub async fn inject(&self, event: TransportEvent) {
+        let _ = self.event_tx.send(Some(event)).await;
+    }
+
+    /// Simulate connection loss: the consumer's `next_event` yields `None`.
+    pub async fn drop_connection(&self) {
+        let _ = self.event_tx.send(None).await;
+    }
+
+    /// All subscriptions the consumer has registered, in order.
+    pub fn subscriptions(&self) -> Vec<Subscription> {
+        lock(&self.log.subscriptions).clone()
+    }
+
+    /// All channels the consumer has unsubscribed, in order.
+    pub fn unsubscribed(&self) -> Vec<Uuid> {
+        lock(&self.log.unsubscribed).clone()
+    }
+
+    /// Pop the oldest event the consumer published, if any.
+    pub fn next_published(&self) -> Option<SignedEvent> {
+        lock(&self.log.published).pop_front()
+    }
+
+    /// How many times the consumer called `reconnect`.
+    pub fn reconnects(&self) -> usize {
+        self.log.reconnects.load(Ordering::SeqCst)
+    }
+}
+
+/// In-memory [`Transport`] with scripted inbound events and observable
+/// outbound state.
+pub struct MockTransport {
+    event_rx: mpsc::Receiver<Option<TransportEvent>>,
+    log: Arc<MockLog>,
+}
+
+impl MockTransport {
+    /// Build a transport plus the handle that scripts and observes it.
+    pub fn pair() -> (Self, MockTransportHandle) {
+        let (event_tx, event_rx) = mpsc::channel(64);
+        let log = Arc::new(MockLog::default());
+        (
+            Self {
+                event_rx,
+                log: Arc::clone(&log),
+            },
+            MockTransportHandle { event_tx, log },
+        )
+    }
+}
+
+impl Transport for MockTransport {
+    fn subscribe(
+        &mut self,
+        subscription: Subscription,
+    ) -> BoxFuture<'_, Result<(), TransportError>> {
+        lock(&self.log.subscriptions).push(subscription);
+        Box::pin(async { Ok(()) })
+    }
+
+    fn unsubscribe(&mut self, channel_id: Uuid) -> BoxFuture<'_, Result<(), TransportError>> {
+        lock(&self.log.unsubscribed).push(channel_id);
+        Box::pin(async { Ok(()) })
+    }
+
+    fn next_event(&mut self) -> BoxFuture<'_, Option<TransportEvent>> {
+        Box::pin(async move { self.event_rx.recv().await.flatten() })
+    }
+
+    fn publish(&self, event: SignedEvent) -> BoxFuture<'_, Result<(), TransportError>> {
+        lock(&self.log.published).push_back(event);
+        Box::pin(async { Ok(()) })
+    }
+
+    fn try_publish(&self, event: SignedEvent) -> Result<(), TransportError> {
+        lock(&self.log.published).push_back(event);
+        Ok(())
+    }
+
+    fn reconnect(&mut self) -> BoxFuture<'_, Result<(), TransportError>> {
+        self.log.reconnects.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok(()) })
+    }
+
+    fn shutdown(self: Box<Self>) -> BoxFuture<'static, ()> {
+        Box::pin(async {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr::{EventBuilder, Keys, Kind};
+
+    use super::*;
+
+    fn signed_event(content: &str) -> SignedEvent {
+        let event = EventBuilder::new(Kind::Custom(9), content)
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        SignedEvent::from_nostr(&event).unwrap()
+    }
+
+    #[tokio::test]
+    async fn scripted_roundtrip_through_the_trait() {
+        let (transport, handle) = MockTransport::pair();
+        let mut transport: Box<dyn Transport> = Box::new(transport);
+        let channel_id = Uuid::new_v4();
+
+        transport
+            .subscribe(Subscription::all(channel_id))
+            .await
+            .unwrap();
+        assert_eq!(handle.subscriptions().len(), 1);
+
+        handle
+            .inject(TransportEvent {
+                channel_id,
+                event: signed_event("inbound"),
+            })
+            .await;
+        let received = transport.next_event().await.unwrap();
+        assert_eq!(received.channel_id, channel_id);
+        assert_eq!(received.event.content, "inbound");
+
+        transport.publish(signed_event("outbound")).await.unwrap();
+        assert_eq!(
+            handle.next_published().map(|e| e.content),
+            Some("outbound".to_string())
+        );
+
+        handle.drop_connection().await;
+        assert!(transport.next_event().await.is_none());
+        transport.reconnect().await.unwrap();
+        assert_eq!(handle.reconnects(), 1);
+
+        transport.unsubscribe(channel_id).await.unwrap();
+        assert_eq!(handle.unsubscribed(), vec![channel_id]);
+        transport.shutdown().await;
+    }
+}

--- a/crates/buzz-transport/src/protocol.rs
+++ b/crates/buzz-transport/src/protocol.rs
@@ -1,0 +1,323 @@
+//! Bridge wire protocol v1 — JSON frames over a carrier stream.
+//!
+//! The remote transport speaks a deliberately small protocol: every frame is
+//! a JSON object with a `type` field, and the payload of the `event` frames
+//! is the *same signed Nostr event JSON* that flows over the relay
+//! WebSocket. The carrier is either a WebSocket (one frame per text
+//! message) or a Unix domain socket (one frame per LF-terminated line).
+//! See `PROTOCOL.md` in this crate for the full specification and a
+//! bridge-implementor's guide.
+//!
+//! Forward compatibility: receivers ignore frames whose `type` they do not
+//! recognize and ignore unknown fields inside known frames. Breaking changes
+//! bump [`PROTOCOL_VERSION`], negotiated in the `hello`/`hello_ack`
+//! handshake.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{SignedEvent, Subscription, TransportError};
+
+/// Bridge protocol version negotiated in the `hello`/`hello_ack` handshake.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Maximum size of a single frame (WebSocket message or socket line),
+/// matching the relay's default inbound frame cap
+/// (`DEFAULT_MAX_FRAME_BYTES` in `buzz-relay`), so any event the relay
+/// accepts also fits in one bridge frame.
+pub const MAX_FRAME_BYTES: usize = 512 * 1024;
+
+/// Frames sent by the Buzz client to the bridge.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientFrame {
+    /// First frame on every connection: protocol version + client identity.
+    Hello {
+        /// Protocol version the client speaks ([`PROTOCOL_VERSION`]).
+        version: u32,
+        /// Hex-encoded public key the client publishes events as.
+        pubkey: String,
+        /// Optional bearer token. On WebSocket carriers the same token also
+        /// travels as an `Authorization` header; on raw-socket carriers
+        /// (which have no headers) this field is the only place it appears.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        token: Option<String>,
+    },
+    /// Declare interest in a channel's events (advisory — see
+    /// [`Subscription`]).
+    Subscribe {
+        /// The channel whose events should be delivered.
+        channel_id: Uuid,
+        /// Event kinds to deliver. Absent/`null` = all kinds; an explicit
+        /// empty list matches nothing (the NIP-01 edge case).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        kinds: Option<Vec<u32>>,
+        /// Only deliver events that `p`-tag the `hello` pubkey.
+        #[serde(default)]
+        require_mention: bool,
+        /// Replay stored events created at or after this Unix timestamp.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        replay_since: Option<u64>,
+    },
+    /// Withdraw interest in a channel's events.
+    Unsubscribe {
+        /// The channel to stop delivering.
+        channel_id: Uuid,
+    },
+    /// A signed event published by the client.
+    Event {
+        /// The signed event (see [`SignedEvent`] for the JSON shape).
+        event: Box<SignedEvent>,
+    },
+}
+
+impl ClientFrame {
+    /// Build the `subscribe` frame for a [`Subscription`].
+    pub fn subscribe(subscription: &Subscription) -> Self {
+        Self::Subscribe {
+            channel_id: subscription.channel_id,
+            kinds: subscription.kinds.clone(),
+            require_mention: subscription.require_mention,
+            replay_since: subscription.replay_since,
+        }
+    }
+}
+
+/// Frames sent by the bridge to the Buzz client.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BridgeFrame {
+    /// Handshake acknowledgment. Must be the bridge's first frame.
+    HelloAck {
+        /// Protocol version the bridge speaks. Must match the client's.
+        version: u32,
+    },
+    /// An inbound signed event, tagged with its channel.
+    Event {
+        /// Which channel this event belongs to.
+        channel_id: Uuid,
+        /// The signed event (see [`SignedEvent`] for the JSON shape).
+        event: Box<SignedEvent>,
+    },
+    /// Optional acknowledgment of a client-published event.
+    Ok {
+        /// Hex ID of the event being acknowledged.
+        event_id: String,
+        /// Whether the bridge accepted the event.
+        accepted: bool,
+        /// Human-readable detail (empty when accepted).
+        #[serde(default)]
+        message: String,
+    },
+    /// Optional end-of-replay marker after a `subscribe` with `replay_since`.
+    Eose {
+        /// The channel whose replay finished.
+        channel_id: Uuid,
+    },
+    /// Human-readable diagnostic from the bridge.
+    Notice {
+        /// The diagnostic text.
+        message: String,
+    },
+}
+
+/// Frame `type` values this version knows in the client → bridge direction.
+const CLIENT_FRAME_TYPES: &[&str] = &["hello", "subscribe", "unsubscribe", "event"];
+
+/// Frame `type` values this version knows in the bridge → client direction.
+const BRIDGE_FRAME_TYPES: &[&str] = &["hello_ack", "event", "ok", "eose", "notice"];
+
+/// Encode a client frame as a JSON text frame.
+pub fn encode_client_frame(frame: &ClientFrame) -> Result<String, TransportError> {
+    serde_json::to_string(frame).map_err(|e| TransportError::Codec(e.to_string()))
+}
+
+/// Encode a bridge frame as a JSON text frame (for bridge implementations
+/// and tests).
+pub fn encode_bridge_frame(frame: &BridgeFrame) -> Result<String, TransportError> {
+    serde_json::to_string(frame).map_err(|e| TransportError::Codec(e.to_string()))
+}
+
+/// Parse a bridge → client frame.
+///
+/// Returns `Ok(None)` for frames whose `type` this version does not know —
+/// they must be ignored for forward compatibility. Malformed JSON or a known
+/// `type` with an invalid body is an error.
+pub fn parse_bridge_frame(text: &str) -> Result<Option<BridgeFrame>, TransportError> {
+    parse_frame(text, BRIDGE_FRAME_TYPES)
+}
+
+/// Parse a client → bridge frame (for bridge implementations and tests).
+///
+/// Same unknown-`type` tolerance as [`parse_bridge_frame`].
+pub fn parse_client_frame(text: &str) -> Result<Option<ClientFrame>, TransportError> {
+    parse_frame(text, CLIENT_FRAME_TYPES)
+}
+
+fn parse_frame<T: serde::de::DeserializeOwned>(
+    text: &str,
+    known_types: &[&str],
+) -> Result<Option<T>, TransportError> {
+    let value: serde_json::Value = serde_json::from_str(text)
+        .map_err(|e| TransportError::Codec(format!("invalid JSON frame: {e}")))?;
+    let Some(frame_type) = value
+        .get("type")
+        .and_then(|t| t.as_str())
+        .map(str::to_owned)
+    else {
+        return Err(TransportError::Codec("frame missing \"type\" field".into()));
+    };
+    if !known_types.contains(&frame_type.as_str()) {
+        return Ok(None);
+    }
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(|e| TransportError::Codec(format!("invalid {frame_type} frame: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr::{EventBuilder, Keys, Kind};
+
+    use super::*;
+
+    fn signed_event() -> SignedEvent {
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9), "hello")
+            .sign_with_keys(&keys)
+            .unwrap();
+        SignedEvent::from_nostr(&event).unwrap()
+    }
+
+    #[test]
+    fn hello_round_trips() {
+        let frame = ClientFrame::Hello {
+            version: PROTOCOL_VERSION,
+            pubkey: "ab".repeat(32),
+            token: None,
+        };
+        let text = encode_client_frame(&frame).unwrap();
+        assert!(text.contains("\"type\":\"hello\""));
+        assert!(!text.contains("token"), "absent token must be omitted");
+        assert_eq!(parse_client_frame(&text).unwrap(), Some(frame));
+
+        let with_token = ClientFrame::Hello {
+            version: PROTOCOL_VERSION,
+            pubkey: "ab".repeat(32),
+            token: Some("sekrit".into()),
+        };
+        let text = encode_client_frame(&with_token).unwrap();
+        assert_eq!(parse_client_frame(&text).unwrap(), Some(with_token));
+    }
+
+    #[test]
+    fn subscribe_frame_matches_subscription() {
+        let sub = Subscription {
+            channel_id: Uuid::new_v4(),
+            kinds: Some(vec![9, 40002]),
+            require_mention: true,
+            replay_since: Some(1_700_000_000),
+        };
+        let text = encode_client_frame(&ClientFrame::subscribe(&sub)).unwrap();
+        match parse_client_frame(&text).unwrap() {
+            Some(ClientFrame::Subscribe {
+                channel_id,
+                kinds,
+                require_mention,
+                replay_since,
+            }) => {
+                assert_eq!(channel_id, sub.channel_id);
+                assert_eq!(kinds, sub.kinds);
+                assert!(require_mention);
+                assert_eq!(replay_since, sub.replay_since);
+            }
+            other => panic!("expected subscribe frame, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn subscribe_optional_fields_default() {
+        let channel_id = Uuid::new_v4();
+        let text = format!(r#"{{"type":"subscribe","channel_id":"{channel_id}"}}"#);
+        match parse_client_frame(&text).unwrap() {
+            Some(ClientFrame::Subscribe {
+                kinds,
+                require_mention,
+                replay_since,
+                ..
+            }) => {
+                assert_eq!(kinds, None);
+                assert!(!require_mention);
+                assert_eq!(replay_since, None);
+            }
+            other => panic!("expected subscribe frame, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn event_frames_carry_the_wire_event_json() {
+        let event = signed_event();
+        let text = encode_bridge_frame(&BridgeFrame::Event {
+            channel_id: Uuid::new_v4(),
+            event: Box::new(event.clone()),
+        })
+        .unwrap();
+        // The embedded event is the unmodified signed-event JSON.
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(
+            value["event"],
+            serde_json::to_value(&event).unwrap(),
+            "event payload must be the unmodified signed-event JSON"
+        );
+        match parse_bridge_frame(&text).unwrap() {
+            Some(BridgeFrame::Event { event: parsed, .. }) => assert_eq!(*parsed, event),
+            other => panic!("expected event frame, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_frame_type_is_ignored() {
+        let text = r#"{"type":"totally_new_frame","payload":42}"#;
+        assert_eq!(parse_bridge_frame(text).unwrap(), None);
+        assert_eq!(parse_client_frame(text).unwrap(), None);
+    }
+
+    #[test]
+    fn unknown_fields_in_known_frames_are_ignored() {
+        let text = r#"{"type":"hello_ack","version":1,"server":"slack-bridge/0.1"}"#;
+        assert_eq!(
+            parse_bridge_frame(text).unwrap(),
+            Some(BridgeFrame::HelloAck { version: 1 })
+        );
+    }
+
+    #[test]
+    fn missing_type_is_an_error() {
+        assert!(matches!(
+            parse_bridge_frame(r#"{"version":1}"#),
+            Err(TransportError::Codec(_))
+        ));
+    }
+
+    #[test]
+    fn malformed_known_frame_is_an_error() {
+        assert!(matches!(
+            parse_bridge_frame(r#"{"type":"hello_ack"}"#),
+            Err(TransportError::Codec(_))
+        ));
+    }
+
+    #[test]
+    fn ok_message_defaults_to_empty() {
+        let text = r#"{"type":"ok","event_id":"abc","accepted":true}"#;
+        match parse_bridge_frame(text).unwrap() {
+            Some(BridgeFrame::Ok {
+                accepted, message, ..
+            }) => {
+                assert!(accepted);
+                assert!(message.is_empty());
+            }
+            other => panic!("expected ok frame, got {other:?}"),
+        }
+    }
+}

--- a/crates/buzz-transport/src/remote.rs
+++ b/crates/buzz-transport/src/remote.rs
@@ -1,0 +1,970 @@
+//! Remote bridge transport — a [`Transport`] over an operator-supplied
+//! endpoint speaking the protocol in [`crate::protocol`].
+//!
+//! This is the "bring your own network" implementation: point it at an
+//! endpoint you run (a Slack bridge, a private-mesh gateway, a local
+//! sidecar, …) and Buzz consumers see the same bidirectional stream of
+//! signed events they would get from a relay. The endpoint can be written
+//! in any language; see `PROTOCOL.md` for the implementor's guide.
+//!
+//! The URL scheme selects the carrier:
+//!
+//! - `wss://` (or loopback/opted-in `ws://`) — one JSON frame per WebSocket
+//!   text message.
+//! - `unix:///path/to/bridge.sock` — one LF-terminated JSON frame per line
+//!   over a Unix domain socket. Local by construction (filesystem
+//!   permissions are the access control), and the easiest carrier for a
+//!   sidecar bridge or a test harness.
+//!
+//! WebSocket carriers can additionally be tunneled through a SOCKS5 proxy
+//! ([`RemoteTransportConfig::socks_proxy`]) — Tor, an SSH `-D` tunnel, or
+//! any private-overlay entry point. Bridge hostnames are resolved at the
+//! proxy, so overlay-only names (`.onion`, mesh-internal DNS) work.
+//!
+//! A background tokio task owns the WebSocket (mirroring the harness relay
+//! client): commands flow in over an mpsc channel, inbound events flow out
+//! over another, and WebSocket pings are answered even while the consumer is
+//! busy.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::mpsc;
+use tokio::time::{sleep, timeout, Instant};
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::header::AUTHORIZATION;
+use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{
+    client_async_tls_with_config, connect_async_with_config, MaybeTlsStream, WebSocketStream,
+};
+#[cfg(unix)]
+use tokio_util::codec::{Framed, LinesCodec};
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use crate::protocol::{
+    encode_client_frame, parse_bridge_frame, BridgeFrame, ClientFrame, MAX_FRAME_BYTES,
+    PROTOCOL_VERSION,
+};
+use crate::socks::SocksProxy;
+use crate::{BoxFuture, SignedEvent, Subscription, Transport, TransportError, TransportEvent};
+
+type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// The connected carrier: JSON frames over a WebSocket or a Unix domain
+/// socket (one LF-terminated line per frame).
+enum BridgeStream {
+    /// `wss://` / `ws://` — one frame per WebSocket text message. Boxed to
+    /// keep the enum small next to the slim Unix variant.
+    WebSocket(Box<WsStream>),
+    /// `unix://` — newline-delimited JSON frames.
+    #[cfg(unix)]
+    Unix(Framed<tokio::net::UnixStream, LinesCodec>),
+}
+
+/// One item from the carrier, with control frames already handled.
+enum StreamItem {
+    /// A JSON text frame.
+    Text(String),
+    /// The carrier closed cleanly (or reached EOF).
+    Closed,
+    /// The carrier failed.
+    Failed(String),
+}
+
+impl BridgeStream {
+    /// Send one JSON text frame.
+    async fn send_text(&mut self, text: String) -> Result<(), TransportError> {
+        match self {
+            Self::WebSocket(ws) => ws
+                .send(Message::Text(text.into()))
+                .await
+                .map_err(|e| TransportError::Connection(e.to_string())),
+            #[cfg(unix)]
+            Self::Unix(framed) => framed
+                .send(text)
+                .await
+                .map_err(|e| TransportError::Connection(e.to_string())),
+        }
+    }
+
+    /// Wait for the next text frame, answering WebSocket pings internally.
+    async fn next_item(&mut self) -> StreamItem {
+        match self {
+            Self::WebSocket(ws) => loop {
+                match ws.next().await {
+                    Some(Ok(Message::Text(text))) => return StreamItem::Text(text.to_string()),
+                    Some(Ok(Message::Ping(data))) => {
+                        let _ = ws.send(Message::Pong(data)).await;
+                    }
+                    Some(Ok(Message::Close(_))) | None => return StreamItem::Closed,
+                    Some(Err(e)) => return StreamItem::Failed(e.to_string()),
+                    Some(Ok(_)) => {} // binary/pong frames — protocol is text-only
+                }
+            },
+            #[cfg(unix)]
+            Self::Unix(framed) => match framed.next().await {
+                Some(Ok(line)) => StreamItem::Text(line),
+                None => StreamItem::Closed,
+                Some(Err(e)) => StreamItem::Failed(e.to_string()),
+            },
+        }
+    }
+
+    /// Close the carrier, best-effort.
+    async fn close(&mut self) {
+        match self {
+            Self::WebSocket(ws) => {
+                let _ = ws.as_mut().close(None).await;
+            }
+            #[cfg(unix)]
+            Self::Unix(framed) => {
+                let _ = SinkExt::<String>::close(framed).await;
+            }
+        }
+    }
+}
+
+/// Time allowed for the WebSocket upgrade plus `hello`/`hello_ack` exchange.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
+/// Command channel capacity (subscribe/publish/etc.).
+const CMD_CHANNEL_CAPACITY: usize = 256;
+/// Inbound event channel capacity.
+const EVENT_CHANNEL_CAPACITY: usize = 1024;
+/// Maximum publishes buffered while disconnected; beyond this the oldest are
+/// dropped with visible accounting.
+const PENDING_PUBLISH_CAP: usize = 256;
+/// Inbound deliveries parked in the background task while the consumer's
+/// event channel is full; when this also fills, the carrier read pauses
+/// (backpressure) instead of blocking command servicing.
+const INBOUND_QUEUE_CAP: usize = 256;
+/// Reconnect backoff: start value, doubling to the cap.
+const RECONNECT_BACKOFF_START: Duration = Duration::from_secs(1);
+/// Reconnect backoff ceiling.
+const RECONNECT_BACKOFF_CAP: Duration = Duration::from_secs(30);
+
+/// Configuration for [`RemoteTransport::connect`].
+///
+/// The `Debug` form redacts `token` and `socks_proxy` — both can carry
+/// credentials (`socks5://user:pass@…`) that must not reach logs.
+#[derive(Clone)]
+pub struct RemoteTransportConfig {
+    /// Bridge endpoint URL. `wss://` for a WebSocket bridge (plaintext
+    /// `ws://` is accepted only for loopback hosts, `.onion` destinations
+    /// via a loopback SOCKS5 proxy, or when `allow_insecure` is set), or
+    /// `unix:///path/to/bridge.sock` for a local Unix-domain socket bridge.
+    pub url: String,
+    /// Hex-encoded public key this client publishes events as; sent in the
+    /// `hello` frame so the bridge can scope mention filtering and access.
+    pub pubkey: String,
+    /// Optional bearer token. Sent in the `hello` frame on every carrier
+    /// and, on WebSocket carriers, additionally as
+    /// `Authorization: Bearer <token>` on the upgrade request.
+    pub token: Option<String>,
+    /// Permit plaintext `ws://` to non-loopback hosts. Off by default;
+    /// intended for explicitly trusted private networks only.
+    pub allow_insecure: bool,
+    /// Optional SOCKS5 proxy (`socks5://[user:pass@]host:port`) to tunnel
+    /// the bridge connection through — Tor, an SSH `-D` tunnel, or any
+    /// private-overlay entry point. The bridge hostname is resolved at the
+    /// proxy (`socks5h` behavior).
+    pub socks_proxy: Option<String>,
+}
+
+impl std::fmt::Debug for RemoteTransportConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RemoteTransportConfig")
+            .field("url", &self.url)
+            .field("pubkey", &self.pubkey)
+            .field("token", &self.token.as_ref().map(|_| "<redacted>"))
+            .field("allow_insecure", &self.allow_insecure)
+            .field(
+                "socks_proxy",
+                &self.socks_proxy.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
+}
+
+/// Commands sent from [`RemoteTransport`] to the background WebSocket task.
+enum RemoteCommand {
+    Subscribe(Subscription),
+    Unsubscribe(Uuid),
+    Publish(Box<SignedEvent>),
+    Reconnect,
+    Shutdown,
+}
+
+/// [`Transport`] implementation over a remote bridge WebSocket.
+///
+/// The `Debug` form intentionally shows no internals — the socket lives in a
+/// background task.
+pub struct RemoteTransport {
+    /// Receiver for events forwarded by the background task. `None` marks
+    /// connection loss.
+    event_rx: mpsc::Receiver<Option<TransportEvent>>,
+    /// Sender for commands to the background task.
+    cmd_tx: mpsc::Sender<RemoteCommand>,
+    /// Handle to the background task, taken by `shutdown`.
+    bg_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl std::fmt::Debug for RemoteTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RemoteTransport").finish_non_exhaustive()
+    }
+}
+
+impl RemoteTransport {
+    /// Dial the bridge, complete the `hello`/`hello_ack` handshake, and
+    /// spawn the background socket task.
+    pub async fn connect(config: RemoteTransportConfig) -> Result<Self, TransportError> {
+        let ws = dial(&config).await?;
+        info!(url = %config.url, "connected to remote transport bridge");
+
+        let (event_tx, event_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
+        let (cmd_tx, cmd_rx) = mpsc::channel(CMD_CHANNEL_CAPACITY);
+        let bg_handle = tokio::spawn(run_background_task(ws, config, cmd_rx, event_tx));
+
+        Ok(Self {
+            event_rx,
+            cmd_tx,
+            bg_handle: Some(bg_handle),
+        })
+    }
+}
+
+impl Transport for RemoteTransport {
+    fn subscribe(
+        &mut self,
+        subscription: Subscription,
+    ) -> BoxFuture<'_, Result<(), TransportError>> {
+        Box::pin(async move {
+            self.cmd_tx
+                .send(RemoteCommand::Subscribe(subscription))
+                .await
+                .map_err(|_| TransportError::Closed)
+        })
+    }
+
+    fn unsubscribe(&mut self, channel_id: Uuid) -> BoxFuture<'_, Result<(), TransportError>> {
+        Box::pin(async move {
+            self.cmd_tx
+                .send(RemoteCommand::Unsubscribe(channel_id))
+                .await
+                .map_err(|_| TransportError::Closed)
+        })
+    }
+
+    fn next_event(&mut self) -> BoxFuture<'_, Option<TransportEvent>> {
+        // The background task sends `None` to signal connection loss.
+        Box::pin(async move { self.event_rx.recv().await.flatten() })
+    }
+
+    fn publish(&self, event: SignedEvent) -> BoxFuture<'_, Result<(), TransportError>> {
+        Box::pin(async move {
+            self.cmd_tx
+                .send(RemoteCommand::Publish(Box::new(event)))
+                .await
+                .map_err(|_| TransportError::Closed)
+        })
+    }
+
+    fn try_publish(&self, event: SignedEvent) -> Result<(), TransportError> {
+        match self
+            .cmd_tx
+            .try_send(RemoteCommand::Publish(Box::new(event)))
+        {
+            Ok(()) => Ok(()),
+            // The trait allows try_publish to drop on a full queue — that is
+            // not a closed transport, so don't report it as one.
+            Err(mpsc::error::TrySendError::Full(cmd)) => {
+                if let RemoteCommand::Publish(event) = cmd {
+                    warn!(
+                        event_id = %event.id,
+                        "command queue full — dropping try_publish event"
+                    );
+                }
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(TransportError::Closed),
+        }
+    }
+
+    fn reconnect(&mut self) -> BoxFuture<'_, Result<(), TransportError>> {
+        Box::pin(async move {
+            self.cmd_tx
+                .send(RemoteCommand::Reconnect)
+                .await
+                .map_err(|_| TransportError::Closed)
+        })
+    }
+
+    fn shutdown(mut self: Box<Self>) -> BoxFuture<'static, ()> {
+        Box::pin(async move {
+            let _ = self.cmd_tx.send(RemoteCommand::Shutdown).await;
+            if let Some(handle) = self.bg_handle.take() {
+                let abort_handle = handle.abort_handle();
+                if timeout(Duration::from_secs(5), handle).await.is_err() {
+                    warn!("remote transport background task did not finish in 5s — aborting");
+                    abort_handle.abort();
+                }
+            }
+        })
+    }
+}
+
+impl Drop for RemoteTransport {
+    fn drop(&mut self) {
+        // Best-effort shutdown signal; the task may already be done.
+        let _ = self.cmd_tx.try_send(RemoteCommand::Shutdown);
+        if let Some(handle) = self.bg_handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// True for `localhost` and loopback IP hosts.
+fn host_is_loopback<S: AsRef<str>>(host: Option<&url::Host<S>>) -> bool {
+    match host {
+        Some(url::Host::Domain(domain)) => domain.as_ref().eq_ignore_ascii_case("localhost"),
+        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+        None => false,
+    }
+}
+
+/// Reject URL schemes that would carry events in plaintext over a network.
+fn validate_url_security(url: &url::Url, allow_insecure: bool) -> Result<(), TransportError> {
+    match url.scheme() {
+        "wss" => Ok(()),
+        "ws" => {
+            if allow_insecure || host_is_loopback(url.host().as_ref()) {
+                Ok(())
+            } else {
+                Err(TransportError::Insecure(format!(
+                    "plaintext ws:// to non-loopback host {:?} — use wss:// \
+                     or opt in explicitly via allow_insecure",
+                    url.host_str().unwrap_or_default()
+                )))
+            }
+        }
+        other => Err(TransportError::Connection(format!(
+            "unsupported URL scheme {other:?} (expected wss:// or ws://)"
+        ))),
+    }
+}
+
+/// Security policy when dialing through a SOCKS5 proxy.
+///
+/// `wss://` is always fine — TLS runs end-to-end through the tunnel.
+/// Plaintext `ws://` requires the proxy itself to be loopback — the
+/// client→proxy hop is plain SOCKS5, so a remote proxy would carry the
+/// frames unencrypted across the network. With a local proxy, plaintext is
+/// accepted for `.onion` destinations (the overlay encrypts beyond the
+/// proxy) or loopback destinations (nothing leaves the machine). The
+/// explicit opt-in bypasses all of this.
+fn validate_proxied_url_security(
+    url: &url::Url,
+    proxy: &SocksProxy,
+    allow_insecure: bool,
+) -> Result<(), TransportError> {
+    match url.scheme() {
+        "wss" => Ok(()),
+        "ws" => {
+            if allow_insecure {
+                return Ok(());
+            }
+            let onion_destination = matches!(
+                url.host(),
+                Some(url::Host::Domain(domain))
+                    if domain.to_ascii_lowercase().ends_with(".onion")
+            );
+            let proxy_is_local = host_is_loopback(Some(proxy.host()));
+            if proxy_is_local && (onion_destination || host_is_loopback(url.host().as_ref())) {
+                Ok(())
+            } else {
+                Err(TransportError::Insecure(format!(
+                    "plaintext ws:// through a SOCKS5 proxy to {:?} — use wss://, \
+                     a .onion destination via a loopback proxy, or opt in \
+                     explicitly via allow_insecure",
+                    url.host_str().unwrap_or_default()
+                )))
+            }
+        }
+        other => Err(TransportError::Connection(format!(
+            "unsupported URL scheme {other:?} (expected wss:// or ws://)"
+        ))),
+    }
+}
+
+/// Dial the bridge over the carrier selected by the URL scheme and complete
+/// the `hello`/`hello_ack` handshake.
+async fn dial(config: &RemoteTransportConfig) -> Result<BridgeStream, TransportError> {
+    let url = url::Url::parse(&config.url)
+        .map_err(|e| TransportError::Connection(format!("invalid bridge URL: {e}")))?;
+
+    let mut stream = timeout(HANDSHAKE_TIMEOUT, connect_carrier(config, &url))
+        .await
+        .map_err(|_| TransportError::Connection("bridge connect timed out".into()))??;
+
+    match timeout(HANDSHAKE_TIMEOUT, handshake(&mut stream, config)).await {
+        Ok(Ok(())) => Ok(stream),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(TransportError::Connection(
+            "bridge did not send hello_ack within the handshake timeout".into(),
+        )),
+    }
+}
+
+/// Open the carrier for the bridge URL: `unix://` connects a Unix domain
+/// socket; `wss://`/`ws://` dial a WebSocket, optionally through the
+/// configured SOCKS5 proxy.
+async fn connect_carrier(
+    config: &RemoteTransportConfig,
+    url: &url::Url,
+) -> Result<BridgeStream, TransportError> {
+    if url.scheme() == "unix" {
+        if config.socks_proxy.is_some() {
+            return Err(TransportError::Connection(
+                "a SOCKS5 proxy cannot carry a unix:// bridge connection".into(),
+            ));
+        }
+        return connect_unix(url).await;
+    }
+
+    let proxy = config
+        .socks_proxy
+        .as_deref()
+        .map(SocksProxy::parse)
+        .transpose()?;
+    match &proxy {
+        Some(proxy) => validate_proxied_url_security(url, proxy, config.allow_insecure)?,
+        None => validate_url_security(url, config.allow_insecure)?,
+    }
+
+    let mut request = config
+        .url
+        .as_str()
+        .into_client_request()
+        .map_err(|e| TransportError::Connection(format!("invalid bridge URL: {e}")))?;
+    if let Some(token) = &config.token {
+        let value = HeaderValue::from_str(&format!("Bearer {token}")).map_err(|e| {
+            TransportError::Connection(format!("bridge token is not a valid header value: {e}"))
+        })?;
+        request.headers_mut().insert(AUTHORIZATION, value);
+    }
+
+    let ws_config = WebSocketConfig::default()
+        .max_message_size(Some(MAX_FRAME_BYTES))
+        .max_frame_size(Some(MAX_FRAME_BYTES));
+    let ws = match &proxy {
+        Some(proxy) => {
+            let host = url
+                .host()
+                .ok_or_else(|| TransportError::Connection("bridge URL has no host".into()))?;
+            let port = url
+                .port_or_known_default()
+                .ok_or_else(|| TransportError::Connection("bridge URL has no port".into()))?;
+            let tunnel = proxy.connect(&host, port).await?;
+            let (ws, _response) =
+                client_async_tls_with_config(request, tunnel, Some(ws_config), None)
+                    .await
+                    .map_err(|e| TransportError::Connection(e.to_string()))?;
+            ws
+        }
+        None => {
+            let (ws, _response) = connect_async_with_config(request, Some(ws_config), false)
+                .await
+                .map_err(|e| TransportError::Connection(e.to_string()))?;
+            ws
+        }
+    };
+    Ok(BridgeStream::WebSocket(Box::new(ws)))
+}
+
+/// Connect a `unix:///path/to/bridge.sock` carrier. Local by construction —
+/// filesystem permissions are the access control, so no TLS policy applies.
+#[cfg(unix)]
+async fn connect_unix(url: &url::Url) -> Result<BridgeStream, TransportError> {
+    if url.host_str().is_some_and(|h| !h.is_empty()) {
+        return Err(TransportError::Connection(
+            "unix:// bridge URLs take an absolute path: unix:///path/to/bridge.sock".into(),
+        ));
+    }
+    let path = url.path();
+    if path.is_empty() || path == "/" {
+        return Err(TransportError::Connection(
+            "unix:// bridge URL has no socket path".into(),
+        ));
+    }
+    let stream = tokio::net::UnixStream::connect(path)
+        .await
+        .map_err(|e| TransportError::Connection(format!("unix socket connect failed: {e}")))?;
+    let codec = LinesCodec::new_with_max_length(MAX_FRAME_BYTES);
+    Ok(BridgeStream::Unix(Framed::new(stream, codec)))
+}
+
+#[cfg(not(unix))]
+async fn connect_unix(_url: &url::Url) -> Result<BridgeStream, TransportError> {
+    Err(TransportError::Connection(
+        "unix:// bridge sockets are not supported on this platform".into(),
+    ))
+}
+
+/// `hello` → `hello_ack` over the connected carrier.
+async fn handshake(
+    stream: &mut BridgeStream,
+    config: &RemoteTransportConfig,
+) -> Result<(), TransportError> {
+    let hello = ClientFrame::Hello {
+        version: PROTOCOL_VERSION,
+        pubkey: config.pubkey.clone(),
+        token: config.token.clone(),
+    };
+    stream.send_text(encode_client_frame(&hello)?).await?;
+
+    loop {
+        match stream.next_item().await {
+            StreamItem::Text(text) => match parse_bridge_frame(&text)? {
+                Some(BridgeFrame::HelloAck { version }) => {
+                    if version != PROTOCOL_VERSION {
+                        return Err(TransportError::Protocol(format!(
+                            "bridge speaks protocol version {version}, \
+                             client speaks {PROTOCOL_VERSION}"
+                        )));
+                    }
+                    return Ok(());
+                }
+                Some(BridgeFrame::Notice { message }) => {
+                    warn!(%message, "bridge notice during handshake");
+                }
+                Some(other) => {
+                    return Err(TransportError::Protocol(format!(
+                        "bridge sent {other:?} before hello_ack"
+                    )));
+                }
+                None => debug!("ignoring unknown frame during handshake"),
+            },
+            StreamItem::Closed => {
+                return Err(TransportError::Connection(
+                    "bridge closed during handshake".into(),
+                ));
+            }
+            StreamItem::Failed(e) => {
+                return Err(TransportError::Connection(format!(
+                    "bridge carrier failed during handshake: {e}"
+                )));
+            }
+        }
+    }
+}
+
+/// Background task: owns the carrier stream, services commands, forwards
+/// events.
+///
+/// Inbound deliveries are parked in a local queue and handed to the
+/// consumer's channel via [`mpsc::Sender::reserve`], never an awaited
+/// `send` — so a consumer that stops draining events can never wedge the
+/// command path (subscribe/publish/shutdown stay serviced, and the carrier
+/// read simply pauses once the queue fills).
+async fn run_background_task(
+    ws: BridgeStream,
+    config: RemoteTransportConfig,
+    mut cmd_rx: mpsc::Receiver<RemoteCommand>,
+    event_tx: mpsc::Sender<Option<TransportEvent>>,
+) {
+    let mut ws = Some(ws);
+    // Active subscriptions, re-sent after every reconnect.
+    let mut subscriptions: HashMap<Uuid, Subscription> = HashMap::new();
+    // Publishes buffered while disconnected, drained on reconnect.
+    let mut pending_publish: VecDeque<SignedEvent> = VecDeque::new();
+    // Deliveries (`Some` = event, `None` = disconnect marker) waiting for
+    // room in `event_tx`.
+    let mut inbound: VecDeque<Option<TransportEvent>> = VecDeque::new();
+
+    loop {
+        tokio::select! {
+            cmd = cmd_rx.recv() => match cmd {
+                None | Some(RemoteCommand::Shutdown) => {
+                    if let Some(mut stream) = ws.take() {
+                        stream.close().await;
+                    }
+                    return;
+                }
+                Some(RemoteCommand::Subscribe(sub)) => {
+                    let frame = ClientFrame::subscribe(&sub);
+                    subscriptions.insert(sub.channel_id, sub);
+                    if let Some(stream) = ws.as_mut() {
+                        if send_frame(stream, &frame).await.is_err() {
+                            disconnect(&mut ws, &mut inbound);
+                        }
+                    }
+                }
+                Some(RemoteCommand::Unsubscribe(channel_id)) => {
+                    subscriptions.remove(&channel_id);
+                    if let Some(stream) = ws.as_mut() {
+                        let frame = ClientFrame::Unsubscribe { channel_id };
+                        if send_frame(stream, &frame).await.is_err() {
+                            disconnect(&mut ws, &mut inbound);
+                        }
+                    }
+                }
+                Some(RemoteCommand::Publish(event)) => match ws.as_mut() {
+                    Some(stream) => {
+                        let frame = ClientFrame::Event { event };
+                        if send_frame(stream, &frame).await.is_err() {
+                            // Keep the event for the reconnect replay
+                            // instead of losing it with the connection.
+                            if let ClientFrame::Event { event } = frame {
+                                buffer_publish(&mut pending_publish, *event);
+                            }
+                            disconnect(&mut ws, &mut inbound);
+                        }
+                    }
+                    None => buffer_publish(&mut pending_publish, *event),
+                },
+                Some(RemoteCommand::Reconnect) => {
+                    if ws.is_some() {
+                        // Already connected — treat as a no-op.
+                        debug!("reconnect requested while connected — ignoring");
+                    } else {
+                        match reconnect_loop(
+                            &config,
+                            &mut cmd_rx,
+                            &mut subscriptions,
+                            &mut pending_publish,
+                        )
+                        .await
+                        {
+                            Some(stream) => ws = Some(stream),
+                            None => return, // shutdown requested while reconnecting
+                        }
+                    }
+                }
+            },
+            // Forward parked deliveries as the consumer makes room.
+            permit = event_tx.reserve(), if !inbound.is_empty() => match permit {
+                Ok(permit) => {
+                    if let Some(delivery) = inbound.pop_front() {
+                        permit.send(delivery);
+                    }
+                }
+                Err(_) => return, // consumer dropped the transport
+            },
+            // Read the carrier only while connected and while the parking
+            // queue has room.
+            item = next_stream_item(&mut ws),
+                if ws.is_some() && inbound.len() < INBOUND_QUEUE_CAP => match item {
+                StreamItem::Text(text) => {
+                    if let Some(event) = handle_bridge_frame(&text) {
+                        inbound.push_back(Some(event));
+                    }
+                }
+                StreamItem::Closed => {
+                    info!("bridge connection closed");
+                    disconnect(&mut ws, &mut inbound);
+                }
+                StreamItem::Failed(e) => {
+                    warn!("bridge carrier error: {e}");
+                    disconnect(&mut ws, &mut inbound);
+                }
+            },
+        }
+    }
+}
+
+/// Await the next carrier item, or forever when disconnected (the select
+/// guard keeps this branch disabled while `ws` is `None`).
+async fn next_stream_item(ws: &mut Option<BridgeStream>) -> StreamItem {
+    match ws.as_mut() {
+        Some(stream) => stream.next_item().await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Drop the carrier and queue the connection-loss marker (`None` on the
+/// event channel) exactly once per disconnection.
+fn disconnect(ws: &mut Option<BridgeStream>, inbound: &mut VecDeque<Option<TransportEvent>>) {
+    if ws.take().is_some() {
+        inbound.push_back(None);
+    }
+}
+
+/// Buffer a publish while disconnected, dropping the oldest beyond the cap.
+fn buffer_publish(pending: &mut VecDeque<SignedEvent>, event: SignedEvent) {
+    if pending.len() >= PENDING_PUBLISH_CAP {
+        if let Some(dropped) = pending.pop_front() {
+            warn!(
+                event_id = %dropped.id,
+                "publish buffer full while disconnected — dropping oldest event"
+            );
+        }
+    }
+    pending.push_back(event);
+}
+
+/// Encode and send one client frame.
+async fn send_frame(stream: &mut BridgeStream, frame: &ClientFrame) -> Result<(), TransportError> {
+    let text = encode_client_frame(frame)?;
+    stream
+        .send_text(text)
+        .await
+        .inspect_err(|e| warn!("bridge send failed: {e}"))
+}
+
+/// Handle one inbound text frame from the bridge, returning the verified
+/// delivery when the frame carries an event.
+fn handle_bridge_frame(text: &str) -> Option<TransportEvent> {
+    match parse_bridge_frame(text) {
+        Ok(Some(BridgeFrame::Event { channel_id, event })) => {
+            if let Err(e) = event.verify() {
+                warn!(event_id = %event.id, "dropping bridge event with invalid signature: {e}");
+                return None;
+            }
+            return Some(TransportEvent {
+                channel_id,
+                event: *event,
+            });
+        }
+        Ok(Some(BridgeFrame::Ok {
+            event_id,
+            accepted,
+            message,
+        })) => {
+            if accepted {
+                debug!(%event_id, "bridge accepted event");
+            } else {
+                warn!(%event_id, %message, "bridge rejected event");
+            }
+        }
+        Ok(Some(BridgeFrame::Eose { channel_id })) => {
+            debug!(%channel_id, "bridge replay complete");
+        }
+        Ok(Some(BridgeFrame::Notice { message })) => {
+            info!(%message, "bridge notice");
+        }
+        Ok(Some(BridgeFrame::HelloAck { .. })) => {
+            debug!("ignoring duplicate hello_ack");
+        }
+        Ok(None) => debug!("ignoring unknown bridge frame"),
+        Err(e) => warn!("ignoring malformed bridge frame: {e}"),
+    }
+    None
+}
+
+/// Redial with jitter-free exponential backoff until success or shutdown.
+///
+/// Returns `None` if shutdown was requested while reconnecting. Commands
+/// arriving during backoff are folded into the pending state (publishes
+/// buffered, subscription set updated) so nothing is lost across the gap.
+async fn reconnect_loop(
+    config: &RemoteTransportConfig,
+    cmd_rx: &mut mpsc::Receiver<RemoteCommand>,
+    subscriptions: &mut HashMap<Uuid, Subscription>,
+    pending_publish: &mut VecDeque<SignedEvent>,
+) -> Option<BridgeStream> {
+    let mut backoff = RECONNECT_BACKOFF_START;
+    loop {
+        match dial(config).await {
+            Ok(mut stream) => {
+                info!(url = %config.url, "reconnected to remote transport bridge");
+                let mut replay_ok = true;
+                for sub in subscriptions.values() {
+                    if send_frame(&mut stream, &ClientFrame::subscribe(sub))
+                        .await
+                        .is_err()
+                    {
+                        replay_ok = false;
+                        break;
+                    }
+                }
+                while replay_ok {
+                    let Some(event) = pending_publish.pop_front() else {
+                        break;
+                    };
+                    if send_frame(
+                        &mut stream,
+                        &ClientFrame::Event {
+                            event: Box::new(event.clone()),
+                        },
+                    )
+                    .await
+                    .is_err()
+                    {
+                        // Requeue so the next reconnect can retry it.
+                        pending_publish.push_front(event);
+                        replay_ok = false;
+                    }
+                }
+                if replay_ok {
+                    return Some(stream);
+                }
+                warn!("connection dropped while replaying state — retrying");
+            }
+            Err(e) => {
+                warn!("bridge reconnect failed: {e} — retrying in {backoff:?}");
+            }
+        }
+
+        // Sleep with backoff, staying responsive to commands.
+        let deadline = Instant::now() + backoff;
+        loop {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .unwrap_or(Duration::ZERO);
+            if remaining.is_zero() {
+                break;
+            }
+            tokio::select! {
+                _ = sleep(remaining) => break,
+                cmd = cmd_rx.recv() => match cmd {
+                    None | Some(RemoteCommand::Shutdown) => return None,
+                    Some(RemoteCommand::Subscribe(sub)) => {
+                        subscriptions.insert(sub.channel_id, sub);
+                    }
+                    Some(RemoteCommand::Unsubscribe(channel_id)) => {
+                        subscriptions.remove(&channel_id);
+                    }
+                    Some(RemoteCommand::Publish(event)) => {
+                        buffer_publish(pending_publish, *event);
+                    }
+                    Some(RemoteCommand::Reconnect) => {} // already reconnecting
+                },
+            }
+        }
+        backoff = (backoff * 2).min(RECONNECT_BACKOFF_CAP);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(url: &str) -> url::Url {
+        url::Url::parse(url).unwrap()
+    }
+
+    #[test]
+    fn wss_is_always_allowed() {
+        assert!(validate_url_security(&parse("wss://bridge.example.com/buzz"), false).is_ok());
+    }
+
+    #[test]
+    fn plain_ws_to_loopback_is_allowed() {
+        assert!(validate_url_security(&parse("ws://localhost:9999/bridge"), false).is_ok());
+        assert!(validate_url_security(&parse("ws://127.0.0.1:9999/bridge"), false).is_ok());
+        assert!(validate_url_security(&parse("ws://[::1]:9999/bridge"), false).is_ok());
+    }
+
+    #[test]
+    fn plain_ws_to_remote_host_is_rejected() {
+        assert!(matches!(
+            validate_url_security(&parse("ws://bridge.example.com/buzz"), false),
+            Err(TransportError::Insecure(_))
+        ));
+        assert!(matches!(
+            validate_url_security(&parse("ws://10.0.0.7:9999/bridge"), false),
+            Err(TransportError::Insecure(_))
+        ));
+    }
+
+    #[test]
+    fn allow_insecure_opts_in_to_plain_ws() {
+        assert!(validate_url_security(&parse("ws://10.0.0.7:9999/bridge"), true).is_ok());
+    }
+
+    #[test]
+    fn non_websocket_schemes_are_rejected() {
+        assert!(matches!(
+            validate_url_security(&parse("https://bridge.example.com/buzz"), true),
+            Err(TransportError::Connection(_))
+        ));
+    }
+
+    #[test]
+    fn proxied_wss_is_always_allowed() {
+        let tor = SocksProxy::parse("socks5://127.0.0.1:9050").unwrap();
+        assert!(validate_proxied_url_security(
+            &parse("wss://bridge.example.com/buzz"),
+            &tor,
+            false
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn proxied_plain_ws_is_allowed_for_onion_and_all_loopback_only() {
+        let local_proxy = SocksProxy::parse("socks5://127.0.0.1:9050").unwrap();
+        let remote_proxy = SocksProxy::parse("socks5://10.0.0.7:1080").unwrap();
+
+        // Tor-style: the overlay provides the encryption.
+        assert!(validate_proxied_url_security(
+            &parse("ws://bridgeexample.onion/buzz"),
+            &local_proxy,
+            false
+        )
+        .is_ok());
+
+        // Everything on-machine: fine.
+        assert!(validate_proxied_url_security(
+            &parse("ws://127.0.0.1:9999/bridge"),
+            &local_proxy,
+            false
+        )
+        .is_ok());
+
+        // Plaintext leaves the machine via the proxy or beyond it: rejected.
+        assert!(matches!(
+            validate_proxied_url_security(
+                &parse("ws://bridge.example.com/buzz"),
+                &local_proxy,
+                false
+            ),
+            Err(TransportError::Insecure(_))
+        ));
+        assert!(matches!(
+            validate_proxied_url_security(
+                &parse("ws://127.0.0.1:9999/bridge"),
+                &remote_proxy,
+                false
+            ),
+            Err(TransportError::Insecure(_))
+        ));
+        // A remote proxy makes even a .onion destination plaintext on the
+        // client→proxy hop — Tor's encryption starts at the proxy.
+        assert!(matches!(
+            validate_proxied_url_security(
+                &parse("ws://bridgeexample.onion/buzz"),
+                &remote_proxy,
+                false
+            ),
+            Err(TransportError::Insecure(_))
+        ));
+
+        // The explicit opt-in still applies.
+        assert!(validate_proxied_url_security(
+            &parse("ws://bridge.example.com/buzz"),
+            &remote_proxy,
+            true
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn publish_buffer_drops_oldest_beyond_cap() {
+        let keys = nostr::Keys::generate();
+        let mut pending = VecDeque::new();
+        for i in 0..(PENDING_PUBLISH_CAP + 3) {
+            let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), format!("m{i}"))
+                .sign_with_keys(&keys)
+                .unwrap();
+            buffer_publish(&mut pending, SignedEvent::from_nostr(&event).unwrap());
+        }
+        assert_eq!(pending.len(), PENDING_PUBLISH_CAP);
+        assert_eq!(pending.front().map(|e| e.content.as_str()), Some("m3"));
+    }
+}

--- a/crates/buzz-transport/src/socks.rs
+++ b/crates/buzz-transport/src/socks.rs
@@ -1,0 +1,303 @@
+//! Minimal SOCKS5 CONNECT client (RFC 1928) with optional username/password
+//! authentication (RFC 1929).
+//!
+//! Hand-rolled on purpose: the client side of CONNECT is a few dozen bytes
+//! of protocol, and owning it keeps the transport dependency-light. Domain
+//! targets are passed to the proxy verbatim (`socks5h` behavior), so name
+//! resolution happens inside the private network — required for overlays
+//! like Tor where the client cannot resolve the destination itself.
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+use crate::TransportError;
+
+const SOCKS_VERSION: u8 = 0x05;
+const METHOD_NO_AUTH: u8 = 0x00;
+const METHOD_USER_PASS: u8 = 0x02;
+const METHOD_NONE_ACCEPTABLE: u8 = 0xFF;
+const CMD_CONNECT: u8 = 0x01;
+const ATYP_IPV4: u8 = 0x01;
+const ATYP_DOMAIN: u8 = 0x03;
+const ATYP_IPV6: u8 = 0x04;
+const AUTH_SUBNEGOTIATION_VERSION: u8 = 0x01;
+
+/// A parsed `socks5://[user:pass@]host:port` proxy address.
+///
+/// Credentials are taken verbatim from the URL (no percent-decoding) and
+/// must each fit RFC 1929's 255-byte limit.
+#[derive(Debug, Clone)]
+pub(crate) struct SocksProxy {
+    host: url::Host<String>,
+    port: u16,
+    auth: Option<(String, String)>,
+}
+
+impl SocksProxy {
+    /// Parse a `socks5://` (or `socks5h://` — both resolve names at the
+    /// proxy) URL into a proxy address.
+    pub(crate) fn parse(raw: &str) -> Result<Self, TransportError> {
+        let url = url::Url::parse(raw)
+            .map_err(|e| TransportError::Connection(format!("invalid SOCKS5 proxy URL: {e}")))?;
+        match url.scheme() {
+            "socks5" | "socks5h" => {}
+            other => {
+                return Err(TransportError::Connection(format!(
+                    "unsupported proxy scheme {other:?} (expected socks5:// or socks5h://)"
+                )));
+            }
+        }
+        // `socks5` is not a "special" scheme, so the url crate leaves IP
+        // literals as opaque domains — normalize them back to IP hosts.
+        let host = match url
+            .host()
+            .ok_or_else(|| TransportError::Connection("SOCKS5 proxy URL has no host".into()))?
+            .to_owned()
+        {
+            url::Host::Domain(domain) => match domain.parse::<std::net::IpAddr>() {
+                Ok(std::net::IpAddr::V4(ip)) => url::Host::Ipv4(ip),
+                Ok(std::net::IpAddr::V6(ip)) => url::Host::Ipv6(ip),
+                Err(_) => url::Host::Domain(domain),
+            },
+            other => other,
+        };
+        let port = url.port().unwrap_or(1080);
+
+        let username = url.username();
+        let auth = match (username.is_empty(), url.password()) {
+            (true, None) => None,
+            (_, password) => {
+                let password = password.unwrap_or_default();
+                if username.len() > 255 || password.len() > 255 {
+                    return Err(TransportError::Connection(
+                        "SOCKS5 credentials exceed the 255-byte RFC 1929 limit".into(),
+                    ));
+                }
+                Some((username.to_string(), password.to_string()))
+            }
+        };
+
+        Ok(Self { host, port, auth })
+    }
+
+    /// The proxy's host, for security-policy decisions by the caller.
+    pub(crate) fn host(&self) -> &url::Host<String> {
+        &self.host
+    }
+
+    /// Open a TCP connection to `target_host:target_port` through the proxy:
+    /// dial the proxy, negotiate authentication, and issue a CONNECT.
+    pub(crate) async fn connect(
+        &self,
+        target_host: &url::Host<&str>,
+        target_port: u16,
+    ) -> Result<TcpStream, TransportError> {
+        let mut stream = match &self.host {
+            url::Host::Domain(domain) => TcpStream::connect((domain.as_str(), self.port)).await,
+            url::Host::Ipv4(ip) => TcpStream::connect((std::net::IpAddr::V4(*ip), self.port)).await,
+            url::Host::Ipv6(ip) => TcpStream::connect((std::net::IpAddr::V6(*ip), self.port)).await,
+        }
+        .map_err(|e| TransportError::Connection(format!("SOCKS5 proxy connect failed: {e}")))?;
+
+        self.negotiate_auth(&mut stream).await?;
+        send_connect(&mut stream, target_host, target_port).await?;
+        Ok(stream)
+    }
+
+    /// Method negotiation plus (if selected) RFC 1929 username/password
+    /// subnegotiation.
+    async fn negotiate_auth(&self, stream: &mut TcpStream) -> Result<(), TransportError> {
+        let methods: &[u8] = if self.auth.is_some() {
+            &[METHOD_NO_AUTH, METHOD_USER_PASS]
+        } else {
+            &[METHOD_NO_AUTH]
+        };
+        let mut greeting = vec![SOCKS_VERSION, methods.len() as u8];
+        greeting.extend_from_slice(methods);
+        stream.write_all(&greeting).await.map_err(socks_io_error)?;
+
+        let mut choice = [0u8; 2];
+        stream
+            .read_exact(&mut choice)
+            .await
+            .map_err(socks_io_error)?;
+        if choice[0] != SOCKS_VERSION {
+            return Err(TransportError::Connection(format!(
+                "proxy is not SOCKS5 (version byte {:#04x})",
+                choice[0]
+            )));
+        }
+        match choice[1] {
+            METHOD_NO_AUTH => Ok(()),
+            METHOD_USER_PASS => {
+                let Some((user, pass)) = &self.auth else {
+                    return Err(TransportError::Connection(
+                        "proxy requires username/password but none were configured".into(),
+                    ));
+                };
+                let mut request = vec![AUTH_SUBNEGOTIATION_VERSION, user.len() as u8];
+                request.extend_from_slice(user.as_bytes());
+                request.push(pass.len() as u8);
+                request.extend_from_slice(pass.as_bytes());
+                stream.write_all(&request).await.map_err(socks_io_error)?;
+
+                let mut status = [0u8; 2];
+                stream
+                    .read_exact(&mut status)
+                    .await
+                    .map_err(socks_io_error)?;
+                if status[0] != AUTH_SUBNEGOTIATION_VERSION {
+                    return Err(TransportError::Connection(format!(
+                        "proxy sent unsupported username/password subnegotiation \
+                         version {:#04x}",
+                        status[0]
+                    )));
+                }
+                if status[1] != 0 {
+                    return Err(TransportError::Connection(
+                        "proxy rejected the SOCKS5 username/password".into(),
+                    ));
+                }
+                Ok(())
+            }
+            METHOD_NONE_ACCEPTABLE => Err(TransportError::Connection(
+                "proxy accepted none of the offered SOCKS5 authentication methods".into(),
+            )),
+            other => Err(TransportError::Connection(format!(
+                "proxy selected unsupported SOCKS5 method {other:#04x}"
+            ))),
+        }
+    }
+}
+
+/// Issue the CONNECT request and consume the proxy's reply, leaving the
+/// stream positioned at the start of the tunneled byte stream.
+async fn send_connect(
+    stream: &mut TcpStream,
+    target_host: &url::Host<&str>,
+    target_port: u16,
+) -> Result<(), TransportError> {
+    let mut request = vec![SOCKS_VERSION, CMD_CONNECT, 0x00];
+    match target_host {
+        url::Host::Domain(domain) => {
+            let bytes = domain.as_bytes();
+            let len = u8::try_from(bytes.len()).map_err(|_| {
+                TransportError::Connection("target hostname exceeds 255 bytes".into())
+            })?;
+            request.push(ATYP_DOMAIN);
+            request.push(len);
+            request.extend_from_slice(bytes);
+        }
+        url::Host::Ipv4(ip) => {
+            request.push(ATYP_IPV4);
+            request.extend_from_slice(&ip.octets());
+        }
+        url::Host::Ipv6(ip) => {
+            request.push(ATYP_IPV6);
+            request.extend_from_slice(&ip.octets());
+        }
+    }
+    request.extend_from_slice(&target_port.to_be_bytes());
+    stream.write_all(&request).await.map_err(socks_io_error)?;
+
+    // Reply: VER REP RSV ATYP BND.ADDR BND.PORT. The bind address must be
+    // fully consumed so the tunnel starts aligned.
+    let mut head = [0u8; 4];
+    stream.read_exact(&mut head).await.map_err(socks_io_error)?;
+    if head[0] != SOCKS_VERSION {
+        return Err(TransportError::Connection(format!(
+            "proxy sent a non-SOCKS5 reply (version byte {:#04x})",
+            head[0]
+        )));
+    }
+    if head[1] != 0 {
+        return Err(TransportError::Connection(format!(
+            "proxy refused the connection: {}",
+            reply_reason(head[1])
+        )));
+    }
+    let addr_len = match head[3] {
+        ATYP_IPV4 => 4,
+        ATYP_IPV6 => 16,
+        ATYP_DOMAIN => {
+            let mut len = [0u8; 1];
+            stream.read_exact(&mut len).await.map_err(socks_io_error)?;
+            len[0] as usize
+        }
+        other => {
+            return Err(TransportError::Connection(format!(
+                "proxy reply has unknown address type {other:#04x}"
+            )));
+        }
+    };
+    let mut bind = vec![0u8; addr_len + 2];
+    stream.read_exact(&mut bind).await.map_err(socks_io_error)?;
+    Ok(())
+}
+
+fn socks_io_error(e: std::io::Error) -> TransportError {
+    TransportError::Connection(format!("SOCKS5 handshake failed: {e}"))
+}
+
+/// Human-readable RFC 1928 §6 reply codes.
+fn reply_reason(code: u8) -> &'static str {
+    match code {
+        0x01 => "general SOCKS server failure",
+        0x02 => "connection not allowed by ruleset",
+        0x03 => "network unreachable",
+        0x04 => "host unreachable",
+        0x05 => "connection refused",
+        0x06 => "TTL expired",
+        0x07 => "command not supported",
+        0x08 => "address type not supported",
+        _ => "unknown reply code",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_host_port_and_default_port() {
+        let proxy = SocksProxy::parse("socks5://127.0.0.1:9050").unwrap();
+        assert_eq!(proxy.host, url::Host::parse("127.0.0.1").unwrap());
+        assert_eq!(proxy.port, 9050);
+        assert!(proxy.auth.is_none());
+
+        let defaulted = SocksProxy::parse("socks5://proxy.internal").unwrap();
+        assert_eq!(defaulted.port, 1080);
+
+        let hostname_resolving = SocksProxy::parse("socks5h://proxy.internal:1081").unwrap();
+        assert_eq!(hostname_resolving.port, 1081);
+    }
+
+    #[test]
+    fn parses_credentials() {
+        let proxy = SocksProxy::parse("socks5://agent:hunter2@10.0.0.1:1080").unwrap();
+        assert_eq!(
+            proxy.auth,
+            Some(("agent".to_string(), "hunter2".to_string()))
+        );
+
+        let user_only = SocksProxy::parse("socks5://agent@10.0.0.1:1080").unwrap();
+        assert_eq!(user_only.auth, Some(("agent".to_string(), String::new())));
+    }
+
+    #[test]
+    fn rejects_non_socks_schemes_and_oversized_credentials() {
+        assert!(matches!(
+            SocksProxy::parse("http://proxy.internal:8080"),
+            Err(TransportError::Connection(_))
+        ));
+        assert!(matches!(
+            SocksProxy::parse("not a url"),
+            Err(TransportError::Connection(_))
+        ));
+        let oversized = format!("socks5://{}:pw@10.0.0.1:1080", "u".repeat(256));
+        assert!(matches!(
+            SocksProxy::parse(&oversized),
+            Err(TransportError::Connection(_))
+        ));
+    }
+}

--- a/crates/buzz-transport/tests/end_to_end.rs
+++ b/crates/buzz-transport/tests/end_to_end.rs
@@ -1,0 +1,240 @@
+//! End-to-end test of the whole seam: two [`RemoteTransport`] clients talk
+//! protocol v1 over real WebSockets to a bridge whose "network" is an
+//! [`InMemoryHub`] — the same shape as a production bridge onto Slack or a
+//! private mesh, with the hub playing the private network.
+//!
+//! ```text
+//! alice: RemoteTransport ──ws──┐                ┌──ws── bob: RemoteTransport
+//!                              ├── hub bridge ──┤
+//!                              └─ InMemoryHub ──┘
+//! ```
+
+use std::collections::HashMap;
+
+use buzz_transport::memory::InMemoryHub;
+use buzz_transport::protocol::{encode_bridge_frame, parse_client_frame, BridgeFrame, ClientFrame};
+use buzz_transport::remote::{RemoteTransport, RemoteTransportConfig};
+use buzz_transport::{SignedEvent, Subscription, Transport, TransportEvent};
+use futures_util::{SinkExt, StreamExt};
+use nostr::{EventBuilder, Keys, Kind, Tag};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+use tokio_tungstenite::tungstenite::Message;
+use uuid::Uuid;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn signed_event(keys: &Keys, channel: Uuid, content: &str) -> SignedEvent {
+    let event = EventBuilder::new(Kind::Custom(9), content)
+        .tags([Tag::parse(["h", &channel.to_string()]).unwrap()])
+        .sign_with_keys(keys)
+        .unwrap();
+    SignedEvent::from_nostr(&event).unwrap()
+}
+
+/// Spawn a bridge that serves protocol v1 over WebSocket and carries events
+/// between clients through `hub`. Each `subscribe` a client sends is
+/// acknowledged on `subs_seen` once it is live on the hub, so tests can
+/// publish without racing subscription registration.
+async fn spawn_hub_bridge(hub: InMemoryHub) -> (String, mpsc::UnboundedReceiver<(String, Uuid)>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (subs_tx, subs_rx) = mpsc::unbounded_channel();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                return;
+            };
+            let hub = hub.clone();
+            let subs_tx = subs_tx.clone();
+            tokio::spawn(async move {
+                let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+                let (mut ws_sink, mut ws_stream) = ws.split();
+
+                // Handshake: hello → hello_ack, remembering the client pubkey.
+                let pubkey = match ws_stream.next().await {
+                    Some(Ok(Message::Text(text))) => {
+                        match parse_client_frame(text.as_str()).unwrap() {
+                            Some(ClientFrame::Hello { pubkey, .. }) => pubkey,
+                            other => panic!("expected hello, got {other:?}"),
+                        }
+                    }
+                    other => panic!("connection ended before hello: {other:?}"),
+                };
+                let ack = BridgeFrame::HelloAck {
+                    version: buzz_transport::protocol::PROTOCOL_VERSION,
+                };
+                ws_sink
+                    .send(Message::Text(encode_bridge_frame(&ack).unwrap().into()))
+                    .await
+                    .unwrap();
+
+                // Writer task: everything the bridge sends funnels through
+                // one channel so delivery pumps never touch the sink.
+                let (out_tx, mut out_rx) = mpsc::channel::<BridgeFrame>(64);
+                tokio::spawn(async move {
+                    while let Some(frame) = out_rx.recv().await {
+                        let text = encode_bridge_frame(&frame).unwrap();
+                        if ws_sink.send(Message::Text(text.into())).await.is_err() {
+                            return;
+                        }
+                    }
+                });
+
+                // The client's outbound events enter the hub through one
+                // participant; each subscription gets its own participant
+                // whose pump forwards hub deliveries back over the socket.
+                let publisher = hub.connect(pubkey.clone());
+                let mut pumps: HashMap<Uuid, tokio::task::JoinHandle<()>> = HashMap::new();
+
+                while let Some(msg) = ws_stream.next().await {
+                    let Ok(Message::Text(text)) = msg else {
+                        break;
+                    };
+                    match parse_client_frame(text.as_str()) {
+                        Ok(Some(ClientFrame::Subscribe {
+                            channel_id,
+                            kinds,
+                            require_mention,
+                            replay_since,
+                        })) => {
+                            // Register on the hub *before* spawning the pump
+                            // so no event published after this frame is lost.
+                            let mut conn = hub.connect(pubkey.clone());
+                            conn.subscribe(Subscription {
+                                channel_id,
+                                kinds,
+                                require_mention,
+                                replay_since,
+                            })
+                            .await
+                            .unwrap();
+                            let _ = subs_tx.send((pubkey.clone(), channel_id));
+
+                            let own_pubkey = pubkey.clone();
+                            let out_tx = out_tx.clone();
+                            let pump = tokio::spawn(async move {
+                                while let Some(TransportEvent { channel_id, event }) =
+                                    conn.next_event().await
+                                {
+                                    // This bridge chooses not to echo a
+                                    // client's own events back to it.
+                                    if event.pubkey == own_pubkey {
+                                        continue;
+                                    }
+                                    let frame = BridgeFrame::Event {
+                                        channel_id,
+                                        event: Box::new(event),
+                                    };
+                                    if out_tx.send(frame).await.is_err() {
+                                        return;
+                                    }
+                                }
+                            });
+                            // Re-subscribing replaces the previous pump.
+                            if let Some(old) = pumps.insert(channel_id, pump) {
+                                old.abort();
+                            }
+                        }
+                        Ok(Some(ClientFrame::Unsubscribe { channel_id })) => {
+                            if let Some(pump) = pumps.remove(&channel_id) {
+                                pump.abort();
+                            }
+                        }
+                        Ok(Some(ClientFrame::Event { event })) => {
+                            let event_id = event.id.clone();
+                            if let Err(e) = publisher.try_publish(*event) {
+                                let nack = BridgeFrame::Ok {
+                                    event_id,
+                                    accepted: false,
+                                    message: e.to_string(),
+                                };
+                                let _ = out_tx.send(nack).await;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                for pump in pumps.into_values() {
+                    pump.abort();
+                }
+            });
+        }
+    });
+
+    (format!("ws://127.0.0.1:{}/bridge", addr.port()), subs_rx)
+}
+
+async fn connect(url: &str, pubkey: String) -> RemoteTransport {
+    RemoteTransport::connect(RemoteTransportConfig {
+        url: url.to_string(),
+        pubkey,
+        token: None,
+        allow_insecure: false,
+        socks_proxy: None,
+    })
+    .await
+    .unwrap()
+}
+
+async fn recv(transport: &mut dyn Transport) -> TransportEvent {
+    timeout(TEST_TIMEOUT, transport.next_event())
+        .await
+        .expect("timed out waiting for an event")
+        .expect("stream ended unexpectedly")
+}
+
+#[tokio::test]
+async fn two_remote_clients_exchange_events_through_a_hub_backed_bridge() {
+    let hub = InMemoryHub::new();
+    let (url, mut subs_seen) = spawn_hub_bridge(hub).await;
+
+    let alice_keys = Keys::generate();
+    let bob_keys = Keys::generate();
+    let alice_pubkey = alice_keys.public_key().to_hex();
+    let bob_pubkey = bob_keys.public_key().to_hex();
+    let channel = Uuid::new_v4();
+
+    let mut alice: Box<dyn Transport> = Box::new(connect(&url, alice_pubkey.clone()).await);
+    let mut bob: Box<dyn Transport> = Box::new(connect(&url, bob_pubkey.clone()).await);
+
+    alice.subscribe(Subscription::all(channel)).await.unwrap();
+    bob.subscribe(Subscription::all(channel)).await.unwrap();
+
+    // Wait until the bridge has both subscriptions live on the hub —
+    // publishing earlier could race the (fire-and-forget) subscribe frames.
+    let mut pending = vec![alice_pubkey.clone(), bob_pubkey.clone()];
+    while !pending.is_empty() {
+        let (pubkey, sub_channel) = timeout(TEST_TIMEOUT, subs_seen.recv())
+            .await
+            .expect("timed out waiting for subscriptions to register")
+            .expect("bridge stopped");
+        assert_eq!(sub_channel, channel);
+        pending.retain(|p| p != &pubkey);
+    }
+
+    // Alice → hub → Bob.
+    alice
+        .publish(signed_event(&alice_keys, channel, "hi bob"))
+        .await
+        .unwrap();
+    let bob_got = recv(bob.as_mut()).await;
+    assert_eq!(bob_got.channel_id, channel);
+    assert_eq!(bob_got.event.content, "hi bob");
+    assert_eq!(bob_got.event.pubkey, alice_pubkey);
+    bob_got.event.verify().unwrap();
+
+    // Bob → hub → Alice. Alice's first delivery is Bob's reply, not an echo
+    // of her own event.
+    bob.publish(signed_event(&bob_keys, channel, "hi alice"))
+        .await
+        .unwrap();
+    let alice_got = recv(alice.as_mut()).await;
+    assert_eq!(alice_got.event.content, "hi alice");
+    assert_eq!(alice_got.event.pubkey, bob_pubkey);
+
+    alice.shutdown().await;
+    bob.shutdown().await;
+}

--- a/crates/buzz-transport/tests/in_memory_stream.rs
+++ b/crates/buzz-transport/tests/in_memory_stream.rs
@@ -1,0 +1,237 @@
+//! Integration tests for the seam contract against the in-memory hub —
+//! several participants exchanging signed events through `Box<dyn Transport>`
+//! with no I/O at all.
+
+use buzz_transport::memory::InMemoryHub;
+use buzz_transport::{SignedEvent, Subscription, Transport, TransportError};
+use nostr::{EventBuilder, Keys, Kind, Tag};
+use tokio::time::{timeout, Duration};
+use uuid::Uuid;
+
+/// Build a signed event in `channel`, optionally `p`-tagging a mention.
+fn signed_event(
+    keys: &Keys,
+    kind: u16,
+    channel: Uuid,
+    content: &str,
+    mention: Option<&str>,
+) -> SignedEvent {
+    let mut tags = vec![Tag::parse(["h", &channel.to_string()]).unwrap()];
+    if let Some(pubkey) = mention {
+        tags.push(Tag::parse(["p", pubkey]).unwrap());
+    }
+    let event = EventBuilder::new(Kind::Custom(kind), content)
+        .tags(tags)
+        .sign_with_keys(keys)
+        .unwrap();
+    SignedEvent::from_nostr(&event).unwrap()
+}
+
+async fn recv(transport: &mut Box<dyn Transport>) -> buzz_transport::TransportEvent {
+    timeout(Duration::from_secs(5), transport.next_event())
+        .await
+        .expect("timed out waiting for an event")
+        .expect("stream ended unexpectedly")
+}
+
+#[tokio::test]
+async fn events_fan_out_between_participants() {
+    let hub = InMemoryHub::new();
+    let alice_keys = Keys::generate();
+    let bob_keys = Keys::generate();
+    let channel = Uuid::new_v4();
+
+    let mut alice: Box<dyn Transport> = Box::new(hub.connect(alice_keys.public_key().to_hex()));
+    let mut bob: Box<dyn Transport> = Box::new(hub.connect(bob_keys.public_key().to_hex()));
+    let mut carol: Box<dyn Transport> = Box::new(hub.connect("carol".to_string()));
+
+    for t in [&mut alice, &mut bob, &mut carol] {
+        t.subscribe(Subscription::all(channel)).await.unwrap();
+    }
+
+    alice
+        .publish(signed_event(&alice_keys, 9, channel, "hi from alice", None))
+        .await
+        .unwrap();
+
+    // Both other participants receive it; the payload survives intact and
+    // still verifies on the receiving side.
+    for receiver in [&mut bob, &mut carol] {
+        let received = recv(receiver).await;
+        assert_eq!(received.channel_id, channel);
+        assert_eq!(received.event.content, "hi from alice");
+        assert_eq!(received.event.pubkey, alice_keys.public_key().to_hex());
+        received.event.verify().unwrap();
+    }
+
+    // Alice never sees her own echo: the next thing she receives is Bob's
+    // reply, not her own event.
+    bob.publish(signed_event(&bob_keys, 9, channel, "hi back", None))
+        .await
+        .unwrap();
+    let alice_got = recv(&mut alice).await;
+    assert_eq!(alice_got.event.content, "hi back");
+}
+
+#[tokio::test]
+async fn subscription_filters_gate_delivery() {
+    let hub = InMemoryHub::new();
+    let sender_keys = Keys::generate();
+    let receiver_pubkey = Keys::generate().public_key().to_hex();
+    let channel = Uuid::new_v4();
+
+    let sender = hub.connect(sender_keys.public_key().to_hex());
+    let mut receiver: Box<dyn Transport> = Box::new(hub.connect(receiver_pubkey.clone()));
+
+    receiver
+        .subscribe(Subscription {
+            channel_id: channel,
+            kinds: Some(vec![9]),
+            require_mention: true,
+            replay_since: None,
+        })
+        .await
+        .unwrap();
+
+    // Filtered out: wrong kind, then right kind without a mention, then an
+    // unsubscribed channel entirely.
+    sender
+        .publish(signed_event(
+            &sender_keys,
+            7,
+            channel,
+            "reaction",
+            Some(&receiver_pubkey),
+        ))
+        .await
+        .unwrap();
+    sender
+        .publish(signed_event(&sender_keys, 9, channel, "no mention", None))
+        .await
+        .unwrap();
+    sender
+        .publish(signed_event(
+            &sender_keys,
+            9,
+            Uuid::new_v4(),
+            "elsewhere",
+            Some(&receiver_pubkey),
+        ))
+        .await
+        .unwrap();
+    // Delivered: right channel, right kind, mentions the receiver.
+    sender
+        .publish(signed_event(
+            &sender_keys,
+            9,
+            channel,
+            "for you",
+            Some(&receiver_pubkey),
+        ))
+        .await
+        .unwrap();
+
+    let received = recv(&mut receiver).await;
+    assert_eq!(received.event.content, "for you");
+}
+
+#[tokio::test]
+async fn unsubscribe_and_resubscribe_take_effect() {
+    let hub = InMemoryHub::new();
+    let sender_keys = Keys::generate();
+    let muted = Uuid::new_v4();
+    let open = Uuid::new_v4();
+
+    let sender = hub.connect(sender_keys.public_key().to_hex());
+    let mut receiver: Box<dyn Transport> = Box::new(hub.connect("receiver".to_string()));
+
+    receiver.subscribe(Subscription::all(muted)).await.unwrap();
+    receiver.subscribe(Subscription::all(open)).await.unwrap();
+    receiver.unsubscribe(muted).await.unwrap();
+
+    sender
+        .publish(signed_event(&sender_keys, 9, muted, "unwanted", None))
+        .await
+        .unwrap();
+    sender
+        .publish(signed_event(&sender_keys, 9, open, "wanted", None))
+        .await
+        .unwrap();
+    assert_eq!(recv(&mut receiver).await.event.content, "wanted");
+
+    // Re-subscribing replaces the previous subscription: narrow `open` to a
+    // kind the sender doesn't use and delivery stops.
+    receiver
+        .subscribe(Subscription {
+            channel_id: open,
+            kinds: Some(vec![7]),
+            require_mention: false,
+            replay_since: None,
+        })
+        .await
+        .unwrap();
+    sender
+        .publish(signed_event(&sender_keys, 9, open, "now filtered", None))
+        .await
+        .unwrap();
+    sender
+        .publish(signed_event(&sender_keys, 7, open, "reaction", None))
+        .await
+        .unwrap();
+    assert_eq!(recv(&mut receiver).await.event.content, "reaction");
+}
+
+#[tokio::test]
+async fn invalid_events_are_rejected_at_publish() {
+    let hub = InMemoryHub::new();
+    let keys = Keys::generate();
+    let channel = Uuid::new_v4();
+    let transport = hub.connect(keys.public_key().to_hex());
+
+    // Tampered content: signature no longer covers the payload.
+    let mut tampered = signed_event(&keys, 9, channel, "original", None);
+    tampered.content = "tampered".into();
+    assert!(matches!(
+        transport.try_publish(tampered),
+        Err(TransportError::InvalidEvent(_))
+    ));
+
+    // Validly signed but not channel-scoped: nothing to route by.
+    let event = EventBuilder::new(Kind::Custom(9), "no channel")
+        .sign_with_keys(&keys)
+        .unwrap();
+    let unrouted = SignedEvent::from_nostr(&event).unwrap();
+    assert!(matches!(
+        transport.try_publish(unrouted),
+        Err(TransportError::InvalidEvent(_))
+    ));
+}
+
+#[tokio::test]
+async fn reconnect_keeps_the_stream_usable() {
+    let hub = InMemoryHub::new();
+    let sender_keys = Keys::generate();
+    let channel = Uuid::new_v4();
+
+    let sender = hub.connect(sender_keys.public_key().to_hex());
+    let mut receiver: Box<dyn Transport> = Box::new(hub.connect("receiver".to_string()));
+    receiver
+        .subscribe(Subscription::all(channel))
+        .await
+        .unwrap();
+
+    receiver.reconnect().await.unwrap();
+    sender
+        .publish(signed_event(
+            &sender_keys,
+            9,
+            channel,
+            "after reconnect",
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(recv(&mut receiver).await.event.content, "after reconnect");
+
+    receiver.shutdown().await;
+}

--- a/crates/buzz-transport/tests/remote_bridge.rs
+++ b/crates/buzz-transport/tests/remote_bridge.rs
@@ -1,0 +1,722 @@
+//! Integration tests for [`RemoteTransport`] against an in-process fake
+//! bridge speaking protocol v1 over a real WebSocket — dialed directly and
+//! through an in-process SOCKS5 proxy.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use buzz_transport::protocol::{
+    encode_bridge_frame, parse_client_frame, BridgeFrame, ClientFrame, MAX_FRAME_BYTES,
+    PROTOCOL_VERSION,
+};
+use buzz_transport::remote::{RemoteTransport, RemoteTransportConfig};
+use buzz_transport::{SignedEvent, Subscription, Transport, TransportError};
+use futures_util::{SinkExt, StreamExt};
+use nostr::{EventBuilder, Keys, Kind};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
+use tokio_tungstenite::tungstenite::Message;
+use uuid::Uuid;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn signed_event(content: &str) -> SignedEvent {
+    let event = EventBuilder::new(Kind::Custom(9), content)
+        .sign_with_keys(&Keys::generate())
+        .unwrap();
+    SignedEvent::from_nostr(&event).unwrap()
+}
+
+/// Instructions from a test to one bridge connection.
+enum BridgeSend {
+    Frame(BridgeFrame),
+    Close,
+}
+
+/// One accepted bridge connection, post-handshake.
+struct BridgeConn {
+    /// Pubkey the client announced in its `hello`.
+    hello_pubkey: String,
+    /// Token carried in the `hello` frame, if any.
+    hello_token: Option<String>,
+    /// `Authorization` header from the WebSocket upgrade, if any.
+    auth_header: Option<String>,
+    /// Client frames received after `hello`.
+    frames: mpsc::Receiver<ClientFrame>,
+    /// Sends frames (or a close) to the client.
+    send: mpsc::Sender<BridgeSend>,
+}
+
+/// Spawn a fake bridge that accepts connections, answers `hello` with a
+/// `hello_ack` carrying `ack_version`, and hands each connection to the test.
+// The Err variant's size is fixed by tungstenite's `accept_hdr_async`
+// callback signature.
+#[allow(clippy::result_large_err)]
+async fn spawn_bridge(ack_version: u32) -> (String, mpsc::Receiver<BridgeConn>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (conn_tx, conn_rx) = mpsc::channel(4);
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                return;
+            };
+            let conn_tx = conn_tx.clone();
+            tokio::spawn(async move {
+                let auth_slot: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+                let slot = Arc::clone(&auth_slot);
+                let callback = move |req: &Request, resp: Response| {
+                    *slot.lock().unwrap() = req
+                        .headers()
+                        .get("authorization")
+                        .and_then(|v| v.to_str().ok())
+                        .map(str::to_owned);
+                    Ok(resp)
+                };
+                let mut ws = tokio_tungstenite::accept_hdr_async(stream, callback)
+                    .await
+                    .unwrap();
+
+                // Handshake: expect hello, reply hello_ack.
+                let (hello_pubkey, hello_token) = loop {
+                    match ws.next().await {
+                        Some(Ok(Message::Text(text))) => {
+                            match parse_client_frame(text.as_str()).unwrap() {
+                                Some(ClientFrame::Hello {
+                                    version,
+                                    pubkey,
+                                    token,
+                                }) => {
+                                    assert_eq!(version, PROTOCOL_VERSION);
+                                    break (pubkey, token);
+                                }
+                                other => panic!("expected hello, got {other:?}"),
+                            }
+                        }
+                        Some(Ok(_)) => continue,
+                        other => panic!("connection ended before hello: {other:?}"),
+                    }
+                };
+                let ack = BridgeFrame::HelloAck {
+                    version: ack_version,
+                };
+                ws.send(Message::Text(encode_bridge_frame(&ack).unwrap().into()))
+                    .await
+                    .unwrap();
+
+                let (frame_tx, frame_rx) = mpsc::channel(64);
+                let (send_tx, mut send_rx) = mpsc::channel(64);
+                let auth_header = auth_slot.lock().unwrap().clone();
+                if conn_tx
+                    .send(BridgeConn {
+                        hello_pubkey,
+                        hello_token,
+                        auth_header,
+                        frames: frame_rx,
+                        send: send_tx,
+                    })
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+
+                loop {
+                    tokio::select! {
+                        out = send_rx.recv() => match out {
+                            Some(BridgeSend::Frame(frame)) => {
+                                let text = encode_bridge_frame(&frame).unwrap();
+                                if ws.send(Message::Text(text.into())).await.is_err() {
+                                    return;
+                                }
+                            }
+                            Some(BridgeSend::Close) | None => {
+                                let _ = ws.close(None).await;
+                                return;
+                            }
+                        },
+                        msg = ws.next() => match msg {
+                            Some(Ok(Message::Text(text))) => {
+                                if let Ok(Some(frame)) = parse_client_frame(text.as_str()) {
+                                    if frame_tx.send(frame).await.is_err() {
+                                        return;
+                                    }
+                                }
+                            }
+                            Some(Ok(Message::Close(_))) | None | Some(Err(_)) => return,
+                            Some(Ok(_)) => {}
+                        },
+                    }
+                }
+            });
+        }
+    });
+
+    (format!("ws://127.0.0.1:{}/bridge", addr.port()), conn_rx)
+}
+
+fn config(url: &str, pubkey: &str, token: Option<&str>) -> RemoteTransportConfig {
+    RemoteTransportConfig {
+        url: url.to_string(),
+        pubkey: pubkey.to_string(),
+        token: token.map(str::to_owned),
+        allow_insecure: false,
+        socks_proxy: None,
+    }
+}
+
+/// Spawn a fake bridge listening on a Unix domain socket, speaking the same
+/// protocol as [`spawn_bridge`] but with one LF-terminated JSON frame per
+/// line. Returns a `unix://` URL for [`RemoteTransportConfig::url`].
+#[cfg(unix)]
+async fn spawn_unix_bridge(ack_version: u32) -> (String, mpsc::Receiver<BridgeConn>) {
+    use tokio_util::codec::{Framed, LinesCodec};
+
+    // Unix socket paths must stay under SUN_LEN (104 bytes on macOS) —
+    // keep the name short.
+    let suffix = Uuid::new_v4().simple().to_string();
+    let path =
+        std::env::temp_dir().join(format!("bzt-{}-{}.sock", std::process::id(), &suffix[..8]));
+    let listener = tokio::net::UnixListener::bind(&path).unwrap();
+    let (conn_tx, conn_rx) = mpsc::channel(4);
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                return;
+            };
+            let conn_tx = conn_tx.clone();
+            tokio::spawn(async move {
+                let mut framed =
+                    Framed::new(stream, LinesCodec::new_with_max_length(MAX_FRAME_BYTES));
+
+                // Handshake: expect hello, reply hello_ack.
+                let (hello_pubkey, hello_token) = match framed.next().await {
+                    Some(Ok(line)) => match parse_client_frame(&line).unwrap() {
+                        Some(ClientFrame::Hello {
+                            version,
+                            pubkey,
+                            token,
+                        }) => {
+                            assert_eq!(version, PROTOCOL_VERSION);
+                            (pubkey, token)
+                        }
+                        other => panic!("expected hello, got {other:?}"),
+                    },
+                    other => panic!("connection ended before hello: {other:?}"),
+                };
+                let ack = BridgeFrame::HelloAck {
+                    version: ack_version,
+                };
+                framed
+                    .send(encode_bridge_frame(&ack).unwrap())
+                    .await
+                    .unwrap();
+
+                let (frame_tx, frame_rx) = mpsc::channel(64);
+                let (send_tx, mut send_rx) = mpsc::channel(64);
+                if conn_tx
+                    .send(BridgeConn {
+                        hello_pubkey,
+                        hello_token,
+                        auth_header: None,
+                        frames: frame_rx,
+                        send: send_tx,
+                    })
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+
+                loop {
+                    tokio::select! {
+                        out = send_rx.recv() => match out {
+                            Some(BridgeSend::Frame(frame)) => {
+                                let text = encode_bridge_frame(&frame).unwrap();
+                                if framed.send(text).await.is_err() {
+                                    return;
+                                }
+                            }
+                            Some(BridgeSend::Close) | None => {
+                                let _ = SinkExt::<String>::close(&mut framed).await;
+                                return;
+                            }
+                        },
+                        line = framed.next() => match line {
+                            Some(Ok(text)) => {
+                                if let Ok(Some(frame)) = parse_client_frame(&text) {
+                                    if frame_tx.send(frame).await.is_err() {
+                                        return;
+                                    }
+                                }
+                            }
+                            None | Some(Err(_)) => return,
+                        },
+                    }
+                }
+            });
+        }
+    });
+
+    (format!("unix://{}", path.display()), conn_rx)
+}
+
+/// Authentication the fake SOCKS5 proxy demands from clients.
+enum SocksAuth {
+    None,
+    UserPass {
+        user: &'static str,
+        pass: &'static str,
+    },
+}
+
+/// Spawn a minimal in-process SOCKS5 server (RFC 1928 CONNECT, optional
+/// RFC 1929 auth). Returns its URL and a counter of established tunnels.
+async fn spawn_socks5(auth: SocksAuth) -> (String, Arc<AtomicUsize>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let tunnels = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&tunnels);
+    let auth = Arc::new(auth);
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut client, _)) = listener.accept().await else {
+                return;
+            };
+            let counter = Arc::clone(&counter);
+            let auth = Arc::clone(&auth);
+            tokio::spawn(async move {
+                // Method negotiation.
+                let mut head = [0u8; 2];
+                client.read_exact(&mut head).await.unwrap();
+                assert_eq!(head[0], 0x05, "client must speak SOCKS5");
+                let mut methods = vec![0u8; head[1] as usize];
+                client.read_exact(&mut methods).await.unwrap();
+                match &*auth {
+                    SocksAuth::None => {
+                        assert!(methods.contains(&0x00), "client must offer no-auth");
+                        client.write_all(&[0x05, 0x00]).await.unwrap();
+                    }
+                    SocksAuth::UserPass { user, pass } => {
+                        if !methods.contains(&0x02) {
+                            client.write_all(&[0x05, 0xFF]).await.unwrap();
+                            return;
+                        }
+                        client.write_all(&[0x05, 0x02]).await.unwrap();
+                        let mut ver_ulen = [0u8; 2];
+                        client.read_exact(&mut ver_ulen).await.unwrap();
+                        assert_eq!(ver_ulen[0], 0x01);
+                        let mut username = vec![0u8; ver_ulen[1] as usize];
+                        client.read_exact(&mut username).await.unwrap();
+                        let mut plen = [0u8; 1];
+                        client.read_exact(&mut plen).await.unwrap();
+                        let mut password = vec![0u8; plen[0] as usize];
+                        client.read_exact(&mut password).await.unwrap();
+                        if username == user.as_bytes() && password == pass.as_bytes() {
+                            client.write_all(&[0x01, 0x00]).await.unwrap();
+                        } else {
+                            client.write_all(&[0x01, 0x01]).await.unwrap();
+                            return;
+                        }
+                    }
+                }
+
+                // CONNECT: parse the target, dial it, splice the streams.
+                let mut request = [0u8; 4];
+                client.read_exact(&mut request).await.unwrap();
+                assert_eq!(&request[..3], &[0x05, 0x01, 0x00]);
+                let target_host = match request[3] {
+                    0x01 => {
+                        let mut octets = [0u8; 4];
+                        client.read_exact(&mut octets).await.unwrap();
+                        std::net::IpAddr::from(octets).to_string()
+                    }
+                    0x03 => {
+                        let mut len = [0u8; 1];
+                        client.read_exact(&mut len).await.unwrap();
+                        let mut domain = vec![0u8; len[0] as usize];
+                        client.read_exact(&mut domain).await.unwrap();
+                        String::from_utf8(domain).unwrap()
+                    }
+                    0x04 => {
+                        let mut octets = [0u8; 16];
+                        client.read_exact(&mut octets).await.unwrap();
+                        std::net::IpAddr::from(octets).to_string()
+                    }
+                    other => panic!("unexpected SOCKS5 address type {other}"),
+                };
+                let mut port_bytes = [0u8; 2];
+                client.read_exact(&mut port_bytes).await.unwrap();
+                let target_port = u16::from_be_bytes(port_bytes);
+
+                let mut upstream =
+                    tokio::net::TcpStream::connect((target_host.as_str(), target_port))
+                        .await
+                        .unwrap();
+                client
+                    .write_all(&[0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+                    .await
+                    .unwrap();
+                counter.fetch_add(1, Ordering::SeqCst);
+                let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream).await;
+            });
+        }
+    });
+
+    (format!("socks5://127.0.0.1:{}", addr.port()), tunnels)
+}
+
+async fn next_frame(conn: &mut BridgeConn) -> ClientFrame {
+    timeout(TEST_TIMEOUT, conn.frames.recv())
+        .await
+        .expect("timed out waiting for client frame")
+        .expect("bridge connection ended")
+}
+
+#[tokio::test]
+async fn full_roundtrip_through_a_fake_bridge() {
+    let (url, mut conns) = spawn_bridge(PROTOCOL_VERSION).await;
+    let pubkey = Keys::generate().public_key().to_hex();
+
+    let mut transport: Box<dyn Transport> = Box::new(
+        RemoteTransport::connect(config(&url, &pubkey, Some("sekrit")))
+            .await
+            .unwrap(),
+    );
+    let mut conn = timeout(TEST_TIMEOUT, conns.recv()).await.unwrap().unwrap();
+    assert_eq!(conn.hello_pubkey, pubkey);
+    assert_eq!(conn.auth_header.as_deref(), Some("Bearer sekrit"));
+    assert_eq!(
+        conn.hello_token.as_deref(),
+        Some("sekrit"),
+        "the token must also ride in the hello frame"
+    );
+
+    // Subscribe → the bridge sees the subscription verbatim.
+    let channel_id = Uuid::new_v4();
+    transport
+        .subscribe(Subscription {
+            channel_id,
+            kinds: Some(vec![9, 40002]),
+            require_mention: true,
+            replay_since: Some(42),
+        })
+        .await
+        .unwrap();
+    match next_frame(&mut conn).await {
+        ClientFrame::Subscribe {
+            channel_id: ch,
+            kinds,
+            require_mention,
+            replay_since,
+        } => {
+            assert_eq!(ch, channel_id);
+            assert_eq!(kinds, Some(vec![9, 40002]));
+            assert!(require_mention);
+            assert_eq!(replay_since, Some(42));
+        }
+        other => panic!("expected subscribe frame, got {other:?}"),
+    }
+
+    // Bridge → client: a tampered event is dropped, a valid one delivered.
+    let mut tampered = signed_event("evil");
+    tampered.content = "tampered".to_string();
+    conn.send
+        .send(BridgeSend::Frame(BridgeFrame::Event {
+            channel_id,
+            event: Box::new(tampered),
+        }))
+        .await
+        .unwrap();
+    let valid = signed_event("hello from the bridge");
+    conn.send
+        .send(BridgeSend::Frame(BridgeFrame::Event {
+            channel_id,
+            event: Box::new(valid.clone()),
+        }))
+        .await
+        .unwrap();
+    let received = timeout(TEST_TIMEOUT, transport.next_event())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(received.channel_id, channel_id);
+    assert_eq!(
+        received.event, valid,
+        "the tampered event must be dropped; only the valid one delivered"
+    );
+
+    // Client → bridge: publish and try_publish both land as event frames.
+    let outbound = signed_event("hello from the agent");
+    transport.publish(outbound.clone()).await.unwrap();
+    match next_frame(&mut conn).await {
+        ClientFrame::Event { event } => assert_eq!(*event, outbound),
+        other => panic!("expected event frame, got {other:?}"),
+    }
+    let ephemeral = signed_event("typing…");
+    transport.try_publish(ephemeral.clone()).unwrap();
+    match next_frame(&mut conn).await {
+        ClientFrame::Event { event } => assert_eq!(*event, ephemeral),
+        other => panic!("expected event frame, got {other:?}"),
+    }
+
+    // Unsubscribe reaches the bridge.
+    transport.unsubscribe(channel_id).await.unwrap();
+    match next_frame(&mut conn).await {
+        ClientFrame::Unsubscribe { channel_id: ch } => assert_eq!(ch, channel_id),
+        other => panic!("expected unsubscribe frame, got {other:?}"),
+    }
+
+    timeout(TEST_TIMEOUT, transport.shutdown()).await.unwrap();
+}
+
+#[tokio::test]
+async fn version_mismatch_fails_the_handshake() {
+    let (url, _conns) = spawn_bridge(PROTOCOL_VERSION + 1).await;
+    let pubkey = Keys::generate().public_key().to_hex();
+    let err = RemoteTransport::connect(config(&url, &pubkey, None))
+        .await
+        .expect_err("handshake must fail on version mismatch");
+    assert!(matches!(err, TransportError::Protocol(_)), "{err:?}");
+}
+
+#[tokio::test]
+async fn plaintext_ws_to_remote_host_is_rejected_before_dialing() {
+    // 192.0.2.0/24 is TEST-NET-1: never routable, and never dialed here
+    // because validation rejects the URL first.
+    let pubkey = Keys::generate().public_key().to_hex();
+    let err = RemoteTransport::connect(config("ws://192.0.2.1:9/bridge", &pubkey, None))
+        .await
+        .expect_err("plaintext ws:// to a remote host must be rejected");
+    assert!(matches!(err, TransportError::Insecure(_)), "{err:?}");
+}
+
+#[tokio::test]
+async fn reconnect_resubscribes_and_flushes_buffered_publishes() {
+    let (url, mut conns) = spawn_bridge(PROTOCOL_VERSION).await;
+    let pubkey = Keys::generate().public_key().to_hex();
+
+    let mut transport: Box<dyn Transport> = Box::new(
+        RemoteTransport::connect(config(&url, &pubkey, None))
+            .await
+            .unwrap(),
+    );
+    let mut conn1 = timeout(TEST_TIMEOUT, conns.recv()).await.unwrap().unwrap();
+
+    let channel_id = Uuid::new_v4();
+    transport
+        .subscribe(Subscription::all(channel_id))
+        .await
+        .unwrap();
+    assert!(matches!(
+        next_frame(&mut conn1).await,
+        ClientFrame::Subscribe { .. }
+    ));
+
+    // Bridge drops the connection: next_event yields the loss marker.
+    conn1.send.send(BridgeSend::Close).await.unwrap();
+    assert!(
+        timeout(TEST_TIMEOUT, transport.next_event())
+            .await
+            .unwrap()
+            .is_none(),
+        "connection loss must surface as None"
+    );
+
+    // Publish while disconnected — buffered, not lost.
+    let buffered = signed_event("published while offline");
+    transport.publish(buffered.clone()).await.unwrap();
+
+    // Reconnect: the transport re-dials, replays the subscription, then
+    // flushes the buffered publish — in that order.
+    transport.reconnect().await.unwrap();
+    let mut conn2 = timeout(TEST_TIMEOUT, conns.recv()).await.unwrap().unwrap();
+    match next_frame(&mut conn2).await {
+        ClientFrame::Subscribe { channel_id: ch, .. } => assert_eq!(ch, channel_id),
+        other => panic!("expected resubscription first, got {other:?}"),
+    }
+    match next_frame(&mut conn2).await {
+        ClientFrame::Event { event } => assert_eq!(*event, buffered),
+        other => panic!("expected buffered publish, got {other:?}"),
+    }
+
+    // Live delivery works again on the new connection.
+    let live = signed_event("after reconnect");
+    conn2
+        .send
+        .send(BridgeSend::Frame(BridgeFrame::Event {
+            channel_id,
+            event: Box::new(live.clone()),
+        }))
+        .await
+        .unwrap();
+    let received = timeout(TEST_TIMEOUT, transport.next_event())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(received.event, live);
+
+    timeout(TEST_TIMEOUT, transport.shutdown()).await.unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn roundtrip_over_a_unix_socket() {
+    let (url, mut conns) = spawn_unix_bridge(PROTOCOL_VERSION).await;
+    let pubkey = Keys::generate().public_key().to_hex();
+
+    // A unix:// carrier has no HTTP headers — the token rides in `hello`.
+    let mut transport: Box<dyn Transport> = Box::new(
+        RemoteTransport::connect(config(&url, &pubkey, Some("sock-sekrit")))
+            .await
+            .unwrap(),
+    );
+    let mut conn = timeout(TEST_TIMEOUT, conns.recv()).await.unwrap().unwrap();
+    assert_eq!(conn.hello_pubkey, pubkey);
+    assert_eq!(conn.hello_token.as_deref(), Some("sock-sekrit"));
+
+    // Full duplex over the socket: subscribe, receive, publish.
+    let channel_id = Uuid::new_v4();
+    transport
+        .subscribe(Subscription::all(channel_id))
+        .await
+        .unwrap();
+    assert!(matches!(
+        next_frame(&mut conn).await,
+        ClientFrame::Subscribe { .. }
+    ));
+
+    let inbound = signed_event("hello over the unix socket");
+    conn.send
+        .send(BridgeSend::Frame(BridgeFrame::Event {
+            channel_id,
+            event: Box::new(inbound.clone()),
+        }))
+        .await
+        .unwrap();
+    let received = timeout(TEST_TIMEOUT, transport.next_event())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(received.channel_id, channel_id);
+    assert_eq!(received.event, inbound);
+
+    let outbound = signed_event("published over the unix socket");
+    transport.publish(outbound.clone()).await.unwrap();
+    match next_frame(&mut conn).await {
+        ClientFrame::Event { event } => assert_eq!(*event, outbound),
+        other => panic!("expected event frame, got {other:?}"),
+    }
+
+    timeout(TEST_TIMEOUT, transport.shutdown()).await.unwrap();
+}
+
+#[tokio::test]
+async fn roundtrip_through_a_socks5_proxy() {
+    let (bridge_url, mut conns) = spawn_bridge(PROTOCOL_VERSION).await;
+    let (proxy_url, tunnels) = spawn_socks5(SocksAuth::None).await;
+    let pubkey = Keys::generate().public_key().to_hex();
+
+    // Loopback destination through a loopback proxy — allowed without the
+    // insecure opt-in.
+    let mut cfg = config(&bridge_url, &pubkey, None);
+    cfg.socks_proxy = Some(proxy_url);
+    let mut transport: Box<dyn Transport> = Box::new(RemoteTransport::connect(cfg).await.unwrap());
+
+    let mut conn = timeout(TEST_TIMEOUT, conns.recv()).await.unwrap().unwrap();
+    assert_eq!(conn.hello_pubkey, pubkey);
+    assert_eq!(
+        tunnels.load(Ordering::SeqCst),
+        1,
+        "the connection must actually flow through the proxy"
+    );
+
+    // Full duplex through the tunnel: subscribe, receive, publish.
+    let channel_id = Uuid::new_v4();
+    transport
+        .subscribe(Subscription::all(channel_id))
+        .await
+        .unwrap();
+    assert!(matches!(
+        next_frame(&mut conn).await,
+        ClientFrame::Subscribe { .. }
+    ));
+
+    let inbound = signed_event("hello through the tunnel");
+    conn.send
+        .send(BridgeSend::Frame(BridgeFrame::Event {
+            channel_id,
+            event: Box::new(inbound.clone()),
+        }))
+        .await
+        .unwrap();
+    let received = timeout(TEST_TIMEOUT, transport.next_event())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(received.event, inbound);
+
+    let outbound = signed_event("published through the tunnel");
+    transport.publish(outbound.clone()).await.unwrap();
+    match next_frame(&mut conn).await {
+        ClientFrame::Event { event } => assert_eq!(*event, outbound),
+        other => panic!("expected event frame, got {other:?}"),
+    }
+
+    timeout(TEST_TIMEOUT, transport.shutdown()).await.unwrap();
+}
+
+#[tokio::test]
+async fn socks5_username_password_authentication() {
+    let (bridge_url, mut conns) = spawn_bridge(PROTOCOL_VERSION).await;
+    let (proxy_url, tunnels) = spawn_socks5(SocksAuth::UserPass {
+        user: "agent",
+        pass: "hunter2",
+    })
+    .await;
+    let pubkey = Keys::generate().public_key().to_hex();
+
+    // Wrong password: the proxy rejects the subnegotiation and the dial
+    // fails as a connection error.
+    let mut wrong = config(&bridge_url, &pubkey, None);
+    wrong.socks_proxy = Some(proxy_url.replace("socks5://", "socks5://agent:nope@"));
+    let err = RemoteTransport::connect(wrong)
+        .await
+        .expect_err("wrong proxy credentials must fail the dial");
+    assert!(matches!(err, TransportError::Connection(_)), "{err:?}");
+    assert_eq!(tunnels.load(Ordering::SeqCst), 0);
+
+    // Correct credentials: the tunnel opens and the handshake completes.
+    let mut cfg = config(&bridge_url, &pubkey, None);
+    cfg.socks_proxy = Some(proxy_url.replace("socks5://", "socks5://agent:hunter2@"));
+    let transport = RemoteTransport::connect(cfg).await.unwrap();
+    let conn = timeout(TEST_TIMEOUT, conns.recv()).await.unwrap().unwrap();
+    assert_eq!(conn.hello_pubkey, pubkey);
+    assert_eq!(tunnels.load(Ordering::SeqCst), 1);
+
+    timeout(TEST_TIMEOUT, Box::new(transport).shutdown())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn plaintext_ws_through_a_proxy_to_a_remote_host_is_rejected() {
+    // Policy check happens before any dialing — the proxy never sees a
+    // connection and the TEST-NET destination is never reached.
+    let (proxy_url, tunnels) = spawn_socks5(SocksAuth::None).await;
+    let pubkey = Keys::generate().public_key().to_hex();
+    let mut cfg = config("ws://192.0.2.1:9/bridge", &pubkey, None);
+    cfg.socks_proxy = Some(proxy_url);
+    let err = RemoteTransport::connect(cfg)
+        .await
+        .expect_err("plaintext ws:// through a proxy to a remote host must be rejected");
+    assert!(matches!(err, TransportError::Insecure(_)), "{err:?}");
+    assert_eq!(tunnels.load(Ordering::SeqCst), 0);
+}


### PR DESCRIPTION
## What

Makes the event pipe pluggable. This PR introduces `crates/buzz-transport` — a `Transport` trait whose contract is **a bidirectional stream of signed events, nothing else** — plus three implementations:

- **Nostr relay** — `HarnessRelay` (the existing NIP-42 relay client in `buzz-acp`) now implements `Transport`, making today's relay connection just one implementation of the seam.
- **`RemoteTransport`** — dials a user-supplied bridge endpoint speaking a small documented JSON protocol ([`PROTOCOL.md`](crates/buzz-transport/PROTOCOL.md)), so anyone can bridge Buzz onto their own network (Slack, a private mesh, anything) in any language.
- **`memory::InMemoryHub`** — the reference implementation: a working in-process hub where participants exchange verified, `h`-tag-routed signed events with no I/O. It pins the seam contract (verification at publish, channel scoping, subscription matching, replace-on-resubscribe, no self-echo) and gives consumers a real stream to integration-test against. The scripted `MockTransport` (feature `test-utils`) remains for call-log assertions.

## Why

Today the harness is hard-wired to the Buzz relay socket. Everything a consumer needs already rides that socket as signed events — messages, membership, discovery, ephemeral signals — so the seam is naturally *one* stream. Extracting it as a trait lets people write their own network backend without touching Buzz internals, and without inventing REST side-channels.

## Design decisions

**Crate-owned `SignedEvent`, not `nostr::Event`.** The public API carries a plain-data struct (`id`, `pubkey`, `created_at`, `kind`, `tags`, `content`, `sig`). The nostr library is an internal detail used for verification and conversion; implementors of the trait and of bridges never need it. Inbound events are verified (id hash + Schnorr sig) and silently dropped on failure — a tampered event never reaches the consumer.

**No handshake at the seam.** The `Transport` trait is subscribe/publish/next_event/reconnect — a stream. The `hello`/`hello_ack` exchange exists only inside the remote bridge wire protocol, where it carries the consumer pubkey (for `require_mention`), the bearer token on raw-socket carriers, and a crisp version-mismatch error.

**Bridge protocol v1** (`PROTOCOL.md`): JSON frames, ≤524,288 bytes (the relay's default frame cap, so any event the relay accepts fits), forward-compatible (unknown frame types and unknown fields are ignored; breaking changes bump `version`). `ok`/`eose` are optional — the stream is fire-and-forget like the relay socket it mirrors. Channel discovery and membership ride the stream as events (kinds 39000/39002), not as APIs.

**Carriers.** The bridge URL scheme selects the carrier:

| Scheme | Carrier | Framing |
|---|---|---|
| `wss://` / `ws://` | WebSocket | one JSON object per text message |
| `unix:///path.sock` | Unix domain socket | NDJSON — one LF-terminated frame per line |

WebSocket carriers can additionally be tunneled through a **SOCKS5 proxy** (`socks5://[user:pass@]host:port`, RFC 1928 + RFC 1929 hand-rolled — no new heavy deps). Domain names are passed to the proxy verbatim (`socks5h` behavior), so overlay-only names like `.onion` resolve inside the private network.

**Security policy.** `wss://` always allowed. Plaintext `ws://` only to loopback, or to `.onion` through a **loopback** SOCKS5 proxy (Tor's encryption starts at the proxy, so the proxy must be on-machine), or with explicit `allow_insecure` opt-in — plaintext never silently leaves the machine. `unix://` is local by construction (filesystem permissions are the ACL). Bearer token travels as an `Authorization` header on WebSocket upgrade *and* in the `hello` frame (raw-socket carriers have no headers).

## Wiring

`buzz_acp::transport::connect_transport` selects the implementation from the environment:

| Variable | Values |
|---|---|
| `BUZZ_TRANSPORT` | `nostr` (default) \| `remote` |
| `BUZZ_TRANSPORT_URL` | `wss://…` \| `unix:///…` |
| `BUZZ_TRANSPORT_TOKEN` | optional bearer token |
| `BUZZ_TRANSPORT_SOCKS_PROXY` | `socks5://[user:pass@]host:port` |
| `BUZZ_TRANSPORT_ALLOW_INSECURE` | `true`/`1` |

## Testing

- 26 unit tests (frame codec, SignedEvent round-trip + verification, SOCKS5 URL parsing, TLS policy, publish buffering, `h`-tag routing, dyn-compatibility).
- 8 remote-bridge integration tests against in-process bridges: full round-trip over WebSocket, over a Unix socket, and through a real in-process SOCKS5 proxy (both no-auth and username/password, including wrong-password rejection and a tunnel-count assertion); version-mismatch handshake failure; plaintext-to-remote rejected before dialing (direct and proxied); reconnect re-subscribes and flushes buffered publishes.
- 5 in-memory integration tests driving multiple participants through `Box<dyn Transport>`: fan-out between three participants (with receive-side verification and no self-echo), kind + mention filters, unsubscribe/re-subscribe replacement, tampered/unroutable events rejected at publish, reconnect.
- 1 end-to-end test of the whole seam: two `RemoteTransport` clients speaking protocol v1 over real WebSockets to a bridge whose backing network is the `InMemoryHub` — exactly the shape of a production bridge, with the hub playing the private network. Alice's event reaches Bob (verified on receipt) and vice versa.
- 4 adapter tests in `buzz-acp`.
- `just ci` green.

## Scope / follow-ups

This PR proves the seam: the trait, both implementations, the protocol doc, and the env-driven factory. Converting the ACP harness main event loop to run on `Box<dyn Transport>` (it still uses the concrete `HarnessRelay` today) and refactoring `buzz-cli` onto the trait are deliberate follow-ups to keep this reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
