### PR TITLE
fix(desktop): hide message deletion notices

### DIFF
--- a/desktop/src/features/messages/lib/formatTimelineMessages.test.mjs
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.test.mjs
@@ -88,6 +88,19 @@ function huddleStarted(overrides = {}) {
   };
 }
 
+function systemMessage(type, overrides = {}) {
+  return {
+    id: HEX64_B,
+    pubkey: PUBKEY_B,
+    kind: 40099,
+    created_at: 1_700_000_001,
+    content: JSON.stringify({ type }),
+    tags: [["h", CHANNEL_ID]],
+    sig: "sig",
+    ...overrides,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Keystone regression: aux events (edits/deletions) apply by `#e` reference,
 // NOT by time-window overlap. This is the invariant the split-query +
@@ -151,6 +164,33 @@ test("kind:9005 (NIP-29 / Buzz-native) deletion hides the target message", () =>
     0,
     "the kind:9 message should be filtered out by the kind:9005 deletion",
   );
+});
+
+test("message deletion notices do not render as timeline rows", () => {
+  const notice = systemMessage("message_deleted", {
+    content: JSON.stringify({
+      type: "message_deleted",
+      actor: PUBKEY_B,
+      target_event_id: HEX64_A,
+      public_reason: "Removed by community moderators",
+    }),
+  });
+
+  assert.deepEqual(formatTimelineMessages([notice], null, undefined, null), []);
+  assert.equal(countTopLevelTimelineRows([notice]), 0);
+  assert.deepEqual(collectMessageAuthorPubkeys([notice]), []);
+});
+
+test("other system messages and malformed payloads remain visible", () => {
+  const memberJoined = systemMessage("member_joined");
+  const malformed = systemMessage("ignored", { content: "not json" });
+
+  assert.equal(
+    formatTimelineMessages([memberJoined, malformed], null, undefined, null)
+      .length,
+    2,
+  );
+  assert.equal(countTopLevelTimelineRows([memberJoined, malformed]), 2);
 });
 
 test("non-deletion event kinds do NOT hide the target message", () => {

--- a/desktop/src/features/messages/lib/formatTimelineMessages.ts
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.ts
@@ -62,6 +62,22 @@ export function isTimelineContentEvent(event: RelayEvent) {
   );
 }
 
+function isMessageDeletionNotice(event: RelayEvent) {
+  if (event.kind !== KIND_SYSTEM_MESSAGE) return false;
+
+  try {
+    const payload: unknown = JSON.parse(event.content);
+    return (
+      typeof payload === "object" &&
+      payload !== null &&
+      "type" in payload &&
+      payload.type === "message_deleted"
+    );
+  } catch {
+    return false;
+  }
+}
+
 function getDeletionTargets(tags: string[][]) {
   return tags
     .filter(
@@ -104,7 +120,11 @@ export function countTopLevelTimelineRows(events: RelayEvent[]): number {
 
   let count = 0;
   for (const event of events) {
-    if (!isTimelineContentEvent(event) || deletedEventIds.has(event.id)) {
+    if (
+      !isTimelineContentEvent(event) ||
+      isMessageDeletionNotice(event) ||
+      deletedEventIds.has(event.id)
+    ) {
       continue;
     }
     const { parentId } = getThreadReference(event.tags);
@@ -252,7 +272,10 @@ export function formatTimelineMessages(
   }
 
   const visibleEvents = events.filter(
-    (event) => isTimelineContentEvent(event) && !deletedEventIds.has(event.id),
+    (event) =>
+      isTimelineContentEvent(event) &&
+      !isMessageDeletionNotice(event) &&
+      !deletedEventIds.has(event.id),
   );
   const eventsById = new Map(visibleEvents.map((event) => [event.id, event]));
   const reactionPresence = new Map<
@@ -551,7 +574,7 @@ export function collectMessageAuthorPubkeys(
   const pubkeys = new Set<string>();
 
   for (const event of events) {
-    if (!isTimelineContentEvent(event)) {
+    if (!isTimelineContentEvent(event) || isMessageDeletionNotice(event)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

- remove `message_deleted` system notices from channel timelines
- exclude hidden notices from visible-row pagination counts
- skip unnecessary author-profile loading for hidden notices
- preserve deletion enforcement and moderation audit events

These notices currently render as repeated "Removed by community moderators" rows after the underlying messages have already disappeared. They add visual noise without restoring any conversational context.

## Testing

- `pnpm --dir desktop test`
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop check`
- `pnpm --dir desktop build`

## Existing issue / PR

None found.
