### PR TITLE
fix(workflow): allow explicit destination channels

### DIFF
--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -708,4 +708,87 @@ mod integration_tests {
             "mentioned member {agent_hex} must be p-tagged so it wakes; got {p_tag_targets:?}"
         );
     }
+
+    #[tokio::test]
+    #[ignore = "requires Postgres"]
+    async fn workflow_send_message_enforces_private_destination_membership() {
+        let state = test_state().await;
+
+        let owner = nostr::Keys::generate();
+        let owner_hex = owner.public_key().to_hex();
+        let outsider = nostr::Keys::generate();
+        let outsider_hex = outsider.public_key().to_hex();
+        let outsider_bytes = outsider.public_key().to_bytes().to_vec();
+
+        let host = format!(
+            "wf-private-destination-{}.example",
+            uuid::Uuid::new_v4().simple()
+        );
+        let community = match state
+            .db
+            .create_community_with_owner(&host, &owner_hex)
+            .await
+            .expect("create community")
+        {
+            CreateCommunityWithOwnerResult::Created(rec) => rec.id,
+            other => panic!("expected fresh community, got {other:?}"),
+        };
+
+        let destination = state
+            .db
+            .create_channel(
+                community,
+                "wf-private-destination",
+                ChannelType::Stream,
+                ChannelVisibility::Private,
+                None,
+                &owner.public_key().to_bytes(),
+                None,
+            )
+            .await
+            .expect("create private destination");
+
+        let sink = RelayActionSink::new(&state);
+        let err = sink
+            .send_message(
+                community,
+                &destination.id.to_string(),
+                "not authorized",
+                &outsider_hex,
+            )
+            .await
+            .expect_err("private destination must reject a nonmember");
+        assert!(matches!(
+            err,
+            ActionSinkError::InvalidInput(ref message)
+                if message == "workflow owner does not have access to destination channel"
+        ));
+
+        state
+            .db
+            .ensure_user(community, &outsider_bytes)
+            .await
+            .expect("ensure outsider user row");
+        state
+            .db
+            .add_member(
+                community,
+                destination.id,
+                &outsider_bytes,
+                MemberRole::Bot,
+                Some(&owner.public_key().to_bytes()),
+            )
+            .await
+            .expect("add workflow owner to destination");
+        state.invalidate_membership_local(community, destination.id, &outsider_bytes);
+
+        sink.send_message(
+            community,
+            &destination.id.to_string(),
+            "authorized",
+            &outsider_hex,
+        )
+        .await
+        .expect("destination member should be allowed");
+    }
 }

