### PR TITLE
fix(desktop): dedupe Codex model effort variants

### DIFF
--- a/desktop/src-tauri/src/commands/agent_model_normalization.rs
+++ b/desktop/src-tauri/src/commands/agent_model_normalization.rs
@@ -1,0 +1,105 @@
+use std::collections::HashSet;
+
+use crate::managed_agents::{AgentModelInfo, AgentModelsResponse};
+
+fn effort_qualified_base_model_id(model_id: &str) -> Option<&str> {
+    let (base_model_id, effort) = model_id.rsplit_once('[')?;
+    let effort = effort.strip_suffix(']')?;
+    (!base_model_id.is_empty() && !effort.is_empty()).then_some(base_model_id)
+}
+
+/// Normalize raw `buzz-acp models --json` output into a typed DTO for the frontend.
+///
+/// Merges models from both ACP paths (stable configOptions + unstable SessionModelState),
+/// deduplicates equivalent entries, and returns a unified list.
+///
+/// Some agents expose a base model through stable config options while retaining
+/// effort-qualified IDs such as `model[high]` in the legacy model state. Buzz's
+/// model setting is currently one-dimensional for those agents, so the qualified
+/// IDs are the actionable choices. Suppress the redundant base entry when those
+/// richer variants are present.
+pub(super) fn normalize_agent_models(
+    raw: &serde_json::Value,
+    persisted_model: Option<String>,
+) -> AgentModelsResponse {
+    let agent_name = raw["agent"]["name"]
+        .as_str()
+        .unwrap_or("unknown")
+        .to_string();
+    let agent_version = raw["agent"]["version"]
+        .as_str()
+        .unwrap_or("unknown")
+        .to_string();
+
+    let mut models: Vec<AgentModelInfo> = Vec::new();
+    let mut seen_ids: HashSet<String> = HashSet::new();
+    let effort_qualified_base_ids: HashSet<&str> = raw["unstable"]["availableModels"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|model| model.get("modelId").and_then(|value| value.as_str()))
+        .filter_map(effort_qualified_base_model_id)
+        .collect();
+
+    // 1. Stable configOptions (preferred). Only entries with category "model"
+    //    are model options — the CLI pre-filters, but we're defensive here.
+    if let Some(config_options) = raw["stable"]["configOptions"].as_array() {
+        for opt in config_options {
+            if opt.get("category").and_then(|c| c.as_str()) != Some("model") {
+                continue;
+            }
+            if let Some(options) = opt.get("options").and_then(|v| v.as_array()) {
+                for o in options {
+                    if let Some(value) = o.get("value").and_then(|v| v.as_str()) {
+                        if effort_qualified_base_ids.contains(value) {
+                            continue;
+                        }
+                        if seen_ids.insert(value.to_string()) {
+                            models.push(AgentModelInfo {
+                                id: value.to_string(),
+                                name: o
+                                    .get("displayName")
+                                    .and_then(|v| v.as_str())
+                                    .map(str::to_string),
+                                description: None,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // 2. Unstable availableModels (fallback — skip duplicates from stable).
+    let mut agent_default_model: Option<String> = None;
+    if let Some(unstable) = raw.get("unstable") {
+        agent_default_model = unstable["currentModelId"].as_str().map(str::to_string);
+        if let Some(available) = unstable["availableModels"].as_array() {
+            for m in available {
+                if let Some(id) = m.get("modelId").and_then(|v| v.as_str()) {
+                    if seen_ids.insert(id.to_string()) {
+                        models.push(AgentModelInfo {
+                            id: id.to_string(),
+                            name: m.get("name").and_then(|v| v.as_str()).map(str::to_string),
+                            description: m
+                                .get("description")
+                                .and_then(|v| v.as_str())
+                                .map(str::to_string),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    let supports_switching = !models.is_empty();
+
+    AgentModelsResponse {
+        agent_name,
+        agent_version,
+        models,
+        agent_default_model,
+        selected_model: persisted_model,
+        supports_switching,
+    }
+}

--- a/desktop/src-tauri/src/commands/agent_model_process.rs
+++ b/desktop/src-tauri/src/commands/agent_model_process.rs
@@ -5,7 +5,7 @@ use crate::managed_agents::{
     redact_env_values_in, AgentModelsResponse,
 };
 
-use super::agent_models::normalize_agent_models;
+use super::agent_model_normalization::normalize_agent_models;
 
 pub(super) async fn run_agent_models_command(
     resolved_acp: PathBuf,

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -4,6 +4,8 @@ use nostr::Keys;
 use serde::Deserialize;
 use tauri::{AppHandle, State};
 
+#[cfg(test)]
+use super::agent_model_normalization::normalize_agent_models;
 use super::agent_model_process::run_agent_models_command;
 // The map-only lookup is reached solely from the base-URL helpers that exist for
 // their unit tests; discovery itself always goes through the process-env variant.
@@ -982,88 +984,6 @@ pub async fn update_managed_agent(
         agent: summary,
         profile_sync_error: None,
     })
-}
-
-// ── Model normalization ───────────────────────────────────────────────────────
-
-/// Normalize raw `buzz-acp models --json` output into a typed DTO for the frontend.
-///
-/// Merges models from both ACP paths (stable configOptions + unstable SessionModelState),
-/// deduplicates by ID (stable takes precedence), and returns a unified list.
-pub(super) fn normalize_agent_models(
-    raw: &serde_json::Value,
-    persisted_model: Option<String>,
-) -> AgentModelsResponse {
-    let agent_name = raw["agent"]["name"]
-        .as_str()
-        .unwrap_or("unknown")
-        .to_string();
-    let agent_version = raw["agent"]["version"]
-        .as_str()
-        .unwrap_or("unknown")
-        .to_string();
-
-    let mut models: Vec<AgentModelInfo> = Vec::new();
-    let mut seen_ids: HashSet<String> = HashSet::new();
-
-    // 1. Stable configOptions (preferred). Only entries with category "model"
-    //    are model options — the CLI pre-filters, but we're defensive here.
-    if let Some(config_options) = raw["stable"]["configOptions"].as_array() {
-        for opt in config_options {
-            if opt.get("category").and_then(|c| c.as_str()) != Some("model") {
-                continue;
-            }
-            if let Some(options) = opt.get("options").and_then(|v| v.as_array()) {
-                for o in options {
-                    if let Some(value) = o.get("value").and_then(|v| v.as_str()) {
-                        if seen_ids.insert(value.to_string()) {
-                            models.push(AgentModelInfo {
-                                id: value.to_string(),
-                                name: o
-                                    .get("displayName")
-                                    .and_then(|v| v.as_str())
-                                    .map(str::to_string),
-                                description: None,
-                            });
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    // 2. Unstable availableModels (fallback — skip duplicates from stable).
-    let mut agent_default_model: Option<String> = None;
-    if let Some(unstable) = raw.get("unstable") {
-        agent_default_model = unstable["currentModelId"].as_str().map(str::to_string);
-        if let Some(available) = unstable["availableModels"].as_array() {
-            for m in available {
-                if let Some(id) = m.get("modelId").and_then(|v| v.as_str()) {
-                    if seen_ids.insert(id.to_string()) {
-                        models.push(AgentModelInfo {
-                            id: id.to_string(),
-                            name: m.get("name").and_then(|v| v.as_str()).map(str::to_string),
-                            description: m
-                                .get("description")
-                                .and_then(|v| v.as_str())
-                                .map(str::to_string),
-                        });
-                    }
-                }
-            }
-        }
-    }
-
-    let supports_switching = !models.is_empty();
-
-    AgentModelsResponse {
-        agent_name,
-        agent_version,
-        models,
-        agent_default_model,
-        selected_model: persisted_model,
-        supports_switching,
-    }
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/commands/agent_models_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_tests.rs
@@ -149,6 +149,99 @@ fn anthropic_model_normalization_uses_display_names() {
 }
 
 #[test]
+fn model_normalization_suppresses_base_ids_with_effort_qualified_variants() {
+    let raw = serde_json::json!({
+        "agent": {
+            "name": "codex-acp",
+            "version": "1.1.7"
+        },
+        "stable": {
+            "configOptions": [{
+                "id": "model",
+                "category": "model",
+                "options": [{
+                    "value": "gpt-5.6-sol",
+                    "name": "GPT-5.6-SOL"
+                }]
+            }]
+        },
+        "unstable": {
+            "currentModelId": "gpt-5.6-sol[medium]",
+            "availableModels": [
+                {
+                    "modelId": "gpt-5.6-sol[low]",
+                    "name": "GPT-5.6-SOL (low)"
+                },
+                {
+                    "modelId": "gpt-5.6-sol[medium]",
+                    "name": "GPT-5.6-SOL (medium)"
+                },
+                {
+                    "modelId": "gpt-5.6-sol[high]",
+                    "name": "GPT-5.6-SOL (high)"
+                }
+            ]
+        }
+    });
+
+    let response = normalize_agent_models(&raw, None);
+    let ids: Vec<&str> = response
+        .models
+        .iter()
+        .map(|model| model.id.as_str())
+        .collect();
+
+    assert_eq!(
+        ids,
+        vec![
+            "gpt-5.6-sol[low]",
+            "gpt-5.6-sol[medium]",
+            "gpt-5.6-sol[high]"
+        ]
+    );
+    assert_eq!(
+        response.agent_default_model.as_deref(),
+        Some("gpt-5.6-sol[medium]")
+    );
+}
+
+#[test]
+fn model_normalization_keeps_stable_ids_without_qualified_variants() {
+    let raw = serde_json::json!({
+        "agent": {
+            "name": "test-agent",
+            "version": "1.0.0"
+        },
+        "stable": {
+            "configOptions": [{
+                "configId": "model",
+                "category": "model",
+                "options": [
+                    { "value": "gpt-5", "displayName": "GPT-5" },
+                    { "value": "gpt-5.6", "displayName": "GPT-5.6" }
+                ]
+            }]
+        },
+        "unstable": {
+            "currentModelId": "gpt-5.6[high]",
+            "availableModels": [{
+                "modelId": "gpt-5.6[high]",
+                "name": "GPT-5.6 (high)"
+            }]
+        }
+    });
+
+    let response = normalize_agent_models(&raw, None);
+    let ids: Vec<&str> = response
+        .models
+        .iter()
+        .map(|model| model.id.as_str())
+        .collect();
+
+    assert_eq!(ids, vec!["gpt-5", "gpt-5.6[high]"]);
+}
+
+#[test]
 fn redaction_env_records_value_used_for_request() {
     let env = BTreeMap::from([("OPENAI_COMPAT_API_KEY".to_string(), "   ".to_string())]);
 

--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ mod agent_config;
 mod agent_discovery;
 mod agent_logs;
 mod agent_metric_archive;
+mod agent_model_normalization;
 mod agent_model_process;
 mod agent_models;
 mod agent_models_env;


### PR DESCRIPTION
## Summary

- suppress a redundant stable base-model option when the ACP legacy model state exposes effort-qualified variants of that exact model
- keep the effort-qualified IDs as the actionable choices, including the harness-reported default
- preserve unrelated stable models and guard against prefix collisions such as `gpt-5` versus `gpt-5.6[high]`

## User impact

Codex model discovery currently exposes both:

- `gpt-5.6-sol`
- `gpt-5.6-sol[low|medium|high]`

Buzz therefore renders the base model alongside each thinking-effort choice. After this change, users see only the actionable low, medium, and high variants.

## Root cause

`normalize_agent_models` merges ACP's stable `configOptions` catalog with its legacy `SessionModelState` catalog and previously deduplicated only exact IDs. Codex ACP now represents the same model family differently across those paths: the stable path uses the base ID, while the compatibility path retains effort-qualified IDs.

Buzz currently persists one model ID for Codex and treats effort as model-owned, so the qualified legacy IDs contain the information needed to apply the user's choice. The normalization layer is therefore the narrowest place to remove the redundant representation without changing persistence or introducing a Codex-specific model table.

The rule is intentionally generic and conservative: a stable ID is suppressed only when an unstable ID has the exact form `<stable-id>[<non-empty qualifier>]`. Stable-only models remain visible.

## Related work

This does not duplicate #2171. That PR adds harness-native effort configuration for Goose and Claude while explicitly retaining Codex's model-owned effort behavior; it does not change model catalog deduplication.

## Verification

- `cargo test --manifest-path desktop/src-tauri/Cargo.toml commands::agent_models::tests --lib` — 20 passed
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --lib -- -D warnings`
- `cd desktop && pnpm check:file-sizes`
- `just ci`
- DCO-signed commit