### PR TITLE
fix(relay): stop claiming an unpushable filter yields an exact COUNT

### DIFF
--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -765,11 +765,18 @@ pub(crate) fn count_fallback_exceeded(candidate_count: usize) -> bool {
 /// an exact count without post-filtering.
 ///
 /// Pushed constraints: kinds, authors (single or multi), ids, since, until,
-/// channel_id (#h single), #p (single), #d (single, NIP-33-only kinds), #e (any),
-/// channel_ids (injected by caller).
+/// channel_id (#h single, and only when the value parses as a channel UUID),
+/// #p (single), #d (single, NIP-33-only kinds), #e (any), channel_ids
+/// (injected by caller).
 ///
-/// Anything else (multi-#p, #t, #a, search, multi-#h, #d on non-NIP-33)
-/// requires post-filtering and cannot use the fast COUNT path.
+/// Anything else (multi-#p, #t, #a, search, multi-#h, non-UUID #h, #d on
+/// non-NIP-33) requires post-filtering and cannot use the fast COUNT path.
+///
+/// An empty value set is never pushable, on any field. Such a filter matches
+/// nothing, but `filter_to_query_params` drops the constraint rather than
+/// emitting a predicate for it, so a pushed-down COUNT would return every
+/// candidate row instead of zero. `kinds: []` is the exception: it already
+/// becomes a match-nothing sentinel the DB layer short-circuits on.
 pub fn filter_fully_pushable(filter: &Filter) -> bool {
     // Check if filter exclusively targets NIP-33 kinds (needed for #d pushability).
     let is_nip33_only = filter.kinds.as_ref().is_some_and(|ks| {
@@ -781,10 +788,23 @@ pub fn filter_fully_pushable(filter: &Filter) -> bool {
 
     for (tag_key, tag_values) in filter.generic_tags.iter() {
         let key = tag_key.to_string();
+        // An empty value set matches no event (`filters_match` rejects a
+        // present tag key with no matching value), but no arm emits a
+        // predicate for it, so a pushed-down COUNT would return every
+        // candidate row instead of zero.
+        if tag_values.is_empty() {
+            return false;
+        }
         match key.as_str() {
             "h" => {
                 // Single #h is pushed as channel_id; multi-#h is not.
                 if tag_values.len() > 1 {
+                    return false;
+                }
+                // ...and only when the value parses as a channel UUID. Callers
+                // derive `channel_id` by parsing it, so a non-UUID value (e.g.
+                // a bare NIP-29 group id) leaves the query unconstrained.
+                if !tag_values.iter().any(|v| v.parse::<uuid::Uuid>().is_ok()) {
                     return false;
                 }
             }
@@ -811,6 +831,14 @@ pub fn filter_fully_pushable(filter: &Filter) -> bool {
                 }
             }
         }
+    }
+    // `authors: []` and `ids: []` match nothing for the same reason, and
+    // `filter_to_query_params` maps both to `None` instead of a predicate.
+    // (`kinds: []` is already handled there as a match-nothing sentinel.)
+    if filter.authors.as_ref().is_some_and(|a| a.is_empty())
+        || filter.ids.as_ref().is_some_and(|i| i.is_empty())
+    {
+        return false;
     }
     // search field is not pushed by filter_to_query_params
     if filter.search.is_some() {
@@ -1278,6 +1306,100 @@ fn topic_for_subscription(channel_id: Option<uuid::Uuid>) -> EventTopic {
 mod tests {
     use super::*;
     use nostr::{Alphabet, Filter, SingleLetterTag};
+
+    /// `filter_fully_pushable` returning `true` promises an exact count with
+    /// no post-filtering, which holds only if the filter's constraints reach
+    /// SQL. Check that implication against the query the COUNT callers build.
+    fn assert_pushable_implies_h_reaches_sql(filter: &Filter, case: &str) {
+        let community = buzz_core::tenant::CommunityId::from_uuid(uuid::Uuid::new_v4());
+        let channel_id = extract_channel_id_from_filter(filter);
+        let query = filter_to_query_params(filter, channel_id, community);
+
+        let h_tag = SingleLetterTag::lowercase(Alphabet::H);
+        if !filter.generic_tags.contains_key(&h_tag) {
+            return;
+        }
+        if filter_fully_pushable(filter) {
+            assert!(
+                query.channel_id.is_some(),
+                "{case}: filter_fully_pushable() claims an exact count, but the \
+                 #h constraint never reaches SQL (channel_id is None), so \
+                 count_events() counts every accessible channel instead",
+            );
+        }
+    }
+
+    /// A single `#h` value that is not a channel UUID, the shape a stock
+    /// NIP-29 client sends (`{"kinds":[9],"#h":["general"]}`). Nothing pushes
+    /// it into SQL, so the COUNT fast path must not be taken.
+    #[test]
+    fn single_unparseable_h_value_is_not_fully_pushable() {
+        let filter = Filter::new()
+            .kind(nostr::Kind::Custom(9))
+            .custom_tags(SingleLetterTag::lowercase(Alphabet::H), ["general"]);
+        // Assert directly too: the helper's check is gated on pushability,
+        // so alone it would run no assertion once this case is fixed.
+        assert!(
+            !filter_fully_pushable(&filter),
+            "a #h value that is not a channel UUID reaches no SQL predicate, \
+             so it must not take the exact-count fast path",
+        );
+        assert_pushable_implies_h_reaches_sql(&filter, "single non-UUID #h");
+    }
+
+    /// `authors: []` and `ids: []` are the same match-nothing shape as an
+    /// empty tag set, on fields `filter_to_query_params` maps to `None`.
+    #[test]
+    fn empty_authors_or_ids_is_never_fully_pushable() {
+        for raw in [
+            r##"{"kinds":[9],"authors":[]}"##,
+            r##"{"kinds":[9],"ids":[]}"##,
+        ] {
+            let filter: Filter = serde_json::from_str(raw).expect("filter parses");
+            assert!(
+                !filter_fully_pushable(&filter),
+                "{raw}: matches nothing but pushes no SQL predicate, so it \
+                 must not take the exact-count fast path",
+            );
+        }
+    }
+
+    /// The empty-set hole is not `#h`-specific: no generic-tag arm can
+    /// represent an empty set in SQL, and such a filter matches no event.
+    /// All of these parse straight from client JSON.
+    #[test]
+    fn empty_tag_value_set_is_never_fully_pushable() {
+        for raw in [
+            r##"{"kinds":[9],"#h":[]}"##,
+            r##"{"kinds":[9],"#p":[]}"##,
+            r##"{"kinds":[9],"#e":[]}"##,
+            r##"{"kinds":[9],"#t":[]}"##,
+            r##"{"kinds":[30078],"#d":[]}"##,
+        ] {
+            let filter: Filter = serde_json::from_str(raw).expect("filter parses");
+            assert!(
+                !filter_fully_pushable(&filter),
+                "{raw}: an empty tag-value set matches nothing but pushes no \
+                 SQL predicate, so it must not take the exact-count fast path",
+            );
+        }
+    }
+
+    /// Guard against over-correcting: a single parseable channel UUID *is*
+    /// pushed as `channel_id`, and must stay on the fast path.
+    #[test]
+    fn single_uuid_h_value_stays_fully_pushable() {
+        let channel = uuid::Uuid::new_v4();
+        let filter = Filter::new().kind(nostr::Kind::Custom(9)).custom_tags(
+            SingleLetterTag::lowercase(Alphabet::H),
+            [channel.to_string()],
+        );
+        assert!(
+            filter_fully_pushable(&filter),
+            "a single channel UUID is pushed as channel_id and must remain pushable",
+        );
+        assert_pushable_implies_h_reaches_sql(&filter, "single UUID #h");
+    }
 
     #[test]
     fn global_queries_push_access_scope_before_limit() {

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -2913,3 +2913,84 @@ async fn test_nip29_relay_rejects_last_owner_self_demotion() {
         "the last owner must keep their role"
     );
 }
+
+/// A COUNT filter whose constraint cannot become a SQL predicate must not be
+/// answered from the pushed-down exact-count path. `filter_fully_pushable`
+/// used to report these as pushable, so `/count` skipped post-filtering and
+/// returned every matching event across all of the caller's accessible
+/// channels instead of zero.
+///
+/// Affected shapes: a single `#h` value that is not a channel UUID (the shape
+/// a stock NIP-29 client sends), and an empty value set on any tag field.
+#[tokio::test]
+#[ignore]
+async fn test_count_unpushable_filters_do_not_count_all_channels() {
+    let http = relay_http_url();
+    let keys = Keys::generate();
+    let pubkey_hex = keys.public_key().to_hex();
+
+    let channel = create_test_channel(&keys).await;
+    let mut client = BuzzTestClient::connect(&relay_url(), &keys)
+        .await
+        .expect("connect");
+    for i in 0..2 {
+        let content = format!("count-probe {} {}", i, uuid::Uuid::new_v4());
+        client
+            .send_text_message(&keys, &channel, &content, 9)
+            .await
+            .expect("send message");
+    }
+    client.disconnect().await.expect("disconnect");
+
+    let http_client = reqwest::Client::new();
+    let count_of = |filter: serde_json::Value| {
+        let http_client = http_client.clone();
+        let http = http.clone();
+        let pubkey_hex = pubkey_hex.clone();
+        async move {
+            let resp = http_client
+                .post(format!("{http}/count"))
+                .header("X-Pubkey", &pubkey_hex)
+                .header("Content-Type", "application/json")
+                .body(serde_json::to_string(&serde_json::json!([filter])).unwrap())
+                .send()
+                .await
+                .expect("submit count");
+            assert!(
+                resp.status().is_success(),
+                "count failed: {}",
+                resp.status()
+            );
+            let body: serde_json::Value = resp.json().await.expect("parse count response");
+            body["count"].as_u64().expect("count field")
+        }
+    };
+
+    // Baseline: the caller can see their own channel's messages, so a wrong
+    // answer below is an over-count rather than an empty database.
+    assert_eq!(
+        count_of(serde_json::json!({"kinds": [9], "#h": [&channel]})).await,
+        2,
+        "sanity: a single channel-UUID #h still counts exactly",
+    );
+
+    // A bare NIP-29 group id parses as no channel, so nothing constrains the
+    // SQL. Before the fix this returned the caller-wide kind:9 total.
+    assert_eq!(
+        count_of(serde_json::json!({"kinds": [9], "#h": ["general"]})).await,
+        0,
+        "a #h value that is not a channel UUID must not count other channels",
+    );
+
+    // An empty value set matches nothing, on any tag field.
+    assert_eq!(
+        count_of(serde_json::json!({"kinds": [9], "#t": []})).await,
+        0,
+        "an empty #t set must not count every accessible event",
+    );
+    assert_eq!(
+        count_of(serde_json::json!({"kinds": [9], "#h": []})).await,
+        0,
+        "an empty #h set must not count every accessible event",
+    );
+}


### PR DESCRIPTION
## Problem

Fixes #3373.

`filter_fully_pushable` decides whether a NIP-45 COUNT can be answered by a plain SQL `COUNT(*)`. When it returns true, both the WebSocket COUNT handler and `POST /count` call `count_events()` with no post-filtering, on the promise in its doc comment of "an exact count without post-filtering".

Some filter shapes broke that promise, because the constraint never reached SQL at all:

- A single `#h` value that is not a channel UUID. Callers derive `channel_id` by parsing the value, so `{"kinds":[9],"#h":["general"]}`, the shape a stock NIP-29 client sends, left the query with no channel predicate while still taking the fast path. The count came back as every matching event in every channel the caller can read, instead of zero.
- An empty value set, which reaches every generic-tag arm plus `authors` and `ids`. `{"kinds":[9],"#t":[]}` matches no event, since `filters_match` rejects a present constraint with no matching value, but `filter_to_query_params` drops it rather than emitting a predicate. These parse straight from client JSON.

`kinds: []` was already handled, via the match-nothing sentinel the DB layer short-circuits on. The REQ path was never affected, because it always post-filters.

## Fix

Report these shapes as not pushable, so they take the existing bounded `query_events` plus `filters_match` fallback, which already computes the correct total. A single `#h` that does parse as a UUID still pins the narrower `channel_id` predicate and stays on the fast path.

Falling back rather than short-circuiting to zero is deliberate for the `#h` case: `filters_match` compares the h-tag literal, and `requires_h_channel_scope` only forces a resolvable h tag for channel-scoped kinds, so an event can legitimately carry a non-UUID h tag and match.

For the empty-set case there is a cheaper option I did not take here: emit the match-nothing sentinel from `filter_to_query_params` so the count stays exact and costs no query. That overloads the sentinel across every consumer of the shared query builder, so it seemed better as its own change if you want it.

## Testing

Unit tests in `handlers::req::tests` cover the non-UUID `#h`, empty tag sets on `#h`/`#p`/`#e`/`#t`/`#d`, and empty `authors`/`ids`, plus a guard test that a single UUID `#h` stays pushable. Each guard was confirmed load-bearing by deleting it on its own and watching its test fail.

`test_count_unpushable_filters_do_not_count_all_channels` in `e2e_relay.rs` covers the wire behavior. Against a relay built from `main` it fails, returning 4 for `{"kinds":[9],"#h":["general"]}` where the answer is 0, counting messages from an unrelated open channel. With the fix it returns 0. Its control assertion, a filter naming the channel's real UUID, returns 2 on both.

`cargo fmt --all --check`, `clippy --workspace --all-targets -D warnings`, and the `buzz-relay` unit suite are clean. One unrelated failure, `api::mesh_demo::demo_join_forwarded_arm_round_trips_echo`, reproduces identically on `main`.

Unrelated but noticed while working here: `uuid::Uuid::parse_str` accepts simple, braced, urn, and uppercase spellings, so a non-canonical `#h` pins `channel_id` while `filters_match` compares the literal and rejects it, making COUNT and REQ disagree. That predates this change and I left it alone, since the right answer depends on whether UUID or literal equality is authoritative for `#h`.
