### PR TITLE
fix(desktop): enable webview media capture on Linux

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1082,6 +1082,7 @@ dependencies = [
  "url",
  "user-idle",
  "uuid",
+ "webkit2gtk",
  "window-vibrancy",
  "windows-sys 0.61.2",
  "zeroize",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -40,6 +40,10 @@ keyring = { version = "3.6.3", default-features = false, features = ["sync-secre
 # connection is dropped, which the plugin does immediately. Default features
 # keep the pure-Rust zbus backend, matching the plugin (no libdbus needed).
 notify-rust = "4"
+# Reaches the WebKitGTK settings behind Tauri's webview to enable media
+# capture. Pinned to the exact version wry depends on, because
+# PlatformWebview::inner() hands back wry's WebView type.
+webkit2gtk = { version = "=2.0.2", features = ["v2_8"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSHapticFeedback"] }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -133,6 +133,46 @@ async fn wait_for_stable_initial_window_geometry<R: tauri::Runtime>(window: &tau
     eprintln!("buzz-desktop: initial window geometry did not settle before reveal timeout");
 }
 
+#[cfg(target_os = "linux")]
+fn enable_webview_media_capture<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) {
+    use webkit2gtk::glib::prelude::Cast;
+    use webkit2gtk::{
+        PermissionRequestExt, SettingsExt, UserMediaPermissionRequest,
+        UserMediaPermissionRequestExt, WebViewExt,
+    };
+
+    // WebKitGTK keeps getUserMedia behind enable-media-stream, off by default,
+    // and denies any permission request that no handler claims. Without both,
+    // navigator.mediaDevices is undefined on Linux and huddle mic capture and
+    // avatar recording never start. macOS and Windows get this from the system
+    // webview, which defers to the OS permission prompt instead.
+    let result = window.with_webview(|webview| {
+        let webview = webview.inner();
+
+        match webview.settings() {
+            Some(settings) => settings.set_enable_media_stream(true),
+            None => eprintln!("buzz-desktop: no webview settings; media capture stays disabled"),
+        }
+
+        // Only device capture is granted here. The frontend never calls
+        // getDisplayMedia, so screen-capture requests keep WebKit's deny.
+        webview.connect_permission_request(|_, request| {
+            let Some(request) = request.downcast_ref::<UserMediaPermissionRequest>() else {
+                return false;
+            };
+            if !request.is_for_audio_device() && !request.is_for_video_device() {
+                return false;
+            }
+            request.allow();
+            true
+        });
+    });
+
+    if let Err(error) = result {
+        eprintln!("buzz-desktop: failed to enable webview media capture: {error}");
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // mesh-llm's async chains (model download, node start/join) overflow
@@ -358,6 +398,13 @@ pub fn run() {
         .manage(commands::pairing::PairingHandle::new())
         .setup(move |app| {
             let app_handle = app.handle().clone();
+
+            // Ahead of the reset-failure bail below so the webview is capture
+            // capable on every boot path, not just the healthy one.
+            #[cfg(target_os = "linux")]
+            if let Some(window) = app_handle.get_webview_window("main") {
+                enable_webview_media_capture(&window);
+            }
 
             // ── Phase 2: boot-time sentinel wipe ──────────────────────────────
             // Must run before migrations and identity resolution so the wipe


### PR DESCRIPTION
Huddle mic capture and avatar recording don't work on Linux. `navigator.mediaDevices` is undefined, so every `getUserMedia` call site fails.

WebKitGTK gates those APIs behind `enable-media-stream`, which is off by default, and denies permission requests that no handler claims. Neither is configured today. macOS and Windows are unaffected, since their system webviews expose the APIs and defer to the OS prompt.

This enables the setting on the main webview and grants audio and video device requests. The frontend never calls `getDisplayMedia`, so screen capture keeps WebKit's default deny.

`webkit2gtk` is pinned to `=2.0.2` to match wry's pin, because `PlatformWebview::inner()` returns wry's type. It was already in the lockfile, so that file changes by one line.

Tested on Ubuntu 24.04 with WebKitGTK 2.52.3. Before: `navigator.mediaDevices` is undefined. After: `getUserMedia({audio: true})` resolves to an active `MediaStream` and `pactl list source-outputs` shows live `WebKitWebProcess` record streams on the capture device. `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, and `cargo test --lib` pass.
