### PR TITLE
fix(desktop): keep collapsed table separators out of spoilers

### DIFF
--- a/desktop/src/shared/lib/remarkSpoilers.test.mjs
+++ b/desktop/src/shared/lib/remarkSpoilers.test.mjs
@@ -137,6 +137,24 @@ test("remarkSpoilers: groups block nodes between delimiter paragraphs", () => {
   assert.equal(tree.children[1].children[0].children[0].type, "image");
 });
 
+test("remarkSpoilers: leaves collapsed GFM table separators as text", () => {
+  const value =
+    "| Time | Purpose ||---:|---|| 0:00 | Frame strategy || 3:30 | Orient the board |";
+  const tree = runPlugin({
+    type: "root",
+    children: [{ type: "paragraph", children: [{ type: "text", value }] }],
+  });
+
+  assert.equal(
+    tree.children[0].children.some((child) => child.type === "spoiler"),
+    false,
+  );
+  assert.equal(
+    tree.children[0].children.map((child) => child.value ?? "").join(""),
+    value,
+  );
+});
+
 test("remarkSpoilers: leaves unmatched delimiters as text", () => {
   const tree = runPlugin({
     type: "root",

--- a/desktop/src/shared/lib/remarkSpoilers.ts
+++ b/desktop/src/shared/lib/remarkSpoilers.ts
@@ -37,17 +37,29 @@ function transformNode(node: Node) {
     transformNode(child);
   }
 
-  node.children = groupBlockSpoilers(groupSpoilers(node.children));
+  node.children = groupBlockSpoilers(
+    groupSpoilers(node.children, node.type === "paragraph"),
+  );
 }
 
-function groupSpoilers(children: Node[]): Node[] {
+function groupSpoilers(
+  children: Node[],
+  rejectTableDelimiterRow: boolean,
+): Node[] {
   const output: Node[] = [];
   let spoilerBuffer: Node[] | null = null;
 
   for (const part of splitDelimiterParts(children)) {
     if (part.type === "delimiter") {
       if (spoilerBuffer) {
-        output.push(buildSpoilerNode(spoilerBuffer));
+        if (rejectTableDelimiterRow && isTableDelimiterRow(spoilerBuffer)) {
+          output.push({ type: "text", value: "||" }, ...spoilerBuffer, {
+            type: "text",
+            value: "||",
+          });
+        } else {
+          output.push(buildSpoilerNode(spoilerBuffer));
+        }
         spoilerBuffer = null;
       } else {
         spoilerBuffer = [];
@@ -98,6 +110,13 @@ function splitDelimiterParts(children: Node[]): Part[] {
   }
 
   return parts;
+}
+
+function isTableDelimiterRow(children: Node[]): boolean {
+  if (children.some((child) => child.type !== "text")) return false;
+
+  const value = children.map((child) => String(child.value ?? "")).join("");
+  return /^\s*:?-{3,}:?(?:\s*\|\s*:?-{3,}:?)+\s*$/.test(value);
 }
 
 function buildSpoilerNode(


### PR DESCRIPTION
## Summary

- preserve collapsed GFM table separator rows as literal text
- prevent `||---:|---|---||` from becoming an animated spoiler canvas
- leave normal spoilers and valid multiline tables unchanged

## Root cause

When table newlines are lost, adjacent row pipes become `||`. The spoiler remark plugin interpreted the delimiter row between those pairs as a hidden spoiler, so the reported "static" was the spoiler particle animation rather than table layout churn.

## Safety

The guard only applies to a paragraph span made entirely of text that exactly matches a multi-column GFM delimiter row. The narrow syntax collision is that an intentional spoiler containing only a delimiter row such as `||---|---||` now renders literally.

## Verification

- desktop pre-push checks passed (3,662 tests)
- desktop TypeScript typecheck passed
- independent review found no blocking issues
