### PR TITLE
fix(acp): cap the per-channel cancelled-batch side-map

### DIFF
--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -540,11 +540,29 @@ impl EventQueue {
     /// the generic queue — they are stored separately and merged by
     /// `flush_next()`. No retry throttle, no backoff.
     pub fn requeue_as_cancelled(&mut self, batch: FlushBatch, reason: CancelReason) {
-        let entry = self.cancelled_batches.entry(batch.channel_id).or_default();
+        let channel_id = batch.channel_id;
+        let entry = self.cancelled_batches.entry(channel_id).or_default();
         // Preserve any already-cancelled events from a prior cancel (double-cancel).
         entry.extend(batch.cancelled_events);
         entry.extend(batch.events);
-        self.cancel_reasons.insert(batch.channel_id, reason);
+        // Enforce the same per-channel cap as the main queue. This side-map is
+        // only cleared when a turn *completes* (or the channel drains), so a
+        // sustained mid-turn interrupt/steer flood — every turn cancelled
+        // before it finishes — would otherwise grow both this map and the
+        // prompt `format_prompt` renders from it (see `cancelled_events`)
+        // without bound. Trim oldest (front) so the most-recent "what you were
+        // working on" events survive, mirroring the queue's overflow handling.
+        if entry.len() > MAX_PENDING_PER_CHANNEL {
+            let overflow = entry.len() - MAX_PENDING_PER_CHANNEL;
+            entry.drain(0..overflow);
+            tracing::warn!(
+                channel_id = %channel_id,
+                limit = MAX_PENDING_PER_CHANNEL,
+                dropped = overflow,
+                "cancelled-batch overflow — dropped oldest cancelled events to enforce cap"
+            );
+        }
+        self.cancel_reasons.insert(channel_id, reason);
     }
 
     /// Returns `true` if any channel has pending events that are not in-flight
@@ -3859,6 +3877,41 @@ mod tests {
             batch3.cancelled_events.len(),
             3,
             "should accumulate all 3 cancelled events"
+        );
+    }
+
+    #[test]
+    fn test_sustained_cancellation_caps_cancelled_batches() {
+        // A mid-turn interrupt/steer flood cancels every turn before it
+        // completes. Each cancel carries the accumulated cancelled events
+        // forward, so without a cap `cancelled_batches[ch]` (and the prompt
+        // rendered from it) would grow one event per cancel, without bound.
+        let mut q = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+
+        let iterations = MAX_PENDING_PER_CHANNEL + 50;
+        for i in 0..iterations {
+            q.push(make_queued(ch, &format!("evt-{i}")));
+            let batch = q.flush_next().expect("a queued event should flush");
+            // Cancel the in-flight turn, then release the channel so the next
+            // flush can run — the real Interrupt/Steer path.
+            q.requeue_as_cancelled(batch, CancelReason::Interrupt);
+            q.mark_complete(ch);
+        }
+
+        let accumulated = q.cancelled_batches.get(&ch).map(Vec::len).unwrap_or(0);
+        assert!(
+            accumulated <= MAX_PENDING_PER_CHANNEL,
+            "cancelled_batches grew past the cap: {accumulated} > {MAX_PENDING_PER_CHANNEL}",
+        );
+
+        // The cap trims the OLDEST events, so the most-recent one survives.
+        let newest = format!("evt-{}", iterations - 1);
+        assert!(
+            q.cancelled_batches
+                .get(&ch)
+                .is_some_and(|evts| evts.iter().any(|be| be.event.content == newest)),
+            "the most-recent cancelled event must be retained",
         );
     }
 


### PR DESCRIPTION
Fixes #3042.

## Problem

The ACP harness's per-channel `cancelled_batches` side-map (`crates/buzz-acp/src/queue.rs`) is never size-capped, while the main event queue beside it is capped at `MAX_PENDING_PER_CHANNEL` (500) in every growth path (`push`, `requeue`, `requeue_preserve_timestamps`, …).

`requeue_as_cancelled` just `extend`s. That map is only cleared when a turn **completes** (or the channel drains), so under a sustained mid-turn interrupt/steer flood — every turn cancelled before it finishes — each cancel carries the accumulated cancelled events forward and the map grows one turn's worth of events per cancel. `format_prompt` then renders every accumulated event (full content + tags) into the prompt on each subsequent turn, so **both harness memory and the LLM prompt grow without bound**: eventual OOM of the agent process plus per-turn token-cost amplification.

Reachable by any channel participant under `respond_to = anyone`, or by one misbehaving key under `allowlist`. Full analysis and repro in #3042.

## Fix

Enforce the same cap the main queue already uses, in `requeue_as_cancelled`, trimming the oldest events so the most-recent "what you were working on" framing survives:

```rust
if entry.len() > MAX_PENDING_PER_CHANNEL {
    let overflow = entry.len() - MAX_PENDING_PER_CHANNEL;
    entry.drain(0..overflow);
    tracing::warn!(channel_id = %channel_id, limit = MAX_PENDING_PER_CHANNEL,
        dropped = overflow, "cancelled-batch overflow — dropped oldest …");
}
```

Same constant, same drop-oldest-with-warn shape as the existing queue overflow handling — this is the consistency fix that closes the one growth path that was missed. A single `drain` keeps it O(n).

## Tests

New `test_sustained_cancellation_caps_cancelled_batches` drives the real cancel cycle (`push → flush_next → requeue_as_cancelled → mark_complete`) `MAX_PENDING_PER_CHANNEL + 50` times and asserts the map stays `<= MAX_PENDING_PER_CHANNEL` and still retains the newest event. It **fails without the fix** (`550 > 500`) — verified by reverting the cap and re-running.

## Validation

Built on Windows with the `x86_64-pc-windows-gnu` toolchain.

- `cargo test -p buzz-acp --lib` — all 20 cancel-path tests pass, including the new one, and the existing `test_double_cancel_preserves_all_events` / `test_drain_channel_clears_cancelled_batches` still pass (behaviour under the cap is unchanged).
- `cargo fmt -p buzz-acp -- --check` — clean.
- Note: 12 tests in `acp.rs` (system-prompt / idle / keepalive / steering) fail on my machine, but they fail identically on clean `origin/main` with this branch stashed — they are pre-existing, timing-sensitive failures on this toolchain, in a different module, unaffected by this one-function change in `queue.rs`.
