### PR TITLE
fix(onboarding): hide skip when both harnesses are ready

### DIFF
--- a/desktop/src/features/onboarding/ui/SetupStep.tsx
+++ b/desktop/src/features/onboarding/ui/SetupStep.tsx
@@ -18,6 +18,7 @@ import { FlappingBee } from "@/shared/ui/buzz-logo/FlappingBee";
 import { Spinner } from "@/shared/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import {
+  allOnboardingRuntimesAreReady,
   getReadyOnboardingRuntimes,
   getVisibleOnboardingRuntimes,
   runtimeIsReadyForOnboarding,
@@ -663,6 +664,9 @@ function SetupStepContent({
       ),
     [runtimeProviders.items],
   );
+  const areAllRuntimesReady = allOnboardingRuntimesAreReady(
+    runtimeProviders.items,
+  );
   const readyRuntimeIdsKey = readyRuntimeIds.join("\0");
   // The key prevents catalog object refreshes from creating an effect loop
   // when the detected ready IDs have not changed.
@@ -695,15 +699,17 @@ function SetupStepContent({
           Next
         </Button>
 
-        <Button
-          className="h-9 rounded-full bg-foreground/10 px-6 text-sm hover:bg-foreground/15"
-          data-testid="onboarding-setup-skip"
-          onClick={() => actions.next([])}
-          type="button"
-          variant="ghost"
-        >
-          Skip for now
-        </Button>
+        {!areAllRuntimesReady ? (
+          <Button
+            className="h-9 rounded-full bg-foreground/10 px-6 text-sm hover:bg-foreground/15"
+            data-testid="onboarding-setup-skip"
+            onClick={() => actions.next([])}
+            type="button"
+            variant="ghost"
+          >
+            Skip for now
+          </Button>
+        ) : null}
 
         <Button
           className="h-9 rounded-full bg-foreground/10 px-6 text-sm hover:bg-foreground/15"

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  allOnboardingRuntimesAreReady,
   getReadyOnboardingRuntimes,
   getVisibleOnboardingRuntimes,
   runtimeIsReadyForOnboarding,
@@ -66,5 +67,28 @@ test("ready onboarding runtimes exclude hidden ready harnesses", () => {
   assert.deepEqual(
     getReadyOnboardingRuntimes(runtimes).map(({ id }) => id),
     ["claude"],
+  );
+});
+
+test("all onboarding runtimes are ready only when both Claude and Codex are ready", () => {
+  assert.equal(
+    allOnboardingRuntimesAreReady([
+      runtime("claude", "available", "logged_in"),
+      runtime("codex", "available", "logged_in"),
+    ]),
+    true,
+  );
+  assert.equal(
+    allOnboardingRuntimesAreReady([
+      runtime("claude", "available", "logged_in"),
+      runtime("codex", "available", "logged_out"),
+    ]),
+    false,
+  );
+  assert.equal(
+    allOnboardingRuntimesAreReady([
+      runtime("claude", "available", "logged_in"),
+    ]),
+    false,
   );
 });

--- a/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
+++ b/desktop/src/features/onboarding/ui/onboardingRuntimeSelection.ts
@@ -37,3 +37,14 @@ export function getReadyOnboardingRuntimes(
     runtimeIsReadyForOnboarding,
   );
 }
+
+export function allOnboardingRuntimesAreReady(
+  runtimes: readonly AcpRuntimeCatalogEntry[],
+) {
+  return ONBOARDING_RUNTIME_ORDER.every((runtimeId) =>
+    runtimes.some(
+      (runtime) =>
+        runtime.id === runtimeId && runtimeIsReadyForOnboarding(runtime),
+    ),
+  );
+}

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -144,7 +144,34 @@ test("ready state is detected and enables Next without persisting a default", as
     page.getByTestId("onboarding-runtime-checkmark-codex"),
   ).toHaveCount(0);
   await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
+  await expect(page.getByTestId("onboarding-setup-skip")).toBeVisible();
   expect(await readSavedRuntime(page)).toBeNull();
+});
+
+test("setup hides Skip for now when both harnesses are ready", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime("claude", "available", { status: "logged_in" }),
+        runtime("codex", "available", { status: "logged_in" }),
+      ],
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+
+  await expect(
+    page.getByTestId("onboarding-runtime-ready-claude"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("onboarding-runtime-ready-codex"),
+  ).toBeVisible();
+  await expect(page.getByTestId("onboarding-setup-next")).toBeEnabled();
+  await expect(page.getByTestId("onboarding-setup-skip")).toHaveCount(0);
 });
 
 test("setup shows runtime discovery loading before rendering harnesses", async ({


### PR DESCRIPTION
## Summary
- hide `Skip for now` after both Claude Code and Codex report ready
- keep the recovery action visible while either supported harness still needs setup
- add unit coverage for the all-ready predicate and Playwright coverage for one-ready and both-ready states

The setup footer previously rendered the bypass action unconditionally, so users who had completed both harnesses still saw a contradictory way to skip configuration next to the enabled `Next` action.

### Related issue
N/A — searched open issues and PRs; no duplicate found.

### Testing
- `just ci`
- focused Playwright onboarding coverage for one-ready, both-ready, and concurrent-install states (3 passed)