### PR TITLE
feat(acp): catch up on @mentions that arrived while the harness was offline

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -30,6 +30,13 @@ pub(crate) const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 900;
 /// Override via `--max-turn-duration` / `BUZZ_ACP_MAX_TURN_DURATION`.
 pub(crate) const DEFAULT_MAX_TURN_DURATION_SECS: u64 = 7200;
 
+/// Default offline-mention catch-up window (6 hours). At startup the harness
+/// replays @mentions newer than its own last message, capped to this window,
+/// so mentions sent while it was down are not silently lost (block/buzz#1743).
+/// Override via `--mention-catchup-secs` / `BUZZ_ACP_MENTION_CATCHUP_SECS`;
+/// 0 disables catch-up.
+pub(crate) const DEFAULT_MENTION_CATCHUP_SECS: u64 = 21_600;
+
 /// Upper bound for `max_turn_duration` (7 days). Any higher is operationally
 /// meaningless and risks arithmetic overflow when deriving the in-flight
 /// deadline (`max_turn_duration + IN_FLIGHT_DEADLINE_BUFFER_SECS`).
@@ -274,6 +281,12 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_TURN_TIMEOUT", hide = true)]
     pub turn_timeout: Option<u64>,
 
+    /// Offline-mention catch-up window in seconds. At startup, @mentions newer
+    /// than the agent's own last message (capped to this window) are replayed
+    /// through the normal event pipeline. 0 = disabled.
+    #[arg(long, env = "BUZZ_ACP_MENTION_CATCHUP_SECS", default_value_t = DEFAULT_MENTION_CATCHUP_SECS)]
+    pub mention_catchup_secs: u64,
+
     #[arg(
         long,
         env = "BUZZ_ACP_SYSTEM_PROMPT",
