### PR TITLE
Support generic CLI file attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,7 @@ dependencies = [
  "dirs",
  "hex",
  "infer",
+ "mime_guess",
  "nostr",
  "rand 0.10.1",
  "reqwest 0.13.4",

--- a/crates/buzz-cli/Cargo.toml
+++ b/crates/buzz-cli/Cargo.toml
@@ -63,6 +63,9 @@ bytes = "1"
 # MIME type detection via magic bytes — file upload validation
 infer = "0.19"
 
+# Extension-backed MIME labels for generic text attachments such as Markdown
+mime_guess = "2"
+
 # URL parsing — extract server domain for Blossom auth tag
 url = { workspace = true }
 

--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -254,15 +254,8 @@ fn upload_filename(file_path: &str) -> Option<String> {
     }
 }
 
-fn apply_local_upload_metadata(
-    desc: &mut BlobDescriptor,
-    filename: Option<&str>,
-    upload_mime: &str,
-) {
+fn apply_local_upload_metadata(desc: &mut BlobDescriptor, filename: Option<&str>) {
     desc.filename = filename.map(ToOwned::to_owned);
-    if desc.mime_type == "application/octet-stream" && upload_mime != "application/octet-stream" {
-        desc.mime_type = upload_mime.to_string();
-    }
 }
 
 /// Returns `true` for moderation command kinds (9040–9044).
@@ -1274,7 +1267,7 @@ impl BuzzClient {
         // itself is not retried; only transient failures on the selected legacy endpoint are.
         match result {
             Ok(mut desc) => {
-                apply_local_upload_metadata(&mut desc, filename.as_deref(), &mime);
+                apply_local_upload_metadata(&mut desc, filename.as_deref());
                 return Ok(desc);
             }
             Err(CliError::Relay { status: s, body: _ })
@@ -1332,7 +1325,7 @@ impl BuzzClient {
                 }
             })
             .await?;
-        apply_local_upload_metadata(&mut desc, filename.as_deref(), &mime);
+        apply_local_upload_metadata(&mut desc, filename.as_deref());
         Ok(desc)
     }
 
@@ -1949,7 +1942,7 @@ mod retry_policy_tests {
     }
 
     #[tokio::test]
