### PR TITLE
feat(projects): add issue board view

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -99,6 +99,7 @@ export default defineConfig({
         "**/inbox-reactions.spec.ts",
         "**/send-channel-binding.spec.ts",
         "**/project-commit-detail.spec.ts",
+        "**/project-issues-board.spec.ts",
         "**/project-inbox.spec.ts",
         "**/project-pr-review.spec.ts",
         "**/persona-model-combobox-screenshots.spec.ts",

--- a/desktop/src/features/projects/lib/projectIssueBoard.d.mts
+++ b/desktop/src/features/projects/lib/projectIssueBoard.d.mts
@@ -1,0 +1,14 @@
+import type { ProjectIssueListItem } from "@/features/projects/hooks";
+import type { ProjectIssueStatus } from "@/features/projects/projectIssues.mjs";
+
+export type ProjectIssueBoardColumn = {
+  status: ProjectIssueStatus;
+  issues: ProjectIssueListItem[];
+};
+
+export function normalizeProjectIssueBoardStatus(
+  status: string,
+): ProjectIssueStatus;
+export function groupProjectIssuesForBoard(
+  issues: ProjectIssueListItem[],
+): ProjectIssueBoardColumn[];

--- a/desktop/src/features/projects/lib/projectIssueBoard.mjs
+++ b/desktop/src/features/projects/lib/projectIssueBoard.mjs
@@ -1,0 +1,41 @@
+import {
+  PROJECT_ISSUE_STATUS,
+  PROJECT_ISSUE_STATUS_ORDER,
+} from "../projectIssues.mjs";
+
+const KNOWN_STATUSES = new Set(PROJECT_ISSUE_STATUS_ORDER);
+
+export function normalizeProjectIssueBoardStatus(status) {
+  return KNOWN_STATUSES.has(status) ? status : PROJECT_ISSUE_STATUS.BACKLOG;
+}
+
+function compareByLastTouched(left, right) {
+  const updatedDifference = right.issue.updatedAt - left.issue.updatedAt;
+  if (updatedDifference !== 0) return updatedDifference;
+
+  const createdDifference = right.issue.createdAt - left.issue.createdAt;
+  if (createdDifference !== 0) return createdDifference;
+
+  return left.issue.title.localeCompare(right.issue.title);
+}
+
+export function groupProjectIssuesForBoard(issues) {
+  const columns = PROJECT_ISSUE_STATUS_ORDER.map((status) => ({
+    status,
+    issues: [],
+  }));
+  const columnsByStatus = new Map(
+    columns.map((column) => [column.status, column]),
+  );
+
+  for (const issue of issues) {
+    const status = normalizeProjectIssueBoardStatus(issue.issue.status);
+    columnsByStatus.get(status)?.issues.push(issue);
+  }
+
+  for (const column of columns) {
+    column.issues.sort(compareByLastTouched);
+  }
+
+  return columns;
+}

--- a/desktop/src/features/projects/lib/projectIssueBoard.test.mjs
+++ b/desktop/src/features/projects/lib/projectIssueBoard.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  groupProjectIssuesForBoard,
+  normalizeProjectIssueBoardStatus,
+} from "./projectIssueBoard.mjs";
+import {
+  PROJECT_ISSUE_STATUS,
+  PROJECT_ISSUE_STATUS_ORDER,
+} from "../projectIssues.mjs";
+
+function item({
+  id,
+  status,
+  updatedAt,
+  createdAt = updatedAt - 10,
+  title = id,
+}) {
+  return {
+    project: { id: `project-${id}` },
+    issue: { id, status, updatedAt, createdAt, title },
+  };
+}
+
+test("board columns follow the canonical issue status order", () => {
+  const columns = groupProjectIssuesForBoard(
+    PROJECT_ISSUE_STATUS_ORDER.map((status, index) =>
+      item({ id: `${index}`, status, updatedAt: index }),
+    ),
+  );
+
+  assert.deepEqual(
+    columns.map((column) => column.status),
+    PROJECT_ISSUE_STATUS_ORDER,
+  );
+  assert.deepEqual(
+    columns.map((column) => column.issues[0]?.issue.status),
+    PROJECT_ISSUE_STATUS_ORDER,
+  );
+});
+
+test("issues sort by last touched without mutating the source array", () => {
+  const issues = [
+    item({ id: "older", status: "Backlog", updatedAt: 10 }),
+    item({ id: "newer", status: "Backlog", updatedAt: 30 }),
+    item({ id: "middle", status: "Backlog", updatedAt: 20 }),
+  ];
+  const sourceOrder = issues.map(({ issue }) => issue.id);
+
+  const backlog = groupProjectIssuesForBoard(issues).find(
+    (column) => column.status === PROJECT_ISSUE_STATUS.BACKLOG,
+  );
+
+  assert.deepEqual(
+    backlog.issues.map(({ issue }) => issue.id),
+    ["newer", "middle", "older"],
+  );
+  assert.deepEqual(
+    issues.map(({ issue }) => issue.id),
+    sourceOrder,
+  );
+});
+
+test("unknown statuses remain visible in Backlog", () => {
+  const unknown = item({
+    id: "future",
+    status: "Future status",
+    updatedAt: 10,
+  });
+  const columns = groupProjectIssuesForBoard([unknown]);
+
+  assert.equal(
+    normalizeProjectIssueBoardStatus(unknown.issue.status),
+    PROJECT_ISSUE_STATUS.BACKLOG,
+  );
+  assert.equal(
+    columns.find((column) => column.status === PROJECT_ISSUE_STATUS.BACKLOG)
+      .issues[0],
+    unknown,
+  );
+});
+
+test("empty input keeps valid empty columns", () => {
+  const columns = groupProjectIssuesForBoard([]);
+
+  assert.equal(columns.length, PROJECT_ISSUE_STATUS_ORDER.length);
+  assert.ok(columns.every((column) => column.issues.length === 0));
+});
+
+test("Done and Closed remain separate", () => {
+  const columns = groupProjectIssuesForBoard([
+    item({ id: "done", status: "Done", updatedAt: 20 }),
+    item({ id: "closed", status: "Closed", updatedAt: 10 }),
+  ]);
+
+  assert.deepEqual(
+    columns
+      .filter((column) => column.issues.length > 0)
+      .map((column) => [column.status, column.issues[0].issue.id]),
+    [
+      [PROJECT_ISSUE_STATUS.DONE, "done"],
+      [PROJECT_ISSUE_STATUS.CLOSED, "closed"],
+    ],
+  );
+});

--- a/desktop/src/features/projects/lib/projectsViewHelpers.ts
+++ b/desktop/src/features/projects/lib/projectsViewHelpers.ts
@@ -6,6 +6,7 @@ import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 
 export type ProjectsViewMode = "grid" | "list";
+export type ProjectsIssueViewMode = ProjectsViewMode | "board";
 export type ProjectsRepositoryScope = "all" | "mine" | "local";
 export type ProjectsWorkItemScope = "all" | "mine";
 export type ProjectsFilter =
@@ -20,6 +21,7 @@ export type ProjectsFilter =
 export type ProjectsSort = "updated" | "created" | "name";
 
 const PROJECTS_VIEW_MODE_STORAGE_KEY = "buzz.projects.viewMode";
+const PROJECTS_ISSUE_VIEW_MODE_STORAGE_KEY = "buzz.projects.issueViewMode";
 const PROJECTS_FILTER_STORAGE_KEY = "buzz.projects.filter";
 const PROJECTS_REPOSITORY_SCOPE_STORAGE_KEY = "buzz.projects.repositoryScope";
 const PROJECTS_PULL_REQUEST_SCOPE_STORAGE_KEY =
@@ -41,6 +43,28 @@ export function readStoredViewMode(): ProjectsViewMode | null {
 export function writeStoredViewMode(viewMode: ProjectsViewMode) {
   try {
     globalThis.localStorage?.setItem(PROJECTS_VIEW_MODE_STORAGE_KEY, viewMode);
+  } catch {
+    // Persistence is best-effort; the in-memory toggle still works.
+  }
+}
+
+export function readStoredIssueViewMode(): ProjectsIssueViewMode {
+  try {
+    const value = globalThis.localStorage?.getItem(
+      PROJECTS_ISSUE_VIEW_MODE_STORAGE_KEY,
+    );
+    return value === "grid" || value === "board" ? value : "list";
+  } catch {
+    return "list";
+  }
+}
+
+export function writeStoredIssueViewMode(viewMode: ProjectsIssueViewMode) {
+  try {
+    globalThis.localStorage?.setItem(
+      PROJECTS_ISSUE_VIEW_MODE_STORAGE_KEY,
+      viewMode,
+    );
   } catch {
     // Persistence is best-effort; the in-memory toggle still works.
   }

--- a/desktop/src/features/projects/projectIssues.d.mts
+++ b/desktop/src/features/projects/projectIssues.d.mts
@@ -41,6 +41,8 @@ export const PROJECT_ISSUE_STATUS: {
   CLOSED: "Closed";
 };
 
+export const PROJECT_ISSUE_STATUS_ORDER: readonly ProjectIssueStatus[];
+
 export function getTag(event: RelayEvent, name: string): string | undefined;
 export function getAllTags(event: RelayEvent, name: string): string[];
 export function getImetaTags(event: RelayEvent): string[][];

--- a/desktop/src/features/projects/projectIssues.mjs
+++ b/desktop/src/features/projects/projectIssues.mjs
@@ -7,6 +7,15 @@ export const PROJECT_ISSUE_STATUS = {
   CLOSED: "Closed",
 };
 
+export const PROJECT_ISSUE_STATUS_ORDER = Object.freeze([
+  PROJECT_ISSUE_STATUS.TRIAGE,
+  PROJECT_ISSUE_STATUS.BACKLOG,
+  PROJECT_ISSUE_STATUS.IN_PROGRESS,
+  PROJECT_ISSUE_STATUS.IN_REVIEW,
+  PROJECT_ISSUE_STATUS.DONE,
+  PROJECT_ISSUE_STATUS.CLOSED,
+]);
+
 function isNonEmptyString(value) {
   return typeof value === "string" && value.length > 0;
 }

--- a/desktop/src/features/projects/ui/ProjectsIssuesBoard.tsx
+++ b/desktop/src/features/projects/ui/ProjectsIssuesBoard.tsx
@@ -1,0 +1,249 @@
+import { Clock3, Hash, MessageSquare, Tag, Users } from "lucide-react";
+
+import type {
+  Project,
+  ProjectIssue,
+  ProjectIssueListItem,
+} from "@/features/projects/hooks";
+import {
+  groupProjectIssuesForBoard,
+  normalizeProjectIssueBoardStatus,
+} from "@/features/projects/lib/projectIssueBoard.mjs";
+import { relativeTime } from "@/features/projects/lib/projectsViewHelpers";
+import type { ProjectWorkItemSection } from "@/features/projects/projectWorkItems";
+import {
+  resolveUserLabel,
+  type UserProfileLookup,
+} from "@/features/profile/lib/identity";
+import { Card } from "@/shared/ui/card";
+import { ProjectsWorkItemsLoadNotice } from "./ProjectsWorkItemsLoadNotice";
+
+type ProjectsIssuesBoardProps = {
+  error: unknown;
+  failedSections: ProjectWorkItemSection[];
+  isLoading: boolean;
+  isRetrying: boolean;
+  issues: ProjectIssueListItem[];
+  onOpen: (project: Project, issue: ProjectIssue) => void;
+  onRetry: () => void;
+  profiles?: UserProfileLookup;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function IssueBoardCard({
+  issue,
+  onOpen,
+  profiles,
+  project,
+}: {
+  issue: ProjectIssue;
+  onOpen: (project: Project, issue: ProjectIssue) => void;
+  profiles?: UserProfileLookup;
+  project: Project;
+}) {
+  const people = [...new Set([issue.author, ...issue.recipients])];
+  const peopleLabel = people
+    .map((pubkey) => resolveUserLabel({ profiles, pubkey }))
+    .join(", ");
+  const visibleLabels = issue.labels.slice(0, 2);
+  const hiddenLabelCount = issue.labels.length - visibleLabels.length;
+  const hasChannelBinding =
+    project.projectChannelId !== null &&
+    UUID_PATTERN.test(project.projectChannelId);
+
+  return (
+    <Card
+      asChild
+      className="rounded-lg border-border/60 bg-card/70 shadow-none transition-colors duration-150 hover:bg-muted/30 focus-within:border-ring"
+    >
+      <button
+        aria-label={`Open ${issue.title} in ${project.name}`}
+        className="block w-full p-3 text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+        data-testid={`projects-issue-board-card-${issue.id}`}
+        onClick={() => onOpen(project, issue)}
+        type="button"
+      >
+        <div className="flex items-start justify-between gap-2">
+          <span className="line-clamp-2 text-sm font-medium leading-5 text-foreground">
+            {issue.title}
+          </span>
+          <span className="shrink-0 rounded-md border border-border/60 bg-muted/30 px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
+            {normalizeProjectIssueBoardStatus(issue.status)}
+          </span>
+        </div>
+
+        <p className="mt-1 truncate text-xs text-muted-foreground">
+          {project.name}
+        </p>
+
+        {visibleLabels.length > 0 ? (
+          <div
+            className="mt-2 flex min-w-0 flex-wrap items-center gap-1"
+            title={`Labels: ${issue.labels.join(", ")}`}
+          >
+            <Tag className="h-3 w-3 shrink-0 text-muted-foreground" />
+            {visibleLabels.map((label) => (
+              <span
+                className="max-w-24 truncate rounded-md bg-muted/50 px-1.5 py-0.5 text-2xs text-muted-foreground"
+                key={label}
+              >
+                {label}
+              </span>
+            ))}
+            {hiddenLabelCount > 0 ? (
+              <span className="text-2xs text-muted-foreground">
+                +{hiddenLabelCount}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+
+        <div className="mt-3 flex flex-wrap items-center gap-x-2.5 gap-y-1 border-t border-border/50 pt-2 text-2xs text-muted-foreground">
+          <span className="flex items-center gap-1" title={peopleLabel}>
+            <Users className="h-3 w-3" />
+            {people.length}
+            <span className="sr-only">
+              {people.length === 1 ? "person" : "people"}
+            </span>
+          </span>
+          <span className="flex items-center gap-1">
+            <MessageSquare className="h-3 w-3" />
+            {issue.comments.length}
+            <span className="sr-only">
+              {issue.comments.length === 1 ? "comment" : "comments"}
+            </span>
+          </span>
+          <span
+            className="flex items-center gap-1"
+            title={new Date(issue.updatedAt * 1_000).toLocaleString()}
+          >
+            <Clock3 className="h-3 w-3" />
+            {relativeTime(issue.updatedAt)}
+          </span>
+        </div>
+
+        <div className="mt-1.5 flex min-w-0 items-center justify-between gap-2 text-2xs text-muted-foreground">
+          <span className="flex items-center gap-0.5 font-mono">
+            <Hash className="h-3 w-3" />
+            {issue.id.slice(0, 8)}
+          </span>
+          {hasChannelBinding ? (
+            <span
+              className="max-w-28 truncate"
+              title={`Project channel ${project.projectChannelId}`}
+            >
+              Channel {project.projectChannelId?.slice(0, 8)}
+            </span>
+          ) : null}
+        </div>
+      </button>
+    </Card>
+  );
+}
+
+export function ProjectsIssuesBoard({
+  error,
+  failedSections,
+  isLoading,
+  isRetrying,
+  issues,
+  onOpen,
+  onRetry,
+  profiles,
+}: ProjectsIssuesBoardProps) {
+  if (isLoading) {
+    return (
+      <div className="border border-border/60 px-4 py-12 text-center text-sm text-muted-foreground">
+        Loading issue board...
+      </div>
+    );
+  }
+
+  const loadNotice = (
+    <ProjectsWorkItemsLoadNotice
+      error={error}
+      failedSections={failedSections}
+      isRetrying={isRetrying}
+      onRetry={onRetry}
+      subject="issues"
+    />
+  );
+
+  if (error && issues.length === 0) {
+    return loadNotice;
+  }
+
+  if (issues.length === 0) {
+    return (
+      <div className="space-y-3">
+        {loadNotice}
+        <div className="border border-dashed border-border/60 px-4 py-12 text-center text-sm text-muted-foreground">
+          No issues yet.
+        </div>
+      </div>
+    );
+  }
+
+  const columns = groupProjectIssuesForBoard(issues);
+
+  return (
+    <div className="space-y-3">
+      {loadNotice}
+      <section
+        aria-label="Issues board"
+        className="max-w-full overflow-x-auto pb-2"
+        data-testid="projects-issues-board"
+      >
+        <div className="grid min-w-max grid-flow-col auto-cols-72 gap-3">
+          {columns.map((column) => {
+            const columnId = `issue-board-${column.status
+              .toLowerCase()
+              .replaceAll(" ", "-")}`;
+            return (
+              <section
+                aria-labelledby={columnId}
+                className="w-72 rounded-xl border border-border/60 bg-muted/15 p-2.5"
+                key={column.status}
+              >
+                <div className="mb-2.5 flex items-center justify-between gap-2 px-0.5">
+                  <h2
+                    className="text-xs font-semibold text-foreground"
+                    id={columnId}
+                  >
+                    {column.status}
+                  </h2>
+                  <span className="rounded-md bg-muted/60 px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
+                    {column.issues.length}
+                    <span className="sr-only">
+                      {column.issues.length === 1 ? " issue" : " issues"}
+                    </span>
+                  </span>
+                </div>
+                {column.issues.length === 0 ? (
+                  <p className="rounded-lg border border-dashed border-border/50 px-3 py-8 text-center text-xs text-muted-foreground">
+                    No {column.status.toLowerCase()} issues
+                  </p>
+                ) : (
+                  <ul className="space-y-2">
+                    {column.issues.map(({ issue, project }) => (
+                      <li key={issue.id}>
+                        <IssueBoardCard
+                          issue={issue}
+                          onOpen={onOpen}
+                          profiles={profiles}
+                          project={project}
+                        />
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/desktop/src/features/projects/ui/ProjectsToolbar.tsx
+++ b/desktop/src/features/projects/ui/ProjectsToolbar.tsx
@@ -1,7 +1,8 @@
-import { LayoutGrid, List } from "lucide-react";
+import { Columns3, LayoutGrid, List } from "lucide-react";
 
 import type {
   ProjectsFilter,
+  ProjectsIssueViewMode,
   ProjectsViewMode,
 } from "@/features/projects/lib/projectsViewHelpers";
 import { cn } from "@/shared/lib/cn";
@@ -47,6 +48,43 @@ export function ProjectsViewModeToggle({
       >
         <List className="h-3.5 w-3.5" />
       </Button>
+    </fieldset>
+  );
+}
+
+export function ProjectsIssueViewModeToggle({
+  viewMode,
+  onViewModeChange,
+}: {
+  viewMode: ProjectsIssueViewMode;
+  onViewModeChange: (viewMode: ProjectsIssueViewMode) => void;
+}) {
+  const options = [
+    { icon: LayoutGrid, label: "Grid layout", value: "grid" },
+    { icon: List, label: "List layout", value: "list" },
+    { icon: Columns3, label: "Board layout", value: "board" },
+  ] as const;
+
+  return (
+    <fieldset className="flex items-center rounded-lg bg-muted/30 p-0.5">
+      <legend className="sr-only">Issue layout</legend>
+      {options.map((option) => {
+        const Icon = option.icon;
+        return (
+          <Button
+            aria-label={option.label}
+            aria-pressed={viewMode === option.value}
+            className="h-7 w-7 px-0"
+            key={option.value}
+            onClick={() => onViewModeChange(option.value)}
+            size="xs"
+            type="button"
+            variant={viewMode === option.value ? "secondary" : "ghost"}
+          >
+            <Icon className="h-3.5 w-3.5" />
+          </Button>
+        );
+      })}
     </fieldset>
   );
 }

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -27,6 +27,7 @@ import { CreateProjectIssueDialog } from "@/features/projects/ui/CreateProjectIs
 import { CreatePullRequestDialog } from "@/features/projects/ui/CreatePullRequestDialog";
 import { ProjectsCreateMenu } from "@/features/projects/ui/ProjectsCreateMenu";
 import { ProjectsIssuesList } from "@/features/projects/ui/ProjectsIssuesList";
+import { ProjectsIssuesBoard } from "@/features/projects/ui/ProjectsIssuesBoard";
 import { ProjectsOverviewPanel } from "@/features/projects/ui/ProjectsOverviewPanel";
 import { ProjectsOverviewRail } from "@/features/projects/ui/ProjectsOverviewRail";
 import { ProjectsPullRequestsList } from "@/features/projects/ui/ProjectsPullRequestsList";
@@ -35,6 +36,7 @@ import { ProjectsListScopeDropdown } from "@/features/projects/ui/ProjectsListSc
 import { PROJECT_LIST_CONTAINER_CLASS } from "@/features/projects/ui/projectListRowStyles";
 import {
   ProjectsToolbar,
+  ProjectsIssueViewModeToggle,
   ProjectsViewModeToggle,
 } from "@/features/projects/ui/ProjectsToolbar";
 import { hasLocalCheckout } from "@/features/projects/lib/projectLocalRepos";
@@ -46,12 +48,14 @@ import {
   projectOwnerIsUser,
   projectPeople,
   type ProjectsFilter,
+  type ProjectsIssueViewMode,
   type ProjectsRepositoryScope,
   type ProjectsSort,
   type ProjectsViewMode,
   type ProjectsWorkItemScope,
   readStoredFilter,
   readStoredIssueScope,
+  readStoredIssueViewMode,
   readStoredPullRequestScope,
   readStoredRepositoryScope,
   readStoredSort,
@@ -59,6 +63,7 @@ import {
   uniqueRepositories,
   writeStoredFilter,
   writeStoredIssueScope,
+  writeStoredIssueViewMode,
   writeStoredPullRequestScope,
   writeStoredRepositoryScope,
   writeStoredSort,
@@ -161,6 +166,8 @@ export function ProjectsView() {
   const [issueScope, setIssueScope] = React.useState<ProjectsWorkItemScope>(
     () => readStoredIssueScope(),
   );
+  const [issueViewMode, setIssueViewMode] =
+    React.useState<ProjectsIssueViewMode>(() => readStoredIssueViewMode());
   const projectsWorkItemsQuery = useProjectsWorkItemsQuery(
     filter === "all" || filter === "prs" || filter === "issues" ? projects : [],
   );
@@ -256,6 +263,14 @@ export function ProjectsView() {
     (scope: ProjectsWorkItemScope) => {
       setIssueScope(scope);
       writeStoredIssueScope(scope);
+    },
+    [],
+  );
+
+  const handleIssueViewModeChange = React.useCallback(
+    (nextViewMode: ProjectsIssueViewMode) => {
+      setIssueViewMode(nextViewMode);
+      writeStoredIssueViewMode(nextViewMode);
     },
     [],
   );
@@ -505,24 +520,37 @@ export function ProjectsView() {
 
   const listControls = (
     <div className="flex flex-wrap items-center gap-2 sm:justify-end">
-      <label className="flex items-center gap-2 text-xs text-muted-foreground">
-        <span className="sr-only">Sort projects</span>
-        <select
-          className="h-8 rounded-md bg-transparent px-2 text-xs text-foreground outline-hidden hover:bg-muted/50 focus:ring-1 focus:ring-ring"
-          onChange={(event) =>
-            handleSortChange(event.target.value as ProjectsSort)
-          }
-          value={sort}
-        >
-          <option value="updated">Recent activity</option>
-          <option value="created">Created date</option>
-          <option value="name">Name</option>
-        </select>
-      </label>
-      <ProjectsViewModeToggle
-        onViewModeChange={handleViewModeChange}
-        viewMode={viewMode}
-      />
+      {filter === "issues" && issueViewMode === "board" ? (
+        <span className="text-xs text-muted-foreground">
+          Most recently touched first
+        </span>
+      ) : (
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="sr-only">Sort projects</span>
+          <select
+            className="h-8 rounded-md bg-transparent px-2 text-xs text-foreground outline-hidden hover:bg-muted/50 focus:ring-1 focus:ring-ring"
+            onChange={(event) =>
+              handleSortChange(event.target.value as ProjectsSort)
+            }
+            value={sort}
+          >
+            <option value="updated">Recent activity</option>
+            <option value="created">Created date</option>
+            <option value="name">Name</option>
+          </select>
+        </label>
+      )}
+      {filter === "issues" ? (
+        <ProjectsIssueViewModeToggle
+          onViewModeChange={handleIssueViewModeChange}
+          viewMode={issueViewMode}
+        />
+      ) : (
+        <ProjectsViewModeToggle
+          onViewModeChange={handleViewModeChange}
+          viewMode={viewMode}
+        />
+      )}
     </div>
   );
 
@@ -714,6 +742,22 @@ export function ProjectsView() {
                       pullRequests={visiblePullRequests}
                       viewMode={viewMode}
                     />
+                  ) : filter === "issues" && issueViewMode === "board" ? (
+                    <ProjectsIssuesBoard
+                      error={projectsWorkItemsQuery.error}
+                      failedSections={
+                        projectsWorkItemsQuery.data?.issues.failedSections ?? []
+                      }
+                      isLoading={projectsWorkItemsQuery.isLoading}
+                      isRetrying={
+                        projectsWorkItemsQuery.isFetching &&
+                        !projectsWorkItemsQuery.isLoading
+                      }
+                      issues={visibleIssues}
+                      onOpen={handleOpenIssue}
+                      onRetry={() => void projectsWorkItemsQuery.refetch()}
+                      profiles={profiles}
+                    />
                   ) : filter === "issues" ? (
                     <ProjectsIssuesList
                       error={projectsWorkItemsQuery.error}
@@ -729,7 +773,7 @@ export function ProjectsView() {
                       onOpen={handleOpenIssue}
                       onRetry={() => void projectsWorkItemsQuery.refetch()}
                       profiles={profiles}
-                      viewMode={viewMode}
+                      viewMode={issueViewMode === "grid" ? "grid" : "list"}
                     />
                   ) : (
                     repositoryItems

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -4956,6 +4956,7 @@ function buildMockProjectEvents(): RelayEvent[] {
   const daySeconds = 86_400;
   const now = Math.floor(Date.now() / 1000);
   const historyDays = 26 * 7;
+  let issueOrdinal = 0;
 
   for (const [projectIndex, seed] of MOCK_PROJECT_SEEDS.entries()) {
     const owner =
@@ -5034,6 +5035,15 @@ function buildMockProjectEvents(): RelayEvent[] {
         const tags = [
           ["a", repoAddress],
           ["subject", subject],
+          ...(kind === KIND_GIT_ISSUE && issueOrdinal % 6 === 0
+            ? [["t", "triage"]]
+            : []),
+          ...(kind === KIND_GIT_ISSUE && issueOrdinal % 6 === 2
+            ? [["t", "in-progress"]]
+            : []),
+          ...(kind === KIND_GIT_ISSUE && issueOrdinal % 6 === 3
+            ? [["t", "in-review"]]
+            : []),
           ...(kind === KIND_GIT_ISSUE ? [] : [["c", commitHash]]),
           ...(kind === KIND_GIT_PULL_REQUEST
             ? [
@@ -5047,7 +5057,40 @@ function buildMockProjectEvents(): RelayEvent[] {
             : []),
         ];
 
-        events.push(createMockEvent(kind, subject, tags, author, createdAt));
+        const rootEvent = createMockEvent(
+          kind,
+          subject,
+          tags,
+          author,
+          createdAt,
+        );
+        events.push(rootEvent);
+
+        if (kind === KIND_GIT_ISSUE) {
+          const statusKind = [
+            KIND_GIT_STATUS_DRAFT,
+            null,
+            null,
+            null,
+            KIND_GIT_STATUS_MERGED,
+            KIND_GIT_STATUS_CLOSED,
+          ][issueOrdinal % 6];
+          if (statusKind !== null) {
+            events.push(
+              createMockEvent(
+                statusKind,
+                "",
+                [
+                  ["a", repoAddress],
+                  ["e", rootEvent.id, "", "root"],
+                ],
+                author,
+                createdAt + 30,
+              ),
+            );
+          }
+          issueOrdinal += 1;
+        }
       }
     }
   }

--- a/desktop/tests/e2e/project-issues-board.spec.ts
+++ b/desktop/tests/e2e/project-issues-board.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge } from "../helpers/bridge";
+
+test.setTimeout(90_000);
+
+const SHOTS = "test-results/project-issues-board";
+const ISSUE_STATUSES = [
+  "Triage",
+  "Backlog",
+  "In Progress",
+  "In Review",
+  "Done",
+  "Closed",
+] as const;
+
+async function seedBoard(page: Page, theme: "buzz" | "buzz-dark" = "buzz") {
+  await page.addInitScript(
+    ({ selectedTheme }) => {
+      window.localStorage.setItem(
+        "buzz-feature-overrides-v1",
+        JSON.stringify({ projects: true }),
+      );
+      window.localStorage.setItem("buzz.projects.issueViewMode", "board");
+      window.localStorage.setItem("buzz-theme", selectedTheme);
+    },
+    { selectedTheme: theme },
+  );
+}
+
+async function openBoard(page: Page) {
+  await installMockBridge(page);
+  const projectsButton = page.getByTestId("open-projects-view");
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    try {
+      await projectsButton.waitFor({ state: "visible", timeout: 20_000 });
+      break;
+    } catch (error) {
+      if (attempt === 2) throw error;
+    }
+  }
+  await projectsButton.click();
+  await page.getByRole("button", { name: "Issues", exact: true }).click();
+  await expect(
+    page.getByRole("region", { name: "Issues board" }),
+  ).toBeVisible();
+}
+
+test("issue board persists, scrolls responsively, and opens issue detail", async ({
+  page,
+}) => {
+  await page.setViewportSize({ height: 900, width: 1440 });
+  await seedBoard(page);
+  await openBoard(page);
+
+  const board = page.getByRole("region", { name: "Issues board" });
+  for (const status of ISSUE_STATUSES) {
+    await expect(
+      board.getByRole("heading", { name: status, exact: true }),
+    ).toBeVisible();
+  }
+  await expect(
+    board.locator('[data-testid^="projects-issue-board-card-"]').first(),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "List layout" }).click();
+  await expect(
+    page.locator('[data-testid^="projects-issue-row-"]').first(),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        window.localStorage.getItem("buzz.projects.issueViewMode"),
+      ),
+    )
+    .toBe("list");
+
+  await page.getByRole("button", { name: "Board layout" }).click();
+  await expect(board).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        window.localStorage.getItem("buzz.projects.issueViewMode"),
+      ),
+    )
+    .toBe("board");
+
+  await waitForAnimations(page);
+  await page.screenshot({
+    path: `${SHOTS}/01-board-light.png`,
+  });
+
+  await page.setViewportSize({ height: 760, width: 820 });
+  await expect
+    .poll(() =>
+      board.evaluate((element) => element.scrollWidth > element.clientWidth),
+    )
+    .toBe(true);
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth,
+    ),
+  ).toBe(true);
+  await waitForAnimations(page);
+  await page.screenshot({
+    path: `${SHOTS}/02-board-narrow.png`,
+  });
+
+  const firstCard = board
+    .locator('[data-testid^="projects-issue-board-card-"]')
+    .first();
+  const cardName = await firstCard.getAttribute("aria-label");
+  await firstCard.focus();
+  await expect(firstCard).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(
+    page.getByRole("heading", {
+      name: cardName?.replace(/^Open /, "").replace(/ in .*$/, ""),
+    }),
+  ).toBeVisible();
+});
+
+test("issue board renders in the Buzz dark theme", async ({ page }) => {
+  await page.setViewportSize({ height: 900, width: 1440 });
+  await seedBoard(page, "buzz-dark");
+  await openBoard(page);
+
+  await expect(page.locator("html")).toHaveClass(/dark/);
+  await waitForAnimations(page);
+  await page.screenshot({
+    path: `${SHOTS}/03-board-dark.png`,
+  });
+});


### PR DESCRIPTION
## Summary

Adds a third, persisted **Board** layout to Projects → Issues while preserving the existing list and grid views.

The board groups issues into Buzz's canonical lifecycle:

- Triage
- Backlog
- In Progress
- In Review
- Done
- Closed

Within each column, cards are ordered by most recent activity and expose the project, labels, people count, comment count, last-touched time, short issue ID, and a valid project-channel binding when present. Cards remain keyboard-operable and open the existing issue detail surface.

## Why

Issue #2934 asks for a practical issue-board surface in Projects. The existing data model already derives lifecycle status, so this PR stays UI-only: no schema, relay protocol, or migration changes.

This deliberately does not redefine issue assignees. PR #3348 is adding explicit assignment semantics; until that lands, the card's **People** count reflects the existing author/recipient model.

Refs #2934.

## Validation

- `pnpm --dir desktop test` — 3,736 passed
- `pnpm --dir desktop typecheck` — passed
- `pnpm --dir desktop check` — passed
- `pnpm --dir desktop build:e2e` — passed
- `pnpm --dir desktop exec playwright test tests/e2e/project-issues-board.spec.ts` — 2 passed
- `just test-unit` — passed (277 auth/core, 85 DB with 139 skipped, 22 conformance, 15 push-gateway with 6 skipped)
- `just ci` — formatting, workspace clippy, desktop/web checks, Flutter analysis, desktop unit tests, production build, and Tauri check passed; the final Tauri test run did not complete because the existing `relay_admission::tests::gate_armed_by_one_path_withholds_another_path` held the shared test lock for more than five minutes, leaving nine sibling tests blocked. The run was stopped and is not represented as green.

## Screenshots

Screenshots cover wide/light, narrow horizontal scrolling, and dark theme. They will be attached in a follow-up comment.
