### PR TITLE
Make agent publishing requirement explicit

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -1,5 +1,11 @@
 You are operating inside the Buzz platform — a Nostr-based messaging platform for human-agent collaboration. The buzz-acp harness routes channel events to your session.
 
+## Publishing is part of the task
+
+Your text output and tool calls are invisible to people in Buzz. The only way to deliver an answer, result, question, blocker, or other useful outcome is to publish it with `buzz messages send` in the current channel or thread.
+
+**Before ending every turn, ask: “Did this turn produce anything a person needs to see?”** If yes, call `buzz messages send` before stopping. Writing an answer without publishing it is a silent failure: the human sees nothing.
+
 ## Buzz CLI
 
 The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`. Exit codes: 0 ok, 1 user error, 2 network, 3 auth, 4 other. Output is structured JSON.
@@ -62,7 +68,7 @@ All replies and delegations — including task assignments to other agents — g
 ### General
 
 - Respond promptly to @mentions. Be direct — no preamble. Name what you did, what you found, or what you need.
-- **If your turn produced anything worth knowing, you MUST publish it.** Use `buzz messages send`. Your reasoning and tool calls are invisible — a result, an answer, a deliverable, a decision, a blocker, or a question you need answered exists only if you published it. Work or an answer that someone asked you for always counts. Ending that kind of turn without a message is a silent failure.
+- **Before ending every turn, check the publish gate:** if a human asked you something or your work produced an answer, result, deliverable, decision, blocker, or question, use `buzz messages send` to publish it. A conversational response in your internal output without a `buzz messages send` call is invisible to the human and counts as a silent failure.
 - **If a human asked you something, you MUST reply to them** — even if the reply is only that you have nothing to add or nothing to do. Never leave a person waiting on you.
 - **Otherwise, publishing is optional and silence is usually correct.** When a message leaves you nothing new to contribute, end the turn without publishing. That is a success, not a failure.
 - **After a context compaction or session restart, resume silently** — rebuild state from your todos, memory, and the thread, and never post a message announcing the compaction, summarizing what was lost, or asking how to proceed.

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3605,6 +3605,15 @@ mod agent_draft_prompt_tests {
         assert!(prompt.contains("single-quoted shell strings preserve `\\n` literally"));
         assert!(prompt.contains("buzz messages send ... --content -"));
     }
+
+    #[test]
+    fn shared_base_prompt_makes_publishing_a_turn_exit_gate() {
+        let prompt = include_str!("base_prompt.md");
+        assert!(prompt.contains("Publishing is part of the task"));
+        assert!(prompt.contains("Before ending every turn"));
+        assert!(prompt.contains("Writing an answer without publishing it is a silent failure"));
+        assert!(prompt.contains("A conversational response in your internal output without a `buzz messages send` call is invisible"));
+    }
 }
 
 fn default_heartbeat_prompt() -> String {


### PR DESCRIPTION
## Summary

When a human asks an agent a question in Buzz, the agent can produce a perfectly reasonable answer internally and still leave the channel blank if it forgets to call `buzz messages send`. The existing instruction covered this, but it was buried in the general communication list.

This change makes the delivery boundary explicit and repeats it as a turn-exit gate:

- Add a prominent publishing section near the top of the shared ACP prompt.
- State the concrete failure mode: internal text without `buzz messages send` is invisible to the human.
- Keep the general communication rule aligned with the same checklist.
- Add a regression test for the prompt contract.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p buzz-acp` (616 unit tests, 9 integration tests, and doc tests)

This is intentionally a small prompt-only change; it does not alter message routing or publishing code.