### PR TITLE
Refine pending message status

### DIFF
--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -505,9 +505,7 @@ export const MessageRow = React.memo(
       message.pending || message.edited ? (
         <>
           {message.pending ? (
-            <p className="font-medium uppercase tracking-[0.14em] text-primary/80">
-              Sending
-            </p>
+            <p className="font-medium text-primary/80">Sending</p>
           ) : null}
           {message.edited ? (
             <Tooltip>


### PR DESCRIPTION
## Summary
- Replace the all-caps, widely tracked pending-message label with sentence-case `Sending`
- Match the surrounding timestamp and metadata spacing

## Why
The status briefly appeared as `SENDING`, unlike nearby message metadata.

## Validation
- Desktop typecheck
- Focused Biome and text guards
- 3,637 desktop unit tests