### PR TITLE
feat(agents): lower default agent parallelism from 24 to 10

### DIFF
--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -745,7 +745,7 @@ pub struct UpdateTeamRequest {
 pub const DEFAULT_ACP_COMMAND: &str = "buzz-acp";
 /// ~5 min (320s) — matches the CLI harness default (BUZZ_ACP_IDLE_TIMEOUT).
 pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 320;
-pub const DEFAULT_AGENT_PARALLELISM: u32 = 24;
+pub const DEFAULT_AGENT_PARALLELISM: u32 = 10;
 
 fn default_agent_parallelism() -> u32 {
     DEFAULT_AGENT_PARALLELISM

--- a/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
+++ b/desktop/src/features/agents/activeAgentTurnsStore.test.mjs
@@ -157,7 +157,9 @@ describe("activeAgentTurnsStore", () => {
     // Mirrors the store's private cap: the harness's hard upper bound on
     // parallel agent subprocesses (`--agents` accepts 1..=32).
     const CAP = 32;
-    /** Desktop's default harness parallelism (DEFAULT_AGENT_PARALLELISM). */
+    /** Desktop's former default harness parallelism; still a legitimate
+     * per-agent turn count (any value up to the harness cap of 32 is valid,
+     * regardless of DEFAULT_AGENT_PARALLELISM). */
     const DEFAULT_PARALLELISM = 24;
     const EPOCH = Date.parse("2024-01-01T00:00:00Z");
     const at = (ms) => new Date(EPOCH + ms).toISOString();
@@ -188,9 +190,10 @@ describe("activeAgentTurnsStore", () => {
       assert.ok(channels.has(`c${CAP + 1}`));
     });
 
-    it("tracks every turn of a default-parallelism agent working in 24 channels", () => {
-      // DEFAULT_AGENT_PARALLELISM is 24, so a single agent legitimately runs 24
-      // concurrent turns. Every one must keep its working badge.
+    it("tracks every turn of a high-parallelism agent working in 24 channels", () => {
+      // Parallelism up to the harness cap (32) is user-configurable, so a
+      // single agent can legitimately run 24 concurrent turns. Every one
+      // must keep its working badge.
       syncAgentTurnsFromEvents(AGENT, startTurns(DEFAULT_PARALLELISM));
       const channels = channelIdsOf(getActiveTurnsForAgent(AGENT));
       assert.equal(


### PR DESCRIPTION
## What

One-line default change: `DEFAULT_AGENT_PARALLELISM` 24 → 10 (`desktop/src-tauri/src/managed_agents/types.rs`), requested by Tyler in [buzz-generic-acp-harnesses](buzz://message?channel=d6d84fdc-47fe-4e41-acf5-a08a4a013e6b&id=a047ead3a34ba804c376bf79f29e355d304162a88c7b2a7121e092547c572022).

## Why

Each unit of parallelism is a **full agent subprocess** per agent × community pair, spawned eagerly and serially at create/start before the harness connects to the relay:

- At 24, a desktop with a few dozen agent×community pairs carries >1,000 potential idle subprocesses.
- Slow-starting harnesses (OpenClaw measured at 4–10s per worker) take minutes to create, and messages sent during that window can be permanently missed (the startup watermark is captured only after eager pool init).
- Parallelism is per-channel concurrency — a channel never uses more than one worker — so 10 still covers concurrent-channel fan-out for typical agents.

Context: verified RCA + live 1-worker/3-mention experiment in the same thread. Demand-driven pool growth (seed 1, grow on contention up to the cap) is agreed as a follow-up; this is the interim risk reduction.

## Scope / blast radius

- Existing agent records keep their persisted `parallelism` value — only new records and unset defaults change.
- Per-agent override unchanged (1..=32 via agent editor / `BUZZ_ACP_AGENTS`).
- Readers of the constant (`team_snapshot`, `personas/snapshot/import`, `commands/agents` mint path) all take the new default transitively; no other code pins 24.
- `activeAgentTurnsStore.test.mjs` comments updated so the 24-turn eviction case is framed against the harness cap (32) instead of the default — coverage unchanged, no assertion touched.

## Verification

At 63bb0c1c4, same shell: desktop Rust `cargo test --lib` 1693/0 (14 ignored) · JS suite 3523/3523 · tsc clean · biome clean on touched file · cargo fmt clean.
