### PR TITLE
docs: link the community ecosystem index (awesome-buzz) from Going further

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ A Rust workspace of focused crates. Single source of truth: the relay. See [ARCH
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — system design, kind ranges, subsystem boundaries
 - **[TESTING.md](TESTING.md)** — multi-agent E2E test suite
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** · **[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)** · **[SECURITY.md](SECURITY.md)** · **[GOVERNANCE.md](GOVERNANCE.md)**
+- **Community:** [awesome-buzz](https://github.com/mpiv-ai/awesome-buzz) — curated index of third-party hook servers, deployment kits, SDKs, clients, and independent teardowns
 
 <details>
 <summary><strong>Configuration</strong> (env vars, defaults work for local dev)</summary>


### PR DESCRIPTION
Adds one line to **Going further** pointing at [awesome-buzz](https://github.com/mpiv-ai/awesome-buzz), a curated, verified index of the third-party ecosystem forming around buzz: hook servers implementing docs/MCP_DRIVEN_HOOKS.md, deployment kits (Railway/Coolify/StartOS/Nix), SDKs, independent iOS clients, and launch-week teardowns. Every entry is link-checked before merge and the list follows standard awesome-list contribution rules.

Disclosure: I maintain the index and one listed project (buzz-hooks, the first third-party implementations of the MCP hook convention). Happy to move the link elsewhere if there's a better home for ecosystem references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)