### PR TITLE
fix(desktop): resolve overlapping mention recipients by span

### DIFF
--- a/desktop/src/features/messages/lib/hasMention.ts
+++ b/desktop/src/features/messages/lib/hasMention.ts
@@ -153,3 +153,106 @@ export function getMentionOffset(text: string, name: string): number | null {
 export function hasMention(text: string, name: string): boolean {
   return getMentionOffset(text, name) !== null;
 }
+
+type MentionOccurrence = {
+  end: number;
+  name: string;
+  preferred: boolean;
+  start: number;
+};
+
+function mentionOccurrences(
+  maskedText: string,
+  name: string,
+  preferred: boolean,
+): MentionOccurrence[] {
+  const escaped = escapeRegExp(name);
+  const pattern = new RegExp(
+    `(^|\\s|\\(|[*_]{1,3}|\\|\\|)(@${escaped})(?=\\|\\||[\\s,;.!?:)\\]}*_]|$)`,
+    "gi",
+  );
+  const occurrences: MentionOccurrence[] = [];
+
+  for (
+    let match = pattern.exec(maskedText);
+    match;
+    match = pattern.exec(maskedText)
+  ) {
+    const start = match.index + match[1].length;
+    occurrences.push({
+      end: start + match[2].length,
+      name,
+      preferred,
+      start,
+    });
+  }
+
+  return occurrences;
+}
+
+/**
+ * Resolve display names represented by outgoing mention spans.
+ *
+ * Autocomplete-selected names take precedence over overlapping candidates.
+ * Otherwise the longest exact display name wins within a span. Independent
+ * spans remain independent, so a short and a long shared-prefix name can both
+ * be intentionally mentioned in one message.
+ */
+export function resolveMentionedNames(
+  text: string,
+  names: readonly string[],
+  preferredNames: readonly string[] = [],
+): string[] {
+  const preferred = new Set(
+    preferredNames.map((name) => name.trim().toLowerCase()).filter(Boolean),
+  );
+  const uniqueNames = new Map<string, string>();
+  for (const name of names) {
+    const trimmed = name.trim();
+    const key = trimmed.toLowerCase();
+    if (trimmed && !uniqueNames.has(key)) uniqueNames.set(key, trimmed);
+  }
+
+  const maskedText = maskMarkdownCode(text);
+  const occurrences = [...uniqueNames.entries()].flatMap(([key, name]) => {
+    const matches = mentionOccurrences(maskedText, name, false);
+    // A name-only autocomplete record cannot identify which occurrence was
+    // selected after later edits. Restrict that preference to an unambiguous
+    // single occurrence so it cannot suppress a longer independent span.
+    const isUnambiguousPreference = preferred.has(key) && matches.length === 1;
+    return matches.map((match) => ({
+      ...match,
+      preferred: isUnambiguousPreference,
+    }));
+  });
+  occurrences.sort(
+    (left, right) =>
+      Number(right.preferred) - Number(left.preferred) ||
+      right.name.length - left.name.length ||
+      left.start - right.start ||
+      left.name.localeCompare(right.name),
+  );
+
+  const selected: MentionOccurrence[] = [];
+  for (const occurrence of occurrences) {
+    const overlaps = selected.some(
+      (current) =>
+        occurrence.start < current.end && occurrence.end > current.start,
+    );
+    if (!overlaps) selected.push(occurrence);
+  }
+  selected.sort(
+    (left, right) => left.start - right.start || right.end - left.end,
+  );
+
+  const resolved: string[] = [];
+  const seen = new Set<string>();
+  for (const occurrence of selected) {
+    const key = occurrence.name.toLowerCase();
+    if (!seen.has(key)) {
+      resolved.push(occurrence.name);
+      seen.add(key);
+    }
+  }
+  return resolved;
+}

--- a/desktop/src/features/messages/lib/outgoingMentionResolution.test.mjs
+++ b/desktop/src/features/messages/lib/outgoingMentionResolution.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { resolveOutgoingMentionPubkeys } from "./outgoingMentionResolution.ts";
+import {
+  resolveOutgoingMentionPersonas,
+  resolveOutgoingMentionPubkeys,
+} from "./outgoingMentionResolution.ts";
 
 function candidate(displayName, pubkey) {
   return { displayName, isMember: true, pubkey };
@@ -67,5 +70,23 @@ test("pasted shared-prefix mentions resolve to the longest member name", () => {
       text: "@Agent.copy please respond",
     }),
     ["copy-pubkey"],
+  );
+});
+
+test("a longer pubkey mention suppresses a selected persona prefix", () => {
+  const persona = { id: "short-persona" };
+
+  assert.deepEqual(
+    resolveOutgoingMentionPersonas({
+      activePersonaById: new Map([[persona.id, persona]]),
+      candidates: [
+        candidate("OriginalName", "short-pubkey"),
+        candidate("OriginalName copy", "long-pubkey"),
+      ],
+      selectedMentions: new Map([["OriginalName copy", "long-pubkey"]]),
+      selectedPersonaMentions: new Map([["OriginalName", "short-persona"]]),
+      text: "@OriginalName copy please respond",
+    }),
+    [],
   );
 });

