### PR TITLE
feat(cli): add --visibility to channels update

### DIFF
--- a/crates/buzz-cli/TESTING.md
+++ b/crates/buzz-cli/TESTING.md
@@ -140,6 +140,10 @@ buzz channels update --channel "$CHANNEL_ID" --name "test-cli-updated" \
   --description "Updated" | jq .
 # Expected: {"event_id":"...","accepted":true,"message":"..."}
 
+# channels update (visibility — requires channel owner/admin)
+buzz channels update --channel "$CHANNEL_ID" --visibility open | jq .
+# Expected: {"event_id":"...","accepted":true,"message":"..."}
+
 # channels topic
 buzz channels topic --channel "$CHANNEL_ID" --topic "Test topic" | jq .
 # Expected: {"event_id":"...","accepted":true,"message":"..."}

--- a/crates/buzz-cli/src/commands/channels.rs
+++ b/crates/buzz-cli/src/commands/channels.rs
@@ -834,6 +834,7 @@ pub async fn cmd_update_channel(
     channel_id: &str,
     name: Option<&str>,
     description: Option<&str>,
+    visibility: Option<&str>,
     ttl: Option<i64>,
     no_ttl: bool,
 ) -> Result<(), CliError> {
@@ -845,15 +846,17 @@ pub async fn cmd_update_channel(
         (None, false) => None,
     };
 
-    if name.is_none() && description.is_none() && ttl_change.is_none() {
+    if name.is_none() && description.is_none() && visibility.is_none() && ttl_change.is_none() {
         return Err(CliError::Usage(
-            "at least one field required (--name, --description, --ttl, --no-ttl)".into(),
+            "at least one field required (--name, --description, --visibility, --ttl, --no-ttl)"
+                .into(),
         ));
     }
     let channel_uuid = parse_uuid(channel_id)?;
 
-    let builder = buzz_sdk::build_update_channel(channel_uuid, name, description, None, ttl_change)
-        .map_err(|e| CliError::Other(format!("build_update_channel failed: {e}")))?;
+    let builder =
+        buzz_sdk::build_update_channel(channel_uuid, name, description, visibility, ttl_change)
+            .map_err(|e| CliError::Other(format!("build_update_channel failed: {e}")))?;
 
     let event = client.sign_event(builder)?;
     let resp = client.submit_event(event).await?;
@@ -1128,6 +1131,7 @@ pub async fn dispatch(
             channel,
             name,
             description,
+            visibility,
             ttl,
             no_ttl,
         } => {
@@ -1136,6 +1140,7 @@ pub async fn dispatch(
                 &channel,
                 name.as_deref(),
                 description.as_deref(),
+                visibility.as_deref(),
                 ttl,
                 no_ttl,
             )

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -570,7 +570,7 @@ pub enum ChannelsCmd {
         #[arg(long, value_name = "PATH")]
         templates_file: Option<String>,
     },
-    /// Update channel name, description, or ephemeral TTL
+    /// Update channel name, description, visibility, or ephemeral TTL
     Update {
         /// Channel UUID
         #[arg(long)]
@@ -581,6 +581,9 @@ pub enum ChannelsCmd {
         /// New channel description
         #[arg(long)]
         description: Option<String>,
+        /// New channel visibility (owner/admin only)
+        #[arg(long, value_parser = ["open", "private"])]
+        visibility: Option<String>,
         /// Make the channel ephemeral (or change its lifetime): seconds until
         /// the relay archives it after the last message. Conflicts with --no-ttl.
         #[arg(long, value_name = "SECONDS", conflicts_with = "no_ttl")]


### PR DESCRIPTION
## Summary

Buzz Desktop can flip an existing channel between public and private (the Visibility dropdown in channel settings), and the relay accepts kind:9002 edit-metadata events with a `visibility` tag from channel owners/admins — but `buzz channels update` only exposed `--name`, `--description`, and TTL. Agents managing channels from the CLI had no way to change visibility.

This wires the existing (and previously unused-from-the-CLI) `visibility` parameter of `buzz_sdk::build_update_channel` through to a new flag:

```
buzz channels update --channel <UUID> --visibility <open|private>
```

## Changes

- `crates/buzz-cli/src/lib.rs` — add `--visibility` to `ChannelsCmd::Update` with `value_parser = ["open", "private"]` (same pattern as the status flags on `pr`/`issues`/`patches`)
- `crates/buzz-cli/src/commands/channels.rs` — thread the value through `cmd_update_channel` into `buzz_sdk::build_update_channel`, and include it in the at-least-one-field check
- `crates/buzz-cli/TESTING.md` — add a runbook entry

No relay or SDK changes needed: `build_update_channel` already validates the value, and relay-side authorization for visibility edits (owner/admin only) already exists in `crates/buzz-relay/src/handlers/side_effects.rs`.

## Testing

- `cargo test -p buzz-cli` — 250 passed
- `cargo fmt -p buzz-cli --check` and `cargo clippy -p buzz-cli --all-targets` — clean
- Live against a production relay: `buzz channels update --channel <uuid> --visibility open` from the built binary → `{"accepted":true,...}`, and the channel's kind:39000 metadata carries the `public` marker tag
- Rejection paths verified: invalid value fails clap parsing with possible values listed; bare `channels update` with no fields returns the usage error naming `--visibility`
