### PR TITLE
fix(acp): isolate Hermes from configured MCP startup

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -371,6 +371,20 @@ fn build_client_capabilities() -> serde_json::Value {
     })
 }
 
+const HERMES_ACP_HOST_ENV: [(&str, &str); 1] = [("HERMES_ACP_SKIP_CONFIGURED_MCP", "1")];
+
+/// Environment defaults required when Buzz owns an ACP runtime process.
+///
+/// Hermes otherwise starts globally configured MCP servers before it responds
+/// to `initialize`. Buzz supplies session MCP servers explicitly through
+/// `session/new`, so unrelated global startup must not block this host.
+fn acp_host_env_for_agent(agent_command: &str) -> &'static [(&'static str, &'static str)] {
+    match crate::config::normalize_agent_command_identity(agent_command).as_str() {
+        "hermes" | "hermes-agent" | "hermes-acp" => &HERMES_ACP_HOST_ENV,
+        _ => &[],
+    }
+}
+
 impl AcpClient {
     /// Kill the agent subprocess and wait for it to exit (no zombies).
     ///
@@ -462,6 +476,16 @@ impl AcpClient {
         }
         if let Some(merged) = codex_config_value {
             cmd.env("CODEX_CONFIG", merged);
+        }
+
+        // Runtime host defaults apply to every AcpClient spawn path, including
+        // model probes and managed sessions. Preserve explicit parent/persona
+        // values under the same operator-wins contract as other environment.
+        for &(key, value) in acp_host_env_for_agent(command) {
+            let supplied_by_persona = extra_env.iter().any(|(extra_key, _)| extra_key == key);
+            if std::env::var_os(key).is_none() && !supplied_by_persona {
+                cmd.env(key, value);
+            }
         }
 
         // Buzz-managed agents must never execute the operator's personal cron
@@ -2037,6 +2061,166 @@ fn configure_no_window(cmd: &mut tokio::process::Command) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn hermes_spawn_skips_unrelated_configured_mcp_startup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // This test exercises the host default. An explicit inherited value is
+        // covered separately and intentionally wins over that default.
+        if std::env::var_os("HERMES_ACP_SKIP_CONFIGURED_MCP").is_some() {
+            return;
+        }
+
+        let test_dir =
+            std::env::temp_dir().join(format!("buzz-acp-hermes-env-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&test_dir).expect("create Hermes env test directory");
+        let hermes_acp = test_dir.join("hermes-acp");
+        std::fs::write(
+            &hermes_acp,
+            r#"#!/bin/sh
+IFS= read -r _request
+if [ "${HERMES_ACP_SKIP_CONFIGURED_MCP:-}" != "1" ]; then
+  echo "missing HERMES_ACP_SKIP_CONFIGURED_MCP=1" >&2
+  exit 64
+fi
+printf '%s\n' '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":2,"agentCapabilities":{},"agentInfo":{"name":"hermes-test","version":"0"}}}'
+sleep 1
+"#,
+        )
+        .expect("write Hermes env test executable");
+        let mut permissions = std::fs::metadata(&hermes_acp)
+            .expect("stat Hermes env test executable")
+            .permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&hermes_acp, permissions)
+            .expect("make Hermes env test executable");
+
+        let mut client = AcpClient::spawn(
+            hermes_acp.to_str().expect("test path is valid UTF-8"),
+            &[],
+            &[],
+            false,
+        )
+        .await
+        .expect("spawn Hermes env test executable");
+        let initialize_result = client.initialize().await;
+        client.shutdown().await;
+        std::fs::remove_dir_all(&test_dir).expect("remove Hermes env test directory");
+
+        assert!(
+            initialize_result.is_ok(),
+            "Buzz-owned Hermes ACP sessions must skip unrelated configured MCP startup; \
+             initialize result: {initialize_result:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn hermes_spawn_preserves_explicit_configured_mcp_policy() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let test_dir =
+            std::env::temp_dir().join(format!("buzz-acp-hermes-env-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&test_dir).expect("create Hermes env test directory");
+        let hermes_agent = test_dir.join("hermes-agent");
+        let expected_key = format!("BUZZ_TEST_EXPECTED_MCP_POLICY_{}", std::process::id());
+        let script = r#"#!/bin/sh
+IFS= read -r _request
+if [ "${HERMES_ACP_SKIP_CONFIGURED_MCP-}" != "${__EXPECTED_KEY__-}" ]; then
+  echo "explicit HERMES_ACP_SKIP_CONFIGURED_MCP policy was overwritten" >&2
+  exit 64
+fi
+printf '%s\n' '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":2,"agentCapabilities":{},"agentInfo":{"name":"hermes-test","version":"0"}}}'
+sleep 1
+"#
+        .replace("__EXPECTED_KEY__", &expected_key);
+        std::fs::write(&hermes_agent, script).expect("write Hermes env test executable");
+        let mut permissions = std::fs::metadata(&hermes_agent)
+            .expect("stat Hermes env test executable")
+            .permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&hermes_agent, permissions)
+            .expect("make Hermes env test executable");
+
+        let explicit_value = "0";
+        let expected_value =
+            std::env::var("HERMES_ACP_SKIP_CONFIGURED_MCP").unwrap_or(explicit_value.into());
+        let extra_env = vec![
+            (
+                "HERMES_ACP_SKIP_CONFIGURED_MCP".to_string(),
+                explicit_value.to_string(),
+            ),
+            (expected_key, expected_value),
+        ];
+        let mut client = AcpClient::spawn(
+            hermes_agent.to_str().expect("test path is valid UTF-8"),
+            &[],
+            &extra_env,
+            false,
+        )
+        .await
+        .expect("spawn Hermes env test executable");
+        let initialize_result = client.initialize().await;
+        client.shutdown().await;
+        std::fs::remove_dir_all(&test_dir).expect("remove Hermes env test directory");
+
+        assert!(
+            initialize_result.is_ok(),
+            "an explicit parent or persona MCP policy must override the Buzz host default; \
+             initialize result: {initialize_result:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_preserves_provider_qualified_model_id() {
+        let result = serde_json::json!({
+            "models": {
+                "currentModelId": "openai-codex:gpt-5.6-sol",
+                "availableModels": [
+                    {
+                        "modelId": "openai-codex:gpt-5.6-luna",
+                        "name": "GPT-5.6 Luna"
+                    }
+                ]
+            }
+        });
+
+        assert_eq!(
+            super::resolve_model_switch_method(&result, "openai-codex:gpt-5.6-luna"),
+            Some(super::ModelSwitchMethod::SetModel {
+                model_id: "openai-codex:gpt-5.6-luna".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn hermes_host_environment_recognizes_supported_command_identities() {
+        for command in [
+            "hermes",
+            "hermes-agent",
+            "hermes-acp",
+            "/opt/hermes/bin/hermes-acp",
+            r"C:\Users\test\bin\HERMES_ACP.EXE",
+        ] {
+            assert_eq!(
+                super::acp_host_env_for_agent(command),
+                &[("HERMES_ACP_SKIP_CONFIGURED_MCP", "1")],
+                "unexpected ACP host environment for {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_hermes_host_environment_is_unchanged() {
+        for command in ["codex-acp", "claude-agent-acp", "goose", "custom-acp"] {
+            assert!(
+                super::acp_host_env_for_agent(command).is_empty(),
+                "non-Hermes command must not receive Hermes host environment: {command}"
+            );
+        }
+    }
 
     #[test]
     fn stop_reason_parses_all_known_values() {

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -465,27 +465,28 @@ impl AcpClient {
         // entry falls through to the standard operator-wins treatment below.
         let codex_merge_active = codex_config_value.is_some();
 
+        // Apply runtime host defaults before persona values. `Command::env`
+        // handles keys using native platform semantics (case-insensitive on
+        // Windows), so a later persona entry overrides the matching default
+        // without a separate, potentially inconsistent key comparison.
+        // Inherited parent values still win over both layers.
+        for &(key, value) in acp_host_env_for_agent(command) {
+            if std::env::var_os(key).is_none() {
+                cmd.env(key, value);
+            }
+        }
+
         for (key, value) in extra_env {
             if key == "CODEX_CONFIG" && codex_merge_active {
                 // Handled by build_codex_config_env; skip here to avoid double-setting.
                 continue;
             }
-            if std::env::var(key).is_err() {
+            if std::env::var_os(key).is_none() {
                 cmd.env(key, value);
             }
         }
         if let Some(merged) = codex_config_value {
             cmd.env("CODEX_CONFIG", merged);
-        }
-
-        // Runtime host defaults apply to every AcpClient spawn path, including
-        // model probes and managed sessions. Preserve explicit parent/persona
-        // values under the same operator-wins contract as other environment.
-        for &(key, value) in acp_host_env_for_agent(command) {
-            let supplied_by_persona = extra_env.iter().any(|(extra_key, _)| extra_key == key);
-            if std::env::var_os(key).is_none() && !supplied_by_persona {
-                cmd.env(key, value);
-            }
         }
 
         // Buzz-managed agents must never execute the operator's personal cron
@@ -2203,6 +2204,8 @@ sleep 1
             "hermes-acp",
             "/opt/hermes/bin/hermes-acp",
             r"C:\Users\test\bin\HERMES_ACP.EXE",
+            r"C:\Users\test\AppData\Roaming\npm\hermes-acp.cmd",
+            r"C:\Tools\Hermes\HERMES-AGENT.BAT",
         ] {
             assert_eq!(
                 super::acp_host_env_for_agent(command),

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -676,7 +676,10 @@ pub(crate) fn normalize_agent_command_identity(command: &str) -> String {
         .next()
         .expect("rsplit always yields at least one element");
     let lower = basename.to_ascii_lowercase();
-    let stem = lower.strip_suffix(".exe").unwrap_or(&lower);
+    let stem = [".exe", ".cmd", ".bat"]
+        .iter()
+        .find_map(|extension| lower.strip_suffix(extension))
+        .unwrap_or(&lower);
     stem.chars()
         .map(|character| match character {
             ' ' | '_' => '-',


### PR DESCRIPTION
## Summary

- prevent Buzz-owned Hermes ACP processes from preloading unrelated profile-configured MCP servers before ACP initialization
- apply `HERMES_ACP_SKIP_CONFIGURED_MCP=1` at the shared `AcpClient::spawn` boundary for normalized `hermes`, `hermes-agent`, and `hermes-acp` commands
- preserve explicit parent/persona values using native environment-key semantics and `var_os` parent-presence checks, leave non-Hermes runtimes unchanged, and keep ACP `session/new` MCP servers available
- normalize Windows `.cmd` and `.bat` runtime shims alongside `.exe`, so the Hermes host policy survives Desktop's resolved npm-shim paths

Buzz Desktop v0.5.0 gives model discovery a 10-second budget. With the literal release environment, Hermes can spend that entire budget starting user-configured MCP servers before responding to `initialize`. The packaged v0.5.0 helper timed out at 10.01s; changing only `HERMES_ACP_SKIP_CONFIGURED_MCP=1` completed discovery in 2.96–3.31s and returned 357 models. This fixes the measured startup boundary rather than increasing the generic timeout or adding Hermes-specific UI.

This is adjacent to, but does not overlap, #3334: that PR addresses command/PATH resolution, while this change applies after Buzz has resolved the executable and is spawning it.

### Related issue

Fixes #3355

### Testing

- captured a process-level RED before the production change: `hermes_spawn_skips_unrelated_configured_mcp_startup` failed with exit 101
- `cargo fmt --all -- --check`
- `cargo test -p buzz-acp hermes_ -- --nocapture` — 4 passed
- `cargo test -p buzz-acp resolve_preserves_provider_qualified_model_id -- --nocapture` — passed
- `cargo test -p buzz-acp --lib -- --skip acp::tests::keepalive_resets_idle_past_deadline` — 622 passed; the skipped unchanged timing test is independently flaky on current `main`
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib agent_models -- --nocapture` — 22 passed
- post-fix real helper probe, with no parent isolation variable: 357 models in 2.75–2.76s for both `hermes-acp` and `hermes acp`
- Windows shim regression test: true RED for `hermes-acp.cmd`, then GREEN for both `.cmd` and `.bat` identities after the shared-normalizer fix
- final rebased `hermes acp` probe: 356 models in 4.00s, including provider-qualified Luna and Sol IDs, with no residual helper or Hermes process after five seconds
- combined real Hermes ACP acceptance harness passed: selected `openai-codex:gpt-5.6-luna`, completed a marked turn with `stopReason=end_turn`, preserved Luna across relaunch, switched to `openai-codex:gpt-5.6-sol`, preserved Sol across a second relaunch, and cleaned every descendant from all three process trees
- integrated ACP-provided session MCP acceptance: Hermes initialized the supplied server and completed `tools/list` on all three sessions despite configured-MCP isolation. The model did not issue a `tools/call` in this run (`mcp_acceptance_call_count=0`), so tool invocation is not claimed.
- focused desktop Playwright run after `pnpm build:e2e`: 20 passed, including custom-model persistence; 12 existing upstream desktop failures remained in files untouched by this Rust-only change (artifacts retained locally)
- `just ci` component validation: workspace/web/mobile/desktop checks, 3,751 desktop tests, Rust unit recipes, web build, and desktop build passed. The canonical run deadlocks in unchanged parallel `relay_admission` tests; the complete Tauri suite passes single-threaded (1,849 passed, 14 ignored, plus 3 diagnostic tests). One unrelated mobile widget test fails reproducibly alone on current `main`; the remaining 874 tests pass when only that test is excluded.

No screenshots: subprocess environment behavior only; no UI changes.
