### PR TITLE
fix(desktop): keep the space after a mention through the markdown parse

### DIFF
--- a/desktop/src/features/messages/lib/markdownTrailingWhitespace.test.mjs
+++ b/desktop/src/features/messages/lib/markdownTrailingWhitespace.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { markdownTrailingWhitespace } from "./markdownTrailingWhitespace.ts";
+
+// The markdown parse behind `setContent` drops end-of-line whitespace, which
+// silently breaks mention chips (`@Name ` → `@Name`, next keystroke →
+// `@Nameabc`, recipient dropped). This decides what gets put back.
+
+test("captures the single trailing space after a mention", () => {
+  assert.equal(markdownTrailingWhitespace("@Morgarita "), " ");
+});
+
+test("captures the trailing space after multiple mentions", () => {
+  assert.equal(markdownTrailingWhitespace("@Vogue @Morgarita "), " ");
+});
+
+test("returns null when there is no trailing whitespace", () => {
+  assert.equal(markdownTrailingWhitespace("@Morgarita"), null);
+  assert.equal(markdownTrailingWhitespace(""), null);
+});
+
+test("returns null for whitespace-only input", () => {
+  // Nothing to trail. Restoring here would leave a composer that reads as
+  // non-empty — Send enabled, placeholder suppressed — on an empty draft.
+  assert.equal(markdownTrailingWhitespace(" "), null);
+  assert.equal(markdownTrailingWhitespace("   \t"), null);
+});
+
+test("captures a mixed run of spaces and tabs", () => {
+  assert.equal(markdownTrailingWhitespace("@Morgarita \t "), " \t ");
+});
+
+test("captures whitespace trailing the last line only", () => {
+  assert.equal(markdownTrailingWhitespace("first line\n@Morgarita "), " ");
+});
+
+test("returns null when the string ends on a newline", () => {
+  // The caret lands on the empty final line, so nothing needs restoring.
+  assert.equal(markdownTrailingWhitespace("@Morgarita \n"), null);
+});
+
+test("ignores interior whitespace", () => {
+  assert.equal(markdownTrailingWhitespace("@Morgarita  hello"), null);
+});

--- a/desktop/src/features/messages/lib/markdownTrailingWhitespace.ts
+++ b/desktop/src/features/messages/lib/markdownTrailingWhitespace.ts
@@ -1,0 +1,58 @@
+import type { Editor } from "@tiptap/core";
+import { Selection } from "@tiptap/pm/state";
+
+/**
+ * The run of spaces/tabs at the very end of `markdown`, or `null` when there
+ * is none.
+ *
+ * A whitespace-only string yields `null` on purpose: there is no content for
+ * the whitespace to trail, and restoring it would leave a "blank" composer
+ * that reads as non-empty (enabling Send, suppressing the placeholder).
+ */
+export function markdownTrailingWhitespace(markdown: string): string | null {
+  return /[^ \t]([ \t]+)$/.exec(markdown)?.[1] ?? null;
+}
+
+/**
+ * Re-append trailing spaces/tabs that a markdown parse dropped.
+ *
+ * `setContent` runs its argument through `tiptap-markdown`, and markdown-it
+ * discards end-of-line whitespace — `"@Name "` parses to `<p>@Name</p>`. That
+ * lone character is load-bearing: mention chips are inline decorations over
+ * plain text (see `mentionHighlightExtension`), matched only when a boundary
+ * follows the name. Restore the caret flush against `@Name` and the next
+ * keystroke produces `@Nameabc`, which stops matching — the chip disappears
+ * and `extractMentionPubkeys` no longer resolves the name, so the recipient is
+ * silently dropped from the outgoing event.
+ *
+ * The whitespace survives *serialization* (drafts on disk keep it), so it is
+ * recoverable here, at the single parse boundary, rather than at each of the
+ * call sites that reload composer content: post-send refill, draft restore on
+ * channel/thread switch, loading a message to edit, cancelling an edit, and
+ * restoring after a failed send.
+ *
+ * Uses the `preventUpdate` meta so the repair is invisible to the user-edit
+ * observers — the same mechanism `setContent`'s `emitUpdate: false` uses.
+ * Without it the insert looks like a keystroke and re-opens the mention
+ * autocomplete on every channel switch.
+ */
+export function restoreMarkdownTrailingWhitespace(
+  editor: Editor,
+  markdown: string,
+): void {
+  const trailing = markdownTrailingWhitespace(markdown);
+  if (!trailing) return;
+
+  const end = Selection.atEnd(editor.state.doc).from;
+  // Idempotence guard: if the parser ever starts preserving the whitespace,
+  // this must not double it.
+  const existing = editor.state.doc.textBetween(
+    Math.max(0, end - trailing.length),
+    end,
+  );
+  if (existing === trailing) return;
+
+  editor.view.dispatch(
+    editor.state.tr.insertText(trailing, end).setMeta("preventUpdate", true),
+  );
+}

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -26,6 +26,7 @@ import {
   mentionHighlightKey,
 } from "./mentionHighlightExtension";
 import { CUSTOM_EMOJI_NODE_NAME } from "./customEmojiNode";
