### PR TITLE
Harden managed agent liveness and response visibility

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -15,7 +15,7 @@ mod usage;
 pub use usage::TurnUsage;
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use acp::{AcpClient, EnvVar, McpServer};
@@ -27,6 +27,10 @@ use buzz_core::kind::{
 use buzz_core::observer::{
     decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
     OBSERVER_MAX_PLAINTEXT_LEN,
+};
+use buzz_core::presence::{
+    MANAGED_AGENT_RUNTIME_LEASE_INTERVAL_SECS, MANAGED_AGENT_RUNTIME_LEASE_TTL_SECS,
+    PRESENCE_HEARTBEAT_INTERVAL_SECS,
 };
 use clap::Parser;
 use config::{
@@ -90,14 +94,38 @@ async fn publish_presence(
     Ok(())
 }
 
+const MANAGED_AGENT_LAST_ERROR_MAX_BYTES: usize = 512;
+
+fn bounded_runtime_error(error: Option<&str>) -> Option<String> {
+    let error = error?;
+    if error.len() <= MANAGED_AGENT_LAST_ERROR_MAX_BYTES {
+        return Some(error.to_owned());
+    }
+    let end = error
+        .char_indices()
+        .take_while(|(index, _)| *index <= MANAGED_AGENT_LAST_ERROR_MAX_BYTES)
+        .map(|(index, _)| index)
+        .last()
+        .unwrap_or(0);
+    Some(error[..end].to_owned())
+}
+
 fn emit_runtime_lifecycle(
     observer: Option<&observer::ObserverHandle>,
+    lease_last_error: &Mutex<Option<String>>,
     start_nonce: &str,
     pubkey: &str,
     relay_url: &str,
     lifecycle: &str,
     error: Option<&str>,
 ) {
+    if let Ok(mut last_error) = lease_last_error.lock() {
+        if lifecycle == "failed" {
+            *last_error = bounded_runtime_error(error);
+        } else if matches!(lifecycle, "listening" | "ready") {
+            *last_error = None;
+        }
+    }
     if let Some(observer) = observer {
         observer.emit(
             "managed_agent_runtime_lifecycle",
@@ -110,6 +138,247 @@ fn emit_runtime_lifecycle(
                 "lifecycle": lifecycle,
                 "error": error,
             }),
+        );
+    }
+}
+
+async fn run_managed_agent_runtime_lease(
+    observer: Option<observer::ObserverHandle>,
+    start_nonce: String,
+    pubkey: String,
+    relay_url: String,
+    last_error: Arc<Mutex<Option<String>>>,
+    mut shutdown: watch::Receiver<()>,
+) {
+    let Some(observer) = observer else {
+        return;
+    };
+    if start_nonce.is_empty() {
+        return;
+    }
+
+    let interval = Duration::from_secs(MANAGED_AGENT_RUNTIME_LEASE_INTERVAL_SECS);
+    let mut ticker = tokio::time::interval_at(tokio::time::Instant::now(), interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.changed() => break,
+            _ = ticker.tick() => {
+                let source_timestamp = chrono::Utc::now();
+                let expires_at = source_timestamp
+                    + chrono::TimeDelta::seconds(MANAGED_AGENT_RUNTIME_LEASE_TTL_SECS as i64);
+                let last_error = last_error.lock().ok().and_then(|value| value.clone());
+                observer.emit(
+                    "managed_agent_runtime_lease",
+                    None,
+                    &observer::ObserverContext::default(),
+                    serde_json::json!({
+                        "pubkey": pubkey,
+                        "relayUrl": relay_url,
+                        "startNonce": start_nonce,
+                        "leaseEpoch": start_nonce,
+                        "sourceTimestamp": source_timestamp.to_rfc3339(),
+                        "expiresAt": expires_at.to_rfc3339(),
+                        "lastError": last_error,
+                    }),
+                );
+            }
+        }
+    }
+}
+
+const MENTION_RESPONSE_SLA_SECS: u64 = 60;
+const MAX_PENDING_MENTION_SLAS: usize = 1_000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MentionSlaState {
+    Pending,
+    Breached,
+    Unknown,
+}
+
+#[derive(Debug)]
+struct PendingMentionSla {
+    event_id: String,
+    channel_id: Uuid,
+    thread_root_id: String,
+    received_at: std::time::Instant,
+    received_at_rfc3339: String,
+    deadline_at_rfc3339: String,
+    state: MentionSlaState,
+}
+
+struct MentionSlaEmission {
+    kind: &'static str,
+    payload: serde_json::Value,
+}
+
+#[derive(Default)]
+struct MentionSlaTracker {
+    pending: VecDeque<PendingMentionSla>,
+}
+
+impl MentionSlaTracker {
+    fn record(
+        &mut self,
+        event: &nostr::Event,
+        channel_id: Uuid,
+        dispatch_state: &str,
+        now: std::time::Instant,
+        wall_now: chrono::DateTime<chrono::Utc>,
+    ) -> Vec<MentionSlaEmission> {
+        let mut emissions = Vec::new();
+        if self
+            .pending
+            .iter()
+            .any(|pending| pending.event_id == event.id.to_hex())
+        {
+            return emissions;
+        }
+        if self.pending.len() >= MAX_PENDING_MENTION_SLAS {
+            if let Some(evicted) = self.pending.pop_front() {
+                emissions.push(MentionSlaEmission {
+                    kind: "mention_response_sla",
+                    payload: serde_json::json!({
+                        "eventId": evicted.event_id,
+                        "channelId": evicted.channel_id,
+                        "threadRootId": evicted.thread_root_id,
+                        "receivedAt": evicted.received_at_rfc3339,
+                        "deadlineAt": evicted.deadline_at_rfc3339,
+                        "status": "unknown",
+                        "reason": "pending_tracker_capacity_exceeded",
+                    }),
+                });
+            }
+        }
+
+        let event_id = event.id.to_hex();
+        let thread_root_id = queue::parse_thread_tags(event)
+            .root_event_id
+            .unwrap_or_else(|| event_id.clone());
+        let received_at_rfc3339 = wall_now.to_rfc3339();
+        let deadline_at_rfc3339 =
+            (wall_now + chrono::TimeDelta::seconds(MENTION_RESPONSE_SLA_SECS as i64)).to_rfc3339();
+        self.pending.push_back(PendingMentionSla {
+            event_id: event_id.clone(),
+            channel_id,
+            thread_root_id: thread_root_id.clone(),
+            received_at: now,
+            received_at_rfc3339: received_at_rfc3339.clone(),
+            deadline_at_rfc3339: deadline_at_rfc3339.clone(),
+            state: MentionSlaState::Pending,
+        });
+        emissions.push(MentionSlaEmission {
+            kind: "mention_received",
+            payload: serde_json::json!({
+                "eventId": event_id,
+                "channelId": channel_id,
+                "threadRootId": thread_root_id,
+                "receivedAt": received_at_rfc3339,
+                "deadlineAt": deadline_at_rfc3339,
+                "dispatchState": dispatch_state,
+                "status": "pending",
+            }),
+        });
+        emissions
+    }
+
+    fn accept_response(
+        &mut self,
+        response: &nostr::Event,
+        channel_id: Uuid,
+        now: std::time::Instant,
+        wall_now: chrono::DateTime<chrono::Utc>,
+    ) -> Option<MentionSlaEmission> {
+        let response_root = queue::parse_thread_tags(response).root_event_id?;
+        let position = self.pending.iter().position(|pending| {
+            pending.channel_id == channel_id && pending.thread_root_id == response_root
+        })?;
+        let pending = self.pending.remove(position)?;
+        let elapsed = now.saturating_duration_since(pending.received_at);
+        let status = match pending.state {
+            MentionSlaState::Pending if elapsed.as_secs() < MENTION_RESPONSE_SLA_SECS => "on_time",
+            MentionSlaState::Pending | MentionSlaState::Breached => "breached",
+            MentionSlaState::Unknown => "unknown",
+        };
+        Some(MentionSlaEmission {
+            kind: "first_response_accepted",
+            payload: serde_json::json!({
+                "eventId": pending.event_id,
+                "responseId": response.id.to_hex(),
+                "channelId": channel_id,
+                "threadRootId": pending.thread_root_id,
+                "receivedAt": pending.received_at_rfc3339,
+                "acceptedAt": wall_now.to_rfc3339(),
+                "elapsedMs": elapsed.as_millis().min(u128::from(u64::MAX)) as u64,
+                "status": status,
+            }),
+        })
+    }
+
+    fn poll_breaches(&mut self, now: std::time::Instant) -> Vec<MentionSlaEmission> {
+        let mut emissions = Vec::new();
+        for pending in &mut self.pending {
+            if pending.state == MentionSlaState::Pending
+                && now.saturating_duration_since(pending.received_at)
+                    >= Duration::from_secs(MENTION_RESPONSE_SLA_SECS)
+            {
+                pending.state = MentionSlaState::Breached;
+                emissions.push(MentionSlaEmission {
+                    kind: "mention_response_sla",
+                    payload: serde_json::json!({
+                        "eventId": pending.event_id,
+                        "channelId": pending.channel_id,
+                        "threadRootId": pending.thread_root_id,
+                        "receivedAt": pending.received_at_rfc3339,
+                        "deadlineAt": pending.deadline_at_rfc3339,
+                        "status": "breached",
+                        "reason": "no_relay_accepted_response",
+                    }),
+                });
+            }
+        }
+        emissions
+    }
+
+    fn mark_transport_unknown(&mut self) -> Vec<MentionSlaEmission> {
+        let mut emissions = Vec::new();
+        for pending in &mut self.pending {
+            if pending.state == MentionSlaState::Unknown {
+                continue;
+            }
+            pending.state = MentionSlaState::Unknown;
+            emissions.push(MentionSlaEmission {
+                kind: "mention_response_sla",
+                payload: serde_json::json!({
+                    "eventId": pending.event_id,
+                    "channelId": pending.channel_id,
+                    "threadRootId": pending.thread_root_id,
+                    "receivedAt": pending.received_at_rfc3339,
+                    "deadlineAt": pending.deadline_at_rfc3339,
+                    "status": "unknown",
+                    "reason": "relay_disconnected_before_response",
+                }),
+            });
+        }
+        emissions
+    }
+}
+
+fn emit_mention_sla(
+    observer: Option<&observer::ObserverHandle>,
+    emissions: impl IntoIterator<Item = MentionSlaEmission>,
+) {
+    let Some(observer) = observer else {
+        return;
+    };
+    for emission in emissions {
+        observer.emit(
+            emission.kind,
+            None,
+            &observer::ObserverContext::default(),
+            emission.payload,
         );
     }
 }
