### PR TITLE
fix(desktop): avoid duplicate remote agent starts

### DIFF
--- a/desktop/src/features/messages/lib/managedAgentMentionReadiness.test.mjs
+++ b/desktop/src/features/messages/lib/managedAgentMentionReadiness.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isLiveAgentPresence,
+  shouldStartManagedAgentForMention,
+} from "./managedAgentMentionReadiness.ts";
+
+const localAgent = (status) => ({
+  backend: { type: "local" },
+  status,
+});
+
+const providerAgent = (status) => ({
+  backend: { type: "provider", id: "remote", config: {} },
+  status,
+});
+
+test("online or away presence is a live external-writer signal", () => {
+  assert.equal(isLiveAgentPresence("online"), true);
+  assert.equal(isLiveAgentPresence("away"), true);
+  assert.equal(isLiveAgentPresence("offline"), false);
+  assert.equal(isLiveAgentPresence(undefined), false);
+});
+
+test("does not start a stopped local record while the identity is live remotely", () => {
+  assert.equal(
+    shouldStartManagedAgentForMention(localAgent("stopped"), "online"),
+    false,
+  );
+  assert.equal(
+    shouldStartManagedAgentForMention(localAgent("stopped"), "away"),
+    false,
+  );
+});
+
+test("starts an inactive local record when no live writer is present", () => {
+  assert.equal(
+    shouldStartManagedAgentForMention(localAgent("stopped"), "offline"),
+    true,
+  );
+  assert.equal(
+    shouldStartManagedAgentForMention(localAgent("stopped"), undefined),
+    true,
+  );
+});
+
+test("keeps already active local and provider records idempotent", () => {
+  assert.equal(
+    shouldStartManagedAgentForMention(localAgent("running"), "offline"),
+    false,
+  );
+  assert.equal(
+    shouldStartManagedAgentForMention(providerAgent("deployed"), "offline"),
+    false,
+  );
+  assert.equal(
+    shouldStartManagedAgentForMention(providerAgent("not_deployed"), "offline"),
+    true,
+  );
+});

--- a/desktop/src/features/messages/lib/managedAgentMentionReadiness.ts
+++ b/desktop/src/features/messages/lib/managedAgentMentionReadiness.ts
@@ -1,0 +1,31 @@
+import type { ManagedAgent, PresenceStatus } from "@/shared/api/types";
+
+export function isLiveAgentPresence(
+  presence: PresenceStatus | undefined,
+): boolean {
+  return presence === "online" || presence === "away";
+}
+
+/**
+ * Whether mention preparation must invoke the managed-agent start/deploy
+ * command.
+ *
+ * Presence wins over the local record: the same signing identity may already
+ * be served by an externally hosted harness while Desktop still has a stopped
+ * local record. Starting that record would create two subscribers and two
+ * replies for one mention.
+ */
+export function shouldStartManagedAgentForMention(
+  agent: Pick<ManagedAgent, "backend" | "status">,
+  presence: PresenceStatus | undefined,
+): boolean {
+  if (isLiveAgentPresence(presence)) {
+    return false;
+  }
+
+  if (agent.backend.type === "provider") {
+    return agent.status !== "deployed";
+  }
+
+  return agent.status !== "running" && agent.status !== "deployed";
+}

