### PR TITLE
feat(desktop): add owner agent health view

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
         "**/welcome-agent-modal-screenshots.spec.ts",
         "**/local-archive-screenshots.spec.ts",
         "**/agent-readiness-screenshots.spec.ts",
+        "**/agent-health-view.spec.ts",
         "**/agent-error-state-screenshots.spec.ts",
         "**/edit-agent.spec.ts",
         "**/doctor-cta-screenshots.spec.ts",

--- a/desktop/src/features/agents/lib/agentHealth.test.mjs
+++ b/desktop/src/features/agents/lib/agentHealth.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildAgentHealthSnapshot } from "./agentHealth.ts";
+
+const agent = {
+  pubkey: "a".repeat(64),
+  name: "Hermes",
+  personaId: null,
+  relayUrl: "wss://buzz.example",
+  acpCommand: "buzz-acp",
+  agentCommand: "codex-acp",
+  agentCommandOverride: null,
+  agentArgs: [],
+  mcpCommand: "",
+  turnTimeoutSeconds: 320,
+  idleTimeoutSeconds: null,
+  maxTurnDurationSeconds: null,
+  parallelism: 1,
+  systemPrompt: "Ship carefully.",
+  avatarUrl: "https://example.com/hermes.jpg",
+  model: "gpt-5",
+  modelSource: "definition",
+  provider: "openai",
+  personaOutOfDate: false,
+  personaOrphaned: false,
+  needsRestart: false,
+  envVars: {},
+  status: "running",
+  pid: 42,
+  createdAt: "2026-07-26T10:00:00Z",
+  updatedAt: "2026-07-26T11:00:00Z",
+  lastStartedAt: "2026-07-26T12:00:00Z",
+  lastStoppedAt: null,
+  lastExitCode: null,
+  lastError: null,
+  lastErrorCode: null,
+  logPath: "/tmp/hermes.log",
+  startOnAppLaunch: true,
+  autoRestartOnConfigChange: true,
+  backend: { type: "local" },
+  backendAgentId: null,
+  respondTo: "owner-only",
+  respondToAllowlist: [],
+};
+
+test("buildAgentHealthSnapshot exposes known fields and honest contract gaps", () => {
+  const snapshot = buildAgentHealthSnapshot({
+    agent,
+    channels: [{ id: "system", name: "System" }],
+    channelsError: false,
+    channelsLoading: false,
+    presenceLoaded: true,
+    presenceStatus: "online",
+  });
+
+  assert.equal(
+    snapshot.fields.find((field) => field.key === "runtime")?.value,
+    "codex-acp",
+  );
+  assert.equal(
+    snapshot.fields.find((field) => field.key === "channels")?.value,
+    "#System",
+  );
+  assert.equal(
+    snapshot.fields.find((field) => field.key === "configuration-version")
+      ?.availability,
+    "unavailable",
+  );
+  assert.match(
+    snapshot.fields.find((field) => field.key === "last-successful-mention")
+      ?.detail ?? "",
+    /does not currently persist/,
+  );
+});
+
+test("buildAgentHealthSnapshot distinguishes loading, unavailable, and warnings", () => {
+  const snapshot = buildAgentHealthSnapshot({
+    agent: {
+      ...agent,
+      avatarUrl: null,
+      model: null,
+      provider: null,
+      personaOrphaned: true,
+      needsRestart: true,
+      lastError: "Authentication failed",
+      lastStartedAt: null,
+    },
+    channels: [],
+    channelsError: true,
+    channelsLoading: false,
+    presenceLoaded: false,
+    presenceStatus: undefined,
+  });
+
+  assert.equal(
+    snapshot.fields.find((field) => field.key === "channels")?.availability,
+    "unavailable",
+  );
+  assert.equal(
+    snapshot.fields.find((field) => field.key === "model")?.availability,
+    "unknown",
+  );
+  assert.deepEqual(
+    snapshot.warnings.map((warning) => warning.key),
+    ["persona-orphaned", "restart", "last-error"],
+  );
+});

