### PR TITLE
feat(desktop): add sidebar categories and manual channel ordering

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -107,6 +107,7 @@ export default defineConfig({
         "**/inbox-refactor-screenshots.spec.ts",
         "**/buzz-theme-screenshots.spec.ts",
         "**/channel-sort.spec.ts",
+        "**/channel-categories-manual-order.spec.ts",
         "**/identity-lost.spec.ts",
         "**/deep-link-invite.spec.ts",
         "**/invite-link-copy.spec.ts",

--- a/desktop/src/features/sidebar/lib/channelManualOrder.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelManualOrder.test.mjs
@@ -6,6 +6,7 @@ import {
   mergeDeletedSectionOrder,
   moveManualChannel,
   normalizeManualOrder,
+  orderIdsForGroup,
   parseChannelManualOrderPayload,
   pruneManualOrderGroups,
   setManualGroupOrder,
@@ -92,6 +93,71 @@ test("move within a group inserts before the hovered channel", () => {
   assert.deepEqual(next.groups.channels, ["c", "a", "b"]);
 });
 
+test("first reorder from implicit Manual enables the group and persists order", () => {
+  // Unset default: no saved groups / manualGroups — user has never reordered.
+  const initial = {
+    version: 1,
+    groups: {},
+    manualGroups: [],
+  };
+  // Live visible order is A–Z deterministic fallback (e.g. alpha live ids).
+  const liveIds = ["a", "b", "c"];
+  const next = moveManualChannel(initial, {
+    channelId: "c",
+    sourceGroup: "channels",
+    targetGroup: "channels",
+    overChannelId: "a",
+    sourceLiveIds: liveIds,
+    targetLiveIds: liveIds,
+  });
+  assert.deepEqual(next.groups.channels, ["c", "a", "b"]);
+  assert.deepEqual(next.manualGroups, ["channels"]);
+  // Source store is not mutated (hydration-safe pure function).
+  assert.deepEqual(initial.manualGroups, []);
+  assert.deepEqual(initial.groups, {});
+});
+
+test("cross-group move enables Manual for both source and target groups", () => {
+  const next = moveManualChannel(
+    {
+      version: 1,
+      groups: {},
+      manualGroups: [],
+    },
+    {
+      channelId: "b",
+      sourceGroup: "channels",
+      targetGroup: "section:work",
+      overChannelId: "d",
+      sourceLiveIds: ["a", "b"],
+      targetLiveIds: ["c", "d"],
+    },
+  );
+  assert.deepEqual(next.groups.channels, ["a"]);
+  assert.deepEqual(next.groups["section:work"], ["c", "b", "d"]);
+  assert.deepEqual(
+    [...next.manualGroups].sort(),
+    ["channels", "section:work"].sort(),
+  );
+});
+
+test("unset default hydration is pure: no manualGroups or groups invented", () => {
+  // Reading an order for display must not require / produce a store write.
+  const store = DEFAULT_MANUAL_ORDER_STORE;
+  const ordered = orderIdsForGroup(store, "channels", ["b", "a", "c"]);
+  // Deterministic A–Z fallback uses live id order when nothing is saved.
+  assert.deepEqual(ordered, ["b", "a", "c"]);
+  assert.deepEqual(store.groups, {});
+  assert.deepEqual(store.manualGroups, []);
+  // normalize alone is also pure.
+  assert.deepEqual(normalizeManualOrder(undefined, ["z", "y"]), ["z", "y"]);
+  assert.equal(
+    parseChannelManualOrderPayload({ version: 1, groups: {} })?.manualGroups
+      .length,
+    0,
+  );
+});
+
 test("move within a group follows the hovered index in both directions", () => {
   const store = {
     version: 1,
@@ -139,6 +205,8 @@ test("move across groups removes from source and inserts into target", () => {
   );
   assert.deepEqual(next.groups.channels, ["a"]);
   assert.deepEqual(next.groups["section:work"], ["c", "b", "d"]);
+  assert.ok(next.manualGroups.includes("channels"));
+  assert.ok(next.manualGroups.includes("section:work"));
 });
 
 test("deleting a section appends its visible order to Channels and prunes its mode", () => {

--- a/desktop/src/features/sidebar/lib/channelManualOrder.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelManualOrder.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_MANUAL_ORDER_STORE,
+  mergeDeletedSectionOrder,
+  moveManualChannel,
+  normalizeManualOrder,
+  parseChannelManualOrderPayload,
+  pruneManualOrderGroups,
+  setManualGroupOrder,
+} from "./channelManualOrder.ts";
+
+test("parse validates groups, removes duplicates, and ignores malformed values", () => {
+  assert.deepEqual(
+    parseChannelManualOrderPayload({
+      version: 1,
+      groups: {
+        channels: ["a", "a", 42, "b"],
+        "section:work": ["c"],
+        broken: "nope",
+      },
+    }),
+    {
+      version: 1,
+      groups: { channels: ["a", "b"], "section:work": ["c"] },
+      manualGroups: [],
+    },
+  );
+  assert.equal(parseChannelManualOrderPayload({ version: 2 }), null);
+  assert.equal(parseChannelManualOrderPayload(null), null);
+});
+
+test("parse bounds oversized remote groups and channel lists", () => {
+  const oversizedGroups = {
+    channels: Array.from({ length: 10_050 }, (_, index) => `channel-${index}`),
+    ...Object.fromEntries(
+      Array.from({ length: 1_050 }, (_, index) => [
+        `section:${index}`,
+        [`channel-${index}`],
+      ]),
+    ),
+  };
+  const parsed = parseChannelManualOrderPayload({
+    version: 1,
+    groups: oversizedGroups,
+  });
+  assert.ok(parsed);
+  assert.equal(Object.keys(parsed.groups).length, 1_000);
+  assert.equal(parsed.groups.channels.length, 10_000);
+});
+
+test("normalize keeps saved live ids, drops stale ids, and appends new ids", () => {
+  assert.deepEqual(
+    normalizeManualOrder(["b", "stale", "b", "a"], ["a", "b", "c"]),
+    ["b", "a", "c"],
+  );
+});
+
+test("set order deduplicates ids without changing other groups", () => {
+  const next = setManualGroupOrder(
+    {
+      version: 1,
+      groups: { "section:work": ["x"] },
+      manualGroups: [],
+    },
+    "channels",
+    ["b", "a", "b"],
+  );
+  assert.deepEqual(next.groups, {
+    "section:work": ["x"],
+    channels: ["b", "a"],
+  });
+});
+
+test("move within a group inserts before the hovered channel", () => {
+  const next = moveManualChannel(
+    {
+      version: 1,
+      groups: { channels: ["a", "b", "c"] },
+      manualGroups: [],
+    },
+    {
+      channelId: "c",
+      sourceGroup: "channels",
+      targetGroup: "channels",
+      overChannelId: "a",
+      sourceLiveIds: ["a", "b", "c"],
+      targetLiveIds: ["a", "b", "c"],
+    },
+  );
+  assert.deepEqual(next.groups.channels, ["c", "a", "b"]);
+});
+
+test("move within a group follows the hovered index in both directions", () => {
+  const store = {
+    version: 1,
+    groups: { channels: ["a", "b", "c", "d"] },
+    manualGroups: ["channels"],
+  };
+  const down = moveManualChannel(store, {
+    channelId: "a",
+    sourceGroup: "channels",
+    targetGroup: "channels",
+    overChannelId: "c",
+    sourceLiveIds: ["a", "b", "c", "d"],
+    targetLiveIds: ["a", "b", "c", "d"],
+  });
+  assert.deepEqual(down.groups.channels, ["b", "c", "a", "d"]);
+  const last = moveManualChannel(store, {
+    channelId: "a",
+    sourceGroup: "channels",
+    targetGroup: "channels",
+    overChannelId: "d",
+    sourceLiveIds: ["a", "b", "c", "d"],
+    targetLiveIds: ["a", "b", "c", "d"],
+  });
+  assert.deepEqual(last.groups.channels, ["b", "c", "d", "a"]);
+});
+
+test("move across groups removes from source and inserts into target", () => {
+  const next = moveManualChannel(
+    {
+      version: 1,
+      groups: {
+        channels: ["a", "b"],
+        "section:work": ["c", "d"],
+      },
+      manualGroups: [],
+    },
+    {
+      channelId: "b",
+      sourceGroup: "channels",
+      targetGroup: "section:work",
+      overChannelId: "d",
+      sourceLiveIds: ["a", "b"],
+      targetLiveIds: ["c", "d"],
+    },
+  );
+  assert.deepEqual(next.groups.channels, ["a"]);
+  assert.deepEqual(next.groups["section:work"], ["c", "b", "d"]);
+});
+
+test("deleting a section appends its visible order to Channels and prunes its mode", () => {
+  const next = mergeDeletedSectionOrder(
+    {
+      version: 1,
+      groups: {
+        channels: ["a", "b"],
+        "section:work": ["d", "c"],
+      },
+      manualGroups: ["channels", "section:work"],
+    },
+    "work",
+    ["d", "c"],
+    ["a", "b"],
+  );
+  assert.deepEqual(next.groups, { channels: ["a", "b", "d", "c"] });
+  assert.deepEqual(next.manualGroups, ["channels"]);
+});
+
+test("pruning keeps only Channels and live custom section groups", () => {
+  const store = {
+    version: 1,
+    groups: {
+      channels: ["a"],
+      "section:work": ["b"],
+      "section:deleted": ["c"],
+      dms: ["d"],
+    },
+    manualGroups: ["channels", "section:work", "section:deleted"],
+  };
+  assert.deepEqual(pruneManualOrderGroups(store, ["work"]).groups, {
+    channels: ["a"],
+    "section:work": ["b"],
+  });
+  assert.deepEqual(pruneManualOrderGroups(store, ["work"]).manualGroups, [
+    "channels",
+    "section:work",
+  ]);
+  assert.equal(
+    pruneManualOrderGroups(DEFAULT_MANUAL_ORDER_STORE, []),
+    DEFAULT_MANUAL_ORDER_STORE,
+  );
+});

--- a/desktop/src/features/sidebar/lib/channelManualOrder.ts
+++ b/desktop/src/features/sidebar/lib/channelManualOrder.ts
@@ -1,0 +1,198 @@
+import type { ChannelSortGroupKey } from "./channelSortPreference";
+
+export type ChannelManualOrderStore = {
+  version: 1;
+  groups: Record<string, string[]>;
+  manualGroups: string[];
+};
+
+export const DEFAULT_MANUAL_ORDER_STORE: ChannelManualOrderStore =
+  Object.freeze({
+    version: 1,
+    groups: {},
+    manualGroups: [],
+  });
+
+const MAX_MANUAL_ORDER_GROUPS = 1_000;
+const MAX_CHANNELS_PER_GROUP = 10_000;
+
+function uniqueStrings(values: unknown[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    if (typeof value !== "string" || seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+    if (result.length >= MAX_CHANNELS_PER_GROUP) break;
+  }
+  return result;
+}
+
+export function parseChannelManualOrderPayload(
+  json: unknown,
+): ChannelManualOrderStore | null {
+  if (typeof json !== "object" || json === null) return null;
+  const obj = json as Record<string, unknown>;
+  if (obj.version !== 1) return null;
+  const groups =
+    typeof obj.groups === "object" &&
+    obj.groups !== null &&
+    !Array.isArray(obj.groups)
+      ? Object.fromEntries(
+          Object.entries(obj.groups as Record<string, unknown>)
+            .slice(0, MAX_MANUAL_ORDER_GROUPS)
+            .flatMap(([key, value]) =>
+              Array.isArray(value) ? [[key, uniqueStrings(value)]] : [],
+            ),
+        )
+      : {};
+  const manualGroups = Array.isArray(obj.manualGroups)
+    ? uniqueStrings(obj.manualGroups).slice(0, MAX_MANUAL_ORDER_GROUPS)
+    : [];
+  return { version: 1, groups, manualGroups };
+}
+
+export function normalizeManualOrder(
+  savedIds: readonly string[] | undefined,
+  liveIds: readonly string[],
+): string[] {
+  const live = new Set(liveIds);
+  const ordered = uniqueStrings([...(savedIds ?? [])]).filter((id) =>
+    live.has(id),
+  );
+  const known = new Set(ordered);
+  for (const id of liveIds) {
+    if (ordered.length >= MAX_CHANNELS_PER_GROUP) break;
+    if (!known.has(id)) {
+      known.add(id);
+      ordered.push(id);
+    }
+  }
+  return ordered;
+}
+
+export function orderIdsForGroup(
+  store: ChannelManualOrderStore,
+  group: ChannelSortGroupKey,
+  liveIds: readonly string[],
+): string[] {
+  return normalizeManualOrder(store.groups[group], liveIds);
+}
+
+export function setManualGroupOrder(
+  store: ChannelManualOrderStore,
+  group: ChannelSortGroupKey,
+  orderedIds: readonly string[],
+): ChannelManualOrderStore {
+  return {
+    ...store,
+    groups: {
+      ...store.groups,
+      [group]: uniqueStrings([...orderedIds]),
+    },
+  };
+}
+
+export function setManualGroupEnabled(
+  store: ChannelManualOrderStore,
+  group: ChannelSortGroupKey,
+  enabled: boolean,
+): ChannelManualOrderStore {
+  const manualGroups = new Set(store.manualGroups);
+  if (enabled) manualGroups.add(group);
+  else manualGroups.delete(group);
+  return { ...store, manualGroups: [...manualGroups] };
+}
+
+export function moveManualChannel(
+  store: ChannelManualOrderStore,
+  input: {
+    channelId: string;
+    sourceGroup: ChannelSortGroupKey;
+    targetGroup: ChannelSortGroupKey;
+    overChannelId?: string;
+    sourceLiveIds: readonly string[];
+    targetLiveIds: readonly string[];
+  },
+): ChannelManualOrderStore {
+  const {
+    channelId,
+    sourceGroup,
+    targetGroup,
+    overChannelId,
+    sourceLiveIds,
+    targetLiveIds,
+  } = input;
+  const sourceWithActive = normalizeManualOrder(
+    store.groups[sourceGroup],
+    sourceLiveIds,
+  );
+  if (sourceGroup === targetGroup) {
+    const oldIndex = sourceWithActive.indexOf(channelId);
+    const newIndex = overChannelId
+      ? sourceWithActive.indexOf(overChannelId)
+      : sourceWithActive.length - 1;
+    if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) {
+      return store;
+    }
+    const target = [...sourceWithActive];
+    target.splice(oldIndex, 1);
+    target.splice(newIndex, 0, channelId);
+    return {
+      ...store,
+      groups: { ...store.groups, [targetGroup]: target },
+    };
+  }
+  const source = sourceWithActive.filter((id) => id !== channelId);
+  const targetBase = normalizeManualOrder(
+    store.groups[targetGroup],
+    targetLiveIds,
+  ).filter((id) => id !== channelId);
+  const target = [...targetBase];
+  const overIndex = overChannelId
+    ? target.indexOf(overChannelId)
+    : target.length;
+  target.splice(overIndex === -1 ? target.length : overIndex, 0, channelId);
+
+  const groups = { ...store.groups, [targetGroup]: target };
+  groups[sourceGroup] = source;
+  return { ...store, groups };
+}
+
+export function mergeDeletedSectionOrder(
+  store: ChannelManualOrderStore,
+  sectionId: string,
+  sectionChannelIds: readonly string[],
+  channelIds: readonly string[],
+): ChannelManualOrderStore {
+  const sectionGroup = `section:${sectionId}` as const;
+  const groups = { ...store.groups };
+  delete groups[sectionGroup];
+  groups.channels = uniqueStrings([...channelIds, ...sectionChannelIds]);
+  return {
+    ...store,
+    groups,
+    manualGroups: store.manualGroups.filter((group) => group !== sectionGroup),
+  };
+}
+
+export function pruneManualOrderGroups(
+  store: ChannelManualOrderStore,
+  liveSectionIds: readonly string[],
+): ChannelManualOrderStore {
+  const liveGroups = new Set<string>([
+    "channels",
+    ...liveSectionIds.map((id) => `section:${id}`),
+  ]);
+  const groups = Object.fromEntries(
+    Object.entries(store.groups).filter(([key]) => liveGroups.has(key)),
+  );
+  const manualGroups = store.manualGroups.filter((key) => liveGroups.has(key));
+  if (
+    Object.keys(groups).length === Object.keys(store.groups).length &&
+    manualGroups.length === store.manualGroups.length
+  ) {
+    return store;
+  }
+  return { ...store, groups, manualGroups };
+}

--- a/desktop/src/features/sidebar/lib/channelManualOrder.ts
+++ b/desktop/src/features/sidebar/lib/channelManualOrder.ts
@@ -127,6 +127,14 @@ export function moveManualChannel(
     store.groups[sourceGroup],
     sourceLiveIds,
   );
+  // First user reorder (or cross-group move) enables Manual for the
+  // affected groups so the preference persists without a mount-time seed.
+  const enableManual = (groups: string[]) => {
+    const next = new Set(store.manualGroups);
+    for (const group of groups) next.add(group);
+    return [...next];
+  };
+
   if (sourceGroup === targetGroup) {
     const oldIndex = sourceWithActive.indexOf(channelId);
     const newIndex = overChannelId
@@ -141,6 +149,7 @@ export function moveManualChannel(
     return {
       ...store,
       groups: { ...store.groups, [targetGroup]: target },
+      manualGroups: enableManual([targetGroup]),
     };
   }
   const source = sourceWithActive.filter((id) => id !== channelId);
@@ -156,7 +165,11 @@ export function moveManualChannel(
 
   const groups = { ...store.groups, [targetGroup]: target };
   groups[sourceGroup] = source;
-  return { ...store, groups };
+  return {
+    ...store,
+    groups,
+    manualGroups: enableManual([sourceGroup, targetGroup]),
+  };
 }
 
 export function mergeDeletedSectionOrder(

--- a/desktop/src/features/sidebar/lib/channelManualOrderStorage.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelManualOrderStorage.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  channelManualOrderStorageKey,
+  readChannelManualOrderStore,
+  writeChannelManualOrderStore,
+} from "./channelManualOrderStorage.ts";
+
+const storage = new Map();
+globalThis.window = {
+  localStorage: {
+    getItem: (key) => storage.get(key) ?? null,
+    setItem: (key, value) => storage.set(key, value),
+  },
+};
+
+test("storage is scoped by identity and normalized relay", () => {
+  const a = channelManualOrderStorageKey("pk", "WSS://Relay.Example.com/");
+  const b = channelManualOrderStorageKey("pk", "wss://relay.example.com");
+  const c = channelManualOrderStorageKey("other", "wss://relay.example.com");
+  assert.equal(a, b);
+  assert.notEqual(a, c);
+});
+
+test("store round-trips and corrupt payload fails safe", () => {
+  const store = {
+    version: 1,
+    groups: { channels: ["b", "a"] },
+    manualGroups: ["channels"],
+  };
+  assert.equal(
+    writeChannelManualOrderStore("pk-roundtrip", store, "wss://relay.test"),
+    true,
+  );
+  assert.deepEqual(
+    readChannelManualOrderStore("pk-roundtrip", "wss://relay.test"),
+    store,
+  );
+
+  const key = channelManualOrderStorageKey("pk-corrupt", "wss://relay.test");
+  storage.set(key, "{broken");
+  assert.deepEqual(
+    readChannelManualOrderStore("pk-corrupt", "wss://relay.test"),
+    { version: 1, groups: {}, manualGroups: [] },
+  );
+});

--- a/desktop/src/features/sidebar/lib/channelManualOrderStorage.ts
+++ b/desktop/src/features/sidebar/lib/channelManualOrderStorage.ts
@@ -1,0 +1,52 @@
+import { normalizeRelayUrl } from "@/features/profile/lib/selfProfileStorage";
+import {
+  DEFAULT_MANUAL_ORDER_STORE,
+  parseChannelManualOrderPayload,
+  type ChannelManualOrderStore,
+} from "./channelManualOrder";
+
+const STORAGE_KEY_PREFIX = "buzz-channel-manual-order.v1";
+
+export function channelManualOrderStorageKey(
+  pubkey: string,
+  relayUrl?: string,
+): string {
+  if (!relayUrl) return `${STORAGE_KEY_PREFIX}:${pubkey}`;
+  return `${STORAGE_KEY_PREFIX}:${pubkey}:${encodeURIComponent(
+    normalizeRelayUrl(relayUrl),
+  )}`;
+}
+
+export function readChannelManualOrderStore(
+  pubkey: string,
+  relayUrl?: string,
+): ChannelManualOrderStore {
+  try {
+    const raw = window.localStorage.getItem(
+      channelManualOrderStorageKey(pubkey, relayUrl),
+    );
+    if (!raw) return DEFAULT_MANUAL_ORDER_STORE;
+    return (
+      parseChannelManualOrderPayload(JSON.parse(raw)) ??
+      DEFAULT_MANUAL_ORDER_STORE
+    );
+  } catch {
+    return DEFAULT_MANUAL_ORDER_STORE;
+  }
+}
+
+export function writeChannelManualOrderStore(
+  pubkey: string,
+  store: ChannelManualOrderStore,
+  relayUrl?: string,
+): boolean {
+  try {
+    window.localStorage.setItem(
+      channelManualOrderStorageKey(pubkey, relayUrl),
+      JSON.stringify(store),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/desktop/src/features/sidebar/lib/channelManualOrderSync.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelManualOrderSync.test.mjs
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+
+import { relayClient } from "@/shared/api/relayClient";
+import { ChannelManualOrderSyncManager } from "./channelManualOrderSync.ts";
+
+function makeStore(groups = {}) {
+  return { version: 1, groups, manualGroups: [] };
+}
+
+function installFakeTimers() {
+  if (typeof globalThis.window === "undefined") globalThis.window = {};
+  const originalSetTimeout = globalThis.window.setTimeout;
+  const originalClearTimeout = globalThis.window.clearTimeout;
+  let callback = null;
+  let nextId = 1;
+  globalThis.window.setTimeout = (fn) => {
+    callback = fn;
+    return nextId++;
+  };
+  globalThis.window.clearTimeout = () => {
+    callback = null;
+  };
+  return {
+    getCallback: () => callback,
+    restore() {
+      globalThis.window.setTimeout = originalSetTimeout;
+      globalThis.window.clearTimeout = originalClearTimeout;
+    },
+  };
+}
+
+test("destroy cancels a pending manual-order publish", () => {
+  const publishCalls = [];
+  mock.method(relayClient, "fetchEvents", () => Promise.resolve([]));
+  mock.method(relayClient, "publishEvent", (...args) => {
+    publishCalls.push(args);
+    return Promise.resolve();
+  });
+  const timers = installFakeTimers();
+
+  try {
+    const manager = new ChannelManualOrderSyncManager("pk-test");
+    manager.publish(makeStore({ channels: ["b", "a"] }));
+    assert.ok(timers.getCallback());
+    manager.destroy();
+    assert.equal(timers.getCallback(), null);
+    assert.equal(manager.getPendingStore(), null);
+    assert.equal(publishCalls.length, 0);
+  } finally {
+    timers.restore();
+    mock.reset();
+  }
+});
+
+test("destroy aborts an in-flight manual-order publish", async () => {
+  let releaseFetch;
+  const publishCalls = [];
+  mock.method(
+    relayClient,
+    "fetchEvents",
+    () =>
+      new Promise((resolve) => {
+        releaseFetch = () => resolve([]);
+      }),
+  );
+  mock.method(relayClient, "publishEvent", (...args) => {
+    publishCalls.push(args);
+    return Promise.resolve();
+  });
+  const timers = installFakeTimers();
+
+  try {
+    const manager = new ChannelManualOrderSyncManager("pk-race");
+    manager.publish(makeStore({ channels: ["a"] }));
+    const callback = timers.getCallback();
+    assert.ok(callback);
+    callback();
+    manager.destroy();
+    releaseFetch();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(publishCalls.length, 0);
+  } finally {
+    timers.restore();
+    mock.reset();
+  }
+});
+
+test("destroy is safe without a pending manual-order publish", () => {
+  const manager = new ChannelManualOrderSyncManager("pk-empty");
+  assert.doesNotThrow(() => manager.destroy());
+});
+
+test("discarding a pending publish clears both timer and stale reconnect state", () => {
+  const timers = installFakeTimers();
+  try {
+    const manager = new ChannelManualOrderSyncManager("pk-discard");
+    manager.publish(makeStore({ channels: ["b", "a"] }));
+    assert.ok(timers.getCallback());
+    assert.ok(manager.getPendingStore());
+    manager.discardPendingPublish();
+    assert.equal(timers.getCallback(), null);
+    assert.equal(manager.getPendingStore(), null);
+  } finally {
+    timers.restore();
+  }
+});
+
+test("a remote update applies when no explicit local edit is pending", () => {
+  const manager = new ChannelManualOrderSyncManager("pk-remote-first");
+  assert.equal(
+    manager.shouldApplyRemote({
+      store: makeStore({ channels: ["a", "b"] }),
+      createdAt: 10,
+      eventId: "remote-a",
+    }),
+    true,
+  );
+});
+
+test("a pending local edit deterministically defers a newer remote update", () => {
+  const timers = installFakeTimers();
+  try {
+    const manager = new ChannelManualOrderSyncManager("pk-local-first");
+    const local = makeStore({ channels: ["b", "a"] });
+    manager.publish(local);
+    assert.equal(
+      manager.shouldApplyRemote({
+        store: makeStore({ channels: ["a", "b"] }),
+        createdAt: 20,
+        eventId: "remote-b",
+      }),
+      false,
+    );
+    assert.deepEqual(manager.getPendingStore(), local);
+    assert.ok(timers.getCallback());
+  } finally {
+    timers.restore();
+  }
+});
+
+test("initial fetch and reconnect cannot replace a pending local edit", () => {
+  const timers = installFakeTimers();
+  try {
+    const manager = new ChannelManualOrderSyncManager("pk-reconnect");
+    const local = makeStore({ channels: ["c", "a", "b"] });
+    manager.publish(local);
+    for (const [createdAt, eventId] of [
+      [30, "initial-fetch"],
+      [40, "reconnect-fetch"],
+    ]) {
+      assert.equal(
+        manager.shouldApplyRemote({
+          store: makeStore({ channels: ["a", "b", "c"] }),
+          createdAt,
+          eventId,
+        }),
+        false,
+      );
+      assert.deepEqual(manager.getPendingStore(), local);
+    }
+  } finally {
+    timers.restore();
+  }
+});

--- a/desktop/src/features/sidebar/lib/channelManualOrderSync.ts
+++ b/desktop/src/features/sidebar/lib/channelManualOrderSync.ts
@@ -1,0 +1,183 @@
+import { relayClient } from "@/shared/api/relayClient";
+import {
+  nip44DecryptFromSelf,
+  nip44EncryptToSelf,
+  signRelayEvent,
+} from "@/shared/api/tauri";
+import type { RelayEvent } from "@/shared/api/types";
+import { KIND_CHANNEL_MANUAL_ORDER } from "@/shared/constants/kinds";
+import {
+  parseChannelManualOrderPayload,
+  type ChannelManualOrderStore,
+} from "./channelManualOrder";
+
+const D_TAG = "channel-manual-order";
+const DEBOUNCE_MS = 2_000;
+
+export type RemoteManualOrder = {
+  store: ChannelManualOrderStore;
+  createdAt: number;
+  eventId: string;
+};
+
+async function decryptAndParse(
+  event: RelayEvent,
+): Promise<RemoteManualOrder | null> {
+  try {
+    const plaintext = await nip44DecryptFromSelf(event.content);
+    const store = parseChannelManualOrderPayload(JSON.parse(plaintext));
+    if (!store) return null;
+    return { store, createdAt: event.created_at, eventId: event.id };
+  } catch {
+    return null;
+  }
+}
+
+export class ChannelManualOrderSyncManager {
+  private pubkey: string;
+  private debounceTimer: number | null = null;
+  private lastRemoteCreatedAt = 0;
+  private pendingStore: ChannelManualOrderStore | null = null;
+  private lastPublishedJson = "";
+  private destroyed = false;
+
+  constructor(pubkey: string) {
+    this.pubkey = pubkey;
+  }
+
+  async fetchRemote(): Promise<RemoteManualOrder | null> {
+    try {
+      const events = await relayClient.fetchEvents({
+        kinds: [KIND_CHANNEL_MANUAL_ORDER],
+        authors: [this.pubkey],
+        "#d": [D_TAG],
+        limit: 1,
+      });
+      if (events.length === 0 || events[0].pubkey !== this.pubkey) return null;
+      const result = await decryptAndParse(events[0]);
+      if (result) {
+        this.shouldApplyRemote(result);
+      }
+      return result;
+    } catch {
+      return null;
+    }
+  }
+
+  publish(store: ChannelManualOrderStore): void {
+    this.pendingStore = store;
+    this.cancelPendingTimer();
+    this.debounceTimer = window.setTimeout(() => {
+      this.debounceTimer = null;
+      void this.doPublish(store);
+    }, DEBOUNCE_MS);
+  }
+
+  private cancelPendingTimer(): void {
+    if (this.debounceTimer !== null) {
+      window.clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+
+  discardPendingPublish(): void {
+    this.cancelPendingTimer();
+    this.pendingStore = null;
+  }
+
+  getPendingStore(): ChannelManualOrderStore | null {
+    return this.pendingStore;
+  }
+
+  shouldApplyRemote(remote: RemoteManualOrder): boolean {
+    this.lastRemoteCreatedAt = Math.max(
+      this.lastRemoteCreatedAt,
+      remote.createdAt,
+    );
+    return this.pendingStore === null;
+  }
+
+  private async refreshRemoteTimestampBeforePublish(): Promise<void> {
+    try {
+      const events = await relayClient.fetchEvents({
+        kinds: [KIND_CHANNEL_MANUAL_ORDER],
+        authors: [this.pubkey],
+        "#d": [D_TAG],
+        limit: 1,
+      });
+      if (events.length === 0 || events[0].pubkey !== this.pubkey) return;
+      const remote = await decryptAndParse(events[0]);
+      if (!remote) return;
+      this.lastRemoteCreatedAt = Math.max(
+        this.lastRemoteCreatedAt,
+        remote.createdAt,
+      );
+    } catch {
+      // Publishing the explicit local edit is still safe: the event timestamp
+      // below is monotonic against every remote value this manager has seen.
+    }
+  }
+
+  private async doPublish(store: ChannelManualOrderStore): Promise<void> {
+    try {
+      await this.refreshRemoteTimestampBeforePublish();
+      if (this.destroyed) return;
+      const json = JSON.stringify(store);
+      if (json === this.lastPublishedJson) {
+        this.pendingStore = null;
+        return;
+      }
+      const ciphertext = await nip44EncryptToSelf(json);
+      const createdAt = Math.max(
+        Math.floor(Date.now() / 1_000),
+        this.lastRemoteCreatedAt + 1,
+      );
+      const event = await signRelayEvent({
+        kind: KIND_CHANNEL_MANUAL_ORDER,
+        content: ciphertext,
+        createdAt,
+        tags: [
+          ["d", D_TAG],
+          ["t", D_TAG],
+        ],
+      });
+      if (this.destroyed) return;
+      await relayClient.publishEvent(
+        event,
+        "Timed out publishing manual channel order.",
+        "Failed to publish manual channel order.",
+      );
+      this.lastRemoteCreatedAt = event.created_at;
+      this.lastPublishedJson = json;
+      this.pendingStore = null;
+    } catch (error) {
+      console.warn("[channelManualOrderSync] publish failed:", error);
+    }
+  }
+
+  async subscribe(
+    onUpdate: (remote: RemoteManualOrder) => void,
+  ): Promise<() => Promise<void>> {
+    return relayClient.subscribeLive(
+      {
+        kinds: [KIND_CHANNEL_MANUAL_ORDER],
+        authors: [this.pubkey],
+        "#d": [D_TAG],
+        limit: 0,
+      },
+      (event: RelayEvent) => {
+        if (event.pubkey !== this.pubkey) return;
+        void decryptAndParse(event).then((result) => {
+          if (!result) return;
+          this.shouldApplyRemote(result);
+          onUpdate(result);
+        });
+      },
+    );
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.discardPendingPublish();
+  }
+}

--- a/desktop/src/features/sidebar/lib/channelSectionsHelpers.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelSectionsHelpers.test.mjs
@@ -1,15 +1,176 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { swapSectionOrder } from "./channelSectionsHelpers.ts";
+import {
+  CHANNELS_BLOCK_ID,
+  appendSectionToStore,
+  applySidebarBlockOrder,
+  getSidebarBlockOrder,
+  normalizeChannelsBlockIndex,
+  removeSectionFromStore,
+  resolveChannelsBlockIndex,
+  swapBlockOrder,
+  swapSectionOrder,
+} from "./channelSectionsHelpers.ts";
 
-function makeStore(sections, assignments = {}) {
-  return { version: 1, sections, assignments };
+function makeStore(sections, assignments = {}, channelsBlockIndex) {
+  return {
+    version: 1,
+    sections,
+    assignments,
+    ...(channelsBlockIndex !== undefined ? { channelsBlockIndex } : {}),
+  };
 }
 
 function makeSection(id, name, order) {
   return { id, name, order };
 }
+
+test("resolveChannelsBlockIndex: missing maps to after all categories", () => {
+  const store = makeStore([makeSection("a", "A", 0), makeSection("b", "B", 1)]);
+  assert.equal(resolveChannelsBlockIndex(store), 2);
+});
+
+test("resolveChannelsBlockIndex: clamps out of range", () => {
+  const store = makeStore([makeSection("a", "A", 0)], {}, 99);
+  assert.equal(resolveChannelsBlockIndex(store), 1);
+  assert.equal(
+    resolveChannelsBlockIndex(makeStore([makeSection("a", "A", 0)], {}, -3)),
+    0,
+  );
+});
+
+test("resolveChannelsBlockIndex: non-integers map to legacy layout", () => {
+  const store = makeStore([makeSection("a", "A", 0), makeSection("b", "B", 1)]);
+  assert.equal(
+    resolveChannelsBlockIndex({ ...store, channelsBlockIndex: 1.5 }),
+    2,
+  );
+});
+
+test("normalizeChannelsBlockIndex: malformed and out of range → undefined", () => {
+  assert.equal(normalizeChannelsBlockIndex(undefined, 2), undefined);
+  assert.equal(normalizeChannelsBlockIndex("1", 2), undefined);
+  assert.equal(normalizeChannelsBlockIndex(Number.NaN, 2), undefined);
+  assert.equal(normalizeChannelsBlockIndex(-1, 2), undefined);
+  assert.equal(normalizeChannelsBlockIndex(3, 2), undefined);
+  // Non-integers are malformed — never truncate into a different position.
+  assert.equal(normalizeChannelsBlockIndex(1.5, 2), undefined);
+  assert.equal(normalizeChannelsBlockIndex(1.9, 2), undefined);
+  assert.equal(normalizeChannelsBlockIndex(0, 2), 0);
+  assert.equal(normalizeChannelsBlockIndex(1, 2), 1);
+  assert.equal(normalizeChannelsBlockIndex(2, 2), 2);
+});
+
+test("getSidebarBlockOrder: default is categories then Channels", () => {
+  const store = makeStore([makeSection("a", "A", 0), makeSection("b", "B", 1)]);
+  assert.deepEqual(getSidebarBlockOrder(store), ["a", "b", CHANNELS_BLOCK_ID]);
+});
+
+test("getSidebarBlockOrder: respects channelsBlockIndex mid-lane", () => {
+  const store = makeStore(
+    [makeSection("a", "A", 0), makeSection("b", "B", 1)],
+    {},
+    1,
+  );
+  assert.deepEqual(getSidebarBlockOrder(store), ["a", CHANNELS_BLOCK_ID, "b"]);
+});
+
+test("applySidebarBlockOrder: reorders sections and records index", () => {
+  const prev = makeStore([makeSection("a", "A", 0), makeSection("b", "B", 1)]);
+  const next = applySidebarBlockOrder(prev, ["b", CHANNELS_BLOCK_ID, "a"]);
+  assert.equal(next.channelsBlockIndex, 1);
+  const byId = Object.fromEntries(next.sections.map((s) => [s.id, s.order]));
+  assert.equal(byId.b, 0);
+  assert.equal(byId.a, 1);
+  assert.deepEqual(getSidebarBlockOrder(next), ["b", CHANNELS_BLOCK_ID, "a"]);
+});
+
+test("swapBlockOrder: moves category across Channels boundary", () => {
+  const store = makeStore(
+    [makeSection("a", "A", 0), makeSection("b", "B", 1)],
+    {},
+    1,
+  );
+  // [A, Channels, B] — move B up across Channels → [A, B, Channels]
+  const up = swapBlockOrder(store, "b", "up");
+  assert.notEqual(up, null);
+  assert.deepEqual(getSidebarBlockOrder(up), ["a", "b", CHANNELS_BLOCK_ID]);
+
+  // [A, Channels, B] — move Channels up → [Channels, A, B]
+  const chUp = swapBlockOrder(store, CHANNELS_BLOCK_ID, "up");
+  assert.notEqual(chUp, null);
+  assert.deepEqual(getSidebarBlockOrder(chUp), [CHANNELS_BLOCK_ID, "a", "b"]);
+});
+
+test("swapBlockOrder: boundary no-ops return null", () => {
+  const store = makeStore([makeSection("a", "A", 0)], {}, 0);
+  // [Channels, A]
+  assert.equal(swapBlockOrder(store, CHANNELS_BLOCK_ID, "up"), null);
+  assert.equal(swapBlockOrder(store, "a", "down"), null);
+});
+
+test("removeSectionFromStore: deleting category before Channels keeps relative place", () => {
+  // [A, Channels, B] channelsBlockIndex=1 — delete A → [Channels, B]
+  const store = makeStore(
+    [makeSection("a", "A", 0), makeSection("b", "B", 1)],
+    { ch1: "a", ch2: "b" },
+    1,
+  );
+  const next = removeSectionFromStore(store, "a");
+  assert.deepEqual(
+    next.sections.map((s) => s.id),
+    ["b"],
+  );
+  assert.equal(next.channelsBlockIndex, 0);
+  assert.deepEqual(getSidebarBlockOrder(next), [CHANNELS_BLOCK_ID, "b"]);
+  assert.equal(next.assignments.ch1, undefined);
+  assert.equal(next.assignments.ch2, "b");
+});
+
+test("removeSectionFromStore: deleting category after Channels keeps index", () => {
+  // [A, Channels, B] — delete B → [A, Channels]
+  const store = makeStore(
+    [makeSection("a", "A", 0), makeSection("b", "B", 1)],
+    {},
+    1,
+  );
+  const next = removeSectionFromStore(store, "b");
+  assert.deepEqual(getSidebarBlockOrder(next), ["a", CHANNELS_BLOCK_ID]);
+  assert.equal(next.channelsBlockIndex, 1);
+});
+
+test("appendSectionToStore: does not shift Channels among existing categories", () => {
+  // [A, Channels, B] — create C → [A, Channels, B, C]
+  const store = makeStore(
+    [makeSection("a", "A", 0), makeSection("b", "B", 1)],
+    {},
+    1,
+  );
+  const next = appendSectionToStore(store, {
+    id: "c",
+    name: "C",
+    order: 0,
+  });
+  assert.equal(next.channelsBlockIndex, 1);
+  assert.deepEqual(getSidebarBlockOrder(next), [
+    "a",
+    CHANNELS_BLOCK_ID,
+    "b",
+    "c",
+  ]);
+});
+
+test("appendSectionToStore: default layout keeps Channels last", () => {
+  const store = makeStore([makeSection("a", "A", 0)]);
+  const next = appendSectionToStore(store, {
+    id: "b",
+    name: "B",
+    order: 0,
+  });
+  assert.equal(next.channelsBlockIndex, undefined);
+  assert.deepEqual(getSidebarBlockOrder(next), ["a", "b", CHANNELS_BLOCK_ID]);
+});
 
 test("move up succeeds: middle section swaps order with the one above", () => {
   const store = makeStore([
@@ -44,9 +205,12 @@ test("move up at top boundary returns null", () => {
   assert.equal(swapSectionOrder(store, "a", "up"), null);
 });
 
-test("move down at bottom boundary returns null", () => {
+test("move down at last category swaps across Channels (not a no-op)", () => {
+  // Unified lane is [A, B, Channels]; moving B down crosses Channels.
   const store = makeStore([makeSection("a", "A", 0), makeSection("b", "B", 1)]);
-  assert.equal(swapSectionOrder(store, "b", "down"), null);
+  const result = swapSectionOrder(store, "b", "down");
+  assert.notEqual(result, null);
+  assert.deepEqual(getSidebarBlockOrder(result), ["a", CHANNELS_BLOCK_ID, "b"]);
 });
 
 test("non-existent section returns null", () => {
@@ -59,21 +223,10 @@ test("single section move up returns null", () => {
   assert.equal(swapSectionOrder(store, "a", "up"), null);
 });
 
-test("single section move down returns null", () => {
+test("single section move down swaps with Channels", () => {
+  // Unified lane is [A, Channels]; moving A down is valid.
   const store = makeStore([makeSection("a", "A", 0)]);
-  assert.equal(swapSectionOrder(store, "a", "down"), null);
-});
-
-test("non-contiguous orders: swap uses actual order values not indices", () => {
-  const store = makeStore([
-    makeSection("a", "A", 0),
-    makeSection("b", "B", 5),
-    makeSection("c", "C", 10),
-  ]);
-  const result = swapSectionOrder(store, "b", "up");
+  const result = swapSectionOrder(store, "a", "down");
   assert.notEqual(result, null);
-  const byId = Object.fromEntries(result.sections.map((s) => [s.id, s.order]));
-  assert.equal(byId.b, 0);
-  assert.equal(byId.a, 5);
-  assert.equal(byId.c, 10);
+  assert.deepEqual(getSidebarBlockOrder(result), [CHANNELS_BLOCK_ID, "a"]);
 });

--- a/desktop/src/features/sidebar/lib/channelSectionsHelpers.ts
+++ b/desktop/src/features/sidebar/lib/channelSectionsHelpers.ts
@@ -1,21 +1,166 @@
 import type { ChannelSectionStore } from "./channelSectionsStorage";
 
+/** Sortable id for the built-in uncategorized Channels block in block order. */
+export const CHANNELS_BLOCK_ID = "__channels__";
+
+/**
+ * Resolves where the uncategorized Channels block sits among custom categories.
+ * Missing / non-integer / out-of-range values map to "after all categories"
+ * (the historical layout). Non-integers are never truncated into a different
+ * position — that would silently rewrite remote state.
+ */
+export function resolveChannelsBlockIndex(
+  store: Pick<ChannelSectionStore, "sections" | "channelsBlockIndex">,
+): number {
+  const sectionCount = store.sections.length;
+  const raw = store.channelsBlockIndex;
+  if (typeof raw !== "number" || !Number.isInteger(raw)) return sectionCount;
+  return Math.max(0, Math.min(sectionCount, raw));
+}
+
+/**
+ * Optional field normalization for parse: only persist an integer in range.
+ * Non-integers (e.g. 1.5), non-numbers, and out-of-range → undefined
+ * (legacy layout). Do not truncate floats — that silently changes remote state.
+ */
+export function normalizeChannelsBlockIndex(
+  value: unknown,
+  sectionCount: number,
+): number | undefined {
+  if (typeof value !== "number" || !Number.isInteger(value)) return undefined;
+  if (value < 0 || value > sectionCount) return undefined;
+  return value;
+}
+
+/**
+ * Display / sortable order of movable sidebar blocks: custom category ids plus
+ * the Channels sentinel. Starred / Forums / DMs stay outside this list.
+ */
+export function getSidebarBlockOrder(
+  store: Pick<ChannelSectionStore, "sections" | "channelsBlockIndex">,
+): string[] {
+  const sorted = store.sections.slice().sort((a, b) => a.order - b.order);
+  const ids = sorted.map((section) => section.id);
+  const index = resolveChannelsBlockIndex(store);
+  return [...ids.slice(0, index), CHANNELS_BLOCK_ID, ...ids.slice(index)];
+}
+
+/**
+ * Apply a full block order (section ids + {@link CHANNELS_BLOCK_ID}).
+ * Unknown ids are ignored; missing live sections append at the end (before
+ * Channels if Channels was not listed, matching default layout).
+ */
+export function applySidebarBlockOrder(
+  prev: ChannelSectionStore,
+  orderedBlockIds: readonly string[],
+): ChannelSectionStore {
+  const liveIds = new Set(prev.sections.map((section) => section.id));
+  const seen = new Set<string>();
+  const orderedSectionIds: string[] = [];
+  let channelsIndex = -1;
+
+  for (const id of orderedBlockIds) {
+    if (id === CHANNELS_BLOCK_ID) {
+      if (channelsIndex === -1) channelsIndex = orderedSectionIds.length;
+      continue;
+    }
+    if (!liveIds.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    orderedSectionIds.push(id);
+  }
+  for (const section of prev.sections
+    .slice()
+    .sort((a, b) => a.order - b.order)) {
+    if (!seen.has(section.id)) orderedSectionIds.push(section.id);
+  }
+  if (channelsIndex === -1) channelsIndex = orderedSectionIds.length;
+  channelsIndex = Math.max(
+    0,
+    Math.min(orderedSectionIds.length, channelsIndex),
+  );
+
+  const orderById = new Map(
+    orderedSectionIds.map((id, order) => [id, order] as const),
+  );
+  const sections = prev.sections.map((section) => ({
+    ...section,
+    order: orderById.get(section.id) ?? section.order,
+  }));
+
+  return {
+    ...prev,
+    sections,
+    channelsBlockIndex: channelsIndex,
+  };
+}
+
+export function swapBlockOrder(
+  prev: ChannelSectionStore,
+  blockId: string,
+  direction: "up" | "down",
+): ChannelSectionStore | null {
+  const order = getSidebarBlockOrder(prev);
+  const idx = order.indexOf(blockId);
+  if (idx === -1) return null;
+  const neighborIdx = direction === "up" ? idx - 1 : idx + 1;
+  if (neighborIdx < 0 || neighborIdx >= order.length) return null;
+  const next = order.slice();
+  const current = next[idx];
+  const neighbor = next[neighborIdx];
+  if (current === undefined || neighbor === undefined) return null;
+  next[idx] = neighbor;
+  next[neighborIdx] = current;
+  return applySidebarBlockOrder(prev, next);
+}
+
+/**
+ * Remove a category and adjust {@link channelsBlockIndex} so the Channels
+ * sentinel keeps its relative place among remaining blocks.
+ *
+ * Example: `[A, Channels, B]` (`channelsBlockIndex=1`) deleting A →
+ * `[Channels, B]` (`channelsBlockIndex=0`), not `[B, Channels]`.
+ */
+export function removeSectionFromStore(
+  prev: ChannelSectionStore,
+  sectionId: string,
+): ChannelSectionStore {
+  const order = getSidebarBlockOrder(prev).filter((id) => id !== sectionId);
+  const sections = prev.sections.filter((section) => section.id !== sectionId);
+  const assignments = { ...prev.assignments };
+  for (const channelId of Object.keys(assignments)) {
+    if (assignments[channelId] === sectionId) {
+      delete assignments[channelId];
+    }
+  }
+  return applySidebarBlockOrder({ ...prev, sections, assignments }, order);
+}
+
+/**
+ * Append a new category at the end of the movable lane without shifting
+ * Channels relative to existing categories (channelsBlockIndex unchanged
+ * when it sits among existing sections; when omitted, resolve stays "after
+ * all categories" including the new one).
+ */
+export function appendSectionToStore(
+  prev: ChannelSectionStore,
+  section: ChannelSectionStore["sections"][number],
+): ChannelSectionStore {
+  const maxOrder =
+    prev.sections.length > 0
+      ? Math.max(...prev.sections.map((s) => s.order))
+      : -1;
+  const nextSection = { ...section, order: maxOrder + 1 };
+  return {
+    ...prev,
+    sections: [...prev.sections, nextSection],
+  };
+}
+
+/** @deprecated Prefer {@link swapBlockOrder}; kept for category-only swaps. */
 export function swapSectionOrder(
   prev: ChannelSectionStore,
   sectionId: string,
   direction: "up" | "down",
 ): ChannelSectionStore | null {
-  const target = prev.sections.find((s) => s.id === sectionId);
-  if (!target) return null;
-  const sorted = prev.sections.slice().sort((a, b) => a.order - b.order);
-  const idx = sorted.findIndex((s) => s.id === sectionId);
-  const neighborIdx = direction === "up" ? idx - 1 : idx + 1;
-  if (neighborIdx < 0 || neighborIdx >= sorted.length) return null;
-  const neighbor = sorted[neighborIdx];
-  const sections = prev.sections.map((s) => {
-    if (s.id === target.id) return { ...s, order: neighbor.order };
-    if (s.id === neighbor.id) return { ...s, order: target.order };
-    return s;
-  });
-  return { ...prev, sections };
+  return swapBlockOrder(prev, sectionId, direction);
 }

--- a/desktop/src/features/sidebar/lib/channelSectionsStorage.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelSectionsStorage.test.mjs
@@ -357,3 +357,40 @@ test("parseChannelSectionPayload: omits icon field when empty or whitespace", ()
     { id: "s3", name: "C", order: 2 },
   ]);
 });
+
+test("parseChannelSectionPayload: optional channelsBlockIndex is kept when in range", () => {
+  const payload = {
+    version: 1,
+    sections: [
+      { id: "a", name: "A", order: 0 },
+      { id: "b", name: "B", order: 1 },
+    ],
+    assignments: {},
+    channelsBlockIndex: 1,
+  };
+  const result = parseChannelSectionPayload(payload);
+  assert.equal(result?.channelsBlockIndex, 1);
+});
+
+test("parseChannelSectionPayload: missing channelsBlockIndex omits field (legacy layout)", () => {
+  const result = parseChannelSectionPayload({
+    version: 1,
+    sections: [{ id: "a", name: "A", order: 0 }],
+    assignments: {},
+  });
+  assert.equal(result?.channelsBlockIndex, undefined);
+  assert.ok(!("channelsBlockIndex" in (result ?? {})));
+});
+
+test("parseChannelSectionPayload: malformed channelsBlockIndex is dropped", () => {
+  for (const bad of [-1, 99, "1", null, Number.NaN, 1.5, 0.9]) {
+    const result = parseChannelSectionPayload({
+      version: 1,
+      sections: [{ id: "a", name: "A", order: 0 }],
+      assignments: {},
+      channelsBlockIndex: bad,
+    });
+    // Non-integers are malformed — never truncates into a different position.
+    assert.equal(result?.channelsBlockIndex, undefined);
+  }
+});

--- a/desktop/src/features/sidebar/lib/channelSectionsStorage.ts
+++ b/desktop/src/features/sidebar/lib/channelSectionsStorage.ts
@@ -1,4 +1,5 @@
 import { normalizeRelayUrl } from "@/features/profile/lib/selfProfileStorage";
+import { normalizeChannelsBlockIndex } from "./channelSectionsHelpers";
 
 const STORAGE_KEY_PREFIX = "buzz-channel-sections.v1";
 
@@ -13,6 +14,12 @@ export type ChannelSectionStore = {
   version: 1;
   sections: ChannelSection[];
   assignments: Record<string, string>;
+  /**
+   * Optional insertion index of the built-in uncategorized Channels block
+   * among custom categories (0 = above all categories). Omitted / invalid
+   * values mean "after all categories" so older v1 payloads keep their layout.
+   */
+  channelsBlockIndex?: number;
 };
 
 export const DEFAULT_STORE: ChannelSectionStore = Object.freeze({
@@ -89,7 +96,16 @@ export function parseChannelSectionPayload(
           ),
         )
       : {};
-  return stripOrphanedAssignments({ version: 1, sections, assignments });
+  const channelsBlockIndex = normalizeChannelsBlockIndex(
+    obj.channelsBlockIndex,
+    sections.length,
+  );
+  return stripOrphanedAssignments({
+    version: 1,
+    sections,
+    assignments,
+    ...(channelsBlockIndex !== undefined ? { channelsBlockIndex } : {}),
+  });
 }
 
 function parseRaw(raw: string | null): ChannelSectionStore | null {

--- a/desktop/src/features/sidebar/lib/channelSectionsSync.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelSectionsSync.test.mjs
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import test, { mock } from "node:test";
 
 import { relayClient } from "@/shared/api/relayClient";
-import { ChannelSectionSyncManager } from "./channelSectionsSync.ts";
+import {
+  ChannelSectionSyncManager,
+  channelSectionStoresEqual,
+  serializeChannelSectionsPayload,
+} from "./channelSectionsSync.ts";
 
 function makeStore(overrides = {}) {
   return {
@@ -270,4 +274,75 @@ test("destroy: cancelPendingPublish clears pendingStore", () => {
     globalThis.window.setTimeout = orig;
     globalThis.window.clearTimeout = origClear;
   }
+});
+
+// ─── channelsBlockIndex serialize + equality (pure helpers) ─────────────────
+
+test("serializeChannelSectionsPayload: includes optional channelsBlockIndex", () => {
+  const payload = serializeChannelSectionsPayload(
+    makeStore({
+      sections: [
+        { id: "a", name: "A", order: 0 },
+        { id: "b", name: "B", order: 1 },
+      ],
+      channelsBlockIndex: 1,
+    }),
+  );
+  assert.equal(payload.version, 1);
+  assert.equal(payload.channelsBlockIndex, 1);
+  assert.equal(payload.sections.length, 2);
+});
+
+test("serializeChannelSectionsPayload: omits channelsBlockIndex when unset", () => {
+  const payload = serializeChannelSectionsPayload(
+    makeStore({ sections: [{ id: "a", name: "A", order: 0 }] }),
+  );
+  assert.equal(Object.hasOwn(payload, "channelsBlockIndex"), false);
+});
+
+test("channelSectionStoresEqual: index-only change is not equal", () => {
+  const base = makeStore({
+    sections: [
+      { id: "a", name: "A", order: 0 },
+      { id: "b", name: "B", order: 1 },
+    ],
+    channelsBlockIndex: 2,
+  });
+  const moved = { ...base, channelsBlockIndex: 0 };
+  assert.equal(channelSectionStoresEqual(base, base), true);
+  assert.equal(
+    channelSectionStoresEqual(base, moved),
+    false,
+    "index-only block move must not compare equal",
+  );
+  assert.equal(channelSectionStoresEqual(moved, moved), true);
+});
+
+test("channelSectionStoresEqual: undefined index equals undefined, not 0", () => {
+  const legacy = makeStore({
+    sections: [{ id: "a", name: "A", order: 0 }],
+  });
+  const zero = makeStore({
+    sections: [{ id: "a", name: "A", order: 0 }],
+    channelsBlockIndex: 0,
+  });
+  assert.equal(channelSectionStoresEqual(legacy, legacy), true);
+  assert.equal(channelSectionStoresEqual(legacy, zero), false);
+});
+
+test("shouldApplyRemote: cold-start remote index wins when no pending local edit", () => {
+  const manager = new ChannelSectionSyncManager("pk-remote-index");
+  const remote = {
+    store: makeStore({
+      sections: [
+        { id: "a", name: "A", order: 0 },
+        { id: "b", name: "B", order: 1 },
+      ],
+      channelsBlockIndex: 0,
+    }),
+    createdAt: 50,
+    eventId: "remote-index",
+  };
+  assert.equal(manager.shouldApplyRemote(remote), true);
+  assert.equal(remote.store.channelsBlockIndex, 0);
 });

--- a/desktop/src/features/sidebar/lib/channelSectionsSync.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelSectionsSync.test.mjs
@@ -92,17 +92,17 @@ test("destroy: cancels pending publish without flushing to the relay", () => {
 });
 
 // Regression guard for the timer-fired race: debounce fires → doPublish starts
-// awaiting fetchOwnBlobBeforePublish → destroy() is called (relayUrl dep
+// awaiting refreshRemoteTimestampBeforePublish → destroy() is called (relayUrl dep
 // change) → publishEvent must never be called even though the timer already
 // fired and cleared itself before destroy() ran.
-test("destroy: aborts in-flight doPublish after fetchOwnBlobBeforePublish resolves", async () => {
+test("destroy: aborts in-flight publish after remote timestamp refresh", async () => {
   // fetchEvents is held until we release it — simulates the latency window.
   let releaseFetch = null;
   const publishCalls = [];
 
   mock.method(relayClient, "fetchEvents", () => {
     return new Promise((resolve) => {
-      // resolve with empty so fetchOwnBlobBeforePublish returns the local store
+      // resolve with empty so the timestamp refresh completes
       releaseFetch = () => resolve([]);
     });
   });
@@ -138,7 +138,7 @@ test("destroy: aborts in-flight doPublish after fetchOwnBlobBeforePublish resolv
 
     // Fire the debounce manually — this starts doPublish() and nulls
     // debounceTimer inside publishSections' callback, leaving the async
-    // doPublish running and awaiting fetchOwnBlobBeforePublish.
+    // doPublish running and awaiting refreshRemoteTimestampBeforePublish.
     const timerFn = capturedCallback;
     capturedCallback = null; // timer cleared itself inside the callback
     timerFn();
@@ -147,8 +147,8 @@ test("destroy: aborts in-flight doPublish after fetchOwnBlobBeforePublish resolv
     // the destroyed flag can stop doPublish.
     manager.destroy();
 
-    // Release the held fetchEvents — fetchOwnBlobBeforePublish resolves with
-    // the local store, then doPublish should check destroyed and abort.
+    // Release the held fetchEvents, then doPublish should check destroyed and
+    // abort before signing or publishing.
     releaseFetch();
 
     // Drain microtasks so doPublish fully runs through to its abort point.
@@ -170,6 +170,69 @@ test("destroy: is safe to call with no pending publish", () => {
   const manager = new ChannelSectionSyncManager("pk-no-pending");
   // Should not throw even with nothing queued.
   assert.doesNotThrow(() => manager.destroy());
+});
+
+test("remote section state applies when no explicit local edit is pending", () => {
+  const manager = new ChannelSectionSyncManager("pk-remote-first");
+  assert.equal(
+    manager.shouldApplyRemote({
+      store: makeStore({
+        sections: [{ id: "remote", name: "Remote category", order: 0 }],
+      }),
+      createdAt: 10,
+      eventId: "remote-first",
+    }),
+    true,
+  );
+});
+
+test("pending local section edit wins over a remote snapshot during debounce", () => {
+  let timerCallback = null;
+  let nextId = 1;
+  if (typeof globalThis.window === "undefined") {
+    globalThis.window = {};
+  }
+  const origSetTimeout = globalThis.window.setTimeout;
+  const origClearTimeout = globalThis.window.clearTimeout;
+  globalThis.window.setTimeout = (fn, _ms) => {
+    timerCallback = fn;
+    return nextId++;
+  };
+  globalThis.window.clearTimeout = (_id) => {
+    timerCallback = null;
+  };
+
+  try {
+    const manager = new ChannelSectionSyncManager("pk-local-wins");
+    const local = makeStore({
+      sections: [{ id: "local", name: "New category", order: 0 }],
+    });
+    const staleRemote = {
+      store: makeStore({ sections: [] }),
+      createdAt: 100,
+      eventId: "remote-before-local-publish",
+    };
+
+    manager.publishSections(local);
+
+    assert.equal(
+      manager.shouldApplyRemote(staleRemote),
+      false,
+      "remote snapshot must not replace an explicit local edit awaiting publish",
+    );
+    assert.deepEqual(
+      manager.getPendingStore(),
+      local,
+      "the pending local category must remain queued",
+    );
+    assert.ok(
+      timerCallback !== null,
+      "the local publish timer must remain armed",
+    );
+  } finally {
+    globalThis.window.setTimeout = origSetTimeout;
+    globalThis.window.clearTimeout = origClearTimeout;
+  }
 });
 
 test("destroy: cancelPendingPublish clears pendingStore", () => {

--- a/desktop/src/features/sidebar/lib/channelSectionsSync.ts
+++ b/desktop/src/features/sidebar/lib/channelSectionsSync.ts
@@ -21,6 +21,51 @@ export type RemoteSections = {
   eventId: string;
 };
 
+/** NIP-78 plaintext shape. Optional channelsBlockIndex keeps v1 backward-readable. */
+export function serializeChannelSectionsPayload(store: ChannelSectionStore): {
+  version: 1;
+  sections: ChannelSection[];
+  assignments: Record<string, string>;
+  channelsBlockIndex?: number;
+} {
+  return {
+    version: 1,
+    sections: store.sections,
+    assignments: store.assignments,
+    ...(typeof store.channelsBlockIndex === "number"
+      ? { channelsBlockIndex: store.channelsBlockIndex }
+      : {}),
+  };
+}
+
+/** Equality used to skip no-op re-publishes (includes index-only moves). */
+export function channelSectionStoresEqual(
+  left: ChannelSectionStore,
+  right: ChannelSectionStore,
+): boolean {
+  if (left.sections.length !== right.sections.length) return false;
+  for (let i = 0; i < right.sections.length; i++) {
+    const a = left.sections[i] as ChannelSection | undefined;
+    const b = right.sections[i] as ChannelSection;
+    if (
+      !a ||
+      a.id !== b.id ||
+      a.name !== b.name ||
+      a.icon !== b.icon ||
+      a.order !== b.order
+    ) {
+      return false;
+    }
+  }
+  const leftKeys = Object.keys(left.assignments);
+  const rightKeys = Object.keys(right.assignments);
+  if (leftKeys.length !== rightKeys.length) return false;
+  for (const key of rightKeys) {
+    if (left.assignments[key] !== right.assignments[key]) return false;
+  }
+  return left.channelsBlockIndex === right.channelsBlockIndex;
+}
+
 async function decryptAndParse(
   event: RelayEvent,
 ): Promise<RemoteSections | null> {
@@ -119,29 +164,7 @@ export class ChannelSectionSyncManager {
 
   private isIdenticalToLastPublished(store: ChannelSectionStore): boolean {
     if (!this.lastPublishedStore) return false;
-    const lastSections = this.lastPublishedStore.sections;
-    const currentSections = store.sections;
-    if (lastSections.length !== currentSections.length) return false;
-    for (let i = 0; i < currentSections.length; i++) {
-      const last = lastSections[i] as ChannelSection | undefined;
-      const current = currentSections[i] as ChannelSection;
-      if (
-        !last ||
-        last.id !== current.id ||
-        last.name !== current.name ||
-        last.icon !== current.icon ||
-        last.order !== current.order
-      )
-        return false;
-    }
-    const lastAssignKeys = Object.keys(this.lastPublishedStore.assignments);
-    const currentAssignKeys = Object.keys(store.assignments);
-    if (lastAssignKeys.length !== currentAssignKeys.length) return false;
-    for (const key of currentAssignKeys) {
-      if (this.lastPublishedStore.assignments[key] !== store.assignments[key])
-        return false;
-    }
-    return true;
+    return channelSectionStoresEqual(this.lastPublishedStore, store);
   }
 
   private async doPublish(store: ChannelSectionStore): Promise<void> {
@@ -155,11 +178,9 @@ export class ChannelSectionSyncManager {
         this.pendingStore = null;
         return;
       }
-      const payload = {
-        version: 1,
-        sections: store.sections,
-        assignments: store.assignments,
-      };
+      // Optional channelsBlockIndex keeps v1 payloads backward-readable:
+      // older clients ignore the field; omit when unset so legacy layout wins.
+      const payload = serializeChannelSectionsPayload(store);
       const ciphertext = await nip44EncryptToSelf(JSON.stringify(payload));
       const createdAt = Math.max(
         Math.floor(Date.now() / 1_000),

--- a/desktop/src/features/sidebar/lib/channelSectionsSync.ts
+++ b/desktop/src/features/sidebar/lib/channelSectionsSync.ts
@@ -58,10 +58,7 @@ export class ChannelSectionSyncManager {
       if (events[0].pubkey !== this.pubkey) return null;
       const result = await decryptAndParse(events[0]);
       if (result) {
-        this.lastRemoteCreatedAt = Math.max(
-          this.lastRemoteCreatedAt,
-          result.createdAt,
-        );
+        this.shouldApplyRemote(result);
       }
       return result;
     } catch {
@@ -80,6 +77,14 @@ export class ChannelSectionSyncManager {
     return this.pendingStore;
   }
 
+  shouldApplyRemote(remote: RemoteSections): boolean {
+    this.lastRemoteCreatedAt = Math.max(
+      this.lastRemoteCreatedAt,
+      remote.createdAt,
+    );
+    return this.pendingStore === null;
+  }
+
   publishSections(store: ChannelSectionStore): void {
     this.pendingStore = store;
     if (this.debounceTimer !== null) {
@@ -91,9 +96,7 @@ export class ChannelSectionSyncManager {
     }, DEBOUNCE_MS);
   }
 
-  private async fetchOwnBlobBeforePublish(
-    store: ChannelSectionStore,
-  ): Promise<ChannelSectionStore> {
+  private async refreshRemoteTimestampBeforePublish(): Promise<void> {
     try {
       const events = await relayClient.fetchEvents({
         kinds: [KIND_CHANNEL_SECTIONS],
@@ -101,17 +104,16 @@ export class ChannelSectionSyncManager {
         "#d": [D_TAG],
         limit: 1,
       });
-      if (events.length === 0 || events[0].pubkey !== this.pubkey) return store;
+      if (events.length === 0 || events[0].pubkey !== this.pubkey) return;
       const remote = await decryptAndParse(events[0]);
-      if (!remote) return store;
-      // Sections use whole-blob LWW: take whichever is newer
-      if (remote.createdAt > this.lastRemoteCreatedAt) {
-        this.lastRemoteCreatedAt = remote.createdAt;
-        return remote.store;
-      }
-      return store;
+      if (!remote) return;
+      this.lastRemoteCreatedAt = Math.max(
+        this.lastRemoteCreatedAt,
+        remote.createdAt,
+      );
     } catch {
-      return store;
+      // Publishing the explicit local edit is still safe: the event timestamp
+      // below is monotonic against every remote value this manager has seen.
     }
   }
 
@@ -144,19 +146,19 @@ export class ChannelSectionSyncManager {
 
   private async doPublish(store: ChannelSectionStore): Promise<void> {
     try {
-      const merged = await this.fetchOwnBlobBeforePublish(store);
-      // Guard: manager may have been destroyed while fetchOwnBlobBeforePublish
+      await this.refreshRemoteTimestampBeforePublish();
+      // Guard: manager may have been destroyed while the remote timestamp
       // was awaited (community switch during in-flight fetch). If so, abort
       // before touching the relay.
       if (this.destroyed) return;
-      if (this.isIdenticalToLastPublished(merged)) {
+      if (this.isIdenticalToLastPublished(store)) {
         this.pendingStore = null;
         return;
       }
       const payload = {
         version: 1,
-        sections: merged.sections,
-        assignments: merged.assignments,
+        sections: store.sections,
+        assignments: store.assignments,
       };
       const ciphertext = await nip44EncryptToSelf(JSON.stringify(payload));
       const createdAt = Math.max(
@@ -185,7 +187,7 @@ export class ChannelSectionSyncManager {
         this.lastRemoteCreatedAt,
         event.created_at,
       );
-      this.lastPublishedStore = merged;
+      this.lastPublishedStore = store;
       this.pendingStore = null;
     } catch (error) {
       console.warn("[channelSectionsSync] publish failed:", error);
@@ -206,10 +208,7 @@ export class ChannelSectionSyncManager {
         if (event.pubkey !== this.pubkey) return;
         void decryptAndParse(event).then((result) => {
           if (result) {
-            this.lastRemoteCreatedAt = Math.max(
-              this.lastRemoteCreatedAt,
-              result.createdAt,
-            );
+            this.shouldApplyRemote(result);
             onUpdate(result);
           }
         });

--- a/desktop/src/features/sidebar/lib/channelSortPreference.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelSortPreference.test.mjs
@@ -3,7 +3,10 @@ import test from "node:test";
 
 import {
   DEFAULT_SORT_MODE,
+  DEFAULT_STREAM_SORT_MODE,
   DEFAULT_STORE,
+  hasExplicitSortPreference,
+  isStreamSortGroup,
   parseChannelSortPayload,
   sectionSortGroupKey,
   sortChannelsForSidebar,
@@ -99,12 +102,38 @@ test("parseChannelSortPayload: non-object input returns null", () => {
 
 test("default sort mode is alpha and default store has no overrides", () => {
   assert.equal(DEFAULT_SORT_MODE, "alpha");
+  assert.equal(DEFAULT_STREAM_SORT_MODE, "manual");
   assert.deepEqual(DEFAULT_STORE.groups, {});
 });
 
-test("sortModeForGroup: unset group falls back to alpha", () => {
-  assert.equal(sortModeForGroup(DEFAULT_STORE, "channels"), "alpha");
+test("isStreamSortGroup: channels and section:* only", () => {
+  assert.equal(isStreamSortGroup("channels"), true);
+  assert.equal(isStreamSortGroup(sectionSortGroupKey("abc")), true);
+  assert.equal(isStreamSortGroup("starred"), false);
+  assert.equal(isStreamSortGroup("forums"), false);
+  assert.equal(isStreamSortGroup("dms"), false);
+});
+
+test("sortModeForGroup: unset stream groups default Manual; non-stream alpha", () => {
+  assert.equal(sortModeForGroup(DEFAULT_STORE, "channels"), "manual");
+  assert.equal(
+    sortModeForGroup(DEFAULT_STORE, sectionSortGroupKey("work")),
+    "manual",
+  );
   assert.equal(sortModeForGroup(DEFAULT_STORE, "dms"), "alpha");
+  assert.equal(sortModeForGroup(DEFAULT_STORE, "starred"), "alpha");
+  assert.equal(sortModeForGroup(DEFAULT_STORE, "forums"), "alpha");
+});
+
+test("sortModeForGroup: explicit A–Z is preserved (not collapsed into unset)", () => {
+  const store = {
+    version: 1,
+    groups: { channels: "alpha", [sectionSortGroupKey("work")]: "alpha" },
+  };
+  assert.equal(sortModeForGroup(store, "channels"), "alpha");
+  assert.equal(sortModeForGroup(store, sectionSortGroupKey("work")), "alpha");
+  assert.equal(hasExplicitSortPreference(store, "channels"), true);
+  assert.equal(hasExplicitSortPreference(DEFAULT_STORE, "channels"), false);
 });
 
 test("sortModeForGroup: set groups are independent", () => {
@@ -115,7 +144,8 @@ test("sortModeForGroup: set groups are independent", () => {
   assert.equal(sortModeForGroup(store, "channels"), "recent");
   assert.equal(sortModeForGroup(store, sectionSortGroupKey("abc")), "recent");
   assert.equal(sortModeForGroup(store, "forums"), "alpha");
-  assert.equal(sortModeForGroup(store, sectionSortGroupKey("xyz")), "alpha");
+  // Unset custom section defaults Manual (stream), not alpha.
+  assert.equal(sortModeForGroup(store, sectionSortGroupKey("xyz")), "manual");
 });
 
 test("sectionSortGroupKey: namespaced by section id", () => {

--- a/desktop/src/features/sidebar/lib/channelSortPreference.test.mjs
+++ b/desktop/src/features/sidebar/lib/channelSortPreference.test.mjs
@@ -44,6 +44,16 @@ test("parseChannelSortPayload: valid per-group payload", () => {
   );
 });
 
+test("parseChannelSortPayload: manual is owned by the separate order store", () => {
+  assert.deepEqual(
+    parseChannelSortPayload({
+      version: 1,
+      groups: { channels: "manual", dms: "recent" },
+    }),
+    { version: 1, groups: { dms: "recent" } },
+  );
+});
+
 test("parseChannelSortPayload: empty groups is valid", () => {
   assert.deepEqual(parseChannelSortPayload({ version: 1, groups: {} }), {
     version: 1,

--- a/desktop/src/features/sidebar/lib/channelSortPreference.ts
+++ b/desktop/src/features/sidebar/lib/channelSortPreference.ts
@@ -3,7 +3,8 @@ import type { Channel } from "@/shared/api/types";
 
 const STORAGE_KEY_PREFIX = "buzz-channel-sort.v1";
 
-export type ChannelSortMode = "alpha" | "recent";
+export type ChannelSortMode = "alpha" | "recent" | "manual";
+type PersistedChannelSortMode = Exclude<ChannelSortMode, "manual">;
 
 /**
  * Key identifying a sidebar grouping that carries its own sort preference.
@@ -18,7 +19,7 @@ export type ChannelSortGroupKey =
 
 export type ChannelSortStore = {
   version: 1;
-  groups: Record<string, ChannelSortMode>;
+  groups: Record<string, PersistedChannelSortMode>;
 };
 
 export const DEFAULT_SORT_MODE: ChannelSortMode = "alpha";
@@ -72,13 +73,13 @@ export function parseChannelSortPayload(
   if (typeof json !== "object" || json === null) return null;
   const obj = json as Record<string, unknown>;
   if (obj.version !== 1) return null;
-  const groups: Record<string, ChannelSortMode> =
+  const groups: Record<string, PersistedChannelSortMode> =
     typeof obj.groups === "object" &&
     obj.groups !== null &&
     !Array.isArray(obj.groups)
       ? Object.fromEntries(
           Object.entries(obj.groups as Record<string, unknown>).filter(
-            (entry): entry is [string, ChannelSortMode] =>
+            (entry): entry is [string, PersistedChannelSortMode] =>
               entry[1] === "alpha" || entry[1] === "recent",
           ),
         )
@@ -118,7 +119,7 @@ export function writeChannelSortStore(
 export function sortModeForGroup(
   store: ChannelSortStore,
   group: ChannelSortGroupKey,
-): ChannelSortMode {
+): PersistedChannelSortMode {
   return store.groups[group] ?? DEFAULT_SORT_MODE;
 }
 
@@ -143,7 +144,7 @@ export function sortChannelsForSidebar(
   channels: Channel[],
   mode: ChannelSortMode,
 ): Channel[] {
-  if (mode === "alpha") {
+  if (mode === "alpha" || mode === "manual") {
     return [...channels].sort(compareChannelsByName);
   }
   return [...channels].sort((left, right) => {

--- a/desktop/src/features/sidebar/lib/channelSortPreference.ts
+++ b/desktop/src/features/sidebar/lib/channelSortPreference.ts
@@ -22,7 +22,16 @@ export type ChannelSortStore = {
   groups: Record<string, PersistedChannelSortMode>;
 };
 
+/** Default for non-stream groups (starred / forums / dms). */
 export const DEFAULT_SORT_MODE: ChannelSortMode = "alpha";
+
+/**
+ * Default for stream groups (Channels + custom categories) when the user has
+ * never saved an explicit A–Z / Recent preference. Manual is implicit — it
+ * does not write sort prefs or seed the order store until the user reorders
+ * or chooses Manual explicitly.
+ */
+export const DEFAULT_STREAM_SORT_MODE: ChannelSortMode = "manual";
 
 export const DEFAULT_STORE: ChannelSortStore = Object.freeze({
   version: 1,
@@ -31,6 +40,19 @@ export const DEFAULT_STORE: ChannelSortStore = Object.freeze({
 
 export function sectionSortGroupKey(sectionId: string): ChannelSortGroupKey {
   return `section:${sectionId}`;
+}
+
+/** Stream sidebar groups that default to Manual when unset. */
+export function isStreamSortGroup(group: ChannelSortGroupKey): boolean {
+  return group === "channels" || group.startsWith("section:");
+}
+
+/** True when the user (or a remote peer) has saved A–Z or Recent for the group. */
+export function hasExplicitSortPreference(
+  store: ChannelSortStore,
+  group: ChannelSortGroupKey,
+): boolean {
+  return Object.hasOwn(store.groups, group);
 }
 
 /**
@@ -116,11 +138,22 @@ export function writeChannelSortStore(
   }
 }
 
+/**
+ * Effective sort mode for a group from the persisted alpha/recent map only.
+ * Does not consult the separate manual-order store — callers that track
+ * explicit Manual via `manualGroups` should treat that as higher priority.
+ *
+ * Unset stream groups return Manual; unset non-stream groups return A–Z.
+ * Explicit A–Z is distinguishable from unset via {@link hasExplicitSortPreference}.
+ */
 export function sortModeForGroup(
   store: ChannelSortStore,
   group: ChannelSortGroupKey,
-): PersistedChannelSortMode {
-  return store.groups[group] ?? DEFAULT_SORT_MODE;
+): ChannelSortMode {
+  const explicit = store.groups[group];
+  if (explicit === "alpha" || explicit === "recent") return explicit;
+  if (isStreamSortGroup(group)) return DEFAULT_STREAM_SORT_MODE;
+  return DEFAULT_SORT_MODE;
 }
 
 function channelRecencyMs(channel: Channel): number | null {

--- a/desktop/src/features/sidebar/lib/useChannelManualOrder.ts
+++ b/desktop/src/features/sidebar/lib/useChannelManualOrder.ts
@@ -1,0 +1,240 @@
+import * as React from "react";
+
+import { relayClient } from "@/shared/api/relayClient";
+import type { ChannelSortGroupKey } from "./channelSortPreference";
+import {
+  DEFAULT_MANUAL_ORDER_STORE,
+  mergeDeletedSectionOrder,
+  moveManualChannel,
+  orderIdsForGroup,
+  pruneManualOrderGroups,
+  setManualGroupEnabled,
+  setManualGroupOrder,
+  type ChannelManualOrderStore,
+} from "./channelManualOrder";
+import {
+  channelManualOrderStorageKey,
+  readChannelManualOrderStore,
+  writeChannelManualOrderStore,
+} from "./channelManualOrderStorage";
+import {
+  ChannelManualOrderSyncManager,
+  type RemoteManualOrder,
+} from "./channelManualOrderSync";
+
+export function useChannelManualOrder(
+  pubkey: string | undefined,
+  relayUrl: string | undefined,
+  liveSectionIds: readonly string[],
+): {
+  orderIds: (
+    group: ChannelSortGroupKey,
+    liveIds: readonly string[],
+  ) => string[];
+  seedOrder: (
+    group: ChannelSortGroupKey,
+    visibleIds: readonly string[],
+  ) => void;
+  isManual: (group: ChannelSortGroupKey) => boolean;
+  setManualMode: (group: ChannelSortGroupKey, enabled: boolean) => void;
+  mergeDeletedSection: (
+    sectionId: string,
+    sectionChannelIds: readonly string[],
+    channelIds: readonly string[],
+  ) => void;
+  moveChannel: (input: {
+    channelId: string;
+    sourceGroup: ChannelSortGroupKey;
+    targetGroup: ChannelSortGroupKey;
+    overChannelId?: string;
+    sourceLiveIds: readonly string[];
+    targetLiveIds: readonly string[];
+  }) => void;
+} {
+  const [store, setStore] = React.useState<ChannelManualOrderStore>(() =>
+    pubkey
+      ? readChannelManualOrderStore(pubkey, relayUrl)
+      : DEFAULT_MANUAL_ORDER_STORE,
+  );
+  const managerRef = React.useRef<ChannelManualOrderSyncManager | null>(null);
+  const lastAppliedRemoteTs = React.useRef(0);
+  const lastAppliedEventId = React.useRef("");
+
+  React.useEffect(() => {
+    if (!pubkey) {
+      setStore(DEFAULT_MANUAL_ORDER_STORE);
+      return;
+    }
+    setStore(readChannelManualOrderStore(pubkey, relayUrl));
+    lastAppliedRemoteTs.current = 0;
+    lastAppliedEventId.current = "";
+    managerRef.current = new ChannelManualOrderSyncManager(pubkey);
+    return () => {
+      managerRef.current?.destroy();
+      managerRef.current = null;
+    };
+  }, [pubkey, relayUrl]);
+
+  React.useEffect(() => {
+    if (!pubkey) return;
+    const key = channelManualOrderStorageKey(pubkey, relayUrl);
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === key) {
+        setStore(readChannelManualOrderStore(pubkey, relayUrl));
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [pubkey, relayUrl]);
+
+  const applyRemote = React.useCallback(
+    (remote: RemoteManualOrder) => {
+      if (!pubkey) return;
+      if (managerRef.current?.shouldApplyRemote(remote) === false) return;
+      if (remote.createdAt < lastAppliedRemoteTs.current) return;
+      if (
+        remote.createdAt === lastAppliedRemoteTs.current &&
+        remote.eventId <= lastAppliedEventId.current
+      )
+        return;
+      lastAppliedRemoteTs.current = remote.createdAt;
+      lastAppliedEventId.current = remote.eventId;
+      if (writeChannelManualOrderStore(pubkey, remote.store, relayUrl)) {
+        setStore(remote.store);
+      }
+    },
+    [pubkey, relayUrl],
+  );
+
+  React.useEffect(() => {
+    if (!pubkey) return;
+    let cancelled = false;
+    let unsubscribe: (() => Promise<void>) | null = null;
+    void managerRef.current?.fetchRemote().then((remote) => {
+      if (cancelled) return;
+      if (remote) {
+        applyRemote(remote);
+      } else {
+        const local = readChannelManualOrderStore(pubkey, relayUrl);
+        if (Object.keys(local.groups).length > 0) {
+          managerRef.current?.publish(local);
+        }
+      }
+    });
+    void managerRef.current?.subscribe(applyRemote).then((dispose) => {
+      if (cancelled) void dispose();
+      else unsubscribe = dispose;
+    });
+    const unsubscribeReconnect = relayClient.subscribeToReconnects(() => {
+      void managerRef.current?.fetchRemote().then((remote) => {
+        if (!cancelled && remote) applyRemote(remote);
+        const pending = managerRef.current?.getPendingStore();
+        if (!cancelled && pending) managerRef.current?.publish(pending);
+      });
+    });
+    return () => {
+      cancelled = true;
+      unsubscribeReconnect();
+      if (unsubscribe) void unsubscribe();
+    };
+  }, [pubkey, relayUrl, applyRemote]);
+
+  const commit = React.useCallback(
+    (
+      updater: (current: ChannelManualOrderStore) => ChannelManualOrderStore,
+    ) => {
+      if (!pubkey) return;
+      setStore((current) => {
+        const next = pruneManualOrderGroups(updater(current), liveSectionIds);
+        if (!writeChannelManualOrderStore(pubkey, next, relayUrl)) {
+          return current;
+        }
+        managerRef.current?.publish(next);
+        return next;
+      });
+    },
+    [pubkey, relayUrl, liveSectionIds],
+  );
+
+  const orderIds = React.useCallback(
+    (group: ChannelSortGroupKey, liveIds: readonly string[]) =>
+      orderIdsForGroup(store, group, liveIds),
+    [store],
+  );
+
+  React.useEffect(() => {
+    if (!pubkey) return;
+    setStore((current) => {
+      const next = pruneManualOrderGroups(current, liveSectionIds);
+      if (next === current) return current;
+      if (!writeChannelManualOrderStore(pubkey, next, relayUrl)) {
+        return current;
+      }
+      managerRef.current?.publish(next);
+      return next;
+    });
+  }, [pubkey, relayUrl, liveSectionIds]);
+
+  const seedOrder = React.useCallback(
+    (group: ChannelSortGroupKey, visibleIds: readonly string[]) => {
+      commit((current) => setManualGroupOrder(current, group, visibleIds));
+    },
+    [commit],
+  );
+
+  const isManual = React.useCallback(
+    (group: ChannelSortGroupKey) => store.manualGroups.includes(group),
+    [store.manualGroups],
+  );
+
+  const setManualMode = React.useCallback(
+    (group: ChannelSortGroupKey, enabled: boolean) => {
+      commit((current) => setManualGroupEnabled(current, group, enabled));
+    },
+    [commit],
+  );
+
+  const moveChannel = React.useCallback(
+    (input: Parameters<typeof moveManualChannel>[1]) => {
+      commit((current) => moveManualChannel(current, input));
+    },
+    [commit],
+  );
+
+  const mergeDeletedSection = React.useCallback(
+    (
+      sectionId: string,
+      sectionChannelIds: readonly string[],
+      channelIds: readonly string[],
+    ) => {
+      commit((current) =>
+        mergeDeletedSectionOrder(
+          current,
+          sectionId,
+          sectionChannelIds,
+          channelIds,
+        ),
+      );
+    },
+    [commit],
+  );
+
+  return React.useMemo(
+    () => ({
+      orderIds,
+      seedOrder,
+      isManual,
+      setManualMode,
+      mergeDeletedSection,
+      moveChannel,
+    }),
+    [
+      isManual,
+      mergeDeletedSection,
+      moveChannel,
+      orderIds,
+      seedOrder,
+      setManualMode,
+    ],
+  );
+}

--- a/desktop/src/features/sidebar/lib/useChannelSections.ts
+++ b/desktop/src/features/sidebar/lib/useChannelSections.ts
@@ -9,7 +9,13 @@ import {
 } from "./channelSectionsStorage";
 import { ChannelSectionSyncManager } from "./channelSectionsSync";
 import type { RemoteSections } from "./channelSectionsSync";
-import { swapSectionOrder } from "./channelSectionsHelpers";
+import {
+  appendSectionToStore,
+  getSidebarBlockOrder,
+  applySidebarBlockOrder,
+  removeSectionFromStore,
+  swapBlockOrder,
+} from "./channelSectionsHelpers";
 
 export type { ChannelSection } from "./channelSectionsStorage";
 
@@ -24,12 +30,17 @@ export function useChannelSections(
 ): {
   sections: ChannelSection[];
   assignments: Record<string, string>;
+  blockOrder: string[];
   createSection: (name: string, icon?: string) => ChannelSection | null;
   renameSection: (sectionId: string, newName: string, icon?: string) => void;
   deleteSection: (sectionId: string) => void;
+  moveBlockUp: (blockId: string) => void;
+  moveBlockDown: (blockId: string) => void;
+  /** @deprecated Prefer moveBlockUp */
   moveSectionUp: (sectionId: string) => void;
+  /** @deprecated Prefer moveBlockDown */
   moveSectionDown: (sectionId: string) => void;
-  reorderSections: (orderedIds: string[]) => void;
+  reorderBlocks: (orderedBlockIds: string[]) => void;
   assignChannel: (channelId: string, sectionId: string) => void;
   unassignChannel: (channelId: string) => void;
 } {
@@ -173,6 +184,9 @@ export function useChannelSections(
   const createSection = React.useCallback(
     (name: string, icon?: string): ChannelSection | null => {
       if (!pubkey) return null;
+      // Read current store so returned section.order matches what we persist.
+      // Append after the existing lane; does not shift Channels among
+      // categories that already sit above/below it.
       const prev = readChannelSectionsStore(pubkey, relayUrl);
       const maxOrder =
         prev.sections.length > 0
@@ -185,10 +199,7 @@ export function useChannelSections(
         order: maxOrder + 1,
       };
       setStore((current) => {
-        const next: ChannelSectionStore = {
-          ...current,
-          sections: [...current.sections, section],
-        };
+        const next = appendSectionToStore(current, section);
         if (!writeChannelSectionsStore(pubkey, next, relayUrl)) return current;
         managerRef.current?.publishSections(next);
         return next;
@@ -233,17 +244,7 @@ export function useChannelSections(
         return;
       }
       setStore((prev) => {
-        const assignments = { ...prev.assignments };
-        for (const channelId of Object.keys(assignments)) {
-          if (assignments[channelId] === sectionId) {
-            delete assignments[channelId];
-          }
-        }
-        const next: ChannelSectionStore = {
-          ...prev,
-          sections: prev.sections.filter((s) => s.id !== sectionId),
-          assignments,
-        };
+        const next = removeSectionFromStore(prev, sectionId);
         if (!writeChannelSectionsStore(pubkey, next, relayUrl)) {
           return prev;
         }
@@ -254,11 +255,11 @@ export function useChannelSections(
     [pubkey, relayUrl],
   );
 
-  const moveSectionUp = React.useCallback(
-    (sectionId: string) => {
+  const moveBlockUp = React.useCallback(
+    (blockId: string) => {
       if (!pubkey) return;
       setStore((prev) => {
-        const next = swapSectionOrder(prev, sectionId, "up");
+        const next = swapBlockOrder(prev, blockId, "up");
         if (!next || !writeChannelSectionsStore(pubkey, next, relayUrl))
           return prev;
         managerRef.current?.publishSections(next);
@@ -268,11 +269,11 @@ export function useChannelSections(
     [pubkey, relayUrl],
   );
 
-  const moveSectionDown = React.useCallback(
-    (sectionId: string) => {
+  const moveBlockDown = React.useCallback(
+    (blockId: string) => {
       if (!pubkey) return;
       setStore((prev) => {
-        const next = swapSectionOrder(prev, sectionId, "down");
+        const next = swapBlockOrder(prev, blockId, "down");
         if (!next || !writeChannelSectionsStore(pubkey, next, relayUrl))
           return prev;
         managerRef.current?.publishSections(next);
@@ -282,15 +283,14 @@ export function useChannelSections(
     [pubkey, relayUrl],
   );
 
-  const reorderSections = React.useCallback(
-    (orderedIds: string[]) => {
+  const moveSectionUp = moveBlockUp;
+  const moveSectionDown = moveBlockDown;
+
+  const reorderBlocks = React.useCallback(
+    (orderedBlockIds: string[]) => {
       if (!pubkey) return;
       setStore((prev) => {
-        const sections = prev.sections.map((s) => {
-          const newOrder = orderedIds.indexOf(s.id);
-          return newOrder === -1 ? s : { ...s, order: newOrder };
-        });
-        const next: ChannelSectionStore = { ...prev, sections };
+        const next = applySidebarBlockOrder(prev, orderedBlockIds);
         if (!writeChannelSectionsStore(pubkey, next, relayUrl)) return prev;
         managerRef.current?.publishSections(next);
         return next;
@@ -338,15 +338,20 @@ export function useChannelSections(
     [pubkey, relayUrl],
   );
 
+  const blockOrder = React.useMemo(() => getSidebarBlockOrder(store), [store]);
+
   return {
     sections,
     assignments: store.assignments,
+    blockOrder,
     createSection,
     renameSection,
     deleteSection,
+    moveBlockUp,
+    moveBlockDown,
     moveSectionUp,
     moveSectionDown,
-    reorderSections,
+    reorderBlocks,
     assignChannel,
     unassignChannel,
   };

--- a/desktop/src/features/sidebar/lib/useChannelSections.ts
+++ b/desktop/src/features/sidebar/lib/useChannelSections.ts
@@ -84,6 +84,8 @@ export function useChannelSections(
     ): ((prev: ChannelSectionStore) => ChannelSectionStore) => {
       return (prev) => {
         if (!pubkey) return prev;
+        if (managerRef.current?.shouldApplyRemote(remote) === false)
+          return prev;
         if (remote.createdAt < lastAppliedRemoteTs.current) return prev;
         if (
           remote.createdAt === lastAppliedRemoteTs.current &&

--- a/desktop/src/features/sidebar/lib/useChannelSortPreference.ts
+++ b/desktop/src/features/sidebar/lib/useChannelSortPreference.ts
@@ -19,8 +19,8 @@ import type { RemoteSortPrefs } from "./channelSortSync";
  * Persistent per-group sidebar sort preferences, scoped by pubkey + relay so
  * they don't bleed across identities or communities (same scoping as channel
  * sections). Each sidebar grouping (starred, channels, forums, dms, and each
- * custom section) carries its own saved Recent/A–Z mode; unset groups default
- * to A–Z. Mirrors changes made in other windows via the storage event.
+ * custom section) carries its own saved Recent/A–Z/Manual mode; unset groups
+ * default to A–Z. Mirrors changes made in other windows via the storage event.
  *
  * Preferences sync across clients via encrypted NIP-78 app data (kind 30078,
  * d-tag `channel-sort`), following the channel-sections pattern: localStorage
@@ -169,7 +169,7 @@ export function useChannelSortPreference(
 
   const setSortModeFor = React.useCallback(
     (group: ChannelSortGroupKey, mode: ChannelSortMode) => {
-      if (!pubkey) return;
+      if (!pubkey || mode === "manual") return;
       setStore((prev) => {
         const withUpdate: ChannelSortStore = {
           ...prev,

--- a/desktop/src/features/sidebar/lib/useSidebarChannelOrganization.ts
+++ b/desktop/src/features/sidebar/lib/useSidebarChannelOrganization.ts
@@ -55,6 +55,11 @@ export function useSidebarChannelOrganization({
       if (mode !== "manual") {
         return sortChannelsForSidebar(groupChannels, mode);
       }
+      // Implicit Manual (default, no user reorder yet): deterministic A–Z.
+      // First reorder / explicit Manual choice enables + seeds persistence.
+      if (!manualOrder.isManual(group)) {
+        return sortChannelsForSidebar(groupChannels, "alpha");
+      }
       const orderedIds = manualOrder.orderIds(
         group,
         groupChannels.map((channel) => channel.id),

--- a/desktop/src/features/sidebar/lib/useSidebarChannelOrganization.ts
+++ b/desktop/src/features/sidebar/lib/useSidebarChannelOrganization.ts
@@ -1,0 +1,202 @@
+import * as React from "react";
+
+import type { Channel } from "@/shared/api/types";
+import {
+  sectionSortGroupKey,
+  sortChannelsForSidebar,
+  type ChannelSortGroupKey,
+  type ChannelSortMode,
+} from "./channelSortPreference";
+import { useChannelManualOrder } from "./useChannelManualOrder";
+import { useChannelSortPreference } from "./useChannelSortPreference";
+import type { ChannelSection } from "./useChannelSections";
+
+type OrganizationInput = {
+  pubkey?: string;
+  relayUrl?: string;
+  channels: Channel[];
+  sections: ChannelSection[];
+  assignments: Record<string, string>;
+  starredChannelIds?: ReadonlySet<string>;
+  assignChannel: (channelId: string, sectionId: string) => void;
+  unassignChannel: (channelId: string) => void;
+};
+
+export function useSidebarChannelOrganization({
+  pubkey,
+  relayUrl,
+  channels,
+  sections,
+  assignments,
+  starredChannelIds,
+  assignChannel,
+  unassignChannel,
+}: OrganizationInput) {
+  const sectionIds = React.useMemo(
+    () => sections.map((section) => section.id),
+    [sections],
+  );
+  const { sortModeFor: persistedSortModeFor, setSortModeFor } =
+    useChannelSortPreference(pubkey, relayUrl, sectionIds);
+  const manualOrder = useChannelManualOrder(pubkey, relayUrl, sectionIds);
+  const sortModeFor = React.useCallback(
+    (group: ChannelSortGroupKey): ChannelSortMode =>
+      manualOrder.isManual(group) ? "manual" : persistedSortModeFor(group),
+    [manualOrder, persistedSortModeFor],
+  );
+  const streamChannels = React.useMemo(
+    () => channels.filter((channel) => channel.channelType === "stream"),
+    [channels],
+  );
+
+  const sortStreamGroup = React.useCallback(
+    (group: ChannelSortGroupKey, groupChannels: Channel[]) => {
+      const mode = sortModeFor(group);
+      if (mode !== "manual") {
+        return sortChannelsForSidebar(groupChannels, mode);
+      }
+      const orderedIds = manualOrder.orderIds(
+        group,
+        groupChannels.map((channel) => channel.id),
+      );
+      const byId = new Map(
+        groupChannels.map((channel) => [channel.id, channel]),
+      );
+      return orderedIds.flatMap((id) => {
+        const channel = byId.get(id);
+        return channel ? [channel] : [];
+      });
+    },
+    [manualOrder, sortModeFor],
+  );
+
+  const sectionBuckets = React.useMemo(() => {
+    const bySection: Record<string, Channel[]> = {};
+    const unassigned: Channel[] = [];
+    const liveSectionIds = new Set(sections.map((section) => section.id));
+    for (const channel of streamChannels) {
+      if (starredChannelIds?.has(channel.id)) continue;
+      const sectionId = assignments[channel.id];
+      if (sectionId && liveSectionIds.has(sectionId)) {
+        if (!bySection[sectionId]) bySection[sectionId] = [];
+        bySection[sectionId].push(channel);
+      } else {
+        unassigned.push(channel);
+      }
+    }
+    for (const sectionId of Object.keys(bySection)) {
+      bySection[sectionId] = sortStreamGroup(
+        sectionSortGroupKey(sectionId),
+        bySection[sectionId],
+      );
+    }
+    return {
+      bySection,
+      unassigned: sortStreamGroup("channels", unassigned),
+    };
+  }, [
+    assignments,
+    sections,
+    sortStreamGroup,
+    starredChannelIds,
+    streamChannels,
+  ]);
+
+  const handleSortModeChange = React.useCallback(
+    (
+      group: ChannelSortGroupKey,
+      mode: ChannelSortMode,
+      visibleChannels: Channel[],
+    ) => {
+      if (mode === "manual") {
+        manualOrder.seedOrder(
+          group,
+          visibleChannels.map((channel) => channel.id),
+        );
+        manualOrder.setManualMode(group, true);
+        return;
+      }
+      manualOrder.setManualMode(group, false);
+      setSortModeFor(group, mode);
+    },
+    [manualOrder, setSortModeFor],
+  );
+
+  const groupChannelIds = React.useMemo(() => {
+    const groups: Record<string, string[]> = {
+      channels: sectionBuckets.unassigned.map((channel) => channel.id),
+    };
+    for (const section of sections) {
+      groups[sectionSortGroupKey(section.id)] = (
+        sectionBuckets.bySection[section.id] ?? []
+      ).map((channel) => channel.id);
+    }
+    return groups;
+  }, [sections, sectionBuckets]);
+
+  const manualGroupKeys = React.useMemo(
+    () =>
+      new Set<ChannelSortGroupKey>(
+        [
+          "channels",
+          ...sections.map((section) => sectionSortGroupKey(section.id)),
+        ].filter(
+          (group): group is ChannelSortGroupKey =>
+            sortModeFor(group as ChannelSortGroupKey) === "manual",
+        ),
+      ),
+    [sections, sortModeFor],
+  );
+
+  const handleMoveChannel = React.useCallback(
+    (input: {
+      channelId: string;
+      sourceGroup: ChannelSortGroupKey;
+      targetGroup: ChannelSortGroupKey;
+      overChannelId?: string;
+    }) => {
+      const { channelId, sourceGroup, targetGroup, overChannelId } = input;
+      if (sourceGroup !== targetGroup) {
+        if (targetGroup === "channels") {
+          unassignChannel(channelId);
+        } else if (targetGroup.startsWith("section:")) {
+          assignChannel(channelId, targetGroup.slice("section:".length));
+        }
+      }
+      manualOrder.moveChannel({
+        channelId,
+        sourceGroup,
+        targetGroup,
+        ...(overChannelId ? { overChannelId } : {}),
+        sourceLiveIds: groupChannelIds[sourceGroup] ?? [],
+        targetLiveIds: groupChannelIds[targetGroup] ?? [],
+      });
+    },
+    [assignChannel, groupChannelIds, manualOrder, unassignChannel],
+  );
+
+  const preserveDeletedSectionOrder = React.useCallback(
+    (sectionId: string) => {
+      manualOrder.mergeDeletedSection(
+        sectionId,
+        (sectionBuckets.bySection[sectionId] ?? []).map(
+          (channel) => channel.id,
+        ),
+        sectionBuckets.unassigned.map((channel) => channel.id),
+      );
+    },
+    [manualOrder, sectionBuckets],
+  );
+
+  return {
+    sectionIds,
+    streamChannels,
+    sectionBuckets,
+    sortModeFor,
+    setSortModeFor,
+    handleSortModeChange,
+    manualGroupKeys,
+    handleMoveChannel,
+    preserveDeletedSectionOrder,
+  };
+}

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -356,7 +356,9 @@ export function AppSidebar({
   const [createSectionState, setCreateSectionState] = React.useState<{
     open: boolean;
     pendingChannelId: string | null;
-  }>({ open: false, pendingChannelId: null });
+    /** Live trigger to refocus after dialog close (survives sortable remount). */
+    restoreFocusSelector: string | null;
+  }>({ open: false, pendingChannelId: null, restoreFocusSelector: null });
   const [renameSectionTarget, setRenameSectionTarget] =
     React.useState<ChannelSection | null>(null);
   const [deleteSectionTarget, setDeleteSectionTarget] =
@@ -415,7 +417,11 @@ export function AppSidebar({
 
   const handleCreateSectionForChannel = React.useCallback(
     (channelId: string) => {
-      setCreateSectionState({ open: true, pendingChannelId: channelId });
+      setCreateSectionState({
+        open: true,
+        pendingChannelId: channelId,
+        restoreFocusSelector: null,
+      });
     },
     [],
   );
@@ -429,7 +435,11 @@ export function AppSidebar({
       if (createSectionState.pendingChannelId) {
         assignChannel(createSectionState.pendingChannelId, section.id);
       }
-      setCreateSectionState({ open: false, pendingChannelId: null });
+      setCreateSectionState({
+        open: false,
+        pendingChannelId: null,
+        restoreFocusSelector: null,
+      });
     },
     [createSection, assignChannel, createSectionState.pendingChannelId],
   );
@@ -671,10 +681,16 @@ export function AppSidebar({
                     onMarkAllChannelsRead={onMarkAllChannelsRead}
                     onBrowseChannels={onBrowseChannels}
                     onCreateCategory={() =>
-                      setCreateSectionState({
-                        open: true,
-                        pendingChannelId: null,
-                      })
+                      // Wait a frame so the section-actions menu can restore
+                      // trigger focus before the dialog focus stack captures it.
+                      openModalNextFrame(() =>
+                        setCreateSectionState({
+                          open: true,
+                          pendingChannelId: null,
+                          restoreFocusSelector:
+                            '[data-testid="section-actions-channels"]',
+                        }),
+                      )
                     }
                     onCreateSectionForChannel={handleCreateSectionForChannel}
                     onCreateChannelInSection={handleCreateChannelInSection}
@@ -861,9 +877,14 @@ export function AppSidebar({
       <CreateSectionDialog
         existingNames={channelSections.map((section) => section.name)}
         open={createSectionState.open}
+        restoreFocusSelector={createSectionState.restoreFocusSelector}
         onOpenChange={(open) => {
           if (!open) {
-            setCreateSectionState({ open: false, pendingChannelId: null });
+            setCreateSectionState({
+              open: false,
+              pendingChannelId: null,
+              restoreFocusSelector: null,
+            });
           }
         }}
         onConfirm={handleCreateSectionConfirm}

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -1,8 +1,6 @@
 // biome-ignore format: keep compact to stay within file size limit
 import * as React from "react";
 import { FeatureGate } from "@/shared/features";
-import { SidebarDndContext } from "@/features/sidebar/ui/SidebarDnd";
-
 import type { Community } from "@/features/communities/types";
 import { AddCommunityDialog } from "@/features/communities/ui/AddCommunityDialog";
 import type { AddCommunityPrefillRequest } from "@/features/communities/addCommunityPrefill";
@@ -15,10 +13,7 @@ import {
 import { useActiveWorkingChannelsById } from "@/features/sidebar/lib/useActiveWorkingChannelsById";
 import { useDmSidebarMetadata } from "@/features/sidebar/useDmSidebarMetadata";
 import { sortDmChannelsForSidebar } from "@/features/sidebar/lib/dmSidebarSort";
-import {
-  sectionSortGroupKey,
-  sortChannelsForSidebar,
-} from "@/features/sidebar/lib/channelSortPreference";
+import { sortChannelsForSidebar } from "@/features/sidebar/lib/channelSortPreference";
 import { useSidebarChannelOrganization } from "@/features/sidebar/lib/useSidebarChannelOrganization";
 import { useSidebarScrollLock } from "@/features/sidebar/lib/useSidebarScrollLock";
 import { isSidebarBackgroundTarget } from "@/features/sidebar/lib/sidebarBackgroundTarget";
@@ -39,10 +34,10 @@ import { MoreUnreadButton } from "@/features/sidebar/ui/MoreUnreadButton";
 import { SidebarSection } from "@/features/sidebar/ui/SidebarSection";
 import {
   ChannelGroupSection,
-  CustomChannelSection,
   SectionActionsMenu,
   SectionQuickAction,
 } from "@/features/sidebar/ui/CustomChannelSection";
+import { SidebarMovableLane } from "@/features/sidebar/ui/SidebarMovableLane";
 import { CreateChannelDialog } from "@/features/sidebar/ui/CreateChannelDialog";
 import { SidebarProfileCard } from "@/features/sidebar/ui/SidebarProfileCard";
 import { SidebarRelayConnectionCard } from "@/features/sidebar/ui/SidebarRelayConnectionCard";
@@ -347,12 +342,13 @@ export function AppSidebar({
   const {
     sections: channelSections,
     assignments: channelAssignments,
+    blockOrder,
     createSection,
     renameSection,
     deleteSection,
-    moveSectionUp,
-    moveSectionDown,
-    reorderSections,
+    moveBlockUp,
+    moveBlockDown,
+    reorderBlocks,
     assignChannel,
     unassignChannel,
   } = useChannelSections(currentPubkey, activeCommunity?.relayUrl);
@@ -373,7 +369,6 @@ export function AppSidebar({
     });
 
   const {
-    sectionIds,
     streamChannels,
     sectionBuckets,
     sortModeFor,
@@ -645,133 +640,57 @@ export function AppSidebar({
                       onLeaveChannel={requestLeaveChannel}
                     />
                   ) : null}
-                  <SidebarDndContext
+                  <SidebarMovableLane
+                    blockOrder={blockOrder}
+                    channelSections={channelSections}
+                    channelAssignments={channelAssignments}
+                    sectionBuckets={sectionBuckets}
                     channelGroups={channelGroups}
                     channels={channels}
-                    sections={channelSections}
-                    sectionIds={sectionIds}
                     manualGroupKeys={manualGroupKeys}
-                    onMoveChannel={handleMoveChannel}
-                    onReorderSections={reorderSections}
-                  >
-                    {channelSections.map((section, idx) => (
-                      <CustomChannelSection
-                        key={section.id}
-                        section={section}
-                        channels={sectionBuckets.bySection[section.id] ?? []}
-                        hasUnread={
-                          sectionBuckets.bySection[section.id]?.some((c) =>
-                            unreadChannelIds.has(c.id),
-                          ) ?? false
-                        }
-                        isCollapsed={collapsedSections[section.id] ?? false}
-                        isActiveChannel={selectedView === "channel"}
-                        activeWorkingByChannelId={activeWorkingByChannelId}
-                        selectedChannelId={selectedChannelId}
-                        unreadChannelCounts={unreadChannelCounts}
-                        unreadChannelIds={unreadChannelIds}
-                        sections={channelSections}
-                        assignments={channelAssignments}
-                        isFirst={idx === 0}
-                        isLast={idx === channelSections.length - 1}
-                        sortMode={sortModeFor(sectionSortGroupKey(section.id))}
-                        onSortModeChange={(mode) =>
-                          handleSortModeChange(
-                            sectionSortGroupKey(section.id),
-                            mode,
-                            sectionBuckets.bySection[section.id] ?? [],
-                          )
-                        }
-                        onToggleCollapsed={() =>
-                          toggleCollapsedSection(section.id)
-                        }
-                        onSelectChannel={onSelectChannel}
-                        onMarkChannelRead={onMarkChannelRead}
-                        onMarkChannelUnread={onMarkChannelUnread}
-                        onMarkSectionRead={() => {
-                          for (const channel of sectionBuckets.bySection[
-                            section.id
-                          ] ?? []) {
-                            onMarkChannelRead(
-                              channel.id,
-                              channel.lastMessageAt,
-                            );
-                          }
-                        }}
-                        onAssignChannel={assignChannel}
-                        onUnassignChannel={unassignChannel}
-                        onCreateSectionForChannel={
-                          handleCreateSectionForChannel
-                        }
-                        onCreateChannel={() =>
-                          handleCreateChannelInSection(section.id)
-                        }
-                        onRenameSection={() => setRenameSectionTarget(section)}
-                        onDeleteSection={() => setDeleteSectionTarget(section)}
-                        onMoveSectionUp={() => moveSectionUp(section.id)}
-                        onMoveSectionDown={() => moveSectionDown(section.id)}
-                        mutedChannelIds={mutedChannelIds}
-                        onMuteChannel={onMuteChannel}
-                        onUnmuteChannel={onUnmuteChannel}
-                        starredChannelIds={starredChannelIds}
-                        onStarChannel={onStarChannel}
-                        onUnstarChannel={onUnstarChannel}
-                        onDeleteChannel={requestDeleteChannel}
-                        onLeaveChannel={requestLeaveChannel}
-                      />
-                    ))}
-                    <ChannelGroupSection
-                      draggable
-                      hasUnread={unreadChannelIds.size > 0}
-                      isCollapsed={collapsedGroups.channels}
-                      isActiveChannel={selectedView === "channel"}
-                      activeWorkingByChannelId={activeWorkingByChannelId}
-                      items={sectionBuckets.unassigned}
-                      sortMode={sortModeFor("channels")}
-                      onSortModeChange={(mode) =>
-                        handleSortModeChange(
-                          "channels",
-                          mode,
-                          sectionBuckets.unassigned,
-                        )
-                      }
-                      actionsTestId="section-actions-channels"
-                      listTestId="stream-list"
-                      quickCreateLabel="Browse channels"
-                      onQuickCreateClick={() => onBrowseChannels?.()}
-                      showQuickCreate
-                      onMarkAllRead={onMarkAllChannelsRead}
-                      onMarkChannelRead={onMarkChannelRead}
-                      onMarkChannelUnread={onMarkChannelUnread}
-                      onSelectChannel={onSelectChannel}
-                      onToggleCollapsed={() => toggleCollapsedGroup("channels")}
-                      selectedChannelId={selectedChannelId}
-                      title="Channels"
-                      unreadChannelCounts={unreadChannelCounts}
-                      unreadChannelIds={unreadChannelIds}
-                      sections={channelSections}
-                      assignments={channelAssignments}
-                      onAssignChannel={assignChannel}
-                      onUnassignChannel={unassignChannel}
-                      onCreateSectionForChannel={handleCreateSectionForChannel}
-                      onCreateCategory={() =>
-                        setCreateSectionState({
-                          open: true,
-                          pendingChannelId: null,
-                        })
-                      }
-                      groupKey="channels"
-                      manualSortEnabled
-                      mutedChannelIds={mutedChannelIds}
-                      onMuteChannel={onMuteChannel}
-                      onUnmuteChannel={onUnmuteChannel}
-                      starredChannelIds={starredChannelIds}
-                      onStarChannel={onStarChannel}
-                      onUnstarChannel={onUnstarChannel}
-                      onDeleteChannel={requestDeleteChannel}
-                      onLeaveChannel={requestLeaveChannel}
-                    />
-                  </SidebarDndContext>
+                    collapsedSections={collapsedSections}
+                    collapsedChannels={collapsedGroups.channels}
+                    isActiveChannel={selectedView === "channel"}
+                    activeWorkingByChannelId={activeWorkingByChannelId}
+                    selectedChannelId={selectedChannelId}
+                    unreadChannelCounts={unreadChannelCounts}
+                    unreadChannelIds={unreadChannelIds}
+                    mutedChannelIds={mutedChannelIds}
+                    starredChannelIds={starredChannelIds}
+                    sortModeFor={sortModeFor}
+                    handleSortModeChange={handleSortModeChange}
+                    handleMoveChannel={handleMoveChannel}
+                    reorderBlocks={reorderBlocks}
+                    moveBlockUp={moveBlockUp}
+                    moveBlockDown={moveBlockDown}
+                    assignChannel={assignChannel}
+                    unassignChannel={unassignChannel}
+                    onSelectChannel={onSelectChannel}
+                    onMarkChannelRead={onMarkChannelRead}
+                    onMarkChannelUnread={onMarkChannelUnread}
+                    onMarkAllChannelsRead={onMarkAllChannelsRead}
+                    onBrowseChannels={onBrowseChannels}
+                    onCreateCategory={() =>
+                      setCreateSectionState({
+                        open: true,
+                        pendingChannelId: null,
+                      })
+                    }
+                    onCreateSectionForChannel={handleCreateSectionForChannel}
+                    onCreateChannelInSection={handleCreateChannelInSection}
+                    onRenameSection={setRenameSectionTarget}
+                    onDeleteSection={setDeleteSectionTarget}
+                    onToggleCollapsedSection={toggleCollapsedSection}
+                    onToggleCollapsedChannels={() =>
+                      toggleCollapsedGroup("channels")
+                    }
+                    onMuteChannel={onMuteChannel}
+                    onUnmuteChannel={onUnmuteChannel}
+                    onStarChannel={onStarChannel}
+                    onUnstarChannel={onUnstarChannel}
+                    onDeleteChannel={requestDeleteChannel}
+                    onLeaveChannel={requestLeaveChannel}
+                  />
                   <FeatureGate feature="forum">
                     <ChannelGroupSection
                       createLabel="New forum"

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -19,7 +19,7 @@ import {
   sectionSortGroupKey,
   sortChannelsForSidebar,
 } from "@/features/sidebar/lib/channelSortPreference";
-import { useChannelSortPreference } from "@/features/sidebar/lib/useChannelSortPreference";
+import { useSidebarChannelOrganization } from "@/features/sidebar/lib/useSidebarChannelOrganization";
 import { useSidebarScrollLock } from "@/features/sidebar/lib/useSidebarScrollLock";
 import { isSidebarBackgroundTarget } from "@/features/sidebar/lib/sidebarBackgroundTarget";
 import { useUnreadOverflow } from "@/features/sidebar/lib/useUnreadOverflow";
@@ -357,17 +357,6 @@ export function AppSidebar({
     unassignChannel,
   } = useChannelSections(currentPubkey, activeCommunity?.relayUrl);
 
-  const sectionIds = React.useMemo(
-    () => channelSections.map((s) => s.id),
-    [channelSections],
-  );
-
-  const { sortModeFor, setSortModeFor } = useChannelSortPreference(
-    currentPubkey,
-    activeCommunity?.relayUrl,
-    sectionIds,
-  );
-
   const [createSectionState, setCreateSectionState] = React.useState<{
     open: boolean;
     pendingChannelId: string | null;
@@ -383,47 +372,26 @@ export function AppSidebar({
       if (channel.id === selectedChannelId) onSelectHome();
     });
 
-  const streamChannels = React.useMemo(
-    () => channels.filter((channel) => channel.channelType === "stream"),
-    [channels],
-  );
-
-  const sectionBuckets = React.useMemo(() => {
-    const bySection: Record<string, Channel[]> = {};
-    const unassigned: Channel[] = [];
-    const sectionIds = new Set(channelSections.map((s) => s.id));
-
-    for (const channel of streamChannels) {
-      if (starredChannelIds?.has(channel.id)) continue;
-      const sectionId = channelAssignments[channel.id];
-      if (sectionId && sectionIds.has(sectionId)) {
-        if (!bySection[sectionId]) {
-          bySection[sectionId] = [];
-        }
-        bySection[sectionId].push(channel);
-      } else {
-        unassigned.push(channel);
-      }
-    }
-    // Apply each grouping's own sort preference; section membership itself
-    // is untouched.
-    for (const sectionId of Object.keys(bySection)) {
-      bySection[sectionId] = sortChannelsForSidebar(
-        bySection[sectionId],
-        sortModeFor(sectionSortGroupKey(sectionId)),
-      );
-    }
-    return {
-      bySection,
-      unassigned: sortChannelsForSidebar(unassigned, sortModeFor("channels")),
-    };
-  }, [
+  const {
+    sectionIds,
     streamChannels,
-    channelSections,
-    channelAssignments,
-    starredChannelIds,
+    sectionBuckets,
     sortModeFor,
-  ]);
+    setSortModeFor,
+    handleSortModeChange,
+    manualGroupKeys,
+    handleMoveChannel,
+    preserveDeletedSectionOrder,
+  } = useSidebarChannelOrganization({
+    pubkey: currentPubkey,
+    relayUrl: activeCommunity?.relayUrl,
+    channels,
+    sections: channelSections,
+    assignments: channelAssignments,
+    starredChannelIds,
+    assignChannel,
+    unassignChannel,
+  });
 
   const starredChannels = React.useMemo(() => {
     if (!starredChannelIds || starredChannelIds.size === 0) return [];
@@ -432,6 +400,23 @@ export function AppSidebar({
       sortModeFor("starred"),
     );
   }, [streamChannels, starredChannelIds, sortModeFor]);
+  const channelGroups = React.useMemo(
+    () => [
+      {
+        key: "channels" as const,
+        name: "Channels",
+        channelIds: sectionBuckets.unassigned.map((channel) => channel.id),
+      },
+      ...channelSections.map((section) => ({
+        key: `section:${section.id}` as const,
+        name: section.name,
+        channelIds: (sectionBuckets.bySection[section.id] ?? []).map(
+          (channel) => channel.id,
+        ),
+      })),
+    ],
+    [channelSections, sectionBuckets],
+  );
 
   const handleCreateSectionForChannel = React.useCallback(
     (channelId: string) => {
@@ -661,11 +646,12 @@ export function AppSidebar({
                     />
                   ) : null}
                   <SidebarDndContext
+                    channelGroups={channelGroups}
                     channels={channels}
                     sections={channelSections}
                     sectionIds={sectionIds}
-                    onAssignChannel={assignChannel}
-                    onUnassignChannel={unassignChannel}
+                    manualGroupKeys={manualGroupKeys}
+                    onMoveChannel={handleMoveChannel}
                     onReorderSections={reorderSections}
                   >
                     {channelSections.map((section, idx) => (
@@ -690,7 +676,11 @@ export function AppSidebar({
                         isLast={idx === channelSections.length - 1}
                         sortMode={sortModeFor(sectionSortGroupKey(section.id))}
                         onSortModeChange={(mode) =>
-                          setSortModeFor(sectionSortGroupKey(section.id), mode)
+                          handleSortModeChange(
+                            sectionSortGroupKey(section.id),
+                            mode,
+                            sectionBuckets.bySection[section.id] ?? [],
+                          )
                         }
                         onToggleCollapsed={() =>
                           toggleCollapsedSection(section.id)
@@ -739,7 +729,11 @@ export function AppSidebar({
                       items={sectionBuckets.unassigned}
                       sortMode={sortModeFor("channels")}
                       onSortModeChange={(mode) =>
-                        setSortModeFor("channels", mode)
+                        handleSortModeChange(
+                          "channels",
+                          mode,
+                          sectionBuckets.unassigned,
+                        )
                       }
                       actionsTestId="section-actions-channels"
                       listTestId="stream-list"
@@ -760,6 +754,14 @@ export function AppSidebar({
                       onAssignChannel={assignChannel}
                       onUnassignChannel={unassignChannel}
                       onCreateSectionForChannel={handleCreateSectionForChannel}
+                      onCreateCategory={() =>
+                        setCreateSectionState({
+                          open: true,
+                          pendingChannelId: null,
+                        })
+                      }
+                      groupKey="channels"
+                      manualSortEnabled
                       mutedChannelIds={mutedChannelIds}
                       onMuteChannel={onMuteChannel}
                       onUnmuteChannel={onUnmuteChannel}
@@ -938,6 +940,7 @@ export function AppSidebar({
       />
 
       <CreateSectionDialog
+        existingNames={channelSections.map((section) => section.name)}
         open={createSectionState.open}
         onOpenChange={(open) => {
           if (!open) {
@@ -948,6 +951,7 @@ export function AppSidebar({
       />
 
       <RenameSectionDialog
+        existingNames={channelSections.map((section) => section.name)}
         open={renameSectionTarget !== null}
         onOpenChange={(open) => {
           if (!open) setRenameSectionTarget(null);
@@ -975,6 +979,7 @@ export function AppSidebar({
         }
         onConfirm={() => {
           if (deleteSectionTarget) {
+            preserveDeletedSectionOrder(deleteSectionTarget.id);
             deleteSection(deleteSectionTarget.id);
             setCollapsedSections((prev) => {
               const next = { ...prev };

--- a/desktop/src/features/sidebar/ui/ChannelContextMenu.tsx
+++ b/desktop/src/features/sidebar/ui/ChannelContextMenu.tsx
@@ -58,7 +58,7 @@ function MoveToSectionSubmenu({
     <ContextMenuSub>
       <ContextMenuSubTrigger>
         <ContextMenuIconSlot />
-        <span>Move to section</span>
+        <span>Move to category</span>
       </ContextMenuSubTrigger>
       <ContextMenuSubContent>
         {sections.map((section) => (
@@ -87,14 +87,14 @@ function MoveToSectionSubmenu({
           <ContextMenuIconSlot>
             <Plus className="h-4 w-4" />
           </ContextMenuIconSlot>
-          <span>New section...</span>
+          <span>New category...</span>
         </ContextMenuItem>
         {currentSectionId ? (
           <ContextMenuItem
             onSelect={() => deferMenuAction(() => onUnassignChannel(channelId))}
           >
             <ContextMenuIconSlot />
-            <span>Remove from section</span>
+            <span>Remove from category</span>
           </ContextMenuItem>
         ) : null}
       </ContextMenuSubContent>

--- a/desktop/src/features/sidebar/ui/ChannelSectionDialogs.tsx
+++ b/desktop/src/features/sidebar/ui/ChannelSectionDialogs.tsx
@@ -46,6 +46,7 @@ type SectionNameDialogProps = {
   initialIcon?: string;
   confirmLabel: string;
   isConfirmDisabled: (trimmed: string, icon: string) => boolean;
+  getNameError?: (trimmed: string) => string | null;
   onConfirm: (value: SectionDialogValue) => void;
 };
 
@@ -58,12 +59,16 @@ function SectionNameDialog({
   initialIcon = "",
   confirmLabel,
   isConfirmDisabled,
+  getNameError,
   onConfirm,
 }: SectionNameDialogProps) {
   const [name, setName] = React.useState(initialValue);
   const [icon, setIcon] = React.useState(initialIcon);
   const [pickerOpen, setPickerOpen] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const inputId = React.useId();
+  const errorId = `${inputId}-error`;
+  const nameError = name.trim() ? getNameError?.(name.trim()) : null;
 
   React.useEffect(() => {
     if (!open) {
@@ -108,7 +113,7 @@ function SectionNameDialog({
               <div className="relative shrink-0">
                 <PopoverTrigger asChild>
                   <button
-                    aria-label="Choose section icon"
+                    aria-label="Choose category icon"
                     className="flex h-9 w-9 items-center justify-center rounded-md border border-input text-lg transition-colors hover:bg-accent"
                     type="button"
                   >
@@ -121,7 +126,7 @@ function SectionNameDialog({
                 </PopoverTrigger>
                 {icon ? (
                   <button
-                    aria-label="Clear section icon"
+                    aria-label="Clear category icon"
                     className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full border border-background bg-muted text-muted-foreground hover:bg-accent hover:text-foreground"
                     onClick={(event) => {
                       event.stopPropagation();
@@ -142,17 +147,32 @@ function SectionNameDialog({
               </PopoverContent>
             </Popover>
             <Input
+              aria-describedby={nameError ? errorId : undefined}
+              aria-invalid={nameError ? true : undefined}
               autoCapitalize="none"
               autoComplete="off"
               autoCorrect="off"
               className="flex-1"
+              id={inputId}
               onChange={(event) => setName(event.target.value)}
-              placeholder="Section name"
+              placeholder="Category name"
               ref={inputRef}
               spellCheck={false}
               value={name}
             />
           </div>
+          <label className="sr-only" htmlFor={inputId}>
+            Category name
+          </label>
+          {nameError ? (
+            <p
+              className="mt-2 text-sm text-destructive"
+              id={errorId}
+              role="alert"
+            >
+              {nameError}
+            </p>
+          ) : null}
           <div className="flex justify-end gap-2 mt-4">
             <DialogClose asChild>
               <Button variant="ghost" type="button">
@@ -176,22 +196,32 @@ export type CreateSectionDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: (value: SectionDialogValue) => void;
+  existingNames?: string[];
 };
 
 export function CreateSectionDialog({
   open,
   onOpenChange,
   onConfirm,
+  existingNames = [],
 }: CreateSectionDialogProps) {
+  const names = new Set(existingNames.map((name) => name.trim().toLowerCase()));
   return (
     <SectionNameDialog
       open={open}
       onOpenChange={onOpenChange}
-      title="Create section"
-      description="Sections let you group related channels in the sidebar."
+      title="Create category"
+      description="Categories group related channels in your sidebar."
       initialValue=""
       confirmLabel="Create"
-      isConfirmDisabled={(trimmed) => trimmed.length === 0}
+      isConfirmDisabled={(trimmed) =>
+        trimmed.length === 0 || names.has(trimmed.toLowerCase())
+      }
+      getNameError={(trimmed) =>
+        names.has(trimmed.toLowerCase())
+          ? "A category with this name already exists."
+          : null
+      }
       onConfirm={onConfirm}
     />
   );
@@ -203,6 +233,7 @@ export type RenameSectionDialogProps = {
   sectionName: string;
   sectionIcon?: string;
   onConfirm: (value: SectionDialogValue) => void;
+  existingNames?: string[];
 };
 
 export function RenameSectionDialog({
@@ -211,19 +242,34 @@ export function RenameSectionDialog({
   sectionName,
   sectionIcon,
   onConfirm,
+  existingNames = [],
 }: RenameSectionDialogProps) {
+  const names = new Set(
+    existingNames
+      .filter(
+        (name) =>
+          name.trim().toLowerCase() !== sectionName.trim().toLowerCase(),
+      )
+      .map((name) => name.trim().toLowerCase()),
+  );
   return (
     <SectionNameDialog
       open={open}
       onOpenChange={onOpenChange}
-      title="Rename section"
-      description="Enter a new name for this section."
+      title="Rename category"
+      description="Enter a new name for this category."
       initialValue={sectionName}
       initialIcon={sectionIcon}
       confirmLabel="Save"
       isConfirmDisabled={(trimmed, icon) =>
         trimmed.length === 0 ||
+        names.has(trimmed.toLowerCase()) ||
         (trimmed === sectionName && icon === (sectionIcon ?? ""))
+      }
+      getNameError={(trimmed) =>
+        names.has(trimmed.toLowerCase())
+          ? "A category with this name already exists."
+          : null
       }
       onConfirm={onConfirm}
     />
@@ -249,14 +295,14 @@ export function DeleteSectionAlertDialog({
     channelCount === 1 ? "1 channel" : `${channelCount} channels`;
   const description =
     channelCount === 0
-      ? `Delete section "${sectionName}"? It has no channels.`
-      : `Delete section "${sectionName}"? Its ${channelLabel} will move back to the default Channels group.`;
+      ? `Delete category "${sectionName}"? It has no channels.`
+      : `Delete category "${sectionName}"? Its ${channelLabel} will move back to the default Channels group.`;
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Delete section</AlertDialogTitle>
+          <AlertDialogTitle>Delete category</AlertDialogTitle>
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/desktop/src/features/sidebar/ui/ChannelSectionDialogs.tsx
+++ b/desktop/src/features/sidebar/ui/ChannelSectionDialogs.tsx
@@ -48,7 +48,22 @@ type SectionNameDialogProps = {
   isConfirmDisabled: (trimmed: string, icon: string) => boolean;
   getNameError?: (trimmed: string) => string | null;
   onConfirm: (value: SectionDialogValue) => void;
+  /**
+   * CSS selector for the control that opened this dialog (e.g. sidebar
+   * section-actions trigger). When the movable Channels/category lane
+   * remounts while the dialog is open, Radix's stored focus node can be
+   * detached; re-querying by selector restores focus to the live trigger.
+   */
+  restoreFocusSelector?: string | null;
 };
+
+function focusRestoreTarget(selector: string | null | undefined) {
+  if (!selector) return;
+  const node = document.querySelector(selector);
+  if (node instanceof HTMLElement) {
+    node.focus();
+  }
+}
 
 function SectionNameDialog({
   open,
@@ -61,11 +76,15 @@ function SectionNameDialog({
   isConfirmDisabled,
   getNameError,
   onConfirm,
+  restoreFocusSelector,
 }: SectionNameDialogProps) {
   const [name, setName] = React.useState(initialValue);
   const [icon, setIcon] = React.useState(initialIcon);
   const [pickerOpen, setPickerOpen] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  // Snap on open so parent can clear the prop during close without losing
+  // the target for onCloseAutoFocus.
+  const restoreFocusSelectorRef = React.useRef<string | null>(null);
   const inputId = React.useId();
   const errorId = `${inputId}-error`;
   const nameError = name.trim() ? getNameError?.(name.trim()) : null;
@@ -75,6 +94,7 @@ function SectionNameDialog({
       setPickerOpen(false);
       return;
     }
+    restoreFocusSelectorRef.current = restoreFocusSelector ?? null;
     setName(initialValue);
     setIcon(initialIcon);
     // Small delay to let dialog animation start before focusing
@@ -82,7 +102,7 @@ function SectionNameDialog({
       inputRef.current?.focus();
     }, 50);
     return () => globalThis.clearTimeout(timerId);
-  }, [open, initialValue, initialIcon]);
+  }, [open, initialValue, initialIcon, restoreFocusSelector]);
 
   function handleIconSelect(selectedIcon: string) {
     setIcon(selectedIcon);
@@ -102,7 +122,18 @@ function SectionNameDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm">
+      <DialogContent
+        className="max-w-sm"
+        onCloseAutoFocus={(event) => {
+          const selector = restoreFocusSelectorRef.current;
+          if (!selector) return;
+          // Prefer the live trigger over Radix's possibly-detached node
+          // after sortable block remounts (Channels wrapper / new category).
+          event.preventDefault();
+          focusRestoreTarget(selector);
+          restoreFocusSelectorRef.current = null;
+        }}
+      >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
@@ -197,6 +228,7 @@ export type CreateSectionDialogProps = {
   onOpenChange: (open: boolean) => void;
   onConfirm: (value: SectionDialogValue) => void;
   existingNames?: string[];
+  restoreFocusSelector?: string | null;
 };
 
 export function CreateSectionDialog({
@@ -204,6 +236,7 @@ export function CreateSectionDialog({
   onOpenChange,
   onConfirm,
   existingNames = [],
+  restoreFocusSelector,
 }: CreateSectionDialogProps) {
   const names = new Set(existingNames.map((name) => name.trim().toLowerCase()));
   return (
@@ -223,6 +256,7 @@ export function CreateSectionDialog({
           : null
       }
       onConfirm={onConfirm}
+      restoreFocusSelector={restoreFocusSelector}
     />
   );
 }

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -10,10 +10,13 @@ import {
   Trash2,
 } from "lucide-react";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import type * as React from "react";
 
-import type { ChannelSortMode } from "@/features/sidebar/lib/channelSortPreference";
+import type {
+  ChannelSortGroupKey,
+  ChannelSortMode,
+} from "@/features/sidebar/lib/channelSortPreference";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -48,6 +51,7 @@ import {
   DraggableChannelRow,
   DroppableSectionBody,
   DroppableUngroupedBody,
+  SortableChannelContext,
   SortableSectionShell,
 } from "@/features/sidebar/ui/SidebarDnd";
 import {
@@ -72,6 +76,7 @@ const SECTION_LABEL_CHEVRON_ICON_CLASS =
 const SORT_OPTIONS: { value: ChannelSortMode; label: string }[] = [
   { value: "recent", label: "Recent" },
   { value: "alpha", label: "A–Z" },
+  { value: "manual", label: "Manual" },
 ];
 
 /**
@@ -128,6 +133,7 @@ export function SectionActionsMenu({
   browseLabel,
   onCreate,
   createLabel,
+  onCreateCategory,
   onNewMessage,
   newMessageLabel,
   onRenameSection,
@@ -138,6 +144,7 @@ export function SectionActionsMenu({
   isLastSection,
   sortMode,
   onSortModeChange,
+  manualSortEnabled = false,
 }: {
   sectionLabel: string;
   testId?: string;
@@ -149,6 +156,7 @@ export function SectionActionsMenu({
   browseLabel?: string;
   onCreate?: () => void;
   createLabel?: string;
+  onCreateCategory?: () => void;
   onNewMessage?: () => void;
   newMessageLabel?: string;
   onRenameSection?: () => void;
@@ -159,8 +167,8 @@ export function SectionActionsMenu({
   isLastSection?: boolean;
   sortMode?: ChannelSortMode;
   onSortModeChange?: (mode: ChannelSortMode) => void;
+  manualSortEnabled?: boolean;
 }) {
-  const triggerRef = useRef<HTMLButtonElement>(null);
   const showSectionManagement = Boolean(onRenameSection || onDeleteSection);
   const showSort = Boolean(sortMode && onSortModeChange);
 
@@ -173,19 +181,12 @@ export function SectionActionsMenu({
           data-testid={testId}
           onClick={(event) => event.stopPropagation()}
           onPointerDown={(event) => event.stopPropagation()}
-          ref={triggerRef}
           type="button"
         >
           <EllipsisVertical className="h-4 w-4" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="end"
-        onCloseAutoFocus={(event) => {
-          event.preventDefault();
-          triggerRef.current?.blur();
-        }}
-      >
+      <DropdownMenuContent align="end">
         {hasUnread && onMarkAllRead ? (
           <DropdownMenuItem onSelect={() => deferMenuAction(onMarkAllRead)}>
             <CheckCheck className="h-4 w-4" />
@@ -213,6 +214,12 @@ export function SectionActionsMenu({
             <span>{createLabel ?? "Create channel"}</span>
           </DropdownMenuItem>
         ) : null}
+        {onCreateCategory ? (
+          <DropdownMenuItem onSelect={() => deferMenuAction(onCreateCategory)}>
+            <Plus className="h-4 w-4" />
+            <span>New category...</span>
+          </DropdownMenuItem>
+        ) : null}
         {showSectionManagement ? (
           <>
             {onRenameSection ? (
@@ -220,7 +227,7 @@ export function SectionActionsMenu({
                 onSelect={() => deferMenuAction(onRenameSection)}
               >
                 <Pencil className="h-4 w-4" />
-                <span>Rename section</span>
+                <span>Rename category</span>
               </DropdownMenuItem>
             ) : null}
             {onMoveSectionUp ? (
@@ -258,7 +265,9 @@ export function SectionActionsMenu({
                   }
                   value={sortMode}
                 >
-                  {SORT_OPTIONS.map((option) => (
+                  {SORT_OPTIONS.filter(
+                    (option) => manualSortEnabled || option.value !== "manual",
+                  ).map((option) => (
                     <DropdownMenuRadioItem
                       key={option.value}
                       value={option.value}
@@ -279,7 +288,7 @@ export function SectionActionsMenu({
               onSelect={() => deferMenuAction(onDeleteSection)}
             >
               <Trash2 className="h-4 w-4" />
-              <span>Delete section</span>
+              <span>Delete category</span>
             </DropdownMenuItem>
           </>
         ) : null}
@@ -365,6 +374,7 @@ export function ChannelGroupSection({
   onAssignChannel,
   onUnassignChannel,
   onCreateSectionForChannel,
+  onCreateCategory,
   mutedChannelIds,
   onMuteChannel,
   onUnmuteChannel,
@@ -373,6 +383,8 @@ export function ChannelGroupSection({
   onUnstarChannel,
   onDeleteChannel,
   onLeaveChannel,
+  groupKey = "channels",
+  manualSortEnabled = false,
 }: {
   browseLabel?: string;
   createLabel?: string;
@@ -415,6 +427,7 @@ export function ChannelGroupSection({
   onAssignChannel?: (channelId: string, sectionId: string) => void;
   onUnassignChannel?: (channelId: string) => void;
   onCreateSectionForChannel?: (channelId: string) => void;
+  onCreateCategory?: () => void;
   mutedChannelIds?: ReadonlySet<string>;
   onMuteChannel?: (channelId: string) => void;
   onUnmuteChannel?: (channelId: string) => void;
@@ -423,19 +436,41 @@ export function ChannelGroupSection({
   onUnstarChannel?: (channelId: string) => void;
   onDeleteChannel?: (channel: Channel) => void;
   onLeaveChannel?: (channel: Channel) => void;
+  groupKey?: ChannelSortGroupKey;
+  manualSortEnabled?: boolean;
 }) {
   const contentId = `sidebar-${listTestId}`;
   const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
 
   const channelList =
     items.length > 0 ? (
-      <SidebarMenu data-testid={listTestId}>
-        {items.map((channel) => (
-          <ContextMenu key={channel.id}>
-            <ContextMenuTrigger asChild>
-              <SidebarMenuItem className="content-visibility-auto-row">
-                {draggable ? (
-                  <DraggableChannelRow channelId={channel.id}>
+      <SortableChannelContext channelIds={items.map((channel) => channel.id)}>
+        <SidebarMenu data-testid={listTestId}>
+          {items.map((channel) => (
+            <ContextMenu key={channel.id}>
+              <ContextMenuTrigger asChild>
+                <SidebarMenuItem className="content-visibility-auto-row">
+                  {draggable ? (
+                    <DraggableChannelRow
+                      channelId={channel.id}
+                      channelName={channel.name}
+                      groupKey={groupKey}
+                    >
+                      <ChannelMenuButton
+                        channel={channel}
+                        activeWorking={activeWorkingByChannelId?.get(
+                          channel.id,
+                        )}
+                        hasUnread={unreadChannelIds.has(channel.id)}
+                        unreadCount={unreadChannelCounts.get(channel.id) ?? 0}
+                        isMuted={mutedChannelIds?.has(channel.id)}
+                        isActive={
+                          isActiveChannel && selectedChannelId === channel.id
+                        }
+                        onSelectChannel={onSelectChannel}
+                      />
+                    </DraggableChannelRow>
+                  ) : (
                     <ChannelMenuButton
                       channel={channel}
                       activeWorking={activeWorkingByChannelId?.get(channel.id)}
@@ -447,46 +482,34 @@ export function ChannelGroupSection({
                       }
                       onSelectChannel={onSelectChannel}
                     />
-                  </DraggableChannelRow>
-                ) : (
-                  <ChannelMenuButton
-                    channel={channel}
-                    activeWorking={activeWorkingByChannelId?.get(channel.id)}
-                    hasUnread={unreadChannelIds.has(channel.id)}
-                    unreadCount={unreadChannelCounts.get(channel.id) ?? 0}
-                    isMuted={mutedChannelIds?.has(channel.id)}
-                    isActive={
-                      isActiveChannel && selectedChannelId === channel.id
-                    }
-                    onSelectChannel={onSelectChannel}
-                  />
-                )}
-              </SidebarMenuItem>
-            </ContextMenuTrigger>
-            <ContextMenuContent>
-              <ChannelContextMenuItems
-                channel={channel}
-                hasUnread={unreadChannelIds.has(channel.id)}
-                isMuted={mutedChannelIds?.has(channel.id)}
-                isStarred={starredChannelIds?.has(channel.id)}
-                sections={sections}
-                assignments={assignments}
-                onMarkChannelRead={onMarkChannelRead}
-                onMarkChannelUnread={onMarkChannelUnread}
-                onMuteChannel={onMuteChannel}
-                onUnmuteChannel={onUnmuteChannel}
-                onStarChannel={onStarChannel}
-                onUnstarChannel={onUnstarChannel}
-                onAssignChannel={onAssignChannel}
-                onUnassignChannel={onUnassignChannel}
-                onCreateSectionForChannel={onCreateSectionForChannel}
-                onDeleteChannel={onDeleteChannel}
-                onLeaveChannel={onLeaveChannel}
-              />
-            </ContextMenuContent>
-          </ContextMenu>
-        ))}
-      </SidebarMenu>
+                  )}
+                </SidebarMenuItem>
+              </ContextMenuTrigger>
+              <ContextMenuContent>
+                <ChannelContextMenuItems
+                  channel={channel}
+                  hasUnread={unreadChannelIds.has(channel.id)}
+                  isMuted={mutedChannelIds?.has(channel.id)}
+                  isStarred={starredChannelIds?.has(channel.id)}
+                  sections={sections}
+                  assignments={assignments}
+                  onMarkChannelRead={onMarkChannelRead}
+                  onMarkChannelUnread={onMarkChannelUnread}
+                  onMuteChannel={onMuteChannel}
+                  onUnmuteChannel={onUnmuteChannel}
+                  onStarChannel={onStarChannel}
+                  onUnstarChannel={onUnstarChannel}
+                  onAssignChannel={onAssignChannel}
+                  onUnassignChannel={onUnassignChannel}
+                  onCreateSectionForChannel={onCreateSectionForChannel}
+                  onDeleteChannel={onDeleteChannel}
+                  onLeaveChannel={onLeaveChannel}
+                />
+              </ContextMenuContent>
+            </ContextMenu>
+          ))}
+        </SidebarMenu>
+      </SortableChannelContext>
     ) : null;
 
   const sectionContent = (
@@ -521,8 +544,10 @@ export function ChannelGroupSection({
               browseLabel={browseLabel}
               onCreate={onCreateClick}
               createLabel={createLabel}
+              onCreateCategory={onCreateCategory}
               sortMode={sortMode}
               onSortModeChange={onSortModeChange}
+              manualSortEnabled={manualSortEnabled}
             />
           </>
         }
@@ -701,6 +726,7 @@ export function CustomChannelSection({
                       isLastSection={isLast}
                       sortMode={sortMode}
                       onSortModeChange={onSortModeChange}
+                      manualSortEnabled
                     />
                   </div>
                 </div>
@@ -708,7 +734,7 @@ export function CustomChannelSection({
               <ContextMenuContent>
                 <ContextMenuItem onClick={onRenameSection}>
                   <Pencil className="h-4 w-4" />
-                  Rename section
+                  Rename category
                 </ContextMenuItem>
                 <ContextMenuItem disabled={isFirst} onClick={onMoveSectionUp}>
                   <ArrowUp className="h-4 w-4" />
@@ -724,65 +750,80 @@ export function CustomChannelSection({
                   onClick={onDeleteSection}
                 >
                   <Trash2 className="h-4 w-4" />
-                  Delete section
+                  Delete category
                 </ContextMenuItem>
               </ContextMenuContent>
             </ContextMenu>
             {!isCollapsed ? (
               <SidebarGroupContent id={contentId}>
                 {channels.length > 0 ? (
-                  <SidebarMenu>
-                    {channels.map((channel) => (
-                      <ContextMenu key={channel.id}>
-                        <ContextMenuTrigger asChild>
-                          <SidebarMenuItem>
-                            <DraggableChannelRow channelId={channel.id}>
-                              <ChannelMenuButton
-                                channel={channel}
-                                activeWorking={activeWorkingByChannelId?.get(
-                                  channel.id,
-                                )}
-                                hasUnread={unreadChannelIds.has(channel.id)}
-                                unreadCount={
-                                  unreadChannelCounts.get(channel.id) ?? 0
-                                }
-                                isMuted={mutedChannelIds?.has(channel.id)}
-                                isActive={
-                                  isActiveChannel &&
-                                  selectedChannelId === channel.id
-                                }
-                                onSelectChannel={onSelectChannel}
-                              />
-                            </DraggableChannelRow>
-                          </SidebarMenuItem>
-                        </ContextMenuTrigger>
-                        <ContextMenuContent>
-                          <ChannelContextMenuItems
-                            channel={channel}
-                            hasUnread={unreadChannelIds.has(channel.id)}
-                            isMuted={mutedChannelIds?.has(channel.id)}
-                            isStarred={starredChannelIds?.has(channel.id)}
-                            sections={sections}
-                            assignments={assignments}
-                            onMarkChannelRead={onMarkChannelRead}
-                            onMarkChannelUnread={onMarkChannelUnread}
-                            onMuteChannel={onMuteChannel}
-                            onUnmuteChannel={onUnmuteChannel}
-                            onStarChannel={onStarChannel}
-                            onUnstarChannel={onUnstarChannel}
-                            onAssignChannel={onAssignChannel}
-                            onUnassignChannel={onUnassignChannel}
-                            onCreateSectionForChannel={
-                              onCreateSectionForChannel
-                            }
-                            onDeleteChannel={onDeleteChannel}
-                            onLeaveChannel={onLeaveChannel}
-                          />
-                        </ContextMenuContent>
-                      </ContextMenu>
-                    ))}
-                  </SidebarMenu>
-                ) : null}
+                  <SortableChannelContext
+                    channelIds={channels.map((channel) => channel.id)}
+                  >
+                    <SidebarMenu data-testid={`section-list-${section.id}`}>
+                      {channels.map((channel) => (
+                        <ContextMenu key={channel.id}>
+                          <ContextMenuTrigger asChild>
+                            <SidebarMenuItem>
+                              <DraggableChannelRow
+                                channelId={channel.id}
+                                channelName={channel.name}
+                                groupKey={`section:${section.id}`}
+                              >
+                                <ChannelMenuButton
+                                  channel={channel}
+                                  activeWorking={activeWorkingByChannelId?.get(
+                                    channel.id,
+                                  )}
+                                  hasUnread={unreadChannelIds.has(channel.id)}
+                                  unreadCount={
+                                    unreadChannelCounts.get(channel.id) ?? 0
+                                  }
+                                  isMuted={mutedChannelIds?.has(channel.id)}
+                                  isActive={
+                                    isActiveChannel &&
+                                    selectedChannelId === channel.id
+                                  }
+                                  onSelectChannel={onSelectChannel}
+                                />
+                              </DraggableChannelRow>
+                            </SidebarMenuItem>
+                          </ContextMenuTrigger>
+                          <ContextMenuContent>
+                            <ChannelContextMenuItems
+                              channel={channel}
+                              hasUnread={unreadChannelIds.has(channel.id)}
+                              isMuted={mutedChannelIds?.has(channel.id)}
+                              isStarred={starredChannelIds?.has(channel.id)}
+                              sections={sections}
+                              assignments={assignments}
+                              onMarkChannelRead={onMarkChannelRead}
+                              onMarkChannelUnread={onMarkChannelUnread}
+                              onMuteChannel={onMuteChannel}
+                              onUnmuteChannel={onUnmuteChannel}
+                              onStarChannel={onStarChannel}
+                              onUnstarChannel={onUnstarChannel}
+                              onAssignChannel={onAssignChannel}
+                              onUnassignChannel={onUnassignChannel}
+                              onCreateSectionForChannel={
+                                onCreateSectionForChannel
+                              }
+                              onDeleteChannel={onDeleteChannel}
+                              onLeaveChannel={onLeaveChannel}
+                            />
+                          </ContextMenuContent>
+                        </ContextMenu>
+                      ))}
+                    </SidebarMenu>
+                  </SortableChannelContext>
+                ) : (
+                  <div
+                    className="px-8 py-1 text-xs text-sidebar-foreground/45"
+                    data-testid={`section-empty-${section.id}`}
+                  >
+                    Drop channels here
+                  </div>
+                )}
               </SidebarGroupContent>
             ) : null}
           </SidebarGroup>

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -334,6 +334,7 @@ export function SectionActionsMenu({
 function ChannelSectionHeader({
   contentId,
   isCollapsed,
+  isMovable,
   onToggleCollapsed,
   title,
   testId,
@@ -341,6 +342,7 @@ function ChannelSectionHeader({
 }: {
   contentId: string;
   isCollapsed: boolean;
+  isMovable?: boolean;
   onToggleCollapsed: () => void;
   title: string;
   testId: string;
@@ -352,7 +354,10 @@ function ChannelSectionHeader({
         <button
           aria-controls={contentId}
           aria-expanded={!isCollapsed}
-          className={SECTION_LABEL_BUTTON_CLASS}
+          className={cn(
+            SECTION_LABEL_BUTTON_CLASS,
+            isMovable && "max-w-[calc(100%-5.25rem)]",
+          )}
           data-testid={`${testId}-section-label`}
           onClick={onToggleCollapsed}
           type="button"
@@ -564,7 +569,7 @@ export function ChannelGroupSection({
       </SortableChannelContext>
     ) : null;
 
-  const sectionContent = (
+  const renderSectionContent = (blockDragHandle?: React.ReactNode) => (
     <SidebarGroup
       className={cn(
         "group/sidebar-section select-none",
@@ -576,6 +581,7 @@ export function ChannelGroupSection({
       <ChannelSectionHeader
         contentId={contentId}
         isCollapsed={isCollapsed}
+        isMovable={Boolean(blockDragHandle)}
         onToggleCollapsed={onToggleCollapsed}
         title={title}
         testId={listTestId}
@@ -609,6 +615,7 @@ export function ChannelGroupSection({
               onSortModeChange={onSortModeChange}
               manualSortEnabled={manualSortEnabled}
             />
+            {blockDragHandle}
           </>
         }
       />
@@ -618,32 +625,29 @@ export function ChannelGroupSection({
     </SidebarGroup>
   );
 
-  const droppable = draggable ? (
-    <DroppableUngroupedBody>{sectionContent}</DroppableUngroupedBody>
-  ) : (
-    sectionContent
-  );
+  const wrapDroppable = (content: React.ReactNode) =>
+    draggable ? (
+      <DroppableUngroupedBody>{content}</DroppableUngroupedBody>
+    ) : (
+      content
+    );
 
-  if (!blockId) return droppable;
+  if (!blockId) return wrapDroppable(renderSectionContent());
 
   return (
     <SortableChannelsBlockShell blockId={blockId}>
       {({ dragHandleProps, isDragging }) => (
-        <div
-          className={cn(
-            "group/sidebar-section relative",
-            isDragging && "opacity-30",
+        <div className={cn("relative", isDragging && "opacity-30")}>
+          {wrapDroppable(
+            renderSectionContent(
+              <BlockDragHandle
+                dragHandleProps={dragHandleProps}
+                isDragging={isDragging}
+                label={title}
+                testId={`block-drag-${blockId}`}
+              />,
+            ),
           )}
-        >
-          <div className="absolute left-0 top-1 z-10">
-            <BlockDragHandle
-              dragHandleProps={dragHandleProps}
-              isDragging={isDragging}
-              label={title}
-              testId={`block-drag-${blockId}`}
-            />
-          </div>
-          {droppable}
         </div>
       )}
     </SortableChannelsBlockShell>
@@ -745,23 +749,13 @@ export function CustomChannelSection({
             <ContextMenu>
               <ContextMenuTrigger asChild>
                 <div className="relative">
-                  <div className="absolute left-0 top-1/2 z-10 -translate-y-1/2">
-                    <BlockDragHandle
-                      dragHandleProps={dragHandleProps}
-                      isDragging={isDragging}
-                      label={section.name}
-                      testId={`block-drag-${section.id}`}
-                    />
-                  </div>
-                  <SidebarGroupLabel
-                    asChild
-                    className={section.icon ? "pl-7" : "pl-8"}
-                  >
+                  <SidebarGroupLabel asChild>
                     <button
                       aria-controls={contentId}
                       aria-expanded={!isCollapsed}
                       className={cn(
                         SECTION_LABEL_BUTTON_CLASS,
+                        "max-w-[calc(100%-5.25rem)]",
                         section.icon && "gap-2",
                       )}
                       onClick={onToggleCollapsed}
@@ -820,6 +814,12 @@ export function CustomChannelSection({
                       sortMode={sortMode}
                       onSortModeChange={onSortModeChange}
                       manualSortEnabled
+                    />
+                    <BlockDragHandle
+                      dragHandleProps={dragHandleProps}
+                      isDragging={isDragging}
+                      label={section.name}
+                      testId={`block-drag-${section.id}`}
                     />
                   </div>
                 </div>

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -449,7 +449,14 @@ export function ChannelGroupSection({
           {items.map((channel) => (
             <ContextMenu key={channel.id}>
               <ContextMenuTrigger asChild>
-                <SidebarMenuItem className="content-visibility-auto-row">
+                {/* WKWebView can retain a stale skipped-paint state when
+                    content-visibility and dnd-kit transforms reorder the same
+                    row. Manual lists are small, so keep draggable rows live. */}
+                <SidebarMenuItem
+                  className={
+                    draggable ? undefined : "content-visibility-auto-row"
+                  }
+                >
                   {draggable ? (
                     <DraggableChannelRow
                       channelId={channel.id}

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -48,10 +48,12 @@ import { ChannelMenuButton } from "@/features/sidebar/ui/SidebarSection";
 import { ChannelContextMenuItems } from "@/features/sidebar/ui/ChannelContextMenu";
 import { deferMenuAction } from "@/features/sidebar/ui/sidebarMenuHelpers";
 import {
+  BlockDragHandle,
   DraggableChannelRow,
   DroppableSectionBody,
   DroppableUngroupedBody,
   SortableChannelContext,
+  SortableChannelsBlockShell,
   SortableSectionShell,
 } from "@/features/sidebar/ui/SidebarDnd";
 import {
@@ -170,6 +172,7 @@ export function SectionActionsMenu({
   manualSortEnabled?: boolean;
 }) {
   const showSectionManagement = Boolean(onRenameSection || onDeleteSection);
+  const showMove = Boolean(onMoveSectionUp || onMoveSectionDown);
   const showSort = Boolean(sortMode && onSortModeChange);
 
   return (
@@ -220,7 +223,7 @@ export function SectionActionsMenu({
             <span>New category...</span>
           </DropdownMenuItem>
         ) : null}
-        {showSectionManagement ? (
+        {showSectionManagement || showMove ? (
           <>
             {onRenameSection ? (
               <DropdownMenuItem
@@ -345,6 +348,11 @@ export function ChannelGroupSection({
   browseLabel,
   createLabel,
   draggable,
+  blockId,
+  isFirstBlock,
+  isLastBlock,
+  onMoveBlockUp,
+  onMoveBlockDown,
   groupClassName,
   hasUnread,
   isCollapsed,
@@ -389,6 +397,12 @@ export function ChannelGroupSection({
   browseLabel?: string;
   createLabel?: string;
   draggable?: boolean;
+  /** When set, the whole group is a movable sidebar block (Channels lane). */
+  blockId?: string;
+  isFirstBlock?: boolean;
+  isLastBlock?: boolean;
+  onMoveBlockUp?: () => void;
+  onMoveBlockDown?: () => void;
   groupClassName?: string;
   isCollapsed: boolean;
   isActiveChannel: boolean;
@@ -521,7 +535,11 @@ export function ChannelGroupSection({
 
   const sectionContent = (
     <SidebarGroup
-      className={cn("group/sidebar-section select-none", groupClassName)}
+      className={cn(
+        "group/sidebar-section select-none",
+        groupClassName,
+        blockId && "relative",
+      )}
       data-section-actions-open={actionsMenuOpen || undefined}
     >
       <ChannelSectionHeader
@@ -552,6 +570,10 @@ export function ChannelGroupSection({
               onCreate={onCreateClick}
               createLabel={createLabel}
               onCreateCategory={onCreateCategory}
+              onMoveSectionUp={onMoveBlockUp}
+              onMoveSectionDown={onMoveBlockDown}
+              isFirstSection={isFirstBlock}
+              isLastSection={isLastBlock}
               sortMode={sortMode}
               onSortModeChange={onSortModeChange}
               manualSortEnabled={manualSortEnabled}
@@ -565,10 +587,35 @@ export function ChannelGroupSection({
     </SidebarGroup>
   );
 
-  return draggable ? (
+  const droppable = draggable ? (
     <DroppableUngroupedBody>{sectionContent}</DroppableUngroupedBody>
   ) : (
     sectionContent
+  );
+
+  if (!blockId) return droppable;
+
+  return (
+    <SortableChannelsBlockShell blockId={blockId}>
+      {({ dragHandleProps, isDragging }) => (
+        <div
+          className={cn(
+            "group/sidebar-section relative",
+            isDragging && "opacity-30",
+          )}
+        >
+          <div className="absolute left-0 top-1 z-10">
+            <BlockDragHandle
+              dragHandleProps={dragHandleProps}
+              isDragging={isDragging}
+              label={title}
+              testId={`block-drag-${blockId}`}
+            />
+          </div>
+          {droppable}
+        </div>
+      )}
+    </SortableChannelsBlockShell>
   );
 }
 
@@ -666,10 +713,18 @@ export function CustomChannelSection({
           >
             <ContextMenu>
               <ContextMenuTrigger asChild>
-                <div className="relative" {...dragHandleProps}>
+                <div className="relative">
+                  <div className="absolute left-0 top-1/2 z-10 -translate-y-1/2">
+                    <BlockDragHandle
+                      dragHandleProps={dragHandleProps}
+                      isDragging={isDragging}
+                      label={section.name}
+                      testId={`block-drag-${section.id}`}
+                    />
+                  </div>
                   <SidebarGroupLabel
                     asChild
-                    className={section.icon ? undefined : "pl-8"}
+                    className={section.icon ? "pl-7" : "pl-8"}
                   >
                     <button
                       aria-controls={contentId}

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -10,7 +10,7 @@ import {
   Trash2,
 } from "lucide-react";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type * as React from "react";
 
 import type {
@@ -171,6 +171,8 @@ export function SectionActionsMenu({
   onSortModeChange?: (mode: ChannelSortMode) => void;
   manualSortEnabled?: boolean;
 }) {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const skipFocusRestoreRef = useRef(false);
   const showSectionManagement = Boolean(onRenameSection || onDeleteSection);
   const showMove = Boolean(onMoveSectionUp || onMoveSectionDown);
   const showSort = Boolean(sortMode && onSortModeChange);
@@ -184,12 +186,22 @@ export function SectionActionsMenu({
           data-testid={testId}
           onClick={(event) => event.stopPropagation()}
           onPointerDown={(event) => event.stopPropagation()}
+          ref={triggerRef}
           type="button"
         >
           <EllipsisVertical className="h-4 w-4" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent
+        align="end"
+        onCloseAutoFocus={(event) => {
+          if (skipFocusRestoreRef.current) {
+            event.preventDefault();
+            triggerRef.current?.blur();
+            skipFocusRestoreRef.current = false;
+          }
+        }}
+      >
         {hasUnread && onMarkAllRead ? (
           <DropdownMenuItem onSelect={() => deferMenuAction(onMarkAllRead)}>
             <CheckCheck className="h-4 w-4" />
@@ -197,7 +209,16 @@ export function SectionActionsMenu({
           </DropdownMenuItem>
         ) : null}
         {onNewMessage ? (
-          <DropdownMenuItem onSelect={() => deferMenuAction(onNewMessage)}>
+          <DropdownMenuItem
+            onSelect={() => {
+              // The deferred New Message route focuses its recipient input.
+              // Do not let Radix restore focus to the sidebar trigger after
+              // that route mounts. Other menu/dialog flows retain the normal
+              // accessible trigger-focus restoration.
+              skipFocusRestoreRef.current = true;
+              deferMenuAction(onNewMessage);
+            }}
+          >
             <Plus className="h-4 w-4" />
             <span>{newMessageLabel ?? "New message"}</span>
           </DropdownMenuItem>
@@ -218,7 +239,17 @@ export function SectionActionsMenu({
           </DropdownMenuItem>
         ) : null}
         {onCreateCategory ? (
-          <DropdownMenuItem onSelect={() => deferMenuAction(onCreateCategory)}>
+          <DropdownMenuItem
+            onSelect={() =>
+              deferMenuAction(() => {
+                // Pin focus on the live trigger before the dialog opens so
+                // Radix's focus stack (and our restore selector) target it —
+                // not a detached menu item — after Escape/cancel.
+                triggerRef.current?.focus();
+                onCreateCategory();
+              })
+            }
+          >
             <Plus className="h-4 w-4" />
             <span>New category...</span>
           </DropdownMenuItem>

--- a/desktop/src/features/sidebar/ui/SidebarDnd.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarDnd.tsx
@@ -25,6 +25,8 @@ import * as React from "react";
 
 import { cn } from "@/shared/lib/cn";
 import type { ChannelSortGroupKey } from "@/features/sidebar/lib/channelSortPreference";
+/** Sentinel id for the Channels block in SortableContext / block order. */
+export { CHANNELS_BLOCK_ID } from "@/features/sidebar/lib/channelSectionsHelpers";
 
 export type DndChannelData = {
   type: "channel";
@@ -32,6 +34,8 @@ export type DndChannelData = {
   groupKey: ChannelSortGroupKey;
 };
 export type DndSectionData = { type: "section"; sectionId: string };
+/** Built-in uncategorized Channels block in the unified movable lane. */
+export type DndChannelsBlockData = { type: "channels-block" };
 export type DndSectionDropData = {
   type: "section-drop";
   sectionId: string;
@@ -205,13 +209,81 @@ export function SortableSectionShell({
   };
 
   return (
-    <div ref={setNodeRef} style={style}>
+    <div ref={setNodeRef} style={style} data-dnd-block={sectionId}>
       {children({
         dragHandleProps: { ...attributes, ...listeners },
         isDragging,
         style,
       })}
     </div>
+  );
+}
+
+export function SortableChannelsBlockShell({
+  blockId,
+  children,
+}: {
+  blockId: string;
+  children: (props: {
+    dragHandleProps: React.HTMLAttributes<HTMLElement>;
+    isDragging: boolean;
+  }) => React.ReactNode;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: blockId,
+    data: { type: "channels-block" } satisfies DndChannelsBlockData,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-dnd-block={blockId}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
+    >
+      {children({
+        dragHandleProps: { ...attributes, ...listeners },
+        isDragging,
+      })}
+    </div>
+  );
+}
+
+/** Quiet category/Channels block grip — mounted always; visible on hover/focus. */
+export function BlockDragHandle({
+  label,
+  dragHandleProps,
+  isDragging,
+  testId,
+}: {
+  label: string;
+  dragHandleProps: React.HTMLAttributes<HTMLElement>;
+  isDragging: boolean;
+  testId?: string;
+}) {
+  return (
+    <button
+      {...dragHandleProps}
+      aria-label={`Move ${label}`}
+      aria-roledescription="sortable category"
+      className={cn(
+        "flex h-7 w-7 touch-none cursor-grab items-center justify-center rounded-md text-sidebar-foreground/40 opacity-0 transition-opacity hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-sidebar-ring group-hover/sidebar-section:opacity-100 group-focus-within/sidebar-section:opacity-100 active:cursor-grabbing [@media(hover:none)]:opacity-100",
+        isDragging && "opacity-100",
+      )}
+      data-testid={testId}
+      type="button"
+    >
+      <GripVertical aria-hidden="true" className="h-4 w-4" />
+    </button>
   );
 }
 
@@ -240,26 +312,32 @@ export function DragOverlaySection({ name }: { name: string }) {
 
 type SidebarDragItem =
   | { type: "channel"; channelId: string; channelName: string }
-  | { type: "section"; sectionId: string; sectionName: string };
+  | { type: "section"; sectionId: string; sectionName: string }
+  | { type: "channels-block" };
+
+const BLOCK_TYPES = new Set(["section", "channels-block"]);
 
 const sidebarCollisionDetection: CollisionDetection = (args) => {
   if (args.active.data.current?.type !== "channel") {
-    const sectionContainers = args.droppableContainers.filter((container) => {
+    // Category / Channels block reordering: collide with other movable blocks
+    // (not channel drop targets) so the pointer can cross the Channels lane.
+    const blockContainers = args.droppableContainers.filter((container) => {
       const type = container.data.current?.type;
       return (
         container.id !== args.active.id &&
-        (type === "section" || type === "section-drop")
+        type !== undefined &&
+        BLOCK_TYPES.has(type as string)
       );
     });
     if (args.pointerCoordinates) {
       return pointerWithin({
         ...args,
-        droppableContainers: sectionContainers,
+        droppableContainers: blockContainers,
       });
     }
     return closestCenter({
       ...args,
-      droppableContainers: sectionContainers,
+      droppableContainers: blockContainers,
     });
   }
   const collisions = args.pointerCoordinates
@@ -286,16 +364,17 @@ const sidebarCollisionDetection: CollisionDetection = (args) => {
 };
 
 export function SidebarDndContext({
-  sectionIds,
+  blockIds,
   channels,
   channelGroups,
   sections,
   children,
   manualGroupKeys,
   onMoveChannel,
-  onReorderSections,
+  onReorderBlocks,
 }: {
-  sectionIds: string[];
+  /** Unified movable lane: section ids + Channels sentinel. */
+  blockIds: string[];
   channels: { id: string; name: string }[];
   channelGroups: {
     key: ChannelSortGroupKey;
@@ -311,7 +390,7 @@ export function SidebarDndContext({
     targetGroup: ChannelSortGroupKey;
     overChannelId?: string;
   }) => void;
-  onReorderSections: (orderedIds: string[]) => void;
+  onReorderBlocks: (orderedBlockIds: string[]) => void;
 }) {
   const [activeDragItem, setActiveDragItem] =
     React.useState<SidebarDragItem | null>(null);
@@ -342,6 +421,8 @@ export function SidebarDndContext({
             sectionId: sec.id,
             sectionName: sec.name,
           });
+      } else if (data.type === "channels-block") {
+        setActiveDragItem({ type: "channels-block" });
       }
     },
     [channels, sections],
@@ -372,17 +453,26 @@ export function SidebarDndContext({
             ? { overChannelId: overData.channelId as string }
             : {}),
         });
-      } else if (activeData.type === "section") {
-        const overSectionId =
-          (overData?.sectionId as string | undefined) ?? (over.id as string);
-        const oldIdx = sectionIds.indexOf(active.id as string);
-        const newIdx = sectionIds.indexOf(overSectionId);
+      } else if (
+        activeData.type === "section" ||
+        activeData.type === "channels-block"
+      ) {
+        const overBlockId = (() => {
+          if (overData?.type === "section") return overData.sectionId as string;
+          if (overData?.type === "channels-block") return over.id as string;
+          // Fall back to sortable id (works for both block types).
+          if (blockIds.includes(over.id as string)) return over.id as string;
+          return undefined;
+        })();
+        if (!overBlockId) return;
+        const oldIdx = blockIds.indexOf(active.id as string);
+        const newIdx = blockIds.indexOf(overBlockId);
         if (oldIdx !== -1 && newIdx !== -1 && oldIdx !== newIdx) {
-          onReorderSections(arrayMove(sectionIds, oldIdx, newIdx));
+          onReorderBlocks(arrayMove(blockIds, oldIdx, newIdx));
         }
       }
     },
-    [sectionIds, manualGroupKeys, onMoveChannel, onReorderSections],
+    [blockIds, manualGroupKeys, onMoveChannel, onReorderBlocks],
   );
 
   const channelName = React.useCallback(
@@ -433,12 +523,20 @@ export function SidebarDndContext({
         return `category ${sectionName(String(data.sectionId))}`;
       }
       if (data?.type === "ungrouped") return "Channels";
+      if (data?.type === "channels-block") return "Channels";
       if (data?.type === "section") {
         return `category ${sectionName(String(data.sectionId))}`;
       }
       return "the sidebar";
     },
     [channelName, sectionName],
+  );
+  const blockLabel = React.useCallback(
+    (data: Record<string, unknown> | undefined) => {
+      if (data?.type === "channels-block") return "Channels";
+      return `category ${sectionName(String(data?.sectionId))}`;
+    },
+    [sectionName],
   );
 
   return (
@@ -447,17 +545,18 @@ export function SidebarDndContext({
         announcements: {
           onDragStart({ active }) {
             const data = active.data.current;
-            return data?.type === "channel"
-              ? `Picked up channel ${channelName(String(data.channelId))}.`
-              : `Picked up category ${sectionName(String(data?.sectionId))}.`;
+            if (data?.type === "channel") {
+              return `Picked up channel ${channelName(String(data.channelId))}.`;
+            }
+            return `Picked up ${blockLabel(data)}.`;
           },
           onDragOver({ active, over }) {
             const activeData = active.data.current;
-            return over
-              ? activeData?.type === "channel"
-                ? `Channel ${channelName(String(activeData.channelId))} is over ${describeChannelDestination(String(activeData.channelId), over)}.`
-                : `Category ${sectionName(String(activeData?.sectionId))} is over ${describeTarget(over)}.`
-              : "The item is no longer over a drop target.";
+            if (!over) return "The item is no longer over a drop target.";
+            if (activeData?.type === "channel") {
+              return `Channel ${channelName(String(activeData.channelId))} is over ${describeChannelDestination(String(activeData.channelId), over)}.`;
+            }
+            return `${blockLabel(activeData)} is over ${describeTarget(over)}.`;
           },
           onDragEnd({ active, over }) {
             const data = active.data.current;
@@ -473,13 +572,14 @@ export function SidebarDndContext({
               }
               return `Moved channel ${name} to ${describeChannelDestination(String(data.channelId), over)}.`;
             }
-            return `Moved category ${sectionName(String(data?.sectionId))} to ${describeTarget(over)}.`;
+            return `Moved ${blockLabel(data)} to ${describeTarget(over)}.`;
           },
           onDragCancel({ active }) {
             const data = active.data.current;
-            return data?.type === "channel"
-              ? `Cancelled moving channel ${channelName(String(data.channelId))}.`
-              : `Cancelled moving category ${sectionName(String(data?.sectionId))}.`;
+            if (data?.type === "channel") {
+              return `Cancelled moving channel ${channelName(String(data.channelId))}.`;
+            }
+            return `Cancelled moving ${blockLabel(data)}.`;
           },
         },
       }}
@@ -489,10 +589,7 @@ export function SidebarDndContext({
       onDragStart={handleDragStart}
       sensors={sensors}
     >
-      <SortableContext
-        items={sectionIds}
-        strategy={verticalListSortingStrategy}
-      >
+      <SortableContext items={blockIds} strategy={verticalListSortingStrategy}>
         {children}
       </SortableContext>
       <DragOverlay>
@@ -500,6 +597,8 @@ export function SidebarDndContext({
           <DragOverlayChannel name={activeDragItem.channelName} />
         ) : activeDragItem?.type === "section" ? (
           <DragOverlaySection name={activeDragItem.sectionName} />
+        ) : activeDragItem?.type === "channels-block" ? (
+          <DragOverlaySection name="Channels" />
         ) : null}
       </DragOverlay>
     </DndContext>

--- a/desktop/src/features/sidebar/ui/SidebarDnd.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarDnd.tsx
@@ -69,7 +69,7 @@ export function DraggableChannelRow({
     <div
       ref={setNodeRef}
       className={cn(
-        "relative [&_[data-sidebar=menu-button]]:pr-8",
+        "group/channel-drag-row relative [&_[data-sidebar=menu-button]]:pr-8",
         isDragging && "opacity-30",
       )}
       data-dnd-channel={channelId}
@@ -84,7 +84,10 @@ export function DraggableChannelRow({
         {...listeners}
         aria-label={`Move ${channelName}`}
         aria-roledescription="sortable channel"
-        className="absolute right-1 top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 touch-none cursor-grab items-center justify-center rounded-md text-sidebar-foreground/40 hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-sidebar-ring active:cursor-grabbing"
+        className={cn(
+          "absolute right-1 top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 touch-none cursor-grab items-center justify-center rounded-md text-sidebar-foreground/40 opacity-0 transition-opacity hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-sidebar-ring group-focus-within/channel-drag-row:opacity-100 group-hover/channel-drag-row:opacity-100 active:cursor-grabbing [@media(hover:none)]:opacity-100",
+          isDragging && "opacity-100",
+        )}
         data-dnd-handle={channelId}
         type="button"
       >

--- a/desktop/src/features/sidebar/ui/SidebarDnd.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarDnd.tsx
@@ -2,52 +2,109 @@
 import {
   DndContext,
   DragOverlay,
+  KeyboardSensor,
   PointerSensor,
+  closestCenter,
   pointerWithin,
-  useDraggable,
   useDroppable,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
 import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
+import type { CollisionDetection } from "@dnd-kit/core";
 import {
   SortableContext,
   arrayMove,
+  sortableKeyboardCoordinates,
   verticalListSortingStrategy,
   useSortable,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Hash } from "lucide-react";
+import { GripVertical, Hash } from "lucide-react";
 import * as React from "react";
 
 import { cn } from "@/shared/lib/cn";
+import type { ChannelSortGroupKey } from "@/features/sidebar/lib/channelSortPreference";
 
-export type DndChannelData = { type: "channel"; channelId: string };
+export type DndChannelData = {
+  type: "channel";
+  channelId: string;
+  groupKey: ChannelSortGroupKey;
+};
 export type DndSectionData = { type: "section"; sectionId: string };
-export type DndSectionDropData = { type: "section-drop"; sectionId: string };
-export type DndUngroupedData = { type: "ungrouped" };
+export type DndSectionDropData = {
+  type: "section-drop";
+  sectionId: string;
+  groupKey: ChannelSortGroupKey;
+};
+export type DndUngroupedData = {
+  type: "ungrouped";
+  groupKey: ChannelSortGroupKey;
+};
 
 export function DraggableChannelRow({
   channelId,
+  channelName,
+  groupKey,
   children,
 }: {
   channelId: string;
+  channelName: string;
+  groupKey: ChannelSortGroupKey;
   children: React.ReactNode;
 }) {
-  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    isDragging,
+    transform,
+    transition,
+  } = useSortable({
     id: channelId,
-    data: { type: "channel", channelId } satisfies DndChannelData,
+    data: { type: "channel", channelId, groupKey } satisfies DndChannelData,
   });
 
   return (
     <div
       ref={setNodeRef}
-      {...attributes}
-      {...listeners}
-      className={cn("touch-none", isDragging && "opacity-30")}
+      className={cn(
+        "relative [&_[data-sidebar=menu-button]]:pr-8",
+        isDragging && "opacity-30",
+      )}
+      data-dnd-channel={channelId}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+      }}
     >
       {children}
+      <button
+        {...attributes}
+        {...listeners}
+        aria-label={`Move ${channelName}`}
+        aria-roledescription="sortable channel"
+        className="absolute right-1 top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 touch-none cursor-grab items-center justify-center rounded-md text-sidebar-foreground/40 hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-sidebar-ring active:cursor-grabbing"
+        data-dnd-handle={channelId}
+        type="button"
+      >
+        <GripVertical aria-hidden="true" className="h-4 w-4" />
+      </button>
     </div>
+  );
+}
+
+export function SortableChannelContext({
+  channelIds,
+  children,
+}: {
+  channelIds: string[];
+  children: React.ReactNode;
+}) {
+  return (
+    <SortableContext items={channelIds} strategy={verticalListSortingStrategy}>
+      {children}
+    </SortableContext>
   );
 }
 
@@ -61,9 +118,14 @@ export function DroppableSectionBody({
   className?: string;
 }) {
   const droppableId = `section-drop:${sectionId}`;
+  const groupKey = `section:${sectionId}` as const;
   const { setNodeRef, isOver } = useDroppable({
     id: droppableId,
-    data: { type: "section-drop", sectionId } satisfies DndSectionDropData,
+    data: {
+      type: "section-drop",
+      sectionId,
+      groupKey,
+    } satisfies DndSectionDropData,
   });
 
   return (
@@ -74,6 +136,7 @@ export function DroppableSectionBody({
         isOver && "ring-2 ring-primary/30",
         className,
       )}
+      data-testid={`section-drop-${sectionId}`}
     >
       {children}
     </div>
@@ -89,7 +152,10 @@ export function DroppableUngroupedBody({
 }) {
   const { setNodeRef, isOver } = useDroppable({
     id: "ungrouped",
-    data: { type: "ungrouped" } satisfies DndUngroupedData,
+    data: {
+      type: "ungrouped",
+      groupKey: "channels",
+    } satisfies DndUngroupedData,
   });
 
   return (
@@ -100,6 +166,7 @@ export function DroppableUngroupedBody({
         isOver && "ring-2 ring-primary/30",
         className,
       )}
+      data-testid="section-drop-channels"
     >
       {children}
     </div>
@@ -172,27 +239,84 @@ type SidebarDragItem =
   | { type: "channel"; channelId: string; channelName: string }
   | { type: "section"; sectionId: string; sectionName: string };
 
+const sidebarCollisionDetection: CollisionDetection = (args) => {
+  if (args.active.data.current?.type !== "channel") {
+    const sectionContainers = args.droppableContainers.filter((container) => {
+      const type = container.data.current?.type;
+      return (
+        container.id !== args.active.id &&
+        (type === "section" || type === "section-drop")
+      );
+    });
+    if (args.pointerCoordinates) {
+      return pointerWithin({
+        ...args,
+        droppableContainers: sectionContainers,
+      });
+    }
+    return closestCenter({
+      ...args,
+      droppableContainers: sectionContainers,
+    });
+  }
+  const collisions = args.pointerCoordinates
+    ? pointerWithin(args)
+    : closestCenter(args);
+
+  const channelCollision = collisions.find((collision) => {
+    if (collision.id === args.active.id) return false;
+    return (
+      args.droppableContainers.find(
+        (container) => container.id === collision.id,
+      )?.data.current?.type === "channel"
+    );
+  });
+  if (channelCollision) return [channelCollision];
+
+  const groupCollision = collisions.find((collision) => {
+    const type = args.droppableContainers.find(
+      (container) => container.id === collision.id,
+    )?.data.current?.type;
+    return type === "section-drop" || type === "ungrouped";
+  });
+  return groupCollision ? [groupCollision] : collisions;
+};
+
 export function SidebarDndContext({
   sectionIds,
   channels,
+  channelGroups,
   sections,
   children,
-  onAssignChannel,
-  onUnassignChannel,
+  manualGroupKeys,
+  onMoveChannel,
   onReorderSections,
 }: {
   sectionIds: string[];
   channels: { id: string; name: string }[];
+  channelGroups: {
+    key: ChannelSortGroupKey;
+    name: string;
+    channelIds: string[];
+  }[];
   sections: { id: string; name: string }[];
   children: React.ReactNode;
-  onAssignChannel: (channelId: string, sectionId: string) => void;
-  onUnassignChannel: (channelId: string) => void;
+  manualGroupKeys: ReadonlySet<ChannelSortGroupKey>;
+  onMoveChannel: (input: {
+    channelId: string;
+    sourceGroup: ChannelSortGroupKey;
+    targetGroup: ChannelSortGroupKey;
+    overChannelId?: string;
+  }) => void;
   onReorderSections: (orderedIds: string[]) => void;
 }) {
   const [activeDragItem, setActiveDragItem] =
     React.useState<SidebarDragItem | null>(null);
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
   );
 
   const handleDragStart = React.useCallback(
@@ -230,11 +354,21 @@ export function SidebarDndContext({
       if (!activeData) return;
       if (activeData.type === "channel") {
         const channelId = activeData.channelId as string;
-        if (overData?.type === "section-drop") {
-          onAssignChannel(channelId, overData.sectionId as string);
-        } else if (overData?.type === "ungrouped") {
-          onUnassignChannel(channelId);
-        }
+        const sourceGroup = activeData.groupKey as ChannelSortGroupKey;
+        const targetGroup = overData?.groupKey as
+          | ChannelSortGroupKey
+          | undefined;
+        if (!targetGroup) return;
+        if (sourceGroup === targetGroup && !manualGroupKeys.has(sourceGroup))
+          return;
+        onMoveChannel({
+          channelId,
+          sourceGroup,
+          targetGroup,
+          ...(overData?.type === "channel"
+            ? { overChannelId: overData.channelId as string }
+            : {}),
+        });
       } else if (activeData.type === "section") {
         const overSectionId =
           (overData?.sectionId as string | undefined) ?? (over.id as string);
@@ -245,12 +379,109 @@ export function SidebarDndContext({
         }
       }
     },
-    [sectionIds, onAssignChannel, onUnassignChannel, onReorderSections],
+    [sectionIds, manualGroupKeys, onMoveChannel, onReorderSections],
+  );
+
+  const channelName = React.useCallback(
+    (id: string) =>
+      channels.find((channel) => channel.id === id)?.name ?? "channel",
+    [channels],
+  );
+  const sectionName = React.useCallback(
+    (id: string) =>
+      sections.find((section) => section.id === id)?.name ?? "category",
+    [sections],
+  );
+  const describeChannelDestination = React.useCallback(
+    (
+      activeChannelId: string,
+      over: {
+        id: string | number;
+        data: { current?: Record<string, unknown> };
+      },
+    ) => {
+      const data = over.data.current;
+      const targetGroup = data?.groupKey as ChannelSortGroupKey | undefined;
+      const group = channelGroups.find((entry) => entry.key === targetGroup);
+      if (!group) return "the sidebar";
+      const overChannelId =
+        data?.type === "channel" ? String(data.channelId) : undefined;
+      let index = group.channelIds.filter(
+        (id) => id !== activeChannelId,
+      ).length;
+      if (overChannelId) {
+        const overIndex = group.channelIds.indexOf(overChannelId);
+        if (overIndex !== -1) index = overIndex;
+      }
+      return `position ${index + 1} in category ${group.name}`;
+    },
+    [channelGroups],
+  );
+  const describeTarget = React.useCallback(
+    (over: {
+      id: string | number;
+      data: { current?: Record<string, unknown> };
+    }) => {
+      const data = over.data.current;
+      if (data?.type === "channel") {
+        return `channel ${channelName(String(data.channelId))}`;
+      }
+      if (data?.type === "section-drop") {
+        return `category ${sectionName(String(data.sectionId))}`;
+      }
+      if (data?.type === "ungrouped") return "Channels";
+      if (data?.type === "section") {
+        return `category ${sectionName(String(data.sectionId))}`;
+      }
+      return "the sidebar";
+    },
+    [channelName, sectionName],
   );
 
   return (
     <DndContext
-      collisionDetection={pointerWithin}
+      accessibility={{
+        announcements: {
+          onDragStart({ active }) {
+            const data = active.data.current;
+            return data?.type === "channel"
+              ? `Picked up channel ${channelName(String(data.channelId))}.`
+              : `Picked up category ${sectionName(String(data?.sectionId))}.`;
+          },
+          onDragOver({ active, over }) {
+            const activeData = active.data.current;
+            return over
+              ? activeData?.type === "channel"
+                ? `Channel ${channelName(String(activeData.channelId))} is over ${describeChannelDestination(String(activeData.channelId), over)}.`
+                : `Category ${sectionName(String(activeData?.sectionId))} is over ${describeTarget(over)}.`
+              : "The item is no longer over a drop target.";
+          },
+          onDragEnd({ active, over }) {
+            const data = active.data.current;
+            if (!over) return "Drag cancelled.";
+            if (data?.type === "channel") {
+              const group = data.groupKey as ChannelSortGroupKey;
+              const targetGroup = over.data.current?.groupKey as
+                | ChannelSortGroupKey
+                | undefined;
+              const name = channelName(String(data.channelId));
+              if (group === targetGroup && !manualGroupKeys.has(group)) {
+                return `${name} was not moved. Choose Manual sort to reorder within this category.`;
+              }
+              return `Moved channel ${name} to ${describeChannelDestination(String(data.channelId), over)}.`;
+            }
+            return `Moved category ${sectionName(String(data?.sectionId))} to ${describeTarget(over)}.`;
+          },
+          onDragCancel({ active }) {
+            const data = active.data.current;
+            return data?.type === "channel"
+              ? `Cancelled moving channel ${channelName(String(data.channelId))}.`
+              : `Cancelled moving category ${sectionName(String(data?.sectionId))}.`;
+          },
+        },
+      }}
+      onDragCancel={() => setActiveDragItem(null)}
+      collisionDetection={sidebarCollisionDetection}
       onDragEnd={handleDragEnd}
       onDragStart={handleDragStart}
       sensors={sensors}

--- a/desktop/src/features/sidebar/ui/SidebarMovableLane.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarMovableLane.tsx
@@ -1,0 +1,250 @@
+import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
+import {
+  CHANNELS_BLOCK_ID,
+  SidebarDndContext,
+} from "@/features/sidebar/ui/SidebarDnd";
+import {
+  ChannelGroupSection,
+  CustomChannelSection,
+} from "@/features/sidebar/ui/CustomChannelSection";
+import {
+  sectionSortGroupKey,
+  type ChannelSortGroupKey,
+  type ChannelSortMode,
+} from "@/features/sidebar/lib/channelSortPreference";
+import type { ChannelSection } from "@/features/sidebar/lib/useChannelSections";
+import type { Channel } from "@/shared/api/types";
+
+type SectionBuckets = {
+  bySection: Record<string, Channel[]>;
+  unassigned: Channel[];
+};
+
+export function SidebarMovableLane({
+  blockOrder,
+  channelSections,
+  channelAssignments,
+  sectionBuckets,
+  channelGroups,
+  channels,
+  manualGroupKeys,
+  collapsedSections,
+  collapsedChannels,
+  isActiveChannel,
+  activeWorkingByChannelId,
+  selectedChannelId,
+  unreadChannelCounts,
+  unreadChannelIds,
+  mutedChannelIds,
+  starredChannelIds,
+  sortModeFor,
+  handleSortModeChange,
+  handleMoveChannel,
+  reorderBlocks,
+  moveBlockUp,
+  moveBlockDown,
+  assignChannel,
+  unassignChannel,
+  onSelectChannel,
+  onMarkChannelRead,
+  onMarkChannelUnread,
+  onMarkAllChannelsRead,
+  onBrowseChannels,
+  onCreateCategory,
+  onCreateSectionForChannel,
+  onCreateChannelInSection,
+  onRenameSection,
+  onDeleteSection,
+  onToggleCollapsedSection,
+  onToggleCollapsedChannels,
+  onMuteChannel,
+  onUnmuteChannel,
+  onStarChannel,
+  onUnstarChannel,
+  onDeleteChannel,
+  onLeaveChannel,
+}: {
+  blockOrder: string[];
+  channelSections: ChannelSection[];
+  channelAssignments: Record<string, string>;
+  sectionBuckets: SectionBuckets;
+  channelGroups: {
+    key: ChannelSortGroupKey;
+    name: string;
+    channelIds: string[];
+  }[];
+  channels: Channel[];
+  manualGroupKeys: ReadonlySet<ChannelSortGroupKey>;
+  collapsedSections: Record<string, boolean>;
+  collapsedChannels: boolean;
+  isActiveChannel: boolean;
+  activeWorkingByChannelId?: ReadonlyMap<string, ActiveChannelTurnSummary>;
+  selectedChannelId: string | null;
+  unreadChannelCounts: ReadonlyMap<string, number>;
+  unreadChannelIds: ReadonlySet<string>;
+  mutedChannelIds?: ReadonlySet<string>;
+  starredChannelIds?: ReadonlySet<string>;
+  sortModeFor: (group: ChannelSortGroupKey) => ChannelSortMode;
+  handleSortModeChange: (
+    group: ChannelSortGroupKey,
+    mode: ChannelSortMode,
+    visible: Channel[],
+  ) => void;
+  handleMoveChannel: (input: {
+    channelId: string;
+    sourceGroup: ChannelSortGroupKey;
+    targetGroup: ChannelSortGroupKey;
+    overChannelId?: string;
+  }) => void;
+  reorderBlocks: (orderedBlockIds: string[]) => void;
+  moveBlockUp: (blockId: string) => void;
+  moveBlockDown: (blockId: string) => void;
+  assignChannel: (channelId: string, sectionId: string) => void;
+  unassignChannel: (channelId: string) => void;
+  onSelectChannel: (channelId: string) => void;
+  onMarkChannelRead: (
+    channelId: string,
+    lastMessageAt: string | null | undefined,
+  ) => void;
+  onMarkChannelUnread: (channelId: string) => void;
+  onMarkAllChannelsRead: () => void;
+  onBrowseChannels?: () => void;
+  onCreateCategory: () => void;
+  onCreateSectionForChannel: (channelId: string) => void;
+  onCreateChannelInSection: (sectionId: string) => void;
+  onRenameSection: (section: ChannelSection) => void;
+  onDeleteSection: (section: ChannelSection) => void;
+  onToggleCollapsedSection: (sectionId: string) => void;
+  onToggleCollapsedChannels: () => void;
+  onMuteChannel?: (channelId: string) => void;
+  onUnmuteChannel?: (channelId: string) => void;
+  onStarChannel?: (channelId: string) => void;
+  onUnstarChannel?: (channelId: string) => void;
+  onDeleteChannel?: (channel: Channel) => void;
+  onLeaveChannel?: (channel: Channel) => void;
+}) {
+  return (
+    <SidebarDndContext
+      channelGroups={channelGroups}
+      channels={channels}
+      sections={channelSections}
+      blockIds={blockOrder}
+      manualGroupKeys={manualGroupKeys}
+      onMoveChannel={handleMoveChannel}
+      onReorderBlocks={reorderBlocks}
+    >
+      {blockOrder.map((blockId, idx) => {
+        if (blockId === CHANNELS_BLOCK_ID) {
+          return (
+            <ChannelGroupSection
+              key={CHANNELS_BLOCK_ID}
+              blockId={CHANNELS_BLOCK_ID}
+              isFirstBlock={idx === 0}
+              isLastBlock={idx === blockOrder.length - 1}
+              onMoveBlockUp={() => moveBlockUp(CHANNELS_BLOCK_ID)}
+              onMoveBlockDown={() => moveBlockDown(CHANNELS_BLOCK_ID)}
+              draggable
+              hasUnread={unreadChannelIds.size > 0}
+              isCollapsed={collapsedChannels}
+              isActiveChannel={isActiveChannel}
+              activeWorkingByChannelId={activeWorkingByChannelId}
+              items={sectionBuckets.unassigned}
+              sortMode={sortModeFor("channels")}
+              onSortModeChange={(mode) =>
+                handleSortModeChange(
+                  "channels",
+                  mode,
+                  sectionBuckets.unassigned,
+                )
+              }
+              actionsTestId="section-actions-channels"
+              listTestId="stream-list"
+              quickCreateLabel="Browse channels"
+              onQuickCreateClick={() => onBrowseChannels?.()}
+              showQuickCreate
+              onMarkAllRead={onMarkAllChannelsRead}
+              onMarkChannelRead={onMarkChannelRead}
+              onMarkChannelUnread={onMarkChannelUnread}
+              onSelectChannel={onSelectChannel}
+              onToggleCollapsed={onToggleCollapsedChannels}
+              selectedChannelId={selectedChannelId}
+              title="Channels"
+              unreadChannelCounts={unreadChannelCounts}
+              unreadChannelIds={unreadChannelIds}
+              sections={channelSections}
+              assignments={channelAssignments}
+              onAssignChannel={assignChannel}
+              onUnassignChannel={unassignChannel}
+              onCreateSectionForChannel={onCreateSectionForChannel}
+              onCreateCategory={onCreateCategory}
+              groupKey="channels"
+              manualSortEnabled
+              mutedChannelIds={mutedChannelIds}
+              onMuteChannel={onMuteChannel}
+              onUnmuteChannel={onUnmuteChannel}
+              starredChannelIds={starredChannelIds}
+              onStarChannel={onStarChannel}
+              onUnstarChannel={onUnstarChannel}
+              onDeleteChannel={onDeleteChannel}
+              onLeaveChannel={onLeaveChannel}
+            />
+          );
+        }
+        const section = channelSections.find((s) => s.id === blockId);
+        if (!section) return null;
+        const sectionChannels = sectionBuckets.bySection[section.id] ?? [];
+        return (
+          <CustomChannelSection
+            key={section.id}
+            section={section}
+            channels={sectionChannels}
+            hasUnread={sectionChannels.some((c) => unreadChannelIds.has(c.id))}
+            isCollapsed={collapsedSections[section.id] ?? false}
+            isActiveChannel={isActiveChannel}
+            activeWorkingByChannelId={activeWorkingByChannelId}
+            selectedChannelId={selectedChannelId}
+            unreadChannelCounts={unreadChannelCounts}
+            unreadChannelIds={unreadChannelIds}
+            sections={channelSections}
+            assignments={channelAssignments}
+            isFirst={idx === 0}
+            isLast={idx === blockOrder.length - 1}
+            sortMode={sortModeFor(sectionSortGroupKey(section.id))}
+            onSortModeChange={(mode) =>
+              handleSortModeChange(
+                sectionSortGroupKey(section.id),
+                mode,
+                sectionChannels,
+              )
+            }
+            onToggleCollapsed={() => onToggleCollapsedSection(section.id)}
+            onSelectChannel={onSelectChannel}
+            onMarkChannelRead={onMarkChannelRead}
+            onMarkChannelUnread={onMarkChannelUnread}
+            onMarkSectionRead={() => {
+              for (const channel of sectionChannels) {
+                onMarkChannelRead(channel.id, channel.lastMessageAt);
+              }
+            }}
+            onAssignChannel={assignChannel}
+            onUnassignChannel={unassignChannel}
+            onCreateSectionForChannel={onCreateSectionForChannel}
+            onCreateChannel={() => onCreateChannelInSection(section.id)}
+            onRenameSection={() => onRenameSection(section)}
+            onDeleteSection={() => onDeleteSection(section)}
+            onMoveSectionUp={() => moveBlockUp(section.id)}
+            onMoveSectionDown={() => moveBlockDown(section.id)}
+            mutedChannelIds={mutedChannelIds}
+            onMuteChannel={onMuteChannel}
+            onUnmuteChannel={onUnmuteChannel}
+            starredChannelIds={starredChannelIds}
+            onStarChannel={onStarChannel}
+            onUnstarChannel={onUnstarChannel}
+            onDeleteChannel={onDeleteChannel}
+            onLeaveChannel={onLeaveChannel}
+          />
+        );
+      })}
+    </SidebarDndContext>
+  );
+}

--- a/desktop/src/shared/constants/kinds.ts
+++ b/desktop/src/shared/constants/kinds.ts
@@ -40,12 +40,13 @@ export const KIND_HUDDLE_PARTICIPANT_JOINED = 48101;
 export const KIND_HUDDLE_PARTICIPANT_LEFT = 48102;
 export const KIND_HUDDLE_ENDED = 48103;
 // NIP-78 application-specific data. All use kind 30078; the relay
-// differentiates them by d-tag ("read-state:<slotId>", "channel-sections", "channel-mutes", "channel-stars", "channel-sort").
+// differentiates them by d-tag ("read-state:<slotId>", "channel-sections", "channel-mutes", "channel-stars", "channel-sort", "channel-manual-order").
 export const KIND_READ_STATE = 30078;
 export const KIND_CHANNEL_SECTIONS = 30078;
 export const KIND_CHANNEL_MUTES = 30078;
 export const KIND_CHANNEL_STARS = 30078;
 export const KIND_CHANNEL_SORT = 30078;
+export const KIND_CHANNEL_MANUAL_ORDER = 30078;
 // NIP-33 persona/team/managed-agent projection events (d-tag keyed). Published
 // backend-side as secrets-stripped snapshots; the inbound sync hook subscribes
 // to all three to patch local records. Mirror of buzz-core's KIND_PERSONA etc.

--- a/desktop/tests/e2e/channel-categories-manual-order.spec.ts
+++ b/desktop/tests/e2e/channel-categories-manual-order.spec.ts
@@ -339,4 +339,194 @@ test.describe("sidebar categories and manual channel order", () => {
     expect(Object.keys(stored.sections.assignments)).toHaveLength(2);
     expect(stored.order.groups[`section:${section.id}`]).toHaveLength(2);
   });
+
+  test("Move up/down reorders a category across Channels and persists after reload", async ({
+    page,
+  }) => {
+    await openApp(page);
+
+    // Create two categories so the movable lane is [Work, Home, Channels].
+    for (const name of ["Work", "Home"]) {
+      await page.getByText("Channels", { exact: true }).hover();
+      await page.getByTestId("section-actions-channels").click();
+      await page.getByRole("menuitem", { name: "New category..." }).click();
+      await page.getByPlaceholder("Category name").fill(name);
+      await page.getByRole("button", { name: "Create" }).click();
+      await expect(page.getByText(name, { exact: true })).toBeVisible();
+    }
+
+    const sections = await page.evaluate((key) => {
+      const value = JSON.parse(window.localStorage.getItem(key) ?? "null");
+      return value.sections as { id: string; name: string }[];
+    }, SECTION_KEY);
+    const work = sections.find((s) => s.name === "Work");
+    const home = sections.find((s) => s.name === "Home");
+    expect(work && home).toBeTruthy();
+    if (!work || !home) throw new Error("categories missing");
+
+    // Move Work down past Home → [Home, Work, Channels]
+    await page.getByTestId(`section-title-${work.id}`).hover();
+    await page.getByTestId(`section-actions-${work.id}`).click();
+    await page.getByRole("menuitem", { name: "Move down" }).click();
+    await waitForMenusToClose(page);
+
+    // Move Channels up past Work → [Home, Channels, Work]
+    await page.getByText("Channels", { exact: true }).hover();
+    await page.getByTestId("section-actions-channels").click();
+    await page.getByRole("menuitem", { name: "Move up" }).click();
+    await waitForMenusToClose(page);
+
+    const afterMove = await page.evaluate((key) => {
+      return JSON.parse(window.localStorage.getItem(key) ?? "null") as {
+        channelsBlockIndex?: number;
+        sections: { id: string; name: string; order: number }[];
+      };
+    }, SECTION_KEY);
+    expect(afterMove.channelsBlockIndex).toBe(1);
+    const ordered = afterMove.sections
+      .slice()
+      .sort((a, b) => a.order - b.order)
+      .map((s) => s.name);
+    expect(ordered).toEqual(["Home", "Work"]);
+
+    // Delete Home (before Channels): must keep Channels above Work.
+    await page.getByTestId(`section-title-${home.id}`).hover();
+    await page.getByTestId(`section-actions-${home.id}`).click();
+    await page.getByRole("menuitem", { name: "Delete category" }).click();
+    await page.getByRole("button", { name: "Delete" }).click();
+    await expect(page.getByTestId(`section-title-${home.id}`)).toHaveCount(0);
+
+    const afterDelete = await page.evaluate((key) => {
+      return JSON.parse(window.localStorage.getItem(key) ?? "null") as {
+        channelsBlockIndex?: number;
+        sections: { id: string; name: string }[];
+      };
+    }, SECTION_KEY);
+    expect(afterDelete.sections.map((s) => s.name)).toEqual(["Work"]);
+    expect(afterDelete.channelsBlockIndex).toBe(0);
+
+    await page.reload();
+    await page.getByTestId("channel-general").click();
+    const afterReload = await page.evaluate((key) => {
+      return JSON.parse(window.localStorage.getItem(key) ?? "null") as {
+        channelsBlockIndex?: number;
+        sections: { id: string; name: string }[];
+      };
+    }, SECTION_KEY);
+    expect(afterReload.channelsBlockIndex).toBe(0);
+    expect(afterReload.sections.map((s) => s.name)).toEqual(["Work"]);
+  });
+
+  test("category block drag handle reorders relative to Channels", async ({
+    page,
+  }) => {
+    await openApp(page);
+    await page.getByText("Channels", { exact: true }).hover();
+    await page.getByTestId("section-actions-channels").click();
+    await page.getByRole("menuitem", { name: "New category..." }).click();
+    await page.getByPlaceholder("Category name").fill("Work");
+    await page.getByRole("button", { name: "Create" }).click();
+
+    const section = await page.evaluate((key) => {
+      const value = JSON.parse(window.localStorage.getItem(key) ?? "null");
+      return value.sections[0] as { id: string };
+    }, SECTION_KEY);
+
+    const categoryHandle = page.getByTestId(`block-drag-${section.id}`);
+    const channelsHandle = page.getByTestId("block-drag-__channels__");
+    await page.getByTestId(`section-title-${section.id}`).hover();
+    await expect(categoryHandle).toHaveCSS("opacity", "1");
+    await page.mouse.move(0, 0);
+    await expect(categoryHandle).toHaveCSS("opacity", "0");
+
+    // Drag Work below Channels → [Channels, Work]
+    await dragOver(page, categoryHandle, channelsHandle);
+    await expect
+      .poll(async () => {
+        const stored = await page.evaluate((key) => {
+          return JSON.parse(window.localStorage.getItem(key) ?? "null") as {
+            channelsBlockIndex?: number;
+          };
+        }, SECTION_KEY);
+        return stored.channelsBlockIndex;
+      })
+      .toBe(0);
+
+    await page.reload();
+    await page.getByTestId("channel-general").click();
+    await expect
+      .poll(async () => {
+        const stored = await page.evaluate((key) => {
+          return JSON.parse(window.localStorage.getItem(key) ?? "null") as {
+            channelsBlockIndex?: number;
+          };
+        }, SECTION_KEY);
+        return stored.channelsBlockIndex;
+      })
+      .toBe(0);
+  });
+
+  test("keyboard users can move a category block across Channels and persist after reload", async ({
+    page,
+  }) => {
+    await openApp(page);
+    await page.getByText("Channels", { exact: true }).hover();
+    await page.getByTestId("section-actions-channels").click();
+    await page.getByRole("menuitem", { name: "New category..." }).click();
+    await page.getByPlaceholder("Category name").fill("Work");
+    await page.getByRole("button", { name: "Create" }).click();
+
+    const section = await page.evaluate((key) => {
+      const value = JSON.parse(window.localStorage.getItem(key) ?? "null");
+      return value.sections[0] as { id: string };
+    }, SECTION_KEY);
+
+    // Default layout: [Work, Channels]. Keyboard-move Work down past Channels.
+    const categoryHandle = page.getByTestId(`block-drag-${section.id}`);
+    const categoryShell = page.locator(`[data-dnd-block="${section.id}"]`);
+    await page.mouse.move(0, 0);
+    await expect(categoryHandle).toHaveCSS("opacity", "0");
+    await categoryHandle.focus();
+    await expect(categoryHandle).toHaveCSS("opacity", "1");
+
+    await categoryHandle.press("Space");
+    // opacity-30 is applied to the section body inside the shell, not the
+    // data-dnd-block wrapper (unlike channel rows). Live-region text only
+    // retains the latest announcement, so do not require "Picked up".
+    await expect(categoryShell.locator(".opacity-30")).toBeVisible();
+    // KeyboardSensor attaches its document keydown listener on the next task.
+    await page.evaluate(
+      () => new Promise<void>((resolve) => window.setTimeout(resolve, 0)),
+    );
+    await categoryHandle.press("ArrowDown");
+    await expect(page.getByRole("status")).toContainText("is over Channels");
+    await categoryHandle.press("Space");
+    await expect(page.getByRole("status")).toContainText(
+      "Moved category Work to Channels.",
+    );
+
+    await expect
+      .poll(async () => {
+        const stored = await page.evaluate((key) => {
+          return JSON.parse(window.localStorage.getItem(key) ?? "null") as {
+            channelsBlockIndex?: number;
+          };
+        }, SECTION_KEY);
+        return stored.channelsBlockIndex;
+      })
+      .toBe(0);
+
+    await page.reload();
+    await page.getByTestId("channel-general").click();
+    await expect
+      .poll(async () => {
+        const stored = await page.evaluate((key) => {
+          return JSON.parse(window.localStorage.getItem(key) ?? "null") as {
+            channelsBlockIndex?: number;
+          };
+        }, SECTION_KEY);
+        return stored.channelsBlockIndex;
+      })
+      .toBe(0);
+  });
 });

--- a/desktop/tests/e2e/channel-categories-manual-order.spec.ts
+++ b/desktop/tests/e2e/channel-categories-manual-order.spec.ts
@@ -1,0 +1,315 @@
+import { expect, test } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+const MOCK_PUBKEY = "deadbeef".repeat(8);
+const RELAY = encodeURIComponent("ws://localhost:3000");
+const SECTION_KEY = `buzz-channel-sections.v1:${MOCK_PUBKEY}:${RELAY}`;
+const SORT_KEY = `buzz-channel-sort.v1:${MOCK_PUBKEY}:${RELAY}`;
+const ORDER_KEY = `buzz-channel-manual-order.v1:${MOCK_PUBKEY}:${RELAY}`;
+
+async function openApp(page: Page) {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+}
+
+async function openSort(page: Page, actionsTestId: string) {
+  await page.getByTestId(actionsTestId).click();
+  await page.getByRole("menuitem", { name: "Sort" }).click();
+}
+
+async function dragOver(
+  page: Page,
+  source: Locator,
+  target: Locator,
+  settleStaticTarget = false,
+) {
+  const from = await source.boundingBox();
+  if (!from) throw new Error("drag source not laid out");
+  await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2 + 10);
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+  );
+  const to = await target.boundingBox();
+  if (!to) throw new Error("drag target not laid out");
+  await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2, {
+    steps: 10,
+  });
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+  );
+  if (settleStaticTarget) {
+    const settledTarget = await target.boundingBox();
+    if (!settledTarget) throw new Error("drag target disappeared");
+    await page.mouse.move(
+      settledTarget.x + settledTarget.width / 2,
+      settledTarget.y + settledTarget.height / 2,
+    );
+  }
+  await expect(page.getByRole("status")).toContainText(" is over ");
+  await page.mouse.up();
+}
+
+async function waitForMenusToClose(page: Page) {
+  await expect(page.getByRole("menu")).toHaveCount(0);
+}
+
+async function waitForKeyboardSensor(page: Page, row: Locator) {
+  await expect(row).toHaveClass(/opacity-30/);
+  await page.evaluate(
+    () => new Promise<void>((resolve) => window.setTimeout(resolve, 0)),
+  );
+}
+
+async function keyboardMoveUp(
+  page: Page,
+  source: Locator,
+  row: Locator,
+  channelName: string,
+) {
+  await source.focus();
+  await source.press("Space");
+  await waitForKeyboardSensor(page, row);
+  await source.press("ArrowUp");
+  await expect(page.getByRole("status")).toContainText(
+    `Channel ${channelName} is over position 1 in category Channels.`,
+  );
+  await source.press("Space");
+}
+
+function draggableChannel(page: Page, name: string) {
+  return page.locator("[data-dnd-channel]").filter({
+    has: page.getByTestId(`channel-${name}`),
+  });
+}
+
+function channelDragHandle(page: Page, name: string) {
+  return draggableChannel(page, name).locator("[data-dnd-handle]");
+}
+
+function channelNames(list: Locator) {
+  return list.locator("[data-testid^='channel-']").evaluateAll((nodes) =>
+    nodes
+      .map((node) => node.getAttribute("data-testid") ?? "")
+      .filter(
+        (id) =>
+          !id.startsWith("channel-unread") &&
+          !id.startsWith("channel-working") &&
+          !id.startsWith("channel-dm-count"),
+      )
+      .map((id) => id.replace(/^channel-/, "")),
+  );
+}
+
+test.describe("sidebar categories and manual channel order", () => {
+  test("creates a category from the Channels menu and rejects a duplicate", async ({
+    page,
+  }) => {
+    await openApp(page);
+
+    await page.getByText("Channels", { exact: true }).hover();
+    await page.getByTestId("section-actions-channels").click();
+    await page.getByRole("menuitem", { name: "New category..." }).click();
+    await page.getByPlaceholder("Category name").fill("Work");
+    await page.getByRole("button", { name: "Create" }).click();
+    await expect(page.getByText("Work", { exact: true })).toBeVisible();
+
+    const stored = await page.evaluate((key) => {
+      return JSON.parse(window.localStorage.getItem(key) ?? "null");
+    }, SECTION_KEY);
+    expect(stored.sections).toHaveLength(1);
+    expect(stored.sections[0].name).toBe("Work");
+
+    await page.getByText("Channels", { exact: true }).hover();
+    await page.getByTestId("section-actions-channels").click();
+    await page.getByRole("menuitem", { name: "New category..." }).click();
+    await page.getByPlaceholder("Category name").fill("work");
+    await expect(page.getByRole("button", { name: "Create" })).toBeDisabled();
+    await expect(
+      page.getByText("A category with this name already exists."),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("section-actions-channels")).toBeFocused();
+  });
+
+  test("renames and deletes a category from its actions menu", async ({
+    page,
+  }) => {
+    await openApp(page);
+    await page.getByText("Channels", { exact: true }).hover();
+    await page.getByTestId("section-actions-channels").click();
+    await page.getByRole("menuitem", { name: "New category..." }).click();
+    await page.getByPlaceholder("Category name").fill("Work");
+    await page.getByRole("button", { name: "Create" }).click();
+
+    const section = await page.evaluate((key) => {
+      const value = JSON.parse(window.localStorage.getItem(key) ?? "null");
+      return value.sections[0] as { id: string };
+    }, SECTION_KEY);
+    const actions = page.getByTestId(`section-actions-${section.id}`);
+    await page.getByText("Work", { exact: true }).hover();
+    await actions.click();
+    await page.getByRole("menuitem", { name: "Rename category" }).click();
+    await page.getByPlaceholder("Category name").fill("Projects");
+    await page.getByRole("button", { name: "Save" }).click();
+    const title = page.getByTestId(`section-title-${section.id}`);
+    await expect(title).toHaveText("Projects");
+
+    await title.hover();
+    await actions.click();
+    await page.getByRole("menuitem", { name: "Delete category" }).click();
+    await page.getByRole("button", { name: "Delete" }).click();
+    await expect(title).toHaveCount(0);
+  });
+
+  test("Manual reorders Channels and restores the exact order after reload", async ({
+    page,
+  }) => {
+    await openApp(page);
+
+    await page.getByText("Channels", { exact: true }).hover();
+    await openSort(page, "section-actions-channels");
+    await page.getByRole("menuitemradio", { name: "Manual" }).click();
+    await waitForMenusToClose(page);
+
+    const list = page.getByTestId("stream-list");
+    const initialOrder = (await channelNames(list)).slice(0, 2);
+    expect(initialOrder).toHaveLength(2);
+    const [firstChannel, secondChannel] = initialOrder;
+    const firstRow = draggableChannel(page, firstChannel);
+    const firstHandle = channelDragHandle(page, firstChannel);
+    await expect(firstRow).not.toHaveClass(/touch-none/);
+    await expect(firstHandle).toHaveClass(/touch-none/);
+    await dragOver(page, firstHandle, draggableChannel(page, secondChannel));
+    await expect
+      .poll(async () => (await channelNames(list)).slice(0, 2))
+      .toEqual([secondChannel, firstChannel]);
+    await expect(page.getByRole("status")).toContainText(
+      `Moved channel ${firstChannel} to position 2 in category Channels.`,
+    );
+
+    const persisted = await page.evaluate(
+      ({ sortKey, orderKey }) => ({
+        sort: JSON.parse(window.localStorage.getItem(sortKey) ?? "null"),
+        order: JSON.parse(window.localStorage.getItem(orderKey) ?? "null"),
+      }),
+      { sortKey: SORT_KEY, orderKey: ORDER_KEY },
+    );
+    expect(persisted.sort?.groups?.channels).toBeUndefined();
+    expect(persisted.order.manualGroups).toContain("channels");
+    expect(persisted.order.groups.channels).toHaveLength(
+      (await channelNames(list)).length,
+    );
+
+    await page.reload();
+    await expect
+      .poll(async () =>
+        (await channelNames(page.getByTestId("stream-list"))).slice(0, 2),
+      )
+      .toEqual([secondChannel, firstChannel]);
+  });
+
+  test("keyboard users can move a channel in Manual order", async ({
+    page,
+  }) => {
+    await openApp(page);
+    await page.getByText("Channels", { exact: true }).hover();
+    await openSort(page, "section-actions-channels");
+    await page.getByRole("menuitemradio", { name: "Manual" }).click();
+    await waitForMenusToClose(page);
+
+    const list = page.getByTestId("stream-list");
+    const initialOrder = (await channelNames(list)).slice(0, 2);
+    expect(initialOrder).toHaveLength(2);
+    const [firstChannel, secondChannel] = initialOrder;
+    const secondHandle = channelDragHandle(page, secondChannel);
+    await secondHandle.focus();
+    await secondHandle.press("Space");
+    await waitForKeyboardSensor(page, draggableChannel(page, secondChannel));
+    // KeyboardSensor attaches its document keydown listener on the next task.
+    // The helper yields a macrotask so Escape exercises the active drag instead
+    // of racing that listener installation.
+    await secondHandle.press("Escape");
+    await expect(page.getByRole("status")).toContainText(
+      `Cancelled moving channel ${secondChannel}.`,
+    );
+    expect((await channelNames(list)).slice(0, 2)).toEqual(initialOrder);
+
+    await keyboardMoveUp(
+      page,
+      secondHandle,
+      draggableChannel(page, secondChannel),
+      secondChannel,
+    );
+    await expect
+      .poll(async () => (await channelNames(list)).slice(0, 2))
+      .toEqual([secondChannel, firstChannel]);
+    await expect(page.getByRole("status")).toContainText(
+      `Moved channel ${secondChannel} to position 1 in category Channels.`,
+    );
+  });
+
+  test("moves channels into an empty category and inserts at a manual position", async ({
+    page,
+  }) => {
+    await openApp(page);
+
+    await page.getByText("Channels", { exact: true }).hover();
+    await page.getByTestId("section-actions-channels").click();
+    await page.getByRole("menuitem", { name: "New category..." }).click();
+    await page.getByPlaceholder("Category name").fill("Work");
+    await page.getByRole("button", { name: "Create" }).click();
+
+    const section = await page.evaluate((key) => {
+      const value = JSON.parse(window.localStorage.getItem(key) ?? "null");
+      return value.sections[0] as { id: string };
+    }, SECTION_KEY);
+    await openSort(page, `section-actions-${section.id}`);
+    await page.getByRole("menuitemradio", { name: "Manual" }).click();
+    await waitForMenusToClose(page);
+
+    await dragOver(
+      page,
+      channelDragHandle(page, "agents"),
+      page.getByTestId(`section-empty-${section.id}`),
+      true,
+    );
+    const categoryList = page.getByTestId(`section-list-${section.id}`);
+    await expect(categoryList.getByTestId("channel-agents")).toBeVisible();
+    await expect(page.getByRole("status")).toContainText(
+      "Moved channel agents to position 1 in category Work.",
+    );
+    // Let dnd-kit's drop transform finish before measuring the next drag
+    // targets; otherwise the second pointer sequence can hit the stale overlay.
+    await page.waitForTimeout(250);
+
+    await dragOver(
+      page,
+      channelDragHandle(page, "general"),
+      draggableChannel(page, "agents"),
+    );
+    await expect
+      .poll(async () => channelNames(categoryList))
+      .toEqual(["general", "agents"]);
+    await expect(page.getByRole("status")).toContainText(
+      "Moved channel general to position 1 in category Work.",
+    );
+
+    const stored = await page.evaluate(
+      ({ sectionKey, orderKey }) => ({
+        sections: JSON.parse(window.localStorage.getItem(sectionKey) ?? "null"),
+        order: JSON.parse(window.localStorage.getItem(orderKey) ?? "null"),
+      }),
+      { sectionKey: SECTION_KEY, orderKey: ORDER_KEY },
+    );
+    expect(Object.keys(stored.sections.assignments)).toHaveLength(2);
+    expect(stored.order.groups[`section:${section.id}`]).toHaveLength(2);
+  });
+});

--- a/desktop/tests/e2e/channel-categories-manual-order.spec.ts
+++ b/desktop/tests/e2e/channel-categories-manual-order.spec.ts
@@ -194,6 +194,14 @@ test.describe("sidebar categories and manual channel order", () => {
     );
     await expect(firstRow).not.toHaveClass(/touch-none/);
     await expect(firstHandle).toHaveClass(/touch-none/);
+    await page.mouse.move(0, 0);
+    await expect(firstHandle).toHaveCSS("opacity", "0");
+    await firstRow.hover();
+    await expect(firstHandle).toHaveCSS("opacity", "1");
+    const secondHandle = channelDragHandle(page, secondChannel);
+    await draggableChannel(page, secondChannel).hover();
+    await expect(firstHandle).toHaveCSS("opacity", "0");
+    await expect(secondHandle).toHaveCSS("opacity", "1");
     await dragOver(page, firstHandle, draggableChannel(page, secondChannel));
     await expect
       .poll(async () => (await channelNames(list)).slice(0, 2))
@@ -245,9 +253,13 @@ test.describe("sidebar categories and manual channel order", () => {
     expect(initialOrder).toHaveLength(2);
     const [firstChannel, secondChannel] = initialOrder;
     const secondHandle = channelDragHandle(page, secondChannel);
+    await page.mouse.move(0, 0);
+    await expect(secondHandle).toHaveCSS("opacity", "0");
     await secondHandle.focus();
+    await expect(secondHandle).toHaveCSS("opacity", "1");
     await secondHandle.press("Space");
     await waitForKeyboardSensor(page, draggableChannel(page, secondChannel));
+    await expect(secondHandle).toHaveCSS("opacity", "1");
     // KeyboardSensor attaches its document keydown listener on the next task.
     // The helper yields a macrotask so Escape exercises the active drag instead
     // of racing that listener installation.

--- a/desktop/tests/e2e/channel-categories-manual-order.spec.ts
+++ b/desktop/tests/e2e/channel-categories-manual-order.spec.ts
@@ -185,6 +185,13 @@ test.describe("sidebar categories and manual channel order", () => {
     const [firstChannel, secondChannel] = initialOrder;
     const firstRow = draggableChannel(page, firstChannel);
     const firstHandle = channelDragHandle(page, firstChannel);
+    const channelRows = list.locator("[data-dnd-channel]").locator("..");
+    const manualRowVisibility = await channelRows.evaluateAll((rows) =>
+      rows.map((row) => getComputedStyle(row).contentVisibility),
+    );
+    expect(manualRowVisibility).toEqual(
+      Array(manualRowVisibility.length).fill("visible"),
+    );
     await expect(firstRow).not.toHaveClass(/touch-none/);
     await expect(firstHandle).toHaveClass(/touch-none/);
     await dragOver(page, firstHandle, draggableChannel(page, secondChannel));
@@ -194,6 +201,14 @@ test.describe("sidebar categories and manual channel order", () => {
     await expect(page.getByRole("status")).toContainText(
       `Moved channel ${firstChannel} to position 2 in category Channels.`,
     );
+    expect(
+      await channelRows.evaluateAll((rows) =>
+        rows.map((row) => getComputedStyle(row).contentVisibility),
+      ),
+    ).toEqual(Array(manualRowVisibility.length).fill("visible"));
+    for (const channelName of await channelNames(list)) {
+      await expect(page.getByTestId(`channel-${channelName}`)).toBeVisible();
+    }
 
     const persisted = await page.evaluate(
       ({ sortKey, orderKey }) => ({

--- a/desktop/tests/e2e/channel-categories-manual-order.spec.ts
+++ b/desktop/tests/e2e/channel-categories-manual-order.spec.ts
@@ -434,10 +434,60 @@ test.describe("sidebar categories and manual channel order", () => {
 
     const categoryHandle = page.getByTestId(`block-drag-${section.id}`);
     const channelsHandle = page.getByTestId("block-drag-__channels__");
-    await page.getByTestId(`section-title-${section.id}`).hover();
-    await expect(categoryHandle).toHaveCSS("opacity", "1");
+    const categoryTitle = page.getByTestId(`section-title-${section.id}`);
+    const channelsLabel = page.getByTestId("stream-list-section-label");
+    const channelsTitle = channelsLabel.locator("[data-sidebar-section-title]");
+    const categoryActions = page.getByTestId(`section-actions-${section.id}`);
+    const channelsActions = page.getByTestId("section-actions-channels");
+
+    await page.evaluate(() => {
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+    });
     await page.mouse.move(0, 0);
     await expect(categoryHandle).toHaveCSS("opacity", "0");
+    await expect(channelsHandle).toHaveCSS("opacity", "0");
+
+    const categoryTitleBox = await categoryTitle.boundingBox();
+    const channelsTitleBox = await channelsTitle.boundingBox();
+    expect(categoryTitleBox).not.toBeNull();
+    expect(channelsTitleBox).not.toBeNull();
+    if (!categoryTitleBox || !channelsTitleBox) {
+      throw new Error("category headers are not laid out");
+    }
+    expect(Math.abs(categoryTitleBox.x - channelsTitleBox.x)).toBeLessThan(1);
+
+    await categoryTitle.hover();
+    await expect(categoryHandle).toHaveCSS("opacity", "1");
+    const categoryHandleBox = await categoryHandle.boundingBox();
+    const categoryActionsBox = await categoryActions.boundingBox();
+    expect(categoryHandleBox).not.toBeNull();
+    expect(categoryActionsBox).not.toBeNull();
+    if (!categoryHandleBox || !categoryActionsBox) {
+      throw new Error("category actions are not laid out");
+    }
+    expect(categoryHandleBox.x).toBeGreaterThan(categoryActionsBox.x);
+
+    await channelsLabel.hover();
+    await expect(channelsHandle).toHaveCSS("opacity", "1");
+    const channelsHandleBox = await channelsHandle.boundingBox();
+    const channelsActionsBox = await channelsActions.boundingBox();
+    expect(channelsHandleBox).not.toBeNull();
+    expect(channelsActionsBox).not.toBeNull();
+    if (!channelsHandleBox || !channelsActionsBox) {
+      throw new Error("Channels actions are not laid out");
+    }
+    expect(channelsHandleBox.x).toBeGreaterThan(channelsActionsBox.x);
+
+    await page.evaluate(() => {
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
+    });
+    await page.mouse.move(0, 0);
+    await expect(categoryHandle).toHaveCSS("opacity", "0");
+    await expect(channelsHandle).toHaveCSS("opacity", "0");
 
     // Drag Work below Channels → [Channels, Work]
     await dragOver(page, categoryHandle, channelsHandle);

--- a/desktop/tests/e2e/virtualization.spec.ts
+++ b/desktop/tests/e2e/virtualization.spec.ts
@@ -163,6 +163,9 @@ test.describe("list virtualization", () => {
     await expect(topHeader).toBeVisible();
     await expect(bottomHeader).toBeVisible();
     await expect(headers).toHaveCount(2);
+    await topHeader.evaluate((element) =>
+      element.scrollIntoView({ block: "center" }),
+    );
 
     const sectionOrder = async () =>
       headers.evaluateAll((rows) =>
@@ -173,7 +176,6 @@ test.describe("list virtualization", () => {
         ),
       );
     expect(await sectionOrder()).toEqual(["Priority", "Archive"]);
-
     // Drag "Priority" past "Archive" — onDragEnd commits arrayMove and persists
     // the new order. The drop must land for the order to flip.
     await dragOver(page, topHeader, bottomHeader);

--- a/desktop/tests/e2e/virtualization.spec.ts
+++ b/desktop/tests/e2e/virtualization.spec.ts
@@ -152,16 +152,18 @@ test.describe("list virtualization", () => {
     await page.getByTestId("channel-general").click();
     await expect(page.getByTestId("chat-title")).toHaveText("general");
 
-    // dnd-kit marks each section's wrapping row with role="button" +
-    // aria-roledescription="sortable" and spreads the drag listeners there, so
-    // the row itself is the handle. Scoping to that attribute reads the live
-    // section order and excludes the inner disclosure button and the (hidden)
-    // assign-to-section context-menu items that reuse the same names.
-    const headers = page.locator('[aria-roledescription="sortable"]');
-    const topHeader = headers.filter({ hasText: "Priority" });
-    const bottomHeader = headers.filter({ hasText: "Archive" });
+    // Each category keeps a stable dnd block wrapper while its dedicated,
+    // accessible grip owns the drag listeners. Scope the live order to the two
+    // seeded custom blocks so the movable built-in Channels block is excluded.
+    const headers = page.locator(
+      '[data-dnd-block="sec-top"], [data-dnd-block="sec-bottom"]',
+    );
+    const topHeader = page.locator('[data-dnd-block="sec-top"]');
+    const bottomHeader = page.locator('[data-dnd-block="sec-bottom"]');
+    const topHandle = page.getByTestId("block-drag-sec-top");
     await expect(topHeader).toBeVisible();
     await expect(bottomHeader).toBeVisible();
+    await expect(topHandle).toBeAttached();
     await expect(headers).toHaveCount(2);
     await topHeader.evaluate((element) =>
       element.scrollIntoView({ block: "center" }),
@@ -178,7 +180,7 @@ test.describe("list virtualization", () => {
     expect(await sectionOrder()).toEqual(["Priority", "Archive"]);
     // Drag "Priority" past "Archive" — onDragEnd commits arrayMove and persists
     // the new order. The drop must land for the order to flip.
-    await dragOver(page, topHeader, bottomHeader);
+    await dragOver(page, topHandle, bottomHeader);
 
     // The drop landed: order flipped. A no-op drag would leave it unchanged.
     await expect.poll(sectionOrder).toEqual(["Archive", "Priority"]);


### PR DESCRIPTION
## Summary

- promote custom channel sections into first-class sidebar categories
- make `Manual` the default for stream groups that have no saved sort preference, while preserving explicit A-Z and Recent choices
- keep custom categories and the built-in uncategorized Channels block in one persisted sortable lane
- support pointer, touch, keyboard, and Move up / Move down movement across the Channels boundary
- persist exact channel order in a separate encrypted `channel-manual-order` NIP-78 document
- preserve pending local category edits during startup/reconnect hydration
- keep draggable sidebar rows paintable in WKWebView
- right-align category and channel drag grips so labels remain flush-left; keep grips hidden at rest and reveal them on hover, keyboard focus, or active drag, with a persistent affordance on non-hover devices
- restore focus to the live Channels actions trigger after closing the category dialog

## Why

Buzz already supported encrypted custom sections and section reordering, but category creation was buried in a channel context menu and exact channel order was not persisted. This extends the existing model instead of adding a competing category subsystem, while making the sidebar behave like a coherent manually ordered lane.

## Behavior

- Create categories from the Channels actions menu.
- Rename, reorder, and safely delete categories.
- Deleting a category returns its channels to the uncategorized Channels group.
- Empty categories remain valid pointer and keyboard drop targets.
- Categories can move above or below the built-in Channels block.
- Starred, Forums, and Direct Messages remain fixed system lanes.
- Manual channel ordering supports same-category and cross-category insertion.
- Keyboard drag supports cancellation, truthful position announcements, and persistence after reload.
- Category labels and carets remain the collapse target; a dedicated right-side grip owns dragging.
- Drag grips stay mounted and accessible but are visually hidden at rest.
- Hovering a draggable row reveals only that row's grip; keyboard focus and active drag keep it visible.
- Non-hover/touch devices retain a persistent move affordance.

## Persistence and compatibility

- Category membership remains in the existing encrypted `channel-sections` v1 document.
- The unified lane stores an optional normalized `channelsBlockIndex`; missing or malformed values preserve the legacy custom-categories-then-Channels layout.
- Index-only changes participate in NIP-78 publication and deduplication.
- Deleting a category adjusts the unified lane so the Channels block does not move accidentally; creating a category appends it without shifting the existing Channels position.
- Exact channel order uses a separate encrypted `channel-manual-order` document.
- Unset stream groups use an implicit deterministic visible-ID fallback; no mount-time seed or publish occurs. The order becomes explicit on the first reorder or explicit Manual selection.
- Stores are scoped by identity and normalized relay.
- Explicit pending local category edits stay authoritative while startup/reconnect hydration is in flight. An idle cold-start remote snapshot still wins when no local edit is pending.

## Regression fixes retained

### Startup sync race

Creating a category before the initial NIP-78 fetch completed could show it briefly, then silently remove it. The pending-local guard prevents an older fetched snapshot from overwriting the edit or cancelling its debounced publish while retaining normal timestamp/event-ID conflict handling for idle remote updates.

### Invisible rows during drag

A draggable row in WKWebView could remain in the DOM and accessibility tree but stop painting when `content-visibility: auto` was combined with dnd-kit transforms. Sortable channel rows now remain paintable while non-draggable rows retain the optimization.

### Focus restoration

Current Block main intentionally skips generic menu focus restoration for New Message so its recipient input keeps focus. Category creation now preserves the live Channels actions trigger separately, allowing Escape/close to restore focus after the sortable lane remounts without regressing New Message.

## Validation

Refreshed upstream branch at `00a615f54f0797c11731ddefe593eeeb1387a560`, rebased onto Block `main` at `9752b816a95e88751b9c7e4d3343fe3210de5d43`:

- `pnpm --dir desktop typecheck`: passed
- `pnpm --dir desktop check`: passed across 1,703 files and all policy guards
- full desktop unit suite: 3,815 / 3,815 passed
- E2E production build: passed
- `channel-categories-manual-order.spec.ts`: 8 / 8 passed with retries disabled
- targeted custom-section drag under content virtualization: 1 / 1 passed with retries disabled
- no lockfile change

The focused browser suite covers category create/duplicate rejection, rename/delete and focus restoration, manual channel reorder plus reload, keyboard channel movement, empty-category insertion, Move up/down across Channels, pointer category-block movement, and keyboard category-block movement plus reload.

## Scope

Desktop only. This branch contains no mobile implementation, NYTEMODE branding, updater/distribution changes, installer changes, or identity/profile changes.