### PR TITLE
fix(desktop): keep destructive actions readable in light themes

### DIFF
--- a/desktop/src/shared/theme/adaptive-theme.test.mjs
+++ b/desktop/src/shared/theme/adaptive-theme.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createThemeVars, luminance } from "./adaptive-theme.ts";
+
+const MINIMUM_TEXT_CONTRAST = 4.5;
+
+function hslComponentsToHex(value) {
+  const match = /^(-?[\d.]+) ([\d.]+)% ([\d.]+)%$/.exec(value);
+  assert.ok(match, `expected HSL components, received ${value}`);
+
+  const hue = (((Number(match[1]) % 360) + 360) % 360) / 360;
+  const saturation = Number(match[2]) / 100;
+  const lightness = Number(match[3]) / 100;
+
+  const hueToRgb = (p, q, channel) => {
+    let normalized = channel;
+    if (normalized < 0) normalized += 1;
+    if (normalized > 1) normalized -= 1;
+    if (normalized < 1 / 6) return p + (q - p) * 6 * normalized;
+    if (normalized < 1 / 2) return q;
+    if (normalized < 2 / 3) return p + (q - p) * (2 / 3 - normalized) * 6;
+    return p;
+  };
+
+  const channels =
+    saturation === 0
+      ? [lightness, lightness, lightness]
+      : (() => {
+          const q =
+            lightness < 0.5
+              ? lightness * (1 + saturation)
+              : lightness + saturation - lightness * saturation;
+          const p = 2 * lightness - q;
+          return [
+            hueToRgb(p, q, hue + 1 / 3),
+            hueToRgb(p, q, hue),
+            hueToRgb(p, q, hue - 1 / 3),
+          ];
+        })();
+
+  return `#${channels
+    .map((channel) =>
+      Math.round(channel * 255)
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`;
+}
+
+function contrastRatio(first, second) {
+  const firstLuminance = luminance(first);
+  const secondLuminance = luminance(second);
+  const lighter = Math.max(firstLuminance, secondLuminance);
+  const darker = Math.min(firstLuminance, secondLuminance);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function mix(first, second, factor) {
+  const channels = (hex) =>
+    [1, 3, 5].map((offset) =>
+      Number.parseInt(hex.slice(offset, offset + 2), 16),
+    );
+  const firstChannels = channels(first);
+  const secondChannels = channels(second);
+
+  return `#${firstChannels
+    .map((channel, index) =>
+      Math.round(channel + (secondChannels[index] - channel) * factor)
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`;
+}
+
+function lightThemeVars(deleted) {
+  return createThemeVars("#ffffff", "#1f2328", "#6e7781", {
+    added: null,
+    deleted,
+    modified: null,
+  }).vars;
+}
+
+function menuSurface(vars) {
+  return mix(
+    hslComponentsToHex(vars["--background"]),
+    hslComponentsToHex(vars["--muted"]),
+    0.2,
+  );
+}
+
+test("destructive text meets WCAG AA contrast in GitHub Light", () => {
+  const vars = lightThemeVars("#d73a49");
+
+  assert.ok(
+    contrastRatio(vars["--status-deleted"], menuSurface(vars)) >=
+      MINIMUM_TEXT_CONTRAST,
+  );
+});
+
+test("pale deleted-background tints become readable destructive text", () => {
+  const vars = lightThemeVars("#ffdce0");
+
+  assert.ok(
+    contrastRatio(vars["--status-deleted"], menuSurface(vars)) >=
+      MINIMUM_TEXT_CONTRAST,
+  );
+});
+
+test("already-compliant destructive colors remain unchanged", () => {
+  const vars = lightThemeVars("#8b0000");
+
+  assert.equal(vars["--status-deleted"], "#8b0000");
+});

--- a/desktop/src/shared/theme/adaptive-theme.test.mjs
+++ b/desktop/src/shared/theme/adaptive-theme.test.mjs
@@ -89,11 +89,19 @@ function menuSurface(vars) {
   );
 }
 
+function focusedMenuSurface(vars) {
+  return mix(menuSurface(vars), hslComponentsToHex(vars["--muted"]), 0.5);
+}
+
 test("destructive text meets WCAG AA contrast in GitHub Light", () => {
   const vars = lightThemeVars("#d73a49");
 
   assert.ok(
     contrastRatio(vars["--status-deleted"], menuSurface(vars)) >=
+      MINIMUM_TEXT_CONTRAST,
+  );
+  assert.ok(
+    contrastRatio(vars["--status-deleted"], focusedMenuSurface(vars)) >=
       MINIMUM_TEXT_CONTRAST,
   );
 });
