### PR TITLE
fix(desktop): resolve the Hermes preset by a command that is on PATH

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -156,10 +156,14 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
     PresetHarness {
         id: "hermes",
         label: "Hermes Agent",
-        command: "hermes-acp",
-        args: &[],
+        // `hermes` is the launcher the Hermes installer writes to ~/.local/bin,
+        // which is on the login-shell PATH. The `hermes-acp` console script
+        // exists only inside Hermes' own venv, which is not, so resolving by
+        // that name fails on a default install.
+        command: "hermes",
+        args: &["acp"],
         install_instructions_url: "https://hermes-agent.nousresearch.com",
-        install_hint: "Buzz talks to Hermes Agent through its hermes-acp command.",
+        install_hint: "Buzz talks to Hermes Agent through its ACP mode (hermes acp).",
         underlying_cli: None,
     },
     PresetHarness {


### PR DESCRIPTION
## What

The `hermes` preset spawns `hermes-acp`. That console script exists only inside the Hermes install's own venv, and that directory is not on the login-shell PATH, so `resolve_command()` returns nothing and the runtime resolves as unavailable.

Because the preset has no auto-installer, an unavailable entry fails `isYourHarnessEntry()` and gets no row under "Your runtimes". It does still show under "Add runtimes", which is what makes this confusing in practice: Hermes is installed and healthy, the catalog lists it, and the runtime list acts as though it is absent.

This switches the preset to `hermes` with `args: ["acp"]`. The Hermes installer writes a `hermes` launcher into `~/.local/bin`, which is on the login-shell PATH and also in `common_binary_paths()`. Both spellings start the same ACP server. It also matches the sibling `openclaw` entry, which is already `command` plus `["acp"]`.

## How I verified it

macOS, Buzz Desktop from Releases, Hermes installed the standard way.

Running the same probe `find_via_login_shell()` uses, under `env -i` so it does not inherit an interactive shell's PATH:

```
$ env -i HOME=$HOME /bin/zsh -l -c 'command -v -- "$1"' _ hermes-acp
(no output)

$ env -i HOME=$HOME /bin/zsh -l -c 'command -v -- "$1"' _ hermes
/Users/me/.local/bin/hermes
```

My first attempt at that probe ran from an interactive shell that already had the venv on PATH, and it resolved fine. That result was wrong. The venv directory is absent from a clean login PATH, and `hermes-acp` is in none of the `common_binary_paths()` fallbacks either (`/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, `~/.local/bin`, mise shims, volta, asdf).

Driving `hermes acp` over stdio completes the handshake:

```json
{"jsonrpc":"2.0","id":1,"result":{
  "agentCapabilities":{"loadSession":true,"promptCapabilities":{"image":true},
  "sessionCapabilities":{"fork":{},"list":{},"resume":{}}},
  "agentInfo":{"name":"hermes-agent","version":"0.20.0"}}}
```

`buzz-acp models --json` with `BUZZ_ACP_AGENT_COMMAND=hermes` and `BUZZ_ACP_AGENT_ARGS=acp` returned the models from that Hermes profile.

## Update since I opened this

Hermes has since shipped its own half of the fix (NousResearch/hermes-agent#73501, merged): fresh installs now write a `hermes-acp` launcher, and `hermes update` self-heals it on existing installs. On a machine that has taken that update, `hermes-acp` does resolve.

That does not make this redundant. It only helps users who have updated Hermes since 28 July, and the ACP docs in that PR still end by telling Buzz users to configure the command as `hermes` with args `["acp"]` as a manual fallback. This change removes the need for the fallback and works regardless of which Hermes build the user has.

## Scope

One data change in `PRESET_HARNESSES`, plus a comment recording why the command name matters. No logic touched, nothing pins the old command string, and `presetLogos.test.mjs` keys off preset `id`, which is unchanged.

Rebased onto current main: `PRESET_HARNESSES` moved to `discovery/presets.rs` since I opened this. The earlier `check-file-sizes` ratchet commit is dropped, because the override list it edited is gone and `presets.rs` sits well under `MAX_LINES` at 477.

## Related

If you would rather keep `hermes-acp` as the preset command now that the Hermes installer provides it, closing this is reasonable. I think it is still worth taking, since it costs nothing and covers installs that have not been updated.
