### PR TITLE
feat(desktop): add Qoder ACP runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,11 +130,11 @@ RUST_LOG=buzz_relay=debug,buzz_db=debug,buzz_auth=debug,buzz_pubsub=debug,tower_
 # BUZZ_RELAY_URL=ws://localhost:3000
 
 # ── Agent subprocess ─────────────────────────────────────────────────────────
-# Binary to spawn as the AI agent (e.g. "goose", "codex-acp", "claude-code").
+# Binary to spawn as the AI agent (e.g. "goose", "codex-acp", "claude-code", "qodercli").
 # BUZZ_ACP_AGENT_COMMAND=goose
 
 # Comma-separated arguments passed to the agent binary.
-# Goose default: "acp". Codex/Claude default: "" (empty).
+# Goose default: "acp". Qoder default: "--acp". Codex/Claude default: "" (empty).
 # BUZZ_ACP_AGENT_ARGS=acp
 
 # Binary for an optional MCP server sidecar (e.g. buzz-dev-mcp for buzz-agent).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -648,7 +648,7 @@ Standalone binary that bridges Buzz relay events to AI agents via the [Agent Com
 **Architecture:**
 
 ```
-Buzz Relay ──WS──→ buzz-acp ──stdio (ACP/JSON-RPC)──→ Agent (goose/codex/claude)
+Buzz Relay ──WS──→ buzz-acp ──stdio (ACP/JSON-RPC)──→ Agent (goose/codex/claude/qoder)
 ```
 
 `buzz-acp` spawns AI agent subprocesses (1–32, default 1), connects to the relay via WebSocket with NIP-42 auth, discovers channels via REST API, and queues `@mention` events per channel. At most one prompt is in-flight per channel. Queued events are batched into a single prompt sent via `session/prompt` over ACP.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Agents are part of the room, not haunted cron jobs.
 |---|---|---|
 | Relay, channels, threads, DMs, canvases, media, search, audit log | Mobile clients (iOS + Android, Flutter) | Web-of-trust reputation across relays |
 | Desktop app (Tauri + React) | Workflow approval gates (infra exists, glue still drying) | Push notifications |
-| `buzz-cli` (agent-first, JSON in / JSON out) + ACP harness (Goose, Codex, Claude Code) | Huddle lifecycle events | Culture features |
+| `buzz-cli` (agent-first, JSON in / JSON out) + ACP harness (Goose, Codex, Claude Code, Qoder) | Huddle lifecycle events | Culture features |
 | YAML workflows: message / reaction / schedule / webhook triggers | | |
 | Git events (NIP-34: patches, repo announcements, status) | | |
 | Git hosting backend | | |
