### PR TITLE
fix(desktop): mention autocomplete drops every relay-directory agent before eligibility runs

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -11,6 +11,7 @@ import {
 } from "@/features/channels/hooks";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import type { MentionSuggestion } from "@/features/messages/ui/MentionAutocomplete";
+import { mergeKnownAgentPubkeys } from "@/features/agents/knownAgentPubkeys";
 import {
   coalesceAgentAutocompleteCandidates,
   coalesceAutocompleteCandidatesByKey,
@@ -221,6 +222,24 @@ export function useMentions(
     return lookup;
   }, [managedAgentsQuery.data, personasQuery.data]);
   const knownAgentPubkeys = mentionableAgentPubkeys;
+  // Managed agents ∪ relay directory. `isAgentIdentityInManagedList` gates the
+  // autocomplete on THIS set, and passing only the managed agents makes every
+  // remotely-hosted agent unmentionable: the relay flags an attested identity
+  // `is_agent` (users.agent_owner_pubkey, write-once), the candidate therefore
+  // arrives with isAgent=true, and the gate drops it before
+  // `shouldHideAgentFromMentions` — so `relayAgentIsSharedWithUser`, the
+  // allowlist and channel membership are never consulted for it. That made the
+  // whole relay-agent branch of the eligibility module unreachable, including
+  // the relay-agent candidate loop below.
+  //
+  // The union is the set this app already treats as "known agents" everywhere
+  // else (`useKnownAgentPubkeys`, same `mergeKnownAgentPubkeys` helper); using
+  // it here restores the intended layering: identity/ownership decides who is
+  // KNOWN, and the eligibility rules decide who is INVOCABLE.
+  const knownOrManagedAgentPubkeys = React.useMemo(
+    () => mergeKnownAgentPubkeys(managedAgentsQuery.data, relayAgentsQuery.data),
+    [managedAgentsQuery.data, relayAgentsQuery.data],
+  );
   const activePersonas = React.useMemo(
     () => (personasQuery.data ?? []).filter((persona) => persona.isActive),
     [personasQuery.data],
@@ -246,7 +265,7 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (!isAgentIdentityInManagedList(candidate, knownOrManagedAgentPubkeys)) {
         return;
       }
       if (


### PR DESCRIPTION
## Problem

`useMentions` gates every autocomplete candidate through `isAgentIdentityInManagedList` against **only the local managed-agent set**. Any candidate flagged `isAgent: true` that is not managed by this desktop is dropped before `shouldHideAgentFromMentions` runs — so `relayAgentIsSharedWithUser`, the `respond_to` allowlist, and channel membership are never consulted for it. The entire relay-agent branch of `agentAutocompleteEligibility` is unreachable from the mention picker.

Net effect: an agent hosted anywhere other than the local desktop (registered in the relay agent directory via kind:10100, attested via NIP-OA, or both) can never be @-mentioned, even when its directory entry explicitly allowlists the current user.

## Reproduction

1. Register a server-hosted agent in the relay directory: kind:10100 with `respond_to: "allowlist"` including your pubkey.
2. Add it to a channel you are in. It appears in the member list.
3. Type `@` — the agent is never offered.
4. Delete its kind:10100 (NIP-09) — the identity is offered again, because with no directory entry it isn't flagged as an agent at all. Publishing the metadata the eligibility module wants to read is exactly what makes the agent invisible to it.

## Fix

Gate the candidate loop on `mergeKnownAgentPubkeys(managedAgentsQuery.data, relayAgentsQuery.data)` — the same managed ∪ relay-directory union the app already treats as "known agents" elsewhere (`useKnownAgentPubkeys`). Identity decides who is *known*; the eligibility rules (`shouldHideAgentFromMentions` → `relayAgentIsSharedWithUser`) keep deciding who is *invocable* — a directory agent whose entry excludes the viewer is still hidden, as before.

One line of behavior change plus a memoized union; no new API surface.