--- a/desktop/src/features/agents/lib/agentHealth.ts
+++ b/desktop/src/features/agents/lib/agentHealth.ts
@@ -1,0 +1,195 @@
+import type {
+  ManagedAgent,
+  PresenceStatus,
+  RespondToMode,
+} from "@/shared/api/types";
+import type { ProfileChannelLink } from "@/features/profile/ui/UserProfilePanelUtils";
+
+export type AgentHealthAvailability = "available" | "unknown" | "unavailable";
+
+export type AgentHealthField = {
+  key: string;
+  label: string;
+  value: string;
+  availability: AgentHealthAvailability;
+  detail?: string;
+};
+
+export type AgentHealthWarning = {
+  key: string;
+  label: string;
+  severity: "warning" | "error";
+};
+
+export type AgentHealthSnapshot = {
+  fields: AgentHealthField[];
+  warnings: AgentHealthWarning[];
+};
+
+function formatRespondTo(mode: RespondToMode): string {
+  if (mode === "owner-only") return "Owner only";
+  if (mode === "allowlist") return "Selected people";
+  return "Anyone";
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return "No run recorded";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return date.toLocaleString();
+}
+
+export function buildAgentHealthSnapshot({
+  agent,
+  channels,
+  channelsError,
+  channelsLoading,
+  presenceLoaded,
+  presenceStatus,
+}: {
+  agent: ManagedAgent;
+  channels: ProfileChannelLink[];
+  channelsError: boolean;
+  channelsLoading: boolean;
+  presenceLoaded: boolean;
+  presenceStatus: PresenceStatus | undefined;
+}): AgentHealthSnapshot {
+  const channelField: AgentHealthField = channelsError
+    ? {
+        key: "channels",
+        label: "Channel memberships",
+        value: "Unavailable",
+        availability: "unavailable",
+        detail: "Buzz could not load channel memberships.",
+      }
+    : channelsLoading
+      ? {
+          key: "channels",
+          label: "Channel memberships",
+          value: "Loading",
+          availability: "unknown",
+        }
+      : {
+          key: "channels",
+          label: "Channel memberships",
+          value:
+            channels.length > 0
+              ? channels.map((channel) => `#${channel.name}`).join(", ")
+              : "None",
+          availability: "available",
+        };
+
+  const warnings: AgentHealthWarning[] = [];
+  if (agent.personaOrphaned) {
+    warnings.push({
+      key: "persona-orphaned",
+      label: "Linked configuration is missing",
+      severity: "error",
+    });
+  }
+  if (agent.needsRestart) {
+    warnings.push({
+      key: "restart",
+      label: "Restart required to apply saved configuration",
+      severity: "warning",
+    });
+  }
+  if (agent.personaOutOfDate) {
+    warnings.push({
+      key: "persona-out-of-date",
+      label: "Agent was created from an older configuration",
+      severity: "warning",
+    });
+  }
+  if (agent.lastError) {
+    warnings.push({
+      key: "last-error",
+      label: agent.lastError,
+      severity: "error",
+    });
+  }
+
+  return {
+    fields: [
+      {
+        key: "avatar",
+        label: "Avatar",
+        value: agent.avatarUrl ? "Configured" : "Not configured",
+        availability: agent.avatarUrl ? "available" : "unavailable",
+      },
+      {
+        key: "saved-instructions",
+        label: "Saved instructions",
+        value: agent.systemPrompt?.trim() ? "Configured" : "Not configured",
+        availability: "available",
+      },
+      {
+        key: "configuration-version",
+        label: "Configuration version",
+        value: "Unavailable",
+        availability: "unavailable",
+        detail: "Managed agents do not currently expose a saved version.",
+      },
+      {
+        key: "configuration-updated",
+        label: "Configuration updated",
+        value: formatTimestamp(agent.updatedAt),
+        availability: "available",
+      },
+      {
+        key: "runtime",
+        label: "Runtime",
+        value: agent.agentCommand || "Unknown",
+        availability: agent.agentCommand ? "available" : "unknown",
+      },
+      {
+        key: "provider",
+        label: "Provider",
+        value: agent.provider || "Unknown",
+        availability: agent.provider ? "available" : "unknown",
+      },
+      {
+        key: "model",
+        label: "Model",
+        value: agent.model || "Unknown",
+        availability: agent.model ? "available" : "unknown",
+      },
+      {
+        key: "response-scope",
+        label: "Response access",
+        value: formatRespondTo(agent.respondTo),
+        availability: "available",
+      },
+      channelField,
+      {
+        key: "last-successful-mention",
+        label: "Last successful mention",
+        value: "Unavailable",
+        availability: "unavailable",
+        detail:
+          "Buzz does not currently persist a per-agent successful-mention timestamp.",
+      },
+      {
+        key: "last-run",
+        label: "Last run",
+        value: formatTimestamp(agent.lastStartedAt),
+        availability: agent.lastStartedAt ? "available" : "unknown",
+        detail: agent.lastStartedAt
+          ? "Most recent managed process start."
+          : "No managed process start has been recorded.",
+      },
+      {
+        key: "presence",
+        label: "Presence",
+        value: !presenceLoaded
+          ? "Loading"
+          : presenceStatus
+            ? presenceStatus[0]?.toUpperCase() + presenceStatus.slice(1)
+            : "Unknown",
+        availability:
+          presenceLoaded && presenceStatus ? "available" : "unknown",
+      },
+    ],
+    warnings,
+  };
+}

