### PR TITLE
Accept drafts from owned remote agents

### DIFF
--- a/desktop/src/features/agents/agentManagementBuffer.test.mjs
+++ b/desktop/src/features/agents/agentManagementBuffer.test.mjs
@@ -21,10 +21,30 @@ test("buffers a draft until ownership and channel data resolve", () => {
   );
 });
 
-test("accepts an owned agent drafting from a shared channel", () => {
+test("accepts a locally managed agent drafting from a shared channel", () => {
   assert.equal(
     classifyAgentManagementOrigin(OWNED_AGENT, SHARED_CHANNEL, AGENT, CHANNEL),
     "accept",
+  );
+});
+
+test("accepts an owner-attested relay agent drafting from a shared channel", () => {
+  assert.equal(
+    classifyAgentManagementOrigin([], SHARED_CHANNEL, AGENT, CHANNEL, [AGENT]),
+    "accept",
+  );
+});
+
+test("buffers a non-local draft until relay ownership resolves", () => {
+  assert.equal(
+    classifyAgentManagementOrigin(
+      [],
+      SHARED_CHANNEL,
+      AGENT,
+      CHANNEL,
+      undefined,
+    ),
+    "buffer",
   );
 });
 
@@ -56,6 +76,7 @@ test("rejects a draft from an agent this Desktop does not own", () => {
       SHARED_CHANNEL,
       AGENT,
       CHANNEL,
+      [],
     ),
     "reject",
   );

--- a/desktop/src/features/agents/agentManagementBuffer.ts
+++ b/desktop/src/features/agents/agentManagementBuffer.ts
@@ -12,12 +12,20 @@ export function classifyAgentManagementOrigin(
     | undefined,
   agentPubkey: string,
   channelId: string,
+  ownedRelayAgentPubkeys?: readonly string[],
 ): "buffer" | "accept" | "reject" {
   if (agents === undefined || channels === undefined) return "buffer";
   const normalizedAgentPubkey = agentPubkey.toLowerCase();
-  const isOwnedAgent = agents.some(
+  const isLocallyManaged = agents.some(
     (agent) => agent.pubkey.toLowerCase() === normalizedAgentPubkey,
   );
+  if (!isLocallyManaged && ownedRelayAgentPubkeys === undefined)
+    return "buffer";
+  const isOwnedAgent =
+    isLocallyManaged ||
+    ownedRelayAgentPubkeys?.some(
+      (pubkey) => pubkey.toLowerCase() === normalizedAgentPubkey,
+    );
   const originChannel = channels.find((channel) => channel.id === channelId);
   return isOwnedAgent &&
     originChannel?.isMember === true &&

--- a/desktop/src/features/agents/useAgentManagement.ts
+++ b/desktop/src/features/agents/useAgentManagement.ts
@@ -15,6 +15,7 @@ import {
   useCreatePersonaMutation,
   useManagedAgentsQuery,
   usePersonasQuery,
+  useRelayAgentsQuery,
   useUpdatePersonaMutation,
 } from "./hooks";
 import {
@@ -23,8 +24,12 @@ import {
   type BackendIntent,
 } from "./lib/instanceInputForDefinition";
 import { useCreatedAgentChannelAttachment } from "./useCreatedAgentChannelAttachment";
+import { combineObserverIngestionAgents } from "./useAgentObserverIngestion";
 import { classifyAgentManagementOrigin } from "./agentManagementBuffer";
 import { useChannelsQuery } from "@/features/channels/hooks";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import { resolveManagedAgentAvatarUrl } from "./ui/managedAgentAvatar";
 import type { AgentCreateIntent } from "./ui/agentCreateIntent";
 import { editPersonaDialogState } from "./ui/personaDialogState";
@@ -62,6 +67,48 @@ export function useAgentManagement() {
   const personasQuery = usePersonasQuery();
   const managedAgentsQuery = useManagedAgentsQuery();
   const channelsQuery = useChannelsQuery();
+  const identityQuery = useIdentityQuery();
+  const currentPubkey = identityQuery.data?.pubkey;
+  const relayAgentsQuery = useRelayAgentsQuery();
+  const relayAgentPubkeys = React.useMemo(
+    () => (relayAgentsQuery.data ?? []).map((agent) => agent.pubkey),
+    [relayAgentsQuery.data],
+  );
+  const profilesQuery = useUsersBatchQuery(relayAgentPubkeys, {
+    enabled: Boolean(currentPubkey) && relayAgentPubkeys.length > 0,
+  });
+  const ownedRelayAgentPubkeys = React.useMemo(() => {
+    if (relayAgentsQuery.data === undefined || currentPubkey === undefined) {
+      return undefined;
+    }
+    if (relayAgentPubkeys.length === 0) return [];
+    if (profilesQuery.data === undefined || profilesQuery.isPlaceholderData) {
+      return undefined;
+    }
+    const ownerByPubkey = new Map<string, string>();
+    for (const [pubkey, summary] of Object.entries(
+      profilesQuery.data.profiles,
+    )) {
+      if (summary.ownerPubkey) {
+        ownerByPubkey.set(
+          normalizePubkey(pubkey),
+          normalizePubkey(summary.ownerPubkey),
+        );
+      }
+    }
+    return combineObserverIngestionAgents(
+      [],
+      relayAgentPubkeys,
+      ownerByPubkey,
+      currentPubkey,
+    ).map((agent) => agent.pubkey);
+  }, [
+    currentPubkey,
+    profilesQuery.data,
+    profilesQuery.isPlaceholderData,
+    relayAgentPubkeys,
+    relayAgentsQuery.data,
+  ]);
   const runtimesQuery = useAcpRuntimesQuery({ enabled: true });
   const createPersonaMutation = useCreatePersonaMutation();
   const updatePersonaMutation = useUpdatePersonaMutation();
@@ -76,6 +123,7 @@ export function useAgentManagement() {
   const sourceAgentPubkey = React.useRef<string | null>(null);
   const managedAgentsRef = React.useRef(managedAgentsQuery.data);
   const channelsRef = React.useRef(channelsQuery.data);
+  const ownedRelayAgentPubkeysRef = React.useRef(ownedRelayAgentPubkeys);
   const bufferedRequestsRef = React.useRef<
     Array<{ agentPubkey: string; request: AgentManagementRequest }>
   >([]);
@@ -88,6 +136,7 @@ export function useAgentManagement() {
           channelsRef.current,
           agentPubkey,
           next.request.channelId,
+          ownedRelayAgentPubkeysRef.current,
         ) !== "accept" ||
         seenRequestIds.current.has(next.requestId)
       ) {
@@ -106,27 +155,38 @@ export function useAgentManagement() {
   React.useEffect(() => {
     managedAgentsRef.current = managedAgentsQuery.data;
     channelsRef.current = channelsQuery.data;
-    if (managedAgentsQuery.data && channelsQuery.data) {
-      const buffered = bufferedRequestsRef.current.splice(0);
-      for (const candidate of buffered) {
+    ownedRelayAgentPubkeysRef.current = ownedRelayAgentPubkeys;
+    const buffered = bufferedRequestsRef.current.splice(0);
+    for (const candidate of buffered) {
+      const decision = classifyAgentManagementOrigin(
+        managedAgentsRef.current,
+        channelsRef.current,
+        candidate.agentPubkey,
+        candidate.request.request.channelId,
+        ownedRelayAgentPubkeysRef.current,
+      );
+      if (decision === "buffer") {
+        bufferedRequestsRef.current.push(candidate);
+      } else {
         acceptOwnedRequest(candidate.agentPubkey, candidate.request);
       }
     }
-  }, [channelsQuery.data, managedAgentsQuery.data]);
+  }, [channelsQuery.data, managedAgentsQuery.data, ownedRelayAgentPubkeys]);
 
   React.useEffect(
     () =>
       subscribeAgentManagementRequests((agentPubkey, next) => {
-        // Observer frames are owner-scoped and authenticated. Any managed agent
-        // this Desktop owns may draft a change; defer the ownership decision
-        // until the managed-agent query has initialized so ephemeral requests
-        // cannot disappear during startup.
+        // Observer frames are owner-scoped and authenticated. Any local or
+        // owner-attested relay agent may draft a change; defer the ownership
+        // decision until its ownership source has initialized so ephemeral
+        // requests cannot disappear during startup.
         if (
           classifyAgentManagementOrigin(
             managedAgentsRef.current,
             channelsRef.current,
             agentPubkey,
             next.request.channelId,
+            ownedRelayAgentPubkeysRef.current,
           ) === "buffer"
         ) {
           bufferedRequestsRef.current.push({ agentPubkey, request: next });


### PR DESCRIPTION
**Problem:** Owner-attested hosted agents can send valid encrypted agent-management drafts, but Desktop silently drops them because the review gate only recognises agents managed by that Desktop installation.

**What it does:** Desktop now recognises relay agents whose verified NIP-OA profile names the signed-in user as owner. The existing shared-channel check still applies, and drafts stay buffered until ownership data has fully resolved.

**Caveats:** The owner must still review and save the form. Unowned agents and agents outside a shared channel remain blocked.

### How to test

1. Open Desktop as the owner of a hosted relay agent, with both identities in the same channel.
2. From that agent, run `buzz agents draft-update --channel <uuid> --agent-name <name> --display-name <new-name>`.
3. Confirm Desktop opens the prefilled edit-agent form and makes no change until it is saved.
4. Repeat from an unowned agent or a channel the owner does not belong to, and confirm no form opens.

<details>
<summary>🤖 Agent notes</summary>

### Why it works

The management gate now applies the same verified owner-attestation source already used for owner-global observer ingestion. It preserves local-agent acceptance, requires channel co-membership, and waits through profile placeholder states so ephemeral drafts are not rejected during refresh races.

### Validation

- `pnpm test`: 3,517 passed
- `pnpm run typecheck`: passed
- `pnpm run build`: passed
- Biome on the three changed files: passed

### Review record

- 2026-07-26, Kimi for Coding, gap verification plus security, buffering and query-race review. Verdict: confirmed the gap and found one placeholder-data race. Resolved by buffering until real profile data arrives.
- 2026-07-26, OpenAI Codex gpt-5.5, security, buffering, query-race and correctness review. Initial verdict: the same placeholder-data race. Re-review after the fix: no actionable findings.

</details>
