### PR TITLE
docs(nips): NIP-OA verification inside unsigned carriers

### DIFF
--- a/docs/nips/NIP-OA.md
+++ b/docs/nips/NIP-OA.md
@@ -90,6 +90,18 @@ Clients SHOULD display provenance only when the `auth` tag verifies successfully
 Clients SHOULD ignore an invalid `auth` tag for protocol purposes.
 Clients MUST NOT display owner provenance when the `auth` tag is invalid.
 
+## Unsigned Carriers
+
+An `auth` tag MAY appear on an unsigned event, including a [NIP-59](59.md) rumor.
+An unsigned carrier has no `sig`, so the authenticity precondition in Client Behavior cannot be satisfied by the carrier itself.
+Verifiers MUST NOT treat an `auth` tag on an unsigned carrier as verified provenance unless an enclosing signed layer authenticates the carrier's `pubkey`.
+For a NIP-59 rumor that layer is the seal: the verifier MUST confirm the seal's signature is valid and that the seal's `pubkey` equals the rumor's `pubkey`, as [NIP-17](17.md) already requires.
+The signing preimage is unchanged and uses the rumor's `pubkey`.
+Conditions are evaluated against the rumor's `kind` and `created_at`, which NIP-59 designates as canonical.
+Verifiers MUST NOT substitute the seal's or gift wrap's `created_at`, which NIP-59 permits to be tweaked.
+An `auth` tag carried inside a gift wrap is not observable by the relay, so the correlation described in Privacy Considerations is disclosed to recipients only.
+Implementations MUST NOT surface the tag outside the decrypted context.
+
 ## Security Properties
 
 The owner key and the agent key are independent keys.


### PR DESCRIPTION
## What this adds

One section to an existing NIP: `## Unsigned Carriers` in `docs/nips/NIP-OA.md`,
placed immediately after `## Client Behavior` and written in NIP-OA's
one-sentence-per-line style.

No new event kind, no new tag, no new cryptography, and no change to the
condition grammar. Nine lines. It resolves an interaction between two of your
own specs that currently makes a legal construction unverifiable.

## The gap

NIP-OA already permits the tag anywhere: "Events MAY include zero or one `auth`
tag." Nothing requires the carrying event to be published, signed, or visible to
a relay. A [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md)
rumor is "the same thing as an unsigned event" and carries `pubkey`, `kind`,
`created_at`, and `id` — everything the preimage and the clause evaluation need.
[NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) already
requires that the seal's pubkey equal the rumor's pubkey, "otherwise any sender
can impersonate any other by simply changing the pubkey on the rumor", so the
seal's signature already authenticates the agent key the preimage uses.

So an owner attestation inside a gift wrap is constructible today, with no new
cryptography and no new tag — except for one rule that forbids it. NIP-OA
§Client Behavior requires:

> Clients MUST validate the event according to the core Nostr event rules,
> including that `id` and `sig` are valid for `event.pubkey`, before treating an
> `auth` tag as verified provenance.

A rumor has an `id` but structurally has no `sig`. A conforming verifier
therefore can never accept an `auth` tag inside a gift wrap, and NIP-OA's
Privacy Considerations leaves only two options: disclose the owner-agent linkage
publicly, or make no provenance claim at all.

## The change

The new section says an `auth` tag MAY appear on an unsigned carrier, and that
the authenticity precondition may be satisfied by an **enclosing signed layer**
rather than by the carrier itself. For a NIP-59 rumor that layer is the seal, and
the verifier must confirm the seal's signature and that the seal's `pubkey`
equals the rumor's — which NIP-17 already requires anyway.

The rest is anti-footgun tightening, all `MUST NOT`s that keep the weaker
precondition from widening anything:

- The signing preimage is unchanged and still uses the rumor's `pubkey`.
- Conditions are evaluated against the rumor's `kind` and `created_at`, which
  NIP-59 designates as canonical. Verifiers MUST NOT substitute the seal's or
  the gift wrap's `created_at`, which NIP-59 permits to be tweaked.
- A tag carried inside a gift wrap is not relay-observable, so the correlation
  described in Privacy Considerations is disclosed to recipients only, and
  implementations MUST NOT surface it outside the decrypted context.

## Test vectors

None required. The credential is NIP-OA's, so NIP-OA's existing vector applies
unchanged with `agent_pubkey` read from the rumor rather than from a published
`event.pubkey`. An implementation that passes NIP-OA's vector passes this.

## History of this proposal

This started as a separate draft ("NIP-AS Sealed Attestation") proposing an
`oa_sealed` tag. I withdrew it after cross-referencing against NIP-OA, NIP-17 and
NIP-59: the tag, the preimage, the grammar and the signature were all NIP-OA's
unchanged, so it amounted to a second name for `auth`. The only genuine obstacle
was the one verification rule above — which is an amendment, not a NIP.

## Disclosure

I build [Eldr](https://github.com/SnoobieJunes/Eldr), a privacy-first personal
messenger on the same Nostr substrate. It's a different shape from Buzz — solo /
untrusted-relay, post-quantum ratcheted, E2EE — and I'm not proposing anything
that would pull Buzz toward it. Eldr proves agent provenance to the recipient
inside its NIP-59 gift wrap, verified after unwrap, which is how I hit this rule.
Its NIP-OA codec is byte-exact against your pinned vector (the "NIP-OA verifies
the spec-provided signature" case is green in Eldr's suite, alongside NIP-44 v2,
NIP-AM and NIP-AO). Mutual conformance is the point; this is a contribution, not
a fork.

## Licensing

Eldr's protocol documents are CC0 1.0 (public domain) by deliberate choice, so
contributing this under Apache-2.0 is unencumbered. I'm the sole copyright
holder, there's no employer with a claim, and per CONTRIBUTING I'm submitting it
under the Apache-2.0 license with the right to do so.

## Notes for review

- **Scope.** The likely objection is "we don't care about gift-wrapped agent
  traffic." That's a scoping answer rather than a correctness one, and it's a
  fair one to give — but the rule as written also forbids any *other* unsigned
  carrier, so the amendment is phrased generally and NIP-59 is only the worked
  example.
- **CI.** Documentation-only; `just ci` covers Rust fmt/clippy/tests and mobile,
  none of which this touches. I haven't run it locally (it requires Docker,
  Postgres, Redis, Flutter, and a Rust toolchain, and this change is markdown-only).
  I can run it if you'd like.
- **Independent.** This PR touches only `NIP-OA.md` and does not depend on my
  other two open PRs.
- **I'm happy to move this to a Discussion or issue** if you'd rather talk about
  the approach first. I opened it as a PR because the change is small and
  concrete, not to skip the conversation.
