### PR TITLE
fix(workflow): reject over-long delay durations at definition time

### DIFF
--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -670,10 +670,6 @@ pub async fn dispatch_action(
 
         Delay { duration } => {
             let secs = parse_duration_secs(duration)?;
-            // Cap delay at 270 seconds (4.5 minutes) — must be less than default_timeout_secs (300s)
-            // to avoid non-deterministic StepTimeout. Long delays (hours/days)
-            // should use the scheduled resume pattern (future work: WF-09).
-            const MAX_DELAY_SECS: u64 = 270;
             if secs > MAX_DELAY_SECS {
                 return Err(WorkflowError::InvalidDefinition(format!(
                     "delay exceeds maximum of {MAX_DELAY_SECS} seconds (got {secs}s); \
@@ -698,6 +694,16 @@ pub async fn dispatch_action(
 fn generate_approval_token(_run_id: Uuid, _step_id: &str) -> String {
     Uuid::new_v4().to_string()
 }
+
+/// Maximum delay a `delay` step may request, in seconds.
+///
+/// Must stay below `default_timeout_secs` (300s) so a delay cannot trip a
+/// non-deterministic `StepTimeout`. Long delays (hours/days) should use the
+/// scheduled resume pattern (future work: WF-09).
+///
+/// Exposed as `pub(crate)` so `schema.rs` can reject over-long delays at
+/// definition time instead of leaving them to fail on every run.
+pub(crate) const MAX_DELAY_SECS: u64 = 270;
 
 /// Parse a duration string like "5m", "1h", "30s" into seconds.
 ///

--- a/crates/buzz-workflow/src/schema.rs
+++ b/crates/buzz-workflow/src/schema.rs
@@ -139,9 +139,12 @@ pub enum ActionDef {
         #[serde(default)]
         timeout: Option<String>,
     },
-    /// Pause execution for a duration (e.g. `"5m"`, `"1h"`).
+    /// Pause execution for a duration (e.g. `"30s"`, `"4m"`).
+    ///
+    /// Capped at [`crate::executor::MAX_DELAY_SECS`] (270s). Longer delays are
+    /// rejected at definition time; use the scheduled resume pattern instead.
     Delay {
-        /// Duration string (e.g. `"5m"`, `"1h"`).
+        /// Duration string (e.g. `"30s"`, `"4m"`). Must not exceed 270s.
         duration: String,
     },
 }
@@ -189,6 +192,25 @@ impl WorkflowDef {
                     "duplicate step id: {}",
                     step.id
                 )));
+            }
+
+            // A delay the executor will always reject is worth catching here,
+            // otherwise the definition saves clean and then fails at the same
+            // step on every run.
+            if let ActionDef::Delay { duration } = &step.action {
+                let secs = crate::executor::parse_duration_secs(duration).map_err(|_| {
+                    WorkflowError::InvalidDefinition(format!(
+                        "step '{}': invalid delay duration '{duration}': expected a duration like '30s', '4m', or '90s'",
+                        step.id
+                    ))
+                })?;
+                if secs > crate::executor::MAX_DELAY_SECS {
+                    return Err(WorkflowError::InvalidDefinition(format!(
+                        "step '{}': delay '{duration}' exceeds the maximum of {}s; use the scheduled resume pattern for long delays",
+                        step.id,
+                        crate::executor::MAX_DELAY_SECS
+                    )));
+                }
             }
         }
 
@@ -345,7 +367,7 @@ mod tests {
             "  - id: react\n    action: add_reaction\n    emoji: white_check_mark\n",
             "  - id: hook\n    action: call_webhook\n    url: https://hooks.example.com/notify\n    method: POST\n",
             "  - id: approve\n    action: request_approval\n    from: '@manager'\n    message: Approve?\n    timeout: 4h\n",
-            "  - id: wait\n    action: delay\n    duration: 5m\n",
+            "  - id: wait\n    action: delay\n    duration: 4m\n",
         );
         let (def, _) = parse_yaml(yaml).expect("parse failed");
         assert_eq!(def.steps.len(), 7);
@@ -855,6 +877,39 @@ mod tests {
         // 30m = 1800s, well above the 60s minimum.
         let yaml = "name: Interval Schedule\ntrigger:\n  on: schedule\n  interval: 30m\nsteps:\n  - id: s1\n    action: send_message\n    text: tick\n";
         assert!(parse_yaml(yaml).is_ok(), "30m interval should be valid");
+    }
+
+    fn delay_yaml(duration: &str) -> String {
+        format!("name: Delay\ntrigger:\n  on: webhook\nsteps:\n  - id: wait\n    action: delay\n    duration: {duration}\n")
+    }
+
+    #[test]
+    fn validate_rejects_delay_above_the_executor_cap() {
+        // 5m = 300s and 1h = 3600s, both above MAX_DELAY_SECS. These used to
+        // save cleanly and then fail on every run.
+        for duration in ["5m", "1h", "271s"] {
+            let err = parse_yaml(&delay_yaml(duration)).unwrap_err();
+            assert!(
+                matches!(err, WorkflowError::InvalidDefinition(_)),
+                "delay {duration} should be rejected at definition time"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_accepts_delay_at_and_below_the_cap() {
+        for duration in ["30s", "4m", "270s"] {
+            assert!(
+                parse_yaml(&delay_yaml(duration)).is_ok(),
+                "delay {duration} should be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_unparseable_delay_duration() {
+        let err = parse_yaml(&delay_yaml("soon")).unwrap_err();
+        assert!(matches!(err, WorkflowError::InvalidDefinition(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- validate `delay` durations in `WorkflowDef::validate()` instead of leaving them to the executor
- reject durations over the 270s cap, and durations that don't parse, at definition time
- move `MAX_DELAY_SECS` out of the executor's match arm so schema and executor share one definition
- fix the doc comments, which used `"5m"` and `"1h"` as examples even though both are over the cap

## Why

`validate()` had no arm for action definitions, so a `delay` step's duration was never checked when a workflow was saved. The executor caps a delay at 270s (`executor.rs`), while the field's own doc comments gave `"5m"` (300s) and `"1h"` (3600s) as the examples. A workflow copying either one validated, saved, showed as enabled, then failed at the same step on every run, with the only signal being a run-time error the user has to go looking for.

`parse_all_action_types` pinned the broken case: it asserted that a definition with `duration: 5m` parses successfully.

The schedule trigger already validates this way. The `interval` branch calls `parse_duration_secs` and rejects sub-60s intervals with a comment explaining the runtime constraint behind it. This adds the same treatment one arm over.

Fixes #3021

## Notes

- Unparseable durations were also a run-time-only failure. They're rejected at save time now too.
- The error messages name the step id, since a workflow can have several delays.
- I left the 270s value alone. If the intent is that long delays should work, that's the scheduled resume pattern the executor comment mentions as WF-09, and a much bigger change. Validating at save time is worth having either way so nobody stores a workflow that can't run.
- `MAX_DELAY_SECS` is `pub(crate)`, matching `parse_duration_secs` next to it, which `schema.rs` already uses.

## Verification

- `cargo test -p buzz-workflow` — 152 passed, 0 failed
- `cargo clippy -p buzz-workflow --all-targets -- -D warnings` — clean
- `cargo fmt --check -p buzz-workflow` — clean

New tests cover rejection at `5m` / `1h` / `271s`, acceptance at `30s` / `4m` / `270s` (the boundary), and rejection of an unparseable duration.
