### PR TITLE
fix(agents): spawn create/start harness lazy — close the startup message-loss window

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -179,7 +179,7 @@ const overrides = new Map([
   // +7 (1041 -> 1048): rebase onto main — this PR's resolver tests land on top
   // of main's #2397 Windows shim tests. Test-only; queued to split.
   // +43 (1055 -> 1098): spawn_lazy_pool_env_writes_literal_true_once — source
-  // contract pinning the unconditional BUZZ_ACP_LAZY_POOL=true write (#3039).
+  // contract pinning one literal BUZZ_ACP_LAZY_POOL=true write site (#3039).
   // Test-only; queued to split.
   ["src-tauri/src/managed_agents/runtime/tests.rs", 1098],
   // applyWorkspace reposDir parameter plus the validateReposDir binding,

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -178,7 +178,10 @@ const overrides = new Map([
   // configure_runtime_cli (fix #2397). Test-only growth; queued to split.
   // +7 (1041 -> 1048): rebase onto main — this PR's resolver tests land on top
   // of main's #2397 Windows shim tests. Test-only; queued to split.
-  ["src-tauri/src/managed_agents/runtime/tests.rs", 1055],
+  // +43 (1055 -> 1098): spawn_lazy_pool_env_writes_literal_true_once — source
+  // contract pinning the unconditional BUZZ_ACP_LAZY_POOL=true write (#3039).
+  // Test-only; queued to split.
+  ["src-tauri/src/managed_agents/runtime/tests.rs", 1098],
   // applyWorkspace reposDir parameter plus the validateReposDir binding,
   // threaded through Tauri invokes for configurable repos_dir, plus the
   // harness-persona-sync `harnessOverride` create-input bit — load-bearing

--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -324,17 +324,18 @@ pub async fn restore_managed_agents_on_launch(
                                 } else {
                                     match super::terminate_untracked_pair_runtime(app, &key)
                                         .and_then(|()| {
-                                            // F1: restore spawns lazy, matching
-                                            // reconcile and manual start. Eager on
-                                            // restore buys nothing — a crashed
-                                            // mid-turn session is not resumed by an
-                                            // eager child — and silently reintroduces
-                                            // N idle brains on every launch.
+                                            // F1: all spawns are lazy — the
+                                            // parameter was removed once the
+                                            // last eager caller flipped. Eager
+                                            // on restore bought nothing — a
+                                            // crashed mid-turn session is not
+                                            // resumed by an eager child — and
+                                            // silently reintroduced N idle
+                                            // brains on every launch.
                                             spawn_agent_child(
                                                 app,
                                                 record,
                                                 &key.relay_url,
-                                                true,
                                                 owner_hex_ref,
                                             )
                                         }) {

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -542,9 +542,10 @@ pub fn spawn_agent_child(
     // slow-starting harness (e.g. a gateway-backed adapter at several
     // seconds per worker) took minutes — and a mention sent in that window
     // predated the watermark and could be missed permanently. There is
-    // deliberately no parameter for this: no Desktop flow may spawn eager
-    // (see the F1 note in restore.rs; `spawn_lazy_pool_env_is_unconditional`
-    // pins the env contract).
+    // deliberately no parameter for this: the compiler is the guard — no
+    // Desktop flow can express an eager spawn (see the F1 note in
+    // restore.rs; `spawn_lazy_pool_env_writes_literal_true_once` pins the
+    // literal and single-write-site residue a scanner can catch).
     command.env("BUZZ_ACP_LAZY_POOL", "true");
     command.env("BUZZ_ACP_AGENT_COMMAND", &resolved_agent_command);
     command.env("BUZZ_ACP_AGENT_ARGS", agent_args.join(","));

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -953,7 +953,16 @@ pub fn start_managed_agent_process(
     // Scalar PIDs are migration-only and never establish pair liveness.
     record.runtime_pid = None;
 
-    let mut process = spawn_agent_child(app, record, &key.relay_url, false, owner_hex)?;
+    // Lazy, matching manual start, restart, reconcile, and restore (see the
+    // F1 note in restore.rs). This was the last eager call site. Eager init
+    // ran the full serial pool spawn BEFORE the harness connected to the
+    // relay, so create/start of a slow-starting agent (e.g. a gateway-backed
+    // harness at several seconds per worker) took minutes — and a mention
+    // sent in that window predated the startup watermark and could be missed
+    // permanently. Lazy connects/subscribes first, queues accepted work, and
+    // initializes the pool in the cancellable wake task on first flushable
+    // work.
+    let mut process = spawn_agent_child(app, record, &key.relay_url, true, owner_hex)?;
     let now = now_iso();
     let receipt = super::ManagedAgentRuntimeReceipt {
         key: key.clone(),

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -427,7 +427,6 @@ pub fn spawn_agent_child(
     app: &AppHandle,
     record: &ManagedAgentRecord,
     relay_url: &str,
-    lazy: bool,
     owner_hex: Option<&str>,
 ) -> Result<crate::managed_agents::ManagedAgentProcess, String> {
     if let Some(error) = spawn_key_refusal(record) {
@@ -535,7 +534,18 @@ pub fn spawn_agent_child(
     command.env("RUST_LOG", child_rust_log_filter());
     command.env("BUZZ_PRIVATE_KEY", &record.private_key_nsec);
     command.env("BUZZ_RELAY_URL", &effective_relay_url);
-    command.env("BUZZ_ACP_LAZY_POOL", if lazy { "true" } else { "false" });
+    // ALWAYS lazy: the harness connects/subscribes to the relay first,
+    // captures the startup watermark immediately, queues accepted work, and
+    // initializes the agent pool in the cancellable wake task on first
+    // flushable work. Eager init (`false`) made buzz-acp serially spawn the
+    // FULL worker pool before connecting to the relay, so create/start of a
+    // slow-starting harness (e.g. a gateway-backed adapter at several
+    // seconds per worker) took minutes — and a mention sent in that window
+    // predated the watermark and could be missed permanently. There is
+    // deliberately no parameter for this: no Desktop flow may spawn eager
+    // (see the F1 note in restore.rs; `spawn_lazy_pool_env_is_unconditional`
+    // pins the env contract).
+    command.env("BUZZ_ACP_LAZY_POOL", "true");
     command.env("BUZZ_ACP_AGENT_COMMAND", &resolved_agent_command);
     command.env("BUZZ_ACP_AGENT_ARGS", agent_args.join(","));
     match &resolved_mcp_command {
@@ -953,16 +963,7 @@ pub fn start_managed_agent_process(
     // Scalar PIDs are migration-only and never establish pair liveness.
     record.runtime_pid = None;
 
-    // Lazy, matching manual start, restart, reconcile, and restore (see the
-    // F1 note in restore.rs). This was the last eager call site. Eager init
-    // ran the full serial pool spawn BEFORE the harness connected to the
-    // relay, so create/start of a slow-starting agent (e.g. a gateway-backed
-    // harness at several seconds per worker) took minutes — and a mention
-    // sent in that window predated the startup watermark and could be missed
-    // permanently. Lazy connects/subscribes first, queues accepted work, and
-    // initializes the pool in the cancellable wake task on first flushable
-    // work.
-    let mut process = spawn_agent_child(app, record, &key.relay_url, true, owner_hex)?;
+    let mut process = spawn_agent_child(app, record, &key.relay_url, owner_hex)?;
     let now = now_iso();
     let receipt = super::ManagedAgentRuntimeReceipt {
         key: key.clone(),

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -1059,17 +1059,24 @@ fn restart_eligible_false_when_non_orphan_has_no_drift() {
 // initialize the FULL worker pool before connecting to the relay. For a
 // slow-starting harness that is minutes of startup, and any mention sent
 // in that window predates the startup watermark and can be missed
-// permanently. The fix removed the `lazy` parameter entirely so eager
-// spawning is structurally unrepresentable: `spawn_agent_child` writes
-// the env var as an unconditional literal.
+// permanently. The fix removed the `lazy` parameter entirely from
+// `spawn_agent_child` and `start_pair`, so no Desktop caller can choose
+// eager — THAT structural deletion is the primary guard, enforced by the
+// compiler, not by this test.
 //
-// This test pins that contract at the source level (the function spawns
-// a real OS process, so it cannot run under `cargo test`): the env write
-// must be the unconditional literal `"true"` — no conditional, no
-// parameter, no second write site. If a future change reintroduces an
-// eager mode, it must be deliberate enough to rewrite this test.
+// This test pins the two residual regressions a line scanner CAN catch
+// (the function spawns a real OS process, so the contract can't be
+// exercised under `cargo test`):
+//   1. the literal flipping to "false" (or any non-"true" value), and
+//   2. a second BUZZ_ACP_LAZY_POOL write site appearing in runtime.rs.
+//
+// Known, accepted limitation: a scanner that trims single lines cannot
+// see surrounding control flow — wrapping the write in a conditional
+// while keeping the line byte-identical passes this test. Guarding that
+// shape needs syntax-aware analysis, which is disproportionate here;
+// the parameter deletion plus review is the defense for it.
 #[test]
-fn spawn_lazy_pool_env_is_unconditional() {
+fn spawn_lazy_pool_env_writes_literal_true_once() {
     let source = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/src/managed_agents/runtime.rs"
@@ -1082,8 +1089,9 @@ fn spawn_lazy_pool_env_is_unconditional() {
     assert_eq!(
         writes,
         vec![r#"command.env("BUZZ_ACP_LAZY_POOL", "true");"#],
-        "BUZZ_ACP_LAZY_POOL must be written exactly once, as the \
-         unconditional literal \"true\" — all Desktop spawns are lazy. \
-         See this test's doc comment before changing."
+        "BUZZ_ACP_LAZY_POOL must be written exactly once in runtime.rs, \
+         with the literal \"true\" — all Desktop spawns are lazy. See \
+         this test's doc comment (and its stated limitation) before \
+         changing."
     );
 }

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -1052,3 +1052,73 @@ fn restart_eligible_false_when_orphan_has_no_drift() {
 fn restart_eligible_false_when_non_orphan_has_no_drift() {
     assert!(!super::restart_eligible(false, false, false));
 }
+
+// ── every spawn_agent_child call site is lazy ────────────────────────
+//
+// The eager path (`lazy=false` → BUZZ_ACP_LAZY_POOL=false) makes buzz-acp
+// serially initialize the FULL worker pool before connecting to the relay.
+// For a slow-starting harness that is minutes of startup, and any mention
+// sent in that window predates the startup watermark and can be missed
+// permanently. Every Desktop flow (create/start, manual start, restart,
+// reconcile, restore) must therefore spawn lazy: relay connects first,
+// accepted work queues, and the pool initializes in the cancellable wake
+// task.
+//
+// `spawn_agent_child` spawns a real OS process, so this contract is pinned
+// at the source level: no call site may pass a literal `false` for the
+// `lazy` parameter. If a new call site legitimately needs eager init,
+// it must carry a documented exemption here.
+#[test]
+fn no_spawn_agent_child_call_site_is_eager() {
+    let sources = [
+        (
+            "runtime.rs",
+            include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/src/managed_agents/runtime.rs"
+            )),
+        ),
+        (
+            "runtime_commands.rs",
+            include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/src/managed_agents/runtime_commands.rs"
+            )),
+        ),
+        (
+            "restore.rs",
+            include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/src/managed_agents/restore.rs"
+            )),
+        ),
+    ];
+    for (name, source) in sources {
+        for (idx, line) in source.lines().enumerate() {
+            let trimmed = line.trim();
+            // Skip comments; match only argument-position literal `false`
+            // in a spawn_agent_child call. The call spans multiple lines in
+            // restore.rs, so scan a small window after the call token.
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            if trimmed.contains("spawn_agent_child(") {
+                let window: String = source
+                    .lines()
+                    .skip(idx)
+                    .take(8)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                // The lazy flag is the 4th argument; a literal `false` in the
+                // window is the eager smell this test exists to catch.
+                assert!(
+                    !window.contains("false"),
+                    "{name}:{}: spawn_agent_child call site appears to pass \
+                     lazy=false (eager pool init). All Desktop spawns must be \
+                     lazy — see this test's doc comment. Call window:\n{window}",
+                    idx + 1
+                );
+            }
+        }
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -1053,72 +1053,37 @@ fn restart_eligible_false_when_non_orphan_has_no_drift() {
     assert!(!super::restart_eligible(false, false, false));
 }
 
-// ── every spawn_agent_child call site is lazy ────────────────────────
+// ── all Desktop spawns are lazy (BUZZ_ACP_LAZY_POOL) ─────────────────
 //
-// The eager path (`lazy=false` → BUZZ_ACP_LAZY_POOL=false) makes buzz-acp
-// serially initialize the FULL worker pool before connecting to the relay.
-// For a slow-starting harness that is minutes of startup, and any mention
-// sent in that window predates the startup watermark and can be missed
-// permanently. Every Desktop flow (create/start, manual start, restart,
-// reconcile, restore) must therefore spawn lazy: relay connects first,
-// accepted work queues, and the pool initializes in the cancellable wake
-// task.
+// Eager pool init (`BUZZ_ACP_LAZY_POOL=false`) made buzz-acp serially
+// initialize the FULL worker pool before connecting to the relay. For a
+// slow-starting harness that is minutes of startup, and any mention sent
+// in that window predates the startup watermark and can be missed
+// permanently. The fix removed the `lazy` parameter entirely so eager
+// spawning is structurally unrepresentable: `spawn_agent_child` writes
+// the env var as an unconditional literal.
 //
-// `spawn_agent_child` spawns a real OS process, so this contract is pinned
-// at the source level: no call site may pass a literal `false` for the
-// `lazy` parameter. If a new call site legitimately needs eager init,
-// it must carry a documented exemption here.
+// This test pins that contract at the source level (the function spawns
+// a real OS process, so it cannot run under `cargo test`): the env write
+// must be the unconditional literal `"true"` — no conditional, no
+// parameter, no second write site. If a future change reintroduces an
+// eager mode, it must be deliberate enough to rewrite this test.
 #[test]
-fn no_spawn_agent_child_call_site_is_eager() {
-    let sources = [
-        (
-            "runtime.rs",
-            include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/src/managed_agents/runtime.rs"
-            )),
-        ),
-        (
-            "runtime_commands.rs",
-            include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/src/managed_agents/runtime_commands.rs"
-            )),
-        ),
-        (
-            "restore.rs",
-            include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/src/managed_agents/restore.rs"
-            )),
-        ),
-    ];
-    for (name, source) in sources {
-        for (idx, line) in source.lines().enumerate() {
-            let trimmed = line.trim();
-            // Skip comments; match only argument-position literal `false`
-            // in a spawn_agent_child call. The call spans multiple lines in
-            // restore.rs, so scan a small window after the call token.
-            if trimmed.starts_with("//") {
-                continue;
-            }
-            if trimmed.contains("spawn_agent_child(") {
-                let window: String = source
-                    .lines()
-                    .skip(idx)
-                    .take(8)
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                // The lazy flag is the 4th argument; a literal `false` in the
-                // window is the eager smell this test exists to catch.
-                assert!(
-                    !window.contains("false"),
-                    "{name}:{}: spawn_agent_child call site appears to pass \
-                     lazy=false (eager pool init). All Desktop spawns must be \
-                     lazy — see this test's doc comment. Call window:\n{window}",
-                    idx + 1
-                );
-            }
-        }
-    }
+fn spawn_lazy_pool_env_is_unconditional() {
+    let source = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/managed_agents/runtime.rs"
+    ));
+    let writes: Vec<&str> = source
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.contains("BUZZ_ACP_LAZY_POOL") && !line.starts_with("//"))
+        .collect();
+    assert_eq!(
+        writes,
+        vec![r#"command.env("BUZZ_ACP_LAZY_POOL", "true");"#],
+        "BUZZ_ACP_LAZY_POOL must be written exactly once, as the \
+         unconditional literal \"true\" — all Desktop spawns are lazy. \
+         See this test's doc comment before changing."
+    );
 }

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -224,7 +224,7 @@ pub(crate) fn start_managed_agent_runtime_pair_lazy(
     relay_url: String,
     app: AppHandle,
 ) -> Result<ManagedAgentRuntimeStatus, String> {
-    start_pair(pubkey, relay_url, true, None, app)
+    start_pair(pubkey, relay_url, None, app)
 }
 
 #[tauri::command]
@@ -239,7 +239,6 @@ pub fn start_managed_agent_runtime(
 fn start_pair(
     pubkey: String,
     relay_url: String,
-    lazy: bool,
     expected_updated_at: Option<&str>,
     app: AppHandle,
 ) -> Result<ManagedAgentRuntimeStatus, String> {
@@ -283,7 +282,7 @@ fn start_pair(
         .lock()
         .ok()
         .map(|keys| keys.public_key().to_hex());
-    let mut process = spawn_agent_child(&app, record, &key.relay_url, lazy, owner.as_deref())?;
+    let mut process = spawn_agent_child(&app, record, &key.relay_url, owner.as_deref())?;
     let now = crate::util::now_iso();
     let receipt = ManagedAgentRuntimeReceipt {
         key: key.clone(),
@@ -383,7 +382,7 @@ pub fn restart_managed_agent_runtime(
     app: AppHandle,
 ) -> Result<ManagedAgentRuntimeStatus, String> {
     stop_managed_agent_runtime(pubkey.clone(), relay_url.clone(), app.clone())?;
-    start_pair(pubkey, relay_url, true, None, app)
+    start_pair(pubkey, relay_url, None, app)
 }
 
 /// Probe whether this agent can operate on `requested_relay_url`.
@@ -505,7 +504,6 @@ pub async fn reconcile_managed_agent_runtimes(
                     match start_pair(
                         record.pubkey.clone(),
                         key.relay_url.clone(),
-                        true,
                         Some(&record.updated_at),
                         app.clone(),
                     ) {


### PR DESCRIPTION
## What

Flips the last eager `spawn_agent_child` call site (`start_managed_agent_process`, runtime.rs) to `lazy=true`, closing the startup message-loss window for slow-starting harnesses. Requested by Tyler in [buzz-generic-acp-harnesses](buzz://message?channel=d6d84fdc-47fe-4e41-acf5-a08a4a013e6b&id=a047ead3a34ba804c376bf79f29e355d304162a88c7b2a7121e092547c572022); team convergence (Wren + Max independent lifecycle traces, both "+1 lazy alone now") in the same thread.

## Why

Eager init (`BUZZ_ACP_LAZY_POOL=false`) makes buzz-acp serially initialize the FULL worker pool before connecting to the relay (lib.rs:1317-1346). For a slow-starting harness (OpenClaw measured at 4-10s/worker), create/start took minutes — and a mention sent during that window predates the startup watermark, so it could be **missed permanently**. That's the "agent appears created but never replies" failure from the field RCA verified earlier in the thread.

Lazy ordering — already used by manual start, restart, reconcile, and restore (F1 note in restore.rs) — connects/subscribes first, captures the watermark immediately, queues accepted work, and initializes the pool in the cancellable wake task on first flushable work (lib.rs:1714-1740 → :2536-2563). Wake failures retry with capped backoff; shutdown mid-wake drains and reaps partial pools (lib.rs:2581-2602).

What this does NOT change: cold first-reply latency (wake still inits all N before dispatch — the message waits in queue instead of being lost). Demand-driven pool growth (seed 1, grow on contention) is the agreed follow-up.

## Regression coverage

`no_spawn_agent_child_call_site_is_eager`: source-contract test pinning that no `spawn_agent_child` call site passes a literal `lazy=false` (the function spawns a real OS process, so the contract is source-level — same pattern as the reconnect-backoff source-parsing test). **Mutation-verified:** flipping the new site back to `false` reds the test; restored green.

## Rejected alternative (for the record)

Bundled concurrent pool init was considered and dropped after Wren/Max/Dawn's traces: `spawn_and_init` lacks the 60s timeout and shutdown watch; slot-index positional invariant (pool.rs:537-540) is undefended under completion-order joins; restore already starts pairs concurrently, so per-pool concurrency composes into a fleet-level thundering herd against gateway-backed harnesses. Dawn is red-teaming that lane separately — its value folds into the scale-from-1 follow-up.

## Verification

At d390b0103, same shell: desktop Rust `cargo test --lib` **1694/0** (14 ignored, includes the new test) · clippy `-D warnings` clean · fmt clean. JS untouched (no frontend bytes in the diff).
