### PR TITLE
fix(desktop): probe legacy app-data dir at most once per install

### DIFF
--- a/desktop/src-tauri/src/migration.rs
+++ b/desktop/src-tauri/src/migration.rs
@@ -25,6 +25,14 @@ const CANONICAL_DEV_IDENTIFIER: &str = "xyz.block.buzz.app.dev";
 const LEGACY_CANONICAL_DEV_IDENTIFIER: &str = "xyz.block.sprout.app.dev";
 const LEGACY_RELEASE_IDENTIFIER: &str = "xyz.block.sprout.app";
 
+/// Marker recording that the legacy-app-data probe has already run.
+///
+/// Lives *inside* the current app-data dir (not its parent, unlike the reset
+/// sentinel) so a boot reset — which wipes `app_data_dir` and the legacy dir
+/// together — also clears it. That ordering is load-bearing: after a reset the
+/// probe must be free to re-run, find the legacy dir gone, and re-mark.
+const LEGACY_APP_DATA_PROBE_SENTINEL: &str = ".legacy-app-data-probed";
+
 /// JSON files symlinked from worktree data directories to the canonical
 /// dev data directory. Only data files — never `agent-pids/` or `logs/`.
 /// `identity.key` is deliberately excluded because worktree instances
@@ -192,6 +200,10 @@ fn run_boot_migrations_inner(app: &tauri::AppHandle, reset_completed: bool) {
 /// the current Buzz identifier directory. The Tauri identifier controls the app
 /// data path, so without this copy a product rename would look like a fresh
 /// install and users would lose their persisted identity and agent settings.
+///
+/// Runs at most once per install: the legacy dir belongs to another app's
+/// container, so probing it repeatedly re-triggers the macOS "access data from
+/// other apps" prompt. See [`migrate_legacy_app_data_dir_at`].
 pub fn migrate_legacy_app_data_dir(app: &tauri::AppHandle) {
     let current_dir = match app.path().app_data_dir() {
         Ok(dir) => dir,
@@ -203,10 +215,41 @@ pub fn migrate_legacy_app_data_dir(app: &tauri::AppHandle) {
     let Some(legacy_dir) = legacy_app_data_dir(&current_dir) else {
         return;
     };
+    migrate_legacy_app_data_dir_at(&legacy_dir, &current_dir);
+}
+
+/// Copy legacy app data from `legacy_dir` into `current_dir`, at most once ever.
+///
+/// The one-shot guard exists for macOS TCC, not for speed. `legacy_dir` sits in
+/// another app's container (`xyz.block.sprout.app`), and on macOS *any* access —
+/// including the `exists()` stat itself — trips the "would like to access data
+/// from other apps" consent prompt. Because the pre-sentinel code probed on every
+/// launch and bailed immediately when the dir was absent, users who never ran
+/// Sprout got a prompt on every single launch that could never lead to a copy.
+///
+/// Writing the marker *before* the probe is deliberate: if the marker cannot be
+/// written we skip the probe entirely rather than risk prompting forever. A
+/// missed migration is recoverable; an unkillable system prompt is not.
+fn migrate_legacy_app_data_dir_at(legacy_dir: &Path, current_dir: &Path) {
+    let sentinel = current_dir.join(LEGACY_APP_DATA_PROBE_SENTINEL);
+    if sentinel.exists() {
+        return;
+    }
+    if let Err(error) =
+        std::fs::create_dir_all(current_dir).and_then(|()| std::fs::write(&sentinel, b""))
+    {
+        eprintln!(
+            "buzz-desktop: app-data-migration: cannot write probe marker {}: {error} — \
+             skipping legacy probe to avoid repeating the macOS consent prompt",
+            sentinel.display()
+        );
+        return;
+    }
+
     if !legacy_dir.exists() {
         return;
     }
-    match copy_dir_all(&legacy_dir, &current_dir) {
+    match copy_dir_all(legacy_dir, current_dir) {
         Ok(()) => eprintln!(
             "buzz-desktop: app-data-migration: copied legacy data from {} to {}",
             legacy_dir.display(),

--- a/desktop/src-tauri/src/migration_tests.rs
+++ b/desktop/src-tauri/src/migration_tests.rs
@@ -62,6 +62,81 @@ fn copy_dir_all_preserves_nested_files_without_overwriting() {
     );
 }
 
+#[test]
+fn legacy_app_data_migration_copies_then_marks_probed() {
+    let dir = tempfile::tempdir().unwrap();
+    let legacy = dir.path().join("xyz.block.sprout.app");
+    let current = dir.path().join("xyz.block.buzz.app");
+    std::fs::create_dir_all(&legacy).unwrap();
+    std::fs::write(legacy.join("identity.key"), "old-key").unwrap();
+
+    migrate_legacy_app_data_dir_at(&legacy, &current);
+
+    assert_eq!(
+        std::fs::read_to_string(current.join("identity.key")).unwrap(),
+        "old-key",
+        "legacy data must still migrate on the first run"
+    );
+    assert!(current.join(LEGACY_APP_DATA_PROBE_SENTINEL).exists());
+}
+
+/// The TCC fix: once probed, a later legacy dir is never touched again. Reading
+/// the foreign container is what triggers the macOS consent prompt, so "did not
+/// copy" here stands in for "did not prompt".
+#[test]
+fn legacy_app_data_migration_does_not_reprobe_after_marker() {
+    let dir = tempfile::tempdir().unwrap();
+    let legacy = dir.path().join("xyz.block.sprout.app");
+    let current = dir.path().join("xyz.block.buzz.app");
+    std::fs::create_dir_all(&current).unwrap();
+    std::fs::write(current.join(LEGACY_APP_DATA_PROBE_SENTINEL), b"").unwrap();
+    std::fs::create_dir_all(&legacy).unwrap();
+    std::fs::write(legacy.join("identity.key"), "old-key").unwrap();
+
+    migrate_legacy_app_data_dir_at(&legacy, &current);
+
+    assert!(
+        !current.join("identity.key").exists(),
+        "a marked install must not read the legacy container again"
+    );
+}
+
+/// The reported bug: no legacy dir at all (user never ran Sprout). The first
+/// launch marks the install so subsequent launches skip the probe entirely.
+#[test]
+fn legacy_app_data_migration_marks_even_when_legacy_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    let legacy = dir.path().join("xyz.block.sprout.app");
+    let current = dir.path().join("xyz.block.buzz.app");
+
+    migrate_legacy_app_data_dir_at(&legacy, &current);
+
+    assert!(
+        current.join(LEGACY_APP_DATA_PROBE_SENTINEL).exists(),
+        "absent legacy dir must still mark, or the prompt repeats forever"
+    );
+}
+
+/// A reset wipes `app_data_dir` (and the legacy dir) together, clearing the
+/// marker — so a genuine post-reset migration can still run.
+#[test]
+fn legacy_app_data_migration_reruns_after_marker_wiped() {
+    let dir = tempfile::tempdir().unwrap();
+    let legacy = dir.path().join("xyz.block.sprout.app");
+    let current = dir.path().join("xyz.block.buzz.app");
+    std::fs::create_dir_all(&legacy).unwrap();
+    std::fs::write(legacy.join("identity.key"), "old-key").unwrap();
+
+    migrate_legacy_app_data_dir_at(&legacy, &current);
+    std::fs::remove_dir_all(&current).unwrap();
+    migrate_legacy_app_data_dir_at(&legacy, &current);
+
+    assert_eq!(
+        std::fs::read_to_string(current.join("identity.key")).unwrap(),
+        "old-key"
+    );
+}
+
 /// Helper: create a temp dir structure mimicking canonical + worktree layout.
 /// Packs live in a `.main` sibling (not canonical) to match real-world state.
 /// Returns `(parent_dir_handle, canonical_dir, worktree_dir)`.


### PR DESCRIPTION
## Problem

`migrate_legacy_app_data_dir` runs on every launch and calls `legacy_dir.exists()` on `~/Library/Application Support/xyz.block.sprout.app` — a *different app's* container. On macOS that stat is itself gated by TCC, so it triggers the **"Buzz would like to access data from other apps"** consent prompt before the function bails.

For anyone who never ran Sprout there is no legacy dir at all, so the probe can never lead to a copy. It only produces a consent prompt, on every single launch, forever.

## Implementation

Gate the probe behind a `.legacy-app-data-probed` marker written inside the current app-data dir.

Two deliberate decisions:

**Marker placement.** Unlike the reset sentinel in `reset.rs` — which lives in the app-data dir's *parent* so it survives the wipe — this marker goes *inside* `app_data_dir`. `run_boot_reset` wipes `app_data_dir` and the legacy dir together, which clears the marker, so a genuine post-reset migration can still run. Putting it in the parent would have permanently suppressed that path.

**Write-before-probe.** The marker is written *before* the `exists()` call. If it can't be written we skip the probe entirely rather than falling through. A missed migration is recoverable; an unkillable system prompt is not.

The body is extracted into `migrate_legacy_app_data_dir_at(legacy_dir, current_dir)` so the behavior is testable without a Tauri `AppHandle`.

## Tests

Four regression tests in `migration_tests.rs`:

- `legacy_app_data_migration_copies_then_marks_probed` — first run still migrates
- `legacy_app_data_migration_does_not_reprobe_after_marker` — the actual fix
- `legacy_app_data_migration_marks_even_when_legacy_absent` — the reported case
- `legacy_app_data_migration_reruns_after_marker_wiped` — reset interaction preserved

I verified these catch the bug rather than merely passing: temporarily disabling the guard makes `does_not_reprobe_after_marker` fail, and restoring it makes it pass. The pre-existing `reset::tests::test_legacy_app_data_removed_on_reset` still passes.

## How to test manually

On a machine with no `~/Library/Application Support/xyz.block.sprout.app`:

1. Launch Buzz → the "access data from other apps" prompt appears (pre-fix).
2. With this change, the first launch writes the marker; subsequent launches never stat the foreign container, so the prompt does not recur.

## Notes

- `cargo fmt` and `cargo clippy --all-targets` are clean on `desktop/src-tauri`.
- Desktop Tauri tests are excluded from the root workspace, so run them with `cargo test --manifest-path desktop/src-tauri/Cargo.toml`. Note this build requires the `binaries/` sidecars to be present.
- Separately filed #2783 for an unrelated macOS TCC issue found while debugging this (sidecar code-signing identifier mismatch). That one is **not** addressed here — this PR only stops the redundant legacy probe.
