### PR TITLE
feat(mobile): p-tag all DM participants so agents respond to plain DMs

### DIFF
--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -4,12 +4,15 @@ import '../../shared/relay/relay.dart';
 import '../channels/channel_management_provider.dart';
 import '../profile/user_cache_provider.dart';
 import '../profile/user_profile.dart';
+import 'channel.dart';
 import 'channel_messages_provider.dart';
+import 'channels_provider.dart';
 
 /// Sends messages by signing an event with the user's nsec and publishing it
 /// over the relay's NIP-42-authenticated WebSocket session.
 class SendMessage {
   final SignedEventRelay _signedEventRelay;
+  final Channel? Function(String channelId) _readChannel;
   final Future<List<ChannelMember>> Function(String channelId) _fetchMembers;
   final Map<String, UserProfile> Function() _readUserCache;
   final void Function(String channelId, NostrEvent event) _addLocalMessage;
@@ -19,6 +22,7 @@ class SendMessage {
 
   SendMessage({
     required SignedEventRelay signedEventRelay,
+    required Channel? Function(String channelId) readChannel,
     required Future<List<ChannelMember>> Function(String channelId)
     fetchMembers,
     required Map<String, UserProfile> Function() readUserCache,
@@ -28,6 +32,7 @@ class SendMessage {
     required void Function(String channelId, String eventId) removeLocalMessage,
     bool Function()? isDeliveryValid,
   }) : _signedEventRelay = signedEventRelay,
+       _readChannel = readChannel,
        _fetchMembers = fetchMembers,
        _readUserCache = readUserCache,
        _addLocalMessage = addLocalMessage,
@@ -57,12 +62,21 @@ class SendMessage {
         mentionPubkeys ?? await _resolveMentions(content, channelId);
     final authorPubkey = _signedEventRelay.pubkey;
 
+    // In a DM, fan out p-tags to every other participant so mention-gated
+    // agent subscriptions see plain messages (matching the desktop's
+    // messageMentionPubkeys). Synchronous cached lookup — if the channel
+    // isn't cached yet, the send proceeds with explicit mentions only.
+    final channel = _readChannel(channelId);
+    final fanoutPubkeys = (channel?.isDm ?? false)
+        ? channel!.participantPubkeys
+        : const <String>[];
+
     // Normalize mentions: lowercase, deduplicate, exclude self (matching
     // the desktop's normalizeMentionPubkeys).
     final selfLower = authorPubkey?.toLowerCase();
     final seenMentions = <String>{?selfLower};
     final normalizedMentions = <String>[
-      for (final pk in resolvedMentions)
+      for (final pk in [...resolvedMentions, ...fanoutPubkeys])
         if (seenMentions.add(pk.toLowerCase())) pk,
     ];
 
@@ -180,6 +194,11 @@ final sendMessageProvider = Provider<SendMessage>((ref) {
       session: ref.read(relaySessionProvider.notifier),
       nsec: config.nsec,
     ),
+    readChannel: (channelId) => ref
+        .read(channelsProvider)
+        .value
+        ?.where((channel) => channel.id == channelId)
+        .firstOrNull,
     fetchMembers: (channelId) =>
         ref.read(channelMembersProvider(channelId).future),
     readUserCache: () => ref.read(userCacheProvider),

--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -65,15 +65,16 @@ class SendMessage {
     final authorPubkey = _signedEventRelay.pubkey;
 
     // In a DM, fan out p-tags to every other participant so mention-gated
-    // agent subscriptions see plain messages (matching the desktop's
-    // messageMentionPubkeys). Wait for the authoritative channel list when
-    // the synchronous cache has not loaded this channel yet.
-    final channel = await _readChannel(channelId);
-    if (channel == null) {
-      throw StateError('Channel not found: $channelId');
+    // agent subscriptions see plain messages. Wait for initial channel
+    // loading, but preserve explicit-mention sends if the list is unavailable.
+    Channel? channel;
+    try {
+      channel = await _readChannel(channelId);
+    } catch (_) {
+      channel = null;
     }
-    final fanoutPubkeys = channel.isDm
-        ? channel.participantPubkeys
+    final fanoutPubkeys = (channel?.isDm ?? false)
+        ? channel!.participantPubkeys
         : const <String>[];
 
     // Normalize mentions: lowercase, deduplicate, exclude self (matching

--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../shared/relay/relay.dart';
@@ -12,7 +14,7 @@ import 'channels_provider.dart';
 /// over the relay's NIP-42-authenticated WebSocket session.
 class SendMessage {
   final SignedEventRelay _signedEventRelay;
-  final Channel? Function(String channelId) _readChannel;
+  final FutureOr<Channel?> Function(String channelId) _readChannel;
   final Future<List<ChannelMember>> Function(String channelId) _fetchMembers;
   final Map<String, UserProfile> Function() _readUserCache;
   final void Function(String channelId, NostrEvent event) _addLocalMessage;
@@ -22,7 +24,7 @@ class SendMessage {
 
   SendMessage({
     required SignedEventRelay signedEventRelay,
-    required Channel? Function(String channelId) readChannel,
+    required FutureOr<Channel?> Function(String channelId) readChannel,
     required Future<List<ChannelMember>> Function(String channelId)
     fetchMembers,
     required Map<String, UserProfile> Function() readUserCache,
@@ -64,21 +66,27 @@ class SendMessage {
 
     // In a DM, fan out p-tags to every other participant so mention-gated
     // agent subscriptions see plain messages (matching the desktop's
-    // messageMentionPubkeys). Synchronous cached lookup — if the channel
-    // isn't cached yet, the send proceeds with explicit mentions only.
-    final channel = _readChannel(channelId);
-    final fanoutPubkeys = (channel?.isDm ?? false)
-        ? channel!.participantPubkeys
+    // messageMentionPubkeys). Wait for the authoritative channel list when
+    // the synchronous cache has not loaded this channel yet.
+    final channel = await _readChannel(channelId);
+    if (channel == null) {
+      throw StateError('Channel not found: $channelId');
+    }
+    final fanoutPubkeys = channel.isDm
+        ? channel.participantPubkeys
         : const <String>[];
 
     // Normalize mentions: lowercase, deduplicate, exclude self (matching
     // the desktop's normalizeMentionPubkeys).
     final selfLower = authorPubkey?.toLowerCase();
     final seenMentions = <String>{?selfLower};
-    final normalizedMentions = <String>[
-      for (final pk in [...resolvedMentions, ...fanoutPubkeys])
-        if (seenMentions.add(pk.toLowerCase())) pk,
-    ];
+    final normalizedMentions = <String>[];
+    for (final pk in [...resolvedMentions, ...fanoutPubkeys]) {
+      final lower = pk.toLowerCase();
+      if (lower.isNotEmpty && seenMentions.add(lower)) {
+        normalizedMentions.add(lower);
+      }
+    }
 
     final tags = <List<String>>[
       ['h', channelId],
@@ -194,11 +202,21 @@ final sendMessageProvider = Provider<SendMessage>((ref) {
       session: ref.read(relaySessionProvider.notifier),
       nsec: config.nsec,
     ),
-    readChannel: (channelId) => ref
-        .read(channelsProvider)
-        .value
-        ?.where((channel) => channel.id == channelId)
-        .firstOrNull,
+    readChannel: (channelId) {
+      final cachedChannel = ref
+          .read(channelsProvider)
+          .value
+          ?.where((channel) => channel.id == channelId)
+          .firstOrNull;
+      if (cachedChannel != null) return cachedChannel;
+      return ref
+          .read(channelsProvider.future)
+          .then(
+            (channels) => channels
+                .where((channel) => channel.id == channelId)
+                .firstOrNull,
+          );
+    },
     fetchMembers: (channelId) =>
         ref.read(channelMembersProvider(channelId).future),
     readUserCache: () => ref.read(userCacheProvider),

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -20,7 +20,7 @@ void main() {
           session: session,
           nsec: nostr.Keys.generate().nsec,
         ),
-        readChannel: (_) => null,
+        readChannel: (_) => _channel(channelType: 'stream'),
         fetchMembers: (_) async => const [],
         readUserCache: () => const {},
         addLocalMessage: (_, event) => localMessages.add(event),
@@ -54,7 +54,7 @@ void main() {
         session: session,
         nsec: nostr.Keys.generate().nsec,
       ),
-      readChannel: (_) => null,
+      readChannel: (_) => _channel(channelType: 'stream'),
       fetchMembers: (_) async => const [],
       readUserCache: () => const {},
       addLocalMessage: (_, event) => localMessages.add(event),
@@ -145,7 +145,7 @@ void main() {
   });
 
   test(
-    'explicit mention overlapping a fan-out participant dedupes to one p tag',
+    'DM recipient tags are lowercase, non-empty, and deduplicated',
     () async {
       final session = _PendingPublishRelaySession();
       final keys = nostr.Keys.generate();
@@ -154,25 +154,21 @@ void main() {
         nsec: keys.nsec,
         readChannel: (channelId) => _channel(
           channelType: 'dm',
-          participantPubkeys: [keys.public, _humanPubkey, _agentPubkey],
+          participantPubkeys: [keys.public, _humanPubkey, _agentPubkey, ''],
         ),
       );
 
-      // The explicit mention arrives uppercase while the roster holds the
-      // lowercase form — dedupe is keyed on the lowercased pubkey.
       final explicitAgent = _agentPubkey.toUpperCase();
       final result = send(
         channelId: _channelId,
         content: 'hey @agent',
-        mentionPubkeys: [explicitAgent],
+        mentionPubkeys: [explicitAgent, ''],
       );
       await session.published;
       session.accept();
       await result;
 
-      // The case-mismatched overlap collapses to a single p tag (first-seen
-      // casing wins), and the rest of the roster still fans out.
-      expect(_pTagPubkeys(session.event), [explicitAgent, _humanPubkey]);
+      expect(_pTagPubkeys(session.event), [_agentPubkey, _humanPubkey]);
     },
   );
 
@@ -213,7 +209,37 @@ void main() {
     },
   );
 
-  test('sends without fan-out when the channel is not cached yet', () async {
+  test('waits for channel loading before publishing a plain DM', () async {
+    final session = _PendingPublishRelaySession();
+    final channel = Completer<Channel?>();
+    final send = _sendMessage(
+      session: session,
+      nsec: nostr.Keys.generate().nsec,
+      readChannel: (_) => channel.future,
+    );
+
+    final result = send(
+      channelId: _channelId,
+      content: 'hello',
+      mentionPubkeys: const [],
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(session.hasPublished, isFalse);
+
+    channel.complete(
+      _channel(
+        channelType: 'dm',
+        participantPubkeys: const [_humanPubkey, _agentPubkey],
+      ),
+    );
+    await session.published;
+    session.accept();
+    await result;
+
+    expect(_pTagPubkeys(session.event), [_humanPubkey, _agentPubkey]);
+  });
+  test('rejects a send when the channel cannot be resolved', () async {
     final session = _PendingPublishRelaySession();
     final send = _sendMessage(
       session: session,
@@ -226,11 +252,21 @@ void main() {
       content: 'hello',
       mentionPubkeys: const [],
     );
-    await session.published;
-    session.accept();
-    await result;
+    final failure = expectLater(
+      result,
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          contains(_channelId),
+        ),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+    if (session.hasPublished) session.reject();
 
-    expect(_pTagPubkeys(session.event), isEmpty);
+    await failure;
+    expect(session.hasPublished, isFalse);
   });
 }
 
@@ -251,7 +287,7 @@ const _parentEventId =
 SendMessage _sendMessage({
   required _PendingPublishRelaySession session,
   required String nsec,
-  required Channel? Function(String channelId) readChannel,
+  required FutureOr<Channel?> Function(String channelId) readChannel,
 }) => SendMessage(
   signedEventRelay: SignedEventRelay(session: session, nsec: nsec),
   readChannel: readChannel,
@@ -286,6 +322,7 @@ class _PendingPublishRelaySession extends RelaySessionNotifier {
   final Completer<NostrEvent> _result = Completer<NostrEvent>();
   final Completer<void> _published = Completer<void>();
   late NostrEvent event;
+  bool get hasPublished => _published.isCompleted;
 
   Future<void> get published => _published.future;
 

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -239,34 +239,41 @@ void main() {
 
     expect(_pTagPubkeys(session.event), [_humanPubkey, _agentPubkey]);
   });
-  test('rejects a send when the channel cannot be resolved', () async {
+  test('sends explicit mentions when the channel is missing', () async {
     final session = _PendingPublishRelaySession();
     final send = _sendMessage(
       session: session,
       nsec: nostr.Keys.generate().nsec,
       readChannel: (_) => null,
     );
+    unawaited(session.published.then((_) => session.accept()));
 
-    final result = send(
+    await send(
       channelId: _channelId,
-      content: 'hello',
-      mentionPubkeys: const [],
+      content: 'hey @someone',
+      mentionPubkeys: const [_mentionPubkey],
     );
-    final failure = expectLater(
-      result,
-      throwsA(
-        isA<StateError>().having(
-          (error) => error.message,
-          'message',
-          contains(_channelId),
-        ),
-      ),
-    );
-    await Future<void>.delayed(Duration.zero);
-    if (session.hasPublished) session.reject();
 
-    await failure;
-    expect(session.hasPublished, isFalse);
+    expect(_pTagPubkeys(session.event), [_mentionPubkey]);
+  });
+
+  test('sends explicit mentions when the channel lookup fails', () async {
+    final session = _PendingPublishRelaySession();
+    final send = _sendMessage(
+      session: session,
+      nsec: nostr.Keys.generate().nsec,
+      readChannel: (_) =>
+          Future<Channel?>.error(Exception('channel list unavailable')),
+    );
+    unawaited(session.published.then((_) => session.accept()));
+
+    await send(
+      channelId: _channelId,
+      content: 'hey @someone',
+      mentionPubkeys: const [_mentionPubkey],
+    );
+
+    expect(_pTagPubkeys(session.event), [_mentionPubkey]);
   });
 }
 

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -144,6 +144,75 @@ void main() {
     expect(_pTagPubkeys(session.event), [_mentionPubkey]);
   });
 
+  test(
+    'explicit mention overlapping a fan-out participant dedupes to one p tag',
+    () async {
+      final session = _PendingPublishRelaySession();
+      final keys = nostr.Keys.generate();
+      final send = _sendMessage(
+        session: session,
+        nsec: keys.nsec,
+        readChannel: (channelId) => _channel(
+          channelType: 'dm',
+          participantPubkeys: [keys.public, _humanPubkey, _agentPubkey],
+        ),
+      );
+
+      // The explicit mention arrives uppercase while the roster holds the
+      // lowercase form — dedupe is keyed on the lowercased pubkey.
+      final explicitAgent = _agentPubkey.toUpperCase();
+      final result = send(
+        channelId: _channelId,
+        content: 'hey @agent',
+        mentionPubkeys: [explicitAgent],
+      );
+      await session.published;
+      session.accept();
+      await result;
+
+      // The case-mismatched overlap collapses to a single p tag (first-seen
+      // casing wins), and the rest of the roster still fans out.
+      expect(_pTagPubkeys(session.event), [explicitAgent, _humanPubkey]);
+    },
+  );
+
+  test(
+    'DM thread reply carries fan-out p tags alongside reply e-tags',
+    () async {
+      final session = _PendingPublishRelaySession();
+      final keys = nostr.Keys.generate();
+      final send = _sendMessage(
+        session: session,
+        nsec: keys.nsec,
+        readChannel: (channelId) => _channel(
+          channelType: 'dm',
+          participantPubkeys: [keys.public, _humanPubkey, _agentPubkey],
+        ),
+      );
+
+      // Nested thread reply, as the thread page sends it: parent + root.
+      final result = send(
+        channelId: _channelId,
+        content: 'replying in-thread',
+        parentEventId: _parentEventId,
+        rootEventId: _rootEventId,
+        mentionPubkeys: const [],
+      );
+      await session.published;
+      session.accept();
+      await result;
+
+      expect(
+        session.event.tags,
+        containsAll([
+          ['e', _rootEventId, '', 'root'],
+          ['e', _parentEventId, '', 'reply'],
+        ]),
+      );
+      expect(_pTagPubkeys(session.event), [_humanPubkey, _agentPubkey]);
+    },
+  );
+
   test('sends without fan-out when the channel is not cached yet', () async {
     final session = _PendingPublishRelaySession();
     final send = _sendMessage(
@@ -173,6 +242,11 @@ const _agentPubkey =
     'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 const _mentionPubkey =
     'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+const _rootEventId =
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+const _parentEventId =
+    'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
 SendMessage _sendMessage({
   required _PendingPublishRelaySession session,

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
+import 'package:buzz/features/channels/channel.dart';
 import 'package:buzz/features/channels/send_message_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
@@ -19,6 +20,7 @@ void main() {
           session: session,
           nsec: nostr.Keys.generate().nsec,
         ),
+        readChannel: (_) => null,
         fetchMembers: (_) async => const [],
         readUserCache: () => const {},
         addLocalMessage: (_, event) => localMessages.add(event),
@@ -52,6 +54,7 @@ void main() {
         session: session,
         nsec: nostr.Keys.generate().nsec,
       ),
+      readChannel: (_) => null,
       fetchMembers: (_) async => const [],
       readUserCache: () => const {},
       addLocalMessage: (_, event) => localMessages.add(event),
@@ -91,9 +94,119 @@ void main() {
       ),
     );
   });
+
+  test('plain DM send p-tags every participant except the sender', () async {
+    final session = _PendingPublishRelaySession();
+    final keys = nostr.Keys.generate();
+    final send = _sendMessage(
+      session: session,
+      nsec: keys.nsec,
+      readChannel: (channelId) => _channel(
+        channelType: 'dm',
+        // Roster includes the sender's own pubkey — it must be excluded.
+        participantPubkeys: [keys.public, _humanPubkey, _agentPubkey],
+      ),
+    );
+
+    final result = send(
+      channelId: _channelId,
+      content: 'hey, can you look at this?',
+      mentionPubkeys: const [],
+    );
+    await session.published;
+    session.accept();
+    await result;
+
+    expect(_pTagPubkeys(session.event), [_humanPubkey, _agentPubkey]);
+  });
+
+  test('non-DM channel carries explicit mentions only', () async {
+    final session = _PendingPublishRelaySession();
+    final keys = nostr.Keys.generate();
+    final send = _sendMessage(
+      session: session,
+      nsec: keys.nsec,
+      readChannel: (channelId) => _channel(
+        channelType: 'stream',
+        participantPubkeys: const [_humanPubkey, _agentPubkey],
+      ),
+    );
+
+    final result = send(
+      channelId: _channelId,
+      content: 'hey @someone',
+      mentionPubkeys: const [_mentionPubkey],
+    );
+    await session.published;
+    session.accept();
+    await result;
+
+    expect(_pTagPubkeys(session.event), [_mentionPubkey]);
+  });
+
+  test('sends without fan-out when the channel is not cached yet', () async {
+    final session = _PendingPublishRelaySession();
+    final send = _sendMessage(
+      session: session,
+      nsec: nostr.Keys.generate().nsec,
+      readChannel: (_) => null,
+    );
+
+    final result = send(
+      channelId: _channelId,
+      content: 'hello',
+      mentionPubkeys: const [],
+    );
+    await session.published;
+    session.accept();
+    await result;
+
+    expect(_pTagPubkeys(session.event), isEmpty);
+  });
 }
 
 const _channelId = '11111111-1111-4111-8111-111111111111';
+
+const _humanPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _agentPubkey =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _mentionPubkey =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+SendMessage _sendMessage({
+  required _PendingPublishRelaySession session,
+  required String nsec,
+  required Channel? Function(String channelId) readChannel,
+}) => SendMessage(
+  signedEventRelay: SignedEventRelay(session: session, nsec: nsec),
+  readChannel: readChannel,
+  fetchMembers: (_) async => const [],
+  readUserCache: () => const {},
+  addLocalMessage: (_, _) {},
+  completeLocalMessage: (_, _) {},
+  removeLocalMessage: (_, _) {},
+);
+
+Channel _channel({
+  required String channelType,
+  List<String> participantPubkeys = const [],
+}) => Channel(
+  id: _channelId,
+  name: 'chat',
+  channelType: channelType,
+  visibility: 'private',
+  description: '',
+  createdBy: _humanPubkey,
+  createdAt: DateTime.utc(2026),
+  memberCount: participantPubkeys.length,
+  participantPubkeys: participantPubkeys,
+);
+
+List<String> _pTagPubkeys(NostrEvent event) => [
+  for (final tag in event.tags)
+    if (tag.isNotEmpty && tag.first == 'p') tag[1],
+];
 
 class _PendingPublishRelaySession extends RelaySessionNotifier {
   final Completer<NostrEvent> _result = Completer<NostrEvent>();


### PR DESCRIPTION
## What problems was I solving

On desktop, DMing an agent "just works": a plain message p-tags every other DM participant, and the buzz-acp harness's mention-gated `#p` subscription treats those tags as the trigger. Mobile only tagged explicit `@mentions`, so a DM'd agent stayed silent unless the sender selected it from the mention picker.

After this PR, mobile resolves the current channel before publishing and adds every other DM participant as a `p` tag. A plain, unmentioned DM therefore wakes the recipient agent when channel state is available.

## What user-facing changes did I ship

- Plain mobile DMs now p-tag all known participants except the sender.
- Thread replies use the same centralized send path and retain their reply `e` tags alongside recipient `p` tags.
- Non-DM channels still emit only explicit mention tags.
- Recipient pubkeys are emitted in lowercase, deduplicated case-insensitively, and empty values are discarded.
- A cache miss waits for `channelsProvider.future`, preventing initial loading from silently dropping DM recipients.
- If channel lookup ultimately returns no entry or fails, the message still publishes with any explicit mentions instead of blocking an otherwise usable composer.

## Implementation

The change remains centralized in two files:

- `mobile/lib/features/channels/send_message_provider.dart`
  - resolves the channel from the synchronous cache or authoritative provider future;
  - fans out recipient tags only for a resolved DM;
  - gracefully degrades to explicit mentions when channel resolution is unavailable;
  - canonicalizes, filters, deduplicates, and self-excludes the resulting pubkeys before signing.
- `mobile/test/features/channels/send_message_provider_test.dart`
  - verifies the signed event tags at the relay boundary.

No channel-page, thread-navigation, message-row, or action-sheet interfaces are changed.

## Verification

```text
flutter test test/features/channels/send_message_provider_test.dart  # 9 passed
just mobile-check                                                    # format, analyze, file-size guard
just mobile-test                                                     # 831 passed, 1 skipped
```

Closes #2835
