### PR TITLE
fix(huddle): deliver voice-mode guidelines to ACP agents

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -21,8 +21,8 @@ use std::time::Duration;
 use acp::{AcpClient, EnvVar, McpServer};
 use anyhow::Result;
 use buzz_core::kind::{
-    KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
+    KIND_HUDDLE_GUIDELINES, KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION,
+    KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::observer::{
     decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
@@ -1230,6 +1230,64 @@ impl Drop for RespawnGuard {
 // sync entry point — `std::env::set_var` is only safe before tokio spawns
 // worker threads (Rust 2024 edition safety requirement).
 
+/// Event kinds the default `mentions` subscription rule matches.
+///
+/// `KIND_HUDDLE_GUIDELINES` belongs here: Buzz Desktop posts the voice-mode
+/// etiquette for a huddle to the ephemeral channel, `p`-tagged to each
+/// enrolled agent. Leaving it out drops the event at both the REQ `kinds`
+/// filter and [`filter::match_event`], so agents join huddles without it and
+/// behave like ordinary chat agents — long, markdown-shaped replies that
+/// never reach TTS in time.
+fn default_mention_kinds() -> Vec<u32> {
+    vec![
+        KIND_STREAM_MESSAGE,
+        KIND_WORKFLOW_APPROVAL_REQUESTED,
+        KIND_STREAM_REMINDER,
+        KIND_HUDDLE_GUIDELINES,
+    ]
+}
+
+#[cfg(test)]
+mod default_mention_kinds_tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    /// A huddle guidelines event addressed to this agent must survive the
+    /// default `mentions` rule. Without `KIND_HUDDLE_GUIDELINES` in the kind
+    /// list this returns `None`, and agents never see voice-mode etiquette.
+    #[tokio::test]
+    async fn default_mentions_rule_admits_huddle_guidelines() {
+        let agent = Keys::generate();
+        let agent_hex = agent.public_key().to_hex();
+        let channel_id = uuid::Uuid::new_v4();
+
+        let rule = filter::SubscriptionRule {
+            name: "mentions".into(),
+            channels: filter::ChannelScope::All("all".into()),
+            kinds: default_mention_kinds(),
+            require_mention: true,
+            filter: None,
+            compiled_filter: None,
+            consecutive_timeouts: std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            prompt_tag: Some("@mention".into()),
+        };
+
+        let event = EventBuilder::new(
+            Kind::Custom(KIND_HUDDLE_GUIDELINES as u16),
+            "You are in a live voice huddle",
+        )
+        .tags(vec![Tag::parse(["p", &agent_hex]).unwrap()])
+        .sign_with_keys(&Keys::generate())
+        .unwrap();
+
+        let matched = filter::match_event(&event, channel_id, &[rule], &agent_hex).await;
+        assert!(
+            matched.is_some(),
+            "huddle guidelines must match the default mentions rule"
+        );
+    }
+}
+
 pub fn run() -> Result<()> {
     config::propagate_legacy_env_vars();
     tokio_main()
@@ -1441,13 +1499,10 @@ async fn tokio_main() -> Result<()> {
             vec![SubscriptionRule {
                 name: "mentions".into(),
                 channels: filter::ChannelScope::All("all".into()),
-                kinds: config.kinds_override.clone().unwrap_or_else(|| {
-                    vec![
-                        KIND_STREAM_MESSAGE,
-                        KIND_WORKFLOW_APPROVAL_REQUESTED,
-                        KIND_STREAM_REMINDER,
-                    ]
-                }),
+                kinds: config
+                    .kinds_override
+                    .clone()
+                    .unwrap_or_else(default_mention_kinds),
                 require_mention: !config.no_mention_filter,
                 filter: None,
                 compiled_filter: None,

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -553,13 +553,22 @@ pub fn build_huddle_ended(
 /// Posted to the **ephemeral** channel (not the parent) so agents see it
 /// via EOSE replay when they subscribe. Uses a dedicated kind so the TTS
 /// pipeline can filter it out without fragile content-prefix matching.
+///
+/// `agent_pubkeys` are added as `p` tags. The ACP harness subscribes to
+/// channels with `#p=[agent_pubkey]` when it runs in mention mode (the
+/// default), so a guidelines event with no `p` tag is never delivered —
+/// the agent then joins the huddle without voice-mode etiquette.
 pub fn build_huddle_guidelines(
     ephemeral_channel_id: &str,
     guidelines_text: &str,
+    agent_pubkeys: &[&str],
 ) -> Result<EventBuilder, String> {
     validate_channel_id(ephemeral_channel_id)?;
     check_content(guidelines_text)?;
-    let tags = vec![tag(vec!["h", ephemeral_channel_id])?];
+    let mut tags = vec![tag(vec!["h", ephemeral_channel_id])?];
+    for pk in agent_pubkeys {
+        tags.push(tag(vec!["p", pk])?);
+    }
     Ok(EventBuilder::new(Kind::Custom(48106), guidelines_text).tags(tags))
 }
 
@@ -995,5 +1004,34 @@ mod tests {
         );
         assert_eq!(p_tags[0], &vec!["p".to_string(), ALICE_HEX.to_string()]);
         assert_eq!(p_tags[1], &vec!["p".to_string(), BOB_HEX.to_string()]);
+    }
+
+    /// The ACP harness subscribes with `#p=[agent_pubkey]` in its default
+    /// mention mode, so guidelines without a `p` tag for each enrolled agent
+    /// are never delivered.
+    #[test]
+    fn huddle_guidelines_p_tag_every_enrolled_agent() {
+        let channel_id = Uuid::new_v4().to_string();
+        let builder = build_huddle_guidelines(&channel_id, "be brief", &[ALICE_HEX, BOB_HEX])
+            .expect("build_huddle_guidelines");
+        let event = builder.sign_with_keys(&Keys::generate()).unwrap();
+        let tags: Vec<Vec<String>> = event.tags.iter().map(|t| t.as_slice().to_vec()).collect();
+
+        assert!(
+            tags.contains(&vec!["h".to_string(), channel_id]),
+            "guidelines must stay channel-scoped, got {tags:?}"
+        );
+        let p_tags: Vec<&Vec<String>> = tags
+            .iter()
+            .filter(|t| t.first().map(String::as_str) == Some("p"))
+            .collect();
+        assert_eq!(
+            p_tags,
+            vec![
+                &vec!["p".to_string(), ALICE_HEX.to_string()],
+                &vec!["p".to_string(), BOB_HEX.to_string()],
+            ],
+            "every enrolled agent needs a p tag, got {p_tags:?}"
+        );
     }
 }

--- a/desktop/src-tauri/src/huddle/agents.rs
+++ b/desktop/src-tauri/src/huddle/agents.rs
@@ -16,9 +16,10 @@ use crate::{app_state::AppState, events, relay::submit_event};
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 /// Voice-mode guidelines posted as kind:48106 (huddle guidelines) to the
-/// ephemeral channel at huddle start. Agents see them via EOSE replay.
-/// Instructs agents on voice-mode etiquette: TTS constraints, brevity,
-/// self-selection, and sentence-at-a-time delivery.
+/// ephemeral channel, `p`-tagged to the agents being enrolled — the ACP
+/// harness subscribes with `#p=[agent_pubkey]` and would otherwise never
+/// receive them. Instructs agents on voice-mode etiquette: TTS constraints,
+/// brevity, self-selection, and sentence-at-a-time delivery.
 ///
 /// Why sentence-at-a-time: the desktop speaks each agent message as it
 /// arrives (queued, in order), so an agent that sends its first sentence
@@ -87,6 +88,31 @@ pub async fn add_agent_to_huddle(
     agent_pubkey: &str,
     state: &AppState,
 ) -> Result<AgentAddResult, String> {
+    // 0. Post voice-mode guidelines addressed to this agent, before the add.
+    //    The guidelines event published at huddle start only carries `p` tags
+    //    for the agents enrolled then, and the agent's channel subscription
+    //    replays from its own membership event — so a late-added agent sees
+    //    neither. Re-posting per agent is cheap (the channel is ephemeral and
+    //    the TTS pipeline filters kind:48106 out) and keeps every agent on the
+    //    same etiquette. Best-effort: never block enrollment.
+    let guidelines = voice_mode_guidelines(&parent_channel_id.to_string());
+    match events::build_huddle_guidelines(
+        &ephemeral_channel_id.to_string(),
+        &guidelines,
+        &[agent_pubkey],
+    ) {
+        Ok(builder) => {
+            if let Err(e) = submit_event(builder, state).await {
+                eprintln!(
+                    "buzz-desktop: huddle guidelines (kind:48106) for {agent_pubkey} failed: {e}"
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("buzz-desktop: build huddle guidelines for {agent_pubkey} failed: {e}");
+        }
+    }
+
     // 1. Add agent to ephemeral channel (required — fail hard on rejection).
     let add_eph = events::build_add_member(ephemeral_channel_id, agent_pubkey, Some("bot"))?;
     submit_event(add_eph, state).await?;

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -226,8 +226,9 @@ pub async fn start_huddle(
         //    complete EOSE before guidelines are stored if we post them after.
         //    Best-effort: don't fail the huddle if this fails.
         let guidelines = agents::voice_mode_guidelines(&parent_channel_id);
+        let guideline_p_tags: Vec<&str> = member_pubkeys.iter().map(String::as_str).collect();
         if let Ok(guidelines_builder) =
-            events::build_huddle_guidelines(&ephemeral_channel_id, &guidelines)
+            events::build_huddle_guidelines(&ephemeral_channel_id, &guidelines, &guideline_p_tags)
         {
             if let Err(e) = submit_event(guidelines_builder, &state).await {
                 eprintln!("buzz-desktop: huddle guidelines (kind:48106) failed: {e}");
@@ -971,8 +972,9 @@ pub async fn add_agent_to_huddle(
         }
     }
 
-    // No guidelines re-post needed — the agent sees the original kind:48106
-    // guidelines via EOSE replay when it subscribes to the ephemeral channel.
+    // Guidelines were re-posted for this agent inside `add_agent_to_huddle`:
+    // the huddle-start event only `p`-tags the agents enrolled then, and this
+    // agent's subscription replays from its own membership event.
 
     // Also add the agent to the visible participants list.
     {


### PR DESCRIPTION
Fixes part of #3071. Related: #2478 (English-only STT — different layer, not addressed here).

## Problem

An agent added to a voice huddle never receives the kind:48106 voice-mode guidelines. It joins the huddle as an ordinary chat agent and replies the way it replies in chat: one long, markdown-shaped message composed over tens of seconds. In a huddle that is silence.

The guidelines are filtered out twice, independently:

1. **`kinds`** — the harness's default `mentions` rule lists `[KIND_STREAM_MESSAGE, KIND_WORKFLOW_APPROVAL_REQUESTED, KIND_STREAM_REMINDER]`. `KIND_HUDDLE_GUIDELINES` is absent, so the event is dropped at the REQ `kinds` filter and again in `filter::match_event` (`crates/buzz-acp/src/filter.rs`, kind check).
2. **`#p`** — `require_mention` is on by default, so the channel REQ carries `#p=[agent_pubkey]`. `build_huddle_guidelines` emitted only an `h` tag, so the relay never returns the event.

There is also a third gap for agents added after the huddle starts: `add_agent_to_huddle` relied on the huddle-start guidelines event, but that event is older than the agent's membership notification, and the harness subscribes with `since = membership_ts - 5s` (`SINCE_SKEW_SECS`). The comment in `huddle/mod.rs` — "No guidelines re-post needed — the agent sees the original kind:48106 guidelines via EOSE replay" — did not hold.

## Change

- `build_huddle_guidelines` takes `agent_pubkeys` and emits a `p` tag per enrolled agent.
- `start_huddle` passes the huddle's `member_pubkeys`.
- `add_agent_to_huddle` posts guidelines addressed to the joining agent before enrolling it. Cheap: the channel is ephemeral and the TTS pipeline already filters kind:48106 out by kind.
- `default_mention_kinds()` extracted in `buzz-acp` and extended with `KIND_HUDDLE_GUIDELINES`.
- Corrected the two doc comments that asserted the EOSE-replay assumption.

Note that agents enrolled by `start_huddle` go through `build_add_member` directly, not `add_agent_to_huddle`, so guidelines are not double-posted for them.

## Tests

- `events::tests::huddle_guidelines_p_tag_every_enrolled_agent` — the builder emits one `p` tag per agent and keeps the `h` scope.
- `default_mention_kinds_tests::default_mentions_rule_admits_huddle_guidelines` — a `p`-tagged guidelines event survives `filter::match_event` under the default rule. Verified non-vacuous: narrowing the rule to `vec![KIND_STREAM_MESSAGE]` makes it fail.

```
cargo test -p buzz-acp                                  599 passed
cargo test --manifest-path desktop/src-tauri/Cargo.toml  1782 passed
cargo clippy -p buzz-acp --all-targets                   clean
cargo clippy --manifest-path desktop/src-tauri/...       clean
cargo fmt --all --check / desktop-tauri fmt              clean
```

## Not verified

I have not reproduced a live huddle against this build — the desktop build needs sidecar binaries I stubbed locally to type-check. The delivery path is covered by the unit tests above; the end-to-end behaviour change (agent actually speaks in a huddle) still wants a manual check by someone with a working desktop dev setup.

## Scope

This addresses delivery of the guidelines only. #3071 also reports huddle membership being revoked mid-huddle (`restricted: channel access revoked`), which I have not diagnosed and is left out of this PR.