--- a/desktop/src/features/messages/lib/outgoingMentionResolution.test.mjs
+++ b/desktop/src/features/messages/lib/outgoingMentionResolution.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveOutgoingMentionPubkeys } from "./outgoingMentionResolution.ts";
+
+function candidate(displayName, pubkey) {
+  return { displayName, isMember: true, pubkey };
+}
+
+test("one longer mention emits only the longer identity pubkey", () => {
+  assert.deepEqual(
+    resolveOutgoingMentionPubkeys({
+      candidates: [
+        candidate("OriginalName", "short-pubkey"),
+        candidate("OriginalName copy", "long-pubkey"),
+      ],
+      selectedMentions: new Map([["OriginalName copy", "long-pubkey"]]),
+      selectedPersonaMentions: new Map(),
+      text: "@OriginalName copy please respond",
+    }),
+    ["long-pubkey"],
+  );
+});
+
+test("separate short and long mention spans emit both pubkeys", () => {
+  assert.deepEqual(
+    resolveOutgoingMentionPubkeys({
+      candidates: [
+        candidate("OriginalName", "short-pubkey"),
+        candidate("OriginalName copy", "long-pubkey"),
+      ],
+      selectedMentions: new Map([
+        ["OriginalName", "short-pubkey"],
+        ["OriginalName copy", "long-pubkey"],
+      ]),
+      selectedPersonaMentions: new Map(),
+      text: "@OriginalName then @OriginalName copy",
+    }),
+    ["short-pubkey", "long-pubkey"],
+  );
+});
+
+test("a selected short mention does not override a later independent longer span", () => {
+  assert.deepEqual(
+    resolveOutgoingMentionPubkeys({
+      candidates: [
+        candidate("OriginalName", "short-pubkey"),
+        candidate("OriginalName copy", "long-pubkey"),
+      ],
+      selectedMentions: new Map([["OriginalName", "short-pubkey"]]),
+      selectedPersonaMentions: new Map(),
+      text: "@OriginalName then @OriginalName copy",
+    }),
+    ["short-pubkey", "long-pubkey"],
+  );
+});
+
+test("pasted shared-prefix mentions resolve to the longest member name", () => {
+  assert.deepEqual(
+    resolveOutgoingMentionPubkeys({
+      candidates: [
+        candidate("Agent", "agent-pubkey"),
+        candidate("Agent.copy", "copy-pubkey"),
+      ],
+      selectedMentions: new Map(),
+      selectedPersonaMentions: new Map(),
+      text: "@Agent.copy please respond",
+    }),
+    ["copy-pubkey"],
+  );
+});