@@ -491,6 +504,8 @@ pub struct Config {
     pub mcp_command: String,
     pub idle_timeout_secs: u64,
     pub max_turn_duration_secs: u64,
+    /// Offline-mention catch-up window in seconds. 0 = disabled.
+    pub mention_catchup_secs: u64,
     pub agents: u32,
     pub heartbeat_interval_secs: u64,
     /// Seconds between per-turn liveness pings. 0 = disabled. Distinct from
@@ -966,6 +981,7 @@ impl Config {
             mcp_command: args.mcp_command,
             idle_timeout_secs,
             max_turn_duration_secs,
+            mention_catchup_secs: args.mention_catchup_secs,
             agents: args.agents,
             heartbeat_interval_secs: heartbeat_interval,
             turn_liveness_secs,
@@ -1340,6 +1356,7 @@ mod tests {
             mcp_command: "".into(),
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: DEFAULT_MAX_TURN_DURATION_SECS,
+            mention_catchup_secs: DEFAULT_MENTION_CATCHUP_SECS,
             agents: 1,
             heartbeat_interval_secs: 0,
             turn_liveness_secs: 10,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1487,6 +1487,25 @@ async fn tokio_main() -> Result<()> {
         }
     }
 
+    // Offline-mention catch-up (block/buzz#1743): replay @mentions that
+    // arrived while the harness was down through the normal event pipeline.
+    // The author gate, mention gate, and queue dedup apply to replayed
+    // events exactly as they do to live ones. Bounded at `watermark - 1` so
+    // the range is disjoint from the live subscription's `since = watermark`.
+    match relay
+        .backfill_mentions(
+            &pubkey_hex,
+            &subscribed_channel_ids,
+            config.mention_catchup_secs,
+            startup_watermark,
+        )
+        .await
+    {
+        Ok(0) => {}
+        Ok(n) => tracing::info!(count = n, "offline-mention catch-up queued"),
+        Err(e) => tracing::warn!("offline-mention catch-up failed: {e}"),
+    }
+
     if let Some((observer, publisher, keys, agent_pubkey, owner_pubkey, owner)) =
         relay_observer_publisher.take()
     {
@@ -4952,6 +4971,7 @@ mod build_mcp_servers_tests {
             mcp_command: "test-mcp-server".into(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
+            mention_catchup_secs: config::DEFAULT_MENTION_CATCHUP_SECS,
             agents: 1,
             heartbeat_interval_secs: 0,
             turn_liveness_secs: 10,
@@ -5118,6 +5138,7 @@ mod error_outcome_emission_tests {
             mcp_command: "test-mcp-server".into(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
+            mention_catchup_secs: config::DEFAULT_MENTION_CATCHUP_SECS,
             agents: 1,
             heartbeat_interval_secs: 0,
             turn_liveness_secs: 10,

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -115,7 +115,7 @@ use std::time::Instant;
 
 use buzz_core::kind::{
     KIND_AGENT_OBSERVER_FRAME, KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION,
-    KIND_TYPING_INDICATOR,
+    KIND_STREAM_MESSAGE, KIND_TYPING_INDICATOR,
 };
 use futures_util::{SinkExt, StreamExt};
 use nostr::{Event, EventBuilder, Keys, Kind, RelayUrl, Tag};
@@ -534,6 +534,9 @@ type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 pub struct HarnessRelay {
     /// Receiver for events forwarded by the background task.
     event_rx: mpsc::Receiver<Option<BuzzEvent>>,
+    /// Offline-mention catch-up events (#1743), drained by `next_event()`
+    /// ahead of live traffic. Filled once at startup by `backfill_mentions`.
+    backfill_buf: VecDeque<BuzzEvent>,
     /// Receiver for encrypted observer control events addressed to this agent.
     observer_control_rx: Option<mpsc::Receiver<Event>>,
     /// Sender for commands to the background task.
@@ -634,6 +637,7 @@ impl HarnessRelay {
 
         Ok(Self {
             event_rx,
+            backfill_buf: VecDeque::new(),
             observer_control_rx: Some(observer_control_rx),
             cmd_tx,
             http: reqwest::Client::builder()
@@ -809,8 +813,92 @@ impl HarnessRelay {
     /// Reads from the background task's event channel. Returns `None` on
     /// connection loss — the caller should call [`reconnect`](Self::reconnect).
     pub async fn next_event(&mut self) -> Option<BuzzEvent> {
+        // Drain offline-mention catch-up first so replayed mentions flow
+        // through the same downstream gates as live traffic (#1743).
+        if let Some(buffered) = self.backfill_buf.pop_front() {
+            return Some(buffered);
+        }
         // The background task sends `None` to signal connection loss.
         self.event_rx.recv().await.flatten()
+    }
+
+    /// Fetch @mentions that arrived while the harness was offline and queue
+    /// them for [`next_event`](Self::next_event) ahead of live traffic
+    /// (block/buzz#1743).
+    ///
+    /// The replay range is `(since, until)` from [`compute_backfill_bounds`]:
+    /// the floor is the newer of one second after the agent's own most recent
+    /// channel message — anything older may already have been answered — and
+    /// `startup_watermark - window_secs` as a hard cap; the ceiling is
+    /// `startup_watermark - 1`, disjoint from the live subscription's
+    /// `since = watermark` REQ so no event is delivered by both paths. The
+    /// query is additionally scoped to the subscribed channels' `#h` tags so
+    /// the result limit cannot be exhausted by mentions from channels the
+    /// harness does not serve.
+    ///
+    /// Replayed events are not special-cased downstream: the author gate,
+    /// mention gate, and queue dedup apply exactly as they do to live events,
+    /// so a mention from a non-allowed author is still dropped.
+    /// `window_secs == 0` disables catch-up entirely.
+    ///
+    /// Returns the number of events queued.
+    pub async fn backfill_mentions(
+        &mut self,
+        agent_pubkey_hex: &str,
+        subscribed: &HashSet<Uuid>,
+        window_secs: u64,
+        startup_watermark: u64,
+    ) -> Result<usize, RelayError> {
+        if subscribed.is_empty() {
+            return Ok(0);
+        }
+        let agent_pk = nostr::PublicKey::parse(agent_pubkey_hex)
+            .map_err(|e| RelayError::Http(format!("invalid agent pubkey: {e}")))?;
+        let stream_kind = Kind::Custom(KIND_STREAM_MESSAGE as u16);
+
+        // Newest own channel message — the "already handled up to here" marker.
+        let own_filter = nostr::Filter::new()
+            .kinds([stream_kind])
+            .authors([agent_pk])
+            .limit(1);
+        let rest = self.rest_client();
+        let newest_own_ts: Option<u64> =
+            rest.query(&[own_filter]).await?.as_array().and_then(|arr| {
+                arr.iter()
+                    .filter_map(|ev| ev.get("created_at").and_then(Value::as_u64))
+                    .max()
+            });
+
+        let Some((floor, until)) =
+            compute_backfill_bounds(startup_watermark, newest_own_ts, window_secs)
+        else {
+            return Ok(0);
+        };
+
+        let mention_filter = nostr::Filter::new()
+            .kinds([stream_kind])
+            .pubkey(agent_pk)
+            .custom_tags(
+                nostr::SingleLetterTag::lowercase(nostr::Alphabet::H),
+                subscribed.iter().map(Uuid::to_string),
+            )
+            .since(nostr::Timestamp::from(floor))
+            .until(nostr::Timestamp::from(until))
+            .limit(100);
+        let raw = rest.query(&[mention_filter]).await?;
+        let events: Vec<Event> = raw
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|ev| serde_json::from_value(ev.clone()).ok())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let picked = select_backfill_events(events, agent_pubkey_hex, subscribed);
+        let count = picked.len();
+        self.backfill_buf.extend(picked);
+        Ok(count)
     }
 
     /// Publish a signed event to the relay via the background WebSocket task.
@@ -3414,6 +3502,64 @@ async fn dns_flat_sleep(
     }
 }
 
+/// Compute the inclusive `(since, until)` bounds for offline-mention
+/// catch-up (block/buzz#1743).
+///
+/// `None` disables catch-up (window of 0, or an empty range). The floor is
+/// the newer of the hard window cap (`watermark - window_secs`) and one
+/// second after the agent's own most recent message — mentions older than
+/// the agent's last sign of life may already have been answered and are
+/// never replayed. The ceiling is one second *before* the startup
+/// watermark: the live subscription REQ uses `since = watermark`
+/// (inclusive), so capping catch-up at `watermark - 1` keeps the two ranges
+/// disjoint — no event can be delivered by both paths.
+fn compute_backfill_bounds(
+    startup_watermark: u64,
+    newest_own_ts: Option<u64>,
+    window_secs: u64,
+) -> Option<(u64, u64)> {
+    if window_secs == 0 {
+        return None;
+    }
+    let cap = startup_watermark.saturating_sub(window_secs);
+    let floor = match newest_own_ts {
+        Some(own) => cap.max(own.saturating_add(1)),
+        None => cap,
+    };
+    let until = startup_watermark.saturating_sub(1);
+    (floor <= until).then_some((floor, until))
+}
+
+/// Filter raw catch-up query results down to replayable mention events:
+/// authored by someone else, carrying a subscribed channel `h` tag, and
+/// actually p-tagging this agent. Returned oldest-first so replay preserves
+/// conversational order.
+fn select_backfill_events(
+    events: Vec<Event>,
+    agent_pubkey_hex: &str,
+    subscribed: &HashSet<Uuid>,
+) -> Vec<BuzzEvent> {
+    let mut picked: Vec<BuzzEvent> = events
+        .into_iter()
+        .filter(|ev| ev.pubkey.to_hex() != agent_pubkey_hex)
+        .filter(|ev| {
+            ev.tags.iter().any(|t| {
+                let parts = t.as_slice();
+                parts.len() >= 2 && parts[0] == "p" && parts[1] == agent_pubkey_hex
+            })
+        })
+        .filter_map(|ev| {
+            let channel_id = extract_h_tag_uuid(&ev)?;
+            subscribed.contains(&channel_id).then_some(BuzzEvent {
+                channel_id,
+                event: ev,
+            })
+        })
+        .collect();
+    picked.sort_by_key(|be| be.event.created_at);
+    picked
+}
+
 /// Extract a channel UUID from the h tag of a Nostr event.
 fn extract_h_tag_uuid(event: &nostr::Event) -> Option<Uuid> {
     event.tags.iter().find_map(|tag| {
@@ -4017,6 +4163,106 @@ mod tests {
             relay_ws_to_http("ws://localhost:3000/"),
             "http://localhost:3000"
         );
+    }
+
+    // ── offline-mention catch-up (#1743) ────────────────────────────────
+
+    #[test]
+    fn backfill_bounds_disabled_when_window_zero() {
+        assert_eq!(compute_backfill_bounds(1_000_000, Some(999_000), 0), None);
+    }
+
+    #[test]
+    fn backfill_bounds_cap_at_window_and_stop_before_live_subscription() {
+        // Own activity far in the past: the window cap wins. The upper bound
+        // stops one second before the startup watermark — events at or after
+        // the watermark are delivered by the live subscription (REQ uses
+        // `since = watermark`, inclusive), so the two ranges are disjoint.
+        assert_eq!(
+            compute_backfill_bounds(1_000_000, Some(1_000), 3_600),
+            Some((996_400, 999_999))
+        );
+        // No own activity at all: still capped to the window.
+        assert_eq!(
+            compute_backfill_bounds(1_000_000, None, 3_600),
+            Some((996_400, 999_999))
+        );
+    }
+
+    #[test]
+    fn backfill_bounds_start_after_own_last_message() {
+        // Own activity inside the window: floor starts just after it, so
+        // mentions the agent may already have answered are not replayed.
+        assert_eq!(
+            compute_backfill_bounds(1_000_000, Some(999_000), 3_600),
+            Some((999_001, 999_999))
+        );
+    }
+
+    #[test]
+    fn backfill_bounds_empty_when_own_activity_reaches_watermark() {
+        // The agent spoke within the last second before the watermark:
+        // nothing left to catch up on.
+        assert_eq!(
+            compute_backfill_bounds(1_000_000, Some(999_999), 3_600),
+            None
+        );
+        assert_eq!(
+            compute_backfill_bounds(1_000_000, Some(1_000_500), 3_600),
+            None
+        );
+    }
+
+    fn make_backfill_event(
+        author: &nostr::Keys,
+        channel: Uuid,
+        mention_hex: &str,
+        created_at_secs: u64,
+    ) -> Event {
+        EventBuilder::new(
+            nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "hello",
+        )
+        .tags([
+            Tag::parse(["h", &channel.to_string()]).unwrap(),
+            Tag::parse(["p", mention_hex]).unwrap(),
+        ])
+        .custom_created_at(nostr::Timestamp::from(created_at_secs))
+        .allow_self_tagging()
+        .sign_with_keys(author)
+        .expect("signing should succeed")
+    }
+
+    #[test]
+    fn select_backfill_events_filters_and_orders() {
+        let agent = nostr::Keys::generate();
+        let other = nostr::Keys::generate();
+        let agent_hex = agent.public_key().to_hex();
+        let chan = Uuid::new_v4();
+        let unsubscribed_chan = Uuid::new_v4();
+        let subscribed: HashSet<Uuid> = [chan].into_iter().collect();
+
+        let newer = make_backfill_event(&other, chan, &agent_hex, 2_000);
+        let older = make_backfill_event(&other, chan, &agent_hex, 1_000);
+        let own = make_backfill_event(&agent, chan, &agent_hex, 1_500);
+        let wrong_channel = make_backfill_event(&other, unsubscribed_chan, &agent_hex, 1_600);
+        let not_me = make_backfill_event(&other, chan, &other.public_key().to_hex(), 1_700);
+
+        let picked = select_backfill_events(
+            vec![newer.clone(), older.clone(), own, wrong_channel, not_me],
+            &agent_hex,
+            &subscribed,
+        );
+
+        assert_eq!(
+            picked.len(),
+            2,
+            "only foreign mentions on subscribed channels survive"
+        );
+        // Oldest first so replay preserves conversational order.
+        assert_eq!(picked[0].event.id, older.id);
+        assert_eq!(picked[1].event.id, newer.id);
+        assert_eq!(picked[0].channel_id, chan);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

At startup — after channel subscriptions are established — the ACP harness now queries the relay for `p`-tag mentions of the agent that arrived while it was offline, and replays them through the normal event pipeline. Mentions sent to a stopped/restarting agent are no longer silently lost.

**How the replay window is bounded (no double-processing):** the `since` floor is the *newer* of

1. one second after the agent's own most recent channel message — anything older than the agent's last sign of life may already have been answered, and is never replayed; and
2. `watermark - window` as a hard cap (`--mention-catchup-secs` / `BUZZ_ACP_MENTION_CATCHUP_SECS`, default 6 h, `0` disables).

The ceiling is `startup_watermark - 1`: the live subscription REQ uses `since = watermark` (inclusive), so the catch-up range is **disjoint** from live delivery — no event can arrive through both paths, and a startup-window mention cannot steer/cancel the turn it triggered.

**Replayed events are not special-cased.** `backfill_mentions` parks them in a buffer that `next_event()` drains ahead of live traffic, so the author gate (`respond_to` policy), mention gate, and queue dedup apply to them exactly as to live events. A mention from a non-allowed author is still dropped, and the queue's existing dedup remains a second line of defense behind the disjoint bounds.

The query is scoped server-side to the subscribed channels' `#h` tags, so the result limit (100) cannot be exhausted by mentions from channels the harness does not serve. Client-side filtering is conservative on top of that: only `kind:9` stream messages, authored by someone else, carrying a subscribed channel `h` tag and a `p` tag equal to the agent's pubkey; replayed oldest-first to preserve conversational order.

### Related issue

Fixes #1743. Reproduces the incident in that thread: agent's host machine restarts, a member mentions the agent during the gap, agent comes back and the mention is gone. Complements #2893 (cross-owner mention visibility) — together they make "@mention any agent in the channel" reliable for multi-user workspaces.

### Testing

- Unit tests for the bounds computation (`compute_backfill_bounds`: disabled window, window cap, own-activity floor, watermark ceiling, empty-range) and for the event selection (`select_backfill_events`: drops own/foreign-target/unsubscribed-channel events, orders oldest-first).
- Full `buzz-acp` suite: 603 pass / 0 fail. `cargo clippy -p buzz-acp` clean, `cargo fmt` applied.
- Manual scenario: agent offline, member sends `@agent hello`, agent starts → catch-up queues the mention (`offline-mention catch-up queued, count=1`) and the agent answers it; second start replays nothing (floor moves past the agent's reply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
