### PR TITLE
docs(compose): clarify BUZZ_CORS_ORIGINS must match client origin, not BUZZ_DOMAIN

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -10,6 +10,18 @@ BUZZ_DOMAIN=buzz.example.com
 RELAY_URL=wss://buzz.example.com
 BUZZ_MEDIA_BASE_URL=https://buzz.example.com/media
 BUZZ_MEDIA_SERVER_DOMAIN=buzz.example.com
+
+# Comma-separated origins allowed to make cross-origin HTTP requests (e.g. the
+# desktop/mobile client's community-connect flow calling GET /api/join-policy).
+# IMPORTANT: this must match the *client's* origin, not this relay's own
+# BUZZ_DOMAIN. Setting it to your relay's own domain — the intuitive-looking
+# default below — makes the browser reject the response with a generic
+# "Load failed" error even though the relay itself answers 200, because the
+# client's Origin header (typically `tauri://localhost` for the production
+# desktop app, or `http://localhost:<port>` for a dev build) never matches.
+# Leave empty for permissive CORS (all origins), which the relay treats as
+# "dev mode" and is safe once BUZZ_REQUIRE_AUTH_TOKEN / BUZZ_REQUIRE_RELAY_MEMBERSHIP
+# are already gating real data access.
 BUZZ_CORS_ORIGINS=https://buzz.example.com
 
 # Production defaults. Closed relay mode requires RELAY_OWNER_PUBKEY and a stable relay key.

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -43,6 +43,12 @@ keypair.
   `<bucket>.minio`. It is not configurable for an external S3 provider through
   `.env`; use the Helm chart or a custom Compose configuration for providers
   such as new Railway Storage Buckets that require `virtual` addressing.
+- `BUZZ_CORS_ORIGINS` must match the *client's* origin, not `BUZZ_DOMAIN`. If
+  the desktop/mobile app's "join a community" flow fails with a generic
+  browser "Load failed" while `curl`ing the relay directly works fine, this is
+  almost always why — see the comment above `BUZZ_CORS_ORIGINS` in
+  `.env.example`. Leaving it empty (permissive CORS) is the simplest fix for
+  a single-operator or closed-relay deployment.
 
 Run `./run.sh backup-hint` for the backup checklist.
 


### PR DESCRIPTION
## Summary
- Self-hosting operators intuitively set `BUZZ_CORS_ORIGINS` to their relay's own domain, matching the pattern of every other `BUZZ_DOMAIN`-derived variable in `.env.example`. That breaks the desktop/mobile client's community-connect flow with a generic browser "Load failed" error — the relay actually responds `200` to `GET /api/join-policy`, but the browser's CORS check rejects the response because the client's real `Origin` (`tauri://localhost` in production, `http://localhost:<port>` in a dev build) never matches `BUZZ_DOMAIN`.
- Hit this during a fresh self-hosted install: relay liveness, NIP-11, the raw WebSocket handshake, and the join-policy endpoint itself all worked fine via `curl`, but the desktop app failed silently until building from source with devtools enabled surfaced the actual CORS console error.
- Fixed our own install by leaving `BUZZ_CORS_ORIGINS` empty (the relay's own supported "permissive" fallback per `config.rs`), which is safe once `BUZZ_REQUIRE_AUTH_TOKEN` / `BUZZ_REQUIRE_RELAY_MEMBERSHIP` already gate real data access.
- This PR is docs-only: expands the existing `.env.example` comment and adds a troubleshooting line to `deploy/compose/README.md`'s Production notes, so the next self-hoster doesn't lose the same time we did.

## Test plan
- [x] `.env.example` comment reviewed for accuracy against `crates/buzz-relay/src/config.rs`'s CORS parsing (comma-separated `BUZZ_CORS_ORIGINS`, empty → `CorsLayer::permissive()`)
- [x] No code changes — verified diff is doc-only (`.env.example`, `README.md`)