### PR TITLE
feat(desktop): surface the Claude account agents run as

### DIFF
--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -54,6 +54,79 @@ pub fn get_default_relay_url() -> String {
     relay::relay_ws_url()
 }
 
+/// Which Claude account the app's spawned agents authenticate as.
+///
+/// Derived from the Claude Code config the agent subprocess inherits:
+/// `CLAUDE_CONFIG_DIR` when set, otherwise `$HOME`. Carries only the account
+/// email and organization (or a flag that an API key is in use) — never any
+/// token or secret.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentClaudeAccount {
+    /// `"oauth"` (a logged-in account), `"apiKey"` (`ANTHROPIC_API_KEY` set), or
+    /// `"none"` (no resolvable account).
+    source: String,
+    /// Account email for the `oauth` source; `None` otherwise.
+    email: Option<String>,
+    /// Organization name for the `oauth` source; `None` otherwise.
+    org: Option<String>,
+    /// The config directory the agent reads, shown for transparency.
+    config_dir: String,
+}
+
+/// Report the Claude account backing the app's agents by inspecting the Claude
+/// Code config directory the agent runtime inherits. An `ANTHROPIC_API_KEY`
+/// takes precedence over any stored login, mirroring the runtime's own
+/// resolution order. Returns account email + organization for a logged-in
+/// account without exposing credentials.
+#[tauri::command]
+pub fn get_agent_claude_account() -> AgentClaudeAccount {
+    let config_dir = std::env::var("CLAUDE_CONFIG_DIR")
+        .or_else(|_| std::env::var("HOME"))
+        .unwrap_or_default();
+
+    // An API key overrides any stored OAuth login for the agent runtime, so
+    // report it as the effective account when present.
+    if std::env::var("ANTHROPIC_API_KEY")
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+    {
+        return AgentClaudeAccount {
+            source: "apiKey".to_string(),
+            email: None,
+            org: None,
+            config_dir,
+        };
+    }
+
+    let config_path = std::path::Path::new(&config_dir).join(".claude.json");
+    let (email, org) = std::fs::read_to_string(&config_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .and_then(|json| {
+            let account = json.get("oauthAccount")?;
+            let email = account
+                .get("emailAddress")
+                .and_then(|value| value.as_str())
+                .map(str::to_string);
+            let org = account
+                .get("organizationName")
+                .and_then(|value| value.as_str())
+                .map(str::to_string);
+            Some((email, org))
+        })
+        .unwrap_or((None, None));
+
+    let source = if email.is_some() { "oauth" } else { "none" };
+
+    AgentClaudeAccount {
+        source: source.to_string(),
+        email,
+        org,
+        config_dir,
+    }
+}
+
 #[tauri::command]
 pub fn auto_connect_default_relay_enabled() -> bool {
     option_env!("BUZZ_DESKTOP_BUILD_AUTO_CONNECT_DEFAULT_RELAY").is_some()

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -694,6 +694,7 @@ pub fn run() {
             get_os_idle_seconds,
             get_default_relay_url,
             auto_connect_default_relay_enabled,
+            get_agent_claude_account,
             get_legacy_workspace_storage,
             is_shared_identity,
             get_relay_ws_url,

--- a/desktop/src/features/settings/ui/AgentDefaultsSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/AgentDefaultsSettingsCard.tsx
@@ -1,5 +1,6 @@
 import { AgentDefaultsEditor } from "@/features/agents/ui/AgentDefaultsEditor";
 import { SectionHeader } from "@/shared/ui/PageHeader";
+import { ClaudeAgentAccountRow } from "./ClaudeAgentAccountRow";
 
 export function AgentDefaultsSettingsCard() {
   return (
@@ -11,6 +12,7 @@ export function AgentDefaultsSettingsCard() {
         title="Agent defaults"
         description="Provider, model, effort, and environment settings inherited by local agents. Agent-specific settings always take priority."
       />
+      <ClaudeAgentAccountRow />
       <AgentDefaultsEditor />
     </section>
   );

--- a/desktop/src/features/settings/ui/ClaudeAgentAccountRow.tsx
+++ b/desktop/src/features/settings/ui/ClaudeAgentAccountRow.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+
+import {
+  type AgentClaudeAccount,
+  getAgentClaudeAccount,
+} from "@/shared/api/tauri";
+
+/**
+ * Read-only row showing which Claude account the app's local agents
+ * authenticate as. Backed by the `get_agent_claude_account` command, which
+ * inspects the Claude Code config directory the agent runtime inherits
+ * (`CLAUDE_CONFIG_DIR`, else `$HOME`). Never reads or displays any token.
+ */
+export function ClaudeAgentAccountRow() {
+  const [account, setAccount] = React.useState<AgentClaudeAccount | null>(null);
+  const [failed, setFailed] = React.useState(false);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    getAgentClaudeAccount()
+      .then((value) => {
+        if (!cancelled) setAccount(value);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  let primary = "Checking…";
+  if (failed) {
+    primary = "Unavailable";
+  } else if (account?.source === "oauth") {
+    primary = account.email ?? "Signed in";
+  } else if (account?.source === "apiKey") {
+    primary = "API key (ANTHROPIC_API_KEY)";
+  } else if (account?.source === "none") {
+    primary = "Not signed in";
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-1 rounded-lg border border-border/70 bg-muted/20 px-3 py-2.5"
+      data-testid="settings-claude-agent-account"
+    >
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        <span className="font-medium text-muted-foreground">
+          Claude account
+        </span>
+        <span className="font-medium text-foreground">{primary}</span>
+      </div>
+      {account?.source === "oauth" && account.org ? (
+        <span className="text-xs text-muted-foreground">{account.org}</span>
+      ) : null}
+      {account ? (
+        <span className="font-mono text-2xs text-muted-foreground">
+          {account.configDir}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -366,6 +366,22 @@ export function autoConnectDefaultRelayEnabled(): Promise<boolean> {
   return invokeTauri<boolean>("auto_connect_default_relay_enabled");
 }
 
+/** Which Claude account the app's spawned agents authenticate as. */
+export type AgentClaudeAccount = {
+  /** "oauth" (logged-in account), "apiKey" (ANTHROPIC_API_KEY set), or "none". */
+  source: "oauth" | "apiKey" | "none";
+  /** Account email for the "oauth" source; null otherwise. */
+  email: string | null;
+  /** Organization name for the "oauth" source; null otherwise. */
+  org: string | null;
+  /** The config directory the agent reads. */
+  configDir: string;
+};
+
+export function getAgentClaudeAccount(): Promise<AgentClaudeAccount> {
+  return invokeTauri<AgentClaudeAccount>("get_agent_claude_account");
+}
+
 export function isSharedIdentity(): Promise<boolean> {
   return invokeTauri<boolean>("is_shared_identity");
 }


### PR DESCRIPTION
## Summary

Adds a read-only **Claude account** row to the **Agent defaults** settings so
you can see which Anthropic account the app's local agents authenticate as,
without dropping to a terminal to inspect `~/.claude`.

This is especially useful when running agents against a non-default account via
`CLAUDE_CONFIG_DIR` (e.g. a work account kept separate from the `claude` CLI's
personal login): the settings UI now confirms the effective account at a glance.

## What it does

- **`buzz-desktop`**: new `get_agent_claude_account` command in
  `commands/identity.rs`, registered in the invoke handler. It reads the Claude
  Code config directory the agent runtime inherits (`CLAUDE_CONFIG_DIR`, falling
  back to `$HOME`), parses `oauthAccount` from `.claude.json`, and returns the
  account email + organization, or reports that an `ANTHROPIC_API_KEY` is in use.
  It never reads or returns any token or secret.
- **frontend**: `getAgentClaudeAccount` API wrapper and `AgentClaudeAccount`
  type in `shared/api/tauri.ts`.
- **settings UI**: `ClaudeAgentAccountRow` rendered in `AgentDefaultsSettingsCard`,
  using stock rem text tokens.

## Display states

- Logged in: `varun.tyagi83@gmail.com` + organization + the config dir.
- `ANTHROPIC_API_KEY` set: shown as an API-key source.
- Nothing resolvable: `Not signed in`.

## Testing

- `cargo fmt --check` (desktop crate), `biome check`, `tsc --noEmit`, and
  `cargo check` all pass.
- Verified in a release build: the row renders in Settings → Agents → Agent
  defaults and correctly shows the account the Claude Code harness runs as.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
