### PR TITLE
fix(relay/git-store): retry 503 backpressure in CAS writes instead of failing the boot probe

### DIFF
--- a/crates/buzz-relay/src/api/git/store.rs
+++ b/crates/buzz-relay/src/api/git/store.rs
@@ -21,10 +21,28 @@
 //! object bytes against the expected digest on `get_verified`; any mismatch is
 //! *detectable*, not silent — that is what A1's "create-only + content-address"
 //! discipline buys us, independent of bucket immutability features.
+//!
+//! ## The 503 sharp edge (backpressure != CAS loss)
+//!
+//! Some conforming, strongly-consistent backends answer a contended same-key
+//! CAS write with HTTP **503** (`ServiceUnavailable`) rather than committing
+//! or losing outright — observed against a single-node RustFS instance under
+//! the A3 boot probe's 32-way `if_match_race` load. 503 is transient
+//! backpressure ("try again"), not a CAS outcome: unlike 412 (a competing
+//! writer genuinely won), a 503'd write was never adjudicated at all, so the
+//! identical write should simply be retried. Treating it as a hard failure —
+//! the pre-existing behavior — makes an otherwise-conforming backend look
+//! non-conforming and refuses to boot. `is_backend_unavailable` +
+//! `retry_on_backpressure` keep 503 distinct from both 2xx and 412: every
+//! write path retries a 503 under a bounded jittered-exponential budget, and
+//! an exhausted budget surfaces as [`StoreError::Backpressure`], never as
+//! `LostRace`.
 
 #![allow(dead_code)] // wired in by the push path in a follow-up commit
 
+use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use s3::creds::Credentials;
@@ -43,6 +61,89 @@ pub enum Precond {
     IfNoneMatchStar,
     /// CAS: succeed iff the current ETag matches.
     IfMatch(ETag),
+}
+
+/// Bounded jittered-exponential backoff for a backend that answers a
+/// contended write with HTTP 503 instead of adjudicating it.
+///
+/// `max_retries` is the number of retries *after* the first attempt, so a
+/// contended key is attempted up to `max_retries + 1` times. Delays use
+/// **full jitter** (uniform in `[0, min(base * 2^attempt, max)]`) — the
+/// AWS-recommended scheme that decorrelates concurrent racers so they don't
+/// re-collide in lockstep against the same backpressured key.
+#[derive(Debug, Clone)]
+pub struct BackoffConfig {
+    /// Retries after the initial attempt. `0` disables retrying.
+    pub max_retries: usize,
+    /// Base delay; the first backoff is jittered within `[0, base]`.
+    pub base_delay: Duration,
+    /// Ceiling on any single (pre-jitter) backoff delay.
+    pub max_delay: Duration,
+}
+
+impl Default for BackoffConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 5,
+            base_delay: Duration::from_millis(75),
+            max_delay: Duration::from_millis(2500),
+        }
+    }
+}
+
+impl BackoffConfig {
+    /// Full-jitter backoff for a 0-based `attempt`: uniform random in
+    /// `[0, min(base_delay * 2^attempt, max_delay)]`.
+    fn delay_for_attempt(&self, attempt: usize) -> Duration {
+        let base_ms = self.base_delay.as_millis() as u64;
+        let max_ms = self.max_delay.as_millis() as u64;
+        // Cap the shift so `1 << attempt` can never overflow; `min(max_ms)`
+        // dominates well before the cap anyway.
+        let factor = 1u64.checked_shl(attempt.min(20) as u32).unwrap_or(u64::MAX);
+        let capped_ms = base_ms.saturating_mul(factor).min(max_ms);
+        let jitter = rand::random::<f64>(); // [0, 1)
+        Duration::from_millis((capped_ms as f64 * jitter) as u64)
+    }
+}
+
+/// Does this raw PUT result carry an HTTP 503 (backend unavailable /
+/// backpressure)?
+///
+/// Under the `fail-on-err` feature a 503 arrives as
+/// `HttpFailWithBody(503, _)`; without it, as an `Ok(resp)` with status 503.
+/// Detect both so the retry path is independent of feature unification.
+fn is_backend_unavailable(result: &Result<s3::request::ResponseData, S3Error>) -> bool {
+    match result {
+        Ok(resp) => resp.status_code() == 503,
+        Err(S3Error::HttpFailWithBody(503, _)) => true,
+        Err(_) => false,
+    }
+}
+
+/// Retry `op` while `should_retry` holds, backing off per `cfg`, up to
+/// `cfg.max_retries` retries. Returns the final result (success, or the last
+/// still-retryable result once the budget is spent).
+///
+/// Generic over the result type so the 503 backoff policy is unit-testable
+/// without a live object store.
+async fn retry_on_backpressure<T, E, F, Fut>(
+    cfg: &BackoffConfig,
+    should_retry: impl Fn(&Result<T, E>) -> bool,
+    mut op: F,
+) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+{
+    let mut attempt = 0usize;
+    loop {
+        let result = op().await;
+        if attempt >= cfg.max_retries || !should_retry(&result) {
+            return result;
+        }
+        tokio::time::sleep(cfg.delay_for_attempt(attempt)).await;
+        attempt += 1;
+    }
 }
 
 /// Result of a CAS pointer write.
