### PR TITLE
feat(cli): add `buzz agents attest` for externally-generated agent keys

### DIFF
--- a/crates/buzz-cli/src/commands/agents.rs
+++ b/crates/buzz-cli/src/commands/agents.rs
@@ -148,7 +148,42 @@ pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), Cli
         }
 
         AgentsCmd::Archived => cmd_archived(client).await,
+
+        AgentsCmd::Attest {
+            agent_pubkey,
+            conditions,
+        } => cmd_attest(client, &agent_pubkey, &conditions),
     }
+}
+
+/// Mint a NIP-OA `["auth", owner_pubkey, conditions, sig]` tag proving the
+/// caller (`client.keys()`) owns `agent_pubkey`. Pure local signing — no
+/// relay round-trip, since the resulting tag is verified by whoever reads it.
+fn cmd_attest(client: &BuzzClient, agent_pubkey: &str, conditions: &str) -> Result<(), CliError> {
+    let output = build_attest_output(client, agent_pubkey, conditions)?;
+    println!("{output}");
+    Ok(())
+}
+
+fn build_attest_output(
+    client: &BuzzClient,
+    agent_pubkey: &str,
+    conditions: &str,
+) -> Result<serde_json::Value, CliError> {
+    validate_hex64(agent_pubkey)?;
+    let agent = PublicKey::from_hex(agent_pubkey)
+        .map_err(|e| CliError::Usage(format!("invalid agent pubkey: {e}")))?;
+    let auth_tag = buzz_sdk::nip_oa::compute_auth_tag(client.keys(), &agent, conditions)
+        .map_err(|e| CliError::Usage(format!("failed to compute auth tag: {e}")))?;
+    Ok(json!({
+        "ok": true,
+        "action": "attest",
+        "owner_pubkey": client.keys().public_key().to_hex(),
+        "agent_pubkey": agent_pubkey,
+        "conditions": conditions,
+        "auth_tag": auth_tag,
+        "message": "Set this as BUZZ_AUTH_TAG on the agent's deployment verbatim.",
+    }))
 }
 
 /// Require `BUZZ_AUTH_TAG` and parse the owner pubkey from it. Used only by
@@ -714,5 +749,56 @@ mod tests {
             .expect("sign");
         let result = verify_archived_event(&event, &self_hex).expect("should pass");
         assert!(result.is_empty());
+    }
+
+    // --- (c) attest: build_attest_output ---
+
+    fn test_client(keys: Keys) -> BuzzClient {
+        BuzzClient::new("http://localhost".into(), keys, None, None).expect("client")
+    }
+
+    #[test]
+    fn attest_produces_verifiable_tag() {
+        let owner = Keys::generate();
+        let agent = Keys::generate();
+        let agent_hex = agent.public_key().to_hex();
+        let client = test_client(owner.clone());
+
+        let output = build_attest_output(&client, &agent_hex, "").expect("attest");
+        assert_eq!(output["ok"], json!(true));
+        assert_eq!(output["owner_pubkey"], json!(owner.public_key().to_hex()));
+        assert_eq!(output["agent_pubkey"], json!(agent_hex));
+
+        let auth_tag_json = output["auth_tag"].as_str().expect("auth_tag is a string");
+        let recovered_owner = buzz_sdk::nip_oa::verify_auth_tag(auth_tag_json, &agent.public_key())
+            .expect("tag verifies against the agent pubkey");
+        assert_eq!(recovered_owner, owner.public_key());
+    }
+
+    #[test]
+    fn attest_rejects_self_attestation() {
+        let owner = Keys::generate();
+        let owner_hex = owner.public_key().to_hex();
+        let client = test_client(owner);
+
+        let err = build_attest_output(&client, &owner_hex, "").unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)));
+    }
+
+    #[test]
+    fn attest_rejects_invalid_pubkey() {
+        let client = test_client(Keys::generate());
+        let err = build_attest_output(&client, "not-hex", "").unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)));
+    }
+
+    #[test]
+    fn attest_rejects_malformed_conditions() {
+        let owner = Keys::generate();
+        let agent = Keys::generate();
+        let client = test_client(owner);
+        let err = build_attest_output(&client, &agent.public_key().to_hex(), "has whitespace")
+            .unwrap_err();
+        assert!(matches!(err, CliError::Usage(_)));
     }
 }

--- a/crates/buzz-cli/src/commands/agents.rs
+++ b/crates/buzz-cli/src/commands/agents.rs
@@ -751,7 +751,7 @@ mod tests {
         assert!(result.is_empty());
     }
 
