### PR TITLE
feat(desktop): add CRM review action cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,10 @@ doc/
 # Local identity files
 identity.key
 **/identity.key
+*.p12
+*.pfx
+*.pem
+*.key
 
 # Claude Code worktrees
 .claude/worktrees/

--- a/Justfile
+++ b/Justfile
@@ -242,6 +242,15 @@ desktop-release-build target="aarch64-apple-darwin":
     pnpm install
     cd {{desktop_dir}} && pnpm tauri build --features mesh-llm --target {{target}}
 
+# Sign and install the locally built macOS app with a stable local identity.
+# Run once with `--create-identity` if this machine has no code-signing identity.
+desktop-install-local-macos *ARGS:
+    ./desktop/scripts/install-local-macos-app.sh {{ARGS}}
+
+# Verify the installed macOS app has a stable Keychain-friendly signature.
+desktop-signing-status:
+    ./desktop/scripts/install-local-macos-app.sh --status
+
 # Run desktop checks suitable for CI / pre-push
 desktop-ci: desktop-check desktop-test desktop-tauri-fmt-check desktop-build desktop-tauri-check desktop-tauri-test
 

--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -60,20 +60,25 @@ pub fn build_imeta_tag(d: &BlobDescriptor) -> Vec<String> {
     tag
 }
 
-/// MIME types accepted for upload.
-const ALLOWED_MIMES: &[&str] = &[
-    "image/jpeg",
-    "image/png",
-    "image/gif",
-    "image/webp",
-    "video/mp4",
-];
-
 /// Maximum file size for image uploads (50 MB).
 const MAX_IMAGE_BYTES: u64 = 50 * 1024 * 1024;
 
 /// Maximum file size for video uploads (500 MB).
 const MAX_VIDEO_BYTES: u64 = 500 * 1024 * 1024;
+
+/// Maximum generic attachment size. This matches the relay's default
+/// `BUZZ_MAX_FILE_BYTES`; the relay remains the final authority.
+const MAX_FILE_BYTES: u64 = 100 * 1024 * 1024;
+
+fn max_upload_bytes(mime: &str) -> u64 {
+    if mime.starts_with("video/") {
+        MAX_VIDEO_BYTES
+    } else if mime.starts_with("image/") {
+        MAX_IMAGE_BYTES
+    } else {
+        MAX_FILE_BYTES
+    }
+}
 
 /// Sign a NIP-98 HTTP auth event (kind:27235) and return the Authorization header value.
 ///
