### PR TITLE
fix(desktop): replace user-idle macOS backend with direct Quartz idle query (fixes launch crash)

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -46,7 +46,6 @@ objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSHa
 keyring = { version = "3.6.3", default-features = false, features = ["apple-native", "vendored"], optional = true }
 security-framework = { version = "3.7.0", features = ["OSX_10_15"] }
 window-vibrancy = "0.6"
-user-idle = { version = "0.6", default-features = false }
 plist = "1"
 
 [target.'cfg(windows)'.dependencies]

--- a/desktop/src-tauri/src/commands/os_idle.rs
+++ b/desktop/src-tauri/src/commands/os_idle.rs
@@ -3,7 +3,11 @@
 /// Wayland). Callers fall back to in-app activity tracking when `None`.
 #[tauri::command]
 pub fn get_os_idle_seconds() -> Option<u64> {
-    #[cfg(any(target_os = "macos", windows))]
+    #[cfg(target_os = "macos")]
+    {
+        macos_idle_seconds()
+    }
+    #[cfg(windows)]
     {
         user_idle::UserIdle::get_time()
             .ok()
@@ -12,5 +16,44 @@ pub fn get_os_idle_seconds() -> Option<u64> {
     #[cfg(not(any(target_os = "macos", windows)))]
     {
         None
+    }
+}
+
+/// `user-idle`'s macOS backend over-releases a Mach port name, which modern
+/// macOS treats as a fatal guarded-port violation (EXC_GUARD) and kills the
+/// process. Ask Quartz directly instead: same combined-session idle time, no
+/// Mach ports involved.
+#[cfg(target_os = "macos")]
+fn macos_idle_seconds() -> Option<u64> {
+    // CGEventSourceStateID kCGEventSourceStateCombinedSessionState
+    const COMBINED_SESSION_STATE: i32 = 0;
+    // CGEventType kCGAnyInputEventType ((CGEventType)(~0))
+    const ANY_INPUT_EVENT_TYPE: u32 = u32::MAX;
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn CGEventSourceSecondsSinceLastEventType(
+            state_id: i32,
+            event_type: u32,
+        ) -> f64;
+    }
+
+    let seconds = unsafe {
+        CGEventSourceSecondsSinceLastEventType(COMBINED_SESSION_STATE, ANY_INPUT_EVENT_TYPE)
+    };
+    seconds.is_finite().then(|| seconds.max(0.0) as u64)
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn macos_idle_seconds_returns_sane_value() {
+        // Regression test for the EXC_GUARD crash: querying idle time must
+        // not touch Mach ports. A day of idle time during a test run means
+        // something is broken.
+        let idle = macos_idle_seconds().expect("idle time should be available");
+        assert!(idle < 86_400);
     }
 }


### PR DESCRIPTION
Fixes #2818

## Problem

On current macOS versions, Buzz Desktop crashes ~9 seconds after every launch with `EXC_GUARD` / `GUARD_TYPE_MACH_PORT` / `INVALID_NAME`. The faulting stack is the `get_os_idle_seconds` Tauri command:

```
mach_port_deallocate
user_idle::UserIdle::get_time
buzz_lib::run::{closure}
tauri::webview::Webview::on_message
```

The `user-idle` crate's macOS backend reads `HIDIdleTime` from IOKit and, on the successful path, releases the iterator and registry entry **twice** (once inside the `present == 1` branch and again at the end of the function — see [`macos_impl.rs`](https://github.com/olback/user-idle-rs/blob/master/src/macos_impl.rs)). Over-releasing a Mach port name is a guarded-port violation on modern macOS, which the kernel treats as fatal instead of returning an error. Since the frontend invokes the idle check unconditionally shortly after startup, the app crashes on every launch.

## Fix

Drop `user-idle` on macOS and query Quartz directly via `CGEventSourceSecondsSinceLastEventType(kCGEventSourceStateCombinedSessionState, kCGAnyInputEventType)`:

- Same semantics: seconds since last OS-wide keyboard/mouse input for the login session, matching the command's documented contract.
- No Mach ports, no IOKit, no accessibility/input-monitoring permission needed.
- One `extern "C"` declaration against the CoreGraphics framework — no new dependencies.

Windows keeps using `user-idle` (its `GetLastInputInfo` backend is unaffected). The macOS `user-idle` dependency is removed from `Cargo.toml`.

## Testing

- `cargo check` passes.
- Added a macOS unit test asserting the idle query returns a sane value, and ran it on the same machine where the shipped app crashes 100% of the time (Intel Mac Pro, macOS 26.2 25C56, crash reports attached to #2818) — the old backend didn't survive a single `get_time` call there, the new one passes:

  ```
  test commands::os_idle::tests::macos_idle_seconds_returns_sane_value ... ok
  ```
- I have not run a full end-to-end app build (sidecar binaries aren't part of this change); happy to test a CI build artifact on the affected machine if useful.
