### PR TITLE
fix(acp): answer top-level DMs inline instead of opening a thread

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -53,6 +53,8 @@ Use the reply destination supplied in the `[Context]` block for ordinary replies
 
 For human-facing work, keep the conversation flat and easy to read. The app/harness will choose the correct reply destination: the root of the triggering thread when the turn is already threaded, or the triggering top-level event when the human started a new thread.
 
+In a direct message, a top-level turn has no thread at all — answer inline in the DM, with no reply anchor. A DM is already a private 1:1 conversation, so threading an ordinary answer only hides it behind a collapsed reply count. Thread inside a DM only when the human opened the thread (the `[Context]` block then supplies its root) or explicitly asks for one.
+
 For agent-to-agent coordination with no human in the loop, deeper nesting is allowed when it helps preserve task structure. Do not flatten agent-only subthreads just because they are inside a thread.
 
 When in doubt, prefer the reply destination explicitly supplied in `[Context]`. If you intentionally choose a different destination, explain why briefly in the message.

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1171,6 +1171,23 @@ fn append_new_thread_reply_instruction(s: &mut String, event_id: &str) {
     ));
 }
 
+/// Append a flat-reply instruction for a top-level DM turn.
+///
+/// A DM is already a private 1:1 surface, so an ordinary reply belongs inline in
+/// the conversation. Threading it hides the answer behind a collapsed "N replies"
+/// affordance the human has to open, and every following exchange starts one
+/// level deeper. Threads inside a DM stay reserved for threads the human opened
+/// — those keep their reply instruction via [`append_reply_instruction`].
+fn append_dm_flat_reply_instruction(s: &mut String) {
+    s.push_str(
+        "\nIMPORTANT: This is a top-level direct message, not a thread. Send \
+         ordinary replies for this turn inline in the DM — do NOT pass \
+         `--reply-to` — so the human reads the answer in the conversation \
+         instead of a collapsed thread. Only open a thread if the human \
+         explicitly asks for one.",
+    );
+}
+
 /// Decide whether a turn is human-facing for reply-anchor purposes.
 ///
 /// A turn is human-facing when the triggering sender is a human, OR a human
@@ -1275,6 +1292,11 @@ fn format_context_hints(
             if let Some(event_id) = reply_anchor {
                 append_reply_instruction(&mut s, event_id);
             }
+        } else {
+            // Top-level DM: say so explicitly. Left unsaid, the agent falls back
+            // to the base-prompt rule for top-level mentions and opens a thread,
+            // burying the answer behind a collapsed "N replies" affordance.
+            append_dm_flat_reply_instruction(&mut s);
         }
         s
     } else if let Some(ref root) = thread_tags.root_event_id {
@@ -3972,9 +3994,10 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_instruction_absent_for_dm_non_reply() {
+    fn test_dm_non_reply_instructs_flat_reply() {
         let ch = Uuid::new_v4();
         let event = make_event("hey there");
+        let event_id = event.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
             events: vec![BatchEvent {
@@ -3998,9 +4021,59 @@ mod tests {
             },
         )
         .join("\n\n");
+        // A top-level DM must be told to answer inline. Left unsaid, the agent
+        // falls back to the top-level-mention rule and opens a thread, hiding
+        // the answer behind a collapsed "N replies" affordance.
         assert!(
-            !prompt.contains("--reply-to"),
-            "DM non-reply should NOT include reply instruction"
+            prompt.contains("top-level direct message"),
+            "top-level DM should carry the flat-reply instruction"
+        );
+        assert!(
+            !prompt.contains(&format!("--reply-to {event_id}")),
+            "top-level DM should NOT anchor a reply to any event"
+        );
+    }
+
+    #[test]
+    fn test_dm_thread_reply_keeps_reply_instruction() {
+        let ch = Uuid::new_v4();
+        let root_id = "d".repeat(64);
+        let event = make_event_with_tags(
+            "still in the thread",
+            vec![vec!["e".into(), root_id, "".into(), "reply".into()]],
+        );
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let ci = PromptChannelInfo {
+            name: "DM".into(),
+            channel_type: "dm".into(),
+        };
+
+        let prompt = format_prompt(
+            &batch,
+            &FormatPromptArgs {
+                channel_info: Some(&ci),
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        // A thread the human opened inside a DM still threads — the flat-reply
+        // instruction is for top-level DM turns only.
+        assert!(
+            prompt.contains("--reply-to"),
+            "DM thread reply should keep its reply instruction"
+        );
+        assert!(
+            !prompt.contains("top-level direct message"),
+            "DM thread reply should NOT get the flat-reply instruction"
         );
     }
 


### PR DESCRIPTION
## Summary

A top-level message in a 1:1 DM gets answered **inside a thread** instead of inline, so a plain
question to your own agent lands behind a collapsed `N replies` affordance you have to open.

Root cause is a silent fall-through in `format_context_hints`: the DM branch only emits a reply
instruction inside the `if let Some(ref root) = thread_tags.root_event_id` arm. A top-level DM has
no thread tags, so `reply_anchor` is `None` and the `[Context]` block says **nothing at all** about
where to reply. With no destination supplied, the agent applies the general rule from
`base_prompt.md` — *"the triggering top-level event when the human started a new thread"* — and
opens a thread rooted at the DM. That rule is right in a channel (the channel branch emits
`append_new_thread_reply_instruction` for exactly this case); in a DM it produces a thread nobody
asked for.

The fix gives the top-level DM case its own explicit instruction — answer inline, no `--reply-to`
— as the `else` of the existing arm, mirroring the channel branch's shape. A DM is already a
private 1:1 conversation; there is nothing to keep tidy with a thread.

**Threaded DM turns are untouched.** A thread the human opened still gets its reply instruction, so
this is orthogonal to #2748 and does not touch the lines #2766/#2778 modify — it stacks cleanly on
either.

### Related issue

Fixes #3075. Split out of #2748, which parks this exact question:

> Worth discussing whether top-level DM exchanges should thread at all — a 1:1 DM arguably reads
> best flat, with threading reserved for explicit user-initiated threads.

Searched open issues/PRs for duplicates: #2748 and its two PRs (#2766, #2778) cover the *anchor*
for replies already inside a thread — a different branch and a different defect. No PR covers this
one.

### Testing

- `cargo test -p buzz-acp` — 599 passed, 0 failed.
- `cargo fmt --all -- --check` clean; `cargo clippy -p buzz-acp --all-targets -- -D warnings` clean.
- `just ci` running locally; I'll confirm in a comment when it settles.

Test changes:

- **New** `test_dm_non_reply_instructs_flat_reply` — a top-level DM prompt carries the flat-reply
  instruction and anchors no event.
- **New** `test_dm_thread_reply_keeps_reply_instruction` — a DM turn *inside* a thread still gets
  its reply instruction and does **not** get the flat-reply one (guards the split).
- **Renamed + retargeted** `test_reply_instruction_absent_for_dm_non_reply` →
  `test_dm_non_reply_instructs_flat_reply`. Flagging this deliberately: the old test asserted
  `!prompt.contains("--reply-to")` for a top-level DM, which pinned the silence this PR removes.
  The new assertions keep the meaningful half — no reply is anchored to any event — while
  requiring the instruction that was missing.
- `test_reply_instruction_present_for_dm_thread_reply` is intentionally left alone; it belongs to
  the #2748 PRs.

Docs: `base_prompt.md` §Threading now states the DM rule alongside the channel rules it already
documents, so the agent-facing contract and the harness agree.
