### PR TITLE
fix(db): replica_fence unit test survives ns-precision clocks

### DIFF
--- a/crates/buzz-db/src/replica_fence.rs
+++ b/crates/buzz-db/src/replica_fence.rs
@@ -521,7 +521,11 @@ mod tests {
         assert!(fence.verified_through().is_none(), "must start closed");
         assert!(!fence.covers(Utc::now() - chrono::Duration::days(365)));
 
-        let ts = Utc::now();
+        // The fence stores microseconds; feed a µs-precision timestamp so the
+        // round-trip equality holds on platforms where Utc::now() has
+        // nanosecond precision (Linux) as well as microsecond (macOS).
+        let ts = DateTime::from_timestamp_micros(Utc::now().timestamp_micros())
+            .expect("valid timestamp");
         fence.advance(ts);
         assert_eq!(fence.verified_through(), Some(ts));
         assert!(fence.covers(ts - chrono::Duration::seconds(1)));


### PR DESCRIPTION
The fence stores microseconds; the test fed a raw Utc::now() and asserted exact round-trip equality — passes on macOS (us clock), fails on Linux (ns clock). Truncate the input to the fence's own precision.

`replica_fence::tests::fence_starts_closed_and_opens_on_advance` feeds a raw `Utc::now()` into the fence and asserts exact round-trip equality — but the fence stores microseconds. On platforms where `Utc::now()` has nanosecond precision (Linux), the sub-microsecond part is truncated and the assertion fails on essentially every run:

```
assertion `left == right` failed
  left: Some(2026-07-27T21:51:31.284163Z)
 right: Some(2026-07-27T21:51:31.284163384Z)
```

On macOS the system clock reports microseconds, so the test passes there — which is presumably why it hasn't been noticed.

Fix: truncate the test's input timestamp to the fence's own precision (`DateTime::from_timestamp_micros(now.timestamp_micros())`), so round-trip equality holds regardless of platform clock resolution. Test-only change, one file.