-    // --- (c) attest: build_attest_output ---
+    // --- (e) attest: build_attest_output ---
 
     fn test_client(keys: Keys) -> BuzzClient {
         BuzzClient::new("http://localhost".into(), keys, None, None).expect("client")
@@ -773,6 +773,27 @@ mod tests {
         let recovered_owner = buzz_sdk::nip_oa::verify_auth_tag(auth_tag_json, &agent.public_key())
             .expect("tag verifies against the agent pubkey");
         assert_eq!(recovered_owner, owner.public_key());
+    }
+
+    #[test]
+    fn attest_binds_conditions_into_the_signed_tag() {
+        let owner = Keys::generate();
+        let agent = Keys::generate();
+        let client = test_client(owner.clone());
+
+        let output =
+            build_attest_output(&client, &agent.public_key().to_hex(), "kind=9").expect("attest");
+        assert_eq!(output["conditions"], json!("kind=9"));
+
+        let auth_tag_json = output["auth_tag"].as_str().expect("auth_tag is a string");
+        buzz_sdk::nip_oa::verify_auth_tag(auth_tag_json, &agent.public_key())
+            .expect("tag verifies with matching conditions");
+
+        // Tampering with the conditions embedded in the tag must invalidate
+        // the signature — conditions are part of the signed preimage, not
+        // just a cosmetic label alongside it.
+        let tampered = auth_tag_json.replacen("kind=9", "kind=1", 1);
+        assert!(buzz_sdk::nip_oa::verify_auth_tag(&tampered, &agent.public_key()).is_err());
     }
 
     #[test]

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -342,6 +342,25 @@ Examples:\n  \
 buzz agents archived"
     )]
     Archived,
+    /// Mint a NIP-OA owner attestation for an externally-generated agent key
+    #[command(
+        after_help = "Signs an [\"auth\", owner_pubkey, conditions, sig] tag with the caller's \
+own identity (BUZZ_PRIVATE_KEY), proving ownership of `agent-pubkey` without needing that \
+key's private material. Use this to attest a key you generated yourself for a \
+non-Desktop-managed deployment (e.g. a headless agent host) — set the printed tag verbatim \
+as that deployment's BUZZ_AUTH_TAG.\n\n\
+Examples:\n  \
+buzz agents attest --agent-pubkey <PUBKEY>\n  \
+buzz agents attest --agent-pubkey <PUBKEY> --conditions \"kind=9\""
+    )]
+    Attest {
+        /// Agent identity pubkey to attest ownership of (hex)
+        #[arg(long)]
+        agent_pubkey: String,
+        /// Optional NIP-OA conditions clause (e.g. "kind=9&created_at<1700000000")
+        #[arg(long, default_value = "")]
+        conditions: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1873,6 +1892,7 @@ mod tests {
             vec![
                 "archive",
                 "archived",
+                "attest",
                 "draft-create",
                 "draft-update",
                 "unarchive"
@@ -1995,7 +2015,7 @@ mod tests {
     #[test]
     fn subcommand_counts_are_stable() {
         let expected: Vec<(&str, usize)> = vec![
-            ("agents", 5),
+            ("agents", 6),
             ("canvas", 2),
             ("channels", 16),
             ("dms", 4),


### PR DESCRIPTION
## Summary
- Adds `buzz agents attest --agent-pubkey <hex> [--conditions ""]`, exposing the existing `nip_oa::compute_auth_tag` signing path (already used internally by Desktop's own agent-creation flow, `desktop/src-tauri/src/commands/agents.rs:667`) as a CLI subcommand.
- Lets an owner mint a valid NIP-OA `["auth", owner_pubkey, conditions, sig]` tag for an agent key they generated *outside* Desktop (e.g. for a Coolify/headless deployment), and set the printed tag verbatim as that deployment's `BUZZ_AUTH_TAG`.

## Why
Desktop's agent-observer ingestion (`useAgentObserverIngestion.ts`) only decrypts/tracks activity frames for an agent that is either locally managed by Desktop, or present in the kind:10100 relay-agent directory *and* carrying a real NIP-OA attestation naming the owner. A key generated outside Desktop (e.g. by `buzz-agent`'s entrypoint for a Coolify deployment) has no such attestation today — the only place that mints one is Desktop's `create_managed_agent`, which always generates its own fresh keypair at the same time. This command closes that gap without any Desktop changes, by exposing the same signing primitive directly to the owner's own CLI identity.

## Test plan
- [x] `cargo test -p buzz-cli` — 254 passed, including new `attest_produces_verifiable_tag` (round-trips through `nip_oa::verify_auth_tag`), `attest_rejects_self_attestation`, `attest_rejects_invalid_pubkey`, `attest_rejects_malformed_conditions`
- [x] `cargo fmt -p buzz-cli -- --check`
- [x] `cargo clippy -p buzz-cli --all-targets -- -D warnings`
- [x] Updated the `subcommand_names_are_stable` / `subcommand_counts_are_stable` inventory snapshots for the new subcommand
- [x] Manual `buzz agents attest --help` sanity check
