### PR TITLE
fix(desktop): signout modal overflow fix

### DIFF
--- a/desktop/src/features/onboarding/ui/NsecMaskedDisplay.tsx
+++ b/desktop/src/features/onboarding/ui/NsecMaskedDisplay.tsx
@@ -94,7 +94,9 @@ export function NsecMaskedDisplay({
         <div className="min-w-0 flex-1">
           <p
             className={`${
-              isBare ? ONBOARDING_KEY_TEXT_CLASS : "text-xs leading-5"
+              isBare
+                ? ONBOARDING_KEY_TEXT_CLASS
+                : "break-all [overflow-wrap:anywhere] font-mono text-xs leading-5"
             } ${
               isRevealed
                 ? `select-text ${isBare ? "" : "text-foreground"}`

--- a/desktop/src/features/settings/ui/SignOutSection.tsx
+++ b/desktop/src/features/settings/ui/SignOutSection.tsx
@@ -163,7 +163,7 @@ export function SignOutSection() {
         }}
         open={isOpen}
       >
-        <AlertDialogContent>
+        <AlertDialogContent className="min-w-0 overflow-x-hidden">
           <AlertDialogHeader>
             <AlertDialogTitle>Sign out and wipe all data?</AlertDialogTitle>
             <AlertDialogDescription>


### PR DESCRIPTION
## Summary
FIxed the CSS that caused the sign-out modal to overflow after revealing the private key. 

### Related issue
<!-- Fixes #1234, or N/A. Before opening: search existing issues/PRs for duplicates — link the closest one, or say "none found". -->
Solves #3245.

### Testing
<!-- How was this verified? UI change? Include before/after screenshots (or a short recording). -->

Before:
<img width="544" height="383" alt="Screenshot 2026-07-27 at 20 08 04" src="https://github.com/user-attachments/assets/144ba0ce-e984-4a6e-87d9-6ecab44859fe" />

After
<img width="450" height="411" alt="Screenshot 2026-07-27 at 21 00 07" src="https://github.com/user-attachments/assets/c32f6f11-e8e4-4134-9cef-8a5e8cf7dd53" />


IMO, I don't like how the blurb above is formatted, but that is a separate issue.