### PR TITLE
ci: gate schema/schema.sql against migrations drift, and fix the current drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       desktop-rust: ${{ steps.filter.outputs.desktop-rust }}
       web: ${{ steps.filter.outputs.web }}
       mobile: ${{ steps.filter.outputs.mobile }}
+      schema: ${{ steps.filter.outputs.schema }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -56,6 +57,12 @@ jobs:
             web:
               - 'web/**'
               - 'pnpm-lock.yaml'
+            schema:
+              - 'migrations/**'
+              - 'schema/**'
+              - 'scripts/check-schema-drift.sh'
+              - 'scripts/attach-schema-partitions.sql'
+              - '.github/workflows/ci.yml'
             mobile:
               - 'mobile/**'
               - 'scripts/mobile-release.sh'
@@ -71,6 +78,24 @@ jobs:
         run: |
           scripts/test-mobile-release-contract.sh
           scripts/test-mobile-release-candidate-publisher.sh
+
+  schema-drift:
+    name: Schema Drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [changes]
+    if: github.event_name == 'push' || needs.changes.outputs.schema == 'true'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
+      # Applies migrations/*.sql to an ephemeral Postgres and fails if
+      # `pgschema plan schema/schema.sql` against that database is non-empty —
+      # i.e. the declarative snapshot no longer describes the schema the
+      # migrations build (#1322).
+      - name: Assert schema/schema.sql matches migrations/
+        run: just check-schema-drift
 
   rust-lint:
     name: Rust Lint

--- a/Justfile
+++ b/Justfile
@@ -641,6 +641,10 @@ mobile-dev:
 # Apply database migrations
 migrate: _ensure-migrations
 
+# Assert schema/schema.sql matches the schema built by migrations/ (#1322)
+check-schema-drift:
+    ./scripts/check-schema-drift.sh
+
 # ─── Utilities ────────────────────────────────────────────────────────────────
 
 # Remove build artifacts

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -56,10 +56,31 @@ CREATE TABLE communities (
     signing_key     BYTEA,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     archived_at     TIMESTAMPTZ,
+    -- Per-community NIP-11 `icon` (kind:9033 command; migrations/0003). An
+    -- http(s) URL or small data:image/* URL — validated at the write path.
+    icon            TEXT,
     CONSTRAINT chk_communities_id_not_nil CHECK (id <> '00000000-0000-0000-0000-000000000000'::uuid)
 );
 
 CREATE UNIQUE INDEX idx_communities_host ON communities (lower(host));
+
+-- ── Git repo name registry (NIP-34 kind:30617) ───────────────────────────────
+-- Repo-name uniqueness moved off local disk so the relay is stateless
+-- (migrations/0002; docs/git-on-object-storage.md). Per-community: the PK
+-- enforces uniqueness atomically (INSERT … ON CONFLICT); `owner_pubkey`
+-- distinguishes idempotent re-announce from collision and backs the
+-- per-pubkey quota via COUNT.
+
+CREATE TABLE git_repo_names (
+    community_id  UUID NOT NULL REFERENCES communities(id),
+    repo_id       TEXT NOT NULL,
+    owner_pubkey  TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (community_id, repo_id)
+);
+
+-- Backs the per-pubkey repo quota: COUNT(*) WHERE community_id = $1 AND owner_pubkey = $2.
+CREATE INDEX idx_git_repo_names_owner ON git_repo_names (community_id, owner_pubkey);
 
 -- ── Channels ──────────────────────────────────────────────────────────────────
 -- Conformance: "Channels and channel membership". `community_id` immutable.
@@ -266,6 +287,13 @@ CREATE INDEX idx_events_not_before ON events (community_id, not_before)
 -- EXPLAIN before its work lands (Quinn option A; Max's index-spelling caveat).
 CREATE INDEX idx_events_search_tsv ON events USING GIN (search_tsv);
 
+-- GIN index for e-tag containment lookups (migrations/0004): the channel-window
+-- aux closure and every other #e fan-out resolve "events targeting these rows"
+-- with JSONB containment (tags @> '[["e","<hex>"]]'). jsonb_path_ops: smaller
+-- and faster than jsonb_ops, supports exactly the @> operator — the only
+-- operator the query path uses. Recurses to all partitions.
+CREATE INDEX idx_events_tags_gin ON events USING GIN (tags jsonb_path_ops);
+
 -- ── Event mentions ────────────────────────────────────────────────────────────
 -- Conformance: "Channel-less global events and DMs" (#p fan-out). The join to
 -- events MUST carry the community tuple (e.community_id = m.community_id AND
@@ -286,6 +314,212 @@ CREATE INDEX idx_event_mentions_pubkey_created
     ON event_mentions (community_id, pubkey_hex, event_created_at DESC);
 CREATE INDEX idx_event_mentions_pubkey_kind_created
     ON event_mentions (community_id, pubkey_hex, event_kind, event_created_at DESC);
+-- Superseded read-state events normally have no p-tags, but malformed/legacy
+-- rows can. Serve defensive mention cleanup without a per-replacement seq scan
+-- (migrations/0007).
+CREATE INDEX idx_event_mentions_community_event
+    ON event_mentions (community_id, event_id);
+
+-- ── NIP-RS retention (kind:30078 read state) ──────────────────────────────────
+-- Bound NIP-RS storage while preserving NIP-33 replay ordering
+-- (migrations/0007/0009/0010/0011). A compact ordering watermark retains the
+-- only historical fact replacement needs without retaining user payloads; the
+-- triggers keep the invariant in PostgreSQL so pre-migration relay binaries
+-- cannot bypass watermark or payload-retention rules during rolling deploys.
+-- Keep the function bodies byte-identical to the latest migration definitions
+-- (0011 for the watermark/purge/hard-delete guards, 0009 for the mention
+-- guard) — the schema-drift gate compares them verbatim.
+
+CREATE TABLE parameterized_event_watermarks (
+    community_id  UUID NOT NULL REFERENCES communities(id),
+    kind          INT NOT NULL,
+    pubkey        BYTEA NOT NULL,
+    d_tag         TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL,
+    event_id      BYTEA NOT NULL,
+    PRIMARY KEY (community_id, kind, pubkey, d_tag)
+);
+
+CREATE FUNCTION guard_nip_rs_watermark() RETURNS trigger AS $$
+DECLARE
+    advanced BOOLEAN;
+BEGIN
+    IF NEW.kind = 30078
+       AND NEW.d_tag ~ '^read-state:[0-9a-f]{32}$'
+       AND (
+           SELECT count(*)
+           FROM jsonb_array_elements(CASE WHEN jsonb_typeof(NEW.tags) = 'array' THEN NEW.tags ELSE '[]'::jsonb END) tag
+           WHERE jsonb_typeof(tag) = 'array'
+             AND tag->0 = '"d"'::jsonb
+       ) = 1
+       AND EXISTS (
+           SELECT 1
+           FROM jsonb_array_elements(CASE WHEN jsonb_typeof(NEW.tags) = 'array' THEN NEW.tags ELSE '[]'::jsonb END) tag
+           WHERE jsonb_typeof(tag) = 'array'
+             AND jsonb_array_length(tag) >= 2
+             AND jsonb_typeof(tag->1) = 'string'
+             AND tag->>0 = 'd'
+             AND tag->>1 = NEW.d_tag
+       )
+       AND (
+           SELECT count(*)
+           FROM jsonb_array_elements(CASE WHEN jsonb_typeof(NEW.tags) = 'array' THEN NEW.tags ELSE '[]'::jsonb END) tag
+           WHERE tag = '["t", "read-state"]'::jsonb
+       ) = 1 THEN
+        INSERT INTO parameterized_event_watermarks
+            (community_id, kind, pubkey, d_tag, created_at, event_id)
+        VALUES
+            (NEW.community_id, NEW.kind, NEW.pubkey, NEW.d_tag, NEW.created_at, NEW.id)
+        ON CONFLICT (community_id, kind, pubkey, d_tag) DO UPDATE SET
+            created_at = EXCLUDED.created_at,
+            event_id = EXCLUDED.event_id
+        WHERE EXCLUDED.created_at > parameterized_event_watermarks.created_at
+           OR (EXCLUDED.created_at = parameterized_event_watermarks.created_at
+               AND EXCLUDED.event_id < parameterized_event_watermarks.event_id)
+        RETURNING TRUE INTO advanced;
+
+        IF NOT COALESCE(advanced, FALSE) THEN
+            IF EXISTS (
+                SELECT 1
+                FROM parameterized_event_watermarks
+                WHERE community_id = NEW.community_id
+                  AND kind = NEW.kind
+                  AND pubkey = NEW.pubkey
+                  AND d_tag = NEW.d_tag
+                  AND created_at = NEW.created_at
+                  AND event_id = NEW.id
+            ) THEN
+                RETURN NULL;
+            END IF;
+
+            RAISE EXCEPTION 'stale NIP-RS event rejected by durable watermark'
+                USING ERRCODE = 'check_violation';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_events_nip_rs_watermark
+    BEFORE INSERT ON events
+    FOR EACH ROW EXECUTE FUNCTION guard_nip_rs_watermark();
+
+CREATE FUNCTION purge_soft_deleted_nip_rs() RETURNS trigger AS $$
+BEGIN
+    IF OLD.deleted_at IS NULL
+       AND NEW.deleted_at IS NOT NULL
+       AND NEW.kind = 30078
+       AND NEW.d_tag ~ '^read-state:[0-9a-f]{32}$'
+       AND (
+           SELECT count(*)
+           FROM jsonb_array_elements(CASE WHEN jsonb_typeof(NEW.tags) = 'array' THEN NEW.tags ELSE '[]'::jsonb END) tag
+           WHERE jsonb_typeof(tag) = 'array'
+             AND tag->0 = '"d"'::jsonb
+       ) = 1
+       AND EXISTS (
+           SELECT 1
+           FROM jsonb_array_elements(CASE WHEN jsonb_typeof(NEW.tags) = 'array' THEN NEW.tags ELSE '[]'::jsonb END) tag
+           WHERE jsonb_typeof(tag) = 'array'
+             AND jsonb_array_length(tag) >= 2
+             AND jsonb_typeof(tag->1) = 'string'
+             AND tag->>0 = 'd'
+             AND tag->>1 = NEW.d_tag
+       )
+       AND (
+           SELECT count(*)
+           FROM jsonb_array_elements(CASE WHEN jsonb_typeof(NEW.tags) = 'array' THEN NEW.tags ELSE '[]'::jsonb END) tag
+           WHERE tag = '["t", "read-state"]'::jsonb
+       ) = 1 THEN
+        PERFORM set_config('buzz.nip_rs_hard_delete', 'on', true);
+
+        DELETE FROM events
+        WHERE community_id = NEW.community_id
+          AND created_at = NEW.created_at
+          AND id = NEW.id;
+
+        DELETE FROM event_mentions
+        WHERE community_id = NEW.community_id AND event_id = NEW.id;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_events_purge_soft_deleted_nip_rs
+    AFTER UPDATE OF deleted_at ON events
+    FOR EACH ROW EXECUTE FUNCTION purge_soft_deleted_nip_rs();
+
+CREATE FUNCTION guard_nip_rs_hard_delete() RETURNS trigger AS $$
+BEGIN
+    IF current_setting('buzz.nip_rs_hard_delete', true) IS DISTINCT FROM 'on' THEN
+        RAISE EXCEPTION 'NIP-RS hard delete requires corrected writer opt-in'
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_events_guard_nip_rs_hard_delete
+    BEFORE DELETE ON events
+    FOR EACH ROW
+    WHEN (OLD.kind = 30078 AND OLD.d_tag ~ '^read-state:[0-9a-f]{32}$')
+    EXECUTE FUNCTION guard_nip_rs_hard_delete();
+
+CREATE FUNCTION guard_event_mention_live() RETURNS trigger AS $$
+BEGIN
+    IF NEW.event_kind IS DISTINCT FROM 30078 THEN
+        RETURN NEW;
+    END IF;
+
+    PERFORM 1
+    FROM events
+    WHERE community_id = NEW.community_id
+      AND id = NEW.event_id
+      AND created_at = NEW.event_created_at
+      AND deleted_at IS NULL
+    FOR KEY SHARE;
+
+    IF NOT FOUND THEN
+        RETURN NULL;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_event_mentions_require_live_event
+    BEFORE INSERT ON event_mentions
+    FOR EACH ROW EXECUTE FUNCTION guard_event_mention_live();
+
+-- ── Mesh status retention (kind:30003 heartbeat) ──────────────────────────────
+-- Only the live head has product value; physically purge superseded heartbeat
+-- payloads when old relay binaries soft-delete them (migrations/0019).
+
+CREATE FUNCTION purge_soft_deleted_buzz_mesh_status() RETURNS trigger AS $$
+BEGIN
+    IF OLD.deleted_at IS NULL
+       AND NEW.deleted_at IS NOT NULL
+       AND NEW.kind = 30003
+       AND NEW.d_tag LIKE 'buzz-mesh-member-status:%'
+       AND NEW.tags @> '[["k", "buzz-mesh-status"]]'::jsonb THEN
+        DELETE FROM events
+        WHERE community_id = NEW.community_id
+          AND created_at = NEW.created_at
+          AND id = NEW.id;
+
+        DELETE FROM event_mentions
+        WHERE community_id = NEW.community_id AND event_id = NEW.id;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_events_purge_soft_deleted_buzz_mesh_status
+    AFTER UPDATE OF deleted_at ON events
+    FOR EACH ROW EXECUTE FUNCTION purge_soft_deleted_buzz_mesh_status();
 
 -- ── Subscriptions ─────────────────────────────────────────────────────────────
 -- Conformance: "Mesh, agents, ACP/MCP, and CLI" (persisted subscriptions).
@@ -572,6 +806,21 @@ CREATE TABLE relay_members (
 
 CREATE INDEX idx_relay_members_role ON relay_members (community_id, role);
 
+-- ── Join policy acceptances ───────────────────────────────────────────────────
+-- Durable evidence of the policy version accepted when an invite claim grants
+-- relay membership (migrations/0020). Rows are scoped to the same community
+-- and member identity as relay_members and are deleted with that membership.
+
+CREATE TABLE join_policy_acceptances (
+    community_id UUID NOT NULL,
+    pubkey TEXT NOT NULL,
+    policy_version TEXT NOT NULL CHECK (length(policy_version) = 64),
+    accepted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (community_id, pubkey, policy_version),
+    FOREIGN KEY (community_id, pubkey)
+        REFERENCES relay_members (community_id, pubkey) ON DELETE CASCADE
+);
+
 -- ── Archived identities (NIP-IA) ──────────────────────────────────────────────
 -- Conformance: archive cannot hide a key in another community. PK scoped.
 
@@ -745,6 +994,33 @@ INSERT INTO _operator_global_tables (table_name, reason) VALUES
     ('communities',           'the tenant registry itself; id IS the community key'),
     ('rate_limit_violations', 'deployment abuse/health; never tenant-observable; community_id is an attribution label only'),
     ('_operator_global_tables', 'the registry table itself');
+
+-- ── Product feedback ──────────────────────────────────────────────────────────
+-- Buzz product feedback is accepted through a dedicated signed event kind and
+-- sidecarred here instead of entering the ordinary events table
+-- (migrations/0017). Rows remain attributable to their source community, while
+-- deployment operators may review the table across communities.
+
+CREATE TABLE product_feedback (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    community_id UUID NOT NULL REFERENCES communities(id),
+    event_id BYTEA NOT NULL CHECK (length(event_id) = 32),
+    submitter_pubkey BYTEA NOT NULL CHECK (length(submitter_pubkey) = 32),
+    category TEXT CHECK (category IN ('bug', 'praise', 'needs-work')),
+    body TEXT NOT NULL CHECK (length(btrim(body)) > 0),
+    tags JSONB NOT NULL DEFAULT '[]'::jsonb CHECK (jsonb_typeof(tags) = 'array'),
+    event_created_at TIMESTAMPTZ NOT NULL,
+    received_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (event_id)
+);
+
+CREATE INDEX idx_product_feedback_received
+    ON product_feedback (received_at DESC, id);
+CREATE INDEX idx_product_feedback_community_received
+    ON product_feedback (community_id, received_at DESC, id);
+
+INSERT INTO _operator_global_tables (table_name, reason) VALUES
+    ('product_feedback', 'deployment product inbox; community_id is provenance only');
 -- NIP-PL effective lease state and durable wake outbox. Every key is led by
 -- community_id: client-provided origin is confirmation only, never routing.
 CREATE TABLE push_leases (
@@ -826,8 +1102,6 @@ CREATE FUNCTION enqueue_push_match_job() RETURNS trigger
 LANGUAGE plpgsql AS $$
 BEGIN
     -- Keep this allowlist identical to the relay's validated NIP-PL descriptor.
-    -- Centralizing it on the events table covers every durable producer,
-    -- including internal paths that bypass live dispatch.
     IF NEW.kind IN (7, 9, 1059, 40007, 46010) THEN
         PERFORM pg_advisory_xact_lock_shared(
             hashtextextended('buzz_push_gate:' || NEW.community_id::text, 0));

--- a/scripts/attach-schema-partitions.sql
+++ b/scripts/attach-schema-partitions.sql
@@ -16,11 +16,17 @@ BEGIN
     ) THEN
         -- pgschema may copy parent triggers onto standalone children. Drop
         -- those copies before ATTACH; PostgreSQL recreates inherited parent
-        -- triggers while attaching and rejects same-named child triggers
-        -- (both the push-match trigger and the replica-fence floor guard).
+        -- triggers while attaching and rejects same-named child triggers.
+        -- Every row trigger declared on the events parent in schema/schema.sql
+        -- must be listed here (push match, channel TTL, floor guard, NIP-RS
+        -- guards, mesh-status purge).
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p_past;
         DROP TRIGGER IF EXISTS events_refresh_channel_ttl ON events_p_past;
         DROP TRIGGER IF EXISTS events_created_at_floor ON events_p_past;
+        DROP TRIGGER IF EXISTS trg_events_nip_rs_watermark ON events_p_past;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_nip_rs ON events_p_past;
+        DROP TRIGGER IF EXISTS trg_events_guard_nip_rs_hard_delete ON events_p_past;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_buzz_mesh_status ON events_p_past;
         ALTER TABLE events ATTACH PARTITION events_p_past
             FOR VALUES FROM (MINVALUE) TO ('2026-01-01');
     END IF;
@@ -33,6 +39,10 @@ BEGIN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p2026_01;
         DROP TRIGGER IF EXISTS events_refresh_channel_ttl ON events_p2026_01;
         DROP TRIGGER IF EXISTS events_created_at_floor ON events_p2026_01;
+        DROP TRIGGER IF EXISTS trg_events_nip_rs_watermark ON events_p2026_01;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_nip_rs ON events_p2026_01;
+        DROP TRIGGER IF EXISTS trg_events_guard_nip_rs_hard_delete ON events_p2026_01;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_buzz_mesh_status ON events_p2026_01;
         ALTER TABLE events ATTACH PARTITION events_p2026_01
             FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
     END IF;
@@ -45,6 +55,10 @@ BEGIN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p2026_02;
         DROP TRIGGER IF EXISTS events_refresh_channel_ttl ON events_p2026_02;
         DROP TRIGGER IF EXISTS events_created_at_floor ON events_p2026_02;
+        DROP TRIGGER IF EXISTS trg_events_nip_rs_watermark ON events_p2026_02;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_nip_rs ON events_p2026_02;
+        DROP TRIGGER IF EXISTS trg_events_guard_nip_rs_hard_delete ON events_p2026_02;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_buzz_mesh_status ON events_p2026_02;
         ALTER TABLE events ATTACH PARTITION events_p2026_02
             FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');
     END IF;
@@ -57,6 +71,10 @@ BEGIN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p2026_03;
         DROP TRIGGER IF EXISTS events_refresh_channel_ttl ON events_p2026_03;
         DROP TRIGGER IF EXISTS events_created_at_floor ON events_p2026_03;
+        DROP TRIGGER IF EXISTS trg_events_nip_rs_watermark ON events_p2026_03;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_nip_rs ON events_p2026_03;
+        DROP TRIGGER IF EXISTS trg_events_guard_nip_rs_hard_delete ON events_p2026_03;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_buzz_mesh_status ON events_p2026_03;
         ALTER TABLE events ATTACH PARTITION events_p2026_03
             FOR VALUES FROM ('2026-03-01') TO ('2026-04-01');
     END IF;
@@ -69,6 +87,10 @@ BEGIN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p2026_04;
         DROP TRIGGER IF EXISTS events_refresh_channel_ttl ON events_p2026_04;
         DROP TRIGGER IF EXISTS events_created_at_floor ON events_p2026_04;
+        DROP TRIGGER IF EXISTS trg_events_nip_rs_watermark ON events_p2026_04;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_nip_rs ON events_p2026_04;
+        DROP TRIGGER IF EXISTS trg_events_guard_nip_rs_hard_delete ON events_p2026_04;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_buzz_mesh_status ON events_p2026_04;
         ALTER TABLE events ATTACH PARTITION events_p2026_04
             FOR VALUES FROM ('2026-04-01') TO ('2026-05-01');
     END IF;
@@ -81,6 +103,10 @@ BEGIN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p2026_05;
         DROP TRIGGER IF EXISTS events_refresh_channel_ttl ON events_p2026_05;
         DROP TRIGGER IF EXISTS events_created_at_floor ON events_p2026_05;
+        DROP TRIGGER IF EXISTS trg_events_nip_rs_watermark ON events_p2026_05;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_nip_rs ON events_p2026_05;
+        DROP TRIGGER IF EXISTS trg_events_guard_nip_rs_hard_delete ON events_p2026_05;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_buzz_mesh_status ON events_p2026_05;
         ALTER TABLE events ATTACH PARTITION events_p2026_05
             FOR VALUES FROM ('2026-05-01') TO ('2026-06-01');
     END IF;
@@ -93,6 +119,10 @@ BEGIN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p2026_06;
         DROP TRIGGER IF EXISTS events_refresh_channel_ttl ON events_p2026_06;
         DROP TRIGGER IF EXISTS events_created_at_floor ON events_p2026_06;
+        DROP TRIGGER IF EXISTS trg_events_nip_rs_watermark ON events_p2026_06;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_nip_rs ON events_p2026_06;
+        DROP TRIGGER IF EXISTS trg_events_guard_nip_rs_hard_delete ON events_p2026_06;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_buzz_mesh_status ON events_p2026_06;
         ALTER TABLE events ATTACH PARTITION events_p2026_06
             FOR VALUES FROM ('2026-06-01') TO ('2026-07-01');
     END IF;
@@ -105,6 +135,10 @@ BEGIN
         DROP TRIGGER IF EXISTS events_enqueue_push_match ON events_p_future;
         DROP TRIGGER IF EXISTS events_refresh_channel_ttl ON events_p_future;
         DROP TRIGGER IF EXISTS events_created_at_floor ON events_p_future;
+        DROP TRIGGER IF EXISTS trg_events_nip_rs_watermark ON events_p_future;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_nip_rs ON events_p_future;
+        DROP TRIGGER IF EXISTS trg_events_guard_nip_rs_hard_delete ON events_p_future;
+        DROP TRIGGER IF EXISTS trg_events_purge_soft_deleted_buzz_mesh_status ON events_p_future;
         ALTER TABLE events ATTACH PARTITION events_p_future
             FOR VALUES FROM ('2026-07-01') TO (MAXVALUE);
     END IF;

--- a/scripts/check-schema-drift.sh
+++ b/scripts/check-schema-drift.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# =============================================================================
+# check-schema-drift.sh — Assert schema/schema.sql matches migrations/
+# =============================================================================
+# The declarative snapshot (schema/schema.sql, applied by CI and local test
+# infra via `pgschema apply`) is hand-maintained and can silently drift from
+# migrations/*.sql — the source of truth the relay applies to real databases
+# (sqlx migrate! at startup). Drift means e2e runs against a different schema
+# than production, and failures surface as opaque downstream errors instead of
+# "the snapshot is out of date" (#1322).
+#
+# This gate makes drift unmergeable:
+#   1. Start an ephemeral Postgres container (same image as docker-compose).
+#   2. Apply migrations/*.sql in order, each in one transaction (matching
+#      sqlx's per-migration transaction semantics).
+#   3. `pgschema plan` the snapshot against that database. An empty plan means
+#      the snapshot describes exactly the schema the migrations build; any
+#      diff is printed and fails the check.
+#
+# Runs standalone: it never touches the buzz-postgres compose service or its
+# data, and cleans up its own container on exit.
+#
+# Usage:
+#   ./scripts/check-schema-drift.sh
+#
+# Environment:
+#   DRIFT_PG_PORT   Host port for the ephemeral Postgres (default: 55432 —
+#                   deliberately not 5432, which is often taken by a local
+#                   Postgres that would shadow the container).
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+DRIFT_PG_PORT="${DRIFT_PG_PORT:-55432}"
+PG_IMAGE="postgres:17-alpine"
+CONTAINER="buzz-schema-drift-pg"
+PGSCHEMA="${REPO_ROOT}/bin/pgschema"
+
+log() { printf '\033[0;34m[drift]\033[0m %s\n' "$*"; }
+ok()  { printf '\033[0;32m[drift]\033[0m %s\n' "$*"; }
+err() { printf '\033[0;31m[drift]\033[0m %s\n' "$*" >&2; }
+
+if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+  err "docker is required (starts an ephemeral Postgres); is the daemon running?"
+  exit 1
+fi
+if [[ ! -x "${PGSCHEMA}" ]]; then
+  err "bin/pgschema not found — activate hermit first (. ./bin/activate-hermit)"
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  err "jq is required to inspect the pgschema plan output"
+  exit 1
+fi
+
+cleanup() { docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+cleanup
+
+log "Starting ephemeral Postgres (${PG_IMAGE}) on port ${DRIFT_PG_PORT}..."
+docker run --rm -d --name "${CONTAINER}" \
+  -e POSTGRES_USER=buzz -e POSTGRES_PASSWORD=buzz_dev \
+  -p "${DRIFT_PG_PORT}:5432" "${PG_IMAGE}" >/dev/null
+
+for _ in $(seq 1 60); do
+  if docker exec "${CONTAINER}" pg_isready -U buzz >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+docker exec "${CONTAINER}" pg_isready -U buzz >/dev/null 2>&1 || {
+  err "Postgres did not become ready within 60s"
+  exit 1
+}
+
+# drift_migrations receives migrations/*.sql; drift_plan is pgschema's scratch
+# database for desired-state planning (same pattern as CI's PGSCHEMA_PLAN_*,
+# avoiding the embedded-Postgres Maven download flake).
+docker exec "${CONTAINER}" psql -U buzz -d postgres \
+  -qc "CREATE DATABASE drift_migrations" \
+  -c  "CREATE DATABASE drift_plan" >/dev/null
+
+log "Applying $(ls migrations/*.sql | wc -l | tr -d ' ') migrations..."
+for migration in migrations/*.sql; do
+  # -1: one transaction per file, matching sqlx migrate! semantics (0007's
+  # LOCK TABLE requires a transaction block).
+  if ! docker exec -i "${CONTAINER}" psql -U buzz -d drift_migrations \
+      -v ON_ERROR_STOP=1 -q -1 < "${migration}"; then
+    err "migration failed to apply: ${migration}"
+    exit 1
+  fi
+done
+ok "Migrations applied"
+
+log "Planning schema/schema.sql against the migration-built database..."
+PLAN_JSON="$(mktemp)"
+PLAN_HUMAN="$(mktemp)"
+trap 'cleanup; rm -f "${PLAN_JSON}" "${PLAN_HUMAN}"' EXIT
+
+PGPASSWORD=buzz_dev \
+PGSCHEMA_PLAN_HOST=localhost \
+PGSCHEMA_PLAN_PORT="${DRIFT_PG_PORT}" \
+PGSCHEMA_PLAN_DB=drift_plan \
+PGSCHEMA_PLAN_USER=buzz \
+PGSCHEMA_PLAN_PASSWORD=buzz_dev \
+"${PGSCHEMA}" plan \
+  --host localhost --port "${DRIFT_PG_PORT}" --user buzz \
+  --db drift_migrations --file schema/schema.sql \
+  --no-color \
+  --output-human "${PLAN_HUMAN}" \
+  --output-json "${PLAN_JSON}" >/dev/null
+
+# An empty plan serializes as `"groups": null`.
+if jq -e '.groups == null or .groups == []' "${PLAN_JSON}" >/dev/null; then
+  ok "schema/schema.sql matches migrations/ — no drift"
+  exit 0
+fi
+
+err "schema/schema.sql does NOT match the schema built by migrations/*.sql."
+err "The plan below is what pgschema would change on the migration-built"
+err "database to reach the snapshot — i.e. the drift. Update schema/schema.sql"
+err "(and, for new events-parent row triggers, scripts/attach-schema-partitions.sql)"
+err "so this plan is empty."
+echo
+cat "${PLAN_HUMAN}"
+exit 1


### PR DESCRIPTION
Fixes #1322

## The drift is real — and live on `main` today

Running the proposed gate against the current tree produced a **223-line plan**: `schema/schema.sql` (the declarative snapshot CI and local test infra apply via `pgschema apply`) is missing ten migrations' worth of schema. Every backend-integration and relay-e2e run today exercises a database without:

| Missing from the snapshot | Source migration |
|---|---|
| `git_repo_names` table + quota index | 0002 |
| `communities.icon` column | 0003 |
| `idx_events_tags_gin` (the #e fan-out GIN index) | 0004 |
| `parameterized_event_watermarks`, `idx_event_mentions_community_event` | 0007 |
| All NIP-RS guard functions/triggers (`guard_nip_rs_watermark`, `purge_soft_deleted_nip_rs`, `guard_nip_rs_hard_delete`, `guard_event_mention_live`) | 0009–0011 |
| `product_feedback` table + operator-global registry row | 0017 |
| `purge_soft_deleted_buzz_mesh_status` trigger | 0019 |
| `join_policy_acceptances` table | 0020 |
| Current `enqueue_push_match_job` body | 0023 |

The snapshot's push-gate function even carries a "keep in sync with migrations/0023" comment — and had drifted anyway, which is the case for automating this.

## What this PR does

1. **Fixes the snapshot**: ports each missing object into `schema/schema.sql`, byte-identical function bodies from the latest defining migration (0011 for the NIP-RS guards, 0019 for mesh purge, 0023 for the push gate), with section comments in the file's existing style.
2. **Adds the gate** (`scripts/check-schema-drift.sh`, `just check-schema-drift`, and a path-filtered **Schema Drift** CI job):
   - applies `migrations/*.sql` in order to an ephemeral `postgres:17-alpine` container (one transaction per file, matching sqlx `migrate!` semantics — 0007's `LOCK TABLE` requires it);
   - runs `pgschema plan --file schema/schema.sql` against that database, reusing the container as the plan DB (same `PGSCHEMA_PLAN_*` pattern CI already uses to avoid the embedded-Postgres download flake);
   - an empty plan passes; a non-empty plan **is** the drift — it's printed verbatim and the check exits 1.
3. **Updates `scripts/attach-schema-partitions.sql`**: the four new `events`-parent row triggers must be dropped from standalone children before `ATTACH` (pgschema copies parent triggers onto children; `ATTACH PARTITION` rejects same-named child triggers). Comment updated to state the invariant: every events-parent row trigger in the snapshot must be listed there.

## Verification

- `just check-schema-drift` on this branch: `No changes detected` → green.
- Red path: removing one column from the snapshot fails with exit 1 and prints the exact `ALTER TABLE … DROP COLUMN` drift plan.
- CI apply path re-validated on the fixed snapshot: `pgschema apply` (284 statements) + `attach-schema-partitions.sql` + a partition-routed `events` insert through the new triggers all succeed.
- The ephemeral container defaults to host port 55432 (not 5432) so a developer's local Postgres can't shadow it, and it never touches the `buzz-postgres` compose service or its data.

## Notes for review

- e2e now runs with the NIP-RS/mesh guard triggers active — i.e. the same schema production databases (built from migrations) already run. If any e2e depended on trigger-free behavior, this surfaces it, which is the point of the gate.
- `attach-schema-partitions.sql` still hardcodes the trigger list per branch; a dynamic "drop all triggers on unattached children" loop would remove that maintenance burden. Kept the existing explicit style here to keep the diff reviewable — happy to follow up if you'd prefer the loop.
