### PR TITLE
feat(desktop): View all multi-agent activity panel in channels

### DIFF
--- a/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  clampHeadline,
   getActivityHeadline,
   isMeaningfulItem,
   isSpineItem,
@@ -47,6 +48,59 @@ test("getActivityHeadline formats tool titles and assistant text", () => {
     "First line",
   );
   assert.equal(getActivityHeadline(makeMessage({ text: "   " })), "Responding");
+});
+
+test("getActivityHeadline clamps long shell and generic tool previews", () => {
+  const longCommand = `printf '${"x".repeat(200)}' > /tmp/out.txt`;
+  const shellHeadline = getActivityHeadline(
+    makeTool({
+      title: "Shell",
+      toolName: "dev__shell",
+      buzzToolName: null,
+      args: { command: longCommand },
+      descriptor: {
+        renderClass: "shell",
+        label: "Ran command",
+        preview: longCommand,
+        source: "harness",
+        groupKey: "shell:command",
+      },
+    }),
+  );
+  assert.ok(shellHeadline);
+  assert.ok(shellHeadline.length <= 72);
+  assert.ok(shellHeadline.endsWith("…"));
+  assert.ok(shellHeadline.startsWith("Ran command ·"));
+
+  const longContent = "A".repeat(120);
+  const genericHeadline = getActivityHeadline(
+    makeTool({
+      title: "Tool",
+      toolName: "dev__generic",
+      buzzToolName: null,
+      args: { content: longContent },
+      descriptor: {
+        renderClass: "generic",
+        label: "Ran tool",
+        preview: longContent,
+        source: "harness",
+        groupKey: "generic",
+      },
+    }),
+  );
+  assert.ok(genericHeadline);
+  assert.ok(genericHeadline.length <= 72);
+  assert.ok(genericHeadline.endsWith("…"));
+});
+
+test("clampHeadline collapses whitespace and ellipsizes", () => {
+  assert.equal(clampHeadline("short"), "short");
+  assert.equal(clampHeadline("line one\nline two with more"), "line one");
+  assert.equal(clampHeadline("  lots   of\tspace  "), "lots of space");
+  const long = "y".repeat(100);
+  const clamped = clampHeadline(long);
+  assert.ok(clamped.length <= 72);
+  assert.equal(clamped, `${"y".repeat(69)}…`);
 });
 
 test("isMeaningfulItem ignores lifecycle noise and raw JSON-RPC metadata", () => {

--- a/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscriptPresentation.ts
@@ -26,38 +26,58 @@ const LIFECYCLE_NOISE = new Set([
   "wire parse error",
 ]);
 
+/** Max length for composer / View-all activity headlines. */
+export const ACTIVITY_HEADLINE_MAX = 72;
+
+/**
+ * Collapse whitespace on the first line and ellipsize to `max` chars.
+ * Prevents shell/tool payload dumps from exploding overview UIs.
+ */
+export function clampHeadline(
+  text: string,
+  max = ACTIVITY_HEADLINE_MAX,
+): string {
+  const firstLine = text.split("\n")[0]?.replace(/\s+/g, " ").trim() ?? "";
+  if (firstLine.length === 0) {
+    return "";
+  }
+  if (firstLine.length <= max) {
+    return firstLine;
+  }
+  return `${firstLine.slice(0, Math.max(0, max - 3))}…`;
+}
+
 /** Human-readable headline for a single transcript item. */
 export function getActivityHeadline(item: TranscriptItem): string | null {
   if (item.type === "tool") {
     const summary = buildCompactToolSummary(item);
-    return [summary.label, summary.preview].filter(Boolean).join(" · ");
+    const joined = [summary.label, summary.preview].filter(Boolean).join(" · ");
+    return joined ? clampHeadline(joined) : null;
   }
 
   if (item.type === "message") {
     if (item.role === "assistant") {
       const trimmed = item.text.trim();
       if (trimmed.length > 0) {
-        const firstLine = trimmed.split("\n")[0]?.trim() ?? "";
-        if (firstLine.length > 0) {
-          return firstLine.length > 72
-            ? `${firstLine.slice(0, 69)}…`
-            : firstLine;
+        const clamped = clampHeadline(trimmed);
+        if (clamped.length > 0) {
+          return clamped;
         }
       }
       return "Responding";
     }
-    return item.title || "User prompt";
+    return clampHeadline(item.title || "User prompt");
   }
 
   if (item.type === "thought") {
-    return item.title === "Plan" ? "Planning" : item.title;
+    return clampHeadline(item.title === "Plan" ? "Planning" : item.title);
   }
 
   if (item.type === "metadata") {
-    return item.title;
+    return clampHeadline(item.title);
   }
 
-  return item.title;
+  return clampHeadline(item.title);
 }
 
 function isLifecycleNoise(

--- a/desktop/src/features/channels/ui/AllAgentsActivityPanel.tsx
+++ b/desktop/src/features/channels/ui/AllAgentsActivityPanel.tsx
@@ -1,0 +1,171 @@
+import * as React from "react";
+import { Loader2 } from "lucide-react";
+
+import type { BotActivityAgent } from "@/features/channels/ui/BotActivityBar";
+import { useWorkingAgentHeadlines } from "@/features/channels/ui/useWorkingAgentHeadlines";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import { useEscapeKey } from "@/shared/hooks/useEscapeKey";
+import { useIsThreadPanelOverlay } from "@/shared/hooks/use-mobile";
+import {
+  AuxiliaryPanel,
+  AuxiliaryPanelBody,
+  AuxiliaryPanelHeader,
+  AuxiliaryPanelHeaderGroup,
+  AuxiliaryPanelHeaderTitleBlock,
+} from "@/shared/layout/AuxiliaryPanel";
+import { cn } from "@/shared/lib/cn";
+import { Shimmer } from "@/shared/ui/Shimmer";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+
+type AllAgentsActivityPanelProps = {
+  agents: BotActivityAgent[];
+  channelId?: string | null;
+  isSinglePanelView?: boolean;
+  layout?: "standalone" | "split";
+  onClose: () => void;
+  onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
+  profiles?: UserProfileLookup;
+  transparentChrome?: boolean;
+  widthPx: number;
+  workingBotPubkeys: string[];
+};
+
+type WorkingAgentActivityCardProps = {
+  agent: BotActivityAgent;
+  avatarUrl: string | null;
+  channelId?: string | null;
+  onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
+};
+
+function WorkingAgentActivityCard({
+  agent,
+  avatarUrl,
+  channelId = null,
+  onOpenAgentSession,
+}: WorkingAgentActivityCardProps) {
+  const headlines = useWorkingAgentHeadlines(true, agent.pubkey, channelId, 8);
+  const latestHeadline = headlines[headlines.length - 1] ?? "Working";
+
+  return (
+    <article
+      className="rounded-lg border border-border/70 bg-background/80 p-3 shadow-xs"
+      data-testid={`all-agents-activity-card-${agent.pubkey}`}
+    >
+      <div className="flex items-start gap-3">
+        <UserAvatar
+          avatarUrl={avatarUrl}
+          className="shrink-0 ring-1 ring-primary/20"
+          displayName={agent.name}
+          size="sm"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate text-sm font-semibold text-foreground">
+              {agent.name}
+            </h3>
+            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-primary/70" />
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            <Shimmer className="inline">{latestHeadline}</Shimmer>
+          </p>
+        </div>
+        <button
+          className="shrink-0 rounded-md px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+          data-testid={`all-agents-activity-open-${agent.pubkey}`}
+          onClick={() => onOpenAgentSession(agent.pubkey, channelId)}
+          type="button"
+        >
+          View
+        </button>
+      </div>
+
+      {headlines.length > 0 ? (
+        <ul className="mt-3 space-y-1.5 border-t border-border/50 pt-3">
+          {headlines.map((headline) => (
+            <li
+              className="rounded-md bg-muted/30 px-2.5 py-1.5 text-xs leading-relaxed text-foreground"
+              key={headline}
+            >
+              {headline}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-3 border-t border-border/50 pt-3 text-xs text-muted-foreground">
+          Waiting for activity…
+        </p>
+      )}
+    </article>
+  );
+}
+
+export function AllAgentsActivityPanel({
+  agents,
+  channelId = null,
+  isSinglePanelView = false,
+  layout = "standalone",
+  onClose,
+  onOpenAgentSession,
+  profiles,
+  transparentChrome = false,
+  widthPx,
+  workingBotPubkeys,
+}: AllAgentsActivityPanelProps) {
+  const isOverlay = useIsThreadPanelOverlay();
+  useEscapeKey(onClose, isOverlay || isSinglePanelView);
+
+  const workingSet = React.useMemo(
+    () => new Set(workingBotPubkeys.map((pubkey) => pubkey.toLowerCase())),
+    [workingBotPubkeys],
+  );
+  const workingAgents = React.useMemo(
+    () =>
+      agents.filter((agent) => workingSet.has(agent.pubkey.toLowerCase())),
+    [agents, workingSet],
+  );
+  const agentAvatarUrl = (agent: BotActivityAgent) =>
+    profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ?? null;
+
+  return (
+    <AuxiliaryPanel
+      isSinglePanelView={isSinglePanelView}
+      layout={layout}
+      onClose={onClose}
+      testId="all-agents-activity-panel"
+      transparentChrome={transparentChrome}
+      widthPx={widthPx}
+      header={
+        <AuxiliaryPanelHeader
+          backdrop={layout !== "split" && !isOverlay}
+          backdropSurface="soft"
+        >
+          <AuxiliaryPanelHeaderGroup align="start">
+            <AuxiliaryPanelHeaderTitleBlock
+              subtitle={`${workingAgents.length} agent${
+                workingAgents.length === 1 ? "" : "s"
+              } working in this channel`}
+              title="All agent activity"
+            />
+          </AuxiliaryPanelHeaderGroup>
+        </AuxiliaryPanelHeader>
+      }
+    >
+      <AuxiliaryPanelBody
+        className={cn(
+          "flex flex-col gap-3 p-4",
+          layout === "split" && "bg-transparent",
+        )}
+      >
+        {workingAgents.map((agent) => (
+          <WorkingAgentActivityCard
+            agent={agent}
+            avatarUrl={agentAvatarUrl(agent)}
+            channelId={channelId}
+            key={agent.pubkey}
+            onOpenAgentSession={onOpenAgentSession}
+          />
+        ))}
+      </AuxiliaryPanelBody>
+    </AuxiliaryPanel>
+  );
+}

--- a/desktop/src/features/channels/ui/AllAgentsActivityPanel.tsx
+++ b/desktop/src/features/channels/ui/AllAgentsActivityPanel.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Loader2 } from "lucide-react";
 
 import type { BotActivityAgent } from "@/features/channels/ui/BotActivityBar";
+import { agentsForAllActivityPanel } from "@/features/channels/ui/botActivityViewAll";
 import { useWorkingAgentHeadlines } from "@/features/channels/ui/useWorkingAgentHeadlines";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { useEscapeKey } from "@/shared/hooks/useEscapeKey";
@@ -118,10 +119,16 @@ export function AllAgentsActivityPanel({
     () => new Set(workingBotPubkeys.map((pubkey) => pubkey.toLowerCase())),
     [workingBotPubkeys],
   );
+  const panelAgents = React.useMemo(
+    () => agentsForAllActivityPanel({ agents, workingBotPubkeys }),
+    [agents, workingBotPubkeys],
+  );
   const workingAgents = React.useMemo(
     () =>
-      agents.filter((agent) => workingSet.has(agent.pubkey.toLowerCase())),
-    [agents, workingSet],
+      panelAgents.filter((agent) =>
+        workingSet.has(agent.pubkey.toLowerCase()),
+      ),
+    [panelAgents, workingSet],
   );
   const agentAvatarUrl = (agent: BotActivityAgent) =>
     profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ?? null;
@@ -141,9 +148,13 @@ export function AllAgentsActivityPanel({
         >
           <AuxiliaryPanelHeaderGroup align="start">
             <AuxiliaryPanelHeaderTitleBlock
-              subtitle={`${workingAgents.length} agent${
-                workingAgents.length === 1 ? "" : "s"
-              } working in this channel`}
+              subtitle={`${panelAgents.length} agent${
+                panelAgents.length === 1 ? "" : "s"
+              } in this channel${
+                workingAgents.length > 0
+                  ? ` · ${workingAgents.length} working now`
+                  : ""
+              }`}
               title="All agent activity"
             />
           </AuxiliaryPanelHeaderGroup>
@@ -156,7 +167,7 @@ export function AllAgentsActivityPanel({
           layout === "split" && "bg-transparent",
         )}
       >
-        {workingAgents.map((agent) => (
+        {panelAgents.map((agent) => (
           <WorkingAgentActivityCard
             agent={agent}
             avatarUrl={agentAvatarUrl(agent)}

--- a/desktop/src/features/channels/ui/AllAgentsActivityPanel.tsx
+++ b/desktop/src/features/channels/ui/AllAgentsActivityPanel.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import { Loader2 } from "lucide-react";
 
+import { ManagedAgentSessionPanel } from "@/features/agents/ui/ManagedAgentSessionPanel";
 import type { BotActivityAgent } from "@/features/channels/ui/BotActivityBar";
 import { agentsForAllActivityPanel } from "@/features/channels/ui/botActivityViewAll";
-import { useWorkingAgentHeadlines } from "@/features/channels/ui/useWorkingAgentHeadlines";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { useEscapeKey } from "@/shared/hooks/useEscapeKey";
 import { useIsThreadPanelOverlay } from "@/shared/hooks/use-mobile";
@@ -15,7 +15,6 @@ import {
   AuxiliaryPanelHeaderTitleBlock,
 } from "@/shared/layout/AuxiliaryPanel";
 import { cn } from "@/shared/lib/cn";
-import { Shimmer } from "@/shared/ui/Shimmer";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 
 type AllAgentsActivityPanelProps = {
@@ -36,6 +35,7 @@ type WorkingAgentActivityCardProps = {
   avatarUrl: string | null;
   channelId?: string | null;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
+  profiles?: UserProfileLookup;
 };
 
 function WorkingAgentActivityCard({
@@ -43,32 +43,25 @@ function WorkingAgentActivityCard({
   avatarUrl,
   channelId = null,
   onOpenAgentSession,
+  profiles,
 }: WorkingAgentActivityCardProps) {
-  const headlines = useWorkingAgentHeadlines(true, agent.pubkey, channelId, 8);
-  const latestHeadline = headlines[headlines.length - 1] ?? "Working";
-
   return (
     <article
-      className="rounded-lg border border-border/70 bg-background/80 p-3 shadow-xs"
+      className="overflow-hidden rounded-lg border border-border/70 bg-background/80 shadow-xs"
       data-testid={`all-agents-activity-card-${agent.pubkey}`}
     >
-      <div className="flex items-start gap-3">
+      <div className="flex items-center gap-3 border-b border-border/50 px-3 py-2.5">
         <UserAvatar
           avatarUrl={avatarUrl}
           className="shrink-0 ring-1 ring-primary/20"
           displayName={agent.name}
           size="sm"
         />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <h3 className="truncate text-sm font-semibold text-foreground">
-              {agent.name}
-            </h3>
-            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-primary/70" />
-          </div>
-          <p className="mt-1 text-xs text-muted-foreground">
-            <Shimmer className="inline">{latestHeadline}</Shimmer>
-          </p>
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <h3 className="truncate text-sm font-semibold text-foreground">
+            {agent.name}
+          </h3>
+          <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-primary/70" />
         </div>
         <button
           className="shrink-0 rounded-md px-2 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
@@ -80,22 +73,32 @@ function WorkingAgentActivityCard({
         </button>
       </div>
 
-      {headlines.length > 0 ? (
-        <ul className="mt-3 space-y-1.5 border-t border-border/50 pt-3">
-          {headlines.map((headline) => (
-            <li
-              className="rounded-md bg-muted/30 px-2.5 py-1.5 text-xs leading-relaxed text-foreground"
-              key={headline}
-            >
-              {headline}
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className="mt-3 border-t border-border/50 pt-3 text-xs text-muted-foreground">
-          Waiting for activity…
-        </p>
-      )}
+      <div className="relative flex h-44 flex-col overflow-hidden">
+        <ManagedAgentSessionPanel
+          agent={{
+            pubkey: agent.pubkey,
+            name: agent.name,
+            status: agent.status ?? "running",
+            avatarUrl,
+          }}
+          autoTail={true}
+          channelId={channelId}
+          className="min-h-0 flex-1 border-0 bg-transparent px-3 text-xs shadow-none **:data-message-id:pointer-events-none"
+          emptyDescription="Waiting for activity…"
+          emptyState="loading"
+          panelPadding={false}
+          profiles={profiles}
+          rawLayout="responsive"
+          showHeader={false}
+          showRaw={false}
+          transcriptContentClassName="py-2"
+          transcriptVariant="compactPreview"
+        />
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-0 h-6 bg-linear-to-b from-background/80 to-transparent"
+        />
+      </div>
     </article>
   );
 }
@@ -115,20 +118,9 @@ export function AllAgentsActivityPanel({
   const isOverlay = useIsThreadPanelOverlay();
   useEscapeKey(onClose, isOverlay || isSinglePanelView);
 
-  const workingSet = React.useMemo(
-    () => new Set(workingBotPubkeys.map((pubkey) => pubkey.toLowerCase())),
-    [workingBotPubkeys],
-  );
   const panelAgents = React.useMemo(
     () => agentsForAllActivityPanel({ agents, workingBotPubkeys }),
     [agents, workingBotPubkeys],
-  );
-  const workingAgents = React.useMemo(
-    () =>
-      panelAgents.filter((agent) =>
-        workingSet.has(agent.pubkey.toLowerCase()),
-      ),
-    [panelAgents, workingSet],
   );
   const agentAvatarUrl = (agent: BotActivityAgent) =>
     profiles?.[agent.pubkey.toLowerCase()]?.avatarUrl ?? null;
@@ -145,16 +137,13 @@ export function AllAgentsActivityPanel({
         <AuxiliaryPanelHeader
           backdrop={layout !== "split" && !isOverlay}
           backdropSurface="soft"
+          inset={layout !== "split" ? "wide" : "default"}
         >
           <AuxiliaryPanelHeaderGroup align="start">
             <AuxiliaryPanelHeaderTitleBlock
               subtitle={`${panelAgents.length} agent${
                 panelAgents.length === 1 ? "" : "s"
-              } in this channel${
-                workingAgents.length > 0
-                  ? ` · ${workingAgents.length} working now`
-                  : ""
-              }`}
+              } working now`}
               title="All agent activity"
             />
           </AuxiliaryPanelHeaderGroup>
@@ -163,9 +152,12 @@ export function AllAgentsActivityPanel({
     >
       <AuxiliaryPanelBody
         className={cn(
-          "flex flex-col gap-3 p-4",
+          // Use px/pb only — a full `p-*` would override the single-panel
+          // `pt-13` inset that clears the overlapping header chrome.
+          "flex flex-col gap-2 overflow-y-auto px-4 pb-4",
           layout === "split" && "bg-transparent",
         )}
+        panelPadding
       >
         {panelAgents.map((agent) => (
           <WorkingAgentActivityCard
@@ -174,6 +166,7 @@ export function AllAgentsActivityPanel({
             channelId={channelId}
             key={agent.pubkey}
             onOpenAgentSession={onOpenAgentSession}
+            profiles={profiles}
           />
         ))}
       </AuxiliaryPanelBody>

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -1,12 +1,7 @@
 import * as React from "react";
 import { Loader2 } from "lucide-react";
 
-import { useAgentTranscript } from "@/features/agents/ui/useObserverEvents";
-import {
-  getActivityHeadline,
-  isMeaningfulItem,
-  isSpineItem,
-} from "@/features/agents/ui/agentSessionTranscriptPresentation";
+import { useWorkingAgentHeadlines } from "@/features/channels/ui/useWorkingAgentHeadlines";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ManagedAgent } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
@@ -20,6 +15,7 @@ type BotActivityBarProps = {
   agents: BotActivityAgent[];
   channelId?: string | null;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
+  onOpenAllAgentActivity?: () => void;
   openAgentSessionPubkey: string | null;
   profiles?: UserProfileLookup;
   workingBotPubkeys: string[];
@@ -34,6 +30,7 @@ export function BotActivityComposerAction({
   agents,
   channelId = null,
   onOpenAgentSession,
+  onOpenAllAgentActivity,
   openAgentSessionPubkey,
   profiles,
   workingBotPubkeys,
@@ -53,46 +50,11 @@ export function BotActivityComposerAction({
   }, [agents, workingBotPubkeys]);
   const singleWorkingAgent =
     workingAgents.length === 1 ? (workingAgents[0] ?? null) : null;
-  const transcript = useAgentTranscript(
+  const activityHeadlines = useWorkingAgentHeadlines(
     Boolean(singleWorkingAgent),
     singleWorkingAgent?.pubkey,
+    channelId,
   );
-  const activityHeadlines = React.useMemo(() => {
-    if (!singleWorkingAgent) {
-      return [];
-    }
-
-    const seen = new Set<string>();
-    const headlines: string[] = [];
-    const scopedTranscript = channelId
-      ? transcript.filter((item) => item.channelId === channelId)
-      : transcript;
-
-    // Two-tier scan: spine items first (reads recede when real work is present).
-    // If no spine headlines are found (session start / idle), fall back to all
-    // meaningful items so the bar isn't left empty.
-    const passFilter: (item: (typeof scopedTranscript)[number]) => boolean =
-      scopedTranscript.some(isSpineItem) ? isSpineItem : isMeaningfulItem;
-
-    for (let i = scopedTranscript.length - 1; i >= 0; i--) {
-      const item = scopedTranscript[i];
-      if (!passFilter(item)) {
-        continue;
-      }
-      const headline = getActivityHeadline(item);
-      if (!headline || seen.has(headline)) {
-        continue;
-      }
-
-      seen.add(headline);
-      headlines.unshift(headline);
-      if (headlines.length >= 5) {
-        break;
-      }
-    }
-
-    return headlines;
-  }, [channelId, singleWorkingAgent, transcript]);
   const [headlineIndex, setHeadlineIndex] = React.useState(0);
 
   const clearHoverTimer = React.useCallback(() => {
@@ -156,7 +118,25 @@ export function BotActivityComposerAction({
         }`
       : `${workingAgents[0]?.name ?? "Agent"} +${workingAgents.length - 1}`;
 
+  const canShowAll =
+    workingAgents.length > 1 && Boolean(onOpenAllAgentActivity);
+  const handleShowAll = React.useCallback(() => {
+    clearHoverTimer();
+    setOpen(false);
+    onOpenAllAgentActivity?.();
+  }, [clearHoverTimer, onOpenAllAgentActivity]);
+  const showAllButtonClassName = cn(
+    "w-full shrink-0 rounded-full border border-border/60 bg-background px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:border-primary/30 hover:bg-primary/5",
+    isInline && "h-7 w-auto",
+  );
+
   return (
+    <div
+      className={cn(
+        "flex min-w-0 items-center gap-2",
+        isInline ? "flex-1" : "inline-flex",
+      )}
+    >
     <Popover onOpenChange={setOpen} open={open}>
       <PopoverTrigger asChild>
         <button
@@ -266,7 +246,30 @@ export function BotActivityComposerAction({
             );
           })}
         </div>
+        {canShowAll ? (
+          <div className="mt-1 border-t border-border/60 px-1 pt-1">
+            <button
+              className={showAllButtonClassName}
+              data-testid="bot-activity-show-all-popover"
+              onClick={handleShowAll}
+              type="button"
+            >
+              Show all
+            </button>
+          </div>
+        ) : null}
       </PopoverContent>
     </Popover>
+    {isInline && canShowAll ? (
+      <button
+        className={showAllButtonClassName}
+        data-testid="bot-activity-show-all"
+        onClick={handleShowAll}
+        type="button"
+      >
+        Show all
+      </button>
+    ) : null}
+    </div>
   );
 }

--- a/desktop/src/features/channels/ui/BotActivityBar.tsx
+++ b/desktop/src/features/channels/ui/BotActivityBar.tsx
@@ -2,6 +2,10 @@ import * as React from "react";
 import { Loader2 } from "lucide-react";
 
 import { useWorkingAgentHeadlines } from "@/features/channels/ui/useWorkingAgentHeadlines";
+import {
+  shouldShowViewAllAgentActivity,
+  type ChannelActivityAgent,
+} from "@/features/channels/ui/botActivityViewAll";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ManagedAgent } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
@@ -9,10 +13,12 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Shimmer } from "@/shared/ui/Shimmer";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 
-export type BotActivityAgent = Pick<ManagedAgent, "pubkey" | "name">;
+export type BotActivityAgent = Pick<ManagedAgent, "pubkey" | "name"> & {
+  status?: ManagedAgent["status"];
+};
 
 type BotActivityBarProps = {
-  agents: BotActivityAgent[];
+  agents: ChannelActivityAgent[];
   channelId?: string | null;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
   onOpenAllAgentActivity?: () => void;
@@ -118,14 +124,15 @@ export function BotActivityComposerAction({
         }`
       : `${workingAgents[0]?.name ?? "Agent"} +${workingAgents.length - 1}`;
 
-  const canShowAll =
-    workingAgents.length > 1 && Boolean(onOpenAllAgentActivity);
-  const handleShowAll = React.useCallback(() => {
+  const canViewAll =
+    Boolean(onOpenAllAgentActivity) &&
+    shouldShowViewAllAgentActivity({ agents, workingBotPubkeys });
+  const handleViewAll = React.useCallback(() => {
     clearHoverTimer();
     setOpen(false);
     onOpenAllAgentActivity?.();
   }, [clearHoverTimer, onOpenAllAgentActivity]);
-  const showAllButtonClassName = cn(
+  const viewAllButtonClassName = cn(
     "w-full shrink-0 rounded-full border border-border/60 bg-background px-2.5 py-1 text-xs font-semibold text-primary transition-colors hover:border-primary/30 hover:bg-primary/5",
     isInline && "h-7 w-auto",
   );
@@ -246,28 +253,28 @@ export function BotActivityComposerAction({
             );
           })}
         </div>
-        {canShowAll ? (
+        {canViewAll ? (
           <div className="mt-1 border-t border-border/60 px-1 pt-1">
             <button
-              className={showAllButtonClassName}
+              className={viewAllButtonClassName}
               data-testid="bot-activity-show-all-popover"
-              onClick={handleShowAll}
+              onClick={handleViewAll}
               type="button"
             >
-              Show all
+              View all
             </button>
           </div>
         ) : null}
       </PopoverContent>
     </Popover>
-    {isInline && canShowAll ? (
+    {isInline && canViewAll ? (
       <button
-        className={showAllButtonClassName}
+        className={viewAllButtonClassName}
         data-testid="bot-activity-show-all"
-        onClick={handleShowAll}
+        onClick={handleViewAll}
         type="button"
       >
-        Show all
+        View all
       </button>
     ) : null}
     </div>

--- a/desktop/src/features/channels/ui/ChannelComposerActivityAccessory.tsx
+++ b/desktop/src/features/channels/ui/ChannelComposerActivityAccessory.tsx
@@ -11,6 +11,9 @@ type ChannelComposerActivityAccessoryProps = {
   onOpenAgentSession: ComponentProps<
     typeof BotActivityComposerAction
   >["onOpenAgentSession"];
+  onOpenAllAgentActivity: ComponentProps<
+    typeof BotActivityComposerAction
+  >["onOpenAllAgentActivity"];
   openAgentSessionPubkey: ComponentProps<
     typeof BotActivityComposerAction
   >["openAgentSessionPubkey"];
@@ -25,6 +28,7 @@ export function ChannelComposerActivityAccessory({
   channel,
   currentPubkey,
   onOpenAgentSession,
+  onOpenAllAgentActivity,
   openAgentSessionPubkey,
   profiles,
   typingPubkeys,
@@ -44,6 +48,7 @@ export function ChannelComposerActivityAccessory({
               agents={agents}
               channelId={channel?.id ?? null}
               onOpenAgentSession={onOpenAgentSession}
+              onOpenAllAgentActivity={onOpenAllAgentActivity}
               openAgentSessionPubkey={openAgentSessionPubkey}
               profiles={profiles}
               workingBotPubkeys={workingBotPubkeys}

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -25,6 +25,8 @@ import { buildVideoReviewContextsByMessageId } from "@/features/messages/lib/vid
 import { useComposerHeightPadding } from "@/features/messages/ui/useComposerHeightPadding";
 import { UserProfilePanel } from "@/features/profile/ui/UserProfilePanel";
 import { ChannelFindBar } from "@/features/search/ui/ChannelFindBar";
+import { AllAgentsActivityPanel } from "@/features/channels/ui/AllAgentsActivityPanel";
+import { agentsForAllActivityPanel } from "@/features/channels/ui/botActivityViewAll";
 import { AgentSessionThreadPanel } from "@/features/channels/ui/AgentSessionThreadPanel";
 import { ChannelManagementAuxiliaryPanel } from "@/features/channels/ui/ChannelManagementAuxiliaryPanel";
 import { RightAuxiliaryPane } from "@/features/channels/ui/RightAuxiliaryPane";
@@ -406,6 +408,14 @@ export const ChannelPane = React.memo(function ChannelPane({
   // whose typing signal never arrives — and vice versa.
   const composerWorkingBotPubkeys = useChannelWorkingAgentPubkeys(
     activeChannel?.id ?? null,
+  );
+  const allActivityPanelAgents = React.useMemo(
+    () =>
+      agentsForAllActivityPanel({
+        agents: activityAgents,
+        workingBotPubkeys: composerWorkingBotPubkeys,
+      }),
+    [activityAgents, composerWorkingBotPubkeys],
   );
   const hasComposerBotActivity = composerWorkingBotPubkeys.length > 0;
   const hasComposerBottomActivity = hasComposerBotActivity || hasTypingActivity;
@@ -796,6 +806,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                   channel={activeChannel}
                   currentPubkey={currentPubkey}
                   onOpenAgentSession={onOpenAgentSession}
+                  onOpenAllAgentActivity={onOpenAllAgentsActivity}
                   openAgentSessionPubkey={openAgentSessionPubkey}
                   profiles={profiles}
                   typingPubkeys={typingPubkeys}
@@ -915,6 +926,26 @@ export const ChannelPane = React.memo(function ChannelPane({
               />
             );
             return wrapThreadPanel(panel);
+          })()
+        ) : allAgentsActivityOpen && allActivityPanelAgents.length > 0 ? (
+          (() => {
+            const panel = (
+              <AllAgentsActivityPanel
+                agents={activityAgents}
+                channelId={activeChannel?.id ?? null}
+                isSinglePanelView={
+                  useSplitAuxiliaryPane ? false : isSinglePanelView
+                }
+                layout={useSplitAuxiliaryPane ? "split" : "standalone"}
+                onClose={onCloseAllAgentsActivity!}
+                onOpenAgentSession={onOpenAgentSession}
+                profiles={profiles}
+                transparentChrome={useSplitAuxiliaryPane}
+                widthPx={threadPanelWidthPx}
+                workingBotPubkeys={composerWorkingBotPubkeys}
+              />
+            );
+            return wrapAux(panel, "all-agents-activity-panel");
           })()
         ) : activeChannel && selectedAgent ? (
           (() => {

--- a/desktop/src/features/channels/ui/ChannelPane.types.ts
+++ b/desktop/src/features/channels/ui/ChannelPane.types.ts
@@ -93,6 +93,9 @@ export type ChannelPaneProps = {
   onExpandThreadReplies: (message: TimelineMessage) => void;
   onJoinChannel?: () => Promise<void>;
   onOpenAgentSession: (pubkey: string, channelId?: string | null) => void;
+  onOpenAllAgentsActivity?: () => void;
+  onCloseAllAgentsActivity?: () => void;
+  allAgentsActivityOpen?: boolean;
   onOpenDm?: (pubkeys: string[]) => Promise<void> | void;
   onOpenMembers?: () => void;
   onOpenProfilePanel: (pubkey: string) => void;

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -140,6 +140,7 @@ export function ChannelScreen({
     widthPx: threadPanelWidthPx,
   } = useThreadPanelWidth();
   const [isMembersSidebarOpen, setIsMembersSidebarOpen] = React.useState(false);
+  const [allAgentsActivityOpen, setAllAgentsActivityOpen] = React.useState(false);
   const [isAddBotOpen, setIsAddBotOpen] = React.useState(false);
   const [channelContentRef, channelContentWidthPx] =
     useElementWidth<HTMLDivElement>();
@@ -604,6 +605,37 @@ export function ChannelScreen({
     setThreadReplyTargetId,
     setThreadScrollTargetId,
   });
+  const handleCloseAllAgentsActivity = React.useCallback(() => {
+    setAllAgentsActivityOpen(false);
+  }, []);
+  const handleOpenAllAgentsActivity = React.useCallback(() => {
+    setOpenThreadHeadId(null);
+    setExpandedThreadReplyIds(new Set());
+    setThreadScrollTargetId(null);
+    setThreadReplyTargetId(null);
+    setChannelManagementOpen(false);
+    handleCloseAgentSession();
+    setProfilePanelPubkey(null);
+    setAllAgentsActivityOpen(true);
+  }, [
+    handleCloseAgentSession,
+    setChannelManagementOpen,
+    setExpandedThreadReplyIds,
+    setOpenThreadHeadId,
+    setProfilePanelPubkey,
+    setThreadReplyTargetId,
+    setThreadScrollTargetId,
+  ]);
+  const handleOpenAgentSessionFromChannel = React.useCallback(
+    (pubkey: string, channelId?: string | null) => {
+      setAllAgentsActivityOpen(false);
+      handleOpenAgentSession(pubkey, channelId);
+    },
+    [handleOpenAgentSession],
+  );
+  React.useEffect(() => {
+    setAllAgentsActivityOpen(false);
+  }, [activeChannelId]);
   const { handleOpenProfilePanel, handleCloseProfilePanel, handleOpenDm } =
     useChannelProfilePanel({
       closeAgentSession: handleCloseAgentSession,
@@ -693,7 +725,8 @@ export function ChannelScreen({
     effectiveOpenThreadHeadId ||
       openAgentSessionPubkey ||
       profilePanelPubkey ||
-      channelManagementOpen,
+      channelManagementOpen ||
+      allAgentsActivityOpen,
   );
   const displayedThreadHeadMessage = threadPanelData.threadHead;
   const displayedThreadAllMessages = threadPanelData.messages;
@@ -796,7 +829,7 @@ export function ChannelScreen({
     ],
   );
   return (
-    <AgentSessionProvider onOpenAgentSession={handleOpenAgentSession}>
+    <AgentSessionProvider onOpenAgentSession={handleOpenAgentSessionFromChannel}>
       <ProfilePanelProvider onOpenProfilePanel={handleOpenProfilePanel}>
         <WelcomeAgentCreateDialog
           guideName={welcomeGuideAgent?.name ?? "your welcome guide"}
@@ -932,7 +965,10 @@ export function ChannelScreen({
                   onMarkUnread={handleMessageMarkUnread}
                   onMarkRead={handleMessageMarkRead}
                   onExpandThreadReplies={handleExpandThreadReplies}
-                  onOpenAgentSession={handleOpenAgentSession}
+                  onOpenAgentSession={handleOpenAgentSessionFromChannel}
+                  onOpenAllAgentsActivity={handleOpenAllAgentsActivity}
+                  onCloseAllAgentsActivity={handleCloseAllAgentsActivity}
+                  allAgentsActivityOpen={allAgentsActivityOpen}
                   onOpenDm={handleOpenDm}
                   onOpenProfilePanel={handleOpenProfilePanel}
                   onResetThreadPanelWidth={handleThreadPanelWidthReset}
@@ -989,7 +1025,7 @@ export function ChannelScreen({
           currentPubkey={currentPubkey}
           open={isMembersSidebarOpen}
           onOpenChange={setIsMembersSidebarOpen}
-          onViewActivity={handleOpenAgentSession}
+          onViewActivity={handleOpenAgentSessionFromChannel}
           relayUrl={activeCommunity?.relayUrl}
         />
       </ProfilePanelProvider>

--- a/desktop/src/features/channels/ui/botActivityViewAll.test.mjs
+++ b/desktop/src/features/channels/ui/botActivityViewAll.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  agentsForAllActivityPanel,
+  shouldShowViewAllAgentActivity,
+} from "./botActivityViewAll.ts";
+
+const AGENT_A = { pubkey: "aa".repeat(32), name: "Alpha", status: "running" };
+const AGENT_B = { pubkey: "bb".repeat(32), name: "Beta", status: "running" };
+const AGENT_C = { pubkey: "cc".repeat(32), name: "Gamma", status: "stopped" };
+
+test("shows view all when two agents are working", () => {
+  assert.equal(
+    shouldShowViewAllAgentActivity({
+      agents: [AGENT_A, AGENT_B, AGENT_C],
+      workingBotPubkeys: [AGENT_A.pubkey, AGENT_B.pubkey],
+    }),
+    true,
+  );
+});
+
+test("shows view all when two agents are running even if only one is working", () => {
+  assert.equal(
+    shouldShowViewAllAgentActivity({
+      agents: [AGENT_A, AGENT_B],
+      workingBotPubkeys: [AGENT_A.pubkey],
+    }),
+    true,
+  );
+});
+
+test("hides view all for a single active agent with no peer work", () => {
+  assert.equal(
+    shouldShowViewAllAgentActivity({
+      agents: [AGENT_A, AGENT_C],
+      workingBotPubkeys: [AGENT_A.pubkey],
+    }),
+    false,
+  );
+});
+
+test("all activity panel includes running and working agents", () => {
+  const panelAgents = agentsForAllActivityPanel({
+    agents: [AGENT_A, AGENT_B, AGENT_C],
+    workingBotPubkeys: [AGENT_A.pubkey],
+  });
+  assert.deepEqual(
+    panelAgents.map((agent) => agent.pubkey),
+    [AGENT_A.pubkey, AGENT_B.pubkey],
+  );
+});

--- a/desktop/src/features/channels/ui/botActivityViewAll.test.mjs
+++ b/desktop/src/features/channels/ui/botActivityViewAll.test.mjs
@@ -20,17 +20,17 @@ test("shows view all when two agents are working", () => {
   );
 });
 
-test("shows view all when two agents are running even if only one is working", () => {
+test("hides view all when only one agent is working even if peers are running", () => {
   assert.equal(
     shouldShowViewAllAgentActivity({
       agents: [AGENT_A, AGENT_B],
       workingBotPubkeys: [AGENT_A.pubkey],
     }),
-    true,
+    false,
   );
 });
 
-test("hides view all for a single active agent with no peer work", () => {
+test("hides view all for a single working agent", () => {
   assert.equal(
     shouldShowViewAllAgentActivity({
       agents: [AGENT_A, AGENT_C],
@@ -40,13 +40,24 @@ test("hides view all for a single active agent with no peer work", () => {
   );
 });
 
-test("all activity panel includes running and working agents", () => {
+test("all activity panel includes only working agents", () => {
   const panelAgents = agentsForAllActivityPanel({
     agents: [AGENT_A, AGENT_B, AGENT_C],
     workingBotPubkeys: [AGENT_A.pubkey],
   });
   assert.deepEqual(
     panelAgents.map((agent) => agent.pubkey),
-    [AGENT_A.pubkey, AGENT_B.pubkey],
+    [AGENT_A.pubkey],
+  );
+});
+
+test("all activity panel preserves agent order among working set", () => {
+  const panelAgents = agentsForAllActivityPanel({
+    agents: [AGENT_B, AGENT_A],
+    workingBotPubkeys: [AGENT_A.pubkey, AGENT_B.pubkey],
+  });
+  assert.deepEqual(
+    panelAgents.map((agent) => agent.pubkey),
+    [AGENT_B.pubkey, AGENT_A.pubkey],
   );
 });

--- a/desktop/src/features/channels/ui/botActivityViewAll.ts
+++ b/desktop/src/features/channels/ui/botActivityViewAll.ts
@@ -1,0 +1,63 @@
+import type { ManagedAgent } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+import type { BotActivityAgent } from "./BotActivityBar";
+
+export type ChannelActivityAgent = BotActivityAgent & {
+  status?: ManagedAgent["status"];
+};
+
+/** Harness is live in this channel (local running or deployed/remote). */
+export function isActiveChannelAgent(agent: ChannelActivityAgent): boolean {
+  if (!agent.status) {
+    return true;
+  }
+  return agent.status === "running" || agent.status === "deployed";
+}
+
+export function countActiveChannelAgents(agents: ChannelActivityAgent[]): number {
+  return agents.filter(isActiveChannelAgent).length;
+}
+
+export function countWorkingChannelAgents(
+  agents: ChannelActivityAgent[],
+  workingBotPubkeys: readonly string[],
+): number {
+  const working = new Set(
+    workingBotPubkeys.map((pubkey) => normalizePubkey(pubkey)),
+  );
+  return agents.filter((agent) =>
+    working.has(normalizePubkey(agent.pubkey)),
+  ).length;
+}
+
+/** View all when two or more agents are running in channel or actively working. */
+export function shouldShowViewAllAgentActivity({
+  agents,
+  workingBotPubkeys,
+}: {
+  agents: ChannelActivityAgent[];
+  workingBotPubkeys: readonly string[];
+}): boolean {
+  return (
+    countActiveChannelAgents(agents) >= 2 ||
+    countWorkingChannelAgents(agents, workingBotPubkeys) >= 2
+  );
+}
+
+export function agentsForAllActivityPanel({
+  agents,
+  workingBotPubkeys,
+}: {
+  agents: ChannelActivityAgent[];
+  workingBotPubkeys: readonly string[];
+}): ChannelActivityAgent[] {
+  const working = new Set(
+    workingBotPubkeys.map((pubkey) => normalizePubkey(pubkey)),
+  );
+  return agents.filter(
+    (agent) =>
+      working.has(normalizePubkey(agent.pubkey)) ||
+      isActiveChannelAgent(agent),
+  );
+}

--- a/desktop/src/features/channels/ui/botActivityViewAll.ts
+++ b/desktop/src/features/channels/ui/botActivityViewAll.ts
@@ -1,23 +1,11 @@
-import type { ManagedAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 import type { BotActivityAgent } from "./BotActivityBar";
+import type { ManagedAgent } from "@/shared/api/types";
 
 export type ChannelActivityAgent = BotActivityAgent & {
   status?: ManagedAgent["status"];
 };
-
-/** Harness is live in this channel (local running or deployed/remote). */
-export function isActiveChannelAgent(agent: ChannelActivityAgent): boolean {
-  if (!agent.status) {
-    return true;
-  }
-  return agent.status === "running" || agent.status === "deployed";
-}
-
-export function countActiveChannelAgents(agents: ChannelActivityAgent[]): number {
-  return agents.filter(isActiveChannelAgent).length;
-}
 
 export function countWorkingChannelAgents(
   agents: ChannelActivityAgent[],
@@ -26,12 +14,11 @@ export function countWorkingChannelAgents(
   const working = new Set(
     workingBotPubkeys.map((pubkey) => normalizePubkey(pubkey)),
   );
-  return agents.filter((agent) =>
-    working.has(normalizePubkey(agent.pubkey)),
-  ).length;
+  return agents.filter((agent) => working.has(normalizePubkey(agent.pubkey)))
+    .length;
 }
 
-/** View all when two or more agents are running in channel or actively working. */
+/** View all when two or more agents are actively working in this channel. */
 export function shouldShowViewAllAgentActivity({
   agents,
   workingBotPubkeys,
@@ -39,12 +26,10 @@ export function shouldShowViewAllAgentActivity({
   agents: ChannelActivityAgent[];
   workingBotPubkeys: readonly string[];
 }): boolean {
-  return (
-    countActiveChannelAgents(agents) >= 2 ||
-    countWorkingChannelAgents(agents, workingBotPubkeys) >= 2
-  );
+  return countWorkingChannelAgents(agents, workingBotPubkeys) >= 2;
 }
 
+/** Only agents currently working — idle harnesses stay out of View all. */
 export function agentsForAllActivityPanel({
   agents,
   workingBotPubkeys,
@@ -55,9 +40,5 @@ export function agentsForAllActivityPanel({
   const working = new Set(
     workingBotPubkeys.map((pubkey) => normalizePubkey(pubkey)),
   );
-  return agents.filter(
-    (agent) =>
-      working.has(normalizePubkey(agent.pubkey)) ||
-      isActiveChannelAgent(agent),
-  );
+  return agents.filter((agent) => working.has(normalizePubkey(agent.pubkey)));
 }

--- a/desktop/src/features/channels/ui/useWorkingAgentHeadlines.ts
+++ b/desktop/src/features/channels/ui/useWorkingAgentHeadlines.ts
@@ -1,0 +1,60 @@
+import * as React from "react";
+
+import {
+  getActivityHeadline,
+  isMeaningfulItem,
+  isSpineItem,
+} from "@/features/agents/ui/agentSessionTranscriptPresentation";
+import { useAgentTranscript } from "@/features/agents/ui/useObserverEvents";
+import type { TranscriptItem } from "@/features/agents/ui/agentSessionTypes";
+
+export function collectActivityHeadlines(
+  transcript: TranscriptItem[],
+  channelId?: string | null,
+  maxHeadlines = 5,
+): string[] {
+  const seen = new Set<string>();
+  const headlines: string[] = [];
+  const scopedTranscript = channelId
+    ? transcript.filter((item) => item.channelId === channelId)
+    : transcript;
+
+  const passFilter: (item: TranscriptItem) => boolean = scopedTranscript.some(
+    isSpineItem,
+  )
+    ? isSpineItem
+    : isMeaningfulItem;
+
+  for (let i = scopedTranscript.length - 1; i >= 0; i--) {
+    const item = scopedTranscript[i];
+    if (!passFilter(item)) {
+      continue;
+    }
+    const headline = getActivityHeadline(item);
+    if (!headline || seen.has(headline)) {
+      continue;
+    }
+
+    seen.add(headline);
+    headlines.unshift(headline);
+    if (headlines.length >= maxHeadlines) {
+      break;
+    }
+  }
+
+  return headlines;
+}
+
+export function useWorkingAgentHeadlines(
+  enabled: boolean,
+  agentPubkey: string | undefined,
+  channelId?: string | null,
+  maxHeadlines = 5,
+): string[] {
+  const transcript = useAgentTranscript(enabled, agentPubkey);
+
+  return React.useMemo(
+    () => collectActivityHeadlines(transcript, channelId, maxHeadlines),
+    [channelId, maxHeadlines, transcript],
+  );
+}

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -1934,6 +1934,48 @@ test("shows and clears activity indicators for active channel agents", async ({
   );
 });
 
+test("view all opens the multi-agent activity panel for two working agents", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
+  await waitForMockLiveSubscription(page, "agents", KIND_TYPING_INDICATOR);
+
+  for (const pubkey of [
+    TEST_IDENTITIES.alice.pubkey,
+    TEST_IDENTITIES.charlie.pubkey,
+  ]) {
+    await page.evaluate(
+      ({ channelName, agentPubkey }) => {
+        window.__BUZZ_E2E_EMIT_MOCK_TYPING__?.({
+          channelName,
+          pubkey: agentPubkey,
+        });
+      },
+      { channelName: "agents", agentPubkey: pubkey },
+    );
+  }
+
+  await expect(page.getByTestId("bot-activity-composer-trigger")).toBeVisible();
+  await expect(page.getByTestId("bot-activity-show-all")).toBeVisible();
+  await expect(page.getByTestId("bot-activity-show-all")).toHaveText("View all");
+
+  await page.getByTestId("bot-activity-show-all").click();
+  await expect(page.getByTestId("all-agents-activity-panel")).toBeVisible();
+  await expect(
+    page.getByTestId(
+      `all-agents-activity-card-${TEST_IDENTITIES.alice.pubkey}`,
+    ),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId(
+      `all-agents-activity-card-${TEST_IDENTITIES.charlie.pubkey}`,
+    ),
+  ).toBeVisible();
+});
+
 test("members sidebar exposes view-activity for a viewer-owned relay agent", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

When multiple agents are working in a channel, the composer activity bar exposes a **View all** control that opens a right-side auxiliary panel of live activity cards. Each card embeds the same compact session transcript used by the single-agent activity pane, pinned to the latest rows, and drills into the full feed via **View**.

- **View all** appears when 2+ agents are actively working (composer row + multi-agent popover)
- Panel lists **working agents only** (idle harnesses stay out)
- Cards reuse `ManagedAgentSessionPanel` with `compactPreview` so tool/message rows match the individual activity look
- Shared headline clamping (`clampHeadline`) prevents shell/tool dumps from exploding overview UIs
- Auxiliary body padding preserves the single-panel top inset so the first card header is not covered

## Test plan

- [ ] With 2+ managed agents working in a channel, confirm **View all** appears next to the inline activity bar
- [ ] Click **View all** → right panel opens with one card per **working** agent (no idle rows)
- [ ] Each card shows recent transcript activity (latest tools/messages), not early session setup
- [ ] Card header (avatar / name / View) is fully visible under the panel title
- [ ] **View** opens that agent's full activity panel
- [ ] Panel closes on Escape / close affordance; channel switch dismisses panel
- [ ] Single-agent path unchanged (no View all when only one agent working)

Originating Buzz channel: `a3ec672d-4a27-40f5-8307-be553f11dad0` (#Welcome)

Made with [Cursor](https://cursor.com)