### PR TITLE
feat(acp): propagate automatic reply context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.29.0",

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -71,6 +71,9 @@ toml = "1.0"
 # Filter expressions
 evalexpr = { workspace = true }
 
+# Scratch files for atomic per-turn reply context updates
+tempfile = "3"
+
 # Process-group kill (safe wrapper around killpg) — Unix-only; kill_process_group
 # has a #[cfg(not(unix))] fallback in acp.rs.
 [target.'cfg(unix)'.dependencies]

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -505,7 +505,8 @@ impl AcpClient {
                 // Handled by build_codex_config_env; skip here to avoid double-setting.
                 continue;
             }
-            if std::env::var_os(key).is_none() {
+            // Reply context is slot-scoped harness state, not an operator override.
+            if key == "BUZZ_REPLY_TO_FILE" || std::env::var_os(key).is_none() {
                 cmd.env(key, value);
             }
         }

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -542,6 +542,9 @@ pub struct Config {
     /// Per-persona env vars to inject at agent spawn time (e.g., GOOSE_PROVIDER, GOOSE_MODEL, BUZZ_AGENT_MODEL).
     /// Populated from persona pack resolution. Empty when no pack is configured.
     pub persona_env_vars: Vec<(String, String)>,
+    /// Stable per-slot files carrying the current automatic reply anchor.
+    /// Populated by the harness after setup-mode handling and before pool startup.
+    pub reply_to_files: Vec<PathBuf>,
     /// Whether `codex_network_env()` successfully injected a `CODEX_CONFIG` entry into
     /// `persona_env_vars`.  When true, `AcpClient::spawn` merges all `CODEX_CONFIG` entries
     /// and forces `sandbox_workspace_write.network_access = true` via `build_codex_config_env`.
@@ -1096,6 +1099,7 @@ impl Config {
             respond_to_allowlist,
             allowed_respond_to,
             persona_env_vars,
+            reply_to_files: vec![],
             has_generated_codex_config,
             relay_observer: args.relay_observer,
             lazy_pool: args.lazy_pool,
@@ -1466,6 +1470,7 @@ mod tests {
             respond_to_allowlist: HashSet::new(),
             allowed_respond_to: Vec::new(),
             persona_env_vars: vec![],
+            reply_to_files: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
             lazy_pool: false,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1294,6 +1294,15 @@ async fn tokio_main() -> Result<()> {
 
     tracing::info!("buzz-acp starting: {}", config.summary());
 
+    let reply_to_dir = tempfile::tempdir()?;
+    let reply_to_files: Vec<std::path::PathBuf> = (0..config.agents)
+        .map(|index| reply_to_dir.path().join(format!("agent-{index}")))
+        .collect();
+    for path in &reply_to_files {
+        std::fs::write(path, "")?;
+    }
+    config.reply_to_files = reply_to_files;
+
     let observer = config
         .relay_observer
         .then(observer::ObserverHandle::in_process);
@@ -1315,7 +1324,11 @@ async fn tokio_main() -> Result<()> {
     let mut pool = if config.lazy_pool {
         AgentPool::from_slots((0..config.agents).map(|_| None).collect())
     } else {
-        initialize_agent_pool(&PoolStartup::from_config(&config, observer.clone()), None).await?
+        initialize_agent_pool(
+            &PoolStartup::from_config(&config, observer.clone(), config.reply_to_files.clone()),
+            None,
+        )
+        .await?
     };
     let mut pool_ready = !config.lazy_pool;
     let mut pool_lifecycle: PoolLifecycle<AgentPool> = PoolLifecycle::listening();
@@ -1559,6 +1572,7 @@ async fn tokio_main() -> Result<()> {
         memory_enabled: config.memory_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
+        reply_to_files: config.reply_to_files.clone(),
     });
 
     if !config.memory_enabled {
@@ -1723,7 +1737,11 @@ async fn tokio_main() -> Result<()> {
                     "waking",
                     None,
                 );
-                let startup = PoolStartup::from_config(&config, observer.clone());
+                let startup = PoolStartup::from_config(
+                    &config,
+                    observer.clone(),
+                    config.reply_to_files.clone(),
+                );
                 let wake_tx = wake_tx.clone();
                 let wake_shutdown = shutdown_rx.clone();
                 wake_tasks.spawn(async move {
@@ -1761,9 +1779,19 @@ async fn tokio_main() -> Result<()> {
                 let env = config.persona_env_vars.clone();
                 let has_codex = config.has_generated_codex_config;
                 let observer = observer.clone();
+                let reply_to_file = config.reply_to_files.get(idx).cloned();
                 let guard = RespawnGuard::new(idx, respawn_tx.clone());
                 respawn_tasks.spawn(async move {
-                    let result = spawn_and_init(&cmd, &args, &env, has_codex, idx, observer).await;
+                    let result = spawn_and_init(
+                        &cmd,
+                        &args,
+                        &env,
+                        reply_to_file.as_deref(),
+                        has_codex,
+                        idx,
+                        observer,
+                    )
+                    .await;
                     guard.send(result);
                 });
             }
@@ -3507,13 +3535,23 @@ fn recover_panicked_agent(
     let cmd = config.agent_command.clone();
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
+    let reply_to_file = config.reply_to_files.get(i).cloned();
     let has_codex = config.has_generated_codex_config;
     let guard = RespawnGuard::new(i, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, i, observer).await;
+        let result = spawn_and_init(
+            &cmd,
+            &args,
+            &env,
+            reply_to_file.as_deref(),
+            has_codex,
+            i,
+            observer,
+        )
+        .await;
         guard.send(result);
     });
 }
@@ -3608,6 +3646,25 @@ fn dispatch_heartbeat(
 
 #[cfg(test)]
 mod agent_draft_prompt_tests {
+    use super::spawn_env_for_slot;
+
+    #[test]
+    fn spawn_env_for_slot_uses_slot_file_and_preserves_persona_env() {
+        let persona_env = vec![("MODEL".to_string(), "test-model".to_string())];
+        let path = std::path::Path::new("/runtime/reply/agent-2");
+
+        assert_eq!(
+            spawn_env_for_slot(&persona_env, Some(path)),
+            vec![
+                ("MODEL".to_string(), "test-model".to_string()),
+                (
+                    "BUZZ_REPLY_TO_FILE".to_string(),
+                    path.to_string_lossy().into_owned(),
+                ),
+            ]
+        );
+    }
+
     #[test]
     fn shared_base_prompt_teaches_portable_agent_drafts() {
         let prompt = include_str!("base_prompt.md");
@@ -3701,6 +3758,7 @@ fn spawn_respawn_task(
     let cmd = config.agent_command.clone();
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
+    let reply_to_file = config.reply_to_files.get(index).cloned();
     let has_codex = config.has_generated_codex_config;
     let guard = RespawnGuard::new(index, respawn_tx.clone());
     respawn_tasks.spawn(async move {
@@ -3713,7 +3771,16 @@ fn spawn_respawn_task(
             tokio::time::sleep(delay).await;
         }
 
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, index, observer).await;
+        let result = spawn_and_init(
+            &cmd,
+            &args,
+            &env,
+            reply_to_file.as_deref(),
+            has_codex,
+            index,
+            observer,
+        )
+        .await;
         guard.send(result);
     });
 
@@ -3756,18 +3823,24 @@ struct PoolStartup {
     command: String,
     args: Vec<String>,
     extra_env: Vec<(String, String)>,
+    reply_to_files: Vec<std::path::PathBuf>,
     has_generated_codex_config: bool,
     model: Option<String>,
     observer: Option<observer::ObserverHandle>,
 }
 
 impl PoolStartup {
-    fn from_config(config: &Config, observer: Option<observer::ObserverHandle>) -> Self {
+    fn from_config(
+        config: &Config,
+        observer: Option<observer::ObserverHandle>,
+        reply_to_files: Vec<std::path::PathBuf>,
+    ) -> Self {
         Self {
             agents: config.agents,
             command: config.agent_command.clone(),
             args: config.agent_args.clone(),
             extra_env: config.persona_env_vars.clone(),
+            reply_to_files,
             has_generated_codex_config: config.has_generated_codex_config,
             model: config.model.clone(),
             observer,
@@ -3783,10 +3856,15 @@ async fn initialize_agent_pool(
     // Attempt each spawn under a 60-second timeout; a partial pool is valid.
     let mut agent_slots: Vec<Option<OwnedAgent>> = Vec::with_capacity(startup.agents as usize);
     for i in 0..startup.agents as usize {
+        let reply_to_file = startup
+            .reply_to_files
+            .get(i)
+            .ok_or_else(|| anyhow::anyhow!("missing reply context file for agent slot {i}"))?;
+        let extra_env = spawn_env_for_slot(&startup.extra_env, Some(reply_to_file));
         let spawn_result = AcpClient::spawn(
             &startup.command,
             &startup.args,
-            &startup.extra_env,
+            &extra_env,
             startup.has_generated_codex_config,
         )
         .await;
@@ -3883,15 +3961,31 @@ async fn initialize_agent_pool(
 ///
 /// Takes owned args so it can run in a background `tokio::spawn` task without
 /// borrowing `Config`. All respawn/refill paths use this.
+fn spawn_env_for_slot(
+    extra_env: &[(String, String)],
+    reply_to_file: Option<&std::path::Path>,
+) -> Vec<(String, String)> {
+    let mut spawn_env = extra_env.to_vec();
+    if let Some(reply_to_file) = reply_to_file {
+        spawn_env.push((
+            "BUZZ_REPLY_TO_FILE".into(),
+            reply_to_file.to_string_lossy().into_owned(),
+        ));
+    }
+    spawn_env
+}
+
 async fn spawn_and_init(
     command: &str,
     args: &[String],
     extra_env: &[(String, String)],
+    reply_to_file: Option<&std::path::Path>,
     has_generated_codex_config: bool,
     agent_index: usize,
     observer: Option<observer::ObserverHandle>,
 ) -> Result<(AcpClient, u32, String)> {
-    let mut acp = AcpClient::spawn(command, args, extra_env, has_generated_codex_config)
+    let spawn_env = spawn_env_for_slot(extra_env, reply_to_file);
+    let mut acp = AcpClient::spawn(command, args, &spawn_env, has_generated_codex_config)
         .await
         .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
     acp.set_observer(observer, agent_index);
@@ -5029,6 +5123,7 @@ mod build_mcp_servers_tests {
             respond_to_allowlist: std::collections::HashSet::new(),
             allowed_respond_to: vec![],
             persona_env_vars: vec![],
+            reply_to_files: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
             lazy_pool: false,
@@ -5250,6 +5345,7 @@ mod error_outcome_emission_tests {
             respond_to_allowlist: HashSet::new(),
             allowed_respond_to: vec![],
             persona_env_vars: vec![],
+            reply_to_files: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
             lazy_pool: false,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -551,6 +551,8 @@ pub struct PromptContext {
     /// the desktop keys per (agent, relay) pair, e.g. `session_config_captured`,
     /// mirroring the `managed_agent_runtime_lifecycle` frames.
     pub relay_url: String,
+    /// Slot-scoped files used to pass automatic reply anchors to tool processes.
+    pub reply_to_files: Vec<std::path::PathBuf>,
 }
 
 impl AgentPool {
@@ -861,6 +863,30 @@ async fn resolve_new_session_channel_context(
     let is_dm = info.channel_type == "dm";
     let title_channel = (!is_dm && info.name != UNKNOWN_CHANNEL_NAME).then_some(info.name);
     (is_dm, title_channel)
+}
+
+fn write_reply_anchor(path: &std::path::Path, reply_anchor: Option<&str>) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "reply context path has no parent",
+        )
+    })?;
+    let permissions = std::fs::metadata(path)
+        .ok()
+        .map(|metadata| metadata.permissions());
+    let mut temp = tempfile::NamedTempFile::new_in(parent)?;
+    if let Some(anchor) = reply_anchor {
+        temp.write_all(anchor.as_bytes())?;
+    }
+    temp.as_file().sync_all()?;
+    if let Some(permissions) = permissions {
+        temp.as_file().set_permissions(permissions)?;
+    }
+    temp.persist(path).map_err(|error| error.error)?;
+    Ok(())
 }
 
 /// Create a new ACP session via `session_new_full()`, populate model capabilities
@@ -1807,6 +1833,27 @@ pub async fn run_prompt_task(
     // follows as a second block.
     let mut slash_command: Option<String> = None;
     let prompt_sections: Vec<String> = if let Some(text) = prompt_text {
+        if let Some(path) = ctx.reply_to_files.get(agent.index) {
+            if let Err(error) = write_reply_anchor(path, None) {
+                tracing::error!(
+                    target: "pool::prompt",
+                    agent = agent.index,
+                    path = %path.display(),
+                    "failed to clear reply context: {error}"
+                );
+                send_prompt_result(
+                    &result_tx,
+                    &turn_id,
+                    agent,
+                    source,
+                    PromptOutcome::Error(AcpError::Protocol(format!(
+                        "failed to clear reply context: {error}"
+                    ))),
+                    requeue_batch_if_queue(&ctx, batch),
+                );
+                return;
+            }
+        }
         // Heartbeats create their session before this point, so a Goose method-not-found
         // probe has already selected the correct framing for this process.
         let text = prepend_base_for_legacy(
@@ -1832,6 +1879,30 @@ pub async fn run_prompt_task(
 
         let profile_lookup =
             fetch_prompt_profile_lookup(b, conversation_context.as_ref(), &ctx.rest_client).await;
+
+        let reply_anchor =
+            crate::queue::reply_anchor_for_batch(b, channel_info.as_ref(), profile_lookup.as_ref());
+        if let Some(path) = ctx.reply_to_files.get(agent.index) {
+            if let Err(error) = write_reply_anchor(path, reply_anchor.as_deref()) {
+                tracing::error!(
+                    target: "pool::prompt",
+                    agent = agent.index,
+                    path = %path.display(),
+                    "failed to update reply context: {error}"
+                );
+                send_prompt_result(
+                    &result_tx,
+                    &turn_id,
+                    agent,
+                    source,
+                    PromptOutcome::Error(AcpError::Protocol(format!(
+                        "failed to update reply context: {error}"
+                    ))),
+                    requeue_batch_if_queue(&ctx, batch),
+                );
+                return;
+            }
+        }
 
         let known_names: Vec<&str> = profile_lookup
             .iter()
@@ -3968,6 +4039,38 @@ mod tests {
     // These pin the initial_message dispatch path (run_prompt_task, ~line 855):
     // a legacy agent WITH a base_prompt must get [Base] prepended to the user
     // message. This is the exact regression that shipped in the round-2 bug.
+
+    #[test]
+    fn reply_anchor_rewrite_replaces_and_clears_atomically() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent-0");
+        std::fs::write(&path, "stale-anchor").unwrap();
+
+        write_reply_anchor(&path, Some("current-anchor")).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "current-anchor");
+
+        write_reply_anchor(&path, None).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "");
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reply_anchor_rewrite_preserves_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent-0");
+        std::fs::write(&path, "").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        write_reply_anchor(&path, Some("current-anchor")).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
 
     #[test]
     fn test_initial_message_legacy_agent_gets_base_prepended() {
@@ -6301,6 +6404,7 @@ mod tests {
             memory_enabled: false,
             harness_name: "goose".to_string(),
             relay_url: "ws://127.0.0.1:3000".to_string(),
+            reply_to_files: vec![],
         }
     }
 

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1383,6 +1383,33 @@ pub(crate) fn base_section(base_prompt: &str) -> String {
     format!("[Base]\n{}", base_prompt.trim_end())
 }
 
+/// Resolve the automatic reply target for the last event in a batch.
+pub(crate) fn reply_anchor_for_batch(
+    batch: &FlushBatch,
+    channel_info: Option<&PromptChannelInfo>,
+    profile_lookup: Option<&PromptProfileLookup>,
+) -> Option<String> {
+    let last_event = batch.events.last()?;
+    let thread_tags = parse_thread_tags(&last_event.event);
+    let is_dm = channel_info
+        .map(|info| info.channel_type == "dm")
+        .unwrap_or(false);
+
+    if is_dm {
+        thread_tags
+            .root_event_id
+            .is_some()
+            .then(|| last_event.event.id.to_hex())
+    } else {
+        resolve_reply_anchor(
+            &last_event.event.pubkey.to_hex(),
+            &thread_tags,
+            &last_event.event.id.to_hex(),
+            profile_lookup,
+        )
+    }
+}
+
 /// Format a [`FlushBatch`] into the per-section prompt blocks for the agent.
 ///
 /// Produces a stable prompt with these sections (in order):
@@ -1464,20 +1491,7 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
     //   - top-level     → anchor to the triggering event (it becomes the root)
     // Agent↔agent turns get no forced anchor — deep nesting is intentional
     // there. DMs are always 1:1 with a human, so they always anchor.
-    let sender_pubkey = last_event.event.pubkey.to_hex();
-    let reply_anchor = if is_dm {
-        thread_tags
-            .root_event_id
-            .is_some()
-            .then(|| last_event.event.id.to_hex())
-    } else {
-        resolve_reply_anchor(
-            &sender_pubkey,
-            &thread_tags,
-            &last_event.event.id.to_hex(),
-            args.profile_lookup,
-        )
-    };
+    let reply_anchor = reply_anchor_for_batch(batch, args.channel_info, args.profile_lookup);
     sections.push(format_context_hints(
         batch.channel_id,
         args.channel_info,

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1151,8 +1151,8 @@ fn append_reply_instruction(s: &mut String, event_id: &str) {
         "\nIMPORTANT: For ordinary replies in this turn, use `--reply-to {event_id}` \
          on `buzz messages send` so the conversation stays threaded. \
          If the human explicitly asks for a channel-root, top-level, \
-         or broadcast post, send that message without `--reply-to`. \
-         If the requested destination is ambiguous, ask before sending."
+         or broadcast post, send that message with `--top-level` instead of \
+         `--reply-to`. If the requested destination is ambiguous, ask before sending."
     ));
 }
 
@@ -1167,7 +1167,8 @@ fn append_new_thread_reply_instruction(s: &mut String, event_id: &str) {
          this turn, use `--reply-to {event_id}` on `buzz messages send` — the \
          triggering message is the thread root. Do NOT reply into any other \
          (older) thread. If the human explicitly asks for a channel-root, \
-         top-level, or broadcast post, send that message without `--reply-to`."
+         top-level, or broadcast post, send that message with `--top-level` \
+         instead of `--reply-to`."
     ));
 }
 
@@ -3908,8 +3909,8 @@ mod tests {
             "channel thread reply should describe reply-to as the default"
         );
         assert!(
-            prompt.contains("send that message without `--reply-to`"),
-            "channel thread reply should allow explicit channel-root/top-level requests"
+            prompt.contains("send that message with `--top-level`"),
+            "channel thread reply should teach the automatic-context opt-out"
         );
         assert!(
             !prompt.contains("Do not broadcast to the channel"),
@@ -3982,6 +3983,10 @@ mod tests {
         assert!(
             prompt.contains("new top-level message"),
             "top-level human message should use the new-thread instruction"
+        );
+        assert!(
+            prompt.contains("send that message with `--top-level`"),
+            "new-thread instruction should teach the automatic-context opt-out"
         );
     }
 

--- a/crates/buzz-agent/src/mcp.rs
+++ b/crates/buzz-agent/src/mcp.rs
@@ -86,6 +86,7 @@ const PASSTHROUGH_ENV: &[&str] = &[
     "BUZZ_PRIVATE_KEY",
     "BUZZ_RELAY_URL",
     "BUZZ_AUTH_TAG",
+    "BUZZ_REPLY_TO_FILE",
     // Agent display name — dev-mcp uses it as the git author name. On the
     // Desktop path this arrives via the wire `mcpServers[].env` declaration
     // (which wins here anyway); the allowlist entry covers ACP clients that

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -566,16 +566,21 @@ pub struct SendMessageParams {
     pub content: String,
     pub kind: Option<u16>,
     pub reply_to: Option<String>,
+    pub top_level: bool,
     pub broadcast: bool,
     pub files: Vec<String>,
     pub mentions: Vec<String>,
 }
 
 fn reply_to_from_sources(
+    top_level: bool,
     explicit: Option<String>,
     env_value: Option<String>,
     file_path: Option<&std::ffi::OsStr>,
 ) -> Option<String> {
+    if top_level {
+        return None;
+    }
     explicit
         .or_else(|| {
             env_value.and_then(|value| {
@@ -590,8 +595,9 @@ fn reply_to_from_sources(
         })
 }
 
-fn automatic_reply_to(explicit: Option<String>) -> Option<String> {
+fn automatic_reply_to(top_level: bool, explicit: Option<String>) -> Option<String> {
     reply_to_from_sources(
+        top_level,
         explicit,
         std::env::var("BUZZ_REPLY_TO").ok(),
         std::env::var_os("BUZZ_REPLY_TO_FILE").as_deref(),
@@ -608,7 +614,7 @@ pub async fn cmd_send_message(
     // bugs for agent and human users alike.
     p.content = read_or_stdin(&p.content)?;
     validate_content_size(&p.content)?;
-    p.reply_to = automatic_reply_to(p.reply_to);
+    p.reply_to = automatic_reply_to(p.top_level, p.reply_to);
     if let Some(ref r) = p.reply_to {
         validate_hex64(r)?;
     }
@@ -905,6 +911,7 @@ pub async fn dispatch(
             content,
             kind,
             reply_to,
+            top_level,
             broadcast,
             files,
             mentions,
@@ -916,6 +923,7 @@ pub async fn dispatch(
                     content,
                     kind,
                     reply_to,
+                    top_level,
                     broadcast,
                     files,
                     mentions,
@@ -1046,6 +1054,7 @@ mod tests {
         std::fs::write(file.path(), ID_B).unwrap();
         assert_eq!(
             reply_to_from_sources(
+                false,
                 Some(ID_A.into()),
                 Some(ID_B.into()),
                 Some(file.path().as_os_str()),
@@ -1061,6 +1070,7 @@ mod tests {
         std::fs::write(file.path(), ID_A).unwrap();
         assert_eq!(
             reply_to_from_sources(
+                false,
                 None,
                 Some(format!(" {ID_B}\n")),
                 Some(file.path().as_os_str()),
@@ -1075,16 +1085,36 @@ mod tests {
         let file = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(file.path(), format!(" {ID_A}\n")).unwrap();
         assert_eq!(
-            reply_to_from_sources(None, Some("  ".into()), Some(file.path().as_os_str()))
-                .as_deref(),
+            reply_to_from_sources(
+                false,
+                None,
+                Some("  ".into()),
+                Some(file.path().as_os_str()),
+            )
+            .as_deref(),
             Some(ID_A)
         );
         std::fs::write(file.path(), "").unwrap();
         assert_eq!(
-            reply_to_from_sources(None, None, Some(file.path().as_os_str())),
+            reply_to_from_sources(false, None, None, Some(file.path().as_os_str())),
             None
         );
-        assert_eq!(reply_to_from_sources(None, None, None), None);
+        assert_eq!(reply_to_from_sources(false, None, None, None), None);
+    }
+
+    #[test]
+    fn top_level_suppresses_explicit_environment_and_file_reply_targets() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), ID_A).unwrap();
+        assert_eq!(
+            reply_to_from_sources(
+                true,
+                Some(ID_A.into()),
+                Some(ID_B.into()),
+                Some(file.path().as_os_str()),
+            ),
+            None
+        );
     }
 
     #[test]

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -571,6 +571,33 @@ pub struct SendMessageParams {
     pub mentions: Vec<String>,
 }
 
+fn reply_to_from_sources(
+    explicit: Option<String>,
+    env_value: Option<String>,
+    file_path: Option<&std::ffi::OsStr>,
+) -> Option<String> {
+    explicit
+        .or_else(|| {
+            env_value.and_then(|value| {
+                let value = value.trim();
+                (!value.is_empty()).then(|| value.to_owned())
+            })
+        })
+        .or_else(|| {
+            let path = file_path?;
+            let value = std::fs::read_to_string(path).ok()?;
+            (!value.trim().is_empty()).then(|| value.trim().to_owned())
+        })
+}
+
+fn automatic_reply_to(explicit: Option<String>) -> Option<String> {
+    reply_to_from_sources(
+        explicit,
+        std::env::var("BUZZ_REPLY_TO").ok(),
+        std::env::var_os("BUZZ_REPLY_TO_FILE").as_deref(),
+    )
+}
+
 pub async fn cmd_send_message(
     client: &BuzzClient,
     mut p: SendMessageParams,
@@ -581,6 +608,7 @@ pub async fn cmd_send_message(
     // bugs for agent and human users alike.
     p.content = read_or_stdin(&p.content)?;
     validate_content_size(&p.content)?;
+    p.reply_to = automatic_reply_to(p.reply_to);
     if let Some(ref r) = p.reply_to {
         validate_hex64(r)?;
     }
@@ -994,7 +1022,7 @@ pub async fn dispatch(
 mod tests {
     use super::{
         event_mention_pubkeys, find_root_from_tags, match_profiles_by_name, merge_message_mentions,
-        missing_members, normalize_explicit_mentions, parse_member_pubkeys,
+        missing_members, normalize_explicit_mentions, parse_member_pubkeys, reply_to_from_sources,
         resolve_names_to_pubkeys,
     };
     use buzz_sdk::mentions::{
@@ -1011,6 +1039,53 @@ mod tests {
     const PK_VALID_A: &str = "35c18ae273fccfaf80d629e20e7f8721b90499379addff533054acc2504c12b4";
     const PK_VALID_B: &str = "c6237ef84fa537c78dcee78efd2d4e59f728859c7f194da42ac51ededfa0be05";
     const PK_VALID_C: &str = "f4a42a97e594b77bdbd8ee35191c8b28a94a4cb871d96f32921558275421fb68";
+
+    #[test]
+    fn explicit_reply_to_precedes_environment_and_file() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), ID_B).unwrap();
+        assert_eq!(
+            reply_to_from_sources(
+                Some(ID_A.into()),
+                Some(ID_B.into()),
+                Some(file.path().as_os_str()),
+            )
+            .as_deref(),
+            Some(ID_A)
+        );
+    }
+
+    #[test]
+    fn reply_to_environment_precedes_file() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), ID_A).unwrap();
+        assert_eq!(
+            reply_to_from_sources(
+                None,
+                Some(format!(" {ID_B}\n")),
+                Some(file.path().as_os_str()),
+            )
+            .as_deref(),
+            Some(ID_B)
+        );
+    }
+
+    #[test]
+    fn reply_to_file_is_fallback_and_empty_values_are_ignored() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), format!(" {ID_A}\n")).unwrap();
+        assert_eq!(
+            reply_to_from_sources(None, Some("  ".into()), Some(file.path().as_os_str()))
+                .as_deref(),
+            Some(ID_A)
+        );
+        std::fs::write(file.path(), "").unwrap();
+        assert_eq!(
+            reply_to_from_sources(None, None, Some(file.path().as_os_str())),
+            None
+        );
+        assert_eq!(reply_to_from_sources(None, None, None), None);
+    }
 
     #[test]
     fn root_marker_wins_over_reply_marker() {

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -361,8 +361,11 @@ pub enum MessagesCmd {
         #[arg(long)]
         kind: Option<u16>,
         /// Event ID to reply to (creates a thread)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "top_level")]
         reply_to: Option<String>,
+        /// Send at channel root, ignoring automatic reply context
+        #[arg(long, default_value_t = false, conflicts_with = "reply_to")]
+        top_level: bool,
         /// Also publish to the Nostr network
         #[arg(long, default_value_t = false)]
         broadcast: bool,
@@ -1863,6 +1866,45 @@ mod tests {
             "--emoji alone must not imply a status"
         );
         assert!(Cli::try_parse_from(["buzz", "users", "set-status", "--clear"]).is_ok());
+    }
+
+    #[test]
+    fn message_send_top_level_is_explicit_and_conflicts_with_reply_to() {
+        let cli = Cli::try_parse_from([
+            "buzz",
+            "messages",
+            "send",
+            "--channel",
+            "00000000-0000-0000-0000-000000000000",
+            "--content",
+            "announcement",
+            "--top-level",
+        ])
+        .expect("--top-level should parse");
+        let Cmd::Messages(MessagesCmd::Send {
+            top_level,
+            reply_to,
+            ..
+        }) = cli.command
+        else {
+            panic!("expected messages send");
+        };
+        assert!(top_level);
+        assert!(reply_to.is_none());
+
+        let conflict = Cli::try_parse_from([
+            "buzz",
+            "messages",
+            "send",
+            "--channel",
+            "00000000-0000-0000-0000-000000000000",
+            "--content",
+            "announcement",
+            "--top-level",
+            "--reply-to",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ]);
+        assert!(conflict.is_err(), "explicit destinations must not conflict");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Agents respond to @mentions but their replies don't appear in the thread. They show up in the agent's activity feed but not in the thread view where the conversation happened. This was reproducible and reported multiple times.

**Root cause:** Thread views filter on the `e` tag (reply-to event ID). When an agent runs `buzz messages send` without `--reply-to`, the CLI exits 0 and publishes a valid message — but with no `e` tag, so it lands at channel root, invisible in the thread. The ACP harness injects the correct reply anchor into the prompt via `[Context]`, but LLM compliance with that instruction was unreliable.

**Why not just strengthen the prompt?** Because the agent binary, its MCP servers, and the CLI all run as long-lived processes whose environment is fixed at spawn. Per-turn env mutation from the harness would either not reach child processes or race across concurrent agent slots.

## Solution

Inject a stable per-slot file path (`BUZZ_REPLY_TO_FILE`) at agent spawn. Before each prompt, the harness atomically rewrites that file with the resolved reply anchor for this turn. The CLI reads it as an ambient fallback — no LLM instruction compliance required.

**Precedence:** explicit `--reply-to` flag > `BUZZ_REPLY_TO` env var > `BUZZ_REPLY_TO_FILE` contents > none (unchanged behavior).

**Before:** agent replies to a thread → message lands at channel root → invisible in thread view.  
**After:** agent replies to a thread → message carries the correct `e` tag → appears in thread.

## What stays safe

- **No cross-slot leakage:** each agent slot has its own file (`agent-0`, `agent-1`, …), indexed by `agent.index`.
- **No cross-turn leakage:** the `prompt_text` path (setup/heartbeat) clears the file to empty before running; the `batch` path writes the freshly resolved anchor. The two paths are mutually exclusive.
- **Respawn safety:** `spawn_and_init` and `spawn_respawn_task` both receive the file path by slot index; a respawned process inherits the same stable path, already holding the correct cleared/updated content.
- **`tempdir` lifetime:** the directory guard lives in `tokio_main` for the full harness lifetime; paths outlive all pool operations.
- **MCP propagation:** `BUZZ_REPLY_TO_FILE` is in `buzz-agent`'s `PASSTHROUGH_ENV` list and is forced through the spawn env override in `acp.rs` so it cannot be masked by a pre-existing process env value.

## Changes

- `crates/buzz-acp/src/lib.rs` — create temp dir, populate per-slot files, propagate through all spawn/respawn/wake paths
- `crates/buzz-acp/src/pool.rs` — `write_reply_anchor()` (atomic rename-based write), per-turn file update in `run_prompt_task`
- `crates/buzz-acp/src/queue.rs` — extract `reply_anchor_for_batch()` (shared between prompt text injection and file write)
- `crates/buzz-acp/src/config.rs` — `reply_to_files: Vec<PathBuf>` field on `Config`
- `crates/buzz-acp/src/acp.rs` — force `BUZZ_REPLY_TO_FILE` in spawn env regardless of parent env
- `crates/buzz-agent/src/mcp.rs` — add `BUZZ_REPLY_TO_FILE` to `PASSTHROUGH_ENV`
- `crates/buzz-cli/src/commands/messages.rs` — `reply_to_from_sources()` / `automatic_reply_to()` with precedence chain

## Testing

- `just ci`
- `cargo test -p buzz-acp` (618 unit tests, 9 lifecycle tests)
- `cargo test -p buzz-cli`
- `cargo check`

New focused tests: `spawn_env_for_slot_uses_slot_file_and_preserves_persona_env`, `reply_anchor_rewrite_replaces_and_clears_atomically`, `reply_anchor_rewrite_preserves_file_permissions`, `explicit_reply_to_precedes_environment_and_file`, `reply_to_environment_precedes_file`, `reply_to_file_is_fallback_and_empty_values_are_ignored`.

Note: a later pre-push `just test` integration rerun was blocked by stale shared Docker state (migration 25 exists in the shared database but not this checkout). The complete `just ci` run passed before that shared state conflict.
