### PR TITLE
fix(desktop): preserve exact agent mentions on send

### DIFF
--- a/desktop/src/features/messages/lib/extractMentionPubkeys.ts
+++ b/desktop/src/features/messages/lib/extractMentionPubkeys.ts
@@ -1,0 +1,58 @@
+import { hasMention, hasUnambiguousMention } from "./hasMention";
+
+type MentionCandidate = {
+  displayName: string | null;
+  isAgent?: boolean;
+  isMember?: boolean;
+  pubkey?: string;
+};
+
+export function extractMentionPubkeysFromCandidates(
+  text: string,
+  registeredMentions: ReadonlyMap<string, string>,
+  registeredPersonaNames: Iterable<string>,
+  candidates: readonly MentionCandidate[],
+): string[] {
+  const pubkeys: string[] = [];
+  const selectedDisplayNames = new Set(
+    [...registeredMentions.keys(), ...registeredPersonaNames].map((name) =>
+      name.trim().toLowerCase(),
+    ),
+  );
+  const unselectedAgentNames = candidates.flatMap((candidate) => {
+    const name = candidate.displayName?.trim();
+    return candidate.pubkey &&
+      candidate.isAgent &&
+      name &&
+      !selectedDisplayNames.has(name.toLowerCase())
+      ? [name]
+      : [];
+  });
+
+  for (const [displayName, pubkey] of registeredMentions) {
+    if (hasMention(text, displayName)) pubkeys.push(pubkey);
+  }
+
+  for (const candidate of candidates) {
+    const name = candidate.displayName;
+    if (!candidate.pubkey || !name) continue;
+    if (
+      !candidate.isMember &&
+      !(
+        candidate.isAgent &&
+        hasUnambiguousMention(text, name, unselectedAgentNames)
+      )
+    ) {
+      continue;
+    }
+    if (
+      !pubkeys.includes(candidate.pubkey) &&
+      !selectedDisplayNames.has(name.trim().toLowerCase()) &&
+      hasMention(text, name)
+    ) {
+      pubkeys.push(candidate.pubkey);
+    }
+  }
+
+  return [...new Set(pubkeys)];
+}

--- a/desktop/src/features/messages/lib/hasMention.ts
+++ b/desktop/src/features/messages/lib/hasMention.ts
@@ -153,3 +153,16 @@ export function getMentionOffset(text: string, name: string): number | null {
 export function hasMention(text: string, name: string): boolean {
   return getMentionOffset(text, name) !== null;
 }
+
+export function hasUnambiguousMention(
+  text: string,
+  name: string,
+  knownNames: readonly string[],
+): boolean {
+  const normalizedName = name.trim().toLowerCase();
+  const matchingNames = knownNames.filter(
+    (candidate) => candidate.trim().toLowerCase() === normalizedName,
+  );
+
+  return matchingNames.length === 1 && hasMention(text, name);
+}

--- a/desktop/src/features/messages/lib/useMentions.test.mjs
+++ b/desktop/src/features/messages/lib/useMentions.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getMentionOffset, hasMention } from "./hasMention.ts";
+import {
+  getMentionOffset,
+  hasMention,
+  hasUnambiguousMention,
+} from "./hasMention.ts";
 
 // ── Plain @mention ────────────────────────────────────────────────────
 
