### PR TITLE
fix(desktop): allow mentioning relay agents Desktop does not manage

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -246,7 +246,12 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      // Relay-invocable agents are not in this Desktop's managed list, so let
+      // shouldHideAgentFromMentions below decide rather than dropping them here.
+      if (
+        !mentionableAgentPubkeys.has(pubkey) &&
+        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+      ) {
         return;
       }
       if (


### PR DESCRIPTION
## Summary

A relay-deployed agent never appears in mention autocomplete, even when its
kind:10100 entry says `respond_to: "anyone"` and its channels overlap the user's.

`addCandidate` gates on `isAgentIdentityInManagedList`, true only for a non-agent
or an agent in Desktop's *local* managed list. A relay agent is neither, so the
candidate is dropped before `shouldHideAgentFromMentions` — which owns this
policy and documents `// Invocable => always show` — ever runs.

## Fix

Skip the managed-list gate when the agent is already in
`mentionableAgentPubkeys`, the set that function treats as invocable. Unchanged
for managed agents, non-agents, and relay agents that are not invocable.

## Testing & Verification

Reproduced on a self-hosted relay with a `buzz-acp` agent in six shared
channels, online, kind:10100 published.

- `pnpm test` — 3505 pass, 0 fail
- `pnpm exec biome check` — clean

No unit test: the gate lives inside a hook. Happy to extract it to
`agentAutocompleteEligibility.ts` for coverage if you'd prefer.

Note `buzz-acp` doesn't publish kind:10100 at all — I published it by hand to
reproduce, so this fix alone isn't sufficient in practice. Can follow up with a
PR having the harness announce itself at startup.
