### PR TITLE
fix(acp): emit [Workspace] section for Windows drive-letter cwd

### DIFF
--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1159,11 +1159,25 @@ fn framed_system_prompt(
 
 /// Render the `[Workspace]` grounding section, or `None` when `cwd` is unusable.
 ///
-/// Skips relative paths and the `/` fallback (`std::env::current_dir()` resolves
-/// to `/` on failure): a `/`-rooted workspace line would actively encourage the
-/// `$HOME`-wide scan this section exists to prevent.
+/// Two invariants gate emission: reject relative paths, and reject any
+/// filesystem root — `/`, `C:\`, `\\?\C:\`, `\\server\share` — since a
+/// root-rooted workspace line would actively encourage the `$HOME`-wide scan
+/// this section exists to prevent. `std::env::current_dir()` resolves to `/`
+/// on failure, so the root check also covers that fallback.
+///
+/// `Path::is_absolute()` is intentionally platform-dependent here (on
+/// Windows it requires a drive/UNC prefix, so a POSIX-style string like
+/// `/Users/me` is not absolute) rather than a bug to "fix" back to a string
+/// prefix test. `cwd` only ever originates from `std::env::current_dir()` in
+/// this same process (see `lib.rs`, where `PromptContext::cwd` is built) —
+/// there is no deserialization, CLI flag, or wire path that can hand this
+/// function a foreign-dialect path, so the compile-time platform always
+/// matches the path's dialect. The POSIX-path tests below are `#[cfg(unix)]`
+/// for the same reason: they assert on a dialect this predicate only accepts
+/// on Unix.
 fn workspace_section(cwd: &str) -> Option<String> {
-    if cwd != "/" && cwd.starts_with('/') {
+    let path = std::path::Path::new(cwd);
+    if path.is_absolute() && path.parent().is_some() {
         Some(format!(
             "[Workspace]\nYour absolute working directory is `{cwd}`. All workspace \
              files — `AGENTS.md`, `RESEARCH/`, `PLANS/`, `GUIDES/`, `WORK_LOGS/`, \
@@ -3806,6 +3820,7 @@ mod tests {
         assert!(framed_system_prompt("/", None, None).is_none());
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_framed_system_prompt_absolute_cwd_prepends_workspace_before_base() {
         let framed = framed_system_prompt("/Users/me/.buzz", Some("base text"), None)
@@ -3841,6 +3856,29 @@ mod tests {
     fn test_workspace_section_relative_cwd_is_none() {
         assert!(workspace_section("relative/path").is_none());
         assert!(workspace_section("").is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_workspace_section_posix_absolute_cwd_is_some() {
+        assert!(workspace_section("/Users/me/.buzz").is_some());
+    }
+
+    #[test]
+    fn test_workspace_section_root_cwd_is_none() {
+        assert!(workspace_section("/").is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_workspace_section_windows_drive_absolute_cwd_is_some() {
+        assert!(workspace_section(r"C:\Users\me\.buzz").is_some());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_workspace_section_windows_drive_root_is_none() {
+        assert!(workspace_section(r"C:\").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`workspace_section()` gated the `[Workspace]` system-prompt block on `cwd.starts_with('/')`, so it was silently dropped for every Windows agent — `cwd` comes from `std::env::current_dir()` (`lib.rs:1547-1550`), which on Windows is always drive-letter form (`C:\Users\<user>\.buzz`).

Replaces the string-prefix test with `Path::is_absolute() && Path::parent().is_some()`, which preserves both invariants the original guard existed for — reject relative paths, reject the `/` sentinel `current_dir()` falls back to on failure — and generalizes the second to reject `C:\`, `\\?\C:\`, and UNC share roots uniformly.

Fixes #3124

## Scope, stated honestly

This is **not** "Windows agents don't know about their workspace." `base_prompt.md:84-100` already ships the Workspace Layout table (`REPOS/`, `OUTBOX/`) and the "never run `find` over `$HOME`" instruction unconditionally on every platform, and the agent's OS cwd *is* the workspace (the child inherits it). What Windows was missing is the **absolute-path anchor** — one reinforcing sentence. Filed and fixed as a correctness bug, not a user-facing breakage.

## Why the platform-dependent predicate is deliberate

`Path::is_absolute` is platform-dependent, and that is correct here rather than a hazard: `cwd` only ever originates from `current_dir()` in the same process on the same host, so the compile-time platform always matches the path's dialect. Audited — `PromptContext` (`pool.rs:482`) has no derives (so no deserialization path), its only production constructor is `lib.rs:1530`, no crate outside `buzz-acp` references it, and there is no CLI flag or env override for cwd. The reasoning is now recorded in the function's doc comment so a future maintainer doesn't "fix" it back to a string prefix test.

Deliberately **not** done: normalizing the cwd string upstream. The same string is the ACP `session/new` cwd (`pool.rs:831`), so rewriting it would change protocol behavior for every harness.

## Tests

- `#[cfg(windows)]`: drive-letter cwd → `Some`; `C:\` → `None`.
- `#[cfg(unix)]`: `/Users/me/.buzz` → `Some`.
- Ungated (platform-neutral): `/` → `None`, `relative/path` → `None`, `""` → `None`.

Two POSIX-path assertions needed `#[cfg(unix)]` gating as a direct consequence of this change — including the pre-existing `test_framed_system_prompt_absolute_cwd_prepends_workspace_before_base`, which was green on Windows before, because `Path::new("/Users/me/.buzz").is_absolute()` is `false` on Windows (root, no drive prefix). Called out explicitly since it's the one non-obvious side effect of the fix.

**Reviewer note:** the `#[cfg(windows)]` tests do not currently execute in CI. `.github/workflows/ci.yml:945-947` runs `cargo clippy` and `cargo check --workspace --all-targets` on `windows-latest` (so they compile), but the only Windows `cargo test` invocations are `-p buzz-dev-mcp` (`:953`) and the Tauri crate (`:988`). Adding `-p buzz-acp` to that step would make them enforcing — happy to include it here if you want it, or leave it separate.

## Test plan

- [x] `cargo test -p buzz-acp workspace_section` — 3 passed
- [x] `cargo test -p buzz-acp framed_system_prompt` — 7 passed
- [x] `cargo fmt --check -p buzz-acp` — clean
- [x] `cargo clippy -p buzz-acp` — clean
- [ ] `cargo test -p buzz-acp` on a Windows target (no Windows host available to me — this is the one gap, and it's exactly what the two `#[cfg(windows)]` tests are for)

## Out of scope, noted for follow-up

Now that Windows agents receive this text:
- The section says "do not search `$HOME`" — POSIX phrasing that reads oddly on Windows (`base_prompt.md:100` has the same issue).
- `{cwd}/REPOS/` renders `C:\Users\me\.buzz/REPOS/` — mixed separators, functional but untidy.

## Related

#3126 — the same `[Workspace]` section never reaches protocol-v1 harnesses (Claude Code, Codex) on *any* platform, because the legacy prompt-framing path never calls `workspace_section` at all. Independent of this predicate bug: a Windows Claude Code agent is affected by both, a macOS one only by #3126. This PR does not address it, and should not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnfD8YHcZF5KbBTcLxc1P1
