### PR TITLE
fix(build): keep shell scripts LF so Windows checkouts do not break bash

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must keep LF: with core.autocrlf=true on Windows they check out
+# as CRLF and bash fails with `$'\r': command not found`.
+*.sh text eol=lf


### PR DESCRIPTION
## Summary

The repo has no `.gitattributes`. With `core.autocrlf=true` — the Git for Windows
default — every checkout rewrites `*.sh` with CRLF, and running them under Git Bash
then fails with `$'\r': command not found`. This breaks the scripts that `just`
recipes and the dev setup depend on (`scripts/instance-env.sh`,
`scripts/seed-local-community.sh`, `deploy/compose/run.sh`, and the rest), and it
recurs after *every* `checkout` / `pull`, so a local fix does not hold.

Adds a single rule pinning `*.sh` to LF.

Deliberately **not** `* text=auto`: that would renormalize the entire working tree
(~2800 files here) and invalidate every cargo and vite build cache for anyone who
already has CRLF checked out. Scoping to `*.sh` fixes the files that actually break
and is a no-op on macOS and Linux.

### Related issue

None found — searched open and closed issues and PRs for `gitattributes`, `CRLF`,
and `line endings`.

### Testing

On Windows 11 with `core.autocrlf=true`, before the change:

```
$ rm scripts/instance-env.sh && git checkout -- scripts/instance-env.sh
$ grep -cU $'\r' scripts/instance-env.sh
71                      # CRLF -> bash fails
```

After the change, same steps across every tracked `*.sh`:

```
$ for f in $(git ls-files '*.sh'); do grep -qU $'\r' "$f" && echo "CRLF: $f"; done
                        # no output — all LF
```

`git status` stays clean; no other file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)