### PR TITLE
chore(desktop): add AgentCreationPreview file-size override to unblock main CI

### DIFF
--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -675,6 +675,10 @@ const overrides = new Map([
   // runtimeSupportsLlmProviderSelection guard on discovery provider (codex fix);
   // hideProviderIds computation for Databricks v1 gate. Queued to split.
   ["src/features/agents/ui/AgentDefinitionDialog.tsx", 1035],
+  // #2630 emoji picker search: the shadow-root search-input autofocus effect
+  // (rAF retry loop) took this file 999 -> 1026 and landed without this entry,
+  // so main's Desktop Core went red. Queued to split with the rest of this list.
+  ["src/features/agents/ui/AgentCreationPreview.tsx", 1026],
 ]);
 
 await runFileSizeCheck({


### PR DESCRIPTION
`Desktop Core` is currently red on `main`, and every open PR that picks up current main inherits the failure.

[#2630](https://github.com/block/buzz/pull/2630) added a shadow-root search-input autofocus effect to `AgentCreationPreview.tsx`, taking the file from 999 to 1026 lines. It sat one line under the 1000-line default beforehand, so that PR's own CI was green while the merged file crossed the cap with no override entry in `desktop/scripts/check-file-sizes.mjs`.

This adds the missing entry at 1026, following the pattern the rest of the overrides list uses. The split stays queued along with the others.

```
- src/features/agents/ui/AgentCreationPreview.tsx: 1026 lines (limit 1000)
```

The override is tight in both directions: at `1026` the gate passes, and at `1025` it reproduces the failure above.
