### PR TITLE
fix(mobile): retain live thread replies in channel window

### DIFF
--- a/mobile/lib/features/channels/channel_messages_provider.dart
+++ b/mobile/lib/features/channels/channel_messages_provider.dart
@@ -220,7 +220,6 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
           ),
         );
       }
-      if (!_isBroadcastReply(event)) return false;
     }
     if (!isTimelineRow &&
         !EventKind.channelAuxEventKinds.contains(event.kind)) {
@@ -459,12 +458,6 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
     });
     return true;
   }
-}
-
-bool _isBroadcastReply(NostrEvent event) {
-  return event.tags.any(
-    (tag) => tag.length >= 2 && tag[0] == 'broadcast' && tag[1] == '1',
-  );
 }
 
 int _currentUnixSeconds() => DateTime.now().millisecondsSinceEpoch ~/ 1000;

--- a/mobile/test/features/channels/channel_messages_provider_test.dart
+++ b/mobile/test/features/channels/channel_messages_provider_test.dart
@@ -7,6 +7,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:buzz/features/channels/channel_messages_provider.dart';
 import 'package:buzz/features/channels/pending_local_messages_provider.dart';
 import 'package:buzz/features/channels/thread_replies_provider.dart';
+import 'package:buzz/features/channels/timeline_message.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
 void main() {
@@ -241,6 +242,79 @@ void main() {
       ['history'],
     );
   });
