### PR TITLE
chore(docker): make Postgres host port configurable via POSTGRES_PORT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_DB: buzz
       PGDATA: /var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
### What changed?

Made the Postgres host port in `docker-compose.yml` overridable via the `POSTGRES_PORT` environment variable (defaults to `5432`).

```yaml
ports:
  - "${POSTGRES_PORT:-5432}:5432"
```

### Why?

The Postgres service hardcoded host port `5432`. When a developer already runs a local Postgres on `5432`, `docker compose up` fails with a port conflict. Letting the host port be overridden via `POSTGRES_PORT` (e.g. `POSTGRES_PORT=5433` in `.env`) avoids the collision without touching the in-container port or the `DATABASE_URL`.

The default keeps current behavior intact, so existing setups are unaffected.

### How is it tested?

- `docker compose config` resolves the port mapping to `5432:5432` by default and honors `POSTGRES_PORT` when set.
- No code or CI changes — compose file only.
