### PR TITLE
fix(desktop): sync persona behavior to linked agent

### DIFF
--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -106,6 +106,13 @@ with a TypeScript lookup table or an id comparison in a component.
    Edit. In Edit,
    selecting Custom command keeps its required command field beside the harness
    picker rather than hiding it in Advanced.
+10. **Persona behavior edits update only the explicitly targeted linked
+    instance.** Existing instances may intentionally override their persona's
+    mint-time defaults. When a definition edit changes `respondTo`, its
+    allowlist, or `parallelism`, mirror that behavior group onto the selected
+    persona-linked managed agent so its running process restarts with the saved
+    policy. Do not fan the edit out to every instance of the definition, and do
+    not overwrite instance behavior for unrelated definition edits.
 
 ## The tests that enforce this
 

--- a/desktop/src/features/agents/lib/personaBehaviorManagedAgentPatch.test.mjs
+++ b/desktop/src/features/agents/lib/personaBehaviorManagedAgentPatch.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  linkedInstanceForPersonaRequest,
+  personaBehaviorManagedAgentPatch,
+} from "./personaBehaviorManagedAgentPatch.ts";
+
+function persona(overrides = {}) {
+  return {
+    id: "persona-1",
+    displayName: "osiris",
+    avatarUrl: null,
+    systemPrompt: "Research carefully.",
+    runtime: "goose",
+    model: null,
+    provider: null,
+    namePool: [],
+    isBuiltIn: true,
+    isActive: true,
+    envVars: {},
+    respondTo: "allowlist",
+    respondToAllowlist: ["a".repeat(64)],
+    parallelism: 4,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function agent(overrides = {}) {
+  return {
+    pubkey: "1".repeat(64),
+    name: "osiris",
+    personaId: "persona-1",
+    ...overrides,
+  };
+}
+
+test("maps an allowlist-to-anyone definition edit to the existing instance", () => {
+  assert.deepEqual(
+    personaBehaviorManagedAgentPatch(
+      persona(),
+      persona({
+        respondTo: "anyone",
+        respondToAllowlist: [],
+        parallelism: 8,
+      }),
+    ),
+    {
+      respondTo: "anyone",
+      respondToAllowlist: [],
+      parallelism: 8,
+    },
+  );
+});
+
+test("clearing behavior restores the instance defaults", () => {
+  assert.deepEqual(
+    personaBehaviorManagedAgentPatch(
+      persona(),
+      persona({ respondTo: null, respondToAllowlist: [], parallelism: null }),
+    ),
+    {
+      respondTo: "owner-only",
+      respondToAllowlist: [],
+      parallelism: 10,
+    },
+  );
+});
+
+test("unrelated definition edits do not overwrite instance overrides", () => {
+  assert.equal(
+    personaBehaviorManagedAgentPatch(
+      persona(),
+      persona({ systemPrompt: "A new prompt." }),
+    ),
+    null,
+  );
+});
+
+test("agent-management resolves one named linked instance", () => {
+  const target = agent();
+  assert.equal(
+    linkedInstanceForPersonaRequest(
+      [
+        target,
+        agent({ pubkey: "2".repeat(64), name: "Osiris Clone" }),
+        agent({ pubkey: "3".repeat(64), personaId: "persona-2" }),
+      ],
+      "persona-1",
+      " OSIRIS ",
+    ),
+    target,
+  );
+});
+
+test("agent-management prefers the requesting instance without fanning out", () => {
+  const first = agent({ pubkey: "1".repeat(64) });
+  const requester = agent({ pubkey: "2".repeat(64) });
+  assert.equal(
+    linkedInstanceForPersonaRequest(
+      [first, requester],
+      "persona-1",
+      "osiris",
+      requester.pubkey.toUpperCase(),
+    ),
+    requester,
+  );
+  assert.equal(
+    linkedInstanceForPersonaRequest([first, requester], "persona-1", "osiris"),
+    null,
+  );
+});

--- a/desktop/src/features/agents/lib/personaBehaviorManagedAgentPatch.ts
+++ b/desktop/src/features/agents/lib/personaBehaviorManagedAgentPatch.ts
@@ -1,0 +1,75 @@
+import type {
+  AgentPersona,
+  ManagedAgent,
+  RespondToMode,
+  UpdateManagedAgentInput,
+} from "@/shared/api/types";
+
+const DEFAULT_RESPOND_TO: RespondToMode = "owner-only";
+const DEFAULT_PARALLELISM = 10;
+
+/**
+ * Build the instance patch for an explicitly edited persona behavior group.
+ *
+ * Definition behavior is a mint-time default, while existing instances can
+ * carry intentional overrides. The selected linked instance is therefore
+ * updated only when the old and new definition behavior differs; unrelated
+ * definition edits must not overwrite its gate or parallelism.
+ */
+export function personaBehaviorManagedAgentPatch(
+  previousPersona: AgentPersona | undefined,
+  persona: AgentPersona,
+): Pick<
+  UpdateManagedAgentInput,
+  "parallelism" | "respondTo" | "respondToAllowlist"
+> | null {
+  if (
+    previousPersona === undefined ||
+    (previousPersona.respondTo === persona.respondTo &&
+      stringArrayEqual(
+        previousPersona.respondToAllowlist ?? [],
+        persona.respondToAllowlist ?? [],
+      ) &&
+      previousPersona.parallelism === persona.parallelism)
+  ) {
+    return null;
+  }
+
+  return {
+    respondTo: persona.respondTo ?? DEFAULT_RESPOND_TO,
+    respondToAllowlist: [...(persona.respondToAllowlist ?? [])],
+    parallelism: persona.parallelism ?? DEFAULT_PARALLELISM,
+  };
+}
+
+export function linkedInstanceForPersonaRequest(
+  agents: readonly ManagedAgent[],
+  personaId: string,
+  agentName: string,
+  requestingPubkey?: string | null,
+): ManagedAgent | null {
+  const targetName = agentName.trim().toLocaleLowerCase();
+  const candidates = agents.filter(
+    (agent) =>
+      agent.personaId === personaId &&
+      agent.name.trim().toLocaleLowerCase() === targetName,
+  );
+  const normalizedRequestingPubkey = requestingPubkey?.trim().toLowerCase();
+  const requestingInstance = normalizedRequestingPubkey
+    ? candidates.find(
+        (agent) => agent.pubkey.toLowerCase() === normalizedRequestingPubkey,
+      )
+    : undefined;
+  if (requestingInstance) return requestingInstance;
+
+  // A definition can mint multiple independently overridden instances. Never
+  // fan a definition edit out when its display name does not identify one.
+  return candidates.length === 1 ? candidates[0] : null;
+}
+
+function stringArrayEqual(left: readonly string[], right: readonly string[]) {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}

--- a/desktop/src/features/agents/useAgentManagement.ts
+++ b/desktop/src/features/agents/useAgentManagement.ts
@@ -15,6 +15,7 @@ import {
   useCreatePersonaMutation,
   useManagedAgentsQuery,
   usePersonasQuery,
+  useUpdateManagedAgentMutation,
   useUpdatePersonaMutation,
 } from "./hooks";
 import {
@@ -24,6 +25,10 @@ import {
 } from "./lib/instanceInputForDefinition";
 import { useCreatedAgentChannelAttachment } from "./useCreatedAgentChannelAttachment";
 import { classifyAgentManagementOrigin } from "./agentManagementBuffer";
+import {
+  linkedInstanceForPersonaRequest,
+  personaBehaviorManagedAgentPatch,
+} from "./lib/personaBehaviorManagedAgentPatch";
 import { useChannelsQuery } from "@/features/channels/hooks";
 import { resolveManagedAgentAvatarUrl } from "./ui/managedAgentAvatar";
 import type { AgentCreateIntent } from "./ui/agentCreateIntent";
@@ -65,6 +70,7 @@ export function useAgentManagement() {
   const runtimesQuery = useAcpRuntimesQuery({ enabled: true });
   const createPersonaMutation = useCreatePersonaMutation();
   const updatePersonaMutation = useUpdatePersonaMutation();
+  const updateManagedAgentMutation = useUpdateManagedAgentMutation();
   const createAgentMutation = useCreateManagedAgentMutation();
   const [request, setRequest] = React.useState<AgentManagementRequest | null>(
     null,
@@ -155,6 +161,7 @@ export function useAgentManagement() {
   const isPending =
     createPersonaMutation.isPending ||
     updatePersonaMutation.isPending ||
+    updateManagedAgentMutation.isPending ||
     createAgentMutation.isPending;
 
   function assertAgentCanActFromOrigin(channelId: string) {
@@ -244,7 +251,25 @@ export function useAgentManagement() {
     setError(null);
     try {
       assertAgentCanActFromOrigin(request.request.channelId);
-      await updatePersonaMutation.mutateAsync(input);
+      const updatedPersona = await updatePersonaMutation.mutateAsync(input);
+      const behaviorPatch = personaBehaviorManagedAgentPatch(
+        currentPersona,
+        updatedPersona,
+      );
+      if (behaviorPatch) {
+        const linkedInstance = linkedInstanceForPersonaRequest(
+          managedAgentsQuery.data ?? [],
+          updatedPersona.id,
+          request.request.agentName,
+          sourceAgentPubkey.current,
+        );
+        if (linkedInstance) {
+          await updateManagedAgentMutation.mutateAsync({
+            pubkey: linkedInstance.pubkey,
+            ...behaviorPatch,
+          });
+        }
+      }
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: personasQueryKey }),
         queryClient.invalidateQueries({ queryKey: managedAgentsQueryKey }),

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
@@ -92,6 +92,76 @@ test("personaManagedAgentUpdate syncs edited persona identity to linked agent", 
   });
 });
 
+test("personaManagedAgentUpdate syncs edited behavior to the linked instance", () => {
+  const allowlisted = persona({
+    respondTo: "allowlist",
+    respondToAllowlist: ["a".repeat(64)],
+    parallelism: 4,
+  });
+  const anyone = persona({
+    respondTo: "anyone",
+    respondToAllowlist: [],
+    parallelism: 8,
+  });
+
+  assert.deepEqual(
+    personaManagedAgentUpdate(
+      agent({
+        name: anyone.displayName,
+        systemPrompt: anyone.systemPrompt,
+        model: anyone.model,
+        envVars: anyone.envVars,
+        respondTo: "allowlist",
+        respondToAllowlist: ["a".repeat(64)],
+        parallelism: 4,
+      }),
+      anyone,
+      { previousPersona: allowlisted },
+    ),
+    {
+      pubkey: "deadbeef".repeat(8),
+      respondTo: "anyone",
+      respondToAllowlist: [],
+      parallelism: 8,
+    },
+  );
+});
+
+test("personaManagedAgentUpdate does not overwrite behavior on unrelated edits", () => {
+  assert.deepEqual(
+    personaManagedAgentUpdate(
+      agent({
+        respondTo: "allowlist",
+        respondToAllowlist: ["b".repeat(64)],
+        parallelism: 2,
+      }),
+      persona({
+        respondTo: "owner-only",
+        respondToAllowlist: [],
+        parallelism: 4,
+      }),
+      {
+        previousPersona: persona({
+          displayName: "Fizz",
+          systemPrompt: "Old prompt",
+          model: "old-model",
+          envVars: { OLD_KEY: "1" },
+          respondTo: "owner-only",
+          respondToAllowlist: [],
+          parallelism: 4,
+        }),
+      },
+    ),
+    {
+      pubkey: "deadbeef".repeat(8),
+      name: "Fizz Prime",
+      systemPrompt: "New prompt",
+      model: "new-model",
+      envVars: { NEW_KEY: "2" },
+    },
+  );
+});
+
 test("personaManagedAgentUpdate skips unrelated or unchanged agents", () => {
   assert.equal(
     personaManagedAgentUpdate(agent({ personaId: "persona-2" }), persona()),

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
@@ -1,3 +1,4 @@
+import { personaBehaviorManagedAgentPatch } from "@/features/agents/lib/personaBehaviorManagedAgentPatch";
 import * as React from "react";
 import type {
   AcpRuntimeCatalogEntry,
@@ -289,6 +290,19 @@ export function personaManagedAgentUpdate(
 
   if (!stringRecordEqual(persona.envVars, agent.envVars)) {
     input.envVars = persona.envVars;
+    hasChanges = true;
+  }
+
+  const behaviorPatch = personaBehaviorManagedAgentPatch(
+    options.previousPersona,
+    persona,
+  );
+  if (behaviorPatch) {
+    // Profile Edit is the only ordinary UI path to the definition editor for a
+    // persona-linked instance. Mirror an explicitly edited behavior group onto
+    // that selected instance; otherwise Save would update only the definition
+    // and leave its running inbound gate/parallelism unchanged.
+    Object.assign(input, behaviorPatch);
     hasChanges = true;
   }
 

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -75,6 +75,7 @@ type MockManagedAgentSeed = {
   name: string;
   avatarUrl?: string | null;
   personaId?: string | null;
+  parallelism?: number;
   /** Harness/runtime id pin; `null` = inherit from persona (native default). */
   runtime?: string | null;
   status?: RawManagedAgent["status"];
@@ -119,6 +120,9 @@ type MockPersonaSeed = {
   model?: string | null;
   provider?: string | null;
   namePool?: string[];
+  respondTo?: "owner-only" | "allowlist" | "anyone";
+  respondToAllowlist?: string[];
+  parallelism?: number | null;
 };
 
 type MockTeamSeed = {
@@ -2012,7 +2016,7 @@ function buildSeededManagedAgent(seed: MockManagedAgentSeed): MockManagedAgent {
     turn_timeout_seconds: 320,
     idle_timeout_seconds: null,
     max_turn_duration_seconds: null,
-    parallelism: 1,
+    parallelism: seed.parallelism ?? 1,
     system_prompt: null,
     avatar_url: seed.avatarUrl ?? null,
     model: null,
@@ -2179,6 +2183,9 @@ function resetMockPersonas(config?: E2eConfig) {
       is_active: persona.isActive ?? true,
       source_team: persona.sourceTeam ?? null,
       env_vars: { ...(persona.envVars ?? {}) },
+      respond_to: persona.respondTo ?? null,
+      respond_to_allowlist: [...(persona.respondToAllowlist ?? [])],
+      parallelism: persona.parallelism ?? null,
       created_at: now,
       updated_at: now,
     });
@@ -7958,6 +7965,7 @@ async function handleUpdateManagedAgent(args: {
     model?: string | null;
     systemPrompt?: string | null;
     envVars?: Record<string, string>;
+    parallelism?: number;
     respondTo?: "owner-only" | "allowlist" | "anyone";
     respondToAllowlist?: string[];
   };
@@ -7974,6 +7982,9 @@ async function handleUpdateManagedAgent(args: {
   }
   if (args.input.envVars !== undefined) {
     agent.env_vars = { ...args.input.envVars };
+  }
+  if (args.input.parallelism !== undefined) {
+    agent.parallelism = args.input.parallelism;
   }
   if (args.input.respondTo !== undefined) {
     agent.respond_to = args.input.respondTo;

--- a/desktop/tests/e2e/edit-agent.spec.ts
+++ b/desktop/tests/e2e/edit-agent.spec.ts
@@ -65,6 +65,39 @@ async function openEditDialog(page: import("@playwright/test").Page) {
   });
 }
 
+async function readManagedAgent(
+  page: import("@playwright/test").Page,
+  pubkey: string,
+): Promise<{
+  parallelism: number;
+  respondTo: string;
+  respondToAllowlist: string[];
+}> {
+  return page.evaluate(async (targetPubkey) => {
+    const tauriWindow = window as Window & {
+      __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+        command: string,
+        payload?: Record<string, unknown>,
+      ) => Promise<unknown>;
+    };
+    const invoke = tauriWindow.__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
+    if (!invoke) throw new Error("Mock invoke bridge is unavailable.");
+    const agents = (await invoke("list_managed_agents")) as Array<{
+      pubkey: string;
+      parallelism: number;
+      respond_to: string;
+      respond_to_allowlist: string[];
+    }>;
+    const agent = agents.find((candidate) => candidate.pubkey === targetPubkey);
+    if (!agent) throw new Error(`Managed agent ${targetPubkey} not found.`);
+    return {
+      parallelism: agent.parallelism,
+      respondTo: agent.respond_to,
+      respondToAllowlist: agent.respond_to_allowlist,
+    };
+  }, pubkey);
+}
+
 /**
  * Pick an option from a PersonaDropdownField (menu-based, not a native
  * <select> — Create's fields are selects, Edit's are not).
@@ -276,6 +309,56 @@ test.describe("edit agent dialog", () => {
     await expect(
       defaults.getByText("claude-opus-4-5", { exact: true }),
     ).toBeVisible();
+  });
+
+  test("profile Edit applies behavior changes to the linked instance", async ({
+    page,
+  }) => {
+    await installMockBridge(page, {
+      bakedBuildEnv: BAKED_DEFAULTS,
+      managedAgents: [
+        {
+          pubkey: AGENT_PUBKEY,
+          name: AGENT_NAME,
+          personaId: PERSONA_ID,
+          status: "stopped",
+          channelNames: ["agents"],
+          respondTo: "allowlist",
+          respondToAllowlist: ["a".repeat(64)],
+          parallelism: 4,
+        },
+      ],
+      personas: [
+        {
+          id: PERSONA_ID,
+          displayName: AGENT_NAME,
+          systemPrompt: "You are the edit-agent e2e persona.",
+          respondTo: "allowlist",
+          respondToAllowlist: ["a".repeat(64)],
+          parallelism: 4,
+        },
+      ],
+    });
+
+    await page.goto("/");
+    await page.getByTestId("open-agents-view").click();
+    await page
+      .getByRole("button", { name: `${AGENT_NAME} agent profile` })
+      .click();
+    await page.getByTestId("user-profile-edit-agent").click();
+    await page.getByRole("button", { name: "Advanced", exact: true }).click();
+    await pickDropdownOption(page, "agent-respond-to", "Anyone");
+    await page.locator("#persona-parallelism").fill("8");
+    await page.getByTestId("persona-dialog-submit").click();
+    await expect(page.getByTestId("persona-dialog")).not.toBeVisible();
+
+    await expect
+      .poll(() => readManagedAgent(page, AGENT_PUBKEY))
+      .toEqual({
+        parallelism: 8,
+        respondTo: "anyone",
+        respondToAllowlist: [],
+      });
   });
 
   test("profile Edit routes persona-linked agents to the definition editor", async ({

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -47,6 +47,7 @@ type MockManagedAgentSeed = {
   pubkey: string;
   name: string;
   personaId?: string | null;
+  parallelism?: number;
   status?: "running" | "stopped" | "deployed" | "not_deployed";
   channelNames?: string[];
   channelIds?: string[];
@@ -103,6 +104,9 @@ type MockPersonaSeed = {
   /** Provider pinned on the persona. Leave empty for Codex/Claude runtimes. */
   provider?: string | null;
   namePool?: string[];
+  respondTo?: "owner-only" | "allowlist" | "anyone";
+  respondToAllowlist?: string[];
+  parallelism?: number | null;
 };
 
 type MockTeamSeed = {


### PR DESCRIPTION
## Summary

- sync explicit persona behavior edits (`Respond to`, allowlist, and parallelism) to the intended linked managed-agent instance
- preserve per-instance overrides during unrelated persona edits and avoid fan-out when multiple instances share a persona
- cover both Profile Edit and agent-management request paths with unit and end-to-end regression tests

## Root cause

The Desktop definition editor persists these settings on the persona definition. Existing agents run from their managed-agent instance record, but the post-edit instance sync only copied identity/runtime fields. As a result, the UI showed the new behavior while the running instance retained its old inbound gate and parallelism.

## Existing work

Issue #2501 tracks the same user-visible `respond_to`/allowlist failure. PRs #2789 and #2505 also attempt to address it, but they propagate definition behavior to every linked instance. This change keeps independently overridden instances intact and updates only the instance the user explicitly edited (or the uniquely resolved requesting instance). It also covers parallelism and both Desktop edit entry points.

Unlike #2789's direct record propagation, this uses the existing managed-agent update mutation, preserving the normal persistence, restart, and relay publication behavior for the selected instance.

## Behavior

The behavior fields are treated as one atomic group when explicitly changed:

- missing response mode resolves to `owner-only`
- missing allowlist resolves to `[]`
- missing parallelism resolves to `10`

Unrelated persona edits do not overwrite per-instance behavior. Agent-management requests prefer the requesting agent pubkey; without one, they update only a unique name/persona match and do nothing when ambiguous.

## Validation

- Desktop unit suite: 3,644 passed
- Desktop checks, typecheck, formatting, and file-size checks passed
- Edit-agent Playwright suite: 8 passed
- Full repository `just check` passed, including Rust clippy/tests, desktop/web builds, and mobile tests

Fixes #2501.
