### PR TITLE
Make one-to-one agent DMs implicitly addressed

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -1,6 +1,6 @@
 # buzz-acp
 
-ACP harness that connects AI agents to Buzz. The harness listens for @mentions on the relay, prompts your agent, and the agent replies using the Buzz CLI.
+ACP harness that connects AI agents to Buzz. The harness listens for @mentions and one-to-one direct messages with the agent on the relay, prompts your agent, and the agent replies using the Buzz CLI.
 
 ```
 Buzz Relay ──WS──→ buzz-acp ──stdio──→ Your Agent
@@ -62,7 +62,7 @@ export GOOSE_MODE=auto
 buzz-acp
 ```
 
-That's it. The harness spawns `goose acp`, connects to the relay, discovers channels, and starts listening. When someone @mentions the agent, goose receives the message and can reply using the Buzz CLI that the harness configures automatically.
+That's it. The harness spawns `goose acp`, connects to the relay, discovers channels, and starts listening. When someone @mentions the agent in a channel—or sends any message in a one-to-one DM with the agent—goose receives the message and can reply using the Buzz CLI that the harness configures automatically. Group DMs still require an explicit @mention.
 
 ## Running with Codex
 
@@ -246,20 +246,20 @@ Forum event kinds:
 - **45002** — Vote on a post or comment
 - **45003** — Comment reply on a forum post
 
-> **Note:** Without `--no-mention-filter` (or `require_mention = false`), the default `subscribe=mentions` mode filters events that don't @mention the agent — forum posts will be invisible.
+> **Note:** Without `--no-mention-filter` (or `require_mention = false`), the default `subscribe=mentions` mode filters events that don't @mention the agent — forum posts will be invisible. The only exception is a verified one-to-one DM containing the agent; group DMs still require a mention.
 
 ## How It Works
 
 1. **Startup** — Spawns N agent subprocesses (default 1), sends ACP `initialize` to each, connects to the relay with NIP-42 auth.
 2. **Channel discovery** — Queries the relay REST API for accessible channels, subscribes to each.
-3. **Event loop** — Listens for @mention events (kind 9 with the agent's pubkey in a `#p` tag). Events queue per channel.
+3. **Event loop** — Listens for @mention events plus all messages in verified one-to-one DMs containing the agent. Events queue per channel.
 4. **Prompting** — When events are pending and no prompt is in flight for that channel, drains all queued events for the oldest channel into a single batched prompt via ACP `session/prompt`.
 5. **Agent response** — The agent processes the prompt and uses the Buzz CLI (`send_message`, `get_messages`, etc.) to interact with Buzz.
 6. **Recovery** — If the agent crashes, the harness respawns it. If the relay disconnects, the harness reconnects with a `since` filter to avoid missing events.
 
 Each channel has at most one prompt in flight. Multiple channels can be processed concurrently when agents > 1.
 
-> **Note:** On startup, the harness replays all unprocessed @mentions since the last run. Expect a burst of activity if there are stale events in the channel.
+> **Note:** On startup, the harness replays all unprocessed @mentions and one-to-one agent-DM messages since the last run. Expect a burst of activity if there are stale events in a channel.
 
 ## Bring Your Own Harness (BYOH)
 

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -1206,9 +1206,15 @@ pub fn load_rules(path: &std::path::Path) -> Result<Vec<SubscriptionRule>, Confi
 }
 
 /// Resolve per-channel NIP-01 filters from config + discovered channels.
+///
+/// Channels in `implicitly_addressed_channels` are verified one-to-one DMs
+/// containing this agent. Every message in those channels is addressed to the
+/// agent, so their relay subscription must not require an explicit `p` tag.
+/// Group DMs and channels with incomplete metadata must not be included.
 pub fn resolve_channel_filters(
     config: &Config,
     discovered_channels: &[Uuid],
+    implicitly_addressed_channels: &HashSet<Uuid>,
     rules: &[SubscriptionRule],
 ) -> HashMap<Uuid, ChannelFilter> {
     use buzz_core::kind::{
@@ -1236,13 +1242,13 @@ pub fn resolve_channel_filters(
                     KIND_STREAM_REMINDER,
                 ]
             });
-            let require_mention = !config.no_mention_filter;
             for ch in &target_channels {
                 result.insert(
                     *ch,
                     ChannelFilter {
                         kinds: Some(kinds.clone()),
-                        require_mention,
+                        require_mention: !config.no_mention_filter
+                            && !implicitly_addressed_channels.contains(ch),
                     },
                 );
             }
@@ -1288,7 +1294,8 @@ pub fn resolve_channel_filters(
                         *ch,
                         ChannelFilter {
                             kinds: merged_kinds,
-                            require_mention,
+                            require_mention: require_mention
+                                && !implicitly_addressed_channels.contains(ch),
                         },
                     );
                 }
@@ -1311,6 +1318,7 @@ pub fn resolve_channel_filters(
 pub fn resolve_dynamic_channel_filter(
     config: &Config,
     channel_id: Uuid,
+    is_implicitly_addressed: bool,
     rules: &[crate::filter::SubscriptionRule],
 ) -> Option<ChannelFilter> {
     use buzz_core::kind::{
@@ -1341,7 +1349,7 @@ pub fn resolve_dynamic_channel_filter(
                     KIND_STREAM_REMINDER,
                 ]
             })),
