### PR TITLE
fix(workflow): honor definition 'enabled' flag on upsert

### DIFF
--- a/crates/buzz-db/src/workflow.rs
+++ b/crates/buzz-db/src/workflow.rs
@@ -320,15 +320,24 @@ pub async fn upsert_workflow(
     definition_json: &str,
     definition_hash: &[u8],
 ) -> Result<()> {
+    // The `enabled` flag lives in the definition (WorkflowDef.enabled, default
+    // true). Honor it on both insert AND update — otherwise re-publishing a
+    // definition with `enabled: false` changes the JSON but leaves the row
+    // enabled, so a disabled workflow keeps firing.
+    let enabled = serde_json::from_str::<serde_json::Value>(definition_json)
+        .ok()
+        .and_then(|v| v.get("enabled").and_then(|e| e.as_bool()))
+        .unwrap_or(true);
     let row = sqlx::query(
         r#"
         INSERT INTO workflows
             (community_id, id, name, owner_pubkey, channel_id, definition, definition_hash, status, enabled)
-        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, 'active', TRUE)
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, 'active', $8)
         ON CONFLICT (community_id, id) DO UPDATE
         SET name = EXCLUDED.name,
             definition = EXCLUDED.definition,
             definition_hash = EXCLUDED.definition_hash,
+            enabled = EXCLUDED.enabled,
             updated_at = NOW()
         WHERE workflows.owner_pubkey = EXCLUDED.owner_pubkey
           AND workflows.channel_id IS NOT DISTINCT FROM EXCLUDED.channel_id
@@ -342,6 +351,7 @@ pub async fn upsert_workflow(
     .bind(channel_id)
     .bind(definition_json)
     .bind(definition_hash)
+    .bind(enabled)
     .fetch_optional(pool)
     .await?;
 


### PR DESCRIPTION
`upsert_workflow`'s `ON CONFLICT DO UPDATE` sets `name`/`definition`/`definition_hash` but never `enabled`. Re-publishing a kind:30620 workflow definition with `enabled: false` therefore updates the stored JSON while leaving the row's `enabled` column `TRUE` — a disabled scheduled workflow keeps firing.

This parses `enabled` from the definition (WorkflowDef.enabled, default true) and applies it on both insert and update. Minimal, contained to the DB helper; no signature change.

Found while disabling a scheduled workflow via a re-published definition.

## Related work

#1593 reports workflows that "keep firing on their cron schedules and cannot be disabled", and attributes it to orphan rows created before #1369, stating that after the d-tag upsert landed "all *new* operations behave correctly".

That is still not true for the disable path on current `main`, for a separate reason: the upsert's `ON CONFLICT DO UPDATE` never writes the `enabled` column, so re-publishing a definition with `enabled: false` updates the JSON and leaves the row enabled. No orphan row required — this reproduces on a workflow created today.

This PR fixes that half. #1593's orphan reconciliation (and its point 2, surfacing side-effect failures) is still needed for the legacy rows.

Rebased onto current `main`; `cargo clippy -p buzz-db` is clean.