+import { restoreMarkdownTrailingWhitespace } from "./markdownTrailingWhitespace";
 import { useComposerCustomEmoji } from "./useComposerCustomEmoji";
 import { buildPlainTextProjection } from "./plainTextProjection";
 import { createLinkInteractionExtension } from "./linkInteractionExtension";
@@ -681,6 +682,7 @@ export function useRichTextEditor({
     (markdown: string) => {
       if (!editor) return;
       editor.commands.setContent(markdown);
+      restoreMarkdownTrailingWhitespace(editor, markdown);
     },
     [editor],
   );
@@ -689,13 +691,12 @@ export function useRichTextEditor({
     (markdown: string) => {
       if (!editor) return;
       // The caller already synchronizes composer state. Keep this programmatic
-      // restoration out of user-edit observers (autocomplete/reconciliation),
-      // then move selection in the same command chain.
-      editor
-        .chain()
-        .setContent(markdown, { emitUpdate: false })
-        .focus("end")
-        .run();
+      // restoration out of user-edit observers (autocomplete/reconciliation).
+      editor.commands.setContent(markdown, { emitUpdate: false });
+      // Repair before focusing: the caret must land *after* any trailing
+      // whitespace the parse dropped, not flush against the last character.
+      restoreMarkdownTrailingWhitespace(editor, markdown);
+      editor.commands.focus("end");
     },
     [editor],
   );

--- a/desktop/tests/e2e/persistent-agent-audience.spec.ts
+++ b/desktop/tests/e2e/persistent-agent-audience.spec.ts
@@ -66,6 +66,25 @@ async function emitRootMessage(
   return event;
 }
 
+/**
+ * Assert the composer's *exact* text, trailing whitespace included.
+ *
+ * `toHaveText` normalizes whitespace, so `"@Morgarita"` and `"@Morgarita "`
+ * both satisfy it — which is how a dropped trailing space shipped past an
+ * assertion written to guard that very space. Mention chips are decorations
+ * over plain text and only match when a boundary follows the name, so the
+ * space is the difference between the next keystroke starting a message and
+ * it corrupting the mention.
+ */
+async function expectExactComposerText(
+  input: ReturnType<Page["getByTestId"]>,
+  expected: string,
+) {
+  await expect
+    .poll(() => input.evaluate((element) => element.textContent))
+    .toBe(expected);
+}
+
 function channelComposer(page: Page) {
   return page.getByTestId("channel-composer-overlay");
 }
@@ -147,7 +166,7 @@ test("persistent agents transition atomically before Enter-send resolves", async
 
   // The network send is still pending, so this is the first observable
   // post-submit editor state rather than the later success hydration pass.
-  await expect(input).toHaveText("@Morgarita ", { timeout: 500 });
+  await expectExactComposerText(input, "@Morgarita ");
   await expect(input.locator(".agent-mention-highlight")).toHaveCount(1, {
     timeout: 500,
   });
@@ -184,6 +203,52 @@ test("persistent agents transition atomically before Enter-send resolves", async
       }),
     )
     .toEqual({ empty: true, atDocumentEnd: true });
+});
+
+test("typing straight after a send extends the message, not the mention", async ({
+  page,
+}) => {
+  await seedAudience(page, [AGENT_A]);
+  await installAudienceFixtures(page);
+  await openThread(page);
+
+  const composer = threadComposer(page);
+  const input = composer.getByTestId("message-input");
+  await input.fill("@Morgarita hello");
+  await input.press("Enter");
+
+  // The post-send refill goes through the markdown parse, which used to eat
+  // the trailing space and leave the caret flush against the mention.
+  await expectExactComposerText(input, "@Morgarita ");
+  await input.pressSequentially("next");
+
+  await expect(input).toHaveText("@Morgarita next");
+  await expect(input.locator(".agent-mention-highlight")).toHaveCount(1);
+});
+
+test("a mention survives the draft round-trip when a thread is reopened", async ({
+  page,
+}) => {
+  await seedAudience(page, [AGENT_A]);
+  await installAudienceFixtures(page);
+  await openThread(page);
+
+  const composer = threadComposer(page);
+  const input = composer.getByTestId("message-input");
+  await expectExactComposerText(input, "@Morgarita ");
+
+  // Leaving the thread persists the composer to the draft store; returning
+  // reloads it through the same markdown parse. Hydration cannot repair the
+  // result — it only inserts mentions that are *absent*, and this one is
+  // present, just unspaced.
+  await openGeneral(page);
+  await openThread(page);
+
+  await expectExactComposerText(input, "@Morgarita ");
+  await input.pressSequentially("hi");
+
+  await expect(input).toHaveText("@Morgarita hi");
+  await expect(input.locator(".agent-mention-highlight")).toHaveCount(1);
 });
 
 test("timeline agent send remains one-shot and returns to the placeholder", async ({


### PR DESCRIPTION
## The problem

Send a message to an agent, start typing the next one, and the caret is already inside the mention chip. The next keystroke fuses into the mention — `@Bumble` + `asdf` becomes `@Bumbleasdf` — the blue chip vanishes, and the message goes out **without the agent as a recipient.** The agent never sees it. The broken chip is only the visible tell; the silent recipient drop is the actual cost.

Two independent reports, which turned out to be one bug reached from two directions:

1. Immediately after sending in a channel.
2. Opening a thread that already had an agent in the composer.

### Root cause

The composer refills itself with `"@Name "` — that trailing space is deliberate, and both producers write it (`useMentions.ts` `insertResolvedMention`, `usePersistentAgentMentionHydration.ts` `resolvePostSendContent`).

The string then goes through `richText.setContent()`, and because `tiptap-markdown` is registered, `setContent(string)` is a **markdown parse**, not a literal insert. markdown-it discards end-of-line whitespace:

```
input:  "@Name "
output: "<p>@Name</p>"
```

So the composer really holds `@Name` with the caret flush against the final character.

That single character is load-bearing. Mention chips are ProseMirror **inline decorations over plain text**, not atomic nodes, and both the decoration regex and the extraction regex require a boundary after the name:

```ts
// mentionHighlightExtension.ts
`(?:^|(?<=[\\s(]))@(${names})(?=\\W|$)`
// mentionPattern.ts
const boundary = "(?=[\\s,;.!?:)\\]}]|$)";
```

Type a word character and both stop matching — decoration gone, `extractMentionPubkeys` returns nothing, no `p` tag on the outgoing event.

Hydration cannot repair it: `hydrate()` only inserts mentions that are **absent** (`usePersistentAgentMentionHydration.ts:67-71`), and the mention is present — just unspaced. The broken state is then persisted back into the draft, so it survives navigation.

### Why it looked timing-dependent

It isn't. It is deterministic, but only on the paths that re-parse. `hydrate()` inserts through `replacePlainTextRange` → `tr.insertText` — verbatim, space intact — which is why a freshly opened channel behaves correctly and the bug reads as a race.

### Why the caret renders mid-word

The caret is at the correct model position (end of document). That position is now *inside* the chip span, and the chip reserves left padding for its absolutely-positioned agent icon (`markdown.css`). Measuring the reported screenshot: chip left edge 34px + width of `Bumble` 50.5px = caret at 84.5px — exactly one `padding-left` short of the glyph run's real end. With the space present the caret sits outside the chip and none of it shows.

### Approaches considered

**Rewrite the post-send call site to use `replacePlainTextRange`** (the verbatim path). Correct for that one site, but there are five sites with the same defect — post-send refill, draft restore, loading a message to edit, cancelling an edit, restoring after a failed send — and it leaves two mechanisms that have to keep agreeing about whitespace.

**Repair at the parse boundary** (this PR). One place, all five sites, and it composes with however the composer is reloaded next.

The repair is only possible because the whitespace survives *serialization* — drafts on disk keep it. Verified against the real serializer/parser pair rather than assumed:

```
defaultMarkdownSerializer.serialize(<p>@Fizz␣</p>) → "@Fizz "   ← space survives the write
defaultMarkdownParser.parse("@Fizz ").textContent → "@Fizz"    ← space dies on the read
```

## The solution

`restoreMarkdownTrailingWhitespace(editor, markdown)` re-appends the run of spaces/tabs the parse dropped, called after the parse in both `setContent` and `setContentAndFocusEnd`.

In `setContentAndFocusEnd` the repair runs **before** `focus("end")`, so the caret lands after the space rather than in front of it. That required unrolling the previous single `.chain()`; the `emitUpdate: false` intent is preserved.

Edge cases:

- **Whitespace-only input returns `null`.** There is nothing for the whitespace to trail, and restoring it would leave a composer that reads as non-empty — Send enabled, placeholder suppressed — on what should be an empty draft.
- **Input ending on a newline returns `null`.** The caret lands on the empty final line; nothing needs restoring.
- **Idempotence guard.** If the parser ever starts preserving trailing whitespace, the existing run is detected and the insert is skipped rather than doubled.
- **`preventUpdate` meta.** The repair dispatch is invisible to the user-edit observers — the same mechanism `setContent`'s `emitUpdate: false` uses. Without it the insert looks like a keystroke and re-opens the mention autocomplete on every channel switch. This is the line most worth a reviewer's eye.

## Tests

The existing guard could not see this bug:

```ts
await expect(input).toHaveText("@Morgarita ", { timeout: 500 });
```

`toHaveText` normalizes whitespace, so `"@Morgarita"` and `"@Morgarita "` both satisfy it — an assertion written specifically to protect the trailing space, blind to its absence. Replaced with an exact `textContent` read via a shared `expectExactComposerText` helper.

Added:

- `markdownTrailingWhitespace.test.mjs` — 8 unit tests over the extraction rule.
- **`typing straight after a send extends the message, not the mention`** — reproduces report 1 by actually typing after the refill.
- **`a mention survives the draft round-trip when a thread is reopened`** — reproduces report 2 by leaving and re-entering the thread, exercising the persist → localStorage → parse path.

Every new assertion was confirmed to **fail without the fix and pass with it** — the tests were run against the unfixed build first, and all three (the two new ones plus the tightened existing one) failed there. A test that cannot fail proves nothing, which is exactly how this bug shipped.

```
desktop unit          3523 passed, 0 failed
typecheck             clean
biome check + guards  clean
playwright smoke      713 passed, 1 failed, 2 flaky, 1 skipped
```

The one smoke failure is `video-attachment.spec.ts:223` (poster frames). It is **pre-existing and unrelated** — verified by reverting this change and re-running that spec alone, where it fails identically.

## Broader context

Mention chips being decorations over raw text rather than atomic nodes means **any** caret adjacent to a mention is one keystroke away from silently dropping a recipient, regardless of how the text arrived. This PR closes the five known ways to land there. A `handleTextInput` guard — insert a space when a word character is typed at the end of a mention decoration — would close the class rather than the instances, but that changes typing behaviour and belongs in its own change.

Worth noting what the failure mode costs: there is no error, no warning, and the message still sends. The only signal is an agent that stays quiet.

Reported by @peterw in the `accent-app` channel.
