### PR TITLE
fix(deploy): add Tauri webview origins to the compose BUZZ_CORS_ORIGINS default

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -10,7 +10,10 @@ BUZZ_DOMAIN=buzz.example.com
 RELAY_URL=wss://buzz.example.com
 BUZZ_MEDIA_BASE_URL=https://buzz.example.com/media
 BUZZ_MEDIA_SERVER_DOMAIN=buzz.example.com
-BUZZ_CORS_ORIGINS=https://buzz.example.com
+# CORS allowlist for the relay HTTP API, comma-separated exact origins. Replace the domain,
+# but keep the tauri entries — the desktop app webview (tauri://localhost on macOS/Linux,
+# http://tauri.localhost on Windows) cannot reach the relay HTTP API without them.
+BUZZ_CORS_ORIGINS=https://buzz.example.com,tauri://localhost,http://tauri.localhost
 
 # Production defaults. Closed relay mode requires RELAY_OWNER_PUBKEY and a stable relay key.
 BUZZ_REQUIRE_AUTH_TOKEN=true

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -28,6 +28,11 @@ keypair.
 - Requires Docker Compose v2.24.4 or newer; the TLS override uses Compose's
   `!reset` tag to remove the direct relay port when Caddy terminates HTTPS.
 - Default `BUZZ_IMAGE` tracks `ghcr.io/block/buzz:main` for early testing. Pin it to `ghcr.io/block/buzz:sha-<7>` or a semver release tag for production once available.
+- `BUZZ_CORS_ORIGINS` must keep the desktop webview origins (`tauri://localhost`
+  for macOS/Linux, `http://tauri.localhost` for Windows) alongside your public
+  domain. The relay treats the list as exact origins with no permissive
+  fallback, so without the tauri entries desktop flows that use the HTTP API
+  (joining a community, invites, moderation) fail with a generic "Load failed".
 - Keep `BUZZ_RELAY_PRIVATE_KEY`, `BUZZ_GIT_HOOK_HMAC_SECRET`, database/Redis,
   and S3 secrets stable across restarts.
 - `RELAY_OWNER_PUBKEY` is intentionally not prefixed with `BUZZ_`; it must be a


### PR DESCRIPTION
## Summary

The compose template `deploy/compose/.env.example` sets `BUZZ_CORS_ORIGINS` to one public domain. The webview of the desktop app has a different origin. The origin is `tauri://localhost` on macOS and Linux. The origin is `http://tauri.localhost` on Windows.

The relay reads `BUZZ_CORS_ORIGINS` as a comma-separated list of exact origins (`crates/buzz-relay/src/config.rs`; `build_cors_layer` in `crates/buzz-relay/src/router.rs`). When the variable is set, the relay does not permit other origins. This design is correct, but the template value does not include the webview origins. Thus the desktop app cannot use the HTTP API of a relay that an operator deploys from the template.

The first failure that the user sees is in the "Join an existing community" flow. The flow stops and shows the error `Load failed`. At the same time, the relay replies correctly to a NIP-11 request from `curl`. Thus the relay seems healthy, and the CORS cause is hard to find.

This change:

- Adds the two webview origins to the default value of `BUZZ_CORS_ORIGINS` in `deploy/compose/.env.example`.
- Adds a comment to the same file. The comment tells the operator to keep the webview origins when they set their own domain.
- Adds a note with the same requirement to the "Production notes" section of `deploy/compose/README.md`.

### Related issue

Fixes #2872.

The closest existing PRs (not duplicates):

- #2617 adds comments about `BUZZ_CORS_ORIGINS` to the root `.env.example`. It does not change the value in the compose template. The two changes are compatible.
- #2862 moves the join-policy fetch to native networking. The invite and moderation calls stay in the webview. Thus the compose template must continue to supply the webview origins.

### Testing

This is a change to a template and a document only. No code paths change, so there are no new tests.

We did the test on a live deployment: Buzz Desktop v0.4.26 on macOS, relay deployed with `deploy/compose` and Caddy TLS.

1. Deploy the relay with the unmodified template value. The join flow fails with the error `Load failed`.
2. Add `tauri://localhost,http://tauri.localhost` to `BUZZ_CORS_ORIGINS`. Restart the relay.
3. Do the join flow again. The desktop app joins the community correctly.
