### PR TITLE
fix(projects): show create button in empty state on a fresh relay

### DIFF
--- a/desktop/src/features/projects/ui/ProjectCards.tsx
+++ b/desktop/src/features/projects/ui/ProjectCards.tsx
@@ -3,6 +3,7 @@ import {
   FolderGit2,
   GitCommit,
   GitPullRequest,
+  Plus,
   TerminalSquare,
   Trash2,
 } from "lucide-react";
@@ -263,7 +264,11 @@ function StatusPill({ status }: { status: string }) {
   );
 }
 
-export function EmptyState() {
+export function EmptyState({
+  onCreateProject,
+}: {
+  onCreateProject?: () => void;
+}) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-3 px-4 py-16 text-center">
       <FolderGit2 className="h-10 w-10 text-muted-foreground/40" />
@@ -273,6 +278,12 @@ export function EmptyState() {
           Projects published to this relay will appear here.
         </p>
       </div>
+      {onCreateProject ? (
+        <Button className="mt-2 gap-2" onClick={onCreateProject} size="sm">
+          <Plus className="h-4 w-4" />
+          Create project
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -447,8 +447,29 @@ export function ProjectsView() {
     );
   }
 
+  const createProjectDialog = (
+    <CreateProjectDialog
+      isCreating={createProjectMutation.isPending}
+      onCreate={async (input) => {
+        const project = await createProjectMutation.mutateAsync(input);
+        toast.success(`Project "${project.name}" created.`);
+        // Land on the list that actually shows the new project — the
+        // Overview only surfaces the top few most-active repositories.
+        handleRepositoryScopeChange("all");
+        handleFilterChange("repositories");
+      }}
+      onOpenChange={setCreateProjectOpen}
+      open={createProjectOpen}
+    />
+  );
+
   if (projects.length === 0) {
-    return <EmptyState />;
+    return (
+      <>
+        {createProjectDialog}
+        <EmptyState onCreateProject={() => setCreateProjectOpen(true)} />
+      </>
+    );
   }
 
   const repositoryItems =
@@ -599,19 +620,7 @@ export function ProjectsView() {
         className="pointer-events-none absolute right-[3px] top-0 z-50 w-1 rounded-full bg-border/80 opacity-0 transition-opacity duration-200"
         ref={scrollIndicatorRef}
       />
-      <CreateProjectDialog
-        isCreating={createProjectMutation.isPending}
-        onCreate={async (input) => {
-          const project = await createProjectMutation.mutateAsync(input);
-          toast.success(`Project "${project.name}" created.`);
-          // Land on the list that actually shows the new project — the
-          // Overview only surfaces the top few most-active repositories.
-          handleRepositoryScopeChange("all");
-          handleFilterChange("repositories");
-        }}
-        onOpenChange={setCreateProjectOpen}
-        open={createProjectOpen}
-      />
+      {createProjectDialog}
       {createPullRequestOpen ? (
         <CreatePullRequestDialog
           onCreated={async (createdProject, pullRequestId) => {


### PR DESCRIPTION
Fixes #2622.

## Problem

On a relay with zero projects, the Projects screen renders only the empty-state placeholder and never shows the toolbar with the create ("+") menu. `ProjectsView.tsx` early-returns a bare `<EmptyState />` when `projects.length === 0`, before the render path that mounts `CreateProjectDialog` and `ProjectsCreateMenu`. Result: there is no way to create the first project from the UI — the create affordance only appears once a project already exists.

## Fix

- `EmptyState` gains an optional `onCreateProject` callback and renders a "Create project" CTA when it is provided (unchanged when it is not).
- `ProjectsView` hoists `CreateProjectDialog` into a reused const and renders it alongside `EmptyState` in the empty branch, wiring the CTA to the existing create-project dialog.

## Testing

Manually: on a fresh relay (no kind 30617 announcements), the Projects screen now shows a working "Create project" button; after creating the first project the normal list view takes over. No behavioral change when projects already exist.