@@ -20,6 +24,33 @@ test("matches the first member in a parenthesized team expansion", () => {
 
 test("matches @Name at end of string", () => {
   assert.equal(hasMention("hello @Alice", "Alice"), true);
+});
+
+test("resolves one uniquely named agent mention before autocomplete selection", () => {
+  assert.equal(
+    hasUnambiguousMention("Can you check this @Bumble", "Bumble", [
+      "Bumble",
+      "Atlas",
+    ]),
+    true,
+  );
+  assert.equal(
+    hasUnambiguousMention("@Bumble, can you check this?", "Bumble", [
+      "Bumble",
+      "Atlas",
+    ]),
+    true,
+  );
+});
+
+test("does not guess between agents with the same display name", () => {
+  assert.equal(
+    hasUnambiguousMention("Can you check this @Bumble", "Bumble", [
+      "Bumble",
+      "Bumble",
+    ]),
+    false,
+  );
 });
 
 test("match is case-insensitive", () => {

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -37,6 +37,7 @@ import { normalizePubkey } from "@/shared/lib/pubkey";
 import { trimMapToSize } from "@/shared/lib/trimMapToSize";
 import { flushMentionDebounce } from "./flushMentionDebounce";
 import { hasMention } from "./hasMention";
+import { extractMentionPubkeysFromCandidates } from "./extractMentionPubkeys";
 import { useDraftMentionRouting } from "./useDraftMentionRouting";
 import { rankMentionCandidates } from "./mentionRanking";
 import { mapMentionCandidateToSuggestion } from "./mentionSuggestionMapping";
@@ -792,42 +793,13 @@ export function useMentions(
   );
 
   const extractMentionPubkeys = React.useCallback(
-    (text: string): string[] => {
-      const pubkeys: string[] = [];
-      const selectedDisplayNames = new Set(
-        [
-          ...mentionMapRef.current.keys(),
-          ...personaMentionMapRef.current.keys(),
-        ].map((name) => name.trim().toLowerCase()),
-      );
-
-      for (const [displayName, pubkey] of mentionMapRef.current) {
-        if (hasMention(text, displayName)) {
-          pubkeys.push(pubkey);
-        }
-      }
-
-      for (const candidate of mentionCandidates) {
-        if (!candidate.pubkey) {
-          continue;
-        }
-        if (!candidate.isMember) {
-          continue;
-        }
-        if (pubkeys.includes(candidate.pubkey)) {
-          continue;
-        }
-        const name = candidate.displayName;
-        if (name && selectedDisplayNames.has(name.trim().toLowerCase())) {
-          continue;
-        }
-        if (name && hasMention(text, name)) {
-          pubkeys.push(candidate.pubkey);
-        }
-      }
-
-      return [...new Set(pubkeys)];
-    },
+    (text: string): string[] =>
+      extractMentionPubkeysFromCandidates(
+        text,
+        mentionMapRef.current,
+        personaMentionMapRef.current.keys(),
+        mentionCandidates,
+      ),
     [mentionCandidates],
   );
 

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -241,6 +241,45 @@ test("@ trigger prioritizes channel members before runnable personas and other m
   expect(fizzIndex).toBeLessThan(charlieIndex);
 });
 
+test("sending an exact agent mention at the end preserves its pubkey tag", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: TEST_IDENTITIES.charlie.pubkey,
+        name: "charlie",
+        status: "running",
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("Can you check this @charlie");
+  await expect(autocomplete(page)).toBeVisible();
+  await page.getByTestId("send-message").click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const events = (
+          window as Window & {
+            __BUZZ_E2E_SIGNED_EVENTS__?: Array<{
+              content: string;
+              tags: string[][];
+            }>;
+          }
+        ).__BUZZ_E2E_SIGNED_EVENTS__;
+        return events?.find((event) => event.content.endsWith("@charlie"))
+          ?.tags;
+      }),
+    )
+    .toContainEqual(["p", TEST_IDENTITIES.charlie.pubkey]);
+});
+
 test("thread autocomplete keeps multiple long names readable in a narrow panel", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- preserve the Nostr `p` tag when a user clicks Send with an exact agent mention still pending as plain autocomplete text
- resolve only uniquely named agents, so duplicate display names are never guessed
- cover trailing mentions, mentions at the beginning, and punctuation boundaries
- move send-time extraction into a focused helper to keep `useMentions.ts` under the repository file-size limit

### Related issue

N/A — searched existing issues and pull requests. #2508, #2514, and #2893 cover cross-machine agent discovery; this fixes the separate send-time path where a known agent is visible but the autocomplete suggestion has not been selected before Send is clicked.

### Testing

- [x] desktop unit suite: 3,723 passed
- [x] mention helper unit tests: 29 passed
- [x] Playwright mention suite: 50 passed
- [x] focused Playwright regression: 1 passed
- [x] `pnpm typecheck`
- [x] Biome check for changed files
- [x] desktop file-size checks
- [x] `just ci` passed workspace fmt/clippy, desktop checks, Tauri fmt/clippy, and web checks
- [ ] `just ci` mobile step did not complete because Hermit's Dart bootstrap stalled without output for more than eight minutes; no mobile files are changed
