### PR TITLE
fix(desktop): keep channel-member agents mentionable across owners

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -7,6 +7,7 @@ import {
   getSharedChannelIds,
   isAgentIdentityInManagedList,
   relayAgentIsSharedWithUser,
+  shouldDropAgentMentionCandidate,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
 
@@ -159,6 +160,44 @@ test("isAgentIdentityInManagedList: keeps people and only current managed agent 
       managedAgentPubkeys,
     ),
     false,
+  );
+});
+
+test("shouldDropAgentMentionCandidate: keeps channel-member agents from other owners (#2508)", () => {
+  const managedAgentPubkeys = new Set([PUB_A]);
+
+  // A channel-member agent managed on someone else's machine must stay
+  // mentionable for every member of the channel.
+  assert.equal(
+    shouldDropAgentMentionCandidate(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+    ),
+    false,
+  );
+  // Locally managed agents stay mentionable even when not channel members.
+  assert.equal(
+    shouldDropAgentMentionCandidate(
+      { isAgent: true, isMember: false, pubkey: PUB_A },
+      managedAgentPubkeys,
+    ),
+    false,
+  );
+  // People are never dropped.
+  assert.equal(
+    shouldDropAgentMentionCandidate(
+      { isAgent: false, isMember: false, pubkey: PUB_B },
+      managedAgentPubkeys,
+    ),
+    false,
+  );
+  // Non-member agent identities from other owners remain restricted (#2149).
+  assert.equal(
+    shouldDropAgentMentionCandidate(
+      { isAgent: true, isMember: false, pubkey: PUB_B },
+      managedAgentPubkeys,
+    ),
+    true,
   );
 });
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -64,6 +64,25 @@ export function isAgentIdentityInManagedList(
   );
 }
 
+/**
+ * Composer drop gate for agent identities (#2508).
+ *
+ * A channel-member agent is never dropped: an agent that has been added to
+ * the channel must stay mentionable for every member, not only the person
+ * whose desktop manages it. The managed-list restriction (#2149) still
+ * applies to non-member agent identities (stale kind:0 discoveries, global
+ * search strays), which is the duplicate-noise case it was introduced for.
+ */
+export function shouldDropAgentMentionCandidate(
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
+  managedAgentPubkeys: ReadonlySet<string>,
+) {
+  return (
+    candidate.isMember !== true &&
+    !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+  );
+}
+
 export function shouldHideAgentFromMentions({
   isAgent,
   isMember,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,7 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  shouldDropAgentMentionCandidate,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,7 +246,7 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (shouldDropAgentMentionCandidate(candidate, managedAgentPubkeys)) {
         return;
       }
       if (


### PR DESCRIPTION
## Summary

Agents that are **members of the current channel** are exempted from the managed-list drop gate in the mention composer, so an agent managed on another machine — or by another user entirely — stays in `@`-autocomplete for every channel member.

**Root cause of #2508:** since #2149 (`a4dfead2`), `useMentions.addCandidate` drops any candidate with `isAgent: true` that is not in the *local* managed-agent list, before `shouldHideAgentFromMentions` (the member/directory logic from #1611) ever runs. `isAgent` is derived from the channel `bot` role and the NIP-OA attestation on the agent's kind:0, so every remote agent is affected regardless of its **Respond-to** setting. Two aggravating factors:

- "Respond to: Anyone" only updates the owner-local kind:30177 record; nothing in the tree publishes the kind:10100 agent profile that `relayAgentIsSharedWithUser` reads, so `mentionableAgentPubkeys` can never include a remote agent (the only kind:10100 writer today is `buzz channels set-add-policy`, which writes a `channel_add_policy`-only profile).
- Because the drop gate precedes it, the "Member (Option B): unknown invocability ⇒ show" branch of `shouldHideAgentFromMentions` became unreachable for exactly the candidates it was designed for.

**The fix** is a new pure helper, `shouldDropAgentMentionCandidate`, used by `useMentions` in place of the raw managed-list check: a channel-member agent is never dropped; the managed-list restriction from #2149 still applies to non-member agent identities (stale kind:0 discoveries, global-search strays), which is the duplicate-noise case it was introduced for. Member agents remain subject to `shouldHideAgentFromMentions`, so an explicit not-invocable signal from a future kind:10100 directory still hides them. The `MembersSidebar` call site (add-to-channel search, non-members by construction) is intentionally unchanged.

### Related issue

Fixes #2508. Same mechanism likely underlies #2349 / the cross-user reports in the #2508 thread.

### Testing

- New regression test: `shouldDropAgentMentionCandidate` keeps channel-member agents from other owners, keeps locally managed agents, never drops people, and still drops non-member foreign agent identities.
- Full desktop unit suite: 3506 pass / 0 fail. `tsc --noEmit` and `biome check` clean.
- Manual scenario (two users, one relay, agents `BP` and `Fizz` each managed on a different machine, both channel members with Respond-to: Anyone): before — each user could only see/tag their own agent; with this change the member agent appears in autocomplete for the other user and the selected mention emits the agent's `p` tag, which the ACP harness (`event_mentions_agent`) requires to wake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
