### PR TITLE
docs: use pnpm build:e2e in E2E rebuild instructions

### DIFF
--- a/desktop/src-tauri/src/managed_agents/screenshot_skill.md
+++ b/desktop/src-tauri/src/managed_agents/screenshot_skill.md
@@ -96,7 +96,9 @@ Right-click shows "Star channel".
 ## Gotchas
 
 1. **Stale server** — `reuseExistingServer: true` means a prior build serves old
-   code. Kill port 4173 and rebuild (`cd desktop && pnpm run build`) after code changes.
+   code. Kill port 4173 and rebuild (`cd desktop && pnpm build:e2e`) after code
+   changes. Never plain `pnpm build` — it strips the E2E mock bridge and specs
+   fail at boot.
 2. **Clip for readability** — full 1280x720 screenshots are hard to read for sidebar
    features. Sidebar = 256px wide; context menus ~450px.
 3. **`post-screenshots.sh` requires `gh` auth** — the script uses `gh api` and

--- a/desktop/tests/e2e/cold-switch-longtask.perf.ts
+++ b/desktop/tests/e2e/cold-switch-longtask.perf.ts
@@ -34,8 +34,8 @@ import { installMockBridge } from "../helpers/bridge";
  * does NOT measure the WKWebView compositor feel on the shipped Tauri shell —
  * that is a separate real-wheel pass.
  *
- * Run it:
- *   pnpm build && npx playwright test --config=playwright.perf.config.ts \
+ * Run it (build:e2e, not build — a plain build strips the mock bridge):
+ *   pnpm build:e2e && npx playwright test --config=playwright.perf.config.ts \
  *     cold-switch-longtask.perf.ts
  */
 

--- a/desktop/tests/e2e/scroll-smoothness.perf.ts
+++ b/desktop/tests/e2e/scroll-smoothness.perf.ts
@@ -25,8 +25,8 @@ import { installMockBridge } from "../helpers/bridge";
  * Sami flagged as the dominant *feel* hazard on the shipped Tauri app — that
  * only reproduces in the real desktop shell and is Tyler's real-wheel pass.
  *
- * Run headed to watch it:
- *   pnpm build && npx playwright test --config=playwright.perf.config.ts --headed
+ * Run headed to watch it (build:e2e, not build — a plain build strips the mock bridge):
+ *   pnpm build:e2e && npx playwright test --config=playwright.perf.config.ts --headed
  */
 
 const SEED_ROWS = 600; // a genuinely busy channel, fully mounted

--- a/desktop/tests/e2e/typing-latency.perf.ts
+++ b/desktop/tests/e2e/typing-latency.perf.ts
@@ -24,8 +24,9 @@ import { installMockBridge } from "../helpers/bridge";
  *           live markdown message lands every 2s.
  *
  * Absolute ms are machine-specific; the quiet-vs-busy DELTA on one machine
- * is the signal. Run it (from desktop/):
- *   pnpm build
+ * is the signal. Run it (from desktop/) — build:e2e, not build; a plain build
+ * strips the mock bridge:
+ *   pnpm build:e2e
  *   npx playwright test --config=playwright.perf.config.ts typing-latency.perf.ts
  */
 

--- a/desktop/tests/e2e/warm-switch-markdown.perf.ts
+++ b/desktop/tests/e2e/warm-switch-markdown.perf.ts
@@ -36,8 +36,8 @@ import { installMockBridge } from "../helpers/bridge";
  * absolute ms are not portable across machines, but before/after deltas on
  * the same machine are.
  *
- * Run it (from desktop/):
- *   pnpm build
+ * Run it (from desktop/) — build:e2e, not build; a plain build strips the mock bridge:
+ *   pnpm build:e2e
  *   npx playwright test --config=playwright.perf.config.ts warm-switch-markdown.perf.ts
  *
  * NOTE: the perf web server reuses an existing server on :4173 — if one is


### PR DESCRIPTION
## Why

Fixes #3207.

Several docs still instruct a plain `pnpm build` (or `pnpm run build`) before re-running Playwright E2E specs. A production-mode build strips the E2E mock Tauri bridge (`installE2eBridgeIfConfigured` in `desktop/src/main.tsx` only compiles it into dev and `--mode e2e` builds), so every spec that calls `installMockBridge` fails at boot with `Cannot read properties of undefined (reading 'invoke')` — which looks exactly like a product bug. Two agent sessions lost real debugging time to this on 2026-07-27.

#2045 already fixed the main AGENTS.md "Stale server" paragraph and added a prominent warning. This PR covers the remaining copies of the wrong instruction:

## What changed

- `desktop/src-tauri/src/managed_agents/screenshot_skill.md` — Gotcha 1 now says `pnpm build:e2e` with a one-line warning about the bridge stripping.
- Header run-instructions in the four perf specs (`typing-latency.perf.ts`, `scroll-smoothness.perf.ts`, `warm-switch-markdown.perf.ts`, `cold-switch-longtask.perf.ts`) — all call `installMockBridge`, so they need the e2e-mode build too.

Docs/comments only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
