### PR TITLE
docs(buzz-acp): correct agent key generation instructions

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -25,13 +25,22 @@ export PATH="$PWD/target/release:$PATH"
 
 ## Generating Keys
 
-Each agent needs a Nostr keypair — this is the agent's identity in Buzz. Use `buzz-admin` to mint one:
+Each agent needs a Nostr keypair — this is the agent's identity in Buzz. Use `buzz-admin` to generate one:
 
 ```bash
-cargo run -p buzz-admin -- mint-token --name "my-agent" --scopes "messages:read,messages:write,channels:read"
+cargo run -p buzz-admin -- generate-key
 ```
 
-This prints an `nsec1...` private key and an API token. **Save both immediately — they're shown only once.**
+This prints a public and secret key pair as hex. **Save the secret key immediately — it is not stored and cannot be recovered.** Set `BUZZ_PRIVATE_KEY` to the secret key to act as this identity.
+
+Then register the agent's public key as a relay member so it can read and publish:
+
+```bash
+BUZZ_RELAY_PRIVATE_KEY=<relay signing key> \
+  cargo run -p buzz-admin -- add-member --pubkey <agent public key>
+```
+
+`add-member` publishes a kind:13534 membership event, so the relay needs a stable signing key: set `BUZZ_RELAY_PRIVATE_KEY` in the relay's environment (uncomment it in `.env`) and restart the relay before running this.
 
 > **Running multiple agents?** Mint a separate keypair for each. Every agent needs its own identity.
 


### PR DESCRIPTION
## Problem

`crates/buzz-acp/README.md` tells you to generate an agent identity with:

```bash
cargo run -p buzz-admin -- mint-token --name "my-agent" --scopes "messages:read,messages:write,channels:read"
```

`mint-token` is not a subcommand of `buzz-admin` — the available commands are
`add-member`, `remove-member`, `list-members`, `generate-key`, `migrate`,
`product-feedback`, and `reconcile-channels`. Following the agent quickstart
fails at the first step.

## Change

Documents the flow that works:

1. `generate-key` to mint the keypair
2. `add-member` to register the agent's pubkey on the relay

Also notes that `add-member` publishes a kind:13534 membership event and so
requires `BUZZ_RELAY_PRIVATE_KEY` to be set on the relay. It is commented out
in `.env.example`, and the relay must be restarted after setting it — the
error surfaces at `add-member` time rather than at relay startup, so it is
easy to hit.

Corrects the described output as well: `generate-key` prints a hex keypair,
not an `nsec1...` key plus an API token.

## Verification

Found while setting up a self-hosted relay and wiring an agent through
`buzz-acp` with `claude-agent-acp`. Both documented commands were run against
a local relay; the agent authenticates and round-trips signed messages.

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)