### PR TITLE
fix(acp): wake agents on forum post and comment @mentions

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -213,7 +213,13 @@ Start with **N=2** for most deployments. Increase if queue depth grows under loa
 
 ## Forum Channels
 
-By default, the ACP harness subscribes to stream message kinds (9, 46010, 40007). To receive forum events, opt in with `--kinds` and disable the mention filter (forum posts don't @mention agents):
+By default, Mentions mode already subscribes to forum post and comment kinds
+(`45001`, `45003`) alongside stream chat, so `@`-mentions on forum roots and
+comments wake agents the same way chat mentions do. Forum votes (`45002`) are
+not included — they are not a summon surface.
+
+To also receive forum events that do **not** `@`-mention the agent (for
+example, summarizing every new post), widen the filter:
 
 **CLI flags:**
 ```bash

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -1130,16 +1130,32 @@ pub fn load_rules(path: &std::path::Path) -> Result<Vec<SubscriptionRule>, Confi
     Ok(config.rules)
 }
 
+/// Default NIP-01 kinds for Mentions mode.
+///
+/// Includes stream chat, workflow approvals, reminders, and forum post/comment
+/// kinds so `@`-mentions on forum roots/comments wake agents the same way chat
+/// mentions do (#2850). Votes (`KIND_FORUM_VOTE`) are omitted — they are not
+/// a summon surface.
+pub fn default_mentions_kinds() -> Vec<u32> {
+    use buzz_core::kind::{
+        KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER,
+        KIND_WORKFLOW_APPROVAL_REQUESTED,
+    };
+    vec![
+        KIND_STREAM_MESSAGE,
+        KIND_WORKFLOW_APPROVAL_REQUESTED,
+        KIND_STREAM_REMINDER,
+        KIND_FORUM_POST,
+        KIND_FORUM_COMMENT,
+    ]
+}
+
 /// Resolve per-channel NIP-01 filters from config + discovered channels.
 pub fn resolve_channel_filters(
     config: &Config,
     discovered_channels: &[Uuid],
     rules: &[SubscriptionRule],
 ) -> HashMap<Uuid, ChannelFilter> {
-    use buzz_core::kind::{
-        KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
-    };
-
     let target_channels: Vec<Uuid> = if let Some(ref overrides) = config.channels_override {
         overrides
             .iter()
@@ -1154,13 +1170,10 @@ pub fn resolve_channel_filters(
 
     match config.subscribe_mode {
         SubscribeMode::Mentions => {
-            let kinds = config.kinds_override.clone().unwrap_or_else(|| {
-                vec![
-                    KIND_STREAM_MESSAGE,
-                    KIND_WORKFLOW_APPROVAL_REQUESTED,
-                    KIND_STREAM_REMINDER,
-                ]
-            });
+            let kinds = config
+                .kinds_override
+                .clone()
+                .unwrap_or_else(default_mentions_kinds);
             let require_mention = !config.no_mention_filter;
             for ch in &target_channels {
                 result.insert(
@@ -1238,10 +1251,6 @@ pub fn resolve_dynamic_channel_filter(
     channel_id: Uuid,
     rules: &[crate::filter::SubscriptionRule],
 ) -> Option<ChannelFilter> {
-    use buzz_core::kind::{
-        KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
-    };
-
     // In Mentions/All mode, if the operator explicitly constrained channels
     // with --channels, only allow dynamic subscription to channels in that
     // allowlist. Config mode ignores --channels (per CLI contract) and uses
@@ -1259,13 +1268,12 @@ pub fn resolve_dynamic_channel_filter(
 
     match config.subscribe_mode {
         SubscribeMode::Mentions => Some(ChannelFilter {
-            kinds: Some(config.kinds_override.clone().unwrap_or_else(|| {
-                vec![
-                    KIND_STREAM_MESSAGE,
-                    KIND_WORKFLOW_APPROVAL_REQUESTED,
-                    KIND_STREAM_REMINDER,
-                ]
-            })),
+            kinds: Some(
+                config
+                    .kinds_override
+                    .clone()
+                    .unwrap_or_else(default_mentions_kinds),
+            ),
             require_mention: !config.no_mention_filter,
         }),
         SubscribeMode::All => Some(ChannelFilter {
@@ -1409,6 +1417,18 @@ mod tests {
             assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_MESSAGE));
             assert!(kinds.contains(&buzz_core::kind::KIND_WORKFLOW_APPROVAL_REQUESTED));
             assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_REMINDER));
+            assert!(
+                kinds.contains(&buzz_core::kind::KIND_FORUM_POST),
+                "forum posts must wake agents on @mention"
+            );
+            assert!(
+                kinds.contains(&buzz_core::kind::KIND_FORUM_COMMENT),
+                "forum comments must wake agents on @mention"
+            );
+            assert!(
+                !kinds.contains(&buzz_core::kind::KIND_FORUM_VOTE),
+                "forum votes are not a summon surface"
+            );
         }
     }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -22,7 +22,6 @@ use acp::{AcpClient, EnvVar, McpServer};
 use anyhow::Result;
 use buzz_core::kind::{
     KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::observer::{
     decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
@@ -1441,13 +1440,10 @@ async fn tokio_main() -> Result<()> {
             vec![SubscriptionRule {
                 name: "mentions".into(),
                 channels: filter::ChannelScope::All("all".into()),
-                kinds: config.kinds_override.clone().unwrap_or_else(|| {
-                    vec![
-                        KIND_STREAM_MESSAGE,
-                        KIND_WORKFLOW_APPROVAL_REQUESTED,
-                        KIND_STREAM_REMINDER,
-                    ]
-                }),
+                kinds: config
+                    .kinds_override
+                    .clone()
+                    .unwrap_or_else(config::default_mentions_kinds),
                 require_mention: !config.no_mention_filter,
                 filter: None,
                 compiled_filter: None,


### PR DESCRIPTION
## Summary
- Mentions mode default kinds now include forum post (`45001`) and forum comment (`45003`), so `@`-mentions on forum surfaces reach buzz-acp the same way chat mentions do.
- Forum votes (`45002`) stay out of the Mentions defaults (not a summon surface).
- Centralized the Mentions defaults in `default_mentions_kinds()` and updated the README.

Fixes #2850

## Test plan
- [x] `cargo test -p buzz-acp --lib test_mentions_mode_`
- [ ] Manual: create a forum post that `@`-mentions a Mentions-mode agent and confirm a turn starts
