### PR TITLE
fix(mobile): preserve channel group edits and sync sorting

### DIFF
--- a/mobile/lib/features/channels/channel_sections/channel_sections_storage.dart
+++ b/mobile/lib/features/channels/channel_sections/channel_sections_storage.dart
@@ -4,6 +4,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 String channelSectionsKey(String pubkey) => 'buzz.channel-sections.v1:$pubkey';
 
+String channelSectionsDirtySinceKey(String pubkey) =>
+    'buzz.channel-sections.dirty-since.v1:$pubkey';
+
 class ChannelSection {
   final String id;
   final String name;
@@ -112,5 +115,19 @@ class ChannelSectionsStorage {
 
   void write(String pubkey, ChannelSectionStore store) {
     _prefs.setString(channelSectionsKey(pubkey), jsonEncode(store.toJson()));
+  }
+
+  /// Unix seconds of the oldest unpublished local edit, or 0 when local state
+  /// has been fully published. Persisted so unpublished edits survive manager
+  /// teardown (relay status flips rebuild the provider) and app restarts.
+  int readDirtySince(String pubkey) =>
+      _prefs.getInt(channelSectionsDirtySinceKey(pubkey)) ?? 0;
+
+  void writeDirtySince(String pubkey, int dirtySince) {
+    if (dirtySince <= 0) {
+      _prefs.remove(channelSectionsDirtySinceKey(pubkey));
+    } else {
+      _prefs.setInt(channelSectionsDirtySinceKey(pubkey), dirtySince);
+    }
   }
 }

--- a/mobile/lib/features/channels/channel_sort/channel_sort_manager.dart
+++ b/mobile/lib/features/channels/channel_sort/channel_sort_manager.dart
@@ -51,6 +51,12 @@ class ChannelSortManager {
   void Function()? _unsubscribe;
   bool _disposed = false;
 
+  /// Base delay for the startup-sync retry backoff. Overridable in tests.
+  final Duration _startupRetryBaseDelay;
+  Timer? _startupRetryTimer;
+  int _startupRetryAttempt = 0;
+  bool _startupFetchSucceeded = false;
+
   /// Unix seconds of the oldest unpublished local edit; 0 when clean.
   /// Persisted so unpublished edits survive manager teardown and restarts.
   int _dirtySince;
@@ -67,12 +73,15 @@ class ChannelSortManager {
     required SignedEventRelay? signedEventRelay,
     required bool remoteEnabled,
     required VoidCallback onChanged,
+    @visibleForTesting
+    Duration startupRetryBaseDelay = const Duration(seconds: 2),
   }) : _storage = ChannelSortStorage(prefs),
        _crypto = crypto,
        _relaySession = relaySession,
        _signedEventRelay = signedEventRelay,
        _remoteEnabled = remoteEnabled,
        _onChanged = onChanged,
+       _startupRetryBaseDelay = startupRetryBaseDelay,
        _store = ChannelSortStorage(prefs).read(pubkey),
        _dirtySince = ChannelSortStorage(prefs).readDirtySince(pubkey);
 
@@ -89,8 +98,20 @@ class ChannelSortManager {
       return;
     }
 
-    final foundRemote = await _fetchAndMerge();
-    await _startLiveSubscription();
+    await _syncWithRelay();
+    _onChanged();
+  }
+
+  /// One startup-sync attempt: fetch the remote blob, start the live
+  /// subscription, then reconcile dirty/seed state. Either step can lose a
+  /// transient race on cold start (the relay rate-limits the burst of
+  /// per-channel subscriptions and rejects with `rate-limited: quota
+  /// exceeded`) — retry with backoff instead of silently giving up.
+  Future<void> _syncWithRelay() async {
+    final foundRemote = _startupFetchSucceeded ? true : await _fetchAndMerge();
+    if (foundRemote != null) _startupFetchSucceeded = true;
+
+    final subscribed = _unsubscribe != null || await _startLiveSubscription();
 
     // Publish-on-reconnect for unpublished local edits, and seed-publish when
     // the relay confirmed it has no blob but local prefs exist. `foundRemote`
@@ -98,12 +119,40 @@ class ChannelSortManager {
     if (_dirtySince > 0 || (foundRemote == false && _store.groups.isNotEmpty)) {
       markDirty();
     }
-    _onChanged();
+
+    if (!_startupFetchSucceeded || !subscribed) {
+      _scheduleStartupRetry();
+    }
+  }
+
+  void _scheduleStartupRetry() {
+    if (_disposed) return;
+    _startupRetryTimer?.cancel();
+    final delayMs = min(
+      _startupRetryBaseDelay.inMilliseconds << min(_startupRetryAttempt, 5),
+      30000,
+    );
+    _startupRetryAttempt++;
+    debugPrint(
+      '[ChannelSortManager] startup sync incomplete; '
+      'retrying in ${delayMs}ms (attempt $_startupRetryAttempt)',
+    );
+    _startupRetryTimer = Timer(Duration(milliseconds: delayMs), () {
+      _startupRetryTimer = null;
+      unawaited(
+        _syncWithRelay().then((_) {
+          if (!_disposed) _onChanged();
+        }),
+      );
+    });
   }
 
   void dispose({bool flushPending = true}) {
     if (_disposed) return;
     _disposed = true;
+
+    _startupRetryTimer?.cancel();
+    _startupRetryTimer = null;
 
     final hadPending = _publishDebounce != null;
     _publishDebounce?.cancel();
@@ -177,14 +226,16 @@ class ChannelSortManager {
       return events.any(
         (e) => e.pubkey == pubkey && e.getTagValue('d') == 'channel-sort',
       );
-    } catch (_) {
+    } catch (error) {
+      debugPrint('[ChannelSortManager] fetch failed: $error');
       // Local state remains usable when relay is unavailable.
       return null;
     }
   }
 
-  Future<void> _startLiveSubscription() async {
-    if (_relaySession == null) return;
+  /// Returns whether the live subscription was established.
+  Future<bool> _startLiveSubscription() async {
+    if (_relaySession == null) return false;
     try {
       _unsubscribe = await _relaySession.subscribe(
         NostrFilter(
@@ -197,8 +248,12 @@ class ChannelSortManager {
         ),
         _handleIncomingEvent,
       );
-    } catch (_) {
-      // Non-fatal — local state and history still work.
+      return true;
+    } catch (error) {
+      debugPrint('[ChannelSortManager] live subscription failed: $error');
+      // Non-fatal — local state and history still work; retried by the
+      // startup-sync backoff.
+      return false;
     }
   }
 

--- a/mobile/lib/features/channels/channel_sort/channel_sort_manager.dart
+++ b/mobile/lib/features/channels/channel_sort/channel_sort_manager.dart
@@ -5,19 +5,16 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:nostr/nostr.dart' as nostr;
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:uuid/uuid.dart';
 
 import '../../../shared/crypto/nip44.dart';
 import '../../../shared/relay/relay.dart';
 import '../read_state/read_state_time.dart';
-import 'channel_sections_storage.dart';
+import 'channel_sort_storage.dart';
 
-const _uuid = Uuid();
-
-class ChannelSectionsCrypto {
+class ChannelSortCrypto {
   final Uint8List _conversationKey;
 
-  ChannelSectionsCrypto(String nsec, String pubkey)
+  ChannelSortCrypto(String nsec, String pubkey)
     : _conversationKey = _deriveKey(nsec, pubkey);
 
   static Uint8List _deriveKey(String nsec, String pubkey) {
@@ -31,17 +28,23 @@ class ChannelSectionsCrypto {
       nip44Decrypt(_conversationKey, ciphertext);
 }
 
-class ChannelSectionsManager {
+/// Syncs per-group sidebar sort preferences across clients via encrypted
+/// NIP-78 app data (kind 30078, d-tag `channel-sort`), mirroring desktop's
+/// `ChannelSortSyncManager`: NIP-44 encrypted-to-self content, debounced
+/// writes, whole-blob last-write-wins, plus the same dirty-state protection
+/// as the mobile sections manager so unpublished edits survive manager
+/// teardown and reconnects.
+class ChannelSortManager {
   final String pubkey;
-  final ChannelSectionsStorage _storage;
-  final ChannelSectionsCrypto _crypto;
+  final ChannelSortStorage _storage;
+  final ChannelSortCrypto _crypto;
   final RelaySessionNotifier? _relaySession;
   final SignedEventRelay? _signedEventRelay;
   final bool _remoteEnabled;
   final VoidCallback _onChanged;
 
-  ChannelSectionStore _store;
-  ChannelSectionStore? _lastPublishedStore;
+  ChannelSortStore _store;
+  ChannelSortStore? _lastPublishedStore;
   Timer? _publishDebounce;
   int _lastRemoteCreatedAt = 0;
   String? _lastRemoteEventId;
@@ -49,34 +52,31 @@ class ChannelSectionsManager {
   bool _disposed = false;
 
   /// Unix seconds of the oldest unpublished local edit; 0 when clean.
-  /// Persisted so unpublished edits survive manager teardown — the provider
-  /// rebuilds this manager on every relay-session status flip, which would
-  /// otherwise drop the pending debounce and let a stale remote blob clobber
-  /// newer local state on the next fetch.
+  /// Persisted so unpublished edits survive manager teardown and restarts.
   int _dirtySince;
 
   /// Bumped on every local edit so a publish only clears the dirty flag when
   /// no new edit landed while the publish was in flight.
   int _editGeneration = 0;
 
-  ChannelSectionsManager({
+  ChannelSortManager({
     required this.pubkey,
     required SharedPreferences prefs,
-    required ChannelSectionsCrypto crypto,
+    required ChannelSortCrypto crypto,
     required RelaySessionNotifier? relaySession,
     required SignedEventRelay? signedEventRelay,
     required bool remoteEnabled,
     required VoidCallback onChanged,
-  }) : _storage = ChannelSectionsStorage(prefs),
+  }) : _storage = ChannelSortStorage(prefs),
        _crypto = crypto,
        _relaySession = relaySession,
        _signedEventRelay = signedEventRelay,
        _remoteEnabled = remoteEnabled,
        _onChanged = onChanged,
-       _store = ChannelSectionsStorage(prefs).read(pubkey),
-       _dirtySince = ChannelSectionsStorage(prefs).readDirtySince(pubkey);
+       _store = ChannelSortStorage(prefs).read(pubkey),
+       _dirtySince = ChannelSortStorage(prefs).readDirtySince(pubkey);
 
-  ChannelSectionStore get store => _store;
+  ChannelSortStore get store => _store;
 
   @visibleForTesting
   bool get isDirty => _dirtySince > 0;
@@ -92,14 +92,10 @@ class ChannelSectionsManager {
     final foundRemote = await _fetchAndMerge();
     await _startLiveSubscription();
 
-    // Publish-on-reconnect: unpublished local edits (persisted dirty flag)
-    // survive teardown/rebuild and get flushed once we're connected again.
-    // Seed-publish: if the relay confirmed it has no blob at all but local
-    // state exists, push local up so other clients can sync. `foundRemote`
+    // Publish-on-reconnect for unpublished local edits, and seed-publish when
+    // the relay confirmed it has no blob but local prefs exist. `foundRemote`
     // is null when the fetch failed — never seed-publish on a failed fetch.
-    if (_dirtySince > 0 ||
-        (foundRemote == false &&
-            (_store.sections.isNotEmpty || _store.assignments.isNotEmpty))) {
+    if (_dirtySince > 0 || (foundRemote == false && _store.groups.isNotEmpty)) {
       markDirty();
     }
     _onChanged();
@@ -121,102 +117,26 @@ class ChannelSectionsManager {
     _unsubscribe = null;
   }
 
-  void createSection(String name) {
+  void setSortModeFor(
+    String groupKey,
+    ChannelSortMode mode, {
+    Iterable<String>? liveSectionIds,
+  }) {
     if (_disposed) return;
-    final maxOrder = _store.sections.fold<int>(
-      -1,
-      (max, s) => s.order > max ? s.order : max,
+    final updated = ChannelSortStore(
+      groups: {..._store.groups, groupKey: mode},
     );
-    final section = ChannelSection(
-      id: _uuid.v4(),
-      name: name.trim(),
-      order: maxOrder + 1,
-    );
-    _store = ChannelSectionStore(
-      sections: [..._store.sections, section],
-      assignments: _store.assignments,
-    );
+    // Prune sort modes left behind by deleted custom sections on write so the
+    // stored map can't grow unboundedly with stale `section:` keys.
+    _store = liveSectionIds != null
+        ? stripOrphanedSectionModes(updated, liveSectionIds)
+        : updated;
     _persist();
     markDirty();
   }
 
-  void renameSection(String sectionId, String newName) {
-    if (_disposed) return;
-    _store = ChannelSectionStore(
-      sections: [
-        for (final s in _store.sections)
-          if (s.id == sectionId)
-            ChannelSection(
-              id: s.id,
-              name: newName.trim(),
-              icon: s.icon,
-              order: s.order,
-            )
-          else
-            s,
-      ],
-      assignments: _store.assignments,
-    );
-    _persist();
-    markDirty();
-  }
-
-  void deleteSection(String sectionId) {
-    if (_disposed) return;
-    final updatedAssignments = Map<String, String>.from(_store.assignments)
-      ..removeWhere((_, sid) => sid == sectionId);
-    _store = ChannelSectionStore(
-      sections: [
-        for (final s in _store.sections)
-          if (s.id != sectionId) s,
-      ],
-      assignments: updatedAssignments,
-    );
-    _persist();
-    markDirty();
-  }
-
-  void moveSectionUp(String sectionId) {
-    if (_disposed) return;
-    final sorted = _sortedSections();
-    final idx = sorted.indexWhere((s) => s.id == sectionId);
-    if (idx <= 0) return;
-    _swapOrders(sorted, idx, idx - 1);
-    markDirty();
-  }
-
-  void moveSectionDown(String sectionId) {
-    if (_disposed) return;
-    final sorted = _sortedSections();
-    final idx = sorted.indexWhere((s) => s.id == sectionId);
-    if (idx < 0 || idx >= sorted.length - 1) return;
-    _swapOrders(sorted, idx, idx + 1);
-    markDirty();
-  }
-
-  void assignChannel(String channelId, String sectionId) {
-    if (_disposed) return;
-    final updated = Map<String, String>.from(_store.assignments)
-      ..[channelId] = sectionId;
-    _store = ChannelSectionStore(
-      sections: _store.sections,
-      assignments: updated,
-    );
-    _persist();
-    markDirty();
-  }
-
-  void unassignChannel(String channelId) {
-    if (_disposed) return;
-    final updated = Map<String, String>.from(_store.assignments)
-      ..remove(channelId);
-    _store = ChannelSectionStore(
-      sections: _store.sections,
-      assignments: updated,
-    );
-    _persist();
-    markDirty();
-  }
+  ChannelSortMode sortModeFor(String groupKey) =>
+      _store.groups[groupKey] ?? kDefaultSortMode;
 
   void markDirty() {
     if (_disposed) return;
@@ -236,8 +156,8 @@ class ChannelSectionsManager {
     });
   }
 
-  /// Returns whether the relay reported a `channel-sections` blob, or null
-  /// when the fetch failed (offline / relay error).
+  /// Returns whether the relay reported a `channel-sort` blob, or null when
+  /// the fetch failed (offline / relay error).
   Future<bool?> _fetchAndMerge() async {
     if (_relaySession == null) return null;
     try {
@@ -246,7 +166,7 @@ class ChannelSectionsManager {
           kinds: const [EventKind.readState],
           authors: [pubkey],
           tags: const {
-            '#d': ['channel-sections'],
+            '#d': ['channel-sort'],
           },
           limit: 1,
         ),
@@ -255,7 +175,7 @@ class ChannelSectionsManager {
       _persist();
       if (!_disposed) _onChanged();
       return events.any(
-        (e) => e.pubkey == pubkey && e.getTagValue('d') == 'channel-sections',
+        (e) => e.pubkey == pubkey && e.getTagValue('d') == 'channel-sort',
       );
     } catch (_) {
       // Local state remains usable when relay is unavailable.
@@ -271,7 +191,7 @@ class ChannelSectionsManager {
           kinds: const [EventKind.readState],
           authors: [pubkey],
           tags: const {
-            '#d': ['channel-sections'],
+            '#d': ['channel-sort'],
           },
           limit: 1,
         ),
@@ -290,16 +210,16 @@ class ChannelSectionsManager {
   }
 
   void _mergeEvent(NostrEvent event) {
-    // Only process channel-sections d-tag events.
+    // Only process channel-sort d-tag events.
     final dTag = event.getTagValue('d');
-    if (dTag != 'channel-sections') return;
+    if (dTag != 'channel-sort') return;
 
     try {
       final plaintext = _crypto.decrypt(event.content);
       final parsed = jsonDecode(plaintext);
       if (parsed is! Map<String, dynamic>) return;
 
-      final incoming = ChannelSectionStore.fromJson(parsed);
+      final incoming = ChannelSortStore.fromJson(parsed);
 
       // Last-write-wins: newer createdAt wins; tie-break by event ID.
       final isNewer =
@@ -311,11 +231,7 @@ class ChannelSectionsManager {
         _lastRemoteCreatedAt = event.createdAt;
         _lastRemoteEventId = event.id;
         // Dirty-state protection: never let a remote blob overwrite
-        // unpublished local edits. Whole-blob LWW would otherwise adopt a
-        // stale remote store fetched right after a teardown/rebuild and
-        // silently drop the just-made edit. We still advance
-        // _lastRemoteCreatedAt above so our eventual publish sorts after the
-        // remote event; the pending publish then reconciles the relay.
+        // unpublished local edits; the pending publish reconciles the relay.
         if (_dirtySince > 0) return;
         _store = incoming;
         _persist();
@@ -334,20 +250,9 @@ class ChannelSectionsManager {
   bool _isIdenticalToLastPublished() {
     final last = _lastPublishedStore;
     if (last == null) return false;
-    if (last.sections.length != _store.sections.length) return false;
-    if (last.assignments.length != _store.assignments.length) return false;
-    for (var i = 0; i < _store.sections.length; i++) {
-      final a = last.sections[i];
-      final b = _store.sections[i];
-      if (a.id != b.id ||
-          a.name != b.name ||
-          a.icon != b.icon ||
-          a.order != b.order) {
-        return false;
-      }
-    }
-    for (final key in _store.assignments.keys) {
-      if (last.assignments[key] != _store.assignments[key]) return false;
+    if (last.groups.length != _store.groups.length) return false;
+    for (final key in _store.groups.keys) {
+      if (last.groups[key] != _store.groups[key]) return false;
     }
     return true;
   }
@@ -381,20 +286,17 @@ class ChannelSectionsManager {
         kind: EventKind.readState,
         content: ciphertext,
         tags: [
-          ['d', 'channel-sections'],
-          ['t', 'channel-sections'],
+          ['d', 'channel-sort'],
+          ['t', 'channel-sort'],
         ],
         createdAt: createdAt,
       );
 
       _lastRemoteCreatedAt = max(_lastRemoteCreatedAt, createdAt);
-      _lastPublishedStore = ChannelSectionStore(
-        sections: List.of(_store.sections),
-        assignments: Map.of(_store.assignments),
-      );
+      _lastPublishedStore = ChannelSortStore(groups: Map.of(_store.groups));
       _clearDirty(generationAtStart);
     } catch (error) {
-      debugPrint('[ChannelSectionsManager] publish failed: $error');
+      debugPrint('[ChannelSortManager] publish failed: $error');
       // Dirty flag stays set; the next initialize() re-schedules the publish.
     }
   }
@@ -410,32 +312,5 @@ class ChannelSectionsManager {
 
   void _persist() {
     _storage.write(pubkey, _store);
-  }
-
-  List<ChannelSection> _sortedSections() {
-    final sorted = _store.sections.toList()
-      ..sort((a, b) => a.order.compareTo(b.order));
-    return sorted;
-  }
-
-  void _swapOrders(List<ChannelSection> sorted, int indexA, int indexB) {
-    final orderA = sorted[indexA].order;
-    final orderB = sorted[indexB].order;
-    final idA = sorted[indexA].id;
-    final idB = sorted[indexB].id;
-
-    _store = ChannelSectionStore(
-      sections: [
-        for (final s in _store.sections)
-          if (s.id == idA)
-            ChannelSection(id: s.id, name: s.name, icon: s.icon, order: orderB)
-          else if (s.id == idB)
-            ChannelSection(id: s.id, name: s.name, icon: s.icon, order: orderA)
-          else
-            s,
-      ],
-      assignments: _store.assignments,
-    );
-    _persist();
   }
 }

--- a/mobile/lib/features/channels/channel_sort/channel_sort_provider.dart
+++ b/mobile/lib/features/channels/channel_sort/channel_sort_provider.dart
@@ -1,0 +1,121 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+import '../../../shared/relay/relay.dart';
+import '../../../shared/theme/theme_provider.dart';
+import '../../../shared/community/community_provider.dart';
+import 'channel_sort_manager.dart';
+import 'channel_sort_storage.dart';
+
+class ChannelSortState {
+  final bool isReady;
+  final ChannelSortStore store;
+
+  /// Bumped on every change to force downstream rebuilds.
+  final int version;
+
+  const ChannelSortState({
+    this.isReady = false,
+    this.store = const ChannelSortStore(),
+    this.version = 0,
+  });
+
+  ChannelSortMode sortModeFor(String groupKey) =>
+      store.groups[groupKey] ?? kDefaultSortMode;
+}
+
+class ChannelSortNotifier extends Notifier<ChannelSortState> {
+  ChannelSortManager? _manager;
+
+  @override
+  ChannelSortState build() {
+    _manager?.dispose(flushPending: false);
+    _manager = null;
+
+    final relayConfig = ref.watch(relayConfigProvider);
+    final sessionState = ref.watch(relaySessionProvider);
+    // Rebuild when the active community changes (pubkey may differ).
+    ref.watch(activeCommunityProvider);
+
+    final nsec = relayConfig.nsec?.trim();
+    if (nsec == null || nsec.isEmpty) {
+      return const ChannelSortState();
+    }
+
+    final pubkey = _safePubkeyFromNsec(nsec);
+    if (pubkey == null || pubkey.isEmpty) {
+      return const ChannelSortState();
+    }
+
+    final ChannelSortCrypto crypto;
+    try {
+      crypto = ChannelSortCrypto(nsec, pubkey);
+    } catch (_) {
+      return const ChannelSortState();
+    }
+
+    final prefs = ref.read(savedPrefsProvider);
+    final signedRelay = SignedEventRelay(
+      session: ref.read(relaySessionProvider.notifier),
+      nsec: nsec,
+    );
+
+    late final ChannelSortManager manager;
+    manager = ChannelSortManager(
+      pubkey: pubkey,
+      prefs: prefs,
+      crypto: crypto,
+      relaySession: ref.read(relaySessionProvider.notifier),
+      signedEventRelay: signedRelay,
+      remoteEnabled: sessionState.status == SessionStatus.connected,
+      onChanged: () => _emitManagerState(manager),
+    );
+    _manager = manager;
+
+    ref.onDispose(() {
+      manager.dispose();
+      if (_manager == manager) {
+        _manager = null;
+      }
+    });
+
+    Future.microtask(() async {
+      await manager.initialize();
+      if (_manager != manager) return;
+      _emitManagerState(manager);
+    });
+
+    return ChannelSortState(isReady: false, store: manager.store, version: 1);
+  }
+
+  void setSortModeFor(
+    String groupKey,
+    ChannelSortMode mode, {
+    Iterable<String>? liveSectionIds,
+  }) =>
+      _manager?.setSortModeFor(groupKey, mode, liveSectionIds: liveSectionIds);
+
+  void _emitManagerState(ChannelSortManager manager) {
+    if (_manager != manager) return;
+    state = ChannelSortState(
+      isReady: true,
+      store: manager.store,
+      version: state.version + 1,
+    );
+  }
+}
+
+final channelSortProvider =
+    NotifierProvider<ChannelSortNotifier, ChannelSortState>(
+      ChannelSortNotifier.new,
+    );
+
+String? _safePubkeyFromNsec(String nsec) {
+  try {
+    final privkeyHex = nostr.Nip19.decode(payload: nsec).data;
+    if (privkeyHex.isEmpty) return null;
+    return nostr.Keys(privkeyHex).public;
+  } catch (_) {
+    return null;
+  }
+}

--- a/mobile/lib/features/channels/channel_sort/channel_sort_storage.dart
+++ b/mobile/lib/features/channels/channel_sort/channel_sort_storage.dart
@@ -1,0 +1,156 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../channel.dart';
+
+String channelSortKey(String pubkey) => 'buzz.channel-sort.v1:$pubkey';
+
+String channelSortDirtySinceKey(String pubkey) =>
+    'buzz.channel-sort.dirty-since.v1:$pubkey';
+
+/// Per-group sidebar sort mode. Matches desktop's `ChannelSortMode` — the
+/// payload strings ('alpha' | 'recent') are shared relay format.
+enum ChannelSortMode {
+  alpha('alpha'),
+  recent('recent');
+
+  final String wireValue;
+
+  const ChannelSortMode(this.wireValue);
+
+  static ChannelSortMode? fromWire(Object? value) {
+    if (value == 'alpha') return ChannelSortMode.alpha;
+    if (value == 'recent') return ChannelSortMode.recent;
+    return null;
+  }
+}
+
+const ChannelSortMode kDefaultSortMode = ChannelSortMode.alpha;
+
+/// Group key for a custom section, matching desktop's `section:<id>` format.
+String sectionSortGroupKey(String sectionId) => 'section:$sectionId';
+
+class ChannelSortStore {
+  final int version;
+
+  /// Group key → sort mode. Fixed groups use their name ('starred',
+  /// 'channels', 'forums', 'dms'); custom sections use `section:<id>`.
+  final Map<String, ChannelSortMode> groups;
+
+  const ChannelSortStore({this.version = 1, this.groups = const {}});
+
+  Map<String, dynamic> toJson() => {
+    'version': version,
+    'groups': {
+      for (final entry in groups.entries) entry.key: entry.value.wireValue,
+    },
+  };
+
+  factory ChannelSortStore.fromJson(Map<String, dynamic> json) {
+    final rawGroups = json['groups'];
+    final groups = <String, ChannelSortMode>{};
+    if (rawGroups is Map) {
+      for (final entry in rawGroups.entries) {
+        final key = entry.key;
+        final mode = ChannelSortMode.fromWire(entry.value);
+        if (key is String && mode != null) {
+          groups[key] = mode;
+        }
+      }
+    }
+    return ChannelSortStore(version: 1, groups: groups);
+  }
+}
+
+/// Drops per-section sort modes whose custom section no longer exists so
+/// deleted sections don't leave stale `section:<id>` keys behind. Fixed group
+/// keys are always kept. Returns the same store when nothing needs stripping.
+ChannelSortStore stripOrphanedSectionModes(
+  ChannelSortStore store,
+  Iterable<String> liveSectionIds,
+) {
+  final liveKeys = {for (final id in liveSectionIds) sectionSortGroupKey(id)};
+  final kept = <String, ChannelSortMode>{
+    for (final entry in store.groups.entries)
+      if (!entry.key.startsWith('section:') || liveKeys.contains(entry.key))
+        entry.key: entry.value,
+  };
+  if (kept.length == store.groups.length) return store;
+  return ChannelSortStore(version: store.version, groups: kept);
+}
+
+/// Sorts one sidebar grouping's channels by the selected mode, mirroring
+/// desktop's `sortChannelsForSidebar`: `alpha` orders by name (id
+/// tie-breaker); `recent` orders by last message time, newest first, with
+/// message-less channels sinking to the bottom alphabetically.
+List<Channel> sortChannelsForList(
+  List<Channel> channels,
+  ChannelSortMode mode,
+) {
+  int byName(Channel left, Channel right) {
+    final name = left.name.toLowerCase().compareTo(right.name.toLowerCase());
+    if (name != 0) return name;
+    return left.id.compareTo(right.id);
+  }
+
+  final sorted = channels.toList();
+  if (mode == ChannelSortMode.alpha) {
+    sorted.sort(byName);
+    return sorted;
+  }
+  sorted.sort((left, right) {
+    final leftMs = left.lastMessageAt?.millisecondsSinceEpoch;
+    final rightMs = right.lastMessageAt?.millisecondsSinceEpoch;
+    if (leftMs != null && rightMs != null && leftMs != rightMs) {
+      return rightMs.compareTo(leftMs);
+    }
+    if (leftMs != null && rightMs == null) return -1;
+    if (leftMs == null && rightMs != null) return 1;
+    return byName(left, right);
+  });
+  return sorted;
+}
+
+class ChannelSortStorage {
+  final SharedPreferences _prefs;
+
+  ChannelSortStorage(this._prefs);
+
+  ChannelSortStore read(String pubkey) {
+    final raw = _prefs.getString(channelSortKey(pubkey));
+    if (raw == null || raw.isEmpty) {
+      return const ChannelSortStore();
+    }
+
+    try {
+      final parsed = jsonDecode(raw);
+      if (parsed is! Map<String, dynamic>) {
+        return const ChannelSortStore();
+      }
+      if (parsed['version'] != 1) {
+        return const ChannelSortStore();
+      }
+      return ChannelSortStore.fromJson(parsed);
+    } catch (_) {
+      return const ChannelSortStore();
+    }
+  }
+
+  void write(String pubkey, ChannelSortStore store) {
+    _prefs.setString(channelSortKey(pubkey), jsonEncode(store.toJson()));
+  }
+
+  /// Unix seconds of the oldest unpublished local edit, or 0 when clean.
+  /// Persisted so unpublished edits survive manager teardown and restarts.
+  int readDirtySince(String pubkey) =>
+      _prefs.getInt(channelSortDirtySinceKey(pubkey)) ?? 0;
+
+  void writeDirtySince(String pubkey, int dirtySince) {
+    if (dirtySince <= 0) {
+      _prefs.remove(channelSortDirtySinceKey(pubkey));
+    } else {
+      _prefs.setInt(channelSortDirtySinceKey(pubkey), dirtySince);
+    }
+  }
+}

--- a/mobile/lib/features/channels/channels_page.dart
+++ b/mobile/lib/features/channels/channels_page.dart
@@ -32,6 +32,8 @@ import 'ephemeral_channel_display.dart';
 import 'channel_mutes/channel_mutes_provider.dart';
 import 'channel_sections/channel_sections_provider.dart';
 import 'channel_sections/channel_sections_storage.dart';
+import 'channel_sort/channel_sort_provider.dart';
+import 'channel_sort/channel_sort_storage.dart';
 import 'channel_stars/channel_stars_provider.dart';
 import 'channels_provider.dart';
 import 'read_state/deferred_read_state_update.dart';

--- a/mobile/lib/features/channels/channels_page/body.dart
+++ b/mobile/lib/features/channels/channels_page/body.dart
@@ -120,6 +120,7 @@ class _SliverChannelsList extends HookConsumerWidget {
     final starredExpanded = useState(true);
     final channelsExpanded = useState(true);
     final dmsExpanded = useState(true);
+    final sortState = ref.watch(channelSortProvider);
     final initialSeedComplete = useState(false);
     final seededPubkey = useRef<String?>(null);
     final seedCompleteForPubkey =
@@ -184,16 +185,33 @@ class _SliverChannelsList extends HookConsumerWidget {
     };
     // Starred is exclusive: a starred channel lives only in the Starred section,
     // not in its custom section or the default Channels list.
-    final starredStreamChannels = streamChannels
-        .where((c) => starredChannelIds.contains(c.id))
-        .toList();
-    final ungroupedStreamChannels = streamChannels
-        .where(
-          (c) =>
-              !assignedChannelIds.contains(c.id) &&
-              !starredChannelIds.contains(c.id),
-        )
-        .toList();
+    final starredStreamChannels = sortChannelsForList(
+      streamChannels.where((c) => starredChannelIds.contains(c.id)).toList(),
+      sortState.sortModeFor('starred'),
+    );
+    final ungroupedStreamChannels = sortChannelsForList(
+      streamChannels
+          .where(
+            (c) =>
+                !assignedChannelIds.contains(c.id) &&
+                !starredChannelIds.contains(c.id),
+          )
+          .toList(),
+      sortState.sortModeFor('channels'),
+    );
+    // DMs default to the display-label alphabetical order (labels can differ
+    // from channel names); Recent mode reorders by last message time.
+    final sortedDmChannels =
+        sortState.sortModeFor('dms') == ChannelSortMode.recent
+        ? sortChannelsForList(dmChannels, ChannelSortMode.recent)
+        : dmChannels;
+
+    final liveSectionIds = [for (final s in userSections) s.id];
+    void setSortMode(String groupKey, ChannelSortMode mode) {
+      ref
+          .read(channelSortProvider.notifier)
+          .setSortModeFor(groupKey, mode, liveSectionIds: liveSectionIds);
+    }
 
     final sectionExpandedStates = useState<Map<String, bool>>({});
 
@@ -228,19 +246,24 @@ class _SliverChannelsList extends HookConsumerWidget {
                 mutedChannelIds: mutedChannelIds,
                 currentPubkey: currentPubkey,
                 emptyLabel: '',
+                sortMode: sortState.sortModeFor('starred'),
+                onSortModeChange: (mode) => setSortMode('starred', mode),
                 onSelectChannel: onSelectChannel,
               ),
             // User-defined sections for stream channels, in user-defined order.
             for (final section in userSections)
               _CustomChannelSection(
                 section: section,
-                channels: streamChannels
-                    .where(
-                      (c) =>
-                          sectionAssignments[c.id] == section.id &&
-                          !starredChannelIds.contains(c.id),
-                    )
-                    .toList(),
+                channels: sortChannelsForList(
+                  streamChannels
+                      .where(
+                        (c) =>
+                            sectionAssignments[c.id] == section.id &&
+                            !starredChannelIds.contains(c.id),
+                      )
+                      .toList(),
+                  sortState.sortModeFor(sectionSortGroupKey(section.id)),
+                ),
                 unreadChannelIds: unreadChannelIds,
                 unreadChannelCounts: unreadChannelCounts,
                 mutedChannelIds: mutedChannelIds,
@@ -302,6 +325,11 @@ class _SliverChannelsList extends HookConsumerWidget {
                 onMoveDown: () => ref
                     .read(channelSectionsProvider.notifier)
                     .moveSectionDown(section.id),
+                sortMode: sortState.sortModeFor(
+                  sectionSortGroupKey(section.id),
+                ),
+                onSortModeChange: (mode) =>
+                    setSortMode(sectionSortGroupKey(section.id), mode),
                 onSelectChannel: onSelectChannel,
                 onMarkChannelRead: (channel) {
                   final ts = dateTimeToUnixSeconds(channel.lastMessageAt);
@@ -328,6 +356,8 @@ class _SliverChannelsList extends HookConsumerWidget {
               mutedChannelIds: mutedChannelIds,
               currentPubkey: currentPubkey,
               emptyLabel: 'No stream channels yet',
+              sortMode: sortState.sortModeFor('channels'),
+              onSortModeChange: (mode) => setSortMode('channels', mode),
               onSelectChannel: onSelectChannel,
             ),
             _ChannelSection(
@@ -336,12 +366,14 @@ class _SliverChannelsList extends HookConsumerWidget {
               showTopDivider: true,
               expanded: dmsExpanded.value,
               onToggle: () => dmsExpanded.value = !dmsExpanded.value,
-              channels: dmChannels,
+              channels: sortedDmChannels,
               unreadChannelIds: unreadChannelIds,
               unreadChannelCounts: unreadChannelCounts,
               mutedChannelIds: mutedChannelIds,
               currentPubkey: currentPubkey,
               emptyLabel: 'No direct messages yet',
+              sortMode: sortState.sortModeFor('dms'),
+              onSortModeChange: (mode) => setSortMode('dms', mode),
               onSelectChannel: onSelectChannel,
             ),
           ],

--- a/mobile/lib/features/channels/channels_page/sections.dart
+++ b/mobile/lib/features/channels/channels_page/sections.dart
@@ -16,6 +16,8 @@ class _CustomChannelSection extends StatelessWidget {
   final VoidCallback onDelete;
   final VoidCallback onMoveUp;
   final VoidCallback onMoveDown;
+  final ChannelSortMode sortMode;
+  final void Function(ChannelSortMode mode) onSortModeChange;
   final Future<void> Function(Channel channel) onSelectChannel;
   final void Function(Channel channel) onMarkChannelRead;
 
@@ -35,6 +37,8 @@ class _CustomChannelSection extends StatelessWidget {
     required this.onDelete,
     required this.onMoveUp,
     required this.onMoveDown,
+    required this.sortMode,
+    required this.onSortModeChange,
     required this.onSelectChannel,
     required this.onMarkChannelRead,
   });
@@ -55,6 +59,8 @@ class _CustomChannelSection extends StatelessWidget {
           onDelete: onDelete,
           onMoveUp: onMoveUp,
           onMoveDown: onMoveDown,
+          sortMode: sortMode,
+          onSortModeChange: onSortModeChange,
         ),
         _AnimatedSectionBody(
           expanded: expanded,
@@ -90,6 +96,8 @@ class _CustomSectionHeader extends ConsumerWidget {
   final VoidCallback onDelete;
   final VoidCallback onMoveUp;
   final VoidCallback onMoveDown;
+  final ChannelSortMode sortMode;
+  final void Function(ChannelSortMode mode) onSortModeChange;
 
   const _CustomSectionHeader({
     required this.section,
@@ -101,6 +109,8 @@ class _CustomSectionHeader extends ConsumerWidget {
     required this.onDelete,
     required this.onMoveUp,
     required this.onMoveDown,
+    required this.sortMode,
+    required this.onSortModeChange,
   });
 
   @override
@@ -184,6 +194,7 @@ class _CustomSectionHeader extends ConsumerWidget {
                       enabled: !isLast,
                       child: const Text('Move Down'),
                     ),
+                    ..._sortMenuItems(sortMode),
                     const PopupMenuItem(value: 'delete', child: Text('Delete')),
                   ],
                 );
@@ -194,6 +205,10 @@ class _CustomSectionHeader extends ConsumerWidget {
                     onMoveUp();
                   case 'move_down':
                     onMoveDown();
+                  case _kSortRecentMenuValue:
+                    onSortModeChange(ChannelSortMode.recent);
+                  case _kSortAlphaMenuValue:
+                    onSortModeChange(ChannelSortMode.alpha);
                   case 'delete':
                     onDelete();
                 }
@@ -222,6 +237,25 @@ CustomEmoji? _resolveCustomEmoji(String icon, List<CustomEmoji> palette) {
   }
   return null;
 }
+
+const String _kSortRecentMenuValue = 'sort_recent';
+const String _kSortAlphaMenuValue = 'sort_alpha';
+
+/// Sort radio items shared by the fixed-group and custom-section menus,
+/// mirroring desktop's Sort → Recent / A–Z options.
+List<PopupMenuEntry<String>> _sortMenuItems(ChannelSortMode current) => [
+  const PopupMenuDivider(),
+  CheckedPopupMenuItem(
+    value: _kSortRecentMenuValue,
+    checked: current == ChannelSortMode.recent,
+    child: const Text('Sort: Recent'),
+  ),
+  CheckedPopupMenuItem(
+    value: _kSortAlphaMenuValue,
+    checked: current == ChannelSortMode.alpha,
+    child: const Text('Sort: A–Z'),
+  ),
+];
 
 class _SectionNameDialog extends HookWidget {
   final String title;
@@ -274,6 +308,8 @@ class _ChannelSection extends StatelessWidget {
   final Set<String> mutedChannelIds;
   final String? currentPubkey;
   final String emptyLabel;
+  final ChannelSortMode? sortMode;
+  final void Function(ChannelSortMode mode)? onSortModeChange;
   final Future<void> Function(Channel channel) onSelectChannel;
 
   const _ChannelSection({
@@ -288,6 +324,8 @@ class _ChannelSection extends StatelessWidget {
     required this.mutedChannelIds,
     required this.currentPubkey,
     required this.emptyLabel,
+    this.sortMode,
+    this.onSortModeChange,
     required this.onSelectChannel,
   });
 
@@ -302,6 +340,8 @@ class _ChannelSection extends StatelessWidget {
           icon: icon,
           expanded: expanded,
           onToggle: onToggle,
+          sortMode: sortMode,
+          onSortModeChange: onSortModeChange,
         ),
         _AnimatedSectionBody(
           expanded: expanded,
@@ -396,17 +436,22 @@ class _SectionHeader extends StatelessWidget {
   final IconData icon;
   final bool expanded;
   final VoidCallback onToggle;
+  final ChannelSortMode? sortMode;
+  final void Function(ChannelSortMode mode)? onSortModeChange;
 
   const _SectionHeader({
     required this.label,
     required this.icon,
     required this.expanded,
     required this.onToggle,
+    this.sortMode,
+    this.onSortModeChange,
   });
 
   @override
   Widget build(BuildContext context) {
     final sectionColor = context.colors.primary;
+    final showSortMenu = sortMode != null && onSortModeChange != null;
 
     return GestureDetector(
       onTap: onToggle,
@@ -436,6 +481,38 @@ class _SectionHeader extends StatelessWidget {
               ),
             ),
             const Spacer(),
+            if (showSortMenu) ...[
+              GestureDetector(
+                onTapUp: (details) async {
+                  final overlay =
+                      Overlay.of(context).context.findRenderObject()!
+                          as RenderBox;
+                  final position = RelativeRect.fromRect(
+                    details.globalPosition & Size.zero,
+                    Offset.zero & overlay.size,
+                  );
+                  final value = await showMenu<String>(
+                    context: context,
+                    position: position,
+                    // _sortMenuItems leads with a divider for the mixed
+                    // custom-section menu; skip it here.
+                    items: _sortMenuItems(sortMode!).skip(1).toList(),
+                  );
+                  switch (value) {
+                    case _kSortRecentMenuValue:
+                      onSortModeChange!(ChannelSortMode.recent);
+                    case _kSortAlphaMenuValue:
+                      onSortModeChange!(ChannelSortMode.alpha);
+                  }
+                },
+                child: Icon(
+                  LucideIcons.ellipsisVertical,
+                  size: _kChannelIconSize,
+                  color: sectionColor,
+                ),
+              ),
+              const SizedBox(width: Grid.quarter),
+            ],
             _SectionChevron(expanded: expanded, color: sectionColor),
           ],
         ),

--- a/mobile/test/features/channels/channel_sections/channel_sections_manager_test.dart
+++ b/mobile/test/features/channels/channel_sections/channel_sections_manager_test.dart
@@ -1,0 +1,351 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr/nostr.dart' as nostr;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:buzz/features/channels/channel_sections/channel_sections_manager.dart';
+import 'package:buzz/features/channels/channel_sections/channel_sections_storage.dart';
+import 'package:buzz/shared/relay/relay.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  late nostr.Keys keychain;
+  late ChannelSectionsCrypto crypto;
+
+  Future<void> setUpEnv() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    keychain = nostr.Keys.generate();
+    crypto = ChannelSectionsCrypto(keychain.nsec, keychain.public);
+  }
+
+  NostrEvent sectionsEvent({
+    required List<Map<String, dynamic>> sections,
+    Map<String, String> assignments = const {},
+    required int createdAt,
+    String id = 'remote-event',
+  }) {
+    final payload = jsonEncode({
+      'version': 1,
+      'sections': sections,
+      'assignments': assignments,
+    });
+    return NostrEvent(
+      id: id,
+      pubkey: keychain.public,
+      createdAt: createdAt,
+      kind: EventKind.readState,
+      tags: const [
+        ['d', 'channel-sections'],
+        ['t', 'channel-sections'],
+      ],
+      content: crypto.encrypt(payload),
+      sig: 'sig',
+    );
+  }
+
+  ChannelSectionsManager buildManager({
+    RelaySessionNotifier? relaySession,
+    SignedEventRelay? signedEventRelay,
+    bool remoteEnabled = true,
+  }) {
+    return ChannelSectionsManager(
+      pubkey: keychain.public,
+      prefs: prefs,
+      crypto: crypto,
+      relaySession: relaySession,
+      signedEventRelay: signedEventRelay,
+      remoteEnabled: remoteEnabled,
+      onChanged: () {},
+    );
+  }
+
+  test('stale remote blob does not clobber unpublished local edits '
+      '(teardown/rebuild regression)', () async {
+    await setUpEnv();
+    final relay = _FakeRelaySession();
+
+    // First manager: user creates a section; the 5s debounce never fires
+    // because the provider tears the manager down on a status flip.
+    final first = buildManager(
+      relaySession: relay,
+      signedEventRelay: _RecordingSignedEventRelay(),
+    );
+    await first.initialize();
+    first.createSection('My Group');
+    expect(first.store.sections, hasLength(1));
+    first.dispose(flushPending: false);
+
+    // The relay still has an older (empty) blob. The rebuilt manager
+    // fetches it on initialize — pre-fix this adopted the stale blob and
+    // the just-created group vanished.
+    relay.historyEvents = [sectionsEvent(sections: const [], createdAt: 100)];
+    final second = buildManager(
+      relaySession: relay,
+      signedEventRelay: _RecordingSignedEventRelay(),
+    );
+    expect(second.isDirty, isTrue, reason: 'dirty flag must survive rebuild');
+    await second.initialize();
+
+    expect(
+      second.store.sections.map((s) => s.name),
+      contains('My Group'),
+      reason: 'unpublished local edit must survive a stale remote fetch',
+    );
+    second.dispose(flushPending: false);
+  });
+
+  test('rebuilt manager re-schedules publish for unpublished edits', () async {
+    await setUpEnv();
+    final relay = _FakeRelaySession();
+
+    final first = buildManager(
+      relaySession: relay,
+      signedEventRelay: _RecordingSignedEventRelay(),
+    );
+    await first.initialize();
+    first.createSection('My Group');
+    first.dispose(flushPending: false);
+
+    final signedRelay = _RecordingSignedEventRelay();
+    final second = buildManager(
+      relaySession: relay,
+      signedEventRelay: signedRelay,
+    );
+    await second.initialize();
+
+    // initialize() must arm the publish debounce for the surviving dirty
+    // state; fire it via flush-on-dispose to avoid waiting 5s.
+    second.dispose(flushPending: true);
+    final submitted = await signedRelay.submitted.future.timeout(
+      const Duration(seconds: 1),
+    );
+    expect(submitted.kind, EventKind.readState);
+    final plaintext = crypto.decrypt(submitted.content);
+    final decoded = jsonDecode(plaintext) as Map<String, dynamic>;
+    expect(
+      (decoded['sections'] as List).map((s) => s['name']),
+      contains('My Group'),
+    );
+  });
+
+  test('successful publish clears the persisted dirty flag', () async {
+    await setUpEnv();
+    final relay = _FakeRelaySession();
+    final signedRelay = _RecordingSignedEventRelay();
+
+    final manager = buildManager(
+      relaySession: relay,
+      signedEventRelay: signedRelay,
+    );
+    await manager.initialize();
+    manager.createSection('My Group');
+    expect(manager.isDirty, isTrue);
+    manager.dispose(flushPending: true);
+    await signedRelay.submitted.future.timeout(const Duration(seconds: 1));
+    // Let the post-submit bookkeeping in _publish complete.
+    await Future<void>.delayed(Duration.zero);
+
+    expect(ChannelSectionsStorage(prefs).readDirtySince(keychain.public), 0);
+  });
+
+  test('clean manager still adopts newer remote blobs (LWW)', () async {
+    await setUpEnv();
+    final relay = _FakeRelaySession();
+    relay.historyEvents = [
+      sectionsEvent(
+        sections: [
+          {'id': 's1', 'name': 'Desktop Group', 'order': 0},
+        ],
+        createdAt: 100,
+      ),
+    ];
+
+    final manager = buildManager(
+      relaySession: relay,
+      signedEventRelay: _RecordingSignedEventRelay(),
+    );
+    await manager.initialize();
+
+    expect(manager.isDirty, isFalse);
+    expect(manager.store.sections.single.name, 'Desktop Group');
+    manager.dispose(flushPending: false);
+  });
+
+  test('offline edits set the persisted dirty flag', () async {
+    await setUpEnv();
+    final manager = buildManager(remoteEnabled: false);
+    await manager.initialize();
+    manager.createSection('Offline Group');
+
+    expect(
+      ChannelSectionsStorage(prefs).readDirtySince(keychain.public),
+      greaterThan(0),
+      reason: 'offline edits must be flagged for publish-on-reconnect',
+    );
+    manager.dispose(flushPending: false);
+  });
+
+  test(
+    'seed-publish schedules when relay confirms no blob but local exists',
+    () async {
+      await setUpEnv();
+      // Local store exists (e.g. created offline earlier) and is clean.
+      ChannelSectionsStorage(prefs).write(
+        keychain.public,
+        const ChannelSectionStore(
+          sections: [ChannelSection(id: 's1', name: 'Local', order: 0)],
+        ),
+      );
+
+      final relay = _FakeRelaySession(); // empty history: confirmed no blob
+      final signedRelay = _RecordingSignedEventRelay();
+      final manager = buildManager(
+        relaySession: relay,
+        signedEventRelay: signedRelay,
+      );
+      await manager.initialize();
+      manager.dispose(flushPending: true);
+
+      final submitted = await signedRelay.submitted.future.timeout(
+        const Duration(seconds: 1),
+      );
+      final decoded =
+          jsonDecode(crypto.decrypt(submitted.content)) as Map<String, dynamic>;
+      expect(
+        (decoded['sections'] as List).map((s) => s['name']),
+        contains('Local'),
+      );
+    },
+  );
+
+  test('no seed-publish when the initial fetch fails', () async {
+    await setUpEnv();
+    ChannelSectionsStorage(prefs).write(
+      keychain.public,
+      const ChannelSectionStore(
+        sections: [ChannelSection(id: 's1', name: 'Local', order: 0)],
+      ),
+    );
+
+    final relay = _FailingRelaySession();
+    final signedRelay = _RecordingSignedEventRelay();
+    final manager = buildManager(
+      relaySession: relay,
+      signedEventRelay: signedRelay,
+    );
+    await manager.initialize();
+    manager.dispose(flushPending: true);
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(
+      signedRelay.submitted.isCompleted,
+      isFalse,
+      reason: 'a failed fetch must never trigger a seed publish',
+    );
+  });
+
+  test('live remote event is ignored while dirty', () async {
+    await setUpEnv();
+    final relay = _FakeRelaySession();
+    final manager = buildManager(
+      relaySession: relay,
+      signedEventRelay: _RecordingSignedEventRelay(),
+    );
+    await manager.initialize();
+    manager.createSection('My Group');
+
+    // Simulate a live stale event arriving before the debounce fires.
+    relay.emit(sectionsEvent(sections: const [], createdAt: 100));
+
+    expect(manager.store.sections.map((s) => s.name), contains('My Group'));
+    manager.dispose(flushPending: false);
+  });
+}
+
+class _SubmittedEvent {
+  final int kind;
+  final String content;
+  final List<List<String>> tags;
+
+  const _SubmittedEvent({
+    required this.kind,
+    required this.content,
+    required this.tags,
+  });
+}
+
+NostrEvent _stubAckEvent() => const NostrEvent(
+  id: 'stub',
+  pubkey: '',
+  createdAt: 0,
+  kind: 0,
+  tags: [],
+  content: '',
+  sig: '',
+);
+
+class _RecordingSignedEventRelay implements SignedEventRelay {
+  final Completer<_SubmittedEvent> submitted = Completer<_SubmittedEvent>();
+
+  @override
+  String? get pubkey => null;
+
+  @override
+  Future<NostrEvent> submit({
+    required int kind,
+    required String content,
+    required List<List<String>> tags,
+    int? createdAt,
+  }) async {
+    if (!submitted.isCompleted) {
+      submitted.complete(
+        _SubmittedEvent(kind: kind, content: content, tags: tags),
+      );
+    }
+    return _stubAckEvent();
+  }
+}
+
+class _FakeRelaySession extends RelaySessionNotifier {
+  List<NostrEvent> historyEvents = [];
+  final List<void Function(NostrEvent)> _listeners = [];
+
+  void emit(NostrEvent event) {
+    for (final listener in List.of(_listeners)) {
+      listener(event);
+    }
+  }
+
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async => historyEvents;
+
+  @override
+  Future<void Function()> subscribe(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+  }) async {
+    _listeners.add(onEvent);
+    return () => _listeners.remove(onEvent);
+  }
+}
+
+class _FailingRelaySession extends RelaySessionNotifier {
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async => throw Exception('relay unavailable');
+
+  @override
+  Future<void Function()> subscribe(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+  }) async => () {};
+}

--- a/mobile/test/features/channels/channel_sort/channel_sort_manager_test.dart
+++ b/mobile/test/features/channels/channel_sort/channel_sort_manager_test.dart
@@ -1,0 +1,213 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr/nostr.dart' as nostr;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:buzz/features/channels/channel_sort/channel_sort_manager.dart';
+import 'package:buzz/features/channels/channel_sort/channel_sort_storage.dart';
+import 'package:buzz/shared/relay/relay.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  late nostr.Keys keychain;
+  late ChannelSortCrypto crypto;
+
+  Future<void> setUpEnv() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    keychain = nostr.Keys.generate();
+    crypto = ChannelSortCrypto(keychain.nsec, keychain.public);
+  }
+
+  NostrEvent sortEvent({
+    required Map<String, String> groups,
+    required int createdAt,
+    String id = 'remote-event',
+  }) {
+    final payload = jsonEncode({'version': 1, 'groups': groups});
+    return NostrEvent(
+      id: id,
+      pubkey: keychain.public,
+      createdAt: createdAt,
+      kind: EventKind.readState,
+      tags: const [
+        ['d', 'channel-sort'],
+        ['t', 'channel-sort'],
+      ],
+      content: crypto.encrypt(payload),
+      sig: 'sig',
+    );
+  }
+
+  ChannelSortManager buildManager({
+    RelaySessionNotifier? relaySession,
+    SignedEventRelay? signedEventRelay,
+    bool remoteEnabled = true,
+  }) {
+    return ChannelSortManager(
+      pubkey: keychain.public,
+      prefs: prefs,
+      crypto: crypto,
+      relaySession: relaySession,
+      signedEventRelay: signedEventRelay,
+      remoteEnabled: remoteEnabled,
+      onChanged: () {},
+    );
+  }
+
+  test('adopts a desktop-published channel-sort blob', () async {
+    await setUpEnv();
+    final relay = _FakeRelaySession();
+    relay.historyEvents = [
+      sortEvent(
+        groups: {'channels': 'recent', 'section:abc': 'recent'},
+        createdAt: 100,
+      ),
+    ];
+
+    final manager = buildManager(
+      relaySession: relay,
+      signedEventRelay: _RecordingSignedEventRelay(),
+    );
+    await manager.initialize();
+
+    expect(manager.sortModeFor('channels'), ChannelSortMode.recent);
+    expect(manager.sortModeFor('section:abc'), ChannelSortMode.recent);
+    expect(manager.sortModeFor('dms'), ChannelSortMode.alpha);
+    manager.dispose(flushPending: false);
+  });
+
+  test('publishes local change in the desktop wire format', () async {
+    await setUpEnv();
+    final relay = _FakeRelaySession();
+    final signedRelay = _RecordingSignedEventRelay();
+    final manager = buildManager(
+      relaySession: relay,
+      signedEventRelay: signedRelay,
+    );
+    await manager.initialize();
+
+    manager.setSortModeFor('dms', ChannelSortMode.recent);
+    manager.dispose(flushPending: true);
+
+    final submitted = await signedRelay.submitted.future.timeout(
+      const Duration(seconds: 1),
+    );
+    expect(submitted.kind, EventKind.readState);
+    expect(
+      submitted.tags.any(
+        (tag) => tag.length == 2 && tag[0] == 'd' && tag[1] == 'channel-sort',
+      ),
+      isTrue,
+    );
+    final decoded =
+        jsonDecode(crypto.decrypt(submitted.content)) as Map<String, dynamic>;
+    expect(decoded['version'], 1);
+    expect(decoded['groups'], {'dms': 'recent'});
+  });
+
+  test(
+    'stale remote blob does not clobber unpublished local sort edits',
+    () async {
+      await setUpEnv();
+      final relay = _FakeRelaySession();
+
+      final first = buildManager(
+        relaySession: relay,
+        signedEventRelay: _RecordingSignedEventRelay(),
+      );
+      await first.initialize();
+      first.setSortModeFor('channels', ChannelSortMode.recent);
+      first.dispose(flushPending: false);
+
+      relay.historyEvents = [sortEvent(groups: const {}, createdAt: 100)];
+      final second = buildManager(
+        relaySession: relay,
+        signedEventRelay: _RecordingSignedEventRelay(),
+      );
+      expect(second.isDirty, isTrue);
+      await second.initialize();
+
+      expect(second.sortModeFor('channels'), ChannelSortMode.recent);
+      second.dispose(flushPending: false);
+    },
+  );
+
+  test('setSortModeFor prunes orphaned section keys', () async {
+    await setUpEnv();
+    final manager = buildManager(remoteEnabled: false);
+    await manager.initialize();
+
+    manager.setSortModeFor('section:dead', ChannelSortMode.recent);
+    manager.setSortModeFor(
+      'channels',
+      ChannelSortMode.recent,
+      liveSectionIds: ['live'],
+    );
+
+    expect(manager.store.groups.keys, ['channels']);
+    manager.dispose(flushPending: false);
+  });
+}
+
+class _SubmittedEvent {
+  final int kind;
+  final String content;
+  final List<List<String>> tags;
+
+  const _SubmittedEvent({
+    required this.kind,
+    required this.content,
+    required this.tags,
+  });
+}
+
+NostrEvent _stubAckEvent() => const NostrEvent(
+  id: 'stub',
+  pubkey: '',
+  createdAt: 0,
+  kind: 0,
+  tags: [],
+  content: '',
+  sig: '',
+);
+
+class _RecordingSignedEventRelay implements SignedEventRelay {
+  final Completer<_SubmittedEvent> submitted = Completer<_SubmittedEvent>();
+
+  @override
+  String? get pubkey => null;
+
+  @override
+  Future<NostrEvent> submit({
+    required int kind,
+    required String content,
+    required List<List<String>> tags,
+    int? createdAt,
+  }) async {
+    if (!submitted.isCompleted) {
+      submitted.complete(
+        _SubmittedEvent(kind: kind, content: content, tags: tags),
+      );
+    }
+    return _stubAckEvent();
+  }
+}
+
+class _FakeRelaySession extends RelaySessionNotifier {
+  List<NostrEvent> historyEvents = [];
+
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async => historyEvents;
+
+  @override
+  Future<void Function()> subscribe(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+  }) async => () {};
+}

--- a/mobile/test/features/channels/channel_sort/channel_sort_manager_test.dart
+++ b/mobile/test/features/channels/channel_sort/channel_sort_manager_test.dart
@@ -149,6 +149,50 @@ void main() {
     expect(manager.store.groups.keys, ['channels']);
     manager.dispose(flushPending: false);
   });
+
+  test('startup fetch rejected by relay rate limit retries until the remote '
+      'blob is adopted (cold-start regression)', () async {
+    await setUpEnv();
+    final relay = _RateLimitedRelaySession(
+      failuresBeforeSuccess: 2,
+      historyEvents: [
+        sortEvent(groups: {'channels': 'recent'}, createdAt: 100),
+      ],
+    );
+
+    final manager = ChannelSortManager(
+      pubkey: keychain.public,
+      prefs: prefs,
+      crypto: crypto,
+      relaySession: relay,
+      signedEventRelay: _RecordingSignedEventRelay(),
+      remoteEnabled: true,
+      onChanged: () {},
+      startupRetryBaseDelay: const Duration(milliseconds: 10),
+    );
+    await manager.initialize();
+
+    expect(manager.sortModeFor('channels'), ChannelSortMode.alpha);
+
+    await _waitUntil(
+      () => manager.sortModeFor('channels') == ChannelSortMode.recent,
+    );
+    expect(relay.subscribeCalls, greaterThan(1));
+    manager.dispose(flushPending: false);
+  });
+}
+
+Future<void> _waitUntil(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 2),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail('condition not met within $timeout');
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
 }
 
 class _SubmittedEvent {
@@ -210,4 +254,47 @@ class _FakeRelaySession extends RelaySessionNotifier {
     void Function(NostrEvent) onEvent, {
     void Function(String message)? onClosed,
   }) async => () {};
+}
+
+/// Rejects the first [failuresBeforeSuccess] fetch and subscribe calls with
+/// the relay's rate-limit error, then succeeds — the Android cold-start
+/// failure mode where the channel-list REQ burst exhausts the relay's
+/// per-connection quota before the sort manager gets a turn.
+class _RateLimitedRelaySession extends RelaySessionNotifier {
+  _RateLimitedRelaySession({
+    required this.failuresBeforeSuccess,
+    this.historyEvents = const [],
+  });
+
+  final int failuresBeforeSuccess;
+  final List<NostrEvent> historyEvents;
+  int fetchCalls = 0;
+  int subscribeCalls = 0;
+  final List<void Function(NostrEvent)> _listeners = [];
+
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    fetchCalls++;
+    if (fetchCalls <= failuresBeforeSuccess) {
+      throw Exception('rate-limited: quota exceeded; retry in 2s');
+    }
+    return historyEvents;
+  }
+
+  @override
+  Future<void Function()> subscribe(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+  }) async {
+    subscribeCalls++;
+    if (subscribeCalls <= failuresBeforeSuccess) {
+      throw Exception('rate-limited: quota exceeded; retry in 1s');
+    }
+    _listeners.add(onEvent);
+    return () => _listeners.remove(onEvent);
+  }
 }

--- a/mobile/test/features/channels/channel_sort/channel_sort_storage_test.dart
+++ b/mobile/test/features/channels/channel_sort/channel_sort_storage_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:buzz/features/channels/channel.dart';
+import 'package:buzz/features/channels/channel_sort/channel_sort_storage.dart';
+
+void main() {
+  group('ChannelSortStore JSON', () {
+    test('round-trips the desktop wire format', () {
+      final store = ChannelSortStore(
+        groups: {
+          'channels': ChannelSortMode.recent,
+          'dms': ChannelSortMode.alpha,
+          'section:abc': ChannelSortMode.recent,
+        },
+      );
+      final decoded = ChannelSortStore.fromJson(store.toJson());
+      expect(decoded.groups, store.groups);
+      expect(store.toJson()['groups'], {
+        'channels': 'recent',
+        'dms': 'alpha',
+        'section:abc': 'recent',
+      });
+    });
+
+    test('drops unknown modes and non-string keys', () {
+      final decoded = ChannelSortStore.fromJson({
+        'version': 1,
+        'groups': {'channels': 'recent', 'starred': 'bogus', 'dms': 42},
+      });
+      expect(decoded.groups, {'channels': ChannelSortMode.recent});
+    });
+  });
+
+  group('stripOrphanedSectionModes', () {
+    test('removes modes for deleted sections, keeps fixed groups', () {
+      final store = ChannelSortStore(
+        groups: {
+          'channels': ChannelSortMode.recent,
+          'section:live': ChannelSortMode.recent,
+          'section:dead': ChannelSortMode.alpha,
+        },
+      );
+      final stripped = stripOrphanedSectionModes(store, ['live']);
+      expect(stripped.groups.keys, ['channels', 'section:live']);
+    });
+
+    test('returns same store when nothing to strip', () {
+      final store = ChannelSortStore(
+        groups: {'section:live': ChannelSortMode.recent},
+      );
+      expect(
+        identical(stripOrphanedSectionModes(store, ['live']), store),
+        isTrue,
+      );
+    });
+  });
+
+  group('ChannelSortStorage', () {
+    test('read/write round-trip and dirty flag persistence', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final storage = ChannelSortStorage(prefs);
+
+      storage.write(
+        'pk',
+        ChannelSortStore(groups: {'channels': ChannelSortMode.recent}),
+      );
+      expect(storage.read('pk').groups, {'channels': ChannelSortMode.recent});
+
+      expect(storage.readDirtySince('pk'), 0);
+      storage.writeDirtySince('pk', 123);
+      expect(storage.readDirtySince('pk'), 123);
+      storage.writeDirtySince('pk', 0);
+      expect(storage.readDirtySince('pk'), 0);
+    });
+
+    test('read tolerates corrupt or versioned-away payloads', () async {
+      SharedPreferences.setMockInitialValues({
+        channelSortKey('pk'): 'not-json',
+        channelSortKey('pk2'): '{"version":2,"groups":{}}',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final storage = ChannelSortStorage(prefs);
+      expect(storage.read('pk').groups, isEmpty);
+      expect(storage.read('pk2').groups, isEmpty);
+    });
+  });
+
+  group('sortChannelsForList', () {
+    Channel channel(String id, String name, {DateTime? lastMessageAt}) =>
+        Channel(
+          id: id,
+          name: name,
+          channelType: 'stream',
+          visibility: 'open',
+          description: '',
+          createdBy: 'pk',
+          createdAt: DateTime.utc(2026),
+          memberCount: 1,
+          lastMessageAt: lastMessageAt,
+        );
+
+    test('alpha sorts by name case-insensitively with id tie-break', () {
+      final sorted = sortChannelsForList([
+        channel('2', 'beta'),
+        channel('1', 'Alpha'),
+        channel('3', 'alpha'),
+      ], ChannelSortMode.alpha);
+      expect(sorted.map((c) => c.id), ['1', '3', '2']);
+    });
+
+    test('recent sorts newest first, message-less channels sink alpha', () {
+      final now = DateTime.utc(2026, 7, 25);
+      final sorted = sortChannelsForList([
+        channel('a', 'quiet-z'),
+        channel(
+          'b',
+          'old',
+          lastMessageAt: now.subtract(const Duration(days: 2)),
+        ),
+        channel('c', 'new', lastMessageAt: now),
+        channel('d', 'quiet-a'),
+      ], ChannelSortMode.recent);
+      expect(sorted.map((c) => c.id), ['c', 'b', 'd', 'a']);
+    });
+  });
+}


### PR DESCRIPTION
**Category:** fix

**User Impact:** Mobile channel-group changes now survive reconnects, and channel sorting stays consistent between mobile and desktop.

**Problem:** Mobile could discard an unpublished channel-group edit when relay status changed during the publish delay, replacing the newer local state with an older relay copy. Mobile also lacked the per-group sorting preferences already available and synced on desktop.

**Solution:** Preserve a durable record of unpublished mobile edits, reconcile them after reconnect, and only seed the relay after confirming no remote state exists. Add desktop-compatible encrypted sort preference sync and mobile controls for sorting Starred, custom groups, Channels, and DMs by recent activity or A–Z.

<details>
<summary>File changes</summary>

**mobile/lib/features/channels/channel_sections/channel_sections_manager.dart**
Tracks unpublished section edits across manager rebuilds, protects newer local state from stale relay data, and republishes safely after reconnect.

**mobile/lib/features/channels/channel_sections/channel_sections_storage.dart**
Persists whether channel-section changes are still waiting to reach the relay so they survive reconnects and app restarts.

**mobile/lib/features/channels/channel_sort/channel_sort_manager.dart**
Adds encrypted relay synchronization for mobile channel-sort preferences using the same contract as desktop, including reconnect protection.

**mobile/lib/features/channels/channel_sort/channel_sort_provider.dart**
Exposes synchronized sort preferences to the mobile channel list and scopes them to the active account and community lifecycle.

**mobile/lib/features/channels/channel_sort/channel_sort_storage.dart**
Defines the shared sort payload, local cache, group-key cleanup, and A–Z/recent channel ordering behavior.

**mobile/lib/features/channels/channels_page.dart**
Connects the channel page to the new sort preference feature.

**mobile/lib/features/channels/channels_page/body.dart**
Applies each group's selected order and routes sort changes from section controls into synchronized preferences.

**mobile/lib/features/channels/channels_page/sections.dart**
Adds checked Recent and A–Z options to built-in and custom channel-group menus using existing mobile UI components.

**mobile/test/features/channels/channel_sections/channel_sections_manager_test.dart**
Covers the edit-loss regression, reconnect publishing, failed-fetch safety, local dirty-state persistence, and clean remote adoption.

**mobile/test/features/channels/channel_sort/channel_sort_manager_test.dart**
Verifies desktop-compatible sort reads and writes, reconnect protection, and cleanup of deleted custom-group preferences.

**mobile/test/features/channels/channel_sort/channel_sort_storage_test.dart**
Covers payload validation, local persistence, orphan cleanup, and both channel ordering modes.

</details>

## Reproduction steps

1. Run the mobile app while connected to a relay and create or modify a custom channel group.
2. Interrupt or cycle the relay connection before the delayed publish completes.
3. Reconnect and confirm the local group change remains visible and is published rather than replaced by older relay state.
4. Open the menu for Starred, a custom group, Channels, or DMs.
5. Select **Sort: Recent** and confirm active channels move first; select **Sort: A–Z** and confirm alphabetical ordering returns.
6. Open desktop with the same account and confirm the selected sort preference is shared across clients.

## Screenshots / demos

No screenshot is included. The visual change uses the existing mobile popup-menu components inside section headers, and the repository does not currently provide a Flutter screenshot or golden-test harness for this flow.
