### PR TITLE
fix(desktop): keep project Inbox previews compact

### DIFF
--- a/desktop/src/shared/styles/globals/markdown.css
+++ b/desktop/src/shared/styles/globals/markdown.css
@@ -118,6 +118,10 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  font-size: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
   overflow: hidden;
 }
 

--- a/desktop/tests/e2e/project-inbox.spec.ts
+++ b/desktop/tests/e2e/project-inbox.spec.ts
@@ -46,7 +46,7 @@ test("Buzz Git pull request renders and stays actionable in Inbox", async ({
         id,
         kind: 1618,
         pubkey: author,
-        content: "Inbox rendering verification",
+        content: "# Inbox rendering verification",
         created_at: Math.floor(Date.now() / 1000) + 1,
         channel_id: null,
         channel_name: "",
@@ -69,6 +69,35 @@ test("Buzz Git pull request renders and stays actionable in Inbox", async ({
 
   const inboxRow = page.getByTestId(`home-inbox-item-${pullRequestId}`);
   await expect(inboxRow).toBeVisible({ timeout: 10_000 });
+  const previewTypography = await inboxRow
+    .locator(".inbox-preview-markdown")
+    .evaluate((preview) => {
+      const firstBlock = preview.firstElementChild;
+      if (!firstBlock) {
+        throw new Error("Expected the Inbox preview to render a first block.");
+      }
+      const previewStyle = getComputedStyle(preview);
+      const firstBlockStyle = getComputedStyle(firstBlock);
+      return {
+        firstBlockTag: firstBlock.tagName,
+        fontSizeMatches: firstBlockStyle.fontSize === previewStyle.fontSize,
+        fontWeightMatches:
+          firstBlockStyle.fontWeight === previewStyle.fontWeight,
+        letterSpacingMatches:
+          firstBlockStyle.letterSpacing === previewStyle.letterSpacing,
+        lineHeightMatches:
+          firstBlockStyle.lineHeight === previewStyle.lineHeight,
+        lineClamp: firstBlockStyle.webkitLineClamp,
+      };
+    });
+  expect(previewTypography).toEqual({
+    firstBlockTag: "H1",
+    fontSizeMatches: true,
+    fontWeightMatches: true,
+    letterSpacingMatches: true,
+    lineHeightMatches: true,
+    lineClamp: "2",
+  });
   await inboxRow.locator(":scope > div").first().click();
 
   const detail = page.getByTestId("home-project-inbox-detail");


### PR DESCRIPTION
## Summary

Project pull request and issue previews in Inbox no longer expand when their content begins with a Markdown heading. Heading-form titles now match neighboring Inbox typography while preserving the existing two-line truncation.

### Related issue

Related: #3117

### Testing

- `pnpm build:e2e`
- `pnpm exec playwright test tests/e2e/project-inbox.spec.ts --project=smoke --retries=0` — passed
- `pnpm exec biome check tests/e2e/project-inbox.spec.ts src/shared/styles/globals/markdown.css` — passed
- `pnpm check:px-text` — passed
- Captured `desktop/test-results/inbox-preview/01-project-preview.png`

The repository-wide desktop file-size gate remains blocked by the pre-existing 1,026-line `AgentCreationPreview.tsx` on `main`; the change itself introduces no file-size regression.
