### PR TITLE
feat(desktop): surface Auth0 signup screen option in hosted community create flow

### DIFF
--- a/desktop/src-tauri/src/builderlab.rs
+++ b/desktop/src-tauri/src/builderlab.rs
@@ -214,13 +214,18 @@ fn api_url(path: &str) -> Result<Url, String> {
         .map_err(|error| format!("invalid Builderlab API URL: {error}"))
 }
 
-fn login_url(return_to: &str) -> Result<Url, String> {
+fn login_url(return_to: &str, screen_hint: Option<&str>) -> Result<Url, String> {
     let mut login_url = api_url("/v1/auth/login")?;
     login_url
         .query_pairs_mut()
         .append_pair("type", "cli")
         .append_pair("product", "buzz")
         .append_pair("returnTo", return_to);
+    if let Some(screen_hint) = screen_hint {
+        login_url
+            .query_pairs_mut()
+            .append_pair("screen_hint", screen_hint);
+    }
     Ok(login_url)
 }
 
@@ -249,6 +254,7 @@ async fn authenticated_user(
 
 #[tauri::command]
 pub(crate) async fn start_builderlab_login(
+    screen_hint: Option<String>,
     app: tauri::AppHandle,
     app_state: tauri::State<'_, crate::app_state::AppState>,
     session: tauri::State<'_, BuilderlabSession>,
@@ -275,7 +281,7 @@ pub(crate) async fn start_builderlab_login(
         let _ = axum::serve(listener, router).await;
     });
 
-    let login_url = login_url(&return_to)?;
+    let login_url = login_url(&return_to, screen_hint.as_deref())?;
     if let Err(error) = app.opener().open_url(login_url.as_str(), None::<&str>) {
         server.abort();
         return Err(format!("could not open Builderlab authentication: {error}"));
@@ -673,7 +679,7 @@ mod tests {
 
     #[test]
     fn login_defaults_to_auth0_login() {
-        let login = login_url("http://127.0.0.1:1234/callback/nonce").unwrap();
+        let login = login_url("http://127.0.0.1:1234/callback/nonce", None).unwrap();
         let query: HashMap<_, _> = login.query_pairs().into_owned().collect();
 
         assert_eq!(query.get("type").map(String::as_str), Some("cli"));
@@ -683,5 +689,19 @@ mod tests {
             Some("http://127.0.0.1:1234/callback/nonce")
         );
         assert!(!query.contains_key("screen_hint"));
+    }
+
+    #[test]
+    fn login_supports_signup_screen_hint() {
+        let login = login_url("http://127.0.0.1:1234/callback/nonce", Some("signup")).unwrap();
+        let query: HashMap<_, _> = login.query_pairs().into_owned().collect();
+
+        assert_eq!(query.get("type").map(String::as_str), Some("cli"));
+        assert_eq!(query.get("product").map(String::as_str), Some("buzz"));
+        assert_eq!(
+            query.get("returnTo").map(String::as_str),
+            Some("http://127.0.0.1:1234/callback/nonce")
+        );
+        assert_eq!(query.get("screen_hint").map(String::as_str), Some("signup"));
     }
 }

--- a/desktop/src/features/communities/hostedCommunityApi.ts
+++ b/desktop/src/features/communities/hostedCommunityApi.ts
@@ -102,8 +102,8 @@ export function clearBuilderlabAuth() {
   return invoke<void>("clear_builderlab_auth");
 }
 
-export function startBuilderlabLogin() {
-  return invoke<BuilderlabAuth>("start_builderlab_login");
+export function startBuilderlabLogin(options?: { screenHint?: string }) {
+  return invoke<BuilderlabAuth>("start_builderlab_login", options);
 }
 
 export async function loadHostedCommunityAccount(): Promise<HostedCommunityAccount> {

--- a/desktop/src/features/communities/ui/HostedCommunityCreateFlow.tsx
+++ b/desktop/src/features/communities/ui/HostedCommunityCreateFlow.tsx
@@ -100,12 +100,13 @@ export function HostedCommunityCreateFlow({
     }
   };
 
-  const signIn = () => {
+  const startLogin = (options?: { screenHint?: string }) => {
+    const isSignup = options?.screenHint === "signup";
     const attempt = ++loginAttempt.current;
     signingIn.current = true;
-    setAction("Signing in…");
+    setAction(isSignup ? "Creating account…" : "Signing in…");
     setError(null);
-    void startBuilderlabLogin()
+    void startBuilderlabLogin(options)
       .then(async (nextAuth) => {
         if (loginAttempt.current !== attempt) return;
         setAuth(nextAuth);
@@ -122,6 +123,9 @@ export function HostedCommunityCreateFlow({
         }
       });
   };
+
+  const signIn = () => startLogin();
+  const signUp = () => startLogin({ screenHint: "signup" });
 
   const connectIdentity = () =>
     run("Connecting identity…", async () => {
@@ -292,12 +296,24 @@ export function HostedCommunityCreateFlow({
           your browser, then bring you back here.
         </p>
         {errorBox}
-        <div className="flex justify-end pt-1">
+        <div className="flex justify-end gap-2 pt-1">
+          <Button
+            disabled={Boolean(action)}
+            onClick={signUp}
+            type="button"
+            variant="outline"
+          >
+            {action === "Creating account…" ? (
+              <LoaderCircle className="h-4 w-4 animate-spin" />
+            ) : null}
+            {action === "Creating account…" ? "Creating account…" : "Create account"}
+            {action ? null : <ExternalLink className="h-4 w-4" />}
+          </Button>
           <Button disabled={Boolean(action)} onClick={signIn} type="button">
             {action === "Signing in…" ? (
               <LoaderCircle className="h-4 w-4 animate-spin" />
             ) : null}
-            {action ?? "Continue to Builderlab"}
+            {action === "Signing in…" ? "Signing in…" : "Sign in"}
             {action ? null : <ExternalLink className="h-4 w-4" />}
           </Button>
         </div>

--- a/desktop/tests/e2e/sidebar.spec.ts
+++ b/desktop/tests/e2e/sidebar.spec.ts
@@ -103,7 +103,7 @@ test("add community starts with create and join choices", async ({ page }) => {
   await expect(
     page.getByRole("heading", { name: "Create a new community" }),
   ).toBeVisible();
-  await page.getByRole("button", { name: "Continue to Builderlab" }).click();
+  await page.getByRole("button", { name: "Sign in" }).click();
   await page.getByRole("button", { name: "Connect and continue" }).click();
   await expect(page.getByLabel("Community address")).toBeVisible();
 });


### PR DESCRIPTION
Fixes #3388

### Summary
This PR threads an optional `screen_hint` parameter through the Rust backend `login_url()` and `start_builderlab_login` Tauri command, and exposes a secondary "Create account" button alongside "Sign in" in the first-time hosted community creation flow (`HostedCommunityCreateFlow.tsx`).

### Changes
1. **Rust backend (`desktop/src-tauri/src/builderlab.rs`)**:
   - Added `screen_hint: Option<&str>` parameter to `login_url()`. When `Some("signup")` is provided, appends `screen_hint=signup` to the Auth0 login URL query parameters.
   - Updated `start_builderlab_login` Tauri command to take `screen_hint: Option<String>` and pass it to `login_url()`.
   - Added unit test `login_supports_signup_screen_hint` and preserved existing `login_defaults_to_auth0_login` test.

2. **Frontend API (`desktop/src/features/communities/hostedCommunityApi.ts`)**:
   - Updated `startBuilderlabLogin(options?: { screenHint?: string })` signature to accept optional `screenHint` and pass it through to `invoke("start_builderlab_login", options)`.

3. **UI Flow (`desktop/src/features/communities/ui/HostedCommunityCreateFlow.tsx`)**:
   - Added a secondary "Create account" button (`variant="outline"`) next to "Sign in" in the initial sign-in step of the first-time community creation flow.
   - Preserved sign-in-only behavior in `HostedCommunityOnboarding.tsx` and `HostedCommunitiesSettingsCard.tsx`.

4. **E2E Tests (`desktop/tests/e2e/sidebar.spec.ts`)**:
   - Updated button selector in `sidebar.spec.ts` to match the "Sign in" button label.

### Assumptions
- First-time community creators may either be new users needing an Auth0 account ("Create account") or returning users ("Sign in").
- Existing onboarded/settings flows continue using default sign-in behavior without signup hints.
