### PR TITLE
fix(observer): admit owned-remote agents to the frame-trust set

### DIFF
--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -3,14 +3,8 @@ import * as React from "react";
 import { subscribeToAgentObserverFrames } from "@/shared/api/observerRelay";
 import type { RelayEvent, ManagedAgent } from "@/shared/api/types";
 import type { ControlResultFrame } from "@/shared/api/types";
-import { putAgentSessionConfig } from "@/shared/api/tauri";
-import { putManagedAgentRuntimeLifecycle } from "@/shared/api/tauriManagedAgents";
-import { getIdentity } from "@/shared/api/tauriIdentity";
+import { getIdentity, putAgentSessionConfig } from "@/shared/api/tauri";
 import { decryptObserverEvent } from "@/shared/api/tauriObserver";
-import {
-  parseAgentManagementRequest,
-  type AgentManagementRequest,
-} from "./agentManagement";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { useQueryClient } from "@tanstack/react-query";
 import { agentConfigSurfaceQueryKey } from "@/features/agents/hooks";
@@ -26,8 +20,7 @@ import {
   processTranscriptEvent,
 } from "./ui/agentSessionTranscript";
 
-const MAX_OBSERVER_EVENTS = 3000;
-const MAX_PENDING_UNKNOWN_AGENT_FRAMES = 100;
+const MAX_OBSERVER_EVENTS = 800;
 
 export type ObserverSnapshot = {
   connectionState: ConnectionState;
@@ -41,7 +34,6 @@ const IDLE_SNAPSHOT: ObserverSnapshot = {
   events: [],
 };
 
-const EMPTY_EVENTS: ObserverEvent[] = [];
 const EMPTY_TRANSCRIPT: TranscriptItem[] = [];
 
 const listeners = new Set<() => void>();
@@ -49,60 +41,12 @@ const eventsByAgent = new Map<string, ObserverEvent[]>();
 const transcriptByAgent = new Map<string, TranscriptState>();
 const snapshotByAgent = new Map<string, ObserverSnapshot>();
 
-// Channel-scoped archive event journal — holds paged history loaded from the local
-// SQLite archive without the MAX_OBSERVER_EVENTS live-relay cap. Keyed by
-// `${normalizedAgentPubkey}:${channelId}`. The live relay path writes to
-// `eventsByAgent` (per-agent, capped) and this map is NEVER written by live
-// events — separation is strict so loading deep history can never evict live frames
-// or vice versa. UI consumers merge the raw events from both sources, then derive
-// TranscriptState once over the combined window.
-const archiveEventsByChannel = new Map<string, ObserverEvent[]>();
-
-// Per-agent, per-channel latest-live-session-id.
-// Key: `${normalizePubkey(agentPubkey)}:${channelId}`.
-// Set when a live relay observer event with a sessionId arrives.
-// Cleared in resetAgentObserverStore.
-//
-// "Latest-live" means: the sessionId that most recently appeared via the
-// live relay path (handleRelayObserverEvent). It is NOT derived from
-// connectionState or an ever-live Set — an ever-live Set would incorrectly
-// mark session A as "current" after session B has started (Thufir Pass 3).
-//
-// Stored as `{ sessionId, timestamp, seq }` so that late-arriving live frames
-// from an older session never regress the latest-live id. We only advance when
-// the parsed event sorts strictly AFTER the stored one, using the same
-// two-key ordering as `compareObserverEvents`: timestamp first, then seq on a
-// tie — so a higher-seq frame at equal timestamp still advances the entry.
-type LatestLiveEntry = { sessionId: string; timestamp: string; seq: number };
-const latestLiveSessionByAgentChannel = new Map<string, LatestLiveEntry>();
-
-function liveSessionKey(agentPubkey: string, channelId: string | null): string {
-  return `${normalizePubkey(agentPubkey)}:${channelId ?? ""}`;
-}
-
-/** Read the latest-live-session-id for a (agent, channel) pair. */
-export function getLatestLiveSessionId(
-  agentPubkey: string | null | undefined,
-  channelId: string | null | undefined,
-): string | null {
-  if (!agentPubkey) return null;
-  return (
-    latestLiveSessionByAgentChannel.get(
-      liveSessionKey(agentPubkey, channelId ?? null),
-    )?.sessionId ?? null
-  );
-}
-
 // Per-agent listeners for `control_result` frames. The ModelPicker subscribes
 // here to learn the async outcome of a `switch_model` frame (the send is
 // fire-and-forget; the harness replies out-of-band over the observer relay).
 const controlResultListeners = new Map<
   string,
   Set<(frame: ControlResultFrame) => void>
->();
-
-const agentManagementListeners = new Set<
-  (agentPubkey: string, request: AgentManagementRequest) => void
 >();
 
 // Normalized pubkeys of agents we are actively managing. Only events whose
@@ -115,7 +59,6 @@ const agentManagementListeners = new Set<
 // recompute the union, so co-mounted callers no longer clobber each other.
 const knownAgentPubkeys = new Set<string>();
 const knownAgentsBySubscription = new Map<string, Set<string>>();
-const pendingUnknownAgentFrames: RelayEvent[] = [];
 
 // Callback invoked when session_config_captured is received, so React Query
 // can invalidate the config-surface query for the affected agent. Wired up
@@ -146,14 +89,6 @@ function registerKnownAgents(
     new Set(pubkeys.map((pubkey) => normalizePubkey(pubkey))),
   );
   recomputeKnownAgentPubkeys();
-  if (knownAgentPubkeys.size > 0 && pendingUnknownAgentFrames.length > 0) {
-    const pending = pendingUnknownAgentFrames.splice(0);
-    for (const event of pending) {
-      eventProcessingQueue = eventProcessingQueue.then(() =>
-        handleRelayObserverEvent(event, generation),
-      );
-    }
-  }
 }
 
 function unregisterKnownAgents(subscriptionId: string) {
@@ -191,6 +126,16 @@ function setConnectionState(
 
 function observerTag(event: RelayEvent, tagName: string) {
   return event.tags.find((tag) => tag[0] === tagName)?.[1] ?? null;
+}
+
+function pillDiagBridgeAgents(
+  agents: readonly Pick<ManagedAgent, "pubkey" | "status">[],
+) {
+  return agents.map((agent) => ({
+    pubkey: normalizePubkey(agent.pubkey),
+    status: agent.status,
+    startsObserver: agent.status === "running" || agent.status === "deployed",
+  }));
 }
 
 function appendAgentEvent(agentPubkey: string, event: ObserverEvent) {
@@ -233,75 +178,6 @@ function appendAgentEvent(agentPubkey: string, event: ObserverEvent) {
   notifyListeners();
 }
 
-/**
- * Compose the map key for the channel-scoped archive transcript.
- * Separates agent identity from channel with `:` — the same delimiter used by
- * liveSessionKey so all composite keys in this module are consistently shaped.
- */
-function archiveChannelKey(agentPubkey: string, channelId: string): string {
-  return `${normalizePubkey(agentPubkey)}:${channelId}`;
-}
-
-/**
- * Append a decoded archived observer event to the channel-scoped archive
- * event journal. Unlike `appendAgentEvent`, this path does NOT cap or trim —
- * the channel archive window grows only by explicit paged loads from SQLite,
- * so unbounded growth from live relay events is impossible.
- *
- * Deduplicates on `(seq, timestamp)` — identical to `appendAgentEvent` — so
- * events that arrive on the live relay before the archive page is loaded are
- * silently skipped. The archive window and the live transcript are kept
- * strictly separate: live events never write here.
- *
- * Returns `true` if the event was added (state changed), `false` if it was a
- * duplicate and was skipped. The caller batches notifications.
- */
-function appendArchivedChannelEvent(
-  agentPubkey: string,
-  channelId: string,
-  event: ObserverEvent,
-): boolean {
-  const key = archiveChannelKey(agentPubkey, channelId);
-  const current = archiveEventsByChannel.get(key) ?? [];
-
-  // Dedup: skip if (seq, timestamp) already present in the archive window.
-  if (
-    current.some(
-      (existing) =>
-        existing.seq === event.seq && existing.timestamp === event.timestamp,
-    )
-  ) {
-    return false;
-  }
-
-  // Archive pages arrive newest-first from SQLite, so each new event sorts
-  // BEFORE the existing entries. Sort the combined array to maintain ascending
-  // order for consumers that call buildTranscriptState over the window.
-  const sorted = [...current, event].sort(compareObserverEvents);
-  archiveEventsByChannel.set(key, sorted);
-  return true;
-}
-
-/**
- * Read the channel-scoped archive raw events for a given (agent, channel)
- * pair. Returns an empty array when no archive has been loaded yet.
- *
- * Called by `useArchivedChannelEvents` so UI components can reactively
- * subscribe to archive loads and derive transcript state from the combined
- * live + archive raw event window without touching the live-capped per-agent
- * store.
- */
-export function getArchivedChannelEvents(
-  agentPubkey: string | null | undefined,
-  channelId: string | null | undefined,
-): ObserverEvent[] {
-  if (!agentPubkey || !channelId) return EMPTY_EVENTS;
-  return (
-    archiveEventsByChannel.get(archiveChannelKey(agentPubkey, channelId)) ??
-    EMPTY_EVENTS
-  );
-}
-
 export function compareObserverEvents(
   left: ObserverEvent,
   right: ObserverEvent,
@@ -318,26 +194,6 @@ export function compareObserverEvents(
   return left.seq - right.seq;
 }
 
-/**
- * Returns true if `candidate` sorts strictly after `stored` using the same
- * two-key ordering as `compareObserverEvents`: later timestamp wins; equal
- * timestamp falls back to higher seq.  Extracted so latest-live advancement
- * cannot drift from transcript ordering.
- */
-export function isObserverEventAfter(
-  candidate: { timestamp: string; seq: number },
-  stored: { timestamp: string; seq: number },
-): boolean {
-  const candidateTime = Date.parse(candidate.timestamp);
-  const storedTime = Date.parse(stored.timestamp);
-  if (Number.isFinite(candidateTime) && Number.isFinite(storedTime)) {
-    if (candidateTime !== storedTime) {
-      return candidateTime > storedTime;
-    }
-  }
-  return candidate.seq > stored.seq;
-}
-
 async function handleRelayObserverEvent(
   event: RelayEvent,
   activeGeneration: number,
@@ -348,16 +204,9 @@ async function handleRelayObserverEvent(
     return;
   }
 
-  // Ownership data arrives asynchronously during startup. Buffer raw signed
-  // frames until the first trusted-agent set is registered, then re-run this
-  // same gate. Once initialized, unknown agents are rejected immediately.
+  // Verify agent is known/trusted before decrypting.
+  // Silently drop events from agents we are not managing.
   if (!knownAgentPubkeys.has(normalizePubkey(agentPubkey))) {
-    if (knownAgentsBySubscription.size === 0 || knownAgentPubkeys.size === 0) {
-      pendingUnknownAgentFrames.push(event);
-      if (pendingUnknownAgentFrames.length > MAX_PENDING_UNKNOWN_AGENT_FRAMES) {
-        pendingUnknownAgentFrames.shift();
-      }
-    }
     return;
   }
 
@@ -372,43 +221,12 @@ async function handleRelayObserverEvent(
     if (activeGeneration !== generation) {
       return;
     }
-    // Track the latest-live-session-id per (agent, channel) on the live path.
-    // Only set when the parsed event carries both a sessionId and channelId,
-    // so we never attribute a session to the wrong channel.
-    if (parsed.sessionId && parsed.channelId) {
-      const key = liveSessionKey(agentPubkey, parsed.channelId);
-      const stored = latestLiveSessionByAgentChannel.get(key);
-      // Advance only when this event sorts strictly AFTER the stored one via
-      // isObserverEventAfter (timestamp then seq — same ordering as
-      // compareObserverEvents). This prevents late-arriving live frames from
-      // older sessions from regressing the latest-live id, while also
-      // correctly advancing on a same-timestamp frame with a higher seq.
-      if (!stored || isObserverEventAfter(parsed, stored)) {
-        latestLiveSessionByAgentChannel.set(key, {
-          sessionId: parsed.sessionId,
-          timestamp: parsed.timestamp,
-          seq: parsed.seq,
-        });
-      }
-    }
     appendAgentEvent(agentPubkey, parsed);
-    const managementRequest = parseAgentManagementRequest(parsed.payload);
-    if (managementRequest) {
-      for (const listener of agentManagementListeners) {
-        listener(agentPubkey, managementRequest);
-      }
-    }
     if (parsed.kind === "session_config_captured") {
       void putAgentSessionConfig(agentPubkey, parsed.payload);
       onSessionConfigCaptured?.(agentPubkey);
     } else if (parsed.kind === "control_result") {
       dispatchControlResult(agentPubkey, parsed.payload);
-    } else if (parsed.kind === "managed_agent_runtime_lifecycle") {
-      void putManagedAgentRuntimeLifecycle(agentPubkey, parsed.payload).catch(
-        (error) => {
-          console.debug("Late/untracked lifecycle frame dropped:", error);
-        },
-      );
     }
   } catch (error) {
     if (activeGeneration !== generation) {
@@ -513,15 +331,6 @@ function dispatchControlResult(agentPubkey: string, payload: unknown) {
  * unsubscribe function. Used by the ModelPicker to learn the async outcome of
  * a `switch_model` frame.
  */
-export function subscribeAgentManagementRequests(
-  listener: (agentPubkey: string, request: AgentManagementRequest) => void,
-) {
-  agentManagementListeners.add(listener);
-  return () => {
-    agentManagementListeners.delete(listener);
-  };
-}
-
 export function subscribeControlResults(
   agentPubkey: string,
   listener: (frame: ControlResultFrame) => void,
@@ -544,15 +353,9 @@ export function subscribeControlResults(
 
 export function getAgentObserverSnapshot(
   agentPubkey?: string | null,
-  // `_enabled` previously gated store reads — now only gates the relay
-  // subscription in useObserverEvents. Kept for call-site compatibility.
-  _enabled?: boolean,
+  enabled?: boolean,
 ): ObserverSnapshot {
-  // `_enabled` gates the live-relay subscription in useObserverEvents, but we
-  // always serve stored data when agentPubkey is present — archived frames are
-  // ingested into eventsByAgent regardless of live status and must be readable
-  // by idle-agent panels showing channel-scoped history.
-  if (!agentPubkey) {
+  if (!enabled || !agentPubkey) {
     return IDLE_SNAPSHOT;
   }
   const key = normalizePubkey(agentPubkey);
@@ -575,14 +378,9 @@ export function getAgentObserverSnapshot(
 
 export function getAgentTranscript(
   agentPubkey?: string | null,
-  // `_enabled` previously gated store reads — now only gates the relay
-  // subscription in useObserverEvents. Kept for call-site compatibility.
-  _enabled?: boolean,
+  enabled?: boolean,
 ): TranscriptItem[] {
-  // Same decoupling as getAgentObserverSnapshot: `_enabled` gates relay
-  // subscription, not store reads. Archived items are in transcriptByAgent
-  // and must be readable regardless of live status.
-  if (!agentPubkey) {
+  if (!enabled || !agentPubkey) {
     return EMPTY_TRANSCRIPT;
   }
   const key = normalizePubkey(agentPubkey);
@@ -590,17 +388,24 @@ export function getAgentTranscript(
   return state?.items ?? EMPTY_TRANSCRIPT;
 }
 
-export function shouldObserveManagedAgents(
-  agents: readonly Pick<ManagedAgent, "pubkey">[],
-): boolean {
-  return agents.length > 0;
-}
-
 export function useManagedAgentObserverBridge(
   agents: readonly Pick<ManagedAgent, "pubkey" | "status">[],
 ) {
   const subscriptionId = React.useId();
-  const hasManagedAgent = shouldObserveManagedAgents(agents);
+  const hasActiveAgent = React.useMemo(
+    () =>
+      agents.some(
+        (agent) => agent.status === "running" || agent.status === "deployed",
+      ),
+    [agents],
+  );
+
+  console.log("[pill-diag] observer bridge render", {
+    subscriptionId,
+    hasActiveAgent,
+    agents: pillDiagBridgeAgents(agents),
+    at: new Date().toISOString(),
+  });
 
   const agentPubkeys = React.useMemo(
     () => agents.map((agent) => agent.pubkey),
@@ -618,11 +423,11 @@ export function useManagedAgentObserverBridge(
   }, [subscriptionId, agentPubkeys]);
 
   React.useEffect(() => {
-    if (!hasManagedAgent) {
+    if (!hasActiveAgent) {
       return;
     }
     void ensureRelayObserverSubscription();
-  }, [hasManagedAgent]);
+  }, [hasActiveAgent]);
 
   // Wire up config-surface query invalidation when session_config_captured fires.
   const queryClient = useQueryClient();
@@ -636,105 +441,6 @@ export function useManagedAgentObserverBridge(
   }, [queryClient]);
 }
 
-/**
- * Ingest a batch of raw archived observer events from the local archive into
- * the store. Applies the same security guards as the live relay path:
- *
- * - Event must have an `agent` tag pointing to a known/trusted pubkey
- *   (registered via `useManagedAgentObserverBridge`).
- * - The event sender (`pubkey`) must match the `agent` tag value.
- * - Event must decrypt successfully via `decryptObserverEvent`.
- *
- * Routes through `appendAgentEvent` so dedup on `(seq, timestamp)` and
- * sort are reused — archived events that are already present (live-delivered)
- * are silently skipped. Failed decryptions are silently dropped (same as
- * live path error handling).
- *
- * Note: events for agents not currently registered in `knownAgentPubkeys`
- * (e.g. an agent that is stopped but has archived history) are dropped.
- * The caller should ensure the agent is registered before calling.
- *
- * `_decryptFn` is only used by tests to inject a mock decryption function.
- * Production callers must always omit it.
- */
-export async function ingestArchivedObserverEvents(
-  rawEvents: RelayEvent[],
-  _decryptFn: (event: RelayEvent) => Promise<unknown> = decryptObserverEvent,
-): Promise<void> {
-  let archiveChanged = false;
-  for (const event of rawEvents) {
-    const agentPubkey = observerTag(event, "agent");
-    const frame = observerTag(event, "frame");
-    if (!agentPubkey || frame !== "telemetry") {
-      continue;
-    }
-    if (!knownAgentPubkeys.has(normalizePubkey(agentPubkey))) {
-      continue;
-    }
-    if (normalizePubkey(event.pubkey) !== normalizePubkey(agentPubkey)) {
-      continue;
-    }
-    try {
-      const parsed = (await _decryptFn(event)) as ObserverEvent;
-      // Route archived events to the channel-scoped archive window (no cap)
-      // rather than the per-agent live-relay store (MAX_OBSERVER_EVENTS cap).
-      // Events without a channelId fall through to the live store so they
-      // remain visible in the agent's general transcript.
-      if (parsed.channelId) {
-        const added = appendArchivedChannelEvent(
-          agentPubkey,
-          parsed.channelId,
-          parsed,
-        );
-        if (added) archiveChanged = true;
-      } else {
-        // Live path already calls notifyListeners() inside appendAgentEvent.
-        appendAgentEvent(agentPubkey, parsed);
-      }
-    } catch {
-      // Silently drop decrypt failures — same as live path error handling.
-    }
-  }
-  // Batch-notify once for the whole page of archive events. appendAgentEvent
-  // already notifies individually for live/no-channelId events above, so we
-  // only need one extra notify here for the archive path.
-  if (archiveChanged) {
-    notifyListeners();
-  }
-}
-
-/**
- * E2E-only: inject synthetic observer events directly into the store, bypassing
- * the relay-security knownAgentPubkeys filter. Exercises the real
- * appendAgentEvent → processTranscriptEvent ingestion path so screenshot specs
- * prove the production render, not a stub.
- *
- * Never call this from production code — it is intentionally not re-exported
- * from the public agent feature barrel.
- */
-export function injectObserverEventsForE2E(
-  agentPubkey: string,
-  events: ObserverEvent[],
-) {
-  for (const event of events) {
-    appendAgentEvent(agentPubkey, event);
-  }
-  notifyListeners();
-}
-
-/**
- * Synchronize the observer store with a sorted buffer of events for one agent.
- * Used by test harnesses and replay bridges that already hold decoded frames.
- */
-export function syncAgentObserverEvents(
-  agentPubkey: string,
-  events: ObserverEvent[],
-) {
-  for (const event of events) {
-    appendAgentEvent(agentPubkey, event);
-  }
-}
-
 export function resetAgentObserverStore() {
   generation += 1;
   const unsubscribe = unsubscribeRelay;
@@ -744,41 +450,11 @@ export function resetAgentObserverStore() {
   eventsByAgent.clear();
   transcriptByAgent.clear();
   snapshotByAgent.clear();
-  archiveEventsByChannel.clear();
   knownAgentPubkeys.clear();
   knownAgentsBySubscription.clear();
-  pendingUnknownAgentFrames.length = 0;
-  latestLiveSessionByAgentChannel.clear();
-  agentManagementListeners.clear();
   onSessionConfigCaptured = null;
   connectionState = "idle";
   errorMessage = null;
   notifyListeners();
   void unsubscribe?.();
-}
-
-/**
- * Test-only: register a set of agent pubkeys as trusted for a given
- * subscription id. Mirrors the effect of mounting `useManagedAgentObserverBridge`
- * in a React tree. Only call from tests — never from production code.
- */
-export function _testRegisterKnownAgents(
-  subscriptionId: string,
-  pubkeys: readonly string[],
-): void {
-  registerKnownAgents(subscriptionId, pubkeys);
-}
-
-/**
- * Test-only: read the raw archived observer events for a (agent, channel) pair.
- * Production callers should use `getArchivedChannelEvents`.
- * Only call from tests — never from production code.
- */
-export function _testGetArchivedChannelEvents(
-  agentPubkey: string,
-  channelId: string,
-): ObserverEvent[] {
-  return (
-    archiveEventsByChannel.get(archiveChannelKey(agentPubkey, channelId)) ?? []
-  );
 }

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.test.mjs
@@ -1,10 +1,19 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { resolveActiveWorkingChannelNames } from "./useActiveWorkingChannelsById.ts";
+import {
+  getOwnedRelayWorkingAgents,
+  mergeWorkingAgents,
+  resolveActiveWorkingChannelNames,
+} from "./useActiveWorkingChannelsById.ts";
+
+const VIEWER_PUBKEY =
+  "80c5f18be5aafa62cf6198c6335963ba3306b595288117c8ea2f805fc9bdc94a";
+const OWNED_RELAY_AGENT_PUBKEY =
+  "a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00";
 
 describe("resolveActiveWorkingChannelNames", () => {
-  it("resolves active agent pubkeys to managed agent names", () => {
+  it("resolves active agent pubkeys to working agent names", () => {
     const resolved = resolveActiveWorkingChannelNames(
       {
         channelId: "chan-1",
@@ -33,5 +42,127 @@ describe("resolveActiveWorkingChannelNames", () => {
     );
 
     assert.deepEqual(resolved.agentNames, ["Ned"]);
+  });
+
+  it("resolves owned relay agent names", () => {
+    const resolved = resolveActiveWorkingChannelNames(
+      {
+        channelId: "chan-1",
+        anchorAt: 0,
+        agentCount: 1,
+        agentPubkeys: [OWNED_RELAY_AGENT_PUBKEY.toUpperCase()],
+      },
+      [{ pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia" }],
+    );
+
+    assert.deepEqual(resolved.agentNames, ["nadia"]);
+  });
+});
+
+describe("getOwnedRelayWorkingAgents", () => {
+  it("keeps relay agents whose NIP-OA owner is the current viewer", () => {
+    assert.deepEqual(
+      getOwnedRelayWorkingAgents(
+        [
+          { pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia" },
+          { pubkey: "other-agent", name: "nelson" },
+        ],
+        {
+          [OWNED_RELAY_AGENT_PUBKEY]: {
+            displayName: "nadia",
+            avatarUrl: null,
+            nip05Handle: null,
+            ownerPubkey: VIEWER_PUBKEY.toUpperCase(),
+            isAgent: true,
+          },
+          "other-agent": {
+            displayName: "nelson",
+            avatarUrl: null,
+            nip05Handle: null,
+            ownerPubkey: "someone-else",
+            isAgent: true,
+          },
+        },
+        VIEWER_PUBKEY,
+      ),
+      [{ pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia", status: "deployed" }],
+    );
+  });
+
+  it("returns no relay agents without a current viewer", () => {
+    assert.deepEqual(
+      getOwnedRelayWorkingAgents(
+        [{ pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia" }],
+        {},
+        undefined,
+      ),
+      [],
+    );
+  });
+
+  it("drops relay agents with missing profiles or null owners", () => {
+    assert.deepEqual(
+      getOwnedRelayWorkingAgents(
+        [
+          { pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia" },
+          { pubkey: "ownerless-agent", name: "ralph" },
+        ],
+        {
+          "ownerless-agent": {
+            displayName: "ralph",
+            avatarUrl: null,
+            nip05Handle: null,
+            ownerPubkey: null,
+            isAgent: true,
+          },
+        },
+        VIEWER_PUBKEY,
+      ),
+      [],
+    );
+  });
+});
+
+describe("mergeWorkingAgents", () => {
+  it("keeps active managed agents ahead of owned relay duplicates", () => {
+    assert.deepEqual(
+      mergeWorkingAgents(
+        [{ pubkey: "AAAA", name: "Ned", status: "running" }],
+        [
+          { pubkey: "aaaa", name: "Relay Ned", status: "deployed" },
+          {
+            pubkey: OWNED_RELAY_AGENT_PUBKEY,
+            name: "nadia",
+            status: "deployed",
+          },
+        ],
+      ),
+      [
+        { pubkey: "AAAA", name: "Ned", status: "running" },
+        { pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia", status: "deployed" },
+      ],
+    );
+  });
+
+  it("uses owned relay status when a duplicate managed agent is stopped", () => {
+    assert.deepEqual(
+      mergeWorkingAgents(
+        [
+          {
+            pubkey: OWNED_RELAY_AGENT_PUBKEY.toUpperCase(),
+            name: "Local Nadia",
+            status: "stopped",
+          },
+        ],
+        [
+          {
+            pubkey: OWNED_RELAY_AGENT_PUBKEY,
+            name: "nadia",
+            status: "deployed",
+          },
+        ],
+      ),
+      [{ pubkey: OWNED_RELAY_AGENT_PUBKEY, name: "nadia", status: "deployed" }],
+    );
   });
 });

--- a/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
+++ b/desktop/src/features/sidebar/lib/useActiveWorkingChannelsById.ts
@@ -1,16 +1,40 @@
 import * as React from "react";
 
-import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
-import { useWorkingChannels } from "@/features/agents/agentWorkingSignal";
-import { useManagedAgentsQuery } from "@/features/agents/hooks";
+import {
+  type ActiveChannelTurnSummary,
+  useActiveAgentTurnsBridge,
+  useActiveAgentTurnsByChannel,
+} from "@/features/agents/activeAgentTurnsStore";
+import {
+  useManagedAgentsQuery,
+  useRelayAgentsQuery,
+} from "@/features/agents/hooks";
+import { useManagedAgentObserverBridge } from "@/features/agents/observerRelayStore";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { ownsAuthorAgent } from "@/features/profile/lib/identity";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import type {
+  ManagedAgent,
+  RelayAgent,
+  UserProfileSummary,
+} from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+
+type WorkingAgentName = Pick<ManagedAgent, "pubkey" | "name">;
+type WorkingAgent = Pick<ManagedAgent, "pubkey" | "name" | "status">;
+type PillDiagProfile = UserProfileSummary & {
+  pubkey?: string;
+};
+type OwnedRelayWorkingAgent = Pick<RelayAgent, "pubkey" | "name"> & {
+  status: "deployed";
+};
 
 export function resolveActiveWorkingChannelNames(
   summary: ActiveChannelTurnSummary,
-  managedAgents: readonly { pubkey: string; name: string }[],
+  workingAgents: readonly WorkingAgentName[],
 ): ActiveChannelTurnSummary {
   const namesByPubkey = new Map(
-    managedAgents.map((agent) => [normalizePubkey(agent.pubkey), agent.name]),
+    workingAgents.map((agent) => [normalizePubkey(agent.pubkey), agent.name]),
   );
 
   return {
@@ -22,31 +46,201 @@ export function resolveActiveWorkingChannelNames(
   };
 }
 
+export function getOwnedRelayWorkingAgents(
+  relayAgents: readonly Pick<RelayAgent, "pubkey" | "name">[],
+  profiles: Record<string, UserProfileSummary> | undefined,
+  currentPubkey: string | undefined,
+): OwnedRelayWorkingAgent[] {
+  if (!currentPubkey) return [];
+
+  return relayAgents.flatMap((agent) => {
+    const profile = profiles?.[normalizePubkey(agent.pubkey)];
+    if (!ownsAuthorAgent(profile, currentPubkey)) {
+      return [];
+    }
+
+    return [{ pubkey: agent.pubkey, name: agent.name, status: "deployed" }];
+  });
+}
+
+function agentCanStartObserver(agent: WorkingAgent) {
+  return agent.status === "running" || agent.status === "deployed";
+}
+
+export function mergeWorkingAgents(
+  managedAgents: readonly WorkingAgent[],
+  ownedRelayAgents: readonly WorkingAgent[],
+): WorkingAgent[] {
+  const mergedByPubkey = new Map<string, WorkingAgent>();
+
+  for (const agent of managedAgents) {
+    mergedByPubkey.set(normalizePubkey(agent.pubkey), agent);
+  }
+
+  for (const agent of ownedRelayAgents) {
+    const pubkey = normalizePubkey(agent.pubkey);
+    const managedAgent = mergedByPubkey.get(pubkey);
+    if (!managedAgent || !agentCanStartObserver(managedAgent)) {
+      mergedByPubkey.set(pubkey, agent);
+    }
+  }
+
+  return [...mergedByPubkey.values()];
+}
+
+function summarizeAgent(agent: WorkingAgentName & { status?: string }) {
+  return {
+    pubkey: normalizePubkey(agent.pubkey),
+    name: agent.name,
+    status: agent.status ?? null,
+  };
+}
+
+function summarizeRelayProfile(
+  pubkey: string,
+  profile: PillDiagProfile | undefined,
+  currentPubkey: string | undefined,
+) {
+  return {
+    pubkey: normalizePubkey(pubkey),
+    profileKeyPubkey: profile?.pubkey ? normalizePubkey(profile.pubkey) : null,
+    displayName: profile?.displayName ?? null,
+    isAgent: profile?.isAgent ?? null,
+    ownerPubkey: profile?.ownerPubkey
+      ? normalizePubkey(profile.ownerPubkey)
+      : null,
+    ownsAuthorAgent: ownsAuthorAgent(profile, currentPubkey),
+  };
+}
+
+function logPillDiagnostics({
+  currentPubkey,
+  managedAgents,
+  relayAgents,
+  profiles,
+  ownedRelayAgents,
+  workingAgents,
+  activeWorkingChannels,
+}: {
+  currentPubkey: string | undefined;
+  managedAgents: readonly WorkingAgent[];
+  relayAgents: readonly Pick<RelayAgent, "pubkey" | "name">[];
+  profiles: Record<string, UserProfileSummary> | undefined;
+  ownedRelayAgents: readonly WorkingAgent[];
+  workingAgents: readonly WorkingAgent[];
+  activeWorkingChannels: readonly ActiveChannelTurnSummary[];
+}) {
+  const normalizedProfiles = Object.fromEntries(
+    relayAgents.map((agent) => {
+      const pubkey = normalizePubkey(agent.pubkey);
+      const profile = profiles?.[pubkey] as PillDiagProfile | undefined;
+      return [
+        pubkey,
+        summarizeRelayProfile(agent.pubkey, profile, currentPubkey),
+      ];
+    }),
+  );
+
+  console.groupCollapsed("[pill-diag] active working channels inputs", {
+    currentPubkey: currentPubkey ? normalizePubkey(currentPubkey) : null,
+    managedAgentCount: managedAgents.length,
+    relayAgentCount: relayAgents.length,
+    ownedRelayAgentCount: ownedRelayAgents.length,
+    workingAgentCount: workingAgents.length,
+    activeChannelCount: activeWorkingChannels.length,
+  });
+  console.log("[pill-diag] currentPubkey", {
+    currentPubkey: currentPubkey ? normalizePubkey(currentPubkey) : null,
+  });
+  console.table(managedAgents.map(summarizeAgent));
+  console.log("[pill-diag] managedAgents", managedAgents.map(summarizeAgent));
+  console.table(relayAgents.map(summarizeAgent));
+  console.log("[pill-diag] relayAgents", relayAgents.map(summarizeAgent));
+  console.log("[pill-diag] profilesByRelayAgent", normalizedProfiles);
+  console.table(ownedRelayAgents.map(summarizeAgent));
+  console.log(
+    "[pill-diag] ownedRelayAgents",
+    ownedRelayAgents.map(summarizeAgent),
+  );
+  console.table(workingAgents.map(summarizeAgent));
+  console.log("[pill-diag] workingAgents", workingAgents.map(summarizeAgent));
+  console.log("[pill-diag] activeWorkingChannels", activeWorkingChannels);
+  console.groupEnd();
+}
+
 export function useActiveWorkingChannelsById(): ReadonlyMap<
   string,
   ActiveChannelTurnSummary
 > {
+  const identityQuery = useIdentityQuery();
+  const currentPubkey = identityQuery.data?.pubkey;
   const managedAgentsQuery = useManagedAgentsQuery();
   const managedAgents = React.useMemo(
     () => managedAgentsQuery.data ?? [],
     [managedAgentsQuery.data],
   );
+  const relayAgentsQuery = useRelayAgentsQuery();
+  const relayAgents = React.useMemo(
+    () => relayAgentsQuery.data ?? [],
+    [relayAgentsQuery.data],
+  );
+  const relayAgentPubkeys = React.useMemo(
+    () => relayAgents.map((agent) => agent.pubkey),
+    [relayAgents],
+  );
+  const relayAgentProfilesQuery = useUsersBatchQuery(relayAgentPubkeys, {
+    enabled: relayAgentPubkeys.length > 0,
+  });
+  const ownedRelayAgents = React.useMemo(
+    () =>
+      getOwnedRelayWorkingAgents(
+        relayAgents,
+        relayAgentProfilesQuery.data?.profiles,
+        currentPubkey,
+      ),
+    [currentPubkey, relayAgentProfilesQuery.data?.profiles, relayAgents],
+  );
+  const workingAgents = React.useMemo(
+    () => mergeWorkingAgents(managedAgents, ownedRelayAgents),
+    [managedAgents, ownedRelayAgents],
+  );
 
-  // Unified working signal: observer-derived turns primary, bot typing as
-  // fallback — so the sidebar badge appears even for agents whose observer
-  // stream is absent for this build/scope.
-  const activeWorkingChannels = useWorkingChannels();
+  useManagedAgentObserverBridge(workingAgents);
+  useActiveAgentTurnsBridge(workingAgents);
+
+  const activeWorkingChannels = useActiveAgentTurnsByChannel();
+
+  React.useEffect(() => {
+    logPillDiagnostics({
+      currentPubkey,
+      managedAgents,
+      relayAgents,
+      profiles: relayAgentProfilesQuery.data?.profiles,
+      ownedRelayAgents,
+      workingAgents,
+      activeWorkingChannels,
+    });
+  }, [
+    activeWorkingChannels,
+    currentPubkey,
+    managedAgents,
+    ownedRelayAgents,
+    relayAgentProfilesQuery.data?.profiles,
+    relayAgents,
+    workingAgents,
+  ]);
+
   return React.useMemo(
     () =>
       new Map(
         activeWorkingChannels.map((summary) => {
           const resolvedSummary = resolveActiveWorkingChannelNames(
             summary,
-            managedAgents,
+            workingAgents,
           );
           return [resolvedSummary.channelId, resolvedSummary];
         }),
       ),
-    [activeWorkingChannels, managedAgents],
+    [activeWorkingChannels, workingAgents],
   );
 }


### PR DESCRIPTION
Cherry-pick of block/buzz PR #1415 (getOwnedRelayWorkingAgents + mergeWorkingAgents → useManagedAgentObserverBridge). Provider-deployed (owned-but-remote) agents were excluded from knownAgentPubkeys, so the desktop dropped their kind-24200 observer frames client-side and the activity panel stayed dark. This merges owned-remote agents (relay profile ownerPubkey == viewer) into the observer bridge that populates the trust set.

Includes the PR's diagnostic [pill-diag] logging (harmless; strip later).