### PR TITLE
chore(ci): bump desktop smoke E2E timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
   desktop-smoke-e2e:
     name: Desktop Smoke E2E (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     needs: [changes]
     if: github.event_name == 'push' || needs.changes.outputs.desktop == 'true' || needs.changes.outputs.desktop-rust == 'true' || needs.changes.outputs.rust == 'true'
     strategy:


### PR DESCRIPTION
Three main-branch runs today had shards killed at exactly 20m17s ("exceeded the maximum execution time of 20m0s"); the killed shard was actively passing tests seconds before the cap. Shard runtime has grown to the limit. 30 matches the other desktop jobs in the same workflow.