### PR TITLE
fix(desktop): refuse unsafe agent workdir fallback to /

### DIFF
--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -77,7 +77,7 @@ pub use storage::*;
 pub use teams::*;
 pub use types::*;
 
-/// Returns the Buzz nest directory (`~/.buzz`) if it exists as a real
+/// Returns a safe Buzz nest directory (`~/.buzz`) if it exists as a real
 /// directory (not a symlink), falling back to the user's home directory.
 ///
 /// Used as the default working directory for spawned agent processes.
@@ -86,25 +86,67 @@ pub use types::*;
 ///
 /// Cached for the process lifetime via `OnceLock`.
 /// Returns `None` in sandboxed/containerized environments where `$HOME` is
-/// unset or points to a non-existent path; callers fall back to inheriting
-/// the parent's CWD.
+/// unset, points to a non-existent path, or resolves to a filesystem root.
+/// Agent spawn callers must reject that state rather than inheriting the
+/// desktop process's CWD, which can be `/` for macOS app launches.
 pub fn default_agent_workdir() -> Option<std::path::PathBuf> {
     use std::sync::OnceLock;
     static WORKDIR: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
     WORKDIR
-        .get_or_init(|| {
-            // Prefer ~/.buzz if it exists (created by ensure_nest()).
-            // Reject symlinks to prevent redirect attacks — is_dir()
-            // follows symlinks, so check symlink_metadata() first.
-            // Fall back to $HOME for resilience.
-            nest_dir()
-                .filter(|p| is_real_dir(p))
-                .or_else(|| dirs::home_dir().filter(|p| p.is_dir()))
-        })
+        .get_or_init(|| select_agent_workdir(nest_dir(), dirs::home_dir()))
         .clone()
+}
+
+fn select_agent_workdir(
+    nest: Option<std::path::PathBuf>,
+    home: Option<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    nest.filter(|path| is_safe_agent_workdir(path))
+        .or_else(|| home.filter(|path| is_safe_agent_workdir(path)))
+}
+
+/// A filesystem root is never a suitable coding-agent workspace: running an
+/// agent there makes common project discovery commands scan the whole machine.
+fn is_safe_agent_workdir(path: &std::path::Path) -> bool {
+    path.parent().is_some() && is_real_dir(path)
 }
 
 /// Returns `true` if `path` is a real directory (not a symlink).
 fn is_real_dir(path: &std::path::Path) -> bool {
     path.symlink_metadata().map(|m| m.is_dir()).unwrap_or(false)
+}
+
+#[cfg(test)]
+mod workdir_tests {
+    use super::select_agent_workdir;
+
+    #[test]
+    fn rejects_filesystem_root_as_agent_workdir() {
+        assert_eq!(
+            select_agent_workdir(Some("/".into()), Some("/".into())),
+            None
+        );
+    }
+
+    #[test]
+    fn prefers_a_real_nest_and_falls_back_to_home() {
+        let nest = tempfile::tempdir().expect("create nest");
+        let home = tempfile::tempdir().expect("create home");
+
+        assert_eq!(
+            select_agent_workdir(
+                Some(nest.path().to_path_buf()),
+                Some(home.path().to_path_buf())
+            ),
+            Some(nest.path().to_path_buf())
+        );
+
+        assert_eq!(
+            select_agent_workdir(
+                Some(nest.path().join("missing")),
+                Some(home.path().to_path_buf())
+            ),
+            Some(home.path().to_path_buf())
+        );
+    }
 }

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -566,10 +566,12 @@ pub fn spawn_agent_child(
         nvm_bin,
     );
 
+    let workdir = super::default_agent_workdir().ok_or_else(|| {
+        "cannot spawn agent without a safe working directory; configure a valid home directory and restart Buzz"
+            .to_string()
+    })?;
     let mut command = std::process::Command::new(&resolved_acp_command);
-    if let Some(home) = super::default_agent_workdir() {
-        command.current_dir(home);
-    }
+    command.current_dir(workdir);
     command.stdin(std::process::Stdio::null());
     command.stdout(std::process::Stdio::from(stdout));
     command.stderr(std::process::Stdio::from(stderr));


### PR DESCRIPTION
## Summary
Agent sessions could silently inherit `/` as the working directory when a safe workspace path was unavailable. That is a bad default for install and file tools.

This change refuses that fallback and keeps the agent on a safe workdir instead.

Fixes #3148

## Test plan
- [ ] Reproduce the unsafe `/` workdir case before the fix
- [ ] Confirm the new guard blocks it and keeps a safe directory
