### PR TITLE
Add Factory Droid as a known ACP runtime

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -98,6 +98,27 @@ buzz-acp
 Older installs that still expose `claude-code-acp` are also supported. `buzz-acp`
 treats both Claude ACP command names as the same zero-arg runtime.
 
+## Running with Factory Droid
+
+The [Factory droid CLI](https://docs.factory.ai/cli/getting-started/quickstart)
+speaks ACP natively — there is no adapter to install.
+
+```bash
+# Install the CLI
+curl -fsSL https://app.factory.ai/cli | sh
+
+# Sign in interactively once (`droid`), or use an API key
+export FACTORY_API_KEY="fk-..."
+
+export BUZZ_ACP_AGENT_COMMAND="droid"
+export BUZZ_ACP_AGENT_ARGS="exec,-o,acp"
+
+buzz-acp
+```
+
+Droid routes models server-side and takes its per-session settings over ACP
+(`session/set_config_option`), so there are no model/provider env vars to set.
+
 ## Configuration
 
 All configuration is via environment variables (or CLI flags — every env var has a matching flag).

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -16,6 +16,7 @@ pub(crate) use runtime_metadata::KnownAcpRuntime;
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
+const FACTORY_DROID_AVATAR_URL: &str = "https://avatars.githubusercontent.com/u/131064358?v=4";
 const BUZZ_AGENT_AVATAR_URL: &str =
     "https://raw.githubusercontent.com/block/buzz/refs/heads/main/crates/buzz-agent/buzz-agent.png";
 
@@ -161,6 +162,43 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         login_hint: Some("Run `codex login` to authenticate."),
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
         auth_probe_args: Some(&["codex", "login", "status"]),
+    },
+    KnownAcpRuntime {
+        id: "factory",
+        label: "Factory Droid",
+        // `droid` speaks ACP natively (`droid exec -o acp`), so the CLI is both
+        // the adapter and the underlying binary — no npm adapter to install and
+        // no separate `underlying_cli` that could report CliMissing.
+        commands: &["droid"],
+        aliases: &["factory-droid", "factorydroid", "droid"],
+        avatar_url: FACTORY_DROID_AVATAR_URL,
+        mcp_command: None,
+        mcp_hooks: false,
+        underlying_cli: None,
+        cli_install_commands: &["curl -fsSL https://app.factory.ai/cli | sh"],
+        cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://app.factory.ai/cli/windows | iex\""],
+        adapter_install_commands: &[],
+        cli_install_instructions_url: "https://docs.factory.ai/cli/getting-started/quickstart",
+        adapter_install_instructions_url: "",
+        cli_install_hint: "Buzz requires the Factory droid CLI; run `droid` once to sign in, or set FACTORY_API_KEY.",
+        adapter_install_hint: "",
+        skill_dir: Some(".factory/skills"),
+        supports_acp_model_switching: true,
+        // Droid takes its session settings over ACP (`session/set_config_option`)
+        // and routes models server-side, so there is no model/provider env var.
+        model_env_var: None,
+        provider_env_var: None,
+        provider_locked: true,
+        default_env: &[],
+        config_file_path: Some("~/.factory/settings.json"),
+        config_file_format: Some("json"),
+        supports_acp_native_config: true,
+        thinking_env_var: None,
+        max_tokens_env_var: None,
+        context_limit_env_var: None,
+        required_normalized_fields: &[],
+        login_hint: None,
+        auth_probe_args: None,
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -349,6 +387,11 @@ pub use overrides::{apply_agent_command_update, create_time_agent_command_overri
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
+        "droid" | "factory" | "factory-droid" | "factorydroid" => Some(vec![
+            "exec".to_string(),
+            "-o".to_string(),
+            "acp".to_string(),
+        ]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,
@@ -370,8 +413,10 @@ pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<Strin
         return default_args;
     }
 
-    if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") && default_args.is_empty()
-    {
+    // A bare `acp` arg is the legacy shape every harness record carried before
+    // per-runtime defaults existed. It only means "speak ACP", so let the
+    // runtime's own default argv decide how to ask for that.
+    if normalized.len() == 1 && normalized[0].eq_ignore_ascii_case("acp") {
         return default_args;
     }
 

--- a/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
@@ -120,5 +120,19 @@ mod tests {
         );
         assert!(codex.adapter_install_instructions_url.contains("codex-acp"));
         assert!(codex.cli_install_hint.contains("desktop app alone"));
+
+        let factory = known_acp_runtime_exact("factory").unwrap();
+        assert_eq!(
+            factory.cli_install_instructions_url,
+            "https://docs.factory.ai/cli/getting-started/quickstart"
+        );
+        // Native ACP: there is no adapter to point at.
+        assert!(factory.adapter_install_instructions_url.is_empty());
+        assert!(factory.adapter_install_hint.is_empty());
+        assert!(factory.cli_install_hint.contains("FACTORY_API_KEY"));
+        assert!(factory
+            .cli_install_commands_windows
+            .iter()
+            .any(|command| command.contains("app.factory.ai/cli/windows")));
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -8,7 +8,7 @@ use super::{
     is_login_shell_path_uninit, is_safe_nvm_tag, managed_agent_avatar_url, normalize_agent_args,
     parse_semver_tag, probe_codex_acp_major_version, record_agent_command,
     refresh_login_shell_path, BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL,
-    GOOSE_AVATAR_URL,
+    FACTORY_DROID_AVATAR_URL, GOOSE_AVATAR_URL,
 };
 use crate::managed_agents::AcpAvailabilityStatus;
 
@@ -81,6 +81,66 @@ fn resolves_buzz_agent_avatar() {
     assert_eq!(
         managed_agent_avatar_url("/usr/local/bin/buzz-agent"),
         Some(BUZZ_AGENT_AVATAR_URL.to_string())
+    );
+}
+
+#[test]
+fn resolves_factory_droid_avatar_for_command_paths_and_aliases() {
+    assert_eq!(
+        managed_agent_avatar_url("droid"),
+        Some(FACTORY_DROID_AVATAR_URL.to_string())
+    );
+    assert_eq!(
+        managed_agent_avatar_url("/opt/homebrew/bin/droid"),
+        Some(FACTORY_DROID_AVATAR_URL.to_string())
+    );
+    assert_eq!(
+        managed_agent_avatar_url("factory-droid"),
+        Some(FACTORY_DROID_AVATAR_URL.to_string())
+    );
+    assert_eq!(
+        managed_agent_avatar_url(r"C:\Tools\droid.exe"),
+        Some(FACTORY_DROID_AVATAR_URL.to_string())
+    );
+}
+
+#[test]
+fn factory_droid_defaults_to_native_acp_argv() {
+    let expected = vec!["exec".to_string(), "-o".to_string(), "acp".to_string()];
+
+    assert_eq!(normalize_agent_args("droid", Vec::new()), expected);
+    assert_eq!(
+        normalize_agent_args("/opt/homebrew/bin/droid", Vec::new()),
+        expected
+    );
+    // Legacy records carry a bare `acp` arg; `droid acp` is not a command, so
+    // it must resolve to the runtime's own ACP argv rather than spawn as-is.
+    assert_eq!(normalize_agent_args("droid", vec!["acp".into()]), expected);
+    // An explicit multi-arg pin is still the operator's call.
+    assert_eq!(
+        normalize_agent_args("droid", vec!["exec".into(), "-o".into(), "json".into()]),
+        vec!["exec".to_string(), "-o".to_string(), "json".to_string()]
+    );
+}
+
+#[test]
+fn factory_droid_needs_no_separate_adapter() {
+    let factory = crate::managed_agents::known_acp_runtime_exact("factory")
+        .expect("factory runtime should be registered");
+
+    assert_eq!(factory.commands, &["droid"]);
+    assert!(factory.underlying_cli.is_none());
+    assert!(factory.adapter_install_commands.is_empty());
+    assert!(!factory.cli_install_commands.is_empty());
+    // Availability must not depend on a second binary being present.
+    assert_eq!(
+        classify_runtime(
+            Some(("droid", std::path::PathBuf::from("/opt/homebrew/bin/droid"))),
+            factory.underlying_cli,
+            false,
+        )
+        .0,
+        AcpAvailabilityStatus::Available
     );
 }
 


### PR DESCRIPTION
## Summary

Registers **Factory Droid** as a known ACP runtime in the desktop app's managed-agent catalog, alongside goose, codex, claude, and buzz-agent. Factory Droid speaks ACP natively (`droid exec -o acp`), so it needs no npm adapter and no separate `underlying_cli`.

## Changes

- **`discovery.rs`**
  - New `FACTORY_DROID_AVATAR_URL` constant (GitHub org avatar for Factory-AI).
  - New `factory` entry in `KNOWN_ACP_RUNTIMES`:
    - `commands: ["droid"]`, aliases `factory-droid` / `factorydroid` / `droid`
    - `underlying_cli: None`, empty `adapter_install_commands` (the `droid` binary is both CLI and ACP surface)
    - `cli_install_commands` for Unix (`curl -fsSL https://app.factory.ai/cli | sh`) and Windows (`irm https://app.factory.ai/cli/windows | iex`)
    - `skill_dir: ".factory/skills"`, `config_file_path: "~/.factory/settings.json"`
    - `provider_locked: true`, no model/provider env vars (droid routes models server-side and takes session settings over ACP via `session/set_config_option`)
    - `supports_acp_native_config: true`, no `auth_probe_args` (auth is interactive `droid` login or `FACTORY_API_KEY`)
  - `default_agent_args`: `droid` / `factory` / `factory-droid` / `factorydroid` → `["exec", "-o", "acp"]`
  - `normalize_agent_args`: generalized the bare-`acp` reset rule to drop the `default_args.is_empty()` guard. A lone `acp` arg now falls back to the runtime's default argv regardless of whether defaults are empty. This prevents legacy `droid acp` records from spawning a non-existent subcommand while keeping goose/claude/codex/buzz-agent behavior identical (their defaults are `["acp"]` or `[]`, so the result is unchanged).

- **`discovery/tests.rs`** — three new tests:
  - `resolves_factory_droid_avatar_for_command_paths_and_aliases`
  - `factory_droid_defaults_to_native_acp_argv` (default argv, legacy bare-`acp` normalization, explicit multi-arg pin passthrough)
  - `factory_droid_needs_no_separate_adapter` (no `underlying_cli`, empty adapter install commands, `Available` classification)

- **`discovery/runtime_metadata.rs`** — extended `vendor_metadata_distinguishes_cli_and_adapter_guidance` with `factory` assertions (install URL, empty adapter fields, `FACTORY_API_KEY` hint, Windows install command).

- **`crates/buzz-acp/README.md`** — new "Running with Factory Droid" section documenting install, `FACTORY_API_KEY`, and `BUZZ_ACP_AGENT_COMMAND`/`ARGS` for the harness.

## Verification

- `cargo check --manifest-path desktop/src-tauri/Cargo.toml` — compiles clean
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml managed_agents::discovery` — 79 passed, 0 failed (incl. 3 new tests + vendor metadata test)
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check` — clean
- Pre-push hooks (rust-tests, desktop-tauri-test, branch-skew) — all passed

## Notes

- Droid was verified to speak ACP natively via a live `droid exec -o acp` initialize handshake: `agentInfo.name: "@factory/cli"`, `title: "Factory Droid"`, auth methods `device-pairing` and `factory-api-key`.
- No changes to onboarding order or `KNOWN_AGENT_BINARIES`; Factory Droid is selectable in the agent creation dialog but not added to the default onboarding flow.
