### PR TITLE
fix(mobile): refetch open threads for live replies on the websocket path

### DIFF
--- a/mobile/lib/features/channels/channel_messages_provider.dart
+++ b/mobile/lib/features/channels/channel_messages_provider.dart
@@ -174,6 +174,7 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
     if (authoritative && event.threadReference.parentId == null) {
       _confirmLocalMessages([event.id]);
     }
+    _invalidateThreadReplies(event);
     if (_usingChannelWindow) {
       _handleWindowLiveEvent(event);
     } else {
@@ -198,30 +199,42 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
     state = AsyncData(flattened);
   }
 
+  /// Refetches the open thread view for a live reply.
+  ///
+  /// [threadRepliesProvider] is a one-shot future, so an open thread only
+  /// picks up a reply when it is invalidated. This runs for both history
+  /// paths: the websocket fallback merges replies into the flat timeline
+  /// alone, which left an open thread stale until an app restart rebuilt the
+  /// future.
+  void _invalidateThreadReplies(NostrEvent event) {
+    if (!EventKind.channelTimelineContentKinds.contains(event.kind)) return;
+    final thread = event.threadReference;
+    if (thread.parentId == null) return;
+
+    final rootId = thread.rootId;
+    if (rootId != null) {
+      ref.invalidate(
+        threadRepliesProvider(
+          ThreadRepliesArgs(channelId: channelId, rootId: rootId),
+        ),
+      );
+    }
+    final parentId = thread.parentId;
+    if (parentId != null && parentId != rootId) {
+      ref.invalidate(
+        threadRepliesProvider(
+          ThreadRepliesArgs(channelId: channelId, rootId: parentId),
+        ),
+      );
+    }
+  }
+
   bool _mergeWindowEventIntoStore(NostrEvent event) {
     final isTimelineRow = EventKind.channelTimelineContentKinds.contains(
       event.kind,
     );
     final thread = isTimelineRow ? event.threadReference : null;
-    if (thread?.parentId != null) {
-      final rootId = thread?.rootId;
-      if (rootId != null) {
-        ref.invalidate(
-          threadRepliesProvider(
-            ThreadRepliesArgs(channelId: channelId, rootId: rootId),
-          ),
-        );
-      }
-      final parentId = thread?.parentId;
-      if (parentId != null && parentId != rootId) {
-        ref.invalidate(
-          threadRepliesProvider(
-            ThreadRepliesArgs(channelId: channelId, rootId: parentId),
-          ),
-        );
-      }
-      if (!_isBroadcastReply(event)) return false;
-    }
+    if (thread?.parentId != null && !_isBroadcastReply(event)) return false;
     if (!isTimelineRow &&
         !EventKind.channelAuxEventKinds.contains(event.kind)) {
       return false;

--- a/mobile/test/features/channels/channel_messages_provider_test.dart
+++ b/mobile/test/features/channels/channel_messages_provider_test.dart
@@ -423,6 +423,58 @@ void main() {
   );
 
   test(
+    'websocket fallback refetches an open thread when a reply arrives live',
+    () async {
+      final relaySession = _RecordingRelaySessionNotifier(
+        queryResults: [
+          Exception('channel window unavailable'),
+          <NostrEvent>[],
+          [
+            _event(
+              id: 'reply',
+              createdAt: 20,
+              extraTags: const [
+                ['e', 'root', '', 'reply'],
+              ],
+            ),
+          ],
+        ],
+      );
+      final container = _buildContainer(relaySession);
+      addTearDown(container.dispose);
+
+      container.read(channelMessagesProvider(_channelId));
+      await relaySession.subscribed;
+      relaySession.completeHistory([_event(id: 'history', createdAt: 10)]);
+      await _pumpEventQueue();
+      // The channel window query failed, so this channel is on the legacy
+      // websocket history path for the rest of the session.
+      expect(relaySession.operations, ['subscribe', 'query', 'fetch']);
+
+      const args = ThreadRepliesArgs(channelId: _channelId, rootId: 'root');
+      expect(await container.read(threadRepliesProvider(args).future), isEmpty);
+
+      relaySession.emit(
+        _event(
+          id: 'reply',
+          createdAt: 20,
+          extraTags: const [
+            ['e', 'root', '', 'reply'],
+          ],
+        ),
+      );
+      await _pumpEventQueue();
+
+      expect(
+        (await container.read(
+          threadRepliesProvider(args).future,
+        )).map((event) => event.id),
+        ['reply'],
+      );
+    },
+  );
+
+  test(
     'successful never-echoed send releases ownership but keeps its row across reconnect',
     () async {
       final relaySession = _RecordingRelaySessionNotifier(


### PR DESCRIPTION
## Summary

Live thread replies never reached an open thread view on mobile's websocket history path.

`threadRepliesProvider` is a one-shot `FutureProvider.family` — an open thread only picks up a new reply when something invalidates it. That invalidation existed and was already correct, but it lived inside `_mergeWindowEventIntoStore`, which is reachable only from the `_usingChannelWindow == true` branch of `_handleLiveEvent`. The websocket fallback branch could never see it: the reply merged into the flat channel timeline and the open thread was never told.

`_fetchNewestHistory` latches that branch for the rest of the session — it catches any error from the channel-window query, logs `channel window unavailable … falling back to WS history`, and sets `_usingChannelWindow = false`. So a single failed `POST /query` is enough to put a session on the path where an open thread stops updating until the app is restarted and the one-shot future re-runs.

This moves the invalidation into `_invalidateThreadReplies(event)` and calls it from `_handleLiveEvent` ahead of the branch, so both history paths refetch.

**The channel-window path is unchanged.** `_mergeWindowEventIntoStore` has exactly one caller, `_handleWindowLiveEvent`, which calls it as its unconditional first statement; `_handleWindowLiveEvent` in turn has exactly one caller — the `_usingChannelWindow == true` branch of `_handleLiveEvent`. The invalidation ran under the same two gates it runs under now (`channelTimelineContentKinds`, `parentId != null`), so every event that reached the old invalidation reaches the new one. The only behavioral delta is the fallback branch gaining it.

Scope, stated plainly: `threadRepliesProvider` queries the same `POST /query` endpoint as the channel window, so this fixes the **transient** case — the endpoint blips, the session latches onto the fallback, the endpoint recovers, and live thread replies keep working instead of requiring a restart. Under a *persistent* `/query` outage the thread view cannot load replies with or without this patch.

### Related issue

Fixes #3046.

Duplicate search — the closest open work in this file neighbourhood, all distinct from this change:

- **#3211** (invite-link joins downgrade `wss://` to plaintext `ws://`), with PRs **#3139** and **#2726**. Genuinely adjacent: a `ws`-scheme `baseUrl` also makes `POST /query` throw, which latches this same fallback. But it is a different defect with a different fix, and neither PR touches `channel_messages_provider.dart` or `thread_replies_provider.dart`.
- **#3053** (live subscriptions — `relay_session.dart`, `channels_provider.dart`) and **#3121** (`thread_detail_page.dart`, layout and typography) — no file overlap.

Searched by issue citation and by changed-file list across all **437** open PRs (`gh pr list --repo block/buzz --state open --limit 1000 --json number,files`): none cite #3046, and none touch either file this change edits.

### Testing

Full mobile suite: **825 passed, 1 skipped.** `flutter analyze` clean; `dart format --output=none --set-exit-if-changed .` clean (283 files, 0 changed).

Added `websocket fallback refetches an open thread when a reply arrives live` to `mobile/test/features/channels/channel_messages_provider_test.dart`. It fails the channel-window query to drive the notifier onto the fallback path, opens the thread, emits a live reply over the subscription, and asserts the thread refetches.

Negative control — the same test with only the `lib/` change reverted:

```
00:00 +0 -1: websocket fallback refetches an open thread when a reply arrives live [E]
  Expected: ['reply']
    Actual: MappedListIterable<NostrEvent, String>:[]
```

An empty thread — the reported symptom. It passes with the change applied.

**Not reproduced against a live relay.** The mechanism was traced at source and is covered by the test above, but I did not observe the failure on a device against a real relay, so I cannot confirm which condition put the reporter on the fallback branch. The behavior is consistent with their follow-up that "closing and re-opening the app allows the threaded replies to be seen," since a restart re-runs the one-shot future. If there is a second path into #3046, I would want to know.

No UI change — no widget, layout, style, or string is touched — so there are no screenshots.
