### PR TITLE
feat(buzz-cli): add 'patches status-list' to read NIP-34 status events

### DIFF
--- a/crates/buzz-cli/src/commands/patches.rs
+++ b/crates/buzz-cli/src/commands/patches.rs
@@ -110,6 +110,38 @@ pub async fn cmd_list_patches(
     Ok(())
 }
 
+/// Read patch status events (kind:1630-1633) for a repo — the read side of sign-off.
+/// Mirrors `cmd_list_patches` but selects status kinds instead of the patch kind, so
+/// operator sign-off (a signed `merged` status event) is queryable, not write-only.
+pub async fn cmd_list_status(
+    client: &BuzzClient,
+    repo_owner: &str,
+    repo_id: &str,
+    patch: Option<&str>,
+    limit: Option<u32>,
+) -> Result<(), CliError> {
+    validate_hex64(repo_owner)?;
+    validate_repo_id(repo_id)?;
+
+    let a_value = format!("30617:{repo_owner}:{repo_id}");
+    let mut filter = serde_json::json!({
+        "kinds": [1630, 1631, 1632, 1633],
+        "#a": [a_value]
+    });
+
+    if let Some(root) = patch {
+        validate_hex64(root)?;
+        filter["#e"] = serde_json::json!([root]);
+    }
+    if let Some(n) = limit {
+        filter["limit"] = serde_json::json!(n);
+    }
+
+    let resp = client.query(&filter).await?;
+    println!("{resp}");
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn cmd_patch_status(
     client: &BuzzClient,
@@ -244,6 +276,12 @@ pub async fn dispatch(cmd: crate::PatchesCmd, client: &BuzzClient) -> Result<(),
             author,
             limit,
         } => cmd_list_patches(client, &repo_owner, &repo_id, author.as_deref(), limit).await,
+        PatchesCmd::StatusList {
+            repo_owner,
+            repo_id,
+            patch,
+            limit,
+        } => cmd_list_status(client, &repo_owner, &repo_id, patch.as_deref(), limit).await,
         PatchesCmd::Status {
             root,
             status,

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -1254,6 +1254,21 @@ pub enum PatchesCmd {
         #[arg(long)]
         limit: Option<u32>,
     },
+    /// Read patch status events (NIP-34 kind:1630-1633) for a repo — the read side of sign-off
+    StatusList {
+        /// Repo owner pubkey (64-char hex)
+        #[arg(long)]
+        repo_owner: String,
+        /// Repo identifier (d-tag)
+        #[arg(long)]
+        repo_id: String,
+        /// Only status events referencing this patch root event id
+        #[arg(long)]
+        patch: Option<String>,
+        /// Maximum number of results
+        #[arg(long)]
+        limit: Option<u32>,
+    },
     /// Set status on a patch (open/merged/closed/draft — NIP-34 kind:1630-1633)
     Status {
         /// Root patch event id (first patch of the series/revision)
@@ -1968,7 +1983,7 @@ mod tests {
         );
         assert_eq!(
             names(&cmd, "patches"),
-            vec!["get", "list", "send", "status"]
+            vec!["get", "list", "send", "status", "status-list"]
         );
         assert_eq!(
             names(&cmd, "issues"),
@@ -2005,7 +2020,7 @@ mod tests {
             ("media", 1),
             ("messages", 8),
             ("pack", 2),
-            ("patches", 4),
+            ("patches", 5),
             ("pr", 5),
             ("reactions", 3),
             ("repos", 4),


### PR DESCRIPTION
## Problem

`buzz patches` can *write* status events (`patches status`) but has no way to *read* them. `patches list` returns only `kind:1617` patches; `patches get` fetches a patch by id. So patch/PR status (`kind:1630–1633`: open/merged/closed/draft) is **write-only** from the CLI — an agent or auditor can set a patch to `merged` but cannot query whether anything was ever merged/closed, or by whom. That makes agent sign-off/review flows impossible to verify from the CLI: the sign-off is a signed event on the relay, but nothing in the CLI surface reads it back.

## Change

Add `buzz patches status-list --repo-owner <hex> --repo-id <id> [--patch <root-id>] [--limit N]`. It mirrors `cmd_list_patches`, selecting the status kinds instead of the patch kind:

- filter `{"kinds":[1630,1631,1632,1633],"#a":["30617:<owner>:<repo>"]}`
- optional `--patch <root-id>` narrows to status events referencing a specific patch root (`#e`)
- reuses the existing `client.query()` path (NIP-98 auth, pagination, retries) — no new I/O

Three parts: a `StatusList` variant in `PatchesCmd` (`lib.rs`), `cmd_list_status` (`commands/patches.rs`), and one dispatch arm. The subcommand-inventory guard tests are updated for the new command.

## Testing

- `cargo fmt` + `cargo clippy -p buzz-cli` clean
- `cargo test -p buzz-cli` passes (250 tests)
- Manually verified against a live relay: `patches status-list` returns the `kind:1631` merged-status events for a repo, matching sign-offs written by `patches status`.

## Notes

Surfaced while dogfooding Buzz's agent sign-off flow (drafted with Claude Code): an agent-proposed patch was signed off, and nothing in the CLI could read the sign-off back. Happy to adjust the name (`status-list` vs folding into `list --status`) or add tests to whatever you'd prefer.