--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -474,29 +474,19 @@ fn resolve_send_message_channel(
         .map(str::trim)
         .filter(|value| !value.is_empty());
 
-    if let Some(workflow_channel_id) = workflow_channel_id {
-        if let Some(explicit_channel) = explicit_channel {
-            let override_channel_id = explicit_channel.parse::<Uuid>().map_err(|e| {
-                WorkflowError::InvalidDefinition(format!(
-                    "SendMessage: invalid channel override UUID: {e}"
-                ))
-            })?;
-            if override_channel_id != workflow_channel_id {
-                return Err(WorkflowError::InvalidDefinition(format!(
-                    "SendMessage: channel override must match the workflow channel ({workflow_channel_id})"
-                )));
-            }
-        }
-        return Ok(workflow_channel_id.to_string());
-    }
-
     if let Some(explicit_channel) = explicit_channel {
+        // Destination authorization belongs to the action sink, which has
+        // access to channel visibility and membership state.
         let override_channel_id = explicit_channel.parse::<Uuid>().map_err(|e| {
             WorkflowError::InvalidDefinition(format!(
                 "SendMessage: invalid channel override UUID: {e}"
             ))
         })?;
         return Ok(override_channel_id.to_string());
+    }
+
+    if let Some(workflow_channel_id) = workflow_channel_id {
+        return Ok(workflow_channel_id.to_string());
     }
 
     if trigger_channel.trim().is_empty() {
@@ -1810,20 +1800,16 @@ mod tests {
     }
 
     #[test]
-    fn send_message_rejects_cross_channel_override_for_bound_workflow() {
+    fn send_message_accepts_cross_channel_override_for_bound_workflow() {
         let workflow_channel_id = Uuid::new_v4();
         let other_channel_id = Uuid::new_v4();
-        let err = resolve_send_message_channel(
+        let resolved = resolve_send_message_channel(
             Some(&other_channel_id.to_string()),
             "",
             Some(workflow_channel_id),
         )
-        .unwrap_err();
-        assert!(matches!(err, WorkflowError::InvalidDefinition(_)));
-        assert!(
-            err.to_string().contains("channel override must match"),
-            "unexpected error: {err}"
-        );
+        .expect("explicit destination should be accepted");
+        assert_eq!(resolved, other_channel_id.to_string());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- allow a channel-bound workflow to honor an explicit `send_message.channel`
- keep destination authorization in `RelayActionSink`, where channel visibility and membership are available
- add regression coverage for explicit destination resolution and private-channel membership enforcement

Fixes #2979.

## Problem

`resolve_send_message_channel` rejects any explicit `channel:` that differs from the workflow's own `channel_id`. Every channel-created workflow has `Some(channel_id)`, so the `channel:` key is effectively write-only: it can only ever name the channel the workflow already posts into. Cross-channel routing is impossible.

The failure is invisible at every layer — the schema and the Desktop form accept `channel:`, the run is created and returns a `run_id`, and run history is unreadable (#2980). From the outside it reads as "workflow steps silently do nothing."

The motivating case is reaction capture: react in any channel, file a deterministic entry into a separate improvement channel. That is the ordinary shape for `reaction_added`, and today it cannot be expressed.

## Security boundary

`RelayActionSink::send_message` is already authoritative and unchanged in that role: it resolves the destination channel, rejects an archived channel, and rejects a workflow owner who is not a member of a non-open destination. The executor no longer duplicates channel policy in a layer that has neither visibility nor membership state.

Removing the executor check therefore does not widen access — it removes a redundant check that was strictly narrower than, and inconsistent with, the enforcing one.

## Verification

- `git diff --check origin/main...HEAD` clean at `afe4aaf5`
- unit test flipped to assert the new behavior (`send_message_accepts_cross_channel_override_for_bound_workflow`)
- new relay integration test asserts a nonmember owner is rejected on a private destination and accepted after being added as a member

Ran locally against a real Postgres 18.4 instance, at `HEAD afe4aaf530a36ee7837bb0efc8674b7503156cef`, clean tree:

```
$ cargo test -p buzz-workflow
running 149 tests
test result: ok. 149 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test -p buzz-workflow executor::tests::send_message
test executor::tests::send_message_accepts_cross_channel_override_for_bound_workflow ... ok
test executor::tests::send_message_canonicalizes_valid_explicit_override_for_global_workflow ... ok
test executor::tests::send_message_uses_bound_workflow_channel_by_default ... ok
test result: ok. 3 passed; 0 failed

$ cargo test -p buzz-relay --lib workflow_sink -- --ignored
test workflow_sink::integration_tests::workflow_send_message_enforces_private_destination_membership ... ok
test workflow_sink::integration_tests::workflow_send_message_p_tags_mentioned_member ... ok
test result: ok. 2 passed; 0 failed
```

Both Postgres-gated integration tests were run (not skipped) against a database with all 24 migrations applied.

Scope of what this covers: `buzz-workflow` in full, and the `workflow_sink` tests in `buzz-relay`. I have not run the entire workspace suite locally — deferring to CI for that.

Note: CI on this PR is still `action_required` (first-time fork contributor). A maintainer approval would let the full suite run.

## Origin

Requested from a Buzz channel thread while diagnosing why a ♻️ → improvement-channel workflow never produced output.
