### PR TITLE
fix(composer): scope multiline block formatting

### DIFF
--- a/desktop/src/features/messages/lib/selectionBlockFormatting.test.mjs
+++ b/desktop/src/features/messages/lib/selectionBlockFormatting.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getSchema } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { EditorState, TextSelection } from "@tiptap/pm/state";
+
+import { isolateSelectionForBlockFormatting } from "./selectionBlockFormatting.ts";
+
+// Matching useRichTextEditor's StarterKit configuration (minus things
+// irrelevant to block isolation).
+const schema = getSchema([
+  StarterKit.configure({
+    hardBreak: { keepMarks: true },
+    heading: false,
+    trailingNode: false,
+    link: false,
+  }),
+]);
+
+const para = (...content) => schema.nodes.paragraph.create(null, content);
+const br = () => schema.nodes.hardBreak.create();
+const t = (text) => schema.text(text);
+
+function doc(...content) {
+  return schema.nodes.doc.create(null, content);
+}
+
+function stateWithCaret(documentNode, caret) {
+  return EditorState.create({
+    doc: documentNode,
+    selection: TextSelection.create(documentNode, caret),
+  });
+}
+
+function paragraphTexts(documentNode) {
+  const texts = [];
+  documentNode.forEach((node) => {
+    texts.push(node.textContent);
+  });
+  return texts;
+}
+
+test("caret between hard breaks isolates only its line", () => {
+  // <p>before␍target␍after</p> with the caret inside "target".
+  const state = stateWithCaret(
+    doc(para(t("before"), br(), t("target"), br(), t("after"))),
+    10,
+  );
+
+  const transaction = state.tr;
+  assert.equal(isolateSelectionForBlockFormatting(transaction), true);
+
+  const next = state.apply(transaction);
+  assert.deepEqual(paragraphTexts(next.doc), ["before", "target", "after"]);
+  assert.equal(next.selection.empty, true);
+  assert.equal(next.selection.$from.parent.textContent, "target");
+});
+
+test("caret on an empty trailing line isolates an empty paragraph", () => {
+  // "before" + Shift+Enter, caret at the end — the reported bug shape.
+  const state = stateWithCaret(doc(para(t("before"), br())), 8);
+
+  const transaction = state.tr;
+  assert.equal(isolateSelectionForBlockFormatting(transaction), true);
+
+  const next = state.apply(transaction);
+  assert.deepEqual(paragraphTexts(next.doc), ["before", ""]);
+  assert.equal(next.selection.empty, true);
+  assert.equal(next.selection.$from.parent.textContent, "");
+});
+
+test("caret on the first line splits only after that line", () => {
+  const state = stateWithCaret(doc(para(t("first"), br(), t("rest"))), 3);
+
+  const transaction = state.tr;
+  assert.equal(isolateSelectionForBlockFormatting(transaction), true);
+
+  const next = state.apply(transaction);
+  assert.deepEqual(paragraphTexts(next.doc), ["first", "rest"]);
+  assert.equal(next.selection.$from.parent.textContent, "first");
+});
+
+test("caret on the last line splits only before that line", () => {
+  const state = stateWithCaret(doc(para(t("rest"), br(), t("last"))), 8);
+
+  const transaction = state.tr;
+  assert.equal(isolateSelectionForBlockFormatting(transaction), true);
+
+  const next = state.apply(transaction);
+  assert.deepEqual(paragraphTexts(next.doc), ["rest", "last"]);
+  assert.equal(next.selection.$from.parent.textContent, "last");
+});
+
+test("caret in a single-line paragraph is a no-op", () => {
+  const state = stateWithCaret(doc(para(t("only line"))), 4);
+
+  const transaction = state.tr;
+  assert.equal(isolateSelectionForBlockFormatting(transaction), false);
+  assert.equal(transaction.steps.length, 0);
+});
+
+test("selection isolation still splits around the selected text", () => {
+  const documentNode = doc(para(t("before selected after")));
+  const state = EditorState.create({
+    doc: documentNode,
+    // "selected" spans positions 8..16.
+    selection: TextSelection.create(documentNode, 8, 16),
+  });
+
+  const transaction = state.tr;
+  assert.equal(isolateSelectionForBlockFormatting(transaction), true);
+
+  const next = state.apply(transaction);
+  assert.deepEqual(paragraphTexts(next.doc), ["before ", "selected", " after"]);
+  assert.equal(
+    next.doc.textBetween(next.selection.from, next.selection.to),
+    "selected",
+  );
+});

--- a/desktop/src/features/messages/lib/selectionBlockFormatting.test.mjs
+++ b/desktop/src/features/messages/lib/selectionBlockFormatting.test.mjs
@@ -8,6 +8,7 @@ import { EditorState, TextSelection } from "@tiptap/pm/state";
 import {
   isolateSelectionForBlockFormatting,
   mergeSelectedTextblocksIntoCodeBlock,
+  splitSelectedLinesForListFormatting,
 } from "./selectionBlockFormatting.ts";
 
 // Matching useRichTextEditor's StarterKit configuration (minus things
@@ -146,4 +147,35 @@ test("selection isolation still splits around the selected text", () => {
     next.doc.textBetween(next.selection.from, next.selection.to),
     "selected",
   );
+});
+
+test("list splitting turns selected hard breaks into separate textblocks", () => {
+  const documentNode = doc(para(t("one"), br(), t("two"), br(), t("three")));
+  const state = EditorState.create({
+    doc: documentNode,
+    selection: TextSelection.create(documentNode, 1, 14),
+  });
+
+  const transaction = state.tr;
+  assert.equal(splitSelectedLinesForListFormatting(transaction), true);
+  const next = state.apply(transaction);
+  assert.deepEqual(paragraphTexts(next.doc), ["one", "two", "three"]);
+});
+
+test("code merge preserves hard breaks", () => {
+  const documentNode = doc(para(t("one"), br(), t("two")), para(t("three")));
+  const state = EditorState.create({
+    doc: documentNode,
+    selection: TextSelection.create(
+      documentNode,
+      1,
+      documentNode.content.size - 1,
+    ),
+  });
+
+  const transaction = state.tr;
+  assert.equal(mergeSelectedTextblocksIntoCodeBlock(transaction), true);
+  const next = state.apply(transaction);
+  assert.equal(next.doc.firstChild.type.name, "codeBlock");
+  assert.equal(next.doc.firstChild.textContent, "one\ntwo\nthree");
 });

