### PR TITLE
fix(desktop): redeploy provider agents after config saves

### DIFF
--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -769,9 +769,10 @@ async fn discover_databricks_models(
 
 /// Update mutable fields on an existing managed agent record.
 ///
-/// Does NOT auto-restart the agent. Runtime config changes (system prompt,
-/// parallelism, commands, toolsets) take effect on the next agent spawn.
-/// Name changes are synced to the relay immediately via a kind:0 re-publish.
+/// Provider-backed agents are re-deployed after an explicit save through the
+/// provider protocol's native idempotent deploy operation. Local-agent runtime
+/// config changes take effect on the next spawn. Name changes are synced to the
+/// relay immediately via a kind:0 re-publish.
 #[tauri::command]
 pub async fn update_managed_agent(
     input: UpdateManagedAgentRequest,
@@ -969,6 +970,34 @@ pub async fn update_managed_agent(
             ));
         }
     }
+
+    // Provider processes are owned outside Desktop, so saving their config
+    // must explicitly hand the new canonical record back to the provider.
+    // `deploy` is the provider protocol's idempotent create-or-update operation.
+    let provider_redeployed =
+        super::agents::redeploy_provider_agent(&app, &state, &summary.pubkey).await?;
+
+    // Provider deploy persists runtime metadata (backend_agent_id, timestamps,
+    // errors). Return a fresh summary so the UI cache reflects that state.
+    let summary = if provider_redeployed {
+        let _store_guard = state
+            .managed_agents_store_lock
+            .lock()
+            .map_err(|e| e.to_string())?;
+        let records = load_managed_agents(&app)?;
+        let runtimes = state
+            .managed_agent_processes
+            .lock()
+            .map_err(|e| e.to_string())?;
+        let record = records
+            .iter()
+            .find(|record| record.pubkey == summary.pubkey)
+            .ok_or_else(|| format!("agent {} not found", summary.pubkey))?;
+        let personas = load_personas(&app).unwrap_or_default();
+        build_managed_agent_summary(&app, record, &runtimes, &personas)?
+    } else {
+        summary
+    };
 
     Ok(UpdateManagedAgentResponse {
         agent: summary,

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -515,6 +515,69 @@ async fn deploy_to_provider(
     Ok(())
 }
 
+/// Extract the provider-specific fields required for an idempotent redeploy.
+fn provider_redeploy_config(
+    record: &ManagedAgentRecord,
+) -> Option<(String, serde_json::Value, Option<String>)> {
+    match &record.backend {
+        BackendKind::Local => None,
+        BackendKind::Provider { id, config } => Some((
+            id.clone(),
+            config.clone(),
+            record.provider_binary_path.clone(),
+        )),
+    }
+}
+
+/// Re-deploy a provider-backed agent from its current saved record.
+///
+/// Provider deploy is deliberately idempotent, so this is also the update
+/// path used after an explicit configuration save. Local agents return
+/// `Ok(false)` because their runtime settings still take effect on next spawn.
+pub(super) async fn redeploy_provider_agent(
+    app: &AppHandle,
+    state: &AppState,
+    pubkey: &str,
+) -> Result<bool, String> {
+    let target = {
+        let _store_guard = state
+            .managed_agents_store_lock
+            .lock()
+            .map_err(|e| e.to_string())?;
+        let records = load_managed_agents(app)?;
+        let record = records
+            .iter()
+            .find(|record| record.pubkey == pubkey)
+            .ok_or_else(|| format!("agent {pubkey} not found"))?;
+
+        match provider_redeploy_config(record) {
+            Some((provider_id, config, cached_binary_path)) => Some((
+                provider_id,
+                config,
+                build_deploy_payload(app, state, record)?,
+                cached_binary_path,
+            )),
+            None => None,
+        }
+    };
+
+    let Some((provider_id, config, agent_json, cached_binary_path)) = target else {
+        return Ok(false);
+    };
+
+    deploy_to_provider(
+        app,
+        state,
+        pubkey,
+        &provider_id,
+        &config,
+        agent_json,
+        cached_binary_path.as_deref(),
+    )
+    .await?;
+    Ok(true)
+}
+
 // Async so the blocking body (disk reads of agent/persona records, per-agent
 // process-liveness syscalls, and a possible save) runs on Tauri's worker pool
 // via spawn_blocking instead of the main UI thread — it was a beachball on the

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -234,6 +234,24 @@ fn normalize_relay_mesh_trims_and_preserves_valid_config() {
 }
 
 #[test]
+fn explicit_save_redeploy_target_is_provider_backed_only() {
+    let mut record = bare_agent_record(None, Some("model-b"), None);
+    assert!(provider_redeploy_config(&record).is_none());
+
+    record.backend = BackendKind::Provider {
+        id: "fixture".to_string(),
+        config: serde_json::json!({"model": "model-b"}),
+    };
+    record.provider_binary_path = Some("/tmp/buzz-backend-fixture".to_string());
+
+    let (provider_id, config, binary_path) =
+        provider_redeploy_config(&record).expect("provider redeploy target");
+    assert_eq!(provider_id, "fixture");
+    assert_eq!(config, serde_json::json!({"model": "model-b"}));
+    assert_eq!(binary_path.as_deref(), Some("/tmp/buzz-backend-fixture"));
+}
+
+#[test]
 fn created_avatar_prefers_explicit_input() {
     let resolved = resolve_created_avatar_url(
         Some(" https://x/input.png "),


### PR DESCRIPTION
## Summary

- invoke the existing idempotent provider `deploy` path after a provider-backed managed agent is explicitly saved
- leave local-agent behavior unchanged (runtime changes still apply on next spawn)
- reload the managed-agent summary after deploy so provider metadata and errors are reflected in the UI
- add regression coverage proving that only provider-backed records produce a redeploy target

Closes #2798.

## Why

`update_managed_agent` currently persists the new provider config to `managed-agents.json`, but the external provider is never called. Desktop therefore shows the new model/config while the deployed agent continues using the previous values. Provider protocol v1 already defines repeated `deploy` calls as idempotent update-in-place/no-op, so no shutdown protocol or UI lifecycle workaround is needed.

## Tests

- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib --no-default-features explicit_save_redeploy_target_is_provider_backed_only`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib --no-default-features agent_models`
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --lib --no-default-features` (passes with four pre-existing `secret_store.rs` dead-code warnings)
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`
- `git diff --check`