-    async fn upload_file_accepts_markdown_with_filename_and_extension_mime() {
+    async fn upload_file_accepts_markdown_with_filename_and_relay_mime() {
         type Capture = Arc<std::sync::Mutex<Option<(String, Vec<u8>)>>>;
 
         let dir = tempfile::tempdir().unwrap();
@@ -1991,7 +1984,7 @@ mod retry_policy_tests {
         let client = test_client(&format!("http://{addr}"));
         let desc = client.upload_file(path.to_str().unwrap()).await.unwrap();
 
-        assert_eq!(desc.mime_type, "text/markdown");
+        assert_eq!(desc.mime_type, "application/octet-stream");
         assert_eq!(desc.filename.as_deref(), Some("RUNBOOK.md"));
 
         let captured = capture.lock().unwrap().clone().unwrap();

--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::path::Path;
 use std::time::Duration;
 
 use base64::engine::general_purpose::STANDARD as B64;
@@ -34,6 +35,9 @@ pub struct BlobDescriptor {
     /// Duration in seconds for video/audio (optional).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<f64>,
+    /// Original client-side basename (optional).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
 }
 
 /// Build an `imeta` tag array from a BlobDescriptor (NIP-92 media metadata).
@@ -57,23 +61,20 @@ pub fn build_imeta_tag(d: &BlobDescriptor) -> Vec<String> {
     if let Some(dur) = d.duration {
         tag.push(format!("duration {dur}"));
     }
+    if let Some(ref filename) = d.filename {
+        tag.push(format!("filename {filename}"));
+    }
     tag
 }
-
-/// MIME types accepted for upload.
-const ALLOWED_MIMES: &[&str] = &[
-    "image/jpeg",
-    "image/png",
-    "image/gif",
-    "image/webp",
-    "video/mp4",
-];
 
 /// Maximum file size for image uploads (50 MB).
 const MAX_IMAGE_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Maximum file size for video uploads (500 MB).
 const MAX_VIDEO_BYTES: u64 = 500 * 1024 * 1024;
+
+/// Maximum file size for generic file uploads (100 MB).
+const MAX_FILE_BYTES: u64 = 100 * 1024 * 1024;
 
 /// Sign a NIP-98 HTTP auth event (kind:27235) and return the Authorization header value.
 ///
@@ -202,6 +203,66 @@ fn should_retry_legacy_upload(status: reqwest::StatusCode) -> bool {
         status,
         reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::METHOD_NOT_ALLOWED
     )
+}
+
+fn generic_extension_mime(file_path: &str) -> Option<String> {
+    let guessed = mime_guess::from_path(file_path).first_raw()?;
+    match guessed {
+        "text/markdown"
+        | "text/plain"
+        | "text/csv"
+        | "application/json"
+        | "application/x-ndjson"
+        | "application/yaml"
+        | "text/yaml" => Some(guessed.to_string()),
+        _ => None,
+    }
+}
+
+fn upload_mime_for_path(file_path: &str, bytes: &[u8]) -> String {
+    infer::get(bytes)
+        .map(|t| t.mime_type().to_string())
+        .or_else(|| generic_extension_mime(file_path))
+        .unwrap_or_else(|| "application/octet-stream".to_string())
+}
+
+fn upload_size_limit(mime: &str) -> u64 {
+    if mime.starts_with("video/") {
+        MAX_VIDEO_BYTES
+    } else if mime.starts_with("image/") {
+        MAX_IMAGE_BYTES
+    } else {
+        MAX_FILE_BYTES
+    }
+}
+
+fn can_fallback_to_legacy_media_upload(mime: &str) -> bool {
+    mime.starts_with("image/") || mime.starts_with("video/")
+}
+
+fn upload_filename(file_path: &str) -> Option<String> {
+    let name = Path::new(file_path).file_name()?.to_string_lossy();
+    let sanitized: String = name
+        .chars()
+        .map(|c| if c.is_control() { '_' } else { c })
+        .collect();
+    let trimmed = sanitized.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.chars().take(255).collect())
+    }
+}
+
+fn apply_local_upload_metadata(
+    desc: &mut BlobDescriptor,
+    filename: Option<&str>,
+    upload_mime: &str,
+) {
+    desc.filename = filename.map(ToOwned::to_owned);
+    if desc.mime_type == "application/octet-stream" && upload_mime != "application/octet-stream" {
+        desc.mime_type = upload_mime.to_string();
+    }
 }
 
 /// Returns `true` for moderation command kinds (9040–9044).
@@ -492,6 +553,43 @@ mod media_download_tests {
         assert!(!should_retry_legacy_upload(
             reqwest::StatusCode::UNSUPPORTED_MEDIA_TYPE
         ));
+    }
+
+    #[test]
+    fn markdown_upload_mime_uses_extension_when_magic_unknown() {
+        assert_eq!(
+            upload_mime_for_path("GUIDES/RUNBOOK.md", b"# Runbook\n"),
+            "text/markdown"
+        );
+    }
+
+    #[test]
+    fn html_extension_stays_generic_when_magic_unknown() {
+        assert_eq!(
+            upload_mime_for_path("download.html", b"not previewable"),
+            "application/octet-stream"
+        );
+    }
+
+    #[test]
+    fn imeta_tag_includes_filename() {
+        let desc = BlobDescriptor {
+            url: "https://relay.test/media/doc.bin".to_string(),
+            sha256: "a".repeat(64),
+            size: 12,
+            mime_type: "text/markdown".to_string(),
+            uploaded: 0,
+            dim: None,
+            blurhash: None,
+            thumb: None,
+            duration: None,
+            filename: Some("RUNBOOK.md".to_string()),
+        };
+
+        let tag = build_imeta_tag(&desc);
+
+        assert!(tag.contains(&"m text/markdown".to_string()));
+        assert!(tag.contains(&"filename RUNBOOK.md".to_string()));
     }
 }
 
