### PR TITLE
docs: replace VPN-vendor references with generic wording

### DIFF
--- a/desktop/src-tauri/src/commands/media_download.rs
+++ b/desktop/src-tauri/src/commands/media_download.rs
@@ -281,7 +281,7 @@ async fn fetch_blob_bytes_with_cap(
     state: &State<'_, AppState>,
     cap: u64,
 ) -> Result<Vec<u8>, String> {
-    // Fetch bytes via the no-redirect media client (goes through WARP tunnel).
+    // Fetch bytes via the no-redirect media client (goes through the VPN tunnel).
     // A no-redirect client keeps the minted media auth token from being
     // forwarded across origins by a relay-issued 3xx (redirect-hop SSRF); a
     // 3xx is returned verbatim and rejected by the `is_success` check below.

--- a/desktop/src-tauri/src/commands/reconnect_hook_config.rs
+++ b/desktop/src-tauri/src/commands/reconnect_hook_config.rs
@@ -18,7 +18,7 @@ pub struct ReconnectHookConfig {
     pub ready_probe: Vec<String>,
     /// RAW SUBSTRING matched in the probe's stdout to consider the transport
     /// ready — NOT a parsed field. Pick a token unlikely to collide with other
-    /// substrings in the probe output (e.g. `warp-cli -j status` JSON, where
+    /// substrings in the probe output (e.g. a VPN CLI's JSON status output, where
     /// "Connected" can collide with "Connecting"/"Disconnected").
     pub ready_match: String,
     /// Per-process wall-clock cap (ms) for each step and the readiness probe

--- a/desktop/src-tauri/src/commands/relay_reconnect.rs
+++ b/desktop/src-tauri/src/commands/relay_reconnect.rs
@@ -4,7 +4,7 @@
 //! builds), this command runs an ordered sequence of subprocess steps followed by
 //! a readiness poll before the frontend fires the relay WebSocket reconnect.
 //!
-//! OSS builds (env var unset) get a pure no-op — zero WARP knowledge compiled in.
+//! OSS builds (env var unset) get a pure no-op — zero VPN-specific knowledge compiled in.
 
 // Single source of truth for the config schema, shared with build.rs via
 // `include!`. See reconnect_hook_config.rs for why this is shared, not a module.
@@ -43,14 +43,14 @@ pub async fn relay_reconnect_hook() -> Result<(), String> {
 /// Run a fixed-argv command (`argv[0]` + `argv[1..]`) with a wall-clock cap.
 ///
 /// `std::process::Command::output()` blocks until the child exits — a wedged
-/// `warp-cli` (the exact degraded-transport case this hook targets) would hang
+/// VPN CLI (the exact degraded-transport case this hook targets) would hang
 /// forever, pinning the blocking-pool thread and leaving the frontend `invoke`
 /// unresolved. So we spawn, poll `try_wait()` every 500ms, and kill+reap on the
 /// deadline. Modeled on `media_transcode.rs` `run_ffmpeg_with_timeout`.
 ///
 /// stdout/stderr are piped and read only after the child exits. The pipe-buffer
 /// deadlock noted there (a child blocking on write() when the ~64 KiB OS pipe
-/// fills) does not apply: `warp-cli` emits a few lines, far below the buffer.
+/// fills) does not apply: these CLIs emit a few lines, far below the buffer.
 fn run_with_timeout(
     argv: &[String],
     timeout: std::time::Duration,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -461,7 +461,7 @@ pub fn run() {
             }
 
             // Start the localhost media streaming proxy. Uses the shared HTTP
-            // client so WARP tunnelling applies. The port is stored in AppState
+            // client so VPN tunnelling applies. The port is stored in AppState
             // and exposed to the frontend via the `get_media_proxy_port` command.
             let proxy_client = state.http_client.clone();
             let proxy_handle = app_handle.clone();

--- a/desktop/src-tauri/src/media_proxy.rs
+++ b/desktop/src-tauri/src/media_proxy.rs
@@ -150,11 +150,11 @@ pub async fn spawn_media_proxy(http_client: reqwest::Client, app_handle: tauri::
     port
 }
 
-/// Proxy media requests through the Rust backend so they traverse the WARP tunnel.
+/// Proxy media requests through the Rust backend so they traverse the VPN tunnel.
 ///
-/// WKWebView's networking stack bypasses WARP, causing 403s from Cloudflare Access.
+/// WKWebView's networking stack bypasses the VPN tunnel, causing 403s from Cloudflare Access.
 /// This handler routes `buzz-media://localhost/{path}` through reqwest, which
-/// runs in the Tauri process and goes through WARP.
+/// runs in the Tauri process and goes through the VPN.
 pub async fn handle_buzz_media(
     app: &tauri::AppHandle,
     request: &http::Request<Vec<u8>>,

--- a/desktop/src/features/messages/ui/MessageReactions.tsx
+++ b/desktop/src/features/messages/ui/MessageReactions.tsx
@@ -61,7 +61,7 @@ function isSameBadgeBurstRect(
  * Render a reaction's emoji: a custom (image) emoji when `emojiUrl` is set,
  * otherwise the unicode/text glyph. `className` sizes the image to match the
  * surrounding text. The relay URL is rewritten through the localhost media
- * proxy (like every other relay-hosted <img>) — WKWebView bypasses WARP, so a
+ * proxy (like every other relay-hosted <img>) — WKWebView bypasses the VPN tunnel, so a
  * direct relay URL gets a Cloudflare Access 403 and renders as a broken image.
  */
 function EmojiGlyph({

--- a/desktop/src/features/profile/lib/selfProfileStorage.ts
+++ b/desktop/src/features/profile/lib/selfProfileStorage.ts
@@ -1,7 +1,7 @@
 /**
  * Cached self-profile store for relay-unreachable scenarios.
  *
- * When the relay is unreachable (e.g. WARP VPN needs reauth), the app cannot
+ * When the relay is unreachable (e.g. corporate VPN needs reauth), the app cannot
  * fetch the user's kind-0 profile. This module persists the last successfully
  * fetched profile — including a base64 avatar snapshot — so the UI can render
  * the user's identity even when offline.

--- a/desktop/src/features/user-status/ui/StatusEmoji.tsx
+++ b/desktop/src/features/user-status/ui/StatusEmoji.tsx
@@ -13,7 +13,7 @@ import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
  * Every place that shows a status emoji renders this, so the shortcode→image
  * resolution can't drift across the (five) display sites — the same reason the
  * picker is unified. The relay URL is rewritten through the localhost media
- * proxy, matching reactions' `EmojiGlyph` (WKWebView bypasses WARP, so a direct
+ * proxy, matching reactions' `EmojiGlyph` (WKWebView bypasses the VPN tunnel, so a direct
  * relay URL 403s and renders broken).
  */
 type StatusEmojiProps = {

--- a/desktop/src/shared/api/relayClientShared.ts
+++ b/desktop/src/shared/api/relayClientShared.ts
@@ -8,7 +8,7 @@ import type { RelayEvent } from "@/shared/api/types";
  * - `connected`    — socket open and AUTH'd.
  * - `reconnecting` — socket dropped, waiting for the backoff timer.
  * - `stalled`      — socket is *open* per the WS layer but no inbound frames
- *                    for a long time (half-open / Warp split-brain). We
+ *                    for a long time (half-open socket / VPN split-brain). We
  *                    surface this so the UI can warn even though tungstenite
  *                    hasn't reported anything wrong yet.
  * - `disconnected` — final/terminal disconnect (auth rejected, community

--- a/desktop/src/shared/api/relayStallWatchdog.test.mjs
+++ b/desktop/src/shared/api/relayStallWatchdog.test.mjs
@@ -44,7 +44,7 @@ test("does not send probes while watching for stalls", async () => {
   await sleep(45);
   wd.stop();
   // The passive watchdog has no send callback by construction. This test is a
-  // regression guard for the WARP bug: liveness checks must not write to a
+  // regression guard for the half-open-socket bug: liveness checks must not write to a
   // socket already suspected of being half-open.
   assert.equal(typeof wd.recordInbound, "function");
 });

--- a/desktop/src/shared/api/tauriMedia.ts
+++ b/desktop/src/shared/api/tauriMedia.ts
@@ -11,7 +11,7 @@ export async function pickAndUploadImage(): Promise<BlobDescriptor | null> {
 }
 
 /**
- * Fetch relay media bytes over IPC (Rust reqwest, WARP-tunneled).
+ * Fetch relay media bytes over IPC (Rust reqwest, VPN-tunneled).
  *
  * Used by the composer image editor: wrapping the bytes in a same-origin
  * `blob:` URL gives the canvas pixel access without CORS, so the media

--- a/desktop/src/shared/lib/mediaUrl.ts
+++ b/desktop/src/shared/lib/mediaUrl.ts
@@ -1,9 +1,9 @@
 /**
  * Rewrite relay media URLs to use the localhost streaming proxy.
  *
- * WKWebView's networking stack bypasses WARP, so direct <img src> requests
+ * WKWebView's networking stack bypasses the VPN tunnel, so direct <img src> requests
  * to the relay get 403'd by Cloudflare Access. The localhost proxy routes
- * fetches through the Rust backend (via reqwest), which goes through WARP.
+ * fetches through the Rust backend (via reqwest), which goes through the VPN.
  *
  * For video, the proxy streams via axum — no buffering the entire file.
  * Images and other media also benefit from this path.

--- a/desktop/src/shared/lib/relayError.ts
+++ b/desktop/src/shared/lib/relayError.ts
@@ -3,7 +3,7 @@
  *
  * The Rust backend (`desktop/src-tauri/src/relay.rs`) prefixes every
  * "relay unreachable" error message with this literal string so that the
- * frontend can distinguish a transient connectivity failure (e.g. WARP VPN
+ * frontend can distinguish a transient connectivity failure (e.g. corporate VPN
  * needs reauth, Cloudflare Access 403) from an application-level error.
  *
  * Contract: the Rust layer MUST emit errors starting with exactly this prefix
@@ -18,7 +18,7 @@ export const RELAY_UNREACHABLE_MESSAGE =
 
 /**
  * Returns true when `error` carries the stable Rust-layer prefix indicating
- * the relay is unreachable (network failure, WARP VPN reauth needed, etc.).
+ * the relay is unreachable (network failure, VPN reauth needed, etc.).
  *
  * Accepts both `Error` instances and raw strings so callers can pass whatever
  * the Tauri IPC or WebSocket layer hands them without pre-normalizing.

--- a/desktop/tests/e2e/custom-emoji.spec.ts
+++ b/desktop/tests/e2e/custom-emoji.spec.ts
@@ -167,7 +167,7 @@ test("native emoji-only messages leave space below the author metadata", async (
 //
 // The bug (shipped in the custom-emoji launch, PR #816): the reaction renderer
 // put the relay emoji URL straight into <img src> without going through
-// rewriteRelayUrl(). WKWebView bypasses WARP, so the direct relay URL gets a
+// rewriteRelayUrl(). WKWebView bypasses the VPN tunnel, so the direct relay URL gets a
 // Cloudflare Access 403 and shows a broken image — even though the same emoji
 // rendered fine inline in chat (that path rewrites). The chat path was covered
 // by the tests above; the reaction path was not, which is why it slipped.

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -62,7 +62,7 @@ content retains attachment disposition. Successful reads produce a structured
 trace containing feedback ID, community ID, and attachment hash, but no feedback
 body or attachment URL.
 
-The human trust boundary remains the private admin ingress. WARP/source-IP
+The human trust boundary remains the private admin ingress. VPN/source-IP
 admission is not per-operator identity. Anyone admitted to the dashboard can
 read attachments for feedback records they can access. Per-person attribution
 or revocation requires authenticated operator identity at ingress/application


### PR DESCRIPTION
## Summary

- Replace all references to a specific corporate VPN product name with generic "VPN" / "corporate VPN" / "VPN tunnel" / "VPN CLI" language across 15 files (21 lines)
- Comment-only and doc-only changes — zero functional impact
- Keeps the OSS repo free of vendor-specific assumptions

`rg -i warp` returns zero hits after this change (excluding `node_modules`, lockfiles).