### PR TITLE
fix(desktop): persist + self-heal failed agent profile sync

### DIFF
--- a/desktop/src-tauri/src/commands/agent_config.rs
+++ b/desktop/src-tauri/src/commands/agent_config.rs
@@ -636,6 +636,7 @@ mod tests {
 
     fn agent_record() -> ManagedAgentRecord {
         ManagedAgentRecord {
+            profile_sync_pending: false,
             pubkey: "agent".to_string(),
             name: "Agent".to_string(),
             persona_id: Some("persona-1".to_string()),

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -827,6 +827,7 @@ pub async fn create_managed_agent(
             pubkey: pubkey.clone(),
             name: name.clone(),
             persona_id: requested_persona_id.clone(),
+            profile_sync_pending: false,
             team_id,
             private_key_nsec: private_key_nsec.clone(),
             auth_tag: auth_tag.clone(),
@@ -978,6 +979,23 @@ pub async fn create_managed_agent(
     .await)
         .err();
 
+    // ── Phase 4b: persist a pending flag if profile sync failed ─────────────
+    // The error is returned to the caller (transient toast), but it must also
+    // be durable so boot-time reconciliation self-heals the kind:0 profile even
+    // when this agent is never (re)started — otherwise the relay keeps a stale
+    // or missing name indefinitely. Cleared by `reconcile_agent_profile`.
+    if profile_sync_error.is_some() {
+        let _store_guard = state
+            .managed_agents_store_lock
+            .lock()
+            .map_err(|e| e.to_string())?;
+        let mut records = load_managed_agents(&app)?;
+        if let Some(record) = records.iter_mut().find(|r| r.pubkey == pubkey) {
+            record.profile_sync_pending = true;
+            save_managed_agents(&app, &records)?;
+        }
+    }
+
     // ── Phase 5: provider deploy (async, outside lock) ───────────────────────
     let spawn_error = if input.spawn_after_create && input.backend != BackendKind::Local {
         if let BackendKind::Provider { ref id, ref config } = input.backend {
@@ -1006,8 +1024,12 @@ pub async fn create_managed_agent(
         spawn_error
     };
 
-    // Rebuild summary if provider deploy may have updated backend_agent_id.
-    let final_agent = if input.backend != BackendKind::Local && spawn_error.is_none() {
+    // Rebuild summary if provider deploy may have updated backend_agent_id, or
+    // if the profile sync set the pending flag, so the response reflects the
+    // current on-disk record (including `profile_sync_pending`).
+    let final_agent = if (input.backend != BackendKind::Local && spawn_error.is_none())
+        || profile_sync_error.is_some()
+    {
         let _store_guard = state
             .managed_agents_store_lock
             .lock()

--- a/desktop/src-tauri/src/commands/agents_profile.rs
+++ b/desktop/src-tauri/src/commands/agents_profile.rs
@@ -137,6 +137,9 @@ pub(crate) async fn reconcile_agent_profile(
     };
 
     if !profile_needs_sync(existing.as_ref(), &data.name, expected_avatar.as_deref()) {
+        // The published profile already matches — clear any stale pending flag
+        // left by an earlier failed sync so the UI badge clears.
+        let _ = clear_profile_sync_pending(state, app, &data.pubkey);
         return Ok(());
     }
 
@@ -150,7 +153,7 @@ pub(crate) async fn reconcile_agent_profile(
         return Ok(());
     }
 
-    sync_managed_agent_profile(
+    let result = sync_managed_agent_profile(
         state,
         &relay_url,
         &agent_keys,
@@ -158,7 +161,12 @@ pub(crate) async fn reconcile_agent_profile(
         expected_avatar.as_deref(),
         data.auth_tag.as_deref(),
     )
-    .await
+    .await;
+    if result.is_ok() {
+        // The relay profile now matches — clear the pending flag.
+        let _ = clear_profile_sync_pending(state, app, &data.pubkey);
+    }
+    result
 }
 
 /// Decide whether a published profile is missing or stale relative to the
@@ -177,6 +185,28 @@ pub(super) fn profile_needs_sync(
             !name_matches || !picture_matches
         }
     }
+}
+
+/// Clear the persisted `profile_sync_pending` flag once the relay profile has
+/// been confirmed in sync. No-op (and skips the disk write) when the flag was
+/// already clear, so calling this on every successful reconcile is cheap.
+fn clear_profile_sync_pending(
+    state: &AppState,
+    app: &AppHandle,
+    pubkey: &str,
+) -> Result<(), String> {
+    let _store_guard = state
+        .managed_agents_store_lock
+        .lock()
+        .map_err(|e| e.to_string())?;
+    let mut records = load_managed_agents(app)?;
+    if let Some(record) = records.iter_mut().find(|r| r.pubkey == pubkey) {
+        if record.profile_sync_pending {
+            record.profile_sync_pending = false;
+            save_managed_agents(app, &records)?;
+        }
+    }
+    Ok(())
 }
 
 // Async so the blocking body (disk reads/writes + process termination) runs off

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -9,6 +9,7 @@ fn bare_agent_record(
     use crate::managed_agents::{BackendKind, RespondTo};
     use std::collections::BTreeMap;
     ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: "agent".to_string(),
         name: "Agent".to_string(),
         persona_id: persona_id.map(str::to_string),

--- a/desktop/src-tauri/src/commands/personas/delete_cascade_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/delete_cascade_tests.rs
@@ -17,6 +17,7 @@ fn make_agent(
     runtime_pid: Option<u32>,
 ) -> ManagedAgentRecord {
     ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: pubkey.to_string(),
         name: "Test Agent".to_string(),
         persona_id: persona_id.map(str::to_string),

--- a/desktop/src-tauri/src/commands/personas/inbound_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/inbound_tests.rs
@@ -155,6 +155,7 @@ const AGENT_PUBKEY: &str = "agentpubkeyhex00000000000000000000000000000000000000
 /// event must NEVER be able to overwrite.
 fn local_agent() -> ManagedAgentRecord {
     ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: AGENT_PUBKEY.to_string(),
         name: "Local Agent".to_string(),
         persona_id: Some("persona-local".to_string()),

--- a/desktop/src-tauri/src/commands/personas/name_propagation_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/name_propagation_tests.rs
@@ -5,6 +5,7 @@ use super::*;
 
 fn agent(persona_id: &str, name: &str, display_name: Option<&str>) -> ManagedAgentRecord {
     ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: format!("pubkey-{name}"),
         name: name.to_string(),
         persona_id: Some(persona_id.to_string()),

--- a/desktop/src-tauri/src/commands/personas/snapshot/import.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/import.rs
@@ -432,6 +432,7 @@ pub async fn confirm_agent_snapshot_import(
             display_name: None,
             slug: None,
             persona_id: Some(persona_id.clone()),
+            profile_sync_pending: false,
             private_key_nsec: private_key_nsec.clone(),
             auth_tag: auth_tag.clone(),
             relay_url: String::new(), // resolves to workspace relay at runtime

--- a/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
@@ -19,6 +19,7 @@ use std::collections::BTreeMap;
 /// persona_id.
 fn make_definition(slug: &str) -> ManagedAgentRecord {
     ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: String::new(),
         slug: Some(slug.to_string()),
         name: slug.to_string(),
@@ -77,6 +78,7 @@ fn make_definition(slug: &str) -> ManagedAgentRecord {
 /// have `slug: None` and link to their definition via `persona_id`.
 fn make_instance(pubkey: &str, persona_id: &str) -> ManagedAgentRecord {
     ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: pubkey.to_string(),
         slug: None,
         persona_id: Some(persona_id.to_string()),

--- a/desktop/src-tauri/src/commands/team_snapshot.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot.rs
@@ -553,6 +553,7 @@ pub async fn confirm_team_snapshot_import(
             display_name: None,
             slug: None,
             persona_id: Some(definition.id.clone()),
+            profile_sync_pending: false,
             private_key_nsec: private_key_nsec.clone(),
             auth_tag: auth_tag.clone(),
             relay_url: String::new(),

--- a/desktop/src-tauri/src/commands/team_snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot/tests.rs
@@ -171,6 +171,7 @@ fn team_export_with_instance_and_memory_level_uses_supplied_entries() {
 
     // Build a fake instance record tied to this team+persona.
     let instance = ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: "a".repeat(64),
         name: "Alice".to_string(),
         display_name: None,

--- a/desktop/src-tauri/src/managed_agents/agent_events.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_events.rs
@@ -158,6 +158,7 @@ mod tests {
 
     fn sample_agent() -> ManagedAgentRecord {
         ManagedAgentRecord {
+            profile_sync_pending: false,
             pubkey: "agentpubkeyhex".to_string(),
             name: "Test Agent".to_string(),
             persona_id: Some("persona-1".to_string()),

--- a/desktop/src-tauri/src/managed_agents/agent_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_snapshot.rs
@@ -473,6 +473,7 @@ mod tests {
     /// relevant to snapshot export are filled; the rest use defaults.
     fn minimal_record() -> ManagedAgentRecord {
         ManagedAgentRecord {
+            profile_sync_pending: false,
             pubkey: "deadbeef".to_string(),
             name: "Test Agent".to_string(),
             display_name: Some("Test Agent Display".to_string()),

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -64,6 +64,7 @@ fn test_runtime() -> &'static KnownAcpRuntime {
 
 fn test_record() -> ManagedAgentRecord {
     ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: "test".to_string(),
         name: "Test Agent".to_string(),
         persona_id: None,

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -230,6 +230,7 @@ fn record_with(
     override_cmd: Option<&str>,
 ) -> crate::managed_agents::types::ManagedAgentRecord {
     crate::managed_agents::types::ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: String::new(),
         name: "r".to_string(),
         persona_id: persona_id.map(str::to_string),

--- a/desktop/src-tauri/src/managed_agents/global_config/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/global_config/tests.rs
@@ -299,6 +299,7 @@ fn default_global_config_serializes_all_fields() {
 
 fn bare_record() -> ManagedAgentRecord {
     ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: "agent".to_string(),
         name: "Agent".to_string(),
         persona_id: None,

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -435,6 +435,7 @@ fn make_persona(id: &str, display_name: &str) -> AgentDefinition {
 
 fn make_agent(name: &str, persona_id: Option<&str>) -> ManagedAgentRecord {
     ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: String::new(),
         name: name.to_string(),
         persona_id: persona_id.map(|s| s.to_string()),

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -1293,6 +1293,7 @@ mod tests {
 
         // Minimal record: only the fields resolve_effective_agent_env reads.
         let record = crate::managed_agents::types::ManagedAgentRecord {
+            profile_sync_pending: false,
             pubkey: "test-pubkey".to_string(),
             name: "test-agent".to_string(),
             persona_id: None,

--- a/desktop/src-tauri/src/managed_agents/relay_mesh.rs
+++ b/desktop/src-tauri/src/managed_agents/relay_mesh.rs
@@ -114,6 +114,7 @@ mod tests {
 
     fn fixture() -> ManagedAgentRecord {
         ManagedAgentRecord {
+            profile_sync_pending: false,
             pubkey: "p".into(),
             name: "n".into(),
             persona_id: None,

--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -403,13 +403,23 @@ pub async fn restore_managed_agents_on_launch(
         }
     }
 
-    // Collect profile reconciliation data for successfully spawned agents before
-    // releasing the lock. This mirrors the fire-and-forget pattern in
-    // start_managed_agent — ensuring boot-restored agents get the same profile
-    // self-healing as UI-started agents.
+    // Collect profile reconciliation data before releasing the lock. This
+    // mirrors the fire-and-forget pattern in start_managed_agent — ensuring
+    // boot-restored agents get the same profile self-healing as UI-started
+    // agents. Also includes agents flagged `profile_sync_pending` (a create-time
+    // sync that failed and hasn't been confirmed published) so a stopped agent
+    // self-heals instead of keeping a stale kind:0 name indefinitely.
     let reconcile_personas = super::load_personas(app).unwrap_or_default();
+    let mut reconcile_pubkeys: Vec<String> = successfully_spawned.clone();
+    for record in &records {
+        if record.profile_sync_pending
+            && !reconcile_pubkeys.iter().any(|p| p == &record.pubkey)
+        {
+            reconcile_pubkeys.push(record.pubkey.clone());
+        }
+    }
     let reconcile_items: Vec<(String, crate::commands::ProfileReconcileData)> =
-        successfully_spawned
+        reconcile_pubkeys
             .iter()
             .filter_map(|pubkey| {
                 let record = records.iter().find(|r| r.pubkey == *pubkey)?;

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -1514,6 +1514,7 @@ pub fn build_managed_agent_summary(
         persona_out_of_date,
         persona_orphaned,
         needs_restart,
+        profile_sync_pending: record.profile_sync_pending,
         env_vars: record.env_vars.clone(),
         backend: record.backend.clone(),
         backend_agent_id: record.backend_agent_id.clone(),

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -130,6 +130,7 @@ fn fixture(
     auth_tag: Option<String>,
 ) -> ManagedAgentRecord {
     ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: "p".into(),
         name: "n".into(),
         persona_id: None,

--- a/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 fn record() -> ManagedAgentRecord {
     ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: "p".repeat(64),
         name: "agent".into(),
         persona_id: None,

--- a/desktop/src-tauri/src/managed_agents/team_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/team_snapshot.rs
@@ -252,6 +252,7 @@ mod tests {
     /// Build a minimal `ManagedAgentRecord` for use as a team member.
     fn agent_record(name: &str) -> ManagedAgentRecord {
         ManagedAgentRecord {
+            profile_sync_pending: false,
             pubkey: format!("{name}-pubkey"),
             name: name.to_string(),
             display_name: Some(format!("{name} Display")),

--- a/desktop/src-tauri/src/managed_agents/teams_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/teams_tests.rs
@@ -163,6 +163,7 @@ fn validate_team_deletion_rejects_built_ins() {
 
 fn managed_agent(name: &str) -> ManagedAgentRecord {
     ManagedAgentRecord {
+        profile_sync_pending: false,
         pubkey: name.to_string(),
         name: name.to_string(),
         persona_id: None,

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -88,6 +88,7 @@ impl AgentDefinition {
             pubkey: String::new(),
             name: self.display_name.clone(),
             persona_id: None,
+            profile_sync_pending: false,
             private_key_nsec: String::new(),
             auth_tag: None,
             relay_url: String::new(),
@@ -398,6 +399,15 @@ pub struct ManagedAgentRecord {
     /// they are rewritten with this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub relay_mesh: Option<RelayMeshConfig>,
+    /// `true` when the agent's kind:0 profile sync failed at create time and
+    /// has not yet been confirmed published on the relay. Drives boot-time
+    /// reconciliation so a stopped agent self-heals its relay profile without a
+    /// manual restart — otherwise the relay keeps a stale/missing name
+    /// indefinitely (the reconcile-on-start path only runs for spawned agents).
+    /// Cleared by `reconcile_agent_profile` once the relay profile matches.
+    /// `#[serde(default)]` so pre-existing records deserialize as `false`.
+    #[serde(default)]
+    pub profile_sync_pending: bool,
 }
 
 /// Typed relay-mesh configuration carried on a [`ManagedAgentRecord`].
@@ -498,6 +508,10 @@ pub struct ManagedAgentSummary {
     /// would." Always `false` for stopped agents and for processes adopted
     /// via a persisted `runtime_pid` (their spawn config is unknown).
     pub needs_restart: bool,
+    /// `true` when the agent's kind:0 relay profile sync failed and hasn't
+    /// been confirmed published. Surface a persistent "profile out of sync"
+    /// marker; it clears once reconciliation succeeds.
+    pub profile_sync_pending: bool,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub env_vars: BTreeMap<String, String>,
     pub backend: BackendKind,

--- a/desktop/src/features/agents/ui/ManagedAgentRow.tsx
+++ b/desktop/src/features/agents/ui/ManagedAgentRow.tsx
@@ -250,6 +250,12 @@ function AgentSummary({
                 Out of date
               </Badge>
             ) : null}
+            {agent.profileSyncPending ? (
+              <Badge className="gap-1" variant="warning">
+                <AlertTriangle className="h-3 w-3" />
+                Profile out of sync
+              </Badge>
+            ) : null}
           </div>
           <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
             <PubKey pubkey={agent.pubkey} />
@@ -271,6 +277,12 @@ function AgentSummary({
             <p className="mt-1.5 text-xs text-amber-600 dark:text-amber-400">
               Template updated since this agent was created. Respawn to apply
               the new configuration.
+            </p>
+          ) : null}
+          {agent.profileSyncPending ? (
+            <p className="mt-1.5 text-xs text-amber-600 dark:text-amber-400">
+              Relay profile sync failed — the relay may show an outdated name.
+              It will be retried automatically.
             </p>
           ) : null}
           {channelNames.length > 0 ? (

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -136,6 +136,7 @@ export type RawManagedAgent = {
   persona_out_of_date: boolean;
   persona_orphaned: boolean;
   needs_restart: boolean;
+  profile_sync_pending: boolean;
   env_vars?: Record<string, string>;
   status: ManagedAgent["status"];
   pid: number | null;
@@ -705,6 +706,7 @@ export function fromRawManagedAgent(agent: RawManagedAgent): ManagedAgent {
     personaOutOfDate: agent.persona_out_of_date ?? false,
     personaOrphaned: agent.persona_orphaned ?? false,
     needsRestart: agent.needs_restart ?? false,
+    profileSyncPending: agent.profile_sync_pending ?? false,
     envVars: agent.env_vars ?? {},
     status: agent.status,
     pid: agent.pid,

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -385,6 +385,12 @@ export type ManagedAgent = {
    * Always `false` for stopped agents.
    */
   needsRestart: boolean;
+  /**
+   * `true` when the agent's kind:0 relay profile sync failed and hasn't been
+   * confirmed published. The relay may show an outdated name; reconciliation
+   * retries automatically and clears this flag on success.
+   */
+  profileSyncPending: boolean;
   /** Per-agent env vars. Layered on top of persona envVars. */
   envVars: Record<string, string>;
   status: "running" | "stopped" | "deployed" | "not_deployed";


### PR DESCRIPTION
## Problem

When a managed agent is created, the desktop publishes its kind:0 (NIP-01) profile to the relay via `sync_managed_agent_profile`. This create-time sync is **fire-and-forget**: on failure it returns `profile_sync_error`, which the UI surfaces as a **transient toast** and then forgets.

The existing profile self-heal (`reconcile_agent_profile`) compares the relay profile to the record and re-publishes on mismatch — but it **only runs for spawned agents** (on explicit start, and on boot restore for auto-started agents).

So a created-but-**stopped** agent whose create-time sync failed transiently is **never** reconciled: its kind:0 name stays stale/missing across restarts, while the desktop record shows the intended name. The two diverge — e.g. an agent record named "SubbySonar" still shows "Fizz" as the message author in the community.

> Note: the **rename** path (`update_managed_agent`) is already atomic — it rolls back the whole update on sync failure — so this gap is specific to **create-time**.

## Fix

Make the failure durable and self-healing:

1. **Persist a `profile_sync_pending` flag** on the agent record when the create-time sync fails (`#[serde(default)]` — no migration; pre-existing records deserialize as `false`).
2. **Boot-time self-heal**: the restore reconcile now also covers flagged agents — **even stopped ones** — so the kind:0 profile is republished on the next app launch without a manual restart.
3. **Clear on success**: `reconcile_agent_profile` clears the flag once the relay profile matches (whether it re-published or found it already in sync).
4. **Persistent UI badge**: the agent card shows a "Profile out of sync" marker instead of relying solely on a transient toast.

## Validation

- `cargo check --tests` — green
- `cargo test --lib` — **1637 passed, 0 failed**
- `tsc --noEmit` — green

## Scope

`ManagedAgentRecord.profile_sync_pending` is a new field, so every struct-literal construction site (4 production + ~20 test fixtures) is updated to initialize it to `false`. The same fire-and-forget pattern exists in the snapshot/team-import sync paths; those could adopt the flag as a follow-up.

Originated from the #buzz channel.
