### PR TITLE
fix(desktop): enable arboard wayland-data-control so copy works on Wayland

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -40,6 +40,14 @@ keyring = { version = "3.6.3", default-features = false, features = ["sync-secre
 # connection is dropped, which the plugin does immediately. Default features
 # keep the pure-Rust zbus backend, matching the plugin (no libdbus needed).
 notify-rust = "4"
+# Wayland clipboard support. Without this feature arboard has only the X11
+# backend, so on a Wayland session it writes through XWayland — where the
+# selection is owned by a client the compositor never surfaces to Wayland
+# clients. `set_text` returns Ok against a clipboard nothing can read (and
+# clears the real one), which surfaces as a copy button that reports success
+# and leaves the clipboard empty. Feature-unifies with the [dependencies]
+# entry; other platforms are unaffected.
+arboard = { version = "3", features = ["wayland-data-control"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSHapticFeedback"] }


### PR DESCRIPTION
Fixes #2896.

## What's broken

Every native copy in the desktop app — invite links, message text, pubkeys — reports success and leaves the clipboard empty on a Wayland session.

## Why

`arboard` only compiles its Wayland backend when the `wayland-data-control` feature is enabled. Without it the Linux build has just the X11 backend, so on a Wayland session it writes through XWayland, where the selection is owned by a client the compositor never surfaces to Wayland clients. `set_text` returns `Ok` against a clipboard nothing can read — and the write clears the real one, which is why the paste comes back *empty* rather than stale.

That `Ok` is what makes it silent: `InviteLinkSection.handleCopy` flips to the "Copied" check state and fires the success toast, and no error toast ever appears.

## Evidence

Measured on Arch Linux / Hyprland against the **0.4.26 release binary**:

```
strings buzz-desktop | grep -c zwlr_data_control_manager_v1   ->  0

arboard set_text                                              ->  Ok
arboard get_text  (X11)   ->  "BUZZ_ARBOARD_TEST_12345"           present
wl-paste          (Wayland) ->  "Nothing is copied"                absent
```

Same probe against a build with this patch: 15 matches for `zwlr_data_control_manager_v1`, and `wl-paste` returns the text.

## The change

One dependency line, declared in the `cfg(target_os = "linux")` section so the feature unifies onto the existing `[dependencies]` entry without touching macOS or Windows builds.

No code changes are needed: `ClipboardState` already holds the `arboard::Clipboard` for the process lifetime, so the data-control backend has a live owner to serve the selection from.

## Testing

Built `tauri build --no-bundle` and running it as my daily driver on Hyprland. Copy buttons that silently no-op'd on the stock 0.4.26 binary now land text on the clipboard.

Reviewers on macOS/Windows: worth confirming the feature-unification doesn't perturb your dependency tree — it shouldn't, `wl-clipboard-rs` is already target-gated inside arboard.