### PR TITLE
fix(mobile): tag DM recipients on send

### DIFF
--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -326,6 +326,9 @@ class ChannelDetailPage extends HookConsumerWidget {
                         channelId: channel.id,
                         content: content,
                         mentionPubkeys: mentionPubkeys,
+                        dmParticipantPubkeys: resolvedChannel.isDm
+                            ? resolvedChannel.participantPubkeys
+                            : null,
                         mediaTags: mediaTags,
                       ),
             )

--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -27,19 +27,25 @@ class SendMessage {
   /// If [rootEventId] is null it defaults to [parentEventId] (direct reply to
   /// thread head). Tags are built to match the desktop's `buildReplyTags`
   /// convention with `root` / `reply` markers. Pass [mediaTags] to append
-  /// relay-validated `imeta` tags and NIP-30 `emoji` tags.
+  /// relay-validated `imeta` tags and NIP-30 `emoji` tags. For a DM, pass
+  /// [dmParticipantPubkeys] so every counterparty receives a `p` tag.
   Future<void> call({
     required String channelId,
     required String content,
     String? parentEventId,
     String? rootEventId,
     List<String>? mentionPubkeys,
+    List<String>? dmParticipantPubkeys,
     List<List<String>> mediaTags = const [],
   }) async {
     // Use explicitly passed pubkeys, or resolve @mentions against
     // channel members to avoid matching the wrong user.
     final resolvedMentions =
         mentionPubkeys ?? await _resolveMentions(content, channelId);
+    final allMentionPubkeys = <String>[
+      ...resolvedMentions,
+      ...?dmParticipantPubkeys,
+    ];
     final authorPubkey = _signedEventRelay.pubkey;
 
     // Normalize mentions: lowercase, deduplicate, exclude self (matching
@@ -47,7 +53,7 @@ class SendMessage {
     final selfLower = authorPubkey?.toLowerCase();
     final seenMentions = <String>{?selfLower};
     final normalizedMentions = <String>[
-      for (final pk in resolvedMentions)
+      for (final pk in allMentionPubkeys)
         if (seenMentions.add(pk.toLowerCase())) pk,
     ];
 

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -144,6 +144,13 @@ class ThreadDetailPage extends HookConsumerWidget {
         channelNamesMap[ch.name.toLowerCase()] = ch.id;
       }
     });
+    final loadedChannels = channelsAsync.asData?.value;
+    final currentChannel = loadedChannels
+        ?.where((candidate) => candidate.id == channelId)
+        .firstOrNull;
+    final dmParticipantPubkeys = currentChannel?.isDm == true
+        ? currentChannel!.participantPubkeys
+        : null;
 
     return FrostedScaffold(
       appBar: const FrostedAppBar(title: Text('Thread')),
@@ -275,6 +282,7 @@ class ThreadDetailPage extends HookConsumerWidget {
                         channelId: channelId,
                         content: content,
                         mentionPubkeys: mentionPubkeys,
+                        dmParticipantPubkeys: dmParticipantPubkeys,
                         parentEventId: threadHead.id,
                         rootEventId: effectiveRootId,
                         mediaTags: mediaTags,

--- a/mobile/test/features/channels/send_message_dm_test.dart
+++ b/mobile/test/features/channels/send_message_dm_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:buzz/features/channels/send_message_provider.dart';
+import 'package:buzz/features/profile/user_profile.dart';
+import 'package:buzz/shared/relay/relay.dart';
+
+void main() {
+  test(
+    'plain DM appends the channel participant without a picker mention',
+    () async {
+      final tags = await _send(dmParticipantPubkeys: ['Recipient']);
+
+      expect(tags, [
+        ['h', 'dm-channel'],
+        ['p', 'Recipient'],
+      ]);
+    },
+  );
+
+  test(
+    'DM mention tags are deduplicated and self-excluded case-insensitively',
+    () async {
+      final tags = await _send(
+        mentionPubkeys: ['EXPLICIT', 'Peer', 'sender'],
+        dmParticipantPubkeys: ['PEER', 'SENDER', 'second'],
+      );
+
+      expect(tags, [
+        ['h', 'dm-channel'],
+        ['p', 'EXPLICIT'],
+        ['p', 'Peer'],
+        ['p', 'second'],
+      ]);
+    },
+  );
+
+  test('non-DM keeps explicit mention semantics', () async {
+    final tags = await _send(
+      mentionPubkeys: ['Explicit'],
+      dmParticipantPubkeys: null,
+    );
+
+    expect(tags, [
+      ['h', 'dm-channel'],
+      ['p', 'Explicit'],
+    ]);
+  });
+
+  test('threaded DM keeps e-tags before p-tags and media tags last', () async {
+    final tags = await _send(
+      mentionPubkeys: ['Explicit'],
+      dmParticipantPubkeys: ['Recipient'],
+      parentEventId: 'parent',
+      rootEventId: 'root',
+      mediaTags: const [
+        ['imeta', 'blob'],
+        ['emoji', 'party'],
+      ],
+    );
+
+    expect(tags, [
+      ['h', 'dm-channel'],
+      ['e', 'root', '', 'root'],
+      ['e', 'parent', '', 'reply'],
+      ['p', 'Explicit'],
+      ['p', 'Recipient'],
+      ['imeta', 'blob'],
+      ['emoji', 'party'],
+    ]);
+  });
+}
+
+Future<List<List<String>>> _send({
+  List<String> mentionPubkeys = const [],
+  List<String>? dmParticipantPubkeys,
+  String? parentEventId,
+  String? rootEventId,
+  List<List<String>> mediaTags = const [],
+}) async {
+  final relay = _RecordingSignedEventRelay();
+  final sender = SendMessage(
+    signedEventRelay: relay,
+    fetchMembers: (_) async => const [],
+    readUserCache: () => const <String, UserProfile>{},
+  );
+
+  await sender(
+    channelId: 'dm-channel',
+    content: 'message',
+    mentionPubkeys: mentionPubkeys,
+    dmParticipantPubkeys: dmParticipantPubkeys,
+    parentEventId: parentEventId,
+    rootEventId: rootEventId,
+    mediaTags: mediaTags,
+  );
+
+  expect(relay.submittedKind, EventKind.streamMessage);
+  return relay.submittedTags!;
+}
+
+class _RecordingSignedEventRelay implements SignedEventRelay {
+  @override
+  String? get pubkey => 'SENDER';
+
+  int? submittedKind;
+  List<List<String>>? submittedTags;
+
+  @override
+  Future<NostrEvent> submit({
+    required int kind,
+    required String content,
+    required List<List<String>> tags,
+    int? createdAt,
+  }) async {
+    submittedKind = kind;
+    submittedTags = tags;
+    return const NostrEvent(
+      id: 'stub',
+      pubkey: '',
+      createdAt: 0,
+      kind: 0,
+      tags: [],
+      content: '',
+      sig: '',
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Mobile DM sends only serialized `p` tags from picker-resolved mentions, so a plain DM could reach the relay without addressing the counterparty. This adds the known DM participants to the existing mention-normalization path.

## Changes

- append DM participant pubkeys after explicit mentions
- reuse the existing case-insensitive dedupe and self-exclusion logic
- pass DM participants from both the channel composer and thread composer
- preserve existing tag order: `h`, thread `e` tags, recipient `p` tags, then media tags
- add focused coverage for plain DM sends, mixed-case dedupe/self exclusion, non-DM behavior, and threaded media ordering

## Verification

- `dart format --output=none --set-exit-if-changed` on all four changed files
- `git diff --check`
- Flutter analysis and tests were not available in the local environment; GitHub Actions is the integration gate

AI assistance: ChatGPT/Codex was used for implementation. The generated patch was independently reviewed, corrected, and reduced to one product commit before publication.

Closes #2835