@@ -103,6 +111,10 @@ test("pale deleted-background tints become readable destructive text", () => {
 
   assert.ok(
     contrastRatio(vars["--status-deleted"], menuSurface(vars)) >=
+      MINIMUM_TEXT_CONTRAST,
+  );
+  assert.ok(
+    contrastRatio(vars["--status-deleted"], focusedMenuSurface(vars)) >=
       MINIMUM_TEXT_CONTRAST,
   );
 });

--- a/desktop/src/shared/theme/adaptive-theme.ts
+++ b/desktop/src/shared/theme/adaptive-theme.ts
@@ -76,6 +76,47 @@ function overlay(hex: string, alpha: number): string {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
+const MINIMUM_TEXT_CONTRAST = 4.5;
+
+function contrastRatio(first: string, second: string): number {
+  const firstLuminance = luminance(first);
+  const secondLuminance = luminance(second);
+  const lighter = Math.max(firstLuminance, secondLuminance);
+  const darker = Math.min(firstLuminance, secondLuminance);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function ensureTextContrast(foreground: string, background: string): string {
+  if (contrastRatio(foreground, background) >= MINIMUM_TEXT_CONTRAST) {
+    return foreground;
+  }
+
+  const black = "#000000";
+  const white = "#ffffff";
+  const target =
+    contrastRatio(black, background) > contrastRatio(white, background)
+      ? black
+      : white;
+  let low = 0;
+  let high = 1;
+
+  // Find the smallest shift toward black or white that clears WCAG AA for
+  // normal text, preserving as much of the theme-provided color as possible.
+  for (let i = 0; i < 20; i++) {
+    const factor = (low + high) / 2;
+    if (
+      contrastRatio(mix(foreground, target, factor), background) >=
+      MINIMUM_TEXT_CONTRAST
+    ) {
+      high = factor;
+    } else {
+      low = factor;
+    }
+  }
+
+  return mix(foreground, target, high);
+}
+
 // =============================================================================
 // Chrome Color Calculation
 // =============================================================================
@@ -201,19 +242,27 @@ export function createThemeVars(
 
   const dir = isDark ? 1 : -1;
   const elevate = (amount: number) => adjust(primaryBg, dir * amount);
+  const hoverBg = elevate(0.06);
+  const popoverBg = elevate(0.08);
+  const menuSurfaceBg = mix(primaryBg, hoverBg, 0.2);
 
-  // Git/accent colors with fallbacks
+  // Git/accent colors with fallbacks. Deleted colors are also used as
+  // destructive foreground text, but some syntax themes provide pale diff
+  // background tints here. Guard against the mixed menu surface used by
+  // popoverSurface.ts, where destructive actions render.
   const fallbackGreen = isDark ? "#3fb950" : "#1a7f37";
   const fallbackRed = isDark ? "#f85149" : "#cf222e";
   const fallbackOrange = isDark ? "#d29922" : "#9a6700";
 
   const accentGreen = gitColors?.added ?? fallbackGreen;
-  const accentRed = gitColors?.deleted ?? fallbackRed;
+  const accentRed = ensureTextContrast(
+    gitColors?.deleted ?? fallbackRed,
+    menuSurfaceBg,
+  );
   const accentOrange = fallbackOrange;
 
   // Derived colors
   const borderColor = mix(primaryBg, syntaxFg, isDark ? 0.15 : 0.12);
-  const hoverBg = elevate(0.06);
   const huddleControlBg = isDark ? mix(hoverBg, syntaxFg, 0.14) : "#333333";
   const huddleControlHoverBg = isDark
     ? mix(huddleControlBg, syntaxFg, 0.08)
@@ -237,7 +286,7 @@ export function createThemeVars(
       // Backgrounds
       "--background": hexToHsl(primaryBg),
       "--card": hexToHsl(primaryBg),
-      "--popover": hexToHsl(elevate(0.08)),
+      "--popover": hexToHsl(popoverBg),
       "--muted": hexToHsl(hoverBg),
       "--accent": hexToHsl(hoverBg),
       "--secondary": hexToHsl(hoverBg),

--- a/desktop/src/shared/theme/adaptive-theme.ts
+++ b/desktop/src/shared/theme/adaptive-theme.ts
@@ -86,15 +86,25 @@ function contrastRatio(first: string, second: string): number {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
-function ensureTextContrast(foreground: string, background: string): string {
-  if (contrastRatio(foreground, background) >= MINIMUM_TEXT_CONTRAST) {
+function ensureTextContrast(foreground: string, backgrounds: string[]): string {
+  const meetsMinimum = (color: string) =>
+    backgrounds.every(
+      (background) => contrastRatio(color, background) >= MINIMUM_TEXT_CONTRAST,
+    );
+
+  if (meetsMinimum(foreground)) {
     return foreground;
   }
 
   const black = "#000000";
   const white = "#ffffff";
   const target =
-    contrastRatio(black, background) > contrastRatio(white, background)
+    Math.min(
+      ...backgrounds.map((background) => contrastRatio(black, background)),
+    ) >
+    Math.min(
+      ...backgrounds.map((background) => contrastRatio(white, background)),
+    )
       ? black
       : white;
   let low = 0;
@@ -104,10 +114,7 @@ function ensureTextContrast(foreground: string, background: string): string {
   // normal text, preserving as much of the theme-provided color as possible.
   for (let i = 0; i < 20; i++) {
     const factor = (low + high) / 2;
-    if (
-      contrastRatio(mix(foreground, target, factor), background) >=
-      MINIMUM_TEXT_CONTRAST
-    ) {
+    if (meetsMinimum(mix(foreground, target, factor))) {
       high = factor;
     } else {
       low = factor;
@@ -245,20 +252,21 @@ export function createThemeVars(
   const hoverBg = elevate(0.06);
   const popoverBg = elevate(0.08);
   const menuSurfaceBg = mix(primaryBg, hoverBg, 0.2);
+  const focusedMenuSurfaceBg = mix(menuSurfaceBg, hoverBg, 0.5);
 
   // Git/accent colors with fallbacks. Deleted colors are also used as
   // destructive foreground text, but some syntax themes provide pale diff
-  // background tints here. Guard against the mixed menu surface used by
-  // popoverSurface.ts, where destructive actions render.
+  // background tints here. Guard against both resting and focused menu
+  // surfaces, where destructive actions render.
   const fallbackGreen = isDark ? "#3fb950" : "#1a7f37";
   const fallbackRed = isDark ? "#f85149" : "#cf222e";
   const fallbackOrange = isDark ? "#d29922" : "#9a6700";
 
   const accentGreen = gitColors?.added ?? fallbackGreen;
-  const accentRed = ensureTextContrast(
-    gitColors?.deleted ?? fallbackRed,
+  const accentRed = ensureTextContrast(gitColors?.deleted ?? fallbackRed, [
     menuSurfaceBg,
-  );
+    focusedMenuSurfaceBg,
+  ]);
   const accentOrange = fallbackOrange;
 
   // Derived colors


### PR DESCRIPTION
## Summary

- keep theme-derived destructive actions at WCAG AA contrast on both the resting menu surface and the `focus:bg-muted/50` composite
- preserve theme colors that already meet the contrast threshold in every rendered state
- cover GitHub Light and pale deleted-background theme values with regression tests

## Root cause

The adaptive theme treated each syntax theme's deleted Git color as foreground text. Some light themes provide a diff-background tint there, so destructive actions could become too pale to read. The focused menu state blends the menu surface with the muted hover color, which also has to be included in the contrast calculation.

## Testing

- `node --import ./test-loader.mjs --experimental-strip-types --test src/shared/theme/adaptive-theme.test.mjs` — 3 passed, asserting at least 4.5:1 on resting and focused surfaces
- `pnpm exec biome check src/shared/theme/adaptive-theme.ts src/shared/theme/adaptive-theme.test.mjs` — passed
- `pnpm build:e2e` — passed
- rendered GitHub Light agent menu — resting Delete action measured at 4.52:1 against the actual menu surface
- `just ci` — lint, Rust workspace checks/tests, desktop checks/tests/build, web checks, and mobile checks passed before one unrelated order-dependent Tauri rate-limit test observed a stale 300-second window; the exact failing test passed in isolation

Fixes #2725
