### PR TITLE
feat: add explicit entry for claude-opus-5 in model config

### DIFF
--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -184,6 +184,7 @@ pub fn anthropic_thinking_config(
 fn anthropic_model_supports_xhigh(model: &str) -> bool {
     model.starts_with("claude-opus-4-7")
         || model.starts_with("claude-opus-4-8")
+        || model.starts_with("claude-opus-5")
         || model.starts_with("claude-sonnet-5")
         || model.starts_with("claude-fable-5")
         || model.starts_with("claude-mythos-5")
@@ -606,6 +607,7 @@ fn is_adaptive_thinking_model(model: &str) -> bool {
     model.starts_with("claude-opus-4-6")
         || model.starts_with("claude-opus-4-7")
         || model.starts_with("claude-opus-4-8")
+        || model.starts_with("claude-opus-5")
         // Sonnet 5.x (any patch/date suffix after "claude-sonnet-5").
         || model.starts_with("claude-sonnet-5")
         // Sonnet 4.6 exactly (not Sonnet 4.5 or earlier — not in the adaptive table).

--- a/desktop/src/features/agents/ui/effortTable.fixture.json
+++ b/desktop/src/features/agents/ui/effortTable.fixture.json
@@ -42,6 +42,13 @@
     "defaultValue": "high"
   },
   {
+  "note": "Anthropic adaptive xhigh-capable: claude-opus-5",
+  "provider": "anthropic",
+  "model": "claude-opus-5",
+  "validValues": ["low", "medium", "high", "xhigh", "max"],
+  "defaultValue": "high"
+},
+  {
     "note": "Anthropic adaptive xhigh-capable: claude-mythos-5",
     "provider": "anthropic",
     "model": "claude-mythos-5",

--- a/desktop/src/features/agents/ui/effortTable.fixture.json
+++ b/desktop/src/features/agents/ui/effortTable.fixture.json
@@ -42,12 +42,12 @@
     "defaultValue": "high"
   },
   {
-  "note": "Anthropic adaptive xhigh-capable: claude-opus-5",
-  "provider": "anthropic",
-  "model": "claude-opus-5",
-  "validValues": ["low", "medium", "high", "xhigh", "max"],
-  "defaultValue": "high"
-},
+    "note": "Anthropic adaptive xhigh-capable: claude-opus-5",
+    "provider": "anthropic",
+    "model": "claude-opus-5",
+    "validValues": ["low", "medium", "high", "xhigh", "max"],
+    "defaultValue": "high"
+  },
   {
     "note": "Anthropic adaptive xhigh-capable: claude-mythos-5",
     "provider": "anthropic",


### PR DESCRIPTION
Fixes #2787

- Added `claude-opus-5` to `config.rs` model classification and adaptive effort helpers.
- Updated fixture test configurations to cover `claude-opus-5`.
- Verified with `cargo test` and JS unit tests.