### PR TITLE
Fix provider agent runtime projection

### DIFF
--- a/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelFields.tsx
@@ -244,6 +244,7 @@ export function buildOwnerFields({
   relayAgent: RelayAgent | undefined;
 }): ProfileField[] {
   const fields: ProfileField[] = [];
+  const isProviderManaged = managedAgent?.backend.type === "provider";
   const respondTo = managedAgent?.respondTo ?? relayAgent?.respondTo ?? null;
   const respondToDisplayValue = respondTo
     ? respondTo === "owner-only" && ownerDisplayName
@@ -290,38 +291,40 @@ export function buildOwnerFields({
     return fields;
   }
 
-  if (managedAgent?.agentCommand) {
-    fields.push({
-      copyValue: managedAgent.agentCommand,
-      displayValue: runtimeLabel(managedAgent.agentCommand),
-      icon: Terminal,
-      label: "Runtime",
-      testId: "user-profile-runtime",
-    });
-  } else if (relayAgent?.agentType) {
-    fields.push({
-      copyValue: relayAgent.agentType,
-      displayValue: runtimeLabel(relayAgent.agentType),
-      icon: Terminal,
-      label: "Runtime",
-      testId: "user-profile-runtime",
-    });
-  } else if (persona?.runtime) {
-    fields.push({
-      copyValue: persona.runtime,
-      displayValue: runtimeLabel(persona.runtime),
-      icon: Terminal,
-      label: "Runtime",
-      testId: "user-profile-runtime",
-    });
-  } else if (ownerPubkey) {
-    fields.push({
-      copyValue: ownerPubkey,
-      displayValue: "Declared owner verified",
-      icon: UserRound,
-      label: "Agent profile",
-      testId: "user-profile-agent-profile",
-    });
+  if (!isProviderManaged) {
+    if (managedAgent?.agentCommand) {
+      fields.push({
+        copyValue: managedAgent.agentCommand,
+        displayValue: runtimeLabel(managedAgent.agentCommand),
+        icon: Terminal,
+        label: "Runtime",
+        testId: "user-profile-runtime",
+      });
+    } else if (relayAgent?.agentType) {
+      fields.push({
+        copyValue: relayAgent.agentType,
+        displayValue: runtimeLabel(relayAgent.agentType),
+        icon: Terminal,
+        label: "Runtime",
+        testId: "user-profile-runtime",
+      });
+    } else if (persona?.runtime) {
+      fields.push({
+        copyValue: persona.runtime,
+        displayValue: runtimeLabel(persona.runtime),
+        icon: Terminal,
+        label: "Runtime",
+        testId: "user-profile-runtime",
+      });
+    } else if (ownerPubkey) {
+      fields.push({
+        copyValue: ownerPubkey,
+        displayValue: "Declared owner verified",
+        icon: UserRound,
+        label: "Agent profile",
+        testId: "user-profile-agent-profile",
+      });
+    }
   }
 
   if (managedAgent) {
@@ -342,7 +345,7 @@ export function buildOwnerFields({
     });
   }
 
-  if (managedAgent?.acpCommand) {
+  if (managedAgent?.acpCommand && !isProviderManaged) {
     fields.push({
       copyValue: managedAgent.acpCommand,
       displayValue: managedAgent.acpCommand,
@@ -352,7 +355,7 @@ export function buildOwnerFields({
     });
   }
 
-  if (managedAgent?.mcpCommand) {
+  if (managedAgent?.mcpCommand && !isProviderManaged) {
     fields.push({
       copyValue: managedAgent.mcpCommand,
       displayValue: managedAgent.mcpCommand,
@@ -373,7 +376,7 @@ export function buildOwnerFields({
     });
   }
 
-  if (managedAgent) {
+  if (managedAgent && !isProviderManaged) {
     fields.push({
       displayValue: managedAgent.startOnAppLaunch ? "Yes" : "No",
       icon: Server,

--- a/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanelSections.tsx
@@ -429,7 +429,7 @@ export function ProfileSummaryView({
                 showDiagnosticsIngress={showDiagnosticsIngress}
                 showInstructionBlock={showInstructionBlock}
               />
-              {isOwner === true && managedAgent !== undefined ? (
+              {isOwner === true && managedAgent?.backend.type === "local" ? (
                 <div className="overflow-hidden rounded-2xl bg-muted/20">
                   <AgentConfigPanel
                     advancedMode="flat"

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -142,6 +142,77 @@ async function addGenericAgent(
   );
 }
 
+async function addProviderAgent(
+  page: Page,
+  channelName: string,
+  agentName: string,
+): Promise<string> {
+  await page.getByTestId(`channel-${channelName}`).click();
+  await expect(page.getByTestId("chat-title")).toHaveText(channelName);
+  const channelId = await page
+    .getByTestId(`channel-${channelName}`)
+    .getAttribute("data-channel-id");
+  if (!channelId) {
+    throw new Error(`Channel ${channelName} is missing a data-channel-id.`);
+  }
+
+  return page.evaluate(
+    async ({ agentName, channelId }) => {
+      const invoke = (
+        window as Window & {
+          __BUZZ_E2E_INVOKE_MOCK_COMMAND__?: (
+            command: string,
+            payload?: Record<string, unknown>,
+          ) => Promise<{ agent?: { pubkey: string } }>;
+        }
+      ).__BUZZ_E2E_INVOKE_MOCK_COMMAND__;
+      if (!invoke) {
+        throw new Error("Mock bridge is not installed.");
+      }
+
+      const created = await invoke("create_managed_agent", {
+        input: {
+          name: agentName,
+          spawnAfterCreate: true,
+          systemPrompt: "Operate on the remote provider host.",
+          agentCommand: "claude-agent-acp",
+          acpCommand: "buzz-acp",
+          mcpCommand: "local-dev-mcp",
+          model: "local-fallback-model",
+          envVars: { PROVIDER_TEST_SECRET: "must-not-render" },
+          backend: {
+            type: "provider",
+            id: "remote-fleet",
+            config: {},
+          },
+        },
+      });
+      const pubkey = created.agent?.pubkey;
+      if (!pubkey) {
+        throw new Error(
+          "Mock provider agent creation did not return a pubkey.",
+        );
+      }
+
+      await invoke("add_channel_members", {
+        channelId,
+        pubkeys: [pubkey],
+        role: "bot",
+      });
+      await (
+        window as Window & {
+          __BUZZ_E2E_QUERY_CLIENT__?: {
+            invalidateQueries: () => Promise<void>;
+          };
+        }
+      ).__BUZZ_E2E_QUERY_CLIENT__?.invalidateQueries();
+
+      return pubkey;
+    },
+    { agentName, channelId },
+  );
+}
+
 async function waitForMockLiveSubscription(page: Page, channelName: string) {
   await expect
     .poll(async () => {
@@ -980,6 +1051,64 @@ test("restored Inbox deep link hides the back arrow", async ({ page }) => {
   await expect(page.getByTestId("auxiliary-panel-close")).toBeVisible();
   await page.getByTestId("auxiliary-panel-close").click();
   await expect(page.getByTestId("agent-session-thread-panel")).toHaveCount(0);
+});
+
+test("provider agent profile does not project local runtime configuration", async ({
+  page,
+}) => {
+  await page.goto("/");
+  const agentPubkey = await addProviderAgent(
+    page,
+    "general",
+    "Remote Provider Agent",
+  );
+  await page.getByTestId("channel-general").click();
+  await waitForMockLiveSubscription(page, "general");
+
+  await page.evaluate(
+    ({ pubkey }) => {
+      const emit = (
+        window as Window & {
+          __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+            channelName: string;
+            content: string;
+            pubkey: string;
+          }) => unknown;
+        }
+      ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__;
+      if (!emit) {
+        throw new Error("Mock message emitter is unavailable.");
+      }
+      emit({
+        channelName: "general",
+        content: "Remote provider profile check",
+        pubkey,
+      });
+    },
+    { pubkey: agentPubkey },
+  );
+
+  const messageRow = page
+    .getByTestId("message-row")
+    .filter({ hasText: "Remote provider profile check" });
+  await expect(messageRow).toBeVisible();
+  await messageRow.locator("button").first().click();
+
+  const panel = page.getByTestId("user-profile-panel");
+  await expect(panel).toBeVisible();
+  await expect(panel.getByTestId("user-profile-backend")).toContainText(
+    "remote-fleet",
+  );
+  await panel.getByRole("tab", { name: "Runtime" }).click();
+
+  await expect(panel.getByTestId("user-profile-runtime")).toHaveCount(0);
+  await expect(panel.getByTestId("user-profile-acp")).toHaveCount(0);
+  await expect(panel.getByTestId("user-profile-mcp")).toHaveCount(0);
+  await expect(panel.getByTestId("user-profile-start-on-launch")).toHaveCount(
+    0,
+  );
+  await expect(panel.getByText("local-fallback-model")).toHaveCount(0);
+  await expect(panel.getByText("must-not-render")).toHaveCount(0);
 });
 
 test("declared owner sees runtime tab for a remote relay agent", async ({


### PR DESCRIPTION
## Summary

- keep provider-backed agent profiles from projecting local runtime, ACP, MCP, startup, model, and environment configuration
- keep the provider backend identifier and status visible
- add an integration regression test with deliberately conflicting local fallback values

## Motivation

Provider-backed agents can currently display local Claude/runtime configuration that is not authoritative for the remote provider and may expose environment values. This is a focused privacy-safe first slice of #3034.

## Test evidence

- `just ci` — passed
- targeted Playwright integration test — passed
- full `profile.spec.ts` integration suite — 26 passed; one unrelated existing media-proxy assertion failed because the mock returned `buzz-media://localhost/...` instead of `http://127.0.0.1:54321/...`

## Risk and rollback

The change only affects owner profile rendering for agents whose backend type is `provider`. Local agents retain the existing runtime/config UI. Reverting this commit restores the previous projection.

## Follow-up

Provider-specific editing/lifecycle UI remains tracked in #3034; this PR intentionally does not broaden provider mutation behavior.