### PR TITLE
release(chart): publish 0.1.7

### DIFF
--- a/deploy/charts/buzz/README.md
+++ b/deploy/charts/buzz/README.md
@@ -12,7 +12,7 @@ This chart has two operating profiles selected by values:
 ## Quickstart (eval only)
 
 ```sh
-helm install buzz oci://ghcr.io/block/buzz/charts/buzz --version 0.1.0 \
+helm install buzz oci://ghcr.io/block/buzz/charts/buzz --version 0.1.7 \
   --create-namespace --namespace buzz \
   --set quickstart=true \
   --set postgresql.enabled=true \


### PR DESCRIPTION
## Why
Publish chart 0.1.7 after the feature PR merged from a fork and therefore intentionally skipped the internal-branch auto-tag job.

## What
- Trigger the `chart-release/0.1.7` release lane
- Update the quickstart example to reference chart 0.1.7

## Risk Assessment
Low — the chart implementation is already merged and tested; this PR creates its immutable release tag and OCI artifact.

## References
- Chart implementation: https://github.com/block/buzz/pull/3322
- `helm unittest` 0.8.2: 43/43 tests passed
- Local pre-push checks passed

Generated with Amp