### PR TITLE
fix(mobile): load current agent presence

### DIFF
--- a/mobile/lib/features/profile/presence_cache_provider.dart
+++ b/mobile/lib/features/profile/presence_cache_provider.dart
@@ -14,6 +14,7 @@ import '../../shared/relay/relay.dart';
 class PresenceCacheNotifier extends Notifier<Map<String, String>> {
   final Set<String> _tracked = {};
   final Set<String> _pendingSnapshotPubkeys = {};
+  final Map<String, int> _liveUpdateVersions = {};
   void Function()? _presenceUnsub;
   Timer? _snapshotBatchTimer;
   int _subscriptionVersion = 0;
@@ -60,6 +61,9 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
     if (_pendingSnapshotPubkeys.isEmpty) return;
     final pubkeys = _pendingSnapshotPubkeys.toList();
     _pendingSnapshotPubkeys.clear();
+    final liveVersionsAtStart = {
+      for (final pubkey in pubkeys) pubkey: _liveUpdateVersions[pubkey] ?? 0,
+    };
 
     try {
       final session = ref.read(relaySessionProvider.notifier);
@@ -71,7 +75,11 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
         ),
       ]);
       for (final event in events) {
-        _handlePresenceEvent(event, useTaggedSubject: true);
+        _handlePresenceEvent(
+          event,
+          useTaggedSubject: true,
+          expectedLiveVersion: liveVersionsAtStart[event.getTagValue('p')],
+        );
       }
     } catch (error) {
       debugPrint('[PresenceCacheNotifier] presence snapshot failed: $error');
@@ -105,7 +113,11 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
     }
   }
 