--- a/desktop/src/features/messages/ui/useMentionSendFlow.ts
+++ b/desktop/src/features/messages/ui/useMentionSendFlow.ts
@@ -13,6 +13,7 @@ import {
 import { resolvePersonaRuntime } from "@/features/agents/lib/resolvePersonaRuntime";
 import { useAddChannelMembersMutation } from "@/features/channels/hooks";
 import { filterEffectiveExplicitAgentPubkeys } from "@/features/messages/lib/effectiveExplicitAgentPubkeys";
+import { shouldStartManagedAgentForMention } from "@/features/messages/lib/managedAgentMentionReadiness";
 import type { UseChannelLinksResult } from "@/features/messages/lib/useChannelLinks";
 import type { UseEmojiAutocompleteResult } from "@/features/messages/lib/useEmojiAutocomplete";
 import {
@@ -25,6 +26,7 @@ import type { UseRichTextEditorResult } from "@/features/messages/lib/useRichTex
 import type { UseDraftsResult } from "@/features/messages/lib/useDrafts";
 import type { CustomEmoji } from "@/shared/lib/remarkCustomEmoji";
 import type { AcpRuntime, ChannelType, ManagedAgent } from "@/shared/api/types";
+import { getPresence } from "@/shared/api/tauri";
 import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
 import { MENTION_REFERENCE_TAG } from "@/shared/lib/resolveMentionNames";
 import { buildCustomEmojiTags } from "@/shared/lib/customEmojiTags";
@@ -131,14 +133,6 @@ function getErrorMessage(error: unknown, fallback: string) {
 
 function uniqueNormalizedPubkeys(pubkeys: Iterable<string>) {
   return [...new Set([...pubkeys].map(normalizePubkey))].filter(Boolean);
-}
-
-function isManagedAgentRunning(agent: ManagedAgent) {
-  return agent.status === "running" || agent.status === "deployed";
-}
-
-function isProviderBackedAgent(agent: ManagedAgent) {
-  return agent.backend.type === "provider";
 }
 
 const DM_THREAD_AGENT_MENTION_ERROR =
@@ -254,26 +248,50 @@ export function useMentionSendFlow({
       ]);
       const errors: string[] = [];
       const pubkeys: string[] = [];
+      const normalizedMentionPubkeys = uniqueNormalizedPubkeys(mentionPubkeys);
+      const inactivePubkeys = normalizedMentionPubkeys.filter((pubkey) => {
+        const agent = managedAgentsByPubkey.get(pubkey);
+        return agent && shouldStartManagedAgentForMention(agent, undefined);
+      });
+      let presenceByPubkey: Record<string, "online" | "away" | "offline"> = {};
+      if (inactivePubkeys.length > 0) {
+        try {
+          presenceByPubkey = await getPresence(inactivePubkeys);
+        } catch (error) {
+          const message = getErrorMessage(
+            error,
+            "Could not verify whether another agent runtime is active.",
+          );
+          return {
+            errors: inactivePubkeys.map((pubkey) => {
+              const agent = managedAgentsByPubkey.get(pubkey);
+              return `${agent?.name ?? truncatePubkey(pubkey)}: ${message}`;
+            }),
+            pubkeys: [] as string[],
+          };
+        }
+      }
 
-      for (const pubkey of uniqueNormalizedPubkeys(mentionPubkeys)) {
+      for (const pubkey of normalizedMentionPubkeys) {
         const agent = managedAgentsByPubkey.get(pubkey);
         if (!agent) {
           continue;
         }
 
         try {
+          const shouldStart = shouldStartManagedAgentForMention(
+            agent,
+            presenceByPubkey[pubkey],
+          );
           if (participantPubkeys.has(pubkey)) {
-            if (isProviderBackedAgent(agent)) {
-              if (agent.status !== "deployed") {
-                await startAgentMutation.mutateAsync(agent.pubkey);
-              }
-            } else if (!isManagedAgentRunning(agent)) {
+            if (shouldStart) {
               await startAgentMutation.mutateAsync(agent.pubkey);
             }
           } else {
             await attachAgentMutation.mutateAsync({
               channelId: capturedChannelId,
               agent,
+              ensureRunning: shouldStart,
               role: "bot",
             });
           }

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -208,6 +208,8 @@ type E2eConfig = {
     personas?: MockPersonaSeed[];
     teams?: MockTeamSeed[];
     relayAgents?: MockRelayAgentSeed[];
+    /** Current presence by pubkey for mention/lifecycle single-writer tests. */
+    presence?: Record<string, PresenceStatus>;
     agentListDelayMs?: number;
     agentMemory?: RawAgentMemoryListing | Record<string, RawAgentMemoryListing>;
     addChannelMembersDelayMs?: number;
@@ -8987,6 +8989,9 @@ export function maybeInstallE2eTauriMocks() {
   resetMockRelayMembers(config);
   resetMockRelayAgents(config);
   resetMockManagedAgents(config);
+  for (const [pubkey, status] of Object.entries(config.mock?.presence ?? {})) {
+    setMockPresenceStatus(pubkey, status);
+  }
   resetMockPersonas(config);
   resetMockTeams(config);
   seedMockSearchProfiles(config);

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -894,6 +894,48 @@ test("mentioning an in-channel stopped managed agent starts it before sending", 
   await expect(mentionChip).toBeVisible();
 });
 
+test("mentioning an externally live agent does not start its stopped local record", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: IN_CHANNEL_MANAGED_AGENT_PUBKEY,
+        name: "fizz",
+        status: "stopped",
+        channelNames: ["general"],
+      },
+    ],
+    presence: {
+      [IN_CHANNEL_MANAGED_AGENT_PUBKEY]: "online",
+    },
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("Hey @fizz");
+  await expect(autocomplete(page).getByText("fizz")).toBeVisible();
+  await input.press("Enter");
+  await page.keyboard.type(" use the remote runtime");
+
+  const baselineStartCount = commandCount(
+    await readCommandLog(page),
+    "start_managed_agent",
+  );
+  await page.getByTestId("send-message").click();
+
+  const mentionChip = page
+    .getByTestId("message-row")
+    .last()
+    .locator("[data-mention].agent-mention-highlight", { hasText: "fizz" });
+  await expect(mentionChip).toBeVisible();
+  expect(
+    commandCount(await readCommandLog(page), "start_managed_agent"),
+  ).toEqual(baselineStartCount);
+});
+
 test("mentioning an in-channel provider managed agent deploys it before sending", async ({
   page,
 }) => {

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -213,6 +213,8 @@ type MockBridgeOptions = {
   personas?: MockPersonaSeed[];
   teams?: MockTeamSeed[];
   relayAgents?: MockRelayAgentSeed[];
+  /** Current presence by pubkey for mention/lifecycle single-writer tests. */
+  presence?: Record<string, "online" | "away" | "offline">;
   agentListDelayMs?: number;
   createManagedAgentDelayMs?: number;
   channelTemplates?: ChannelTemplate[];


### PR DESCRIPTION
## Summary

- check fresh relay presence before mention preflight starts a stopped local managed-agent record
- treat `online` and `away` as evidence that the same signing identity already has a live writer
- preserve existing local start and provider deploy behavior when presence is offline
- fail closed when presence cannot be verified, avoiding a second subscriber and duplicate replies

## Why

A managed-agent identity can be hosted outside Buzz Desktop while its local
record remains stopped. Mention-send preflight previously started that local
record, so both the external harness and Desktop answered the same event.

Originating Buzz conversation:
`buzz://message?channel=234c1f8d-27dc-4a73-a96c-4c90fa39b0a9&id=02ecaa8db76a1d17054d22f430548e1d1b61a1b3fb4295e16bd928559d68f653`

## Verification

- `pnpm --dir desktop test` — 3491 passed
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop check`
- `pnpm --dir desktop build:e2e`
- `pnpm --dir desktop exec playwright test tests/e2e/mentions.spec.ts --project=smoke` — 50 passed
