### PR TITLE
fix(desktop): contrast-guard the destructive accent from theme git colors

### DIFF
--- a/desktop/src/shared/theme/adaptive-theme.test.mjs
+++ b/desktop/src/shared/theme/adaptive-theme.test.mjs
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  contrastRatio,
+  createThemeVars,
+  hexToHsl,
+  resolveDestructiveAccent,
+} from "./adaptive-theme.ts";
+import {
+  SYNTAX_THEMES,
+  extractThemeInfo,
+  loadThemeData,
+} from "./theme-loader.ts";
+
+// The engine renders destructive text on the plain background, on the popover
+// surface (background 80% / muted 20%) and on a focused dropdown row (popover
+// 50% / muted 50%). Reconstruct those from the emitted vars to check the
+// shipped values rather than a reimplementation of the derivation.
+const MIN_SHIPPED_CONTRAST = 4.4;
+
+function toHex({ r, g, b }) {
+  const clamp = (n) => Math.max(0, Math.min(255, Math.round(n)));
+  return `#${[r, g, b].map((c) => clamp(c).toString(16).padStart(2, "0")).join("")}`;
+}
+
+function hexToRgb(hex) {
+  const long = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (long) {
+    return {
+      r: parseInt(long[1], 16),
+      g: parseInt(long[2], 16),
+      b: parseInt(long[3], 16),
+    };
+  }
+  const short = /^#?([a-f\d])([a-f\d])([a-f\d])$/i.exec(hex);
+  return {
+    r: parseInt(short[1] + short[1], 16),
+    g: parseInt(short[2] + short[2], 16),
+    b: parseInt(short[3] + short[3], 16),
+  };
+}
+
+function mixHex(hex1, hex2, factor) {
+  const c1 = hexToRgb(hex1);
+  const c2 = hexToRgb(hex2);
+  return toHex({
+    r: c1.r + (c2.r - c1.r) * factor,
+    g: c1.g + (c2.g - c1.g) * factor,
+    b: c1.b + (c2.b - c1.b) * factor,
+  });
+}
+
+/** Parse the "H S% L%" component form emitted by hexToHsl back into hex. */
+function hslVarToHex(value) {
+  const [h, s, l] = value.split(" ").map((part) => Number.parseFloat(part));
+  const sn = s / 100;
+  const ln = l / 100;
+  if (sn === 0) {
+    const channel = ln * 255;
+    return toHex({ r: channel, g: channel, b: channel });
+  }
+  const q = ln < 0.5 ? ln * (1 + sn) : ln + sn - ln * sn;
+  const p = 2 * ln - q;
+  const channelAt = (offset) => {
+    let t = h / 360 + offset;
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  return toHex({
+    r: channelAt(1 / 3) * 255,
+    g: channelAt(0) * 255,
+    b: channelAt(-1 / 3) * 255,
+  });
+}
+
+function surfacesFromVars(vars) {
+  const background = hslVarToHex(vars["--background"]);
+  const muted = hslVarToHex(vars["--muted"]);
+  const popover = mixHex(background, muted, 0.2);
+  return [background, popover, mixHex(popover, muted, 0.5)];
+}
+
+function minContrast(color, surfaces) {
+  return Math.min(...surfaces.map((surface) => contrastRatio(color, surface)));
+}
+
+test("hslVarToHex round-trips hexToHsl", () => {
+  for (const hex of ["#ffffff", "#000000", "#808080", "#cf222e", "#f85149"]) {
+    const roundTripped = hexToRgb(hslVarToHex(hexToHsl(hex)));
+    const original = hexToRgb(hex);
+    for (const channel of ["r", "g", "b"]) {
+      assert.ok(
+        Math.abs(roundTripped[channel] - original[channel]) <= 2,
+        `${hex} channel ${channel}: ${roundTripped[channel]} vs ${original[channel]}`,
+      );
+    }
+  }
+});
+
+test("contrastRatio matches the WCAG poles", () => {
+  assert.ok(Math.abs(contrastRatio("#000000", "#ffffff") - 21) < 0.01);
+  assert.ok(Math.abs(contrastRatio("#ffffff", "#000000") - 21) < 0.01);
+  assert.equal(contrastRatio("#cf222e", "#cf222e"), 1);
+});
+
+test("resolveDestructiveAccent keeps a compliant theme accent", () => {
+  const surfaces = ["#ffffff", "#fcfcfc", "#f6f6f6"];
+  assert.equal(
+    resolveDestructiveAccent("#a0111f", "#cf222e", surfaces),
+    "#a0111f",
+  );
+});
+
+test("resolveDestructiveAccent keeps an accent between the floor and AA", () => {
+  // github-light's #d73a49 misses 4.5:1 on the focused-row surface but stays
+  // well above the 3:1 readability floor — theme fidelity wins.
+  const surfaces = ["#ffffff", "#fcfcfc", "#f6f6f6"];
+  const worst = minContrast("#d73a49", surfaces);
+  assert.ok(worst >= 3 && worst < 4.5, `precondition, got ${worst}`);
+  assert.equal(
+    resolveDestructiveAccent("#d73a49", "#cf222e", surfaces),
+    "#d73a49",
+  );
+});
+
+test("resolveDestructiveAccent substitutes the fallback for an unreadable accent", () => {
+  // slack-ochin ships #FFF for gitDecoration.deletedResourceForeground on a
+  // white background (issue #2725).
+  const surfaces = ["#ffffff", "#fcfcfc", "#f6f6f6"];
+  assert.ok(minContrast("#FFF", surfaces) < 3);
+  assert.equal(
+    resolveDestructiveAccent("#FFF", "#cf222e", surfaces),
+    "#cf222e",
+  );
+});
+
+test("resolveDestructiveAccent nudges when the fallback also misses", () => {
+  const surfaces = ["#999999", "#a0a0a0", "#909090"];
+  assert.ok(minContrast("#e5534b", surfaces) < 3);
+  assert.ok(minContrast("#f85149", surfaces) < 4.5);
+
+  const resolved = resolveDestructiveAccent("#e5534b", "#f85149", surfaces);
+  assert.ok(
+    minContrast(resolved, surfaces) >= 4.5,
+    `resolved ${resolved} only reaches ${minContrast(resolved, surfaces)}`,
+  );
+  assert.notEqual(resolved, "#000000");
+
+  const { r, g, b } = hexToRgb(resolved);
+  assert.ok(r > g && r > b, `resolved ${resolved} lost its red hue`);
+});
+
+test("slack-ochin destructive text is readable", () => {
+  // Real slack-ochin values via extractThemeInfo(loadThemeData("slack-ochin")).
+  const { vars } = createThemeVars("#FFF", "#000", "#357b42", {
+    added: "#ECB22E",
+    deleted: "#FFF",
+    modified: "#ECB22E",
+  });
+
+  const destructive = hslVarToHex(vars["--destructive"]);
+  assert.notEqual(destructive, "#ffffff");
+  assert.ok(
+    minContrast(destructive, surfacesFromVars(vars)) >= MIN_SHIPPED_CONTRAST,
+    `slack-ochin --destructive ${destructive} is unreadable`,
+  );
+});
+
+test("every bundled theme emits readable destructive text", async () => {
+  for (const name of SYNTAX_THEMES) {
+    const info = extractThemeInfo(name, await loadThemeData(name));
+    const { isDark, vars } = createThemeVars(info.bg, info.fg, info.comment, {
+      added: info.added,
+      deleted: info.deleted,
+      modified: info.modified,
+    });
+
+    const surfaces = surfacesFromVars(vars);
+    const themeAccent = info.deleted ?? (isDark ? "#f85149" : "#cf222e");
+    const rawWorst = minContrast(themeAccent, surfaces);
+    const destructive = hslVarToHex(vars["--destructive"]);
+    const shipped = minContrast(destructive, surfaces);
+
+    if (rawWorst >= 3.05) {
+      // Above the keep floor: the theme's own accent survives verbatim.
+      assert.equal(vars["--destructive"], hexToHsl(themeAccent), name);
+    } else if (rawWorst < 2.95) {
+      // Below the floor: the replacement must reach AA.
+      assert.ok(
+        shipped >= MIN_SHIPPED_CONTRAST,
+        `${name}: --destructive ${destructive} reaches only ${shipped.toFixed(2)}`,
+      );
+    } else {
+      // Within HSL-rounding distance of the floor: either branch is
+      // acceptable, but the result must still read.
+      assert.ok(shipped >= 2.9, name);
+    }
+  }
+});
+
+test("compliant theme accents stay byte-identical", async () => {
+  // Both ship a deleted color that already clears the threshold and differs
+  // from the curated fallback, so an unchanged output can only come from the
+  // pass-through branch.
+  for (const [name, deleted] of [
+    ["gruvbox-light-hard", "#cc241d"],
+    ["catppuccin-mocha", "#f38ba8"],
+  ]) {
+    const info = extractThemeInfo(name, await loadThemeData(name));
+    assert.equal(info.deleted, deleted);
+
+    const { vars } = createThemeVars(info.bg, info.fg, info.comment, {
+      added: info.added,
+      deleted: info.deleted,
+      modified: info.modified,
+    });
+    assert.equal(vars["--destructive"], hexToHsl(deleted), name);
+  }
+});

--- a/desktop/src/shared/theme/adaptive-theme.ts
+++ b/desktop/src/shared/theme/adaptive-theme.ts
@@ -56,6 +56,17 @@ export function luminance(hex: string): number {
   return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
 }
 
+/**
+ * WCAG 2.x contrast ratio between two colors: `(lighter + 0.05) / (darker +
+ * 0.05)` over their relative luminances. Ranges from 1 (identical colors) to
+ * 21 (black on white).
+ */
+export function contrastRatio(hexA: string, hexB: string): number {
+  const lumA = luminance(hexA);
+  const lumB = luminance(hexB);
+  return (Math.max(lumA, lumB) + 0.05) / (Math.min(lumA, lumB) + 0.05);
+}
+
 function mix(hex1: string, hex2: string, factor: number): string {
   const c1 = hexToRgb(hex1);
   const c2 = hexToRgb(hex2);
@@ -168,6 +179,73 @@ export function hexToHsl(hex: string): string {
 }
 
 // =============================================================================
+// Destructive Accent Contrast Guard
+// =============================================================================
+
+const DESTRUCTIVE_KEEP_FLOOR = 3;
+const MIN_DESTRUCTIVE_CONTRAST = 4.5;
+
+function minContrastAcross(color: string, surfaces: readonly string[]): number {
+  return Math.min(...surfaces.map((surface) => contrastRatio(color, surface)));
+}
+
+/**
+ * Pick a destructive accent that stays legible as text on every surface it can
+ * render on.
+ *
+ * A theme's git-decoration colors are diff-gutter tints rather than text
+ * colors and carry no readability guarantee: slack-ochin ships `#FFF` for
+ * `gitDecoration.deletedResourceForeground`, which `--destructive` then painted
+ * as white-on-white menu text (issue #2725).
+ *
+ * Two-tier on purpose: a theme accent is kept verbatim as long as it clears
+ * {@link DESTRUCTIVE_KEEP_FLOOR} (the WCAG 3:1 floor for large text — below it
+ * the accent no longer reads at all), so curated palettes that merely miss AA
+ * are not retinted. Only a genuinely unreadable accent is replaced, and the
+ * replacement must clear {@link MIN_DESTRUCTIVE_CONTRAST}: the curated fallback
+ * red when it does, otherwise the fallback pushed toward whichever pole (white
+ * or black) the surfaces leave the most room for, by the smallest amount that
+ * clears the threshold (or the pole itself on surfaces where the ratio is
+ * unreachable).
+ */
+export function resolveDestructiveAccent(
+  themeAccent: string,
+  fallbackAccent: string,
+  surfaces: readonly string[],
+): string {
+  if (minContrastAcross(themeAccent, surfaces) >= DESTRUCTIVE_KEEP_FLOOR) {
+    return themeAccent;
+  }
+  if (minContrastAcross(fallbackAccent, surfaces) >= MIN_DESTRUCTIVE_CONTRAST) {
+    return fallbackAccent;
+  }
+
+  const pole =
+    minContrastAcross("#ffffff", surfaces) >=
+    minContrastAcross("#000000", surfaces)
+      ? "#ffffff"
+      : "#000000";
+  let low = 0;
+  let high = 1;
+
+  for (let i = 0; i < 20; i++) {
+    const mid = (low + high) / 2;
+    const minContrast = minContrastAcross(
+      mix(fallbackAccent, pole, mid),
+      surfaces,
+    );
+
+    if (minContrast >= MIN_DESTRUCTIVE_CONTRAST) {
+      high = mid;
+    } else {
+      low = mid;
+    }
+  }
+
+  return mix(fallbackAccent, pole, high);
+}
+
+// =============================================================================
 // Adaptive Theme Generator — emits shadcn CSS vars directly
 // =============================================================================
 
@@ -214,6 +292,15 @@ export function createThemeVars(
   // Derived colors
   const borderColor = mix(primaryBg, syntaxFg, isDark ? 0.15 : 0.12);
   const hoverBg = elevate(0.06);
+  // Mirrors POPOVER_SURFACE_CLASS in shared/ui/popoverSurface.ts
+  const popoverSurface = mix(primaryBg, hoverBg, 0.2);
+  // Mirrors the `focus:bg-muted/50` dropdown item in shared/ui/dropdown-menu.tsx
+  const focusedRowSurface = mix(popoverSurface, hoverBg, 0.5);
+  const destructiveAccent = resolveDestructiveAccent(accentRed, fallbackRed, [
+    primaryBg,
+    popoverSurface,
+    focusedRowSurface,
+  ]);
   const huddleControlBg = isDark ? mix(hoverBg, syntaxFg, 0.14) : "#333333";
   const huddleControlHoverBg = isDark
     ? mix(huddleControlBg, syntaxFg, 0.08)
@@ -261,7 +348,7 @@ export function createThemeVars(
       "--secondary-foreground": textFg,
 
       // Destructive
-      "--destructive": hexToHsl(accentRed),
+      "--destructive": hexToHsl(destructiveAccent),
       "--destructive-foreground": primaryFg,
 
       // Borders


### PR DESCRIPTION
### Problem

With a light system theme active, the "Delete agent" menu item renders white on white (#2725). The theme engine feeds `--destructive` verbatim from the syntax theme's git-decoration colors: `theme-loader.ts` reads `gitDecoration.deletedResourceForeground` (falling back to diff-gutter background tints), and themes make no readability promise for these values. slack-ochin ships `#FFF`, so destructive text sits at 1.0:1 on the popover surface.

### Fix

`createThemeVars` now resolves the destructive accent through a contrast guard before emitting `--destructive`:

- Composes the surfaces destructive text actually renders on: the base background, the popover surface (`POPOVER_SURFACE_CLASS`: background 80% / muted 20%), and a focused menu row (`focus:bg-muted/50` over the popover).
- Keeps the theme's own accent while it clears a 3:1 floor (WCAG large-text minimum) on the worst of those surfaces, so curated palettes that merely miss AA are not retinted.
- Replaces a genuinely unreadable accent with the existing curated fallback red, pushed toward the readable pole by bounded binary search when the fallback itself misses 4.5:1 on unusual surfaces. Mirrors the `getReviewAccentForeground` pattern already in `ThemeProvider.tsx`.

13 of the 62 bundled themes change, each previously between 1.0:1 and 2.9:1 on its own surfaces: slack-ochin (1.0), min-dark (1.5), monokai (1.6), one-dark-pro (1.8), min-light (2.1), gruvbox-dark-soft (2.2), gruvbox-dark-medium (2.4), tokyo-night (2.5), gruvbox-dark-hard (2.7), snazzy-light (2.7), nord (2.7), everforest-light (2.8), kanagawa-wave (2.9). The other 49 emit byte-identical vars, including buzz, github-*, catppuccin-*, and dracula. The floor is a single constant (`DESTRUCTIVE_KEEP_FLOOR`); raising it to 4.5 would retint 37 themes including the first-party palette, so 3:1 was chosen deliberately. One-line change if a stricter bar is preferred.

The issue links a patch on the reporter's fork that nudges the hue of both status colors against the popover var. This PR instead substitutes the curated fallback and scopes to `--destructive`, so compliant themes keep their exact colors.

Deliberately out of scope: `--status-added` / `--status-deleted` share the root cause (slack-ochin's activity-row deletion counts and DiffViewer markers still receive `#FFF`), but changing them shifts diff colors across themes. Follow-up material.

### Tests

`desktop/src/shared/theme/adaptive-theme.test.mjs` (node:test, runs in `pnpm test` / `just ci`): contrast-ratio poles, all three resolver branches, an exact slack-ochin regression fixture, and a matrix over all 62 bundled themes asserting kept accents stay byte-identical and replaced accents reach 4.5:1 on the recomposed surfaces. With the guard reverted, the slack-ochin fixture and 13 matrix themes fail.

Manual: Settings, pick slack-ochin (or let a light system theme resolve to it), open an agent profile menu. "Delete agent" is readable red instead of invisible.

### Checks

- [x] `just ci` passes (fmt + clippy + unit tests + mobile)
- [x] Integration tests pass (`just test`)
- [x] New public APIs / tools / endpoints are documented
- [x] No new `unwrap()` in production code paths
- [x] No new `unsafe` blocks
