### PR TITLE
feat(desktop): open repository files from message links

### DIFF
--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -46,6 +46,7 @@ mod project_git;
 mod project_git_branches;
 mod project_git_diff;
 mod project_git_exec;
+mod project_git_focus;
 mod project_git_merge_error;
 mod project_git_push;
 mod project_git_workflow;

--- a/desktop/src-tauri/src/commands/project_git.rs
+++ b/desktop/src-tauri/src/commands/project_git.rs
@@ -1,6 +1,8 @@
 use super::project_git_exec::{
-    build_git_auth_config, clean_branch, clean_target_ref, run_git, validate_workspace_clone_url,
-    GitAuthConfig,
+    build_git_auth_config, clean_branch, run_git, validate_workspace_clone_url, GitAuthConfig,
+};
+use super::project_git_focus::{
+    clean_repository_target, select_repository_tree_lines, RepositoryTarget,
 };
 use super::project_git_push::push_project_local_repository_blocking;
 use super::project_repo_paths::{canonical_repos_roots, find_local_repo_dir};
@@ -313,9 +315,10 @@ fn parse_ls_tree(
     repo_dir: &std::path::Path,
     output: &str,
     latest_commit_by_path: &std::collections::HashMap<String, ProjectRepoCommitInfo>,
+    focus_path: Option<&str>,
 ) -> Vec<ProjectRepoFileInfo> {
-    output
-        .lines()
+    select_repository_tree_lines(output, focus_path, 250, 250)
+        .into_iter()
         .filter_map(|line| {
             let (meta, path) = line.split_once('\t')?;
             let mut parts = meta.split_whitespace();
@@ -339,7 +342,6 @@ fn parse_ls_tree(
                 latest_commit: latest_commit_by_path.get(path).cloned(),
             })
         })
-        .take(250)
         .collect()
 }
 