--- a/desktop/src/features/messages/lib/selectionBlockFormatting.test.mjs
+++ b/desktop/src/features/messages/lib/selectionBlockFormatting.test.mjs
@@ -5,7 +5,10 @@ import { getSchema } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import { EditorState, TextSelection } from "@tiptap/pm/state";
 
-import { isolateSelectionForBlockFormatting } from "./selectionBlockFormatting.ts";
+import {
+  isolateSelectionForBlockFormatting,
+  mergeSelectedTextblocksIntoCodeBlock,
+} from "./selectionBlockFormatting.ts";
 
 // Matching useRichTextEditor's StarterKit configuration (minus things
 // irrelevant to block isolation).
@@ -98,6 +101,32 @@ test("caret in a single-line paragraph is a no-op", () => {
   const transaction = state.tr;
   assert.equal(isolateSelectionForBlockFormatting(transaction), false);
   assert.equal(transaction.steps.length, 0);
+});
+
+test("exact block-boundary selection excludes endpoint paragraphs", () => {
+  const documentNode = doc(para(t("alpha")), para(t("beta")), para(t("gamma")));
+  for (const backward of [false, true]) {
+    const state = EditorState.create({
+      doc: documentNode,
+      selection: TextSelection.create(
+        documentNode,
+        backward ? 14 : 6,
+        backward ? 6 : 14,
+      ),
+    });
+    const transaction = state.tr;
+    isolateSelectionForBlockFormatting(transaction);
+    assert.equal(mergeSelectedTextblocksIntoCodeBlock(transaction), true);
+    const next = state.apply(transaction);
+    assert.deepEqual(
+      next.doc.toJSON(),
+      doc(
+        para(t("alpha")),
+        schema.nodes.codeBlock.create(null, t("beta")),
+        para(t("gamma")),
+      ).toJSON(),
+    );
+  }
 });
 
 test("selection isolation still splits around the selected text", () => {

--- a/desktop/src/features/messages/lib/selectionBlockFormatting.test.mjs
+++ b/desktop/src/features/messages/lib/selectionBlockFormatting.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getSchema } from "@tiptap/core";
+import { getSchema, Node } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import { EditorState, TextSelection } from "@tiptap/pm/state";
+
+import { CustomEmojiNode } from "./customEmojiNode.ts";
 
 import {
   isolateSelectionForBlockFormatting,
@@ -13,6 +15,21 @@ import {
 
 // Matching useRichTextEditor's StarterKit configuration (minus things
 // irrelevant to block isolation).
+const MentionNode = Node.create({
+  name: "mention",
+  group: "inline",
+  inline: true,
+  atom: true,
+  addAttributes: () => ({ label: { default: "" } }),
+});
+const UnknownLeaf = Node.create({
+  name: "unknownLeaf",
+  group: "inline",
+  inline: true,
+  atom: true,
+  addAttributes: () => ({ internalId: { default: "secret" } }),
+});
+
 const schema = getSchema([
   StarterKit.configure({
     hardBreak: { keepMarks: true },
@@ -20,6 +37,12 @@ const schema = getSchema([
     trailingNode: false,
     link: false,
   }),
+  MentionNode,
+  CustomEmojiNode.configure({
+    resolveUrl: () => undefined,
+    shortcodes: () => [],
+  }),
+  UnknownLeaf,
 ]);
 
 const para = (...content) => schema.nodes.paragraph.create(null, content);
@@ -178,4 +201,30 @@ test("code merge preserves hard breaks", () => {
   const next = state.apply(transaction);
   assert.equal(next.doc.firstChild.type.name, "codeBlock");
   assert.equal(next.doc.firstChild.textContent, "one\ntwo\nthree");
+});
+
+test("code merge preserves meaningful inline atoms and drops unknown leaves", () => {
+  const documentNode = doc(
+    para(
+      t("hello "),
+      schema.nodes.mention.create({ label: "@Taylor Ho" }),
+      t(" "),
+      schema.nodes.customEmoji.create({ shortcode: "party" }),
+      schema.nodes.unknownLeaf.create(),
+    ),
+  );
+  const state = EditorState.create({
+    doc: documentNode,
+    selection: TextSelection.create(
+      documentNode,
+      1,
+      documentNode.content.size - 1,
+    ),
+  });
+
+  const transaction = state.tr;
+  assert.equal(mergeSelectedTextblocksIntoCodeBlock(transaction), true);
+  const next = state.apply(transaction);
+  assert.equal(next.doc.firstChild.textContent, "hello @Taylor Ho :party:");
+  assert.equal(next.doc.firstChild.textContent.includes("secret"), false);
 });

--- a/desktop/src/features/messages/lib/selectionBlockFormatting.ts
+++ b/desktop/src/features/messages/lib/selectionBlockFormatting.ts
@@ -1,3 +1,4 @@
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { TextSelection, type Transaction } from "@tiptap/pm/state";
 import { canSplit } from "@tiptap/pm/transform";
 
@@ -146,6 +147,96 @@ export function isolateSelectionForBlockFormatting(
       isBackward ? to : from,
       isBackward ? from : to,
     ),
+  );
+  return true;
+}
+
+/** Split each selected hard-break line into a textblock before list wrapping. */
+export function splitSelectedLinesForListFormatting(
+  transaction: Transaction,
+): boolean {
+  if (!(transaction.selection instanceof TextSelection)) return false;
+  if (transaction.selection.empty) {
+    return isolateCaretLineForBlockFormatting(transaction);
+  }
+
+  const isBackward = transaction.selection.anchor > transaction.selection.head;
+  isolateSelectionForBlockFormatting(transaction);
+  let { from, to } = transaction.selection;
+  const breakPositions: number[] = [];
+
+  transaction.doc.nodesBetween(from, to, (node, position) => {
+    if (node.type.name === "hardBreak") breakPositions.push(position);
+  });
+
+  for (const position of breakPositions.reverse()) {
+    transaction.delete(position, position + 1);
+    ({ from, to } = mapRangeThroughLatestStep(transaction, from, to));
+    if (!canSplit(transaction.doc, position)) continue;
+    transaction.split(position);
+    ({ from, to } = mapRangeThroughLatestStep(transaction, from, to));
+  }
+
+  transaction.setSelection(
+    TextSelection.create(
+      transaction.doc,
+      isBackward ? to : from,
+      isBackward ? from : to,
+    ),
+  );
+  return true;
+}
+
+function selectedTextblocks(
+  transaction: Transaction,
+): Array<{ node: ProseMirrorNode; position: number }> {
+  const blocks: Array<{ node: ProseMirrorNode; position: number }> = [];
+  const { from, to } = transaction.selection;
+  transaction.doc.nodesBetween(
+    Math.max(0, from - 1),
+    Math.min(transaction.doc.content.size, to + 1),
+    (node, position) => {
+      if (node.isTextblock) {
+        blocks.push({ node, position });
+        return false;
+      }
+      return true;
+    },
+  );
+  return blocks;
+}
+
+function textblockTextForCode(node: ProseMirrorNode): string {
+  return node.textBetween(0, node.content.size, "\n", (leaf) =>
+    leaf.type.name === "hardBreak"
+      ? "\n"
+      : (leaf.type.spec.leafText?.(leaf) ?? ""),
+  );
+}
+
+/** Replace selected textblocks with one newline-joined code block. */
+export function mergeSelectedTextblocksIntoCodeBlock(
+  transaction: Transaction,
+): boolean {
+  if (!(transaction.selection instanceof TextSelection)) return false;
+  if (transaction.selection.empty) {
+    isolateCaretLineForBlockFormatting(transaction);
+    return false;
+  }
+
+  const blocks = selectedTextblocks(transaction);
+  const codeBlock = transaction.doc.type.schema.nodes.codeBlock;
+  const first = blocks[0];
+  const last = blocks.at(-1);
+  if (!(codeBlock && first && last)) return false;
+
+  const text = blocks.map(({ node }) => textblockTextForCode(node)).join("\n");
+  const from = first.position;
+  const to = last.position + last.node.nodeSize;
+  const content = text ? transaction.doc.type.schema.text(text) : undefined;
+  transaction.replaceWith(from, to, codeBlock.create(null, content));
+  transaction.setSelection(
+    TextSelection.create(transaction.doc, from + 1, from + 1 + text.length),
   );
   return true;
 }

--- a/desktop/src/features/messages/lib/selectionBlockFormatting.ts
+++ b/desktop/src/features/messages/lib/selectionBlockFormatting.ts
@@ -310,10 +310,7 @@ export function mergeSelectedTextblocksIntoCodeBlock(
   transaction: Transaction,
 ): boolean {
   if (!(transaction.selection instanceof TextSelection)) return false;
-  if (transaction.selection.empty) {
-    isolateCaretLineForBlockFormatting(transaction);
-    return false;
-  }
+  if (transaction.selection.empty) return false;
 
   const blocks = selectedTextblocks(transaction);
   const codeBlock = transaction.doc.type.schema.nodes.codeBlock;

--- a/desktop/src/features/messages/lib/selectionBlockFormatting.ts
+++ b/desktop/src/features/messages/lib/selectionBlockFormatting.ts
@@ -92,6 +92,67 @@ function isolateCaretLineForBlockFormatting(transaction: Transaction): boolean {
   return true;
 }
 
+function listItemTextRange(
+  $position: Transaction["selection"]["$from"],
+): { from: number; to: number } | null {
+  let itemDepth = -1;
+  for (let depth = $position.depth; depth > 0; depth -= 1) {
+    if ($position.node(depth).type.name === "listItem") {
+      itemDepth = depth;
+      break;
+    }
+  }
+  if (itemDepth < 0) return null;
+
+  const item = $position.node(itemDepth);
+  const itemPosition = $position.before(itemDepth);
+  let from: number | null = null;
+  let to: number | null = null;
+  item.descendants((node, relativePosition) => {
+    if (!node.isTextblock) return true;
+    const position = itemPosition + 1 + relativePosition;
+    from ??= position + 1;
+    to = position + node.nodeSize - 1;
+    return false;
+  });
+  return from === null || to === null ? null : { from, to };
+}
+
+/** Expand partial list endpoint selections to whole list-item textblocks. */
+function expandSelectionToListItems(transaction: Transaction): boolean {
+  const selection = transaction.selection;
+  if (!(selection instanceof TextSelection) || selection.empty) return false;
+
+  const startItem = listItemTextRange(selection.$from);
+  const endItem = listItemTextRange(selection.$to);
+  if (!(startItem || endItem)) return false;
+
+  const isBackward = selection.anchor > selection.head;
+  const from = startItem?.from ?? selection.from;
+  const to = endItem?.to ?? selection.to;
+  transaction.setSelection(
+    TextSelection.create(
+      transaction.doc,
+      isBackward ? to : from,
+      isBackward ? from : to,
+    ),
+  );
+  return true;
+}
+
+export function selectionIncludesList(transaction: Transaction): boolean {
+  const { from, to } = transaction.selection;
+  let includesList = false;
+  transaction.doc.nodesBetween(from, to, (node) => {
+    if (node.type.name === "listItem") {
+      includesList = true;
+      return false;
+    }
+    return !includesList;
+  });
+  return includesList;
+}
+
 function normalizeSelectionBlockBoundaries(transaction: Transaction): boolean {
   const selection = transaction.selection;
   if (!(selection instanceof TextSelection) || selection.empty) return false;
@@ -148,6 +209,7 @@ export function isolateSelectionForBlockFormatting(
     return isolateCaretLineForBlockFormatting(transaction);
   }
 
+  expandSelectionToListItems(transaction);
   normalizeSelectionBlockBoundaries(transaction);
   const isBackward = transaction.selection.anchor > transaction.selection.head;
   let { from, to } = transaction.selection;

--- a/desktop/src/features/messages/lib/selectionBlockFormatting.ts
+++ b/desktop/src/features/messages/lib/selectionBlockFormatting.ts
@@ -29,13 +29,77 @@ function mapRangeThroughLatestStep(
 }
 
 /**
- * Isolate a non-empty text selection at exact block boundaries.
+ * Isolate the hard-break-delimited line under a collapsed caret.
+ *
+ * The composer represents Shift+Enter lines as `hardBreak` nodes inside one
+ * paragraph, so a block toggle at a collapsed caret otherwise reformats every
+ * line of the draft. Replacing the line's bordering hard breaks with block
+ * splits gives the caret's line its own textblock, which scopes the following
+ * block toggle to just that line.
+ */
+function isolateCaretLineForBlockFormatting(transaction: Transaction): boolean {
+  const { $from } = transaction.selection;
+  if (!$from.parent.isTextblock || !$from.parent.inlineContent) return false;
+
+  const blockStart = $from.start();
+  const blockEnd = $from.end();
+  let caret = transaction.selection.from;
+
+  let lineFrom = blockStart;
+  let lineTo = blockEnd;
+  $from.parent.forEach((child, offset) => {
+    if (child.type.name !== "hardBreak") return;
+    const breakFrom = blockStart + offset;
+    const breakTo = breakFrom + child.nodeSize;
+    if (breakTo <= caret) lineFrom = breakTo;
+    if (breakFrom >= caret) lineTo = Math.min(lineTo, breakFrom);
+  });
+
+  // No hard breaks around the caret — the line already is the whole
+  // textblock, so the block toggle is correctly scoped as-is.
+  if (lineFrom === blockStart && lineTo === blockEnd) return false;
+
+  const nodeAfterLine = transaction.doc.resolve(lineTo).nodeAfter;
+  if (nodeAfterLine?.type.name === "hardBreak") {
+    transaction.delete(lineTo, lineTo + nodeAfterLine.nodeSize);
+    if (canSplit(transaction.doc, lineTo)) {
+      transaction.split(lineTo);
+      const stepMap = transaction.steps.at(-1)?.getMap();
+      if (stepMap) {
+        caret = stepMap.map(caret, -1);
+        lineFrom = stepMap.map(lineFrom, -1);
+      }
+    }
+  }
+
+  const nodeBeforeLine = transaction.doc.resolve(lineFrom).nodeBefore;
+  if (nodeBeforeLine?.type.name === "hardBreak") {
+    transaction.delete(lineFrom - nodeBeforeLine.nodeSize, lineFrom);
+    let stepMap = transaction.steps.at(-1)?.getMap();
+    if (stepMap) {
+      caret = stepMap.map(caret, 1);
+      lineFrom = stepMap.map(lineFrom, -1);
+    }
+    if (canSplit(transaction.doc, lineFrom)) {
+      transaction.split(lineFrom);
+      stepMap = transaction.steps.at(-1)?.getMap();
+      if (stepMap) caret = stepMap.map(caret, 1);
+    }
+  }
+
+  transaction.setSelection(TextSelection.create(transaction.doc, caret));
+  return true;
+}
+
+/**
+ * Isolate the current text selection at exact block boundaries.
  *
  * ProseMirror's block commands operate on whole textblocks. The composer can
  * hold an entire draft in one paragraph, so toggling a list or code block for
  * a substring otherwise formats the whole draft. Splitting at the selection
  * end and start first gives the selected text its own block while preserving
- * the surrounding content as sibling paragraphs.
+ * the surrounding content as sibling paragraphs. A collapsed caret isolates
+ * its hard-break-delimited line so the block format starts at that line.
  *
  * This mutates the transaction supplied by a Tiptap command chain so the
  * isolation and the following block toggle remain one undoable edit.
@@ -43,11 +107,12 @@ function mapRangeThroughLatestStep(
 export function isolateSelectionForBlockFormatting(
   transaction: Transaction,
 ): boolean {
-  if (
-    !(transaction.selection instanceof TextSelection) ||
-    transaction.selection.empty
-  ) {
+  if (!(transaction.selection instanceof TextSelection)) {
     return false;
+  }
+
+  if (transaction.selection.empty) {
+    return isolateCaretLineForBlockFormatting(transaction);
   }
 
   const isBackward = transaction.selection.anchor > transaction.selection.head;

--- a/desktop/src/features/messages/lib/selectionBlockFormatting.ts
+++ b/desktop/src/features/messages/lib/selectionBlockFormatting.ts
@@ -297,12 +297,23 @@ function selectedTextblocks(
   return blocks;
 }
 
+function leafTextForCode(leaf: ProseMirrorNode): string {
+  if (leaf.type.name === "hardBreak") return "\n";
+
+  const schemaText = leaf.type.spec.leafText?.(leaf);
+  if (schemaText !== undefined) return schemaText;
+
+  // Inline atoms should survive conversion whenever they expose a meaningful
+  // textual identity. Unknown leaves intentionally fall back to an empty
+  // string rather than leaking implementation attributes into user content.
+  const attrs = leaf.attrs as Record<string, unknown>;
+  if (typeof attrs.label === "string") return attrs.label;
+  if (typeof attrs.shortcode === "string") return `:${attrs.shortcode}:`;
+  return "";
+}
+
 function textblockTextForCode(node: ProseMirrorNode): string {
-  return node.textBetween(0, node.content.size, "\n", (leaf) =>
-    leaf.type.name === "hardBreak"
-      ? "\n"
-      : (leaf.type.spec.leafText?.(leaf) ?? ""),
-  );
+  return node.textBetween(0, node.content.size, "\n", leafTextForCode);
 }
 
 /** Replace selected textblocks with one newline-joined code block. */

--- a/desktop/src/features/messages/lib/selectionBlockFormatting.ts
+++ b/desktop/src/features/messages/lib/selectionBlockFormatting.ts
@@ -92,6 +92,38 @@ function isolateCaretLineForBlockFormatting(transaction: Transaction): boolean {
   return true;
 }
 
+function normalizeSelectionBlockBoundaries(transaction: Transaction): boolean {
+  const selection = transaction.selection;
+  if (!(selection instanceof TextSelection) || selection.empty) return false;
+
+  const isBackward = selection.anchor > selection.head;
+  let { from, to } = selection;
+  if (
+    selection.$from.parent.isTextblock &&
+    selection.$from.parentOffset === selection.$from.parent.content.size &&
+    selection.$from.depth > 0
+  ) {
+    from = selection.$from.after();
+  }
+  if (
+    selection.$to.parent.isTextblock &&
+    selection.$to.parentOffset === 0 &&
+    selection.$to.depth > 0
+  ) {
+    to = selection.$to.before();
+  }
+  if (from >= to) return false;
+
+  transaction.setSelection(
+    TextSelection.create(
+      transaction.doc,
+      isBackward ? to : from,
+      isBackward ? from : to,
+    ),
+  );
+  return from !== selection.from || to !== selection.to;
+}
+
 /**
  * Isolate the current text selection at exact block boundaries.
  *
@@ -116,6 +148,7 @@ export function isolateSelectionForBlockFormatting(
     return isolateCaretLineForBlockFormatting(transaction);
   }
 
+  normalizeSelectionBlockBoundaries(transaction);
   const isBackward = transaction.selection.anchor > transaction.selection.head;
   let { from, to } = transaction.selection;
 
@@ -192,17 +225,13 @@ function selectedTextblocks(
 ): Array<{ node: ProseMirrorNode; position: number }> {
   const blocks: Array<{ node: ProseMirrorNode; position: number }> = [];
   const { from, to } = transaction.selection;
-  transaction.doc.nodesBetween(
-    Math.max(0, from - 1),
-    Math.min(transaction.doc.content.size, to + 1),
-    (node, position) => {
-      if (node.isTextblock) {
-        blocks.push({ node, position });
-        return false;
-      }
-      return true;
-    },
-  );
+  transaction.doc.nodesBetween(from, to, (node, position) => {
+    if (node.isTextblock) {
+      blocks.push({ node, position });
+      return false;
+    }
+    return true;
+  });
   return blocks;
 }
 

--- a/desktop/src/features/messages/ui/FormattingToolbar.tsx
+++ b/desktop/src/features/messages/ui/FormattingToolbar.tsx
@@ -269,7 +269,13 @@ export const FormattingToolbar = React.memo(function FormattingToolbar({
   }, [formattingChain]);
 
   const toggleBlockquote = React.useCallback(() => {
-    formattingChain()?.toggleBlockquote().run();
+    formattingChain()
+      ?.command(({ tr }) => {
+        isolateSelectionForBlockFormatting(tr);
+        return true;
+      })
+      .toggleBlockquote()
+      .run();
   }, [formattingChain]);
 
   const toggleSpoiler = React.useCallback(() => {

--- a/desktop/src/features/messages/ui/FormattingToolbar.tsx
+++ b/desktop/src/features/messages/ui/FormattingToolbar.tsx
@@ -16,7 +16,11 @@ import {
 
 import { cn } from "@/shared/lib/cn";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
-import { isolateSelectionForBlockFormatting } from "@/features/messages/lib/selectionBlockFormatting";
+import {
+  isolateSelectionForBlockFormatting,
+  mergeSelectedTextblocksIntoCodeBlock,
+  splitSelectedLinesForListFormatting,
+} from "@/features/messages/lib/selectionBlockFormatting";
 import { getEditorSpoilerRangeState } from "@/features/messages/lib/spoilerFormatting";
 import { SPOILER_MARK_NAME } from "@/features/messages/lib/spoilerMark";
 
@@ -196,14 +200,35 @@ export const FormattingToolbar = React.memo(function FormattingToolbar({
   }, [formattingChain]);
 
   const toggleCodeBlock = React.useCallback(() => {
-    formattingChain()
-      ?.command(({ tr }) => {
-        isolateSelectionForBlockFormatting(tr);
-        return true;
-      })
-      .toggleCodeBlock()
+    const chain = formattingChain();
+    if (!chain) return;
+    if (editor?.state.selection.empty) {
+      chain
+        .command(({ tr }) => {
+          isolateSelectionForBlockFormatting(tr);
+          return true;
+        })
+        .toggleCodeBlock()
+        .run();
+      return;
+    }
+
+    const selection = editor?.state.selection;
+    const isInList = selection
+      ? Array.from(
+          { length: selection.$from.depth + 1 },
+          (_, depth) => selection.$from.node(depth).type.name,
+        ).some((name) => name === "bulletList" || name === "orderedList")
+      : false;
+    let conversion = chain.command(({ tr }) => {
+      isolateSelectionForBlockFormatting(tr);
+      return true;
+    });
+    if (isInList) conversion = conversion.clearNodes();
+    conversion
+      .command(({ tr }) => mergeSelectedTextblocksIntoCodeBlock(tr))
       .run();
-  }, [formattingChain]);
+  }, [editor, formattingChain]);
 
   const restorePendingSelection = React.useCallback(() => {
     formattingChain()?.run();
@@ -251,7 +276,7 @@ export const FormattingToolbar = React.memo(function FormattingToolbar({
   const toggleBulletList = React.useCallback(() => {
     formattingChain()
       ?.command(({ tr }) => {
-        isolateSelectionForBlockFormatting(tr);
+        splitSelectedLinesForListFormatting(tr);
         return true;
       })
       .toggleBulletList()
@@ -261,7 +286,7 @@ export const FormattingToolbar = React.memo(function FormattingToolbar({
   const toggleOrderedList = React.useCallback(() => {
     formattingChain()
       ?.command(({ tr }) => {
-        isolateSelectionForBlockFormatting(tr);
+        splitSelectedLinesForListFormatting(tr);
         return true;
       })
       .toggleOrderedList()

--- a/desktop/src/features/messages/ui/FormattingToolbar.tsx
+++ b/desktop/src/features/messages/ui/FormattingToolbar.tsx
@@ -19,6 +19,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import {
   isolateSelectionForBlockFormatting,
   mergeSelectedTextblocksIntoCodeBlock,
+  selectionIncludesList,
   splitSelectedLinesForListFormatting,
 } from "@/features/messages/lib/selectionBlockFormatting";
 import { getEditorSpoilerRangeState } from "@/features/messages/lib/spoilerFormatting";
@@ -213,18 +214,14 @@ export const FormattingToolbar = React.memo(function FormattingToolbar({
       return;
     }
 
-    const selection = editor?.state.selection;
-    const isInList = selection
-      ? Array.from(
-          { length: selection.$from.depth + 1 },
-          (_, depth) => selection.$from.node(depth).type.name,
-        ).some((name) => name === "bulletList" || name === "orderedList")
-      : false;
     let conversion = chain.command(({ tr }) => {
       isolateSelectionForBlockFormatting(tr);
       return true;
     });
-    if (isInList) conversion = conversion.clearNodes();
+    conversion = conversion.command(({ tr, chain: currentChain }) => {
+      if (!selectionIncludesList(tr)) return true;
+      return currentChain().liftListItem("listItem").run();
+    });
     conversion
       .command(({ tr }) => mergeSelectedTextblocksIntoCodeBlock(tr))
       .run();
@@ -279,6 +276,10 @@ export const FormattingToolbar = React.memo(function FormattingToolbar({
         splitSelectedLinesForListFormatting(tr);
         return true;
       })
+      .command(({ tr, chain: currentChain }) => {
+        if (!selectionIncludesList(tr)) return true;
+        return currentChain().liftListItem("listItem").run();
+      })
       .toggleBulletList()
       .run();
   }, [formattingChain]);
@@ -289,6 +290,10 @@ export const FormattingToolbar = React.memo(function FormattingToolbar({
         splitSelectedLinesForListFormatting(tr);
         return true;
       })
+      .command(({ tr, chain: currentChain }) => {
+        if (!selectionIncludesList(tr)) return true;
+        return currentChain().liftListItem("listItem").run();
+      })
       .toggleOrderedList()
       .run();
   }, [formattingChain]);
@@ -298,6 +303,10 @@ export const FormattingToolbar = React.memo(function FormattingToolbar({
       ?.command(({ tr }) => {
         isolateSelectionForBlockFormatting(tr);
         return true;
+      })
+      .command(({ tr, chain: currentChain }) => {
+        if (!selectionIncludesList(tr)) return true;
+        return currentChain().liftListItem("listItem").run();
       })
       .toggleBlockquote()
       .run();

--- a/desktop/src/features/messages/ui/FormattingToolbar.tsx
+++ b/desktop/src/features/messages/ui/FormattingToolbar.tsx
@@ -203,29 +203,26 @@ export const FormattingToolbar = React.memo(function FormattingToolbar({
   const toggleCodeBlock = React.useCallback(() => {
     const chain = formattingChain();
     if (!chain) return;
-    if (editor?.state.selection.empty) {
-      chain
-        .command(({ tr }) => {
+    chain
+      .command(({ tr, chain: currentChain }) => {
+        if (tr.selection.empty) {
           isolateSelectionForBlockFormatting(tr);
-          return true;
-        })
-        .toggleCodeBlock()
-        .run();
-      return;
-    }
+          return currentChain().toggleCodeBlock().run();
+        }
 
-    let conversion = chain.command(({ tr }) => {
-      isolateSelectionForBlockFormatting(tr);
-      return true;
-    });
-    conversion = conversion.command(({ tr, chain: currentChain }) => {
-      if (!selectionIncludesList(tr)) return true;
-      return currentChain().liftListItem("listItem").run();
-    });
-    conversion
-      .command(({ tr }) => mergeSelectedTextblocksIntoCodeBlock(tr))
+        isolateSelectionForBlockFormatting(tr);
+        if (selectionIncludesList(tr)) {
+          return currentChain()
+            .liftListItem("listItem")
+            .command(({ tr: currentTransaction }) =>
+              mergeSelectedTextblocksIntoCodeBlock(currentTransaction),
+            )
+            .run();
+        }
+        return mergeSelectedTextblocksIntoCodeBlock(tr);
+      })
       .run();
-  }, [editor, formattingChain]);
+  }, [formattingChain]);
 
   const restorePendingSelection = React.useCallback(() => {
     formattingChain()?.run();

--- a/desktop/tests/e2e/composer-selection-formatting.spec.ts
+++ b/desktop/tests/e2e/composer-selection-formatting.spec.ts
@@ -38,6 +38,39 @@ async function selectText(input: Locator, selectedText: string) {
   }, selectedText);
 }
 
+async function selectTextRange(
+  input: Locator,
+  firstText: string,
+  lastText: string,
+) {
+  await input.evaluate(
+    (element, texts) => {
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+      let first: Text | null = null;
+      let last: Text | null = null;
+      while (walker.nextNode()) {
+        const node = walker.currentNode as Text;
+        if (!first && node.data.includes(texts.firstText)) first = node;
+        if (node.data.includes(texts.lastText)) last = node;
+      }
+      if (!(first && last))
+        throw new Error("Could not find selection endpoints");
+      const range = document.createRange();
+      range.setStart(first, first.data.indexOf(texts.firstText));
+      range.setEnd(
+        last,
+        last.data.indexOf(texts.lastText) + texts.lastText.length,
+      );
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      (element as HTMLElement).focus();
+      document.dispatchEvent(new Event("selectionchange"));
+    },
+    { firstText, lastText },
+  );
+}
+
 async function dragSelectText(
   page: Page,
   input: Locator,
@@ -209,6 +242,111 @@ for (const format of [
     await expect(input.locator(":scope > p").last()).toHaveText("after");
   });
 }
+
+for (const list of [
+  { label: "Bullet list", selector: "ul" },
+  { label: "Ordered list", selector: "ol" },
+] as const) {
+  test(`selected hard-break lines become separate ${list.label.toLowerCase()} items`, async ({
+    page,
+  }) => {
+    await openGeneral(page);
+    const input = page.getByTestId("message-input");
+    await input.click();
+    await input.pressSequentially("one");
+    await input.press("Shift+Enter");
+    await input.pressSequentially("two");
+    await input.press("Shift+Enter");
+    await input.pressSequentially("three");
+    await selectTextRange(input, "one", "three");
+    await page
+      .getByTestId("selection-formatting-tray")
+      .getByRole("button", { name: list.label })
+      .click();
+
+    const items = input.locator(`:scope > ${list.selector} > li`);
+    await expect(items).toHaveCount(3);
+    await expect(items).toHaveText(["one", "two", "three"]);
+  });
+}
+
+test("selected hard-break lines stay newline-separated in one code block", async ({
+  page,
+}) => {
+  await openGeneral(page);
+  const input = page.getByTestId("message-input");
+  await input.click();
+  await input.pressSequentially("one");
+  await input.press("Shift+Enter");
+  await input.pressSequentially("two");
+  await input.press("Shift+Enter");
+  await input.pressSequentially("three");
+  await selectTextRange(input, "one", "three");
+  await page
+    .getByTestId("selection-formatting-tray")
+    .getByRole("button", { name: "Code block" })
+    .click();
+
+  await expect(input.locator(":scope > pre")).toHaveCount(1);
+  await expect(input.locator(":scope > pre")).toHaveText("one\ntwo\nthree");
+
+  await page.getByTestId("send-message").click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as Window & {
+              __BUZZ_E2E_SIGNED_EVENTS__?: Array<{ content: string }>;
+            }
+          ).__BUZZ_E2E_SIGNED_EVENTS__?.at(-1)?.content,
+      ),
+    )
+    .toBe("```\none\ntwo\nthree\n```");
+});
+
+test("selected list items become one multiline code block and keep neighbors", async ({
+  page,
+}) => {
+  await openGeneral(page);
+  const input = page.getByTestId("message-input");
+  await input.click();
+  await input.pressSequentially("before");
+  await input.press("Shift+Enter");
+  await input.pressSequentially("one");
+  await input.press("Shift+Enter");
+  await input.pressSequentially("two");
+  await input.press("Shift+Enter");
+  await input.pressSequentially("after");
+  await selectTextRange(input, "before", "after");
+  await page
+    .getByTestId("selection-formatting-tray")
+    .getByRole("button", { name: "Bullet list" })
+    .click();
+  await selectTextRange(input, "one", "two");
+  await page
+    .getByTestId("selection-formatting-tray")
+    .getByRole("button", { name: "Code block" })
+    .click();
+
+  await expect(input.locator(":scope > pre")).toHaveCount(1);
+  await expect(input.locator(":scope > pre")).toHaveText("one\ntwo");
+  await expect(input.locator(":scope > ul li")).toHaveText(["before", "after"]);
+
+  await page.getByTestId("send-message").click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as Window & {
+              __BUZZ_E2E_SIGNED_EVENTS__?: Array<{ content: string }>;
+            }
+          ).__BUZZ_E2E_SIGNED_EVENTS__?.at(-1)?.content,
+      ),
+    )
+    .toBe("- before\n\n```\none\ntwo\n```\n\n- after");
+});
 
 test("caret-only block formatting serializes the prior draft unchanged", async ({
   page,

--- a/desktop/tests/e2e/composer-selection-formatting.spec.ts
+++ b/desktop/tests/e2e/composer-selection-formatting.spec.ts
@@ -243,6 +243,25 @@ for (const format of [
   });
 }
 
+test("Code block uses the restored multiline selection after mouseup collapse", async ({
+  page,
+}) => {
+  await openGeneral(page);
+
+  const input = page.getByTestId("message-input");
+  await input.click();
+  await input.pressSequentially("before");
+  await input.press("Shift+Enter");
+  await input.pressSequentially("selected");
+  await input.press("Shift+Enter");
+  await input.pressSequentially("after");
+  await applySelectionFormat(page, input, "Code block", true);
+
+  await expect(input.locator(":scope > p").first()).toHaveText("before");
+  await expect(input.locator(":scope > pre")).toHaveText("selected");
+  await expect(input.locator(":scope > p").last()).toHaveText("after");
+});
+
 for (const list of [
   { label: "Bullet list", selector: "ul" },
   { label: "Ordered list", selector: "ol" },

--- a/desktop/tests/e2e/composer-selection-formatting.spec.ts
+++ b/desktop/tests/e2e/composer-selection-formatting.spec.ts
@@ -93,7 +93,7 @@ async function dragSelectText(
 async function applySelectionFormat(
   page: Page,
   input: Locator,
-  label: "Bullet list" | "Code block" | "Ordered list",
+  label: "Bullet list" | "Code block" | "Ordered list" | "Quote",
   collapseAfterMouseDown = false,
   useMouseSelection = false,
 ) {
@@ -136,10 +136,19 @@ test.beforeEach(async ({ page }) => {
   await installMockBridge(page);
 });
 
+async function applyCaretFormat(
+  page: Page,
+  label: "Bullet list" | "Code block" | "Ordered list" | "Quote",
+) {
+  await page.getByRole("button", { name: "Toggle formatting" }).first().click();
+  await page.getByRole("button", { name: label, exact: true }).click();
+}
+
 for (const format of [
   { label: "Code block", selector: "pre" },
   { label: "Bullet list", selector: "ul" },
   { label: "Ordered list", selector: "ol" },
+  { label: "Quote", selector: "blockquote" },
 ] as const) {
   test(`${format.label} applies only to the selected composer text`, async ({
     page,
@@ -157,7 +166,76 @@ for (const format of [
     await expect(input.locator(":scope > p").last()).toHaveText(" after");
     await expect(input).toHaveText("before selected after");
   });
+
+  test(`${format.label} starts at a collapsed caret on a new line`, async ({
+    page,
+  }) => {
+    await openGeneral(page);
+
+    const input = page.getByTestId("message-input");
+    await input.click();
+    await input.pressSequentially("before");
+    await input.press("Shift+Enter");
+    await applyCaretFormat(page, format.label);
+    await input.pressSequentially("inside");
+
+    await expect(input.locator(":scope > p").first()).toHaveText("before");
+    await expect(input.locator(`:scope > ${format.selector}`)).toHaveText(
+      "inside",
+    );
+  });
+
+  test(`${format.label} at a collapsed caret formats only the caret's line`, async ({
+    page,
+  }) => {
+    await openGeneral(page);
+
+    const input = page.getByTestId("message-input");
+    await input.click();
+    await input.pressSequentially("before");
+    await input.press("Shift+Enter");
+    await input.pressSequentially("target");
+    await input.press("Shift+Enter");
+    await input.pressSequentially("after");
+    // Collapse the caret into the middle line.
+    await selectText(input, "target");
+    await input.press("ArrowRight");
+    await applyCaretFormat(page, format.label);
+
+    await expect(input.locator(":scope > p").first()).toHaveText("before");
+    await expect(input.locator(`:scope > ${format.selector}`)).toHaveText(
+      "target",
+    );
+    await expect(input.locator(":scope > p").last()).toHaveText("after");
+  });
 }
+
+test("caret-only block formatting serializes the prior draft unchanged", async ({
+  page,
+}) => {
+  await openGeneral(page);
+
+  const input = page.getByTestId("message-input");
+  await input.click();
+  await input.pressSequentially("before");
+  await input.press("Shift+Enter");
+  await applyCaretFormat(page, "Bullet list");
+  await input.pressSequentially("item");
+
+  await page.getByTestId("send-message").click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as Window & {
+              __BUZZ_E2E_SIGNED_EVENTS__?: Array<{ content: string }>;
+            }
+          ).__BUZZ_E2E_SIGNED_EVENTS__?.at(-1)?.content,
+      ),
+    )
+    .toBe("before\n\n- item");
+});
 
 test("block formatting preserves the lines around a selected composer line", async ({
   page,

--- a/desktop/tests/e2e/composer-selection-formatting.spec.ts
+++ b/desktop/tests/e2e/composer-selection-formatting.spec.ts
@@ -320,14 +320,41 @@ test("partial list-item selections snap to whole items for block formats", async
       .getByRole("button", { name: format })
       .click();
 
-    await expect(input).toContainText("before");
-    await expect(input).toContainText("first");
-    await expect(input).toContainText("second");
-    await expect(input).toContainText("after");
-    await expect(input.locator(":scope > ul li")).toContainText([
-      "before",
-      "after",
-    ]);
+    const structure = await input.locator(":scope > *").evaluateAll((nodes) =>
+      nodes.map((node) => ({
+        tag: node.tagName.toLowerCase(),
+        text: node.textContent,
+        items: Array.from(
+          node.querySelectorAll(":scope > li"),
+          (item) => item.textContent,
+        ),
+      })),
+    );
+    const expected = {
+      "Code block": [
+        { tag: "ul", text: "before", items: ["before"] },
+        { tag: "pre", text: "first\nsecond", items: [] },
+        { tag: "ul", text: "after", items: ["after"] },
+      ],
+      "Bullet list": [
+        {
+          tag: "ul",
+          text: "beforefirstsecondafter",
+          items: ["before", "first", "second", "after"],
+        },
+      ],
+      "Ordered list": [
+        { tag: "ul", text: "before", items: ["before"] },
+        { tag: "ol", text: "firstsecond", items: ["first", "second"] },
+        { tag: "ul", text: "after", items: ["after"] },
+      ],
+      Quote: [
+        { tag: "ul", text: "before", items: ["before"] },
+        { tag: "blockquote", text: "firstsecond", items: [] },
+        { tag: "ul", text: "after", items: ["after"] },
+      ],
+    }[format];
+    expect(structure).toEqual(expected);
     await page.reload();
   }
 });

--- a/desktop/tests/e2e/composer-selection-formatting.spec.ts
+++ b/desktop/tests/e2e/composer-selection-formatting.spec.ts
@@ -270,6 +270,49 @@ for (const list of [
   });
 }
 
+test("partial list-item selections snap to whole items for block formats", async ({
+  page,
+}) => {
+  for (const format of [
+    "Code block",
+    "Bullet list",
+    "Ordered list",
+    "Quote",
+  ] as const) {
+    await openGeneral(page);
+    const input = page.getByTestId("message-input");
+    await input.click();
+    await input.pressSequentially("before");
+    await input.press("Shift+Enter");
+    await input.pressSequentially("first");
+    await input.press("Shift+Enter");
+    await input.pressSequentially("second");
+    await input.press("Shift+Enter");
+    await input.pressSequentially("after");
+    await selectTextRange(input, "before", "after");
+    await page
+      .getByTestId("selection-formatting-tray")
+      .getByRole("button", { name: "Bullet list" })
+      .click();
+
+    await selectTextRange(input, "irst", "seco");
+    await page
+      .getByTestId("selection-formatting-tray")
+      .getByRole("button", { name: format })
+      .click();
+
+    await expect(input).toContainText("before");
+    await expect(input).toContainText("first");
+    await expect(input).toContainText("second");
+    await expect(input).toContainText("after");
+    await expect(input.locator(":scope > ul li")).toContainText([
+      "before",
+      "after",
+    ]);
+    await page.reload();
+  }
+});
+
 test("selected hard-break lines stay newline-separated in one code block", async ({
   page,
 }) => {


### PR DESCRIPTION
**Category:** fix
**User Impact:** Composer block formatting now applies to the intended line or selection without collapsing multiline content.

**Problem:** Block formatting from a Shift+Enter line could convert the entire draft, selected visual lines could collapse into one list item, and code conversion could lose line breaks. **Solution:** Scope caret formatting to its hard-break-delimited line and normalize explicit selections for the destination block type while preserving neighboring content and visual line boundaries.

<details>
<summary>File changes</summary>

**desktop/src/features/messages/lib/selectionBlockFormatting.ts**
Scopes collapsed-caret block actions to the active visual line and normalizes multiline selections for lists and code blocks.

**desktop/src/features/messages/lib/selectionBlockFormatting.test.mjs**
Adds unit coverage for caret-line isolation across line positions and selection directions.

**desktop/src/features/messages/ui/FormattingToolbar.tsx**
Routes list, quote, and code-block actions through the selection-aware formatting transaction.

**desktop/tests/e2e/composer-selection-formatting.spec.ts**
Covers caret-only formatting, multiline list conversion, list-to-code conversion, preserved hard breaks, Markdown output, and backward selections.

</details>

## Reproduction steps

1. In the desktop composer, enter several lines using Shift+Enter and place the caret on one line.
2. Apply a bullet list, ordered list, quote, or code block; only the caret line should change.
3. Select several Shift+Enter lines and apply a list; each visual line should become its own item.
4. Select several list items and apply Code block; they should become one multiline code block while unselected neighbors remain intact.
5. Select several Shift+Enter lines and apply Code block; each line break should remain visible.

## Screenshots/Demos
<img width="508" height="222" alt="Screen Recording 2026-07-27 at 5 29 19 PM" src="https://github.com/user-attachments/assets/35640dea-0cfb-44f1-9b0b-a993c69cb55f" />

Expected multiline code-block result: https://buzz.block.builderlab.xyz/media/d2e2668093af3b67d896a32e9799daccd236da9fc9e24ec56ddb4ebf7d01dd96.png
