### PR TITLE
feat(desktop): auto-enable huddle transcription for agents

### DIFF
--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -267,6 +267,7 @@ pub async fn start_huddle(
                 // Only store agents that were successfully enrolled.
                 *hs.agent_pubkeys.lock().unwrap_or_else(|e| e.into_inner()) =
                     successful_agents.clone();
+                hs.maybe_auto_enable_transcription_for_agents();
                 // Include the current user + successfully enrolled agents as participants.
                 // Use successful_agents (not member_pubkeys) so failed enrollments
                 // are not reflected in the participant list.
@@ -776,7 +777,7 @@ pub async fn check_pipeline_hotstart(state: State<'_, AppState>) -> Result<(), S
                 .ok();
             let fresh_members = fetch_channel_members(eph_id, None, &state).await.ok();
 
-            if fresh_agents.is_some() || fresh_members.is_some() {
+            let transcription_auto_enabled = if fresh_agents.is_some() || fresh_members.is_some() {
                 let mut hs = state.huddle()?;
                 if let Some(agents) = fresh_agents {
                     *hs.agent_pubkeys.lock().unwrap_or_else(|e| e.into_inner()) = agents;
@@ -785,6 +786,19 @@ pub async fn check_pipeline_hotstart(state: State<'_, AppState>) -> Result<(), S
                     hs.participants = members;
                 }
                 hs.last_agent_refresh = Some(std::time::Instant::now());
+                hs.maybe_auto_enable_transcription_for_agents()
+            } else {
+                false
+            };
+
+            if transcription_auto_enabled {
+                if let Some(manager) = models::global_model_manager() {
+                    manager.start_stt_download(state.http_client.clone());
+                }
+                if let Err(e) = maybe_start_stt_pipeline(&state, eph_id).await {
+                    eprintln!("buzz-desktop: STT agent-presence start failed: {e}");
+                }
+                state.emit_huddle_state_changed();
             }
         }
     }
@@ -974,13 +988,25 @@ pub async fn add_agent_to_huddle(
     // No guidelines re-post needed — the agent sees the original kind:48106
     // guidelines via EOSE replay when it subscribes to the ephemeral channel.
 
-    // Also add the agent to the visible participants list.
-    {
+    // Also add the agent to the visible participants list. The first agent
+    // auto-enables transcription unless the user already chose a state.
+    let transcription_auto_enabled = {
         let mut hs = state.huddle()?;
         if !hs.participants.contains(&agent_pubkey) {
-            hs.participants.push(agent_pubkey);
+            hs.participants.push(agent_pubkey.clone());
+        }
+        hs.maybe_auto_enable_transcription_for_agents()
+    };
+
+    if transcription_auto_enabled {
+        if let Some(manager) = models::global_model_manager() {
+            manager.start_stt_download(state.http_client.clone());
+        }
+        if let Err(e) = maybe_start_stt_pipeline(&state, &eph_id).await {
+            eprintln!("buzz-desktop: STT agent-add start failed: {e}");
         }
     }
+    state.emit_huddle_state_changed();
 
     Ok(result)
 }

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -71,8 +71,10 @@ use tauri::State;
 use uuid::Uuid;
 
 use crate::{app_state::AppState, events, relay::submit_event};
-
-use pipeline::{maybe_start_stt_pipeline, maybe_start_tts_pipeline, post_connect_setup};
+use pipeline::{
+    maybe_start_stt_pipeline, maybe_start_tts_pipeline, post_connect_setup,
+    start_auto_enabled_transcription,
+};
 use relay_api::{
     count_human_members, fetch_channel_members, parse_channel_uuid, validate_pubkey_hex,
     MAX_HUDDLE_AGENTS,
@@ -790,15 +792,8 @@ pub async fn check_pipeline_hotstart(state: State<'_, AppState>) -> Result<(), S
             } else {
                 false
             };
-
             if transcription_auto_enabled {
-                if let Some(manager) = models::global_model_manager() {
-                    manager.start_stt_download(state.http_client.clone());
-                }
-                if let Err(e) = maybe_start_stt_pipeline(&state, eph_id).await {
-                    eprintln!("buzz-desktop: STT agent-presence start failed: {e}");
-                }
-                state.emit_huddle_state_changed();
+                start_auto_enabled_transcription(&state, eph_id).await;
             }
         }
     }
@@ -987,9 +982,6 @@ pub async fn add_agent_to_huddle(
 
     // No guidelines re-post needed — the agent sees the original kind:48106
     // guidelines via EOSE replay when it subscribes to the ephemeral channel.
-
-    // Also add the agent to the visible participants list. The first agent
-    // auto-enables transcription unless the user already chose a state.
     let transcription_auto_enabled = {
         let mut hs = state.huddle()?;
         if !hs.participants.contains(&agent_pubkey) {
@@ -997,16 +989,11 @@ pub async fn add_agent_to_huddle(
         }
         hs.maybe_auto_enable_transcription_for_agents()
     };
-
     if transcription_auto_enabled {
-        if let Some(manager) = models::global_model_manager() {
-            manager.start_stt_download(state.http_client.clone());
-        }
-        if let Err(e) = maybe_start_stt_pipeline(&state, &eph_id).await {
-            eprintln!("buzz-desktop: STT agent-add start failed: {e}");
-        }
+        start_auto_enabled_transcription(&state, &eph_id).await;
+    } else {
+        state.emit_huddle_state_changed();
     }
-    state.emit_huddle_state_changed();
 
     Ok(result)
 }

--- a/desktop/src-tauri/src/huddle/pipeline.rs
+++ b/desktop/src-tauri/src/huddle/pipeline.rs
@@ -185,6 +185,17 @@ pub(crate) async fn maybe_start_stt_pipeline(
     Ok(true)
 }
 
+/// Start STT after agent presence automatically enables transcription.
+pub(crate) async fn start_auto_enabled_transcription(state: &AppState, ephemeral_channel_id: &str) {
+    if let Some(manager) = models::global_model_manager() {
+        manager.start_stt_download(state.http_client.clone());
+    }
+    if let Err(error) = maybe_start_stt_pipeline(state, ephemeral_channel_id).await {
+        eprintln!("buzz-desktop: auto-enabled STT failed to start: {error}");
+    }
+    state.emit_huddle_state_changed();
+}
+
 /// Attempt to start the TTS pipeline if TTS models are present and TTS is enabled.
 ///
 /// Returns `Ok(true)` if the pipeline was started, `Ok(false)` if preconditions

--- a/desktop/src-tauri/src/huddle/pipeline.rs
+++ b/desktop/src-tauri/src/huddle/pipeline.rs
@@ -31,8 +31,9 @@ pub(crate) async fn post_connect_setup(
         fetch_channel_members(ephemeral_channel_id, None, state),
     );
     if let Ok(agents) = agents_result {
-        let hs = state.huddle()?;
+        let mut hs = state.huddle()?;
         *hs.agent_pubkeys.lock().unwrap_or_else(|e| e.into_inner()) = agents;
+        hs.maybe_auto_enable_transcription_for_agents();
     }
 
     if let Ok(all_members) = all_members_result {
@@ -42,10 +43,13 @@ pub(crate) async fn post_connect_setup(
         }
     }
 
-    // Prepare TTS for agent voice. STT is transcript-specific and starts only
-    // when transcription is explicitly enabled.
+    // Prepare voice models. Agent presence may have auto-enabled transcription;
+    // explicit user choices remain authoritative.
     if let Some(mgr) = models::global_model_manager() {
         mgr.start_tts_download(state.http_client.clone());
+        if state.huddle()?.transcription_enabled {
+            mgr.start_stt_download(state.http_client.clone());
+        }
     }
 
     // Connect audio relay WebSocket (Opus encode/decode pipeline).
@@ -62,10 +66,13 @@ pub(crate) async fn post_connect_setup(
         hs.audio_relay_pcm_tx = Some(pcm_tx);
     }
 
-    // Start TTS immediately. STT/transcript posting is opt-in and starts only
-    // after the user explicitly enables transcription.
+    // Start TTS immediately, then STT when transcription is enabled either by
+    // the user or by authoritative agent membership.
     if let Err(e) = maybe_start_tts_pipeline(state).await {
         eprintln!("buzz-desktop: TTS pipeline failed to start: {e}");
+    }
+    if let Err(e) = maybe_start_stt_pipeline(state, ephemeral_channel_id).await {
+        eprintln!("buzz-desktop: STT pipeline failed to start: {e}");
     }
 
     Ok(())

--- a/desktop/src-tauri/src/huddle/pipeline.rs
+++ b/desktop/src-tauri/src/huddle/pipeline.rs
@@ -30,10 +30,16 @@ pub(crate) async fn post_connect_setup(
         fetch_channel_members(ephemeral_channel_id, Some("bot"), state),
         fetch_channel_members(ephemeral_channel_id, None, state),
     );
-    if let Ok(agents) = agents_result {
+    let transcription_auto_enabled = if let Ok(agents) = agents_result {
         let mut hs = state.huddle()?;
         *hs.agent_pubkeys.lock().unwrap_or_else(|e| e.into_inner()) = agents;
-        hs.maybe_auto_enable_transcription_for_agents();
+        hs.maybe_auto_enable_transcription_for_agents()
+    } else {
+        false
+    };
+
+    if transcription_auto_enabled {
+        state.emit_huddle_state_changed();
     }
 
     if let Ok(all_members) = all_members_result {

--- a/desktop/src-tauri/src/huddle/state.rs
+++ b/desktop/src-tauri/src/huddle/state.rs
@@ -80,6 +80,15 @@ pub struct HuddleState {
     pub tts_enabled: bool,
     /// Whether STT transcript posting is enabled for this huddle.
     pub transcription_enabled: bool,
+    /// Whether the user has explicitly used the transcription control in this
+    /// huddle. Agent presence may auto-enable transcription only while this is
+    /// false, so membership refreshes never undo an explicit user choice.
+    ///
+    /// This is backend-only session state: keeping it in `HuddleState` makes it
+    /// survive frontend remounts and audio reconnects, while huddle teardown
+    /// resets it for the next session.
+    #[serde(skip)]
+    pub transcription_user_controlled: bool,
     /// Shared flag: true while TTS is playing audio.
     /// Shared with the STT pipeline for barge-in / echo gating.
     #[serde(skip)]
@@ -157,6 +166,7 @@ impl Clone for HuddleState {
             is_creator: self.is_creator,
             tts_enabled: self.tts_enabled,
             transcription_enabled: self.transcription_enabled,
+            transcription_user_controlled: self.transcription_user_controlled,
             tts_active: Arc::clone(&self.tts_active),
             tts_cancel: Arc::clone(&self.tts_cancel),
             tts_starting: Arc::clone(&self.tts_starting),
@@ -184,6 +194,7 @@ impl Default for HuddleState {
             is_creator: false,
             tts_enabled: true,
             transcription_enabled: false,
+            transcription_user_controlled: false,
             tts_active: Arc::new(AtomicBool::new(false)),
             tts_cancel: Arc::new(AtomicBool::new(false)),
             tts_starting: Arc::new(AtomicBool::new(false)),
@@ -197,6 +208,32 @@ impl Default for HuddleState {
 }
 
 impl HuddleState {
+    /// Record an explicit transcription choice made through the existing user
+    /// control. Later agent membership refreshes must preserve this choice.
+    pub(crate) fn set_transcription_enabled_by_user(&mut self, enabled: bool) {
+        self.transcription_enabled = enabled;
+        self.transcription_user_controlled = true;
+    }
+
+    /// Enable transcription when an agent is present and the user has not
+    /// explicitly chosen a transcription state for this huddle.
+    ///
+    /// Returns true only for the transition from disabled to enabled, allowing
+    /// callers to start models/pipelines and emit state exactly once. Removing
+    /// the last agent deliberately leaves the current state unchanged.
+    pub(crate) fn maybe_auto_enable_transcription_for_agents(&mut self) -> bool {
+        let has_agent = !self
+            .agent_pubkeys
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_empty();
+        if has_agent && !self.transcription_user_controlled && !self.transcription_enabled {
+            self.transcription_enabled = true;
+            return true;
+        }
+        false
+    }
+
     /// Reset to default state while preserving the session generation counter.
     /// Used by start_huddle rollback, join_huddle rollback, and teardown_huddle
     /// to invalidate in-flight transcription tasks without losing the generation.
@@ -204,6 +241,65 @@ impl HuddleState {
         let gen = Arc::clone(&self.session_generation);
         *self = Self::default();
         self.session_generation = gen;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HuddleState;
+
+    fn set_agents(state: &HuddleState, agents: &[&str]) {
+        *state
+            .agent_pubkeys
+            .lock()
+            .unwrap_or_else(|error| error.into_inner()) =
+            agents.iter().map(|agent| (*agent).to_owned()).collect();
+    }
+
+    #[test]
+    fn first_agent_auto_enables_transcription_once() {
+        let mut state = HuddleState::default();
+        set_agents(&state, &["agent"]);
+
+        assert!(state.maybe_auto_enable_transcription_for_agents());
+        assert!(state.transcription_enabled);
+        assert!(!state.maybe_auto_enable_transcription_for_agents());
+    }
+
+    #[test]
+    fn explicit_user_disable_is_not_undone_by_agent_presence() {
+        let mut state = HuddleState::default();
+        set_agents(&state, &["agent"]);
+        assert!(state.maybe_auto_enable_transcription_for_agents());
+
+        state.set_transcription_enabled_by_user(false);
+
+        assert!(!state.maybe_auto_enable_transcription_for_agents());
+        assert!(!state.transcription_enabled);
+    }
+
+    #[test]
+    fn last_agent_leaving_preserves_current_transcription_state() {
+        let mut state = HuddleState::default();
+        set_agents(&state, &["agent"]);
+        assert!(state.maybe_auto_enable_transcription_for_agents());
+
+        set_agents(&state, &[]);
+
+        assert!(!state.maybe_auto_enable_transcription_for_agents());
+        assert!(state.transcription_enabled);
+    }
+
+    #[test]
+    fn clone_preserves_user_control_across_frontend_state_reads() {
+        let mut state = HuddleState::default();
+        state.set_transcription_enabled_by_user(false);
+
+        let mut clone = state.clone();
+        set_agents(&clone, &["agent"]);
+
+        assert!(clone.transcription_user_controlled);
+        assert!(!clone.maybe_auto_enable_transcription_for_agents());
     }
 }
 

--- a/desktop/src-tauri/src/huddle/transcription.rs
+++ b/desktop/src-tauri/src/huddle/transcription.rs
@@ -15,10 +15,12 @@ use super::{models, pipeline::maybe_start_stt_pipeline};
 pub async fn start_stt_pipeline(state: State<'_, AppState>) -> Result<(), String> {
     let ephemeral_channel_id = {
         let mut hs = state.huddle()?;
-        hs.transcription_enabled = true;
-        hs.ephemeral_channel_id
+        let ephemeral_channel_id = hs
+            .ephemeral_channel_id
             .clone()
-            .ok_or("no active huddle — start or join a huddle first")?
+            .ok_or("no active huddle — start or join a huddle first")?;
+        hs.set_transcription_enabled_by_user(true);
+        ephemeral_channel_id
     };
 
     match maybe_start_stt_pipeline(&state, &ephemeral_channel_id).await {
@@ -41,14 +43,18 @@ pub async fn set_huddle_transcription_enabled(
 ) -> Result<(), String> {
     let (ephemeral_channel_id, old_stt) = {
         let mut hs = state.huddle()?;
-        hs.transcription_enabled = enabled;
+        let ephemeral_channel_id = hs
+            .ephemeral_channel_id
+            .clone()
+            .ok_or("no active huddle — start or join a huddle first")?;
+        hs.set_transcription_enabled_by_user(enabled);
 
         if enabled {
-            (hs.ephemeral_channel_id.clone(), None)
+            (ephemeral_channel_id, None)
         } else {
             hs.session_generation.fetch_add(1, Ordering::Release);
             hs.stt_starting.store(false, Ordering::Release);
-            (hs.ephemeral_channel_id.clone(), hs.stt_pipeline.take())
+            (ephemeral_channel_id, hs.stt_pipeline.take())
         }
     };
 
@@ -58,12 +64,10 @@ pub async fn set_huddle_transcription_enabled(
     drop(old_stt);
 
     if enabled {
-        let eph_id =
-            ephemeral_channel_id.ok_or("no active huddle — start or join a huddle first")?;
         if let Some(manager) = models::global_model_manager() {
             manager.start_stt_download(state.http_client.clone());
         }
-        if let Err(e) = maybe_start_stt_pipeline(&state, &eph_id).await {
+        if let Err(e) = maybe_start_stt_pipeline(&state, &ephemeral_channel_id).await {
             eprintln!("buzz-desktop: STT transcript start failed: {e}");
         }
     }


### PR DESCRIPTION
## Summary

Agent huddles now enable transcription automatically when the first agent is present, so the agent receives the human side of the conversation without requiring a separate transcription toggle.

- Detects agents at huddle start, after authoritative membership refreshes, and when an agent is added locally.
- Starts or downloads STT when transcription is auto-enabled and notifies the frontend immediately.
- Preserves an explicit user enable or disable for the rest of the huddle, including reconnects and frontend remounts.
- Leaves transcription enabled when the last agent departs instead of changing a user-visible state implicitly.

### Related issue

N/A. No matching open issue or pull request was found for automatic agent-huddle transcription.

### Testing

Reviewer-reproducible state transition coverage:

```bash
. ./bin/activate-hermit
cargo test --manifest-path desktop/src-tauri/Cargo.toml huddle::state::tests
```

Observed output:

```text
running 4 tests
test huddle::state::tests::first_agent_auto_enables_transcription_once ... ok
test huddle::state::tests::explicit_user_disable_is_not_undone_by_agent_presence ... ok
test huddle::state::tests::last_agent_leaving_preserves_current_transcription_state ... ok
test huddle::state::tests::clone_preserves_user_control_across_frontend_state_reads ... ok

test result: ok. 4 passed; 0 failed
```

Full local gate:

```bash
just ci
```

This passed formatting, lint, file-size checks, unit tests, and desktop, Tauri, web, and mobile builds/tests. The pre-push checks also passed.

Manual live audio verification was not run because it requires an active huddle with another participant, an enrolled agent, microphone access, and a downloaded STT model. This change does not alter frontend layout or styling, so there is no new visual state to screenshot.