@@ -87,6 +188,19 @@ pub enum StoreError {
         expected: String,
         /// Digest computed from the returned bytes.
         actual: String,
+    },
+    /// The backend answered a write with HTTP 503 (unavailable / backpressure)
+    /// even after the bounded retry budget was exhausted. **Distinct from
+    /// `LostRace` (412):** the write was never adjudicated — the backend
+    /// declined to answer at all — so a caller must not treat it as a lost
+    /// race (that would let a false winner through unnoticed on the next
+    /// `IfMatch` chain link).
+    #[error("backend unavailable (503) after {attempts} retries: {key}")]
+    Backpressure {
+        /// Object key the throttled write targeted.
+        key: String,
+        /// Number of retries attempted before giving up (`BackoffConfig::max_retries`).
+        attempts: usize,
     },
     /// Any other backend / transport error.
     #[error("s3 backend error: {0}")]
@@ -169,6 +283,8 @@ impl From<ProbeFailure> for StoreError {
 #[derive(Clone)]
 pub struct GitStore {
     bucket: Arc<Bucket>,
+    /// Backoff budget for HTTP 503 (backpressure) retries on write paths.
+    backoff: BackoffConfig,
 }
 
 impl GitStore {
@@ -214,7 +330,50 @@ impl GitStore {
             .with_path_style();
         Ok(Self {
             bucket: Arc::from(bucket),
+            backoff: BackoffConfig::default(),
         })
+    }
+
+    /// Override the 503 backoff budget (mainly for tests that need a tiny
+    /// budget so a persistent 503 surfaces quickly).
+    pub fn with_backoff_config(mut self, backoff: BackoffConfig) -> Self {
+        self.backoff = backoff;
+        self
+    }
+
+    /// PUT `key` with 503 backoff-retry applied. Returns the raw retried
+    /// result so callers can classify 2xx / 412 / other themselves; a
+    /// persistent 503 is left for the caller to map to
+    /// `StoreError::Backpressure` (see `backpressure_err`).
+    async fn put_with_backoff(
+        &self,
+        key: &str,
+        body: &[u8],
+        content_type: &str,
+        headers: axum::http::HeaderMap,
+    ) -> Result<s3::request::ResponseData, S3Error> {
+        retry_on_backpressure(&self.backoff, is_backend_unavailable, || {
+            let headers = headers.clone();
+            async move {
+                self.bucket
+                    .put_object_with_content_type_and_headers(
+                        key,
+                        body,
+                        content_type,
+                        Some(headers),
+                    )
+                    .await
+            }
+        })
+        .await
+    }
+
+    /// Build the `Backpressure` error for `key` from the configured budget.
+    fn backpressure_err(&self, key: &str) -> StoreError {
+        StoreError::Backpressure {
+            key: key.to_string(),
+            attempts: self.backoff.max_retries,
+        }
     }
 
     /// Compute the hex SHA-256 of `bytes`. The content-addressed key.
@@ -261,8 +420,7 @@ impl GitStore {
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::IF_NONE_MATCH, "*".parse().unwrap());
         match self
-            .bucket
-            .put_object_with_content_type_and_headers(&key, bytes, content_type, Some(headers))
+            .put_with_backoff(&key, bytes, content_type, headers)
             .await
         {
             Ok(resp) if (200..300).contains(&resp.status_code()) => Ok(key),
@@ -270,6 +428,9 @@ impl GitStore {
             // same bytes (by construction — the key is the digest). A1 is
             // preserved without a defensive GET.
             Err(S3Error::HttpFailWithBody(412, _)) => Ok(key),
+            // Retry budget spent on a persistent 503: backpressure, not a
+            // semantic outcome — surface it as `Backpressure`.
+            Err(S3Error::HttpFailWithBody(503, _)) => Err(self.backpressure_err(&key)),
             Ok(resp) => Err(StoreError::Backend(S3Error::HttpFailWithBody(
                 resp.status_code(),
                 "unexpected status".into(),
@@ -296,17 +457,12 @@ impl GitStore {
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::IF_NONE_MATCH, "*".parse().unwrap());
         match self
-            .bucket
-            .put_object_with_content_type_and_headers(
-                &key,
-                idx_bytes,
-                "application/x-git-index",
-                Some(headers),
-            )
+            .put_with_backoff(&key, idx_bytes, "application/x-git-index", headers)
             .await
         {
             Ok(resp) if (200..300).contains(&resp.status_code()) => Ok(key),
             Err(S3Error::HttpFailWithBody(412, _)) => Ok(key),
+            Err(S3Error::HttpFailWithBody(503, _)) => Err(self.backpressure_err(&key)),
             Ok(resp) => Err(StoreError::Backend(S3Error::HttpFailWithBody(
                 resp.status_code(),
                 "unexpected status".into(),
@@ -501,19 +657,26 @@ impl GitStore {
                 );
             }
         }
+        // 503 (backpressure) is retried with backoff inside `put_with_backoff`;
+        // a persistent 503 falls through to `classify_cas` as
+        // `HttpFailWithBody(503, _)` and becomes `StoreError::Backpressure` —
+        // never `LostRace` (412).
         let result = self
-            .bucket
-            .put_object_with_content_type_and_headers(key, body, "application/json", Some(headers))
+            .put_with_backoff(key, body, "application/json", headers)
             .await;
-        Self::classify_cas(result)
+        self.classify_cas(key, result)
     }
 
     /// Map a rust-s3 PUT outcome to a `CasOutcome`.
     ///
-    /// 412 → `LostRace`. 2xx → `Won(etag)` (etag read from response headers,
-    /// empty if missing — callers must tolerate empty etag and re-HEAD if they
-    /// need it strictly). Everything else bubbles as `StoreError::Backend`.
+    /// 412 → `LostRace`. 503 → `StoreError::Backpressure` (backend unavailable
+    /// surviving the retry budget — a distinct signal from a lost race). 2xx →
+    /// `Won(etag)` (etag read from response headers, empty if missing —
+    /// callers must tolerate empty etag and re-HEAD if they need it strictly).
+    /// Everything else bubbles as `StoreError::Backend`.
     fn classify_cas(
+        &self,
+        key: &str,
         result: Result<s3::request::ResponseData, S3Error>,
     ) -> Result<CasOutcome, StoreError> {
         match result {
@@ -539,6 +702,7 @@ impl GitStore {
                 Ok(CasOutcome::Won(ETag(etag)))
             }
             Err(S3Error::HttpFailWithBody(412, _)) => Ok(CasOutcome::LostRace),
+            Err(S3Error::HttpFailWithBody(503, _)) => Err(self.backpressure_err(key)),
             Ok(resp) => Err(StoreError::Backend(S3Error::HttpFailWithBody(
                 resp.status_code(),
                 "unexpected status".into(),
@@ -678,6 +842,21 @@ impl GitStore {
                             "transport drop (pre-classification: socket/send failure)"
                         );
                     }
+                    // A 503 that survived the backoff budget is *unknown*, not
+                    // negative: the racer was backpressured and never got a
+                    // classified CAS answer. Drop it from the observer set
+                    // exactly like a transport drop — the `classified >= 2`
+                    // floor still guards A3, and a backend that legitimately
+                    // sheds load under contention no longer false-fails.
+                    Err(StoreError::Backpressure { .. }) => {
+                        transport_drops += 1;
+                        tracing::warn!(
+                            phase = "if_match_race",
+                            round,
+                            racer = i,
+                            "backpressure drop (503 past retry budget; unknown observation)"
+                        );
+                    }
                     Err(e) => {
                         return Err(ProbeFailure {
                             phase: "if_match_race",
@@ -771,6 +950,18 @@ impl GitStore {
                             round,
                             racer = i,
                             "transport drop (pre-classification: socket/send failure)"
+                        );
+                    }
+                    // Persistent 503 → unknown observation (see the
+                    // `if_match_race` arm): drop it rather than false-fail a
+                    // backend that legitimately sheds load under contention.
+                    Err(StoreError::Backpressure { .. }) => {
+                        transport_drops += 1;
+                        tracing::warn!(
+                            phase = "if_none_match_race",
+                            round,
+                            racer = i,
+                            "backpressure drop (503 past retry budget; unknown observation)"
                         );
                     }
                     Err(e) => {
@@ -891,17 +1082,16 @@ impl GitStore {
         let mut headers = axum::http::HeaderMap::new();
         headers.insert(axum::http::header::IF_NONE_MATCH, "*".parse().unwrap());
         match self
-            .bucket
-            .put_object_with_content_type_and_headers(
-                key,
-                bytes,
-                "application/octet-stream",
-                Some(headers),
-            )
+            .put_with_backoff(key, bytes, "application/octet-stream", headers)
             .await
         {
             Ok(resp) => Ok(resp.status_code()),
             Err(S3Error::HttpFailWithBody(412, _)) => Ok(412),
+            // Persistent 503 after the retry budget: report it as a typed
+            // `Backpressure` so the probe can drop it as an *unknown*
+            // observation (like a transport drop) rather than false-fail the
+            // conformance gate against a correctly backpressuring backend.
+            Err(S3Error::HttpFailWithBody(503, _)) => Err(self.backpressure_err(key)),
             Err(e) => Err(StoreError::Backend(e)),
         }
     }
@@ -927,19 +1117,126 @@ mod tests {
         }
     }
 
+    fn test_store() -> GitStore {
+        // `Bucket::new` does not open a connection, so this builds a usable
+        // `GitStore` for pure classification tests without any live backend.
+        GitStore::new(
+            "http://localhost:9000",
+            "buzz_dev",
+            "buzz_dev_secret",
+            "buzz-git",
+            "us-east-1",
+        )
+        .expect("build store")
+    }
+
     #[test]
     fn classify_cas_412_is_lost_race() {
         let r = Err(S3Error::HttpFailWithBody(412, "PreconditionFailed".into()));
-        assert_eq!(GitStore::classify_cas(r).unwrap(), CasOutcome::LostRace);
+        assert_eq!(
+            test_store().classify_cas("probe/pointer", r).unwrap(),
+            CasOutcome::LostRace
+        );
+    }
+
+    #[test]
+    fn classify_cas_503_is_backpressure_not_lost_race() {
+        // The core RustFS edge case: a 503 (backend unavailable under
+        // contention) must NOT collapse into `LostRace` (412). It is a
+        // distinct, typed "unadjudicated" signal.
+        let r = Err(S3Error::HttpFailWithBody(503, "ServiceUnavailable".into()));
+        let err = test_store()
+            .classify_cas("probe/pointer", r)
+            .expect_err("503 must not be a CasOutcome");
+        match err {
+            StoreError::Backpressure { key, attempts } => {
+                assert_eq!(key, "probe/pointer");
+                assert_eq!(attempts, BackoffConfig::default().max_retries);
+            }
+            other => panic!("expected Backpressure, got {other:?}"),
+        }
     }
 
     #[test]
     fn classify_cas_other_4xx_bubbles() {
         let r = Err(S3Error::HttpFailWithBody(403, "AccessDenied".into()));
         assert!(matches!(
-            GitStore::classify_cas(r),
+            test_store().classify_cas("probe/pointer", r),
             Err(StoreError::Backend(S3Error::HttpFailWithBody(403, _)))
         ));
+    }
+
+    #[test]
+    fn is_backend_unavailable_distinguishes_503_from_412() {
+        assert!(is_backend_unavailable(&Err(S3Error::HttpFailWithBody(
+            503,
+            "ServiceUnavailable".into()
+        ))));
+        assert!(!is_backend_unavailable(&Err(S3Error::HttpFailWithBody(
+            412,
+            "PreconditionFailed".into()
+        ))));
+    }
+
+    #[test]
+    fn backoff_delay_never_exceeds_configured_max() {
+        let cfg = BackoffConfig {
+            max_retries: 5,
+            base_delay: Duration::from_millis(75),
+            max_delay: Duration::from_millis(2500),
+        };
+        for attempt in 0..10 {
+            assert!(cfg.delay_for_attempt(attempt) <= cfg.max_delay);
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_on_backpressure_retries_then_succeeds() {
+        let cfg = BackoffConfig {
+            max_retries: 3,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(5),
+        };
+        let attempts = std::sync::atomic::AtomicUsize::new(0);
+        let result: Result<u32, u32> = retry_on_backpressure(
+            &cfg,
+            |r: &Result<u32, u32>| matches!(r, Err(503)),
+            || {
+                let n = attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                async move {
+                    if n < 2 {
+                        Err(503)
+                    } else {
+                        Ok(n as u32)
+                    }
+                }
+            },
+        )
+        .await;
+        assert_eq!(result, Ok(2));
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn retry_on_backpressure_stops_at_budget() {
+        let cfg = BackoffConfig {
+            max_retries: 2,
+            base_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(5),
+        };
+        let attempts = std::sync::atomic::AtomicUsize::new(0);
+        let result: Result<u32, u32> = retry_on_backpressure(
+            &cfg,
+            |r: &Result<u32, u32>| matches!(r, Err(503)),
+            || {
+                attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                async move { Err(503) }
+            },
+        )
+        .await;
+        assert_eq!(result, Err(503));
+        // Initial attempt + max_retries retries = 3 total calls.
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 3);
     }
 
     #[test]


### PR DESCRIPTION
- A conforming, strongly-consistent object store can answer a contended same-key CAS write with 503 rather than committing or losing outright, especially a single-node backend under the A3 boot probe's 32-way concurrent write load. That happened running against RustFS and the boot probe treated it as a hard failure, making an otherwise-conforming backend look non-conforming and refusing to boot.
- 503 is transient backpressure, not a CAS outcome, unlike 412 where a competing writer genuinely won. A 503'd write was never adjudicated, so it should simply be retried under a bounded budget rather than surfaced as a fatal error.
- Related but distinct from #2774, which addresses R2's 429 rate limiting specifically. This targets 503 backpressure from a different class of backend, so it uses its own config/error types to stay independent of that unmerged change.