### PR TITLE
fix(discovery): inject PATH into Codex adapter planning

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -500,7 +500,9 @@ const overrides = new Map([
   // Includes unit tests for detection, routing, and -Command body preservation.
   // +16: test_powershell_command_goose_catalog_dequoted proves the \$→$ escape
   // fix for the Goose Windows installer (PR #2680 interaction with #2750).
-  ["src-tauri/src/commands/agent_discovery.rs", 1826],
+  // +10: pass an explicit PATH through Codex adapter install planning so unit
+  // tests avoid the process-global login-shell PATH cache.
+  ["src-tauri/src/commands/agent_discovery.rs", 1836],
   // draft-persistence predicate: submit-time `loadDraft` check + inline comment
   // + deps-array entry in submitMessage closes the never-persisted-boundary
   // defect (Thufir Pass-3 finding). Load-bearing correctness fix; queued to

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -44,11 +44,19 @@ pub(crate) fn plan_adapter_install<'c>(
     runtime_id: &str,
     adapter_path: Option<&std::path::Path>,
     adapter_install_commands: &'c [&'c str],
+    adapter_probe_path: Option<&str>,
 ) -> Option<Vec<&'c str>> {
     match adapter_path {
         // Adapter present and current — no install needed.
         Some(_) if runtime_id != "codex" => None,
-        Some(path) if !crate::managed_agents::codex_adapter_is_outdated(path) => None,
+        Some(path)
+            if !crate::managed_agents::codex_adapter_is_outdated_with_path(
+                path,
+                adapter_probe_path,
+            ) =>
+        {
+            None
+        }
         // Codex adapter is outdated: uninstall the old package first so npm
         // doesn't hit EEXIST on the shared `codex-acp` bin-link, then install.
         Some(_) => Some(vec![
@@ -176,10 +184,12 @@ fn install_acp_runtime_blocking(runtime_id: &str) -> Result<InstallRuntimeResult
         .commands
         .iter()
         .find_map(|cmd| crate::managed_agents::resolve_command(cmd));
+    let adapter_probe_path = crate::managed_agents::readiness::cli_probe::augmented_path();
     if let Some(cmds) = plan_adapter_install(
         runtime_id,
         adapter_path.as_deref(),
         runtime.adapter_install_commands,
+        adapter_probe_path.as_deref(),
     ) {
         let use_managed_npm =
             cmds.iter().any(|cmd| is_npm_global_install(cmd)) && managed_node_runtime_supported();
@@ -1180,7 +1190,7 @@ mod tests {
             .expect("chmod script");
 
         let install_cmds = &["npm install -g @agentclientprotocol/codex-acp"];
-        let plan = plan_adapter_install("codex", Some(&bin), install_cmds);
+        let plan = plan_adapter_install("codex", Some(&bin), install_cmds, Some("/usr/bin:/bin"));
 
         assert!(
             plan.is_some(),
@@ -1215,7 +1225,7 @@ mod tests {
             .expect("chmod script");
 
         let install_cmds = &["npm install -g @agentclientprotocol/codex-acp"];
-        let plan = plan_adapter_install("codex", Some(&bin), install_cmds);
+        let plan = plan_adapter_install("codex", Some(&bin), install_cmds, Some("/usr/bin:/bin"));
 
         assert!(
             plan.is_none(),
@@ -1226,7 +1236,7 @@ mod tests {
     #[test]
     fn test_plan_adapter_install_returns_catalog_cmds_when_no_adapter_path() {
         let install_cmds = &["npm install -g @agentclientprotocol/codex-acp"];
-        let plan = plan_adapter_install("codex", None, install_cmds);
+        let plan = plan_adapter_install("codex", None, install_cmds, None);
         assert!(plan.is_some(), "missing adapter must trigger install plan");
         // Missing arm: use the catalog's install commands directly (no prior
         // package to uninstall — fresh install, not a reinstall).
@@ -1250,7 +1260,7 @@ mod tests {
             .expect("chmod script");
 
         let install_cmds = &["npm install -g @block/goose-acp"];
-        let plan = plan_adapter_install("goose", Some(&bin), install_cmds);
+        let plan = plan_adapter_install("goose", Some(&bin), install_cmds, None);
         assert!(
             plan.is_none(),
             "non-codex runtime with resolved binary must not trigger reinstall"

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -1153,9 +1153,26 @@ pub(crate) fn codex_adapter_availability(path: &Path) -> AcpAvailabilityStatus {
 }
 
 /// Returns `true` when the codex-acp binary at `path` is outdated (major version < 1)
-/// or cannot be probed. Thin wrapper around [`codex_adapter_availability`].
+/// or cannot be probed using `augmented_path`. Thin wrapper around
+/// [`codex_adapter_is_outdated_with_path`].
+#[cfg(test)]
 pub(crate) fn codex_adapter_is_outdated(path: &Path) -> bool {
-    codex_adapter_availability(path) == AcpAvailabilityStatus::AdapterOutdated
+    codex_adapter_is_outdated_with_path(
+        path,
+        crate::managed_agents::readiness::cli_probe::augmented_path().as_deref(),
+    )
+}
+
+/// Returns `true` when the codex-acp binary at `path` is outdated (major version < 1)
+/// or cannot be probed with the supplied PATH.
+pub(crate) fn codex_adapter_is_outdated_with_path(
+    path: &Path,
+    augmented_path: Option<&str>,
+) -> bool {
+    match probe_codex_acp_major_version_with_path(path, augmented_path) {
+        Some(major) if major >= 1 => false,
+        _ => true,
+    }
 }
 
 /// Intermediate struct built before the (potentially slow) auth probe phase.

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -1169,10 +1169,10 @@ pub(crate) fn codex_adapter_is_outdated_with_path(
     path: &Path,
     augmented_path: Option<&str>,
 ) -> bool {
-    match probe_codex_acp_major_version_with_path(path, augmented_path) {
-        Some(major) if major >= 1 => false,
-        _ => true,
-    }
+    !matches!(
+        probe_codex_acp_major_version_with_path(path, augmented_path),
+        Some(major) if major >= 1
+    )
 }
 
 /// Intermediate struct built before the (potentially slow) auth probe phase.


### PR DESCRIPTION
## Why
The Codex adapter install-plan test depended on the process-global login-shell PATH cache, making it flaky under concurrent or loaded CI runs.

## What
- Thread an explicit probe PATH through adapter install planning
- Use a controlled PATH in Codex install-plan tests
- Update the existing desktop file-size allowance for the focused seam

## Risk Assessment
Low — production behavior keeps using the same augmented PATH; only dependency injection and deterministic tests change.

## References
- Failure: https://github.com/block/buzz/actions/runs/30110680608/job/89539202266
- Validation: `just desktop-tauri-test`; `cd desktop && pnpm check`; full pre-push hooks

Generated with Codex