-  void _handlePresenceEvent(NostrEvent event, {bool useTaggedSubject = false}) {
+  void _handlePresenceEvent(
+    NostrEvent event, {
+    bool useTaggedSubject = false,
+    int? expectedLiveVersion,
+  }) {
     // Relay snapshot events are signed by the relay and identify the queried
     // subject with a p-tag. Live events are self-signed, so their author is the
     // subject and an arbitrary p-tag must not be allowed to impersonate it.
@@ -114,6 +126,13 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
     if (!_tracked.contains(pubkey)) return;
     final status = event.content;
     if (status != 'online' && status != 'away' && status != 'offline') return;
+    if (expectedLiveVersion != null &&
+        (_liveUpdateVersions[pubkey] ?? 0) != expectedLiveVersion) {
+      return;
+    }
+    if (!useTaggedSubject) {
+      _liveUpdateVersions[pubkey] = (_liveUpdateVersions[pubkey] ?? 0) + 1;
+    }
     if (state[pubkey] == status) return;
     final updated = Map<String, String>.from(state);
     updated[pubkey] = status;

--- a/mobile/lib/features/profile/presence_cache_provider.dart
+++ b/mobile/lib/features/profile/presence_cache_provider.dart
@@ -8,12 +8,14 @@ import '../../shared/relay/relay.dart';
 /// In-memory cache of other users' presence.
 ///
 /// Subscribes to kind:20001 presence events over the relay WebSocket for
-/// real-time updates. There is no longer a REST backstop — agents that
-/// publish presence purely over WS are fine, and TTL expiry will be handled
-/// by the relay-side `presence:true` filter extension when that lands.
+/// real-time updates and queries the relay's presence snapshot when a pubkey
+/// is first tracked. The snapshot closes the gap between an agent publishing
+/// online and mobile opening its live subscription.
 class PresenceCacheNotifier extends Notifier<Map<String, String>> {
   final Set<String> _tracked = {};
+  final Set<String> _pendingSnapshotPubkeys = {};
   void Function()? _presenceUnsub;
+  Timer? _snapshotBatchTimer;
   int _subscriptionVersion = 0;
 
   @override
@@ -23,10 +25,13 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
     ref.onDispose(() {
       _presenceUnsub?.call();
       _presenceUnsub = null;
+      _snapshotBatchTimer?.cancel();
+      _snapshotBatchTimer = null;
     });
 
     if (sessionState.status == SessionStatus.connected) {
       _subscribePresenceUpdates();
+      _queuePresenceSnapshot(_tracked);
     }
 
     return {};
@@ -34,15 +39,43 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
 
   /// Track presence for [pubkeys].
   ///
-  /// Currently a no-op for the actual fetch — we rely on live kind:20001
-  /// events. The tracked set is still used to filter incoming events so the
-  /// cache doesn't grow unbounded.
+  /// New pubkeys are resolved in one batched relay snapshot query. Live
+  /// kind:20001 events continue to update the cache after that initial read.
   void track(List<String> pubkeys) {
     final normalized = pubkeys.map((pk) => pk.toLowerCase()).toList();
-    _tracked.addAll(normalized);
-    // TODO(presence): once the relay supports a `presence:true` filter
-    // extension, issue a one-shot fetch here for the latest known state per
-    // pubkey. Until then, presence is "online whenever they publish".
+    final newlyTracked = normalized.where(_tracked.add);
+    _queuePresenceSnapshot(newlyTracked);
+  }
+
+  void _queuePresenceSnapshot(Iterable<String> pubkeys) {
+    _pendingSnapshotPubkeys.addAll(pubkeys);
+    if (_pendingSnapshotPubkeys.isEmpty || _snapshotBatchTimer != null) return;
+    _snapshotBatchTimer = Timer(Duration.zero, () {
+      _snapshotBatchTimer = null;
+      unawaited(_fetchPresenceSnapshot());
+    });
+  }
+
+  Future<void> _fetchPresenceSnapshot() async {
+    if (_pendingSnapshotPubkeys.isEmpty) return;
+    final pubkeys = _pendingSnapshotPubkeys.toList();
+    _pendingSnapshotPubkeys.clear();
+
+    try {
+      final session = ref.read(relaySessionProvider.notifier);
+      final events = await session.queryRelay([
+        NostrFilter(
+          kinds: const [EventKind.presenceUpdate],
+          authors: pubkeys,
+          limit: pubkeys.length,
+        ),
+      ]);
+      for (final event in events) {
+        _handlePresenceEvent(event, useTaggedSubject: true);
+      }
+    } catch (error) {
+      debugPrint('[PresenceCacheNotifier] presence snapshot failed: $error');
+    }
   }
 
   /// Subscribe to kind:20001 presence events over WebSocket.
@@ -72,8 +105,12 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
     }
   }
 
-  void _handlePresenceEvent(NostrEvent event) {
-    final pubkey = event.pubkey.toLowerCase();
+  void _handlePresenceEvent(NostrEvent event, {bool useTaggedSubject = false}) {
+    // Relay snapshot events are signed by the relay and identify the queried
+    // subject with a p-tag. Live events are self-signed, so their author is the
+    // subject and an arbitrary p-tag must not be allowed to impersonate it.
+    final taggedSubject = useTaggedSubject ? event.getTagValue('p') : null;
+    final pubkey = (taggedSubject ?? event.pubkey).toLowerCase();
     if (!_tracked.contains(pubkey)) return;
     final status = event.content;
     if (status != 'online' && status != 'away' && status != 'offline') return;

--- a/mobile/test/features/profile/presence_cache_provider_test.dart
+++ b/mobile/test/features/profile/presence_cache_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -41,6 +43,24 @@ void main() {
 
     expect(relaySession.queries, hasLength(1));
     expect(relaySession.queries.single.single.authors, ['alice', 'bob']);
+  });
+
+  test('snapshot does not overwrite a newer live presence update', () async {
+    final snapshot = Completer<List<NostrEvent>>();
+    final relaySession = _RecordingRelaySessionNotifier()
+      ..queryCompleter = snapshot;
+    final container = _buildContainer(relaySession: relaySession);
+    addTearDown(container.dispose);
+
+    container.read(presenceCacheProvider);
+    container.read(presenceCacheProvider.notifier).track(['alice']);
+    await _pumpEventQueue();
+
+    relaySession.emit(_presence('alice', 'offline'));
+    snapshot.complete([_snapshotPresence('alice', 'online')]);
+    await _pumpEventQueue();
+
+    expect(container.read(presenceCacheProvider)['alice'], 'offline');
   });
 
   test('WS presence event updates cache for tracked pubkey', () async {
@@ -233,6 +253,7 @@ class _RecordingRelaySessionNotifier extends RelaySessionNotifier {
   final List<List<NostrFilter>> queries = [];
   final List<void Function(NostrEvent)> _listeners = [];
   List<NostrEvent> queryResults = [];
+  Completer<List<NostrEvent>>? queryCompleter;
 
   @override
   SessionState build() => const SessionState(status: SessionStatus.connected);
@@ -243,6 +264,8 @@ class _RecordingRelaySessionNotifier extends RelaySessionNotifier {
     Duration timeout = const Duration(seconds: 8),
   }) async {
     queries.add(filters);
+    final completer = queryCompleter;
+    if (completer != null) return completer.future;
     return queryResults;
   }
 

--- a/mobile/test/features/profile/presence_cache_provider_test.dart
+++ b/mobile/test/features/profile/presence_cache_provider_test.dart
@@ -6,12 +6,43 @@ import 'package:buzz/shared/relay/relay.dart';
 
 /// Tests for [PresenceCacheNotifier] in the pure-Nostr world.
 ///
-/// The cache is now purely WS-driven: the notifier subscribes to kind:20001
-/// (presence updates) over the relay session and only mutates state for
-/// pubkeys that have been registered via [PresenceCacheNotifier.track].
-/// There is no longer a REST backstop — the previous test seeded state via
-/// a `GET /api/presence` call which has been removed.
+/// The cache combines relay snapshot reads for newly tracked pubkeys with a
+/// kind:20001 WebSocket subscription for later presence changes.
 void main() {
+  test('track fetches current presence from the relay snapshot', () async {
+    final relaySession = _RecordingRelaySessionNotifier()
+      ..queryResults = [_snapshotPresence('alice', 'online')];
+    final container = _buildContainer(relaySession: relaySession);
+    addTearDown(container.dispose);
+
+    container.read(presenceCacheProvider);
+    container.read(presenceCacheProvider.notifier).track(['alice']);
+    await _pumpEventQueue();
+
+    expect(container.read(presenceCacheProvider)['alice'], 'online');
+    expect(relaySession.queries, hasLength(1));
+    expect(relaySession.queries.single.single.kinds, [
+      EventKind.presenceUpdate,
+    ]);
+    expect(relaySession.queries.single.single.authors, ['alice']);
+  });
+
+  test('batches newly tracked pubkeys into one snapshot query', () async {
+    final relaySession = _RecordingRelaySessionNotifier();
+    final container = _buildContainer(relaySession: relaySession);
+    addTearDown(container.dispose);
+
+    container.read(presenceCacheProvider);
+    final notifier = container.read(presenceCacheProvider.notifier);
+    notifier.track(['alice']);
+    notifier.track(['bob']);
+    notifier.track(['alice']);
+    await _pumpEventQueue();
+
+    expect(relaySession.queries, hasLength(1));
+    expect(relaySession.queries.single.single.authors, ['alice', 'bob']);
+  });
+
   test('WS presence event updates cache for tracked pubkey', () async {
     final relaySession = _RecordingRelaySessionNotifier();
     final container = _buildContainer(relaySession: relaySession);
@@ -131,6 +162,32 @@ void main() {
     // There should be no literal "pubkey" key in the map.
     expect(cache.containsKey('pubkey'), isFalse);
   });
+
+  test('live presence uses its author instead of a tagged subject', () async {
+    final relaySession = _RecordingRelaySessionNotifier();
+    final container = _buildContainer(relaySession: relaySession);
+    addTearDown(container.dispose);
+
+    container.read(presenceCacheProvider);
+    container.read(presenceCacheProvider.notifier).track(['alice', 'bob']);
+    relaySession.emit(
+      NostrEvent(
+        id: 'tagged-live-presence',
+        pubkey: 'alice',
+        createdAt: 1000,
+        kind: EventKind.presenceUpdate,
+        tags: const [
+          ['p', 'bob'],
+        ],
+        content: 'online',
+        sig: 'sig',
+      ),
+    );
+
+    final cache = container.read(presenceCacheProvider);
+    expect(cache['alice'], 'online');
+    expect(cache.containsKey('bob'), isFalse);
+  });
 }
 
 NostrEvent _presence(String pubkey, String status) => NostrEvent(
@@ -139,6 +196,18 @@ NostrEvent _presence(String pubkey, String status) => NostrEvent(
   createdAt: 1000,
   kind: EventKind.presenceUpdate,
   tags: const [],
+  content: status,
+  sig: 'sig',
+);
+
+NostrEvent _snapshotPresence(String pubkey, String status) => NostrEvent(
+  id: 'snapshot-$pubkey-$status',
+  pubkey: 'relay',
+  createdAt: 1000,
+  kind: EventKind.presenceUpdate,
+  tags: [
+    ['p', pubkey],
+  ],
   content: status,
   sig: 'sig',
 );
@@ -161,10 +230,21 @@ ProviderContainer _buildContainer({
 
 class _RecordingRelaySessionNotifier extends RelaySessionNotifier {
   final List<NostrFilter> filters = [];
+  final List<List<NostrFilter>> queries = [];
   final List<void Function(NostrEvent)> _listeners = [];
+  List<NostrEvent> queryResults = [];
 
   @override
   SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<List<NostrEvent>> queryRelay(
+    List<NostrFilter> filters, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    queries.add(filters);
+    return queryResults;
+  }
 
   @override
   Future<void Function()> subscribe(


### PR DESCRIPTION
## Summary

- fetch current presence when mobile starts tracking agent pubkeys
- batch newly tracked pubkeys into one signed relay query
- keep the existing WebSocket subscription for subsequent live updates
- resolve relay-synthesized snapshot subjects from their `p` tags while keeping live events author-scoped
- prevent an older snapshot response from overwriting a newer live presence update

## Why

Mobile initialized every missing presence entry as offline and only listened for future kind 20001 events. If an agent was already online before mobile subscribed, the UI could show it as offline even while desktop showed it online.

The relay already exposes current ephemeral presence through the generic authenticated `/query` bridge when a kind 20001 filter includes authors. This change uses that existing Nostr bridge instead of adding a new endpoint.

## Testing

- focused Dart formatting and analysis pass
- mobile file-size guard passes
- `flutter test test/features/profile/presence_cache_provider_test.dart` (11 tests)
- regression coverage for current snapshots, batching, snapshot/live ordering, live updates, invalid states, and tagged-subject impersonation

`just ci` was run but current upstream `main` is not green independently of this change:

- desktop file-size guard: `AgentCreationPreview.tsx` is 1025 lines with a 1000-line limit
- mobile analysis: `_FakeReadStateNotifier.markContextRead` has a stale override in `activity_page_test.dart`

This branch does not modify either failing file.

## Manual verification

1. Start an agent before opening mobile.
2. Open a channel or profile that displays the agent.
3. Confirm the existing presence indicator shows online without waiting for a later heartbeat.
4. Stop the agent and confirm the live offline update still applies.

No screenshot is included because this changes the data source for the existing presence indicator, not its visual layout.