### PR TITLE
Add one-line agent card descriptions

### DIFF
--- a/desktop/src-tauri/src/commands/agent_config.rs
+++ b/desktop/src-tauri/src/commands/agent_config.rs
@@ -680,6 +680,7 @@ mod tests {
             respond_to: RespondTo::OwnerOnly,
             respond_to_allowlist: vec![],
             display_name: None,
+            description: None,
             slug: None,
             runtime: None,
             name_pool: Vec::new(),
@@ -701,6 +702,7 @@ mod tests {
         AgentDefinition {
             id: "persona-1".to_string(),
             display_name: "Persona".to_string(),
+            description: None,
             avatar_url: None,
             system_prompt: "You are a persona.".to_string(),
             runtime: None,

--- a/desktop/src-tauri/src/commands/agent_models_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_tests.rs
@@ -386,6 +386,7 @@ fn model_discovery_ignores_stale_record_for_linked_agent() {
     let persona = crate::managed_agents::AgentDefinition {
         id: "persona-1".to_string(),
         display_name: "Persona".to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: "You are a persona.".to_string(),
         runtime: Some("goose".to_string()),

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -936,6 +936,9 @@ pub async fn create_managed_agent(
             respond_to: minted.respond_to,
             respond_to_allowlist: minted.respond_to_allowlist.clone(),
             display_name: None,
+            description: linked_persona
+                .as_ref()
+                .and_then(|persona| persona.description.clone()),
             slug: None,
             runtime: None,
             name_pool: Vec::new(),

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -48,6 +48,7 @@ fn bare_agent_record(
         respond_to: RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
         display_name: None,
+        description: None,
         slug: None,
         runtime: None,
         name_pool: vec![],
@@ -67,6 +68,7 @@ fn persona_record(id: &str, model: Option<&str>, provider: Option<&str>) -> Agen
     AgentDefinition {
         id: id.to_string(),
         display_name: "Test Persona".to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: "".to_string(),
         runtime: None,

--- a/desktop/src-tauri/src/commands/personas/delete_cascade_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/delete_cascade_tests.rs
@@ -56,6 +56,7 @@ fn make_agent(
         respond_to: RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
         display_name: None,
+        description: None,
         slug: None,
         runtime: None,
         name_pool: vec![],

--- a/desktop/src-tauri/src/commands/personas/inbound_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/inbound_tests.rs
@@ -12,6 +12,7 @@ fn local_in_app() -> AgentDefinition {
     AgentDefinition {
         id: UUID.to_string(),
         display_name: "Local".to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: "local prompt".to_string(),
         runtime: Some("goose".to_string()),
@@ -37,6 +38,7 @@ fn inbound_for(d_tag: &str, display_name: &str) -> AgentDefinition {
     AgentDefinition {
         id: d_tag.to_string(),
         display_name: display_name.to_string(),
+        description: None,
         avatar_url: Some("https://example.com/a.png".to_string()),
         system_prompt: "remote prompt".to_string(),
         runtime: Some("acp".to_string()),
@@ -198,6 +200,7 @@ fn local_agent() -> ManagedAgentRecord {
         respond_to: crate::managed_agents::RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
         display_name: None,
+        description: None,
         slug: None,
         runtime: None,
         name_pool: Vec::new(),

--- a/desktop/src-tauri/src/commands/personas/mod.rs
+++ b/desktop/src-tauri/src/commands/personas/mod.rs
@@ -30,6 +30,19 @@ fn trim_optional(value: Option<String>) -> Option<String> {
     })
 }
 
+fn normalize_description(value: Option<String>) -> Result<Option<String>, String> {
+    let normalized = value
+        .map(|candidate| candidate.split_whitespace().collect::<Vec<_>>().join(" "))
+        .filter(|candidate| !candidate.is_empty());
+    if normalized
+        .as_ref()
+        .is_some_and(|candidate| candidate.chars().count() > 160)
+    {
+        return Err("One-line description must be 160 characters or fewer".to_string());
+    }
+    Ok(normalized)
+}
+
 mod pending;
 pub(in crate::commands) use pending::retain_persona_pending;
 pub(super) use pending::tombstone_persona_pending;
@@ -58,6 +71,7 @@ pub async fn create_persona(
     tokio::task::spawn_blocking(move || {
         let state = app.state::<AppState>();
         let display_name = trim_required(&input.display_name, "Display name")?;
+        let description = normalize_description(input.description)?;
         // System prompt optional: core memory is auto-injected. Empty is valid.
         let system_prompt = input.system_prompt.trim().to_string();
         let avatar_url = trim_optional(input.avatar_url);
@@ -80,6 +94,7 @@ pub async fn create_persona(
         let mut persona = AgentDefinition {
             id: Uuid::new_v4().to_string(),
             display_name,
+            description,
             avatar_url,
             system_prompt,
             runtime,
@@ -159,6 +174,7 @@ pub async fn update_persona(
         move || -> Result<(AgentDefinition, ProfileSyncParams), String> {
             let state = app.state::<AppState>();
             let display_name = trim_required(&input.display_name, "Display name")?;
+            let description = normalize_description(input.description)?;
             let system_prompt = input.system_prompt.clone();
             let avatar_url = trim_optional(input.avatar_url);
             let runtime = trim_optional(input.runtime);
@@ -181,6 +197,7 @@ pub async fn update_persona(
             let old_display_name = persona.display_name.clone();
 
             persona.display_name = display_name;
+            persona.description = description;
             persona.avatar_url = avatar_url;
             persona.system_prompt = system_prompt;
             persona.runtime = runtime;

--- a/desktop/src-tauri/src/commands/personas/name_propagation_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/name_propagation_tests.rs
@@ -45,6 +45,7 @@ fn agent(persona_id: &str, name: &str, display_name: Option<&str>) -> ManagedAge
         respond_to: Default::default(),
         respond_to_allowlist: vec![],
         display_name: display_name.map(str::to_string),
+        description: None,
         slug: None,
         runtime: None,
         name_pool: vec![],

--- a/desktop/src-tauri/src/commands/personas/snapshot/import.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/import.rs
@@ -396,6 +396,7 @@ pub async fn confirm_agent_snapshot_import(
         let persona = AgentDefinition {
             id: persona_id.clone(),
             display_name: display_name.clone(),
+            description: snapshot.profile.about.clone(),
             avatar_url: effective_avatar.clone(),
             system_prompt: snapshot
                 .definition
@@ -430,6 +431,7 @@ pub async fn confirm_agent_snapshot_import(
             pubkey: pubkey.clone(),
             name: display_name.clone(),
             display_name: None,
+            description: persona.description.clone(),
             slug: None,
             persona_id: Some(persona_id.clone()),
             private_key_nsec: private_key_nsec.clone(),

--- a/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/personas/snapshot/tests.rs
@@ -23,6 +23,7 @@ fn make_definition(slug: &str) -> ManagedAgentRecord {
         slug: Some(slug.to_string()),
         name: slug.to_string(),
         display_name: None,
+        description: None,
         persona_id: None,
         private_key_nsec: String::new(),
         auth_tag: None,

--- a/desktop/src-tauri/src/commands/team_snapshot.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot.rs
@@ -121,6 +121,7 @@ fn definition_from_snapshot(
     Ok(AgentDefinition {
         id: Uuid::new_v4().to_string(),
         display_name: member.profile.display_name.trim().to_string(),
+        description: member.profile.about.clone(),
         avatar_url: effective_avatar(member),
         system_prompt: member.definition.system_prompt.clone().unwrap_or_default(),
         runtime: member.definition.runtime.clone(),
@@ -551,6 +552,7 @@ pub async fn confirm_team_snapshot_import(
             pubkey: pubkey.clone(),
             name: display_name.clone(),
             display_name: None,
+            description: definition.description.clone(),
             slug: None,
             persona_id: Some(definition.id.clone()),
             private_key_nsec: private_key_nsec.clone(),

--- a/desktop/src-tauri/src/commands/team_snapshot/tests.rs
+++ b/desktop/src-tauri/src/commands/team_snapshot/tests.rs
@@ -56,6 +56,7 @@ fn team_export_round_trip_preserves_team_and_excludes_member_memory() {
         AgentDefinition {
             id: "alice".to_string(),
             display_name: "Alice".to_string(),
+            description: None,
             avatar_url: None,
             system_prompt: "Alice prompt".to_string(),
             runtime: Some("goose".to_string()),
@@ -76,6 +77,7 @@ fn team_export_round_trip_preserves_team_and_excludes_member_memory() {
         AgentDefinition {
             id: "bob".to_string(),
             display_name: "Bob".to_string(),
+            description: None,
             avatar_url: None,
             system_prompt: "Bob prompt".to_string(),
             runtime: Some("goose".to_string()),
@@ -137,6 +139,7 @@ fn team_export_with_instance_and_memory_level_uses_supplied_entries() {
     let definitions = vec![AgentDefinition {
         id: "alice".to_string(),
         display_name: "Alice".to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: "Alice prompt".to_string(),
         runtime: Some("goose".to_string()),
@@ -174,6 +177,7 @@ fn team_export_with_instance_and_memory_level_uses_supplied_entries() {
         pubkey: "a".repeat(64),
         name: "Alice".to_string(),
         display_name: None,
+        description: None,
         slug: None,
         persona_id: Some("alice".to_string()),
         private_key_nsec: String::new(),

--- a/desktop/src-tauri/src/managed_agents/agent_events.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_events.rs
@@ -203,6 +203,7 @@ mod tests {
             // Unified-model fields carry real values so the exclusion test
             // proves they are absent from the wire, not vacuously empty.
             display_name: Some("Display Name Secretish".to_string()),
+            description: None,
             slug: Some("sample-slug".to_string()),
             runtime: Some("goose".to_string()),
             name_pool: vec!["poolname".to_string()],

--- a/desktop/src-tauri/src/managed_agents/agent_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_snapshot.rs
@@ -210,7 +210,7 @@ pub fn build_snapshot(
             .display_name
             .clone()
             .unwrap_or_else(|| record.name.clone()),
-        about: None, // kind:0 `about` not yet surfaced in ManagedAgentRecord
+        about: record.description.clone(),
         avatar_data_url,
         avatar_url: avatar_url_ref,
     };
@@ -476,6 +476,7 @@ mod tests {
             pubkey: "deadbeef".to_string(),
             name: "Test Agent".to_string(),
             display_name: Some("Test Agent Display".to_string()),
+            description: Some("A portable test agent.".to_string()),
             persona_id: Some("SENTINEL_PERSONA_ID".to_string()), // MUST NOT appear in snapshot
             team_id: Some("SENTINEL_TEAM_ID".to_string()),       // MUST NOT appear in snapshot
             private_key_nsec: "nsec1secret".to_string(),         // MUST NOT appear in snapshot

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -101,6 +101,7 @@ fn test_record() -> ManagedAgentRecord {
         respond_to: crate::managed_agents::types::RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
         display_name: None,
+        description: None,
         slug: None,
         runtime: None,
         name_pool: Vec::new(),

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -277,6 +277,7 @@ fn persona_with_runtime(id: &str, runtime: Option<&str>) -> crate::managed_agent
     crate::managed_agents::AgentDefinition {
         id: id.to_string(),
         display_name: id.to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: String::new(),
         runtime: runtime.map(str::to_string),
@@ -354,6 +355,7 @@ fn record_with(
         respond_to: Default::default(),
         respond_to_allowlist: vec![],
         display_name: None,
+        description: None,
         slug: None,
         runtime: runtime.map(str::to_string),
         name_pool: Vec::new(),

--- a/desktop/src-tauri/src/managed_agents/effective_config/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/effective_config/tests.rs
@@ -10,6 +10,7 @@ fn definition(
     AgentDefinition {
         id: id.to_string(),
         display_name: "Test Definition".to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: prompt.to_string(),
         runtime: None,
@@ -76,6 +77,7 @@ fn record(
         respond_to: RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
         display_name: None,
+        description: None,
         slug: None,
         runtime: None,
         name_pool: vec![],

--- a/desktop/src-tauri/src/managed_agents/global_config/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/global_config/tests.rs
@@ -338,6 +338,7 @@ fn bare_record() -> ManagedAgentRecord {
         respond_to: RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
         display_name: None,
+        description: None,
         slug: None,
         runtime: None,
         name_pool: vec![],
@@ -357,6 +358,7 @@ fn persona(id: &str, model: Option<&str>, provider: Option<&str>) -> AgentDefini
     AgentDefinition {
         id: id.to_string(),
         display_name: "Test Persona".to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: "".to_string(),
         runtime: None,
@@ -616,6 +618,7 @@ fn record_runtime_wins_over_persona_runtime_for_command_resolution() {
     let persona = AgentDefinition {
         id: "p1".to_string(),
         display_name: "Goose persona".to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: "".to_string(),
         runtime: Some("goose".to_string()),

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -414,6 +414,7 @@ fn make_persona(id: &str, display_name: &str) -> AgentDefinition {
     AgentDefinition {
         id: id.to_string(),
         display_name: display_name.to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: String::new(),
         runtime: None,
@@ -475,6 +476,7 @@ fn make_agent(name: &str, persona_id: Option<&str>) -> ManagedAgentRecord {
         respond_to_allowlist: vec![],
         env_vars: std::collections::BTreeMap::new(),
         display_name: None,
+        description: None,
         slug: None,
         runtime: None,
         name_pool: Vec::new(),

--- a/desktop/src-tauri/src/managed_agents/persona_events.rs
+++ b/desktop/src-tauri/src/managed_agents/persona_events.rs
@@ -16,10 +16,10 @@ use crate::app_state::AppState;
 ///
 /// Field order MUST match the NIP-AP reference vectors (`docs/nips/NIP-AP.md`
 /// content body: `display_name, system_prompt, avatar_url, runtime, model,
-/// provider, name_pool`). serde emits fields in declaration order, so this
-/// order pins the exact content bytes and therefore the NIP-01 event id — a
-/// reorder here breaks cross-implementation interop. Guarded by
-/// `content_matches_nip_ap_vector`.
+/// provider, name_pool`; newer optional fields follow). serde emits fields in
+/// declaration order, so this order pins the exact content bytes and therefore
+/// the NIP-01 event id — a reorder here breaks cross-implementation interop.
+/// Guarded by `content_matches_nip_ap_vector`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PersonaEventContent {
     pub display_name: String,
@@ -39,6 +39,10 @@ pub struct PersonaEventContent {
     pub provider: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub name_pool: Vec<String>,
+    /// Short presentation copy shown beneath the agent name. Appended after
+    /// the original NIP-AP fields so records without it keep identical bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Definition-level defaults copied onto instances at creation
     /// (NIP-AP behavioral fields). Absent = defer to client defaults;
     /// `skip_serializing_if` keeps pre-revision hashes stable.
@@ -180,6 +184,7 @@ pub fn persona_from_event(event: &nostr::Event) -> Result<AgentDefinition, Strin
     Ok(AgentDefinition {
         id: d_tag.clone(),
         display_name: content.display_name,
+        description: content.description,
         avatar_url: content.avatar_url,
         system_prompt: content.system_prompt.unwrap_or_default(),
         runtime: content.runtime,
@@ -347,6 +352,7 @@ pub fn persona_event_content(record: &AgentDefinition) -> PersonaEventContent {
         model: record.model.clone(),
         provider: record.provider.clone(),
         name_pool: record.name_pool.clone(),
+        description: record.description.clone(),
         // NIP-AP behavioral defaults: live since the create-path unification
         // (B5) — carried on AgentDefinition in wire shape and copied verbatim.
         // Quad-absent records serialize identically to the reserved era, so

--- a/desktop/src-tauri/src/managed_agents/persona_events/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/persona_events/tests.rs
@@ -45,6 +45,7 @@ fn sample_record() -> ManagedAgentRecord {
         respond_to: RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
         display_name: None,
+        description: None,
         slug: None,
         runtime: None,
         name_pool: Vec::new(),
@@ -141,6 +142,7 @@ fn sample_persona() -> AgentDefinition {
     AgentDefinition {
         id: "test-persona".to_string(),
         display_name: "Test Persona".to_string(),
+        description: None,
         avatar_url: Some("https://example.com/avatar.png".to_string()),
         system_prompt: "You are a test assistant.".to_string(),
         runtime: Some("goose".to_string()),
@@ -252,7 +254,8 @@ fn build_persona_event_produces_correct_kind() {
 
 #[test]
 fn round_trip_serialization() {
-    let record = sample_persona();
+    let mut record = sample_persona();
+    record.description = Some("Handles focused test work.".to_string());
     let builder = build_persona_event(&record).unwrap();
     let keys = nostr::Keys::generate();
     let event = builder.sign_with_keys(&keys).unwrap();
@@ -260,6 +263,10 @@ fn round_trip_serialization() {
     let restored = persona_from_event(&event).unwrap();
     assert_eq!(restored.id, "test-slug");
     assert_eq!(restored.display_name, "Test Persona");
+    assert_eq!(
+        restored.description.as_deref(),
+        Some("Handles focused test work.")
+    );
     assert_eq!(
         restored.avatar_url,
         Some("https://example.com/avatar.png".to_string())
@@ -299,6 +306,7 @@ fn content_matches_nip_ap_vector() {
         model: Some("claude-opus-4".to_string()),
         provider: Some("anthropic".to_string()),
         name_pool: vec!["Alpha".to_string(), "Beta".to_string()],
+        description: None,
         respond_to: None,
         respond_to_allowlist: Vec::new(),
         parallelism: None,
@@ -347,6 +355,7 @@ fn content_matches_nip_ap_vector() {
     let record = AgentDefinition {
         id: "test-agent".to_string(),
         display_name: "Test Agent".to_string(),
+        description: None,
         avatar_url: Some("https://example.com/avatar.png".to_string()),
         system_prompt: "You are a test assistant.".to_string(),
         runtime: Some("goose".to_string()),
@@ -376,6 +385,7 @@ fn round_trip_minimal_persona() {
     let record = AgentDefinition {
         id: "minimal".to_string(),
         display_name: "Minimal".to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: "Hello".to_string(),
         runtime: None,
@@ -471,6 +481,7 @@ fn quad_absent_definition_hash_stable_across_activation() {
     let record = AgentDefinition {
         id: "quad-absent".to_string(),
         display_name: "Test".to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: "Hello".to_string(),
         runtime: Some("goose".to_string()),
@@ -513,6 +524,7 @@ fn persona_from_event_content_for_test(content: PersonaEventContent) -> AgentDef
     AgentDefinition {
         id: "staged".to_string(),
         display_name: content.display_name,
+        description: None,
         avatar_url: content.avatar_url,
         system_prompt: content.system_prompt.unwrap_or_default(),
         runtime: content.runtime,
@@ -536,6 +548,7 @@ fn persona_from_event_content_for_test(content: PersonaEventContent) -> AgentDef
 fn persona_content_hash_is_deterministic() {
     let content = PersonaEventContent {
         display_name: "Test".to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: Some("Hello".to_string()),
         runtime: None,
@@ -556,6 +569,7 @@ fn persona_content_hash_is_deterministic() {
 fn persona_content_hash_changes_on_edit() {
     let content1 = PersonaEventContent {
         display_name: "Test".to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: Some("Hello".to_string()),
         runtime: None,

--- a/desktop/src-tauri/src/managed_agents/personas.rs
+++ b/desktop/src-tauri/src/managed_agents/personas.rs
@@ -7,6 +7,7 @@ use crate::{managed_agents::AgentDefinition, util::now_iso};
 struct BuiltInPersona {
     id: &'static str,
     display_name: &'static str,
+    description: &'static str,
     avatar_url: Option<&'static str>,
     system_prompt: &'static str,
     name_pool: &'static [&'static str],
@@ -29,6 +30,7 @@ const BUILT_IN_PERSONAS: &[BuiltInPersona] = &[
     BuiltInPersona {
         id: "builtin:fizz",
         display_name: "Fizz",
+        description: "Turns ideas into finished work.",
         avatar_url: Some(FIZZ_AVATAR),
         system_prompt: FIZZ_SYSTEM_PROMPT,
         name_pool: &[
@@ -42,6 +44,7 @@ const BUILT_IN_PERSONAS: &[BuiltInPersona] = &[
     BuiltInPersona {
         id: "builtin:honey",
         display_name: "Honey",
+        description: "Makes ideas clear, warm, and well-shaped.",
         avatar_url: Some(HONEY_AVATAR),
         system_prompt: HONEY_SYSTEM_PROMPT,
         name_pool: &["Honey"],
@@ -52,6 +55,7 @@ const BUILT_IN_PERSONAS: &[BuiltInPersona] = &[
     BuiltInPersona {
         id: "builtin:bumble",
         display_name: "Bumble",
+        description: "Explores questions and brings back useful evidence.",
         avatar_url: Some(BUMBLE_AVATAR),
         system_prompt: BUMBLE_SYSTEM_PROMPT,
         name_pool: &["Bumble"],
@@ -113,6 +117,7 @@ fn built_in_persona_records(now: &str) -> Vec<AgentDefinition> {
         .map(|persona| AgentDefinition {
             id: persona.id.to_string(),
             display_name: persona.display_name.to_string(),
+            description: Some(persona.description.to_string()),
             avatar_url: persona.avatar_url.map(|s| s.to_string()),
             system_prompt: persona.system_prompt.to_string(),
             runtime: persona.runtime.map(|s| s.to_string()),
@@ -174,6 +179,10 @@ fn merge_personas(mut stored: Vec<AgentDefinition>, now: &str) -> (Vec<AgentDefi
         if let Some(existing) = stored.iter_mut().find(|record| record.id == built_in.id) {
             if !existing.is_builtin {
                 existing.is_builtin = true;
+                changed = true;
+            }
+            if existing.description.is_none() {
+                existing.description = built_in.description;
                 changed = true;
             }
         } else {

--- a/desktop/src-tauri/src/managed_agents/personas/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/personas/tests.rs
@@ -10,6 +10,7 @@ fn custom_persona(id: &str, display_name: &str) -> AgentDefinition {
     AgentDefinition {
         id: id.to_string(),
         display_name: display_name.to_string(),
+        description: None,
         avatar_url: Some("https://example.com/avatar.png".to_string()),
         system_prompt: "Custom prompt".to_string(),
         runtime: None,
@@ -39,6 +40,7 @@ fn merge_personas_adds_missing_built_ins() {
     assert!(records
         .iter()
         .any(|record| record.id == "builtin:fizz" && record.runtime.is_none()));
+    assert!(records.iter().all(|record| record.description.is_some()));
     let display_names: Vec<&str> = records
         .iter()
         .map(|record| record.display_name.as_str())
@@ -70,6 +72,7 @@ fn merge_personas_preserves_builtin_edits() {
     edited_builtin.is_builtin = true;
     edited_builtin.is_active = true;
     edited_builtin.system_prompt = "User-edited instructions".to_string();
+    edited_builtin.description = Some("My saved Fizz description.".to_string());
     edited_builtin.name_pool = vec!["User-edited name".to_string()];
     edited_builtin.env_vars =
         std::collections::BTreeMap::from([("USER_SETTING".to_string(), "value".to_string())]);
@@ -82,6 +85,7 @@ fn merge_personas_preserves_builtin_edits() {
         .find(|record| record.id == "builtin:fizz")
         .expect("fizz built-in should exist");
     assert_eq!(fizz.display_name, edited_builtin.display_name);
+    assert_eq!(fizz.description, edited_builtin.description);
     assert_eq!(fizz.system_prompt, edited_builtin.system_prompt);
     assert_eq!(fizz.name_pool, edited_builtin.name_pool);
     assert_eq!(fizz.env_vars, edited_builtin.env_vars);

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -1505,6 +1505,7 @@ mod tests {
             respond_to: Default::default(),
             respond_to_allowlist: vec![],
             display_name: None,
+            description: None,
             slug: None,
             runtime: None,
             name_pool: Vec::new(),

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -170,6 +170,7 @@ fn fixture(
         respond_to,
         respond_to_allowlist: allowlist,
         display_name: None,
+        description: None,
         slug: None,
         runtime: None,
         name_pool: Vec::new(),
@@ -286,6 +287,7 @@ fn persona_with_provider(
     crate::managed_agents::AgentDefinition {
         id: id.to_string(),
         display_name: id.to_string(),
+        description: None,
         avatar_url: None,
         system_prompt: prompt.to_string(),
         runtime: None,

--- a/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/spawn_hash/tests.rs
@@ -44,6 +44,7 @@ fn record() -> ManagedAgentRecord {
         respond_to: Default::default(),
         respond_to_allowlist: vec![],
         display_name: None,
+        description: None,
         slug: None,
         runtime: None,
         name_pool: Vec::new(),
@@ -62,6 +63,7 @@ fn persona(id: &str, runtime: Option<&str>, prompt: &str) -> AgentDefinition {
     AgentDefinition {
         id: id.into(),
         display_name: id.into(),
+        description: None,
         avatar_url: None,
         system_prompt: prompt.into(),
         runtime: runtime.map(str::to_string),

--- a/desktop/src-tauri/src/managed_agents/team_snapshot.rs
+++ b/desktop/src-tauri/src/managed_agents/team_snapshot.rs
@@ -255,6 +255,7 @@ mod tests {
             pubkey: format!("{name}-pubkey"),
             name: name.to_string(),
             display_name: Some(format!("{name} Display")),
+            description: None,
             persona_id: Some("SENTINEL_PERSONA_ID".to_string()), // MUST NOT appear
             private_key_nsec: "nsec1secret".to_string(),         // MUST NOT appear
             auth_tag: Some("auth-tag-secret".to_string()),       // MUST NOT appear

--- a/desktop/src-tauri/src/managed_agents/teams_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/teams_tests.rs
@@ -203,6 +203,7 @@ fn managed_agent(name: &str) -> ManagedAgentRecord {
         respond_to: crate::managed_agents::RespondTo::OwnerOnly,
         respond_to_allowlist: vec![],
         display_name: None,
+        description: None,
         slug: None,
         runtime: None,
         name_pool: vec![],

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -16,6 +16,9 @@ pub enum BackendKind {
 pub struct AgentDefinition {
     pub id: String,
     pub display_name: String,
+    /// Short presentation copy shown beneath the agent name in cards.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     pub avatar_url: Option<String>,
     pub system_prompt: String,
     /// Preferred ACP runtime ID (e.g., 'goose', 'claude', 'codex'). Determines which agent binary
@@ -125,6 +128,7 @@ impl AgentDefinition {
             respond_to: RespondTo::default(),
             respond_to_allowlist: Vec::new(),
             display_name: Some(self.display_name),
+            description: self.description,
             slug: Some(self.id),
             runtime: self.runtime,
             name_pool: self.name_pool,
@@ -153,6 +157,7 @@ impl ManagedAgentRecord {
                 .display_name
                 .clone()
                 .unwrap_or_else(|| self.name.clone()),
+            description: self.description.clone(),
             avatar_url: self.avatar_url.clone(),
             system_prompt: self.system_prompt.clone().unwrap_or_default(),
             runtime: self.runtime.clone(),
@@ -336,6 +341,10 @@ pub struct ManagedAgentRecord {
     /// from `AgentDefinition.display_name` (unified agent model, Phase 1A).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    /// Definition-owned one-line presentation copy. `None` for legacy and
+    /// definition-less records.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     /// Stable definition slug — the former `AgentDefinition.id`. Key-less
     /// records (definitions not yet instantiated) publish kind:30175 at
     /// `d_tag = slug`, preserving the pre-merge event coordinates. `None` for

--- a/desktop/src-tauri/src/managed_agents/types/requests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/requests.rs
@@ -75,6 +75,8 @@ pub fn apply_persona_behavior(
 #[serde(rename_all = "camelCase")]
 pub struct CreatePersonaRequest {
     pub display_name: String,
+    #[serde(default)]
+    pub description: Option<String>,
     pub avatar_url: Option<String>,
     pub system_prompt: String,
     #[serde(default)]
@@ -98,6 +100,8 @@ pub struct CreatePersonaRequest {
 pub struct UpdatePersonaRequest {
     pub id: String,
     pub display_name: String,
+    #[serde(default)]
+    pub description: Option<String>,
     pub avatar_url: Option<String>,
     pub system_prompt: String,
     #[serde(default)]
@@ -267,6 +271,7 @@ mod tests {
         AgentDefinition {
             id: "p-1".to_string(),
             display_name: "Test".to_string(),
+            description: None,
             avatar_url: None,
             system_prompt: "prompt".to_string(),
             runtime: None,

--- a/desktop/src-tauri/src/managed_agents/types/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/tests.rs
@@ -474,6 +474,7 @@ fn sample_persona() -> AgentDefinition {
     AgentDefinition {
         id: "custom:helper".to_string(),
         display_name: "Helper".to_string(),
+        description: Some("Helps turn requests into clear next steps.".to_string()),
         avatar_url: Some("https://example.com/a.png".to_string()),
         system_prompt: "You help.".to_string(),
         runtime: Some("goose".to_string()),
@@ -500,6 +501,10 @@ fn persona_into_agent_record_is_keyless_and_slugged() {
     assert!(record.private_key_nsec.is_empty());
     assert_eq!(record.slug.as_deref(), Some("custom:helper"));
     assert_eq!(record.display_name.as_deref(), Some("Helper"));
+    assert_eq!(
+        record.description.as_deref(),
+        Some("Helps turn requests into clear next steps.")
+    );
     assert_eq!(record.system_prompt.as_deref(), Some("You help."));
     assert_eq!(record.runtime.as_deref(), Some("goose"));
     assert_eq!(record.source_team.as_deref(), Some("team-1"));

--- a/desktop/src-tauri/src/mesh_llm/recovery.rs
+++ b/desktop/src-tauri/src/mesh_llm/recovery.rs
@@ -402,6 +402,7 @@ mod tests {
         let mut record = crate::managed_agents::AgentDefinition {
             id: pubkey.to_string(),
             display_name: pubkey.to_string(),
+            description: None,
             avatar_url: None,
             system_prompt: String::new(),
             runtime: None,

--- a/desktop/src-tauri/src/migration_avatar_tests.rs
+++ b/desktop/src-tauri/src/migration_avatar_tests.rs
@@ -27,6 +27,7 @@ fn refresh_builtin_agent_avatars_updates_seeded_values_and_preserves_customizati
     let definition = crate::managed_agents::AgentDefinition {
         id: "builtin:fizz".to_string(),
         display_name: "Fizz".to_string(),
+        description: None,
         avatar_url: Some(old_fizz.to_string()),
         system_prompt: "A customized built-in prompt".to_string(),
         runtime: Some("goose".to_string()),

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -102,6 +102,12 @@ with a TypeScript lookup table or an id comparison in a component.
    Edit. In Edit,
    selecting Custom command keeps its required command field beside the harness
    picker rather than hiding it in Advanced.
+10. **Agent card descriptions belong to definitions.** The editable one-line
+    description is persisted on `AgentDefinition`, projected through the
+    persona event/store compatibility view, and rendered by the shared
+    `AgentIdentityCard`. Legacy definitions fall back to the first instruction
+    sentence in `resolveAgentDescriptor`; do not infer descriptions separately
+    in individual card surfaces.
 
 ## The tests that enforce this
 

--- a/desktop/src/features/agents/lib/agentDescriptor.test.mjs
+++ b/desktop/src/features/agents/lib/agentDescriptor.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveAgentDescriptor } from "./agentDescriptor.ts";
+
+test("prefers and normalizes an explicit one-line description", () => {
+  assert.equal(
+    resolveAgentDescriptor("  Turns ideas\ninto finished work.  ", "ignored"),
+    "Turns ideas into finished work.",
+  );
+});
+
+test("falls back to the first instruction sentence for legacy agents", () => {
+  assert.equal(
+    resolveAgentDescriptor(
+      null,
+      "You are a careful researcher. Compare sources and cite evidence.",
+    ),
+    "You are a careful researcher.",
+  );
+});
+
+test("keeps an instruction without sentence punctuation", () => {
+  assert.equal(
+    resolveAgentDescriptor(undefined, "Help the team ship"),
+    "Help the team ship",
+  );
+});
+
+test("keeps every card populated when both fields are blank", () => {
+  assert.equal(resolveAgentDescriptor(null, "   "), "No description yet");
+});

--- a/desktop/src/features/agents/lib/agentDescriptor.ts
+++ b/desktop/src/features/agents/lib/agentDescriptor.ts
@@ -1,0 +1,25 @@
+const FALLBACK_AGENT_DESCRIPTOR = "No description yet";
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Resolve the persistent one-line copy shown on agent cards.
+ *
+ * Legacy definitions do not have an explicit description, so their first
+ * instruction sentence is used until the user saves a dedicated one-liner.
+ */
+export function resolveAgentDescriptor(
+  description: string | null | undefined,
+  systemPrompt: string | null | undefined,
+): string {
+  const explicit = collapseWhitespace(description ?? "");
+  if (explicit) return explicit;
+
+  const prompt = collapseWhitespace(systemPrompt ?? "");
+  if (!prompt) return FALLBACK_AGENT_DESCRIPTOR;
+
+  const firstSentenceEnd = prompt.search(/[.!?](?:\s|$)/);
+  return firstSentenceEnd >= 0 ? prompt.slice(0, firstSentenceEnd + 1) : prompt;
+}

--- a/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentDefinitionDialog.tsx
@@ -125,6 +125,7 @@ export function AgentDefinitionDialog({
   createSubmitBlocked = false,
 }: AgentDefinitionDialogProps) {
   const [displayName, setDisplayName] = React.useState("");
+  const [agentDescription, setAgentDescription] = React.useState("");
   const [aiDefaultsOpen, setAiDefaultsOpen] = React.useState(false);
   const aiDefaultsTriggerRef = React.useRef<HTMLButtonElement>(null);
   const [avatarUrl, setAvatarUrl] = React.useState("");
@@ -185,6 +186,7 @@ export function AgentDefinitionDialog({
     }
 
     setDisplayName(initialValues.displayName);
+    setAgentDescription(initialValues.description ?? "");
     setAvatarUrl(initialValues.avatarUrl ?? "");
     setSystemPrompt(initialValues.systemPrompt);
     setRuntime(initialValues.runtime ?? "");
@@ -283,6 +285,7 @@ export function AgentDefinitionDialog({
   function handleOpenChange(next: boolean) {
     if (!next) {
       setDisplayName("");
+      setAgentDescription("");
       setAvatarUrl("");
       setSystemPrompt("");
       setRuntime("");
@@ -333,6 +336,7 @@ export function AgentDefinitionDialog({
           : undefined;
     const baseInput = {
       displayName: displayName.trim(),
+      description: agentDescription.trim() || undefined,
       avatarUrl: avatarUrl.trim() || undefined,
       systemPrompt: systemPrompt,
       runtime: runtimeForSubmit,
@@ -801,6 +805,43 @@ export function AgentDefinitionDialog({
                   value={displayName}
                 />
               </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between gap-3">
+                <label
+                  className="text-sm font-medium text-foreground"
+                  htmlFor="persona-description"
+                >
+                  One-line description
+                </label>
+                <span className="text-xs text-muted-foreground">
+                  {agentDescription.length}/160
+                </span>
+              </div>
+              <div
+                className={cn(
+                  "flex min-h-11 items-center px-3",
+                  PERSONA_FIELD_SHELL_CLASS,
+                )}
+              >
+                <Input
+                  autoCorrect="on"
+                  className={cn(
+                    "h-8 px-0 py-0 leading-6",
+                    PERSONA_FIELD_CONTROL_CLASS,
+                  )}
+                  disabled={isPending}
+                  id="persona-description"
+                  maxLength={160}
+                  onChange={(event) => setAgentDescription(event.target.value)}
+                  placeholder="Turns ideas into finished work."
+                  value={agentDescription}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Shown under the agent name on thumbnails.
+              </p>
             </div>
 
             <div className="space-y-1.5">

--- a/desktop/src/features/agents/ui/AgentIdentityCard.tsx
+++ b/desktop/src/features/agents/ui/AgentIdentityCard.tsx
@@ -10,6 +10,7 @@ type AgentIdentityCardProps = {
   avatar?: ReactNode;
   avatarUrl?: string | null;
   dataTestId: string;
+  description?: string | null;
   label: string;
   modelLabel?: string | null;
   onClick: () => void;
@@ -23,6 +24,7 @@ export function AgentIdentityCard({
   avatar,
   avatarUrl,
   dataTestId,
+  description,
   label,
   modelLabel,
   onClick,
@@ -72,6 +74,15 @@ export function AgentIdentityCard({
         <span className="min-w-0 truncate font-semibold text-foreground tracking-normal">
           {label}
         </span>
+        {description ? (
+          <span
+            className="min-w-0 truncate text-xs font-normal text-foreground/70"
+            data-testid={`${dataTestId}-description`}
+            title={description}
+          >
+            {description}
+          </span>
+        ) : null}
         {modelLabel ? (
           <span className="min-w-0 truncate text-xs font-normal text-secondary-foreground/75">
             {modelLabel}

--- a/desktop/src/features/agents/ui/PersonaCatalogDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaCatalogDialog.tsx
@@ -189,8 +189,15 @@ function PersonaCatalogChooser({
                       className="h-6 w-6 text-3xs"
                       label={persona.displayName}
                     />
-                    <span className="min-w-0 flex-1 truncate text-sm font-medium">
-                      {persona.displayName}
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium">
+                        {persona.displayName}
+                      </span>
+                      {persona.description ? (
+                        <span className="block truncate text-xs text-sidebar-foreground/55">
+                          {persona.description}
+                        </span>
+                      ) : null}
                     </span>
                   </button>
                 );
@@ -274,6 +281,11 @@ function PersonaCatalogDetail({ persona }: { persona: AgentPersona }) {
           <h3 className="truncate text-xl font-semibold leading-snug">
             {persona.displayName}
           </h3>
+          {persona.description ? (
+            <p className="mt-0.5 truncate text-sm text-muted-foreground">
+              {persona.description}
+            </p>
+          ) : null}
           {persona.isBuiltIn ? null : <PersonaAddedBy className="mt-0.5" />}
         </div>
       </div>

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -7,6 +7,7 @@ import {
 } from "lucide-react";
 
 import { resolveAgentCardModelLabel } from "@/features/agents/lib/agentCardModelLabel";
+import { resolveAgentDescriptor } from "@/features/agents/lib/agentDescriptor";
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import { useUserProfileQuery } from "@/features/profile/hooks";
@@ -315,6 +316,10 @@ function AgentPersonaCard({
       }
       avatarUrl={avatarUrl}
       dataTestId={`persona-agent-row-${persona.id}`}
+      description={resolveAgentDescriptor(
+        persona.description,
+        persona.systemPrompt,
+      )}
       label={title}
       modelLabel={modelLabel}
       onClick={() => {
@@ -390,6 +395,10 @@ function StandaloneAgentCard({
       }
       avatarUrl={profileQuery.data?.avatarUrl}
       dataTestId={`managed-agent-${agent.pubkey}`}
+      description={resolveAgentDescriptor(
+        profileQuery.data?.about,
+        agent.systemPrompt,
+      )}
       label={title}
       modelLabel={resolveAgentCardModelLabel({
         agent,

--- a/desktop/src/features/agents/ui/personaDialogState.test.mjs
+++ b/desktop/src/features/agents/ui/personaDialogState.test.mjs
@@ -62,6 +62,7 @@ test("createPersonaDialogState returns a fresh empty draft", () => {
   assert.equal(first.title, "Create agent");
   assert.deepEqual(first.initialValues, {
     displayName: "",
+    description: "",
     avatarUrl: "",
     systemPrompt: "",
     runtime: undefined,
@@ -74,6 +75,7 @@ test("duplicatePersonaDialogState copies persona fields into a new draft", () =>
   const state = duplicatePersonaDialogState({
     id: "persona-1",
     displayName: "Solo",
+    description: "Keeps plans direct and focused.",
     avatarUrl: "avatar://solo",
     systemPrompt: "Be direct.",
     runtime: "provider-a",
@@ -87,6 +89,7 @@ test("duplicatePersonaDialogState copies persona fields into a new draft", () =>
 
   assert.deepEqual(state.initialValues, {
     displayName: "Solo copy",
+    description: "Keeps plans direct and focused.",
     avatarUrl: "avatar://solo",
     systemPrompt: "Be direct.",
     runtime: "provider-a",
@@ -127,6 +130,7 @@ test("editPersonaDialogState preserves the persona id for updates", () => {
   const state = editPersonaDialogState({
     id: "persona-2",
     displayName: "Kit",
+    description: "Keeps it weird.",
     avatarUrl: null,
     systemPrompt: "Keep it weird.",
     runtime: null,
@@ -144,6 +148,7 @@ test("editPersonaDialogState preserves the persona id for updates", () => {
   assert.deepEqual(state.initialValues, {
     id: "persona-2",
     displayName: "Kit",
+    description: "Keeps it weird.",
     avatarUrl: "",
     systemPrompt: "Keep it weird.",
     runtime: undefined,

--- a/desktop/src/features/agents/ui/personaDialogState.ts
+++ b/desktop/src/features/agents/ui/personaDialogState.ts
@@ -44,6 +44,7 @@ export function createPersonaDialogState(): PersonaDialogState {
     submitLabel: "Create agent",
     initialValues: {
       displayName: "",
+      description: "",
       avatarUrl: "",
       systemPrompt: "",
       runtime: undefined,
@@ -62,6 +63,7 @@ export function duplicatePersonaDialogState(
     submitLabel: "Create agent",
     initialValues: {
       displayName: `${persona.displayName} copy`,
+      description: persona.description ?? "",
       avatarUrl: persona.avatarUrl ?? "",
       systemPrompt: persona.systemPrompt,
       runtime: persona.runtime ?? undefined,
@@ -112,6 +114,7 @@ export function editPersonaDialogState(
     initialValues: {
       id: persona.id,
       displayName: persona.displayName,
+      description: persona.description ?? "",
       avatarUrl: persona.avatarUrl ?? "",
       systemPrompt: persona.systemPrompt,
       runtime: persona.runtime ?? undefined,

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
@@ -162,7 +162,7 @@ export function buildPersonaDraftProfile(persona: AgentPersona): Profile {
     pubkey: "",
     displayName: persona.displayName,
     avatarUrl: persona.avatarUrl,
-    about: null,
+    about: persona.description,
     nip05Handle: null,
     ownerPubkey: null,
     // Draft profile synthesised from persona config — not backed by a kind:0 event.

--- a/desktop/src/shared/api/tauriPersonas.ts
+++ b/desktop/src/shared/api/tauriPersonas.ts
@@ -9,6 +9,7 @@ import type {
 export type RawPersona = {
   id: string;
   display_name: string;
+  description?: string | null;
   avatar_url: string | null;
   system_prompt: string;
   runtime?: string | null;
@@ -32,6 +33,7 @@ export function fromRawPersona(persona: RawPersona): AgentPersona {
   return {
     id: persona.id,
     displayName: persona.display_name,
+    description: persona.description ?? null,
     avatarUrl: persona.avatar_url,
     systemPrompt: persona.system_prompt,
     runtime: persona.runtime ?? null,
@@ -61,6 +63,7 @@ export async function createPersona(
     await invokeTauri<RawPersona>("create_persona", {
       input: {
         displayName: input.displayName,
+        description: input.description,
         avatarUrl: input.avatarUrl,
         systemPrompt: input.systemPrompt,
         runtime: input.runtime,
@@ -81,6 +84,7 @@ export async function updatePersona(
     input: {
       id: input.id,
       displayName: input.displayName,
+      description: input.description,
       avatarUrl: input.avatarUrl,
       systemPrompt: input.systemPrompt,
       runtime: input.runtime,

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -759,6 +759,7 @@ export type UpdateManagedAgentInput = {
 export type AgentPersona = {
   id: string;
   displayName: string;
+  description: string | null;
   avatarUrl: string | null;
   systemPrompt: string;
   /** Preferred ACP runtime ID (e.g. "goose", "claude"). */
@@ -796,6 +797,7 @@ export type PersonaBehaviorInput = {
 
 export type CreatePersonaInput = {
   displayName: string;
+  description?: string;
   avatarUrl?: string;
   systemPrompt: string;
   runtime?: string;
@@ -809,6 +811,7 @@ export type CreatePersonaInput = {
 export type UpdatePersonaInput = {
   id: string;
   displayName: string;
+  description?: string;
   avatarUrl?: string;
   systemPrompt: string;
   runtime?: string;

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -110,6 +110,7 @@ type MockRelayAgentSeed = {
 type MockPersonaSeed = {
   id?: string;
   displayName: string;
+  description?: string | null;
   avatarUrl?: string | null;
   systemPrompt: string;
   isActive?: boolean;
@@ -792,6 +793,7 @@ type RawManagedAgentPrereqs = {
 type RawPersona = {
   id: string;
   display_name: string;
+  description?: string | null;
   avatar_url: string | null;
   system_prompt: string;
   runtime?: string | null;
@@ -2133,18 +2135,21 @@ function resetMockPersonas(config?: E2eConfig) {
     {
       id: "builtin:fizz",
       display_name: "Fizz",
+      description: "Turns ideas into finished work.",
       avatar_url: null,
       system_prompt: "You are Fizz.",
     },
     {
       id: "builtin:honey",
       display_name: "Honey",
+      description: "Makes ideas clear, warm, and well-shaped.",
       avatar_url: null,
       system_prompt: "You are Honey.",
     },
     {
       id: "builtin:bumble",
       display_name: "Bumble",
+      description: "Explores questions and brings back useful evidence.",
       avatar_url: null,
       system_prompt: "You are Bumble.",
     },
@@ -2152,6 +2157,7 @@ function resetMockPersonas(config?: E2eConfig) {
   mockPersonas = builtInPersonas.map((persona) => ({
     id: persona.id,
     display_name: persona.display_name,
+    description: persona.description,
     avatar_url: persona.avatar_url,
     system_prompt: persona.system_prompt,
     runtime: null,
@@ -2169,6 +2175,7 @@ function resetMockPersonas(config?: E2eConfig) {
     mockPersonas.push({
       id: persona.id ?? crypto.randomUUID(),
       display_name: persona.displayName,
+      description: persona.description ?? null,
       avatar_url: persona.avatarUrl ?? null,
       system_prompt: persona.systemPrompt,
       runtime: persona.runtime ?? null,
@@ -7302,6 +7309,7 @@ function applyMockPersonaBehavior(
 async function handleCreatePersona(args: {
   input: {
     displayName: string;
+    description?: string;
     avatarUrl?: string;
     systemPrompt: string;
     runtime?: string;
@@ -7315,6 +7323,7 @@ async function handleCreatePersona(args: {
   const persona: RawPersona = {
     id: crypto.randomUUID(),
     display_name: args.input.displayName.trim(),
+    description: args.input.description?.trim() || null,
     avatar_url: args.input.avatarUrl?.trim() || null,
     system_prompt: args.input.systemPrompt.trim(),
     runtime: args.input.runtime?.trim() || null,
@@ -7336,6 +7345,7 @@ async function handleUpdatePersona(args: {
   input: {
     id: string;
     displayName: string;
+    description?: string;
     avatarUrl?: string;
     systemPrompt: string;
     runtime?: string;
@@ -7352,6 +7362,7 @@ async function handleUpdatePersona(args: {
     throw new Error(`agent ${args.input.id} not found`);
   }
   persona.display_name = args.input.displayName.trim();
+  persona.description = args.input.description?.trim() || null;
   persona.avatar_url = args.input.avatarUrl?.trim() || null;
   persona.system_prompt = args.input.systemPrompt.trim();
   persona.runtime = args.input.runtime?.trim() || null;
@@ -7721,7 +7732,14 @@ async function handleCreateManagedAgent(
     pubkey,
     display_name: name,
     avatar_url: avatarUrl,
-    about: args.input.systemPrompt?.trim() || null,
+    about:
+      linkedPersona?.description ??
+      args.input.systemPrompt
+        ?.trim()
+        .match(/^.*?[.!?](?:\s|$)/)?.[0]
+        ?.trim() ??
+      args.input.systemPrompt?.trim() ??
+      null,
     nip05_handle: null,
     owner_pubkey: MOCK_IDENTITY_PUBKEY,
     is_agent: true,

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -245,6 +245,9 @@ test("built-in persona edits persist", async ({ page }) => {
 
   const dialog = page.getByTestId("persona-dialog");
   await dialog.getByLabel("Agent name").fill("My Fizz");
+  await dialog
+    .getByLabel("One-line description")
+    .fill("Turns ambitious ideas into shipped work.");
   await dialog.getByLabel("Agent instruction").fill("User-edited instructions");
   await dialog.getByRole("button", { name: "Save changes" }).click();
 
@@ -252,13 +255,25 @@ test("built-in persona edits persist", async ({ page }) => {
   await expect(page.getByTestId("agents-library-personas")).toContainText(
     "My Fizz",
   );
+  await expect(
+    page.getByTestId("persona-agent-row-builtin:fizz-description"),
+  ).toHaveText("Turns ambitious ideas into shipped work.");
+  await expect(
+    page.getByTestId("persona-agent-row-builtin:fizz-description"),
+  ).toHaveAttribute("title", "Turns ambitious ideas into shipped work.");
   const personas = await invokeTauri<
-    Array<{ id: string; display_name: string; system_prompt: string }>
+    Array<{
+      id: string;
+      display_name: string;
+      description: string | null;
+      system_prompt: string;
+    }>
   >(page, "list_personas");
   expect(
     personas.find((persona) => persona.id === "builtin:fizz"),
   ).toMatchObject({
     display_name: "My Fizz",
+    description: "Turns ambitious ideas into shipped work.",
     system_prompt: "User-edited instructions",
   });
 });

--- a/docs/nips/NIP-AP.md
+++ b/docs/nips/NIP-AP.md
@@ -68,6 +68,7 @@ The `content` field is a **plaintext** (unencrypted) JSON object:
   "model": "<string | null>",
   "provider": "<string | null>",
   "name_pool": ["<string>", ...],
+  "description": "<string | null>",
   "respond_to": "<string | null>",
   "respond_to_allowlist": ["<64-hex pubkey>", ...],
   "parallelism": "<integer | null>"
@@ -90,6 +91,7 @@ The `content` field is a **plaintext** (unencrypted) JSON object:
 | `model` | string \| null | `null` | Model identifier (e.g. `"claude-opus-4"`). |
 | `provider` | string \| null | `null` | Model provider (e.g. `"anthropic"`). |
 | `name_pool` | string[] | `[]` | Pool of display names for agent instances spawned from this definition. When non-empty, the spawning system picks a name from this pool for each new agent instance, enabling multiple concurrent agents from the same definition to have distinct identities. |
+| `description` | string \| null | `null` | Short human-readable summary shown beneath the agent name. Writers SHOULD keep this to a single line and at most 160 characters. |
 | `respond_to` | string \| null | `null` | **Reserved.** Default respond-to policy for instances spawned from this definition: `"anyone"`, `"owner-only"`, or `"allowlist"`. `null` defers to the client default. |
 | `respond_to_allowlist` | string[] | `[]` | **Reserved.** Allowlisted author pubkeys (64-char lowercase hex) when `respond_to` is `"allowlist"`. Ignored otherwise. |
 | `parallelism` | integer \| null | `null` | **Reserved.** Default max concurrent turns for spawned instances. `null` defers to the client default. |


### PR DESCRIPTION
## Summary

- add an editable one-line description to agent definitions
- show descriptions beneath agent names on cards, with prompt-based fallback for legacy agents
- persist descriptions through persona events and agent/team snapshots
- seed concise descriptions for Fizz, Honey, and Bumble

## Validation

- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop test` (3,633 passed)
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml` (1,784 passed, 14 ignored)
- focused Playwright integration: `built-in persona edits persist`
- Biome and Rust formatting checks