### PR TITLE
fix(desktop): separate Nostr name from display name

### DIFF
--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -435,7 +435,7 @@ pub async fn get_channel_members(
                 profile_map.insert(
                     pk,
                     (
-                        profile.display_name,
+                        profile.display_name.or(profile.name),
                         nostr_convert::profile_has_valid_oa_owner(ev),
                     ),
                 );

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -435,7 +435,18 @@ pub async fn get_channel_members(
                 profile_map.insert(
                     pk,
                     (
-                        profile.display_name.or(profile.name),
+                        profile
+                            .display_name
+                            .and_then(|value| {
+                                let value = value.trim();
+                                (!value.is_empty()).then(|| value.to_string())
+                            })
+                            .or_else(|| {
+                                profile.name.and_then(|value| {
+                                    let value = value.trim();
+                                    (!value.is_empty()).then(|| value.to_string())
+                                })
+                            }),
                         nostr_convert::profile_has_valid_oa_owner(ev),
                     ),
                 );

--- a/desktop/src-tauri/src/commands/profile.rs
+++ b/desktop/src-tauri/src/commands/profile.rs
@@ -67,7 +67,12 @@ pub async fn update_profile(
             about: about.as_deref(),
             nip05: nip05_handle.as_deref(),
         },
-    )?;
+    )?
+    .custom_created_at(monotonic_created_at(
+        prior_events
+            .first()
+            .map(|event| event.created_at.as_secs() as i64),
+    ));
     submit_event(builder, &state).await?;
 
     // Re-fetch to return canonical profile.

