### PR TITLE
fix(desktop): stop create-agent form clobbering provider config on keystroke

### DIFF
--- a/desktop/src/features/agents/ui/WhereToRunSection.tsx
+++ b/desktop/src/features/agents/ui/WhereToRunSection.tsx
@@ -31,6 +31,12 @@ export function WhereToRunSection({
       setProbeError(null);
       return;
     }
+    // Once probed, don't re-probe: every keystroke in ProviderConfigFields
+    // produces a new `draft`, and re-running the probe would clobber the
+    // user's edits back to schema defaults. Switching providers resets the
+    // draft to emptyWhereToRunDraft (probedProvider: null), so a fresh probe
+    // still fires on provider change.
+    if (draft.probedProvider) return;
     let cancelled = false;
     setProbeError(null);
     void probeBackendProvider(selectedBackendProvider.binaryPath)
@@ -50,7 +56,9 @@ export function WhereToRunSection({
         onDraftChange({
           ...draft,
           probedProvider: result,
-          providerConfig: defaults,
+          // Seed defaults without overwriting any values the user already
+          // typed, so a late-resolving probe can never erase input.
+          providerConfig: { ...defaults, ...draft.providerConfig },
         });
       })
       .catch((error: unknown) => {


### PR DESCRIPTION
## What

Fixes the create-agent form resetting provider `config_schema` fields to their schema defaults (or wiping them) on every keystroke, which made non-default values impossible to enter from the UI.

Fixes #3216.

## Root cause

In `desktop/src/features/agents/ui/WhereToRunSection.tsx`, the provider-probe `useEffect` listed the entire `draft` in its dependency array. Every keystroke in `ProviderConfigFields` calls `onDraftChange({ ...draft, providerConfig })`, producing a new `draft` → the effect re-fires → the probe re-runs → on resolve it overwrites `providerConfig` with defaults rebuilt from `config_schema`. Against a fast local provider binary the probe is near-instant, so the field appears to reset on the keystroke itself.

Fields with a `default` snapped back to it; fields without one were wiped to empty. It's also a churn bug — one provider probe per keystroke.

## Fix

- Early-return guard `if (draft.probedProvider) return;` so the probe runs once per selection instead of on every draft change. Switching providers still re-probes correctly, because the "Run on" `<select>` resets the draft to `emptyWhereToRunDraft` (`probedProvider: null`).
- On probe resolve, seed `providerConfig: { ...defaults, ...draft.providerConfig }` so a late-resolving probe can never erase values the user already typed (defense-in-depth).

## Testing

- `just desktop-typecheck` — pass
- `just desktop-test` — pass
- `just desktop-check` (Biome) — no findings on changed source

#### Testing against custom provider

Evidence of the fix, vs the video in #3216 

https://github.com/user-attachments/assets/943b4235-c566-4e6d-a93b-571551370ed5

## Notes

Discovered while building an out-of-tree backend provider (Databricks sandbox / Lakebox) that advertises a defaulted `inference_auth` field which couldn't be switched away from its default via the UI. No provider-side workaround exists — the reset is entirely client-side.
