### PR TITLE
feat(buzz-acp): register zcode-acp as a known ACP agent

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -618,7 +618,8 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        | "claudecode" | "buzz-agent"
+        | "zcode" | "zcode-acp" => Some(Vec::new()),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

Adds `zcode` / `zcode-acp` to the `default_agent_args` match in `buzz-acp` so the adapter spawns cleanly without requiring `--agent-args` to be passed explicitly. This is the same one-line-style registration Codex, Goose, and Claude Code already have.

```diff
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        | "claudecode" | "buzz-agent"
+        | "zcode" | "zcode-acp" => Some(Vec::new()),
         _ => None,
     }
 }
```

## Why

`zcode-acp` is a standalone ACP adapter that brings the [ZCode](https://z.ai) CLI into ACP hosts — the same role `zed-industries/codex-acp` plays for Codex. It speaks ACP v1 directly over stdio, so once `buzz-acp` recognises the command name, the rest of the integration is the ACP contract (no protocol-specific code is needed on the Buzz side).

- **Repo:** https://github.com/jpalmae/zcode-acp
- **License:** Apache-2.0 (matches Buzz and the ACP SDK)

## What the adapter provides (parity with codex-acp)

| Capability | Status |
| --- | --- |
| `initialize` with capabilities + auth methods | ✅ |
| `authenticate` / `logout` (Z.AI OAuth init/poll, AES-256-GCM credential store compatible with `zcode login`) | ✅ |
| `session/new` / `load` / `resume` / `list` / `close` | ✅ |
| `session/prompt` with streaming (`part.delta` → `AgentMessageChunk` / `AgentThoughtChunk`) | ✅ |
| Tool calls (`tool.updated` → `ToolCall` + `ToolCallUpdate`) | ✅ |
| `session/requestPermission` bridged bidirectionally (`interaction/requestPermission` ↔ ACP) | ✅ |
| `UsageUpdate`, `session/setMode`, `session/cancel` | ✅ |

## How it talks to ZCode

ZCode ships as a Node bundle (`zcode.cjs`) that exposes a stdio `app-server` speaking the "ZCode Protocol" (NDJSON; one JSON object per line, no `"jsonrpc":"2.0"` field). The adapter spawns one `app-server` per ACP session and drives it: `session/create` + `session/subscribe` + `session/send`, consuming `session/event` notifications (`part.delta`, `tool.updated`, `permission.requested`, `turn.completed`). The protocol surface was reverse-engineered from the running binary and is typed in [`src/zcode/protocol.rs`](https://github.com/jpalmae/zcode-acp/blob/main/src/zcode/protocol.rs).

## Usage

```bash
# After installing zcode-acp on PATH (or passing its full path):
buzz-acp --agent-command zcode-acp --secret-key <nostr-hex-key> ...
```

A persona pack is provided in the adapter repo (`pack/zcode.persona.md` with `runtime: zcode`) for first-class UI integration.

## Verification

- `cargo check -p buzz-acp` passes with the change applied.
- The adapter itself: `cargo build` clean, 6/6 unit tests pass, `cargo clippy --all-targets` is warning-free, and a full E2E round-trip (initialize → session/new → session/prompt streaming text + a tool call → `end_turn` → session/close) passes against a fake `app-server`.

## Notes / out of scope

- The adapter lives in its own repo (`jpalmae/zcode-acp`), mirroring how `codex-acp` is maintained outside `openai/codex`. No adapter code is added to this repository.
- ZCode's own model provider config (`~/.zcode/cli/config.json`, populated by `zcode login`) is a runtime prerequisite, not something this PR touches.