--- a/desktop/src-tauri/src/commands/profile.rs
+++ b/desktop/src-tauri/src/commands/profile.rs
@@ -39,6 +39,7 @@ pub async fn get_profile(state: State<'_, AppState>) -> Result<ProfileInfo, Stri
 #[tauri::command]
 pub async fn update_profile(
     display_name: Option<String>,
+    name: Option<String>,
     avatar_url: Option<String>,
     about: Option<String>,
     nip05_handle: Option<String>,
@@ -56,28 +57,17 @@ pub async fn update_profile(
     )
     .await?;
 
-    // Pull the current content as a JSON object so we can merge with
-    // the caller's overrides.
-    let current: Value = prior_events
-        .first()
-        .and_then(|ev| serde_json::from_str::<Value>(&ev.content).ok())
-        .unwrap_or(Value::Null);
-
-    let dn = display_name
-        .as_deref()
-        .or_else(|| current.get("display_name").and_then(Value::as_str));
-    let name = current.get("name").and_then(Value::as_str);
-    let picture = avatar_url
-        .as_deref()
-        .or_else(|| current.get("picture").and_then(Value::as_str));
-    let ab = about
-        .as_deref()
-        .or_else(|| current.get("about").and_then(Value::as_str));
-    let nip05 = nip05_handle
-        .as_deref()
-        .or_else(|| current.get("nip05").and_then(Value::as_str));
-
-    let builder = events::build_profile(dn, name, picture, ab, nip05)?;
+    let current = profile_metadata_from_prior(prior_events.first())?;
+    let builder = events::build_patched_profile(
+        current,
+        events::ProfileMetadataPatch {
+            display_name: display_name.as_deref(),
+            name: name.as_deref(),
+            picture: avatar_url.as_deref(),
+            about: about.as_deref(),
+            nip05: nip05_handle.as_deref(),
+        },
+    )?;
     submit_event(builder, &state).await?;
 
     // Re-fetch to return canonical profile.
@@ -123,9 +113,7 @@ pub async fn update_profile_at_relay(
     )
     .await?;
     let prior_event = prior_events.first();
-    let current: Value = prior_event
-        .and_then(|event| serde_json::from_str::<Value>(&event.content).ok())
-        .unwrap_or(Value::Null);
+    let current = profile_metadata_from_prior(prior_event)?;
     let current_avatar_url = current
         .get("picture")
         .and_then(Value::as_str)
@@ -148,21 +136,34 @@ pub async fn update_profile_at_relay(
 }
 
 fn build_deferred_profile_event(
-    current: &Value,
+    current: &serde_json::Map<String, Value>,
     avatar_url: &str,
     prior_event: Option<&nostr::Event>,
 ) -> Result<nostr::EventBuilder, String> {
-    let display_name = current.get("display_name").and_then(Value::as_str);
-    let name = current.get("name").and_then(Value::as_str);
-    let about = current.get("about").and_then(Value::as_str);
-    let nip05 = current.get("nip05").and_then(Value::as_str);
+    Ok(events::build_patched_profile(
+        current.clone(),
+        events::ProfileMetadataPatch {
+            picture: Some(avatar_url),
+            ..Default::default()
+        },
+    )?
+    .custom_created_at(monotonic_created_at(
+        prior_event.map(|event| event.created_at.as_secs() as i64),
+    )))
+}
 
-    Ok(
-        events::build_profile(display_name, name, Some(avatar_url), about, nip05)?
-            .custom_created_at(monotonic_created_at(
-                prior_event.map(|event| event.created_at.as_secs() as i64),
-            )),
-    )
+fn profile_metadata_from_prior(
+    prior_event: Option<&nostr::Event>,
+) -> Result<serde_json::Map<String, Value>, String> {
+    let Some(prior_event) = prior_event else {
+        return Ok(serde_json::Map::new());
+    };
+    let value: Value = serde_json::from_str(&prior_event.content)
+        .map_err(|error| format!("existing kind:0 content is not valid JSON: {error}"))?;
+    value
+        .as_object()
+        .cloned()
+        .ok_or_else(|| "existing kind:0 content must be a JSON object".to_string())
 }
 
 fn capture_expected_signer(state: &AppState, expected_pubkey: &str) -> Result<nostr::Keys, String> {
@@ -405,6 +406,7 @@ fn current_pubkey_hex_unwrap(state: &AppState) -> String {
 fn empty_profile_info(pubkey: &str) -> ProfileInfo {
     ProfileInfo {
         pubkey: pubkey.to_string(),
+        name: None,
         display_name: None,
         avatar_url: None,
         about: None,
@@ -452,7 +454,9 @@ mod tests {
         .expect("sign prior profile");
 
         let builder = build_deferred_profile_event(
-            &serde_json::json!({"display_name": "Larry"}),
+            serde_json::json!({"display_name": "Larry"})
+                .as_object()
+                .expect("metadata object"),
             "https://example.com/avatar.png",
             Some(&prior_event),
         )
@@ -466,6 +470,101 @@ mod tests {
             serde_json::from_str::<Value>(&event.content).unwrap()["picture"],
             "https://example.com/avatar.png"
         );
+    }
+
+    #[test]
+    fn profile_patch_preserves_unknown_fields_and_applies_name_semantics() {
+        let keys = nostr::Keys::generate();
+        let current = serde_json::json!({
+            "display_name": "Vitor Cepeda Lopes",
+            "name": "old",
+            "website": "https://vitorcepedalopes.com",
+            "banner": "https://example.com/banner.png",
+            "custom": {"nested": true}
+        })
+        .as_object()
+        .expect("metadata object")
+        .clone();
+
+        let event = events::build_patched_profile(
+            current,
+            events::ProfileMetadataPatch {
+                name: Some("  theangrypit  "),
+                ..Default::default()
+            },
+        )
+        .expect("build patched profile")
+        .sign_with_keys(&keys)
+        .expect("sign patched profile");
+        let content: Value = serde_json::from_str(&event.content).expect("profile JSON");
+
+        assert_eq!(content["name"], "theangrypit");
+        assert_eq!(content["display_name"], "Vitor Cepeda Lopes");
+        assert_eq!(content["website"], "https://vitorcepedalopes.com");
+        assert_eq!(content["banner"], "https://example.com/banner.png");
+        assert_eq!(content["custom"]["nested"], true);
+
+        let event = events::build_patched_profile(
+            content.as_object().expect("metadata object").clone(),
+            events::ProfileMetadataPatch {
+                name: Some("   "),
+                ..Default::default()
+            },
+        )
+        .expect("build profile without name")
+        .sign_with_keys(&keys)
+        .expect("sign profile without name");
+        let content: Value = serde_json::from_str(&event.content).expect("profile JSON");
+
+        assert!(content.get("name").is_none());
+        assert_eq!(content["website"], "https://vitorcepedalopes.com");
+    }
+
+    #[test]
+    fn deferred_avatar_patch_preserves_unknown_profile_fields() {
+        let keys = nostr::Keys::generate();
+        let current = serde_json::json!({
+            "display_name": "Vitor Cepeda Lopes",
+            "name": "theangrypit",
+            "website": "https://vitorcepedalopes.com",
+            "banner": "https://example.com/banner.png"
+        });
+        let event = build_deferred_profile_event(
+            current.as_object().expect("metadata object"),
+            "https://example.com/new-avatar.png",
+            None,
+        )
+        .expect("build deferred profile")
+        .sign_with_keys(&keys)
+        .expect("sign deferred profile");
+        let content: Value = serde_json::from_str(&event.content).expect("profile JSON");
+
+        assert_eq!(content["picture"], "https://example.com/new-avatar.png");
+        assert_eq!(content["name"], "theangrypit");
+        assert_eq!(content["website"], "https://vitorcepedalopes.com");
+        assert_eq!(content["banner"], "https://example.com/banner.png");
+    }
+
+    #[test]
+    fn invalid_or_non_object_prior_profile_fails_closed() {
+        let keys = nostr::Keys::generate();
+        let invalid = nostr::EventBuilder::new(nostr::Kind::Metadata, "not-json")
+            .sign_with_keys(&keys)
+            .expect("sign invalid profile");
+        let array = nostr::EventBuilder::new(nostr::Kind::Metadata, "[]")
+            .sign_with_keys(&keys)
+            .expect("sign array profile");
+
+        assert!(profile_metadata_from_prior(Some(&invalid))
+            .unwrap_err()
+            .starts_with("existing kind:0 content is not valid JSON:"));
+        assert_eq!(
+            profile_metadata_from_prior(Some(&array)).unwrap_err(),
+            "existing kind:0 content must be a JSON object"
+        );
+        assert!(profile_metadata_from_prior(None)
+            .expect("missing profile starts empty")
+            .is_empty());
     }
 
     #[test]

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -11,6 +11,10 @@
 use buzz_core_pkg::kind::{KIND_IA_ARCHIVE_REQUEST, KIND_IA_UNARCHIVE_REQUEST};
 use nostr::{EventBuilder, EventId, Kind, Tag};
 use uuid::Uuid;
+
+mod profile;
+pub use profile::{build_patched_profile, build_profile, ProfileMetadataPatch};
+
 // ── Constants ────────────────────────────────────────────────────────────────
 
 /// Maximum content size — matches buzz-sdk (64 KiB).
@@ -465,36 +469,6 @@ pub fn build_set_canvas(channel_id: Uuid, content: &str) -> Result<EventBuilder,
     check_content(content)?;
     let tags = vec![tag(vec!["h", &channel_id.to_string()])?];
     Ok(EventBuilder::new(Kind::Custom(40100), content).tags(tags))
-}
-
-// ── Profile ──────────────────────────────────────────────────────────────────
-
-/// Kind 0 — NIP-01 profile metadata (full snapshot).
-pub fn build_profile(
-    display_name: Option<&str>,
-    name: Option<&str>,
-    picture: Option<&str>,
-    about: Option<&str>,
-    nip05: Option<&str>,
-) -> Result<EventBuilder, String> {
-    let mut map = serde_json::Map::new();
-    if let Some(v) = display_name {
-        map.insert("display_name".into(), serde_json::Value::String(v.into()));
-    }
-    if let Some(v) = name {
-        map.insert("name".into(), serde_json::Value::String(v.into()));
-    }
-    if let Some(v) = picture {
-        map.insert("picture".into(), serde_json::Value::String(v.into()));
-    }
-    if let Some(v) = about {
-        map.insert("about".into(), serde_json::Value::String(v.into()));
-    }
-    if let Some(v) = nip05 {
-        map.insert("nip05".into(), serde_json::Value::String(v.into()));
-    }
-    let content = serde_json::Value::Object(map).to_string();
-    Ok(EventBuilder::new(Kind::Custom(0), content))
 }
 
 // ── Huddles ──────────────────────────────────────────────────────────────────

--- a/desktop/src-tauri/src/events/profile.rs
+++ b/desktop/src-tauri/src/events/profile.rs
@@ -1,0 +1,76 @@
+use nostr::{EventBuilder, Kind};
+
+/// Kind 0 — NIP-01 profile metadata (full snapshot).
+pub fn build_profile(
+    display_name: Option<&str>,
+    name: Option<&str>,
+    picture: Option<&str>,
+    about: Option<&str>,
+    nip05: Option<&str>,
+) -> Result<EventBuilder, String> {
+    let mut map = serde_json::Map::new();
+    if let Some(v) = display_name {
+        map.insert("display_name".into(), serde_json::Value::String(v.into()));
+    }
+    if let Some(v) = name {
+        map.insert("name".into(), serde_json::Value::String(v.into()));
+    }
+    if let Some(v) = picture {
+        map.insert("picture".into(), serde_json::Value::String(v.into()));
+    }
+    if let Some(v) = about {
+        map.insert("about".into(), serde_json::Value::String(v.into()));
+    }
+    if let Some(v) = nip05 {
+        map.insert("nip05".into(), serde_json::Value::String(v.into()));
+    }
+    let content = serde_json::Value::Object(map).to_string();
+    Ok(EventBuilder::new(Kind::Custom(0), content))
+}
+
+/// Partial update for an existing kind:0 metadata object.
+///
+/// Kind:0 events are replaceable full snapshots, so callers must start from
+/// the complete prior object and patch only fields explicitly supplied by the
+/// user. `None` preserves a field, a non-empty string sets its trimmed value,
+/// and an empty/whitespace-only string removes it.
+#[derive(Default)]
+pub struct ProfileMetadataPatch<'a> {
+    pub display_name: Option<&'a str>,
+    pub name: Option<&'a str>,
+    pub picture: Option<&'a str>,
+    pub about: Option<&'a str>,
+    pub nip05: Option<&'a str>,
+}
+
+pub fn build_patched_profile(
+    mut metadata: serde_json::Map<String, serde_json::Value>,
+    patch: ProfileMetadataPatch<'_>,
+) -> Result<EventBuilder, String> {
+    patch_profile_field(&mut metadata, "display_name", patch.display_name);
+    patch_profile_field(&mut metadata, "name", patch.name);
+    patch_profile_field(&mut metadata, "picture", patch.picture);
+    patch_profile_field(&mut metadata, "about", patch.about);
+    patch_profile_field(&mut metadata, "nip05", patch.nip05);
+
+    Ok(EventBuilder::new(
+        Kind::Custom(0),
+        serde_json::Value::Object(metadata).to_string(),
+    ))
+}
+
+fn patch_profile_field(
+    metadata: &mut serde_json::Map<String, serde_json::Value>,
+    field: &str,
+    value: Option<&str>,
+) {
+    let Some(value) = value else {
+        return;
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        metadata.remove(field);
+    } else {
+        metadata.insert(field.to_string(), serde_json::Value::String(value.into()));
+    }
+}

--- a/desktop/src-tauri/src/models.rs
+++ b/desktop/src-tauri/src/models.rs
@@ -29,6 +29,7 @@ pub struct IdentityInfo {
 #[derive(Serialize, Deserialize)]
 pub struct ProfileInfo {
     pub pubkey: String,
+    pub name: Option<String>,
     pub display_name: Option<String>,
     pub avatar_url: Option<String>,
     pub about: Option<String>,

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -288,10 +288,11 @@ pub fn profile_info_from_event(event: &Event) -> Result<ProfileInfo, String> {
     let v: Value = serde_json::from_str(&event.content)
         .map_err(|e| format!("kind:0 content is not valid JSON: {e}"))?;
 
+    let name = v.get("name").and_then(Value::as_str).map(str::to_string);
     let display_name = v
         .get("display_name")
         .and_then(Value::as_str)
-        .or_else(|| v.get("name").and_then(Value::as_str))
+        .or(name.as_deref())
         .map(str::to_string);
     let avatar_url = v.get("picture").and_then(Value::as_str).map(str::to_string);
     let about = v.get("about").and_then(Value::as_str).map(str::to_string);
@@ -299,6 +300,7 @@ pub fn profile_info_from_event(event: &Event) -> Result<ProfileInfo, String> {
 
     Ok(ProfileInfo {
         pubkey: event.pubkey.to_hex(),
+        name,
         display_name,
         avatar_url,
         about,
@@ -766,6 +768,7 @@ mod tests {
             vec![],
         );
         let p = profile_info_from_event(&e).unwrap();
+        assert_eq!(p.name.as_deref(), Some("alice"));
         assert_eq!(p.display_name.as_deref(), Some("Alice"));
         assert_eq!(p.avatar_url.as_deref(), Some("http://x/a.png"));
         assert_eq!(p.about.as_deref(), Some("hi"));
@@ -786,6 +789,7 @@ mod tests {
     fn profile_info_falls_back_to_name() {
         let e = ev(0, r#"{"name":"bob"}"#, vec![]);
         let p = profile_info_from_event(&e).unwrap();
+        assert_eq!(p.name.as_deref(), Some("bob"));
         assert_eq!(p.display_name.as_deref(), Some("bob"));
     }
 

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -287,8 +287,6 @@ pub fn channel_members_from_event(event: &Event) -> Result<ChannelMembersRespons
 pub fn profile_info_from_event(event: &Event) -> Result<ProfileInfo, String> {
     let v: Value = serde_json::from_str(&event.content)
         .map_err(|e| format!("kind:0 content is not valid JSON: {e}"))?;
-
-    let name = v.get("name").and_then(Value::as_str).map(str::to_string);
     let display_name = v
         .get("display_name")
         .and_then(Value::as_str)
@@ -299,7 +297,7 @@ pub fn profile_info_from_event(event: &Event) -> Result<ProfileInfo, String> {
 
     Ok(ProfileInfo {
         pubkey: event.pubkey.to_hex(),
-        name,
+        name: v.get("name").and_then(Value::as_str).map(str::to_string),
         display_name,
         avatar_url,
         about,
@@ -786,10 +784,9 @@ mod tests {
 
     #[test]
     fn profile_info_keeps_name_and_display_name_independent() {
-        let e = ev(0, r#"{"name":"bob"}"#, vec![]);
-        let p = profile_info_from_event(&e).unwrap();
+        let p = profile_info_from_event(&ev(0, r#"{"name":"bob"}"#, vec![])).unwrap();
         assert_eq!(p.name.as_deref(), Some("bob"));
-        assert!(p.display_name.is_none());
+        assert_eq!(p.display_name, None);
     }
 
     #[test]

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -292,7 +292,6 @@ pub fn profile_info_from_event(event: &Event) -> Result<ProfileInfo, String> {
     let display_name = v
         .get("display_name")
         .and_then(Value::as_str)
-        .or(name.as_deref())
         .map(str::to_string);
     let avatar_url = v.get("picture").and_then(Value::as_str).map(str::to_string);
     let about = v.get("about").and_then(Value::as_str).map(str::to_string);
@@ -786,11 +785,11 @@ mod tests {
     }
 
     #[test]
-    fn profile_info_falls_back_to_name() {
+    fn profile_info_keeps_name_and_display_name_independent() {
         let e = ev(0, r#"{"name":"bob"}"#, vec![]);
         let p = profile_info_from_event(&e).unwrap();
         assert_eq!(p.name.as_deref(), Some("bob"));
-        assert_eq!(p.display_name.as_deref(), Some("bob"));
+        assert!(p.display_name.is_none());
     }
 
     #[test]

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -287,21 +287,17 @@ pub fn channel_members_from_event(event: &Event) -> Result<ChannelMembersRespons
 pub fn profile_info_from_event(event: &Event) -> Result<ProfileInfo, String> {
     let v: Value = serde_json::from_str(&event.content)
         .map_err(|e| format!("kind:0 content is not valid JSON: {e}"))?;
-    let display_name = v
-        .get("display_name")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    let avatar_url = v.get("picture").and_then(Value::as_str).map(str::to_string);
-    let about = v.get("about").and_then(Value::as_str).map(str::to_string);
-    let nip05_handle = v.get("nip05").and_then(Value::as_str).map(str::to_string);
 
     Ok(ProfileInfo {
         pubkey: event.pubkey.to_hex(),
         name: v.get("name").and_then(Value::as_str).map(str::to_string),
-        display_name,
-        avatar_url,
-        about,
-        nip05_handle,
+        display_name: v
+            .get("display_name")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        avatar_url: v.get("picture").and_then(Value::as_str).map(str::to_string),
+        about: v.get("about").and_then(Value::as_str).map(str::to_string),
+        nip05_handle: v.get("nip05").and_then(Value::as_str).map(str::to_string),
         owner_pubkey: profile_valid_oa_owner_pubkey(event),
         has_profile_event: true,
     })
@@ -332,13 +328,17 @@ pub fn users_batch_from_events(
     for (pk, ev) in &latest {
         let v: Value = serde_json::from_str(&ev.content).unwrap_or(Value::Null);
         let owner_pubkey = profile_valid_oa_owner_pubkey(ev);
-        let summary = UserProfileSummaryInfo {
-            display_name: v
-                .get("display_name")
+        let nonblank = |key| {
+            v.get(key)
                 .and_then(Value::as_str)
-                .or_else(|| v.get("name").and_then(Value::as_str))
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        };
+        let summary = UserProfileSummaryInfo {
+            display_name: nonblank("display_name")
+                .or_else(|| nonblank("name"))
                 .map(str::to_string),
-            name: v.get("name").and_then(Value::as_str).map(str::to_string),
+            name: nonblank("name").map(str::to_string),
             avatar_url: v.get("picture").and_then(Value::as_str).map(str::to_string),
             nip05_handle: v.get("nip05").and_then(Value::as_str).map(str::to_string),
             is_agent: owner_pubkey.is_some(),
@@ -765,7 +765,6 @@ mod tests {
             vec![],
         );
         let p = profile_info_from_event(&e).unwrap();
-        assert_eq!(p.name.as_deref(), Some("alice"));
         assert_eq!(p.display_name.as_deref(), Some("Alice"));
         assert_eq!(p.avatar_url.as_deref(), Some("http://x/a.png"));
         assert_eq!(p.about.as_deref(), Some("hi"));
@@ -804,7 +803,7 @@ mod tests {
             .custom_created_at(nostr::Timestamp::from(1000))
             .sign_with_keys(&keys)
             .unwrap();
-        let e_new = EventBuilder::new(Kind::Metadata, r#"{"display_name":"New"}"#)
+        let e_new = EventBuilder::new(Kind::Metadata, r#"{"display_name":"   ","name":"  New  "}"#)
             .custom_created_at(nostr::Timestamp::from(2000))
             .sign_with_keys(&keys)
             .unwrap();

--- a/desktop/src/features/channels/ui/agentSessionSelection.test.mjs
+++ b/desktop/src/features/channels/ui/agentSessionSelection.test.mjs
@@ -1,7 +1,31 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { resolveAgentSessionReturnTarget } from "./agentSessionSelection.ts";
+import {
+  resolveAgentSessionReturnTarget,
+  resolveSelectedAgentSession,
+} from "./agentSessionSelection.ts";
+
+test("uses a name-only Nostr profile for a fallback agent session", () => {
+  const pubkey = "a".repeat(64);
+
+  assert.equal(
+    resolveSelectedAgentSession({
+      agentSessionAgents: [],
+      openAgentSessionPubkey: pubkey,
+      profilePanelPubkey: pubkey,
+      profiles: {
+        [pubkey]: {
+          avatarUrl: null,
+          displayName: null,
+          name: "Bumble",
+          pubkey,
+        },
+      },
+    })?.name,
+    "Bumble",
+  );
+});
 
 test("returns the open thread when activity opens over a thread", () => {
   assert.deepEqual(

--- a/desktop/src/features/channels/ui/agentSessionSelection.ts
+++ b/desktop/src/features/channels/ui/agentSessionSelection.ts
@@ -35,7 +35,7 @@ export function resolveSelectedAgentSession({
   const profile = profiles?.[openAgentSessionPubkey.toLowerCase()];
   return {
     pubkey: openAgentSessionPubkey,
-    name: profile?.displayName?.trim() || "Agent",
+    name: profile?.displayName?.trim() || profile?.name?.trim() || "Agent",
     status: "deployed",
     agentSource: "relay",
     canInterruptTurn: false,

--- a/desktop/src/features/huddle/components/HuddleBar.tsx
+++ b/desktop/src/features/huddle/components/HuddleBar.tsx
@@ -390,6 +390,7 @@ export function HuddleBar({
     () =>
       clampReactionName(
         profileQuery.data?.displayName?.trim() ||
+          profileQuery.data?.name?.trim() ||
           identityQuery.data?.displayName?.trim() ||
           fallbackNameForPubkey(currentPubkey),
       ),
@@ -397,6 +398,7 @@ export function HuddleBar({
       currentPubkey,
       identityQuery.data?.displayName,
       profileQuery.data?.displayName,
+      profileQuery.data?.name,
     ],
   );
 

--- a/desktop/src/features/messages/lib/formatTimelineMessages.test.mjs
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.test.mjs
@@ -416,6 +416,50 @@ test("reaction pills sort by earliest created_at ascending", () => {
   );
 });
 
+test("reaction actor labels fall back from blank display_name to name", () => {
+  const MSG_ID =
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+  const message = {
+    id: MSG_ID,
+    pubkey: PUBKEY_A,
+    kind: 9,
+    created_at: 1_700_000_000,
+    content: "hello",
+    tags: [["h", CHANNEL_ID]],
+    sig: "sig",
+  };
+  const reaction = {
+    id: `d${"d".repeat(63)}`,
+    pubkey: PUBKEY_B,
+    kind: 7,
+    created_at: 1_700_001_001,
+    content: "🎉",
+    tags: [
+      ["h", CHANNEL_ID],
+      ["e", MSG_ID],
+    ],
+    sig: "sig",
+  };
+
+  const output = formatTimelineMessages(
+    [message, reaction],
+    null,
+    undefined,
+    null,
+    {
+      [PUBKEY_B]: {
+        avatarUrl: null,
+        displayName: "   ",
+        name: "alice",
+        nip05Handle: null,
+        ownerPubkey: null,
+      },
+    },
+  );
+
+  assert.equal(output[0].reactions?.[0]?.users[0]?.displayName, "alice");
+});
+
 test("reaction pills with equal created_at tiebreak deterministically on emoji string", () => {
   const MSG_ID =
     "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";

--- a/desktop/src/features/messages/lib/formatTimelineMessages.ts
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.ts
@@ -386,6 +386,7 @@ export function formatTimelineMessages(
       currentPubkeyLower && actorPubkey === currentPubkeyLower
         ? "You"
         : profile?.displayName?.trim() ||
+          profile?.name?.trim() ||
           profile?.nip05Handle?.trim() ||
           truncatePubkey(actorPubkey);
     existing.users.push({

--- a/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
@@ -156,7 +156,10 @@ export function CommunityOnboardingFlow({
   const queryClient = useQueryClient();
   const systemColorScheme = useSystemColorScheme();
   const [displayName, setDisplayName] = React.useState("");
+  const [name, setName] = React.useState("");
+  const nameWasEditedRef = React.useRef(false);
   const [avatarUrl, setAvatarUrl] = React.useState("");
+  const avatarWasEditedRef = React.useRef(false);
   const [localAvatarPreviewUrl, setLocalAvatarPreviewUrl] = React.useState<
     string | null
   >(null);
@@ -327,7 +330,7 @@ export function CommunityOnboardingFlow({
     transaction?.stage === "finalizing" ||
     transaction?.stage === "entering";
 
-  // Seed display name and avatar from the relay profile when the profile step
+  // Seed display name, Nostr handle, and avatar from the relay profile when the profile step
   // is shown. This covers the case where the skip raced or was bypassed (e.g.,
   // the user navigated Back). Only seeds fields that are still empty so that
   // any user edits are preserved.
@@ -340,7 +343,10 @@ export function CommunityOnboardingFlow({
             prev === "" ? (profile.displayName ?? "") : prev,
           );
         }
-        if (profile.avatarUrl) {
+        if (!nameWasEditedRef.current && profile.name) {
+          setName((prev) => (prev === "" ? (profile.name ?? "") : prev));
+        }
+        if (!avatarWasEditedRef.current && profile.avatarUrl) {
           setAvatarUrl((prev) =>
             prev === "" ? (profile.avatarUrl ?? "") : prev,
           );
@@ -424,12 +430,18 @@ export function CommunityOnboardingFlow({
       const candidateAvatarUrl = avatarUrl.trim();
       const presentationState = avatarPresentation?.state;
       const shouldSaveCandidate =
+        avatarWasEditedRef.current &&
         candidateAvatarUrl.length > 0 &&
         presentationState !== "failed" &&
         presentationState !== "pending";
+      const shouldClearAvatar =
+        avatarWasEditedRef.current && candidateAvatarUrl.length === 0;
 
       const deferredAvatar =
-        candidateAvatarUrl && presentationState && presentationState !== "ready"
+        avatarWasEditedRef.current &&
+        candidateAvatarUrl &&
+        presentationState &&
+        presentationState !== "ready"
           ? registerAvatarWhenReady({
               avatarUrl: candidateAvatarUrl,
               relayUrl: transaction.relayUrl,
@@ -439,7 +451,12 @@ export function CommunityOnboardingFlow({
       try {
         const profile = await updateProfile({
           displayName: displayName.trim(),
-          avatarUrl: shouldSaveCandidate ? candidateAvatarUrl : undefined,
+          ...(nameWasEditedRef.current ? { name: name.trim() } : {}),
+          avatarUrl: shouldSaveCandidate
+            ? candidateAvatarUrl
+            : shouldClearAvatar
+              ? ""
+              : undefined,
         });
         deferredAvatar?.release({
           expectedPubkey: profile.pubkey,
@@ -565,8 +582,8 @@ export function CommunityOnboardingFlow({
                       Build your profile
                     </h1>
                     <p className="mx-auto mt-3 max-w-[380px] text-sm leading-6 text-foreground/80">
-                      Add a name and avatar. They’ll show up on your messages,
-                      reactions, and agent handoffs.
+                      Add a display name, Nostr handle, and avatar. They’ll show
+                      up on your messages, reactions, and agent handoffs.
                     </p>
                   </div>
                   <div className="flex min-h-0 w-full flex-1 flex-col items-center justify-center pt-8">
@@ -581,23 +598,52 @@ export function CommunityOnboardingFlow({
                       htmlFor="community-display-name"
                     >
                       <span className="mb-2 block pl-4 text-sm text-foreground">
-                        Your username
+                        Display name
                       </span>
                       <Input
-                        aria-label="Community username"
-                        autoCapitalize="none"
-                        autoComplete="username"
+                        aria-label="Community display name"
+                        autoComplete="name"
                         autoCorrect="off"
                         className="h-14 rounded-2xl border-[color:rgb(var(--buzz-onboarding-avatar-control-fg)_/_0.28)] bg-[rgb(var(--buzz-onboarding-avatar-dialog-bg)/0.95)] px-5 text-sm shadow-none placeholder:text-muted-foreground/60 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[color:rgb(var(--buzz-onboarding-avatar-control-fg)_/_0.5)] md:text-sm"
                         data-testid="community-profile-name-key"
                         disabled={isPending || isUploadingAvatar}
                         id="community-display-name"
                         onChange={(event) => setDisplayName(event.target.value)}
-                        placeholder="Enter your username here"
+                        placeholder="Enter your display name"
                         ref={nameInputRef}
                         spellCheck={false}
                         type="text"
                         value={displayName}
+                      />
+                    </label>
+                    <label
+                      className="mt-4 block w-full max-w-[412px] text-left"
+                      htmlFor="community-name"
+                    >
+                      <span className="mb-1 block pl-4 text-sm text-foreground">
+                        Nostr handle{" "}
+                        <span className="text-foreground/60">(optional)</span>
+                      </span>
+                      <span className="mb-2 block pl-4 text-xs text-foreground/65">
+                        A short profile name. It does not need to be unique.
+                      </span>
+                      <Input
+                        aria-label="Community Nostr handle"
+                        autoCapitalize="none"
+                        autoComplete="off"
+                        autoCorrect="off"
+                        className="h-14 rounded-2xl border-[color:rgb(var(--buzz-onboarding-avatar-control-fg)_/_0.28)] bg-[rgb(var(--buzz-onboarding-avatar-dialog-bg)/0.95)] px-5 text-sm shadow-none placeholder:text-muted-foreground/60 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[color:rgb(var(--buzz-onboarding-avatar-control-fg)_/_0.5)] md:text-sm"
+                        data-testid="community-profile-handle"
+                        disabled={isPending || isUploadingAvatar}
+                        id="community-name"
+                        onChange={(event) => {
+                          nameWasEditedRef.current = true;
+                          setName(event.target.value);
+                        }}
+                        placeholder="e.g. theangrypit"
+                        spellCheck={false}
+                        type="text"
+                        value={name}
                       />
                     </label>
                   </div>
@@ -736,7 +782,10 @@ export function CommunityOnboardingFlow({
                         onEmojiAvatarChange={animateEmojiAvatarChange}
                         onLocalPreviewChange={setLocalAvatarPreviewUrl}
                         onUploadingChange={setIsUploadingAvatar}
-                        onUrlChange={setAvatarUrl}
+                        onUrlChange={(nextAvatarUrl) => {
+                          avatarWasEditedRef.current = true;
+                          setAvatarUrl(nextAvatarUrl);
+                        }}
                         presentation="onboarding-modal"
                         previewName={displayName.trim() || "Your profile"}
                         testIdPrefix="community-avatar"

--- a/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
@@ -330,10 +330,9 @@ export function CommunityOnboardingFlow({
     transaction?.stage === "finalizing" ||
     transaction?.stage === "entering";
 
-  // Seed display name, Nostr handle, and avatar from the relay profile when the profile step
-  // is shown. This covers the case where the skip raced or was bypassed (e.g.,
-  // the user navigated Back). Only seeds fields that are still empty so that
-  // any user edits are preserved.
+  // Seed profile fields from the relay when this step is shown. This covers
+  // cases where the skip raced or was bypassed (for example, after navigating
+  // Back). Only untouched fields are seeded.
   React.useEffect(() => {
     if (!isProfileStage) return;
     void getProfile()

--- a/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/OnboardingFlow.tsx
@@ -108,6 +108,7 @@ function resolveSavedProfile({
   return {
     avatarUrl: profile?.avatarUrl ?? "",
     displayName: sanitizeDisplayName(profile?.displayName),
+    name: profile?.name ?? "",
   };
 }
 
@@ -119,10 +120,12 @@ function createProfileUpdatePayload({
   savedProfile: OnboardingProfileValues;
 }) {
   const nextDisplayName = draftProfile.displayName.trim();
+  const nextName = draftProfile.name.trim();
   const nextAvatarUrl = draftProfile.avatarUrl.trim();
   const updatePayload: {
     avatarUrl?: string;
     displayName?: string;
+    name?: string;
   } = {};
 
   if (
@@ -130,6 +133,10 @@ function createProfileUpdatePayload({
     nextDisplayName !== savedProfile.displayName
   ) {
     updatePayload.displayName = nextDisplayName;
+  }
+
+  if (nextName !== savedProfile.name) {
+    updatePayload.name = nextName;
   }
 
   if (nextAvatarUrl.length > 0 && nextAvatarUrl !== savedProfile.avatarUrl) {
@@ -331,6 +338,13 @@ export function OnboardingFlow({
     [updateProfileDraft],
   );
 
+  const updateNameDraft = React.useCallback(
+    (value: string) => {
+      updateProfileDraft({ name: value });
+    },
+    [updateProfileDraft],
+  );
+
   const updateAvatarUrlDraft = React.useCallback(
     (value: string) => {
       updateProfileDraft({ avatarUrl: value });
@@ -347,9 +361,15 @@ export function OnboardingFlow({
     setProfileDraft((current) => ({
       ...current,
       displayName: savedProfile.displayName,
+      name: savedProfile.name,
     }));
     showAvatarPage();
-  }, [profileUpdateMutation, savedProfile.displayName, showAvatarPage]);
+  }, [
+    profileUpdateMutation,
+    savedProfile.displayName,
+    savedProfile.name,
+    showAvatarPage,
+  ]);
 
   const saveErrorMessage =
     profileSaveError instanceof Error ? profileSaveError.message : null;
@@ -357,6 +377,10 @@ export function OnboardingFlow({
     avatar: {
       draftUrl: profileDraft.avatarUrl,
       savedUrl: savedProfile.avatarUrl,
+    },
+    handle: {
+      draftValue: profileDraft.name,
+      savedValue: savedProfile.name,
     },
     isUploadingAvatar,
     isSaving: isSavingProfile || isProfileAdvancePending,
@@ -558,6 +582,7 @@ export function OnboardingFlow({
                   },
                   updateAvatarUrl: updateAvatarUrlDraft,
                   updateDisplayName: updateDisplayNameDraft,
+                  updateName: updateNameDraft,
                 }}
                 direction={transitionDirection}
                 state={profileStepState}

--- a/desktop/src/features/onboarding/ui/ProfileStep.tsx
+++ b/desktop/src/features/onboarding/ui/ProfileStep.tsx
@@ -7,6 +7,7 @@ import { useReconnectRelay } from "@/shared/api/useReconnectRelay";
 import { cn } from "@/shared/lib/cn";
 import { isRelayUnreachableError } from "@/shared/lib/relayError";
 import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
 import { Spinner } from "@/shared/ui/spinner";
 import { ONBOARDING_PRIMARY_CTA_CLASS } from "./OnboardingChrome";
 import { OnboardingFooter } from "./OnboardingFooter";
@@ -200,9 +201,11 @@ export function ProfileStep({
     skipForNow,
     submit,
     updateDisplayName,
+    updateName,
   } = actions;
-  const { isSaving, name, saveRecovery } = state;
+  const { handle, isSaving, name, saveRecovery } = state;
   const displayNameDraft = name.draftValue;
+  const handleDraft = handle.draftValue;
   const hasDisplayNameDraft = displayNameDraft.length > 0;
   const canSubmit = displayNameDraft.trim().length > 0 && !isSaving;
   const inputRef = React.useRef<HTMLInputElement | null>(null);
@@ -273,6 +276,39 @@ export function ProfileStep({
             value={displayNameDraft}
           />
         </div>
+      </label>
+
+      <label
+        className="mt-6 block w-full max-w-[576px] text-left"
+        htmlFor="onboarding-name"
+      >
+        <span className="text-sm font-medium text-foreground">
+          Nostr handle{" "}
+          <span className="font-normal text-muted-foreground">(optional)</span>
+        </span>
+        <p className="mt-1 text-sm text-muted-foreground">
+          A short name for your Nostr profile. It does not need to be unique.
+        </p>
+        <Input
+          aria-label="Nostr handle"
+          autoCapitalize="none"
+          autoComplete="off"
+          autoCorrect="off"
+          className="mt-3"
+          data-testid="onboarding-name"
+          disabled={isSaving}
+          id="onboarding-name"
+          onChange={(event) => updateName(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && canSubmit) {
+              event.preventDefault();
+              submit();
+            }
+          }}
+          placeholder="e.g. theangrypit"
+          spellCheck={false}
+          value={handleDraft}
+        />
       </label>
 
       {saveRecovery.errorMessage ? (

--- a/desktop/src/features/onboarding/ui/types.ts
+++ b/desktop/src/features/onboarding/ui/types.ts
@@ -22,6 +22,7 @@ export type OnboardingProfileSeed = {
 export type OnboardingProfileValues = {
   avatarUrl: string;
   displayName: string;
+  name: string;
 };
 
 export type ProfileStepSaveRecovery = {
@@ -42,6 +43,7 @@ export type ProfileStepAvatarState = {
 
 export type ProfileStepState = {
   avatar: ProfileStepAvatarState;
+  handle: ProfileStepNameState;
   isUploadingAvatar: boolean;
   isSaving: boolean;
   name: ProfileStepNameState;
@@ -58,6 +60,7 @@ export type ProfileStepActions = {
   submit: () => void;
   updateAvatarUrl: (value: string) => void;
   updateDisplayName: (value: string) => void;
+  updateName: (value: string) => void;
 };
 
 export type SetupStepActions = {

--- a/desktop/src/features/onboarding/welcomeKickoff.ts
+++ b/desktop/src/features/onboarding/welcomeKickoff.ts
@@ -678,7 +678,7 @@ export function useWelcomeKickoff(
         const owner = await getProfile()
           .then((profile) => ({
             pubkey: profile.pubkey,
-            displayName: profile.displayName,
+            displayName: profile.displayName ?? profile.name,
           }))
           .catch(() => null);
         const openerResult = await sendManagedAgentChannelMessage(

--- a/desktop/src/features/onboarding/welcomeKickoff.ts
+++ b/desktop/src/features/onboarding/welcomeKickoff.ts
@@ -678,7 +678,8 @@ export function useWelcomeKickoff(
         const owner = await getProfile()
           .then((profile) => ({
             pubkey: profile.pubkey,
-            displayName: profile.displayName ?? profile.name,
+            displayName:
+              profile.displayName?.trim() || profile.name?.trim() || null,
           }))
           .catch(() => null);
         const openerResult = await sendManagedAgentChannelMessage(

--- a/desktop/src/features/profile/hooks.ts
+++ b/desktop/src/features/profile/hooks.ts
@@ -534,7 +534,7 @@ export function useUpdateProfileMutation() {
         await updateCachedChannelMemberDisplayName(
           queryClient,
           pubkey,
-          profile.displayName ?? profile.name,
+          profile.displayName?.trim() || profile.name?.trim() || null,
         );
 
         // Own author labels/avatars render through the users-batch delta

--- a/desktop/src/features/profile/hooks.ts
+++ b/desktop/src/features/profile/hooks.ts
@@ -534,7 +534,7 @@ export function useUpdateProfileMutation() {
         await updateCachedChannelMemberDisplayName(
           queryClient,
           pubkey,
-          profile.displayName,
+          profile.displayName ?? profile.name,
         );
 
         // Own author labels/avatars render through the users-batch delta

--- a/desktop/src/features/profile/hooks.ts
+++ b/desktop/src/features/profile/hooks.ts
@@ -76,6 +76,7 @@ async function persistSelfProfile(
   writeSelfProfileCache(relayUrl, pubkey, {
     version: 1,
     displayName: profile.displayName,
+    name: profile.name,
     avatarUrl: profile.avatarUrl,
     about: profile.about,
     avatarDataUrl,
@@ -110,6 +111,7 @@ export function useProfileQuery(enabled = true) {
         ? ({
             pubkey,
             displayName: cached.displayName,
+            name: cached.name,
             avatarUrl: cached.avatarUrl,
             about: cached.about,
             nip05Handle: null,
@@ -404,6 +406,7 @@ export function useUsersBatchQuery(
             // These cached summaries are never used for the onboarding gate.
             hasProfileEvent: false,
             ...summary,
+            name: summary.name ?? null,
           },
       );
     }

--- a/desktop/src/features/profile/lib/identity.test.mjs
+++ b/desktop/src/features/profile/lib/identity.test.mjs
@@ -24,9 +24,26 @@ const summary = (over = {}) => ({
 test("formatOwnerLabel resolves a known owner's display name", () => {
   assert.equal(
     formatOwnerLabel(OWNER_PUBKEY, null, {
-      [OWNER_PUBKEY]: summary({ displayName: "baxen" }),
+      [OWNER_PUBKEY]: summary({
+        displayName: "baxen",
+        nip05Handle: null,
+      }),
     }),
     "baxen",
+  );
+});
+
+test("formatOwnerLabel prefers NIP-05 when all owner identity fields coexist", () => {
+  assert.equal(
+    formatOwnerLabel(OWNER_PUBKEY, null, {
+      [OWNER_PUBKEY]: {
+        pubkey: OWNER_PUBKEY,
+        name: "legacy-name",
+        displayName: "Human Name",
+        nip05Handle: "owner@example.com",
+      },
+    }),
+    "owner@example.com",
   );
 });
 

--- a/desktop/src/features/profile/lib/identity.test.mjs
+++ b/desktop/src/features/profile/lib/identity.test.mjs
@@ -1,13 +1,19 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { formatOwnerLabel, profileLookupsEqual } from "./identity.ts";
+import {
+  formatOwnerLabel,
+  mergeCurrentProfileIntoLookup,
+  profileLookupsEqual,
+  resolveUserLabel,
+} from "./identity.ts";
 
 const OWNER_PUBKEY =
   "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
 const summary = (over = {}) => ({
   displayName: "Ada",
+  name: null,
   avatarUrl: "https://x/a.png",
   nip05Handle: "ada@x",
   ownerPubkey: null,
@@ -58,6 +64,7 @@ test("profileLookupsEqual: same count, different keys is not equal", () => {
 test("profileLookupsEqual: a changed field is not equal", () => {
   for (const field of [
     "displayName",
+    "name",
     "avatarUrl",
     "nip05Handle",
     "ownerPubkey",
@@ -76,6 +83,47 @@ test("profileLookupsEqual: a changed field is not equal", () => {
 
 test("profileLookupsEqual: two empty lookups are equal", () => {
   assert.equal(profileLookupsEqual({}, {}), true);
+});
+
+test("resolveUserLabel uses a legacy kind-0 name when display_name is absent", () => {
+  assert.equal(
+    resolveUserLabel({
+      pubkey: OWNER_PUBKEY,
+      profiles: {
+        [OWNER_PUBKEY]: summary({
+          displayName: null,
+          name: "legacy-name",
+          nip05Handle: null,
+        }),
+      },
+    }),
+    "legacy-name",
+  );
+});
+
+test("mergeCurrentProfileIntoLookup keeps the raw name available to label resolution", () => {
+  const profiles = mergeCurrentProfileIntoLookup(
+    {
+      [OWNER_PUBKEY]: summary({
+        displayName: "legacy-name",
+        name: "legacy-name",
+      }),
+    },
+    {
+      pubkey: OWNER_PUBKEY,
+      name: "legacy-name",
+      displayName: null,
+      avatarUrl: null,
+      nip05Handle: null,
+    },
+  );
+
+  assert.equal(profiles?.[OWNER_PUBKEY]?.displayName, null);
+  assert.equal(profiles?.[OWNER_PUBKEY]?.name, "legacy-name");
+  assert.equal(
+    resolveUserLabel({ pubkey: OWNER_PUBKEY, profiles }),
+    "legacy-name",
+  );
 });
 
 // Render-count proof for the Tier-1 typing-storm fix (#1533 discipline).

--- a/desktop/src/features/profile/lib/identity.test.mjs
+++ b/desktop/src/features/profile/lib/identity.test.mjs
@@ -101,7 +101,7 @@ test("resolveUserLabel uses a legacy kind-0 name when display_name is absent", (
   );
 });
 
-test("mergeCurrentProfileIntoLookup keeps the raw name available to label resolution", () => {
+test("mergeCurrentProfileIntoLookup uses a nonblank name as its presentation label", () => {
   const profiles = mergeCurrentProfileIntoLookup(
     {
       [OWNER_PUBKEY]: summary({
@@ -112,6 +112,31 @@ test("mergeCurrentProfileIntoLookup keeps the raw name available to label resolu
     {
       pubkey: OWNER_PUBKEY,
       name: "legacy-name",
+      displayName: "   ",
+      avatarUrl: null,
+      nip05Handle: null,
+    },
+  );
+
+  assert.equal(profiles?.[OWNER_PUBKEY]?.displayName, "legacy-name");
+  assert.equal(profiles?.[OWNER_PUBKEY]?.name, "legacy-name");
+  assert.equal(
+    resolveUserLabel({ pubkey: OWNER_PUBKEY, profiles }),
+    "legacy-name",
+  );
+});
+
+test("mergeCurrentProfileIntoLookup does not restore a cleared name from stale lookup data", () => {
+  const profiles = mergeCurrentProfileIntoLookup(
+    {
+      [OWNER_PUBKEY]: summary({
+        displayName: "legacy-name",
+        name: "legacy-name",
+      }),
+    },
+    {
+      pubkey: OWNER_PUBKEY,
+      name: null,
       displayName: null,
       avatarUrl: null,
       nip05Handle: null,
@@ -119,8 +144,8 @@ test("mergeCurrentProfileIntoLookup keeps the raw name available to label resolu
   );
 
   assert.equal(profiles?.[OWNER_PUBKEY]?.displayName, null);
-  assert.equal(profiles?.[OWNER_PUBKEY]?.name, "legacy-name");
-  assert.equal(
+  assert.equal(profiles?.[OWNER_PUBKEY]?.name, null);
+  assert.notEqual(
     resolveUserLabel({ pubkey: OWNER_PUBKEY, profiles }),
     "legacy-name",
   );

--- a/desktop/src/features/profile/lib/identity.ts
+++ b/desktop/src/features/profile/lib/identity.ts
@@ -64,7 +64,10 @@ function getResolvedProfile(
 export function mergeCurrentProfileIntoLookup(
   profiles: UserProfileLookup | undefined,
   currentProfile:
-    | Pick<Profile, "pubkey" | "displayName" | "avatarUrl" | "nip05Handle">
+    | Pick<
+        Profile,
+        "pubkey" | "name" | "displayName" | "avatarUrl" | "nip05Handle"
+      >
     | null
     | undefined,
 ) {
@@ -76,9 +79,10 @@ export function mergeCurrentProfileIntoLookup(
     ...(profiles ?? {}),
     [normalizePubkey(currentProfile.pubkey)]: {
       displayName: currentProfile.displayName,
-      // `Profile` does not carry the kind-0 `name`; keep whatever the batch
-      // lookup already resolved so mention aliases survive the merge.
-      name: profiles?.[normalizePubkey(currentProfile.pubkey)]?.name ?? null,
+      name:
+        currentProfile.name ??
+        profiles?.[normalizePubkey(currentProfile.pubkey)]?.name ??
+        null,
       avatarUrl: currentProfile.avatarUrl,
       nip05Handle: currentProfile.nip05Handle,
       isAgent: profiles?.[normalizePubkey(currentProfile.pubkey)]?.isAgent,
@@ -116,6 +120,11 @@ export function resolveUserLabel(input: {
   const displayName = profile?.displayName?.trim();
   if (displayName) {
     return displayName;
+  }
+
+  const name = profile?.name?.trim();
+  if (name) {
+    return name;
   }
 
   const nip05Handle = profile?.nip05Handle?.trim();

--- a/desktop/src/features/profile/lib/identity.ts
+++ b/desktop/src/features/profile/lib/identity.ts
@@ -175,7 +175,7 @@ export function resolveUserSecondaryLabel(input: {
 
 /**
  * Label for an agent's owner: "you" when the current user owns it, otherwise
- * the owner's display name, NIP-05 handle, or truncated pubkey.
+ * the owner's NIP-05 handle, display name, Nostr name, or truncated pubkey.
  */
 export function formatOwnerLabel(
   ownerPubkey: string | null | undefined,
@@ -196,9 +196,9 @@ export function formatOwnerLabel(
 
   const owner = ownerProfiles?.[normalizedOwnerPubkey];
   return (
+    owner?.nip05Handle?.trim() ||
     owner?.displayName?.trim() ||
     owner?.name?.trim() ||
-    owner?.nip05Handle?.trim() ||
     truncatePubkey(ownerPubkey)
   );
 }

--- a/desktop/src/features/profile/lib/identity.ts
+++ b/desktop/src/features/profile/lib/identity.ts
@@ -78,11 +78,11 @@ export function mergeCurrentProfileIntoLookup(
   return {
     ...(profiles ?? {}),
     [normalizePubkey(currentProfile.pubkey)]: {
-      displayName: currentProfile.displayName,
-      name:
-        currentProfile.name ??
-        profiles?.[normalizePubkey(currentProfile.pubkey)]?.name ??
+      displayName:
+        currentProfile.displayName?.trim() ||
+        currentProfile.name?.trim() ||
         null,
+      name: currentProfile.name,
       avatarUrl: currentProfile.avatarUrl,
       nip05Handle: currentProfile.nip05Handle,
       isAgent: profiles?.[normalizePubkey(currentProfile.pubkey)]?.isAgent,
@@ -163,9 +163,10 @@ export function resolveUserSecondaryLabel(input: {
 }) {
   const profile = getResolvedProfile(input.pubkey, input.profiles);
   const displayName = profile?.displayName?.trim();
+  const name = profile?.name?.trim();
   const nip05Handle = profile?.nip05Handle?.trim();
 
-  if (displayName && nip05Handle) {
+  if ((displayName || name) && nip05Handle) {
     return nip05Handle;
   }
 
@@ -196,6 +197,7 @@ export function formatOwnerLabel(
   const owner = ownerProfiles?.[normalizedOwnerPubkey];
   return (
     owner?.displayName?.trim() ||
+    owner?.name?.trim() ||
     owner?.nip05Handle?.trim() ||
     truncatePubkey(ownerPubkey)
   );

--- a/desktop/src/features/profile/lib/profileActivityAgent.test.mjs
+++ b/desktop/src/features/profile/lib/profileActivityAgent.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveProfileActivityAgent } from "./profileActivityAgent.ts";
+
+test("uses a name-only Nostr profile for agent activity", () => {
+  const agent = resolveProfileActivityAgent({
+    effectivePubkey: "a".repeat(64),
+    isBot: true,
+    managedAgent: undefined,
+    profile: {
+      avatarUrl: null,
+      displayName: null,
+      name: "Bumble",
+    },
+    relayAgent: undefined,
+    viewerIsOwner: true,
+  });
+
+  assert.equal(agent?.name, "Bumble");
+});

--- a/desktop/src/features/profile/lib/profileActivityAgent.ts
+++ b/desktop/src/features/profile/lib/profileActivityAgent.ts
@@ -18,7 +18,11 @@ export function resolveProfileActivityAgent({
   effectivePubkey: string | null;
   isBot: boolean;
   managedAgent: ManagedAgent | undefined;
-  profile: { avatarUrl?: string | null; displayName?: string | null } | null;
+  profile: {
+    avatarUrl?: string | null;
+    displayName?: string | null;
+    name?: string | null;
+  } | null;
   relayAgent: RelayAgent | undefined;
   viewerIsOwner: boolean;
 }): ProfileActivityAgent | null {
@@ -37,7 +41,9 @@ export function resolveProfileActivityAgent({
 
   return {
     avatarUrl: profile?.avatarUrl ?? null,
-    name: relayAgent?.name ?? profile?.displayName?.trim() ?? "Agent",
+    name:
+      relayAgent?.name ??
+      (profile?.displayName?.trim() || profile?.name?.trim() || "Agent"),
     pubkey: effectivePubkey,
     status: relayAgent?.status === "offline" ? "stopped" : "deployed",
   };

--- a/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
+++ b/desktop/src/features/profile/lib/selfProfileStorage.test.mjs
@@ -124,6 +124,7 @@ test("parseSelfProfileCache: valid v1 payload round-trips", () => {
   const payload = {
     version: 1,
     displayName: "Alice",
+    name: "alice",
     avatarUrl: "https://relay.example.com/media/abc.jpg",
     about: "Building better communities",
     avatarDataUrl: "data:image/jpeg;base64,/9j/4A==",
@@ -137,6 +138,7 @@ test("parseSelfProfileCache: null fields are preserved", () => {
   const payload = {
     version: 1,
     displayName: null,
+    name: null,
     avatarUrl: null,
     about: null,
     avatarDataUrl: null,
@@ -203,6 +205,7 @@ test("parseSelfProfileCache: non-finite updatedAt is coerced to 0", () => {
   const resultNaN = parseSelfProfileCache({
     version: 1,
     displayName: null,
+    name: null,
     avatarUrl: null,
     avatarDataUrl: null,
     updatedAt: NaN,
@@ -279,6 +282,7 @@ function makeCache(overrides = {}) {
   return {
     version: 1,
     displayName: null,
+    name: null,
     avatarUrl: null,
     avatarDataUrl: null,
     updatedAt: 0,

--- a/desktop/src/features/profile/lib/selfProfileStorage.ts
+++ b/desktop/src/features/profile/lib/selfProfileStorage.ts
@@ -30,6 +30,8 @@ export const SELF_PROFILE_CACHE_EVENT = "buzz:self-profile-cache";
 export type SelfProfileCache = {
   version: 1;
   displayName: string | null;
+  /** Kind-0 `name`, kept distinct from the human-facing display name. */
+  name: string | null;
   /** Original relay URL from the kind-0 profile event. */
   avatarUrl: string | null;
   about: string | null;
@@ -54,6 +56,7 @@ export type SelfProfileCache = {
 const DEFAULT_CACHE: SelfProfileCache = Object.freeze({
   version: 1,
   displayName: null,
+  name: null,
   avatarUrl: null,
   about: null,
   avatarDataUrl: null,
@@ -82,6 +85,7 @@ export function parseSelfProfileCache(json: unknown): SelfProfileCache | null {
 
   const displayName =
     typeof obj.displayName === "string" ? obj.displayName : null;
+  const name = typeof obj.name === "string" ? obj.name : null;
   const avatarUrl = typeof obj.avatarUrl === "string" ? obj.avatarUrl : null;
   const about = typeof obj.about === "string" ? obj.about : null;
   // Defense-in-depth: avatarDataUrl flows into an <img src> sink; only accept
@@ -103,6 +107,7 @@ export function parseSelfProfileCache(json: unknown): SelfProfileCache | null {
   return {
     version: 1,
     displayName,
+    name,
     avatarUrl,
     about,
     avatarDataUrl,

--- a/desktop/src/features/profile/profileCacheSync.ts
+++ b/desktop/src/features/profile/profileCacheSync.ts
@@ -70,6 +70,7 @@ export async function refreshProfileCaches(
   const baseCache = {
     version: 1 as const,
     displayName: profile.displayName,
+    name: profile.name,
     avatarUrl: profile.avatarUrl,
     about: profile.about,
     avatarDataUrl: resolveAvatarDataUrl(profile.avatarUrl, null, existing),

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -80,9 +80,9 @@ import {
   type ProfilePanelTab,
   type ProfilePanelView,
   resolveAgentInstruction,
+  resolveOwnerHandle,
   resolvePanelProfile,
   resolveProfileDisplayName,
-  truncatePubkey,
   type UserProfilePanelProps,
   useRetainedPersona,
 } from "@/features/profile/ui/UserProfilePanelUtils";
@@ -675,24 +675,14 @@ export function UserProfilePanel({
   });
   const ownerHandle = React.useMemo(() => {
     if (ownerPubkey) {
-      const ownerProfile = ownerProfileQuery.data;
-      return (
-        ownerProfile?.nip05Handle?.trim() ||
-        ownerProfile?.displayName?.trim() ||
-        truncatePubkey(ownerPubkey)
-      );
+      return resolveOwnerHandle(ownerProfileQuery.data, ownerPubkey);
     }
 
     if (currentPubkey === undefined || isOwner !== true) {
       return null;
     }
 
-    const currentProfile = currentProfileQuery.data;
-    return (
-      currentProfile?.nip05Handle?.trim() ||
-      currentProfile?.displayName?.trim() ||
-      truncatePubkey(currentPubkey)
-    );
+    return resolveOwnerHandle(currentProfileQuery.data, currentPubkey);
   }, [
     currentProfileQuery.data,
     currentPubkey,

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
@@ -7,6 +7,8 @@ import {
   personaManagedAgentUpdate,
   profilePanelTabFromSearch,
   profilePanelViewFromSearch,
+  resolveOwnerHandle,
+  resolveProfileDisplayName,
 } from "./UserProfilePanelUtils.ts";
 
 function agent(overrides = {}) {
@@ -188,4 +190,27 @@ test("profilePanelTabFromSearch falls back to info for invalid values", () => {
   assert.equal(parseProfilePanelTab("missing"), null);
   assert.equal(profilePanelTabFromSearch("missing"), "info");
   assert.equal(profilePanelTabFromSearch(null), "info");
+});
+
+test("profile labels fall back to the independent Nostr name field", () => {
+  const profile = {
+    pubkey: "deadbeef".repeat(8),
+    name: "legacy-name",
+    displayName: null,
+    avatarUrl: null,
+    about: null,
+    nip05Handle: null,
+    ownerPubkey: null,
+    hasProfileEvent: true,
+  };
+
+  assert.equal(
+    resolveProfileDisplayName({
+      persona: undefined,
+      profile,
+      pubkey: profile.pubkey,
+    }),
+    "legacy-name",
+  );
+  assert.equal(resolveOwnerHandle(profile, profile.pubkey), "legacy-name");
 });

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
@@ -196,7 +196,7 @@ test("profile labels fall back to the independent Nostr name field", () => {
   const profile = {
     pubkey: "deadbeef".repeat(8),
     name: "legacy-name",
-    displayName: null,
+    displayName: "   ",
     avatarUrl: null,
     about: null,
     nip05Handle: null,

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
@@ -214,3 +214,18 @@ test("profile labels fall back to the independent Nostr name field", () => {
   );
   assert.equal(resolveOwnerHandle(profile, profile.pubkey), "legacy-name");
 });
+
+test("owner labels keep display_name ahead of the Nostr name fallback", () => {
+  const profile = {
+    pubkey: "deadbeef".repeat(8),
+    name: "legacy-name",
+    displayName: "Human Name",
+    avatarUrl: null,
+    about: null,
+    nip05Handle: null,
+    ownerPubkey: null,
+    hasProfileEvent: true,
+  };
+
+  assert.equal(resolveOwnerHandle(profile, profile.pubkey), "Human Name");
+});

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
@@ -247,8 +247,8 @@ export function resolveOwnerHandle(
 
   return (
     profile?.nip05Handle?.trim() ||
-    profile?.name?.trim() ||
     profile?.displayName?.trim() ||
+    profile?.name?.trim() ||
     truncatePubkey(currentPubkey)
   );
 }

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
@@ -230,9 +230,9 @@ export function resolveProfileDisplayName({
   pubkey: string | null;
 }) {
   return (
-    profile?.displayName ??
-    profile?.name ??
-    persona?.displayName ??
+    profile?.displayName?.trim() ||
+    profile?.name?.trim() ||
+    persona?.displayName?.trim() ||
     (pubkey ? truncatePubkey(pubkey) : "Agent")
   );
 }

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
@@ -160,6 +160,7 @@ export function getRelayAgentChannelIds(
 export function buildPersonaDraftProfile(persona: AgentPersona): Profile {
   return {
     pubkey: "",
+    name: null,
     displayName: persona.displayName,
     avatarUrl: persona.avatarUrl,
     about: null,

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
@@ -231,6 +231,7 @@ export function resolveProfileDisplayName({
 }) {
   return (
     profile?.displayName ??
+    profile?.name ??
     persona?.displayName ??
     (pubkey ? truncatePubkey(pubkey) : "Agent")
   );
@@ -246,6 +247,7 @@ export function resolveOwnerHandle(
 
   return (
     profile?.nip05Handle?.trim() ||
+    profile?.name?.trim() ||
     profile?.displayName?.trim() ||
     truncatePubkey(currentPubkey)
   );

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -237,7 +237,8 @@ export function UserProfilePopover({
       relayAgentsQuery.isPending ||
       managedAgentsQuery.isPending ||
       usersBatchQuery.isPending);
-  const displayName = profile?.displayName ?? truncatePubkey(pubkey);
+  const displayName =
+    profile?.displayName ?? profile?.name ?? truncatePubkey(pubkey);
   // Owner signal mirrors UserProfilePanel: a declared NIP-OA owner whose agent
   // runs elsewhere holds no local seckey, so key custody (`isOwner`) alone
   // wrongly hides the affordance from them — and gating on bot-ness alone shows
@@ -431,6 +432,7 @@ export function UserProfilePopover({
         (await openDmMutation.mutateAsync({ pubkeys: [pubkey] }));
       const senderName =
         selfProfileQuery.data?.displayName?.trim() ||
+        selfProfileQuery.data?.name?.trim() ||
         identity.displayName.trim() ||
         truncatePubkey(identity.pubkey);
       const content = buildWaveMessageContent(senderName);
@@ -503,6 +505,7 @@ export function UserProfilePopover({
     pubkey,
     queryClient,
     selfProfileQuery.data?.displayName,
+    selfProfileQuery.data?.name,
     showHumanProfileActions,
     showProfileActions,
   ]);

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -238,7 +238,9 @@ export function UserProfilePopover({
       managedAgentsQuery.isPending ||
       usersBatchQuery.isPending);
   const displayName =
-    profile?.displayName ?? profile?.name ?? truncatePubkey(pubkey);
+    profile?.displayName?.trim() ||
+    profile?.name?.trim() ||
+    truncatePubkey(pubkey);
   // Owner signal mirrors UserProfilePanel: a declared NIP-OA owner whose agent
   // runs elsewhere holds no local seckey, so key custody (`isOwner`) alone
   // wrongly hides the affordance from them — and gating on bot-ness alone shows

--- a/desktop/src/features/pulse/ui/NoteCard.tsx
+++ b/desktop/src/features/pulse/ui/NoteCard.tsx
@@ -65,10 +65,11 @@ function ReplyParentContext({
   );
   const fetchedProfile = parentProfileQuery.data ?? null;
   const parentDisplayName = parentNote
-    ? (cachedProfile?.displayName ??
-      fetchedProfile?.displayName ??
-      fetchedProfile?.name ??
-      truncatePubkey(parentNote.pubkey))
+    ? cachedProfile?.displayName?.trim() ||
+      cachedProfile?.name?.trim() ||
+      fetchedProfile?.displayName?.trim() ||
+      fetchedProfile?.name?.trim() ||
+      truncatePubkey(parentNote.pubkey)
     : null;
   const parentAvatarUrl =
     cachedProfile?.avatarUrl ?? fetchedProfile?.avatarUrl ?? null;
@@ -144,7 +145,10 @@ export function NoteCard({
   members = [],
   actions,
 }: NoteCardProps) {
-  const displayName = profile?.displayName ?? truncatePubkey(note.pubkey);
+  const displayName =
+    profile?.displayName?.trim() ||
+    profile?.name?.trim() ||
+    truncatePubkey(note.pubkey);
   const avatarUrl = profile?.avatarUrl ?? null;
   const [isReplyComposerOpen, setIsReplyComposerOpen] = React.useState(false);
   const actionButtonClass =

--- a/desktop/src/features/pulse/ui/NoteCard.tsx
+++ b/desktop/src/features/pulse/ui/NoteCard.tsx
@@ -67,6 +67,7 @@ function ReplyParentContext({
   const parentDisplayName = parentNote
     ? (cachedProfile?.displayName ??
       fetchedProfile?.displayName ??
+      fetchedProfile?.name ??
       truncatePubkey(parentNote.pubkey))
     : null;
   const parentAvatarUrl =

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -136,10 +136,12 @@ export function ProfileSettingsCard({
   const updateProfileMutation = useUpdateProfileMutation();
   const profile = profileQuery.data;
 
+  const currentName = profile?.name ?? "";
   const currentDisplayName = profile?.displayName ?? "";
   const currentAvatarUrl = profile?.avatarUrl ?? "";
   const currentAbout = profile?.about ?? "";
   const [displayNameDraft, setDisplayNameDraft] = React.useState("");
+  const [nameDraft, setNameDraft] = React.useState("");
   const [avatarUrlDraft, setAvatarUrlDraft] = React.useState("");
   const [aboutDraft, setAboutDraft] = React.useState("");
   const [uploadedAvatarUrlDraft, setUploadedAvatarUrlDraft] = React.useState<
@@ -173,6 +175,12 @@ export function ProfileSettingsCard({
   const avatarEditorFinishTimeoutRef = React.useRef<number | null>(null);
   const savedScrollTopRef = React.useRef<number | null>(null);
   isEditingProfileMetadataRef.current = isEditingProfileMetadata;
+
+  React.useEffect(() => {
+    if (!isEditingProfileMetadataRef.current) {
+      setNameDraft(currentName);
+    }
+  }, [currentName]);
 
   React.useEffect(() => {
     if (!isEditingProfileMetadataRef.current) {
@@ -243,17 +251,22 @@ export function ProfileSettingsCard({
   }, []);
 
   const nextDisplayName = displayNameDraft.trim();
+  const nextName = nameDraft.trim();
   const nextAvatarUrl = avatarUrlDraft.trim();
   const nextAbout = aboutDraft.trim();
   const updatePayload = React.useMemo(() => {
     const payload: {
       displayName?: string;
+      name?: string;
       avatarUrl?: string;
       about?: string;
     } = {};
 
     if (nextDisplayName.length > 0 && nextDisplayName !== currentDisplayName) {
       payload.displayName = nextDisplayName;
+    }
+    if (nextName !== currentName) {
+      payload.name = nextName;
     }
     if (nextAvatarUrl.length > 0 && nextAvatarUrl !== currentAvatarUrl) {
       payload.avatarUrl = nextAvatarUrl;
@@ -267,9 +280,11 @@ export function ProfileSettingsCard({
     currentAbout,
     currentAvatarUrl,
     currentDisplayName,
+    currentName,
     nextAbout,
     nextAvatarUrl,
     nextDisplayName,
+    nextName,
   ]);
 
   const hasPendingDisplayNameClearRequest =
@@ -393,21 +408,16 @@ export function ProfileSettingsCard({
       return false;
     }
 
-    await updateProfileMutation.mutateAsync(updatePayload);
+    const updatedProfile =
+      await updateProfileMutation.mutateAsync(updatePayload);
     setIsEditingProfileMetadata(false);
-    setDisplayNameDraft(updatePayload.displayName ?? currentDisplayName);
-    setAvatarUrlDraft(updatePayload.avatarUrl ?? currentAvatarUrl);
-    setAboutDraft(updatePayload.about ?? currentAbout);
+    setNameDraft(updatedProfile.name ?? "");
+    setDisplayNameDraft(updatedProfile.displayName ?? "");
+    setAvatarUrlDraft(updatedProfile.avatarUrl ?? "");
+    setAboutDraft(updatedProfile.about ?? "");
     toast.success("Profile saved");
     return true;
-  }, [
-    canSave,
-    currentAbout,
-    currentAvatarUrl,
-    currentDisplayName,
-    updatePayload,
-    updateProfileMutation,
-  ]);
+  }, [canSave, updatePayload, updateProfileMutation]);
 
   const handleProfileMetadataEdit = React.useCallback(() => {
     if (!isEditingProfileMetadata) {
@@ -714,6 +724,42 @@ export function ProfileSettingsCard({
                                   title={displayNameDraft || "Not set"}
                                 >
                                   {displayNameDraft || "Not set"}
+                                </p>
+                              )}
+                            </div>
+                          </div>
+
+                          <div className="flex min-h-16 items-center gap-4 px-4 py-3">
+                            <div className="min-w-0 flex-1 space-y-1">
+                              <label
+                                className="block text-sm font-medium"
+                                htmlFor="profile-name"
+                              >
+                                Nostr handle
+                              </label>
+                              <p className="text-xs text-muted-foreground/75">
+                                A short profile name. It does not need to be
+                                unique.
+                              </p>
+                              {isEditingProfileMetadata ? (
+                                <Input
+                                  className="h-auto border-0 bg-transparent px-0 py-0 text-sm text-muted-foreground shadow-none placeholder:text-muted-foreground/60 focus-visible:ring-0"
+                                  data-testid="profile-name"
+                                  disabled={updateProfileMutation.isPending}
+                                  id="profile-name"
+                                  onChange={(event) =>
+                                    setNameDraft(event.target.value)
+                                  }
+                                  placeholder="e.g. theangrypit"
+                                  value={nameDraft}
+                                />
+                              ) : (
+                                <p
+                                  className="min-w-0 truncate text-sm text-muted-foreground"
+                                  data-testid="profile-name-value"
+                                  title={nameDraft || "Not set"}
+                                >
+                                  {nameDraft || "Not set"}
                                 </p>
                               )}
                             </div>

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -311,6 +311,7 @@ export function ProfileSettingsCard({
   const resolvedName =
     nextDisplayName ||
     profile?.displayName ||
+    profile?.name ||
     fallbackDisplayName ||
     "Your profile";
   const resolvedPubkey = profile?.pubkey ?? currentPubkey ?? "Unavailable";

--- a/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/ProfileSettingsCard.tsx
@@ -310,9 +310,9 @@ export function ProfileSettingsCard({
 
   const resolvedName =
     nextDisplayName ||
-    profile?.displayName ||
-    profile?.name ||
-    fallbackDisplayName ||
+    profile?.displayName?.trim() ||
+    profile?.name?.trim() ||
+    fallbackDisplayName?.trim() ||
     "Your profile";
   const resolvedPubkey = profile?.pubkey ?? currentPubkey ?? "Unavailable";
   const nip05Handle = profile?.nip05Handle ?? "Not set";

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -485,7 +485,7 @@ export function AppSidebar({
       directMessages,
       enabled: shouldLoadDmMetadata,
       fallbackDisplayName,
-      profileDisplayName: profile?.displayName,
+      profileDisplayName: profile?.displayName ?? profile?.name,
     });
   const sortedDirectMessages = React.useMemo(
     () =>
@@ -506,6 +506,7 @@ export function AppSidebar({
   });
   const resolvedDisplayName =
     profile?.displayName?.trim() ||
+    profile?.name?.trim() ||
     fallbackDisplayName?.trim() ||
     "Current identity";
   const isCreatingAny =

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -485,7 +485,8 @@ export function AppSidebar({
       directMessages,
       enabled: shouldLoadDmMetadata,
       fallbackDisplayName,
-      profileDisplayName: profile?.displayName ?? profile?.name,
+      profileDisplayName:
+        profile?.displayName?.trim() || profile?.name?.trim() || null,
     });
   const sortedDirectMessages = React.useMemo(
     () =>

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -148,11 +148,8 @@ type AppSidebarProps = {
   onSelectHome: () => void;
   onSelectChannel: (channelId: string) => void;
   onOpenSearchResult: (hit: SearchHit) => void;
-  /**
-   * Full channel set used for global search. Unlike `channels` (which is
-   * scoped to the viewer's joined sidebar list), this includes open channels
-   * the viewer hasn't joined, so search can surface them.
-   */
+  /** Full channel set for global search, including open channels the viewer
+   * has not joined; `channels` only contains their joined sidebar list. */
   searchChannels: Channel[];
   searchFocusRequest: number;
   onSelectSettings: (section?: SettingsSection) => void;

--- a/desktop/src/shared/api/tauriProfiles.ts
+++ b/desktop/src/shared/api/tauriProfiles.ts
@@ -10,6 +10,7 @@ import type {
 
 type RawProfile = {
   pubkey: string;
+  name: string | null;
   display_name: string | null;
   avatar_url: string | null;
   about: string | null;
@@ -38,6 +39,7 @@ type RawSearchUsersResponse = {
 function fromRawProfile(profile: RawProfile): Profile {
   return {
     pubkey: profile.pubkey,
+    name: profile.name ?? null,
     displayName: profile.display_name,
     avatarUrl: profile.avatar_url,
     about: profile.about,

--- a/desktop/src/shared/api/tauriProfiles.ts
+++ b/desktop/src/shared/api/tauriProfiles.ts
@@ -19,7 +19,10 @@ type RawProfile = {
   has_profile_event?: boolean;
 };
 
-type RawUserProfileSummary = Omit<RawProfile, "pubkey" | "about"> & {
+type RawUserProfileSummary = Omit<
+  RawProfile,
+  "pubkey" | "name" | "about" | "has_profile_event"
+> & {
   name?: string | null;
   is_agent?: boolean;
 };

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -107,17 +107,14 @@ export type { Identity, IdentityStorage } from "./identityTypes";
 
 export type Profile = {
   pubkey: string;
-  /** Kind-0 `name`, a short user-chosen handle. It is not guaranteed unique. */
-  name: string | null;
+  name: string | null; // Kind-0 short handle; not guaranteed unique.
   displayName: string | null;
   avatarUrl: string | null;
   about: string | null;
   nip05Handle: string | null;
   ownerPubkey: string | null;
-  /** True when a real kind:0 metadata event exists on the relay for this pubkey.
-   * False for the synthesized fallback returned when no event is present.
-   * Used by the onboarding gate to distinguish new users from returning users
-   * whose display name happens to be empty. */
+  /** True for a real kind:0 event, false for a synthesized missing-event
+   * fallback. Distinguishes new users from returning users with no display name. */
   hasProfileEvent: boolean;
 };
 
@@ -154,8 +151,7 @@ export type UserSearchPage = {
 
 export type UpdateProfileInput = {
   displayName?: string;
-  /** Kind-0 `name`. Empty/whitespace removes it; omission preserves it. */
-  name?: string;
+  name?: string; // Empty/whitespace removes it; omission preserves it.
   avatarUrl?: string;
   about?: string;
   nip05Handle?: string;

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -107,6 +107,8 @@ export type { Identity, IdentityStorage } from "./identityTypes";
 
 export type Profile = {
   pubkey: string;
+  /** Kind-0 `name`, a short user-chosen handle. It is not guaranteed unique. */
+  name: string | null;
   displayName: string | null;
   avatarUrl: string | null;
   about: string | null;
@@ -152,6 +154,8 @@ export type UserSearchPage = {
 
 export type UpdateProfileInput = {
   displayName?: string;
+  /** Kind-0 `name`. Empty/whitespace removes it; omission preserves it. */
+  name?: string;
   avatarUrl?: string;
   about?: string;
   nip05Handle?: string;

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -5839,7 +5839,7 @@ async function handleGetProfile(config: E2eConfig | undefined) {
   return {
     pubkey: identity.pubkey,
     name: content.name ?? null,
-    display_name: content.display_name ?? content.name ?? null,
+    display_name: content.display_name ?? null,
     about: content.about ?? null,
     avatar_url: content.picture ?? null,
     nip05_handle: content.nip05 ?? null,
@@ -5995,7 +5995,7 @@ async function handleGetUserProfile(
   return {
     pubkey: targetPubkey,
     name: content.name ?? null,
-    display_name: content.display_name ?? content.name ?? null,
+    display_name: content.display_name ?? null,
     about: content.about ?? null,
     avatar_url: content.picture ?? null,
     nip05_handle: content.nip05 ?? null,

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -5826,6 +5826,7 @@ async function handleGetProfile(config: E2eConfig | undefined) {
   if (events.length === 0) {
     return {
       pubkey: identity.pubkey,
+      name: null,
       display_name: null,
       about: null,
       avatar_url: null,
@@ -5837,6 +5838,7 @@ async function handleGetProfile(config: E2eConfig | undefined) {
   const content = JSON.parse(events[0].content ?? "{}");
   return {
     pubkey: identity.pubkey,
+    name: content.name ?? null,
     display_name: content.display_name ?? content.name ?? null,
     about: content.about ?? null,
     avatar_url: content.picture ?? null,
@@ -5849,6 +5851,7 @@ async function handleGetProfile(config: E2eConfig | undefined) {
 async function handleUpdateProfile(
   args: {
     displayName?: string;
+    name?: string;
     avatarUrl?: string;
     about?: string;
     nip05Handle?: string;
@@ -5873,10 +5876,12 @@ async function handleUpdateProfile(
 
     const profile = ensureMockProfile(config);
     const hasDisplayNameUpdate = typeof args.displayName === "string";
+    const hasNameUpdate = typeof args.name === "string";
     const hasAvatarUrlUpdate = typeof args.avatarUrl === "string";
     const hasAboutUpdate = typeof args.about === "string";
     const hasNip05HandleUpdate = typeof args.nip05Handle === "string";
     const nextDisplayName = args.displayName?.trim() ?? "";
+    const nextName = args.name?.trim() ?? "";
     const nextAvatarUrl = args.avatarUrl?.trim() ?? "";
     const nextAbout = args.about?.trim() ?? "";
     const nextNip05Handle = args.nip05Handle?.trim() ?? "";
@@ -5884,6 +5889,9 @@ async function handleUpdateProfile(
     if (hasDisplayNameUpdate && nextDisplayName !== profile.display_name) {
       profile.display_name = nextDisplayName || null;
       applyMockDisplayName(profile.pubkey, profile.display_name);
+    }
+    if (hasNameUpdate && nextName !== profile.name) {
+      profile.name = nextName || null;
     }
     if (hasAvatarUrlUpdate && nextAvatarUrl !== profile.avatar_url) {
       profile.avatar_url = nextAvatarUrl || null;
@@ -5902,16 +5910,35 @@ async function handleUpdateProfile(
   const currentEvents = await relayQuery(config, [
     { kinds: [0], authors: [identity.pubkey], limit: 1 },
   ]);
-  const currentContent = currentEvents[0]
+  const currentContent: unknown = currentEvents[0]
     ? JSON.parse(currentEvents[0].content ?? "{}")
     : {};
-  const profileContent = JSON.stringify({
-    display_name: args.displayName ?? currentContent.display_name ?? undefined,
-    name: currentContent.display_name ?? undefined,
-    picture: args.avatarUrl ?? currentContent.picture ?? undefined,
-    about: args.about ?? currentContent.about ?? undefined,
-    nip05: args.nip05Handle ?? currentContent.nip05 ?? undefined,
-  });
+  if (
+    typeof currentContent !== "object" ||
+    currentContent === null ||
+    Array.isArray(currentContent)
+  ) {
+    throw new Error("Existing profile metadata must be a JSON object.");
+  }
+  const updated: Record<string, unknown> = { ...currentContent };
+  for (const [field, value] of [
+    ["display_name", args.displayName],
+    ["name", args.name],
+    ["picture", args.avatarUrl],
+    ["about", args.about],
+    ["nip05", args.nip05Handle],
+  ] as const) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed) {
+      updated[field] = trimmed;
+    } else {
+      delete updated[field];
+    }
+  }
+  const profileContent = JSON.stringify(updated);
   await submitSignedEvent(config, {
     kind: 0,
     content: profileContent,
@@ -5919,9 +5946,9 @@ async function handleUpdateProfile(
   });
 
   // Return the updated profile in RawProfile shape
-  const updated = JSON.parse(profileContent);
   return {
     pubkey: identity.pubkey,
+    name: updated.name ?? null,
     display_name: updated.display_name ?? null,
     about: updated.about ?? null,
     avatar_url: updated.picture ?? null,
@@ -5955,6 +5982,7 @@ async function handleGetUserProfile(
   if (events.length === 0) {
     return {
       pubkey: targetPubkey,
+      name: null,
       display_name: null,
       about: null,
       avatar_url: null,
@@ -5966,6 +5994,7 @@ async function handleGetUserProfile(
   const content = JSON.parse(events[0].content ?? "{}");
   return {
     pubkey: targetPubkey,
+    name: content.name ?? null,
     display_name: content.display_name ?? content.name ?? null,
     about: content.about ?? null,
     avatar_url: content.picture ?? null,

--- a/desktop/tests/e2e/onboarding-avatar-skip.spec.ts
+++ b/desktop/tests/e2e/onboarding-avatar-skip.spec.ts
@@ -20,6 +20,7 @@ test("avatar step always shows Skip for now button without an error", async ({
   await page.goto("/");
 
   await page.getByTestId("onboarding-display-name").fill("Morty QA");
+  await page.getByTestId("onboarding-name").fill("morty");
   await page.getByTestId("onboarding-next").click();
 
   await expect(page.getByTestId("onboarding-page-avatar")).toBeVisible();
@@ -83,12 +84,25 @@ test("avatar step skip button completes community profile setup", async ({
   await page.goto("/");
 
   await page.getByTestId("onboarding-display-name").fill("Morty QA");
+  await page.getByTestId("onboarding-name").fill("morty");
   await page.getByTestId("onboarding-next").click();
 
   await expect(page.getByTestId("onboarding-page-avatar")).toBeVisible();
   await page.getByTestId("onboarding-skip").click();
 
   await expect(page.getByTestId("onboarding-gate")).not.toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        (window.__BUZZ_E2E_COMMAND_PAYLOADS__ ?? [])
+          .filter(({ command }) => command === "update_profile")
+          .map(({ payload }) => payload),
+      ),
+    )
+    .toContainEqual({
+      displayName: "Morty QA",
+      name: "morty",
+    });
 });
 
 test("avatar Next button still requires an avatar to be chosen", async ({

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -2405,6 +2405,12 @@ test("delayed profile seed does not undo an explicit avatar clear", async ({
 
   const existingAvatarUrl =
     "https://mock.relay/media/existing-community-avatar.png";
+  await page.route(`${existingAvatarUrl}*`, async (route) => {
+    await route.fulfill({
+      body: Buffer.from(ONE_PIXEL_PNG_BASE64, "base64"),
+      contentType: "image/png",
+    });
+  });
   await seedCurrentAvatar(page, existingAvatarUrl);
   await expect(page.getByTestId("community-avatar-circle-image")).toBeVisible();
 
@@ -2414,7 +2420,9 @@ test("delayed profile seed does not undo an explicit avatar clear", async ({
   await page.getByTestId("community-team-intro-back").click();
 
   await page.getByTestId("community-avatar-open").click();
-  await page.getByTestId("community-avatar-url").fill("");
+  const avatarUrlInput = page.getByTestId("community-avatar-url");
+  await avatarUrlInput.fill("https://example.com/replacement-avatar.png");
+  await avatarUrlInput.fill("");
   await page.getByTestId("community-avatar-done").click();
   await expect(page.getByTestId("community-avatar-empty")).toBeVisible();
 

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -2019,7 +2019,7 @@ test("connected first-community profile keeps Back bottom-left and balances the 
     borderRadius: "16px",
     fontSize: "14px",
   });
-  await expect(page.getByText("Your username", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("Community Nostr handle")).toBeVisible();
   await expect(page.getByTestId("community-onboarding-flow")).toHaveAttribute(
     "data-system-color-scheme",
     /^(light|dark)$/,
@@ -2346,7 +2346,7 @@ test("connected first-community profile keeps Back bottom-left and balances the 
     .toBeNull();
 });
 
-test("name-only community profile save preserves an existing avatar", async ({
+test("community profile save preserves existing avatar and untouched handle", async ({
   page,
 }) => {
   await seedCommunityProfileStage(page, "txn-avatar-preserve-existing");
@@ -2359,6 +2359,10 @@ test("name-only community profile save preserves an existing avatar", async ({
   const existingAvatarUrl =
     "https://mock.relay/media/existing-community-avatar.png";
   await seedCurrentAvatar(page, existingAvatarUrl);
+  await invokeMockCommand(page, "update_profile", { name: "existing-handle" });
+  await page.evaluate(() => {
+    window.__BUZZ_E2E_COMMAND_PAYLOADS__ = [];
+  });
   await page.getByTestId("community-profile-name-key").fill("Tyler");
   await page.getByTestId("community-profile-next").click();
 
@@ -2375,11 +2379,65 @@ test("name-only community profile save preserves an existing avatar", async ({
       ),
     )
     .toEqual([undefined]);
+  const profile = await invokeMockCommand<{
+    avatar_url: string | null;
+    display_name: string | null;
+    name: string | null;
+  }>(page, "get_profile");
+  expect(profile.avatar_url).toBe(existingAvatarUrl);
+  expect(profile.display_name).toBe("Tyler");
+  expect(profile.name).toBe("existing-handle");
+});
+
+test("delayed profile seed does not undo an explicit avatar clear", async ({
+  page,
+}) => {
+  await seedCommunityProfileStage(page, "txn-avatar-clear-seed-race");
+  await installMockBridge(
+    page,
+    { profileReadDelayMs: 750 },
+    {
+      relayWsUrl: "wss://default.example.com",
+      skipOnboardingSeed: true,
+    },
+  );
+  await page.goto("/");
+
+  const existingAvatarUrl =
+    "https://mock.relay/media/existing-community-avatar.png";
+  await seedCurrentAvatar(page, existingAvatarUrl);
+  await expect(page.getByTestId("community-avatar-circle-image")).toBeVisible();
+
+  await page.getByTestId("community-profile-name-key").fill("Tyler");
+  await page.getByTestId("community-profile-next").click();
+  await expect(page.getByTestId("community-team-intro-back")).toBeVisible();
+  await page.getByTestId("community-team-intro-back").click();
+
+  await page.getByTestId("community-avatar-open").click();
+  await page.getByTestId("community-avatar-url").fill("");
+  await page.getByTestId("community-avatar-done").click();
+  await expect(page.getByTestId("community-avatar-empty")).toBeVisible();
+
+  // The second profile read started when Back reopened this stage and resolves
+  // after the explicit clear. It must not restore the relay's older avatar.
+  await page.waitForTimeout(1_000);
+  await expect(page.getByTestId("community-avatar-empty")).toBeVisible();
+
+  await page.getByTestId("community-profile-next").click();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        (window.__BUZZ_E2E_COMMAND_PAYLOADS__ ?? [])
+          .filter(({ command }) => command === "update_profile")
+          .map(({ payload }) => (payload as { avatarUrl?: string }).avatarUrl),
+      ),
+    )
+    .toContain("");
   const profile = await invokeMockCommand<{ avatar_url: string | null }>(
     page,
     "get_profile",
   );
-  expect(profile.avatar_url).toBe(existingAvatarUrl);
+  expect(profile.avatar_url).toBeNull();
 });
 
 test("pending avatar stays navigable, clears failures, and retries", async ({

--- a/desktop/tests/e2e/profile.spec.ts
+++ b/desktop/tests/e2e/profile.spec.ts
@@ -214,6 +214,7 @@ test("keeps the saved profile description after a community round trip", async (
 test("updates the relay-backed profile from settings", async ({ page }) => {
   const stamp = Date.now();
   const displayName = `Tyler QA ${stamp}`;
+  const name = `tyler-${stamp}`;
   const avatarUrl = `https://example.com/avatar-${stamp}.png`;
   const about = `Coordinating relay profile setup ${stamp}`;
   await page.goto("/");
@@ -235,12 +236,14 @@ test("updates the relay-backed profile from settings", async ({ page }) => {
   await expect(page.getByTestId("profile-metadata-edit")).toHaveText("Done");
   await expect(page.getByTestId("profile-about")).toBeVisible();
   await page.getByTestId("profile-display-name").fill(displayName);
+  await page.getByTestId("profile-name").fill(name);
   await page.getByTestId("profile-about").fill(about);
   await page.getByTestId("profile-metadata-edit").click();
 
   await expect(page.getByTestId("profile-display-name-value")).toHaveText(
     displayName,
   );
+  await expect(page.getByTestId("profile-name-value")).toHaveText(name);
   await expect(page.getByTestId("profile-about-value")).toHaveText(about);
 
   await page.getByTestId("profile-avatar-edit").click();
@@ -251,6 +254,7 @@ test("updates the relay-backed profile from settings", async ({ page }) => {
   await expect(page.getByTestId("profile-display-name-value")).toHaveText(
     displayName,
   );
+  await expect(page.getByTestId("profile-name-value")).toHaveText(name);
   await expect(page.getByTestId("profile-nip05")).toContainText("Not set");
   await page.getByTestId("profile-avatar-edit").click();
   await expect(page.getByTestId("profile-avatar-url")).toHaveValue("");
@@ -265,6 +269,7 @@ test("updates the relay-backed profile from settings", async ({ page }) => {
   await expect(page.getByTestId("profile-display-name-value")).toHaveText(
     displayName,
   );
+  await expect(page.getByTestId("profile-name-value")).toHaveText(name);
   await expandIdentity(page);
   await expect(page.getByTestId("profile-nip05")).toContainText("Not set");
   await page.getByTestId("profile-avatar-edit").click();
@@ -285,6 +290,7 @@ test("saves profile metadata from the block Done button", async ({ page }) => {
   await expect(page.getByTestId("profile-metadata-edit")).toHaveText("Done");
   await expect(page.getByTestId("profile-about")).toBeVisible();
   await page.getByTestId("profile-display-name").fill("Save Button QA");
+  await page.getByTestId("profile-name").fill("save-button-qa");
   await page.getByTestId("profile-about").fill("Temporary profile note");
   await expect(page.getByTestId("profile-save")).toHaveCount(0);
 
@@ -293,6 +299,9 @@ test("saves profile metadata from the block Done button", async ({ page }) => {
   await expect(page.getByTestId("profile-display-name")).toHaveCount(0);
   await expect(page.getByTestId("profile-display-name-value")).toHaveText(
     "Save Button QA",
+  );
+  await expect(page.getByTestId("profile-name-value")).toHaveText(
+    "save-button-qa",
   );
   await expect(page.getByTestId("profile-about-value")).toHaveText(
     "Temporary profile note",
@@ -306,6 +315,12 @@ test("saves profile metadata from the block Done button", async ({ page }) => {
   await waitForReactEffects(page);
   await expect(page.getByTestId("profile-about-value")).toHaveText("Not set");
   await expect(page.getByTestId("profile-save")).toHaveCount(0);
+
+  await page.getByTestId("profile-metadata-edit").click();
+  await page.getByTestId("profile-name").fill("   ");
+  await page.getByTestId("profile-metadata-edit").click();
+  await waitForReactEffects(page);
+  await expect(page.getByTestId("profile-name-value")).toHaveText("Not set");
 
   await page.getByTestId("profile-metadata-edit").click();
   await page.getByTestId("profile-display-name").fill("");


### PR DESCRIPTION
## Summary

- add an editable Nostr `name`/handle alongside the richer `display_name` in first-community onboarding and Profile settings
- carry both fields through the Desktop TypeScript and Tauri contracts while keeping the public key as canonical identity
- patch the existing raw kind-0 object so unrelated and unmodeled metadata survives profile edits, failing closed when prior metadata is malformed
- keep cache, E2E bridge, compatibility fallbacks, avatar handling, canonical post-save readback, and agent activity labels aligned with the two-field model
- add focused Rust, unit, and browser regression coverage, including delayed profile seeding after an explicit avatar clear

### Related issue

Fixes #2796

Related preservation work: #2534, #2545, #2606.

### Root cause

Buzz Desktop labels the onboarding value as a username but publishes it as `display_name`. The supported UI has no independent `name` field, even though existing metadata can contain one. The prior update path also reconstructed a modeled subset of kind-0 metadata, which could discard unrelated fields while adding the missing editor.

This patch treats `name` and `display_name` as independent metadata and updates the existing raw JSON object before signing the replacement kind-0 event. Compatibility fallback from `display_name` to `name` is limited to presentation boundaries, including sidebar, identity lookup, profile activity, and fallback agent-session labels.

### User impact

Users can represent a short Nostr handle separately from their human-facing display name without changing keys, roles, authentication, relay admission, or NIP-05. Existing display-name-only and name-only profiles remain compatible, and editing one modeled field preserves the other fields.

### Testing

Fresh post-rebase evidence at `abeeb060a` against `upstream/main` `63496cc1d`:

- `git diff --check upstream/main...HEAD`
- 3,786/3,786 Desktop frontend tests passed
- Desktop TypeScript typecheck passed
- Biome checked 1,696 Desktop files with no errors
- Desktop file-size ratchet passed with `CHECK_FILE_SIZES_BASE=upstream/main`
- focused name-only agent presentation regressions passed: 6/6
  - profile activity uses the raw `name`
  - fallback agent session uses the raw `name`
  - existing activity return-target tests remain green

The pre-rebase branch also passed the complete `just desktop-ci` gate, focused Rust profile tests, and four focused Playwright profile/onboarding tests. Fresh GitHub checks on the rebased branch are the authority for the full current snapshot.

The patch is currently `test_proven` for the Desktop frontend and focused profile paths. It does not claim supported-path runtime or end-to-end signed-event proof.

### Manual test plan

1. Create or import a profile containing different `name` and `display_name` values.
2. Open Profile settings and confirm both controls display the exact stored values.
3. Edit only the handle, save, reopen settings, and confirm the display name, avatar, about, NIP-05, and unrelated kind-0 metadata remain unchanged.
4. Edit only the display name and repeat the preservation check.
5. Run first-community onboarding with distinct handle and display-name values and inspect the signed kind-0 readback.
6. Clear the avatar before a delayed profile seed resolves and confirm the old avatar is not restored.
7. Open activity for a name-only NIP-OA agent without a managed/relay agent record and confirm its `name` is shown instead of `Agent`.

### Non-goals

- NIP-05 provisioning or verification UI
- globally unique usernames
- key, signer, role, authentication, or relay changes
- public-relay profile replication
- database migrations