@@ -206,7 +206,7 @@ A Rust workspace of focused crates. Single source of truth: the relay. See [ARCH
 
 **Services** — `buzz-db` (Postgres) · `buzz-auth` (NIP-42/98 Schnorr auth, rate limiting) · `buzz-pubsub` (Redis, presence, typing) · `buzz-search` (Postgres FTS) · `buzz-audit` (hash-chain log). Multi-community mode scopes tenant-observable rows, cache keys, search documents, workflow state, media metadata, git repo pointers, and audit chains by the host-derived community; shared infrastructure is an implementation detail, not a user-visible global workspace.
 
-**Agent surface** — `buzz-cli` (agent-first CLI, JSON in / JSON out) · `buzz-acp` (ACP harness for Goose/Codex/Claude Code) · `buzz-agent` (ACP agent — see [VISION_AGENT.md](VISION_AGENT.md)) · `buzz-dev-mcp` (shell + file-edit tools) · `buzz-workflow` (YAML automation) · `buzz-persona` (agent persona packs)
+**Agent surface** — `buzz-cli` (agent-first CLI, JSON in / JSON out) · `buzz-acp` (ACP harness for Goose/Codex/Claude Code/Qoder) · `buzz-agent` (ACP agent — see [VISION_AGENT.md](VISION_AGENT.md)) · `buzz-dev-mcp` (shell + file-edit tools) · `buzz-workflow` (YAML automation) · `buzz-persona` (agent persona packs)
 
 **Git & pairing** — `git-sign-nostr` / `git-credential-nostr` (nostr-signed git) · `buzz-pair-relay` / `buzz-pairing-cli` (relay pairing)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -179,7 +179,7 @@ header fallback. There is no REST API for fetching message threads — use
 
 ## ACP Harness (optional, end-to-end with a real agent)
 
-`buzz-acp` connects an ACP-speaking agent (goose, codex, claude code,
+`buzz-acp` connects an ACP-speaking agent (goose, codex, claude code, Qoder,
 buzz-agent) to the relay. The harness listens for events, drives the
 agent over stdio, and the agent replies through MCP tools.
 
@@ -222,7 +222,7 @@ buzz-acp                                    # foreground; logs to stdout (run in
 
 > **Using a different ACP agent?** The default recipe assumes `goose` is on
 > `$PATH` and configured (`goose --version` should print). For codex / claude
-> code / buzz-agent, set `BUZZ_ACP_AGENT_COMMAND` and `BUZZ_ACP_AGENT_ARGS`
+> code / Qoder / buzz-agent, set `BUZZ_ACP_AGENT_COMMAND` and `BUZZ_ACP_AGENT_ARGS`
 > accordingly — see `crates/buzz-acp/README.md`. Without these, buzz-acp
 > will fail to spawn the agent subprocess on startup.
 

--- a/VISION.md
+++ b/VISION.md
@@ -213,7 +213,7 @@ Greenfield. Agent swarms build in parallel, integrating at the event store bound
 |-|------|
 | ✅ | Core relay, auth, pub/sub, search, audit |
 | ✅ | MCP server — full feature surface |
-| ✅ | ACP agent harness — goose, codex, claude code |
+| ✅ | ACP agent harness — goose, codex, claude code, Qoder |
 | ✅ | Desktop client (Tauri) — Stream, Home, Forum, DMs, Agents, Workflows, Search, Settings, Profiles, Presence |
 | ✅ | Channel features — messaging, threads, reactions, canvases, media uploads, editing, deletion, typing indicators, NIP-29, soft-delete |
 | ✅ | Workflow engine — YAML-as-code, execution traces, message/reaction/schedule/webhook triggers |

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -9,7 +9,7 @@ Buzz Relay ──WS──→ buzz-acp ──stdio──→ Your Agent
                                        (send_message, etc.)
 ```
 
-Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/agentclientprotocol/codex-acp)), and **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)).
+Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/agentclientprotocol/codex-acp)), **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)), and **Qoder**.
 
 ## Prerequisites
 
@@ -97,6 +97,26 @@ buzz-acp
 
 Older installs that still expose `claude-code-acp` are also supported. `buzz-acp`
 treats both Claude ACP command names as the same zero-arg runtime.
+
+## Running with Qoder
+
+[Qoder CLI](https://docs.qoder.com/en/cli/acp) implements ACP directly, so no
+adapter is required.
+
+```bash
+# Install and authenticate Qoder CLI first.
+curl -fsSL https://qoder.com/install | bash
+qodercli login
+
+# Run through Qoder's native ACP server.
+export BUZZ_ACP_AGENT_COMMAND="qodercli"
+export BUZZ_ACP_AGENT_ARGS="--acp"
+
+buzz-acp
+```
+
+The harness also normalizes the legacy default argument `acp` to Qoder's
+required `--acp` flag.
 
 ## Configuration
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -175,7 +175,7 @@ impl std::fmt::Display for PermissionMode {
     about = "Query available models from the configured agent"
 )]
 pub struct ModelsArgs {
-    /// Agent binary to spawn (e.g. "goose", "claude-agent-acp", "codex-acp").
+    /// Agent binary to spawn (e.g. "goose", "claude-agent-acp", "codex-acp", "qodercli").
     #[command(flatten)]
     pub agent: AuthAgentArgs,
 
@@ -187,7 +187,7 @@ pub struct ModelsArgs {
 /// Shared agent-spawn flags for lightweight local ACP helper subcommands.
 #[derive(Debug, Parser)]
 pub struct AuthAgentArgs {
-    /// Agent binary to spawn (e.g. "goose", "claude-agent-acp", "codex-acp").
+    /// Agent binary to spawn (e.g. "goose", "claude-agent-acp", "codex-acp", "qodercli").
     #[arg(long, env = "BUZZ_ACP_AGENT_COMMAND", default_value = "goose")]
     pub agent_command: String,
 
@@ -617,6 +617,7 @@ pub(crate) fn normalize_agent_command_identity(command: &str) -> String {
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
+        "qoder" | "qoder-cli" | "qodercli" => Some(vec!["--acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,
@@ -691,11 +692,10 @@ pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<Strin
         return default_args;
     }
 
-    // Older callers relied on the Goose-specific default even for runtimes like
-    // Codex and Claude. Treat that legacy fallback as "no args" for zero-arg
-    // providers so desktop- and env-based launches behave the same way.
-    if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") && default_args.is_empty()
-    {
+    // Older callers relied on the Goose-specific default even for other
+    // runtimes. Replace that legacy fallback with the selected runtime's
+    // canonical ACP arguments.
+    if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") {
         return default_args;
     }
 
@@ -1438,6 +1438,19 @@ mod tests {
     fn normalizes_goose_args_to_acp() {
         assert_eq!(normalize_agent_args("goose", Vec::new()), vec!["acp"]);
         assert_eq!(normalize_agent_args("goose", vec!["".into()]), vec!["acp"]);
+    }
+
+    #[test]
+    fn normalizes_qoder_args_to_acp_flag() {
+        assert_eq!(normalize_agent_args("qodercli", Vec::new()), vec!["--acp"]);
+        assert_eq!(
+            normalize_agent_args("/usr/local/bin/qodercli", vec!["acp".into()]),
+            vec!["--acp"]
+        );
+        assert_eq!(
+            normalize_agent_args("Qoder CLI", vec!["--acp".into()]),
+            vec!["--acp"]
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/agent_config.rs
+++ b/desktop/src-tauri/src/commands/agent_config.rs
@@ -621,6 +621,7 @@ mod tests {
             model_env_var: Some("GOOSE_MODEL"),
             provider_env_var: Some("GOOSE_PROVIDER"),
             provider_locked: false,
+            provider_locked_label: None,
             default_env: &[],
             config_file_path: Some("~/.config/goose/config.yaml"),
             config_file_format: Some("yaml"),
@@ -630,7 +631,7 @@ mod tests {
             context_limit_env_var: Some("GOOSE_CONTEXT_LIMIT"),
             required_normalized_fields: &["model", "provider"],
             login_hint: None,
-            auth_probe_args: None,
+            auth_probe: None,
         }
     }
 

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
@@ -39,6 +39,7 @@ pub(crate) fn read_config_surface(
     let model_env_var = runtime_meta.and_then(|m| m.model_env_var);
     let provider_env_var = runtime_meta.and_then(|m| m.provider_env_var);
     let provider_locked = runtime_meta.is_some_and(|m| m.provider_locked);
+    let provider_locked_label = runtime_meta.and_then(|m| m.provider_locked_label);
     let thinking_env_var = runtime_meta.and_then(|m| m.thinking_env_var);
     let supports_acp_native = runtime_meta.is_some_and(|m| m.supports_acp_native_config);
     let required_fields: &[&str] = runtime_meta
@@ -86,6 +87,7 @@ pub(crate) fn read_config_surface(
             &file_config.provider,
             provider_env_var,
             provider_locked,
+            provider_locked_label,
             required_fields.contains(&"provider"),
         ),
         mode: build_mode_field(&file_config.mode, &acp_mode, is_pre_spawn, session_cache),
@@ -361,11 +363,13 @@ fn build_provider_field(
     file_provider: &Option<String>,
     provider_env_var: Option<&str>,
     provider_locked: bool,
+    provider_locked_label: Option<&str>,
     is_required: bool,
 ) -> Option<NormalizedField> {
     if provider_locked {
+        let label = provider_locked_label.unwrap_or("Provider");
         return Some(NormalizedField {
-            value: Some("Anthropic (locked)".to_string()),
+            value: Some(format!("{label} (locked)")),
             origin: ConfigOrigin::HarnessConstraint,
             write_via: ConfigWriteMechanism::ReadOnly,
             overridden_value: None,

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -5,7 +5,7 @@
 use std::{collections::BTreeMap, path::Path, sync::Mutex};
 
 use super::*;
-use crate::managed_agents::discovery::KnownAcpRuntime;
+use crate::managed_agents::discovery::{known_acp_runtime_exact, KnownAcpRuntime};
 use crate::managed_agents::types::ManagedAgentRecord;
 
 static GOOSE_PATH_ROOT_LOCK: Mutex<()> = Mutex::new(());
@@ -49,6 +49,7 @@ fn test_runtime() -> &'static KnownAcpRuntime {
         model_env_var: Some("GOOSE_MODEL"),
         provider_env_var: Some("GOOSE_PROVIDER"),
         provider_locked: false,
+        provider_locked_label: None,
         default_env: &[],
         config_file_path: Some("~/.config/goose/config.yaml"),
         config_file_format: Some("yaml"),
@@ -58,7 +59,7 @@ fn test_runtime() -> &'static KnownAcpRuntime {
         context_limit_env_var: Some("GOOSE_CONTEXT_LIMIT"),
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
-        auth_probe_args: None,
+        auth_probe: None,
     }
 }
 
@@ -208,15 +209,26 @@ fn record_model_overrides_file_model() {
 }
 
 #[test]
-fn provider_locked_shows_locked() {
+fn provider_locked_uses_catalog_label() {
     let record = test_record();
     let runtime = &KnownAcpRuntime {
         provider_locked: true,
+        provider_locked_label: Some("Anthropic"),
         ..*test_runtime()
     };
     let surface = read_config_surface(&record, Some(runtime), None, None);
     let provider = surface.normalized.provider.unwrap();
     assert_eq!(provider.value.as_deref(), Some("Anthropic (locked)"));
+    assert_eq!(provider.origin, ConfigOrigin::HarnessConstraint);
+}
+
+#[test]
+fn qoder_provider_constraint_is_not_labeled_anthropic() {
+    let record = test_record();
+    let runtime = known_acp_runtime_exact("qoder").expect("Qoder runtime");
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+    let provider = surface.normalized.provider.expect("provider constraint");
+    assert_eq!(provider.value.as_deref(), Some("Qoder (locked)"));
     assert_eq!(provider.origin, ConfigOrigin::HarnessConstraint);
 }
 
@@ -625,6 +637,7 @@ fn buzz_agent_runtime() -> &'static KnownAcpRuntime {
         model_env_var: Some("BUZZ_AGENT_MODEL"),
         provider_env_var: Some("BUZZ_AGENT_PROVIDER"),
         provider_locked: false,
+        provider_locked_label: None,
         default_env: &[],
         config_file_path: None,
         config_file_format: None,
@@ -634,7 +647,7 @@ fn buzz_agent_runtime() -> &'static KnownAcpRuntime {
         context_limit_env_var: Some("BUZZ_AGENT_MAX_CONTEXT_TOKENS"),
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
-        auth_probe_args: None,
+        auth_probe: None,
     }
 }
 
@@ -764,7 +777,7 @@ fn buzz_agent_thinking_effort_env_var_not_double_surfaced_in_advanced() {
 
 #[test]
 fn missing_required_provider_still_returns_dropdown_field() {
-    let provider = build_provider_field(&None, &None, Some("GOOSE_PROVIDER"), false, true)
+    let provider = build_provider_field(&None, &None, Some("GOOSE_PROVIDER"), false, None, true)
         .expect("required provider field should be surfaced even when empty");
 
     assert_eq!(provider.value, None);
@@ -774,5 +787,7 @@ fn missing_required_provider_still_returns_dropdown_field() {
 
 #[test]
 fn missing_optional_provider_stays_hidden() {
-    assert!(build_provider_field(&None, &None, Some("GOOSE_PROVIDER"), false, false).is_none());
+    assert!(
+        build_provider_field(&None, &None, Some("GOOSE_PROVIDER"), false, None, false).is_none()
+    );
 }

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -13,7 +13,7 @@ mod agent_args;
 mod runtime_metadata;
 
 pub use agent_args::normalize_agent_args;
-pub(crate) use runtime_metadata::KnownAcpRuntime;
+pub(crate) use runtime_metadata::{AuthProbe, AuthProbeSuccess, KnownAcpRuntime};
 
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
@@ -89,6 +89,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         model_env_var: Some("GOOSE_MODEL"),
         provider_env_var: Some("GOOSE_PROVIDER"),
         provider_locked: false,
+        provider_locked_label: None,
         default_env: &[("GOOSE_MODE", "auto")],
         config_file_path: Some("~/.config/goose/config.yaml"),
         config_file_format: Some("yaml"),
@@ -98,7 +99,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         context_limit_env_var: Some("GOOSE_CONTEXT_LIMIT"),
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
-        auth_probe_args: None,
+        auth_probe: None,
     },
     KnownAcpRuntime {
         id: "claude",
@@ -121,6 +122,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         model_env_var: None,
         provider_env_var: None,
         provider_locked: true,
+        provider_locked_label: Some("Anthropic"),
         default_env: &[],
         config_file_path: Some("~/.claude/settings.json"),
         config_file_format: Some("json"),
@@ -130,7 +132,10 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         context_limit_env_var: None,
         required_normalized_fields: &[],
         login_hint: Some("Run the Claude CLI to complete authentication."),
-        auth_probe_args: Some(&["claude", "auth", "status"]),
+        auth_probe: Some(AuthProbe {
+            args: &["claude", "auth", "status"],
+            success: AuthProbeSuccess::ExitStatus,
+        }),
     },
     KnownAcpRuntime {
         id: "codex",
@@ -153,6 +158,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         model_env_var: None,
         provider_env_var: None,
         provider_locked: false,
+        provider_locked_label: None,
         default_env: &[],
         config_file_path: Some("~/.codex/config.toml"),
         config_file_format: Some("toml"),
@@ -163,7 +169,10 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         required_normalized_fields: &[],
         login_hint: Some("Run `codex login` to authenticate."),
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
-        auth_probe_args: Some(&["codex", "login", "status"]),
+        auth_probe: Some(AuthProbe {
+            args: &["codex", "login", "status"],
+            success: AuthProbeSuccess::ExitStatus,
+        }),
     },
     KnownAcpRuntime {
         id: "qoder",
@@ -186,6 +195,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         model_env_var: None,
         provider_env_var: None,
         provider_locked: true,
+        provider_locked_label: Some("Qoder"),
         default_env: &[],
         config_file_path: Some("~/.qoder/settings.json"),
         config_file_format: Some("json"),
@@ -196,7 +206,10 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         required_normalized_fields: &[],
         login_hint: Some("Run `qodercli login` to authenticate."),
         // Qoder always exits 0; the JSON `logged_in` field carries auth state.
-        auth_probe_args: Some(&["qodercli", "status", "-o", "json"]),
+        auth_probe: Some(AuthProbe {
+            args: &["qodercli", "status", "-o", "json"],
+            success: AuthProbeSuccess::JsonBoolean { field: "logged_in" },
+        }),
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -219,6 +232,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         model_env_var: Some("BUZZ_AGENT_MODEL"),
         provider_env_var: Some("BUZZ_AGENT_PROVIDER"),
         provider_locked: false,
+        provider_locked_label: None,
         default_env: &[],
         config_file_path: None,
         config_file_format: None,
@@ -228,7 +242,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         context_limit_env_var: Some("BUZZ_AGENT_MAX_CONTEXT_TOKENS"),
         required_normalized_fields: &["model", "provider"],
         login_hint: None,
-        auth_probe_args: None,
+        auth_probe: None,
     },
 ];
 
@@ -915,13 +929,13 @@ pub(crate) fn is_npm_global_install(cmd: &str) -> bool {
 /// background threads to prevent pipe-buffer deadlock. On timeout the child is
 /// killed and `Unknown` is returned; no orphaned threads or processes are left
 /// behind. Returns `Unknown` on timeout.
-fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
+fn probe_auth_status(binary_path: &Path, probe: AuthProbe) -> AuthStatus {
     use crate::managed_agents::readiness::cli_probe;
 
     let augmented_path = cli_probe::augmented_path();
 
     let mut command = std::process::Command::new(binary_path);
-    command.args(&probe_args[1..]);
+    command.args(&probe.args[1..]);
     if let Some(ref path) = augmented_path {
         command.env("PATH", path);
     }
@@ -1000,9 +1014,15 @@ fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
     let stdout_bytes = stdout_thread.join().unwrap_or_default();
     let stderr_bytes = stderr_thread.join().unwrap_or_default();
 
-    match cli_probe::classify_probe_output(&stdout_bytes, &stderr_bytes, exit_status.success()) {
+    match cli_probe::classify_probe_output(
+        &stdout_bytes,
+        &stderr_bytes,
+        exit_status.success(),
+        probe.success,
+    ) {
         cli_probe::ProbeOutcome::LoggedIn => AuthStatus::LoggedIn,
         cli_probe::ProbeOutcome::LoggedOut => AuthStatus::LoggedOut,
+        cli_probe::ProbeOutcome::Unknown => AuthStatus::Unknown,
         cli_probe::ProbeOutcome::ConfigInvalid { stderr_excerpt } => AuthStatus::ConfigInvalid {
             diagnostic: stderr_excerpt,
         },
@@ -1281,6 +1301,7 @@ fn discover_acp_runtime_phase1(runtime: &'static KnownAcpRuntime) -> PartialEntr
             mcp_command: runtime.mcp_command.map(str::to_string),
             model_env_var: runtime.model_env_var.map(str::to_string),
             provider_env_var: runtime.provider_env_var.map(str::to_string),
+            provider_locked: runtime.provider_locked,
             thinking_env_var: runtime.thinking_env_var.map(str::to_string),
             install_hint,
             install_instructions_url: install_instructions_url.to_string(),
@@ -1321,15 +1342,11 @@ pub fn discover_acp_runtimes() -> Vec<AcpRuntimeCatalogEntry> {
             if partial.entry.availability != AcpAvailabilityStatus::Available {
                 return None;
             }
-            let probe_args = partial.runtime.auth_probe_args?;
+            let probe = partial.runtime.auth_probe?;
             // Need the resolved binary path for the CLI (e.g. the actual `claude` binary).
-            let binary_path = resolve_command(probe_args[0])?;
-            let probe_args_owned: Vec<String> = probe_args.iter().map(|s| s.to_string()).collect();
+            let binary_path = resolve_command(probe.args[0])?;
 
-            let handle = std::thread::spawn(move || {
-                let refs: Vec<&str> = probe_args_owned.iter().map(String::as_str).collect();
-                probe_auth_status(&binary_path, &refs)
-            });
+            let handle = std::thread::spawn(move || probe_auth_status(&binary_path, probe));
             Some((idx, handle))
         })
         .collect();
@@ -1352,7 +1369,7 @@ pub fn discover_acp_runtimes() -> Vec<AcpRuntimeCatalogEntry> {
         if partial.entry.auth_status == AuthStatus::Unknown {
             partial.entry.auth_status = if partial.entry.availability
                 == AcpAvailabilityStatus::Available
-                && partial.runtime.auth_probe_args.is_none()
+                && partial.runtime.auth_probe.is_none()
             {
                 AuthStatus::NotApplicable
             } else {

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -9,13 +9,16 @@ use crate::managed_agents::{
     AcpAvailabilityStatus, AcpRuntimeCatalogEntry, AuthStatus, CommandAvailabilityInfo,
 };
 
+mod agent_args;
 mod runtime_metadata;
 
+pub use agent_args::normalize_agent_args;
 pub(crate) use runtime_metadata::KnownAcpRuntime;
 
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
+const QODER_AVATAR_URL: &str = "https://github.com/QoderAI.png?size=128";
 const BUZZ_AGENT_AVATAR_URL: &str =
     "https://raw.githubusercontent.com/block/buzz/refs/heads/main/crates/buzz-agent/buzz-agent.png";
 
@@ -161,6 +164,39 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         login_hint: Some("Run `codex login` to authenticate."),
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
         auth_probe_args: Some(&["codex", "login", "status"]),
+    },
+    KnownAcpRuntime {
+        id: "qoder",
+        label: "Qoder",
+        commands: &["qodercli"],
+        aliases: &["qoder-cli"],
+        avatar_url: QODER_AVATAR_URL,
+        mcp_command: None,
+        mcp_hooks: false,
+        underlying_cli: Some("qodercli"),
+        cli_install_commands: &["curl -fsSL https://qoder.com/install | bash"],
+        cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://qoder.com/install.ps1 | iex\""],
+        adapter_install_commands: &[],
+        cli_install_instructions_url: "https://docs.qoder.com/en/cli/quick-start",
+        adapter_install_instructions_url: "",
+        cli_install_hint: "Buzz requires the Qoder CLI.",
+        adapter_install_hint: "",
+        skill_dir: Some(".qoder/skills"),
+        supports_acp_model_switching: true,
+        model_env_var: None,
+        provider_env_var: None,
+        provider_locked: true,
+        default_env: &[],
+        config_file_path: Some("~/.qoder/settings.json"),
+        config_file_format: Some("json"),
+        supports_acp_native_config: false,
+        thinking_env_var: None,
+        max_tokens_env_var: None,
+        context_limit_env_var: None,
+        required_normalized_fields: &[],
+        login_hint: Some("Run `qodercli login` to authenticate."),
+        // Qoder always exits 0; the JSON `logged_in` field carries auth state.
+        auth_probe_args: Some(&["qodercli", "status", "-o", "json"]),
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -345,38 +381,6 @@ pub fn effective_agent_command(
 
 mod overrides;
 pub use overrides::{apply_agent_command_update, create_time_agent_command_override};
-
-fn default_agent_args(command: &str) -> Option<Vec<String>> {
-    match normalize_command_identity(command).as_str() {
-        "goose" => Some(vec!["acp".to_string()]),
-        "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
-        _ => None,
-    }
-}
-
-pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<String> {
-    let normalized = agent_args
-        .into_iter()
-        .map(|arg| arg.trim().to_string())
-        .filter(|arg| !arg.is_empty())
-        .collect::<Vec<_>>();
-
-    let Some(default_args) = default_agent_args(command) else {
-        return normalized;
-    };
-
-    if normalized.is_empty() {
-        return default_args;
-    }
-
-    if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") && default_args.is_empty()
-    {
-        return default_args;
-    }
-
-    normalized
-}
 
 fn profile_target_dirs(root: &Path) -> [PathBuf; 2] {
     if cfg!(debug_assertions) {
@@ -941,6 +945,7 @@ fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
         if let Some(mut pipe) = stdout_pipe {
             let _ = pipe.read_to_end(&mut buf);
         }
+        buf
     });
     let stderr_thread = std::thread::spawn(move || {
         let mut buf = Vec::new();
@@ -992,10 +997,10 @@ fn probe_auth_status(binary_path: &Path, probe_args: &[&str]) -> AuthStatus {
     };
 
     let _ = wait_thread.join();
-    let _ = stdout_thread.join();
+    let stdout_bytes = stdout_thread.join().unwrap_or_default();
     let stderr_bytes = stderr_thread.join().unwrap_or_default();
 
-    match cli_probe::classify_probe_output(&stderr_bytes, exit_status.success()) {
+    match cli_probe::classify_probe_output(&stdout_bytes, &stderr_bytes, exit_status.success()) {
         cli_probe::ProbeOutcome::LoggedIn => AuthStatus::LoggedIn,
         cli_probe::ProbeOutcome::LoggedOut => AuthStatus::LoggedOut,
         cli_probe::ProbeOutcome::ConfigInvalid { stderr_excerpt } => AuthStatus::ConfigInvalid {

--- a/desktop/src-tauri/src/managed_agents/discovery/agent_args.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/agent_args.rs
@@ -1,0 +1,73 @@
+use super::normalize_command_identity;
+
+fn default_agent_args(command: &str) -> Option<Vec<String>> {
+    match normalize_command_identity(command).as_str() {
+        "goose" => Some(vec!["acp".to_string()]),
+        "qoder" | "qoder-cli" | "qodercli" => Some(vec!["--acp".to_string()]),
+        "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
+        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        _ => None,
+    }
+}
+
+pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<String> {
+    let normalized = agent_args
+        .into_iter()
+        .map(|arg| arg.trim().to_string())
+        .filter(|arg| !arg.is_empty())
+        .collect::<Vec<_>>();
+
+    let Some(default_args) = default_agent_args(command) else {
+        return normalized;
+    };
+
+    if normalized.is_empty() {
+        return default_args;
+    }
+
+    if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") {
+        return default_args;
+    }
+
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_agent_args;
+
+    #[test]
+    fn normalizes_buzz_agent_args_to_empty() {
+        assert_eq!(
+            normalize_agent_args("buzz-agent", Vec::new()),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            normalize_agent_args("buzz-agent", vec!["acp".into()]),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn normalizes_claude_and_codex_args_to_empty() {
+        for command in ["claude-agent-acp", "claude-code-acp", "codex-acp"] {
+            assert_eq!(
+                normalize_agent_args(command, vec!["acp".into()]),
+                Vec::<String>::new()
+            );
+        }
+    }
+
+    #[test]
+    fn normalizes_qoder_args_to_acp_flag() {
+        assert_eq!(normalize_agent_args("qodercli", Vec::new()), vec!["--acp"]);
+        assert_eq!(
+            normalize_agent_args("/usr/local/bin/qodercli", vec!["acp".into()]),
+            vec!["--acp"]
+        );
+        assert_eq!(
+            normalize_agent_args("Qoder CLI", vec!["--acp".into()]),
+            vec!["--acp"]
+        );
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
@@ -1,3 +1,21 @@
+/// How a successful authentication probe communicates the login state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AuthProbeSuccess {
+    /// A zero exit status means authenticated.
+    ExitStatus,
+    /// A zero exit status only means the command ran; the named JSON field is
+    /// authoritative and must contain a boolean.
+    JsonBoolean { field: &'static str },
+}
+
+/// Static authentication-probe metadata for a known ACP runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AuthProbe {
+    /// `args[0]` is the binary name; the remainder are the subcommand arguments.
+    pub args: &'static [&'static str],
+    pub success: AuthProbeSuccess,
+}
+
 /// Static capabilities and installation metadata for a known ACP runtime.
 pub(crate) struct KnownAcpRuntime {
     pub id: &'static str,
@@ -41,6 +59,8 @@ pub(crate) struct KnownAcpRuntime {
     pub model_env_var: Option<&'static str>,
     pub provider_env_var: Option<&'static str>,
     pub provider_locked: bool,
+    /// Provider name displayed when `provider_locked` is true.
+    pub provider_locked_label: Option<&'static str>,
     pub default_env: &'static [(&'static str, &'static str)],
     pub config_file_path: Option<&'static str>,
     #[allow(dead_code)] // reserved for format-based dispatch when readers are unified
@@ -59,9 +79,9 @@ pub(crate) struct KnownAcpRuntime {
     /// Human-readable hint shown in Doctor when the runtime is available but not
     /// authenticated. `None` for runtimes that have no login step (goose, buzz-agent).
     pub login_hint: Option<&'static str>,
-    /// CLI args for probing authentication status. `args[0]` is the binary name;
-    /// the remainder are the subcommand. `None` for runtimes with no login step.
-    pub auth_probe_args: Option<&'static [&'static str]>,
+    /// Authentication probe and its success contract. `None` for runtimes with
+    /// no login step.
+    pub auth_probe: Option<AuthProbe>,
 }
 
 impl KnownAcpRuntime {
@@ -128,9 +148,13 @@ mod tests {
         );
         assert!(qoder.adapter_install_commands.is_empty());
         assert_eq!(
-            qoder.auth_probe_args,
-            Some(&["qodercli", "status", "-o", "json"][..])
+            qoder.auth_probe,
+            Some(super::AuthProbe {
+                args: &["qodercli", "status", "-o", "json"],
+                success: super::AuthProbeSuccess::JsonBoolean { field: "logged_in" },
+            })
         );
         assert_eq!(qoder.skill_dir, Some(".qoder/skills"));
+        assert_eq!(qoder.provider_locked_label, Some("Qoder"));
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
@@ -120,5 +120,17 @@ mod tests {
         );
         assert!(codex.adapter_install_instructions_url.contains("codex-acp"));
         assert!(codex.cli_install_hint.contains("desktop app alone"));
+
+        let qoder = known_acp_runtime_exact("qoder").unwrap();
+        assert_eq!(
+            qoder.cli_install_instructions_url,
+            "https://docs.qoder.com/en/cli/quick-start"
+        );
+        assert!(qoder.adapter_install_commands.is_empty());
+        assert_eq!(
+            qoder.auth_probe_args,
+            Some(&["qodercli", "status", "-o", "json"][..])
+        );
+        assert_eq!(qoder.skill_dir, Some(".qoder/skills"));
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -5,10 +5,10 @@ use super::{
     apply_agent_command_update, classify_runtime, codex_adapter_availability,
     codex_adapter_is_outdated, create_time_agent_command_override, default_agent_command,
     effective_agent_command, find_nvm_default_bin, find_via_login_shell,
-    is_login_shell_path_uninit, is_safe_nvm_tag, managed_agent_avatar_url, normalize_agent_args,
-    parse_semver_tag, probe_codex_acp_major_version, record_agent_command,
-    refresh_login_shell_path, BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL,
-    GOOSE_AVATAR_URL,
+    is_login_shell_path_uninit, is_safe_nvm_tag, managed_agent_avatar_url, parse_semver_tag,
+    probe_codex_acp_major_version, record_agent_command, refresh_login_shell_path,
+    BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL, GOOSE_AVATAR_URL,
+    QODER_AVATAR_URL,
 };
 use crate::managed_agents::AcpAvailabilityStatus;
 
@@ -37,6 +37,10 @@ fn resolves_known_avatar_for_command_paths_and_aliases() {
         managed_agent_avatar_url("/usr/local/bin/claude-code-acp"),
         Some(CLAUDE_CODE_AVATAR_URL.to_string())
     );
+    assert_eq!(
+        managed_agent_avatar_url("/Users/example/.local/bin/qodercli"),
+        Some(QODER_AVATAR_URL.to_string())
+    );
 }
 
 #[test]
@@ -49,27 +53,6 @@ fn default_agent_command_resolves_bundled_buzz_agent() {
     // The create-path default must be the bundled buzz-agent, never the
     // bare `goose` that isn't on PATH on a stock Windows install.
     assert_eq!(default_agent_command(), "buzz-agent");
-    // And buzz-agent takes no `acp` arg — confirm no arg leakage from the default.
-    assert_eq!(
-        normalize_agent_args(&default_agent_command(), vec!["acp".into()]),
-        Vec::<String>::new()
-    );
-}
-
-#[test]
-fn normalizes_claude_and_codex_args_to_empty() {
-    assert_eq!(
-        normalize_agent_args("claude-agent-acp", vec!["acp".into()]),
-        Vec::<String>::new()
-    );
-    assert_eq!(
-        normalize_agent_args("claude-code-acp", vec!["acp".into()]),
-        Vec::<String>::new()
-    );
-    assert_eq!(
-        normalize_agent_args("codex-acp", vec!["acp".into()]),
-        Vec::<String>::new()
-    );
 }
 
 #[test]
@@ -81,18 +64,6 @@ fn resolves_buzz_agent_avatar() {
     assert_eq!(
         managed_agent_avatar_url("/usr/local/bin/buzz-agent"),
         Some(BUZZ_AGENT_AVATAR_URL.to_string())
-    );
-}
-
-#[test]
-fn normalizes_buzz_agent_args_to_empty() {
-    assert_eq!(
-        normalize_agent_args("buzz-agent", Vec::new()),
-        Vec::<String>::new()
-    );
-    assert_eq!(
-        normalize_agent_args("buzz-agent", vec!["acp".into()]),
-        Vec::<String>::new()
     );
 }
 
@@ -1074,34 +1045,28 @@ fn test_command_basenames_dotted_name_no_extra_candidates() {
 
 // ── Phase B: cli_install_commands_for_os ────────────────────────────────────
 
-/// Claude and Codex have non-empty default cli_install_commands (install.sh).
+/// Every external vendor CLI has a non-empty default install command.
 #[test]
-fn test_claude_and_codex_have_cli_install_commands() {
-    let claude = super::known_acp_runtime_exact("claude").unwrap();
-    let codex = super::known_acp_runtime_exact("codex").unwrap();
-    assert!(
-        !claude.cli_install_commands.is_empty(),
-        "claude must have cli install commands"
-    );
-    assert!(
-        !codex.cli_install_commands.is_empty(),
-        "codex must have cli install commands"
-    );
+fn test_vendor_runtimes_have_cli_install_commands() {
+    for runtime_id in ["claude", "codex", "qoder"] {
+        let runtime = super::known_acp_runtime_exact(runtime_id).unwrap();
+        assert!(
+            !runtime.cli_install_commands.is_empty(),
+            "{runtime_id} must have cli install commands"
+        );
+    }
 }
 
-/// cli_install_commands_for_os returns a non-empty slice for claude and codex.
+/// cli_install_commands_for_os returns a non-empty slice for every vendor CLI.
 #[test]
-fn test_cli_install_commands_for_os_non_empty_for_claude_codex() {
-    let claude = super::known_acp_runtime_exact("claude").unwrap();
-    let codex = super::known_acp_runtime_exact("codex").unwrap();
-    assert!(
-        !claude.cli_install_commands_for_os().is_empty(),
-        "claude must have install commands on every platform"
-    );
-    assert!(
-        !codex.cli_install_commands_for_os().is_empty(),
-        "codex must have install commands on every platform"
-    );
+fn test_cli_install_commands_for_os_non_empty_for_vendor_runtimes() {
+    for runtime_id in ["claude", "codex", "qoder"] {
+        let runtime = super::known_acp_runtime_exact(runtime_id).unwrap();
+        assert!(
+            !runtime.cli_install_commands_for_os().is_empty(),
+            "{runtime_id} must have install commands on every platform"
+        );
+    }
 }
 
 /// On Windows, every vendor CLI selects its official PowerShell installer.
@@ -1111,11 +1076,13 @@ fn test_cli_install_commands_for_os_selects_powershell_on_windows() {
     let claude = super::known_acp_runtime_exact("claude").unwrap();
     let codex = super::known_acp_runtime_exact("codex").unwrap();
     let goose = super::known_acp_runtime_exact("goose").unwrap();
+    let qoder = super::known_acp_runtime_exact("qoder").unwrap();
 
     // Windows must select the PowerShell commands, not the curl|bash ones.
     let claude_cmds = claude.cli_install_commands_for_os();
     let codex_cmds = codex.cli_install_commands_for_os();
     let goose_cmds = goose.cli_install_commands_for_os();
+    let qoder_cmds = qoder.cli_install_commands_for_os();
 
     assert_ne!(
         claude_cmds, claude.cli_install_commands,
@@ -1124,6 +1091,10 @@ fn test_cli_install_commands_for_os_selects_powershell_on_windows() {
     assert_ne!(
         codex_cmds, codex.cli_install_commands,
         "Windows must NOT use the default curl|bash commands for codex"
+    );
+    assert_ne!(
+        qoder_cmds, qoder.cli_install_commands,
+        "Windows must NOT use the default curl|bash commands for qoder"
     );
     assert_eq!(goose_cmds, goose.cli_install_commands_windows);
 
@@ -1135,6 +1106,12 @@ fn test_cli_install_commands_for_os_selects_powershell_on_windows() {
     assert!(
         codex_cmds.iter().any(|c| c.contains("powershell")),
         "codex Windows install must use powershell; got: {codex_cmds:?}"
+    );
+    assert!(
+        qoder_cmds
+            .iter()
+            .any(|c| c.contains("qoder.com/install.ps1")),
+        "Qoder Windows install must use install.ps1; got: {qoder_cmds:?}"
     );
     assert!(
         goose_cmds.iter().any(|c| c.contains("download_cli.ps1")),

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -122,7 +122,12 @@ fn ensure_nest_creates_skill_file() {
     // On unix, harness-specific symlinks should resolve to the canonical dir.
     #[cfg(unix)]
     {
-        for dir in [".goose/skills", ".claude/skills", ".codex/skills"] {
+        for dir in [
+            ".goose/skills",
+            ".claude/skills",
+            ".codex/skills",
+            ".qoder/skills",
+        ] {
             let link = root.join(dir).join("buzz-cli");
             assert!(
                 link.symlink_metadata().unwrap().file_type().is_symlink(),
@@ -168,6 +173,8 @@ fn ensure_nest_skill_dir_has_700_permissions() {
         ".claude/skills",
         ".codex",
         ".codex/skills",
+        ".qoder",
+        ".qoder/skills",
     ] {
         let path = root.join(dir);
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
@@ -253,7 +260,12 @@ fn ensure_skill_symlinks_are_idempotent() {
     // Second call should succeed without errors.
     ensure_nest_at(&root).unwrap();
     // All symlinks still valid and point to relative targets.
-    for dir in [".goose/skills", ".claude/skills", ".codex/skills"] {
+    for dir in [
+        ".goose/skills",
+        ".claude/skills",
+        ".codex/skills",
+        ".qoder/skills",
+    ] {
         let link = root.join(dir).join("buzz-cli");
         assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
         assert!(

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -244,9 +244,8 @@ impl AgentReadiness {
 ///   - `openai` → `OPENAI_COMPAT_API_KEY`
 ///   - `databricks` / `databricks_v2` → `DATABRICKS_HOST` (token optional —
 ///     OAuth PKCE is the fallback)
-/// * **claude**: a successful `claude auth status` probe.
-/// * **codex**: a successful `codex login status` probe (checks the codex
-///   credential store — NOT `OPENAI_API_KEY`).
+/// * **CLI-login runtimes**: the runtime catalog's authentication probe must
+///   succeed (for example Claude, Codex, and Qoder).
 /// * **unknown / custom command**: always `Ready` (no requirements known).
 ///
 /// Databricks note: `DATABRICKS_TOKEN` is `.unwrap_or_default()` in
@@ -283,13 +282,14 @@ fn collect_missing_requirements(
             let file_cfg = read_goose_file_config();
             goose_requirements(effective, file_cfg.as_ref())
         }
-        "claude" => cli_login::requirements(
-            &["claude", "auth", "status"],
-            "complete Claude Code authentication by running the Claude CLI",
-            rt,
-        ),
-        "codex" => cli_login::requirements(&["codex", "login", "status"], "run `codex login`", rt),
-        _ => vec![],
+        _ => match rt.auth_probe_args {
+            Some(probe_args) => cli_login::requirements(
+                probe_args,
+                rt.login_hint.unwrap_or("Complete CLI authentication."),
+                rt,
+            ),
+            None => vec![],
+        },
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -282,9 +282,9 @@ fn collect_missing_requirements(
             let file_cfg = read_goose_file_config();
             goose_requirements(effective, file_cfg.as_ref())
         }
-        _ => match rt.auth_probe_args {
-            Some(probe_args) => cli_login::requirements(
-                probe_args,
+        _ => match rt.auth_probe {
+            Some(probe) => cli_login::requirements(
+                probe,
                 rt.login_hint.unwrap_or("Complete CLI authentication."),
                 rt,
             ),
@@ -491,7 +491,14 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::*;
-    use crate::managed_agents::discovery::known_acp_runtime_exact;
+    use crate::managed_agents::discovery::{known_acp_runtime_exact, AuthProbe, AuthProbeSuccess};
+
+    fn exit_status_probe(args: &'static [&'static str]) -> AuthProbe {
+        AuthProbe {
+            args,
+            success: AuthProbeSuccess::ExitStatus,
+        }
+    }
 
     /// Build a minimal `EffectiveAgentEnv` with the given env map and command.
     fn make_env(command: &str, env: BTreeMap<String, String>) -> EffectiveAgentEnv {
@@ -833,7 +840,11 @@ mod tests {
         // Use a not-installed runtime so the requirement is always emitted
         // regardless of whether codex is on the test machine's PATH.
         let rt = make_cli_runtime(&["__buzz_nonexistent_adapter_xyz789__"], None);
-        let reqs = cli_login::requirements(&["codex", "login", "status"], "run `codex login`", &rt);
+        let reqs = cli_login::requirements(
+            exit_status_probe(&["codex", "login", "status"]),
+            "run `codex login`",
+            &rt,
+        );
         // Whether codex is installed or not, the copy (if any) must not mention OPENAI_API_KEY.
         for req in &reqs {
             if let Requirement::CliLogin { setup_copy, .. } = req {
@@ -880,6 +891,7 @@ mod tests {
             model_env_var: None,
             provider_env_var: None,
             provider_locked: false,
+            provider_locked_label: None,
             default_env: &[],
             supports_acp_native_config: false,
             thinking_env_var: None,
@@ -887,7 +899,7 @@ mod tests {
             context_limit_env_var: None,
             required_normalized_fields: &[],
             login_hint: None,
-            auth_probe_args: None,
+            auth_probe: None,
         }
     }
 
@@ -917,7 +929,7 @@ mod tests {
             Some("__buzz_nonexistent_cli_abc123__"),
         );
         let reqs = cli_login::requirements(
-            &["__buzz_nonexistent_binary_abc123__", "status"],
+            exit_status_probe(&["__buzz_nonexistent_binary_abc123__", "status"]),
             "install the tool first",
             &rt,
         );
@@ -950,7 +962,11 @@ mod tests {
         // → AdapterMissing state → no probe run → CliLogin{AdapterMissing}.
         let exe = present_binary_str();
         let rt = make_cli_runtime(&["__buzz_nonexistent_adapter_xyz789__"], Some(exe));
-        let reqs = cli_login::requirements(&[exe, "--list"], "install the adapter", &rt);
+        let reqs = cli_login::requirements(
+            exit_status_probe(static_commands(vec![exe, "--list"])),
+            "install the adapter",
+            &rt,
+        );
         assert!(
             !reqs.is_empty(),
             "adapter missing must produce a CliLogin requirement"
@@ -977,7 +993,11 @@ mod tests {
             static_commands(vec![exe]),              // adapter found via absolute path
             Some("__buzz_nonexistent_cli_abc123__"), // underlying CLI missing
         );
-        let reqs = cli_login::requirements(&[exe, "--list"], "install the CLI", &rt);
+        let reqs = cli_login::requirements(
+            exit_status_probe(static_commands(vec![exe, "--list"])),
+            "install the CLI",
+            &rt,
+        );
         assert!(
             !reqs.is_empty(),
             "CLI missing must produce a CliLogin requirement"
@@ -1003,7 +1023,7 @@ mod tests {
         let exe = present_binary_str();
         let rt = make_cli_runtime(static_commands(vec![exe]), Some(exe));
         let reqs = cli_login::requirements(
-            &[exe, "--list"],
+            exit_status_probe(static_commands(vec![exe, "--list"])),
             "this should not show (probe exits 0)",
             &rt,
         );
@@ -1023,8 +1043,11 @@ mod tests {
         // → CliLogin{Available} (tooling installed, needs login).
         let exe = present_binary_str();
         let rt = make_cli_runtime(static_commands(vec![exe]), Some(exe));
-        let reqs =
-            cli_login::requirements(&[exe, "--buzz-probe-fail-xyz"], "run `tool login`", &rt);
+        let reqs = cli_login::requirements(
+            exit_status_probe(static_commands(vec![exe, "--buzz-probe-fail-xyz"])),
+            "run `tool login`",
+            &rt,
+        );
         assert!(
             !reqs.is_empty(),
             "non-zero probe must produce a CliLogin requirement (logged out)"
@@ -1075,6 +1098,7 @@ mod tests {
             model_env_var: None,
             provider_env_var: None,
             provider_locked: false,
+            provider_locked_label: None,
             default_env: &[],
             supports_acp_native_config: false,
             thinking_env_var: None,
@@ -1082,7 +1106,7 @@ mod tests {
             context_limit_env_var: None,
             required_normalized_fields: &[],
             login_hint: None,
-            auth_probe_args: None,
+            auth_probe: None,
         }
     }
 
@@ -1137,7 +1161,7 @@ mod tests {
             Some(exe),
         );
         let reqs = cli_login::requirements(
-            &[exe, "--buzz-probe-must-not-run-xyz"],
+            exit_status_probe(static_commands(vec![exe, "--buzz-probe-must-not-run-xyz"])),
             "run `codex login`",
             &rt,
         );
@@ -1177,7 +1201,7 @@ mod tests {
             Some(exe),
         );
         let reqs = cli_login::requirements(
-            &[exe, "--buzz-probe-must-not-run-xyz"],
+            exit_status_probe(static_commands(vec![exe, "--buzz-probe-must-not-run-xyz"])),
             "run `codex login`",
             &rt,
         );

--- a/desktop/src-tauri/src/managed_agents/readiness/cli_login.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_login.rs
@@ -10,7 +10,7 @@ use crate::managed_agents::{
 
 use super::{cli_probe, Requirement};
 
-/// Requirements for CLI-login runtimes (claude, codex).
+/// Requirements for runtimes whose catalog metadata declares a CLI login probe.
 pub(super) fn requirements(
     probe_args: &[&str],
     setup_copy: &str,

--- a/desktop/src-tauri/src/managed_agents/readiness/cli_login.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_login.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use crate::managed_agents::{
     discovery::{
-        classify_runtime, codex_adapter_availability, find_command, resolve_command,
+        classify_runtime, codex_adapter_availability, find_command, resolve_command, AuthProbe,
         KnownAcpRuntime,
     },
     AcpAvailabilityStatus,
@@ -12,10 +12,11 @@ use super::{cli_probe, Requirement};
 
 /// Requirements for runtimes whose catalog metadata declares a CLI login probe.
 pub(super) fn requirements(
-    probe_args: &[&str],
+    probe: AuthProbe,
     setup_copy: &str,
     runtime: &KnownAcpRuntime,
 ) -> Vec<Requirement> {
+    let probe_args = probe.args;
     let adapter_result = runtime
         .commands
         .iter()
@@ -47,7 +48,7 @@ pub(super) fn requirements(
                 )];
             };
             let augmented_path = cli_probe::augmented_path();
-            match cli_probe::login_probe(&binary_path, probe_args, augmented_path.as_deref()) {
+            match cli_probe::login_probe(&binary_path, probe, augmented_path.as_deref()) {
                 cli_probe::ProbeOutcome::LoggedIn => vec![],
                 cli_probe::ProbeOutcome::LoggedOut => vec![missing_requirement(
                     probe_args,
@@ -61,6 +62,11 @@ pub(super) fn requirements(
                         diagnostic: stderr_excerpt,
                     }]
                 }
+                cli_probe::ProbeOutcome::Unknown => vec![missing_requirement(
+                    probe_args,
+                    setup_copy,
+                    AcpAvailabilityStatus::Available,
+                )],
             }
         }
         other => vec![missing_requirement(probe_args, setup_copy, other)],

--- a/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use crate::managed_agents::discovery::{AuthProbe, AuthProbeSuccess};
 use crate::managed_agents::runtime::build_augmented_path;
 
 /// Build the augmented PATH for CLI probes and other native child processes
@@ -29,6 +30,9 @@ pub(crate) enum ProbeOutcome {
     /// The CLI exited non-zero without a config-parse signal — treat as
     /// "not authenticated."
     LoggedOut,
+    /// The probe process succeeded, but its structured response did not satisfy
+    /// the runtime's declared authentication contract.
+    Unknown,
     /// The CLI exited non-zero and its stderr contains a config-parse error
     /// (e.g. from `~/.codex/config.toml`). The user needs to fix their
     /// config, not re-run login.
@@ -55,18 +59,18 @@ const CONFIG_PARSE_SIGNALS: &[&str] = &["error loading configuration", "unknown 
 /// such as node/python when the app was launched with a bare GUI PATH.
 pub(crate) fn login_probe(
     binary_path: &Path,
-    probe_args: &[&str],
+    probe: AuthProbe,
     augmented_path: Option<&str>,
 ) -> ProbeOutcome {
     let mut command = std::process::Command::new(binary_path);
-    command.args(&probe_args[1..]);
+    command.args(&probe.args[1..]);
     if let Some(path) = augmented_path {
         command.env("PATH", path);
     }
     crate::util::configure_no_window(&mut command);
 
     match command.output() {
-        Ok(o) => classify_probe_output(&o.stdout, &o.stderr, o.status.success()),
+        Ok(o) => classify_probe_output(&o.stdout, &o.stderr, o.status.success(), probe.success),
         Err(_) => ProbeOutcome::LoggedOut,
     }
 }
@@ -80,20 +84,22 @@ pub(crate) fn classify_probe_output(
     stdout_bytes: &[u8],
     stderr_bytes: &[u8],
     exit_success: bool,
+    success_contract: AuthProbeSuccess,
 ) -> ProbeOutcome {
     if exit_success {
-        // Some CLIs (notably Qoder) return a successful process exit even
-        // when authentication is absent, and expose the real state as JSON.
-        // Honor that structured signal when present while preserving the
-        // exit-code contract for every existing probe.
-        if serde_json::from_slice::<serde_json::Value>(stdout_bytes)
-            .ok()
-            .and_then(|value| value.get("logged_in")?.as_bool())
-            == Some(false)
-        {
-            return ProbeOutcome::LoggedOut;
+        match success_contract {
+            AuthProbeSuccess::ExitStatus => return ProbeOutcome::LoggedIn,
+            AuthProbeSuccess::JsonBoolean { field } => {
+                return match serde_json::from_slice::<serde_json::Value>(stdout_bytes)
+                    .ok()
+                    .and_then(|value| value.get(field)?.as_bool())
+                {
+                    Some(true) => ProbeOutcome::LoggedIn,
+                    Some(false) => ProbeOutcome::LoggedOut,
+                    None => ProbeOutcome::Unknown,
+                };
+            }
         }
-        return ProbeOutcome::LoggedIn;
     }
     let stderr = String::from_utf8_lossy(stderr_bytes);
     let stderr_lower = stderr.to_lowercase();
@@ -113,11 +119,19 @@ pub(crate) fn classify_probe_output(
 #[cfg(test)]
 mod tests {
     use super::{ProbeOutcome, CONFIG_PARSE_SIGNALS};
+    use crate::managed_agents::discovery::{AuthProbe, AuthProbeSuccess};
+
+    const EXIT_STATUS_PROBE: AuthProbe = AuthProbe {
+        args: &["fake-codex", "login", "status"],
+        success: AuthProbeSuccess::ExitStatus,
+    };
+    const JSON_PROBE_SUCCESS: AuthProbeSuccess =
+        AuthProbeSuccess::JsonBoolean { field: "logged_in" };
 
     #[test]
     fn successful_json_probe_honors_logged_in_false() {
         assert_eq!(
-            super::classify_probe_output(br#"{"logged_in":false}"#, b"", true),
+            super::classify_probe_output(br#"{"logged_in":false}"#, b"", true, JSON_PROBE_SUCCESS,),
             ProbeOutcome::LoggedOut
         );
     }
@@ -125,7 +139,35 @@ mod tests {
     #[test]
     fn successful_json_probe_honors_logged_in_true() {
         assert_eq!(
-            super::classify_probe_output(br#"{"logged_in":true}"#, b"", true),
+            super::classify_probe_output(br#"{"logged_in":true}"#, b"", true, JSON_PROBE_SUCCESS,),
+            ProbeOutcome::LoggedIn
+        );
+    }
+
+    #[test]
+    fn successful_json_probe_rejects_malformed_or_missing_state() {
+        for stdout in [
+            &b"not-json"[..],
+            &br#"{}"#[..],
+            &br#"{"logged_in":"yes"}"#[..],
+        ] {
+            assert_eq!(
+                super::classify_probe_output(stdout, b"", true, JSON_PROBE_SUCCESS),
+                ProbeOutcome::Unknown,
+                "structured probes must not fail open for {stdout:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn successful_exit_status_probe_preserves_existing_contract() {
+        assert_eq!(
+            super::classify_probe_output(
+                b"non-json output",
+                b"",
+                true,
+                AuthProbeSuccess::ExitStatus
+            ),
             ProbeOutcome::LoggedIn
         );
     }
@@ -180,11 +222,7 @@ mod tests {
             std::env::join_paths([interpreter_dir.as_path()]).expect("join augmented PATH");
         let augmented_path = augmented_path.to_string_lossy().into_owned();
         assert_eq!(
-            super::login_probe(
-                &script_path,
-                &["fake-codex", "login", "status"],
-                Some(&augmented_path),
-            ),
+            super::login_probe(&script_path, EXIT_STATUS_PROBE, Some(&augmented_path),),
             ProbeOutcome::LoggedIn,
             "the injected augmented PATH should allow /usr/bin/env to find the interpreter"
         );
@@ -215,7 +253,10 @@ mod tests {
 
         let outcome = super::login_probe(
             &script_path,
-            &["fake-codex-bad-config", "login", "status"],
+            AuthProbe {
+                args: &["fake-codex-bad-config", "login", "status"],
+                success: AuthProbeSuccess::ExitStatus,
+            },
             None,
         );
         assert!(
@@ -253,7 +294,10 @@ mod tests {
 
         let outcome = super::login_probe(
             &script_path,
-            &["fake-codex-logged-out", "login", "status"],
+            AuthProbe {
+                args: &["fake-codex-logged-out", "login", "status"],
+                success: AuthProbeSuccess::ExitStatus,
+            },
             None,
         );
         assert_eq!(

--- a/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness/cli_probe.rs
@@ -24,7 +24,7 @@ pub(crate) fn augmented_path() -> Option<String> {
 /// Outcome of a CLI login-status probe.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum ProbeOutcome {
-    /// The CLI reported a successful login (exit 0).
+    /// The CLI reported a successful login.
     LoggedIn,
     /// The CLI exited non-zero without a config-parse signal — treat as
     /// "not authenticated."
@@ -66,8 +66,7 @@ pub(crate) fn login_probe(
     crate::util::configure_no_window(&mut command);
 
     match command.output() {
-        Ok(o) if o.status.success() => ProbeOutcome::LoggedIn,
-        Ok(o) => classify_probe_output(&o.stderr, false),
+        Ok(o) => classify_probe_output(&o.stdout, &o.stderr, o.status.success()),
         Err(_) => ProbeOutcome::LoggedOut,
     }
 }
@@ -75,10 +74,25 @@ pub(crate) fn login_probe(
 /// Classify collected probe output into a `ProbeOutcome`.
 ///
 /// Shared between `login_probe` (which has the full `Output`) and the
-/// process-level timeout path in `probe_auth_status` (which drains stderr
-/// on a background thread and collects it separately).
-pub(crate) fn classify_probe_output(stderr_bytes: &[u8], exit_success: bool) -> ProbeOutcome {
+/// process-level timeout path in `probe_auth_status` (which drains stdout and
+/// stderr on background threads and collects them separately).
+pub(crate) fn classify_probe_output(
+    stdout_bytes: &[u8],
+    stderr_bytes: &[u8],
+    exit_success: bool,
+) -> ProbeOutcome {
     if exit_success {
+        // Some CLIs (notably Qoder) return a successful process exit even
+        // when authentication is absent, and expose the real state as JSON.
+        // Honor that structured signal when present while preserving the
+        // exit-code contract for every existing probe.
+        if serde_json::from_slice::<serde_json::Value>(stdout_bytes)
+            .ok()
+            .and_then(|value| value.get("logged_in")?.as_bool())
+            == Some(false)
+        {
+            return ProbeOutcome::LoggedOut;
+        }
         return ProbeOutcome::LoggedIn;
     }
     let stderr = String::from_utf8_lossy(stderr_bytes);
@@ -99,6 +113,22 @@ pub(crate) fn classify_probe_output(stderr_bytes: &[u8], exit_success: bool) -> 
 #[cfg(test)]
 mod tests {
     use super::{ProbeOutcome, CONFIG_PARSE_SIGNALS};
+
+    #[test]
+    fn successful_json_probe_honors_logged_in_false() {
+        assert_eq!(
+            super::classify_probe_output(br#"{"logged_in":false}"#, b"", true),
+            ProbeOutcome::LoggedOut
+        );
+    }
+
+    #[test]
+    fn successful_json_probe_honors_logged_in_true() {
+        assert_eq!(
+            super::classify_probe_output(br#"{"logged_in":true}"#, b"", true),
+            ProbeOutcome::LoggedIn
+        );
+    }
 
     #[cfg(unix)]
     #[test]

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -46,6 +46,7 @@ pub(crate) const KNOWN_AGENT_BINARIES: &[&str] = &[
     "codex-acp",
     "codex_acp",
     "goose",
+    "qodercli",
     // buzz-dev-mcp's multicall personalities (rg, tree, buzz,
     // git-credential-nostr, git-sign-nostr) are short-lived per-tool-call
     // invocations — not listed here.

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -557,6 +557,13 @@ fn name_matches_known_binary_rejects_node() {
 }
 
 #[test]
+fn name_matches_known_binary_accepts_qodercli() {
+    assert!(super::name_matches_known_binary("qodercli"));
+    assert!(super::name_matches_known_binary("qodercli-helper"));
+    assert!(!super::name_matches_known_binary("my-qodercli"));
+}
+
+#[test]
 fn name_matches_interpreter_accepts_node() {
     // `node` IS a known script interpreter and must be recognized.
     assert!(super::name_matches_interpreter("node"));

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -18,8 +18,9 @@ pub struct AgentDefinition {
     pub display_name: String,
     pub avatar_url: Option<String>,
     pub system_prompt: String,
-    /// Preferred ACP runtime ID (e.g., 'goose', 'claude', 'codex'). Determines which agent binary
-    /// Buzz spawns. When deploying from this persona, this runtime is pre-selected in the UI.
+    /// Preferred ACP runtime ID (e.g., 'goose', 'claude', 'codex', 'qoder'). Determines which
+    /// agent binary Buzz spawns. When deploying from this persona, this runtime is pre-selected
+    /// in the UI.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime: Option<String>,
     /// Opaque, harness-specific model identifier string. Format depends on the runtime and its LLM

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -580,6 +580,8 @@ pub struct AcpRuntimeCatalogEntry {
     pub model_env_var: Option<String>,
     /// Environment variable used to apply the selected LLM provider, when supported.
     pub provider_env_var: Option<String>,
+    /// Whether the runtime owns its provider and must not retain a Buzz-selected value.
+    pub provider_locked: bool,
     /// Environment variable used to apply thinking effort, when supported.
     pub thinking_env_var: Option<String>,
     pub install_hint: String,

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -72,7 +72,7 @@ with a TypeScript lookup table or an id comparison in a component.
    touching this flow or the shared renderer.
 8. **Omit the Model control only after a confirmed successful empty
    discovery on an optional-model harness.** When the field model marks model
-   as `acpNative` (Claude Code / Codex), `shouldRenderModelControl` hides the
+   as `acpNative` (Claude Code / Codex / Qoder), `shouldRenderModelControl` hides the
    picker while discovery is in flight and after IPC resolves with no usable
    options (`modelDiscoverySuccessfulEmpty` / `isSuccessfulEmptyDiscovery`).
    A thrown or unavailable discovery keeps the control so #2246 failure UI can

--- a/desktop/src/features/agents/lib/agentConfigCore.test.mjs
+++ b/desktop/src/features/agents/lib/agentConfigCore.test.mjs
@@ -22,6 +22,7 @@ function runtime(id, metadata = {}) {
     mcpCommand: null,
     modelEnvVar: null,
     providerEnvVar: null,
+    providerLocked: false,
     thinkingEnvVar: null,
     installHint: "",
     installInstructionsUrl: "",
@@ -124,6 +125,22 @@ test("Codex omits separate effort because model IDs own it", () => {
   assert.deepEqual(model.omissions, [
     { kind: "effort", reason: "ownedByModelId" },
   ]);
+});
+
+test("provider-locked catalog metadata suppresses a contradictory provider env key", () => {
+  const model = deriveAgentConfigFieldModel({
+    config,
+    runtime: runtime("qoder", {
+      providerEnvVar: "SHOULD_NOT_BE_USED",
+      providerLocked: true,
+    }),
+    scope: "global",
+  });
+
+  assert.deepEqual(
+    model.fields.map((item) => item.kind),
+    ["model"],
+  );
 });
 
 test("catalog mismatch cleanup is named and restricted to onboarding", () => {

--- a/desktop/src/features/agents/lib/agentConfigCore.ts
+++ b/desktop/src/features/agents/lib/agentConfigCore.ts
@@ -105,7 +105,7 @@ export function deriveAgentConfigFieldModel({
   const fields: AgentConfigFieldDescriptor[] = [];
   const omissions: AgentConfigOmission[] = [];
 
-  if (runtime?.providerEnvVar) {
+  if (runtime?.providerEnvVar && !runtime.providerLocked) {
     fields.push({
       kind: "provider",
       optionSource: "providerCatalog",

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -503,7 +503,7 @@ export function AgentDefinitionDialog({
     modelFieldVisible,
     open,
     // Gate provider by runtime: runtimes that don't support LLM provider
-    // selection (codex, claude) must not inherit the global provider — doing
+    // selection (codex, claude, qoder) must not inherit the global provider — doing
     // so causes them to discover models from the wrong provider.
     provider: runtimeSupportsLlmProviderSelection(runtime)
       ? effectiveProvider

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -38,7 +38,6 @@ import {
   PERSONA_FIELD_CONTROL_CLASS,
   PERSONA_FIELD_SHELL_CLASS,
   PERSONA_LABEL_OPTIONAL_CLASS,
-  runtimeSupportsLlmProviderSelection,
   shouldClearKnownModelForSelectionScope,
   sortPersonaRuntimes,
   type PersonaDropdownOption,
@@ -53,6 +52,7 @@ import {
   isEditAgentProviderSaveValid,
   resolveAgentCommandUpdate,
   resolveInheritedRuntimeSubmission,
+  resolveProviderUpdate,
   resolveRuntimeProviderCapability,
 } from "./personaRuntimeModel";
 import {
@@ -254,7 +254,7 @@ export function AgentInstanceEditDialog({
     const matched =
       runtimes.find((r) => r.command?.trim() === originalCommand) ??
       runtimes.find((r) => r.id === originalCommand);
-    return runtimeSupportsLlmProviderSelection(matched?.id ?? "");
+    return resolveRuntimeProviderCapability(matched) === "capable";
   }, [runtimes, originalAgentCommand]);
 
   // The runtime id that will actually be active after submit. When inheriting,
@@ -295,8 +295,13 @@ export function AgentInstanceEditDialog({
     selectedRuntimeId,
   ]);
 
-  const llmProviderFieldVisible =
-    runtimeSupportsLlmProviderSelection(prospectiveRuntimeId);
+  const prospectiveRuntime = React.useMemo(
+    () => runtimes.find((runtime) => runtime.id === prospectiveRuntimeId),
+    [prospectiveRuntimeId, runtimes],
+  );
+  const providerRuntimeCapability =
+    resolveRuntimeProviderCapability(prospectiveRuntime);
+  const llmProviderFieldVisible = providerRuntimeCapability === "capable";
 
   // One-shot focus: when the dialog opens from a card deep-link, scroll and
   // focus the relevant field. The effect re-runs when `llmProviderFieldVisible`
@@ -524,9 +529,8 @@ export function AgentInstanceEditDialog({
       selectionOnRuntimeChange(selection, {
         previousRuntime: previousRuntimeId,
         nextRuntime: nextRuntime?.id ?? nextRuntimeId,
-        nextRuntimeCanChooseProvider: runtimeSupportsLlmProviderSelection(
-          nextRuntime?.id ?? nextRuntimeId,
-        ),
+        nextRuntimeCanChooseProvider:
+          resolveRuntimeProviderCapability(nextRuntime) === "capable",
         lockedRuntimeReset: "full",
       }),
     );
@@ -613,19 +617,6 @@ export function AgentInstanceEditDialog({
         agentCommandOverride: agent.agentCommandOverride ?? null,
       });
 
-      // Classify the effective post-submit runtime's provider capability as a
-      // tri-state: "capable" persists the provider, "locked" clears it (only
-      // when we KNOW it's provider-locked, e.g. Claude), "unknown" OMITS it so a
-      // transient/custom state never becomes a destructive write. Resolved
-      // STATICALLY (by id) so a not-yet-loaded catalog can't misclassify a known
-      // runtime as "unknown" — see resolveRuntimeProviderCapability. The runtime
-      // id is the shared prospectiveRuntimeId, so submit and the block-save gate
-      // always agree on which runtime is being saved.
-      const providerRuntimeCapability = resolveRuntimeProviderCapability(
-        prospectiveRuntimeId,
-        runtimeSupportsLlmProviderSelection(prospectiveRuntimeId),
-      );
-
       // Provider + env to persist — the shared inherited-submission snapshot
       // (same values the credential gate validates), so gate ↔ record ↔ spawn
       // all agree. See resolveInheritedRuntimeSubmission.
@@ -669,16 +660,11 @@ export function AgentInstanceEditDialog({
         //   "locked"   → clear: send null if provider was set, else omit.
         //   "unknown"  → omit always (never send null for a transient state).
         // llmProviderFieldVisible is for UX visibility only; not used here.
-        provider:
-          providerRuntimeCapability === "capable"
-            ? normalizedSubmitProvider !== (agent.provider ?? null)
-              ? normalizedSubmitProvider
-              : undefined
-            : providerRuntimeCapability === "locked"
-              ? (agent.provider ?? null) !== null
-                ? null
-                : undefined
-              : undefined, // "unknown" → omit always
+        provider: resolveProviderUpdate({
+          capability: providerRuntimeCapability,
+          provider: normalizedSubmitProvider,
+          originalProvider: agent.provider ?? null,
+        }),
         envVars: envVarsEqual(submitEnvVars, agent.envVars)
           ? undefined
           : submitEnvVars,

--- a/desktop/src/features/agents/ui/agentInstanceEditPinning.test.mjs
+++ b/desktop/src/features/agents/ui/agentInstanceEditPinning.test.mjs
@@ -10,6 +10,7 @@ import {
   hasMissingRequiredEnvKey,
   resolveAgentCommandUpdate,
   resolveInheritedRuntimeSubmission,
+  resolveProviderUpdate,
   resolveRuntimeProviderCapability,
 } from "./personaRuntimeModel.ts";
 
@@ -28,8 +29,27 @@ import {
 // re-host that re-derives any seam independently fails here.
 
 const runtimes = [
-  { id: "buzz-agent", command: "buzz-agent-cmd", defaultArgs: [] },
-  { id: "claude", command: "claude-cmd", defaultArgs: [] },
+  {
+    id: "buzz-agent",
+    command: "buzz-agent-cmd",
+    defaultArgs: [],
+    providerEnvVar: "BUZZ_AGENT_PROVIDER",
+    providerLocked: false,
+  },
+  {
+    id: "claude",
+    command: "claude-cmd",
+    defaultArgs: [],
+    providerEnvVar: null,
+    providerLocked: true,
+  },
+  {
+    id: "qoder",
+    command: "qodercli",
+    defaultArgs: [],
+    providerEnvVar: null,
+    providerLocked: true,
+  },
 ];
 
 // Mirrors the component's prospectiveRuntimeId memo: when inheriting, resolve
@@ -209,20 +229,35 @@ test("rehost_submit_persistsToggleAsCommandClear_andOmitsHarnessOverride", () =>
   const { prospectiveRuntimeId, inheritedSubmission } =
     inheritTransitionState();
   const capability = resolveRuntimeProviderCapability(
-    prospectiveRuntimeId,
-    runtimeSupportsLlmProviderSelection(prospectiveRuntimeId),
+    runtimes.find((runtime) => runtime.id === prospectiveRuntimeId),
   );
   assert.equal(capability, "capable");
-  const providerUpdate =
-    capability === "capable"
-      ? inheritedSubmission.provider !== (pinnedAgent.provider ?? null)
-        ? inheritedSubmission.provider
-        : undefined
-      : undefined;
+  const providerUpdate = resolveProviderUpdate({
+    capability,
+    provider: inheritedSubmission.provider,
+    originalProvider: pinnedAgent.provider ?? null,
+  });
   assert.equal(
     providerUpdate,
     "anthropic",
     "submit must persist the gate-validated submission provider for the prospective runtime",
+  );
+});
+
+test("rehost_submit_switchingToQoder_clearsStaleProvider", () => {
+  const qoder = runtimes.find((runtime) => runtime.id === "qoder");
+  const capability = resolveRuntimeProviderCapability(qoder);
+  const providerUpdate = resolveProviderUpdate({
+    capability,
+    provider: null,
+    originalProvider: "anthropic",
+  });
+
+  assert.equal(capability, "locked");
+  assert.equal(
+    providerUpdate,
+    null,
+    "switching from a provider-backed runtime to Qoder must clear the stale provider",
   );
 });
 

--- a/desktop/src/features/agents/ui/personaRuntimeModel.test.mjs
+++ b/desktop/src/features/agents/ui/personaRuntimeModel.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   resolveInheritedRuntimeSubmission,
+  resolveProviderUpdate,
   resolveRuntimeProviderCapability,
   shouldClearModelForRuntimeChange,
 } from "./personaRuntimeModel.ts";
@@ -186,26 +187,64 @@ test("resolveInheritedRuntimeSubmission yields a null model on the inherit-trans
   assert.equal(result.model, null);
 });
 
-test("resolveRuntimeProviderCapability classifies provider-capable runtimes as capable", () => {
-  assert.equal(resolveRuntimeProviderCapability("buzz-agent", true), "capable");
-  assert.equal(resolveRuntimeProviderCapability("goose", true), "capable");
-});
-
-test("resolveRuntimeProviderCapability classifies known CLI-login runtimes as locked before the catalog loads", () => {
-  // The core fix: a not-yet-loaded catalog must not force these to "unknown".
-  assert.equal(resolveRuntimeProviderCapability("claude", false), "locked");
-  assert.equal(resolveRuntimeProviderCapability("codex", false), "locked");
-  assert.equal(resolveRuntimeProviderCapability(" claude ", false), "locked");
-});
-
-test("resolveRuntimeProviderCapability leaves genuinely unknown/custom runtimes as unknown", () => {
-  // Preserves the tri-state's "omit rather than destructively write" behavior
-  // for ids we can't statically classify (custom command, empty, unknown).
-  assert.equal(resolveRuntimeProviderCapability("custom", false), "unknown");
-  assert.equal(resolveRuntimeProviderCapability("", false), "unknown");
+test("resolveRuntimeProviderCapability classifies catalog provider metadata", () => {
   assert.equal(
-    resolveRuntimeProviderCapability("some-vendor-cli", false),
-    "unknown",
+    resolveRuntimeProviderCapability({
+      providerEnvVar: "BUZZ_AGENT_PROVIDER",
+      providerLocked: false,
+    }),
+    "capable",
+  );
+  assert.equal(
+    resolveRuntimeProviderCapability({
+      providerEnvVar: "IGNORED_PROVIDER",
+      providerLocked: true,
+    }),
+    "locked",
+  );
+  assert.equal(
+    resolveRuntimeProviderCapability({
+      providerEnvVar: null,
+      providerLocked: false,
+    }),
+    "locked",
+  );
+});
+
+test("resolveRuntimeProviderCapability classifies Qoder as locked from the catalog", () => {
+  assert.equal(
+    resolveRuntimeProviderCapability({
+      providerEnvVar: null,
+      providerLocked: true,
+    }),
+    "locked",
+  );
+});
+
+test("resolveRuntimeProviderCapability treats unavailable catalog metadata as unknown", () => {
+  assert.equal(resolveRuntimeProviderCapability(undefined), "unknown");
+});
+
+test("resolveProviderUpdate clears stale providers for Qoder and preserves unknown states", () => {
+  const qoderCapability = resolveRuntimeProviderCapability({
+    providerEnvVar: null,
+    providerLocked: true,
+  });
+  assert.equal(
+    resolveProviderUpdate({
+      capability: qoderCapability,
+      provider: null,
+      originalProvider: "anthropic",
+    }),
+    null,
+  );
+  assert.equal(
+    resolveProviderUpdate({
+      capability: "unknown",
+      provider: null,
+      originalProvider: "anthropic",
+    }),
+    undefined,
   );
 });
 

--- a/desktop/src/features/agents/ui/personaRuntimeModel.ts
+++ b/desktop/src/features/agents/ui/personaRuntimeModel.ts
@@ -1,42 +1,50 @@
+import type { AcpRuntimeCatalogEntry } from "@/shared/api/types";
+
 /** Runtime provider-capability tri-state used by the submit path. */
 export type ProviderRuntimeCapability = "capable" | "locked" | "unknown";
 
 /**
- * Classify a runtime id's provider-selection capability as a tri-state,
- * independent of whether the runtime catalog has loaded yet.
+ * Classify a runtime's provider-selection capability from the Rust catalog.
  *
  * The submit path keys its provider write on this: "capable" persists the
  * provider, "locked" clears it, and "unknown" OMITS the field so a transient
  * loading/error state (or a genuinely unknown/custom command) never becomes a
  * destructive write.
  *
- * Before the catalog loads, `prospectiveRuntimeId` can already be a known
- * persona runtime string (e.g. `buzz-agent`). A catalog lookup then returns
- * `undefined`, which would misclassify a provider-backed runtime as "unknown"
- * and omit the provider while still clearing the command override / writing env
- * — leaving the record inheriting a provider-backed runtime with a null
- * provider. To avoid that, we resolve capability STATICALLY for known ids:
- *
- * - buzz-agent / goose → "capable" (`isProviderCapable`, id-based).
- * - claude / codex → "locked" (CLI-login runtimes; no LLM provider selection).
- * - anything else (custom, empty, genuinely unknown) → "unknown".
- *
- * `isProviderCapable` is the caller-supplied {@link
- * runtimeSupportsLlmProviderSelection} result, kept as the single source of
- * truth for the capable set rather than re-hardcoding it here.
+ * An absent catalog entry is deliberately "unknown": loading failures must not
+ * clear saved state. Any catalog-known runtime without an unlocked provider env
+ * key is "locked", including native-provider runtimes such as Qoder.
  */
 export function resolveRuntimeProviderCapability(
-  runtimeId: string,
-  isProviderCapable: boolean,
+  runtime:
+    | Pick<AcpRuntimeCatalogEntry, "providerEnvVar" | "providerLocked">
+    | undefined,
 ): ProviderRuntimeCapability {
-  if (isProviderCapable) {
+  if (!runtime) {
+    return "unknown";
+  }
+  if (runtime.providerEnvVar !== null && !runtime.providerLocked) {
     return "capable";
   }
-  const id = runtimeId.trim();
-  if (id === "claude" || id === "codex") {
-    return "locked";
+  return "locked";
+}
+
+/** Resolve the tri-state provider field sent by the instance edit mutation. */
+export function resolveProviderUpdate(input: {
+  capability: ProviderRuntimeCapability;
+  provider: string | null;
+  originalProvider: string | null;
+}): string | null | undefined {
+  switch (input.capability) {
+    case "capable":
+      return input.provider !== input.originalProvider
+        ? input.provider
+        : undefined;
+    case "locked":
+      return input.originalProvider !== null ? null : undefined;
+    case "unknown":
+      return undefined;
   }
-  return "unknown";
 }
 
 export function shouldClearModelForRuntimeChange(

--- a/desktop/src/features/onboarding/ui/agentReadiness.test.mjs
+++ b/desktop/src/features/onboarding/ui/agentReadiness.test.mjs
@@ -15,6 +15,10 @@ function makeRuntime(overrides = {}) {
     binaryPath: "/usr/local/bin/goose",
     defaultArgs: [],
     mcpCommand: null,
+    modelEnvVar: null,
+    providerEnvVar: "GOOSE_PROVIDER",
+    providerLocked: false,
+    thinkingEnvVar: null,
     installHint: "",
     installInstructionsUrl: "https://example.com",
     canAutoInstall: false,
@@ -40,7 +44,14 @@ function makeConfig(overrides = {}) {
 // ---------------------------------------------------------------------------
 
 test("resolveAgentReadiness_cli_returns_ready_when_preferred_cli_runtime_is_logged_in", () => {
-  const runtimes = [makeRuntime({ id: "claude", label: "Claude" })];
+  const runtimes = [
+    makeRuntime({
+      id: "claude",
+      label: "Claude",
+      providerEnvVar: null,
+      providerLocked: true,
+    }),
+  ];
   const result = resolveAgentReadiness(
     runtimes,
     makeConfig({ preferred_runtime: "claude" }),
@@ -54,7 +65,12 @@ test("resolveAgentReadiness_cli_returns_ready_when_preferred_cli_runtime_is_logg
 
 test("resolveAgentReadiness_uses_only_the_preferred_runtime", () => {
   const runtimes = [
-    makeRuntime({ id: "claude", label: "Claude" }),
+    makeRuntime({
+      id: "claude",
+      label: "Claude",
+      providerEnvVar: null,
+      providerLocked: true,
+    }),
     makeRuntime({ id: "goose", label: "Goose" }),
   ];
   const result = resolveAgentReadiness(runtimes, makeConfig(), "preferred");
@@ -71,6 +87,28 @@ test("resolveAgentReadiness_cli_skips_logged_out_runtimes", () => {
   ];
   const result = resolveAgentReadiness(runtimes, makeConfig(), "preferred");
   assert.equal(result.ready, false);
+});
+
+test("resolveAgentReadiness_recognizes_authenticated_Qoder_from_catalog_capabilities", () => {
+  const runtimes = [
+    makeRuntime({
+      id: "qoder",
+      label: "Qoder",
+      providerEnvVar: null,
+      providerLocked: true,
+      authStatus: { status: "logged_in" },
+    }),
+  ];
+  const result = resolveAgentReadiness(
+    runtimes,
+    makeConfig({ preferred_runtime: "qoder" }),
+    "preferred",
+  );
+  assert.deepEqual(result, {
+    ready: true,
+    reason: "cli",
+    runtimeLabel: "Qoder",
+  });
 });
 
 test("resolveAgentReadiness_goose_requires_provider_and_model", () => {
@@ -132,6 +170,7 @@ test("resolveAgentReadiness_cli_ignores_buzz_agent_runtime", () => {
     makeRuntime({
       id: "buzz-agent",
       label: "buzz-agent",
+      providerEnvVar: "BUZZ_AGENT_PROVIDER",
       authStatus: { status: "not_applicable" },
     }),
   ];
@@ -146,7 +185,13 @@ test("resolveAgentReadiness_cli_ignores_buzz_agent_runtime", () => {
 test("resolveAgentReadiness_buzz_agent_ready_when_provider_model_and_key_set", () => {
   // anthropic requires ANTHROPIC_API_KEY
   const result = resolveAgentReadiness(
-    [makeRuntime({ id: "buzz-agent", label: "Buzz Agent" })],
+    [
+      makeRuntime({
+        id: "buzz-agent",
+        label: "Buzz Agent",
+        providerEnvVar: "BUZZ_AGENT_PROVIDER",
+      }),
+    ],
     makeConfig({
       preferred_runtime: "buzz-agent",
       provider: "anthropic",
@@ -197,7 +242,14 @@ test("resolveAgentReadiness_neither_returns_not_ready", () => {
 });
 
 test("resolveAgentReadiness_welcome_readiness_uses_ready_cli_without_preference", () => {
-  const runtimes = [makeRuntime({ id: "claude", label: "Claude" })];
+  const runtimes = [
+    makeRuntime({
+      id: "claude",
+      label: "Claude",
+      providerEnvVar: null,
+      providerLocked: true,
+    }),
+  ];
   const result = resolveAgentReadiness(
     runtimes,
     makeConfig({ preferred_runtime: null }),

--- a/desktop/src/features/onboarding/ui/agentReadiness.ts
+++ b/desktop/src/features/onboarding/ui/agentReadiness.ts
@@ -12,9 +12,10 @@ export type AgentReadinessResult =
 /**
  * Determine whether the user has a working agent path configured.
  *
- * CLI path: the preferred Claude or Codex runtime is available and logged in.
- * Provider path: the preferred Buzz Agent or Goose runtime has provider and
- * model set, plus all required credential env vars for that provider.
+ * CLI path: the preferred catalog runtime has no Buzz-managed provider field
+ * and is available and authenticated.
+ * Provider path: the preferred runtime has a provider field, provider and model
+ * set, plus all required credential env vars for that provider.
  *
  * Returns enough info for the UI to say which path matched, or that neither did.
  */
@@ -25,12 +26,7 @@ export function resolveAgentReadiness(
 ): AgentReadinessResult {
   if (scope === "any") {
     for (const runtime of runtimes) {
-      if (runtime.id === "buzz-agent") continue;
-      if (
-        runtime.availability === "available" &&
-        (runtime.authStatus.status === "logged_in" ||
-          runtime.authStatus.status === "not_applicable")
-      ) {
+      if (isReadyCliRuntime(runtime)) {
         return { ready: true, reason: "cli", runtimeLabel: runtime.label };
       }
     }
@@ -46,11 +42,7 @@ export function resolveAgentReadiness(
     return { ready: false };
   }
 
-  if (
-    (preferredRuntime.id === "claude" || preferredRuntime.id === "codex") &&
-    (preferredRuntime.authStatus.status === "logged_in" ||
-      preferredRuntime.authStatus.status === "not_applicable")
-  ) {
+  if (isReadyCliRuntime(preferredRuntime)) {
     return {
       ready: true,
       reason: "cli",
@@ -58,7 +50,7 @@ export function resolveAgentReadiness(
     };
   }
 
-  if (preferredRuntime.id !== "buzz-agent" && preferredRuntime.id !== "goose") {
+  if (preferredRuntime.providerEnvVar === null) {
     return { ready: false };
   }
 
@@ -75,4 +67,13 @@ export function resolveAgentReadiness(
   }
 
   return { ready: false };
+}
+
+function isReadyCliRuntime(runtime: AcpRuntimeCatalogEntry): boolean {
+  return (
+    runtime.providerEnvVar === null &&
+    runtime.availability === "available" &&
+    (runtime.authStatus.status === "logged_in" ||
+      runtime.authStatus.status === "not_applicable")
+  );
 }

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
@@ -12,9 +12,10 @@ function runtime(id, availability, status) {
   return { id, availability, authStatus: { status } };
 }
 
-test("only Claude Code and Codex are visible in onboarding", () => {
+test("only supported CLI harnesses are visible in onboarding", () => {
   assert.equal(runtimeIsVisibleInOnboarding("claude"), true);
   assert.equal(runtimeIsVisibleInOnboarding("codex"), true);
+  assert.equal(runtimeIsVisibleInOnboarding("qoder"), true);
   assert.equal(runtimeIsVisibleInOnboarding("goose"), false);
   assert.equal(runtimeIsVisibleInOnboarding("buzz-agent"), false);
   assert.equal(runtimeIsVisibleInOnboarding("custom"), false);
@@ -24,13 +25,14 @@ test("visible onboarding runtimes use the product order", () => {
   const runtimes = [
     runtime("buzz-agent", "available", "not_applicable"),
     runtime("codex", "available", "logged_in"),
+    runtime("qoder", "available", "logged_in"),
     runtime("goose", "available", "not_applicable"),
     runtime("claude", "available", "logged_in"),
   ];
 
   assert.deepEqual(
     getVisibleOnboardingRuntimes(runtimes).map(({ id }) => id),
-    ["claude", "codex"],
+    ["claude", "codex", "qoder"],
   );
 });
 
@@ -43,6 +45,10 @@ test("readiness requires an available and authenticated runtime", () => {
     runtimeIsReadyForOnboarding(
       runtime("codex", "available", "not_applicable"),
     ),
+    true,
+  );
+  assert.equal(
+    runtimeIsReadyForOnboarding(runtime("qoder", "available", "logged_in")),
     true,
   );
   assert.equal(
@@ -66,5 +72,14 @@ test("ready onboarding runtimes exclude hidden ready harnesses", () => {
   assert.deepEqual(
     getReadyOnboardingRuntimes(runtimes).map(({ id }) => id),
     ["claude"],
+  );
+});
+
+test("ready onboarding runtimes include authenticated Qoder", () => {
+  assert.deepEqual(
+    getReadyOnboardingRuntimes([
+      runtime("qoder", "available", "logged_in"),
+    ]).map(({ id }) => id),
+    ["qoder"],
   );
 });

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
@@ -1,6 +1,6 @@
 import type { AcpRuntimeCatalogEntry } from "@/shared/api/types";
 
-export const ONBOARDING_RUNTIME_ORDER = ["claude", "codex"];
+export const ONBOARDING_RUNTIME_ORDER = ["claude", "codex", "qoder"];
 
 const VISIBLE_ONBOARDING_RUNTIME_IDS = new Set<string>(
   ONBOARDING_RUNTIME_ORDER,

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -180,6 +180,8 @@ export type RawAcpRuntimeCatalogEntry = {
   mcp_command: string | null;
   model_env_var?: string | null;
   provider_env_var?: string | null;
+  /** Optional only for older E2E fixtures; the Rust catalog always supplies it. */
+  provider_locked?: boolean;
   thinking_env_var?: string | null;
   install_hint: string;
   install_instructions_url: string;
@@ -741,6 +743,7 @@ function fromRawAcpRuntimeCatalogEntry(
     mcpCommand: entry.mcp_command,
     modelEnvVar: entry.model_env_var ?? null,
     providerEnvVar: entry.provider_env_var ?? null,
+    providerLocked: entry.provider_locked ?? false,
     thinkingEnvVar: entry.thinking_env_var ?? null,
     installHint: entry.install_hint,
     installInstructionsUrl: entry.install_instructions_url,

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -543,6 +543,8 @@ export type AcpRuntimeCatalogEntry = {
   modelEnvVar: string | null;
   /** Environment variable used to apply the selected LLM provider, when supported. */
   providerEnvVar: string | null;
+  /** True when the harness owns provider selection and Buzz must clear any saved provider. */
+  providerLocked: boolean;
   /** Environment variable used to apply thinking effort, when supported. */
   thinkingEnvVar: string | null;
   installHint: string;

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -6911,6 +6911,7 @@ function withMockRuntimeConfigMetadata(
           : runtime.id === "goose"
             ? "GOOSE_PROVIDER"
             : null,
+    provider_locked: runtime.provider_locked ?? false,
     thinking_env_var:
       "thinking_env_var" in runtime
         ? runtime.thinking_env_var

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -3,7 +3,7 @@ import { installMockBridge } from "../helpers/bridge";
 import { passThroughBackupStep } from "../helpers/onboarding";
 
 function runtime(
-  id: "buzz-agent" | "claude" | "codex" | "goose",
+  id: "buzz-agent" | "claude" | "codex" | "goose" | "qoder",
   availability: string,
   authStatus: Record<string, unknown>,
   overrides: Record<string, unknown> = {},
@@ -17,7 +17,9 @@ function runtime(
           ? "Claude Code"
           : id === "codex"
             ? "Codex"
-            : "Goose",
+            : id === "qoder"
+              ? "Qoder"
+              : "Goose",
     avatar_url: "",
     availability,
     command: availability === "available" ? id : null,
@@ -57,9 +59,7 @@ async function readSavedRuntime(page: Parameters<typeof installMockBridge>[0]) {
   });
 }
 
-test("setup shows only Claude Code and Codex as detected harnesses", async ({
-  page,
-}) => {
+test("setup shows the supported CLI harnesses", async ({ page }) => {
   await installMockBridge(
     page,
     {
@@ -68,6 +68,16 @@ test("setup shows only Claude Code and Codex as detected harnesses", async ({
         runtime("goose", "available", { status: "not_applicable" }),
         runtime("codex", "available", { status: "logged_in" }),
         runtime("claude", "available", { status: "logged_in" }),
+        runtime(
+          "qoder",
+          "available",
+          { status: "logged_in" },
+          {
+            command: "qodercli",
+            binary_path: "/usr/local/bin/qodercli",
+            provider_locked: true,
+          },
+        ),
       ],
     },
     { skipCommunitySeed: true, skipOnboardingSeed: true },
@@ -77,6 +87,7 @@ test("setup shows only Claude Code and Codex as detected harnesses", async ({
 
   await expect(page.getByTestId("onboarding-runtime-claude")).toBeVisible();
   await expect(page.getByTestId("onboarding-runtime-codex")).toBeVisible();
+  await expect(page.getByTestId("onboarding-runtime-qoder")).toBeVisible();
   await expect(page.getByTestId("onboarding-runtime-goose")).toHaveCount(0);
   await expect(page.getByTestId("onboarding-runtime-buzz-agent")).toHaveCount(
     0,
@@ -145,6 +156,47 @@ test("ready state is detected and enables Next without persisting a default", as
   ).toHaveCount(0);
   await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
   expect(await readSavedRuntime(page)).toBeNull();
+});
+
+test("authenticated Qoder can continue and become the default harness", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime(
+          "qoder",
+          "available",
+          { status: "logged_in" },
+          {
+            command: "qodercli",
+            binary_path: "/usr/local/bin/qodercli",
+            provider_locked: true,
+          },
+        ),
+      ],
+      globalAgentConfig: {
+        env_vars: {},
+        provider: "anthropic",
+        model: null,
+        preferred_runtime: null,
+      },
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  await expect(page.getByTestId("onboarding-runtime-ready-qoder")).toHaveText(
+    "READY",
+  );
+  await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
+  await page.getByTestId("onboarding-setup-next").click();
+  await expect(page.getByTestId("global-agent-default-harness")).toHaveText(
+    "Qoder",
+  );
+  await expect.poll(() => readSavedRuntime(page)).toBe("qoder");
 });
 
 test("setup shows runtime discovery loading before rendering harnesses", async ({

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -92,7 +92,7 @@ type MockPersonaSeed = {
   sourceTeam?: string | null;
   envVars?: Record<string, string>;
   /**
-   * Runtime the persona is pinned to (e.g. "goose", "codex", "claude"). Lets a
+   * Runtime the persona is pinned to (e.g. "goose", "codex", "claude", "qoder"). Lets a
    * spec seed a CLI-login runtime whose provider picker is hidden, so the Edit
    * dialog's provider-aware submit gate can be driven end-to-end. Omitted →
    * null (definition inherits the app default at open).


### PR DESCRIPTION
## Summary

- add Qoder as a first-class desktop ACP runtime using its native `qodercli --acp` server
- provide platform install commands, login guidance, runtime configuration metadata, model discovery, managed-process cleanup, and `.qoder/skills` integration
- include authenticated Qoder installations in onboarding, readiness detection, and preferred-runtime selection
- expose provider ownership through the Rust runtime catalog so switching to Qoder clears stale Buzz-managed provider state and displays `Qoder (locked)` correctly
- define typed authentication-probe contracts and validate Qoder's `logged_in` JSON boolean strictly, failing closed on malformed, missing, or incorrectly typed responses

## Why

Buzz already supports Goose, Codex, and Claude Code, but Qoder users could not select or launch Qoder from the managed-agent runtime catalog. Qoder implements ACP directly, so Buzz can integrate it without an adapter.

Qoder's unauthenticated `status` command exits successfully and reports the real state through `{"logged_in": false}`. Exit status alone therefore cannot establish authentication. The catalog now declares whether a probe uses exit status or a required JSON boolean, preserving the existing Claude/Codex behavior while making Qoder fail closed.

The runtime catalog is also the single source of truth for provider capability. This prevents frontend runtime-ID guesses, removes stale providers when moving from a provider-backed runtime to Qoder, and keeps locked-provider labels runtime-specific.

## User impact

Users can install or select Qoder in Buzz, authenticate with `qodercli login`, choose it during onboarding, save it as the preferred runtime, launch its native ACP server, discover and switch Qoder models through ACP, and use Buzz skills from Qoder workspaces.

Existing agents switched to Qoder no longer retain an incompatible provider from their previous runtime. Invalid Qoder status output is shown conservatively as not ready instead of being accepted as authenticated.

## Validation

- `just ci` — passed
- desktop unit suite — 3,519 passed
- desktop Tauri suite — 1,643 unit tests plus 3 mixer diagnostics passed
- onboarding Playwright suite — 20 passed
- mobile Flutter suite — 585 passed, 1 skipped
- `cargo test -p buzz-acp` — 599 library tests and 9 integration tests passed
- `git diff --check` — passed
- manual Qoder CLI 1.1.5 ACP initialization returned `agentInfo.name = "qoder-cli"`; unauthenticated session creation correctly requested authentication