--- a/desktop/src/features/agents/ui/AgentHealthCard.tsx
+++ b/desktop/src/features/agents/ui/AgentHealthCard.tsx
@@ -1,0 +1,127 @@
+import { AlertTriangle, CheckCircle2, CircleHelp } from "lucide-react";
+
+import { buildAgentHealthSnapshot } from "@/features/agents/lib/agentHealth";
+import type { ManagedAgent, PresenceStatus } from "@/shared/api/types";
+import type { ProfileChannelLink } from "@/features/profile/ui/UserProfilePanelUtils";
+import { Badge } from "@/shared/ui/badge";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+
+export function AgentHealthCard({
+  agent,
+  channels,
+  channelsError,
+  channelsLoading,
+  presenceLoaded,
+  presenceStatus,
+}: {
+  agent: ManagedAgent;
+  channels: ProfileChannelLink[];
+  channelsError: boolean;
+  channelsLoading: boolean;
+  presenceLoaded: boolean;
+  presenceStatus: PresenceStatus | undefined;
+}) {
+  const snapshot = buildAgentHealthSnapshot({
+    agent,
+    channels,
+    channelsError,
+    channelsLoading,
+    presenceLoaded,
+    presenceStatus,
+  });
+
+  return (
+    <section className="space-y-3" data-testid="agent-health-card">
+      <div>
+        <h3 className="text-sm font-semibold text-foreground">Agent health</h3>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+          Owner-only configuration and runtime facts. Unknown and unavailable
+          values are never inferred.
+        </p>
+      </div>
+
+      {snapshot.warnings.length > 0 ? (
+        <div
+          className="space-y-2 rounded-2xl border border-amber-500/30 bg-amber-500/5 p-3"
+          data-testid="agent-health-warnings"
+        >
+          <p className="text-xs font-medium text-foreground">
+            Configuration warnings
+          </p>
+          {snapshot.warnings.map((warning) => (
+            <div className="flex items-start gap-2" key={warning.key}>
+              <AlertTriangle
+                className={
+                  warning.severity === "error"
+                    ? "mt-0.5 h-4 w-4 shrink-0 text-destructive"
+                    : "mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
+                }
+              />
+              <p className="text-xs leading-5 text-muted-foreground">
+                {warning.label}
+              </p>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div
+          className="flex items-center gap-2 rounded-2xl bg-muted/20 px-4 py-3"
+          data-testid="agent-health-no-warnings"
+        >
+          <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+          <p className="text-xs text-muted-foreground">
+            No configuration warnings reported.
+          </p>
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-2xl bg-muted/20">
+        {snapshot.fields.map((field) => (
+          <div
+            className="flex items-start gap-3 border-b border-border/40 px-4 py-3 last:border-b-0"
+            data-availability={field.availability}
+            data-testid={`agent-health-${field.key}`}
+            key={field.key}
+          >
+            {field.key === "avatar" ? (
+              <UserAvatar
+                avatarUrl={agent.avatarUrl}
+                className="shrink-0"
+                displayName={agent.name}
+                size="sm"
+              />
+            ) : (
+              <CircleHelp className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+            )}
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-xs font-medium text-foreground">
+                  {field.label}
+                </p>
+                {field.availability !== "available" ? (
+                  <Badge
+                    variant={
+                      field.availability === "unavailable"
+                        ? "secondary"
+                        : "outline"
+                    }
+                  >
+                    {field.availability}
+                  </Badge>
+                ) : null}
+              </div>
+              <p className="mt-0.5 wrap-break-word text-sm text-muted-foreground">
+                {field.value}
+              </p>
+              {field.detail ? (
+                <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                  {field.detail}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -791,6 +791,7 @@ export function UserProfilePanel({
           channelCount={profileChannels.length}
           channelIdToName={channelIdToName}
           channels={profileChannels}
+          channelsError={channelsQuery.isError}
           channelsLoading={channelsQuery.isLoading}
           displayName={displayName}
           followMutation={followMutation}
@@ -824,6 +825,7 @@ export function UserProfilePanel({
           onOpenInstructions={() => setView("instructions")}
           onTabChange={setTab}
           onOpenDm={onOpenDm}
+          presenceLoaded={presenceQuery.isSuccess}
           presenceStatus={presenceStatus}
           profile={profile}
           pubkey={effectivePubkey}

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 import { MemorySection } from "@/features/agent-memory/ui/MemorySection";
 import { useAgentWorking } from "@/features/agents/agentWorkingSignal";
 import { getManagedAgentPrimaryActionLabel } from "@/features/agents/lib/managedAgentControlActions";
+import { AgentHealthCard } from "@/features/agents/ui/AgentHealthCard";
 import { ManagedAgentLogPanel } from "@/features/agents/ui/ManagedAgentLogPanel";
 import { AgentConfigPanel } from "@/features/agents/ui/AgentConfigPanel";
 import { getPresenceLabel } from "@/features/presence/lib/presence";
@@ -73,6 +74,7 @@ export type ProfileSummaryViewProps = {
   channelIdToName: Record<string, string>;
   channels: ProfileChannelLink[];
   channelsLoading: boolean;
+  channelsError: boolean;
   displayName: string;
   followMutation: ReturnType<typeof useFollowMutation>;
   canInstantiateAgent: boolean;
@@ -105,6 +107,7 @@ export type ProfileSummaryViewProps = {
   onOpenInstructions: () => void;
   onTabChange: (tab: ProfilePanelTab, options?: { replace?: boolean }) => void;
   onOpenDm?: (pubkeys: string[]) => Promise<void> | void;
+  presenceLoaded: boolean;
   presenceStatus: "online" | "away" | "offline" | undefined;
   profile: ReturnType<typeof useUserProfileQuery>["data"];
   pubkey: string | null;
@@ -186,6 +189,7 @@ export function ProfileSummaryView({
   channelIdToName,
   channels,
   channelsLoading,
+  channelsError,
   displayName,
   followMutation,
   canInstantiateAgent,
@@ -218,6 +222,7 @@ export function ProfileSummaryView({
   onOpenInstructions,
   onTabChange,
   onOpenDm,
+  presenceLoaded,
   presenceStatus,
   profile,
   pubkey,
@@ -414,6 +419,16 @@ export function ProfileSummaryView({
           ) : null}
           {activeTab === "runtime" ? (
             <>
+              {isOwner === true && managedAgent !== undefined ? (
+                <AgentHealthCard
+                  agent={managedAgent}
+                  channels={channels}
+                  channelsError={channelsError}
+                  channelsLoading={channelsLoading}
+                  presenceLoaded={presenceLoaded}
+                  presenceStatus={presenceStatus}
+                />
+              ) : null}
               <ProfileRuntimeTabContent
                 agentInstruction={agentInstruction}
                 autoRestartEnabled={

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -69,6 +69,10 @@ type MockManagedAgentSeed = {
   pubkey: string;
   name: string;
   avatarUrl?: string | null;
+  agentCommand?: string;
+  systemPrompt?: string | null;
+  model?: string | null;
+  provider?: string | null;
   personaId?: string | null;
   status?: RawManagedAgent["status"];
   channelNames?: string[];
@@ -1987,16 +1991,17 @@ function buildSeededManagedAgent(seed: MockManagedAgentSeed): MockManagedAgent {
     persona_id: seed.personaId ?? null,
     relay_url: DEFAULT_RELAY_WS_URL,
     acp_command: "buzz-acp",
-    agent_command: "goose",
+    agent_command: seed.agentCommand ?? "goose",
     agent_args: ["acp"],
     mcp_command: "",
     turn_timeout_seconds: 320,
     idle_timeout_seconds: null,
     max_turn_duration_seconds: null,
     parallelism: 1,
-    system_prompt: null,
+    system_prompt: seed.systemPrompt ?? null,
     avatar_url: seed.avatarUrl ?? null,
-    model: null,
+    model: seed.model ?? null,
+    provider: seed.provider ?? null,
     env_vars: {},
     status,
     pid: status === "running" ? 42000 + mockManagedAgents.length : null,

--- a/desktop/tests/e2e/agent-health-view.spec.ts
+++ b/desktop/tests/e2e/agent-health-view.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+import { waitForAnimations } from "../helpers/animations";
+
+const SHOTS = "test-results/agent-health-view";
+const AGENT = {
+  pubkey: TEST_IDENTITIES.outsider.pubkey,
+  name: "Hermes",
+  avatarUrl: "https://api.dicebear.com/9.x/initials/svg?seed=Hermes",
+  agentCommand: "codex-acp",
+  systemPrompt: "Own engineering and infrastructure work.",
+  model: "gpt-5",
+  provider: "openai",
+  status: "running" as const,
+  respondTo: "owner-only" as const,
+};
+
+async function openHealthCard(
+  page: import("@playwright/test").Page,
+  viewport: { width: number; height: number },
+) {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("open-agents-view").click();
+  const agentButton = page.getByRole("button", {
+    name: `${AGENT.name} agent profile`,
+  });
+  await expect(agentButton).toBeVisible({ timeout: 10_000 });
+  await agentButton.click();
+  const panel = page.getByTestId("user-profile-panel");
+  await expect(panel).toBeVisible();
+  await panel.getByRole("tab", { name: "Runtime" }).click();
+  await expect(panel.getByTestId("agent-health-card")).toBeVisible();
+  await page.setViewportSize(viewport);
+  return panel;
+}
+
+test.describe("agent health view", () => {
+  test("390px loading and empty memberships remain explicit", async ({
+    page,
+  }) => {
+    await installMockBridge(page, {
+      agentListDelayMs: 150,
+      channelsReadDelayMs: 1_500,
+      managedAgents: [{ ...AGENT, model: null, provider: null }],
+    });
+
+    const panel = await openHealthCard(page, { width: 390, height: 844 });
+    await expect(panel.getByTestId("agent-health-channels")).toContainText(
+      "Loading",
+    );
+    await expect(panel.getByTestId("agent-health-model")).toHaveAttribute(
+      "data-availability",
+      "unknown",
+    );
+    await waitForAnimations(page);
+    await panel.screenshot({ path: `${SHOTS}/390-loading-partial.png` });
+
+    await expect(panel.getByTestId("agent-health-channels")).toContainText(
+      "None",
+      { timeout: 5_000 },
+    );
+    await waitForAnimations(page);
+    await panel.screenshot({ path: `${SHOTS}/390-empty.png` });
+  });
+
+  test("768px channel error is unavailable, not empty", async ({ page }) => {
+    await installMockBridge(page, {
+      channelsReadError: "membership query unavailable",
+      managedAgents: [AGENT],
+    });
+
+    const panel = await openHealthCard(page, { width: 768, height: 900 });
+    const channels = panel.getByTestId("agent-health-channels");
+    await expect(channels).toHaveAttribute("data-availability", "unavailable");
+    await expect(channels).toContainText("Buzz could not load");
+    await waitForAnimations(page);
+    await panel.screenshot({ path: `${SHOTS}/768-error.png` });
+  });
+
+  test("1280px populated state and warnings render together", async ({
+    page,
+  }) => {
+    await installMockBridge(page, {
+      managedAgents: [
+        {
+          ...AGENT,
+          channelNames: ["engineering", "agents"],
+          needsRestart: true,
+          lastError: "Provider authentication needs attention",
+        },
+      ],
+    });
+
+    const panel = await openHealthCard(page, { width: 1280, height: 900 });
+    await expect(panel.getByTestId("agent-health-provider")).toContainText(
+      "openai",
+    );
+    await expect(panel.getByTestId("agent-health-model")).toContainText(
+      "gpt-5",
+    );
+    await expect(panel.getByTestId("agent-health-channels")).toContainText(
+      "#engineering",
+    );
+    await expect(panel.getByTestId("agent-health-warnings")).toContainText(
+      "Restart required",
+    );
+    await expect(
+      panel.getByTestId("agent-health-last-successful-mention"),
+    ).toHaveAttribute("data-availability", "unavailable");
+    await waitForAnimations(page);
+    await panel.screenshot({ path: `${SHOTS}/1280-populated-warnings.png` });
+  });
+});

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -46,6 +46,11 @@ type MockCommandAvailability = {
 type MockManagedAgentSeed = {
   pubkey: string;
   name: string;
+  avatarUrl?: string | null;
+  agentCommand?: string;
+  systemPrompt?: string | null;
+  model?: string | null;
+  provider?: string | null;
   personaId?: string | null;
   status?: "running" | "stopped" | "deployed" | "not_deployed";
   channelNames?: string[];

--- a/docs/agent-health-view.md
+++ b/docs/agent-health-view.md
@@ -1,0 +1,26 @@
+# Agent health view
+
+The owner-facing health card is a projection of data Buzz already owns. It
+does not add a second runtime capability table or infer health from names.
+
+Current sources:
+
+- managed-agent summary: avatar configuration, saved instructions presence,
+  configuration update time, runtime, provider, model, response access, process
+  start time, and configuration warnings;
+- channel query: current visible channel memberships;
+- presence query: current relay presence.
+
+Known contract gaps are shown as `Unavailable`:
+
+- managed-agent configuration has an update timestamp but no saved version;
+- Buzz does not persist a per-agent timestamp for the last successful mention.
+
+`Last run` is explicitly the latest managed process start. It is not presented
+as the latest successful turn. A future turn-history contract should replace
+that projection rather than silently changing its meaning.
+
+This is a focused first slice of the broader readiness manifest proposed in
+issue #2931. Runtime capabilities, authentication readiness, observer health,
+effective permissions, and tool risk classification remain outside this view
+until their authoritative contracts are wired through.


### PR DESCRIPTION
## Summary

- add an owner-only agent health card to the managed-agent Runtime tab
- project authoritative avatar, saved-instruction state, configuration timestamp, runtime, provider, model, response access, memberships, process start, presence, and warnings
- show configuration version and last successful mention as explicitly unavailable instead of inferring them
- document the current source contracts and add unit plus responsive Playwright coverage

## Verification

- `just ci`
- `cd desktop && pnpm build:e2e && pnpm exec playwright test tests/e2e/agent-health-view.spec.ts`
- visual review at 390px, 768px, and 1280px across loading, empty, error, partially known, populated, and warning states

## Known contract gaps

- managed agents do not expose a saved configuration version
- Buzz does not persist a per-agent successful-mention timestamp
- `Last run` is labeled and documented as the latest managed process start

## Origin

Buzz thread: `buzz://message?channel=4e4cba92-66fe-4785-b7c7-bc1c8941e180&id=556453ba93d875536c3926269e5266e044f4aafb02c544e09d27a7e4e269439b`

