### PR TITLE
fix(desktop): restore the inbox icon in the sidebar

### DIFF
--- a/desktop/src/features/sidebar/ui/AppSidebarPinnedHeader.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebarPinnedHeader.tsx
@@ -1,4 +1,4 @@
-import { Activity, Bell, Bot, FolderGit2, Zap } from "lucide-react";
+import { Activity, Bot, FolderGit2, Inbox, Zap } from "lucide-react";
 
 import { TopbarSearch } from "@/features/search/ui/TopbarSearch";
 import { FeatureGate } from "@/shared/features";
@@ -103,7 +103,7 @@ export function AppSidebarPrimaryMenu({
             tooltip="Inbox"
             type="button"
           >
-            <Bell className="h-4 w-4" />
+            <Inbox className="h-4 w-4" />
             <SidebarMenuLabel>Inbox</SidebarMenuLabel>
           </SidebarMenuButton>
           {homeBadgeCount > 0 ? (

--- a/desktop/tests/e2e/inbox-refactor-screenshots.spec.ts
+++ b/desktop/tests/e2e/inbox-refactor-screenshots.spec.ts
@@ -174,7 +174,7 @@ test.describe("inbox refactor screenshots", () => {
     await page.screenshot({ path: `${SHOTS}/01-current-filters.png` });
   });
 
-  test("02 — Inbox label, bell icon, and overflow controls", async ({
+  test("02 — Inbox label, inbox icon, and overflow controls", async ({
     page,
   }) => {
     await installMockBridge(page, { mode: "mock" });
@@ -185,11 +185,13 @@ test.describe("inbox refactor screenshots", () => {
     });
 
     // The sidebar must be in frame — the label is the point of this shot.
-    await expect(
-      page
-        .getByTestId("sidebar-primary-menu")
-        .getByRole("button", { name: "Inbox", exact: true }),
-    ).toBeVisible();
+    const inboxButton = page
+      .getByTestId("sidebar-primary-menu")
+      .getByRole("button", { name: "Inbox", exact: true });
+    await expect(inboxButton).toBeVisible();
+    // Inbox is a destination, not a notification tray, so it carries the inbox
+    // glyph rather than a bell. Asserted because nothing else pins the icon.
+    await expect(inboxButton.locator("svg.lucide-inbox")).toHaveCount(1);
 
     await page.getByTestId("inbox-options-trigger").click();
     await expect(page.getByText("Show unread only")).toBeVisible();


### PR DESCRIPTION
## Why

The Inbox surface was briefly renamed to **Activity** during #2045 and picked up a bell icon to match. The name was reverted to **Inbox** before merge, but the icon was not.

A bell says "notification tray." Inbox is a destination — a focused, conversation-oriented place to catch up on work relevant to you, including drafts and reminders that have nothing to do with notifications. The glyph should say that.

## What changed

- Swap the sidebar entry from Lucide `Bell` to Lucide `Inbox`.
- Assert the icon in `inbox-refactor-screenshots.spec.ts`. Nothing pinned it before, which is exactly how it drifted through a rename.

This also brings desktop back in line with mobile, which already uses `LucideIcons.inbox300` / `inbox500` for the same destination.

## Deliberately unchanged

The bell on **reminder** rows in the list pane (`InboxListPane.tsx`, reminders → bell, drafts → file) stays. A bell is the right glyph for a reminder; that one was never about the surface's identity.

## Verification

- The new assertion is a real guard, not a no-op: with `Bell` restored the test fails with `Expected: 1, Received: 0` on `svg.lucide-inbox`. Confirmed before committing.
- `biome` and `tsc` clean.
- Playwright smoke: `inbox-refactor-screenshots` 4 passed; `smoke`, `navigation`, `channels`, `sidebar-more-unread-overlap`, `home-collapsed-top-chrome`, `workspace-rail` — 107 passed, 1 skipped.
- Screenshot below is the regenerated `02-current-controls` shot from the spec.