@@ -1113,16 +1118,11 @@ impl BuzzClient {
             .map(|t| t.mime_type().to_string())
             .unwrap_or_else(|| "application/octet-stream".to_string());
 
-        if !ALLOWED_MIMES.contains(&mime.as_str()) {
-            return Err(CliError::Usage(format!("unsupported file type: {mime}")));
-        }
-
-        // 3. Size check
-        let max = if mime.starts_with("video/") {
-            MAX_VIDEO_BYTES
-        } else {
-            MAX_IMAGE_BYTES
-        };
+        // 3. Size check. The relay owns content-type validation for generic
+        // attachments (documents, archives, and deny-listed active content).
+        // Keeping a partial MIME allow-list here would reject safe formats
+        // such as PDFs before the relay can apply its authoritative policy.
+        let max = max_upload_bytes(&mime);
         if bytes.len() as u64 > max {
             return Err(CliError::Usage(format!(
                 "file too large: {} bytes (max {})",
@@ -1588,7 +1588,7 @@ mod retry_policy_tests {
     use axum::body::Body;
     use axum::extract::State;
     use axum::http::{HeaderMap, Response, StatusCode};
-    use axum::routing::post;
+    use axum::routing::{post, put};
     use axum::Router;
     use nostr::{EventBuilder, Keys, Kind};
     use tokio::net::TcpListener;
@@ -2199,6 +2199,45 @@ mod retry_policy_tests {
         );
     }
 
+    /// Generic attachments are validated by the relay, which knows the active
+    /// file deny-list. The CLI must not reject a safe document before it reaches
+    /// that authoritative validation path.
+    #[tokio::test]
+    async fn upload_file_allows_relay_validated_pdf_attachments() {
+        use std::io::Write;
+
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"%PDF-1.7\n% local test fixture\n").unwrap();
+        let file_path = tmp.path().to_str().unwrap().to_string();
+
+        let attempts = Arc::new(AtomicU32::new(0));
+        let attempts_for_handler = attempts.clone();
+        let app = Router::new().route(
+            "/upload",
+            put(move |_headers: HeaderMap, _body: Body| {
+                let attempts = attempts_for_handler.clone();
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    let body = r#"{"url":"https://relay.test/media/document.pdf","sha256":"aabbcc","size":28,"type":"application/pdf","uploaded":0}"#;
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .header("content-type", "application/json")
+                        .body(Body::from(body))
+                        .unwrap()
+                }
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let client = test_client(&format!("http://{addr}"));
+        let descriptor = client.upload_file(&file_path).await.unwrap();
+
+        assert_eq!(descriptor.mime_type, "application/pdf");
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
     /// When all retry attempts for a stored event end with a partial body (200
     /// headers, dropped connection), the final error must be `DeliveryUnknown`
     /// (retryable:false) — the relay may have stored the event on any attempt, so
@@ -2297,7 +2336,8 @@ mod retry_policy_tests {
 #[cfg(test)]
 mod tests {
     use super::{
-        advance_query_cursor, create_response_with_id, extract_relay_response_field, BuzzClient,
+        advance_query_cursor, create_response_with_id, extract_relay_response_field,
+        max_upload_bytes, BuzzClient, MAX_FILE_BYTES, MAX_IMAGE_BYTES, MAX_VIDEO_BYTES,
     };
     use nostr::{EventBuilder, Keys, Kind, Tag};
 
@@ -2313,6 +2353,14 @@ mod tests {
 
         assert_eq!(filter["until"], serde_json::json!(10));
         assert_eq!(filter["before_id"], serde_json::json!("b".repeat(64)));
+    }
+
+    #[test]
+    fn generic_attachments_use_the_relay_file_limit() {
+        assert_eq!(max_upload_bytes("application/octet-stream"), MAX_FILE_BYTES);
+        assert_eq!(max_upload_bytes("application/pdf"), MAX_FILE_BYTES);
+        assert_eq!(max_upload_bytes("image/png"), MAX_IMAGE_BYTES);
+        assert_eq!(max_upload_bytes("video/mp4"), MAX_VIDEO_BYTES);
     }
 
     #[test]

--- a/crates/buzz-cli/src/commands/channels.rs
+++ b/crates/buzz-cli/src/commands/channels.rs
@@ -19,7 +19,22 @@ fn extract_channel_metadata(e: &serde_json::Value) -> serde_json::Value {
         "name": extract_tag_value(e, "name"),
         "description": extract_tag_value(e, "about"),
         "created_at": e.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0),
+        "archived": channel_is_archived(e),
     })
+}
+
+fn channel_is_archived(event: &serde_json::Value) -> bool {
+    event
+        .get("tags")
+        .and_then(|tags| tags.as_array())
+        .is_some_and(|tags| {
+            tags.iter().any(|tag| {
+                tag.as_array().is_some_and(|values| {
+                    values.first().and_then(|value| value.as_str()) == Some("archived")
+                        && values.get(1).and_then(|value| value.as_str()) == Some("true")
+                })
+            })
+        })
 }
 
 pub async fn cmd_list_channels(
@@ -172,7 +187,6 @@ impl ChannelSummary {
         let mut name: Option<String> = None;
         let mut channel_type: Option<String> = None;
         let mut visibility: Option<String> = None;
-        let mut archived = false;
         let mut about: Option<String> = None;
         let mut topic: Option<String> = None;
         let mut purpose: Option<String> = None;
@@ -194,7 +208,6 @@ impl ChannelSummary {
                 "about" => about = val.map(str::to_string),
                 "topic" => topic = val.map(str::to_string),
                 "purpose" => purpose = val.map(str::to_string),
-                "archived" => archived = val == Some("true"),
                 _ => {}
             }
         }
@@ -204,7 +217,7 @@ impl ChannelSummary {
             name: name?,
             channel_type,
             visibility,
-            archived,
+            archived: channel_is_archived(event),
             about,
             topic,
             purpose,
@@ -1177,9 +1190,9 @@ pub async fn dispatch_canvas(cmd: crate::CanvasCmd, client: &BuzzClient) -> Resu
 mod tests {
     use super::{
         apply_cardinality_rule, build_template_report, cmd_set_add_policy,
-        finalize_roster_resolution, name_matches, resolve_roster_with_archive_filter,
-        validate_ttl_seconds, ArchivedExclusion, ChannelSummary, ResolvedAgent, RosterResolution,
-        SkippedSlug,
+        extract_channel_metadata, finalize_roster_resolution, name_matches,
+        resolve_roster_with_archive_filter, validate_ttl_seconds, ArchivedExclusion,
+        ChannelSummary, ResolvedAgent, RosterResolution, SkippedSlug,
     };
     use crate::client::BuzzClient;
     use crate::CliError;
@@ -1220,6 +1233,18 @@ mod tests {
         ]));
         let s = ChannelSummary::from_event(&ev).expect("parse");
         assert!(s.archived);
+    }
+
+    #[test]
+    fn metadata_projection_preserves_archived_state() {
+        let ev = event(json!([
+            ["d", "11111111-1111-1111-1111-111111111111"],
+            ["name", "old-channel"],
+            ["archived", "true"],
+        ]));
+
+        let metadata = extract_channel_metadata(&ev);
+        assert_eq!(metadata["archived"], true);
     }
 
     #[test]

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -18,6 +18,26 @@ Desktop chat shell with:
 - `pnpm format` - Biome format (write)
 - `pnpm check` - Biome check
 
+## Local macOS Install
+
+Local unsigned Tauri builds are ad-hoc signed, so macOS Keychain trusts the
+exact binary hash. After each rebuild, the `buzz-desktop` Keychain item can ask
+again even if "Always Allow" was selected before.
+
+Use the local installer to sign Buzz with a stable local code-signing identity:
+
+```bash
+just desktop-install-local-macos --create-identity
+just desktop-signing-status
+```
+
+After the first run, omit `--create-identity`. If macOS prompts for Keychain
+access once after the signed install, choose "Always Allow"; later local rebuilds
+signed with the same identity should keep the same Keychain authorization.
+
+See [Desktop Local macOS Signing](../docs/desktop-local-macos-signing.md) for
+the migration and new-machine runbook.
+
 ## Structure
 
 - `src/shared` - reusable app-wide code (`ui`, `lib`, `styles`)

--- a/desktop/scripts/install-local-macos-app.sh
+++ b/desktop/scripts/install-local-macos-app.sh
@@ -15,6 +15,7 @@ DRY_RUN=0
 STATUS_ONLY=0
 SEARCH_LIST_CHANGED=0
 ORIGINAL_KEYCHAINS=""
+IDENTITY_TMPDIR=""
 
 usage() {
   cat <<'USAGE'
@@ -191,7 +192,19 @@ ensure_keychain_in_search_list() {
   SEARCH_LIST_CHANGED=1
 }
 
-trap restore_keychain_search_list EXIT
+cleanup_on_exit() {
+  local status=$?
+
+  if [[ -n "$IDENTITY_TMPDIR" && -d "$IDENTITY_TMPDIR" ]]; then
+    chmod -R u+w "$IDENTITY_TMPDIR" >/dev/null 2>&1 || true
+    rm -rf -- "$IDENTITY_TMPDIR" >/dev/null 2>&1 || true
+  fi
+
+  restore_keychain_search_list || true
+  exit "$status"
+}
+
+trap cleanup_on_exit EXIT
 
 find_identity_hash() {
   security find-identity -p codesigning -v 2>/dev/null |
@@ -208,8 +221,8 @@ create_identity() {
     return 0
   fi
 
-  local tmpdir
-  tmpdir="$(mktemp -d /tmp/buzz-local-codesign.XXXXXX)"
+  IDENTITY_TMPDIR="$(mktemp -d /tmp/buzz-local-codesign.XXXXXX)"
+  local tmpdir="$IDENTITY_TMPDIR"
   local cert="$tmpdir/codesign.crt"
   local key="$tmpdir/codesign.key"
   local p12="$tmpdir/codesign.p12"
@@ -236,7 +249,8 @@ create_identity() {
   security add-trusted-cert -r trustRoot -p codeSign -k "$KEYCHAIN_PATH" "$cert" >/dev/null
 
   chmod -R u+w "$tmpdir"
-  rm -R "$tmpdir"
+  rm -rf -- "$tmpdir"
+  IDENTITY_TMPDIR=""
 }
 
 sign_nested_executables() {

--- a/desktop/scripts/install-local-macos-app.sh
+++ b/desktop/scripts/install-local-macos-app.sh
@@ -1,0 +1,449 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DESKTOP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+APP_PATH="$DESKTOP_DIR/src-tauri/target/release/bundle/macos/Buzz.app"
+INSTALL_PATH="${BUZZ_INSTALL_APP_PATH:-/Applications/Buzz.app}"
+ENTITLEMENTS_PATH="$DESKTOP_DIR/src-tauri/Entitlements.plist"
+IDENTITY_NAME="${BUZZ_LOCAL_CODESIGN_IDENTITY:-Buzz Local Code Signing}"
+KEYCHAIN_PATH="${BUZZ_CODESIGN_KEYCHAIN:-}"
+CREATE_IDENTITY=0
+NO_INSTALL=0
+DRY_RUN=0
+STATUS_ONLY=0
+SEARCH_LIST_CHANGED=0
+ORIGINAL_KEYCHAINS=""
+
+usage() {
+  cat <<'USAGE'
+Usage: desktop/scripts/install-local-macos-app.sh [options]
+
+Signs a locally built Buzz.app with a stable local code-signing identity, then
+installs it to /Applications/Buzz.app. This keeps macOS Keychain ACLs stable
+across local rebuilds; ad-hoc signatures fall back to a cdhash requirement and
+make "Always Allow" prompts come back after each rebuild.
+
+Options:
+  --app PATH             Buzz.app bundle to sign.
+  --install-path PATH    Destination app path. Default: /Applications/Buzz.app
+  --identity NAME        Code-signing identity common name.
+                         Default: Buzz Local Code Signing
+  --keychain PATH        Keychain containing/receiving the identity.
+                         Default: login keychain
+  --create-identity      Create a trusted local code-signing identity if absent.
+  --no-install           Sign and verify APP_PATH only.
+  --status               Verify the installed app and Keychain signing state.
+  --dry-run              Print actions without mutating files/keychains.
+  -h, --help             Show this help.
+
+Examples:
+  just desktop-install-local-macos --create-identity
+  just desktop-signing-status
+  desktop/scripts/install-local-macos-app.sh --no-install --app /tmp/Buzz.app
+USAGE
+}
+
+log() {
+  printf '==> %s\n' "$*"
+}
+
+warn() {
+  printf 'warning: %s\n' "$*" >&2
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+print_cmd() {
+  printf '+'
+  local arg
+  for arg in "$@"; do
+    printf ' %q' "$arg"
+  done
+  printf '\n'
+}
+
+run() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    print_cmd "$@"
+  else
+    "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app)
+      [[ $# -ge 2 ]] || die "--app requires a path"
+      APP_PATH="$2"
+      shift 2
+      ;;
+    --install-path)
+      [[ $# -ge 2 ]] || die "--install-path requires a path"
+      INSTALL_PATH="$2"
+      shift 2
+      ;;
+    --identity)
+      [[ $# -ge 2 ]] || die "--identity requires a name"
+      IDENTITY_NAME="$2"
+      shift 2
+      ;;
+    --keychain)
+      [[ $# -ge 2 ]] || die "--keychain requires a path"
+      KEYCHAIN_PATH="$2"
+      shift 2
+      ;;
+    --create-identity)
+      CREATE_IDENTITY=1
+      shift
+      ;;
+    --no-install)
+      NO_INSTALL=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --status|--verify-installed)
+      STATUS_ONLY=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+done
+
+# `defaults read` treats a relative app bundle path as a preferences domain,
+# rather than an Info.plist path. Make an explicit --app path absolute before
+# inspecting or signing the bundle.
+if [[ "$STATUS_ONLY" != "1" ]]; then
+  APP_PATH="$(cd "$(dirname "$APP_PATH")" && pwd)/$(basename "$APP_PATH")"
+fi
+
+[[ "$(uname -s)" == "Darwin" ]] || die "macOS is required"
+command -v codesign >/dev/null 2>&1 || die "codesign not found"
+command -v security >/dev/null 2>&1 || die "security not found"
+if [[ "$STATUS_ONLY" != "1" ]]; then
+  command -v openssl >/dev/null 2>&1 || die "openssl not found"
+  command -v ditto >/dev/null 2>&1 || die "ditto not found"
+fi
+
+if [[ -z "$KEYCHAIN_PATH" ]]; then
+  KEYCHAIN_PATH="$(security login-keychain | tr -d ' "')"
+fi
+
+[[ -n "$KEYCHAIN_PATH" ]] || die "could not resolve login keychain"
+if [[ "$STATUS_ONLY" != "1" ]]; then
+  [[ -d "$APP_PATH" ]] || die "missing app bundle: $APP_PATH"
+  [[ -f "$APP_PATH/Contents/Info.plist" ]] || die "missing Info.plist in $APP_PATH"
+  [[ -f "$ENTITLEMENTS_PATH" ]] || die "missing entitlements: $ENTITLEMENTS_PATH"
+
+  BUNDLE_ID="$(defaults read "$APP_PATH/Contents/Info" CFBundleIdentifier 2>/dev/null || true)"
+  [[ "$BUNDLE_ID" == "xyz.block.buzz.app" ]] || die "unexpected bundle id '$BUNDLE_ID'"
+fi
+
+capture_keychain_search_list() {
+  ORIGINAL_KEYCHAINS="$(security list-keychains -d user | sed 's/^ *"//; s/"$//')"
+}
+
+restore_keychain_search_list() {
+  [[ "$SEARCH_LIST_CHANGED" == "1" ]] || return 0
+  [[ "$DRY_RUN" == "1" ]] && return 0
+  [[ -n "$ORIGINAL_KEYCHAINS" ]] || return 0
+
+  local -a keychains=()
+  local keychain
+  while IFS= read -r keychain; do
+    [[ -n "$keychain" ]] && keychains+=("$keychain")
+  done <<< "$ORIGINAL_KEYCHAINS"
+
+  [[ "${#keychains[@]}" -gt 0 ]] || return 0
+  security list-keychains -d user -s "${keychains[@]}" >/dev/null
+}
+
+ensure_keychain_in_search_list() {
+  capture_keychain_search_list
+
+  local found=0
+  local -a keychains=("$KEYCHAIN_PATH")
+  local keychain
+  while IFS= read -r keychain; do
+    [[ -z "$keychain" ]] && continue
+    if [[ "$keychain" == "$KEYCHAIN_PATH" ]]; then
+      found=1
+      continue
+    fi
+    keychains+=("$keychain")
+  done <<< "$ORIGINAL_KEYCHAINS"
+
+  [[ "$found" == "1" ]] && return 0
+  run security list-keychains -d user -s "${keychains[@]}"
+  SEARCH_LIST_CHANGED=1
+}
+
+trap restore_keychain_search_list EXIT
+
+find_identity_hash() {
+  security find-identity -p codesigning -v 2>/dev/null |
+    awk -v needle="\"$IDENTITY_NAME\"" 'index($0, needle) { print $2; exit }'
+}
+
+create_identity() {
+  log "Creating local code-signing identity '$IDENTITY_NAME'"
+  warn "macOS may ask for your keychain password. This is expected and not bypassed."
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    print_cmd security import "<generated-p12>" -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
+    print_cmd security add-trusted-cert -r trustRoot -p codeSign -k "$KEYCHAIN_PATH" "<generated-cert>"
+    return 0
+  fi
+
+  local tmpdir
+  tmpdir="$(mktemp -d /tmp/buzz-local-codesign.XXXXXX)"
+  local cert="$tmpdir/codesign.crt"
+  local key="$tmpdir/codesign.key"
+  local p12="$tmpdir/codesign.p12"
+  local p12_password
+  p12_password="$(openssl rand -hex 24)"
+
+  openssl req -new -x509 -nodes -days 3650 -newkey rsa:2048 \
+    -subj "/CN=$IDENTITY_NAME" \
+    -addext "basicConstraints=critical,CA:true" \
+    -addext "keyUsage=critical,digitalSignature,keyCertSign" \
+    -addext "extendedKeyUsage=codeSigning" \
+    -addext "subjectKeyIdentifier=hash" \
+    -keyout "$key" \
+    -out "$cert" >/dev/null 2>&1
+
+  openssl pkcs12 -legacy -export \
+    -name "$IDENTITY_NAME" \
+    -inkey "$key" \
+    -in "$cert" \
+    -out "$p12" \
+    -passout "pass:$p12_password" >/dev/null 2>&1
+
+  security import "$p12" -k "$KEYCHAIN_PATH" -P "$p12_password" -T /usr/bin/codesign >/dev/null
+  security add-trusted-cert -r trustRoot -p codeSign -k "$KEYCHAIN_PATH" "$cert" >/dev/null
+
+  chmod -R u+w "$tmpdir"
+  rm -R "$tmpdir"
+}
+
+sign_nested_executables() {
+  local identity_hash="$1"
+  local executable
+
+  while IFS= read -r executable; do
+    log "Signing $(basename "$executable")"
+    run codesign --force --options runtime --timestamp=none --sign "$identity_hash" "$executable"
+  done < <(find "$APP_PATH/Contents/MacOS" -type f -perm -111 | sort)
+}
+
+sign_app_bundle() {
+  local identity_hash="$1"
+
+  log "Signing Buzz.app bundle"
+  run codesign --force --deep --options runtime --timestamp=none \
+    --entitlements "$ENTITLEMENTS_PATH" \
+    --sign "$identity_hash" \
+    "$APP_PATH"
+}
+
+designated_requirement() {
+  codesign -d -r- "$1" 2>&1 | sed 's/^# //'
+}
+
+verify_signature() {
+  local app="$1"
+  local requirement
+
+  log "Verifying signature for $app"
+  run codesign --verify --deep --strict --verbose=2 "$app"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    return 0
+  fi
+
+  requirement="$(designated_requirement "$app")"
+  printf '%s\n' "$requirement"
+
+  if grep -Fq 'designated => cdhash' <<< "$requirement"; then
+    die "signature is still ad-hoc/cdhash based; Keychain prompts will not be stable"
+  fi
+  if ! grep -Fq 'identifier "xyz.block.buzz.app"' <<< "$requirement"; then
+    die "designated requirement does not include the Buzz bundle identifier"
+  fi
+  if ! grep -Fq 'certificate leaf = H' <<< "$requirement"; then
+    warn "designated requirement is not leaf-hash based; inspect before relying on Keychain ACL stability"
+  fi
+}
+
+print_status() {
+  local exit_code=0
+  local bundle_id=""
+  local requirement=""
+  local leaf_hash=""
+
+  printf 'install_path=%s\n' "$INSTALL_PATH"
+  printf 'identity_name=%s\n' "$IDENTITY_NAME"
+
+  if [[ ! -d "$INSTALL_PATH" ]]; then
+    printf 'installed_app=missing\n'
+    return 1
+  fi
+
+  bundle_id="$(defaults read "$INSTALL_PATH/Contents/Info" CFBundleIdentifier 2>/dev/null || true)"
+  printf 'bundle_id=%s\n' "${bundle_id:-unknown}"
+  if [[ "$bundle_id" != "xyz.block.buzz.app" ]]; then
+    printf 'bundle_id_status=unexpected\n'
+    exit_code=1
+  else
+    printf 'bundle_id_status=ok\n'
+  fi
+
+  if codesign --verify --deep --strict --verbose=2 "$INSTALL_PATH" >/dev/null 2>&1; then
+    printf 'signature=valid\n'
+  else
+    printf 'signature=invalid\n'
+    exit_code=1
+  fi
+
+  requirement="$(designated_requirement "$INSTALL_PATH" || true)"
+  printf '%s\n' "$requirement"
+
+  if grep -Fq 'designated => cdhash' <<< "$requirement"; then
+    printf 'keychain_acl_stability=bad_cdhash\n'
+    exit_code=1
+  elif grep -Fq 'identifier "xyz.block.buzz.app"' <<< "$requirement" &&
+    grep -Fq 'certificate leaf = H' <<< "$requirement"; then
+    printf 'keychain_acl_stability=stable\n'
+  else
+    printf 'keychain_acl_stability=unknown\n'
+    exit_code=1
+  fi
+
+  leaf_hash="$(sed -n 's/.*certificate leaf = H"\([^"]*\)".*/\1/p' <<< "$requirement" | head -n 1)"
+  if [[ -n "$leaf_hash" ]] &&
+    security find-identity -p codesigning -v 2>/dev/null | grep -iq "$leaf_hash"; then
+    printf 'local_signing_identity=present\n'
+  elif [[ -n "$(find_identity_hash || true)" ]]; then
+    printf 'local_signing_identity=present_by_name\n'
+  else
+    printf 'local_signing_identity=missing\n'
+    exit_code=1
+  fi
+
+  if security find-generic-password -s buzz-desktop >/dev/null 2>&1; then
+    printf 'buzz_desktop_keychain_item=present\n'
+  else
+    printf 'buzz_desktop_keychain_item=missing\n'
+  fi
+
+  if pgrep -f "$INSTALL_PATH/Contents/MacOS/buzz-desktop" >/dev/null 2>&1; then
+    printf 'running_from_install_path=yes\n'
+  else
+    printf 'running_from_install_path=no\n'
+  fi
+
+  return "$exit_code"
+}
+
+wait_for_buzz_to_quit() {
+  local pattern="$INSTALL_PATH/Contents/MacOS/buzz-desktop"
+
+  if ! pgrep -f "$pattern" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  log "Asking running Buzz to quit"
+  /usr/bin/osascript -e 'tell application id "xyz.block.buzz.app" to quit' >/dev/null 2>&1 || true
+
+  local _
+  for _ in $(seq 1 20); do
+    if ! pgrep -f "$pattern" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+
+  die "Buzz is still running; quit it and rerun this script"
+}
+
+install_app() {
+  local install_parent
+  local backup_path
+  install_parent="$(dirname "$INSTALL_PATH")"
+  backup_path="$install_parent/Buzz.before-local-codesign-$(date +%Y%m%d-%H%M%S).app"
+
+  [[ -d "$install_parent" ]] || die "install parent does not exist: $install_parent"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    if [[ -e "$INSTALL_PATH" ]]; then
+      print_cmd mv "$INSTALL_PATH" "$backup_path"
+    fi
+    print_cmd ditto "$APP_PATH" "$INSTALL_PATH"
+    return 0
+  fi
+
+  wait_for_buzz_to_quit
+
+  if [[ -e "$INSTALL_PATH" ]]; then
+    log "Backing up existing app to $backup_path"
+    mv "$INSTALL_PATH" "$backup_path"
+  fi
+
+  log "Installing signed app to $INSTALL_PATH"
+  if ! ditto "$APP_PATH" "$INSTALL_PATH"; then
+    if [[ -d "$backup_path" && ! -e "$INSTALL_PATH" ]]; then
+      warn "Install failed; restoring previous app"
+      mv "$backup_path" "$INSTALL_PATH"
+    fi
+    exit 1
+  fi
+}
+
+if [[ "$STATUS_ONLY" == "1" ]]; then
+  print_status
+  exit $?
+fi
+
+ensure_keychain_in_search_list
+
+IDENTITY_HASH="$(find_identity_hash || true)"
+if [[ -z "$IDENTITY_HASH" ]]; then
+  if [[ "$CREATE_IDENTITY" == "1" ]]; then
+    create_identity
+    IDENTITY_HASH="$(find_identity_hash || true)"
+    if [[ -z "$IDENTITY_HASH" && "$DRY_RUN" == "1" ]]; then
+      IDENTITY_HASH="DRYRUN-LOCAL-CODESIGN-IDENTITY"
+    fi
+  else
+    die "missing code-signing identity '$IDENTITY_NAME'. Rerun with --create-identity once."
+  fi
+fi
+
+[[ -n "$IDENTITY_HASH" ]] || die "could not create/find a valid code-signing identity"
+
+log "Using code-signing identity $IDENTITY_NAME ($IDENTITY_HASH)"
+sign_nested_executables "$IDENTITY_HASH"
+sign_app_bundle "$IDENTITY_HASH"
+verify_signature "$APP_PATH"
+
+if [[ "$NO_INSTALL" == "1" ]]; then
+  log "Signed app left in place: $APP_PATH"
+  exit 0
+fi
+
+install_app
+verify_signature "$INSTALL_PATH"
+log "Done. The next Keychain prompt should need one final Always Allow for this stable identity."

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -478,11 +478,23 @@ fn is_duplicate_channel_rejection(error: &str) -> bool {
     error.contains("relay rejected event:") && error.contains("duplicate: channel already exists")
 }
 
-fn is_matching_starter_channel(channel: &ChannelInfo, spec: &StarterChannelSpec) -> bool {
+fn has_starter_channel_identity(channel: &ChannelInfo, spec: &StarterChannelSpec) -> bool {
     normalize_channel_name(&channel.name) == normalize_channel_name(spec.name)
         && channel.channel_type == "stream"
         && channel.visibility == "open"
-        && channel.archived_at.is_none()
+}
+
+fn is_matching_starter_channel(channel: &ChannelInfo, spec: &StarterChannelSpec) -> bool {
+    has_starter_channel_identity(channel, spec) && channel.archived_at.is_none()
+}
+
+fn has_active_non_starter_channel(channels: &[ChannelInfo]) -> bool {
+    channels.iter().any(|channel| {
+        channel.archived_at.is_none()
+            && !STARTER_CHANNELS
+                .iter()
+                .any(|spec| has_starter_channel_identity(channel, spec))
+    })
 }
 
 fn has_all_starter_channels(channels: &[ChannelInfo]) -> bool {
@@ -613,6 +625,13 @@ pub async fn ensure_starter_channels(
     state: State<'_, AppState>,
 ) -> Result<Vec<ChannelInfo>, String> {
     let mut existing_channels = get_channels(state.clone()).await?;
+
+    // A configured community owns its channel taxonomy. Do not recreate starter
+    // channels that its members deliberately archived after creating other routes.
+    if has_active_non_starter_channel(&existing_channels) {
+        return Ok(existing_channels);
+    }
+
     let relay_scope = relay_api_base_url_with_override(&state);
     let creator_keys = state.signing_keys()?;
     let creator_pubkey = creator_keys.public_key().to_hex();

--- a/desktop/src-tauri/src/commands/channels_tests.rs
+++ b/desktop/src-tauri/src/commands/channels_tests.rs
@@ -301,3 +301,51 @@ fn starter_match_requires_open_unarchived_stream_by_normalized_name() {
     channel.archived_at = Some("2026-07-16T00:00:00Z".to_string());
     assert!(!is_matching_starter_channel(&channel, spec));
 }
+
+#[test]
+fn active_custom_channels_prevent_starter_channel_reseeding() {
+    let starter = ChannelInfo {
+        id: "starter-general".to_string(),
+        name: "general".to_string(),
+        channel_type: "stream".to_string(),
+        visibility: "open".to_string(),
+        description: String::new(),
+        topic: None,
+        purpose: None,
+        member_count: 0,
+        member_pubkeys: Vec::new(),
+        last_message_at: None,
+        archived_at: None,
+        participants: Vec::new(),
+        participant_pubkeys: Vec::new(),
+        is_member: true,
+        ttl_seconds: None,
+        ttl_deadline: None,
+    };
+    let mut custom = ChannelInfo {
+        id: "crm-general".to_string(),
+        name: "crm-general".to_string(),
+        channel_type: "stream".to_string(),
+        visibility: "private".to_string(),
+        description: String::new(),
+        topic: None,
+        purpose: None,
+        member_count: 1,
+        member_pubkeys: Vec::new(),
+        last_message_at: None,
+        archived_at: None,
+        participants: Vec::new(),
+        participant_pubkeys: Vec::new(),
+        is_member: true,
+        ttl_seconds: None,
+        ttl_deadline: None,
+    };
+
+    assert!(!has_active_non_starter_channel(&[starter]));
+    assert!(has_active_non_starter_channel(std::slice::from_ref(
+        &custom
+    )));
+
+    custom.archived_at = Some("2026-07-27T00:00:00Z".to_string());
+    assert!(!has_active_non_starter_channel(&[custom]));
+}

--- a/desktop/src-tauri/src/mesh_llm/recovery.rs
+++ b/desktop/src-tauri/src/mesh_llm/recovery.rs
@@ -243,17 +243,22 @@ pub(crate) async fn rearm_relay_mesh_for_running_agents(app: &AppHandle) -> Resu
     let _rearm_guard = state.mesh_recovery.rearm_lock.lock().await;
     let recovery = recover_stale_mesh_runtime(&state, MeshRecoveryUrgency::Watchdog).await;
     let active_pubkeys = active_managed_agent_pubkeys(&state);
+    let records = crate::managed_agents::load_managed_agents(app).unwrap_or_default();
+    let personas = crate::managed_agents::load_personas(app).unwrap_or_default();
+    let global = crate::managed_agents::load_global_agent_config(app).unwrap_or_default();
+
+    let has_running_mesh_agent = || {
+        records.iter().any(|record| {
+            running_relay_mesh_model_id(record, &active_pubkeys, &personas, &global).is_some()
+        })
+    };
 
     match recovery {
         MeshRuntimeRecovery::Live
         | MeshRuntimeRecovery::Debouncing
         | MeshRuntimeRecovery::Replaced => return Ok(()),
         MeshRuntimeRecovery::RestartRequired => {
-            let records = crate::managed_agents::load_managed_agents(app).unwrap_or_default();
-            if !records
-                .iter()
-                .any(|record| is_running_relay_mesh_agent(record, &active_pubkeys))
-            {
+            if !has_running_mesh_agent() {
                 // A foreground save may still be bringing up its first ingress.
                 // Only an already-running consumer justifies an automatic app
                 // relaunch from the background watchdog.
@@ -271,25 +276,30 @@ pub(crate) async fn rearm_relay_mesh_for_running_agents(app: &AppHandle) -> Resu
             ));
         }
         MeshRuntimeRecovery::Absent => {
-            let records = crate::managed_agents::load_managed_agents(app).unwrap_or_default();
-            if !records
-                .iter()
-                .any(|record| is_running_relay_mesh_agent(record, &active_pubkeys))
-            {
+            if !has_running_mesh_agent() {
                 return Ok(());
             }
         }
         MeshRuntimeRecovery::Evicted => {}
     }
 
-    let records = crate::managed_agents::load_managed_agents(app).unwrap_or_default();
     let mesh_records: Vec<_> = records
         .into_iter()
-        .filter(|record| is_running_relay_mesh_agent(record, &active_pubkeys))
+        .filter_map(|record| {
+            let model_id =
+                running_relay_mesh_model_id(&record, &active_pubkeys, &personas, &global)?;
+            Some((record, model_id))
+        })
         .collect();
     let mut first_error = None;
-    for record in &mesh_records {
-        match crate::commands::mesh_llm::ensure_relay_mesh_for_record(app, record, false).await {
+    for (record, model_id) in &mesh_records {
+        match crate::commands::mesh_llm::ensure_relay_mesh_for_record(
+            app,
+            Some(model_id.as_str()),
+            false,
+        )
+        .await
+        {
             Ok(()) => {
                 if let Err(error) = clear_mesh_last_error_if_set(app, &record.pubkey) {
                     eprintln!("buzz-mesh: failed to clear recovery error: {error}");
@@ -322,16 +332,24 @@ fn active_managed_agent_pubkeys(state: &AppState) -> HashSet<String> {
         .unwrap_or_default()
 }
 
-fn is_running_relay_mesh_agent(
+fn running_relay_mesh_model_id(
     record: &crate::managed_agents::ManagedAgentRecord,
     active_pubkeys: &HashSet<String>,
-) -> bool {
-    record.backend == crate::managed_agents::BackendKind::Local
-        && crate::managed_agents::relay_mesh_model_id(record).is_some()
-        && active_pubkeys.contains(&record.pubkey.to_ascii_lowercase())
-        && record
+    personas: &[crate::managed_agents::AgentDefinition],
+    global: &crate::managed_agents::GlobalAgentConfig,
+) -> Option<String> {
+    if record.backend != crate::managed_agents::BackendKind::Local
+        || !active_pubkeys.contains(&record.pubkey.to_ascii_lowercase())
+        || !record
             .runtime_pid
             .is_none_or(crate::managed_agents::process_is_running)
+    {
+        return None;
+    }
+
+    crate::managed_agents::effective_config::resolve_effective_relay_mesh_model_id(
+        record, personas, global,
+    )
 }
 
 fn persist_mesh_last_error(app: &AppHandle, pubkey: &str, error: &str) -> Result<(), String> {
@@ -420,6 +438,29 @@ mod tests {
             .collect()
     }
 
+    fn mesh_definition(id: &str, model: &str) -> crate::managed_agents::AgentDefinition {
+        crate::managed_agents::AgentDefinition {
+            id: id.to_string(),
+            display_name: id.to_string(),
+            avatar_url: None,
+            system_prompt: String::new(),
+            runtime: None,
+            model: Some(model.to_string()),
+            provider: Some("relay-mesh".to_string()),
+            name_pool: Vec::new(),
+            is_builtin: false,
+            is_active: true,
+            source_team: None,
+            source_team_persona_slug: None,
+            env_vars: std::collections::BTreeMap::new(),
+            respond_to: None,
+            respond_to_allowlist: Vec::new(),
+            parallelism: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
     #[tokio::test]
     async fn closed_port_is_distinct_from_unhealthy_bound_port() {
         assert_eq!(
@@ -459,28 +500,61 @@ mod tests {
     #[test]
     fn only_running_relay_mesh_agents_trigger_rearm() {
         let empty = active_set(&[]);
-        assert!(!is_running_relay_mesh_agent(
+        assert!(running_relay_mesh_model_id(
             &mesh_record("stopped", Some(std::process::id())),
-            &empty
-        ));
+            &empty,
+            &[],
+            &crate::managed_agents::GlobalAgentConfig::default(),
+        )
+        .is_none());
 
         let active = active_set(&["live"]);
-        assert!(is_running_relay_mesh_agent(
+        assert!(running_relay_mesh_model_id(
             &mesh_record("live", Some(std::process::id())),
-            &active
-        ));
-        assert!(is_running_relay_mesh_agent(
+            &active,
+            &[],
+            &crate::managed_agents::GlobalAgentConfig::default(),
+        )
+        .is_some());
+        assert!(running_relay_mesh_model_id(
             &mesh_record("live", None),
-            &active
-        ));
+            &active,
+            &[],
+            &crate::managed_agents::GlobalAgentConfig::default(),
+        )
+        .is_some());
 
         let mut non_mesh = mesh_record("plain", Some(std::process::id()));
         non_mesh.env_vars.clear();
         non_mesh.relay_mesh = None;
-        assert!(!is_running_relay_mesh_agent(
+        assert!(running_relay_mesh_model_id(
             &non_mesh,
-            &active_set(&["plain"])
-        ));
+            &active_set(&["plain"]),
+            &[],
+            &crate::managed_agents::GlobalAgentConfig::default(),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn linked_agent_rearm_uses_its_definition_mesh_model() {
+        let mut record = mesh_record("linked", None);
+        record.persona_id = Some("shared-compute".to_string());
+        record.provider = Some("openai".to_string());
+        record.model = Some("stale-record-model".to_string());
+        record.env_vars.clear();
+        record.relay_mesh = None;
+
+        assert_eq!(
+            running_relay_mesh_model_id(
+                &record,
+                &active_set(&["linked"]),
+                &[mesh_definition("shared-compute", "definition-model")],
+                &crate::managed_agents::GlobalAgentConfig::default(),
+            )
+            .as_deref(),
+            Some("definition-model")
+        );
     }
 
     #[test]

--- a/desktop/src/features/messages/ui/CrmActionCard.tsx
+++ b/desktop/src/features/messages/ui/CrmActionCard.tsx
@@ -1,0 +1,153 @@
+import * as React from "react";
+import { Check, Copy, X } from "lucide-react";
+
+import type { TimelineReaction } from "@/features/messages/types";
+import {
+  extractCrmRedditDraft,
+  type CrmActionCard as CrmAction,
+} from "@/features/messages/ui/crmActionCardParser";
+import { copyTextToClipboard } from "@/shared/lib/clipboard";
+import { Button } from "@/shared/ui/button";
+
+const APPROVE_EMOJI = "✅";
+const CANCEL_EMOJI = "❌";
+const LEAD_CATEGORY_CHOICES = [
+  { label: "Interested", reaction: "👍" },
+  { label: "Meeting Request", reaction: "📅" },
+  { label: "Information Request", reaction: "ℹ️" },
+  { label: "Not Interested", reaction: "👎" },
+  { label: "Out Of Office", reaction: "🕒" },
+  { label: "Do Not Contact", reaction: "⛔" },
+  { label: "Wrong Person", reaction: "🔀" },
+] as const;
+
+export function CrmActionCard({
+  action,
+  canToggle,
+  pending,
+  reactions,
+  onSelect,
+}: {
+  action: CrmAction;
+  canToggle: boolean;
+  pending: boolean;
+  reactions: TimelineReaction[];
+  onSelect: (emoji: string) => Promise<void>;
+}) {
+  const [selectedReaction, setSelectedReaction] = React.useState<string | null>(null);
+  const expiresAt = Date.parse(action.expiresAt);
+  const expired = !Number.isFinite(expiresAt) || Date.now() >= expiresAt;
+  const decided = reactions.some(
+    (reaction) =>
+      reaction.reactedByCurrentUser &&
+      (reaction.emoji === APPROVE_EMOJI ||
+        reaction.emoji === CANCEL_EMOJI ||
+        LEAD_CATEGORY_CHOICES.some((choice) => choice.reaction === reaction.emoji)),
+  );
+  const disabled = !canToggle || pending || expired || decided;
+  const redditDraft = action.actionType === "reddit_mark_posted"
+    ? extractCrmRedditDraft(action.content)
+    : null;
+
+  if (action.actionType === "lead_categorize") {
+    return (
+      <div className="my-2 max-w-md rounded-lg border border-input/50 bg-muted/20 p-3">
+        <p className="text-sm font-medium">Categorize lead</p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {LEAD_CATEGORY_CHOICES.map((choice) => (
+            <Button
+              disabled={disabled}
+              key={choice.reaction}
+              onClick={() => setSelectedReaction(choice.reaction)}
+              size="sm"
+              type="button"
+              variant={selectedReaction === choice.reaction ? "default" : "outline"}
+            >
+              {choice.label}
+            </Button>
+          ))}
+        </div>
+        <div className="mt-3 flex gap-2">
+          <Button
+            disabled={disabled || !selectedReaction}
+            onClick={() => selectedReaction && void onSelect(selectedReaction)}
+            size="sm"
+            type="button"
+          >
+            <Check aria-hidden="true" />
+            Record category
+          </Button>
+          <Button
+            disabled={disabled}
+            onClick={() => void onSelect(CANCEL_EMOJI)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <X aria-hidden="true" />
+            Cancel
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (action.actionType === "outreach_approve") {
+    return (
+      <div className="my-2 max-w-md rounded-lg border border-input/50 bg-muted/20 p-3">
+        <p className="text-sm font-medium">Review outreach draft</p>
+        <div className="mt-3 flex gap-2">
+          <Button disabled={disabled} onClick={() => void onSelect(APPROVE_EMOJI)} size="sm" type="button">
+            <Check aria-hidden="true" />
+            Approve and send
+          </Button>
+          <Button disabled={disabled} onClick={() => void onSelect(CANCEL_EMOJI)} size="sm" type="button" variant="outline">
+            <X aria-hidden="true" />
+            Reject draft
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-2 max-w-md rounded-lg border border-input/50 bg-muted/20 p-3">
+      <p className="text-sm font-medium">
+        Mark Reddit draft as posted
+      </p>
+      <div className="mt-3 flex gap-2">
+        {redditDraft ? (
+          <Button
+            disabled={pending}
+            onClick={() => copyTextToClipboard(redditDraft, "Draft copied")}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <Copy aria-hidden="true" />
+            Copy draft
+          </Button>
+        ) : null}
+        <Button
+          disabled={disabled}
+          onClick={() => void onSelect(APPROVE_EMOJI)}
+          size="sm"
+          type="button"
+        >
+          <Check aria-hidden="true" />
+          Approve
+        </Button>
+        <Button
+          disabled={disabled}
+          onClick={() => void onSelect(CANCEL_EMOJI)}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          <X aria-hidden="true" />
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/messages/ui/CrmActionCard.tsx
+++ b/desktop/src/features/messages/ui/CrmActionCard.tsx
@@ -3,6 +3,7 @@ import { Check, Copy, Pencil, X } from "lucide-react";
 
 import type { TimelineReaction } from "@/features/messages/types";
 import {
+  extractCrmCalendarSlots,
   extractCrmRedditDraft,
   type CrmActionCard as CrmAction,
 } from "@/features/messages/ui/crmActionCardParser";
@@ -21,16 +22,25 @@ const LEAD_CATEGORY_CHOICES = [
   { label: "Do Not Contact", reaction: "⛔" },
   { label: "Wrong Person", reaction: "🔀" },
 ] as const;
+const CALENDAR_SLOT_REACTIONS = new Set(["1️⃣", "2️⃣", "3️⃣"]);
 
 function isFinalDecisionReaction(
   actionType: CrmAction["actionType"],
   emoji: string,
 ): boolean {
-  if (emoji === APPROVE_EMOJI || emoji === CANCEL_EMOJI) return true;
-  if (actionType === "lead_categorize") {
-    return LEAD_CATEGORY_CHOICES.some((choice) => choice.reaction === emoji);
+  switch (actionType) {
+    case "reddit_mark_posted":
+      return emoji === APPROVE_EMOJI || emoji === CANCEL_EMOJI;
+    case "lead_categorize":
+      return (
+        emoji === CANCEL_EMOJI ||
+        LEAD_CATEGORY_CHOICES.some((choice) => choice.reaction === emoji)
+      );
+    case "outreach_approve":
+      return emoji === APPROVE_EMOJI || emoji === CANCEL_EMOJI;
+    case "calendar_book":
+      return emoji === CANCEL_EMOJI || CALENDAR_SLOT_REACTIONS.has(emoji);
   }
-  return false;
 }
 
 export function CrmActionCard({
@@ -61,6 +71,10 @@ export function CrmActionCard({
     action.actionType === "reddit_mark_posted"
       ? extractCrmRedditDraft(action.content)
       : null;
+  const calendarSlots =
+    action.actionType === "calendar_book"
+      ? extractCrmCalendarSlots(action.content)
+      : [];
 
   if (action.actionType === "lead_categorize") {
     return (
@@ -91,6 +105,51 @@ export function CrmActionCard({
           >
             <Check aria-hidden="true" />
             Record category
+          </Button>
+          <Button
+            disabled={disabled}
+            onClick={() => void onSelect(CANCEL_EMOJI)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <X aria-hidden="true" />
+            Cancel
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (action.actionType === "calendar_book") {
+    return (
+      <div className="my-2 max-w-md rounded-lg border border-input/50 bg-muted/20 p-3">
+        <p className="text-sm font-medium">Book meeting</p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {calendarSlots.map((choice) => (
+            <Button
+              disabled={disabled}
+              key={choice.reaction}
+              onClick={() => setSelectedReaction(choice.reaction)}
+              size="sm"
+              type="button"
+              variant={
+                selectedReaction === choice.reaction ? "default" : "outline"
+              }
+            >
+              {choice.label}
+            </Button>
+          ))}
+        </div>
+        <div className="mt-3 flex gap-2">
+          <Button
+            disabled={disabled || !selectedReaction}
+            onClick={() => selectedReaction && void onSelect(selectedReaction)}
+            size="sm"
+            type="button"
+          >
+            <Check aria-hidden="true" />
+            Confirm booking
           </Button>
           <Button
             disabled={disabled}

--- a/desktop/src/features/messages/ui/CrmActionCard.tsx
+++ b/desktop/src/features/messages/ui/CrmActionCard.tsx
@@ -86,25 +86,31 @@ export function CrmActionCard({
     action.actionType === "calendar_book"
       ? action.calendarSlots ?? []
       : [];
+  const leadControlReactions =
+    action.actionType === "lead_control"
+      ? (action.leadControlChoices ??
+        LEAD_CONTROL_CHOICES.map((choice) => choice.reaction))
+      : [];
   const selectedLeadControl =
     action.actionType === "lead_control"
-      ? [...reactions]
+      ? ([...reactions]
           .reverse()
           .find(
             (reaction) =>
               reaction.reactedByCurrentUser &&
-              LEAD_CONTROL_CHOICES.some(
-                (choice) => choice.reaction === reaction.emoji,
-              ),
-          )?.emoji ?? null
+              leadControlReactions.includes(reaction.emoji),
+          )?.emoji ?? null)
       : null;
 
   if (action.actionType === "lead_control") {
+    const availableLeadControlChoices = LEAD_CONTROL_CHOICES.filter((choice) =>
+      leadControlReactions.includes(choice.reaction),
+    );
     return (
       <div className="my-2 max-w-md rounded-lg border border-input/50 bg-muted/20 p-3">
         <p className="text-sm font-medium">Lead safeguards</p>
         <div className="mt-3 flex flex-wrap gap-2">
-          {LEAD_CONTROL_CHOICES.map((choice) => {
+          {availableLeadControlChoices.map((choice) => {
             const Icon = choice.icon;
             const selected = selectedLeadControl === choice.reaction;
 
@@ -116,7 +122,7 @@ export function CrmActionCard({
                 onClick={() => {
                   if (!selected) {
                     void onChooseLeadControl(
-                      LEAD_CONTROL_CHOICES.map((item) => item.reaction),
+                      availableLeadControlChoices.map((item) => item.reaction),
                       choice.reaction,
                     );
                   }

--- a/desktop/src/features/messages/ui/CrmActionCard.tsx
+++ b/desktop/src/features/messages/ui/CrmActionCard.tsx
@@ -1,5 +1,13 @@
 import * as React from "react";
-import { Building2, Check, Copy, Pencil, ShieldBan, Trash2, X } from "lucide-react";
+import {
+  Building2,
+  Check,
+  Copy,
+  Pencil,
+  ShieldBan,
+  Trash2,
+  X,
+} from "lucide-react";
 
 import type { TimelineReaction } from "@/features/messages/types";
 import {
@@ -83,9 +91,7 @@ export function CrmActionCard({
       ? extractCrmRedditDraft(action.content)
       : null;
   const calendarSlots =
-    action.actionType === "calendar_book"
-      ? action.calendarSlots ?? []
-      : [];
+    action.actionType === "calendar_book" ? (action.calendarSlots ?? []) : [];
   const leadControlReactions =
     action.actionType === "lead_control"
       ? (action.leadControlChoices ??

--- a/desktop/src/features/messages/ui/CrmActionCard.tsx
+++ b/desktop/src/features/messages/ui/CrmActionCard.tsx
@@ -3,7 +3,6 @@ import { Check, Copy, Pencil, X } from "lucide-react";
 
 import type { TimelineReaction } from "@/features/messages/types";
 import {
-  extractCrmCalendarSlots,
   extractCrmRedditDraft,
   type CrmActionCard as CrmAction,
 } from "@/features/messages/ui/crmActionCardParser";
@@ -73,7 +72,7 @@ export function CrmActionCard({
       : null;
   const calendarSlots =
     action.actionType === "calendar_book"
-      ? extractCrmCalendarSlots(action.content)
+      ? action.calendarSlots ?? []
       : [];
 
   if (action.actionType === "lead_categorize") {

--- a/desktop/src/features/messages/ui/CrmActionCard.tsx
+++ b/desktop/src/features/messages/ui/CrmActionCard.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Check, Copy, X } from "lucide-react";
+import { Check, Copy, Pencil, X } from "lucide-react";
 
 import type { TimelineReaction } from "@/features/messages/types";
 import {
@@ -11,6 +11,7 @@ import { Button } from "@/shared/ui/button";
 
 const APPROVE_EMOJI = "✅";
 const CANCEL_EMOJI = "❌";
+const EDIT_EMOJI = "✏️";
 const LEAD_CATEGORY_CHOICES = [
   { label: "Interested", reaction: "👍" },
   { label: "Meeting Request", reaction: "📅" },
@@ -20,6 +21,17 @@ const LEAD_CATEGORY_CHOICES = [
   { label: "Do Not Contact", reaction: "⛔" },
   { label: "Wrong Person", reaction: "🔀" },
 ] as const;
+
+function isFinalDecisionReaction(
+  actionType: CrmAction["actionType"],
+  emoji: string,
+): boolean {
+  if (emoji === APPROVE_EMOJI || emoji === CANCEL_EMOJI) return true;
+  if (actionType === "lead_categorize") {
+    return LEAD_CATEGORY_CHOICES.some((choice) => choice.reaction === emoji);
+  }
+  return false;
+}
 
 export function CrmActionCard({
   action,
@@ -34,20 +46,21 @@ export function CrmActionCard({
   reactions: TimelineReaction[];
   onSelect: (emoji: string) => Promise<void>;
 }) {
-  const [selectedReaction, setSelectedReaction] = React.useState<string | null>(null);
+  const [selectedReaction, setSelectedReaction] = React.useState<string | null>(
+    null,
+  );
   const expiresAt = Date.parse(action.expiresAt);
   const expired = !Number.isFinite(expiresAt) || Date.now() >= expiresAt;
   const decided = reactions.some(
     (reaction) =>
       reaction.reactedByCurrentUser &&
-      (reaction.emoji === APPROVE_EMOJI ||
-        reaction.emoji === CANCEL_EMOJI ||
-        LEAD_CATEGORY_CHOICES.some((choice) => choice.reaction === reaction.emoji)),
+      isFinalDecisionReaction(action.actionType, reaction.emoji),
   );
   const disabled = !canToggle || pending || expired || decided;
-  const redditDraft = action.actionType === "reddit_mark_posted"
-    ? extractCrmRedditDraft(action.content)
-    : null;
+  const redditDraft =
+    action.actionType === "reddit_mark_posted"
+      ? extractCrmRedditDraft(action.content)
+      : null;
 
   if (action.actionType === "lead_categorize") {
     return (
@@ -61,7 +74,9 @@ export function CrmActionCard({
               onClick={() => setSelectedReaction(choice.reaction)}
               size="sm"
               type="button"
-              variant={selectedReaction === choice.reaction ? "default" : "outline"}
+              variant={
+                selectedReaction === choice.reaction ? "default" : "outline"
+              }
             >
               {choice.label}
             </Button>
@@ -97,11 +112,32 @@ export function CrmActionCard({
       <div className="my-2 max-w-md rounded-lg border border-input/50 bg-muted/20 p-3">
         <p className="text-sm font-medium">Review outreach draft</p>
         <div className="mt-3 flex gap-2">
-          <Button disabled={disabled} onClick={() => void onSelect(APPROVE_EMOJI)} size="sm" type="button">
+          <Button
+            disabled={disabled}
+            onClick={() => void onSelect(APPROVE_EMOJI)}
+            size="sm"
+            type="button"
+          >
             <Check aria-hidden="true" />
             Approve and send
           </Button>
-          <Button disabled={disabled} onClick={() => void onSelect(CANCEL_EMOJI)} size="sm" type="button" variant="outline">
+          <Button
+            disabled={disabled}
+            onClick={() => void onSelect(EDIT_EMOJI)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <Pencil aria-hidden="true" />
+            Edit draft
+          </Button>
+          <Button
+            disabled={disabled}
+            onClick={() => void onSelect(CANCEL_EMOJI)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
             <X aria-hidden="true" />
             Reject draft
           </Button>
@@ -112,9 +148,7 @@ export function CrmActionCard({
 
   return (
     <div className="my-2 max-w-md rounded-lg border border-input/50 bg-muted/20 p-3">
-      <p className="text-sm font-medium">
-        Mark Reddit draft as posted
-      </p>
+      <p className="text-sm font-medium">Mark Reddit draft as posted</p>
       <div className="mt-3 flex gap-2">
         {redditDraft ? (
           <Button

--- a/desktop/src/features/messages/ui/CrmActionCard.tsx
+++ b/desktop/src/features/messages/ui/CrmActionCard.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Check, Copy, Pencil, X } from "lucide-react";
+import { Building2, Check, Copy, Pencil, ShieldBan, Trash2, X } from "lucide-react";
 
 import type { TimelineReaction } from "@/features/messages/types";
 import {
@@ -21,6 +21,11 @@ const LEAD_CATEGORY_CHOICES = [
   { label: "Do Not Contact", reaction: "⛔" },
   { label: "Wrong Person", reaction: "🔀" },
 ] as const;
+const LEAD_CONTROL_CHOICES = [
+  { icon: ShieldBan, label: "Block person", reaction: "⛔" },
+  { icon: Building2, label: "Block company", reaction: "🏢" },
+  { icon: Trash2, label: "Remove from campaign", reaction: "🗑️" },
+] as const;
 const CALENDAR_SLOT_REACTIONS = new Set(["1️⃣", "2️⃣", "3️⃣"]);
 
 function isFinalDecisionReaction(
@@ -39,6 +44,8 @@ function isFinalDecisionReaction(
       return emoji === APPROVE_EMOJI || emoji === CANCEL_EMOJI;
     case "calendar_book":
       return emoji === CANCEL_EMOJI || CALENDAR_SLOT_REACTIONS.has(emoji);
+    case "lead_control":
+      return emoji === APPROVE_EMOJI;
   }
 }
 
@@ -48,12 +55,17 @@ export function CrmActionCard({
   pending,
   reactions,
   onSelect,
+  onChooseLeadControl,
 }: {
   action: CrmAction;
   canToggle: boolean;
   pending: boolean;
   reactions: TimelineReaction[];
   onSelect: (emoji: string) => Promise<void>;
+  onChooseLeadControl: (
+    choices: readonly string[],
+    emoji: string,
+  ) => Promise<void>;
 }) {
   const [selectedReaction, setSelectedReaction] = React.useState<string | null>(
     null,
@@ -74,6 +86,68 @@ export function CrmActionCard({
     action.actionType === "calendar_book"
       ? action.calendarSlots ?? []
       : [];
+  const selectedLeadControl =
+    action.actionType === "lead_control"
+      ? [...reactions]
+          .reverse()
+          .find(
+            (reaction) =>
+              reaction.reactedByCurrentUser &&
+              LEAD_CONTROL_CHOICES.some(
+                (choice) => choice.reaction === reaction.emoji,
+              ),
+          )?.emoji ?? null
+      : null;
+
+  if (action.actionType === "lead_control") {
+    return (
+      <div className="my-2 max-w-md rounded-lg border border-input/50 bg-muted/20 p-3">
+        <p className="text-sm font-medium">Lead safeguards</p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {LEAD_CONTROL_CHOICES.map((choice) => {
+            const Icon = choice.icon;
+            const selected = selectedLeadControl === choice.reaction;
+
+            return (
+              <Button
+                aria-pressed={selected}
+                disabled={disabled}
+                key={choice.reaction}
+                onClick={() => {
+                  if (!selected) {
+                    void onChooseLeadControl(
+                      LEAD_CONTROL_CHOICES.map((item) => item.reaction),
+                      choice.reaction,
+                    );
+                  }
+                }}
+                size="sm"
+                type="button"
+                variant={selected ? "default" : "outline"}
+              >
+                <Icon aria-hidden="true" />
+                {choice.label}
+              </Button>
+            );
+          })}
+        </div>
+        {selectedLeadControl ? (
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button
+              disabled={disabled}
+              onClick={() => void onSelect(APPROVE_EMOJI)}
+              size="sm"
+              type="button"
+              variant="destructive"
+            >
+              <Check aria-hidden="true" />
+              Apply change
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    );
+  }
 
   if (action.actionType === "lead_categorize") {
     return (

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -41,7 +41,10 @@ import { Markdown } from "@/shared/ui/markdown";
 import type { VideoReviewContext } from "@/shared/ui/VideoPlayer";
 import { MessageActionBar } from "./MessageActionBar";
 import { CrmActionCard } from "./CrmActionCard";
-import { parseCrmActionCard } from "./crmActionCardParser";
+import {
+  isCrmActionControlReaction,
+  parseCrmActionCard,
+} from "./crmActionCardParser";
 import { MessageAgentOwner } from "./MessageAgentOwner";
 import { MessageAuthorText, MessageHeaderRow } from "./MessageHeader";
 import { MessageTimestamp } from "./MessageTimestamp";
@@ -306,6 +309,16 @@ export const MessageRow = React.memo(
     const crmActionCard = React.useMemo(
       () => parseCrmActionCard(message.body),
       [message.body],
+    );
+    const visibleReactions = React.useMemo(
+      () =>
+        crmActionCard
+          ? reactions.filter(
+              (reaction) =>
+                !isCrmActionControlReaction(crmActionCard, reaction.emoji),
+            )
+          : reactions,
+      [crmActionCard, reactions],
     );
 
     const renderBody = () => {
@@ -587,7 +600,7 @@ export const MessageRow = React.memo(
         {continuationMetadataNode}
         <MessageReactions
           messageId={message.id}
-          reactions={reactions}
+          reactions={visibleReactions}
           canToggle={canToggleReactions}
           pending={reactionPending}
           burstEmojiOnRender={badgeBurstEmoji}

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -40,6 +40,8 @@ import { resolveMentionProps } from "@/shared/lib/resolveMentionNames";
 import { Markdown } from "@/shared/ui/markdown";
 import type { VideoReviewContext } from "@/shared/ui/VideoPlayer";
 import { MessageActionBar } from "./MessageActionBar";
+import { CrmActionCard } from "./CrmActionCard";
+import { parseCrmActionCard } from "./crmActionCardParser";
 import { MessageAgentOwner } from "./MessageAgentOwner";
 import { MessageAuthorText, MessageHeaderRow } from "./MessageHeader";
 import { MessageTimestamp } from "./MessageTimestamp";
@@ -301,6 +303,10 @@ export const MessageRow = React.memo(
     }, [collapseDepthGuideActions]);
     const getTag = (name: string) =>
       message.tags?.find((tag) => tag[0] === name)?.[1];
+    const crmActionCard = React.useMemo(
+      () => parseCrmActionCard(message.body),
+      [message.body],
+    );
 
     const renderBody = () => {
       switch (message.kind) {
@@ -365,7 +371,7 @@ export const MessageRow = React.memo(
                 message,
                 isKnownAgentPubkey,
               )}
-              content={message.body}
+              content={crmActionCard?.content ?? message.body}
               customEmoji={customEmoji}
               imetaByUrl={imetaByUrl}
               agentMentionPubkeysByName={agentMentionPubkeysByName}
@@ -378,6 +384,16 @@ export const MessageRow = React.memo(
           );
       }
     };
+
+    const crmActionCardNode = crmActionCard ? (
+      <CrmActionCard
+        action={crmActionCard}
+        canToggle={canToggleReactions}
+        onSelect={handleReactionSelect}
+        pending={reactionPending}
+        reactions={reactions}
+      />
+    ) : null;
 
     const isThreadReplyLayout = layoutVariant === "thread-reply";
     const guideBleedRem = isThreadReplyLayout ? 0.25 : 0;
@@ -567,6 +583,7 @@ export const MessageRow = React.memo(
     const messageBodyNode = (
       <>
         {renderBody()}
+        {crmActionCardNode}
         {continuationMetadataNode}
         <MessageReactions
           messageId={message.id}

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -170,6 +170,7 @@ export const MessageRow = React.memo(
       pending: reactionPending,
       errorMessage: reactionErrorMessage,
       select: handleReactionSelect,
+      chooseExclusive: handleExclusiveReactionChoice,
     } = useReactionHandler(message, onToggleReaction);
     const { openReminder, activeReminderEventIds } = useRemindLater();
     const hasActiveReminder = activeReminderEventIds.has(message.id);
@@ -402,6 +403,7 @@ export const MessageRow = React.memo(
       <CrmActionCard
         action={crmActionCard}
         canToggle={canToggleReactions}
+        onChooseLeadControl={handleExclusiveReactionChoice}
         onSelect={handleReactionSelect}
         pending={reactionPending}
         reactions={reactions}

--- a/desktop/src/features/messages/ui/crmActionCard.test.mjs
+++ b/desktop/src/features/messages/ui/crmActionCard.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { extractCrmRedditDraft, parseCrmActionCard } from "./crmActionCardParser.ts";
+
+const marker = "crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:reddit_mark_posted:2026-07-26T20:15:00+00:00";
+
+test("parses a strict CRM action marker and removes it from rendered content", () => {
+  assert.deepEqual(parseCrmActionCard(`Mark Reddit draft as posted.\n${marker}`), {
+    actionId: "8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a",
+    actionType: "reddit_mark_posted",
+    expiresAt: "2026-07-26T20:15:00+00:00",
+    content: "Mark Reddit draft as posted.",
+  });
+});
+
+test("parses the supported lead categorization action marker", () => {
+  assert.equal(
+    parseCrmActionCard("Categorize lead as: Interested.\ncrm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:lead_categorize:2026-07-26T20:15:00+00:00")?.actionType,
+    "lead_categorize",
+  );
+});
+
+test("parses the supported outreach approval action marker", () => {
+  assert.equal(
+    parseCrmActionCard("Review outreach.\ncrm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:outreach_approve:2026-07-26T20:15:00+00:00")?.actionType,
+    "outreach_approve",
+  );
+});
+
+test("preserves read-only Reddit review content ahead of the action controls", () => {
+  const review = [
+    "Reddit post: Storage question",
+    "Subreddit: r/selfstorage",
+    "Open thread: https://www.reddit.com/r/selfstorage/comments/1",
+    "",
+    "Draft to copy manually:",
+    "```",
+    "Safe reply text",
+    "```",
+    "",
+    "Mark Reddit draft as posted.",
+    marker,
+  ].join("\n");
+
+  const card = parseCrmActionCard(review);
+  assert.equal(card?.actionType, "reddit_mark_posted");
+  assert.match(card?.content ?? "", /Open thread: https:\/\/www\.reddit\.com/);
+  assert.match(card?.content ?? "", /```\nSafe reply text\n```/);
+  assert.doesNotMatch(card?.content ?? "", /crm-action:v1:/);
+  assert.equal(extractCrmRedditDraft(card?.content ?? ""), "Safe reply text");
+});
+
+test("does not expose a copy value without the explicit Reddit draft delimiter", () => {
+  assert.equal(extractCrmRedditDraft("A fenced block is not necessarily a Reddit draft.\n```\nIgnore me\n```"), null);
+});
+
+test("uses only the terminal CRM marker when review content contains a marker-like line", () => {
+  const injected = "crm-action:v1:00000000-0000-4000-8000-000000000000:lead_categorize:2026-07-26T20:15:00+00:00";
+  const card = parseCrmActionCard(`Draft to copy manually:\n${injected}\n\nMark Reddit draft as posted.\n${marker}`);
+
+  assert.equal(card?.actionId, "8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a");
+  assert.equal(card?.actionType, "reddit_mark_posted");
+  assert.ok((card?.content ?? "").includes(injected));
+});
+
+test("rejects malformed or unsupported markers", () => {
+  assert.equal(parseCrmActionCard("crm-action:v1:not-a-uuid:reddit_mark_posted:2026-07-26T20:15:00+00:00"), null);
+  assert.equal(parseCrmActionCard("crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:delete_company:2026-07-26T20:15:00+00:00"), null);
+  assert.equal(parseCrmActionCard("crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:reddit_mark_posted:not-a-date"), null);
+});

--- a/desktop/src/features/messages/ui/crmActionCard.test.mjs
+++ b/desktop/src/features/messages/ui/crmActionCard.test.mjs
@@ -50,6 +50,25 @@ test("parses the supported calendar booking action marker", () => {
   );
 });
 
+test("parses lead safeguards and keeps their transport reactions out of the thread", () => {
+  const safeguards = parseCrmActionCard(
+    [
+      "## Lead safeguards",
+      "",
+      "**Lead:** arnaud@example.com",
+      "crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:lead_control:2026-07-26T20:15:00+00:00",
+    ].join("\n"),
+  );
+
+  assert.equal(safeguards?.actionType, "lead_control");
+  assert.equal(isCrmActionControlReaction(safeguards, "⛔"), true);
+  assert.equal(isCrmActionControlReaction(safeguards, "🏢"), true);
+  assert.equal(isCrmActionControlReaction(safeguards, "🗑️"), true);
+  assert.equal(isCrmActionControlReaction(safeguards, "✅"), true);
+  assert.equal(isCrmActionControlReaction(safeguards, "❌"), false);
+  assert.equal(isCrmActionControlReaction(safeguards, "❤️"), false);
+});
+
 test("extracts only numbered calendar slots in their displayed order", () => {
   const content = [
     "# Schedule a meeting",

--- a/desktop/src/features/messages/ui/crmActionCard.test.mjs
+++ b/desktop/src/features/messages/ui/crmActionCard.test.mjs
@@ -65,6 +65,30 @@ test("extracts only numbered calendar slots in their displayed order", () => {
   ]);
 });
 
+test("keeps calendar slots for controls but removes their duplicate text from the message", () => {
+  const card = parseCrmActionCard(
+    [
+      "# Schedule a meeting",
+      "",
+      "**Contact:** Arnaud Lafosse",
+      "**Timezone:** Europe/Paris",
+      "",
+      "**Slot 1:** Tue 28 Jul, 10:00 CEST",
+      "**Slot 2:** Tue 28 Jul, 10:15 CEST",
+      "",
+      "Choose a meeting slot using the action card.",
+      "Expires: 2026-07-27T13:38:32.008779+00:00",
+      "crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:calendar_book:2026-07-27T13:38:32.008779+00:00",
+    ].join("\n"),
+  );
+
+  assert.equal(card?.content.includes("**Slot 1:**"), false);
+  assert.deepEqual(card?.calendarSlots, [
+    { label: "Tue 28 Jul, 10:00 CEST", reaction: "1️⃣" },
+    { label: "Tue 28 Jul, 10:15 CEST", reaction: "2️⃣" },
+  ]);
+});
+
 test("preserves read-only Reddit review content ahead of the action controls", () => {
   const review = [
     "Reddit post: Storage question",

--- a/desktop/src/features/messages/ui/crmActionCard.test.mjs
+++ b/desktop/src/features/messages/ui/crmActionCard.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   extractCrmCalendarSlots,
   extractCrmRedditDraft,
+  isCrmActionControlReaction,
   parseCrmActionCard,
 } from "./crmActionCardParser.ts";
 
@@ -63,6 +64,16 @@ test("extracts only numbered calendar slots in their displayed order", () => {
     { label: "Mon 27 Jul, 10:00 CEST", reaction: "1️⃣" },
     { label: "Tue 28 Jul, 14:30 CEST", reaction: "2️⃣" },
   ]);
+});
+
+test("hides CRM control reactions without hiding ordinary message reactions", () => {
+  const calendar = parseCrmActionCard(
+    "Choose a meeting slot.\ncrm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:calendar_book:2026-07-26T20:15:00+00:00",
+  );
+
+  assert.equal(isCrmActionControlReaction(calendar, "3️⃣"), true);
+  assert.equal(isCrmActionControlReaction(calendar, "❌"), true);
+  assert.equal(isCrmActionControlReaction(calendar, "❤️"), false);
 });
 
 test("keeps calendar slots for controls but removes their duplicate text from the message", () => {

--- a/desktop/src/features/messages/ui/crmActionCard.test.mjs
+++ b/desktop/src/features/messages/ui/crmActionCard.test.mjs
@@ -51,6 +51,50 @@ test("preserves read-only Reddit review content ahead of the action controls", (
   assert.equal(extractCrmRedditDraft(card?.content ?? ""), "Safe reply text");
 });
 
+test("hides CRM action transport chrome from the readable Reddit review", () => {
+  const review = [
+    "[CRM Buzz action 8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a]",
+    "# 🚀 New Reddit Opportunity",
+    "",
+    "**Post:** [Storage question](https://www.reddit.com/r/selfstorage/comments/1)",
+    "**Subreddit:** r/selfstorage",
+    "**Category:** Acquisition",
+    "**Confidence:** 🟢 high",
+    "",
+    "## 🤖 AI Draft",
+    "",
+    "Draft to copy manually:",
+    "```",
+    "Safe reply text",
+    "```",
+    "",
+    "Mark Reddit draft as posted.",
+    "Use Approve only after the Reddit post is live.",
+    "Expires: 2026-07-27T09:31:48.865306+00:00",
+    marker,
+  ].join("\n");
+
+  const card = parseCrmActionCard(review);
+  assert.equal(
+    card?.content,
+    [
+      "# 🚀 New Reddit Opportunity",
+      "",
+      "**Post:** [Storage question](https://www.reddit.com/r/selfstorage/comments/1)",
+      "**Subreddit:** r/selfstorage",
+      "**Category:** Acquisition",
+      "**Confidence:** 🟢 high",
+      "",
+      "## 🤖 AI Draft",
+      "",
+      "Draft to copy manually:",
+      "```",
+      "Safe reply text",
+      "```",
+    ].join("\n"),
+  );
+});
+
 test("does not expose a copy value without the explicit Reddit draft delimiter", () => {
   assert.equal(extractCrmRedditDraft("A fenced block is not necessarily a Reddit draft.\n```\nIgnore me\n```"), null);
 });

--- a/desktop/src/features/messages/ui/crmActionCard.test.mjs
+++ b/desktop/src/features/messages/ui/crmActionCard.test.mjs
@@ -1,31 +1,68 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { extractCrmRedditDraft, parseCrmActionCard } from "./crmActionCardParser.ts";
+import {
+  extractCrmCalendarSlots,
+  extractCrmRedditDraft,
+  parseCrmActionCard,
+} from "./crmActionCardParser.ts";
 
-const marker = "crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:reddit_mark_posted:2026-07-26T20:15:00+00:00";
+const marker =
+  "crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:reddit_mark_posted:2026-07-26T20:15:00+00:00";
 
 test("parses a strict CRM action marker and removes it from rendered content", () => {
-  assert.deepEqual(parseCrmActionCard(`Mark Reddit draft as posted.\n${marker}`), {
-    actionId: "8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a",
-    actionType: "reddit_mark_posted",
-    expiresAt: "2026-07-26T20:15:00+00:00",
-    content: "Mark Reddit draft as posted.",
-  });
+  assert.deepEqual(
+    parseCrmActionCard(`Mark Reddit draft as posted.\n${marker}`),
+    {
+      actionId: "8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a",
+      actionType: "reddit_mark_posted",
+      expiresAt: "2026-07-26T20:15:00+00:00",
+      content: "Mark Reddit draft as posted.",
+    },
+  );
 });
 
 test("parses the supported lead categorization action marker", () => {
   assert.equal(
-    parseCrmActionCard("Categorize lead as: Interested.\ncrm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:lead_categorize:2026-07-26T20:15:00+00:00")?.actionType,
+    parseCrmActionCard(
+      "Categorize lead as: Interested.\ncrm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:lead_categorize:2026-07-26T20:15:00+00:00",
+    )?.actionType,
     "lead_categorize",
   );
 });
 
 test("parses the supported outreach approval action marker", () => {
   assert.equal(
-    parseCrmActionCard("Review outreach.\ncrm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:outreach_approve:2026-07-26T20:15:00+00:00")?.actionType,
+    parseCrmActionCard(
+      "Review outreach.\ncrm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:outreach_approve:2026-07-26T20:15:00+00:00",
+    )?.actionType,
     "outreach_approve",
   );
+});
+
+test("parses the supported calendar booking action marker", () => {
+  assert.equal(
+    parseCrmActionCard(
+      "Choose a meeting slot.\ncrm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:calendar_book:2026-07-26T20:15:00+00:00",
+    )?.actionType,
+    "calendar_book",
+  );
+});
+
+test("extracts only numbered calendar slots in their displayed order", () => {
+  const content = [
+    "# Schedule a meeting",
+    "",
+    "**Slot 1:** Mon 27 Jul, 10:00 CEST",
+    "**Slot 2:** Tue 28 Jul, 14:30 CEST",
+    "",
+    "Choose a meeting slot using the action card.",
+  ].join("\n");
+
+  assert.deepEqual(extractCrmCalendarSlots(content), [
+    { label: "Mon 27 Jul, 10:00 CEST", reaction: "1️⃣" },
+    { label: "Tue 28 Jul, 14:30 CEST", reaction: "2️⃣" },
+  ]);
 });
 
 test("preserves read-only Reddit review content ahead of the action controls", () => {
@@ -96,7 +133,12 @@ test("hides CRM action transport chrome from the readable Reddit review", () => 
 });
 
 test("does not expose a copy value without the explicit Reddit draft delimiter", () => {
-  assert.equal(extractCrmRedditDraft("A fenced block is not necessarily a Reddit draft.\n```\nIgnore me\n```"), null);
+  assert.equal(
+    extractCrmRedditDraft(
+      "A fenced block is not necessarily a Reddit draft.\n```\nIgnore me\n```",
+    ),
+    null,
+  );
 });
 
 test("preserves an internal code fence when the CRM uses a longer outer fence", () => {
@@ -118,8 +160,11 @@ test("preserves an internal code fence when the CRM uses a longer outer fence", 
 });
 
 test("uses only the terminal CRM marker when review content contains a marker-like line", () => {
-  const injected = "crm-action:v1:00000000-0000-4000-8000-000000000000:lead_categorize:2026-07-26T20:15:00+00:00";
-  const card = parseCrmActionCard(`Draft to copy manually:\n${injected}\n\nMark Reddit draft as posted.\n${marker}`);
+  const injected =
+    "crm-action:v1:00000000-0000-4000-8000-000000000000:lead_categorize:2026-07-26T20:15:00+00:00";
+  const card = parseCrmActionCard(
+    `Draft to copy manually:\n${injected}\n\nMark Reddit draft as posted.\n${marker}`,
+  );
 
   assert.equal(card?.actionId, "8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a");
   assert.equal(card?.actionType, "reddit_mark_posted");
@@ -127,7 +172,22 @@ test("uses only the terminal CRM marker when review content contains a marker-li
 });
 
 test("rejects malformed or unsupported markers", () => {
-  assert.equal(parseCrmActionCard("crm-action:v1:not-a-uuid:reddit_mark_posted:2026-07-26T20:15:00+00:00"), null);
-  assert.equal(parseCrmActionCard("crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:delete_company:2026-07-26T20:15:00+00:00"), null);
-  assert.equal(parseCrmActionCard("crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:reddit_mark_posted:not-a-date"), null);
+  assert.equal(
+    parseCrmActionCard(
+      "crm-action:v1:not-a-uuid:reddit_mark_posted:2026-07-26T20:15:00+00:00",
+    ),
+    null,
+  );
+  assert.equal(
+    parseCrmActionCard(
+      "crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:delete_company:2026-07-26T20:15:00+00:00",
+    ),
+    null,
+  );
+  assert.equal(
+    parseCrmActionCard(
+      "crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:reddit_mark_posted:not-a-date",
+    ),
+    null,
+  );
 });

--- a/desktop/src/features/messages/ui/crmActionCard.test.mjs
+++ b/desktop/src/features/messages/ui/crmActionCard.test.mjs
@@ -55,6 +55,24 @@ test("does not expose a copy value without the explicit Reddit draft delimiter",
   assert.equal(extractCrmRedditDraft("A fenced block is not necessarily a Reddit draft.\n```\nIgnore me\n```"), null);
 });
 
+test("preserves an internal code fence when the CRM uses a longer outer fence", () => {
+  const review = [
+    "Draft to copy manually:",
+    "````",
+    "Use this example:",
+    "```text",
+    "safe content",
+    "```",
+    "Then continue the reply.",
+    "````",
+  ].join("\n");
+
+  assert.equal(
+    extractCrmRedditDraft(review),
+    "Use this example:\n```text\nsafe content\n```\nThen continue the reply.",
+  );
+});
+
 test("uses only the terminal CRM marker when review content contains a marker-like line", () => {
   const injected = "crm-action:v1:00000000-0000-4000-8000-000000000000:lead_categorize:2026-07-26T20:15:00+00:00";
   const card = parseCrmActionCard(`Draft to copy manually:\n${injected}\n\nMark Reddit draft as posted.\n${marker}`);

--- a/desktop/src/features/messages/ui/crmActionCard.test.mjs
+++ b/desktop/src/features/messages/ui/crmActionCard.test.mjs
@@ -69,6 +69,34 @@ test("parses lead safeguards and keeps their transport reactions out of the thre
   assert.equal(isCrmActionControlReaction(safeguards, "❤️"), false);
 });
 
+test("renders only the lead safeguards frozen by CRM", () => {
+  const safeguards = parseCrmActionCard(
+    [
+      "## Lead safeguards",
+      "",
+      "**Lead:** arnaud@example.com",
+      "crm-action-options:v1:lead_control:⛔,🗑️",
+      "crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:lead_control:2026-07-26T20:15:00+00:00",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(safeguards?.leadControlChoices, ["⛔", "🗑️"]);
+  assert.doesNotMatch(safeguards?.content ?? "", /crm-action-options/);
+});
+
+test("keeps legacy lead safeguard cards usable when no choice marker exists", () => {
+  const safeguards = parseCrmActionCard(
+    [
+      "## Lead safeguards",
+      "",
+      "**Lead:** arnaud@example.com",
+      "crm-action:v1:8ca5bd14-00d4-45cc-88ec-4bb1609e7d4a:lead_control:2026-07-26T20:15:00+00:00",
+    ].join("\n"),
+  );
+
+  assert.equal(safeguards?.leadControlChoices, undefined);
+});
+
 test("extracts only numbered calendar slots in their displayed order", () => {
   const content = [
     "# Schedule a meeting",

--- a/desktop/src/features/messages/ui/crmActionCardParser.ts
+++ b/desktop/src/features/messages/ui/crmActionCardParser.ts
@@ -7,7 +7,10 @@ export type CrmActionCard = {
     | "calendar_book";
   expiresAt: string;
   content: string;
+  calendarSlots?: CrmCalendarSlot[];
 };
+
+export type CrmCalendarSlot = { label: string; reaction: string };
 
 const MARKER =
   /(?:^|\n)crm-action:v1:([0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}):(reddit_mark_posted|lead_categorize|outreach_approve|calendar_book):(\S+)\s*$/i;
@@ -31,10 +34,14 @@ function readableContent(
   body: string,
   actionType: CrmActionCard["actionType"],
 ): string {
-  return body
+  const readable = body
     .replace(ACTION_HEADER, "")
-    .replace(ACTION_FOOTERS[actionType], "")
-    .trim();
+    .replace(ACTION_FOOTERS[actionType], "");
+
+  return (actionType === "calendar_book"
+    ? readable.replace(CALENDAR_SLOT, "").replace(/\n{3,}/g, "\n\n")
+    : readable
+  ).trim();
 }
 
 /**
@@ -48,7 +55,7 @@ export function parseCrmActionCard(body: string): CrmActionCard | null {
   const expiresAt = match[3];
   if (!Number.isFinite(Date.parse(expiresAt))) return null;
 
-  return {
+  const action: CrmActionCard = {
     actionId: match[1],
     actionType: match[2] as CrmActionCard["actionType"],
     expiresAt,
@@ -57,6 +64,12 @@ export function parseCrmActionCard(body: string): CrmActionCard | null {
       match[2] as CrmActionCard["actionType"],
     ),
   };
+
+  if (action.actionType === "calendar_book") {
+    action.calendarSlots = extractCrmCalendarSlots(body);
+  }
+
+  return action;
 }
 
 /** Return only the explicitly delimited read-only Reddit draft, if present. */
@@ -69,8 +82,8 @@ export function extractCrmRedditDraft(content: string): string | null {
 /** Return the booked-slot choices that CRM explicitly rendered for this card. */
 export function extractCrmCalendarSlots(
   content: string,
-): Array<{ label: string; reaction: string }> {
-  const slots: Array<{ label: string; reaction: string }> = [];
+): CrmCalendarSlot[] {
+  const slots: CrmCalendarSlot[] = [];
   const seen = new Set<number>();
 
   for (const match of content.matchAll(CALENDAR_SLOT)) {

--- a/desktop/src/features/messages/ui/crmActionCardParser.ts
+++ b/desktop/src/features/messages/ui/crmActionCardParser.ts
@@ -1,0 +1,35 @@
+export type CrmActionCard = {
+  actionId: string;
+  actionType: "reddit_mark_posted" | "lead_categorize" | "outreach_approve";
+  expiresAt: string;
+  content: string;
+};
+
+const MARKER = /(?:^|\n)crm-action:v1:([0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}):(reddit_mark_posted|lead_categorize|outreach_approve):(\S+)\s*$/i;
+const REDDIT_DRAFT = /(?:^|\n)Draft to copy manually:\s*\n```[^\n]*\n([\s\S]*?)\n```/i;
+
+/**
+ * Parses CRM's versioned action marker. The marker is removed before Markdown
+ * rendering, so it stays a transport contract rather than visible UI chrome.
+ */
+export function parseCrmActionCard(body: string): CrmActionCard | null {
+  const match = MARKER.exec(body);
+  if (!match) return null;
+
+  const expiresAt = match[3];
+  if (!Number.isFinite(Date.parse(expiresAt))) return null;
+
+  return {
+    actionId: match[1],
+    actionType: match[2] as CrmActionCard["actionType"],
+    expiresAt,
+    content: body.slice(0, match.index).trim(),
+  };
+}
+
+/** Return only the explicitly delimited read-only Reddit draft, if present. */
+export function extractCrmRedditDraft(content: string): string | null {
+  const match = REDDIT_DRAFT.exec(content);
+  const draft = match?.[1]?.trim();
+  return draft || null;
+}

--- a/desktop/src/features/messages/ui/crmActionCardParser.ts
+++ b/desktop/src/features/messages/ui/crmActionCardParser.ts
@@ -4,7 +4,8 @@ export type CrmActionCard = {
     | "reddit_mark_posted"
     | "lead_categorize"
     | "outreach_approve"
-    | "calendar_book";
+    | "calendar_book"
+    | "lead_control";
   expiresAt: string;
   content: string;
   calendarSlots?: CrmCalendarSlot[];
@@ -17,10 +18,11 @@ const CONTROL_REACTIONS: Record<CrmActionCard["actionType"], readonly string[]> 
   lead_categorize: ["👍", "📅", "ℹ️", "👎", "🕒", "⛔", "🔀", "❌"],
   outreach_approve: ["✅", "❌", "✏️"],
   calendar_book: ["1️⃣", "2️⃣", "3️⃣", "❌"],
+  lead_control: ["⛔", "🏢", "🗑️", "✅"],
 };
 
 const MARKER =
-  /(?:^|\n)crm-action:v1:([0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}):(reddit_mark_posted|lead_categorize|outreach_approve|calendar_book):(\S+)\s*$/i;
+  /(?:^|\n)crm-action:v1:([0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}):(reddit_mark_posted|lead_categorize|outreach_approve|calendar_book|lead_control):(\S+)\s*$/i;
 const REDDIT_DRAFT =
   /(?:^|\n)Draft to copy manually:\s*\n(`{3,})[^\n]*\n([\s\S]*?)\n\1(?=\n|$)/i;
 const CALENDAR_SLOT = /^\*\*Slot ([1-3]):\*\*\s*(.+)$/gim;
@@ -35,6 +37,8 @@ const ACTION_FOOTERS: Record<CrmActionCard["actionType"], RegExp> = {
     /\n*Approve to send this frozen draft, or reject it\.\nExpires: [^\n]+\s*$/i,
   calendar_book:
     /\n*Choose a meeting slot using the action card\.\nExpires: [^\n]+\s*$/i,
+  lead_control:
+    /\n*Choose a safeguard using the action card\.\nExpires: [^\n]+\s*$/i,
 };
 
 function readableContent(

--- a/desktop/src/features/messages/ui/crmActionCardParser.ts
+++ b/desktop/src/features/messages/ui/crmActionCardParser.ts
@@ -1,21 +1,40 @@
 export type CrmActionCard = {
   actionId: string;
-  actionType: "reddit_mark_posted" | "lead_categorize" | "outreach_approve";
+  actionType:
+    | "reddit_mark_posted"
+    | "lead_categorize"
+    | "outreach_approve"
+    | "calendar_book";
   expiresAt: string;
   content: string;
 };
 
-const MARKER = /(?:^|\n)crm-action:v1:([0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}):(reddit_mark_posted|lead_categorize|outreach_approve):(\S+)\s*$/i;
-const REDDIT_DRAFT = /(?:^|\n)Draft to copy manually:\s*\n(`{3,})[^\n]*\n([\s\S]*?)\n\1(?=\n|$)/i;
-const ACTION_HEADER = /^\[CRM Buzz action [0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\]\s*\n?/i;
+const MARKER =
+  /(?:^|\n)crm-action:v1:([0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}):(reddit_mark_posted|lead_categorize|outreach_approve|calendar_book):(\S+)\s*$/i;
+const REDDIT_DRAFT =
+  /(?:^|\n)Draft to copy manually:\s*\n(`{3,})[^\n]*\n([\s\S]*?)\n\1(?=\n|$)/i;
+const CALENDAR_SLOT = /^\*\*Slot ([1-3]):\*\*\s*(.+)$/gim;
+const ACTION_HEADER =
+  /^\[CRM Buzz action [0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\]\s*\n?/i;
 const ACTION_FOOTERS: Record<CrmActionCard["actionType"], RegExp> = {
-  reddit_mark_posted: /\n*Mark Reddit draft as posted\.\nUse Approve only after the Reddit post is live\.\nExpires: [^\n]+\s*$/i,
-  lead_categorize: /\n*Choose a lead category using the action card\.\nThe selected category will be recorded and queued for SmartLead synchronization\.\nExpires: [^\n]+\s*$/i,
-  outreach_approve: /\n*Approve to send this frozen draft, or reject it\.\nExpires: [^\n]+\s*$/i,
+  reddit_mark_posted:
+    /\n*Mark Reddit draft as posted\.\nUse Approve only after the Reddit post is live\.\nExpires: [^\n]+\s*$/i,
+  lead_categorize:
+    /\n*Choose a lead category using the action card\.\nThe selected category will be recorded and queued for SmartLead synchronization\.\nExpires: [^\n]+\s*$/i,
+  outreach_approve:
+    /\n*Approve to send this frozen draft, or reject it\.\nExpires: [^\n]+\s*$/i,
+  calendar_book:
+    /\n*Choose a meeting slot using the action card\.\nExpires: [^\n]+\s*$/i,
 };
 
-function readableContent(body: string, actionType: CrmActionCard["actionType"]): string {
-  return body.replace(ACTION_HEADER, "").replace(ACTION_FOOTERS[actionType], "").trim();
+function readableContent(
+  body: string,
+  actionType: CrmActionCard["actionType"],
+): string {
+  return body
+    .replace(ACTION_HEADER, "")
+    .replace(ACTION_FOOTERS[actionType], "")
+    .trim();
 }
 
 /**
@@ -33,7 +52,10 @@ export function parseCrmActionCard(body: string): CrmActionCard | null {
     actionId: match[1],
     actionType: match[2] as CrmActionCard["actionType"],
     expiresAt,
-    content: readableContent(body.slice(0, match.index), match[2] as CrmActionCard["actionType"]),
+    content: readableContent(
+      body.slice(0, match.index),
+      match[2] as CrmActionCard["actionType"],
+    ),
   };
 }
 
@@ -42,4 +64,22 @@ export function extractCrmRedditDraft(content: string): string | null {
   const match = REDDIT_DRAFT.exec(content);
   const draft = match?.[2]?.trim();
   return draft || null;
+}
+
+/** Return the booked-slot choices that CRM explicitly rendered for this card. */
+export function extractCrmCalendarSlots(
+  content: string,
+): Array<{ label: string; reaction: string }> {
+  const slots: Array<{ label: string; reaction: string }> = [];
+  const seen = new Set<number>();
+
+  for (const match of content.matchAll(CALENDAR_SLOT)) {
+    const slotNumber = Number(match[1]);
+    const label = match[2]?.trim();
+    if (!label || seen.has(slotNumber)) continue;
+    seen.add(slotNumber);
+    slots.push({ label, reaction: `${slotNumber}\uFE0F\u20E3` });
+  }
+
+  return slots;
 }

--- a/desktop/src/features/messages/ui/crmActionCardParser.ts
+++ b/desktop/src/features/messages/ui/crmActionCardParser.ts
@@ -12,6 +12,13 @@ export type CrmActionCard = {
 
 export type CrmCalendarSlot = { label: string; reaction: string };
 
+const CONTROL_REACTIONS: Record<CrmActionCard["actionType"], readonly string[]> = {
+  reddit_mark_posted: ["✅", "❌"],
+  lead_categorize: ["👍", "📅", "ℹ️", "👎", "🕒", "⛔", "🔀", "❌"],
+  outreach_approve: ["✅", "❌", "✏️"],
+  calendar_book: ["1️⃣", "2️⃣", "3️⃣", "❌"],
+};
+
 const MARKER =
   /(?:^|\n)crm-action:v1:([0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}):(reddit_mark_posted|lead_categorize|outreach_approve|calendar_book):(\S+)\s*$/i;
 const REDDIT_DRAFT =
@@ -70,6 +77,14 @@ export function parseCrmActionCard(body: string): CrmActionCard | null {
   }
 
   return action;
+}
+
+/** Action reactions are signed transport controls, not conversation feedback. */
+export function isCrmActionControlReaction(
+  action: CrmActionCard | null,
+  emoji: string,
+): boolean {
+  return Boolean(action && CONTROL_REACTIONS[action.actionType].includes(emoji));
 }
 
 /** Return only the explicitly delimited read-only Reddit draft, if present. */

--- a/desktop/src/features/messages/ui/crmActionCardParser.ts
+++ b/desktop/src/features/messages/ui/crmActionCardParser.ts
@@ -9,6 +9,7 @@ export type CrmActionCard = {
   expiresAt: string;
   content: string;
   calendarSlots?: CrmCalendarSlot[];
+  leadControlChoices?: string[];
 };
 
 export type CrmCalendarSlot = { label: string; reaction: string };
@@ -26,6 +27,9 @@ const MARKER =
 const REDDIT_DRAFT =
   /(?:^|\n)Draft to copy manually:\s*\n(`{3,})[^\n]*\n([\s\S]*?)\n\1(?=\n|$)/i;
 const CALENDAR_SLOT = /^\*\*Slot ([1-3]):\*\*\s*(.+)$/gim;
+const LEAD_CONTROL_OPTIONS =
+  /(?:^|\n)crm-action-options:v1:lead_control:([^\n]+)\s*(?=\n|$)/i;
+const LEAD_CONTROL_REACTIONS = new Set(["⛔", "🏢", "🗑️"]);
 const ACTION_HEADER =
   /^\[CRM Buzz action [0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\]\s*\n?/i;
 const ACTION_FOOTERS: Record<CrmActionCard["actionType"], RegExp> = {
@@ -47,7 +51,8 @@ function readableContent(
 ): string {
   const readable = body
     .replace(ACTION_HEADER, "")
-    .replace(ACTION_FOOTERS[actionType], "");
+    .replace(ACTION_FOOTERS[actionType], "")
+    .replace(LEAD_CONTROL_OPTIONS, "");
 
   return (actionType === "calendar_book"
     ? readable.replace(CALENDAR_SLOT, "").replace(/\n{3,}/g, "\n\n")
@@ -78,6 +83,12 @@ export function parseCrmActionCard(body: string): CrmActionCard | null {
 
   if (action.actionType === "calendar_book") {
     action.calendarSlots = extractCrmCalendarSlots(body);
+  }
+  if (action.actionType === "lead_control") {
+    const choices = extractCrmLeadControlChoices(body);
+    if (choices !== undefined) {
+      action.leadControlChoices = choices;
+    }
   }
 
   return action;
@@ -114,4 +125,15 @@ export function extractCrmCalendarSlots(
   }
 
   return slots;
+}
+
+/** Return only the safeguard choices frozen by CRM for this review. */
+export function extractCrmLeadControlChoices(
+  content: string,
+): string[] | undefined {
+  const encoded = LEAD_CONTROL_OPTIONS.exec(content)?.[1];
+  if (!encoded) return undefined;
+  return [...new Set(encoded.split(",").map((emoji) => emoji.trim()))].filter(
+    (emoji) => LEAD_CONTROL_REACTIONS.has(emoji),
+  );
 }

--- a/desktop/src/features/messages/ui/crmActionCardParser.ts
+++ b/desktop/src/features/messages/ui/crmActionCardParser.ts
@@ -14,7 +14,10 @@ export type CrmActionCard = {
 
 export type CrmCalendarSlot = { label: string; reaction: string };
 
-const CONTROL_REACTIONS: Record<CrmActionCard["actionType"], readonly string[]> = {
+const CONTROL_REACTIONS: Record<
+  CrmActionCard["actionType"],
+  readonly string[]
+> = {
   reddit_mark_posted: ["✅", "❌"],
   lead_categorize: ["👍", "📅", "ℹ️", "👎", "🕒", "⛔", "🔀", "❌"],
   outreach_approve: ["✅", "❌", "✏️"],
@@ -54,9 +57,10 @@ function readableContent(
     .replace(ACTION_FOOTERS[actionType], "")
     .replace(LEAD_CONTROL_OPTIONS, "");
 
-  return (actionType === "calendar_book"
-    ? readable.replace(CALENDAR_SLOT, "").replace(/\n{3,}/g, "\n\n")
-    : readable
+  return (
+    actionType === "calendar_book"
+      ? readable.replace(CALENDAR_SLOT, "").replace(/\n{3,}/g, "\n\n")
+      : readable
   ).trim();
 }
 
@@ -99,7 +103,9 @@ export function isCrmActionControlReaction(
   action: CrmActionCard | null,
   emoji: string,
 ): boolean {
-  return Boolean(action && CONTROL_REACTIONS[action.actionType].includes(emoji));
+  return Boolean(
+    action && CONTROL_REACTIONS[action.actionType].includes(emoji),
+  );
 }
 
 /** Return only the explicitly delimited read-only Reddit draft, if present. */
@@ -110,9 +116,7 @@ export function extractCrmRedditDraft(content: string): string | null {
 }
 
 /** Return the booked-slot choices that CRM explicitly rendered for this card. */
-export function extractCrmCalendarSlots(
-  content: string,
-): CrmCalendarSlot[] {
+export function extractCrmCalendarSlots(content: string): CrmCalendarSlot[] {
   const slots: CrmCalendarSlot[] = [];
   const seen = new Set<number>();
 

--- a/desktop/src/features/messages/ui/crmActionCardParser.ts
+++ b/desktop/src/features/messages/ui/crmActionCardParser.ts
@@ -6,7 +6,7 @@ export type CrmActionCard = {
 };
 
 const MARKER = /(?:^|\n)crm-action:v1:([0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}):(reddit_mark_posted|lead_categorize|outreach_approve):(\S+)\s*$/i;
-const REDDIT_DRAFT = /(?:^|\n)Draft to copy manually:\s*\n```[^\n]*\n([\s\S]*?)\n```/i;
+const REDDIT_DRAFT = /(?:^|\n)Draft to copy manually:\s*\n(`{3,})[^\n]*\n([\s\S]*?)\n\1(?=\n|$)/i;
 
 /**
  * Parses CRM's versioned action marker. The marker is removed before Markdown
@@ -30,6 +30,6 @@ export function parseCrmActionCard(body: string): CrmActionCard | null {
 /** Return only the explicitly delimited read-only Reddit draft, if present. */
 export function extractCrmRedditDraft(content: string): string | null {
   const match = REDDIT_DRAFT.exec(content);
-  const draft = match?.[1]?.trim();
+  const draft = match?.[2]?.trim();
   return draft || null;
 }

--- a/desktop/src/features/messages/ui/crmActionCardParser.ts
+++ b/desktop/src/features/messages/ui/crmActionCardParser.ts
@@ -7,6 +7,16 @@ export type CrmActionCard = {
 
 const MARKER = /(?:^|\n)crm-action:v1:([0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}):(reddit_mark_posted|lead_categorize|outreach_approve):(\S+)\s*$/i;
 const REDDIT_DRAFT = /(?:^|\n)Draft to copy manually:\s*\n(`{3,})[^\n]*\n([\s\S]*?)\n\1(?=\n|$)/i;
+const ACTION_HEADER = /^\[CRM Buzz action [0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\]\s*\n?/i;
+const ACTION_FOOTERS: Record<CrmActionCard["actionType"], RegExp> = {
+  reddit_mark_posted: /\n*Mark Reddit draft as posted\.\nUse Approve only after the Reddit post is live\.\nExpires: [^\n]+\s*$/i,
+  lead_categorize: /\n*Choose a lead category using the action card\.\nThe selected category will be recorded and queued for SmartLead synchronization\.\nExpires: [^\n]+\s*$/i,
+  outreach_approve: /\n*Approve to send this frozen draft, or reject it\.\nExpires: [^\n]+\s*$/i,
+};
+
+function readableContent(body: string, actionType: CrmActionCard["actionType"]): string {
+  return body.replace(ACTION_HEADER, "").replace(ACTION_FOOTERS[actionType], "").trim();
+}
 
 /**
  * Parses CRM's versioned action marker. The marker is removed before Markdown
@@ -23,7 +33,7 @@ export function parseCrmActionCard(body: string): CrmActionCard | null {
     actionId: match[1],
     actionType: match[2] as CrmActionCard["actionType"],
     expiresAt,
-    content: body.slice(0, match.index).trim(),
+    content: readableContent(body.slice(0, match.index), match[2] as CrmActionCard["actionType"]),
   };
 }
 

--- a/desktop/src/features/messages/ui/useReactionHandler.test.mjs
+++ b/desktop/src/features/messages/ui/useReactionHandler.test.mjs
@@ -92,17 +92,9 @@ test("applyOptimisticReaction: no-op when adding an emoji the user already react
 });
 
 test("replaceOwnChoiceReactions: keeps exactly one selected safeguard reaction", () => {
-  const source = [
-    pill("⛔", 1, true),
-    pill("🏢", 1),
-    pill("❤️", 1),
-  ];
+  const source = [pill("⛔", 1, true), pill("🏢", 1), pill("❤️", 1)];
 
-  const result = replaceOwnChoiceReactions(
-    source,
-    ["⛔", "🏢", "🗑️"],
-    "🏢",
-  );
+  const result = replaceOwnChoiceReactions(source, ["⛔", "🏢", "🗑️"], "🏢");
 
   assert.deepEqual(
     result.map((reaction) => [reaction.emoji, reaction.reactedByCurrentUser]),

--- a/desktop/src/features/messages/ui/useReactionHandler.test.mjs
+++ b/desktop/src/features/messages/ui/useReactionHandler.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   applyOptimisticReaction,
+  replaceOwnChoiceReactions,
   selectDisplayReactions,
 } from "./useReactionHandler.ts";
 
@@ -87,6 +88,36 @@ test("applyOptimisticReaction: no-op when adding an emoji the user already react
     result,
     source,
     "must return same reference when already reacted",
+  );
+});
+
+test("replaceOwnChoiceReactions: keeps exactly one selected safeguard reaction", () => {
+  const source = [
+    pill("⛔", 1, true),
+    pill("🏢", 1),
+    pill("❤️", 1),
+  ];
+
+  const result = replaceOwnChoiceReactions(
+    source,
+    ["⛔", "🏢", "🗑️"],
+    "🏢",
+  );
+
+  assert.deepEqual(
+    result.map((reaction) => [reaction.emoji, reaction.reactedByCurrentUser]),
+    [
+      ["🏢", true],
+      ["❤️", false],
+    ],
+  );
+});
+
+test("replaceOwnChoiceReactions: does not toggle off an already active selection", () => {
+  const source = [pill("🏢", 1, true)];
+  assert.equal(
+    replaceOwnChoiceReactions(source, ["⛔", "🏢", "🗑️"], "🏢"),
+    source,
   );
 });
 

--- a/desktop/src/features/messages/ui/useReactionHandler.ts
+++ b/desktop/src/features/messages/ui/useReactionHandler.ts
@@ -260,13 +260,7 @@ export function useReactionHandler(
         setPending(false);
       }
     },
-    [
-      message,
-      onToggleReaction,
-      pending,
-      reactions,
-      sourceReactions,
-    ],
+    [message, onToggleReaction, pending, reactions, sourceReactions],
   );
 
   return {

--- a/desktop/src/features/messages/ui/useReactionHandler.ts
+++ b/desktop/src/features/messages/ui/useReactionHandler.ts
@@ -20,6 +20,8 @@ type ReactionHandler = {
   errorMessage: string | null;
   /** Call to toggle an emoji reaction. Safe to fire-and-forget. */
   select: (emoji: string) => Promise<void>;
+  /** Replace the current user's choice among a mutually exclusive reaction set. */
+  chooseExclusive: (choices: readonly string[], emoji: string) => Promise<void>;
 };
 
 /** @visibleForTesting */
@@ -75,6 +77,33 @@ export function applyOptimisticReaction(
       users: [{ pubkey: "", displayName: "You", avatarUrl: null }],
     },
   ];
+}
+
+/** @visibleForTesting */
+export function replaceOwnChoiceReactions(
+  reactions: TimelineReaction[],
+  choices: readonly string[],
+  selectedEmoji: string,
+): TimelineReaction[] {
+  const choiceSet = new Set(choices);
+  let next = reactions;
+
+  for (const reaction of reactions) {
+    if (
+      reaction.reactedByCurrentUser &&
+      choiceSet.has(reaction.emoji) &&
+      reaction.emoji !== selectedEmoji
+    ) {
+      next = applyOptimisticReaction(next, reaction.emoji, true);
+    }
+  }
+
+  return next.some(
+    (reaction) =>
+      reaction.emoji === selectedEmoji && reaction.reactedByCurrentUser,
+  )
+    ? next
+    : applyOptimisticReaction(next, selectedEmoji, false);
 }
 
 /**
@@ -179,5 +208,73 @@ export function useReactionHandler(
     ],
   );
 
-  return { reactions, canToggle, pending, errorMessage, select };
+  const chooseExclusive = React.useCallback(
+    async (choices: readonly string[], emoji: string) => {
+      if (!onToggleReaction || pending || !choices.includes(emoji)) {
+        return;
+      }
+
+      const activeChoices = reactions.filter(
+        (reaction) =>
+          reaction.reactedByCurrentUser && choices.includes(reaction.emoji),
+      );
+      const alreadySelected = activeChoices.some(
+        (reaction) => reaction.emoji === emoji,
+      );
+      const otherActiveChoices = activeChoices.filter(
+        (reaction) => reaction.emoji !== emoji,
+      );
+      if (alreadySelected && otherActiveChoices.length === 0) {
+        return;
+      }
+
+      setErrorMessage(null);
+      setPending(true);
+      setOptimisticState((current) => {
+        const baseReactions =
+          current && current.sourceReactions === sourceReactions
+            ? current.reactions
+            : reactions;
+
+        return {
+          reactions: replaceOwnChoiceReactions(baseReactions, choices, emoji),
+          sourceReactions,
+        };
+      });
+      try {
+        for (const reaction of otherActiveChoices) {
+          await onToggleReaction(message, reaction.emoji, true);
+        }
+        if (!alreadySelected) {
+          await onToggleReaction(message, emoji, false);
+        }
+      } catch (error) {
+        setOptimisticState(null);
+        const nextMessage =
+          error instanceof Error
+            ? error.message
+            : "Failed to update the reaction.";
+        setErrorMessage(nextMessage);
+        throw error;
+      } finally {
+        setPending(false);
+      }
+    },
+    [
+      message,
+      onToggleReaction,
+      pending,
+      reactions,
+      sourceReactions,
+    ],
+  );
+
+  return {
+    reactions,
+    canToggle,
+    pending,
+    errorMessage,
+    select,
+    chooseExclusive,
+  };
 }

--- a/desktop/src/features/onboarding/hooks.ts
+++ b/desktop/src/features/onboarding/hooks.ts
@@ -10,8 +10,8 @@ import { channelsQueryKey } from "@/features/channels/hooks";
 import {
   ensureStarterChannels,
   ensureWelcomeChannel,
-  hasEnsuredWelcomeChannel,
-  markWelcomeChannelEnsured,
+  hasSettledChannelOnboarding,
+  markChannelOnboardingSettled,
   notifyWelcomeChannelReady,
   rememberPendingWelcomeChannel,
 } from "@/features/onboarding/welcome";
@@ -57,7 +57,7 @@ function seedWelcomeExperience(
         queryClient.invalidateQueries({ queryKey: managedAgentsQueryKey }),
         queryClient.invalidateQueries({ queryKey: relayAgentsQueryKey }),
       ]);
-      markWelcomeChannelEnsured(pubkey, communityScope);
+      markChannelOnboardingSettled(pubkey, communityScope);
     } catch (error) {
       console.warn("Failed to seed the private Welcome experience.", error);
     }
@@ -91,6 +91,21 @@ export async function initializeStarterChannels(
     } catch (error) {
       starterChannelsError = error;
       console.warn("Failed to initialize public starter channels.", error);
+    }
+
+    if (starterChannels?.kind === "custom") {
+      queryClient.setQueryData<Channel[]>(channelsQueryKey, (channels = []) => {
+        const ensuredIds = new Set(
+          starterChannels.channels.map((channel) => channel.id),
+        );
+        return [
+          ...starterChannels.channels,
+          ...channels.filter((channel) => !ensuredIds.has(channel.id)),
+        ];
+      });
+      markChannelOnboardingSettled(pubkey, communityScope);
+      await queryClient.invalidateQueries({ queryKey: channelsQueryKey });
+      return { ok: true };
     }
 
     const welcomeChannel = await ensureWelcomeChannel(
@@ -581,7 +596,7 @@ export function useAppOnboardingState(isSharedIdentity: boolean) {
       !currentPubkey ||
       !starterChannelsCommunityScope ||
       !readOnboardingCompletion(currentPubkey) ||
-      hasEnsuredWelcomeChannel(currentPubkey, starterChannelsCommunityScope)
+      hasSettledChannelOnboarding(currentPubkey, starterChannelsCommunityScope)
     ) {
       return;
     }

--- a/desktop/src/features/onboarding/welcome.test.mjs
+++ b/desktop/src/features/onboarding/welcome.test.mjs
@@ -6,9 +6,9 @@ import {
   ensureStarterChannels,
   ensureWelcomeChannel,
   findPrivateWelcomeChannel,
-  hasEnsuredWelcomeChannel,
+  hasSettledChannelOnboarding,
   isWelcomeExperienceChannel,
-  markWelcomeChannelEnsured,
+  markChannelOnboardingSettled,
   rememberPendingWelcomeChannel,
   WELCOME_CHANNEL_DESCRIPTION,
   WELCOME_CHANNEL_NAME,
@@ -251,26 +251,26 @@ test("pending Welcome channel is consumed only after it appears in the channel l
   }
 });
 
-test("Welcome ensured marker is scoped to the current identity and community", () => {
+test("channel onboarding marker is scoped to the current identity and community", () => {
   const { restore } = installWindowSessionStorage();
   try {
-    markWelcomeChannelEnsured("pubkey-a", "wss://community-a.example");
+    markChannelOnboardingSettled("pubkey-a", "wss://community-a.example");
 
     assert.equal(
-      hasEnsuredWelcomeChannel("pubkey-a", "wss://community-a.example"),
+      hasSettledChannelOnboarding("pubkey-a", "wss://community-a.example"),
       true,
     );
     assert.equal(
-      hasEnsuredWelcomeChannel("pubkey-a", "wss://community-b.example"),
+      hasSettledChannelOnboarding("pubkey-a", "wss://community-b.example"),
       false,
     );
     assert.equal(
-      hasEnsuredWelcomeChannel("pubkey-b", "wss://community-a.example"),
+      hasSettledChannelOnboarding("pubkey-b", "wss://community-a.example"),
       false,
     );
-    assert.equal(hasEnsuredWelcomeChannel("pubkey-a", null), false);
+    assert.equal(hasSettledChannelOnboarding("pubkey-a", null), false);
     assert.equal(
-      hasEnsuredWelcomeChannel(null, "wss://community-a.example"),
+      hasSettledChannelOnboarding(null, "wss://community-a.example"),
       false,
     );
   } finally {
@@ -299,10 +299,65 @@ test("ensureStarterChannels reuses existing open starter channels", async () => 
     },
   });
 
+  assert.equal(result.kind, "starter");
   assert.equal(result.generalChannel, general);
   assert.equal(result.welcomeChannel, welcomeEveryone);
   assert.deepEqual(result.channels, [general, welcomeEveryone]);
   assert.equal(ensureCalls, 0);
+});
+
+test("ensureStarterChannels preserves a configured community taxonomy", async () => {
+  const crmLeads = makeChannel({
+    id: "crm-leads-channel",
+    name: "crm-leads",
+    visibility: "private",
+  });
+  let ensureCalls = 0;
+
+  const result = await ensureStarterChannels({
+    getChannels: async () => [crmLeads],
+    ensureStarterChannels: async () => {
+      ensureCalls += 1;
+      return [];
+    },
+  });
+
+  assert.equal(result.kind, "custom");
+  assert.deepEqual(result.channels, [crmLeads]);
+  assert.equal(ensureCalls, 0);
+});
+
+test("ensureStarterChannels does not treat archived custom channels as active taxonomy", async () => {
+  const archivedCrmLeads = makeChannel({
+    archivedAt: "2026-07-27T00:00:00.000Z",
+    id: "crm-leads-channel",
+    name: "crm-leads",
+    visibility: "private",
+  });
+  const general = makeChannel({
+    id: "general-channel",
+    name: "general",
+    visibility: "open",
+  });
+  const welcomeEveryone = makeChannel({
+    id: "welcome-everyone-channel",
+    name: "welcome-everyone",
+    visibility: "open",
+  });
+  let ensureCalls = 0;
+
+  const result = await ensureStarterChannels({
+    getChannels: async () => [archivedCrmLeads],
+    ensureStarterChannels: async () => {
+      ensureCalls += 1;
+      return [general, welcomeEveryone];
+    },
+  });
+
+  assert.equal(result.kind, "starter");
+  assert.equal(result.generalChannel, general);
+  assert.equal(result.welcomeChannel, welcomeEveryone);
+  assert.equal(ensureCalls, 1);
 });
 
 test("ensureStarterChannels resumes when one starter channel is missing", async () => {
@@ -326,6 +381,7 @@ test("ensureStarterChannels resumes when one starter channel is missing", async 
     },
   });
 
+  assert.equal(result.kind, "starter");
   assert.equal(result.generalChannel, general);
   assert.equal(result.welcomeChannel, welcomeEveryone);
   assert.deepEqual(result.channels, [general, welcomeEveryone]);

--- a/desktop/src/features/onboarding/welcome.ts
+++ b/desktop/src/features/onboarding/welcome.ts
@@ -24,7 +24,11 @@ const PENDING_WELCOME_CHANNEL_STORAGE_KEY =
 const WELCOME_INITIAL_UNREAD_SUPPRESSION_STORAGE_KEY =
   "buzz:onboarding-welcome-initial-unread-suppression.v1";
 const PENDING_WELCOME_CHANNEL_MAX_AGE_MS = 5 * 60 * 1000;
-const WELCOME_CHANNEL_ENSURED_STORAGE_KEY = "buzz-welcome-channel-ensured.v2";
+// Keep the existing key so a normal community does not repeat setup after an
+// upgrade. It now records settled channel onboarding, which can be either the
+// starter experience or an existing community-owned taxonomy.
+const CHANNEL_ONBOARDING_SETTLED_STORAGE_KEY =
+  "buzz-welcome-channel-ensured.v2";
 
 type WelcomeChannelClient = {
   createChannel: (input: CreateChannelInput) => Promise<Channel>;
@@ -39,11 +43,15 @@ type StarterChannelsClient = {
   getChannels: () => Promise<Channel[]>;
 };
 
-export type StarterChannelsResult = {
+type StarterChannelPair = {
   channels: Channel[];
   generalChannel: Channel;
   welcomeChannel: Channel;
 };
+
+export type StarterChannelsResult =
+  | ({ kind: "starter" } & StarterChannelPair)
+  | { kind: "custom"; channels: Channel[] };
 
 type WelcomeChannelOptions = {
   allowedMemberPubkeys?: readonly string[];
@@ -67,11 +75,17 @@ function normalizeChannelName(name: string) {
   return name.trim().toLowerCase();
 }
 
-function isOpenStreamStarterChannel(channel: Channel, name: string) {
+function hasStarterChannelIdentity(channel: Channel, name: string) {
   return (
     normalizeChannelName(channel.name) === normalizeChannelName(name) &&
     channel.channelType === "stream" &&
-    channel.visibility === "open" &&
+    channel.visibility === "open"
+  );
+}
+
+function isOpenStreamStarterChannel(channel: Channel, name: string) {
+  return (
+    hasStarterChannelIdentity(channel, name) &&
     channel.archivedAt === null &&
     channel.isMember
   );
@@ -86,7 +100,7 @@ function findStarterChannel(channels: Channel[], name: string) {
 
 export function findStarterChannels(
   channels: Channel[],
-): Omit<StarterChannelsResult, "channels"> | null {
+): Omit<StarterChannelPair, "channels"> | null {
   const generalChannel = findStarterChannel(
     channels,
     STARTER_GENERAL_CHANNEL_NAME,
@@ -101,6 +115,16 @@ export function findStarterChannels(
   }
 
   return { generalChannel, welcomeChannel };
+}
+
+function hasActiveCustomChannel(channels: Channel[]) {
+  return channels.some(
+    (channel) =>
+      channel.archivedAt === null &&
+      ![STARTER_GENERAL_CHANNEL_NAME, STARTER_WELCOME_CHANNEL_NAME].some(
+        (starterName) => hasStarterChannelIdentity(channel, starterName),
+      ),
+  );
 }
 
 function hasOnlyCurrentOrAllowedMembers(
@@ -264,33 +288,47 @@ export async function ensureStarterChannels(
   const existingStarters = findStarterChannels(existingChannels);
   if (existingStarters) {
     return {
+      kind: "starter",
       channels: existingChannels,
       ...existingStarters,
     };
   }
 
-  const ensuredChannels = await client.ensureStarterChannels();
-  const ensuredStarters = findStarterChannels(ensuredChannels);
-  if (!ensuredStarters) {
-    throw new Error("Starter channels were not available after setup");
+  // A joined community can define its own operational taxonomy. Do not create
+  // generic onboarding channels on top of active routes such as crm-leads.
+  if (hasActiveCustomChannel(existingChannels)) {
+    return { kind: "custom", channels: existingChannels };
   }
 
-  return {
-    channels: ensuredChannels,
-    ...ensuredStarters,
-  };
+  const ensuredChannels = await client.ensureStarterChannels();
+  const ensuredStarters = findStarterChannels(ensuredChannels);
+  if (ensuredStarters) {
+    return {
+      kind: "starter",
+      channels: ensuredChannels,
+      ...ensuredStarters,
+    };
+  }
+
+  // The native command can discover a configured community after the first
+  // list call (for example while memberships are settling).
+  if (hasActiveCustomChannel(ensuredChannels)) {
+    return { kind: "custom", channels: ensuredChannels };
+  }
+
+  throw new Error("Starter channels were not available after setup");
 }
 
-export function welcomeChannelEnsuredStorageKey(
+export function channelOnboardingSettledStorageKey(
   pubkey: string,
   communityScope: string,
 ) {
-  return `${WELCOME_CHANNEL_ENSURED_STORAGE_KEY}:${encodeURIComponent(
+  return `${CHANNEL_ONBOARDING_SETTLED_STORAGE_KEY}:${encodeURIComponent(
     communityScope,
   )}:${pubkey}`;
 }
 
-export function hasEnsuredWelcomeChannel(
+export function hasSettledChannelOnboarding(
   pubkey: string | null | undefined,
   communityScope: string | null | undefined,
 ) {
@@ -301,7 +339,7 @@ export function hasEnsuredWelcomeChannel(
   try {
     return (
       window.localStorage.getItem(
-        welcomeChannelEnsuredStorageKey(pubkey, communityScope),
+        channelOnboardingSettledStorageKey(pubkey, communityScope),
       ) === "true"
     );
   } catch {
@@ -309,7 +347,7 @@ export function hasEnsuredWelcomeChannel(
   }
 }
 
-export function markWelcomeChannelEnsured(
+export function markChannelOnboardingSettled(
   pubkey: string | null | undefined,
   communityScope: string | null | undefined,
 ) {
@@ -319,7 +357,7 @@ export function markWelcomeChannelEnsured(
 
   try {
     window.localStorage.setItem(
-      welcomeChannelEnsuredStorageKey(pubkey, communityScope),
+      channelOnboardingSettledStorageKey(pubkey, communityScope),
       "true",
     );
   } catch {

--- a/docs/desktop-local-macos-signing.md
+++ b/docs/desktop-local-macos-signing.md
@@ -1,0 +1,67 @@
+# Desktop Local macOS Signing
+
+Local Tauri builds are ad-hoc signed by default. macOS Keychain then trusts the
+exact `buzz-desktop` binary hash, so a rebuild can bring back the Keychain
+prompt even after selecting "Always Allow".
+
+Buzz keeps the reusable fix in the repo:
+
+- `desktop/scripts/install-local-macos-app.sh` signs and installs `Buzz.app`.
+- `just desktop-install-local-macos` runs the installer.
+- `just desktop-signing-status` verifies the installed signature and Keychain
+  readiness.
+
+## First Setup On A Mac
+
+Build the app, create the local signing identity once, install, then verify:
+
+```bash
+. ./bin/activate-hermit
+just desktop-release-build
+just desktop-install-local-macos --create-identity
+just desktop-signing-status
+```
+
+The first launch may still show one Keychain prompt for `buzz-desktop`. Choose
+"Always Allow" once. Later local installs signed with the same identity should
+reuse the same Keychain authorization.
+
+## Later Local Rebuilds
+
+After the identity exists on that machine:
+
+```bash
+. ./bin/activate-hermit
+just desktop-release-build
+just desktop-install-local-macos
+just desktop-signing-status
+```
+
+## New Computer
+
+Use the same first-setup flow on the new Mac. This creates a new local signing
+identity on that computer, then you approve `buzz-desktop` in Keychain once.
+
+If the login Keychain was migrated from an old Mac and you want the exact same
+certificate leaf hash, export/import the `Buzz Local Code Signing` identity
+manually as an encrypted `.p12` and keep it outside the repo. Do not commit
+`.p12`, `.pfx`, `.pem`, or private-key files.
+
+## Expected Healthy Status
+
+`just desktop-signing-status` should report:
+
+```text
+signature=valid
+keychain_acl_stability=stable
+local_signing_identity=present
+```
+
+The designated requirement must look like:
+
+```text
+designated => identifier "xyz.block.buzz.app" and certificate leaf = H"..."
+```
+
+If it says `designated => cdhash`, the installed app is still ad-hoc signed and
+Keychain prompts can return after each rebuild.


### PR DESCRIPTION
## Summary
- render CRM action markers as native desktop review cards
- support category, approval, and cancellation controls through existing reaction authorization
- add a local-only Copy draft control for explicitly delimited Reddit review text

## Validation
- `pnpm exec node --import ./test-loader.mjs --experimental-strip-types --test src/features/messages/ui/crmActionCard.test.mjs`
- `pnpm typecheck`

The card preserves the existing CRM-side authorization and expiry checks; this PR does not enable any production action consumer.