### PR TITLE
fix(mobile): match markContextRead signature in activity test fake

### DIFF
--- a/mobile/test/features/activity/activity_page_test.dart
+++ b/mobile/test/features/activity/activity_page_test.dart
@@ -423,7 +423,11 @@ class _FakeReadStateNotifier extends ReadStateNotifier {
   );
 
   @override
-  void markContextRead(String contextId, int unixTimestamp) {
+  void markContextRead(
+    String contextId,
+    int unixTimestamp, {
+    bool clearForcedMessages = false,
+  }) {
     state = state.copyWithContext(contextId, unixTimestamp);
   }
 }


### PR DESCRIPTION
Main's Mobile Analyze job fails with `invalid_override` on `_FakeReadStateNotifier.markContextRead`.

The fake was added in #2889 against the then-current `ReadStateNotifier.markContextRead(String, int)`. The forced-unread work added an optional named `clearForcedMessages` param to the real method. Both PRs were green independently; the semantic conflict only surfaced once both were on main.

The fake tracks read state only, so it accepts the flag and ignores it.
