### PR TITLE
feat(desktop): add per-agent usage dashboard

### DIFF
--- a/desktop/src-tauri/src/commands/agent_logs.rs
+++ b/desktop/src-tauri/src/commands/agent_logs.rs
@@ -1,11 +1,14 @@
+use std::path::PathBuf;
+
 use serde::Serialize;
 use tauri::{AppHandle, Manager};
 
 use crate::{
     app_state::AppState,
     managed_agents::{
-        latest_managed_agent_log_path, load_managed_agents, read_log_tail, BackendKind,
-        ManagedAgentLogResponse,
+        build_managed_agent_summary, latest_managed_agent_log_path, load_global_agent_config,
+        load_managed_agents, load_personas, managed_agent_log_path, managed_agent_runtime_log_path,
+        read_log_tail, workspace_pair_key, BackendKind, ManagedAgentLogResponse,
     },
 };
 
@@ -24,6 +27,10 @@ struct ParsedAgentUsage {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+/// Bounded local usage and effective runtime metadata for one managed agent.
+///
+/// Prompt measurements are derived from harness logs and are estimates rather
+/// than provider billing data. No prompt or message content is serialized.
 pub struct AgentUsageSummary {
     pubkey: String,
     name: String,
@@ -77,6 +84,12 @@ fn parse_agent_usage(content: &str) -> ParsedAgentUsage {
     usage
 }
 
+fn select_usage_log_path(pair_path: Option<PathBuf>, legacy_path: PathBuf) -> PathBuf {
+    pair_path
+        .filter(|path| path.exists())
+        .unwrap_or(legacy_path)
+}
+
 #[tauri::command]
 pub async fn get_managed_agent_log(
     pubkey: String,
@@ -117,29 +130,48 @@ pub async fn get_managed_agent_log(
 #[tauri::command]
 pub async fn get_agent_usage_dashboard(app: AppHandle) -> Result<Vec<AgentUsageSummary>, String> {
     tokio::task::spawn_blocking(move || {
-        let records = {
+        let agent_contexts = {
             let state = app.state::<AppState>();
             let _store_guard = state
                 .managed_agents_store_lock
                 .lock()
                 .map_err(|error| error.to_string())?;
-            load_managed_agents(&app)?
+            let records = load_managed_agents(&app)?;
+            let personas = load_personas(&app).unwrap_or_default();
+            let global = load_global_agent_config(&app).unwrap_or_default();
+            let runtimes = state
+                .managed_agent_processes
+                .lock()
+                .map_err(|error| error.to_string())?;
+
+            records
+                .iter()
+                .filter(|record| {
+                    !record.pubkey.is_empty() && matches!(&record.backend, BackendKind::Local)
+                })
+                .map(|record| {
+                    let summary =
+                        build_managed_agent_summary(&app, record, &runtimes, &personas, &global)?;
+                    let legacy_log_path = managed_agent_log_path(&app, &record.pubkey)?;
+                    let pair_log_path = workspace_pair_key(&app, record)
+                        .and_then(|key| managed_agent_runtime_log_path(&app, &key).ok());
+                    let log_path = select_usage_log_path(pair_log_path, legacy_log_path);
+                    Ok((summary, log_path))
+                })
+                .collect::<Result<Vec<_>, String>>()?
         };
         let mut summaries = Vec::new();
 
-        for record in records.into_iter().filter(|record| {
-            !record.pubkey.is_empty() && matches!(&record.backend, BackendKind::Local)
-        }) {
-            let log_path = managed_agent_log_path(&app, &record.pubkey)?;
+        for (summary, log_path) in agent_contexts {
             let content = read_log_tail(&log_path, USAGE_LOG_SAMPLE_LINES)?;
             let usage = parse_agent_usage(&content);
 
             summaries.push(AgentUsageSummary {
-                pubkey: record.pubkey,
-                name: record.name,
-                model: record.model,
-                parallelism: record.parallelism,
-                is_running: record.runtime_pid.is_some(),
+                pubkey: summary.pubkey,
+                name: summary.name,
+                model: summary.model,
+                parallelism: summary.parallelism,
+                is_running: summary.status == "running",
                 prompt_count: usage.prompt_count,
                 prompt_bytes: usage.prompt_bytes,
                 estimated_prompt_tokens: usage.prompt_bytes.saturating_add(3) / 4,
@@ -194,5 +226,20 @@ ERROR dead-lettering batch immediately — provider usage limit reached
         assert_eq!(usage.prompt_count, 0);
         assert_eq!(usage.prompt_bytes, 0);
         assert_eq!(usage.session_start_count, 1);
+    }
+
+    #[test]
+    fn usage_log_prefers_existing_pair_scope_and_falls_back_to_legacy() {
+        let temp = tempfile::tempdir().unwrap();
+        let pair = temp.path().join("pair.log");
+        let legacy = temp.path().join("legacy.log");
+
+        assert_eq!(
+            select_usage_log_path(Some(pair.clone()), legacy.clone()),
+            legacy
+        );
+
+        std::fs::write(&pair, "pair usage").unwrap();
+        assert_eq!(select_usage_log_path(Some(pair.clone()), legacy), pair);
     }
 }

--- a/desktop/src-tauri/src/commands/agent_logs.rs
+++ b/desktop/src-tauri/src/commands/agent_logs.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use tauri::{AppHandle, Manager};
 
 use crate::{
@@ -7,6 +8,74 @@ use crate::{
         ManagedAgentLogResponse,
     },
 };
+
+const USAGE_LOG_SAMPLE_LINES: usize = 20_000;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ParsedAgentUsage {
+    prompt_count: u64,
+    prompt_bytes: u64,
+    peak_prompt_bytes: u64,
+    session_start_count: u64,
+    large_prompt_count: u64,
+    retry_count: u64,
+    quota_limit_count: u64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentUsageSummary {
+    pubkey: String,
+    name: String,
+    model: Option<String>,
+    parallelism: u32,
+    is_running: bool,
+    prompt_count: u64,
+    prompt_bytes: u64,
+    estimated_prompt_tokens: u64,
+    peak_prompt_bytes: u64,
+    session_start_count: u64,
+    large_prompt_count: u64,
+    retry_count: u64,
+    quota_limit_count: u64,
+}
+
+fn parse_u64_field(line: &str, field: &str) -> Option<u64> {
+    let prefix = format!("{field}=");
+    line.split_whitespace()
+        .find_map(|part| part.strip_prefix(&prefix))
+        .and_then(|value| value.trim_end_matches([',', ';']).parse().ok())
+}
+
+fn parse_agent_usage(content: &str) -> ParsedAgentUsage {
+    let mut usage = ParsedAgentUsage::default();
+
+    for line in content.lines() {
+        if line.contains("prompt prepared") && !line.contains("large prompt prepared") {
+            if let Some(bytes) = parse_u64_field(line, "prompt_bytes") {
+                usage.prompt_count += 1;
+                usage.prompt_bytes = usage.prompt_bytes.saturating_add(bytes);
+                usage.peak_prompt_bytes = usage.peak_prompt_bytes.max(bytes);
+            }
+            if line.contains("is_new_session=true") {
+                usage.session_start_count += 1;
+            }
+        }
+        if line.contains("large prompt prepared") {
+            usage.large_prompt_count += 1;
+        }
+        if line.contains("requeueing failed batch with backoff")
+            || line.contains("requeued for retry")
+        {
+            usage.retry_count += 1;
+        }
+        if line.contains("provider usage limit reached") {
+            usage.quota_limit_count += 1;
+        }
+    }
+
+    usage
+}
 
 #[tauri::command]
 pub async fn get_managed_agent_log(
@@ -37,4 +106,93 @@ pub async fn get_managed_agent_log(
     })
     .await
     .map_err(|e| format!("spawn_blocking failed: {e}"))?
+}
+
+/// Return bounded, per-agent prompt-cost proxies from local harness logs.
+///
+/// ACP adapters do not all expose exact provider token counts. Prompt bytes
+/// are therefore reported as a transparent input-size proxy, with the
+/// conventional bytes/4 token estimate clearly labeled as an estimate in the
+/// UI. The bounded tail avoids loading unbounded historical logs.
+#[tauri::command]
+pub async fn get_agent_usage_dashboard(app: AppHandle) -> Result<Vec<AgentUsageSummary>, String> {
+    tokio::task::spawn_blocking(move || {
+        let records = {
+            let state = app.state::<AppState>();
+            let _store_guard = state
+                .managed_agents_store_lock
+                .lock()
+                .map_err(|error| error.to_string())?;
+            load_managed_agents(&app)?
+        };
+        let mut summaries = Vec::new();
+
+        for record in records.into_iter().filter(|record| {
+            !record.pubkey.is_empty() && matches!(&record.backend, BackendKind::Local)
+        }) {
+            let log_path = managed_agent_log_path(&app, &record.pubkey)?;
+            let content = read_log_tail(&log_path, USAGE_LOG_SAMPLE_LINES)?;
+            let usage = parse_agent_usage(&content);
+
+            summaries.push(AgentUsageSummary {
+                pubkey: record.pubkey,
+                name: record.name,
+                model: record.model,
+                parallelism: record.parallelism,
+                is_running: record.runtime_pid.is_some(),
+                prompt_count: usage.prompt_count,
+                prompt_bytes: usage.prompt_bytes,
+                estimated_prompt_tokens: usage.prompt_bytes.saturating_add(3) / 4,
+                peak_prompt_bytes: usage.peak_prompt_bytes,
+                session_start_count: usage.session_start_count,
+                large_prompt_count: usage.large_prompt_count,
+                retry_count: usage.retry_count,
+                quota_limit_count: usage.quota_limit_count,
+            });
+        }
+
+        summaries.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(summaries)
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking failed: {e}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_agent_usage_summarizes_prompt_cost_and_failures() {
+        let log = r#"
+INFO pool::prompt: prompt prepared prompt_bytes=12000 prompt_blocks=5 is_new_session=true
+INFO pool::prompt: prompt prepared prompt_bytes=800 prompt_blocks=2 is_new_session=false
+WARN pool::prompt: large prompt prepared prompt_bytes=52000
+WARN requeueing failed batch with backoff retry_count=1
+ERROR dead-lettering batch immediately — provider usage limit reached
+"#;
+
+        assert_eq!(
+            parse_agent_usage(log),
+            ParsedAgentUsage {
+                prompt_count: 2,
+                prompt_bytes: 12_800,
+                peak_prompt_bytes: 12_000,
+                session_start_count: 1,
+                large_prompt_count: 1,
+                retry_count: 1,
+                quota_limit_count: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_agent_usage_ignores_malformed_prompt_measurements() {
+        let usage = parse_agent_usage(
+            "INFO prompt prepared prompt_bytes=unknown is_new_session=true\nINFO unrelated",
+        );
+        assert_eq!(usage.prompt_count, 0);
+        assert_eq!(usage.prompt_bytes, 0);
+        assert_eq!(usage.session_start_count, 1);
+    }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -802,6 +802,7 @@ pub fn run() {
             set_managed_agent_auto_restart,
             delete_managed_agent,
             get_managed_agent_log,
+            get_agent_usage_dashboard,
             get_agent_models,
             discover_agent_models,
             get_agent_config_surface,

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -38,6 +38,7 @@ import {
   saveCustomHarness,
   updateManagedAgent,
 } from "@/shared/api/tauri";
+import { getAgentUsageDashboard } from "@/shared/api/tauriAgentUsage";
 import type { HarnessDefinitionInput } from "@/shared/api/tauri";
 import {
   setManagedAgentAutoRestart,
@@ -110,6 +111,7 @@ export const personasQueryKey = ["personas"] as const;
 export const acpRuntimesQueryKey = ["acp-runtimes"] as const;
 export const acpAuthMethodsQueryKey = ["acp-auth-methods"] as const;
 export const managedAgentPrereqsQueryKey = ["managed-agent-prereqs"] as const;
+export const agentUsageDashboardQueryKey = ["agent-usage-dashboard"] as const;
 export const backendProvidersQueryKey = ["backend-providers"] as const;
 export const gitBashPrerequisiteQueryKey = ["git-bash-prerequisite"] as const;
 
@@ -895,6 +897,16 @@ export function useManagedAgentLogQuery(
     retry: false,
     staleTime: 3_000,
     refetchInterval: pubkey ? 30_000 : false,
+  });
+}
+
+export function useAgentUsageDashboardQuery() {
+  return useQuery({
+    queryKey: agentUsageDashboardQueryKey,
+    queryFn: getAgentUsageDashboard,
+    retry: false,
+    staleTime: 10_000,
+    refetchInterval: 30_000,
   });
 }
 

--- a/desktop/src/features/agents/ui/AgentUsageDashboard.tsx
+++ b/desktop/src/features/agents/ui/AgentUsageDashboard.tsx
@@ -1,0 +1,164 @@
+import { RefreshCw } from "lucide-react";
+
+import { useAgentUsageDashboardQuery } from "@/features/agents/hooks";
+import type { AgentUsageSummary } from "@/shared/api/agentUsageTypes";
+import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/shared/ui/card";
+
+const COMPACT_NUMBER = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 1,
+  notation: "compact",
+});
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatPromptEstimate(summary: AgentUsageSummary): string {
+  if (summary.promptCount === 0) return "—";
+  return `≈${COMPACT_NUMBER.format(summary.estimatedPromptTokens)}`;
+}
+
+type AgentUsageDashboardProps = {
+  onOpenAgent: (pubkey: string) => void;
+};
+
+export function AgentUsageDashboard({ onOpenAgent }: AgentUsageDashboardProps) {
+  const usageQuery = useAgentUsageDashboardQuery();
+  const summaries = usageQuery.data ?? [];
+
+  return (
+    <Card className="mx-auto w-full max-w-[996px]">
+      <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between sm:space-y-0">
+        <div className="space-y-1.5">
+          <CardTitle className="text-base">Agent usage</CardTitle>
+          <CardDescription>
+            Buzz-side input measurements from each local agent log. Estimated
+            tokens are prompt bytes ÷ 4, not provider billing totals.
+          </CardDescription>
+        </div>
+        <Button
+          aria-label="Refresh agent usage"
+          disabled={usageQuery.isFetching}
+          onClick={() => {
+            void usageQuery.refetch();
+          }}
+          size="sm"
+          variant="outline"
+        >
+          <RefreshCw className={usageQuery.isFetching ? "animate-spin" : ""} />
+          Refresh
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {usageQuery.error instanceof Error ? (
+          <p className="text-sm text-destructive">
+            Could not read agent usage: {usageQuery.error.message}
+          </p>
+        ) : usageQuery.isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading usage…</p>
+        ) : summaries.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No local agent instances are available yet.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[780px] border-collapse text-left text-sm">
+              <thead>
+                <tr className="border-b border-border/70 text-xs text-muted-foreground">
+                  <th className="pb-2 pr-4 font-medium">Agent</th>
+                  <th className="px-3 pb-2 font-medium">Workers</th>
+                  <th className="px-3 pb-2 font-medium">Prompts</th>
+                  <th className="px-3 pb-2 font-medium">Est. input</th>
+                  <th className="px-3 pb-2 font-medium">Prompt bytes</th>
+                  <th className="px-3 pb-2 font-medium">Peak</th>
+                  <th className="px-3 pb-2 font-medium">Retries</th>
+                  <th className="pl-3 pb-2 font-medium">Quota stops</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summaries.map((summary) => (
+                  <tr
+                    className="border-b border-border/50 last:border-b-0"
+                    key={summary.pubkey}
+                  >
+                    <td className="py-3 pr-4">
+                      <button
+                        className="font-medium hover:underline focus-visible:rounded-sm focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+                        onClick={() => onOpenAgent(summary.pubkey)}
+                        type="button"
+                      >
+                        {summary.name}
+                      </button>
+                      <div className="max-w-48 truncate text-xs text-muted-foreground">
+                        {summary.model ?? "Inherited model"}
+                        {summary.isRunning ? " · running" : " · stopped"}
+                      </div>
+                    </td>
+                    <td className="px-3 py-3">
+                      <Badge
+                        variant={
+                          summary.parallelism > 10 ? "warning" : "secondary"
+                        }
+                      >
+                        {summary.parallelism}
+                      </Badge>
+                    </td>
+                    <td className="px-3 py-3 tabular-nums">
+                      <div>{summary.promptCount.toLocaleString()}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {summary.sessionStartCount.toLocaleString()} sessions
+                      </div>
+                    </td>
+                    <td className="px-3 py-3 tabular-nums">
+                      {formatPromptEstimate(summary)}
+                    </td>
+                    <td className="px-3 py-3 tabular-nums">
+                      {summary.promptCount > 0
+                        ? formatBytes(summary.promptBytes)
+                        : "—"}
+                    </td>
+                    <td className="px-3 py-3 tabular-nums">
+                      <div>
+                        {summary.promptCount > 0
+                          ? formatBytes(summary.peakPromptBytes)
+                          : "—"}
+                      </div>
+                      {summary.largePromptCount > 0 ? (
+                        <div className="text-xs text-amber-600 dark:text-amber-400">
+                          {summary.largePromptCount.toLocaleString()} over 50 KB
+                        </div>
+                      ) : null}
+                    </td>
+                    <td className="px-3 py-3 tabular-nums">
+                      {summary.retryCount.toLocaleString()}
+                    </td>
+                    <td className="pl-3 py-3 tabular-nums">
+                      {summary.quotaLimitCount.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {summaries.length > 0 ? (
+          <p className="mt-3 text-xs text-muted-foreground">
+            Each row samples at most the latest 20,000 log lines. Provider
+            adapters do not consistently expose exact input, output, cache, or
+            billing totals.
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -8,6 +8,7 @@ import { AddAgentToChannelDialog } from "./AddAgentToChannelDialog";
 import { AddTeamToChannelDialog } from "./AddTeamToChannelDialog";
 import { AgentDefaultsDialog } from "./AgentDefaultsDialog";
 import { AgentDialog } from "./AgentDialog";
+import { AgentUsageDashboard } from "./AgentUsageDashboard";
 import { PersonaCatalogDialog } from "./PersonaCatalogDialog";
 import { PersonaDeleteDialog } from "./PersonaDeleteDialog";
 import { PersonaShareDialog } from "./PersonaShareDialog";
@@ -212,6 +213,12 @@ export function AgentsView() {
             title="Agents"
           />
           <div className="flex flex-col gap-8">
+            <AgentUsageDashboard
+              onOpenAgent={(pubkey) => {
+                openProfilePanel?.(pubkey);
+              }}
+            />
+
             <UnifiedAgentsSection
               defaultModel={inheritedDefaults.model.value}
               actionErrorMessage={agents.actionErrorMessage}

--- a/desktop/src/shared/api/agentUsageTypes.ts
+++ b/desktop/src/shared/api/agentUsageTypes.ts
@@ -1,0 +1,16 @@
+export type AgentUsageSummary = {
+  pubkey: string;
+  name: string;
+  model: string | null;
+  parallelism: number;
+  isRunning: boolean;
+  promptCount: number;
+  promptBytes: number;
+  /** Approximation only: measured prompt UTF-8 bytes divided by four. */
+  estimatedPromptTokens: number;
+  peakPromptBytes: number;
+  sessionStartCount: number;
+  largePromptCount: number;
+  retryCount: number;
+  quotaLimitCount: number;
+};

--- a/desktop/src/shared/api/tauriAgentUsage.ts
+++ b/desktop/src/shared/api/tauriAgentUsage.ts
@@ -1,0 +1,14 @@
+import { invokeTauri } from "@/shared/api/tauri";
+import type { AgentUsageSummary } from "@/shared/api/agentUsageTypes";
+
+/**
+ * Read bounded local usage and effective runtime metadata for every managed
+ * agent.
+ *
+ * Prompt measurements are derived from harness logs and are estimates rather
+ * than provider billing data. No prompt or message content crosses this
+ * boundary.
+ */
+export async function getAgentUsageDashboard(): Promise<AgentUsageSummary[]> {
+  return invokeTauri<AgentUsageSummary[]>("get_agent_usage_dashboard");
+}

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -10991,6 +10991,8 @@ export function maybeInstallE2eTauriMocks() {
         return handleGetManagedAgentLog(
           payload as Parameters<typeof handleGetManagedAgentLog>[0],
         );
+      case "get_agent_usage_dashboard":
+        return [];
       case "get_agent_models":
         return {
           agentName: "mock-agent",


### PR DESCRIPTION
## Summary

- add a per-agent usage table to the desktop Agents view
- report bounded local aggregates for prompt count and bytes, estimated input tokens, peak prompt size, sessions, retries, quota stops, effective model, runtime state, and worker count
- read the active workspace-instance log with a legacy-log fallback for older installations
- refresh automatically while the view is mounted and provide a manual refresh action
- parse only the latest 20,000 local log lines per agent

## Privacy and accuracy

The command returns aggregate counters only. It does not return prompt or message content. Estimated input tokens are explicitly labeled as a bytes-divided-by-four approximation rather than provider billing data.

Prompt-size telemetry is emitted by the companion ACP safeguards in #3066; until that lands, existing logs may show zero prompt measurements.

### Related issue

Related to #2631 and companion PR #3066. This PR adds local resource-usage visibility; it does not change agent parallelism defaults or pool-startup behavior.

### Testing

- focused parser and log-selection unit tests
- strict desktop Clippy
- desktop formatting, file-size, text-size, and pubkey checks
- TypeScript and production frontend build
- `just ci`

### Manual testing

1. Open the desktop Agents view with one or more managed agents configured.
2. Verify that each row reports its effective model, runtime state, worker count, and locally available usage aggregates.
3. Use the refresh control and verify that the table reloads without exposing prompt or message content.
4. Leave the view open and verify that it refreshes automatically.