@@ -348,6 +350,7 @@ fn snapshot_from_repo(
     auth: &GitAuthConfig,
     branch_name: Option<&str>,
     base_branch: Option<&str>,
+    focus_path: Option<&str>,
 ) -> ProjectRepoSnapshotInfo {
     let latest_commit = run_git(
         &["log", "-1", "--format=%H%x00%h%x00%an%x00%ae%x00%at%x00%s"],
@@ -397,10 +400,13 @@ fn snapshot_from_repo(
         )
         .map(|output| parse_latest_commit_by_path(&output))
         .unwrap_or_default();
-
-        run_git(&["ls-tree", "-r", "--long", "HEAD"], Some(repo_dir), auth)
-            .map(|output| parse_ls_tree(repo_dir, &output, &latest_commit_by_path))
-            .unwrap_or_default()
+        run_git(
+            &["ls-tree", "-r", "--long", "-z", "HEAD"],
+            Some(repo_dir),
+            auth,
+        )
+        .map(|output| parse_ls_tree(repo_dir, &output, &latest_commit_by_path, focus_path))
+        .unwrap_or_default()
     } else {
         Vec::new()
     };
@@ -712,18 +718,18 @@ pub async fn get_project_repo_snapshot(
     base_branch: Option<String>,
     target_ref: Option<String>,
     target_commit: Option<String>,
+    target_path: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<ProjectRepoSnapshotInfo, String> {
     validate_workspace_clone_url(&clone_url, &state)?;
     let auth = build_git_auth_config(&state)?;
     let branch = clean_branch(default_branch);
     let base_branch = clean_branch(base_branch);
-    let target_ref = clean_target_ref(target_ref);
-    let target_commit = target_commit
-        .map(|value| value.to_ascii_lowercase())
-        .filter(|value| matches!(value.len(), 40 | 64))
-        .filter(|value| value.chars().all(|c| c.is_ascii_hexdigit()));
-
+    let RepositoryTarget {
+        target_ref,
+        target_commit,
+        target_path,
+    } = clean_repository_target(target_ref, target_commit, target_path)?;
     tauri::async_runtime::spawn_blocking(move || {
         let temp_dir = tempfile::tempdir().map_err(|error| format!("create temp dir: {error}"))?;
         let repo_dir = temp_dir.path().join("repo");
@@ -783,8 +789,13 @@ pub async fn get_project_repo_snapshot(
             }
         }
 
-        let snapshot =
-            snapshot_from_repo(&repo_dir, &auth, branch.as_deref(), base_branch.as_deref());
+        let snapshot = snapshot_from_repo(
+            &repo_dir,
+            &auth,
+            branch.as_deref(),
+            base_branch.as_deref(),
+            target_path.as_deref(),
+        );
         Ok(snapshot)
     })
     .await

--- a/desktop/src-tauri/src/commands/project_git_exec.rs
+++ b/desktop/src-tauri/src/commands/project_git_exec.rs
@@ -267,13 +267,29 @@ pub(crate) fn clean_branch(value: Option<String>) -> Option<String> {
 
 pub(crate) fn clean_target_ref(value: Option<String>) -> Option<String> {
     let value = value?.trim().to_string();
-    for prefix in ["refs/tags/", "refs/nostr/"] {
+    for prefix in ["refs/heads/", "refs/tags/", "refs/nostr/"] {
         if let Some(name) = value.strip_prefix(prefix) {
             let clean_name = clean_branch(Some(name.to_string()))?;
+            if prefix == "refs/heads/"
+                && (clean_name.ends_with('.')
+                    || clean_name.ends_with(".lock")
+                    || clean_name.contains("//")
+                    || clean_name
+                        .split('/')
+                        .any(|component| component.starts_with('.')))
+            {
+                return None;
+            }
             return (clean_name == name).then_some(format!("{prefix}{clean_name}"));
         }
     }
     None
+}
+
+pub(crate) fn clean_target_commit(value: Option<String>) -> Option<String> {
+    let value = value?.trim().to_ascii_lowercase();
+    (matches!(value.len(), 40 | 64) && value.chars().all(|c| c.is_ascii_hexdigit()))
+        .then_some(value)
 }
 
 pub(crate) fn validate_clone_url(clone_url: &str) -> Result<(), String> {
@@ -393,9 +409,9 @@ fn validate_clone_url_against_relay(clone_url: &str, relay_base: &str) -> Result
 #[cfg(test)]
 mod tests {
     use super::{
-        clean_branch, clean_target_ref, credential_helper_config_value, git_needs_credentials,
-        git_subcommand, validate_clone_url, validate_clone_url_against_relay,
-        validate_local_clone_url,
+        clean_branch, clean_target_commit, clean_target_ref, credential_helper_config_value,
+        git_needs_credentials, git_subcommand, validate_clone_url,
+        validate_clone_url_against_relay, validate_local_clone_url,
     };
 
     #[test]
@@ -463,7 +479,11 @@ mod tests {
     }
 
     #[test]
-    fn clean_target_ref_accepts_only_tags_and_pull_request_refs() {
+    fn clean_target_ref_accepts_heads_tags_and_pull_request_refs() {
+        assert_eq!(
+            clean_target_ref(Some("refs/heads/feature/x-1".into())),
+            Some("refs/heads/feature/x-1".to_string())
+        );
         assert_eq!(
             clean_target_ref(Some("refs/tags/v1.0.0".into())),
             Some("refs/tags/v1.0.0".to_string())
@@ -472,8 +492,36 @@ mod tests {
             clean_target_ref(Some("refs/nostr/abc123".into())),
             Some("refs/nostr/abc123".to_string())
         );
-        assert_eq!(clean_target_ref(Some("refs/heads/main".into())), None);
+        assert_eq!(clean_target_ref(Some("refs/heads/../main".into())), None);
         assert_eq!(clean_target_ref(Some("refs/tags/../main".into())), None);
+    }
+
+    #[test]
+    fn clean_target_ref_rejects_noncanonical_head_names() {
+        for value in [
+            "refs/heads/main.",
+            "refs/heads/main.lock",
+            "refs/heads/feature//main",
+            "refs/heads/.hidden/main",
+            "refs/heads/feature/.hidden",
+        ] {
+            assert_eq!(clean_target_ref(Some(value.into())), None, "{value}");
+        }
+    }
+
+    #[test]
+    fn clean_target_commit_accepts_full_hashes_and_rejects_other_values() {
+        assert_eq!(
+            clean_target_commit(Some(" AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA ".into())),
+            Some("a".repeat(40))
+        );
+        assert_eq!(
+            clean_target_commit(Some("B".repeat(64))),
+            Some("b".repeat(64))
+        );
+        for value in ["", "abc", &"g".repeat(40), &"a".repeat(39)] {
+            assert_eq!(clean_target_commit(Some(value.into())), None, "{value}");
+        }
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/project_git_focus.rs
+++ b/desktop/src-tauri/src/commands/project_git_focus.rs
@@ -1,0 +1,211 @@
+use super::project_git_exec::{clean_target_commit, clean_target_ref};
+
+pub(crate) struct RepositoryTarget {
+    pub(crate) target_ref: Option<String>,
+    pub(crate) target_commit: Option<String>,
+    pub(crate) target_path: Option<String>,
+}
+
+pub(crate) fn clean_repository_target(
+    target_ref: Option<String>,
+    target_commit: Option<String>,
+    target_path: Option<String>,
+) -> Result<RepositoryTarget, String> {
+    Ok(RepositoryTarget {
+        target_ref: target_ref
+            .map(|value| {
+                clean_target_ref(Some(value))
+                    .ok_or_else(|| "Invalid repository target ref.".to_string())
+            })
+            .transpose()?,
+        target_commit: target_commit
+            .map(|value| {
+                clean_target_commit(Some(value))
+                    .ok_or_else(|| "Invalid repository target commit.".to_string())
+            })
+            .transpose()?,
+        target_path: target_path
+            .map(|value| {
+                clean_repository_focus_path(Some(value))
+                    .ok_or_else(|| "Invalid repository target path.".to_string())
+            })
+            .transpose()?,
+    })
+}
+
+const MAX_FOCUS_PATH_BYTES: usize = 4096;
+
+pub(crate) fn clean_repository_focus_path(value: Option<String>) -> Option<String> {
+    let value = value?;
+    if value.is_empty()
+        || value.len() > MAX_FOCUS_PATH_BYTES
+        || value.starts_with(['/', '\\'])
+        || value.ends_with('/')
+        || value.contains('\\')
+        || value.chars().any(char::is_control)
+        || value
+            .split('/')
+            .any(|component| component.is_empty() || matches!(component, "." | ".."))
+    {
+        return None;
+    }
+    Some(value)
+}
+
+fn tree_line_path(line: &str) -> Option<&str> {
+    line.split_once('\t').map(|(_, path)| path)
+}
+
+pub(crate) fn select_repository_tree_lines<'a>(
+    output: &'a str,
+    focus_path: Option<&str>,
+    base_limit: usize,
+    focus_limit: usize,
+) -> Vec<&'a str> {
+    let records: Vec<_> = output
+        .split_terminator('\0')
+        .filter(|record| !record.is_empty())
+        .collect();
+    let mut selected: Vec<_> = records.iter().take(base_limit).copied().collect();
+    let Some(focus_path) = focus_path else {
+        return selected;
+    };
+    let directory_prefix = format!("{focus_path}/");
+    selected.extend(
+        records
+            .iter()
+            .skip(base_limit)
+            .filter(|line| {
+                tree_line_path(line)
+                    .is_some_and(|path| path == focus_path || path.starts_with(&directory_prefix))
+            })
+            .take(focus_limit)
+            .copied(),
+    );
+    selected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repository_target_normalizes_all_explicit_coordinates() {
+        let target = clean_repository_target(
+            Some("refs/heads/feature/repo-links".into()),
+            Some("A".repeat(40)),
+            Some("GUIDES/setup.md".into()),
+        )
+        .expect("valid target");
+        assert_eq!(
+            target.target_ref.as_deref(),
+            Some("refs/heads/feature/repo-links")
+        );
+        assert_eq!(
+            target.target_commit.as_deref(),
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
+        assert_eq!(target.target_path.as_deref(), Some("GUIDES/setup.md"));
+    }
+
+    #[test]
+    fn repository_target_rejects_any_invalid_explicit_coordinate() {
+        assert!(clean_repository_target(Some("refs/heads/main.lock".into()), None, None).is_err());
+        assert!(clean_repository_target(None, Some("short".into()), None).is_err());
+        assert!(clean_repository_target(None, None, Some("../README.md".into())).is_err());
+    }
+
+    #[test]
+    fn focus_path_accepts_safe_repository_coordinates() {
+        assert_eq!(
+            clean_repository_focus_path(Some("GUIDES/setup/install.md".into())).as_deref(),
+            Some("GUIDES/setup/install.md")
+        );
+    }
+
+    #[test]
+    fn focus_path_rejects_absolute_traversal_ambiguous_and_control_paths() {
+        for value in [
+            "",
+            "/etc/passwd",
+            "../README.md",
+            "docs/../README.md",
+            "docs//README.md",
+            "docs/./README.md",
+            "docs\\README.md",
+            "docs/README.md/",
+            "docs/\u{0}README.md",
+        ] {
+            assert_eq!(
+                clean_repository_focus_path(Some(value.into())),
+                None,
+                "{value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn focused_file_outside_base_cap_is_appended_once() {
+        let output = [
+            "100644 blob a 1\tA.txt",
+            "100644 blob b 1\tB.txt",
+            "100644 blob c 1\tGUIDES/RUNBOOK.md",
+        ]
+        .join("\0");
+        assert_eq!(
+            select_repository_tree_lines(&output, Some("GUIDES/RUNBOOK.md"), 2, 20),
+            vec![
+                "100644 blob a 1\tA.txt",
+                "100644 blob b 1\tB.txt",
+                "100644 blob c 1\tGUIDES/RUNBOOK.md",
+            ]
+        );
+    }
+
+    #[test]
+    fn focused_directory_adds_descendants_without_partial_prefix_matches() {
+        let output = [
+            "100644 blob a 1\tA.txt",
+            "100644 blob b 1\tGUIDES.md",
+            "100644 blob c 1\tGUIDES/setup/install.md",
+            "100644 blob d 1\tGUIDES/RUNBOOK.md",
+        ]
+        .join("\0");
+        assert_eq!(
+            select_repository_tree_lines(&output, Some("GUIDES"), 1, 20),
+            vec![
+                "100644 blob a 1\tA.txt",
+                "100644 blob c 1\tGUIDES/setup/install.md",
+                "100644 blob d 1\tGUIDES/RUNBOOK.md",
+            ]
+        );
+    }
+
+    #[test]
+    fn nul_delimited_non_ascii_path_matches_without_git_c_quoting() {
+        let output = ["100644 blob a 1\tA.txt", "100644 blob b 1\tcafé.txt"].join("\0");
+        assert_eq!(
+            select_repository_tree_lines(&output, Some("café.txt"), 1, 20),
+            vec!["100644 blob a 1\tA.txt", "100644 blob b 1\tcafé.txt",]
+        );
+    }
+
+    #[test]
+    fn focused_entries_respect_their_own_cap() {
+        let output = [
+            "100644 blob a 1\tA.txt",
+            "100644 blob b 1\tdocs/1.md",
+            "100644 blob c 1\tdocs/2.md",
+            "100644 blob d 1\tdocs/3.md",
+        ]
+        .join("\0");
+        assert_eq!(
+            select_repository_tree_lines(&output, Some("docs"), 1, 2),
+            vec![
+                "100644 blob a 1\tA.txt",
+                "100644 blob b 1\tdocs/1.md",
+                "100644 blob c 1\tdocs/2.md",
+            ]
+        );
+    }
+}

--- a/desktop/src/app/navigation/useAppNavigation.ts
+++ b/desktop/src/app/navigation/useAppNavigation.ts
@@ -110,9 +110,15 @@ export function useAppNavigation() {
         pullRequestId?: string;
         issueId?: string;
         repositoryId?: string;
+        repoRef?: string;
+        repoPath?: string;
       },
-    ) =>
-      commitNavigation(
+    ) => {
+      const repositoryTarget =
+        behavior?.repoRef && behavior.repoPath
+          ? { repoRef: behavior.repoRef, repoPath: behavior.repoPath }
+          : {};
+      return commitNavigation(
         {
           to: "/projects/$projectId",
           params: {
@@ -129,10 +135,12 @@ export function useAppNavigation() {
             ...(behavior?.repositoryId
               ? { repositoryId: behavior.repositoryId }
               : {}),
+            ...repositoryTarget,
           },
         },
         behavior,
-      ),
+      );
+    },
     [commitNavigation],
   );
 

--- a/desktop/src/app/routes/projects.$projectId.tsx
+++ b/desktop/src/app/routes/projects.$projectId.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { createFileRoute } from "@tanstack/react-router";
 
+import { validateProjectDetailSearch } from "@/features/projects/lib/projectDetailSearch";
 import { usePreviewFeatureWarning } from "@/shared/features";
 import { ViewLoadingFallback } from "@/shared/ui/ViewLoadingFallback";
 
@@ -11,24 +12,20 @@ const ProjectDetailScreen = React.lazy(async () => {
 
 export const Route = createFileRoute("/projects/$projectId")({
   component: ProjectDetailRouteComponent,
-  validateSearch: (search: Record<string, unknown>) => ({
-    commitHash:
-      typeof search.commitHash === "string" ? search.commitHash : undefined,
-    pullRequestId:
-      typeof search.pullRequestId === "string"
-        ? search.pullRequestId
-        : undefined,
-    issueId: typeof search.issueId === "string" ? search.issueId : undefined,
-    repositoryId:
-      typeof search.repositoryId === "string" ? search.repositoryId : undefined,
-  }),
+  validateSearch: validateProjectDetailSearch,
 });
 
 function ProjectDetailRouteComponent() {
   usePreviewFeatureWarning("projects");
   const { projectId } = Route.useParams();
-  const { commitHash, pullRequestId, issueId, repositoryId } =
-    Route.useSearch();
+  const {
+    commitHash,
+    pullRequestId,
+    issueId,
+    repositoryId,
+    repoRef,
+    repoPath,
+  } = Route.useSearch();
 
   return (
     <React.Suspense fallback={<ViewLoadingFallback kind="projects" />}>
@@ -37,6 +34,8 @@ function ProjectDetailRouteComponent() {
         issueId={issueId}
         projectId={projectId}
         pullRequestId={pullRequestId}
+        repoPath={repoPath}
+        repoRef={repoRef}
         repositoryId={repositoryId}
       />
     </React.Suspense>

--- a/desktop/src/features/projects/hooks.ts
+++ b/desktop/src/features/projects/hooks.ts
@@ -38,6 +38,10 @@ import type {
   RelayEvent,
 } from "@/shared/api/types";
 import { summarizeProjectActivityEvents } from "./projectActivity.mjs";
+import {
+  projectRepoSnapshotCloneUrl,
+  projectRepoSnapshotTarget,
+} from "./lib/projectRepoSnapshotTarget";
 import type { ProjectIssue } from "./projectIssues.mjs";
 import {
   nextProjectIssueCommentCreatedAt,
@@ -428,23 +432,27 @@ async function createProjectIssueComment({
 
 async function fetchProjectRepoSnapshot(
   project: Repository,
-  branchName?: string | null,
+  selectedBranch?: string | null,
   pullRequest?: ProjectPullRequest | null,
   tag?: { name: string; commit: string } | null,
+  repositoryTarget?: { ref: string; path: string } | null,
 ): Promise<ProjectRepoSnapshot | null> {
-  const cloneUrl = pullRequest?.cloneUrls[0] ?? project.cloneUrls[0];
+  const cloneUrl = projectRepoSnapshotCloneUrl({
+    projectCloneUrls: project.cloneUrls,
+    pullRequestCloneUrls: pullRequest?.cloneUrls,
+    repositoryTarget,
+  });
   if (!cloneUrl) return null;
-
   return getProjectRepoSnapshot({
     cloneUrl,
-    defaultBranch: branchName ?? project.defaultBranch,
-    baseBranch: project.defaultBranch,
-    targetCommit: tag?.commit ?? pullRequest?.commit ?? null,
-    targetRef: tag
-      ? `refs/tags/${tag.name}`
-      : pullRequest
-        ? `refs/nostr/${pullRequest.id}`
-        : null,
+    targetPath: repositoryTarget?.path ?? null,
+    ...projectRepoSnapshotTarget({
+      selectedBranch,
+      projectDefaultBranch: project.defaultBranch,
+      pullRequest,
+      tag,
+      repositoryRef: repositoryTarget?.ref,
+    }),
   });
 }
 
@@ -658,6 +666,7 @@ export function useProjectRepoSnapshotQuery(
   pullRequest?: ProjectPullRequest | null,
   tag?: { name: string; commit: string } | null,
   enabled = true,
+  repositoryTarget?: { ref: string; path: string } | null,
 ) {
   const selectedBranch = branchName ?? project?.defaultBranch ?? null;
 
@@ -672,6 +681,8 @@ export function useProjectRepoSnapshotQuery(
       pullRequest?.commit ?? "none",
       tag?.name ?? "no-tag",
       tag?.commit ?? "no-tag-commit",
+      repositoryTarget?.ref ?? "no-repository-ref",
+      repositoryTarget?.path ?? "no-repository-path",
     ],
     queryFn: () => {
       if (!project) throw new Error("No project selected.");
@@ -680,6 +691,7 @@ export function useProjectRepoSnapshotQuery(
         selectedBranch,
         pullRequest,
         tag,
+        repositoryTarget,
       );
     },
     staleTime: 30_000,

--- a/desktop/src/features/projects/lib/projectDetailRouteState.ts
+++ b/desktop/src/features/projects/lib/projectDetailRouteState.ts
@@ -1,0 +1,24 @@
+export type ProjectDetailScreenProps = {
+  commitHash?: string;
+  projectId: string;
+  pullRequestId?: string;
+  issueId?: string;
+  repoPath?: string;
+  repoRef?: string;
+  repositoryId?: string;
+};
+
+export const PROJECT_DETAIL_PANEL_SEARCH_KEYS = [
+  "profile",
+  "profileTab",
+  "profileView",
+] as const;
+
+export const PROJECT_REPOSITORY_SEARCH_KEYS = [
+  "repositoryId",
+  "repoRef",
+  "repoPath",
+  "issueId",
+  "pullRequestId",
+  "commitHash",
+] as const;

--- a/desktop/src/features/projects/lib/projectDetailSearch.test.mjs
+++ b/desktop/src/features/projects/lib/projectDetailSearch.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateProjectDetailSearch } from "./projectDetailSearch.ts";
+
+const COMMIT = "a".repeat(40);
+
+test("validates existing search and repository target atomically", () => {
+  assert.deepEqual(
+    validateProjectDetailSearch({
+      commitHash: "commit",
+      pullRequestId: "pr",
+      issueId: "issue",
+      repositoryId: "repository",
+      repoRef: COMMIT.toUpperCase(),
+      repoPath: "src/main.ts",
+    }),
+    {
+      commitHash: "commit",
+      pullRequestId: "pr",
+      issueId: "issue",
+      repositoryId: "repository",
+      repoRef: COMMIT,
+      repoPath: "src/main.ts",
+    },
+  );
+});
+
+test("drops incomplete or unsafe repository target search without dropping repository selection", () => {
+  assert.deepEqual(
+    validateProjectDetailSearch({
+      repositoryId: "repository",
+      repoRef: "main",
+    }),
+    {
+      commitHash: undefined,
+      pullRequestId: undefined,
+      issueId: undefined,
+      repositoryId: "repository",
+      repoRef: undefined,
+      repoPath: undefined,
+    },
+  );
+  assert.deepEqual(
+    validateProjectDetailSearch({
+      repositoryId: "repository",
+      repoRef: "main",
+      repoPath: "../secret",
+    }),
+    {
+      commitHash: undefined,
+      pullRequestId: undefined,
+      issueId: undefined,
+      repositoryId: "repository",
+      repoRef: undefined,
+      repoPath: undefined,
+    },
+  );
+});

--- a/desktop/src/features/projects/lib/projectDetailSearch.ts
+++ b/desktop/src/features/projects/lib/projectDetailSearch.ts
@@ -1,0 +1,44 @@
+import {
+  normalizeRepositoryPath,
+  parseRepositoryRef,
+} from "../../../shared/lib/repositoryTarget.ts";
+
+export type ProjectDetailSearch = {
+  commitHash: string | undefined;
+  pullRequestId: string | undefined;
+  issueId: string | undefined;
+  repositoryId: string | undefined;
+  repoRef: string | undefined;
+  repoPath: string | undefined;
+};
+
+export function validateProjectDetailSearch(
+  search: Record<string, unknown>,
+): ProjectDetailSearch {
+  const commitHash =
+    typeof search.commitHash === "string" ? search.commitHash : undefined;
+  const pullRequestId =
+    typeof search.pullRequestId === "string" ? search.pullRequestId : undefined;
+  const issueId =
+    typeof search.issueId === "string" ? search.issueId : undefined;
+  const repositoryId =
+    typeof search.repositoryId === "string" ? search.repositoryId : undefined;
+  const parsedRef =
+    typeof search.repoRef === "string"
+      ? parseRepositoryRef(search.repoRef)
+      : null;
+  const repoPath =
+    typeof search.repoPath === "string"
+      ? normalizeRepositoryPath(search.repoPath)
+      : null;
+  const hasRepositoryTarget = Boolean(parsedRef && repoPath);
+
+  return {
+    commitHash,
+    pullRequestId,
+    issueId,
+    repositoryId,
+    repoRef: hasRepositoryTarget ? parsedRef?.value : undefined,
+    repoPath: hasRepositoryTarget ? (repoPath ?? undefined) : undefined,
+  };
+}

--- a/desktop/src/features/projects/lib/projectRepoSnapshotTarget.test.mjs
+++ b/desktop/src/features/projects/lib/projectRepoSnapshotTarget.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  projectRepoSnapshotCloneUrl,
+  projectRepoSnapshotTarget,
+} from "./projectRepoSnapshotTarget.ts";
+
+const COMMIT = "a".repeat(40);
+
+test("explicit branch target outranks selected branch, tag, and pull request", () => {
+  assert.deepEqual(
+    projectRepoSnapshotTarget({
+      selectedBranch: "main",
+      projectDefaultBranch: "main",
+      pullRequest: { id: "pr-1", commit: "b".repeat(40) },
+      tag: { name: "v1", commit: "c".repeat(40) },
+      repositoryRef: "feature/repo-links",
+    }),
+    {
+      defaultBranch: "feature/repo-links",
+      baseBranch: "main",
+      targetRef: "refs/heads/feature/repo-links",
+      targetCommit: null,
+    },
+  );
+});
+
+test("explicit commit target outranks branch, tag, and pull request", () => {
+  assert.deepEqual(
+    projectRepoSnapshotTarget({
+      selectedBranch: "main",
+      projectDefaultBranch: "main",
+      pullRequest: { id: "pr-1", commit: "b".repeat(40) },
+      tag: { name: "v1", commit: "c".repeat(40) },
+      repositoryRef: COMMIT,
+    }),
+    {
+      defaultBranch: "main",
+      baseBranch: "main",
+      targetRef: null,
+      targetCommit: COMMIT,
+    },
+  );
+});
+
+test("existing tag and pull-request precedence is preserved without a repository link", () => {
+  assert.deepEqual(
+    projectRepoSnapshotTarget({
+      selectedBranch: "release",
+      projectDefaultBranch: "main",
+      pullRequest: { id: "pr-1", commit: "b".repeat(40) },
+      tag: { name: "v1", commit: "c".repeat(40) },
+      repositoryRef: null,
+    }),
+    {
+      defaultBranch: "release",
+      baseBranch: "main",
+      targetRef: "refs/tags/v1",
+      targetCommit: "c".repeat(40),
+    },
+  );
+});
+
+test("explicit repository targets use the canonical project clone URL", () => {
+  assert.equal(
+    projectRepoSnapshotCloneUrl({
+      projectCloneUrls: ["https://relay.example/git/owner/project"],
+      pullRequestCloneUrls: ["https://fork.example/git/owner/fork"],
+      repositoryTarget: { ref: "main", path: "README.md" },
+    }),
+    "https://relay.example/git/owner/project",
+  );
+});
+
+test("ordinary pull request snapshots retain pull request clone precedence", () => {
+  assert.equal(
+    projectRepoSnapshotCloneUrl({
+      projectCloneUrls: ["https://relay.example/git/owner/project"],
+      pullRequestCloneUrls: ["https://fork.example/git/owner/fork"],
+      repositoryTarget: null,
+    }),
+    "https://fork.example/git/owner/fork",
+  );
+});

--- a/desktop/src/features/projects/lib/projectRepoSnapshotTarget.ts
+++ b/desktop/src/features/projects/lib/projectRepoSnapshotTarget.ts
@@ -1,0 +1,56 @@
+import { parseRepositoryRef } from "../../../shared/lib/repositoryTarget.ts";
+
+type PullRequestTarget = {
+  cloneUrls: string[];
+  id: string;
+  commit: string | null;
+};
+type TagTarget = { name: string; commit: string };
+
+export function projectRepoSnapshotCloneUrl(input: {
+  projectCloneUrls: readonly string[];
+  pullRequestCloneUrls?: readonly string[];
+  repositoryTarget?: { ref: string; path: string } | null;
+}): string | undefined {
+  return input.repositoryTarget
+    ? input.projectCloneUrls[0]
+    : (input.pullRequestCloneUrls?.[0] ?? input.projectCloneUrls[0]);
+}
+
+export function projectRepoSnapshotTarget(input: {
+  selectedBranch: string | null | undefined;
+  projectDefaultBranch: string;
+  pullRequest?: PullRequestTarget | null;
+  tag?: TagTarget | null;
+  repositoryRef?: string | null;
+}) {
+  const explicitRef = input.repositoryRef
+    ? parseRepositoryRef(input.repositoryRef)
+    : null;
+  if (explicitRef?.kind === "branch") {
+    return {
+      defaultBranch: explicitRef.value,
+      baseBranch: input.projectDefaultBranch,
+      targetRef: `refs/heads/${explicitRef.value}`,
+      targetCommit: null,
+    };
+  }
+  if (explicitRef?.kind === "commit") {
+    return {
+      defaultBranch: input.selectedBranch ?? input.projectDefaultBranch,
+      baseBranch: input.projectDefaultBranch,
+      targetRef: null,
+      targetCommit: explicitRef.value,
+    };
+  }
+  return {
+    defaultBranch: input.selectedBranch ?? input.projectDefaultBranch,
+    baseBranch: input.projectDefaultBranch,
+    targetRef: input.tag
+      ? `refs/tags/${input.tag.name}`
+      : input.pullRequest
+        ? `refs/nostr/${input.pullRequest.id}`
+        : null,
+    targetCommit: input.tag?.commit ?? input.pullRequest?.commit ?? null,
+  };
+}

--- a/desktop/src/features/projects/lib/repositoryDeepLinkTarget.test.mjs
+++ b/desktop/src/features/projects/lib/repositoryDeepLinkTarget.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import * as repositoryTarget from "./repositoryDeepLinkTarget.ts";
+import {
+  effectiveProjectRepoSource,
+  projectTabForRepositoryTarget,
+  repositoryTargetResultKey,
+  resolveRepositoryDeepLinkTarget,
+  shouldResolveRepositoryTarget,
+} from "./repositoryDeepLinkTarget.ts";
+
+const files = [
+  { path: "README.md", kind: "blob" },
+  { path: "GUIDES/RUNBOOK.md", kind: "blob" },
+  { path: "GUIDES/setup/install.md", kind: "blob" },
+];
+
+test("resolves an exact repository file", () => {
+  assert.deepEqual(
+    resolveRepositoryDeepLinkTarget(files, "GUIDES/RUNBOOK.md"),
+    {
+      kind: "file",
+      file: files[1],
+      parentPath: "GUIDES",
+    },
+  );
+});
+
+test("resolves an existing directory from file prefixes", () => {
+  assert.deepEqual(resolveRepositoryDeepLinkTarget(files, "GUIDES/setup"), {
+    kind: "directory",
+    path: "GUIDES/setup",
+  });
+});
+
+test("does not treat a partial filename prefix as a directory", () => {
+  assert.deepEqual(resolveRepositoryDeepLinkTarget(files, "GUIDES/RUN"), {
+    kind: "missing",
+  });
+});
+
+test("repository targets force remote snapshots while ordinary routes preserve source", () => {
+  assert.equal(effectiveProjectRepoSource("local", "README.md"), "remote");
+  assert.equal(effectiveProjectRepoSource("remote", "README.md"), "remote");
+  assert.equal(effectiveProjectRepoSource("local", undefined), "local");
+  assert.equal(effectiveProjectRepoSource("remote", undefined), "remote");
+});
+
+test("repository targets open the files tab while ordinary routes open overview", () => {
+  assert.equal(projectTabForRepositoryTarget("README.md"), "files");
+  assert.equal(projectTabForRepositoryTarget(undefined), "overview");
+});
+
+test("failed targets retry when the ref becomes available", () => {
+  const attempt = { key: "target\0tree", outcome: "error" };
+  assert.equal(
+    shouldResolveRepositoryTarget({
+      attempt,
+      hasError: true,
+      isLoading: false,
+      resolutionKey: "target\0tree",
+    }),
+    false,
+  );
+  assert.equal(
+    shouldResolveRepositoryTarget({
+      attempt,
+      hasError: false,
+      isLoading: false,
+      resolutionKey: "target\0tree",
+    }),
+    true,
+  );
+});
+
+test("resolved targets retry only for a changed repository tree", () => {
+  const attempt = { key: "target\0tree-a", outcome: "resolved" };
+  assert.equal(
+    shouldResolveRepositoryTarget({
+      attempt,
+      hasError: false,
+      isLoading: false,
+      resolutionKey: "target\0tree-a",
+    }),
+    false,
+  );
+  assert.equal(
+    shouldResolveRepositoryTarget({
+      attempt,
+      hasError: false,
+      isLoading: false,
+      resolutionKey: "target\0tree-b",
+    }),
+    true,
+  );
+});
+
+test("repository target resolution is re-armed when snapshot contents change", () => {
+  const targetKey = "main\0GUIDES/RUNBOOK.md";
+  assert.notEqual(
+    repositoryTargetResultKey(targetKey, "commit-a\0README.md"),
+    repositoryTargetResultKey(targetKey, "commit-b\0README.md"),
+  );
+});
+
+test("repository target failures offer the repository root", () => {
+  const onClick = () => {};
+  const action = repositoryTarget.repositoryRootToastAction?.(onClick);
+  assert.ok(action, "repository root action is available");
+  assert.equal(action.label, "Open repository root");
+  assert.equal(action.onClick, onClick);
+});

--- a/desktop/src/features/projects/lib/repositoryDeepLinkTarget.ts
+++ b/desktop/src/features/projects/lib/repositoryDeepLinkTarget.ts
@@ -1,0 +1,67 @@
+export function effectiveProjectRepoSource(
+  selectedSource: "remote" | "local",
+  repositoryPath: string | undefined,
+): "remote" | "local" {
+  return repositoryPath ? "remote" : selectedSource;
+}
+
+export type RepositoryDeepLinkTarget<T extends { path: string }> =
+  | { kind: "file"; file: T; parentPath: string }
+  | { kind: "directory"; path: string }
+  | { kind: "missing" };
+
+export function resolveRepositoryDeepLinkTarget<T extends { path: string }>(
+  files: readonly T[],
+  targetPath: string,
+): RepositoryDeepLinkTarget<T> {
+  const file = files.find((candidate) => candidate.path === targetPath);
+  if (file) {
+    const slash = targetPath.lastIndexOf("/");
+    return {
+      kind: "file",
+      file,
+      parentPath: slash >= 0 ? targetPath.slice(0, slash) : "",
+    };
+  }
+  const directoryPrefix = `${targetPath}/`;
+  if (files.some((candidate) => candidate.path.startsWith(directoryPrefix))) {
+    return { kind: "directory", path: targetPath };
+  }
+  return { kind: "missing" };
+}
+
+export function projectTabForRepositoryTarget(
+  targetPath: string | undefined,
+): "files" | "overview" {
+  return targetPath ? "files" : "overview";
+}
+
+export type RepositoryTargetAttempt = {
+  key: string;
+  outcome: "error" | "resolved";
+};
+
+export function shouldResolveRepositoryTarget(input: {
+  attempt: RepositoryTargetAttempt | null;
+  hasError: boolean;
+  isLoading: boolean;
+  resolutionKey: string | null;
+}): boolean {
+  if (!input.resolutionKey || input.isLoading) return false;
+  if (input.attempt?.key !== input.resolutionKey) return true;
+  return input.attempt.outcome === "error" && !input.hasError;
+}
+
+export function repositoryTargetResultKey(
+  targetKey: string,
+  filesKey: string,
+): string {
+  return `${targetKey}\0${filesKey}`;
+}
+
+export function repositoryRootToastAction(onClick: () => void): {
+  label: string;
+  onClick: () => void;
+} {
+  return { label: "Open repository root", onClick };
+}

--- a/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
+++ b/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
@@ -59,6 +59,12 @@ import {
   projectBranchOptionsFromSync,
   resolveProjectDefaultBranch,
 } from "@/features/projects/lib/projectBranches";
+import {
+  PROJECT_DETAIL_PANEL_SEARCH_KEYS,
+  PROJECT_REPOSITORY_SEARCH_KEYS,
+  type ProjectDetailScreenProps,
+} from "@/features/projects/lib/projectDetailRouteState";
+import { effectiveProjectRepoSource } from "@/features/projects/lib/repositoryDeepLinkTarget";
 import { normalizeRepositoryUrl } from "@/features/projects/lib/projectsViewHelpers";
 import { selectProjectRepository } from "@/features/projects/projectModels";
 import { KIND_REPO_ANNOUNCEMENT } from "@/shared/constants/kinds";
@@ -82,28 +88,16 @@ import {
   snapshotHasContent,
 } from "./projectDetailHelpers";
 
-type ProjectDetailScreenProps = {
-  commitHash?: string;
-  projectId: string;
-  pullRequestId?: string;
-  issueId?: string;
-  repositoryId?: string;
-};
-
-const PROJECT_DETAIL_PANEL_SEARCH_KEYS = [
-  "profile",
-  "profileTab",
-  "profileView",
-] as const;
-const PROJECT_REPOSITORY_SEARCH_KEYS = [
-  "repositoryId",
-  "issueId",
-  "pullRequestId",
-  "commitHash",
-] as const;
-
 export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
-  const { commitHash, projectId, pullRequestId, issueId, repositoryId } = props;
+  const {
+    commitHash,
+    projectId,
+    pullRequestId,
+    issueId,
+    repoPath,
+    repoRef,
+    repositoryId,
+  } = props;
   const { goChannel, goProject, goProjects } = useAppNavigation();
   const { activeCommunity } = useCommunities();
   const mainInsetRef = useMainInsetRef();
@@ -205,6 +199,16 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
     },
     [],
   );
+  const handleGoToProjectHome = React.useCallback(() => {
+    if (repoPath) {
+      void goProject(projectId, { replace: true });
+      return;
+    }
+    setSelectedPullRequestId(null);
+    setSelectedIssueId(null);
+    setSelectedCommitHash(null);
+    setTabsResetKey((key) => key + 1);
+  }, [goProject, projectId, repoPath]);
   const issuesQuery = useProjectIssuesQuery(repository);
   const selectedBranchPullRequest = React.useMemo(() => {
     const projectRepositories = new Set(
@@ -231,30 +235,32 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
   const [repoSource, setRepoSource] = React.useState<"remote" | "local">(
     "remote",
   );
+  const effectiveRepoSource = effectiveProjectRepoSource(repoSource, repoPath);
   const repoSnapshotQuery = useProjectRepoSnapshotQuery(
     repository,
     activeBranch,
     selectedTag ? null : selectedBranchPullRequest,
     activeTag,
     repoRemote.host.kind === "buzz",
+    repoRef && repoPath ? { ref: repoRef, path: repoPath } : null,
   );
   const repoDiffQuery = useProjectRepoDiffQuery(
     repository,
     activeBranch,
     activeRepoPullRequest,
-    repoSource === "remote",
+    effectiveRepoSource === "remote",
   );
   const localRepoDiffQuery = useProjectLocalRepoDiffQuery(
     repository,
     activeCommunity?.reposDir,
     activeBranch,
     activeRepoPullRequest,
-    repoSource === "local" && Boolean(activeRepoPullRequest),
+    effectiveRepoSource === "local" && Boolean(activeRepoPullRequest),
   );
   const commitDiffQuery = useProjectCommitDiffQuery(
     repository,
     selectedCommitHash,
-    repoSource,
+    effectiveRepoSource,
     activeCommunity?.reposDir,
   );
   const localRepoSnapshotQuery = useProjectLocalRepoSnapshotQuery(
@@ -292,11 +298,15 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
   );
   const hasRemoteSnapshot = snapshotHasContent(repoSnapshotQuery.data);
   const displayedRepoDiff =
-    repoSource === "local" ? localRepoDiffQuery.data : repoDiffQuery.data;
+    effectiveRepoSource === "local"
+      ? localRepoDiffQuery.data
+      : repoDiffQuery.data;
   const displayedRepoDiffError =
-    repoSource === "local" ? localRepoDiffQuery.error : repoDiffQuery.error;
+    effectiveRepoSource === "local"
+      ? localRepoDiffQuery.error
+      : repoDiffQuery.error;
   const displayedRepoDiffLoading =
-    repoSource === "local"
+    effectiveRepoSource === "local"
       ? localRepoDiffQuery.isLoading
       : repoDiffQuery.isLoading;
   const branchOptionsWithLocal = projectBranchOptionsFromSync(
@@ -322,13 +332,13 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
       selectBranch(branch);
       if (
         branch &&
-        repoSource === "local" &&
+        effectiveRepoSource === "local" &&
         branch !== repoSyncStatusQuery.data?.localBranch
       ) {
         setRepoSource("remote");
       }
     },
-    [repoSource, repoSyncStatusQuery.data?.localBranch, selectBranch],
+    [effectiveRepoSource, repoSyncStatusQuery.data?.localBranch, selectBranch],
   );
   const handleTagChange = React.useCallback(
     (tag: string) => {
@@ -386,7 +396,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
     deleteBranchDisabled:
       branchActions.deletePending || Boolean(deleteBranchReason),
     deleteBranchTitle: deleteBranchReason ?? "Delete this remote branch",
-    source: selectedTag ? "remote" : repoSource,
+    source: selectedTag ? "remote" : effectiveRepoSource,
     onSourceChange: setRepoSource,
     localDisabled:
       Boolean(selectedTag) ||
@@ -775,7 +785,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
   const selectedIssue =
     issuesQuery.data?.find((item) => item.id === selectedIssueId) ?? null;
   const displayedSnapshotCommits =
-    repoSource === "local"
+    effectiveRepoSource === "local"
       ? (localRepoSnapshotQuery.data?.snapshot.commits ?? [])
       : (repoSnapshotQuery.data?.commits ?? []);
   const selectedCommit = selectedCommitHash
@@ -810,17 +820,11 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
   const activeTabCrumb = activeWorkItemCrumb
     ? null
     : (PROJECT_TAB_CRUMB_LABELS[activeTab] ?? null);
-  const handleGoToProjectHome = () => {
-    setSelectedPullRequestId(null);
-    setSelectedIssueId(null);
-    setSelectedCommitHash(null);
-    // Remount the workspace tabs so the project page opens on Overview
-    // instead of whatever tab the work item left behind.
-    setTabsResetKey((key) => key + 1);
-  };
   const handleRepositoryChange = (nextRepositoryId: string) => {
     applyRepositorySearch({
       repositoryId: nextRepositoryId,
+      repoRef: null,
+      repoPath: null,
       issueId: null,
       pullRequestId: null,
       commitHash: null,
@@ -867,7 +871,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                       </h2>
                       {repoRemote.webUrl &&
                       (repoRemote.host.kind !== "external" ||
-                        repoSource === "local") ? (
+                        effectiveRepoSource === "local") ? (
                         <Button
                           asChild
                           aria-label="Open project web page"
@@ -933,6 +937,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                 localSnapshotLoading={localRepoSnapshotQuery.isLoading}
                 onBranchChange={handleBranchChange}
                 onOpenMergeRecoveryTerminal={handleOpenMergeRecoveryTerminal}
+                onOpenRepositoryRoot={handleGoToProjectHome}
                 onOpenTerminal={() => {
                   void handleOpenTerminal();
                 }}
@@ -954,7 +959,9 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                 pullRequestsLoading={pullRequestsQuery.isLoading}
                 repoContributors={repoContributors}
                 repoHost={repoRemote.host}
-                repoSource={repoSource}
+                repoSource={effectiveRepoSource}
+                repositoryPath={repoPath}
+                repositoryRef={repoRef}
                 selectedCommitHash={selectedCommitHash}
                 selectedIssueId={selectedIssueId}
                 selectedPullRequestId={selectedPullRequestId}

--- a/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
@@ -21,11 +21,19 @@ import {
   Terminal,
 } from "lucide-react";
 import * as React from "react";
+import { toast } from "sonner";
 
 import type {
   ProjectRepoFile,
   ProjectRepoSnapshot,
 } from "@/features/projects/hooks";
+import {
+  type RepositoryTargetAttempt,
+  repositoryRootToastAction,
+  repositoryTargetResultKey,
+  resolveRepositoryDeepLinkTarget,
+  shouldResolveRepositoryTarget,
+} from "@/features/projects/lib/repositoryDeepLinkTarget";
 import { relativeTime } from "@/features/projects/lib/projectsViewHelpers";
 import { useUserSearchQuery } from "@/features/profile/hooks";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
@@ -44,6 +52,7 @@ import {
   RepoSyncActionButton,
   RepositoryBranchDropdown,
 } from "./ProjectRepositorySource";
+import { RepositoryTargetRef } from "./RepositoryTargetRef";
 
 function pluralize(count: number, singular: string) {
   return `${count} ${singular}${count === 1 ? "" : "s"}`;
@@ -618,7 +627,10 @@ export function RepositoryFilesPanel({
   profiles,
   fallbackAuthorPubkey,
   sourceControls,
+  targetPath,
+  targetRef,
   unavailableMessage,
+  onOpenRepositoryRoot,
 }: {
   files: ProjectRepoFile[];
   snapshot: ProjectRepoSnapshot | null | undefined;
@@ -628,7 +640,10 @@ export function RepositoryFilesPanel({
   fallbackAuthorPubkey?: string;
   /** Branch picker + remote/local toggle rendered in the panel header. */
   sourceControls?: RepoSourceHeaderControls;
+  targetPath?: string;
+  targetRef?: string;
   unavailableMessage?: string;
+  onOpenRepositoryRoot: () => void;
 }) {
   const [currentPath, setCurrentPath] = React.useState("");
   const [selectedFile, setSelectedFile] =
@@ -681,6 +696,67 @@ export function RepositoryFilesPanel({
     setSelectedFile(null);
   }, [filesKey]);
 
+  const targetAttemptRef = React.useRef<RepositoryTargetAttempt | null>(null);
+  const targetKey = targetPath ? `${targetRef ?? ""}\0${targetPath}` : null;
+  const targetSnapshotKey = `${latestCommit?.hash ?? ""}\0${filesKey}`;
+  const targetResolutionKey = targetKey
+    ? repositoryTargetResultKey(targetKey, targetSnapshotKey)
+    : null;
+
+  React.useEffect(() => {
+    if (!targetResolutionKey) {
+      targetAttemptRef.current = null;
+      return;
+    }
+    if (
+      !shouldResolveRepositoryTarget({
+        attempt: targetAttemptRef.current,
+        hasError: Boolean(error || unavailableMessage),
+        isLoading,
+        resolutionKey: targetResolutionKey,
+      })
+    ) {
+      return;
+    }
+
+    setCurrentPath("");
+    setSelectedFile(null);
+    if (error || unavailableMessage) {
+      targetAttemptRef.current = { key: targetResolutionKey, outcome: "error" };
+      toast.error("Could not open repository link.", {
+        action: repositoryRootToastAction(onOpenRepositoryRoot),
+        description:
+          unavailableMessage ?? "The requested repository ref is unavailable.",
+      });
+      return;
+    }
+
+    targetAttemptRef.current = {
+      key: targetResolutionKey,
+      outcome: "resolved",
+    };
+    const target = resolveRepositoryDeepLinkTarget(files, targetPath ?? "");
+    if (target.kind === "file") {
+      setCurrentPath(target.parentPath);
+      setSelectedFile(target.file);
+    } else if (target.kind === "directory") {
+      setCurrentPath(target.path);
+    } else {
+      toast.error("Repository path not found.", {
+        action: repositoryRootToastAction(onOpenRepositoryRoot),
+        description: targetPath,
+      });
+    }
+  }, [
+    files,
+    isLoading,
+    onOpenRepositoryRoot,
+    error,
+    targetPath,
+    targetResolutionKey,
+    unavailableMessage,
+  ]);
+
   // Loading/error/empty states keep the header controls visible — the
   // remote/local toggle must stay reachable when one source fails to load.
   const stateMessage = isLoading
@@ -693,7 +769,7 @@ export function RepositoryFilesPanel({
           ? "No files have been pushed yet."
           : null;
   if (stateMessage) {
-    if (!sourceControls) {
+    if (!sourceControls && !targetRef) {
       return (
         <div
           className={PROJECT_DETAIL_PANEL_MESSAGE_CLASS}
@@ -706,25 +782,31 @@ export function RepositoryFilesPanel({
     return (
       <div className={PROJECT_DETAIL_PANEL_CLASS} data-project-detail-panel>
         <div className="flex min-h-14 min-w-0 items-center gap-1 border-border/50 border-b px-3 py-3">
-          <RepoSourceDropdown controls={sourceControls} />
-          <RepositoryBranchDropdown
-            branch={sourceControls.branch}
-            branchOptions={sourceControls.branchOptions}
-            compact
-            createBranchDisabled={sourceControls.createBranchDisabled}
-            createBranchTitle={sourceControls.createBranchTitle}
-            deleteBranchDisabled={sourceControls.deleteBranchDisabled}
-            deleteBranchTitle={sourceControls.deleteBranchTitle}
-            onBranchChange={sourceControls.onBranchChange}
-            onCreateBranch={sourceControls.onCreateBranch}
-            onDeleteBranch={sourceControls.onDeleteBranch}
-            onTagChange={sourceControls.onTagChange}
-            selectedTag={sourceControls.selectedTag}
-            tagOptions={sourceControls.tagOptions}
-          />
-          <div className="ml-auto flex shrink-0 items-center">
-            <RepoSyncActionButton controls={sourceControls} />
-          </div>
+          {targetRef ? (
+            <RepositoryTargetRef value={targetRef} />
+          ) : sourceControls ? (
+            <>
+              <RepoSourceDropdown controls={sourceControls} />
+              <RepositoryBranchDropdown
+                branch={sourceControls.branch}
+                branchOptions={sourceControls.branchOptions}
+                compact
+                createBranchDisabled={sourceControls.createBranchDisabled}
+                createBranchTitle={sourceControls.createBranchTitle}
+                deleteBranchDisabled={sourceControls.deleteBranchDisabled}
+                deleteBranchTitle={sourceControls.deleteBranchTitle}
+                onBranchChange={sourceControls.onBranchChange}
+                onCreateBranch={sourceControls.onCreateBranch}
+                onDeleteBranch={sourceControls.onDeleteBranch}
+                onTagChange={sourceControls.onTagChange}
+                selectedTag={sourceControls.selectedTag}
+                tagOptions={sourceControls.tagOptions}
+              />
+              <div className="ml-auto flex shrink-0 items-center">
+                <RepoSyncActionButton controls={sourceControls} />
+              </div>
+            </>
+          ) : null}
         </div>
         <div className="p-4 text-sm text-muted-foreground">{stateMessage}</div>
       </div>
@@ -746,7 +828,9 @@ export function RepositoryFilesPanel({
   return (
     <div className={PROJECT_DETAIL_PANEL_CLASS} data-project-detail-panel>
       <div className="flex min-h-14 min-w-0 items-center gap-1 border-border/50 border-b px-3 py-3">
-        {sourceControls ? (
+        {targetRef ? (
+          <RepositoryTargetRef value={targetRef} />
+        ) : sourceControls ? (
           <>
             <RepoSourceDropdown controls={sourceControls} />
             <RepositoryBranchDropdown
@@ -770,7 +854,7 @@ export function RepositoryFilesPanel({
             Files
           </BreadcrumbButton>
         )}
-        {sourceControls && pathSegments.length > 0 ? (
+        {(sourceControls || targetRef) && pathSegments.length > 0 ? (
           <>
             <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
             <BreadcrumbButton onClick={() => setCurrentPath("")}>
@@ -789,7 +873,7 @@ export function RepositoryFilesPanel({
             </React.Fragment>
           );
         })}
-        {sourceControls ? (
+        {sourceControls && !targetRef ? (
           <div className="ml-auto flex shrink-0 items-center">
             <RepoSyncActionButton controls={sourceControls} />
           </div>

--- a/desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx
+++ b/desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx
@@ -23,6 +23,7 @@ import {
   type ViewerGitIdentity,
 } from "@/features/projects/lib/projectContributorMatching";
 import type { ProjectRepoHost } from "@/features/projects/lib/projectRepoHost";
+import { projectTabForRepositoryTarget } from "@/features/projects/lib/repositoryDeepLinkTarget";
 import { projectRepoUnavailableReason } from "@/features/projects/lib/projectRepoAvailability";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { Button } from "@/shared/ui/button";
@@ -142,6 +143,7 @@ export function WorkspaceTabs({
   onSelectedTabChange,
   onBranchChange,
   onOpenMergeRecoveryTerminal,
+  onOpenRepositoryRoot,
   onOpenTerminal,
   snapshot,
   snapshotError,
@@ -150,6 +152,8 @@ export function WorkspaceTabs({
   repoContributors,
   repoSource,
   repoHost,
+  repositoryPath,
+  repositoryRef,
   sourceControls,
   terminalTitle,
   viewerGitIdentity,
@@ -181,6 +185,7 @@ export function WorkspaceTabs({
   onSelectedTabChange?: (tab: string) => void;
   onBranchChange: (branch: string | null) => void;
   onOpenMergeRecoveryTerminal?: OpenMergeRecoveryTerminal;
+  onOpenRepositoryRoot: () => void;
   onOpenTerminal?: () => void;
   snapshot: ProjectRepoSnapshot | null | undefined;
   snapshotError: unknown;
@@ -189,6 +194,8 @@ export function WorkspaceTabs({
   repoContributors: ProjectRepoContributor[];
   repoSource: "remote" | "local";
   repoHost: ProjectRepoHost;
+  repositoryPath?: string;
+  repositoryRef?: string;
   /** Branch picker + remote/local toggle for the Code tab header. */
   sourceControls?: RepoSourceHeaderControls;
   terminalTitle?: string;
@@ -240,7 +247,9 @@ export function WorkspaceTabs({
     [pullRequests, selectedCommitHash],
   );
   const isPullRequestSelected = Boolean(selectedPullRequest);
-  const [selectedTab, setSelectedTab] = React.useState("overview");
+  const [selectedTab, setSelectedTab] = React.useState<string>(() =>
+    projectTabForRepositoryTarget(repositoryPath),
+  );
   const [pullRequestCommentTarget, setPullRequestCommentTarget] =
     React.useState<{
       anchor: ProjectPullRequestCommentAnchor;
@@ -249,6 +258,10 @@ export function WorkspaceTabs({
   const [createIssueOpen, setCreateIssueOpen] = React.useState(false);
   const [createPullRequestOpen, setCreatePullRequestOpen] =
     React.useState(false);
+
+  React.useEffect(() => {
+    setSelectedTab(projectTabForRepositoryTarget(repositoryPath));
+  }, [repositoryPath]);
 
   React.useEffect(() => {
     onSelectedTabChange?.(selectedTab);
@@ -525,9 +538,12 @@ export function WorkspaceTabs({
           fallbackAuthorPubkey={project.owner}
           files={files}
           isLoading={displayedSnapshotLoading}
+          onOpenRepositoryRoot={onOpenRepositoryRoot}
           profiles={profiles}
           snapshot={displayedSnapshot}
           sourceControls={sourceControls}
+          targetPath={repositoryPath}
+          targetRef={repositoryRef}
           unavailableMessage={
             externalHost
               ? `Not mirrored on Buzz. Repository files are hosted on ${externalHost}.`

--- a/desktop/src/features/projects/ui/RepositoryTargetRef.tsx
+++ b/desktop/src/features/projects/ui/RepositoryTargetRef.tsx
@@ -1,0 +1,16 @@
+import { GitBranch, GitCommit } from "lucide-react";
+
+export function RepositoryTargetRef({ value }: { value: string }) {
+  const isCommit = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(value);
+  const Icon = isCommit ? GitCommit : GitBranch;
+  const label = isCommit ? value.slice(0, 7) : value;
+  return (
+    <span
+      className="flex h-7 min-w-0 max-w-64 items-center gap-1.5 rounded-md border border-input bg-background px-3 font-mono text-sm font-medium"
+      title={value}
+    >
+      <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}

--- a/desktop/src/shared/api/projectGit.ts
+++ b/desktop/src/shared/api/projectGit.ts
@@ -162,6 +162,7 @@ export async function getProjectRepoSnapshot(input: {
   baseBranch?: string | null;
   targetRef?: string | null;
   targetCommit?: string | null;
+  targetPath?: string | null;
 }): Promise<ProjectRepoSnapshot> {
   const snapshot = await invokeTauri<RawProjectRepoSnapshot>(
     "get_project_repo_snapshot",
@@ -171,6 +172,7 @@ export async function getProjectRepoSnapshot(input: {
       baseBranch: input.baseBranch ?? null,
       targetRef: input.targetRef ?? null,
       targetCommit: input.targetCommit ?? null,
+      targetPath: input.targetPath ?? null,
     },
   );
   return fromRawProjectRepoSnapshot(snapshot);

--- a/desktop/src/shared/lib/entityLink.test.mjs
+++ b/desktop/src/shared/lib/entityLink.test.mjs
@@ -5,6 +5,7 @@ import {
   buildIssueLink,
   buildPullRequestLink,
   buildRepoLink,
+  buildRepoTargetLink,
   entityLinkProjectRouteId,
   isEntityLink,
   parseEntityLink,
@@ -59,6 +60,114 @@ test("parseEntityLink round-trips built links", () => {
     ok: true,
     value: { type: "repo", owner: OWNER, dtag: "buzz-world" },
   });
+});
+
+test("repository target builder preserves root identity and round-trips", () => {
+  const href = buildRepoTargetLink({
+    owner: OWNER.toUpperCase(),
+    dtag: "buzz-world",
+    ref: "feature/repo-links",
+    path: "PLANS/Plan 1.md",
+  });
+  assert.equal(
+    href,
+    `buzz://repo?owner=${OWNER}&d=buzz-world&ref=feature%2Frepo-links&path=PLANS%2FPlan+1.md`,
+  );
+  assert.deepEqual(parseEntityLink(href), {
+    ok: true,
+    value: {
+      type: "repo",
+      owner: OWNER,
+      dtag: "buzz-world",
+      target: {
+        ref: "feature/repo-links",
+        refKind: "branch",
+        path: "PLANS/Plan 1.md",
+      },
+    },
+  });
+  const parsed = parseEntityLink(href);
+  assert.ok(parsed.ok);
+  assert.equal(
+    entityLinkProjectRouteId(parsed.value),
+    `30617:${OWNER}:buzz-world`,
+  );
+  assert.equal(
+    buildRepoLink({ owner: OWNER, dtag: "buzz-world" }),
+    `buzz://repo?owner=${OWNER}&d=buzz-world`,
+  );
+});
+
+test("repository target classifies full commits", () => {
+  const commit = "B".repeat(40);
+  const parsed = parseEntityLink(
+    buildRepoTargetLink({
+      owner: OWNER,
+      dtag: "buzz-world",
+      ref: commit,
+      path: "README.md",
+    }),
+  );
+  assert.ok(parsed.ok && parsed.value.type === "repo" && parsed.value.target);
+  assert.deepEqual(parsed.value.target, {
+    ref: commit.toLowerCase(),
+    refKind: "commit",
+    path: "README.md",
+  });
+});
+
+test("repository target rejects incomplete, duplicate, old, and invalid coordinates", () => {
+  const base = `buzz://repo?owner=${OWNER}&d=buzz-world`;
+  const cases = [
+    [`${base}&ref=main`, "incomplete-repo-target"],
+    [`${base}&path=README.md`, "incomplete-repo-target"],
+    [`${base}&ref=main&ref=dev&path=README.md`, "duplicate-param"],
+    [`${base}&ref=main&path=README.md&path=OTHER.md`, "duplicate-param"],
+    [
+      `buzz://repo?owner=${OWNER}&repo=buzz&ref=main&path=README.md`,
+      "unknown-param",
+    ],
+    [`${base}&ref=refs%2Ftags%2Fv1&path=README.md`, "invalid-ref"],
+    [`${base}&ref=feature%2F..%2Fmain&path=README.md`, "invalid-ref"],
+    [`${base}&ref=bad+ref&path=README.md`, "invalid-ref"],
+    [`${base}&ref=main&path=%2Fetc%2Fpasswd`, "invalid-path"],
+    [`${base}&ref=main&path=docs%2F..%2FREADME.md`, "invalid-path"],
+    [`${base}&ref=main&path=docs%5CREADME.md`, "invalid-path"],
+    [`${base}&ref=main&path=docs%2F%2FREADME.md`, "invalid-path"],
+  ];
+  for (const [href, reason] of cases) {
+    assert.deepEqual(parseEntityLink(href), { ok: false, reason }, href);
+  }
+});
+
+test("repository target rejects URL credentials and ports", () => {
+  assert.deepEqual(
+    parseEntityLink(`buzz://user@repo?owner=${OWNER}&d=buzz-world`),
+    { ok: false, reason: "invalid-structure" },
+  );
+  assert.deepEqual(
+    parseEntityLink(`buzz://repo:99?owner=${OWNER}&d=buzz-world`),
+    { ok: false, reason: "invalid-structure" },
+  );
+});
+
+test("repository target builder rejects invalid ref and path", () => {
+  assert.throws(() =>
+    buildRepoTargetLink({
+      owner: OWNER,
+      dtag: "buzz-world",
+      ref: "bad ref",
+      path: "README.md",
+    }),
+  );
+  assert.throws(() =>
+    buildRepoTargetLink({
+      owner: OWNER,
+      dtag: "buzz-world",
+      ref: "main",
+      path: "../README.md",
+    }),
+  );
 });
 
 test("parseEntityLink lowercase-normalizes hex identifiers", () => {

--- a/desktop/src/shared/lib/entityLink.ts
+++ b/desktop/src/shared/lib/entityLink.ts
@@ -13,12 +13,29 @@
  * must stay compatible (see the golden-format tests on both sides).
  */
 
+import {
+  normalizeRepositoryPath,
+  parseRepositoryRef,
+  type RepositoryRefKind,
+} from "./repositoryTarget.ts";
+
 const ENTITY_LINK_SCHEME = "buzz:";
+
+export type RepositoryEntityTarget = {
+  ref: string;
+  refKind: RepositoryRefKind;
+  path: string;
+};
 
 export type ParsedEntityLink =
   | { type: "pr"; id: string; owner: string; dtag: string }
   | { type: "issue"; id: string; owner: string; dtag: string }
-  | { type: "repo"; owner: string; dtag: string };
+  | {
+      type: "repo";
+      owner: string;
+      dtag: string;
+      target?: RepositoryEntityTarget;
+    };
 
 export type EntityLinkParseResult =
   | { ok: true; value: ParsedEntityLink }
@@ -50,6 +67,27 @@ function checkEventId(id: string): void {
 export function buildRepoLink(input: { owner: string; dtag: string }): string {
   checkCoordinate(input.owner, input.dtag);
   return `buzz://repo?owner=${input.owner.toLowerCase()}&d=${input.dtag}`;
+}
+
+/** Build a canonical repository link with an atomic ref/path target. */
+export function buildRepoTargetLink(input: {
+  owner: string;
+  dtag: string;
+  ref: string;
+  path: string;
+}): string {
+  checkCoordinate(input.owner, input.dtag);
+  const parsedRef = parseRepositoryRef(input.ref);
+  const path = normalizeRepositoryPath(input.path);
+  if (!parsedRef) throw new Error("entityLink: invalid repository ref");
+  if (!path) throw new Error("entityLink: invalid repository path");
+  const params = new URLSearchParams({
+    owner: input.owner.toLowerCase(),
+    d: input.dtag,
+    ref: parsedRef.value,
+    path,
+  });
+  return `buzz://repo?${params.toString()}`;
 }
 
 /** Build a `buzz://pr` link for a pull request event (kind 1618). */
@@ -120,6 +158,10 @@ export function parseEntityLink(url: string): EntityLinkParseResult {
     return { ok: false, reason: "wrong-host" };
   }
 
+  if (parsed.username || parsed.password || parsed.port) {
+    return { ok: false, reason: "invalid-structure" };
+  }
+
   // Require empty/root path — path segments are reserved for future versioning.
   if (parsed.pathname !== "" && parsed.pathname !== "/") {
     return { ok: false, reason: "unexpected-path" };
@@ -131,7 +173,7 @@ export function parseEntityLink(url: string): EntityLinkParseResult {
   }
 
   // Validate known params and reject unknown ones, and enforce single-instance.
-  const KNOWN_REPO_PARAMS = new Set(["owner", "d"]);
+  const KNOWN_REPO_PARAMS = new Set(["owner", "d", "ref", "path"]);
   const KNOWN_EVENT_PARAMS = new Set(["id", "owner", "d"]);
   const knownParams = host === "repo" ? KNOWN_REPO_PARAMS : KNOWN_EVENT_PARAMS;
 
@@ -157,9 +199,30 @@ export function parseEntityLink(url: string): EntityLinkParseResult {
   }
 
   if (host === "repo") {
+    const hasRef = parsed.searchParams.has("ref");
+    const hasPath = parsed.searchParams.has("path");
+    if (hasRef !== hasPath) {
+      return { ok: false, reason: "incomplete-repo-target" };
+    }
+    if (!hasRef) {
+      return {
+        ok: true,
+        value: { type: "repo", owner: owner.toLowerCase(), dtag },
+      };
+    }
+
+    const parsedRef = parseRepositoryRef(parsed.searchParams.get("ref") ?? "");
+    if (!parsedRef) return { ok: false, reason: "invalid-ref" };
+    const path = normalizeRepositoryPath(parsed.searchParams.get("path") ?? "");
+    if (!path) return { ok: false, reason: "invalid-path" };
     return {
       ok: true,
-      value: { type: "repo", owner: owner.toLowerCase(), dtag },
+      value: {
+        type: "repo",
+        owner: owner.toLowerCase(),
+        dtag,
+        target: { ref: parsedRef.value, refKind: parsedRef.kind, path },
+      },
     };
   }
 

--- a/desktop/src/shared/lib/repositoryTarget.test.mjs
+++ b/desktop/src/shared/lib/repositoryTarget.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeRepositoryPath,
+  parseRepositoryRef,
+} from "./repositoryTarget.ts";
+
+test("parseRepositoryRef classifies commits and normalizes head refs", () => {
+  assert.deepEqual(parseRepositoryRef("A".repeat(40)), {
+    kind: "commit",
+    value: "a".repeat(40),
+  });
+  assert.deepEqual(parseRepositoryRef("B".repeat(64)), {
+    kind: "commit",
+    value: "b".repeat(64),
+  });
+  assert.deepEqual(parseRepositoryRef("refs/heads/feature/repo-links"), {
+    kind: "branch",
+    value: "feature/repo-links",
+  });
+});
+
+test("parseRepositoryRef rejects ambiguous and non-head refs", () => {
+  for (const value of [
+    "",
+    "-main",
+    "/main",
+    "main/",
+    "main.",
+    "main.lock",
+    "feature/../main",
+    "feature//main",
+    ".hidden/main",
+    "feature/.hidden",
+    "bad ref",
+    "refs/tags/v1",
+    "refs/nostr/main",
+  ]) {
+    assert.equal(parseRepositoryRef(value), null, value);
+  }
+});
+
+test("normalizeRepositoryPath accepts relative Unicode paths", () => {
+  assert.equal(
+    normalizeRepositoryPath("GUIDES/café setup.md"),
+    "GUIDES/café setup.md",
+  );
+});
+
+test("normalizeRepositoryPath rejects absolute, traversal, ambiguous, control, and oversized paths", () => {
+  for (const value of [
+    "",
+    "/etc/passwd",
+    "../README.md",
+    "docs/../README.md",
+    "docs//README.md",
+    "docs/./README.md",
+    "docs\\README.md",
+    "docs/README.md/",
+    `docs/${String.fromCharCode(0)}README.md`,
+    "é".repeat(2049),
+  ]) {
+    assert.equal(normalizeRepositoryPath(value), null, JSON.stringify(value));
+  }
+});

--- a/desktop/src/shared/lib/repositoryTarget.ts
+++ b/desktop/src/shared/lib/repositoryTarget.ts
@@ -1,0 +1,67 @@
+const COMMIT_PATTERN = /^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/;
+const BRANCH_CHARACTERS = /^[A-Za-z0-9/_.-]+$/;
+const MAX_REPOSITORY_PATH_BYTES = 4096;
+const UTF8_ENCODER = new TextEncoder();
+
+export type RepositoryRefKind = "branch" | "commit";
+
+export type ParsedRepositoryRef = {
+  kind: RepositoryRefKind;
+  value: string;
+};
+
+/** Parse a conservative branch name or a full 40/64-character commit hash. */
+export function parseRepositoryRef(value: string): ParsedRepositoryRef | null {
+  const trimmed = value.trim();
+  if (COMMIT_PATTERN.test(trimmed)) {
+    return { kind: "commit", value: trimmed.toLowerCase() };
+  }
+  if (trimmed.startsWith("refs/") && !trimmed.startsWith("refs/heads/")) {
+    return null;
+  }
+  const branch = trimmed.replace(/^refs\/heads\//, "");
+  if (
+    !branch ||
+    branch.startsWith("-") ||
+    branch.startsWith("/") ||
+    branch.endsWith("/") ||
+    branch.endsWith(".") ||
+    branch.endsWith(".lock") ||
+    branch.includes("..") ||
+    branch.includes("//") ||
+    !BRANCH_CHARACTERS.test(branch) ||
+    branch.split("/").some((component) => component.startsWith("."))
+  ) {
+    return null;
+  }
+  return { kind: "branch", value: branch };
+}
+
+function containsControlCharacter(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 0x1f || codePoint === 0x7f;
+  });
+}
+
+/** Validate a repository-relative file or directory coordinate. */
+export function normalizeRepositoryPath(value: string): string | null {
+  if (
+    !value ||
+    UTF8_ENCODER.encode(value).length > MAX_REPOSITORY_PATH_BYTES ||
+    value.startsWith("/") ||
+    value.startsWith("\\") ||
+    value.endsWith("/") ||
+    value.includes("\\") ||
+    containsControlCharacter(value)
+  ) {
+    return null;
+  }
+  const segments = value.split("/");
+  if (
+    segments.some((segment) => !segment || segment === "." || segment === "..")
+  ) {
+    return null;
+  }
+  return value;
+}

--- a/desktop/src/shared/ui/markdown.test.mjs
+++ b/desktop/src/shared/ui/markdown.test.mjs
@@ -638,6 +638,15 @@ test("buzzDeepLinkUrlTransform: preserves buzz://repo entity link href", () => {
   assert.doesNotMatch(html, /href=""/);
 });
 
+test("buzzDeepLinkUrlTransform: preserves canonical repository target href", () => {
+  const targetLink = `buzz://repo?owner=${OWNER_HEX}&d=buzz-world&ref=feature%2Frepo-links&path=GUIDES%2FRUNBOOK.md`;
+  const html = renderMarkdown(`[Runbook](${targetLink})`);
+  assert.match(html, /href="buzz:\/\/repo\?/);
+  assert.match(html, /ref=feature%2Frepo-links/);
+  assert.match(html, /path=GUIDES%2FRUNBOOK\.md/);
+  assert.doesNotMatch(html, /href=""/);
+});
+
 test("buzzDeepLinkUrlTransform: strips malformed buzz://pr (unknown param)", () => {
   // Strict parser rejects unknown params — transform falls back to default sanitizer.
   const html = renderMarkdown(
@@ -711,6 +720,38 @@ test("renderEntityLinkAnchor_noRelayOrigin_cloneUrlReturnsNull", () => {
     null,
     "clone URL without a relay origin must return null (fail closed)",
   );
+});
+
+test("renderEntityLinkAnchor_repositoryTarget_preservesNavigationTarget", () => {
+  const targetLink = `buzz://repo?owner=${OWNER_HEX}&d=buzz-world&ref=feature%2Frepo-links&path=GUIDES%2FRUNBOOK.md`;
+  let opened = null;
+  let prevented = false;
+  const el = renderEntityLinkAnchor({
+    anchorProps: {},
+    children: React.createElement("span", null, "Runbook"),
+    href: targetLink,
+    onOpenEntityLink: (link) => {
+      opened = link;
+    },
+    relayOrigin: null,
+  });
+  assert.notEqual(el, null);
+  el.props.onClick({
+    preventDefault() {
+      prevented = true;
+    },
+  });
+  assert.equal(prevented, true);
+  assert.deepEqual(opened, {
+    type: "repo",
+    owner: OWNER_HEX,
+    dtag: "buzz-world",
+    target: {
+      ref: "feature/repo-links",
+      refKind: "branch",
+      path: "GUIDES/RUNBOOK.md",
+    },
+  });
 });
 
 test("renderEntityLinkAnchor_directEntityLink_returnsAnchorRegardlessOfOrigin", () => {

--- a/desktop/src/shared/ui/markdown/entityLinks.tsx
+++ b/desktop/src/shared/ui/markdown/entityLinks.tsx
@@ -24,6 +24,9 @@ export function useOpenEntityLink(): (link: ParsedEntityLink) => void {
       void goProject(entityLinkProjectRouteId(link), {
         ...(link.type === "pr" ? { pullRequestId: link.id } : {}),
         ...(link.type === "issue" ? { issueId: link.id } : {}),
+        ...(link.type === "repo" && link.target
+          ? { repoRef: link.target.ref, repoPath: link.target.path }
+          : {}),
       });
     },
     [goProject],


### PR DESCRIPTION
## Summary

- extend the existing canonical first-party `buzz://repo` entity link with an optional atomic repository target
- preserve repository links through Markdown sanitization and route clicks inside Buzz
- navigate through the canonical `30617:<owner>:<d-tag>` project identity, select the requested branch or full commit, and open the requested file or directory
- let native repository snapshots include a bounded target path beyond the normal 250-entry tree cap
- fail closed on malformed coordinates and offer **Open repository root** when a ref or path is unavailable

Closes #2906.

## URI contract

Root links remain byte-compatible:

```text
buzz://repo?owner=<64-hex-pubkey>&d=<repo-dtag>
```

Target links extend that same canonical identity:

```text
buzz://repo?owner=<64-hex-pubkey>&d=<repo-dtag>&ref=<branch-or-40/64-hex-commit>&path=<repository-relative-path>
```

`ref` and `path` are atomic. The parser rejects credentials, ports, URI path components, fragments, unknown or duplicate parameters, malformed identifiers, absolute paths, backslashes, control characters, empty components, `.` / `..`, invalid Git refs, and the discarded parallel `repo=` form.

## Implementation

- one canonical entity-link parser and builder; no parallel repository-file URL authority
- route-search validation preserves current `repositoryId` behavior and atomically accepts or discards target state
- target mode uses the canonical project clone, forces a remote snapshot, opens Files, and resolves files or directories after the requested snapshot loads
- existing pull-request, tag, default-branch, external-host, and multi-repository behavior remains unchanged when no target is present
- native snapshots use NUL-delimited `git ls-tree`, validate explicit refs, commits, and paths before Git work, and add only the exact file or bounded directory descendants outside the normal tree cap
- malformed or unavailable targets fail closed with repository-root recovery

## Validation

Fresh verification after rebasing onto current `main`:

- focused parser, Markdown, navigation, snapshot, and target slice: **104 passed**
- full Desktop suite: **4,313 passed**
- Desktop typecheck and production build: passed
- focused Tauri project-git suite: **38 passed**
- Cargo fmt and Clippy with warnings denied: passed
- changed-file Biome, pixel-text, pubkey-truncation, diff, and conflict-marker checks: passed
- all touched files comply with the file-size ratchet; the remaining findings are identical to current upstream's pre-existing set
