### PR TITLE
fix(workflow): bypass system proxies for webhooks

### DIFF
--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -805,6 +805,9 @@ async fn call_webhook_impl(
     // different address than the one validated above (DNS rebinding TOCTOU).
     let client = Client::builder()
         .timeout(Duration::from_secs(10))
+        // A system proxy would resolve the original hostname itself, bypassing
+        // the validated and pinned address above.
+        .no_proxy()
         // Disable redirects — a redirect to an internal host bypasses the SSRF check.
         .redirect(reqwest::redirect::Policy::none())
         .resolve(host, std::net::SocketAddr::new(safe_ip, port))


### PR DESCRIPTION
## Summary

Disable automatic system-proxy discovery for workflow webhook requests.

## Why

Webhook destinations are resolved, validated, and pinned before the request to prevent DNS-rebinding SSRF. If reqwest uses a system proxy, the proxy can resolve the original hostname itself instead of connecting to the validated address, bypassing that pinning guarantee.

Calling `no_proxy()` keeps these security-sensitive requests on the directly validated connection path. Redirects remain disabled.

## Test plan

- `cargo fmt --all -- --check`
- `cargo test -p buzz-workflow --features reqwest` (149 passed)
- `cargo clippy -p buzz-workflow --all-targets --features reqwest -- -D warnings`
- `git diff --check`