@@ -1108,21 +1206,13 @@ impl BuzzClient {
         let bytes = std::fs::read(file_path)
             .map_err(|e| CliError::Other(format!("failed to read {file_path}: {e}")))?;
 
-        // 2. Detect MIME from magic bytes
-        let mime = infer::get(&bytes)
-            .map(|t| t.mime_type().to_string())
-            .unwrap_or_else(|| "application/octet-stream".to_string());
-
-        if !ALLOWED_MIMES.contains(&mime.as_str()) {
-            return Err(CliError::Usage(format!("unsupported file type: {mime}")));
-        }
+        // 2. Detect MIME from magic bytes, falling back to a narrow extension
+        // allowlist for text/data formats that have no signature (notably .md).
+        let mime = upload_mime_for_path(file_path, &bytes);
+        let filename = upload_filename(file_path);
 
         // 3. Size check
-        let max = if mime.starts_with("video/") {
-            MAX_VIDEO_BYTES
-        } else {
-            MAX_IMAGE_BYTES
-        };
+        let max = upload_size_limit(&mime);
         if bytes.len() as u64 > max {
             return Err(CliError::Usage(format!(
                 "file too large: {} bytes (max {})",
@@ -1183,46 +1273,67 @@ impl BuzzClient {
         // (404 or 405), fall back to the legacy /media/upload endpoint.  The 404/405 switch
         // itself is not retried; only transient failures on the selected legacy endpoint are.
         match result {
-            Ok(desc) => return Ok(desc),
+            Ok(mut desc) => {
+                apply_local_upload_metadata(&mut desc, filename.as_deref(), &mime);
+                return Ok(desc);
+            }
             Err(CliError::Relay { status: s, body: _ })
+                if should_retry_legacy_upload(
+                    reqwest::StatusCode::from_u16(s).unwrap_or(reqwest::StatusCode::NOT_FOUND),
+                ) && can_fallback_to_legacy_media_upload(&mime) =>
+            {
+                // Fall through to legacy endpoint below.
+            }
+            Err(CliError::Relay { status: s, body })
                 if should_retry_legacy_upload(
                     reqwest::StatusCode::from_u16(s).unwrap_or(reqwest::StatusCode::NOT_FOUND),
                 ) =>
             {
-                // Fall through to legacy endpoint below.
+                return Err(CliError::Relay {
+                    status: s,
+                    body: if body.is_empty() {
+                        "generic file upload requires relay /upload support".to_string()
+                    } else {
+                        body
+                    },
+                });
             }
             Err(e) => return Err(e),
         }
 
         let legacy_url = format!("{}/media/upload", self.relay_url);
-        self.with_retry_body(|| {
-            let upload_body = upload_body.clone();
-            let legacy_url = legacy_url.clone();
-            let mime = mime.clone();
-            let sha256 = sha256.clone();
-            async move {
-                let auth_header = sign_blossom_upload(&self.keys, &sha256, &mime, &self.relay_url)?;
-                let resp = self
-                    .with_auth_tag(
-                        self.http
-                            .put(&legacy_url)
-                            .timeout(upload_timeout)
-                            .header("Authorization", auth_header)
-                            .header("Content-Type", &mime)
-                            .header("X-SHA-256", &sha256)
-                            .body(upload_body),
-                    )
-                    .send()
-                    .await?;
-                if !resp.status().is_success() {
-                    let status = resp.status().as_u16();
-                    let body = resp.text().await.unwrap_or_default();
-                    return Err(CliError::Relay { status, body });
+        let mut desc = self
+            .with_retry_body(|| {
+                let upload_body = upload_body.clone();
+                let legacy_url = legacy_url.clone();
+                let mime = mime.clone();
+                let sha256 = sha256.clone();
+                async move {
+                    let auth_header =
+                        sign_blossom_upload(&self.keys, &sha256, &mime, &self.relay_url)?;
+                    let resp = self
+                        .with_auth_tag(
+                            self.http
+                                .put(&legacy_url)
+                                .timeout(upload_timeout)
+                                .header("Authorization", auth_header)
+                                .header("Content-Type", &mime)
+                                .header("X-SHA-256", &sha256)
+                                .body(upload_body),
+                        )
+                        .send()
+                        .await?;
+                    if !resp.status().is_success() {
+                        let status = resp.status().as_u16();
+                        let body = resp.text().await.unwrap_or_default();
+                        return Err(CliError::Relay { status, body });
+                    }
+                    resp.json::<BlobDescriptor>().await.map_err(CliError::from)
                 }
-                resp.json::<BlobDescriptor>().await.map_err(CliError::from)
-            }
-        })
-        .await
+            })
+            .await?;
+        apply_local_upload_metadata(&mut desc, filename.as_deref(), &mime);
+        Ok(desc)
     }
 
     /// Download a Blossom media blob using BUD-01 `t=get` auth.
@@ -1587,8 +1698,8 @@ mod retry_policy_tests {
 
     use axum::body::Body;
     use axum::extract::State;
-    use axum::http::{HeaderMap, Response, StatusCode};
-    use axum::routing::post;
+    use axum::http::{HeaderMap, Response, StatusCode, Uri};
+    use axum::routing::{post, put};
     use axum::Router;
     use nostr::{EventBuilder, Keys, Kind};
     use tokio::net::TcpListener;
@@ -1835,6 +1946,98 @@ mod retry_policy_tests {
             attempts.load(Ordering::SeqCst) >= 2,
             "must have retried at least once"
         );
+    }
+
+    #[tokio::test]
+    async fn upload_file_accepts_markdown_with_filename_and_extension_mime() {
+        type Capture = Arc<std::sync::Mutex<Option<(String, Vec<u8>)>>>;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("RUNBOOK.md");
+        std::fs::write(&path, b"# Runbook\n").unwrap();
+
+        let capture: Capture = Arc::new(std::sync::Mutex::new(None));
+        let capture_for_handler = capture.clone();
+
+        let app = Router::new()
+            .route(
+                "/upload",
+                put(
+                    |State(capture): State<Capture>,
+                     headers: HeaderMap,
+                     body: bytes::Bytes| async move {
+                        let content_type = headers
+                            .get("content-type")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or("")
+                            .to_string();
+                        *capture.lock().unwrap() = Some((content_type, body.to_vec()));
+
+                        let response_body = r#"{"url":"https://relay.test/media/doc.bin","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","size":10,"type":"application/octet-stream","uploaded":0}"#;
+                        Response::builder()
+                            .status(StatusCode::OK)
+                            .header("content-type", "application/json")
+                            .body(Body::from(response_body))
+                            .unwrap()
+                    },
+                ),
+            )
+            .with_state(capture_for_handler);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let client = test_client(&format!("http://{addr}"));
+        let desc = client.upload_file(path.to_str().unwrap()).await.unwrap();
+
+        assert_eq!(desc.mime_type, "text/markdown");
+        assert_eq!(desc.filename.as_deref(), Some("RUNBOOK.md"));
+
+        let captured = capture.lock().unwrap().clone().unwrap();
+        assert_eq!(captured.0, "text/markdown");
+        assert_eq!(captured.1, b"# Runbook\n");
+    }
+
+    #[tokio::test]
+    async fn generic_upload_missing_standard_route_does_not_try_legacy_media_route() {
+        type Paths = Arc<std::sync::Mutex<Vec<String>>>;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("RUNBOOK.md");
+        std::fs::write(&path, b"# Runbook\n").unwrap();
+
+        let paths: Paths = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let paths_for_handler = paths.clone();
+
+        let app = Router::new()
+            .route(
+                "/{*path}",
+                put(|State(paths): State<Paths>, uri: Uri| async move {
+                    paths.lock().unwrap().push(uri.path().to_string());
+                    Response::builder()
+                        .status(StatusCode::NOT_FOUND)
+                        .body(Body::from("missing"))
+                        .unwrap()
+                }),
+            )
+            .with_state(paths_for_handler);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let client = test_client(&format!("http://{addr}"));
+        let err = client
+            .upload_file(path.to_str().unwrap())
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(err, CliError::Relay { status: 404, .. }),
+            "expected standard /upload 404, got {err:?}"
+        );
+        assert_eq!(*paths.lock().unwrap(), vec!["/upload".to_string()]);
     }
 
     /// Spin up a one-shot axum server that handles `GET /info` (and any other GET).

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -13,6 +13,36 @@ use buzz_sdk::mentions::{
     MENTION_CAP,
 };
 
+fn escape_markdown_link_label(label: &str) -> String {
+    label
+        .replace('\\', "\\\\")
+        .replace('[', "\\[")
+        .replace(']', "\\]")
+}
+
+fn attachment_display_label(desc: &crate::client::BlobDescriptor) -> String {
+    desc.filename
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| desc.url.rsplit('/').next().map(ToOwned::to_owned))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "file".to_string())
+}
+
+fn format_attachment_markdown_line(desc: &crate::client::BlobDescriptor) -> String {
+    if desc.mime_type.starts_with("video/") {
+        return format!("\n![video]({})", desc.url);
+    }
+    if desc.mime_type.starts_with("image/") {
+        return format!("\n![image]({})", desc.url);
+    }
+
+    let label = escape_markdown_link_label(&attachment_display_label(desc));
+    format!("\n[{label}]({})", desc.url)
+}
+
 /// Extract the thread root event ID from a Nostr tag array.
 ///
 /// Parses `"e"` tags with NIP-10 markers:
@@ -504,13 +534,7 @@ pub async fn cmd_send_message(
             .await
             .map_err(|e| CliError::Other(format!("upload failed for {file_path}: {e}")))?;
         media_tags.push(crate::client::build_imeta_tag(&desc));
-        if desc.mime_type.starts_with("video/") {
-            media_content.push_str("\n![video](");
-        } else {
-            media_content.push_str("\n![image](");
-        }
-        media_content.push_str(&desc.url);
-        media_content.push(')');
+        media_content.push_str(&format_attachment_markdown_line(&desc));
     }
     let final_content = if media_content.is_empty() {
         p.content.clone()
@@ -876,7 +900,11 @@ pub async fn dispatch(
 
 #[cfg(test)]
 mod tests {
-    use super::{find_root_from_tags, match_profiles_by_name, parse_member_pubkeys};
+    use super::{
+        find_root_from_tags, format_attachment_markdown_line, match_profiles_by_name,
+        parse_member_pubkeys,
+    };
+    use crate::client::BlobDescriptor;
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
     };
@@ -891,6 +919,46 @@ mod tests {
     const PK_VALID_A: &str = "35c18ae273fccfaf80d629e20e7f8721b90499379addff533054acc2504c12b4";
     const PK_VALID_B: &str = "c6237ef84fa537c78dcee78efd2d4e59f728859c7f194da42ac51ededfa0be05";
     const PK_VALID_C: &str = "f4a42a97e594b77bdbd8ee35191c8b28a94a4cb871d96f32921558275421fb68";
+
+    fn attachment_desc(mime_type: &str, filename: Option<&str>) -> BlobDescriptor {
+        BlobDescriptor {
+            url: "https://relay.test/media/doc.bin".to_string(),
+            sha256: "a".repeat(64),
+            size: 12,
+            mime_type: mime_type.to_string(),
+            uploaded: 0,
+            dim: None,
+            blurhash: None,
+            thumb: None,
+            duration: None,
+            filename: filename.map(ToOwned::to_owned),
+        }
+    }
+
+    #[test]
+    fn generic_attachment_uses_file_link_markdown_with_escaped_filename() {
+        let desc = attachment_desc("text/markdown", Some("Run[book]\\v1.md"));
+
+        assert_eq!(
+            format_attachment_markdown_line(&desc),
+            "\n[Run\\[book\\]\\\\v1.md](https://relay.test/media/doc.bin)"
+        );
+    }
+
+    #[test]
+    fn media_attachments_keep_inline_markdown() {
+        let image = attachment_desc("image/png", Some("image.png"));
+        let video = attachment_desc("video/mp4", Some("clip.mp4"));
+
+        assert_eq!(
+            format_attachment_markdown_line(&image),
+            "\n![image](https://relay.test/media/doc.bin)"
+        );
+        assert_eq!(
+            format_attachment_markdown_line(&video),
+            "\n![video](https://relay.test/media/doc.bin)"
+        );
+    }
 
     #[test]
     fn root_marker_wins_over_reply_marker() {


### PR DESCRIPTION
## Summary

Adds generic file attachment support to `buzz-cli` so agents can attach Markdown and other document files as normal file links instead of image markdown.

## What Changed

- Allows the standard `/upload` path to accept non-image/non-video files while keeping the legacy `/media/upload` fallback image/video-only.
- Preserves sanitized filenames in `BlobDescriptor` and `imeta`.
- Derives extension-backed MIME labels for text files, including `text/markdown` for `.md` files.
- Renders `messages send --file` attachments as image, video, or generic file markdown based on MIME type.
- Adds tests for Markdown upload metadata and generic attachment message rendering.

## Why

Prepared agent docs like `RESEARCH/foo.md` and `GUIDES/foo.md` are currently only local workspace paths, so humans cannot open them from Buzz. The relay already supports generic uploads and Desktop already renders file cards for matching non-media links. This closes the CLI-side gap so agents can post a concise summary plus an attached document card.

## Validation

- `cargo fmt --package buzz-cli -- --check`
- `git diff --check`
- `cargo test -p buzz-cli` (`257` passed plus bin/doc-test harness)
- `cargo clippy -p buzz-cli --all-targets -- -D warnings`
