### PR TITLE
fix(web): open off-site links in a new tab

### DIFF
--- a/web/src/features/invite/ui/InvitePage.tsx
+++ b/web/src/features/invite/ui/InvitePage.tsx
@@ -9,9 +9,8 @@ import {
 import { hasNip07Provider } from "@/shared/lib/nostr-signer";
 import { relayWsUrl } from "@/shared/lib/relay-url";
 import { Button } from "@/shared/ui/button";
+import { Markdown } from "@/shared/ui/markdown";
 import * as React from "react";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 
 import { InviteJoinPolicyNotice } from "./InviteJoinPolicyNotice";
 
@@ -372,9 +371,7 @@ export function InvitePage({ code }: { code: string }) {
               </button>
             </div>
             <div className="prose prose-sm max-w-none">
-              <Markdown remarkPlugins={[remarkGfm]}>
-                {document.markdown}
-              </Markdown>
+              <Markdown>{document.markdown}</Markdown>
             </div>
           </div>
         </div>

--- a/web/src/features/repos/ui/RepoBlobViewer.tsx
+++ b/web/src/features/repos/ui/RepoBlobViewer.tsx
@@ -10,11 +10,10 @@
 import { ArrowLeft, Check, Copy, Download, FileText, Play } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link, useParams } from "@tanstack/react-router";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
 
 import { Button } from "@/shared/ui/button";
+import { Markdown } from "@/shared/ui/markdown";
 import type { BlobView } from "../git-client";
 import { useGitBlob, useGitHtmlDoc } from "../use-git-browse";
 import { useRepoContext } from "../use-repo-context";
@@ -182,7 +181,7 @@ function ViewerBody({
     case "markdown":
       return (
         <div className="prose prose-sm dark:prose-invert max-w-none rounded-lg border border-black/10 bg-white/50 p-4 dark:border-white/10 dark:bg-white/5">
-          <Markdown remarkPlugins={[remarkGfm]}>{view.content}</Markdown>
+          <Markdown>{view.content}</Markdown>
         </div>
       );
     case "html":

--- a/web/src/features/repos/ui/RepoReadmeSection.tsx
+++ b/web/src/features/repos/ui/RepoReadmeSection.tsx
@@ -1,6 +1,5 @@
+import { Markdown } from "@/shared/ui/markdown";
 import { BookOpen } from "lucide-react";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import type { ReadmeResult } from "../git-client";
 
 export function RepoReadmeSection({
@@ -35,7 +34,7 @@ export function RepoReadmeSection({
         {readme.filename}
       </h2>
       <div className="prose prose-sm dark:prose-invert max-w-none rounded-lg border border-black/10 bg-white/50 p-4 dark:border-white/10 dark:bg-white/5">
-        <Markdown remarkPlugins={[remarkGfm]}>{readme.content}</Markdown>
+        <Markdown>{readme.content}</Markdown>
       </div>
     </div>
   );

--- a/web/src/shared/ui/markdown.tsx
+++ b/web/src/shared/ui/markdown.tsx
@@ -1,0 +1,44 @@
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+/**
+ * True when following `href` leaves this site. Same-origin paths, in-page
+ * anchors, and custom schemes (`buzz://`, `mailto:`) stay in the current tab —
+ * a new tab for those would just leave an empty one behind.
+ */
+export function isOffSiteHref(href: string | undefined): boolean {
+  if (!href) return false;
+  try {
+    const url = new URL(href, window.location.href);
+    return (
+      /^https?:$/.test(url.protocol) && url.origin !== window.location.origin
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Markdown (GitHub flavour) that opens off-site links in a new tab. */
+export function Markdown({ children }: { children: string }) {
+  return (
+    <ReactMarkdown
+      components={{
+        a({ node: _node, href, ...props }) {
+          return isOffSiteHref(href) ? (
+            <a
+              href={href}
+              rel="noopener noreferrer"
+              target="_blank"
+              {...props}
+            />
+          ) : (
+            <a href={href} {...props} />
+          );
+        },
+      }}
+      remarkPlugins={[remarkGfm]}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+}

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -120,6 +120,45 @@ test("invite requires age and legal consent before opening Buzz", async ({
   expect(consentBox?.width).toBe(acceptButtonBox?.width);
 });
 
+test("markdown opens off-site links in a new tab, in-app links in place", async ({
+  page,
+}) => {
+  await page.route("**/api/join-policy", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        policy: {
+          terms_markdown: [
+            "Read the [full policy](https://example.com/terms),",
+            "our [help centre](/help), and [section two](#two).",
+          ].join(" "),
+          age_attestation_required: false,
+          version: "policy-v1",
+        },
+      }),
+    });
+  });
+  await page.route("https://api.github.com/**", async (route) => {
+    await route.fulfill({ status: 500 });
+  });
+
+  await page.goto("/invite/demo-code");
+  await page.getByRole("button", { name: "Terms of Service" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "Terms of Service" });
+  const offSite = dialog.getByRole("link", { name: "full policy" });
+  await expect(offSite).toHaveAttribute("target", "_blank");
+  await expect(offSite).toHaveAttribute("rel", /noreferrer/);
+
+  await expect(
+    dialog.getByRole("link", { name: "help centre" }),
+  ).not.toHaveAttribute("target", "_blank");
+  await expect(
+    dialog.getByRole("link", { name: "section two" }),
+  ).not.toHaveAttribute("target", "_blank");
+});
+
 test("invite can enroll a NIP-07 identity for browser access", async ({
   page,
 }) => {


### PR DESCRIPTION
## Problem

In the web client, links inside markdown-rendered content navigate the current
tab. Click a link in a repo's README, a previewed `.md` file, or the Terms /
Privacy documents on the invite page, and you're pulled out of Buzz entirely —
losing the repo you were browsing or, worse, the invite you were mid-way
through accepting.

Hand-written anchors already got this right (`View on web`, `Download it now`).
Markdown was the gap, and it's the surface most likely to contain arbitrary
third-party links.

## Fix

A shared `Markdown` component (`web/src/shared/ui/markdown.tsx`) that adds
`target="_blank"` + `rel="noopener noreferrer"` to cross-origin `http(s)` links
only. The three existing call sites now use it instead of each configuring
`react-markdown` themselves, which also de-duplicates the `remarkGfm` wiring.

Deliberately left navigating in place:

- Same-origin paths and in-page anchors — normal in-app navigation.
- Custom schemes, notably the `buzz://` deep links behind *Open in Buzz* and
  *Accept invite in Buzz*. Opening those in a new tab hands off to the desktop
  app and strands an empty tab behind it.

No new dependency — `rehype-external-links` would do this, but it isn't worth a
package for an eight-line predicate.

## Test

`web/tests/e2e/smoke.spec.ts` gains a case that serves a join policy whose
terms markdown contains an off-site link, an in-app path, and an in-page
anchor, then asserts only the first opens in a new tab. Confirmed failing
before the fix (`Expected "_blank", Received ""`), passing after.

Full web smoke suite: 7/7 pass. `pnpm check` and `pnpm typecheck` clean.
