### PR TITLE
fix(desktop): allow shared agent mentions

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -7,6 +7,7 @@ import {
   getSharedChannelIds,
   isAgentIdentityInManagedList,
   relayAgentIsSharedWithUser,
+  shouldAdmitMentionCandidate,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
 
@@ -136,7 +137,50 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
-test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
+test("shouldAdmitMentionCandidate: admits a cross-owner channel bot with anyone access", () => {
+  const mentionableAgentPubkeys = getMentionableAgentPubkeys({
+    currentPubkey: CURRENT_PUBKEY,
+    managedAgentPubkeys: [],
+    relayAgents: [
+      {
+        pubkey: PUB_B,
+        ownerPubkey: OTHER_OWNER_PUBKEY,
+        respondTo: "anyone",
+        respondToAllowlist: [],
+        channelIds: ["general"],
+      },
+    ],
+    sharedChannelIds: new Set(["general"]),
+  });
+
+  assert.equal(
+    shouldAdmitMentionCandidate({
+      isArchived: false,
+      isAgent: true,
+      isMember: true,
+      pubkey: PUB_B,
+      mentionableAgentPubkeys,
+      directoryAgentPubkeys: new Set([PUB_B]),
+    }),
+    true,
+  );
+});
+
+test("shouldAdmitMentionCandidate: rejects archived identities", () => {
+  assert.equal(
+    shouldAdmitMentionCandidate({
+      isArchived: true,
+      isAgent: false,
+      isMember: true,
+      pubkey: PUB_B,
+      mentionableAgentPubkeys: new Set(),
+      directoryAgentPubkeys: new Set(),
+    }),
+    false,
+  );
+});
+
+test("isAgentIdentityInManagedList: scopes add-member search to managed agent identities", () => {
   const managedAgentPubkeys = new Set([PUB_A]);
 
   assert.equal(

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -58,6 +58,8 @@ export function isAgentIdentityInManagedList(
   candidate: { isAgent?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
 ) {
+  // This is an ownership filter for add-member search. Mention autocomplete
+  // uses the invocability policy in shouldAdmitMentionCandidate instead.
   return (
     candidate.isAgent !== true ||
     managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
@@ -95,6 +97,18 @@ export function shouldHideAgentFromMentions({
   // mentionability is still loading could be hidden prematurely — keep the
   // two sets derived from the same query.
   return directoryAgentPubkeys.has(normalized);
+}
+
+export function shouldAdmitMentionCandidate(args: {
+  isArchived: boolean;
+  isAgent: boolean;
+  isMember: boolean;
+  pubkey: string;
+  mentionableAgentPubkeys: ReadonlySet<string>;
+  directoryAgentPubkeys: ReadonlySet<string>;
+}) {
+  if (args.isArchived) return false;
+  return !shouldHideAgentFromMentions(args);
 }
 
 type AgentAutocompleteCandidate = {

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,8 +16,7 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
-  shouldHideAgentFromMentions,
+  shouldAdmitMentionCandidate,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
   useInfiniteUserSearchQuery,
@@ -243,14 +242,9 @@ export function useMentions(
 
     const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
       const pubkey = normalizePubkey(candidate.pubkey);
-      if (isArchivedDiscovery(pubkey)) {
-        return;
-      }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
-        return;
-      }
       if (
-        shouldHideAgentFromMentions({
+        !shouldAdmitMentionCandidate({
+          isArchived: isArchivedDiscovery(pubkey),
           isAgent: candidate.isAgent === true,
           isMember: candidate.isMember === true,
           pubkey,
@@ -420,7 +414,6 @@ export function useMentions(
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,
     managedAgentPersonaIdsByPubkey,
-    managedAgentPubkeys,
     managedAgentsQuery.data,
     memberPubkeys,
     members,


### PR DESCRIPTION
## Summary
- allow Desktop mention autocomplete to include another owner's agent when the existing relay policy says the current user can invoke it
- preserve archived-candidate exclusion and the existing preference for live managed identities
- keep the local-ownership filter scoped to add-member search
- add regression coverage for a cross-owner channel bot configured with `respondTo: anyone`
## Problem
`useMentions` rejected every agent identity that was not in the current user's locally managed-agent set before applying the existing mention visibility and invocability policy.
That removed cross-owner channel bots from autocomplete even when they were shared with the user and configured to respond to anyone. Because the candidate never entered the mention map, message sending received no recipient pubkey and emitted no corresponding `p` tag.
## Fix
Move the complete mention candidate decision behind a tested admission helper that applies:
1. archived identity exclusion
2. the existing invocability and relay-directory visibility policy
The ownership-only helper remains unchanged for add-member search, where that restriction is intentional.
## Testing
- `cd desktop && pnpm check`
- `cd desktop && pnpm test` — 3,631 passed
- `cd desktop && pnpm typecheck`
- `cd desktop && pnpm build`
The regression test covers a channel bot owned by another user, with no locally managed identity and `respondTo: anyone`, at the candidate-admission seam used by `useMentions`.