### PR TITLE
fix(desktop): let channel-member agents into the @mention picker

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -246,7 +246,10 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (
+        !candidate.isMember &&
+        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+      ) {
         return;
       }
       if (


### PR DESCRIPTION
## Problem

The desktop @mention autocomplete filters agent identities to the current user's **own** managed-agent list. Agents owned by someone else never appear in the picker — even when they're already members of the channel — so you can't `@mention` a teammate's agent that's sitting right there in the channel.

## Fix

One-line filter relaxation in `desktop/src/features/messages/lib/useMentions.ts` (`addCandidate`). An agent now passes the pre-filter if it's in your managed list **or** it's a channel member:

```diff
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (
+        !candidate.isMember &&
+        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+      ) {
         return;
       }
```

The downstream `shouldHideAgentFromMentions` gate (already present, "Option B") then makes the real visibility decision for member agents: it hides only agents with an explicit *not-invocable* relay-directory (kind:10100) entry, and shows agents whose invocability is unknown. This change simply stops member agents from being dropped **before** they reach that gate.

## Scope notes

- **Agents only.** `isAgentIdentityInManagedList` already returns `true` for non-agents, so human members are unaffected.
- No change to access/permissions — only *who the autocomplete offers*.
- A structurally identical filter exists in `features/channels/ui/MembersSidebar.tsx:285` (member-list display). Left untouched — out of scope for the mention picker; can follow up if desired.

## Verification

- `pnpm test` — **3631 pass / 0 fail**. The member-shown path is already covered by `agentAutocompleteEligibility.test.mjs` ("shows member agents with unknown invocability"); this change removes the pre-filter that blocked reaching it.
- `pnpm typecheck` — clean.
- `pnpm exec biome check` on the changed file — clean.

Originating discussion: Buzz channel #WC.