--- a/desktop/src/features/messages/lib/outgoingMentionResolution.ts
+++ b/desktop/src/features/messages/lib/outgoingMentionResolution.ts
@@ -1,0 +1,107 @@
+import type { MentionCandidate } from "./mentionCandidates";
+import { resolveMentionedNames } from "./hasMention";
+import type { AgentPersona } from "@/shared/api/types";
+
+export type PersonaMentionTarget = {
+  displayName: string;
+  persona: AgentPersona;
+};
+
+type OutgoingMentionPubkeyOptions = {
+  candidates: readonly Pick<
+    MentionCandidate,
+    "displayName" | "isMember" | "pubkey"
+  >[];
+  selectedMentions: ReadonlyMap<string, string>;
+  selectedPersonaMentions: ReadonlyMap<string, string>;
+  text: string;
+};
+
+export function resolveOutgoingMentionPubkeys({
+  candidates,
+  selectedMentions,
+  selectedPersonaMentions,
+  text,
+}: OutgoingMentionPubkeyOptions): string[] {
+  const pubkeys: string[] = [];
+  const selectedNames = [
+    ...selectedMentions.keys(),
+    ...selectedPersonaMentions.keys(),
+  ];
+  const selectedDisplayNames = new Set(
+    selectedNames.map((name) => name.trim().toLowerCase()),
+  );
+  const resolvedDisplayNames = new Set(
+    resolveMentionedNames(
+      text,
+      [
+        ...selectedNames,
+        ...candidates.flatMap((candidate) =>
+          candidate.displayName ? [candidate.displayName] : [],
+        ),
+      ],
+      selectedNames,
+    ).map((name) => name.toLowerCase()),
+  );
+
+  for (const [displayName, pubkey] of selectedMentions) {
+    if (resolvedDisplayNames.has(displayName.trim().toLowerCase())) {
+      pubkeys.push(pubkey);
+    }
+  }
+
+  for (const candidate of candidates) {
+    const name = candidate.displayName;
+    if (
+      !candidate.pubkey ||
+      !candidate.isMember ||
+      pubkeys.includes(candidate.pubkey) ||
+      !name ||
+      selectedDisplayNames.has(name.trim().toLowerCase()) ||
+      !resolvedDisplayNames.has(name.trim().toLowerCase())
+    ) {
+      continue;
+    }
+    pubkeys.push(candidate.pubkey);
+  }
+
+  return [...new Set(pubkeys)];
+}
+
+type OutgoingMentionPersonaOptions = {
+  activePersonaById: ReadonlyMap<string, AgentPersona>;
+  selectedPersonaMentions: ReadonlyMap<string, string>;
+  text: string;
+};
+
+export function resolveOutgoingMentionPersonas({
+  activePersonaById,
+  selectedPersonaMentions,
+  text,
+}: OutgoingMentionPersonaOptions): PersonaMentionTarget[] {
+  const targets: PersonaMentionTarget[] = [];
+  const seen = new Set<string>();
+  const displayNames = [...selectedPersonaMentions.keys()];
+  const resolvedDisplayNames = new Set(
+    resolveMentionedNames(text, displayNames, displayNames).map((name) =>
+      name.toLowerCase(),
+    ),
+  );
+
+  for (const [displayName, personaId] of selectedPersonaMentions) {
+    if (
+      seen.has(personaId) ||
+      !resolvedDisplayNames.has(displayName.trim().toLowerCase())
+    ) {
+      continue;
+    }
+
+    const persona = activePersonaById.get(personaId);
+    if (!persona) continue;
+
+    targets.push({ displayName, persona });
+    seen.add(personaId);
+  }
+
+  return targets;
+}