-            require_mention: !config.no_mention_filter,
+            require_mention: !config.no_mention_filter && !is_implicitly_addressed,
         }),
         SubscribeMode::All => Some(ChannelFilter {
             kinds: config.kinds_override.clone(),
@@ -1382,7 +1390,7 @@ pub fn resolve_dynamic_channel_filter(
 
             Some(ChannelFilter {
                 kinds: merged_kinds,
-                require_mention,
+                require_mention: require_mention && !is_implicitly_addressed,
             })
         }
     }
@@ -1475,7 +1483,7 @@ mod tests {
     fn test_mentions_mode_default_kinds() {
         let config = test_config(SubscribeMode::Mentions);
         let channels = vec![Uuid::new_v4(), Uuid::new_v4()];
-        let result = resolve_channel_filters(&config, &channels, &[]);
+        let result = resolve_channel_filters(&config, &channels, &HashSet::new(), &[]);
 
         assert_eq!(result.len(), 2);
         for ch in &channels {
@@ -1489,11 +1497,30 @@ mod tests {
     }
 
     #[test]
+    fn test_mentions_mode_treats_verified_one_to_one_agent_dm_as_implicitly_addressed() {
+        let config = test_config(SubscribeMode::Mentions);
+        let dm = Uuid::new_v4();
+        let stream = Uuid::new_v4();
+        let confirmed_dms = HashSet::from([dm]);
+
+        let result = resolve_channel_filters(&config, &[dm, stream], &confirmed_dms, &[]);
+
+        assert!(
+            !result.get(&dm).unwrap().require_mention,
+            "verified one-to-one agent DMs must receive messages without an explicit p tag"
+        );
+        assert!(
+            result.get(&stream).unwrap().require_mention,
+            "non-DM channels stay mention-filtered"
+        );
+    }
+
+    #[test]
     fn test_mentions_mode_custom_kinds() {
         let mut config = test_config(SubscribeMode::Mentions);
         config.kinds_override = Some(vec![1, 7]);
         let channels = vec![Uuid::new_v4()];
-        let result = resolve_channel_filters(&config, &channels, &[]);
+        let result = resolve_channel_filters(&config, &channels, &HashSet::new(), &[]);
 
         let f = result.get(&channels[0]).unwrap();
         assert_eq!(f.kinds.as_ref().unwrap(), &[1, 7]);
@@ -1504,7 +1531,7 @@ mod tests {
         let mut config = test_config(SubscribeMode::Mentions);
         config.no_mention_filter = true;
         let channels = vec![Uuid::new_v4()];
-        let result = resolve_channel_filters(&config, &channels, &[]);
+        let result = resolve_channel_filters(&config, &channels, &HashSet::new(), &[]);
 
         let f = result.get(&channels[0]).unwrap();
         assert!(!f.require_mention);
@@ -1706,7 +1733,7 @@ mod tests {
     fn test_all_mode_wildcard() {
         let config = test_config(SubscribeMode::All);
         let channels = vec![Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
-        let result = resolve_channel_filters(&config, &channels, &[]);
+        let result = resolve_channel_filters(&config, &channels, &HashSet::new(), &[]);
 
         assert_eq!(result.len(), 3);
         for ch in &channels {
@@ -1724,7 +1751,7 @@ mod tests {
         let mut config = test_config(SubscribeMode::All);
         config.kinds_override = Some(vec![9, 7]);
         let channels = vec![Uuid::new_v4()];
-        let result = resolve_channel_filters(&config, &channels, &[]);
+        let result = resolve_channel_filters(&config, &channels, &HashSet::new(), &[]);
 
         let f = result.get(&channels[0]).unwrap();
         assert_eq!(f.kinds.as_ref().unwrap(), &[9, 7]);
@@ -1740,7 +1767,7 @@ mod tests {
         config.channels_override = Some(vec![ch_a.to_string(), ch_unknown.to_string()]);
 
         let discovered = vec![ch_a, ch_b];
-        let result = resolve_channel_filters(&config, &discovered, &[]);
+        let result = resolve_channel_filters(&config, &discovered, &HashSet::new(), &[]);
 
         // Only ch_a should be present (intersection of override and discovered).
         assert_eq!(result.len(), 1);
@@ -1760,7 +1787,7 @@ mod tests {
             false,
         )];
 
-        let result = resolve_channel_filters(&config, &[ch], &rules);
+        let result = resolve_channel_filters(&config, &[ch], &HashSet::new(), &rules);
         assert_eq!(result.len(), 1);
         let f = result.get(&ch).unwrap();
         assert_eq!(f.kinds.as_ref().unwrap(), &[9]);
@@ -1779,7 +1806,7 @@ mod tests {
             false,
         )];
 
-        let result = resolve_channel_filters(&config, &[ch_a, ch_b], &rules);
+        let result = resolve_channel_filters(&config, &[ch_a, ch_b], &HashSet::new(), &rules);
         assert_eq!(result.len(), 1);
         assert!(result.contains_key(&ch_a));
         assert!(!result.contains_key(&ch_b));
@@ -1795,7 +1822,7 @@ mod tests {
             make_rule("reactions", ChannelScope::All("all".into()), vec![7], false),
         ];
 
-        let result = resolve_channel_filters(&config, &[ch], &rules);
+        let result = resolve_channel_filters(&config, &[ch], &HashSet::new(), &rules);
         let f = result.get(&ch).unwrap();
         // Kinds should be the union: [9, 7].
         let kinds = f.kinds.as_ref().expect("should have merged kinds");
@@ -1815,7 +1842,7 @@ mod tests {
             make_rule("broad", ChannelScope::All("all".into()), vec![], false),
         ];
 
-        let result = resolve_channel_filters(&config, &[ch], &rules);
+        let result = resolve_channel_filters(&config, &[ch], &HashSet::new(), &rules);
         let f = result.get(&ch).unwrap();
         // Once any rule has empty kinds (wildcard), merged result is None (wildcard).
         assert!(f.kinds.is_none(), "wildcard should propagate");
@@ -1834,7 +1861,7 @@ mod tests {
             false,
         )];
 
-        let result = resolve_channel_filters(&config, &[ch], &rules);
+        let result = resolve_channel_filters(&config, &[ch], &HashSet::new(), &rules);
         assert!(result.is_empty());
     }
 
@@ -1848,9 +1875,35 @@ mod tests {
             make_rule("lax", ChannelScope::All("all".into()), vec![7], false),
         ];
 
-        let result = resolve_channel_filters(&config, &[ch], &rules);
+        let result = resolve_channel_filters(&config, &[ch], &HashSet::new(), &rules);
         let f = result.get(&ch).unwrap();
         assert!(!f.require_mention, "most permissive (false) should win");
+    }
+
+    #[test]
+    fn test_config_mode_implicitly_addressed_channel_overrides_rule_mention_requirement() {
+        let config = test_config(SubscribeMode::Config);
+        let dm = Uuid::new_v4();
+        let rules = vec![make_rule(
+            "mention-only",
+            ChannelScope::All("all".into()),
+            vec![9],
+            true,
+        )];
+
+        let result = resolve_channel_filters(&config, &[dm], &HashSet::from([dm]), &rules);
+
+        assert!(!result.get(&dm).unwrap().require_mention);
+    }
+
+    #[test]
+    fn test_dynamic_one_to_one_agent_dm_is_implicitly_addressed() {
+        let config = test_config(SubscribeMode::Mentions);
+        let dm = Uuid::new_v4();
+
+        let filter = resolve_dynamic_channel_filter(&config, dm, true, &[]).unwrap();
+
+        assert!(!filter.require_mention);
     }
 
     #[test]

--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -349,9 +349,11 @@ const MAX_CONSECUTIVE_TIMEOUTS: u32 = 5;
 ///
 /// 1. **channels** — if not `"all"`, the event's channel UUID must be in the list.
 /// 2. **kinds** — if non-empty, the event kind must be in the list.
-/// 3. **require_mention** — if `true`, a `p` tag matching `agent_pubkey_hex` must
-///    exist. Tag kind is checked via `tag.as_slice()` for stable, library-independent
-///    access.
+/// 3. **require_mention** — if `true` and `implicitly_addressed` is `false`, an
+///    agent mention must exist. In DMs, recipient `p` tags are routing metadata,
+///    so only an explicit `mention` reference counts. Outside DMs, `p` tags are
+///    also accepted for compatibility. Verified one-to-one DMs containing the
+///    agent pass `implicitly_addressed = true`.
 /// 4. **filter** — if `Some`, the evalexpr expression must evaluate to `true`.
 ///
 /// # Fail-closed filter error handling
@@ -370,6 +372,8 @@ pub async fn match_event(
     channel_id: uuid::Uuid,
     rules: &[SubscriptionRule],
     agent_pubkey_hex: &str,
+    implicitly_addressed: bool,
+    is_dm: bool,
 ) -> Option<MatchedRule> {
     let filter_ctx = FilterContext::from_event(event, channel_id);
 
@@ -384,18 +388,13 @@ pub async fn match_event(
             continue;
         }
 
-        // 3. Mention check — look for a `p` tag whose first element equals
-        //    agent_pubkey_hex. Uses tag.as_slice() for stable, library-independent
-        //    access — avoids relying on the Display impl of tag kind.
-        if rule.require_mention {
-            let mentioned = event.tags.iter().any(|tag| {
-                let s = tag.as_slice();
-                s.first().map(|k| k.as_str()) == Some("p")
-                    && s.get(1).map(|v| v.as_str()) == Some(agent_pubkey_hex)
-            });
-            if !mentioned {
-                continue;
-            }
+        // 3. Mention check. DM `p` tags include every participant for delivery
+        // and notifications, so they do not prove an explicit @mention.
+        if rule.require_mention
+            && !implicitly_addressed
+            && !event_mentions_agent(event, agent_pubkey_hex, is_dm)
+        {
+            continue;
         }
 
         // 4. Optional evalexpr filter expression.
@@ -459,6 +458,26 @@ pub async fn match_event(
     None
 }
 
+/// Whether an event explicitly addresses the agent.
+///
+/// Buzz emits `mention` reference tags for composer-authored @mentions. In DMs,
+/// ordinary recipient `p` tags include every participant and therefore cannot
+/// distinguish an explicit mention. Streams retain `p`-tag compatibility for
+/// older clients.
+pub(crate) fn event_mentions_agent(
+    event: &nostr::Event,
+    agent_pubkey_hex: &str,
+    is_dm: bool,
+) -> bool {
+    event.tags.iter().any(|tag| {
+        let parts = tag.as_slice();
+        let kind = parts.first().map(|value| value.as_str());
+        let pubkey = parts.get(1).map(|value| value.as_str());
+        pubkey == Some(agent_pubkey_hex)
+            && (kind == Some("mention") || (!is_dm && kind == Some("p")))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -474,12 +493,16 @@ mod tests {
             .unwrap()
     }
 
-    /// Build a test event with an explicit `p` tag.
-    fn make_event_with_p_tag(kind: u32, content: &str, p_hex: &str) -> nostr::Event {
+    fn make_event_with_reference_tag(
+        kind: u32,
+        content: &str,
+        tag_kind: &str,
+        pubkey_hex: &str,
+    ) -> nostr::Event {
         let keys = Keys::generate();
-        let p_tag = Tag::parse(["p", p_hex]).expect("tag parse");
+        let reference_tag = Tag::parse([tag_kind, pubkey_hex]).expect("tag parse");
         EventBuilder::new(Kind::Custom(kind as u16), content)
-            .tags([p_tag])
+            .tags([reference_tag])
             .sign_with_keys(&keys)
             .unwrap()
     }
@@ -601,7 +624,9 @@ mod tests {
             ),
         ];
 
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
+        let matched = match_event(&event, channel_id, &rules, "", false, false)
+            .await
+            .unwrap();
         assert_eq!(matched.rule_index, 0);
         assert_eq!(matched.prompt_tag, "tag-first");
     }
@@ -630,7 +655,9 @@ mod tests {
             ),
         ];
 
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
+        let matched = match_event(&event, channel_id, &rules, "", false, false)
+            .await
+            .unwrap();
         assert_eq!(matched.rule_index, 1);
         assert_eq!(matched.prompt_tag, "matched");
     }
@@ -640,7 +667,9 @@ mod tests {
         let agent_pubkey = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 
         let event_no_mention = make_event(9, "hello");
-        let event_with_mention = make_event_with_p_tag(9, "hello", agent_pubkey);
+        let event_with_p_tag = make_event_with_reference_tag(9, "hello", "p", agent_pubkey);
+        let event_with_mention_tag =
+            make_event_with_reference_tag(9, "hello", "mention", agent_pubkey);
         let channel_id = any_channel();
 
         let rules = vec![make_rule(
@@ -653,14 +682,67 @@ mod tests {
         )];
 
         // Without mention — no match.
-        let result = match_event(&event_no_mention, channel_id, &rules, agent_pubkey).await;
+        let result = match_event(
+            &event_no_mention,
+            channel_id,
+            &rules,
+            agent_pubkey,
+            false,
+            false,
+        )
+        .await;
         assert!(result.is_none());
 
-        // With mention — matches.
-        let matched = match_event(&event_with_mention, channel_id, &rules, agent_pubkey)
-            .await
-            .unwrap();
+        // Streams retain p-tag compatibility.
+        let matched = match_event(
+            &event_with_p_tag,
+            channel_id,
+            &rules,
+            agent_pubkey,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
         assert_eq!(matched.prompt_tag, "mentioned");
+
+        // A group-DM recipient p tag is not an explicit mention.
+        let group_dm_recipient = match_event(
+            &event_with_p_tag,
+            channel_id,
+            &rules,
+            agent_pubkey,
+            false,
+            true,
+        )
+        .await;
+        assert!(group_dm_recipient.is_none());
+
+        // A composer-authored mention reference does count in a group DM.
+        let group_dm_mention = match_event(
+            &event_with_mention_tag,
+            channel_id,
+            &rules,
+            agent_pubkey,
+            false,
+            true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(group_dm_mention.prompt_tag, "mentioned");
+
+        // A verified one-to-one agent DM is implicitly addressed with no tags.
+        let implicit_agent_dm_match = match_event(
+            &event_no_mention,
+            channel_id,
+            &rules,
+            agent_pubkey,
+            true,
+            true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(implicit_agent_dm_match.prompt_tag, "mentioned");
     }
 
     #[tokio::test]
@@ -677,7 +759,7 @@ mod tests {
             None,
         )];
 
-        let result = match_event(&event, channel_id, &rules, "").await;
+        let result = match_event(&event, channel_id, &rules, "", false, false).await;
         assert!(result.is_none());
     }
 
@@ -725,7 +807,9 @@ mod tests {
             None, // no explicit tag
         )];
 
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
+        let matched = match_event(&event, channel_id, &rules, "", false, false)
+            .await
+            .unwrap();
         assert_eq!(matched.prompt_tag, "my-rule");
     }
 
@@ -755,7 +839,7 @@ mod tests {
         ];
 
         // Must return None — not "catch-all".
-        let result = match_event(&event, channel_id, &rules, "").await;
+        let result = match_event(&event, channel_id, &rules, "", false, false).await;
         assert!(
             result.is_none(),
             "filter error must fail closed, not fall through to next rule"
@@ -781,7 +865,7 @@ mod tests {
             .store(MAX_CONSECUTIVE_TIMEOUTS, Ordering::Relaxed);
 
         let rules = vec![rule];
-        let result = match_event(&event, channel_id, &rules, "").await;
+        let result = match_event(&event, channel_id, &rules, "", false, false).await;
         assert!(result.is_none(), "disabled rule must return None");
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -257,7 +257,7 @@ async fn author_allowed(
     }
 }
 
-/// Resolve whether `channel_id` is a DM, for the inbound author gate.
+/// DM classification used by both implicit addressing and the inbound author gate.
 ///
 /// Resolution order:
 /// 1. Startup discovery metadata (`startup_info`) — covers channels known at
@@ -267,21 +267,58 @@ async fn author_allowed(
 ///    the agent was added to *after* startup (the exploit path: an
 ///    agent-initiated DM is exactly such a channel).
 ///
-/// Fail-closed: if the fetch fails or times out, the channel is treated as a
-/// DM for this event and the result is NOT cached, so a later event retries
-/// the fetch instead of pinning a mis-classification.
-pub(crate) async fn is_dm_channel(
+/// Only a DM whose metadata names exactly two participants, including this
+/// agent, is implicitly addressed. Group DMs and incomplete metadata still
+/// require an explicit mention.
+///
+/// Fail-closed: if the fetch fails or times out, the channel is treated as a DM
+/// for author authorization but not for implicit addressing. The result is NOT
+/// cached, so a later event retries resolution instead of pinning a
+/// mis-classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DmChannelClassification {
+    pub implicitly_addressed: bool,
+    pub for_author_gate: bool,
+}
+
+pub(crate) fn is_one_to_one_agent_dm(
+    channel_type: &str,
+    participant_pubkeys: &[String],
+    agent_pubkey_hex: &str,
+) -> bool {
+    channel_type == "dm"
+        && participant_pubkeys.len() == 2
+        && participant_pubkeys
+            .iter()
+            .any(|pubkey| pubkey.eq_ignore_ascii_case(agent_pubkey_hex))
+}
+
+pub(crate) async fn classify_dm_channel(
     channel_id: Uuid,
     channel_info: &pool::ChannelInfoResolver,
-) -> bool {
+    agent_pubkey_hex: &str,
+) -> DmChannelClassification {
     match channel_info.resolve(channel_id).await {
-        Some(info) => info.channel_type == "dm",
+        Some(info) => {
+            let is_dm = info.channel_type == "dm";
+            DmChannelClassification {
+                implicitly_addressed: is_one_to_one_agent_dm(
+                    &info.channel_type,
+                    &info.participant_pubkeys,
+                    agent_pubkey_hex,
+                ),
+                for_author_gate: is_dm,
+            }
+        }
         None => {
             tracing::warn!(
                 channel_id = %channel_id,
                 "channel type unresolved — treating as DM for author gate (fail closed)"
             );
-            true
+            DmChannelClassification {
+                implicitly_addressed: false,
+                for_author_gate: true,
+            }
         }
     }
 }
@@ -1435,6 +1472,13 @@ async fn tokio_main() -> Result<()> {
 
     tracing::info!("discovered {} channel(s)", channel_info_map.len());
     let channel_ids: Vec<Uuid> = channel_info_map.keys().copied().collect();
+    let implicitly_addressed_channels: HashSet<Uuid> = channel_info_map
+        .iter()
+        .filter_map(|(id, info)| {
+            is_one_to_one_agent_dm(&info.channel_type, &info.participant_pubkeys, &pubkey_hex)
+                .then_some(*id)
+        })
+        .collect();
 
     let rules: Vec<SubscriptionRule> = match config.subscribe_mode {
         SubscribeMode::Mentions => {
@@ -1473,7 +1517,12 @@ async fn tokio_main() -> Result<()> {
         }
     };
 
-    let channel_filters = config::resolve_channel_filters(&config, &channel_ids, &rules);
+    let channel_filters = config::resolve_channel_filters(
+        &config,
+        &channel_ids,
+        &implicitly_addressed_channels,
+        &rules,
+    );
     if channel_filters.is_empty() {
         tracing::warn!("no channel subscriptions resolved — agent will sit idle");
     }
@@ -1968,15 +2017,33 @@ async fn tokio_main() -> Result<()> {
 
                                     if subscribed_channel_ids.contains(&ch) {
                                         tracing::debug!(channel_id = %ch, "membership notification: channel already subscribed");
-                                    } else if let Some(filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules) {
-                                        tracing::info!(channel_id = %ch, "membership notification: subscribing to new channel");
-                                        if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
-                                            tracing::warn!("failed to subscribe to new channel {ch}: {e}");
-                                        } else {
-                                            subscribed_channel_ids.insert(ch);
-                                        }
                                     } else {
-                                        tracing::debug!(channel_id = %ch, "membership notification: no matching rules — skipping");
+                                        let is_implicitly_addressed = ctx
+                                            .channel_info
+                                            .resolve(ch)
+                                            .await
+                                            .is_some_and(|info| {
+                                                is_one_to_one_agent_dm(
+                                                    &info.channel_type,
+                                                    &info.participant_pubkeys,
+                                                    &pubkey_hex,
+                                                )
+                                            });
+                                        if let Some(filter) = config::resolve_dynamic_channel_filter(
+                                            &config,
+                                            ch,
+                                            is_implicitly_addressed,
+                                            &rules,
+                                        ) {
+                                            tracing::info!(channel_id = %ch, is_implicitly_addressed, "membership notification: subscribing to new channel");
+                                            if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
+                                                tracing::warn!("failed to subscribe to new channel {ch}: {e}");
+                                            } else {
+                                                subscribed_channel_ids.insert(ch);
+                                            }
+                                        } else {
+                                            tracing::debug!(channel_id = %ch, "membership notification: no matching rules — skipping");
+                                        }
                                     }
                                 } else {
                                     subscribed_channel_ids.remove(&ch);
@@ -2144,18 +2211,21 @@ async fn tokio_main() -> Result<()> {
                             // launched by the same human). Allowlist adds the
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
+                            let dm_classification =
+                                classify_dm_channel(
+                                    buzz_event.channel_id,
+                                    &ctx.channel_info,
+                                    &pubkey_hex,
+                                )
+                                .await;
+
                             {
                                 let author = buzz_event.event.pubkey.to_hex();
-                                // DM hardening: resolve channel type (fail-closed
-                                // to DM) so allowlist/anyone modes cannot be
-                                // exercised by non-owner authors inside DMs.
-                                let is_dm =
-                                    is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                                 let allowed = author_allowed(
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
                                     &author,
-                                    is_dm,
+                                    dm_classification.for_author_gate,
                                     &owner_cache,
                                     &ctx.rest_client,
                                 )
@@ -2165,14 +2235,22 @@ async fn tokio_main() -> Result<()> {
                                         channel_id = %buzz_event.channel_id,
                                         author = %buzz_event.event.pubkey.to_hex(),
                                         mode = %config.respond_to,
-                                        is_dm,
+                                        is_dm = dm_classification.for_author_gate,
                                         "inbound author gate — dropping event"
                                     );
                                     continue;
                                 }
                             }
 
-                            let matched = filter::match_event(&buzz_event.event, buzz_event.channel_id, &rules, &pubkey_hex).await;
+                            let matched = filter::match_event(
+                                &buzz_event.event,
+                                buzz_event.channel_id,
+                                &rules,
+                                &pubkey_hex,
+                                dm_classification.implicitly_addressed,
+                                dm_classification.for_author_gate,
+                            )
+                            .await;
                             let prompt_tag = match matched {
                                 Some(m) => m.prompt_tag,
                                 None => {
@@ -4605,14 +4683,16 @@ mod author_gate_tests {
         );
     }
 
-    // ── is_dm_channel resolution ──────────────────────────────────────────
+    // ── DM channel classification ─────────────────────────────────────────
 
     fn resolver(startup: HashMap<Uuid, relay::ChannelInfo>) -> pool::ChannelInfoResolver {
         pool::ChannelInfoResolver::new(startup, dummy_rest_client())
     }
 
     #[tokio::test]
-    async fn test_is_dm_channel_uses_definitive_startup_metadata() {
+    async fn test_dm_classification_uses_definitive_startup_metadata() {
+        let agent_pubkey = "a".repeat(64);
+        let human_pubkey = "b".repeat(64);
         let dm_id = Uuid::new_v4();
         let stream_id = Uuid::new_v4();
         let startup = HashMap::from([
@@ -4621,6 +4701,7 @@ mod author_gate_tests {
                 relay::ChannelInfo {
                     name: "dm".into(),
                     channel_type: "dm".into(),
+                    participant_pubkeys: vec![agent_pubkey.clone(), human_pubkey],
                 },
             ),
             (
@@ -4628,26 +4709,68 @@ mod author_gate_tests {
                 relay::ChannelInfo {
                     name: "stream".into(),
                     channel_type: "stream".into(),
+                    participant_pubkeys: Vec::new(),
                 },
             ),
         ]);
         let resolver = resolver(startup);
-        assert!(is_dm_channel(dm_id, &resolver).await);
-        assert!(!is_dm_channel(stream_id, &resolver).await);
+        let dm = classify_dm_channel(dm_id, &resolver, &agent_pubkey).await;
+        assert!(dm.implicitly_addressed);
+        assert!(dm.for_author_gate);
+        let stream = classify_dm_channel(stream_id, &resolver, &agent_pubkey).await;
+        assert!(!stream.implicitly_addressed);
+        assert!(!stream.for_author_gate);
+    }
+
+    #[test]
+    fn test_only_one_to_one_dm_containing_agent_is_implicitly_addressed() {
+        let agent = "a".repeat(64);
+        let human = "b".repeat(64);
+        let third = "c".repeat(64);
+
+        assert!(is_one_to_one_agent_dm(
+            "dm",
+            &[agent.clone(), human.clone()],
+            &agent,
+        ));
+        assert!(
+            !is_one_to_one_agent_dm("dm", &[agent.clone(), human.clone(), third.clone()], &agent,),
+            "group DMs must still require an explicit mention"
+        );
+        assert!(
+            !is_one_to_one_agent_dm("dm", &[human, third], &agent),
+            "a two-person DM without this agent must not be implicitly addressed"
+        );
+        assert!(!is_one_to_one_agent_dm(
+            "stream",
+            &[agent.clone(), "d".repeat(64)],
+            &agent,
+        ));
+        assert!(
+            !is_one_to_one_agent_dm("dm", &[], &agent),
+            "missing participant metadata must require a mention"
+        );
     }
 
     #[tokio::test]
-    async fn test_is_dm_channel_fails_closed_for_unknown_startup_metadata() {
+    async fn test_dm_classification_fails_closed_for_unknown_startup_metadata() {
+        let agent_pubkey = "a".repeat(64);
         let id = Uuid::new_v4();
         let startup = HashMap::from([(
             id,
             relay::ChannelInfo {
                 name: "unknown".into(),
                 channel_type: "unknown".into(),
+                participant_pubkeys: Vec::new(),
             },
         )]);
+        let classification = classify_dm_channel(id, &resolver(startup), &agent_pubkey).await;
         assert!(
-            is_dm_channel(id, &resolver(startup)).await,
+            !classification.implicitly_addressed,
+            "unknown metadata must not enable implicit addressing"
+        );
+        assert!(
+            classification.for_author_gate,
             "missing startup metadata must not be trusted as a stream"
         );
     }
@@ -4699,17 +4822,33 @@ mod author_gate_tests {
     }
 
     #[tokio::test]
-    async fn test_is_dm_channel_lazy_resolves_declared_dm_and_caches_it() {
+    async fn test_dm_classification_lazy_resolves_declared_dm_and_caches_it() {
         use std::sync::atomic::Ordering;
 
         let id = Uuid::new_v4();
+        let agent_pubkey = "a".repeat(64);
+        let human_pubkey = "b".repeat(64);
         let response = serde_json::json!([{
-            "tags": [["d", id.to_string()], ["name", "DM"], ["t", "dm"]]
+            "tags": [
+                ["d", id.to_string()],
+                ["name", "DM"],
+                ["t", "dm"],
+                ["p", agent_pubkey],
+                ["p", human_pubkey]
+            ]
         }]);
         let (resolver, requests, server) = lazy_resolver_with_response(response).await;
 
-        assert!(is_dm_channel(id, &resolver).await);
-        assert!(is_dm_channel(id, &resolver).await);
+        assert!(
+            classify_dm_channel(id, &resolver, &agent_pubkey)
+                .await
+                .implicitly_addressed
+        );
+        assert!(
+            classify_dm_channel(id, &resolver, &agent_pubkey)
+                .await
+                .implicitly_addressed
+        );
         assert_eq!(
             requests.load(Ordering::SeqCst),
             1,
@@ -4720,20 +4859,28 @@ mod author_gate_tests {
 
     #[tokio::test]
     async fn test_discovery_without_metadata_stays_fail_closed_at_author_gate() {
+        let agent_pubkey = "a".repeat(64);
         let id = Uuid::new_v4();
         let discovered = relay::merge_discovered_channels(vec![id], &serde_json::json!([]));
         let channel_info = resolver(discovered);
         let owner_cache = cache_with_sibling();
         let allowlist = HashSet::from([EXTERNAL.to_string()]);
 
-        let is_dm = is_dm_channel(id, &channel_info).await;
-        assert!(is_dm, "unknown startup metadata must fail closed as DM");
+        let dm_classification = classify_dm_channel(id, &channel_info, &agent_pubkey).await;
+        assert!(
+            !dm_classification.implicitly_addressed,
+            "unknown startup metadata must not enable implicit addressing"
+        );
+        assert!(
+            dm_classification.for_author_gate,
+            "unknown startup metadata must fail closed as DM"
+        );
         assert!(
             !author_allowed(
                 &RespondTo::Allowlist,
                 &allowlist,
                 EXTERNAL,
-                is_dm,
+                dm_classification.for_author_gate,
                 &owner_cache,
                 &dummy_rest_client(),
             )
@@ -4743,10 +4890,14 @@ mod author_gate_tests {
     }
 
     #[tokio::test]
-    async fn test_is_dm_channel_fails_closed_when_lazy_resolution_fails() {
+    async fn test_dm_classification_fails_closed_when_lazy_resolution_fails() {
+        let agent_pubkey = "a".repeat(64);
+        let classification =
+            classify_dm_channel(Uuid::new_v4(), &resolver(HashMap::new()), &agent_pubkey).await;
+        assert!(!classification.implicitly_addressed);
         assert!(
-            is_dm_channel(Uuid::new_v4(), &resolver(HashMap::new())).await,
-            "an unresolvable channel type must be treated as a DM"
+            classification.for_author_gate,
+            "an unresolvable channel type must be treated as a DM for author authorization"
         );
     }
 }

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -451,6 +451,7 @@ impl ChannelInfoResolver {
                     PromptChannelInfo {
                         name: info.name,
                         channel_type: info.channel_type,
+                        participant_pubkeys: info.participant_pubkeys,
                     },
                 ))
             })
@@ -2326,9 +2327,11 @@ pub(crate) async fn fetch_channel_info(
                     }
                 }
                 let channel_type = crate::relay::channel_type_from_tags(tags);
+                let participant_pubkeys = crate::relay::participant_pubkeys_from_tags(tags);
                 Some(PromptChannelInfo {
                     name: name.unwrap_or(UNKNOWN_CHANNEL_NAME).to_string(),
                     channel_type,
+                    participant_pubkeys,
                 })
             }
             Ok(Err(e)) => {

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -995,6 +995,7 @@ pub struct ContextMessage {
 pub struct PromptChannelInfo {
     pub name: String,
     pub channel_type: String,
+    pub participant_pubkeys: Vec<String>,
 }
 
 /// Minimal profile fields needed to label users in ACP prompts.
@@ -2976,6 +2977,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "engineering".into(),
             channel_type: "stream".into(),
+            participant_pubkeys: Vec::new(),
         };
 
         let prompt = format_prompt(
@@ -3007,6 +3009,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "DM".into(),
             channel_type: "dm".into(),
+            participant_pubkeys: Vec::new(),
         };
 
         let prompt = format_prompt(
@@ -3117,6 +3120,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "DM".into(),
             channel_type: "dm".into(),
+            participant_pubkeys: Vec::new(),
         };
         let ctx = ConversationContext::Dm {
             messages: vec![ContextMessage {
@@ -3373,6 +3377,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "DM".into(),
             channel_type: "dm".into(),
+            participant_pubkeys: Vec::new(),
         };
         // Thread context fetched (as the fetch path does for DM replies).
         let ctx = ConversationContext::Thread {
@@ -3430,6 +3435,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "DM".into(),
             channel_type: "dm".into(),
+            participant_pubkeys: Vec::new(),
         };
 
         // No context fetched — hints only.
@@ -3925,6 +3931,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "DM".into(),
             channel_type: "dm".into(),
+            participant_pubkeys: Vec::new(),
         };
 
         let prompt = format_prompt(
@@ -3988,6 +3995,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "DM".into(),
             channel_type: "dm".into(),
+            participant_pubkeys: Vec::new(),
         };
 
         let prompt = format_prompt(

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -133,6 +133,7 @@ use crate::config::ChannelFilter;
 pub struct ChannelInfo {
     pub name: String,
     pub channel_type: String,
+    pub participant_pubkeys: Vec<String>,
 }
 
 pub(crate) fn channel_type_from_tags(tags: &[serde_json::Value]) -> String {
@@ -158,6 +159,34 @@ pub(crate) fn channel_type_from_tags(tags: &[serde_json::Value]) -> String {
     }
 }
 
+/// Extract valid, unique participant pubkeys from channel metadata `p` tags.
+///
+/// Buzz includes all DM participants on the kind:39000 metadata event. Invalid
+/// or duplicate values are ignored so they cannot accidentally make a channel
+/// look like a verified one-to-one DM.
+pub(crate) fn participant_pubkeys_from_tags(tags: &[serde_json::Value]) -> Vec<String> {
+    let mut participants = Vec::new();
+    for tag in tags {
+        let Some(arr) = tag.as_array() else {
+            continue;
+        };
+        if arr.first().and_then(|value| value.as_str()) != Some("p") {
+            continue;
+        }
+        let Some(raw_pubkey) = arr.get(1).and_then(|value| value.as_str()) else {
+            return Vec::new();
+        };
+        let pubkey = raw_pubkey.trim().to_ascii_lowercase();
+        if pubkey.len() != 64 || !pubkey.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Vec::new();
+        }
+        if !participants.contains(&pubkey) {
+            participants.push(pubkey);
+        }
+    }
+    participants
+}
+
 /// Build the discovered-channel subscribe set from the membership UUIDs and the
 /// kind:39000 metadata events, **skipping any channel flagged `archived=true`**.
 ///
@@ -172,7 +201,7 @@ pub(crate) fn merge_discovered_channels(
     channel_uuids: Vec<Uuid>,
     meta_events: &serde_json::Value,
 ) -> HashMap<Uuid, ChannelInfo> {
-    let mut meta_map: HashMap<Uuid, (String, String)> = HashMap::new();
+    let mut meta_map: HashMap<Uuid, (String, String, Vec<String>)> = HashMap::new();
     let mut archived: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
     if let Some(arr) = meta_events.as_array() {
         for ev in arr {
@@ -203,7 +232,8 @@ pub(crate) fn merge_discovered_channels(
                     }
                     let ch_name = name.unwrap_or("unknown").to_string();
                     let ch_type = channel_type_from_tags(tags);
-                    meta_map.insert(uuid, (ch_name, ch_type));
+                    let participant_pubkeys = participant_pubkeys_from_tags(tags);
+                    meta_map.insert(uuid, (ch_name, ch_type, participant_pubkeys));
                 }
             }
         }
@@ -214,10 +244,17 @@ pub(crate) fn merge_discovered_channels(
         if archived.contains(&uuid) {
             continue;
         }
-        let (name, channel_type) = meta_map
+        let (name, channel_type, participant_pubkeys) = meta_map
             .remove(&uuid)
-            .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
-        map.insert(uuid, ChannelInfo { name, channel_type });
+            .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string(), Vec::new()));
+        map.insert(
+            uuid,
+            ChannelInfo {
+                name,
+                channel_type,
+                participant_pubkeys,
+            },
+        );
     }
     map
 }
@@ -4093,9 +4130,39 @@ mod tests {
     #[test]
     fn merge_discovered_channels_uses_declared_dm_type_without_hidden_hint() {
         let channel = Uuid::new_v4();
-        let meta = serde_json::json!([meta_event(channel, "dm", &["t", "dm"])]);
+        let agent = "a".repeat(64);
+        let human = "b".repeat(64);
+        let meta = serde_json::json!([meta_event(
+            channel,
+            "dm",
+            &["t", "dm", "p", &agent, "p", &human, "p", &agent],
+        )]);
         let map = merge_discovered_channels(vec![channel], &meta);
         assert_eq!(map[&channel].channel_type, "dm");
+        assert_eq!(
+            map[&channel].participant_pubkeys,
+            vec![agent, human],
+            "DM participant metadata is normalized and deduplicated"
+        );
+    }
+
+    #[test]
+    fn merge_discovered_channels_rejects_incomplete_dm_participant_metadata() {
+        let channel = Uuid::new_v4();
+        let agent = "a".repeat(64);
+        let human = "b".repeat(64);
+        let meta = serde_json::json!([meta_event(
+            channel,
+            "dm",
+            &["t", "dm", "p", &agent, "p", &human, "p", "invalid"],
+        )]);
+
+        let map = merge_discovered_channels(vec![channel], &meta);
+
+        assert!(
+            map[&channel].participant_pubkeys.is_empty(),
+            "malformed participant metadata must fail closed"
+        );
     }
 
     #[test]

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -27,7 +27,8 @@
 //! 1. Apply `ignore_self` gate.
 //! 2. Apply `author_allowed` gate (same as normal mode) so the nudge goes
 //!    only to authors the real agent would answer.
-//! 3. Require an explicit @mention via `event_mentions_agent`.
+//! 3. Require an explicit @mention except in a verified one-to-one DM with
+//!    this agent.
 //! 4. Apply `filter::match_event` so channel/kind rules still constrain.
 //! 5. Build and publish a nudge reply (surface-correct copy).
 //! 6. Deduplicate by event-id (reconnect replay must not double-nudge).
@@ -73,7 +74,7 @@ pub(crate) enum AcpAvailabilityStatus {
 use crate::{
     author_allowed,
     config::Config,
-    event_mentions_agent, filter,
+    filter,
     relay::{HarnessRelay, RelayEventPublisher},
 };
 
@@ -302,10 +303,10 @@ impl SetupPayload {
 /// Run the setup-mode event loop.
 ///
 /// Connects to the relay, subscribes to channels, and responds to @mentions
-/// of this agent with a surface-correct setup nudge. Never starts the agent
-/// pool. Reconnects on relay close (mirroring normal mode) so the nudge
-/// listener survives transient disconnects; `nudged_event_ids` deduplication
-/// guards against replay on reconnect.
+/// or messages in a verified one-to-one DM with this agent, using a
+/// surface-correct setup nudge. Never starts the agent pool. Reconnects on
+/// relay close (mirroring normal mode) so the nudge listener survives transient disconnects;
+/// `nudged_event_ids` deduplication guards against replay on reconnect.
 pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) -> Result<()> {
     tracing::info!(
         agent = %payload.agent_name,
@@ -346,8 +347,8 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
     let startup_owner = crate::resolve_agent_owner(&config);
     let owner_cache = crate::OwnerCache::new(startup_owner);
 
-    // Discover channels and subscribe (using a "mentions" rule so we get
-    // notified when someone @-mentions the agent).
+    // Discover channels and subscribe. Only verified one-to-one DMs with this
+    // agent are implicitly addressed.
     let channel_info_map = relay
         .discover_channels()
         .await
@@ -359,12 +360,27 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
     );
 
     let channel_ids: Vec<Uuid> = channel_info_map.keys().copied().collect();
+    let implicitly_addressed_channels: HashSet<Uuid> = channel_info_map
+        .iter()
+        .filter_map(|(id, info)| {
+            crate::is_one_to_one_agent_dm(
+                &info.channel_type,
+                &info.participant_pubkeys,
+                &pubkey_hex,
+            )
+            .then_some(*id)
+        })
+        .collect();
 
-    // Build subscription rules: mentions only (setup mode must not react to
-    // every message in a channel).
+    // Build subscription rules: mentions everywhere except one-to-one agent DMs.
     let rules = build_setup_subscription_rules(&config);
 
-    let channel_filters = crate::config::resolve_channel_filters(&config, &channel_ids, &rules);
+    let channel_filters = crate::config::resolve_channel_filters(
+        &config,
+        &channel_ids,
+        &implicitly_addressed_channels,
+        &rules,
+    );
 
     if channel_filters.is_empty() {
         tracing::warn!(
@@ -405,7 +421,7 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION
             || kind_u32 == KIND_MEMBER_REMOVED_NOTIFICATION
         {
-            handle_setup_membership(&mut relay, &buzz_event, &config, &rules, &channel_ids).await;
+            handle_setup_membership(&mut relay, &buzz_event, &config, &rules, &channel_info).await;
             continue;
         }
 
@@ -419,9 +435,18 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
             continue;
         }
 
-        // Require an explicit @mention of this agent — setup mode must not
-        // nudge on every channel event even if subscribe_mode is "all".
-        if !event_mentions_agent(&buzz_event.event, &pubkey_hex) {
+        let dm_classification =
+            crate::classify_dm_channel(buzz_event.channel_id, &channel_info, &pubkey_hex).await;
+
+        // Group DMs and channels still require an explicit mention. Only a
+        // verified one-to-one DM with this agent is implicitly addressed.
+        if !dm_classification.implicitly_addressed
+            && !filter::event_mentions_agent(
+                &buzz_event.event,
+                &pubkey_hex,
+                dm_classification.for_author_gate,
+            )
+        {
             continue;
         }
 
@@ -429,12 +454,11 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         // to authors the real agent would have answered. Same DM hardening:
         // in DMs only owner/siblings get a nudge (fail-closed on unknown type).
         let author_hex = buzz_event.event.pubkey.to_hex();
-        let is_dm = crate::is_dm_channel(buzz_event.channel_id, &channel_info).await;
         let allowed = author_allowed(
             &config.respond_to,
             &config.respond_to_allowlist,
             &author_hex,
-            is_dm,
+            dm_classification.for_author_gate,
             &owner_cache,
             &rest_client,
         )
@@ -446,6 +470,8 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
             buzz_event.channel_id,
             &rules,
             &pubkey_hex,
+            dm_classification.implicitly_addressed,
+            dm_classification.for_author_gate,
         )
         .await
         .is_some();
@@ -514,10 +540,9 @@ pub(crate) fn should_nudge_for_event(
 
 /// Build the subscription rules used in setup mode.
 ///
-/// Always uses "mentions" mode: setup mode must not react to every event.
-/// Even if the agent's normal config is `subscribe_mode = all`, setup mode
-/// enforces explicit @mention filtering (see `event_mentions_agent` call in
-/// the loop above).
+/// Setup mode reacts only to explicit mentions in channels and to messages in
+/// verified one-to-one DMs with the agent. Even if the agent's normal config
+/// is `subscribe_mode = all`, it must not react to every stream or group-DM event.
 fn build_setup_subscription_rules(config: &Config) -> Vec<filter::SubscriptionRule> {
     use crate::config::SubscribeMode;
 
@@ -527,8 +552,8 @@ fn build_setup_subscription_rules(config: &Config) -> Vec<filter::SubscriptionRu
         .unwrap_or_else(|| vec![KIND_STREAM_MESSAGE, KIND_WORKFLOW_APPROVAL_REQUESTED]);
 
     match &config.subscribe_mode {
-        // Config mode: load the actual rules, but they will be filtered by
-        // the explicit event_mentions_agent check in the main loop anyway.
+        // Config mode: load the actual rules, with the main loop still
+        // enforcing explicit mentions outside one-to-one agent DMs.
         SubscribeMode::Config => match crate::config::load_rules(&config.config_path) {
             Ok(rules) => rules,
             Err(e) => {
@@ -565,20 +590,34 @@ async fn handle_setup_membership(
     buzz_event: &crate::relay::BuzzEvent,
     config: &Config,
     rules: &[filter::SubscriptionRule],
-    _initial_channel_ids: &[Uuid],
+    channel_info: &crate::pool::ChannelInfoResolver,
 ) {
     let kind_u32 = buzz_event.event.kind.as_u16() as u32;
     let channel_id = buzz_event.channel_id;
 
     if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION {
         // Subscribe to the newly-joined channel.
-        let ids = vec![channel_id];
-        let filters = crate::config::resolve_channel_filters(config, &ids, rules);
-        for (cid, filter) in filters {
-            if let Err(e) = relay.subscribe_channel(cid, filter).await {
-                tracing::warn!("setup-mode: failed to subscribe to new channel {cid}: {e}");
+        let is_implicitly_addressed = channel_info.resolve(channel_id).await.is_some_and(|info| {
+            crate::is_one_to_one_agent_dm(
+                &info.channel_type,
+                &info.participant_pubkeys,
+                &config.keys.public_key().to_hex(),
+            )
+        });
+        if let Some(filter) = crate::config::resolve_dynamic_channel_filter(
+            config,
+            channel_id,
+            is_implicitly_addressed,
+            rules,
+        ) {
+            if let Err(e) = relay.subscribe_channel(channel_id, filter).await {
+                tracing::warn!("setup-mode: failed to subscribe to new channel {channel_id}: {e}");
             } else {
-                tracing::info!("setup-mode: subscribed to new channel {cid}");
+                tracing::info!(
+                    channel_id = %channel_id,
+                    is_implicitly_addressed,
+                    "setup-mode: subscribed to new channel"
+                );
             }
         }
     } else if kind_u32 == KIND_MEMBER_REMOVED_NOTIFICATION {


### PR DESCRIPTION
## Summary

- Treat verified one-to-one DMs containing the running agent as implicitly addressed.
- Keep group DMs mention-gated by distinguishing recipient `p` tags from explicit `mention` references.
- Carry DM participant metadata through startup and dynamic channel resolution, including setup mode.

Buzz adds recipient `p` tags to every DM participant for delivery and notifications. The ACP harness previously treated those tags as explicit mentions, so it could not safely distinguish a one-to-one agent DM from a group DM. This change uses signed channel participant metadata and explicit mention-reference tags to make that distinction.

Missing or malformed channel metadata fails closed and keeps mention filtering enabled.

### Related issue

None found.

### Testing

- `cargo test -p buzz-acp` (620 unit tests, 9 integration tests)
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `just ci`
