### PR TITLE
fix: p-tag the parent author on threaded replies (NIP-10)

### DIFF
--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -3885,6 +3885,8 @@ pub(crate) async fn post_failure_notice(
         Some(buzz_sdk::ThreadRef {
             root_event_id: root_id,
             parent_event_id: parent_id,
+            // System dead-letter notice, not a reply to a person.
+            parent_author: None,
         })
     });
     let builder =

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -611,12 +611,16 @@ async fn publish_setup_nudge(
         Some(ThreadRef {
             root_event_id: root_id,
             parent_event_id: root_id,
+            // Already p-tagged as the asker via the explicit mention below.
+            parent_author: None,
         })
     } else {
         // Top-level event: reply to the triggering event.
         Some(ThreadRef {
             root_event_id: triggering_event.id,
             parent_event_id: triggering_event.id,
+            // Already p-tagged as the asker via the explicit mention below.
+            parent_author: None,
         })
     };
 

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -77,9 +77,17 @@ async fn resolve_thread_ref(
         _ => parent_eid,
     };
 
+    // NIP-10 reply `p` tag: the parent event is already fetched, so its signer
+    // rides along and the reply notifies the author it replies to.
+    let parent_author = event
+        .get("pubkey")
+        .and_then(|v| v.as_str())
+        .and_then(|hex| nostr::PublicKey::parse(hex).ok());
+
     Ok(ThreadRef {
         root_event_id: root_eid,
         parent_event_id: parent_eid,
+        parent_author,
     })
 }
 

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -186,15 +186,37 @@ fn thread_tags(thread_ref: &ThreadRef, tags: &mut Vec<Tag>) -> Result<(), SdkErr
         tags.push(tag(&["e", &root, "", "root"])?);
         tags.push(tag(&["e", &parent, "", "reply"])?);
     }
+    // NIP-10: a reply SHOULD `p`-tag the author it replies to, so the parent
+    // author's `{"kinds":[9],"#p":[self]}` notification filter matches. Deduped
+    // against explicit mentions by `mention_tags`. A self-reply's `p` tag is
+    // scrubbed by nostr's default self-tag handling, which is what we want (no
+    // self-notification).
+    if let Some(author) = thread_ref.parent_author {
+        tags.push(tag(&["p", &author.to_hex()])?);
+    }
     Ok(())
 }
 
 /// Deduplicate and cap mentions, emitting p-tags.
