### PR TITLE
fix(desktop): skip the empty default-model step after skipping harness setup

### DIFF
--- a/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
+++ b/desktop/src/features/onboarding/ui/DefaultConfigStep.tsx
@@ -46,9 +46,11 @@ function formatHarnessLabel(runtime: AcpRuntimeCatalogEntry | undefined) {
 }
 
 function AgentDefaultsSection({
+  onNoReadyRuntimes,
   onPersistenceStateChange,
   readyRuntimeIds,
 }: {
+  onNoReadyRuntimes: () => void;
   onPersistenceStateChange: (state: {
     canComplete: boolean;
     flush: () => Promise<void>;
@@ -181,6 +183,17 @@ function AgentDefaultsSection({
     selectedRuntimeId,
   ]);
 
+  React.useEffect(() => {
+    if (configSurfaceLoading || runtimesQuery.isError) return;
+    if (effectiveReadyRuntimeIds.length > 0) return;
+    onNoReadyRuntimes();
+  }, [
+    configSurfaceLoading,
+    effectiveReadyRuntimeIds,
+    onNoReadyRuntimes,
+    runtimesQuery.isError,
+  ]);
+
   const flushPersistence = React.useCallback(
     () => coalescerRef.current?.flush() ?? Promise.resolve(),
     [],
@@ -304,6 +317,7 @@ export function DefaultConfigStep({
       <div className="flex w-full flex-1 items-center justify-center py-10">
         <div className="w-full max-w-[328px]">
           <AgentDefaultsSection
+            onNoReadyRuntimes={actions.returnToSetup}
             onPersistenceStateChange={setPersistenceState}
             readyRuntimeIds={readyRuntimeIds}
           />

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -71,6 +71,7 @@ export function MachineOnboardingFlow({
     },
     [],
   );
+  const showSetupPage = React.useCallback(() => setPage("setup"), []);
 
   const loadFreshIdentity = React.useCallback(async () => {
     setIsPending(true);
@@ -257,8 +258,9 @@ export function MachineOnboardingFlow({
           ) : (
             <DefaultConfigStep
               actions={{
-                back: () => setPage("setup"),
+                back: showSetupPage,
                 complete: () => complete(selectedPubkey ?? undefined),
+                returnToSetup: showSetupPage,
               }}
               direction="forward"
               readyRuntimeIds={readyRuntimeIds}

--- a/desktop/src/features/onboarding/ui/types.ts
+++ b/desktop/src/features/onboarding/ui/types.ts
@@ -65,6 +65,7 @@ export type SetupStepActions = {
 export type DefaultConfigStepActions = {
   back: () => void;
   complete: () => void;
+  returnToSetup: () => void;
 };
 
 export type SetupStepRuntimeState = {

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -552,6 +552,31 @@ test("defaults Back returns to harness setup", async ({ page }) => {
   await expect(page.getByTestId("onboarding-page-2")).toBeVisible();
 });
 
+test("skipping harness setup returns to setup, not the empty defaults step", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime("claude", "adapter_missing", { status: "unknown" }),
+        runtime("codex", "not_installed", { status: "unknown" }),
+      ],
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+  await navigateToSetupPage(page);
+  await page.getByTestId("onboarding-setup-skip").click();
+  await expect(page.getByText("Join or create a community")).toBeVisible();
+
+  await page.getByTestId("welcome-setup-back").click();
+
+  await expect(page.getByTestId("onboarding-page-2")).toBeVisible();
+  await expect(page.getByTestId("onboarding-page-config")).toHaveCount(0);
+  await expect(page.getByTestId("onboarding-setup-next")).toBeDisabled();
+});
+
 test("defaults auto-selects the only ready visible harness", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

`Skip for now` on **Set up your agent harnesses** completes machine onboarding without a harness. Pressing `Back` on the following **Join or create a community** screen reopened machine onboarding at step 4, **Configure your default model settings** — a dead end: the harness picker has no options, the model picker has nothing to load, and `Next` stays disabled, so the only way out is `Back` again.

`WelcomeSetup`'s `onBack` unconditionally resumes at the `config` page (`reopenMachineConfig` in `desktop/src/app/App.tsx`), but that step exists only to choose among *ready* harnesses. It now reports upward when nothing is ready and the flow returns to harness setup, where the user can install or sign in first.

The condition only fires when no harness is ready at all. The handoff from setup always carries a non-empty ready list, so the forward path is untouched, as is the existing transient-auth-recheck error state (`configSurfaceError`).

| Back after skipping — before | after |
| --- | --- |
| <img width="1280" height="720" alt="01-before-empty-default-model-step" src="https://github.com/user-attachments/assets/7987a83e-1f6b-4a59-8ae9-07498d801681" /> | <img width="1280" height="720" alt="02-after-back-lands-on-harness-setup" src="https://github.com/user-attachments/assets/f333ece5-b9dd-47ee-a968-74be35135ba5" /> |

### Related issue

None found. The closest open PR is #2923 (hides `Skip for now` once both harnesses are ready) — the opposite state, no overlap with this change.

### Testing

- `just ci` — green
- `playwright test --project=smoke onboarding-agent-defaults.spec.ts` — 20 passed, including the new `skipping harness setup returns to setup, not the empty defaults step`
- `playwright test --project=integration onboarding.spec.ts` — 58 passed; that suite contains `first-community shows the scenario cards for localhost`, which asserts `Back` **does** reach the config page when a harness is ready, so both directions stay covered

Manual, on a machine with no Claude Code / Codex CLI: create an identity → past the backup step → `Skip for now` on **Set up your agent harnesses** → `Back` on **Join or create a community**. Lands on harness setup with the install actions available, instead of the empty default-model step.
