### PR TITLE
fix(desktop): include relay agents in picker results

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -5,7 +5,7 @@ import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isAgentIdentityInKnownDirectories,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
@@ -136,27 +136,39 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
-test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
+test("isAgentIdentityInKnownDirectories: keeps people and known managed or relay agents", () => {
   const managedAgentPubkeys = new Set([PUB_A]);
+  const directoryAgentPubkeys = new Set([PUB_B]);
 
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentIdentityInKnownDirectories(
       { isAgent: false, pubkey: PUB_B },
       managedAgentPubkeys,
+      directoryAgentPubkeys,
     ),
     true,
   );
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentIdentityInKnownDirectories(
       { isAgent: true, pubkey: PUB_A.toUpperCase() },
       managedAgentPubkeys,
+      directoryAgentPubkeys,
     ),
     true,
   );
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentIdentityInKnownDirectories(
       { isAgent: true, pubkey: PUB_B },
       managedAgentPubkeys,
+      directoryAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentIdentityInKnownDirectories(
+      { isAgent: true, pubkey: PUB_C },
+      managedAgentPubkeys,
+      directoryAgentPubkeys,
     ),
     false,
   );

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -54,14 +54,14 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
-export function isAgentIdentityInManagedList(
+export function isAgentIdentityInKnownDirectories(
   candidate: { isAgent?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
+  directoryAgentPubkeys: ReadonlySet<string>,
 ) {
-  return (
-    candidate.isAgent !== true ||
-    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
-  );
+  if (candidate.isAgent !== true) return true;
+  const pubkey = normalizePubkey(candidate.pubkey);
+  return managedAgentPubkeys.has(pubkey) || directoryAgentPubkeys.has(pubkey);
 }
 
 export function shouldHideAgentFromMentions({

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -9,7 +9,7 @@ import {
 import { attachManagedAgentToChannel } from "@/features/agents/channelAgents";
 import {
   coalesceAgentAutocompleteCandidates,
-  isAgentIdentityInManagedList,
+  isAgentIdentityInKnownDirectories,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
@@ -272,6 +272,11 @@ export function MembersSidebar({
         .filter((label): label is string => Boolean(label)),
     );
     const managedAgentPubkeys = new Set(managedAgentsByPubkey.keys());
+    const directoryAgentPubkeys = new Set(
+      (relayAgentsQuery.data ?? []).map((agent) =>
+        normalizePubkey(agent.pubkey),
+      ),
+    );
 
     const addCandidate = (candidate: AddMemberSearchCandidate) => {
       const pubkey = normalizePubkey(candidate.pubkey);
@@ -282,7 +287,11 @@ export function MembersSidebar({
           )) ||
         memberPubkeys.has(pubkey) ||
         isArchivedDiscovery(pubkey) ||
-        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+        !isAgentIdentityInKnownDirectories(
+          candidate,
+          managedAgentPubkeys,
+          directoryAgentPubkeys,
+        )
       ) {
         return;
       }

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,7 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isAgentIdentityInKnownDirectories as isKnown,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,7 +246,7 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (!isKnown(candidate, managedAgentPubkeys, directoryAgentPubkeys)) {
         return;
       }
       if (


### PR DESCRIPTION
## Summary

- include relay-directory agents in mention autocomplete and member search
- keep existing managed-agent behavior while allowing shared relay-managed agents
- add regression coverage for known managed and relay identities

## Problem

Relay-managed agents that are already channel members are filtered out of the `@` picker because candidates are accepted only when their identity exists in the local managed-agent list. This leaves shared agents invisible in autocomplete even though the channel member list contains them.

## Testing

- `pnpm check` passed for desktop, including formatting and file-size checks
- desktop regression suite passed: 3,731 tests
- desktop TypeScript and production build passed
- Rust formatting, clippy, unit tests, and desktop-native tests passed
- web checks and production build passed
- focused agent picker regression suite passed: 18 tests

`just ci` reaches the unrelated mobile suite and fails in the existing `ChannelDetailPage keeps follow mode off while a tall newest message stays visible` test at `mobile/test/features/channels/channel_detail_page_test.dart:985`. The failure reproduces when that mobile test is run alone. This pull request does not change any mobile files.

## Manual verification

In Buzz 0.5.0, a channel containing relay-managed agents reproduces the issue: the channel roster includes the agents, but typing `@` omits them from the picker. With this change, known relay agents pass candidate filtering in both mention autocomplete and member search.

No matching open issue or pull request was found.

No agent configuration rules changed.
