### PR TITLE
fix(core): keep required p tag on self-owned engrams

### DIFF
--- a/crates/buzz-core/src/engram.rs
+++ b/crates/buzz-core/src/engram.rs
@@ -467,6 +467,11 @@ pub fn build_event(
 
     EventBuilder::new(Kind::Custom(KIND_AGENT_ENGRAM as u16), ciphertext)
         .tags(tags)
+        // NIP-AE requires exactly one `p` tag naming the owner. When an
+        // identity keeps memory for itself (agent == owner), the builder's
+        // default self-tagging filter would silently strip that tag and
+        // produce an envelope that fails head selection.
+        .allow_self_tagging()
         .custom_created_at(nostr::Timestamp::from(created_at))
         .sign_with_keys(agent_keys)
         .map_err(|e| EngramError::Sign(e.to_string()))
@@ -1045,5 +1050,34 @@ mod tests {
             extract_refs("I refer to [[mem/me]] from inside mem/me's value"),
             vec!["mem/me".to_string()]
         );
+    }
+
+    #[test]
+    fn self_owned_engram_keeps_required_p_tag() {
+        // An identity keeping memory for itself (agent == owner) must still
+        // produce a NIP-AE-valid envelope: the builder's self-tagging filter
+        // silently stripped the required `p` tag before this was pinned.
+        let keys = Keys::generate();
+        let me = keys.public_key();
+        let body = Body::Memory {
+            slug: "mem/self".to_string(),
+            value: Some("note to self".to_string()),
+        };
+        let event = build_event(&keys, &me, &body, 1_700_000_000).expect("event builds");
+        let p_values: Vec<String> = event
+            .tags
+            .iter()
+            .filter(|tag| tag.kind() == nostr::TagKind::p())
+            .filter_map(|tag| tag.content().map(str::to_string))
+            .collect();
+        assert_eq!(
+            p_values,
+            vec![me.to_hex()],
+            "exactly one p tag naming the owner"
+        );
+
+        let decoded = validate_and_decrypt(&event, &me, &me, keys.secret_key(), &me)
+            .expect("self-owned engram validates and decrypts");
+        assert_eq!(decoded, body);
     }
 }


### PR DESCRIPTION
## Summary

`engram::build_event` silently produced NIP-AE-invalid envelopes whenever an
identity keeps memory for itself (`agent == owner`): the required owner `p`
tag was missing from the signed event.

Root cause: nostr's `EventBuilder` strips self-referencing `p` tags by
default (an anti-self-notification convention). NIP-AE's envelope rules
require **exactly one `p` tag naming the owner** (`docs/nips/NIP-AE.md`,
*Event envelope*), and head selection queries filter on `["p", pubkey_o]` —
so a self-owned write was accepted by relays but invisible to every read:
`buzz mem set` reported success while `buzz mem get`/`ls` returned nothing.

## Fix

Call `.allow_self_tagging()` in `build_event`. One line, plus a regression
test pinning the self-owned round trip (envelope carries exactly one `p` tag
naming the owner; `validate_and_decrypt` succeeds).

Distinct-key behavior is unaffected — the NIP-AE reference test vectors and
the full engram suite pass unchanged (35 tests).

## How this was found

Exercising NIP-AE from a single-identity deployment (a personal relay node
whose owner keeps engrams under its own key, rather than the hosted
agent-serves-owner pairing). NIP-AE's shapes work well for that case — the
spec doesn't forbid `pubkey_a == pubkey_o`, and the NIP-44 conversation key
is well-defined for self — this envelope bug was the only obstacle. If
maintainers would prefer the spec to state explicitly that self-owned pairs
are supported, happy to follow up with a one-line clarification to
`docs/nips/NIP-AE.md`.

## Testing

- `cargo test -p buzz-core engram` — 35 passed, including the new
  `self_owned_engram_keeps_required_p_tag` regression test
- Verified live: self-owned `buzz mem set`/`get`/`ls` round-trips against a
  relay after the fix; before it, `set` succeeded and `get` returned
  not-found

🤖 Generated with [Claude Code](https://claude.com/claude-code)
