### PR TITLE
fix(cli): hide secret environment values in help

### DIFF
--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -82,11 +82,11 @@ struct Cli {
     relay: String,
 
     /// Nostr private key (hex or nsec). This is the CLI's identity.
-    #[arg(long, env = "BUZZ_PRIVATE_KEY")]
+    #[arg(long, env = "BUZZ_PRIVATE_KEY", hide_env_values = true)]
     private_key: Option<String>,
 
     /// NIP-OA auth tag JSON (owner attestation). Injected into every signed event.
-    #[arg(long, env = "BUZZ_AUTH_TAG")]
+    #[arg(long, env = "BUZZ_AUTH_TAG", hide_env_values = true)]
     auth_tag: Option<String>,
 
     /// Output format: 'json' (default, full fields) or 'compact' (reduced fields).

--- a/crates/buzz-cli/tests/help_redaction.rs
+++ b/crates/buzz-cli/tests/help_redaction.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+#[test]
+fn help_hides_secret_environment_values() {
+    let private_key_sentinel = "private-key-value-must-not-appear";
+    let auth_tag_sentinel = "auth-tag-value-must-not-appear";
+
+    let output = Command::new(env!("CARGO_BIN_EXE_buzz"))
+        .arg("--help")
+        .env("BUZZ_PRIVATE_KEY", private_key_sentinel)
+        .env("BUZZ_AUTH_TAG", auth_tag_sentinel)
+        .output()
+        .expect("run buzz --help");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("help output is UTF-8");
+
+    assert!(stdout.contains("[env: BUZZ_PRIVATE_KEY]"));
+    assert!(stdout.contains("[env: BUZZ_AUTH_TAG]"));
+    assert!(!stdout.contains(private_key_sentinel));
+    assert!(!stdout.contains(auth_tag_sentinel));
+}


### PR DESCRIPTION
## Summary
- hide `BUZZ_PRIVATE_KEY` and `BUZZ_AUTH_TAG` values in clap-generated help while retaining their environment variable names
- add a subprocess regression test proving synthetic secret values never appear in `buzz --help`

## Security impact
Without `hide_env_values`, clap renders active environment values in help output. This can disclose the CLI identity private key when help output is captured in logs or agent transcripts.

## Tests
- `cargo test -p buzz-cli --test help_redaction`
- `cargo test -p buzz-cli --lib`
- `cargo fmt -p buzz-cli -- --check`
- `cargo clippy -p buzz-cli --tests -- -D warnings`