### PR TITLE
fix(acp): admit trusted workflow wake messages

### DIFF
--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -27,7 +27,7 @@ pub enum FilterError {
 pub struct FilterContext {
     /// Event content (message body).
     pub content: String,
-    /// Event author pubkey as hex string.
+    /// Verified attributed author pubkey as a hex string.
     pub author: String,
     /// Nostr event kind number.
     pub kind: u32,
@@ -38,11 +38,11 @@ pub struct FilterContext {
 }
 
 impl FilterContext {
-    /// Build a `FilterContext` from a Nostr event and its channel UUID.
-    pub fn from_event(event: &nostr::Event, channel_id: uuid::Uuid) -> Self {
+    /// Build a `FilterContext` using the verified author attributed upstream.
+    pub fn from_event(event: &nostr::Event, channel_id: uuid::Uuid, author: &str) -> Self {
         Self {
             content: event.content.clone(),
-            author: event.pubkey.to_hex(),
+            author: author.to_string(),
             kind: event.kind.as_u16() as u32,
             channel_id: channel_id.to_string(),
             timestamp: event.created_at.as_secs(),
@@ -253,7 +253,7 @@ pub async fn evaluate_filter(
 /// | Name         | Type   | Source                    |
 /// |--------------|--------|---------------------------|
 /// | `content`    | string | `event.content`           |
-/// | `author`     | string | `event.pubkey` (hex)      |
+/// | `author`     | string | verified author (hex)     |
 /// | `kind`       | int    | `event.kind`              |
 /// | `channel_id` | string | channel UUID              |
 /// | `timestamp`  | int    | `event.created_at`        |
@@ -370,8 +370,9 @@ pub async fn match_event(
     channel_id: uuid::Uuid,
     rules: &[SubscriptionRule],
     agent_pubkey_hex: &str,
+    author: &str,
 ) -> Option<MatchedRule> {
-    let filter_ctx = FilterContext::from_event(event, channel_id);
+    let filter_ctx = FilterContext::from_event(event, channel_id, author);
 
     for (index, rule) in rules.iter().enumerate() {
         // 1. Channel scope check.
@@ -488,6 +489,26 @@ mod tests {
         Uuid::new_v4()
     }
 
+    fn context_for(event: &nostr::Event, channel_id: Uuid) -> FilterContext {
+        FilterContext::from_event(event, channel_id, &event.pubkey.to_hex())
+    }
+
+    async fn match_signed_event(
+        event: &nostr::Event,
+        channel_id: Uuid,
+        rules: &[SubscriptionRule],
+        agent_pubkey_hex: &str,
+    ) -> Option<MatchedRule> {
+        match_event(
+            event,
+            channel_id,
+            rules,
+            agent_pubkey_hex,
+            &event.pubkey.to_hex(),
+        )
+        .await
+    }
+
     fn make_rule(
         name: &str,
         channels: ChannelScope,
@@ -512,7 +533,7 @@ mod tests {
     fn test_filter_context_from_event() {
         let event = make_event(9, "hello world");
         let channel_id = any_channel();
-        let ctx = FilterContext::from_event(&event, channel_id);
+        let ctx = context_for(&event, channel_id);
 
         assert_eq!(ctx.content, "hello world");
         assert_eq!(ctx.author, event.pubkey.to_hex());
@@ -524,7 +545,7 @@ mod tests {
     #[tokio::test]
     async fn test_evaluate_filter_str_contains() {
         let event = make_event(9, "P1 incident in production");
-        let ctx = FilterContext::from_event(&event, any_channel());
+        let ctx = context_for(&event, any_channel());
 
         let result = evaluate_filter(r#"str_contains(content, "P1")"#, &ctx, None)
             .await
@@ -540,7 +561,7 @@ mod tests {
     #[tokio::test]
     async fn test_evaluate_filter_kind_check() {
         let event = make_event(9, "some content");
-        let ctx = FilterContext::from_event(&event, any_channel());
+        let ctx = context_for(&event, any_channel());
 
         let result = evaluate_filter("kind == 9", &ctx, None).await.unwrap();
         assert!(result);
@@ -552,7 +573,7 @@ mod tests {
     #[tokio::test]
     async fn test_evaluate_filter_too_long() {
         let event = make_event(9, "content");
-        let ctx = FilterContext::from_event(&event, any_channel());
+        let ctx = context_for(&event, any_channel());
 
         let long_expr = "a".repeat(MAX_EXPR_LEN + 1);
         let err = evaluate_filter(&long_expr, &ctx, None).await.unwrap_err();
@@ -567,7 +588,7 @@ mod tests {
     #[tokio::test]
     async fn test_evaluate_filter_precompiled_node() {
         let event = make_event(9, "hello world");
-        let ctx = FilterContext::from_event(&event, any_channel());
+        let ctx = context_for(&event, any_channel());
 
         let node =
             Arc::new(evalexpr::build_operator_tree(r#"str_contains(content, "hello")"#).unwrap());
@@ -601,7 +622,9 @@ mod tests {
             ),
         ];
 
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
+        let matched = match_signed_event(&event, channel_id, &rules, "")
+            .await
+            .unwrap();
         assert_eq!(matched.rule_index, 0);
         assert_eq!(matched.prompt_tag, "tag-first");
     }
@@ -630,9 +653,33 @@ mod tests {
             ),
         ];
 
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
+        let matched = match_signed_event(&event, channel_id, &rules, "")
+            .await
+            .unwrap();
         assert_eq!(matched.rule_index, 1);
         assert_eq!(matched.prompt_tag, "matched");
+    }
+
+    #[tokio::test]
+    async fn test_match_event_uses_attributed_author() {
+        let event = make_event(9, "scheduled wake");
+        let owner = Keys::generate().public_key().to_hex();
+        let rules = vec![make_rule(
+            "owner-only",
+            ChannelScope::All("all".into()),
+            vec![9],
+            false,
+            Some(&format!(r#"author == "{owner}""#)),
+            None,
+        )];
+
+        assert!(match_event(&event, any_channel(), &rules, "", &owner)
+            .await
+            .is_some());
+        let signer = event.pubkey.to_hex();
+        assert!(match_event(&event, any_channel(), &rules, "", &signer)
+            .await
+            .is_none());
     }
 
     #[tokio::test]
@@ -653,11 +700,11 @@ mod tests {
         )];
 
         // Without mention — no match.
-        let result = match_event(&event_no_mention, channel_id, &rules, agent_pubkey).await;
+        let result = match_signed_event(&event_no_mention, channel_id, &rules, agent_pubkey).await;
         assert!(result.is_none());
 
         // With mention — matches.
-        let matched = match_event(&event_with_mention, channel_id, &rules, agent_pubkey)
+        let matched = match_signed_event(&event_with_mention, channel_id, &rules, agent_pubkey)
             .await
             .unwrap();
         assert_eq!(matched.prompt_tag, "mentioned");
@@ -677,7 +724,7 @@ mod tests {
             None,
         )];
 
-        let result = match_event(&event, channel_id, &rules, "").await;
+        let result = match_signed_event(&event, channel_id, &rules, "").await;
         assert!(result.is_none());
     }
 
@@ -725,7 +772,9 @@ mod tests {
             None, // no explicit tag
         )];
 
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
+        let matched = match_signed_event(&event, channel_id, &rules, "")
+            .await
+            .unwrap();
         assert_eq!(matched.prompt_tag, "my-rule");
     }
 
@@ -755,7 +804,7 @@ mod tests {
         ];
 
         // Must return None — not "catch-all".
-        let result = match_event(&event, channel_id, &rules, "").await;
+        let result = match_signed_event(&event, channel_id, &rules, "").await;
         assert!(
             result.is_none(),
             "filter error must fail closed, not fall through to next rule"
@@ -781,7 +830,7 @@ mod tests {
             .store(MAX_CONSECUTIVE_TIMEOUTS, Ordering::Relaxed);
 
         let rules = vec![rule];
-        let result = match_event(&event, channel_id, &rules, "").await;
+        let result = match_signed_event(&event, channel_id, &rules, "").await;
         assert!(result.is_none(), "disabled rule must return None");
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -42,7 +42,7 @@ use pool::{
 };
 use pool_lifecycle::PoolLifecycle;
 use queue::{CancelReason, EventQueue, FlushBatch, QueuedEvent, ThreadTags};
-use relay::{HarnessRelay, RelayEventPublisher};
+use relay::{HarnessRelay, RelayEventPublisher, RelayStreamItem};
 use tokio::sync::{mpsc, watch};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
@@ -65,6 +65,66 @@ const MODELS_TIMEOUT: Duration = Duration::from_secs(10);
 /// Timeout for `buzz-acp authenticate`. Browser-based vendor auth can require
 /// human interaction, so it must not share the short probe timeout.
 const AUTHENTICATE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+/// Refresh the trusted relay signing identity independently of inbound events.
+///
+/// A fixed timer avoids letting an attacker force HTTP work by attaching the
+/// reserved `buzz:workflow` tag to otherwise valid channel messages.
+const RELAY_IDENTITY_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
+const RELAY_IDENTITY_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+const RELAY_IDENTITY_FETCH_TIMEOUT: Duration = Duration::from_secs(2);
+
+async fn fetch_trusted_relay_pubkey(relay: &HarnessRelay) -> Option<PublicKey> {
+    match tokio::time::timeout(
+        RELAY_IDENTITY_FETCH_TIMEOUT,
+        relay.relay_workflow_signer_pubkey(),
+    )
+    .await
+    {
+        Ok(Ok(Some(pubkey))) => Some(pubkey),
+        Ok(Ok(None)) => {
+            tracing::warn!(
+                "relay NIP-11 document has no workflow signer; workflow events will fail closed"
+            );
+            None
+        }
+        Ok(Err(error)) => {
+            tracing::warn!(
+                %error,
+                "failed to verify relay identity; workflow events will fail closed"
+            );
+            None
+        }
+        Err(_) => {
+            tracing::warn!(
+                timeout_ms = RELAY_IDENTITY_FETCH_TIMEOUT.as_millis(),
+                "relay identity lookup timed out; workflow events will fail closed"
+            );
+            None
+        }
+    }
+}
+
+fn replace_trusted_workflow_signer(
+    trusted_signer: &mut Option<PublicKey>,
+    refreshed_signer: Option<PublicKey>,
+) -> bool {
+    *trusted_signer = refreshed_signer;
+    trusted_signer.is_none()
+}
+
+#[cfg(test)]
+mod relay_identity_refresh_tests {
+    use super::*;
+
+    #[test]
+    fn failed_reconnect_refresh_revokes_the_previous_workflow_signer() {
+        let mut trusted = Some(nostr::Keys::generate().public_key());
+
+        assert!(replace_trusted_workflow_signer(&mut trusted, None));
+        assert_eq!(trusted, None);
+    }
+}
 
 /// Publish a kind:20001 presence update event via the WebSocket connection.
 ///
@@ -1344,6 +1404,15 @@ async fn tokio_main() -> Result<()> {
         HarnessRelay::connect(&config.relay_url, &config.keys, &pubkey_hex, relay_auth_tag)
             .await
             .map_err(|e| anyhow::anyhow!("relay connect error: {e}"))?;
+    let mut relay_workflow_signer = fetch_trusted_relay_pubkey(&relay).await;
+    let mut relay_identity_refresh = tokio::time::interval_at(
+        tokio::time::Instant::now() + RELAY_IDENTITY_REFRESH_INTERVAL,
+        RELAY_IDENTITY_REFRESH_INTERVAL,
+    );
+    relay_identity_refresh.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    if relay_workflow_signer.is_none() {
+        relay_identity_refresh.reset_after(RELAY_IDENTITY_RETRY_INTERVAL);
+    }
 
     // Tell the relay background task the watermark so it can use
     // `since = watermark - 5s` on the first REQ instead of `since=now`.
@@ -1902,11 +1971,25 @@ async fn tokio_main() -> Result<()> {
                     }
                     None
                 }
+                _ = relay_identity_refresh.tick() => {
+                    let _ = result_rx;
+                    let refreshed_signer = fetch_trusted_relay_pubkey(&relay).await;
+                    if replace_trusted_workflow_signer(
+                        &mut relay_workflow_signer,
+                        refreshed_signer,
+                    ) {
+                        relay_identity_refresh.reset_after(RELAY_IDENTITY_RETRY_INTERVAL);
+                    } else {
+                        relay_identity_refresh.reset();
+                    }
+                    None
+                }
                 // Remaining branches don't touch pool — evaluated when pool is idle.
                 buzz_event = relay.next_event() => {
                     let _ = result_rx; // end split borrow before relay handling
                     match buzz_event {
-                        Some(buzz_event) => {
+                        Some(RelayStreamItem::Event(buzz_event)) => {
+                            let buzz_event = *buzz_event;
                             let kind_u32 = buzz_event.event.kind.as_u16() as u32;
 
                             if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION
@@ -2025,7 +2108,19 @@ async fn tokio_main() -> Result<()> {
                                 continue;
                             }
 
-                            if config.ignore_self && buzz_event.event.pubkey.to_hex() == pubkey_hex {
+                            let Some(inbound_author) = effective_inbound_author(
+                                &buzz_event.event,
+                                relay_workflow_signer.as_ref(),
+                            ) else {
+                                tracing::warn!(
+                                    event_id = %buzz_event.event.id,
+                                    signer = %buzz_event.event.pubkey,
+                                    "dropping unverifiable workflow event"
+                                );
+                                continue;
+                            };
+
+                            if config.ignore_self && inbound_author == pubkey_hex {
                                 tracing::debug!(channel_id = %buzz_event.channel_id, "dropping self-authored event");
                                 continue;
                             }
@@ -2145,7 +2240,6 @@ async fn tokio_main() -> Result<()> {
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
                             {
-                                let author = buzz_event.event.pubkey.to_hex();
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
@@ -2154,7 +2248,7 @@ async fn tokio_main() -> Result<()> {
                                 let allowed = author_allowed(
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
-                                    &author,
+                                    &inbound_author,
                                     is_dm,
                                     &owner_cache,
                                     &ctx.rest_client,
@@ -2163,7 +2257,8 @@ async fn tokio_main() -> Result<()> {
                                 if !allowed {
                                     tracing::debug!(
                                         channel_id = %buzz_event.channel_id,
-                                        author = %buzz_event.event.pubkey.to_hex(),
+                                        author = %inbound_author,
+                                        signer = %buzz_event.event.pubkey.to_hex(),
                                         mode = %config.respond_to,
                                         is_dm,
                                         "inbound author gate — dropping event"
@@ -2180,9 +2275,7 @@ async fn tokio_main() -> Result<()> {
                                     continue;
                                 }
                             };
-                            // Capture author pubkey before queue.push() moves
-                            // buzz_event.event (needed for mode gate below).
-                            let author_hex = buzz_event.event.pubkey.to_hex();
+                            // Capture the event ID before queue.push() moves the event.
                             let event_id_hex = buzz_event.event.id.to_hex();
                             // Clone for the non-cancelling steer fork, which
                             // needs the event to render the steer body. The
@@ -2224,7 +2317,7 @@ async fn tokio_main() -> Result<()> {
                                 // event that reaches here.
                                 let signal = mode_gate_signal(
                                     config.multiple_event_handling,
-                                    &author_hex,
+                                    &inbound_author,
                                     owner_cache.get(),
                                 );
                                 if let Some(signal) = signal {
@@ -2266,13 +2359,32 @@ async fn tokio_main() -> Result<()> {
                                 }
                             }
                         }
-                        None => {
+                        Some(RelayStreamItem::Reconnected) => {
+                            let refreshed_signer = fetch_trusted_relay_pubkey(&relay).await;
+                            if replace_trusted_workflow_signer(
+                                &mut relay_workflow_signer,
+                                refreshed_signer,
+                            ) {
+                                // The ordered marker prevents replayed events
+                                // from reaching the author gate before this
+                                // fail-closed refresh. Retry promptly without
+                                // tying HTTP work to untrusted event traffic.
+                                relay_identity_refresh.reset_immediately();
+                            } else {
+                                relay_identity_refresh.reset();
+                            }
+                        }
+                        Some(RelayStreamItem::Disconnected) => {
                             tracing::warn!("relay event stream ended — requesting reconnect");
                             if let Err(e) = relay.reconnect().await {
                                 tracing::error!("relay background task is gone: {e} — exiting");
                                 tokio::time::sleep(Duration::from_secs(1)).await;
                                 break;
                             }
+                        }
+                        None => {
+                            tracing::error!("relay background task exited — shutting down");
+                            break;
                         }
                     }
                     None
@@ -2714,6 +2826,39 @@ fn event_mentions_agent(event: &nostr::Event, agent_pubkey_hex: &str) -> bool {
         t.as_slice().first().map(|s| s.as_str()) == Some("p")
             && t.as_slice().get(1).map(|s| s.as_str()) == Some(agent_pubkey_hex)
     })
+}
+
+fn is_workflow_event(event: &nostr::Event) -> bool {
+    event
+        .tags
+        .iter()
+        .any(|tag| tag.as_slice().first().map(String::as_str) == Some("buzz:workflow"))
+}
+
+/// Return the author used by the inbound gate.
+///
+/// The relay action sink signs workflow output with its advertised workflow
+/// signer and writes the workflow owner as the first `p` tag. Workflow events
+/// fail closed unless their ID and signature verify, their signer matches that
+/// trusted key, and the owner tag is valid.
+fn effective_inbound_author(
+    event: &nostr::Event,
+    relay_workflow_signer: Option<&PublicKey>,
+) -> Option<String> {
+    if !is_workflow_event(event) {
+        return Some(event.pubkey.to_hex());
+    }
+
+    if event.verify().is_err() || relay_workflow_signer != Some(&event.pubkey) {
+        return None;
+    }
+
+    let owner_tag = event
+        .tags
+        .iter()
+        .find(|tag| tag.as_slice().first().map(String::as_str) == Some("p"))?;
+    let owner = owner_tag.as_slice().get(1)?;
+    PublicKey::from_hex(owner).ok().map(|owner| owner.to_hex())
 }
 
 fn is_owner_control_command(
@@ -4407,6 +4552,80 @@ mod author_gate_tests {
         cache.cache_sibling(STRANGER.into(), false);
         cache.cache_sibling(EXTERNAL.into(), false);
         cache
+    }
+
+    #[tokio::test]
+    async fn test_verified_workflow_attribution_preserves_dm_author_gate() {
+        use nostr::{EventBuilder, Keys, Kind, Tag};
+
+        let relay = Keys::generate();
+        let workflow_owner = Keys::generate();
+        let watcher = Keys::generate();
+        let workflow_event = |signer: &Keys| {
+            EventBuilder::new(
+                Kind::Custom(KIND_STREAM_MESSAGE as u16),
+                "@watcher scheduled scan",
+            )
+            .tags([
+                Tag::public_key(workflow_owner.public_key()),
+                Tag::parse(["h", &Uuid::new_v4().to_string()]).expect("valid h tag"),
+                Tag::parse(["buzz:workflow", "true"]).expect("valid workflow tag"),
+                Tag::public_key(watcher.public_key()),
+            ])
+            .sign_with_keys(signer)
+            .expect("event signs")
+        };
+
+        let event = workflow_event(&relay);
+        assert!(event_mentions_agent(&event, &watcher.public_key().to_hex()));
+        let attributed_author =
+            effective_inbound_author(&event, Some(&relay.public_key())).expect("trusted workflow");
+        assert_eq!(
+            attributed_author,
+            workflow_owner.public_key().to_hex(),
+            "verified workflow output must be attributed to its owner"
+        );
+        assert_eq!(
+            effective_inbound_author(&event, None),
+            None,
+            "missing relay identity must drop a workflow event"
+        );
+
+        let cache = OwnerCache::new(Some(watcher.public_key().to_hex()));
+        cache.cache_sibling(workflow_owner.public_key().to_hex(), true);
+        assert!(
+            author_allowed(
+                &RespondTo::OwnerOnly,
+                &HashSet::new(),
+                &attributed_author,
+                true,
+                &cache,
+                &dummy_rest_client()
+            )
+            .await,
+            "a workflow owned by a verified same-owner sibling must reach the watcher in a DM"
+        );
+
+        let spoofed_event = workflow_event(&Keys::generate());
+        assert_eq!(
+            effective_inbound_author(&spoofed_event, Some(&relay.public_key())),
+            None,
+            "a non-relay signer must not borrow workflow attribution"
+        );
+
+        let mut forged: serde_json::Value =
+            serde_json::to_value(workflow_event(&relay)).expect("event serializes");
+        forged["sig"] = serde_json::Value::String("00".repeat(64));
+        let forged: nostr::Event = serde_json::from_value(forged).expect("event deserializes");
+        assert!(
+            forged.verify().is_err(),
+            "the test fixture must have an invalid signature"
+        );
+        assert_eq!(
+            effective_inbound_author(&forged, Some(&relay.public_key())),
+            None,
+            "a forged relay signature must not borrow workflow attribution"
+        );
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2267,7 +2267,14 @@ async fn tokio_main() -> Result<()> {
                                 }
                             }
 
-                            let matched = filter::match_event(&buzz_event.event, buzz_event.channel_id, &rules, &pubkey_hex).await;
+                            let matched = filter::match_event(
+                                &buzz_event.event,
+                                buzz_event.channel_id,
+                                &rules,
+                                &pubkey_hex,
+                                &inbound_author,
+                            )
+                            .await;
                             let prompt_tag = match matched {
                                 Some(m) => m.prompt_tag,
                                 None => {
@@ -2835,6 +2842,27 @@ fn is_workflow_event(event: &nostr::Event) -> bool {
         .any(|tag| tag.as_slice().first().map(String::as_str) == Some("buzz:workflow"))
 }
 
+fn workflow_owner(event: &nostr::Event) -> Option<PublicKey> {
+    let owner_tag = event
+        .tags
+        .iter()
+        .find(|tag| tag.as_slice().first().map(String::as_str) == Some("p"))?;
+    PublicKey::from_hex(owner_tag.as_slice().get(1)?).ok()
+}
+
+/// Return the author of an event that has already passed inbound admission.
+///
+/// Workflow events are immutable and reach the queue only after
+/// [`effective_inbound_author`] verifies their signature and relay signer, so
+/// downstream filtering and prompt rendering can reuse the owner tag.
+pub(crate) fn admitted_event_author(event: &nostr::Event) -> PublicKey {
+    if is_workflow_event(event) {
+        workflow_owner(event).unwrap_or(event.pubkey)
+    } else {
+        event.pubkey
+    }
+}
+
 /// Return the author used by the inbound gate.
 ///
 /// The relay action sink signs workflow output with its advertised workflow
@@ -2853,12 +2881,7 @@ fn effective_inbound_author(
         return None;
     }
 
-    let owner_tag = event
-        .tags
-        .iter()
-        .find(|tag| tag.as_slice().first().map(String::as_str) == Some("p"))?;
-    let owner = owner_tag.as_slice().get(1)?;
-    PublicKey::from_hex(owner).ok().map(|owner| owner.to_hex())
+    workflow_owner(event).map(|owner| owner.to_hex())
 }
 
 fn is_owner_control_command(
@@ -4556,7 +4579,7 @@ mod author_gate_tests {
 
     #[tokio::test]
     async fn test_verified_workflow_attribution_preserves_dm_author_gate() {
-        use nostr::{EventBuilder, Keys, Kind, Tag};
+        use nostr::{EventBuilder, Keys, Kind, Tag, ToBech32};
 
         let relay = Keys::generate();
         let workflow_owner = Keys::generate();
@@ -4584,6 +4607,18 @@ mod author_gate_tests {
             attributed_author,
             workflow_owner.public_key().to_hex(),
             "verified workflow output must be attributed to its owner"
+        );
+        let prompt_event = queue::BatchEvent {
+            event: event.clone(),
+            prompt_tag: "scheduled".into(),
+            received_at: std::time::Instant::now(),
+        };
+        let prompt = queue::format_event_block(Uuid::new_v4(), None, &prompt_event, None);
+        let owner_hex = workflow_owner.public_key().to_hex();
+        let owner_npub = workflow_owner.public_key().to_bech32().expect("owner npub");
+        assert!(
+            prompt.contains(&format!("From: {owner_npub} (hex: {owner_hex})")),
+            "prompt must render the verified workflow owner, not the relay signer"
         );
         assert_eq!(
             effective_inbound_author(&event, None),

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1079,8 +1079,9 @@ pub(crate) fn format_event_block(
     be: &BatchEvent,
     profile_lookup: Option<&PromptProfileLookup>,
 ) -> String {
-    let hex = be.event.pubkey.to_hex();
-    let npub = be.event.pubkey.to_bech32().unwrap_or_else(|_| hex.clone());
+    let author = crate::admitted_event_author(&be.event);
+    let hex = author.to_hex();
+    let npub = author.to_bech32().unwrap_or_else(|_| hex.clone());
 
     let time = chrono::DateTime::from_timestamp(be.event.created_at.as_secs() as i64, 0)
         .map(|dt| dt.to_rfc3339())
@@ -1464,7 +1465,7 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
     //   - top-level     → anchor to the triggering event (it becomes the root)
     // Agent↔agent turns get no forced anchor — deep nesting is intentional
     // there. DMs are always 1:1 with a human, so they always anchor.
-    let sender_pubkey = last_event.event.pubkey.to_hex();
+    let sender_pubkey = crate::admitted_event_author(&last_event.event).to_hex();
     let reply_anchor = if is_dm {
         thread_tags
             .root_event_id
@@ -3968,6 +3969,52 @@ mod tests {
         assert!(
             prompt.contains("new top-level message"),
             "top-level human message should use the new-thread instruction"
+        );
+    }
+
+    #[test]
+    fn test_workflow_reply_anchor_uses_attributed_owner() {
+        let ch = Uuid::new_v4();
+        let relay = Keys::generate();
+        let owner = Keys::generate();
+        let watcher = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9), "@watcher scheduled scan")
+            .tags([
+                nostr::Tag::public_key(owner.public_key()),
+                nostr::Tag::parse(["buzz:workflow", "true"]).unwrap(),
+                nostr::Tag::public_key(watcher.public_key()),
+            ])
+            .sign_with_keys(&relay)
+            .unwrap();
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "scheduled".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let profiles = HashMap::from([
+            (owner.public_key().to_hex(), profile(true)),
+            (watcher.public_key().to_hex(), profile(true)),
+        ]);
+
+        // Model an already-admitted workflow event. The relay signer has no
+        // profile and would be treated as human; the attributed owner and every
+        // mentioned identity are agents, so no human-facing anchor is needed.
+        let prompt = format_prompt(
+            &batch,
+            &FormatPromptArgs {
+                profile_lookup: Some(&profiles),
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+        assert!(
+            !prompt.contains("--reply-to"),
+            "reply anchoring must classify the attributed workflow owner, not the relay signer"
         );
     }
 

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -118,7 +118,7 @@ use buzz_core::kind::{
     KIND_TYPING_INDICATOR,
 };
 use futures_util::{SinkExt, StreamExt};
-use nostr::{Event, EventBuilder, Keys, Kind, RelayUrl, Tag};
+use nostr::{Event, EventBuilder, Keys, Kind, PublicKey, RelayUrl, Tag};
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
 use tokio::time::timeout;
@@ -533,7 +533,7 @@ type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 /// Ping frames, preventing disconnection during long agent turns.
 pub struct HarnessRelay {
     /// Receiver for events forwarded by the background task.
-    event_rx: mpsc::Receiver<Option<BuzzEvent>>,
+    event_rx: mpsc::Receiver<RelayStreamItem>,
     /// Receiver for encrypted observer control events addressed to this agent.
     observer_control_rx: Option<mpsc::Receiver<Event>>,
     /// Sender for commands to the background task.
@@ -550,6 +550,16 @@ pub struct HarnessRelay {
     /// Wrapped in `Option` so `shutdown()` can take ownership without conflicting
     /// with `Drop` (which only has `&mut self`).
     bg_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+/// Ordered messages from the relay task to the harness.
+///
+/// Reconnect markers share the event channel so a signer refresh cannot race
+/// replayed events from the new socket.
+pub enum RelayStreamItem {
+    Event(Box<BuzzEvent>),
+    Disconnected,
+    Reconnected,
 }
 
 /// Cloneable publisher handle for signed events on the relay background socket.
@@ -607,7 +617,7 @@ impl HarnessRelay {
         let (ws, handshake_buffer) =
             retry_initial_connect(|| do_connect(relay_url, keys, auth_tag.as_ref())).await?;
 
-        let (event_tx, event_rx) = mpsc::channel::<Option<BuzzEvent>>(event_channel_capacity());
+        let (event_tx, event_rx) = mpsc::channel::<RelayStreamItem>(event_channel_capacity());
         let (observer_control_tx, observer_control_rx) =
             mpsc::channel::<Event>(event_channel_capacity());
         let (cmd_tx, cmd_rx) = mpsc::channel::<RelayCommand>(CMD_CHANNEL_CAPACITY);
@@ -728,6 +738,33 @@ impl HarnessRelay {
         }
     }
 
+    /// Fetch the relay key trusted for workflow messages.
+    ///
+    /// New relays advertise `buzz_workflow_signer`, including development
+    /// relays with an ephemeral process key. Older relays fall back to the
+    /// stable NIP-11 `self` key.
+    pub(crate) async fn relay_workflow_signer_pubkey(
+        &self,
+    ) -> Result<Option<PublicKey>, RelayError> {
+        let response = self
+            .http
+            .get(relay_ws_to_http(&self.relay_url))
+            .header("Accept", "application/nostr+json")
+            .send()
+            .await
+            .map_err(|e| RelayError::Http(e.to_string()))?;
+
+        if !response.status().is_success() {
+            return Ok(None);
+        }
+
+        let info = response
+            .json::<Value>()
+            .await
+            .map_err(|e| RelayError::Http(format!("invalid NIP-11 document: {e}")))?;
+        workflow_signer_from_nip11(&info)
+    }
+
     /// Subscribe to events in a channel using the given filter.
     ///
     /// Sends a `Subscribe` command to the background task, which issues the
@@ -804,13 +841,13 @@ impl HarnessRelay {
         Ok(())
     }
 
-    /// Wait for the next event from any subscribed channel.
+    /// Wait for the next ordered relay stream item.
     ///
-    /// Reads from the background task's event channel. Returns `None` on
-    /// connection loss — the caller should call [`reconnect`](Self::reconnect).
-    pub async fn next_event(&mut self) -> Option<BuzzEvent> {
-        // The background task sends `None` to signal connection loss.
-        self.event_rx.recv().await.flatten()
+    /// A [`RelayStreamItem::Disconnected`] marker asks the caller to request
+    /// reconnection. A [`RelayStreamItem::Reconnected`] marker always precedes
+    /// events replayed from the replacement socket.
+    pub async fn next_event(&mut self) -> Option<RelayStreamItem> {
+        self.event_rx.recv().await
     }
 
     /// Publish a signed event to the relay via the background WebSocket task.
@@ -891,6 +928,20 @@ impl HarnessRelay {
             .map_err(|_| RelayError::ConnectionClosed)?;
         Ok(())
     }
+}
+
+fn workflow_signer_from_nip11(info: &Value) -> Result<Option<PublicKey>, RelayError> {
+    let Some(signer) = info
+        .get("buzz_workflow_signer")
+        .or_else(|| info.get("self"))
+        .and_then(Value::as_str)
+    else {
+        return Ok(None);
+    };
+
+    PublicKey::from_hex(signer)
+        .map(Some)
+        .map_err(|e| RelayError::Http(format!("invalid NIP-11 workflow signer pubkey: {e}")))
 }
 
 impl HarnessRelay {
@@ -1534,7 +1585,7 @@ async fn execute_connected_command(
 async fn run_background_task(
     mut ws: WsStream,
     initial_handshake_buffer: std::collections::VecDeque<RelayMessage>,
-    event_tx: mpsc::Sender<Option<BuzzEvent>>,
+    event_tx: mpsc::Sender<RelayStreamItem>,
     observer_control_tx: mpsc::Sender<Event>,
     mut cmd_rx: mpsc::Receiver<RelayCommand>,
     keys: Keys,
@@ -1560,7 +1611,7 @@ async fn run_background_task(
         warn!("handshake buffer contained a drop signal — attempting autonomous reconnect");
         // Don't wait for a caller-driven Reconnect command — the caller was
         // never notified (no sentinel sent). Go straight to reconnect loop.
-        let _ = event_tx.try_send(None);
+        let _ = event_tx.try_send(RelayStreamItem::Disconnected);
         match try_autonomous_reconnect(
             &mut ws,
             &mut cmd_rx,
@@ -1643,7 +1694,7 @@ async fn run_background_task(
                 ResubscribeResult::Shutdown => return,
                 ResubscribeResult::RetryConnection => {
                     warn!("proactive resubscribe had failures — triggering reconnect");
-                    let _ = event_tx.try_send(None);
+                    let _ = event_tx.try_send(RelayStreamItem::Disconnected);
                     match try_autonomous_reconnect(
                         &mut ws,
                         &mut cmd_rx,
@@ -1819,7 +1870,7 @@ async fn run_background_task(
                            // Signal the caller, then attempt autonomous reconnect.
                            // Use try_send to avoid blocking on backpressure — recovery
                            // must not stall when the event channel is full.
-                           let _ = event_tx.try_send(None);
+                           let _ = event_tx.try_send(RelayStreamItem::Disconnected);
                            let outcome = try_autonomous_reconnect(
                                &mut ws,
                                &mut cmd_rx,
@@ -1900,7 +1951,7 @@ async fn run_background_task(
                                if !ok {
                                    // Send failed — socket is likely dead. Trigger reconnect.
                                    warn!("command send failed — triggering reconnect");
-                                   let _ = event_tx.try_send(None);
+                                   let _ = event_tx.try_send(RelayStreamItem::Disconnected);
                                    match try_autonomous_reconnect(
                                        &mut ws, &mut cmd_rx, &mut state, &keys, &relay_url,
         &agent_pubkey_hex, &event_tx,
@@ -1939,7 +1990,7 @@ async fn run_background_task(
                            // No pong received after our last ping — connection is dead.
                            warn!("no pong received within {:?} — connection dead, reconnecting", PONG_TIMEOUT);
                            // Use try_send to avoid blocking on backpressure during recovery.
-                           let _ = event_tx.try_send(None);
+                           let _ = event_tx.try_send(RelayStreamItem::Disconnected);
                            match try_autonomous_reconnect(
                                &mut ws, &mut cmd_rx, &mut state, &keys, &relay_url,
         &agent_pubkey_hex, &event_tx,
@@ -1972,7 +2023,7 @@ async fn run_background_task(
                            if let Err(e) = ws_send_timeout(&mut ws, Message::Ping(vec![].into()), WS_SEND_TIMEOUT_SECS).await {
                                warn!("failed to send ping: {e} — triggering reconnect");
                                // Use try_send to avoid blocking on backpressure during recovery.
-                               let _ = event_tx.try_send(None);
+                               let _ = event_tx.try_send(RelayStreamItem::Disconnected);
                                match try_autonomous_reconnect(
                                    &mut ws, &mut cmd_rx, &mut state, &keys, &relay_url,
         &agent_pubkey_hex, &event_tx,
@@ -2043,7 +2094,7 @@ async fn run_background_task(
 async fn handle_ws_message(
     msg: Message,
     ws: &mut WsStream,
-    event_tx: &mpsc::Sender<Option<BuzzEvent>>,
+    event_tx: &mpsc::Sender<RelayStreamItem>,
     observer_control_tx: &mpsc::Sender<Event>,
     state: &mut BgState,
     keys: &Keys,
@@ -2112,7 +2163,7 @@ async fn handle_ws_message(
                                 "event channel at ≥80% capacity — backpressure imminent"
                             );
                         }
-                        match event_tx.try_send(Some(buzz_event)) {
+                        match event_tx.try_send(RelayStreamItem::Event(Box::new(buzz_event))) {
                             Ok(()) => {
                                 state.membership_last_seen =
                                     Some(state.membership_last_seen.unwrap_or(0).max(ts));
@@ -2154,7 +2205,7 @@ async fn handle_ws_message(
                                     "event channel at ≥80% capacity — backpressure imminent"
                                 );
                             }
-                            match event_tx.try_send(Some(buzz_event)) {
+                            match event_tx.try_send(RelayStreamItem::Event(Box::new(buzz_event))) {
                                 Ok(()) => {}
                                 Err(mpsc::error::TrySendError::Full(_)) => {
                                     // Remove from dedup set so the replayed event
@@ -2393,7 +2444,7 @@ async fn handle_ws_message(
 async fn process_handshake_buffer(
     ws: &mut WsStream,
     buffer: std::collections::VecDeque<RelayMessage>,
-    event_tx: &mpsc::Sender<Option<BuzzEvent>>,
+    event_tx: &mpsc::Sender<RelayStreamItem>,
     observer_control_tx: &mpsc::Sender<Event>,
     state: &mut BgState,
     keys: &Keys,
@@ -2897,7 +2948,7 @@ async fn try_autonomous_reconnect(
     keys: &Keys,
     relay_url: &str,
     agent_pubkey_hex: &str,
-    event_tx: &mpsc::Sender<Option<BuzzEvent>>,
+    event_tx: &mpsc::Sender<RelayStreamItem>,
     observer_control_tx: &mpsc::Sender<Event>,
     auth_tag: Option<&nostr::Tag>,
 ) -> ReconnectOutcome {
@@ -2925,6 +2976,9 @@ async fn try_autonomous_reconnect(
             Ok((new_ws, handshake_buffer)) => {
                 *ws = new_ws;
                 info!("autonomous reconnect succeeded (attempt {})", attempt + 1);
+                if event_tx.send(RelayStreamItem::Reconnected).await.is_err() {
+                    return ReconnectOutcome::Shutdown;
+                }
                 let handshake_ok = process_handshake_buffer(
                     ws,
                     handshake_buffer,
@@ -3026,7 +3080,7 @@ async fn wait_for_reconnect(
     keys: &Keys,
     relay_url: &str,
     agent_pubkey_hex: &str,
-    event_tx: &mpsc::Sender<Option<BuzzEvent>>,
+    event_tx: &mpsc::Sender<RelayStreamItem>,
     observer_control_tx: &mpsc::Sender<Event>,
     skip_drain: bool,
     auth_tag: Option<&nostr::Tag>,
@@ -3063,6 +3117,9 @@ async fn wait_for_reconnect(
             Ok((new_ws, handshake_buffer)) => {
                 *ws = new_ws;
                 info!("relay reconnected to {relay_url}");
+                if event_tx.send(RelayStreamItem::Reconnected).await.is_err() {
+                    return ReconnectOutcome::Shutdown;
+                }
                 let handshake_ok = process_handshake_buffer(
                     ws,
                     handshake_buffer,
@@ -3550,6 +3607,9 @@ pub(crate) fn parse_relay_message(text: &str) -> Result<RelayMessage, RelayError
                     .cloned()
                     .ok_or_else(|| RelayError::UnexpectedMessage(text.to_string()))?,
             )?;
+            event
+                .verify()
+                .map_err(|e| RelayError::UnexpectedMessage(format!("invalid EVENT: {e}")))?;
             Ok(RelayMessage::Event {
                 subscription_id: sub_id,
                 event: Box::new(event),
@@ -3996,6 +4056,28 @@ mod tests {
     use super::*;
 
     #[test]
+    fn workflow_signer_supports_ephemeral_extension_and_stable_fallback() {
+        let ephemeral = Keys::generate().public_key();
+        let stable = Keys::generate().public_key();
+
+        assert_eq!(
+            workflow_signer_from_nip11(&json!({
+                "buzz_workflow_signer": ephemeral.to_hex(),
+                "self": stable.to_hex(),
+            }))
+            .unwrap(),
+            Some(ephemeral),
+            "the current workflow signer must take precedence over stable self"
+        );
+        assert_eq!(
+            workflow_signer_from_nip11(&json!({"self": stable.to_hex()})).unwrap(),
+            Some(stable),
+            "older relays must remain compatible through NIP-11 self"
+        );
+        assert_eq!(workflow_signer_from_nip11(&json!({})).unwrap(), None);
+    }
+
+    #[test]
     fn relay_ws_to_http_plain() {
         assert_eq!(
             relay_ws_to_http("ws://localhost:3000"),
@@ -4163,6 +4245,33 @@ mod tests {
             }
             _ => panic!("expected Ok"),
         }
+    }
+
+    #[test]
+    fn parse_event_verifies_id_and_signature() {
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::TextNote, "valid")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let valid = json!(["EVENT", "sub-1", event]).to_string();
+        assert!(matches!(
+            parse_relay_message(&valid).unwrap(),
+            RelayMessage::Event { .. }
+        ));
+
+        let mut forged = json!(["EVENT", "sub-1", event]);
+        forged[2]["content"] = Value::String("tampered".into());
+        assert!(matches!(
+            parse_relay_message(&forged.to_string()),
+            Err(RelayError::UnexpectedMessage(message)) if message.contains("invalid EVENT")
+        ));
+
+        let mut forged = json!(["EVENT", "sub-1", event]);
+        forged[2]["sig"] = Value::String("00".repeat(64));
+        assert!(matches!(
+            parse_relay_message(&forged.to_string()),
+            Err(RelayError::UnexpectedMessage(message)) if message.contains("invalid EVENT")
+        ));
     }
 
     #[test]
@@ -4382,6 +4491,99 @@ mod tests {
                 replay_since: Some(1_000),
             },
         );
+    }
+
+    #[tokio::test]
+    async fn reconnected_marker_precedes_buffered_workflow_replay() {
+        use buzz_core::kind::KIND_STREAM_MESSAGE;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind reconnect relay");
+        let relay_url = format!("ws://{}", listener.local_addr().expect("relay address"));
+        let channel_id = Uuid::new_v4();
+        let owner = Keys::generate();
+        let relay_signer = Keys::generate();
+        let trusted_signer = relay_signer.public_key();
+        let workflow_event = EventBuilder::new(
+            Kind::Custom(KIND_STREAM_MESSAGE as u16),
+            "scheduled workflow wake",
+        )
+        .tags([
+            Tag::public_key(owner.public_key()),
+            Tag::parse(["h", &channel_id.to_string()]).expect("valid channel tag"),
+            Tag::parse(["buzz:workflow", "true"]).expect("valid workflow tag"),
+        ])
+        .sign_with_keys(&relay_signer)
+        .expect("sign workflow event");
+        let subscription_id = channel_sub_id(channel_id);
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept reconnect");
+            let mut ws = tokio_tungstenite::accept_async(stream)
+                .await
+                .expect("complete reconnect handshake");
+            ws.send(Message::Text(
+                json!(["AUTH", "reconnect-challenge"]).to_string().into(),
+            ))
+            .await
+            .expect("send auth challenge");
+
+            let auth = next_test_frame(&mut ws).await;
+            assert_eq!(auth[0], "AUTH");
+            let auth_event_id = auth[1]["id"].as_str().expect("AUTH event id");
+
+            // do_connect buffers messages received while waiting for AUTH OK.
+            ws.send(Message::Text(
+                json!(["EVENT", subscription_id, workflow_event])
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .expect("send buffered workflow event");
+            ws.send(Message::Text(
+                json!(["OK", auth_event_id, true, ""]).to_string().into(),
+            ))
+            .await
+            .expect("accept AUTH");
+
+            let req = next_test_frame(&mut ws).await;
+            assert_eq!(req[0], "REQ");
+        });
+
+        let (mut old_ws, _old_server) = test_ws_pair().await;
+        let (_cmd_tx, mut cmd_rx) = mpsc::channel(4);
+        let (event_tx, mut event_rx) = mpsc::channel(4);
+        let (observer_tx, _observer_rx) = mpsc::channel(4);
+        let mut state = BgState::new();
+        seed_test_subscription(&mut state, channel_id);
+        let agent_keys = Keys::generate();
+        let outcome = try_autonomous_reconnect(
+            &mut old_ws,
+            &mut cmd_rx,
+            &mut state,
+            &agent_keys,
+            &relay_url,
+            &agent_keys.public_key().to_hex(),
+            &event_tx,
+            &observer_tx,
+            None,
+        )
+        .await;
+
+        assert!(matches!(outcome, ReconnectOutcome::Ok));
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(RelayStreamItem::Reconnected)
+        ));
+        let Some(RelayStreamItem::Event(replay)) = event_rx.recv().await else {
+            panic!("workflow replay must follow the reconnect marker");
+        };
+        assert_eq!(
+            crate::effective_inbound_author(&replay.event, Some(&trusted_signer)),
+            Some(owner.public_key().to_hex())
+        );
+        server.await.expect("join reconnect relay");
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -500,6 +500,7 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
             buzz_event.channel_id,
             &rules,
             &pubkey_hex,
+            &author_hex,
         )
         .await
         .is_some();

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -74,7 +74,7 @@ use crate::{
     author_allowed,
     config::Config,
     event_mentions_agent, filter,
-    relay::{HarnessRelay, RelayEventPublisher},
+    relay::{HarnessRelay, RelayEventPublisher, RelayStreamItem},
 };
 
 // ── Payload ───────────────────────────────────────────────────────────────────
@@ -330,6 +330,15 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         HarnessRelay::connect(&config.relay_url, &config.keys, &pubkey_hex, relay_auth_tag)
             .await
             .map_err(|e| anyhow::anyhow!("setup-mode relay connect error: {e}"))?;
+    let mut relay_workflow_signer = crate::fetch_trusted_relay_pubkey(&relay).await;
+    let mut relay_identity_refresh = tokio::time::interval_at(
+        tokio::time::Instant::now() + crate::RELAY_IDENTITY_REFRESH_INTERVAL,
+        crate::RELAY_IDENTITY_REFRESH_INTERVAL,
+    );
+    relay_identity_refresh.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    if relay_workflow_signer.is_none() {
+        relay_identity_refresh.reset_after(crate::RELAY_IDENTITY_RETRY_INTERVAL);
+    }
 
     if let Err(e) = relay.set_startup_watermark(startup_watermark).await {
         tracing::warn!("setup-mode: failed to set startup watermark: {e}");
@@ -389,13 +398,48 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
     let mut nudged_event_ids: HashSet<EventId> = HashSet::new();
 
     loop {
-        let Some(buzz_event) = relay.next_event().await else {
-            tracing::warn!("setup-mode: relay event stream ended — requesting reconnect");
-            if let Err(e) = relay.reconnect().await {
-                tracing::error!("setup-mode: relay background task is gone: {e} — exiting");
+        let relay_item = tokio::select! {
+            biased;
+            _ = relay_identity_refresh.tick() => {
+                let refreshed_signer = crate::fetch_trusted_relay_pubkey(&relay).await;
+                if crate::replace_trusted_workflow_signer(
+                    &mut relay_workflow_signer,
+                    refreshed_signer,
+                ) {
+                    relay_identity_refresh.reset_after(crate::RELAY_IDENTITY_RETRY_INTERVAL);
+                } else {
+                    relay_identity_refresh.reset();
+                }
+                continue;
+            }
+            item = relay.next_event() => item,
+        };
+        let buzz_event = match relay_item {
+            Some(RelayStreamItem::Event(event)) => *event,
+            Some(RelayStreamItem::Disconnected) => {
+                tracing::warn!("setup-mode: relay event stream ended — requesting reconnect");
+                if let Err(e) = relay.reconnect().await {
+                    tracing::error!("setup-mode: relay background task is gone: {e} — exiting");
+                    break;
+                }
+                continue;
+            }
+            Some(RelayStreamItem::Reconnected) => {
+                let refreshed_signer = crate::fetch_trusted_relay_pubkey(&relay).await;
+                if crate::replace_trusted_workflow_signer(
+                    &mut relay_workflow_signer,
+                    refreshed_signer,
+                ) {
+                    relay_identity_refresh.reset_immediately();
+                } else {
+                    relay_identity_refresh.reset();
+                }
+                continue;
+            }
+            None => {
+                tracing::error!("setup-mode: relay background task exited");
                 break;
             }
-            continue;
         };
 
         let kind_u32 = buzz_event.event.kind.as_u16() as u32;
@@ -414,8 +458,19 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
             continue;
         }
 
+        let Some(author_hex) =
+            crate::effective_inbound_author(&buzz_event.event, relay_workflow_signer.as_ref())
+        else {
+            tracing::warn!(
+                event_id = %buzz_event.event.id,
+                signer = %buzz_event.event.pubkey,
+                "setup-mode: dropping unverifiable workflow event"
+            );
+            continue;
+        };
+
         // ignore_self: don't react to our own messages.
-        if buzz_event.event.pubkey.to_hex() == pubkey_hex {
+        if author_hex == pubkey_hex {
             continue;
         }
 
@@ -428,7 +483,6 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         // Apply the same author gate as normal mode so the nudge only goes
         // to authors the real agent would have answered. Same DM hardening:
         // in DMs only owner/siblings get a nudge (fail-closed on unknown type).
-        let author_hex = buzz_event.event.pubkey.to_hex();
         let is_dm = crate::is_dm_channel(buzz_event.channel_id, &channel_info).await;
         let allowed = author_allowed(
             &config.respond_to,
@@ -466,6 +520,7 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
             &config.keys,
             buzz_event.channel_id,
             &buzz_event.event,
+            &author_hex,
             &payload,
         )
         .await
@@ -591,12 +646,13 @@ async fn handle_setup_membership(
 /// Build and publish a setup nudge reply to the triggering event.
 ///
 /// Threading: flat reply to the thread root if one exists; otherwise reply
-/// to the triggering event itself. P-tags the asker.
+/// to the triggering event itself. P-tags the attributed asker.
 async fn publish_setup_nudge(
     publisher: &RelayEventPublisher,
     keys: &nostr::Keys,
     channel_id: Uuid,
     triggering_event: &nostr::Event,
+    author_hex: &str,
     payload: &SetupPayload,
 ) -> Result<()> {
     use buzz_sdk::ThreadRef;
@@ -621,13 +677,12 @@ async fn publish_setup_nudge(
     };
 
     let body = payload.nudge_body();
-    let author_hex = triggering_event.pubkey.to_hex();
 
     let event_builder = buzz_sdk::build_message(
         channel_id,
         &body,
         thread_ref.as_ref(),
-        &[&author_hex], // p-tag the asker
+        &[author_hex], // p-tag the asker
         false,
         &[],
     )
@@ -650,6 +705,46 @@ async fn publish_setup_nudge(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn setup_nudge_p_tags_the_attributed_workflow_owner() {
+        let (publisher, mut published) = RelayEventPublisher::test_pair();
+        let relay = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let owner_hex = owner.public_key().to_hex();
+        let relay_hex = relay.public_key().to_hex();
+        let triggering_event =
+            nostr::EventBuilder::new(nostr::Kind::TextNote, "relay-signed workflow output")
+                .sign_with_keys(&relay)
+                .expect("sign triggering event");
+        let payload = SetupPayload {
+            agent_name: "Fizz".to_string(),
+            agent_pubkey: "test".to_string(),
+            requirements: vec![],
+        };
+
+        publish_setup_nudge(
+            &publisher,
+            &nostr::Keys::generate(),
+            Uuid::new_v4(),
+            &triggering_event,
+            &owner_hex,
+            &payload,
+        )
+        .await
+        .expect("publish setup nudge");
+
+        let event = published.recv().await.expect("published event");
+        let p_tags = event
+            .tags
+            .iter()
+            .filter(|tag| tag.as_slice().first().map(String::as_str) == Some("p"));
+        let recipients: Vec<&str> = p_tags
+            .filter_map(|tag| tag.as_slice().get(1).map(String::as_str))
+            .collect();
+        assert!(recipients.contains(&owner_hex.as_str()));
+        assert!(!recipients.contains(&relay_hex.as_str()));
+    }
 
     #[test]
     fn setup_payload_from_raw_returns_none_when_absent() {

--- a/crates/buzz-relay/src/nip11.rs
+++ b/crates/buzz-relay/src/nip11.rs
@@ -55,6 +55,13 @@ pub struct RelayInfo {
     /// Relay's own signing pubkey (NIP-11 `self` field, NIP-43).
     #[serde(rename = "self", skip_serializing_if = "Option::is_none")]
     pub relay_self: Option<String>,
+    /// Current key used to sign relay-generated workflow messages.
+    ///
+    /// Unlike `self`, this Buzz extension is also present when the process uses
+    /// an ephemeral development key. Clients must not use it for NIP-43 or
+    /// other long-lived authoritative relay state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub buzz_workflow_signer: Option<String>,
 }
 
 /// Protocol and resource limits advertised in the NIP-11 document.
@@ -124,6 +131,10 @@ impl RelayInfo {
     /// unconditionally) requires clients to verify those events against
     /// `self`. Pass `Some` whenever the relay has a stable signing key.
     ///
+    /// `workflow_signer` is the current process key used for relay-generated
+    /// workflow messages. It is advertised even when that key is ephemeral;
+    /// clients must refresh it and use it only for workflow-message attribution.
+    ///
     /// `icon` is the community's workspace icon (see
     /// [`workspace_icon_for_host`]) — a host-scoped scalar, pre-fetched by
     /// the caller so `build` itself stays static-input.
@@ -135,6 +146,7 @@ impl RelayInfo {
     /// programmer error to advertise NIP-43 without a `relay_self`.
     pub fn build(
         relay_self: Option<&str>,
+        workflow_signer: Option<&str>,
         icon: Option<&str>,
         advertise_nip43: bool,
         max_message_length: usize,
@@ -164,6 +176,7 @@ impl RelayInfo {
             limitation: Some(relay_limitation(max_message_length)),
             pairing_relay_url: pairing_relay_url.map(str::to_string),
             relay_self: relay_self.map(|s| s.to_string()),
+            buzz_workflow_signer: workflow_signer.map(str::to_string),
         }
     }
 }
@@ -234,9 +247,11 @@ fn push_descriptor(
 /// host-scoped workspace icon.
 pub(crate) async fn nip11_document(state: &crate::state::AppState, raw_host: &str) -> RelayInfo {
     let (relay_self, advertise_nip43) = nip11_facts(state);
+    let workflow_signer = state.relay_keypair.public_key().to_hex();
     let icon = workspace_icon_for_host(state, raw_host).await;
     let mut info = RelayInfo::build(
         relay_self.as_deref(),
+        Some(&workflow_signer),
         icon.as_deref(),
         advertise_nip43,
         state.config.max_frame_bytes,
@@ -329,6 +344,7 @@ pub(crate) fn nip11_facts(state: &crate::state::AppState) -> (Option<String>, bo
 const _RELAY_INFO_BUILD_STATIC_INPUT_FENCE: fn(
     Option<&str>,
     Option<&str>,
+    Option<&str>,
     bool,
     usize,
     Option<&str>,
@@ -386,13 +402,14 @@ mod tests {
 
     #[test]
     fn build_advertises_buzz_repository_url() {
-        let info = RelayInfo::build(None, None, false, DEFAULT_MAX_FRAME_BYTES, None);
+        let info = RelayInfo::build(None, None, None, false, DEFAULT_MAX_FRAME_BYTES, None);
         assert_eq!(info.software, "https://github.com/block/buzz");
     }
 
     #[test]
     fn configured_pairing_relay_is_advertised_and_unset_value_is_omitted() {
         let info = RelayInfo::build(
+            None,
             None,
             None,
             false,
@@ -406,7 +423,7 @@ mod tests {
             Some("wss://pairing.buzz.xyz")
         );
 
-        let info = RelayInfo::build(None, None, false, DEFAULT_MAX_FRAME_BYTES, None);
+        let info = RelayInfo::build(None, None, None, false, DEFAULT_MAX_FRAME_BYTES, None);
         let json = serde_json::to_value(&info).expect("serialize");
         assert!(json.get("pairing_relay_url").is_none());
     }
@@ -417,6 +434,7 @@ mod tests {
     #[test]
     fn icon_is_mirrored_and_empty_or_absent_is_omitted() {
         let info = RelayInfo::build(
+            None,
             None,
             Some("data:image/webp;base64,UklGRg=="),
             false,
@@ -434,7 +452,7 @@ mod tests {
         );
 
         for icon in [None, Some("")] {
-            let info = RelayInfo::build(None, icon, false, DEFAULT_MAX_FRAME_BYTES, None);
+            let info = RelayInfo::build(None, None, icon, false, DEFAULT_MAX_FRAME_BYTES, None);
             assert!(info.icon.is_none());
             let json = serde_json::to_value(&info).expect("serialize");
             assert!(
@@ -454,7 +472,7 @@ mod tests {
 
     #[test]
     fn max_message_length_uses_configured_frame_limit() {
-        let info = RelayInfo::build(None, None, false, 262_144, None);
+        let info = RelayInfo::build(None, None, None, false, 262_144, None);
         let limitation = info.limitation.expect("limitation");
         assert_eq!(limitation.max_message_length, Some(262_144));
     }
@@ -482,11 +500,14 @@ mod tests {
         );
     }
 
-    /// Open relay, ephemeral key — both `self` and NIP-43 are absent.
+    /// Open relay, ephemeral key — `self` and NIP-43 are absent, while the
+    /// current workflow signer remains discoverable.
     #[test]
     fn build_open_relay_ephemeral_key_omits_self_and_nip43() {
-        let info = RelayInfo::build(None, None, false, DEFAULT_MAX_FRAME_BYTES, None);
+        let pk = "0000000000000000000000000000000000000000000000000000000000000001";
+        let info = RelayInfo::build(None, Some(pk), None, false, DEFAULT_MAX_FRAME_BYTES, None);
         assert!(info.relay_self.is_none());
+        assert_eq!(info.buzz_workflow_signer.as_deref(), Some(pk));
         assert!(!info.supported_nips.contains(&NIP_RELAY_MEMBERSHIP));
     }
 
@@ -498,8 +519,16 @@ mod tests {
     #[test]
     fn build_open_relay_stable_key_advertises_self_but_not_nip43() {
         let pk = "0000000000000000000000000000000000000000000000000000000000000001";
-        let info = RelayInfo::build(Some(pk), None, false, DEFAULT_MAX_FRAME_BYTES, None);
+        let info = RelayInfo::build(
+            Some(pk),
+            Some(pk),
+            None,
+            false,
+            DEFAULT_MAX_FRAME_BYTES,
+            None,
+        );
         assert_eq!(info.relay_self.as_deref(), Some(pk));
+        assert_eq!(info.buzz_workflow_signer.as_deref(), Some(pk));
         assert!(!info.supported_nips.contains(&NIP_RELAY_MEMBERSHIP));
     }
 
@@ -507,8 +536,16 @@ mod tests {
     #[test]
     fn build_membership_relay_advertises_self_and_nip43() {
         let pk = "0000000000000000000000000000000000000000000000000000000000000001";
-        let info = RelayInfo::build(Some(pk), None, true, DEFAULT_MAX_FRAME_BYTES, None);
+        let info = RelayInfo::build(
+            Some(pk),
+            Some(pk),
+            None,
+            true,
+            DEFAULT_MAX_FRAME_BYTES,
+            None,
+        );
         assert_eq!(info.relay_self.as_deref(), Some(pk));
+        assert_eq!(info.buzz_workflow_signer.as_deref(), Some(pk));
         assert!(info.supported_nips.contains(&NIP_RELAY_MEMBERSHIP));
     }
 
@@ -518,6 +555,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "advertise_nip43=true requires relay_self=Some")]
     fn build_nip43_without_self_panics_in_debug() {
-        let _ = RelayInfo::build(None, None, true, DEFAULT_MAX_FRAME_BYTES, None);
+        let _ = RelayInfo::build(None, None, None, true, DEFAULT_MAX_FRAME_BYTES, None);
     }
 }

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -148,6 +148,22 @@ fn resolve_mention_pubkeys(text: &str, members: &[(String, String)]) -> Vec<Stri
     out
 }
 
+fn workflow_message_base_tags(
+    author_pubkey_hex: &str,
+    channel_id: &str,
+) -> Result<Vec<Tag>, ActionSinkError> {
+    Ok(vec![
+        // Keep workflow ownership first: buzz-acp uses the first `p` tag as
+        // the attributed owner and later `p` tags as wake targets.
+        Tag::parse(["p", author_pubkey_hex])
+            .map_err(|e| ActionSinkError::EventBuild(format!("p tag: {e}")))?,
+        Tag::parse(["h", channel_id])
+            .map_err(|e| ActionSinkError::EventBuild(format!("h tag: {e}")))?,
+        Tag::parse(["buzz:workflow", "true"])
+            .map_err(|e| ActionSinkError::EventBuild(format!("workflow tag: {e}")))?,
+    ])
+}
+
 /// Relay-side action sink — executes workflow side-effects directly.
 ///
 /// Holds a **weak** reference to `AppState` to avoid an `Arc` reference cycle:
@@ -257,14 +273,7 @@ impl ActionSink for RelayActionSink {
             //    - `buzz:workflow` tag prevents recursive workflow triggering
             //    - one `p` tag per `@Name` that resolves to a channel member,
             //      so mentioned agents are woken (wake is `p`-tag gated)
-            let mut tags = vec![
-                Tag::parse(["p", &author_pubkey_hex])
-                    .map_err(|e| ActionSinkError::EventBuild(format!("p tag: {e}")))?,
-                Tag::parse(["h", &channel_id_canonical])
-                    .map_err(|e| ActionSinkError::EventBuild(format!("h tag: {e}")))?,
-                Tag::parse(["buzz:workflow", "true"])
-                    .map_err(|e| ActionSinkError::EventBuild(format!("workflow tag: {e}")))?,
-            ];
+            let mut tags = workflow_message_base_tags(&author_pubkey_hex, &channel_id_canonical)?;
 
             // Resolve `@Name` mentions to channel-member pubkeys and append a
             // `p` tag for each (skipping the author, already tagged above). A
@@ -375,6 +384,13 @@ mod tests {
     // A 64-char hex pubkey built from a single repeated nibble, for readable tests.
     fn pk(nibble: char) -> String {
         std::iter::repeat_n(nibble, 64).collect()
+    }
+
+    #[test]
+    fn workflow_owner_is_the_first_p_tag() {
+        let owner = pk('a');
+        let tags = workflow_message_base_tags(&owner, &Uuid::new_v4().to_string()).unwrap();
+        assert_eq!(tags[0].as_slice(), ["p", owner.as_str()]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix scheduled workflow messages being rejected by the owner-only ACP author gate because the relay, rather than the workflow owner, signs workflow output.
- Advertise the current workflow signer in NIP-11 and verify the workflow event signature and signer before attributing its first `p` tag as the owner.
- Refresh the trusted signer out of band and before reconnect replay; fail closed when the signer is unavailable or changes.
- Carry the verified workflow owner through subscription filters, setup-mode filters, prompt sender metadata, and human-aware reply anchoring instead of exposing the relay signer downstream.
- Preserve the owner as the first workflow-output `p` tag while keeping mentioned-agent wake targets.

## Validation

At `c98ca6a`:

- `cargo fmt --all -- --check`
- `cargo clippy -p buzz-acp --all-targets --all-features -- -D warnings`
- `cargo test -p buzz-acp`: 623 unit tests and 9 lifecycle tests passed; doc tests passed.
- Independent security review completed with no findings.

At `e46802e` before the ACP-only follow-up:

- `cargo clippy -p buzz-acp -p buzz-relay --all-targets --all-features -- -D warnings`
- `cargo test -p buzz-relay nip11::tests --lib`: 15 passed.
- `cargo test -p buzz-relay workflow_sink::tests --lib`: 18 passed.
- Repository targets `test-unit`, `desktop-test`, `desktop-build`, `desktop-tauri-check`, `desktop-tauri-test`, and `web-build` passed.

## Known unrelated validation gaps

- `just ci` reaches mobile analysis, where Flutter 3.44 reports the existing `axisAlignment` deprecation in `mobile/lib/features/pairing/pairing_page/pairing_welcome_view.dart:114`.
- The mobile test suite reports four existing widget-test failures under Flutter 3.44; this branch does not touch mobile code.
- The full `buzz-relay` suite and isolated pre-existing admin/media database tests hit `Sqlx(PoolTimedOut)` in the local database environment. The changed relay modules pass their focused tests.
