### PR TITLE
fix(desktop): prefer bundled sidecars in releases

### DIFF
--- a/desktop/src-tauri/src/managed_agents/command_search.rs
+++ b/desktop/src-tauri/src/managed_agents/command_search.rs
@@ -1,0 +1,53 @@
+use std::path::PathBuf;
+
+pub(super) fn ordered_command_search_dirs(
+    workspace_dirs: Vec<PathBuf>,
+    current_dirs: Vec<PathBuf>,
+    exe_parent: Option<PathBuf>,
+    prefer_exe_parent: bool,
+) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if prefer_exe_parent {
+        dirs.extend(exe_parent.clone());
+    }
+    dirs.extend(workspace_dirs);
+    dirs.extend(current_dirs);
+    if !prefer_exe_parent {
+        dirs.extend(exe_parent);
+    }
+
+    dirs.into_iter().fold(Vec::new(), |mut unique, dir| {
+        if !unique.contains(&dir) {
+            unique.push(dir);
+        }
+        unique
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_search_prefers_bundled_executable() {
+        let workspace = vec![PathBuf::from("/source/target/release")];
+        let current = vec![PathBuf::from("/cwd/target/release")];
+        let bundled = PathBuf::from("/Applications/Buzz.app/Contents/MacOS");
+
+        let dirs = ordered_command_search_dirs(workspace, current, Some(bundled.clone()), true);
+
+        assert_eq!(dirs.first(), Some(&bundled));
+    }
+
+    #[test]
+    fn debug_search_keeps_bundled_executable_last_and_deduplicates() {
+        let workspace = vec![PathBuf::from("/source/target/debug")];
+        let current = workspace.clone();
+        let bundled = PathBuf::from("/Applications/Buzz.app/Contents/MacOS");
+
+        let dirs =
+            ordered_command_search_dirs(workspace.clone(), current, Some(bundled.clone()), false);
+
+        assert_eq!(dirs, vec![workspace[0].clone(), bundled]);
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -496,22 +496,22 @@ fn profile_target_dirs(root: &Path) -> [PathBuf; 2] {
 }
 
 fn command_search_dirs() -> Vec<PathBuf> {
-    let mut dirs = profile_target_dirs(&workspace_root_dir()).to_vec();
-    if let Ok(current_dir) = std::env::current_dir() {
-        dirs.extend(profile_target_dirs(&current_dir));
-    }
+    let workspace_dirs = profile_target_dirs(&workspace_root_dir()).to_vec();
+    let current_dirs = std::env::current_dir()
+        .ok()
+        .map(|dir| profile_target_dirs(&dir).to_vec())
+        .unwrap_or_default();
+    let exe_parent = std::env::current_exe()
+        .ok()
+        .and_then(|path| path.parent().map(Path::to_path_buf));
 
-    dirs.extend(
-        std::env::current_exe()
-            .ok()
-            .and_then(|path| path.parent().map(Path::to_path_buf)),
-    );
-    dirs.into_iter().fold(Vec::new(), |mut unique, dir| {
-        if !unique.contains(&dir) {
-            unique.push(dir);
-        }
-        unique
-    })
+    // Releases prefer bundled binaries; debug keeps `just dev` target priority.
+    super::command_search::ordered_command_search_dirs(
+        workspace_dirs,
+        current_dirs,
+        exe_parent,
+        !cfg!(debug_assertions),
+    )
 }
 
 fn is_executable_file(path: &Path) -> bool {

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -6,6 +6,7 @@ pub(crate) use agent_env::{
     baked_build_env, build_buzz_agent_provider_defaults, discovery_env_with_baked_floor,
 };
 mod backend;
+mod command_search;
 pub(crate) mod config_bridge;
 pub(crate) mod custom_harnesses;
 mod discovery;


### PR DESCRIPTION
## Summary

- prefer binaries beside the desktop executable in installed release builds
- preserve target-directory priority for debug development builds
- deduplicate search directories while retaining their priority order
- cover release and debug ordering with focused unit tests

## Why

An installed release could discover a source checkout's target binary before the sidecars bundled with the app. That makes the installed application depend on unrelated local build artifacts and can mix versions after an update.

### Related issue

None found. Existing open sidecar issues concern different packaging, signing, or platform-specific failures.

### Testing

- focused release/debug search-order unit tests
- strict desktop Clippy
- Rust formatting and desktop file-size checks
- `just ci`

### Manual testing

1. Install a release build that includes bundled sidecars while a source checkout contains separately built sidecar binaries.
2. Start a managed agent from the installed application.
3. Verify from the application logs that the bundled sidecar beside the desktop executable was selected.
4. In a debug build, verify that the target-directory binary still takes priority.
