### PR TITLE
feat(acp): add isolated browser MCP bridge

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4140,10 +4140,37 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
 }
 
 fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
-    if config.mcp_command.is_empty() {
-        return vec![];
+    let browser = std::env::var("BUZZ_ACP_BROWSER_MCP_COMMAND")
+        .ok()
+        .filter(|command| !command.is_empty())
+        .map(|command| {
+            let args = std::env::var("BUZZ_ACP_BROWSER_MCP_ARGS")
+                .ok()
+                .and_then(|raw| serde_json::from_str::<Vec<String>>(&raw).ok())
+                .unwrap_or_default();
+            (command, args)
+        });
+    build_mcp_servers_with_browser(config, browser)
+}
+
+fn build_mcp_servers_with_browser(
+    config: &Config,
+    browser: Option<(String, Vec<String>)>,
+) -> Vec<McpServer> {
+    let mut servers = Vec::new();
+    if let Some((command, args)) = browser {
+        servers.push(McpServer {
+            name: "playwright".into(),
+            command,
+            args,
+            env: vec![],
+        });
     }
-    vec![McpServer {
+
+    if config.mcp_command.is_empty() {
+        return servers;
+    }
+    servers.push(McpServer {
         name: std::path::Path::new(&config.mcp_command)
             .file_stem()
             .and_then(|s| s.to_str())
@@ -4193,7 +4220,8 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
             }
             env
         },
-    }]
+    });
+    servers
 }
 
 #[cfg(test)]
@@ -5146,6 +5174,43 @@ mod build_mcp_servers_tests {
             servers[0].name, "mcp",
             "Path::new(\".\").file_stem() is None — should fall back to \"mcp\""
         );
+    }
+
+    #[test]
+    fn browser_mcp_is_added_alongside_dev_mcp() {
+        let config = test_config();
+        let servers = build_mcp_servers_with_browser(
+            &config,
+            Some((
+                "/opt/homebrew/bin/npx".into(),
+                vec![
+                    "--yes".into(),
+                    "@playwright/mcp@0.0.78".into(),
+                    "--browser".into(),
+                    "chrome".into(),
+                    "--isolated".into(),
+                ],
+            )),
+        );
+
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers[0].name, "playwright");
+        assert_eq!(servers[0].command, "/opt/homebrew/bin/npx");
+        assert_eq!(servers[0].args[1], "@playwright/mcp@0.0.78");
+        assert_eq!(servers[1].name, "test-mcp-server");
+    }
+
+    #[test]
+    fn browser_mcp_works_without_dev_mcp() {
+        let mut config = test_config();
+        config.mcp_command.clear();
+        let servers = build_mcp_servers_with_browser(
+            &config,
+            Some(("npx".into(), vec!["@playwright/mcp@0.0.78".into()])),
+        );
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "playwright");
     }
 }
 

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -71,6 +71,8 @@ pub(crate) const RESERVED_ENV_KEYS: &[&str] = &[
     "BUZZ_ACP_AGENT_COMMAND",
     "BUZZ_ACP_AGENT_ARGS",
     "BUZZ_ACP_MCP_COMMAND",
+    "BUZZ_ACP_BROWSER_MCP_COMMAND",
+    "BUZZ_ACP_BROWSER_MCP_ARGS",
     // Security gates: respond-to mode + allowlist + legacy owner-only
     // fallback. Overriding would make the running agent's gate diverge
     // from the saved/UI-visible settings.

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -590,6 +590,25 @@ pub fn spawn_agent_child(
             command.env("BUZZ_ACP_MCP_COMMAND", "");
         }
     }
+    // Codex's Chrome extension broker is owned by the Codex host and is not
+    // exposed through ACP. Give Buzz-managed Codex sessions an independent,
+    // isolated browser boundary via the official Playwright MCP server instead.
+    // Pin the package version so agent startup cannot silently change behavior.
+    if known_acp_runtime(effective_command).is_some_and(|runtime| runtime.id == "codex") {
+        if let Some(npx) = resolve_command("npx") {
+            command.env("BUZZ_ACP_BROWSER_MCP_COMMAND", npx);
+            command.env(
+                "BUZZ_ACP_BROWSER_MCP_ARGS",
+                r#"["--yes","@playwright/mcp@0.0.78","--browser","chrome","--isolated"]"#,
+            );
+        } else {
+            command.env("BUZZ_ACP_BROWSER_MCP_COMMAND", "");
+            command.env("BUZZ_ACP_BROWSER_MCP_ARGS", "[]");
+        }
+    } else {
+        command.env("BUZZ_ACP_BROWSER_MCP_COMMAND", "");
+        command.env("BUZZ_ACP_BROWSER_MCP_ARGS", "[]");
+    }
     // Enable MCP hook tools (_Stop, _PostCompact) for agents that need them.
     // Uses "*" because build_mcp_servers() hard-codes the server name to "buzz-mcp".
     let runtime_meta = known_acp_runtime(effective_command);


### PR DESCRIPTION
## Summary

- provision a pinned Playwright MCP server for Codex managed agents
- run the browser in isolated mode and forward it through ACP alongside the existing developer MCP
- reserve the browser bridge environment variables so user configuration cannot override the managed command
- cover browser-only and browser-plus-developer-MCP configurations

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p buzz-acp` — 618 unit tests and 9 integration tests passed
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml` — 1,813 passed, 14 ignored, then the unrelated virtual-clock test `relay_admission::tests::concurrent_429_extends_the_window_for_parked_waiters` failed (expected 5s, observed 300.001s)
- full desktop rerun hit parallel virtual-clock interference in the same `relay_admission` test module and was stopped after multiple tests exceeded 60 seconds

Task thread: `buzz://message?channel=2db0f46d-71e4-46c2-9798-3b248dac5fff&id=57ce1ee8ae97ce047b426f380176aa7153f2fcd42bc2396a3e8a6e5d39ea2153`
