### PR TITLE
fix(cli): preserve attachments on buzz messages edit (#3022)

### DIFF
--- a/crates/buzz-cli/README.md
+++ b/crates/buzz-cli/README.md
@@ -36,7 +36,9 @@ buzz messages get --channel <uuid> --limit 20
 buzz messages thread --channel <uuid> --event <event-id>
 buzz messages search --query "architecture"
 buzz messages search --author <pubkey|npub|name> --since <unix-ts>
-buzz messages edit --event <event-id> --content "Updated text"
+buzz messages edit --event <event-id> --content "Updated text"           # attachments preserved
+buzz messages edit --event <event-id> --content "Updated text" --file pic.png  # replace attachments
+buzz messages edit --event <event-id> --content "Updated text" --no-media  # drop all attachments
 buzz messages delete --event <event-id>
 
 # Diffs

--- a/crates/buzz-cli/TESTING.md
+++ b/crates/buzz-cli/TESTING.md
@@ -223,7 +223,8 @@ buzz messages thread --channel "$CHANNEL_ID" --event "$EVENT_ID" | jq .
 buzz messages search --query "Hello" | jq .
 buzz messages search --query "CLI test" --limit 5 | jq .
 
-# messages edit
+# messages edit (existing attachments are preserved by default;
+#   --file replaces them, --no-media clears them)
 buzz messages edit --event "$EVENT_ID" --content "Edited by CLI test" | jq .
 
 # messages delete

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -86,6 +86,15 @@ async fn resolve_thread_ref(
 /// Resolve the channel UUID for an event by querying for it via POST /query.
 /// Extracts the `h` tag value from the returned event's tags.
 async fn resolve_channel_id(client: &BuzzClient, event_id: &str) -> Result<Uuid, CliError> {
+    let event = fetch_event_by_id(client, event_id).await?;
+    channel_id_from_event(&event, event_id)
+}
+
+/// Fetch a single event by its ID via POST /query.
+async fn fetch_event_by_id(
+    client: &BuzzClient,
+    event_id: &str,
+) -> Result<serde_json::Value, CliError> {
     let filter = serde_json::json!({
         "ids": [event_id]
     });
@@ -95,9 +104,13 @@ async fn resolve_channel_id(client: &BuzzClient, event_id: &str) -> Result<Uuid,
     let arr = events
         .as_array()
         .ok_or_else(|| CliError::Other("query response is not an array".into()))?;
-    let event = arr
-        .first()
-        .ok_or_else(|| CliError::Other(format!("event {event_id} not found")))?;
+    arr.first()
+        .cloned()
+        .ok_or_else(|| CliError::Other(format!("event {event_id} not found")))
+}
+
+/// Extract the channel UUID from an event's h-tag.
+fn channel_id_from_event(event: &serde_json::Value, event_id: &str) -> Result<Uuid, CliError> {
     let tags = event
         .get("tags")
         .and_then(|t| t.as_array())
@@ -147,6 +160,27 @@ fn resolve_names_to_pubkeys(
         }
     }
     Ok(resolved)
+}
+
+/// Extract raw `imeta` tag vectors from a fetched event's JSON tags.
+/// Only `imeta` tags are returned — no other tag kinds are carried.
+fn extract_imeta_tags(event: &serde_json::Value) -> Vec<Vec<String>> {
+    event
+        .get("tags")
+        .and_then(|t| t.as_array())
+        .map(|tags| {
+            tags.iter()
+                .filter_map(|t| t.as_array())
+                .filter(|parts| parts.first().and_then(|v| v.as_str()) == Some("imeta"))
+                .map(|parts| {
+                    parts
+                        .iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Resolve mention text against the channel membership snapshot.
@@ -812,19 +846,61 @@ pub async fn cmd_delete_message(
 }
 
 /// Edit a message you previously sent.
+///
+/// Attachment semantics:
+/// - No `--file` and no `--no-media`: preserves existing attachments (default carry-forward)
+/// - `--file` provided: replaces attachments with the uploaded file(s) and appends markdown
+/// - `--no-media`: removes all attachments from the message
 pub async fn cmd_edit_message(
     client: &BuzzClient,
     event_id: &str,
     content: &str,
+    files: &[String],
+    no_media: bool,
 ) -> Result<(), CliError> {
     validate_hex64(event_id)?;
     validate_content_size(content)?;
 
-    // Resolve channel_id from the event's h-tag
-    let channel_uuid = resolve_channel_id(client, event_id).await?;
+    // Fetch the target event once; derive both the channel id and the
+    // carry-forward attachment set from that single query.
+    let target_event = fetch_event_by_id(client, event_id).await?;
+    let channel_uuid = channel_id_from_event(&target_event, event_id)?;
     let target_eid = parse_event_id(event_id)?;
 
-    let builder = buzz_sdk::build_edit(channel_uuid, target_eid, content)
+    // Decide media_tags and final_content based on flags
+    let (media_tags, final_content) = if no_media {
+        // --no-media: clear all attachments
+        (Vec::new(), content.to_string())
+    } else if !files.is_empty() {
+        // --file provided: upload files and replace attachments
+        let mut media_tags: Vec<Vec<String>> = Vec::new();
+        let mut media_content = String::new();
+        for file_path in files {
+            let desc = client
+                .upload_file(file_path)
+                .await
+                .map_err(|e| CliError::Other(format!("upload failed for {file_path}: {e}")))?;
+            media_tags.push(crate::client::build_imeta_tag(&desc));
+            if desc.mime_type.starts_with("video/") {
+                media_content.push_str("\n![video](");
+            } else {
+                media_content.push_str("\n![image](");
+            }
+            media_content.push_str(&desc.url);
+            media_content.push(')');
+        }
+        let final_content = if media_content.is_empty() {
+            content.to_string()
+        } else {
+            format!("{}{media_content}", content)
+        };
+        (media_tags, final_content)
+    } else {
+        // Default: preserve existing attachments
+        (extract_imeta_tags(&target_event), content.to_string())
+    };
+
+    let builder = buzz_sdk::build_edit(channel_uuid, target_eid, &final_content, &media_tags)
         .map_err(|e| CliError::Other(format!("build_edit failed: {e}")))?;
 
     let event = client.sign_event(builder)?;
@@ -928,7 +1004,12 @@ pub async fn dispatch(
             )
             .await
         }
-        MessagesCmd::Edit { event, content } => cmd_edit_message(client, &event, &content).await,
+        MessagesCmd::Edit {
+            event,
+            content,
+            files,
+            no_media,
+        } => cmd_edit_message(client, &event, &content, &files, no_media).await,
         MessagesCmd::Delete {
             event,
             action_id,
@@ -993,8 +1074,8 @@ pub async fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::{
-        event_mention_pubkeys, find_root_from_tags, match_profiles_by_name, merge_message_mentions,
-        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        event_mention_pubkeys, extract_imeta_tags, find_root_from_tags, match_profiles_by_name,
+        merge_message_mentions, missing_members, normalize_explicit_mentions, parse_member_pubkeys,
         resolve_names_to_pubkeys,
     };
     use buzz_sdk::mentions::{
@@ -1371,5 +1452,43 @@ mod tests {
             profile_event(PK_VALID_A, Some("Aaron"), None),
         ];
         assert_eq!(match_profiles_by_name(&events, "Aaron").len(), 1);
+    }
+
+    #[test]
+    fn extract_imeta_tags_returns_only_imeta() {
+        let event = json!({
+            "tags": [
+                ["h", "channel-uuid"],
+                ["e", "event-id", "", "reply"],
+                ["imeta", "url", "https://example.com/image.png", "m", "image/png"],
+                ["emoji", "🎉"],
+                ["imeta", "url", "https://example.com/video.mp4", "m", "video/mp4"],
+            ]
+        });
+        let imeta_tags = extract_imeta_tags(&event);
+        assert_eq!(imeta_tags.len(), 2);
+        // Verify the full imeta vectors are preserved
+        assert_eq!(imeta_tags[0][0], "imeta");
+        assert_eq!(imeta_tags[0][1], "url");
+        assert_eq!(imeta_tags[1][0], "imeta");
+    }
+
+    #[test]
+    fn extract_imeta_tags_empty_when_none() {
+        let event = json!({
+            "tags": [
+                ["h", "channel-uuid"],
+                ["e", "event-id"],
+            ]
+        });
+        let imeta_tags = extract_imeta_tags(&event);
+        assert!(imeta_tags.is_empty());
+    }
+
+    #[test]
+    fn extract_imeta_tags_handles_missing_tags() {
+        let event = json!({});
+        let imeta_tags = extract_imeta_tags(&event);
+        assert!(imeta_tags.is_empty());
     }
 }

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -424,6 +424,12 @@ pub enum MessagesCmd {
         /// New message content
         #[arg(long)]
         content: String,
+        /// Replace attachments: upload file(s) and include as imeta tags. Conflicts with --no-media.
+        #[arg(long = "file", conflicts_with = "no_media")]
+        files: Vec<String>,
+        /// Remove all attachments from the message.
+        #[arg(long, default_value_t = false)]
+        no_media: bool,
     },
     /// Delete a message by event ID
     Delete {
@@ -2369,7 +2375,7 @@ mod tests {
         );
     }
 
-    // ── projects update mutation group ────────────────────────────────────────
+// ── projects update mutation group ────────────────────────────────────────
 
     /// Multiple independent fields must be accepted in the same invocation.
     #[test]
@@ -2474,5 +2480,64 @@ mod tests {
             .is_err(),
             "--visibility chartreuse on update must be rejected at parse time"
         );
+    }
+
+    #[test]
+    fn messages_edit_file_conflicts_with_no_media() {
+        use clap::Parser;
+
+        // Should error: both --file and --no-media provided
+        let result = Cli::try_parse_from(vec![
+            "buzz",
+            "messages",
+            "edit",
+            "--event",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--content",
+            "test",
+            "--file",
+            "a.png",
+            "--no-media",
+        ]);
+        assert!(result.is_err());
+
+        // Should succeed: only --file
+        let result = Cli::try_parse_from(vec![
+            "buzz",
+            "messages",
+            "edit",
+            "--event",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--content",
+            "test",
+            "--file",
+            "a.png",
+        ]);
+        assert!(result.is_ok());
+
+        // Should succeed: only --no-media
+        let result = Cli::try_parse_from(vec![
+            "buzz",
+            "messages",
+            "edit",
+            "--event",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--content",
+            "test",
+            "--no-media",
+        ]);
+        assert!(result.is_ok());
+
+        // Should succeed: neither flag
+        let result = Cli::try_parse_from(vec![
+            "buzz",
+            "messages",
+            "edit",
+            "--event",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--content",
+            "test",
+        ]);
+        assert!(result.is_ok());
     }
 }

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -380,16 +380,22 @@ pub fn build_diff_message(
 }
 
 /// Build an edit event targeting an existing message (kind 40003).
+///
+/// - `media_tags`: raw imeta tag vectors — the FULL replacement attachment
+///   set for the edited message (clients treat an edit's imeta tags as
+///   authoritative; an edit with none clears attachments).
 pub fn build_edit(
     channel_id: Uuid,
     target_event_id: nostr::EventId,
     new_content: &str,
+    media_tags: &[Vec<String>],
 ) -> Result<EventBuilder, SdkError> {
     check_content(new_content, 64 * 1024)?;
-    let tags = vec![
+    let mut tags = vec![
         tag(&["h", &channel_id.to_string()])?,
         tag(&["e", &target_event_id.to_hex()])?,
     ];
+    imeta_tags(media_tags, &mut tags)?;
     Ok(EventBuilder::new(Kind::Custom(40003), new_content).tags(tags))
 }
 
@@ -2542,7 +2548,7 @@ mod tests {
     fn edit_happy_path() {
         let cid = uuid();
         let eid = event_id();
-        let ev = sign(build_edit(cid, eid, "new content").unwrap());
+        let ev = sign(build_edit(cid, eid, "new content", &[]).unwrap());
         assert_eq!(ev.kind.as_u16(), 40003);
         assert!(has_tag(&ev, "e", &eid.to_hex()));
     }
@@ -2553,9 +2559,60 @@ mod tests {
         let eid = event_id();
         let big = "x".repeat(64 * 1024 + 1);
         assert!(matches!(
-            build_edit(cid, eid, &big),
+            build_edit(cid, eid, &big, &[]),
             Err(SdkError::ContentTooLarge { .. })
         ));
+    }
+
+    #[test]
+    fn edit_with_media() {
+        let cid = uuid();
+        let eid = event_id();
+        let media_tags = vec![vec![
+            "imeta".to_string(),
+            "url https://example.com/image.png".to_string(),
+            "m image/png".to_string(),
+        ]];
+        let ev = sign(build_edit(cid, eid, "new content", &media_tags).unwrap());
+        assert_eq!(ev.kind.as_u16(), 40003);
+        assert!(has_tag(&ev, "e", &eid.to_hex()));
+        assert!(has_tag(&ev, "h", &cid.to_string()));
+        // Verify the imeta tag is present
+        let imeta_tags: Vec<_> = ev
+            .tags
+            .iter()
+            .filter(|t| {
+                let s = t.as_slice();
+                s.first().map(|v| v.as_str()) == Some("imeta")
+            })
+            .collect();
+        assert_eq!(imeta_tags.len(), 1);
+    }
+
+    #[test]
+    fn edit_without_media_has_no_imeta() {
+        let cid = uuid();
+        let eid = event_id();
+        let ev = sign(build_edit(cid, eid, "new content", &[]).unwrap());
+        assert_eq!(ev.kind.as_u16(), 40003);
+        let imeta_tags: Vec<_> = ev
+            .tags
+            .iter()
+            .filter(|t| {
+                let s = t.as_slice();
+                s.first().map(|v| v.as_str()) == Some("imeta")
+            })
+            .collect();
+        assert_eq!(imeta_tags.len(), 0);
+    }
+
+    #[test]
+    fn edit_rejects_malformed_media_tag() {
+        let cid = uuid();
+        let eid = event_id();
+        let malformed_tags = vec![vec![]];
+        let result = build_edit(cid, eid, "new content", &malformed_tags);
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`buzz messages edit` silently deletes a message's attachments. `build_edit` (`crates/buzz-sdk/src/builders.rs`) emits only `h` + `e` tags — never `imeta`. The desktop render/cache overlay (`desktop/src/features/messages/lib/applyEditTagOverlay.mjs`) treats an edit carrying zero `imeta` tags as "the attachment set is now empty" — this is intentional (it's how deliberate attachment removal works), and is pinned by a test. Because the CLI never carried `imeta` forward, an agent fixing a typo in its own message deletes the screenshot it attached. `buzz` exits 0, nothing warns, and there's no flag to restore them.

Desktop was fixed for its own builder in #755; the CLI was never brought along. Closes #3022.

## Fix

Fixed at the builder + CLI, **not** the overlay (the overlay's replace-on-`imeta` semantics is correct and load-bearing for desktop removal).

- **`build_edit` gains a `media_tags: &[Vec<String>]` parameter** and emits `imeta` via the same `imeta_tags()` helper `build_message` already uses (same validation path).
- **`buzz messages edit` gains `--file` and `--no-media`:**
  - *(neither flag — default)* **carry-forward**: fetch the target event and preserve its existing `imeta` tags, so today's invocations stop losing attachments.
  - `--file <path>` *(repeatable)*: upload and **replace** attachments — identical upload path to `buzz messages send` (this is why the flag is `--file`, matching `send`, not `--media`).
  - `--no-media`: **clear** all attachments (explicit). Mutually exclusive with `--file` (enforced by clap).

The single relay fetch already performed to resolve the channel id is reused to read the carry-forward `imeta` — **no extra round-trip**. A failed/absent fetch aborts *before* signing, so an attachment-wiping edit can never be published on error.

## Tests

- `buzz-sdk`: `edit_with_media` (imeta emitted), `edit_without_media_has_no_imeta` (clear contract), `edit_rejects_malformed_media_tag`.
- `buzz-cli`: `extract_imeta_tags_returns_only_imeta` / `_empty_when_none` / `_handles_missing_tags` (only `imeta` carried, full vectors preserved), and a clap test that `--file` + `--no-media` is rejected.

```
cargo test -p buzz-sdk     # 238 passed
cargo test -p buzz-cli     # 254 passed
cargo fmt --all -- --check # clean
cargo clippy -p buzz-sdk -p buzz-cli -- -D warnings  # clean
```

## Known follow-ups (non-blocking)

- **No automated end-to-end test** for the full fetch→extract→build path — the unit tests cover the pieces; the full flow is covered by the manual runbook in `crates/buzz-cli/TESTING.md` (no mocked-relay harness exists for CLI command handlers). Verified manually.
- **Inline `![image](url)` markdown in the old body is not carried forward** — `--content` replaces the body wholesale. The `imeta` attachment (what desktop renders) is preserved; only inline markdown in a plaintext client would be affected. Left as-is to keep the change surgical.