### PR TITLE
fix(admin): fail loudly when DATABASE_URL is unset instead of falling back to dev credentials

### DIFF
--- a/crates/buzz-admin/src/main.rs
+++ b/crates/buzz-admin/src/main.rs
@@ -22,7 +22,7 @@
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use buzz_core::kind::KIND_NIP43_MEMBERSHIP_LIST;
 use buzz_core::tenant::{relay_url_authority, TenantContext};
 use buzz_db::{Db, DbConfig};
@@ -418,8 +418,9 @@ async fn connect_member_services() -> Result<(Db, Arc<PubSubManager>, Keys)> {
 }
 
 async fn connect_db() -> Result<Db> {
-    let db_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "postgres://buzz:buzz_dev@localhost:5432/buzz".to_string());
+    let db_url = std::env::var("DATABASE_URL").context(
+        "DATABASE_URL is not set. Set it in your environment or source .env before running buzz-admin.",
+    )?;
     let db = Db::new(&DbConfig {
         database_url: db_url,
         ..DbConfig::default()

--- a/crates/buzz-admin/tests/db_url_unset.rs
+++ b/crates/buzz-admin/tests/db_url_unset.rs
@@ -1,0 +1,31 @@
+//! Regression test for #2837: `buzz-admin` must fail loudly when
+//! `DATABASE_URL` is unset, instead of silently falling back to hardcoded
+//! dev database credentials.
+//!
+//! Spawns the built `buzz-admin` binary with `DATABASE_URL` removed from the
+//! environment and asserts a non-zero exit code plus a clear error message.
+//! This guards against reintroducing the `unwrap_or_else(|_| "postgres://buzz:buzz_dev@...")`
+//! fallback that masked missing configuration as a Postgres auth failure.
+
+use std::process::Command;
+
+#[test]
+fn migrate_fails_loudly_when_database_url_unset() {
+    let bin = env!("CARGO_BIN_EXE_buzz-admin");
+    let output = Command::new(bin)
+        .arg("migrate")
+        .env_remove("DATABASE_URL")
+        .output()
+        .expect("failed to spawn buzz-admin");
+
+    assert!(
+        !output.status.success(),
+        "buzz-admin migrate should fail when DATABASE_URL is unset, but exited successfully"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("DATABASE_URL"),
+        "stderr should mention DATABASE_URL, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- replace `unwrap_or_else(|_| "postgres://buzz:buzz_dev@localhost:5432/buzz")` in `connect_db()` with `std::env::var("DATABASE_URL").context(...)?`
- add `Context` to the `anyhow` import
- add regression test spawning `buzz-admin migrate` with `DATABASE_URL` unset

## Why

buzz-admin silently substituted hardcoded dev credentials when
`DATABASE_URL` was missing, masking a missing-config problem as a
misleading `password authentication failed for user "buzz"` error on
deployments with hardened credentials. Failing loudly surfaces the real
problem and points the operator at `.env`.

The relay doesn't load `.env` internally either — both binaries rely on
`just`'s `set dotenv-load := true`. Failing hard makes `buzz-admin`
consistent with the relay's behavior (no silent fallback) rather than
introducing a new inconsistency.

## Test plan

- `cargo fmt -p buzz-admin -- --check`
- `cargo test -p buzz-admin --test db_url_unset` (1 passed)
- `cargo clippy -p buzz-admin --all-targets -- -D warnings`
- `git diff --check`

Closes #2837