@@ -1501,6 +1770,7 @@ async fn tokio_main() -> Result<()> {
     }
 
     let runtime_start_nonce = std::env::var("BUZZ_MANAGED_AGENT_START_NONCE").unwrap_or_default();
+    let runtime_lease_last_error = Arc::new(Mutex::new(None));
     let dedup_mode = config.dedup_mode;
     let mut queue =
         EventQueue::new(dedup_mode).with_in_flight_deadline(config.max_turn_duration_secs);
@@ -1518,6 +1788,7 @@ async fn tokio_main() -> Result<()> {
     if config.lazy_pool {
         emit_runtime_lifecycle(
             observer.as_ref(),
+            &runtime_lease_last_error,
             &runtime_start_nonce,
             &pubkey_hex,
             &config.relay_url,
@@ -1582,7 +1853,7 @@ async fn tokio_main() -> Result<()> {
     let mut heartbeat_in_flight = false;
 
     let mut presence_heartbeat = if config.presence_enabled {
-        let interval = Duration::from_secs(60);
+        let interval = Duration::from_secs(PRESENCE_HEARTBEAT_INTERVAL_SECS);
         Some(tokio::time::interval_at(
             tokio::time::Instant::now() + interval,
             interval,
@@ -1602,6 +1873,9 @@ async fn tokio_main() -> Result<()> {
     };
     let mut typing_channels: HashMap<Uuid, ThreadTags> = HashMap::new();
     let mut presence_task: Option<tokio::task::JoinHandle<()>> = None;
+    let mut mention_sla_tracker = MentionSlaTracker::default();
+    let mut mention_sla_tick = tokio::time::interval(Duration::from_secs(1));
+    mention_sla_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     // Runs at the TOP of every loop iteration via Instant check — cannot be
     // starved by the biased select. Slot refill spawns background tasks so
@@ -1631,6 +1905,14 @@ async fn tokio_main() -> Result<()> {
 
     // ── Step 7: Shutdown signal ───────────────────────────────────────────────
     let (shutdown_tx, mut shutdown_rx) = watch::channel(());
+    let runtime_lease_task = tokio::spawn(run_managed_agent_runtime_lease(
+        observer.clone(),
+        runtime_start_nonce.clone(),
+        pubkey_hex.clone(),
+        config.relay_url.clone(),
+        Arc::clone(&runtime_lease_last_error),
+        shutdown_rx.clone(),
+    ));
 
     let tx = shutdown_tx.clone();
     tokio::spawn(async move {
@@ -1719,6 +2001,7 @@ async fn tokio_main() -> Result<()> {
             {
                 emit_runtime_lifecycle(
                     observer.as_ref(),
+                    &runtime_lease_last_error,
                     &runtime_start_nonce,
                     &pubkey_hex,
                     &config.relay_url,
@@ -1870,6 +2153,7 @@ async fn tokio_main() -> Result<()> {
                         ) {
                             emit_runtime_lifecycle(
                                 observer.as_ref(),
+                                &runtime_lease_last_error,
                                 &runtime_start_nonce,
                                 &pubkey_hex,
                                 &config.relay_url,
@@ -2025,7 +2309,20 @@ async fn tokio_main() -> Result<()> {
                                 continue;
                             }
 
-                            if config.ignore_self && buzz_event.event.pubkey.to_hex() == pubkey_hex {
+                            let is_self_authored =
+                                buzz_event.event.pubkey.to_hex() == pubkey_hex;
+                            if is_self_authored && kind_u32 == KIND_STREAM_MESSAGE {
+                                if let Some(emission) = mention_sla_tracker.accept_response(
+                                    &buzz_event.event,
+                                    buzz_event.channel_id,
+                                    std::time::Instant::now(),
+                                    chrono::Utc::now(),
+                                ) {
+                                    emit_mention_sla(observer.as_ref(), [emission]);
+                                }
+                            }
+
+                            if config.ignore_self && is_self_authored {
                                 tracing::debug!(channel_id = %buzz_event.channel_id, "dropping self-authored event");
                                 continue;
                             }
@@ -2195,6 +2492,8 @@ async fn tokio_main() -> Result<()> {
                             // first. `nostr::Event::clone` is cheap (Arc-
                             // backed payload) so the cost is negligible.
                             let event_for_steer = buzz_event.event.clone();
+                            let was_in_flight =
+                                queue.is_channel_in_flight(buzz_event.channel_id);
                             let prompt_tag_for_steer = prompt_tag.clone();
                             let accepted = queue.push(QueuedEvent {
                                 channel_id: buzz_event.channel_id,
@@ -2202,6 +2501,23 @@ async fn tokio_main() -> Result<()> {
                                 received_at: std::time::Instant::now(),
                                 prompt_tag,
                             });
+                            if accepted && event_mentions_agent(&event_for_steer, &pubkey_hex) {
+                                let dispatch_state = if !pool_ready {
+                                    "waiting_for_runtime"
+                                } else if was_in_flight {
+                                    "queued_behind_active_turn"
+                                } else {
+                                    "accepted_for_dispatch"
+                                };
+                                let emissions = mention_sla_tracker.record(
+                                    &event_for_steer,
+                                    buzz_event.channel_id,
+                                    dispatch_state,
+                                    std::time::Instant::now(),
+                                    chrono::Utc::now(),
+                                );
+                                emit_mention_sla(observer.as_ref(), emissions);
+                            }
                             // 👀 — immediate "seen" reaction, only if the event
                             // was actually queued (not dropped by DedupMode::Drop).
                             // Fire-and-forget: on rare fast-failure paths the
@@ -2268,6 +2584,10 @@ async fn tokio_main() -> Result<()> {
                         }
                         None => {
                             tracing::warn!("relay event stream ended — requesting reconnect");
+                            emit_mention_sla(
+                                observer.as_ref(),
+                                mention_sla_tracker.mark_transport_unknown(),
+                            );
                             if let Err(e) = relay.reconnect().await {
                                 tracing::error!("relay background task is gone: {e} — exiting");
                                 tokio::time::sleep(Duration::from_secs(1)).await;
@@ -2275,6 +2595,14 @@ async fn tokio_main() -> Result<()> {
                             }
                         }
                     }
+                    None
+                }
+                _ = mention_sla_tick.tick() => {
+                    let _ = result_rx;
+                    emit_mention_sla(
+                        observer.as_ref(),
+                        mention_sla_tracker.poll_breaches(std::time::Instant::now()),
+                    );
                     None
                 }
                 _ = async {
@@ -2550,6 +2878,7 @@ async fn tokio_main() -> Result<()> {
                         pool_ready = true;
                         emit_runtime_lifecycle(
                             observer.as_ref(),
+                            &runtime_lease_last_error,
                             &runtime_start_nonce,
                             &pubkey_hex,
                             &config.relay_url,
@@ -2566,6 +2895,7 @@ async fn tokio_main() -> Result<()> {
                         debug_assert_eq!(pool_lifecycle.failed_error(), Some(error.as_str()));
                         emit_runtime_lifecycle(
                             observer.as_ref(),
+                            &runtime_lease_last_error,
                             &runtime_start_nonce,
                             &pubkey_hex,
                             &config.relay_url,
@@ -2689,6 +3019,13 @@ async fn tokio_main() -> Result<()> {
             Ok(Err(e)) => tracing::warn!("failed to set offline presence: {e}"),
             Err(_) => tracing::warn!("offline presence timed out"),
         }
+    }
+
+    // Stop lease refreshes before tearing down the observer publisher. A
+    // missing terminal lease now expires to Unknown; only Desktop's explicit
+    // owner stop action is allowed to claim Stopped.
+    if let Err(error) = runtime_lease_task.await {
+        tracing::warn!("runtime lease task failed during shutdown: {error}");
     }
 
     if let Some(handle) = relay_observer_publisher_task.take() {
@@ -4225,6 +4562,139 @@ mod heartbeat_base_prompt_tests {
         let prompt = "[System: Heartbeat]\nrun feed get";
         let composed = pool::prepend_base_for_legacy(2, Some("you are a helpful agent"), prompt);
         assert_eq!(composed, prompt);
+    }
+}
+
+#[cfg(test)]
+mod mention_sla_tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    fn incoming_mention(keys: &Keys) -> nostr::Event {
+        EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "please respond")
+            .tags([Tag::parse(["p", &"ab".repeat(32)]).unwrap()])
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    fn reply(keys: &Keys, root: &str) -> nostr::Event {
+        EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "done")
+            .tags([Tag::parse(["e", root, "", "reply"]).unwrap()])
+            .sign_with_keys(keys)
+            .unwrap()
+    }
+
+    #[test]
+    fn receipt_then_relay_accepted_reply_clears_exactly_once() {
+        let mention_keys = Keys::generate();
+        let response_keys = Keys::generate();
+        let mention = incoming_mention(&mention_keys);
+        let channel_id = Uuid::new_v4();
+        let now = std::time::Instant::now();
+        let wall_now = chrono::Utc::now();
+        let mut tracker = MentionSlaTracker::default();
+
+        let received = tracker.record(&mention, channel_id, "accepted_for_dispatch", now, wall_now);
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].kind, "mention_received");
+        assert_eq!(received[0].payload["status"], "pending");
+
+        let response = reply(&response_keys, &mention.id.to_hex());
+        let accepted = tracker
+            .accept_response(
+                &response,
+                channel_id,
+                now + Duration::from_secs(12),
+                wall_now + chrono::TimeDelta::seconds(12),
+            )
+            .unwrap();
+        assert_eq!(accepted.kind, "first_response_accepted");
+        assert_eq!(accepted.payload["eventId"], mention.id.to_hex());
+        assert_eq!(accepted.payload["responseId"], response.id.to_hex());
+        assert_eq!(accepted.payload["status"], "on_time");
+        assert!(tracker
+            .accept_response(
+                &response,
+                channel_id,
+                now + Duration::from_secs(13),
+                wall_now,
+            )
+            .is_none());
+    }
+
+    #[test]
+    fn reply_to_another_thread_does_not_clear_pending_mention() {
+        let mention = incoming_mention(&Keys::generate());
+        let channel_id = Uuid::new_v4();
+        let now = std::time::Instant::now();
+        let wall_now = chrono::Utc::now();
+        let mut tracker = MentionSlaTracker::default();
+        tracker.record(&mention, channel_id, "accepted_for_dispatch", now, wall_now);
+
+        let unrelated = reply(&Keys::generate(), &"cd".repeat(32));
+        assert!(tracker
+            .accept_response(
+                &unrelated,
+                channel_id,
+                now + Duration::from_secs(1),
+                wall_now,
+            )
+            .is_none());
+        assert_eq!(tracker.pending.len(), 1);
+    }
+
+    #[test]
+    fn no_response_breaches_at_sixty_seconds_and_late_reply_stays_breached() {
+        let mention = incoming_mention(&Keys::generate());
+        let channel_id = Uuid::new_v4();
+        let now = std::time::Instant::now();
+        let wall_now = chrono::Utc::now();
+        let mut tracker = MentionSlaTracker::default();
+        tracker.record(&mention, channel_id, "waiting_for_runtime", now, wall_now);
+
+        assert!(tracker
+            .poll_breaches(now + Duration::from_secs(59))
+            .is_empty());
+        let breach = tracker.poll_breaches(now + Duration::from_secs(60));
+        assert_eq!(breach.len(), 1);
+        assert_eq!(breach[0].payload["status"], "breached");
+        assert!(tracker
+            .poll_breaches(now + Duration::from_secs(61))
+            .is_empty());
+
+        let response = reply(&Keys::generate(), &mention.id.to_hex());
+        let accepted = tracker
+            .accept_response(
+                &response,
+                channel_id,
+                now + Duration::from_secs(65),
+                wall_now + chrono::TimeDelta::seconds(65),
+            )
+            .unwrap();
+        assert_eq!(accepted.payload["status"], "breached");
+    }
+
+    #[test]
+    fn relay_disconnect_projects_unknown_until_correlated_reply_arrives() {
+        let mention = incoming_mention(&Keys::generate());
+        let channel_id = Uuid::new_v4();
+        let now = std::time::Instant::now();
+        let wall_now = chrono::Utc::now();
+        let mut tracker = MentionSlaTracker::default();
+        tracker.record(&mention, channel_id, "accepted_for_dispatch", now, wall_now);
+
+        let unknown = tracker.mark_transport_unknown();
+        assert_eq!(unknown.len(), 1);
+        assert_eq!(unknown[0].payload["status"], "unknown");
+        assert!(tracker
+            .poll_breaches(now + Duration::from_secs(120))
+            .is_empty());
+
+        let response = reply(&Keys::generate(), &mention.id.to_hex());
+        let accepted = tracker
+            .accept_response(&response, channel_id, now, wall_now)
+            .unwrap();
+        assert_eq!(accepted.payload["status"], "unknown");
     }
 }
 

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -3153,6 +3153,9 @@ async fn wait_for_reconnect(
 /// - `kinds` is included only when `filter.kinds` is `Some`; `None` = wildcard.
 /// - `#p` is included only when `filter.require_mention` is `true`.
 /// - `#h` is always included (channel-scoped subscription).
+/// - A second OR-filter receives this agent's own kind:9 messages. The main
+///   loop never prompts on those when `ignore_self` is enabled; it uses them
+///   only as relay-accepted evidence for mention-response SLA telemetry.
 /// - On first subscribe (`since` is `None`) adds `since=now` to avoid replaying
 ///   history. On reconnect (`since` is `Some`) subtracts [`SINCE_SKEW_SECS`].
 ///
@@ -3193,7 +3196,18 @@ async fn send_subscribe(
     };
     req_filter.insert("since".into(), json!(since_ts));
 
-    let req = json!(["REQ", sub_id, Value::Object(req_filter)]);
+    let response_monitor_filter = json!({
+        "kinds": [buzz_core::kind::KIND_STREAM_MESSAGE],
+        "authors": [agent_pubkey_hex],
+        "#h": [channel_id.to_string()],
+        "since": since_ts,
+    });
+    let req = json!([
+        "REQ",
+        sub_id,
+        Value::Object(req_filter),
+        response_monitor_filter
+    ]);
 
     match serde_json::to_string(&req) {
         Ok(text) => {

--- a/crates/buzz-core/src/presence.rs
+++ b/crates/buzz-core/src/presence.rs
@@ -2,6 +2,28 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Interval used by connected clients to refresh their signed presence lease.
+///
+/// The relay lease is deliberately three intervals long, leaving one complete
+/// interval of scheduling/network margin after a single dropped refresh.
+pub const PRESENCE_HEARTBEAT_INTERVAL_SECS: u64 = 30;
+
+/// Lifetime of a presence lease in the relay's shared store.
+///
+/// Keep this at three times [`PRESENCE_HEARTBEAT_INTERVAL_SECS`]. A client that
+/// misses one refresh then has another full heartbeat interval to recover
+/// before the relay expires its lease.
+pub const PRESENCE_LEASE_TTL_SECS: u64 = PRESENCE_HEARTBEAT_INTERVAL_SECS * 3;
+
+/// Refresh interval for the owner-encrypted managed-agent runtime lease.
+pub const MANAGED_AGENT_RUNTIME_LEASE_INTERVAL_SECS: u64 = 15;
+
+/// Lifetime of a managed-agent runtime lease.
+///
+/// Three intervals tolerate one lost encrypted observer frame while retaining
+/// a bounded stale-to-unknown transition.
+pub const MANAGED_AGENT_RUNTIME_LEASE_TTL_SECS: u64 = MANAGED_AGENT_RUNTIME_LEASE_INTERVAL_SECS * 3;
+
 /// Allowed presence statuses for the REST/MCP surface.
 ///
 /// The WebSocket path (kind:20001) accepts arbitrary status strings for
@@ -69,5 +91,25 @@ mod tests {
         assert_eq!(format!("{}", PresenceStatus::Online), "online");
         assert_eq!(format!("{}", PresenceStatus::Away), "away");
         assert_eq!(format!("{}", PresenceStatus::Offline), "offline");
+    }
+
+    #[test]
+    fn lease_survives_one_missed_heartbeat_with_a_full_interval_of_margin() {
+        let one_missed_refresh_gap = PRESENCE_HEARTBEAT_INTERVAL_SECS * 2;
+        assert!(one_missed_refresh_gap < PRESENCE_LEASE_TTL_SECS);
+        assert_eq!(
+            PRESENCE_LEASE_TTL_SECS - one_missed_refresh_gap,
+            PRESENCE_HEARTBEAT_INTERVAL_SECS
+        );
+    }
+
+    #[test]
+    fn managed_runtime_lease_survives_one_missed_frame_then_expires() {
+        let one_missed_refresh_gap = MANAGED_AGENT_RUNTIME_LEASE_INTERVAL_SECS * 2;
+        assert!(one_missed_refresh_gap < MANAGED_AGENT_RUNTIME_LEASE_TTL_SECS);
+        assert_eq!(
+            MANAGED_AGENT_RUNTIME_LEASE_TTL_SECS - one_missed_refresh_gap,
+            MANAGED_AGENT_RUNTIME_LEASE_INTERVAL_SECS
+        );
     }
 }

--- a/crates/buzz-pubsub/src/lib.rs
+++ b/crates/buzz-pubsub/src/lib.rs
@@ -328,7 +328,8 @@ impl PubSubManager {
         publisher::publish_event(&self.pool, ctx, topic, event).await
     }
 
-    /// Set presence with 60s TTL. Call on connect and every 30s heartbeat.
+    /// Set presence with the shared lease TTL. Call on connect and every
+    /// shared heartbeat interval.
     pub async fn set_presence(
         &self,
         ctx: &TenantContext,

--- a/crates/buzz-pubsub/src/presence.rs
+++ b/crates/buzz-pubsub/src/presence.rs
@@ -1,10 +1,11 @@
 //! Presence tracking — online/away status with TTL.
 //!
 //! Stored as `SET buzz:{community}:presence:{pubkey_hex} "online" EX 90`.
-//! TTL is 3x the 30s heartbeat interval so a single missed heartbeat doesn't
-//! cause presence flap. Clean disconnect deletes immediately.
+//! The TTL and refresh interval share one contract in `buzz-core`, so relay
+//! storage and connected clients cannot silently drift apart. Clean disconnect
+//! deletes immediately.
 
-use buzz_core::TenantContext;
+use buzz_core::{presence::PRESENCE_LEASE_TTL_SECS, TenantContext};
 use deadpool_redis::Pool;
 use nostr::PublicKey;
 use std::collections::HashMap;
@@ -12,8 +13,8 @@ use std::collections::HashMap;
 use crate::error::PubSubError;
 use crate::topic::BUZZ_PREFIX;
 
-/// 3x the 30s heartbeat — single missed heartbeat won't cause presence flap.
-pub const PRESENCE_TTL_SECS: u64 = 90;
+/// Presence lease lifetime, retained under the historical public name.
+pub const PRESENCE_TTL_SECS: u64 = PRESENCE_LEASE_TTL_SECS;
 
 /// Returns the Redis key for the presence entry of `pubkey` under `ctx`.
 pub fn presence_key(ctx: &TenantContext, pubkey: &PublicKey) -> String {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -48,9 +48,9 @@ use huddle::{
 };
 use managed_agents::{
     backfill_persona_snapshots, ensure_nest, list_managed_agent_runtimes,
-    put_managed_agent_runtime_lifecycle, reconcile_managed_agent_runtimes,
-    restart_managed_agent_runtime, start_managed_agent_runtime, stop_managed_agent_runtime,
-    try_regenerate_nest,
+    put_managed_agent_runtime_lease, put_managed_agent_runtime_lifecycle,
+    reconcile_managed_agent_runtimes, restart_managed_agent_runtime, start_managed_agent_runtime,
+    stop_managed_agent_runtime, try_regenerate_nest,
 };
 #[cfg(not(feature = "mesh-llm"))]
 use mesh_llm_stubs::*;
@@ -797,6 +797,7 @@ pub fn run() {
             restart_managed_agent_runtime,
             reconcile_managed_agent_runtimes,
             put_managed_agent_runtime_lifecycle,
+            put_managed_agent_runtime_lease,
             create_managed_agent,
             start_managed_agent,
             stop_managed_agent,

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -44,6 +44,18 @@ struct StatusInputs<'a> {
     global: &'a super::GlobalAgentConfig,
 }
 
+fn effective_runtime_lifecycle(runtime: &ManagedAgentPairRuntime) -> ManagedAgentRuntimeLifecycle {
+    if matches!(
+        runtime.lifecycle,
+        ManagedAgentRuntimeLifecycle::Failed | ManagedAgentRuntimeLifecycle::Unknown
+    ) || std::time::Instant::now() <= runtime.lease_deadline
+    {
+        runtime.lifecycle.clone()
+    } else {
+        ManagedAgentRuntimeLifecycle::Unknown
+    }
+}
+
 fn status_for_with(
     app: &AppHandle,
     record: &super::ManagedAgentRecord,
@@ -63,18 +75,39 @@ fn status_for_with(
         requested_relay_url,
         local_setup,
         lifecycle: runtime
-            .map(|runtime| runtime.lifecycle.clone())
+            .map(effective_runtime_lifecycle)
             .unwrap_or(ManagedAgentRuntimeLifecycle::Stopped),
         pid: runtime.map(|runtime| runtime.child.id()),
         error: runtime.and_then(|runtime| runtime.error.clone()),
         log_path: managed_agent_runtime_log_path(app, key)
             .ok()
             .map(|path| path.display().to_string()),
+        observer_sequence: runtime.and_then(|runtime| runtime.last_runtime_observer_seq),
+        last_observed_at: runtime.and_then(|runtime| runtime.last_observed_at.clone()),
+        lease_expires_at: runtime.and_then(|runtime| runtime.lease_expires_at.clone()),
     }
 }
 
 fn emit_status(app: &AppHandle, status: &ManagedAgentRuntimeStatus) {
     let _ = app.emit(STATUS_EVENT, status);
+}
+
+const RUNTIME_OBSERVER_MAX_CLOCK_SKEW_SECS: i64 = 30;
+const RUNTIME_OBSERVER_REPLAY_WINDOW_SECS: i64 = 300;
+const RUNTIME_LAST_ERROR_MAX_BYTES: usize = 512;
+
+fn validate_runtime_observer_timestamp(source_timestamp: &str) -> Result<(), String> {
+    let source = chrono::DateTime::parse_from_rfc3339(source_timestamp)
+        .map_err(|_| "runtime observer source timestamp is not RFC3339".to_string())?
+        .with_timezone(&chrono::Utc);
+    let now = chrono::Utc::now();
+    if source > now + chrono::TimeDelta::seconds(RUNTIME_OBSERVER_MAX_CLOCK_SKEW_SECS) {
+        return Err("runtime observer source timestamp is in the future".into());
+    }
+    if source < now - chrono::TimeDelta::seconds(RUNTIME_OBSERVER_REPLAY_WINDOW_SECS) {
+        return Err("runtime observer frame is outside the replay window".into());
+    }
+    Ok(())
 }
 
 fn observer_lifecycle_key(
@@ -89,6 +122,20 @@ fn observer_lifecycle_key(
         ManagedAgentRuntimeLifecycle::Starting | ManagedAgentRuntimeLifecycle::Stopped
     ) {
         return Err("observer cannot author starting or stopped lifecycle".into());
+    }
+    if payload.lifecycle == ManagedAgentRuntimeLifecycle::Unknown {
+        return Err("observer cannot author unknown lifecycle".into());
+    }
+    if payload.observer_sequence == 0 {
+        return Err("runtime observer sequence must be positive".into());
+    }
+    validate_runtime_observer_timestamp(&payload.source_timestamp)?;
+    if payload
+        .error
+        .as_ref()
+        .is_some_and(|error| error.len() > RUNTIME_LAST_ERROR_MAX_BYTES)
+    {
+        return Err("lifecycle error exceeds the runtime observer limit".into());
     }
     if payload.lifecycle == ManagedAgentRuntimeLifecycle::Failed && payload.error.is_none() {
         return Err("failed lifecycle requires an error".into());
@@ -123,6 +170,12 @@ pub fn put_managed_agent_runtime_lifecycle(
         return Err("lifecycle frame does not match the current harness generation".into());
     }
     if runtime
+        .last_runtime_observer_seq
+        .is_some_and(|sequence| payload.observer_sequence <= sequence)
+    {
+        return Err("lifecycle frame is stale or duplicated".into());
+    }
+    if runtime
         .child
         .try_wait()
         .map_err(|e| e.to_string())?
@@ -130,8 +183,103 @@ pub fn put_managed_agent_runtime_lifecycle(
     {
         return Err("lifecycle frame arrived after process exit".into());
     }
+    runtime.last_runtime_observer_seq = Some(payload.observer_sequence);
+    runtime.last_observed_at = Some(payload.source_timestamp);
     runtime.lifecycle = payload.lifecycle;
     runtime.error = payload.error;
+    let status = status_for(&app, record, &key, Some(runtime), None);
+    emit_status(&app, &status);
+    Ok(status)
+}
+
+fn observer_lease_key(
+    outer_pubkey: &str,
+    payload: &super::ManagedAgentRuntimeLeaseObserverPayload,
+) -> Result<(ManagedAgentRuntimeKey, std::time::Duration), String> {
+    if !outer_pubkey.eq_ignore_ascii_case(&payload.pubkey) {
+        return Err("observer signer does not match lease payload pubkey".into());
+    }
+    if payload.start_nonce != payload.lease_epoch {
+        return Err("runtime lease epoch does not match its generation nonce".into());
+    }
+    if payload.observer_sequence == 0 {
+        return Err("runtime observer sequence must be positive".into());
+    }
+    if payload
+        .last_error
+        .as_ref()
+        .is_some_and(|error| error.len() > RUNTIME_LAST_ERROR_MAX_BYTES)
+    {
+        return Err("runtime lease error exceeds the observer limit".into());
+    }
+    validate_runtime_observer_timestamp(&payload.source_timestamp)?;
+    let source = chrono::DateTime::parse_from_rfc3339(&payload.source_timestamp)
+        .map_err(|_| "runtime lease source timestamp is not RFC3339".to_string())?
+        .with_timezone(&chrono::Utc);
+    let expires = chrono::DateTime::parse_from_rfc3339(&payload.expires_at)
+        .map_err(|_| "runtime lease expiry is not RFC3339".to_string())?
+        .with_timezone(&chrono::Utc);
+    let lease_ttl = std::time::Duration::from_secs(
+        buzz_core_pkg::presence::MANAGED_AGENT_RUNTIME_LEASE_TTL_SECS,
+    );
+    if expires.signed_duration_since(source)
+        != chrono::TimeDelta::seconds(lease_ttl.as_secs() as i64)
+    {
+        return Err("runtime lease duration does not match the shared contract".into());
+    }
+    let remaining = expires
+        .signed_duration_since(chrono::Utc::now())
+        .to_std()
+        .map_err(|_| "runtime lease is already expired".to_string())?
+        .min(lease_ttl);
+    Ok((
+        ManagedAgentRuntimeKey::new(payload.pubkey.clone(), &payload.relay_url)?,
+        remaining,
+    ))
+}
+
+#[tauri::command]
+pub fn put_managed_agent_runtime_lease(
+    outer_pubkey: String,
+    payload: super::ManagedAgentRuntimeLeaseObserverPayload,
+    app: AppHandle,
+) -> Result<ManagedAgentRuntimeStatus, String> {
+    let (key, remaining) = observer_lease_key(&outer_pubkey, &payload)?;
+    let state = app.state::<AppState>();
+    let records = load_managed_agents(&app)?;
+    let record = records
+        .iter()
+        .find(|record| record.pubkey.eq_ignore_ascii_case(&key.pubkey))
+        .ok_or_else(|| format!("agent {} not found", key.pubkey))?;
+    let mut runtimes = state
+        .managed_agent_processes
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let runtime = runtimes
+        .get_mut(&key)
+        .ok_or_else(|| "lease frame does not match a tracked runtime pair".to_string())?;
+    if runtime.start_nonce != payload.start_nonce {
+        return Err("lease frame does not match the current harness generation".into());
+    }
+    if runtime
+        .last_runtime_observer_seq
+        .is_some_and(|sequence| payload.observer_sequence <= sequence)
+    {
+        return Err("lease frame is stale or duplicated".into());
+    }
+    if runtime
+        .child
+        .try_wait()
+        .map_err(|error| error.to_string())?
+        .is_some()
+    {
+        return Err("lease frame arrived after process exit".into());
+    }
+    runtime.last_runtime_observer_seq = Some(payload.observer_sequence);
+    runtime.lease_deadline = std::time::Instant::now() + remaining;
+    runtime.last_observed_at = Some(payload.source_timestamp);
+    runtime.lease_expires_at = Some(payload.expires_at);
+    runtime.error = payload.last_error;
     let status = status_for(&app, record, &key, Some(runtime), None);
     emit_status(&app, &status);
     Ok(status)
@@ -162,15 +310,27 @@ pub fn list_managed_agent_runtimes(
         .map_err(|e| e.to_string())?;
     let exited_keys: Vec<_> = runtimes
         .iter_mut()
-        .filter_map(|(key, runtime)| match runtime.child.try_wait() {
-            Ok(Some(_)) | Err(_) => Some(key.clone()),
-            Ok(None) => None,
+        .filter_map(|(key, runtime)| {
+            match (
+                runtime.lifecycle == ManagedAgentRuntimeLifecycle::Unknown,
+                runtime.child.try_wait(),
+            ) {
+                (true, _) => None,
+                (false, Ok(Some(_))) | (false, Err(_)) => Some(key.clone()),
+                (false, Ok(None)) => None,
+            }
         })
         .collect();
     let records_changed = !exited_keys.is_empty();
     let mut statuses = Vec::new();
     for key in exited_keys {
-        runtimes.remove(&key);
+        let error = "Harness process exited without an explicit owner stop.".to_string();
+        let Some(runtime) = runtimes.get_mut(&key) else {
+            continue;
+        };
+        runtime.lifecycle = ManagedAgentRuntimeLifecycle::Unknown;
+        runtime.error = Some(error.clone());
+        runtime.lease_deadline = std::time::Instant::now();
         super::remove_agent_runtime_receipt(&app, &key);
         state.clear_agent_session_cache(&key);
         if let Some(record) = records
@@ -178,12 +338,12 @@ pub fn list_managed_agent_runtimes(
             .find(|record| record.pubkey.eq_ignore_ascii_case(&key.pubkey))
         {
             record.updated_at = crate::util::now_iso();
-            record.last_stopped_at = Some(record.updated_at.clone());
+            record.last_error = Some(error);
             let status = status_for_with(
                 &app,
                 record,
                 &key,
-                None,
+                Some(runtime),
                 None,
                 StatusInputs {
                     personas: &personas,
@@ -191,7 +351,6 @@ pub fn list_managed_agent_runtimes(
                 },
             );
             emit_status(&app, &status);
-            statuses.push(status);
         }
     }
     statuses.extend(runtimes.iter().filter_map(|(key, runtime)| {
@@ -443,6 +602,9 @@ fn unkeyable_failed_status(
         pid: None,
         error: Some(error),
         log_path: None,
+        observer_sequence: None,
+        last_observed_at: None,
+        lease_expires_at: None,
     }
 }
 
@@ -581,6 +743,8 @@ mod tests {
             pubkey: "aa".repeat(32),
             relay_url: relay_url.into(),
             start_nonce: "test-generation".into(),
+            observer_sequence: 1,
+            source_timestamp: chrono::Utc::now().to_rfc3339(),
             lifecycle,
             error: error.map(str::to_owned),
         }
@@ -712,5 +876,81 @@ mod tests {
             Some("unexpected"),
         );
         assert!(observer_lifecycle_key(&ready_with_error.pubkey, &ready_with_error).is_err());
+    }
+
+    fn lease_payload() -> super::super::ManagedAgentRuntimeLeaseObserverPayload {
+        let source = chrono::Utc::now();
+        let expires = source
+            + chrono::TimeDelta::seconds(
+                buzz_core_pkg::presence::MANAGED_AGENT_RUNTIME_LEASE_TTL_SECS as i64,
+            );
+        super::super::ManagedAgentRuntimeLeaseObserverPayload {
+            pubkey: "aa".repeat(32),
+            relay_url: "wss://relay.example".into(),
+            start_nonce: "test-generation".into(),
+            lease_epoch: "test-generation".into(),
+            observer_sequence: 7,
+            source_timestamp: source.to_rfc3339(),
+            expires_at: expires.to_rfc3339(),
+            last_error: None,
+        }
+    }
+
+    #[test]
+    fn observer_lease_accepts_current_generation_and_shared_duration() {
+        let lease = lease_payload();
+        let (key, remaining) = observer_lease_key(&lease.pubkey, &lease).unwrap();
+        assert_eq!(key.relay_url, "wss://relay.example");
+        assert!(
+            remaining.as_secs() <= buzz_core_pkg::presence::MANAGED_AGENT_RUNTIME_LEASE_TTL_SECS
+        );
+        assert!(remaining.as_secs() > 0);
+
+        let mut future_lease = lease_payload();
+        let future_source = chrono::Utc::now() + chrono::TimeDelta::seconds(20);
+        future_lease.source_timestamp = future_source.to_rfc3339();
+        future_lease.expires_at = (future_source
+            + chrono::TimeDelta::seconds(
+                buzz_core_pkg::presence::MANAGED_AGENT_RUNTIME_LEASE_TTL_SECS as i64,
+            ))
+        .to_rfc3339();
+        let (_, remaining) = observer_lease_key(&future_lease.pubkey, &future_lease).unwrap();
+        assert_eq!(
+            remaining.as_secs(),
+            buzz_core_pkg::presence::MANAGED_AGENT_RUNTIME_LEASE_TTL_SECS
+        );
+    }
+
+    #[test]
+    fn observer_lease_rejects_cross_agent_and_epoch_mismatch() {
+        let mut lease = lease_payload();
+        assert!(observer_lease_key(&"bb".repeat(32), &lease).is_err());
+        lease.lease_epoch = "older-generation".into();
+        assert!(observer_lease_key(&lease.pubkey, &lease).is_err());
+    }
+
+    #[test]
+    fn observer_lease_rejects_expired_or_wrong_duration() {
+        let mut lease = lease_payload();
+        lease.expires_at = chrono::Utc::now()
+            .checked_sub_signed(chrono::TimeDelta::seconds(1))
+            .unwrap()
+            .to_rfc3339();
+        assert!(observer_lease_key(&lease.pubkey, &lease).is_err());
+
+        let mut lease = lease_payload();
+        lease.expires_at = (chrono::Utc::now() + chrono::TimeDelta::seconds(300)).to_rfc3339();
+        assert!(observer_lease_key(&lease.pubkey, &lease).is_err());
+    }
+
+    #[test]
+    fn observer_lease_rejects_unbounded_error_and_zero_sequence() {
+        let mut lease = lease_payload();
+        lease.last_error = Some("x".repeat(RUNTIME_LAST_ERROR_MAX_BYTES + 1));
+        assert!(observer_lease_key(&lease.pubkey, &lease).is_err());
+
+        let mut lease = lease_payload();
+        lease.observer_sequence = 0;
+        assert!(observer_lease_key(&lease.pubkey, &lease).is_err());
     }
 }

--- a/desktop/src-tauri/src/managed_agents/runtime_types.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_types.rs
@@ -38,6 +38,7 @@ pub enum ManagedAgentRuntimeLifecycle {
     Listening,
     Waking,
     Ready,
+    Unknown,
     Failed,
     Stopped,
 }
@@ -50,6 +51,19 @@ pub struct ManagedAgentPairRuntime {
     /// Unpredictable identity for this exact harness generation. Lifecycle
     /// frames from prior processes are rejected even when the pair is live.
     pub start_nonce: String,
+    /// Highest encrypted runtime observer sequence accepted for this process.
+    /// Prevents delayed lifecycle or lease frames from regressing state.
+    pub last_runtime_observer_seq: Option<u64>,
+    /// Local monotonic deadline derived from the signed lease duration.
+    ///
+    /// Wall-clock timestamps remain in the status payload for operators, but
+    /// expiry decisions use this deadline so system clock adjustments cannot
+    /// revive or prematurely expire a runtime.
+    pub lease_deadline: std::time::Instant,
+    /// Signed source timestamp from the newest accepted runtime lease.
+    pub last_observed_at: Option<String>,
+    /// Signed expiry timestamp from the newest accepted runtime lease.
+    pub lease_expires_at: Option<String>,
 }
 
 impl std::ops::Deref for ManagedAgentPairRuntime {
@@ -74,6 +88,16 @@ impl ManagedAgentPairRuntime {
             lifecycle: ManagedAgentRuntimeLifecycle::Starting,
             error: None,
             start_nonce,
+            last_runtime_observer_seq: None,
+            // A newly spawned process gets one lease window to initialize its
+            // relay observer. If no signed lease arrives, status degrades to
+            // Unknown rather than claiming the process is offline.
+            lease_deadline: std::time::Instant::now()
+                + std::time::Duration::from_secs(
+                    buzz_core_pkg::presence::MANAGED_AGENT_RUNTIME_LEASE_TTL_SECS,
+                ),
+            last_observed_at: None,
+            lease_expires_at: None,
         }
     }
 }
@@ -92,6 +116,9 @@ pub struct ManagedAgentRuntimeStatus {
     pub pid: Option<u32>,
     pub error: Option<String>,
     pub log_path: Option<String>,
+    pub observer_sequence: Option<u64>,
+    pub last_observed_at: Option<String>,
+    pub lease_expires_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -100,8 +127,23 @@ pub struct ManagedAgentRuntimeLifecycleObserverPayload {
     pub pubkey: String,
     pub relay_url: String,
     pub start_nonce: String,
+    pub observer_sequence: u64,
+    pub source_timestamp: String,
     pub lifecycle: ManagedAgentRuntimeLifecycle,
     pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagedAgentRuntimeLeaseObserverPayload {
+    pub pubkey: String,
+    pub relay_url: String,
+    pub start_nonce: String,
+    pub lease_epoch: String,
+    pub observer_sequence: u64,
+    pub source_timestamp: String,
+    pub expires_at: String,
+    pub last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/desktop/src/features/agents/managedAgentRuntimeStatus.test.mjs
+++ b/desktop/src/features/agents/managedAgentRuntimeStatus.test.mjs
@@ -6,6 +6,7 @@ import {
   agentCommunityStatusDetail,
   canonicalRelayUrl,
   findManagedAgentRuntime,
+  managedAgentPairAction,
   managedAgentRuntimeKey,
 } from "./managedAgentRuntimeStatus.ts";
 
@@ -17,11 +18,18 @@ const runtime = (overrides = {}) => ({
   pid: 1,
   error: null,
   logPath: null,
+  observerSequence: 1,
+  lastObservedAt: "2026-07-27T18:00:00Z",
+  leaseExpiresAt: "2026-07-27T18:00:45Z",
   ...overrides,
 });
 
-test("projects every backend lifecycle to the four product labels", () => {
+test("projects every backend lifecycle without conflating unknown and stopped", () => {
   assert.equal(agentCommunityAvailability(runtime()), "Here");
+  assert.equal(
+    agentCommunityAvailability(runtime({ lifecycle: "unknown" })),
+    "Unknown",
+  );
   for (const lifecycle of ["starting", "listening", "waking"]) {
     assert.equal(agentCommunityAvailability(runtime({ lifecycle })), "Waking");
   }
@@ -52,6 +60,19 @@ test("unavailable detail distinguishes stopped and failed", () => {
       runtime({ lifecycle: "failed", error: "Relay timed out" }),
     ),
     "Relay timed out",
+  );
+});
+
+test("unknown explains uncertainty and offers restart", () => {
+  assert.equal(
+    agentCommunityStatusDetail(
+      runtime({ lifecycle: "unknown", error: "Observer lease expired" }),
+    ),
+    "Observer lease expired",
+  );
+  assert.equal(
+    managedAgentPairAction(runtime({ lifecycle: "unknown" })),
+    "restart",
   );
 });
 

--- a/desktop/src/features/agents/managedAgentRuntimeStatus.ts
+++ b/desktop/src/features/agents/managedAgentRuntimeStatus.ts
@@ -3,6 +3,7 @@ import type { ManagedAgentRuntimeStatus } from "@/shared/api/types";
 export type AgentCommunityAvailability =
   | "Here"
   | "Waking"
+  | "Unknown"
   | "Needs setup on this device"
   | "Unavailable";
 
@@ -18,6 +19,8 @@ export function agentCommunityAvailability(
       return "Waking";
     case "ready":
       return "Here";
+    case "unknown":
+      return "Unknown";
     case "failed":
     case "stopped":
       return "Unavailable";
@@ -30,6 +33,10 @@ export function agentCommunityStatusDetail(
   if (!runtime.localSetup)
     return "Set up this agent on this device to start it.";
   if (runtime.lifecycle === "stopped") return "Stopped by you";
+  if (runtime.lifecycle === "unknown")
+    return (
+      runtime.error ?? "Connection lost; current state cannot be verified."
+    );
   if (runtime.lifecycle === "failed")
     return runtime.error ?? "Could not connect";
   return null;
@@ -49,7 +56,8 @@ export function managedAgentPairAction(
   runtime: ManagedAgentRuntimeStatus | undefined,
 ): ManagedAgentPairAction {
   if (!runtime || runtime.lifecycle === "stopped") return "start";
-  if (runtime.lifecycle === "failed") return "restart";
+  if (runtime.lifecycle === "failed" || runtime.lifecycle === "unknown")
+    return "restart";
   return "stop";
 }
 

--- a/desktop/src/features/agents/observerRelayStore.ts
+++ b/desktop/src/features/agents/observerRelayStore.ts
@@ -4,7 +4,10 @@ import { subscribeToAgentObserverFrames } from "@/shared/api/observerRelay";
 import type { RelayEvent, ManagedAgent } from "@/shared/api/types";
 import type { ControlResultFrame } from "@/shared/api/types";
 import { putAgentSessionConfig } from "@/shared/api/tauri";
-import { putManagedAgentRuntimeLifecycle } from "@/shared/api/tauriManagedAgents";
+import {
+  putManagedAgentRuntimeLease,
+  putManagedAgentRuntimeLifecycle,
+} from "@/shared/api/tauriManagedAgents";
 import { getIdentity } from "@/shared/api/tauriIdentity";
 import { decryptObserverEvent } from "@/shared/api/tauriObserver";
 import {
@@ -404,11 +407,27 @@ async function handleRelayObserverEvent(
     } else if (parsed.kind === "control_result") {
       dispatchControlResult(agentPubkey, parsed.payload);
     } else if (parsed.kind === "managed_agent_runtime_lifecycle") {
-      void putManagedAgentRuntimeLifecycle(agentPubkey, parsed.payload).catch(
+      const payload =
+        typeof parsed.payload === "object" && parsed.payload !== null
+          ? {
+              ...parsed.payload,
+              observerSequence: parsed.seq,
+              sourceTimestamp: parsed.timestamp,
+            }
+          : parsed.payload;
+      void putManagedAgentRuntimeLifecycle(agentPubkey, payload).catch(
         (error) => {
           console.debug("Late/untracked lifecycle frame dropped:", error);
         },
       );
+    } else if (parsed.kind === "managed_agent_runtime_lease") {
+      const payload =
+        typeof parsed.payload === "object" && parsed.payload !== null
+          ? { ...parsed.payload, observerSequence: parsed.seq }
+          : parsed.payload;
+      void putManagedAgentRuntimeLease(agentPubkey, payload).catch((error) => {
+        console.debug("Stale/untracked runtime lease dropped:", error);
+      });
     }
   } catch (error) {
     if (activeGeneration !== generation) {

--- a/desktop/src/features/agents/ui/agentMentionSlaTranscript.ts
+++ b/desktop/src/features/agents/ui/agentMentionSlaTranscript.ts
@@ -1,0 +1,82 @@
+import type { ObserverEvent } from "./agentSessionTypes";
+import { asRecord, asString } from "./agentSessionUtils";
+
+export type MentionSlaTranscriptItem = {
+  id: string;
+  renderClass: "status" | "error";
+  title: string;
+  text: string;
+  channelId: string | null;
+};
+
+export function describeMentionSlaEvent(
+  event: ObserverEvent,
+): MentionSlaTranscriptItem | null {
+  const payload = asRecord(event.payload);
+  const mentionId = asString(payload.eventId) ?? String(event.seq);
+  const channelId = asString(payload.channelId) ?? event.channelId ?? null;
+
+  if (event.kind === "mention_received") {
+    const dispatchState =
+      asString(payload.dispatchState) ?? "accepted_for_dispatch";
+    const deadlineAt = asString(payload.deadlineAt);
+    const dispatchText =
+      dispatchState === "waiting_for_runtime"
+        ? "Waiting for the agent runtime"
+        : dispatchState === "queued_behind_active_turn"
+          ? "Queued behind the active turn"
+          : "Accepted for dispatch";
+    return {
+      id: `mention-received:${mentionId}`,
+      renderClass: "status",
+      title: "Mention received",
+      text: deadlineAt
+        ? `${dispatchText}. Response deadline: ${deadlineAt}.`
+        : `${dispatchText}.`,
+      channelId,
+    };
+  }
+
+  if (event.kind === "mention_response_sla") {
+    const status = asString(payload.status) ?? "unknown";
+    const reason = asString(payload.reason);
+    const reasonText =
+      reason === "no_relay_accepted_response"
+        ? "No relay-accepted response arrived within 60 seconds."
+        : reason === "relay_disconnected_before_response"
+          ? "The relay disconnected before response timing could be verified."
+          : reason === "pending_tracker_capacity_exceeded"
+            ? "Response timing could not be retained because the pending tracker reached capacity."
+            : "Response timing could not be verified.";
+    return {
+      id: `mention-sla:${mentionId}:${status}`,
+      renderClass: status === "breached" ? "error" : "status",
+      title:
+        status === "breached"
+          ? "Response SLA breached"
+          : "Response status unknown",
+      text: reasonText,
+      channelId,
+    };
+  }
+
+  if (event.kind !== "first_response_accepted") return null;
+
+  const status = asString(payload.status) ?? "unknown";
+  const elapsedMs =
+    typeof payload.elapsedMs === "number" ? payload.elapsedMs : null;
+  const elapsedText =
+    elapsedMs == null ? "" : ` after ${(elapsedMs / 1_000).toFixed(1)} seconds`;
+  return {
+    id: `mention-response:${mentionId}`,
+    renderClass: status === "breached" ? "error" : "status",
+    title:
+      status === "on_time"
+        ? "Response accepted"
+        : status === "breached"
+          ? "Late response accepted"
+          : "Response timing unknown",
+    text: `The relay accepted the first response${elapsedText}.`,
+    channelId,
+  };
+}

--- a/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.test.mjs
@@ -42,6 +42,79 @@ function activityTitle(item) {
   return formatToolTitle(item.buzzToolName ?? item.toolName, item.title);
 }
 
+test("buildTranscript surfaces mention receipt, SLA breach, and late relay acceptance", () => {
+  const mentionId = "a".repeat(64);
+  const channelId = "22222222-2222-2222-2222-222222222222";
+  const items = buildTranscript([
+    {
+      ...baseEvent,
+      seq: 1,
+      kind: "mention_received",
+      channelId: null,
+      payload: {
+        eventId: mentionId,
+        channelId,
+        dispatchState: "queued_behind_active_turn",
+        deadlineAt: "2026-06-18T00:01:00Z",
+      },
+    },
+    {
+      ...baseEvent,
+      seq: 2,
+      kind: "mention_response_sla",
+      channelId: null,
+      payload: {
+        eventId: mentionId,
+        channelId,
+        status: "breached",
+        reason: "no_relay_accepted_response",
+      },
+    },
+    {
+      ...baseEvent,
+      seq: 3,
+      kind: "first_response_accepted",
+      channelId: null,
+      payload: {
+        eventId: mentionId,
+        channelId,
+        status: "breached",
+        elapsedMs: 72_500,
+      },
+    },
+  ]);
+
+  assert.deepEqual(
+    items.map((item) => item.title),
+    ["Mention received", "Response SLA breached", "Late response accepted"],
+  );
+  assert.equal(items[0].channelId, channelId);
+  assert.match(items[0].text, /Queued behind the active turn/);
+  assert.equal(items[1].renderClass, "error");
+  assert.match(items[1].text, /within 60 seconds/);
+  assert.equal(items[2].renderClass, "error");
+  assert.match(items[2].text, /72\.5 seconds/);
+});
+
+test("buildTranscript distinguishes unknown response timing from a breach", () => {
+  const [item] = buildTranscript([
+    {
+      ...baseEvent,
+      kind: "mention_response_sla",
+      payload: {
+        eventId: "b".repeat(64),
+        channelId: baseEvent.channelId,
+        status: "unknown",
+        reason: "relay_disconnected_before_response",
+      },
+    },
+  ]);
+
+  assert.equal(item.title, "Response status unknown");
+  assert.equal(item.renderClass, "status");
+  assert.match(item.text, /relay disconnected/);
+});
+
 // --- stub-overflow vanish (pins the pre-existing degraded-frame behavior) ---
 
 test("buildTranscript drops a session/prompt turn whose frame was stubbed by the size trimmer", () => {

--- a/desktop/src/features/agents/ui/agentSessionTranscript.ts
+++ b/desktop/src/features/agents/ui/agentSessionTranscript.ts
@@ -12,6 +12,7 @@ import {
   normalizeToolStatus,
 } from "./agentSessionToolCatalog";
 import { classifyTool } from "./agentSessionToolClassifier";
+import { describeMentionSlaEvent } from "./agentMentionSlaTranscript";
 import { asRecord, asString, titleCase } from "./agentSessionUtils";
 import {
   describeTurnStarted,
@@ -715,7 +716,19 @@ export function processTranscriptEvent(
     sessionId: event.sessionId ?? d.latestSessionId,
   };
 
-  if (event.kind === "raw_json_rpc") {
+  const mentionSlaItem = describeMentionSlaEvent(event);
+  if (mentionSlaItem) {
+    upsertLifecycleItem(
+      d,
+      mentionSlaItem.id,
+      mentionSlaItem.renderClass,
+      mentionSlaItem.title,
+      mentionSlaItem.text,
+      event.timestamp,
+      { ...ctx, channelId: mentionSlaItem.channelId },
+      event.kind,
+    );
+  } else if (event.kind === "raw_json_rpc") {
     upsertMetadata(
       d,
       `raw-json-rpc:${ch}:${event.seq}`,

--- a/desktop/src/features/settings/ui/ActiveAgentCommunitiesSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ActiveAgentCommunitiesSettingsCard.tsx
@@ -115,7 +115,8 @@ export function ActiveAgentCommunitiesSettingsCard() {
                       ? "Working…"
                       : runtime.lifecycle === "stopped"
                         ? "Start"
-                        : runtime.lifecycle === "failed"
+                        : runtime.lifecycle === "failed" ||
+                            runtime.lifecycle === "unknown"
                           ? "Restart"
                           : "Stop"}
                   </Button>

--- a/desktop/src/shared/api/managedAgentRuntimeTypes.ts
+++ b/desktop/src/shared/api/managedAgentRuntimeTypes.ts
@@ -1,0 +1,24 @@
+export type ManagedAgentRuntimeLifecycle =
+  | "starting"
+  | "listening"
+  | "waking"
+  | "ready"
+  | "unknown"
+  | "failed"
+  | "stopped";
+
+export type ManagedAgentRuntimeStatus = {
+  pubkey: string;
+  /** Exact submitted descriptor, present only on startup reconcile results. */
+  requestedRelayUrl?: string;
+  /** Canonical, backend-owned pair identity component. Do not normalize in TS. */
+  relayUrl: string;
+  localSetup: boolean;
+  lifecycle: ManagedAgentRuntimeLifecycle;
+  pid: number | null;
+  error: string | null;
+  logPath: string | null;
+  observerSequence: number | null;
+  lastObservedAt: string | null;
+  leaseExpiresAt: string | null;
+};

--- a/desktop/src/shared/api/tauriManagedAgents.ts
+++ b/desktop/src/shared/api/tauriManagedAgents.ts
@@ -89,6 +89,16 @@ export async function putManagedAgentRuntimeLifecycle(
   });
 }
 
+export async function putManagedAgentRuntimeLease(
+  outerPubkey: string,
+  payload: unknown,
+): Promise<ManagedAgentRuntimeStatus> {
+  return invokeTauri("put_managed_agent_runtime_lease", {
+    outerPubkey,
+    payload,
+  });
+}
+
 export async function reconcileManagedAgentRuntimes(
   communities: readonly { relayUrl: string }[],
 ): Promise<ManagedAgentRuntimeStatus[]> {

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -314,26 +314,10 @@ export type RelayAgent = {
   respondToAllowlist: string[];
 };
 
-export type ManagedAgentRuntimeLifecycle =
-  | "starting"
-  | "listening"
-  | "waking"
-  | "ready"
-  | "failed"
-  | "stopped";
-
-export type ManagedAgentRuntimeStatus = {
-  pubkey: string;
-  /** Exact submitted descriptor, present only on startup reconcile results. */
-  requestedRelayUrl?: string;
-  /** Canonical, backend-owned pair identity component. Do not normalize in TS. */
-  relayUrl: string;
-  localSetup: boolean;
-  lifecycle: ManagedAgentRuntimeLifecycle;
-  pid: number | null;
-  error: string | null;
-  logPath: string | null;
-};
+export type {
+  ManagedAgentRuntimeLifecycle,
+  ManagedAgentRuntimeStatus,
+} from "./managedAgentRuntimeTypes";
 
 export type ManagedAgentBackend =
   | { type: "local" }


### PR DESCRIPTION
## Summary

- Align ACP presence refresh with the shared 30-second heartbeat and 90-second relay lease.
- Add owner-encrypted managed-agent runtime leases with ordered observer frames and stale-to-Unknown behavior.
- Track accepted mentions through the first relay-accepted visible reply and surface on-time, breached, or unknown outcomes.

## Root cause

ACP refreshed presence every 60 seconds while the relay lease expired after 90 seconds. One dropped refresh therefore created a deterministic false-offline interval. Existing public presence also could not distinguish verified shutdown from crash or transport uncertainty, and there was no mention-to-visible-reply SLA correlation.

## Validation

- `cargo test -p buzz-acp --lib` — 619 passed.
- `cargo test -p buzz-core -p buzz-pubsub` — 254 passed; 11 Redis-only tests ignored.
- `cargo clippy -p buzz-acp -p buzz-core -p buzz-pubsub --all-targets -- -D warnings` — passed.
- `pnpm check`, `pnpm typecheck`, `pnpm test` in `desktop/` — passed; 3,640 tests.
- Root Rust formatting and Desktop Tauri formatting checks — passed.
- Full Tauri unit compilation is not available on the managed verification VM because its GLib/GObject/WebKit development packages are absent and sudo is disabled.

## Safety

No production service, machine API, deployment, or unrelated branch was changed. This PR remains draft pending Aegis independent review.