--- a/desktop/src/features/messages/lib/outgoingMentionResolution.ts
+++ b/desktop/src/features/messages/lib/outgoingMentionResolution.ts
@@ -70,20 +70,33 @@ export function resolveOutgoingMentionPubkeys({
 
 type OutgoingMentionPersonaOptions = {
   activePersonaById: ReadonlyMap<string, AgentPersona>;
+  candidates: readonly Pick<MentionCandidate, "displayName">[];
+  selectedMentions: ReadonlyMap<string, string>;
   selectedPersonaMentions: ReadonlyMap<string, string>;
   text: string;
 };
 
 export function resolveOutgoingMentionPersonas({
   activePersonaById,
+  candidates,
+  selectedMentions,
   selectedPersonaMentions,
   text,
 }: OutgoingMentionPersonaOptions): PersonaMentionTarget[] {
   const targets: PersonaMentionTarget[] = [];
   const seen = new Set<string>();
-  const displayNames = [...selectedPersonaMentions.keys()];
+  const selectedNames = [
+    ...selectedMentions.keys(),
+    ...selectedPersonaMentions.keys(),
+  ];
+  const displayNames = [
+    ...selectedNames,
+    ...candidates.flatMap((candidate) =>
+      candidate.displayName ? [candidate.displayName] : [],
+    ),
+  ];
   const resolvedDisplayNames = new Set(
-    resolveMentionedNames(text, displayNames, displayNames).map((name) =>
+    resolveMentionedNames(text, displayNames, selectedNames).map((name) =>
       name.toLowerCase(),
     ),
   );

--- a/desktop/src/features/messages/lib/useMentions.test.mjs
+++ b/desktop/src/features/messages/lib/useMentions.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getMentionOffset, hasMention } from "./hasMention.ts";
+import {
+  getMentionOffset,
+  hasMention,
+  resolveMentionedNames,
+} from "./hasMention.ts";
 
 // ── Plain @mention ────────────────────────────────────────────────────
 
@@ -134,4 +138,53 @@ test("does not treat escaped or unclosed backticks as code", () => {
 test("requires matching inline-code delimiter lengths", () => {
   assert.equal(hasMention("`` @Alice ` still code ``", "Alice"), false);
   assert.equal(hasMention("`` @Alice `", "Alice"), true);
+});
+
+// ── Overlapping candidate names ──────────────────────────────────────
+
+function resolvedNames(text, names, preferredNames = []) {
+  return resolveMentionedNames(text, names, preferredNames);
+}
+
+test("prefers the longest display name for one overlapping mention span", () => {
+  assert.deepEqual(
+    resolvedNames("@OriginalName copy please respond", [
+      "OriginalName",
+      "OriginalName copy",
+    ]),
+    ["OriginalName copy"],
+  );
+});
+
+test("preserves separate intentional short and long mentions", () => {
+  assert.deepEqual(
+    resolvedNames("@OriginalName then @OriginalName copy", [
+      "OriginalName",
+      "OriginalName copy",
+    ]),
+    ["OriginalName", "OriginalName copy"],
+  );
+});
+
+test("prefers an explicit autocomplete selection over a longer overlap", () => {
+  assert.deepEqual(
+    resolvedNames(
+      "@OriginalName copy please respond",
+      ["OriginalName", "OriginalName copy"],
+      ["OriginalName"],
+    ),
+    ["OriginalName"],
+  );
+});
+
+test("resolves three shared prefixes and punctuation collisions deterministically", () => {
+  assert.deepEqual(
+    resolvedNames("@Agent.copy and @Agent copy senior", [
+      "Agent",
+      "Agent.copy",
+      "Agent copy",
+      "Agent copy senior",
+    ]),
+    ["Agent.copy", "Agent copy senior"],
+  );
 });

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -26,7 +26,6 @@ import {
 import { useIdentityQuery } from "@/shared/api/hooks";
 import type { AutocompleteEdit } from "./useRichTextEditor";
 import type {
-  AgentPersona,
   ChannelMember,
   ChannelType,
   UserSearchResult,
@@ -36,7 +35,11 @@ import { detectPrefixQuery } from "@/shared/lib/detectPrefixQuery";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { trimMapToSize } from "@/shared/lib/trimMapToSize";
 import { flushMentionDebounce } from "./flushMentionDebounce";
-import { hasMention } from "./hasMention";
+import {
+  resolveOutgoingMentionPersonas,
+  resolveOutgoingMentionPubkeys,
+  type PersonaMentionTarget,
+} from "./outgoingMentionResolution";
 import { useDraftMentionRouting } from "./useDraftMentionRouting";
 import { rankMentionCandidates } from "./mentionRanking";
 import { mapMentionCandidateToSuggestion } from "./mentionSuggestionMapping";
@@ -49,10 +52,7 @@ import {
 } from "./mentionCandidates";
 const MENTION_DEBOUNCE_MS = 120;
 const MENTION_SUGGESTION_LIMIT = 50;
-export type PersonaMentionTarget = {
-  displayName: string;
-  persona: AgentPersona;
-};
+export type { PersonaMentionTarget } from "./outgoingMentionResolution";
 type UseMentionsOptions = {
   channelType?: ChannelType | null;
 };
@@ -792,66 +792,23 @@ export function useMentions(
   );
 
   const extractMentionPubkeys = React.useCallback(
-    (text: string): string[] => {
-      const pubkeys: string[] = [];
-      const selectedDisplayNames = new Set(
-        [
-          ...mentionMapRef.current.keys(),
-          ...personaMentionMapRef.current.keys(),
-        ].map((name) => name.trim().toLowerCase()),
-      );
-
-      for (const [displayName, pubkey] of mentionMapRef.current) {
-        if (hasMention(text, displayName)) {
-          pubkeys.push(pubkey);
-        }
-      }
-
-      for (const candidate of mentionCandidates) {
-        if (!candidate.pubkey) {
-          continue;
-        }
-        if (!candidate.isMember) {
-          continue;
-        }
-        if (pubkeys.includes(candidate.pubkey)) {
-          continue;
-        }
-        const name = candidate.displayName;
-        if (name && selectedDisplayNames.has(name.trim().toLowerCase())) {
-          continue;
-        }
-        if (name && hasMention(text, name)) {
-          pubkeys.push(candidate.pubkey);
-        }
-      }
-
-      return [...new Set(pubkeys)];
-    },
+    (text: string): string[] =>
+      resolveOutgoingMentionPubkeys({
+        candidates: mentionCandidates,
+        selectedMentions: mentionMapRef.current,
+        selectedPersonaMentions: personaMentionMapRef.current,
+        text,
+      }),
     [mentionCandidates],
   );
 
   const extractMentionPersonas = React.useCallback(
-    (text: string): PersonaMentionTarget[] => {
-      const targets: PersonaMentionTarget[] = [];
-      const seen = new Set<string>();
-
-      for (const [displayName, personaId] of personaMentionMapRef.current) {
-        if (seen.has(personaId) || !hasMention(text, displayName)) {
-          continue;
-        }
-
-        const persona = activePersonaById.get(personaId);
-        if (!persona) {
-          continue;
-        }
-
-        targets.push({ displayName, persona });
-        seen.add(personaId);
-      }
-
-      return targets;
-    },
+    (text: string): PersonaMentionTarget[] =>
+      resolveOutgoingMentionPersonas({
+        activePersonaById,
+        selectedPersonaMentions: personaMentionMapRef.current,
+        text,
+      }),
     [activePersonaById],
   );
 

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -806,10 +806,12 @@ export function useMentions(
     (text: string): PersonaMentionTarget[] =>
       resolveOutgoingMentionPersonas({
         activePersonaById,
+        candidates: mentionCandidates,
+        selectedMentions: mentionMapRef.current,
         selectedPersonaMentions: personaMentionMapRef.current,
         text,
       }),
-    [activePersonaById],
+    [activePersonaById, mentionCandidates],
   );
 
   const cancelMentionAutocomplete = React.useCallback(() => {


### PR DESCRIPTION
## Summary

- resolve outgoing mentions by their concrete text spans instead of independently accepting every candidate whose name is a prefix of the visible mention
- preserve an explicit autocomplete selection when its display name occurs once; when later edits create multiple occurrences, stop treating that name-only record as a global preference
- for pasted/manual ambiguous text, choose the longest exact display name within each overlapping span
- keep separate intentional short-name and long-name mentions independent, so both identities are emitted only when both spans are actually present
- move recipient extraction into a focused helper, keeping `useMentions.ts` below the repository's file-size limit

Before this change, `@OriginalName copy` matched both `OriginalName` and `OriginalName copy`, so Desktop emitted two `p` tags and could start two distinct managed agents even though the composer visibly named only the copy.

### Related issue

Fixes #2909

No competing implementation was found before opening this PR. Related historical mention work addresses autocomplete or other routing mechanisms, not outgoing overlapping-span tag extraction.

### Testing

- focused mention and outgoing-recipient regressions — **35 passed**
- `pnpm typecheck`
- full Desktop test suite — passed
- `pnpm build`
- Biome format/check on all changed files
- `git diff --check`

The unrelated runtime file-size ratchet was subsequently restored upstream by the `runtime.rs` module split. After extracting the new recipient helper, `useMentions.ts` remains below its 1,000-line limit.