+///
+/// Seeds its dedup set from `p` tags already on `tags` (e.g. a reply's parent
+/// author emitted by [`thread_tags`]) so an explicit mention of that same
+/// pubkey does not produce a duplicate `p` tag.
 fn mention_tags(mentions: &[&str], tags: &mut Vec<Tag>) -> Result<(), SdkError> {
     if mentions.len() > crate::mentions::MENTION_CAP {
         return Err(SdkError::TooManyMentions);
     }
-    let mut seen = std::collections::HashSet::new();
+    let mut seen: std::collections::HashSet<String> = tags
+        .iter()
+        .filter_map(|t| {
+            let s = t.as_slice();
+            if s.first().map(String::as_str) == Some("p") {
+                s.get(1).map(|v| v.to_ascii_lowercase())
+            } else {
+                None
+            }
+        })
+        .collect();
     for &hex in mentions {
         let lower = hex.to_ascii_lowercase();
         if seen.insert(lower.clone()) {
@@ -2304,6 +2326,7 @@ mod tests {
         let tr = ThreadRef {
             root_event_id: eid,
             parent_event_id: eid,
+            parent_author: None,
         };
         let ev = sign(build_message(cid, "reply", Some(&tr), &[], false, &[]).unwrap());
         // Direct reply: only one e-tag with "reply" marker
@@ -2327,6 +2350,7 @@ mod tests {
         let tr = ThreadRef {
             root_event_id: root,
             parent_event_id: parent,
+            parent_author: None,
         };
         let ev = sign(build_message(cid, "nested", Some(&tr), &[], false, &[]).unwrap());
         let e_tags: Vec<_> = ev
@@ -2341,6 +2365,69 @@ mod tests {
             .collect();
         assert!(markers.contains(&"root"));
         assert!(markers.contains(&"reply"));
+    }
+
+    #[test]
+    fn reply_p_tags_the_parent_author() {
+        let cid = uuid();
+        let eid = event_id();
+        let author = Keys::generate().public_key();
+        let tr = ThreadRef {
+            root_event_id: eid,
+            parent_event_id: eid,
+            parent_author: Some(author),
+        };
+        let ev = sign(build_message(cid, "reply", Some(&tr), &[], false, &[]).unwrap());
+        // NIP-10: the reply carries the parent author's `p` tag.
+        assert!(has_tag(&ev, "p", &author.to_hex()));
+    }
+
+    #[test]
+    fn reply_parent_author_not_duplicated_by_mention() {
+        let cid = uuid();
+        let eid = event_id();
+        let author = Keys::generate().public_key();
+        let author_hex = author.to_hex();
+        let tr = ThreadRef {
+            root_event_id: eid,
+            parent_event_id: eid,
+            parent_author: Some(author),
+        };
+        // The parent author is also typed as an explicit @mention.
+        let ev = sign(build_message(cid, "reply", Some(&tr), &[&author_hex], false, &[]).unwrap());
+        let p_for_author = ev
+            .tags
+            .iter()
+            .filter(|t| {
+                let s = t.as_slice();
+                s.first().map(|v| v.as_str()) == Some("p")
+                    && s.get(1).map(|v| v.as_str()) == Some(author_hex.as_str())
+            })
+            .count();
+        assert_eq!(
+            p_for_author, 1,
+            "parent author must appear as a single p tag"
+        );
+    }
+
+    #[test]
+    fn self_reply_drops_the_parent_p_tag() {
+        // Replying to your own message: the parent-author `p` tag equals the
+        // signer, which nostr scrubs by default — so no self-notification, and
+        // `build_message` deliberately does not opt into self-tagging here.
+        let cid = uuid();
+        let me = keys();
+        let eid = event_id();
+        let tr = ThreadRef {
+            root_event_id: eid,
+            parent_event_id: eid,
+            parent_author: Some(me.public_key()),
+        };
+        let ev = build_message(cid, "reply", Some(&tr), &[], false, &[])
+            .unwrap()
+            .sign_with_keys(&me)
+            .expect("sign");
+        assert!(!has_tag(&ev, "p", &me.public_key().to_hex()));
     }
 
     #[test]
@@ -2419,6 +2506,7 @@ mod tests {
         let tr = ThreadRef {
             root_event_id: eid,
             parent_event_id: eid,
+            parent_author: None,
         };
         let ev = sign(build_forum_comment(cid, "comment", &tr, &[], &[]).unwrap());
         assert_eq!(ev.kind.as_u16(), 45003);

--- a/crates/buzz-sdk/src/lib.rs
+++ b/crates/buzz-sdk/src/lib.rs
@@ -25,11 +25,19 @@ pub use buzz_core::kind;
 ///
 /// - Direct reply (root == parent): emits `["e", root, "", "reply"]`
 /// - Nested reply (root ≠ parent): emits `["e", root, "", "root"]` + `["e", parent, "", "reply"]`
+///
+/// `parent_author` is the signer of the parent event. When set, the reply also
+/// carries a `["p", <parent_author>]` tag — NIP-10 says a reply SHOULD name the
+/// pubkeys being replied to, and it is what makes the reply reach the parent
+/// author's `{"kinds":[9],"#p":[self]}` notification filter. `None` preserves
+/// the prior (no parent `p` tag) behavior for callers that do not resolve it.
 pub struct ThreadRef {
     /// The root event of the thread.
     pub root_event_id: nostr::EventId,
     /// The immediate parent being replied to.
     pub parent_event_id: nostr::EventId,
+    /// Signer of the parent event, p-tagged when present.
+    pub parent_author: Option<nostr::PublicKey>,
 }
 
 /// Metadata for diff/patch messages (kind 40008).

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -523,6 +523,9 @@ async fn resolve_thread_ref(
     Ok(events::ThreadRef {
         root_event_id: root_eid,
         parent_event_id: parent_eid,
+        // The parent event is already fetched, so its signer rides along as the
+        // NIP-10 reply `p` tag — the reply notifies the author it replies to.
+        parent_author: Some(parent.pubkey),
     })
 }
 

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -42,9 +42,14 @@ fn check_content(content: &str) -> Result<(), String> {
 }
 
 /// NIP-10 thread reference.
+///
+/// `parent_author` is the signer of the parent event. When set, a reply built
+/// from this ref also carries the parent author's `p` tag so it reaches their
+/// `{"kinds":[9],"#p":[self]}` notification filter (NIP-10 reply SHOULD).
 pub struct ThreadRef {
     pub root_event_id: EventId,
     pub parent_event_id: EventId,
+    pub parent_author: Option<nostr::PublicKey>,
 }
 
 fn thread_tags(tr: &ThreadRef) -> Result<Vec<Tag>, String> {
@@ -337,7 +342,19 @@ pub fn build_message_with_client_tags(
     if let Some(tr) = thread_ref {
         tags.extend(thread_tags(tr)?);
     }
-    tags.extend(mention_tags(mentions)?);
+    // Merge the reply's parent author into the mention set (NIP-10 reply `p`
+    // tag). `mention_tags` dedupes, so an explicit @mention of the same pubkey
+    // stays a single tag; a self-reply's `p` tag is scrubbed by nostr (build
+    // path does not opt into self-tagging), so it never self-notifies.
+    let parent_author_hex = thread_ref
+        .and_then(|tr| tr.parent_author)
+        .map(|pk| pk.to_hex());
+    let merged_mentions: Vec<&str> = parent_author_hex
+        .iter()
+        .map(String::as_str)
+        .chain(mentions.iter().copied())
+        .collect();
+    tags.extend(mention_tags(&merged_mentions)?);
     imeta_tags(media_tags, &mut tags)?;
     emoji_tags(custom_emoji_tags, &mut tags)?;
     mention_reference_tags(mention_ref_tags, &mut tags)?;
@@ -390,7 +407,14 @@ pub fn build_forum_comment(
     check_content(content)?;
     let mut tags = vec![tag(vec!["h", &channel_id.to_string()])?];
     tags.extend(thread_tags(thread_ref)?);
-    tags.extend(mention_tags(mentions)?);
+    // NIP-10 reply `p` tag for the parent author, deduped against mentions.
+    let parent_author_hex = thread_ref.parent_author.map(|pk| pk.to_hex());
+    let merged_mentions: Vec<&str> = parent_author_hex
+        .iter()
+        .map(String::as_str)
+        .chain(mentions.iter().copied())
+        .collect();
+    tags.extend(mention_tags(&merged_mentions)?);
     imeta_tags(media_tags, &mut tags)?;
     mention_reference_tags(mention_ref_tags, &mut tags)?;
     Ok(EventBuilder::new(Kind::Custom(45003), content).tags(tags))

--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -40,13 +40,16 @@ class SendMessage {
   /// For thread replies, pass [parentEventId] and optionally [rootEventId].
   /// If [rootEventId] is null it defaults to [parentEventId] (direct reply to
   /// thread head). Tags are built to match the desktop's `buildReplyTags`
-  /// convention with `root` / `reply` markers. Pass [mediaTags] to append
-  /// relay-validated `imeta` tags and NIP-30 `emoji` tags.
+  /// convention with `root` / `reply` markers. Pass [parentAuthorPubkey] so the
+  /// reply carries the NIP-10 `p` tag that notifies the author being replied
+  /// to. Pass [mediaTags] to append relay-validated `imeta` tags and NIP-30
+  /// `emoji` tags.
   Future<void> call({
     required String channelId,
     required String content,
     String? parentEventId,
     String? rootEventId,
+    String? parentAuthorPubkey,
     List<String>? mentionPubkeys,
     List<List<String>> mediaTags = const [],
   }) async {
@@ -57,12 +60,21 @@ class SendMessage {
         mentionPubkeys ?? await _resolveMentions(content, channelId);
     final authorPubkey = _signedEventRelay.pubkey;
 
+    // NIP-10 reply `p` tag: the author being replied to is notified. Prepended
+    // to the mention set so the normalization below dedupes it against an
+    // explicit @mention and drops it when it is the sender (self-reply → no
+    // self-notification).
+    final mentionsWithParent = <String>[
+      if (parentAuthorPubkey != null) parentAuthorPubkey,
+      ...resolvedMentions,
+    ];
+
     // Normalize mentions: lowercase, deduplicate, exclude self (matching
     // the desktop's normalizeMentionPubkeys).
     final selfLower = authorPubkey?.toLowerCase();
     final seenMentions = <String>{?selfLower};
     final normalizedMentions = <String>[
-      for (final pk in resolvedMentions)
+      for (final pk in mentionsWithParent)
         if (seenMentions.add(pk.toLowerCase())) pk,
     ];
 

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -539,6 +539,7 @@ class ThreadDetailPage extends HookConsumerWidget {
                             content: content,
                             mentionPubkeys: mentionPubkeys,
                             parentEventId: threadHead.id,
+                            parentAuthorPubkey: threadHead.pubkey,
                             rootEventId: effectiveRootId,
                             mediaTags: mediaTags,
                           ),

--- a/mobile/lib/features/forum/forum_provider.dart
+++ b/mobile/lib/features/forum/forum_provider.dart
@@ -118,6 +118,7 @@ class ForumEventDelivery {
     required String channelId,
     required String parentEventId,
     required String content,
+    String? parentAuthorPubkey,
     List<String> mentionPubkeys = const [],
     List<List<String>> mediaTags = const [],
   }) async {
@@ -125,6 +126,7 @@ class ForumEventDelivery {
       kind: EventKind.forumComment,
       channelId: channelId,
       parentEventId: parentEventId,
+      parentAuthorPubkey: parentAuthorPubkey,
       content: content,
       mentionPubkeys: mentionPubkeys,
       mediaTags: mediaTags,
@@ -140,6 +142,7 @@ class ForumEventDelivery {
     required String channelId,
     required String content,
     String? parentEventId,
+    String? parentAuthorPubkey,
     required List<String> mentionPubkeys,
     required List<List<String>> mediaTags,
   }) async {
@@ -150,10 +153,17 @@ class ForumEventDelivery {
       );
     }
 
+    // NIP-10 reply `p` tag: notify the parent author. Prepended so the
+    // normalization dedupes it against an explicit @mention and drops it on a
+    // self-reply (no self-notification).
+    final mentionsWithParent = <String>[
+      if (parentAuthorPubkey != null) parentAuthorPubkey,
+      ...mentionPubkeys,
+    ];
     final selfPubkey = _relay.pubkey?.toLowerCase();
     final seen = <String>{?selfPubkey};
     final normalizedMentions = [
-      for (final pk in mentionPubkeys)
+      for (final pk in mentionsWithParent)
         if (seen.add(pk.toLowerCase())) pk,
     ];
 

--- a/mobile/lib/features/forum/forum_thread_page.dart
+++ b/mobile/lib/features/forum/forum_thread_page.dart
@@ -311,6 +311,7 @@ class _ThreadContent extends HookConsumerWidget {
                 }) => forumDelivery.createReply(
                   channelId: channelId,
                   parentEventId: post.eventId,
+                  parentAuthorPubkey: post.pubkey,
                   content: content,
                   mentionPubkeys: mentionPubkeys,
                   mediaTags: mediaTags,


### PR DESCRIPTION
Fixes #3032.

## Problem

A threaded reply carries the NIP-10 `e` markers (`root`/`reply`) but no `p` tag for the author being replied to. Buzz notifications are `#p`-based, so replying to someone in a thread never notifies them unless you *also* type their `@name`. In a thread you are by definition replying to a specific person — they should be notified.

Same class as #2568/#2634 (reactions dropped the `p` tag); @vitorpamplona flagged it as the reply-side counterpart. NIP-10 says a reply SHOULD name the pubkeys it replies to.

The `p` tag came only from explicit `@mentions` on every surface: the SDK `thread_tags` (builders.rs), the desktop `send_channel_message`, and mobile `send_message_provider`/`createForumReply`. Notification reads are `#p`-only with no `e`-tag fallback (desktop feed, mobile activity, push leases), and the relay never injects a parent `p` tag on ingest — so no `p` tag genuinely means no notification.

## Fix

Carry the parent event's **signer** as the reply's `p` tag, deduped against explicit mentions and self-excluded — consistent with the "use the signer, not the display author" decision from #2634.

**SDK** (`buzz-sdk`) — `ThreadRef` gains `parent_author: Option<PublicKey>`. `thread_tags` emits its `p` tag; `mention_tags` now seeds its dedup set from `p` tags already on the event, so an explicit `@mention` of the same pubkey stays a single tag. Covers `build_message` (kind 9), `build_forum_comment` (45003), and `build_diff_message` (40008). A self-reply's `p` tag is scrubbed by nostr's default self-tag handling (the builder does not opt into self-tagging), so no self-notification.

**CLI** (`buzz-cli`) — `resolve_thread_ref` already fetches the parent event, so its signer populates `parent_author` at no extra cost. This also covers agent replies, which post via the buzz CLI.

**ACP** — `setup_mode` already p-tags the asker via an explicit mention (unchanged); the dead-letter failure notice is a system message (`parent_author: None`).

**Desktop** — `resolve_thread_ref` already fetches the parent (to read its root), so `parent.pubkey` rides along as `parent_author` — no extra query. `build_message_with_client_tags` and `build_forum_comment` merge it into the mention set (deduped, self-scrubbed).

**Mobile** — the thread compose bar and forum thread page hold the parent message, so its `pubkey` is threaded through `SendMessage.call` and `createForumReply`; both prepend it to the mention set, which already dedupes and drops self.

## Behaviour

- Reply to someone in a thread → they get a mentions-feed entry and a push, without needing an explicit `@`.
- Reply to your own message → no self-notification (self `p` tag scrubbed / excluded).
- Reply that also `@`-mentions the parent → a single `p` tag, not a duplicate.

## Product note

This is NIP-10-conformant and matches Slack/Discord thread-reply behaviour, so I've treated it as a bug. If the team would rather gate reply-notifications behind a preference, the change is small to adjust — but the missing `p` tag is a wire-conformance gap regardless. Raised in #3032.

## Validation

Toolchain note: built on Windows with `x86_64-pc-windows-gnu` (no MSVC linker locally).

- `cargo test -p buzz-sdk --lib` — **238 passed**, including three new tests: the reply carries the parent `p` tag, it is not duplicated when also `@`-mentioned, and a self-reply drops it.
- `cargo check`/`--tests` on `buzz-cli`, `buzz-acp`, and `desktop/src-tauri` — clean (0 errors). `cargo test` on the desktop crate can't link locally (`sherpa-onnx-sys` native lib), so CI-Linux runs those.
- `cargo fmt --check` and `clippy -D warnings` on the workspace crates + desktop rustfmt — clean.
- Mobile (Dart) is unverified locally (no toolchain that bootstraps on Windows); the change is mechanical (one param, prepended to an existing dedup) and CI's Mobile job covers it.

Independent of #2634 — no file overlap.
