### PR TITLE
fix(sdk,desktop): keep self-targeted p tags on membership and PR status events

### DIFF
--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -573,6 +573,12 @@ pub fn build_profile(
 }
 
 /// Build a NIP-29 add-member event (kind 9000).
+///
+/// `.allow_self_tagging()` is required: self-add is a first-class relay path
+/// (`side_effects.rs` — "Self-add: always allowed regardless of policy"), so
+/// `actor == target` and the `["p", target]` tag matches the signer. nostr
+/// 0.44 strips matching `p` tags by default, which would make a self-targeted
+/// add reach the relay with no target at all and fail as `missing p tag`.
 pub fn build_add_member(
     channel_id: Uuid,
     target_pubkey: &str,
@@ -586,10 +592,16 @@ pub fn build_add_member(
     if let Some(r) = role {
         tags.push(tag(&["role", r.as_str()])?);
     }
-    Ok(EventBuilder::new(Kind::Custom(9000), "").tags(tags))
+    Ok(EventBuilder::new(Kind::Custom(9000), "")
+        .tags(tags)
+        .allow_self_tagging())
 }
 
 /// Build a NIP-29 remove-member event (kind 9001).
+///
+/// Self-remove is a supported relay path (allowed unless the actor is the last
+/// owner), so this needs `.allow_self_tagging()` for the same reason as
+/// [`build_add_member`].
 pub fn build_remove_member(
     channel_id: Uuid,
     target_pubkey: &str,
@@ -599,7 +611,9 @@ pub fn build_remove_member(
         tag(&["h", &channel_id.to_string()])?,
         tag(&["p", &target_pubkey.to_ascii_lowercase()])?,
     ];
-    Ok(EventBuilder::new(Kind::Custom(9001), "").tags(tags))
+    Ok(EventBuilder::new(Kind::Custom(9001), "")
+        .tags(tags)
+        .allow_self_tagging())
 }
 
 /// Build a NIP-29 leave-request event (kind 9022).
@@ -2822,6 +2836,45 @@ mod tests {
         let ev = sign(build_add_member(cid, pubkey, None::<MemberRole>).unwrap());
         assert_eq!(ev.kind.as_u16(), 9000);
         assert!(tag_values(&ev, "role").is_empty());
+    }
+
+    /// Self-add is a supported relay path ("Self-add: always allowed
+    /// regardless of policy"), so the `p` tag must survive signing even when
+    /// it names the signer. Without `.allow_self_tagging()` nostr 0.44 strips
+    /// it and the relay rejects the event as `invalid: missing p tag`.
+    #[test]
+    fn add_member_self_targeted_keeps_p_tag() {
+        let keys = keys();
+        let self_hex = keys.public_key().to_hex();
+        let ev = build_add_member(uuid(), &self_hex, Some(MemberRole::Bot))
+            .unwrap()
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert_eq!(ev.kind.as_u16(), 9000);
+        assert!(
+            has_tag(&ev, "p", &self_hex),
+            "self `p` tag was stripped at signing: {:?}",
+            ev.tags.iter().map(|t| t.as_slice()).collect::<Vec<_>>()
+        );
+        assert!(has_tag(&ev, "role", "bot"));
+    }
+
+    /// Self-remove is allowed unless the actor is the last owner — same
+    /// stripping hazard as [`add_member_self_targeted_keeps_p_tag`].
+    #[test]
+    fn remove_member_self_targeted_keeps_p_tag() {
+        let keys = keys();
+        let self_hex = keys.public_key().to_hex();
+        let ev = build_remove_member(uuid(), &self_hex)
+            .unwrap()
+            .sign_with_keys(&keys)
+            .unwrap();
+        assert_eq!(ev.kind.as_u16(), 9001);
+        assert!(
+            has_tag(&ev, "p", &self_hex),
+            "self `p` tag was stripped at signing: {:?}",
+            ev.tags.iter().map(|t| t.as_slice()).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/project_git_workflow.rs
+++ b/desktop/src-tauri/src/commands/project_git_workflow.rs
@@ -197,9 +197,13 @@ fn build_merged_status_event(
         .map(Tag::parse)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|error| format!("build merged status tags: {error}"))?;
+    // `.allow_self_tagging()`: `owner` is this signer's own pubkey, so nostr
+    // 0.44 would strip `["p", owner]` and ship the status event without the
+    // recipient the readers index on.
     EventBuilder::new(Kind::Custom(1631), "")
         .tags(tags)
         .custom_created_at(Timestamp::from(created_at))
+        .allow_self_tagging()
         .sign_with_keys(keys)
         .map(|event| event.as_json())
         .map_err(|error| format!("sign merged pull request status: {error}"))
@@ -235,9 +239,12 @@ fn build_pull_request_status_event(
         .map(Tag::parse)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|error| format!("build pull request status tags: {error}"))?;
+    // See `build_merged_status_event` — `owner` is the signer, so the
+    // `["p", owner]` tag needs `.allow_self_tagging()` to survive.
     EventBuilder::new(kind, "")
         .tags(tags)
         .custom_created_at(Timestamp::from(created_at.max(Timestamp::now().as_secs())))
+        .allow_self_tagging()
         .sign_with_keys(keys)
         .map(|event| event.as_json())
         .map_err(|error| format!("sign pull request status: {error}"))
@@ -727,6 +734,68 @@ mod tests {
             "https://relay.example/git/owner/repo",
             "https://relay.example/git/fork/repo"
         ));
+    }
+
+    /// The owner `p` tag names the signer, so nostr 0.44 scrubs it unless the
+    /// builder opts into self-tagging. Readers index PR status events by
+    /// `#p` (`projectPullRequests.mjs` reads them back as `recipients`), so a
+    /// stripped tag silently drops the owner from the participant set.
+    #[test]
+    fn pull_request_status_events_keep_the_owner_p_tag() {
+        let keys = Keys::generate();
+        let owner = keys.public_key().to_hex();
+        let repo_address = format!("30617:{owner}:buzz");
+        let author = "b".repeat(64);
+
+        let merged = Event::from_json(
+            build_merged_status_event(
+                &keys,
+                &repo_address,
+                &"d".repeat(64),
+                &author,
+                &"e".repeat(40),
+                123,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            merged
+                .tags
+                .iter()
+                .any(|tag| tag.as_slice() == ["p", owner.as_str()]),
+            "kind 1631 lost the owner `p` tag: {:?}",
+            merged.tags
+        );
+
+        for (status, kind) in [("open", 1630u16), ("closed", 1632), ("draft", 1633)] {
+            let event = Event::from_json(
+                build_pull_request_status_event(
+                    &keys,
+                    &repo_address,
+                    &"d".repeat(64),
+                    &author,
+                    status,
+                    123,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(event.kind.as_u16(), kind);
+            assert!(
+                event
+                    .tags
+                    .iter()
+                    .any(|tag| tag.as_slice() == ["p", owner.as_str()]),
+                "kind {kind} ({status}) lost the owner `p` tag: {:?}",
+                event.tags
+            );
+            // The author is a distinct pubkey, so it must still ride along.
+            assert!(event
+                .tags
+                .iter()
+                .any(|tag| tag.as_slice() == ["p", author.as_str()]));
+        }
     }
 
     #[test]

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -219,6 +219,11 @@ pub fn build_delete_channel(channel_id: Uuid) -> Result<EventBuilder, String> {
 // ── Membership ───────────────────────────────────────────────────────────────
 
 /// Kind 9000 — add member.
+///
+/// `.allow_self_tagging()` is required: self-add is a first-class relay path,
+/// so `actor == target` and the `["p", target]` tag matches the signer. nostr
+/// 0.44 strips matching `p` tags by default, which would send the event with
+/// no target and fail as `missing p tag`.
 pub fn build_add_member(
     channel_id: Uuid,
     target_pubkey: &str,
@@ -232,17 +237,24 @@ pub fn build_add_member(
     if let Some(r) = role {
         tags.push(tag(vec!["role", r])?);
     }
-    Ok(EventBuilder::new(Kind::Custom(9000), "").tags(tags))
+    Ok(EventBuilder::new(Kind::Custom(9000), "")
+        .tags(tags)
+        .allow_self_tagging())
 }
 
 /// Kind 9001 — remove member.
+///
+/// Self-remove is a supported relay path, so this needs
+/// `.allow_self_tagging()` for the same reason as [`build_add_member`].
 pub fn build_remove_member(channel_id: Uuid, target_pubkey: &str) -> Result<EventBuilder, String> {
     check_pubkey(target_pubkey)?;
     let tags = vec![
         tag(vec!["h", &channel_id.to_string()])?,
         tag(vec!["p", &target_pubkey.to_ascii_lowercase()])?,
     ];
-    Ok(EventBuilder::new(Kind::Custom(9001), "").tags(tags))
+    Ok(EventBuilder::new(Kind::Custom(9001), "")
+        .tags(tags)
+        .allow_self_tagging())
 }
 
 // ── Messages ─────────────────────────────────────────────────────────────────
@@ -883,6 +895,58 @@ mod tests {
         assert_eq!(tags[2], vec!["reason", "returned"]);
         assert_eq!(tags.len(), 3, "self unarchive must not carry auth tag");
         assert_eq!(event.pubkey.to_hex(), TARGET_HEX);
+    }
+
+    // ── Self-targeted membership keeps its `p` tag ──────────────────────
+    //
+    // Self-add and self-remove are supported relay paths, so `actor ==
+    // target`. Without `.allow_self_tagging()` nostr 0.44 scrubs the `p` tag
+    // that names the signer and the relay rejects with `missing p tag`.
+
+    fn self_membership_tags(builder: EventBuilder) -> (Vec<Vec<String>>, String) {
+        let secret = nostr::SecretKey::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000000004",
+        )
+        .unwrap();
+        let keys = Keys::new(secret);
+        let event = builder.sign_with_keys(&keys).unwrap();
+        (
+            event.tags.iter().map(|t| t.as_slice().to_vec()).collect(),
+            keys.public_key().to_hex(),
+        )
+    }
+
+    #[test]
+    fn add_member_self_targeted_keeps_p_tag() {
+        let secret = nostr::SecretKey::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000000004",
+        )
+        .unwrap();
+        let self_hex = Keys::new(secret).public_key().to_hex();
+        let channel = Uuid::parse_str(CH_ID).unwrap();
+        let (tags, signer) =
+            self_membership_tags(build_add_member(channel, &self_hex, Some("bot")).unwrap());
+        assert!(
+            tags.iter().any(|t| t[0] == "p" && t[1] == signer),
+            "self `p` tag was stripped at signing: {tags:?}"
+        );
+        assert!(tags.iter().any(|t| t[0] == "role" && t[1] == "bot"));
+    }
+
+    #[test]
+    fn remove_member_self_targeted_keeps_p_tag() {
+        let secret = nostr::SecretKey::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000000004",
+        )
+        .unwrap();
+        let self_hex = Keys::new(secret).public_key().to_hex();
+        let channel = Uuid::parse_str(CH_ID).unwrap();
+        let (tags, signer) =
+            self_membership_tags(build_remove_member(channel, &self_hex).unwrap());
+        assert!(
+            tags.iter().any(|t| t[0] == "p" && t[1] == signer),
+            "self `p` tag was stripped at signing: {tags:?}"
+        );
     }
 
     const CH_ID: &str = "11111111-1111-4111-8111-111111111111";


### PR DESCRIPTION
## Summary

nostr 0.44's `EventBuilder` silently strips any `p` tag whose value matches the signing pubkey unless the builder opts in via `.allow_self_tagging()`. Buzz treats `p` tags as protocol routing data, not a self-notify privacy scrub, so several builders whose target can legitimately be the signer were shipping events with the target missing.

Two concrete failures:

- **kind 9000/9001 self-add and self-remove are unreachable.** These are first-class relay paths — `side_effects.rs` reads `// Self-add: always allowed regardless of policy`, pinned by `test_nip29_put_user_self_add_bypasses_policy` ("an agent can always add itself"). But neither the SDK nor the desktop builder could express them: the `p` tag naming the signer was stripped, so the relay saw no target and rejected with `invalid: missing p tag`. The misleading error made this look like an authorization failure.
- **Every PR lifecycle event silently lost its owner.** `build_merged_status_event` / `build_pull_request_status_event` derive `owner` from the signing key and then p-tag it, so `owner == signer` by construction and kinds 1630–1633 always shipped without `["p", owner]`. No error — readers index those events by `#p` as `recipients` (`projectPullRequests.mjs`), so the owner just quietly vanished from the participant set.

Root cause is historical: `.allow_self_tagging()` arrived with NIP-IA (#733) and was later added to the kind:9000 **e2e test** (#3017), but never to the shipped builders. Every self-targeted test hand-rolls its own `EventBuilder` to work around it.

### Related issue

None found — searched existing issues and PRs; nothing covers the self-tag stripping behavior.

### Testing

`cargo fmt --all --check` and clippy (`-D warnings`, both `buzz-sdk` and the desktop Tauri crate) are clean. 243/243 `buzz-sdk` and 1820/1820 desktop Tauri unit tests pass. The ~9 `buzz-relay` failures reproduce identically on a stashed clean tree — pre-existing, infra-dependent media/admin tests, unrelated to this change.

The five added regression tests are the point of the change: existing tests sign with a key *distinct* from the target, so they passed either way and this survived CI. The new ones sign with the target's **own** key and assert the `p` tag survives. Each was confirmed to fail before the fix and pass after:

```
self `p` tag was stripped at signing: [["h", "11111111-1111-4111-8111-111111111111"], ["role", "bot"]]
kind 1631 lost the owner `p` tag: [Tag(["e", …]), Tag(["a", …]), Tag(["p", "bbbb…"]), …]
```

No UI change, so no screenshots. Verification is at the wire-form level — the live relay e2e suite needs Postgres/Redis and was not run.

### Not addressed here

The same hazard remains in other `p`-emitting builders, deliberately scoped out because they change discovery/notification semantics and deserve their own review: note-to-self DMs (`build_dm_open` — currently unimplementable, fails as `pubkeys must contain at least 1 other participant`), the git SDK builders (issue/status/PR/patch, where the CLI defaults recipients to the repo owner), and the desktop `sign_event` Tauri passthrough.

Self-mentions are no longer on that list — `build_message`, `build_forum_post`, and `build_forum_comment` were fixed on `main` while this PR was open, and that work is preserved here.

There is no single signing chokepoint that would fix this globally — `buzz-cli` has one (`client.rs:588`), but the desktop signs in ~50 scattered places. A lint or shared signing helper is probably worth considering so the next builder doesn't reintroduce it.