+
+  test('live non-broadcast reply updates its parent thread summary', () async {
+    final relaySession = _RecordingRelaySessionNotifier(
+      queryResults: [
+        [_event(id: 'root', createdAt: 10), _bounds()],
+      ],
+    );
+    final container = _buildContainer(relaySession);
+    addTearDown(container.dispose);
+
+    container.read(channelMessagesProvider(_channelId));
+    await relaySession.subscribed;
+    await _pumpEventQueue();
+
+    relaySession.emit(
+      _event(
+        id: 'reply',
+        createdAt: 20,
+        extraTags: const [
+          ['e', 'root', '', 'reply'],
+        ],
+      ),
+    );
+    await _pumpEventQueue();
+
+    final notifier = container.read(
+      channelMessagesProvider(_channelId).notifier,
+    );
+    final events = container.read(channelMessagesProvider(_channelId)).value!;
+    final entries = buildMainTimelineEntries(
+      formatTimeline(events),
+      relaySummaries: notifier.threadSummaries,
+    );
+
+    expect(entries.single.summary?.replyCount, 1);
+  });
+
+  test(
+    'live non-broadcast reply stays out of the top-level timeline',
+    () async {
+      final relaySession = _RecordingRelaySessionNotifier(
+        queryResults: [
+          [_event(id: 'root', createdAt: 10), _bounds()],
+        ],
+      );
+      final container = _buildContainer(relaySession);
+      addTearDown(container.dispose);
+
+      container.read(channelMessagesProvider(_channelId));
+      await relaySession.subscribed;
+      await _pumpEventQueue();
+
+      relaySession.emit(
+        _event(
+          id: 'reply',
+          createdAt: 20,
+          extraTags: const [
+            ['e', 'root', '', 'reply'],
+          ],
+        ),
+      );
+      await _pumpEventQueue();
+
+      final events = container.read(channelMessagesProvider(_channelId)).value!;
+      expect(events.map((event) => event.id), ['root', 'reply']);
+      expect(
+        buildMainTimelineEntries(
+          formatTimeline(events),
+        ).map((entry) => entry.message.id),
+        ['root'],
+      );
+    },
+  );
 
   test('reconnect hydration cannot retain a rolled-back local row', () async {
     final relaySession = _RecordingRelaySessionNotifier(

--- a/mobile/test/features/channels/channel_messages_provider_test.dart
+++ b/mobile/test/features/channels/channel_messages_provider_test.dart
@@ -243,6 +243,46 @@ void main() {
     );
   });
 
+  test('reconnect hydration cannot retain a rolled-back local row', () async {
+    final relaySession = _RecordingRelaySessionNotifier(
+      queryResults: [
+        [_event(id: 'history', createdAt: 10), _bounds()],
+        [_event(id: 'history', createdAt: 10), _bounds()],
+      ],
+    );
+    final container = _buildContainer(relaySession);
+    addTearDown(container.dispose);
+
+    container.read(channelMessagesProvider(_channelId));
+    await relaySession.subscribed;
+    await _pumpEventQueue();
+    final notifier = container.read(
+      channelMessagesProvider(_channelId).notifier,
+    );
+    notifier.addLocalMessage(_event(id: 'local', createdAt: 20));
+
+    relaySession.setConnected(false);
+    await _pumpEventQueue();
+    relaySession.setConnected(true);
+    await _pumpEventQueue();
+    expect(
+      container
+          .read(channelMessagesProvider(_channelId))
+          .value
+          ?.map((event) => event.id),
+      ['history', 'local'],
+    );
+
+    notifier.removeLocalMessage('local');
+    expect(
+      container
+          .read(channelMessagesProvider(_channelId))
+          .value
+          ?.map((event) => event.id),
+      ['history'],
+    );
+  });
+
   test('live non-broadcast reply updates its parent thread summary', () async {
     final relaySession = _RecordingRelaySessionNotifier(
       queryResults: [
@@ -315,46 +355,6 @@ void main() {
       );
     },
   );
-
-  test('reconnect hydration cannot retain a rolled-back local row', () async {
-    final relaySession = _RecordingRelaySessionNotifier(
-      queryResults: [
-        [_event(id: 'history', createdAt: 10), _bounds()],
-        [_event(id: 'history', createdAt: 10), _bounds()],
-      ],
-    );
-    final container = _buildContainer(relaySession);
-    addTearDown(container.dispose);
-
-    container.read(channelMessagesProvider(_channelId));
-    await relaySession.subscribed;
-    await _pumpEventQueue();
-    final notifier = container.read(
-      channelMessagesProvider(_channelId).notifier,
-    );
-    notifier.addLocalMessage(_event(id: 'local', createdAt: 20));
-
-    relaySession.setConnected(false);
-    await _pumpEventQueue();
-    relaySession.setConnected(true);
-    await _pumpEventQueue();
-    expect(
-      container
-          .read(channelMessagesProvider(_channelId))
-          .value
-          ?.map((event) => event.id),
-      ['history', 'local'],
-    );
-
-    notifier.removeLocalMessage('local');
-    expect(
-      container
-          .read(channelMessagesProvider(_channelId))
-          .value
-          ?.map((event) => event.id),
-      ['history'],
-    );
-  });
 
   test(
     'thread replies are inserted, deduped, and rolled back locally',


### PR DESCRIPTION
## Summary

Mobile received ordinary live thread replies but discarded them at the channel-window storage boundary unless they carried `broadcast=1`. Because the replies never reached the window store, the parent message could not update its thread summary until the app reloaded the channel from the relay.

This change:

- retains live non-broadcast thread replies in the mobile channel-window store
- leaves the existing render-layer filter responsible for keeping ordinary replies out of the top-level timeline
- removes the now-unused store-layer broadcast helper
- adds regression coverage proving a live reply increments the parent reply count without becoming a top-level row

## Related issue

Fixes #3293.

An issue/PR search found no duplicates

## Testing

- `flutter test test/features/channels/channel_messages_provider_test.dart` — 15 passed
- `just mobile-check` — formatting, Flutter analysis, and mobile file-size checks passed
- `flutter test` — 826 passed, 1 skipped
- `git diff --check` — passed
- before/after smoke test on a my Pixel 8a:
  - Baseline `2ce2d71cc`: an incoming threaded reply did not update the parent summary until the app was restarted.
  - Fix `0f7fec6ca`: the parent gained the reply summary live without restart, and the reply remained out of the top-level timeline.

No screenshots or recordings captured