### PR TITLE
feat(messaging): add Slack-parity message forwarding (kind 40009)

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -1212,7 +1212,8 @@ pub fn resolve_channel_filters(
     rules: &[SubscriptionRule],
 ) -> HashMap<Uuid, ChannelFilter> {
     use buzz_core::kind::{
-        KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
+        KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_FORWARD, KIND_STREAM_REMINDER,
+        KIND_WORKFLOW_APPROVAL_REQUESTED,
     };
 
     let target_channels: Vec<Uuid> = if let Some(ref overrides) = config.channels_override {
@@ -1232,6 +1233,7 @@ pub fn resolve_channel_filters(
             let kinds = config.kinds_override.clone().unwrap_or_else(|| {
                 vec![
                     KIND_STREAM_MESSAGE,
+                    KIND_STREAM_MESSAGE_FORWARD,
                     KIND_WORKFLOW_APPROVAL_REQUESTED,
                     KIND_STREAM_REMINDER,
                 ]
@@ -1314,7 +1316,8 @@ pub fn resolve_dynamic_channel_filter(
     rules: &[crate::filter::SubscriptionRule],
 ) -> Option<ChannelFilter> {
     use buzz_core::kind::{
-        KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
+        KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_FORWARD, KIND_STREAM_REMINDER,
+        KIND_WORKFLOW_APPROVAL_REQUESTED,
     };
 
     // In Mentions/All mode, if the operator explicitly constrained channels
@@ -1337,6 +1340,7 @@ pub fn resolve_dynamic_channel_filter(
             kinds: Some(config.kinds_override.clone().unwrap_or_else(|| {
                 vec![
                     KIND_STREAM_MESSAGE,
+                    KIND_STREAM_MESSAGE_FORWARD,
                     KIND_WORKFLOW_APPROVAL_REQUESTED,
                     KIND_STREAM_REMINDER,
                 ]
@@ -1483,6 +1487,7 @@ mod tests {
             assert!(f.require_mention, "mentions mode requires mention");
             let kinds = f.kinds.as_ref().expect("should have kinds");
             assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_MESSAGE));
+            assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_MESSAGE_FORWARD));
             assert!(kinds.contains(&buzz_core::kind::KIND_WORKFLOW_APPROVAL_REQUESTED));
             assert!(kinds.contains(&buzz_core::kind::KIND_STREAM_REMINDER));
         }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -22,7 +22,7 @@ use acp::{AcpClient, EnvVar, McpServer};
 use anyhow::Result;
 use buzz_core::kind::{
     KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
+    KIND_STREAM_MESSAGE_FORWARD, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::observer::{
     decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
@@ -1442,6 +1442,7 @@ async fn tokio_main() -> Result<()> {
                 kinds: config.kinds_override.clone().unwrap_or_else(|| {
                     vec![
                         KIND_STREAM_MESSAGE,
+                        KIND_STREAM_MESSAGE_FORWARD,
                         KIND_WORKFLOW_APPROVAL_REQUESTED,
                         KIND_STREAM_REMINDER,
                     ]

--- a/crates/buzz-cli/TESTING.md
+++ b/crates/buzz-cli/TESTING.md
@@ -82,8 +82,8 @@ export BUZZ_PRIVATE_KEY="nsec1..."   # from the mint output
 
 | Scope | Self-mintable | Needed for |
 |-------|:---:|------------|
-| `messages:read` | ✅ | `messages get`, `messages thread`, `messages search`, `feed get` |
-| `messages:write` | ✅ | `messages send`, `messages edit`, `messages delete`, `reactions`, `messages vote` |
+| `messages:read` | ✅ | `messages get`, `messages thread`, `messages search`, `feed get`, `messages forward` (source fetch) |
+| `messages:write` | ✅ | `messages send`, `messages forward`, `messages edit`, `messages delete`, `reactions`, `messages vote` |
 | `channels:read` | ✅ | `channels list`, `channels get`, `channels members` |
 | `channels:write` | ✅ | `channels create`, `channels update`, `channels join`, `channels leave`, `channels topic`, `channels purpose` |
 | `users:read` | ✅ | `users get`, `users presence` |
@@ -228,6 +228,68 @@ buzz messages edit --event "$EVENT_ID" --content "Edited by CLI test" | jq .
 
 # messages delete
 buzz messages delete --event "$REPLY_ID" | jq .
+```
+
+Forwarding (kind:40009) copies the complete signed original into a `fwd` tag —
+the relay re-verifies that signature, so a forward is a fact, not a claim. The
+`--note` is your own text; the original is never merged into it. `--to-channel`
+takes a channel UUID or a DM UUID (DMs are channels), and needs a second
+channel to forward into:
+
+```bash
+# A second destination channel
+DEST_ID=$(buzz channels create --name "fwd-dest-$RANDOM" --type stream \
+  --visibility open | jq -r '.channel_id')
+
+# A message to forward
+SRC_MSG=$(buzz messages send --channel "$CHANNEL_ID" --content "Forward me" | jq -r '.event_id')
+
+# messages forward (no note)
+FWD=$(buzz messages forward --event "$SRC_MSG" --to-channel "$DEST_ID" | jq .)
+echo "$FWD"
+# Expected: {"event_id":"...","accepted":true,"message":"..."}
+FWD_ID=$(echo "$FWD" | jq -r '.event_id')
+
+# messages forward with a note (mentions in the note resolve against the destination)
+buzz messages forward --event "$SRC_MSG" --to-channel "$DEST_ID" \
+  --note "@someone relevant to us" | jq .
+
+# messages forward with a note from stdin
+echo 'Note with `backticks` stays literal.' \
+  | buzz messages forward --event "$SRC_MSG" --to-channel "$DEST_ID" --note - | jq .
+
+# Forward into a DM (see 6.6 for $DM_ID)
+buzz messages forward --event "$SRC_MSG" --to-channel "$DM_ID" | jq .
+
+# Forwards are part of the default message-kind set, so a plain read shows them
+buzz messages get --channel "$DEST_ID" | jq '[.[] | select(.kind == 40009)] | length'
+# Expected: >= 1 (default kinds are 9, 40002, 40008, 45001, 45003, 40009)
+buzz messages search --query "relevant to us" | jq '[.[] | select(.kind == 40009)] | length'
+# Expected: >= 1 — forward notes are searchable in the default kind set
+
+# Inspect the forward envelope in the destination
+buzz messages get --channel "$DEST_ID" --kinds 40009 | jq '.[0].tags'
+# Expected tags: ["h",<dest>], ["fwd",<original event JSON>], ["k","9"],
+#   ["fwd-src",<source uuid>,"channel"], ["q",<original id>,"",<original author>]
+# For a private-channel or DM source there is no "q" tag and the label is
+# "private" / "dm".
+
+# Forwarding a forward flattens — the embedded original is forwarded, never nested
+buzz messages forward --event "$FWD_ID" --to-channel "$CHANNEL_ID" | jq .
+# Expected: the new forward's "k" tag is still "9" and its fwd-src is the
+# original source channel, not "$DEST_ID"
+
+# A forward is a normal own message: edit the note, delete it, reply to it
+buzz messages edit --event "$FWD_ID" --content "Updated note" | jq .
+buzz messages delete --event "$FWD_ID" | jq .
+
+# Error paths (exit 1)
+buzz messages forward --event "$(printf 'f%.0s' {1..64})" --to-channel "$DEST_ID"
+# Expected: exit 1, "event ... not found"
+
+CANVAS_ID=$(buzz canvas set --channel "$CHANNEL_ID" --content "# c" | jq -r '.event_id')
+buzz messages forward --event "$CANVAS_ID" --to-channel "$DEST_ID"
+# Expected: exit 1, "kind 40100 cannot be forwarded (forwardable kinds: 9, 40002, 45001, 45003)"
 ```
 
 ### 6.4 Diff Messages

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -1,3 +1,5 @@
+use buzz_core::forward::{ForwardEnvelope, ForwardSourceType, FORWARDABLE_KINDS};
+use buzz_core::kind::{event_kind_u32, KIND_STREAM_MESSAGE_FORWARD};
 use buzz_sdk::{DeleteMessageOptions, DiffMeta, ThreadRef, VoteDirection};
 use nostr::PublicKey;
 use uuid::Uuid;
@@ -5,7 +7,7 @@ use uuid::Uuid;
 use crate::client::{normalize_events, normalize_write_response, BuzzClient};
 use crate::error::CliError;
 use crate::validate::{
-    infer_language, parse_event_id, parse_uuid, read_or_stdin, truncate_diff,
+    infer_language, parse_event_id, parse_uuid, read_or_stdin, sdk_err, truncate_diff,
     validate_content_size, validate_hex64, validate_uuid, MAX_DIFF_BYTES,
 };
 use buzz_sdk::mentions::{
@@ -273,7 +275,7 @@ pub async fn cmd_get_messages(
     let limit = limit.unwrap_or(50).min(200);
 
     let mut filter = serde_json::json!({
-        "kinds": [9, 40002, 40008, 45001, 45003],
+        "kinds": [9, 40002, 40008, 45001, 45003, KIND_STREAM_MESSAGE_FORWARD],
         "#h": [channel_id],
         "limit": limit
     });
@@ -358,7 +360,7 @@ pub async fn cmd_search(
     };
 
     let mut filter = serde_json::json!({
-        "kinds": [9, 40002, 45001, 45003],
+        "kinds": [9, 40002, 45001, 45003, KIND_STREAM_MESSAGE_FORWARD],
         "limit": limit
     });
     if let Some(q) = query {
@@ -573,6 +575,207 @@ pub async fn cmd_send_message(
 
     let event = client.sign_event(builder)?;
 
+    let resp = client.submit_event(event).await?;
+    println!("{}", normalize_write_response(&resp));
+    Ok(())
+}
+
+pub struct ForwardMessageParams {
+    pub event_id: String,
+    pub to_channel_id: String,
+    pub note: Option<String>,
+}
+
+/// Kinds fetched when resolving `--event`: everything forwardable, plus kind
+/// 40009 itself so a forward-of-a-forward can be flattened to its original.
+fn forward_fetch_kinds() -> Vec<u32> {
+    let mut kinds = FORWARDABLE_KINDS.to_vec();
+    kinds.push(KIND_STREAM_MESSAGE_FORWARD);
+    kinds
+}
+
+fn forwardable_kinds_list() -> String {
+    FORWARDABLE_KINDS
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Fetch one complete *signed* event by id.
+///
+/// Deliberately bypasses [`normalize_events`], which drops `sig`: a forward
+/// carries the original verbatim so the relay can re-verify its signature, so
+/// the signature has to survive this round trip. `kinds` is passed through when
+/// present — `ids` filters skip the relay p-gate, but the query stays explicit.
+async fn fetch_signed_event(
+    client: &BuzzClient,
+    event_id: &str,
+    kinds: Option<&[u32]>,
+) -> Result<Option<nostr::Event>, CliError> {
+    let mut filter = serde_json::json!({ "ids": [event_id], "limit": 1 });
+    if let Some(kinds) = kinds {
+        filter["kinds"] = serde_json::json!(kinds);
+    }
+    let raw = client.query(&filter).await?;
+    let events: Vec<serde_json::Value> = serde_json::from_str(&raw)
+        .map_err(|e| CliError::Other(format!("failed to parse query response: {e}")))?;
+    let Some(first) = events.into_iter().next() else {
+        return Ok(None);
+    };
+    let event = serde_json::from_value::<nostr::Event>(first)
+        .map_err(|e| CliError::Other(format!("relay returned an unparseable event: {e}")))?;
+    Ok(Some(event))
+}
+
+/// Explain why `--event` resolved to nothing: either the event exists but its
+/// kind is not forwardable (name the kind), or it genuinely isn't there.
+///
+/// A failure of the diagnostic lookup itself is propagated verbatim — a timeout
+/// or relay error must keep its network/relay exit code instead of being
+/// misreported as a client-side input error.
+async fn unforwardable_event_error(client: &BuzzClient, event_id: &str) -> CliError {
+    match fetch_signed_event(client, event_id, None).await {
+        Ok(Some(event)) => CliError::Usage(format!(
+            "kind {} cannot be forwarded (forwardable kinds: {})",
+            event_kind_u32(&event),
+            forwardable_kinds_list()
+        )),
+        Ok(None) => CliError::Usage(format!("event {event_id} not found")),
+        Err(e) => e,
+    }
+}
+
+/// Read an event's channel UUID straight off its `h` tag.
+fn event_channel_uuid(event: &nostr::Event) -> Result<Uuid, CliError> {
+    event
+        .tags
+        .iter()
+        .map(|t| t.as_slice())
+        .find(|parts| parts.first().is_some_and(|name| name == "h"))
+        .and_then(|parts| parts.get(1))
+        .and_then(|value| Uuid::parse_str(value).ok())
+        .ok_or_else(|| {
+            CliError::Usage(format!(
+                "event {} has no valid h tag — cannot determine its source channel",
+                event.id.to_hex()
+            ))
+        })
+}
+
+/// Classify a source channel from its kind:39000 metadata tags.
+///
+/// Fails closed: without an explicit `public` tag the channel counts as
+/// private, which drops the `q` back-reference and the linkable attribution
+/// rather than advertising a link readers may not be able to follow.
+fn forward_source_type_from_metadata(event: &serde_json::Value) -> ForwardSourceType {
+    let mut channel_type = "";
+    let mut public = false;
+    for tag in event
+        .get("tags")
+        .and_then(|t| t.as_array())
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+    {
+        let Some(parts) = tag.as_array() else {
+            continue;
+        };
+        match parts.first().and_then(|v| v.as_str()).unwrap_or("") {
+            "t" => channel_type = parts.get(1).and_then(|v| v.as_str()).unwrap_or(""),
+            "public" => public = true,
+            _ => {}
+        }
+    }
+
+    if channel_type == buzz_core::channel::ChannelType::Dm.as_str() {
+        ForwardSourceType::Dm
+    } else if public {
+        ForwardSourceType::Channel
+    } else {
+        ForwardSourceType::Private
+    }
+}
+
+/// Resolve the `fwd-src` class of the channel the original lives in.
+async fn resolve_forward_source_type(
+    client: &BuzzClient,
+    source_channel_id: &str,
+) -> Result<ForwardSourceType, CliError> {
+    let filter = serde_json::json!({
+        "kinds": [39000],
+        "#d": [source_channel_id],
+        "limit": 1,
+    });
+    let raw = client.query(&filter).await?;
+    let events: Vec<serde_json::Value> = serde_json::from_str(&raw).unwrap_or_default();
+    let event = events.first().ok_or_else(|| {
+        CliError::Other(format!(
+            "no channel metadata for source channel {source_channel_id} — cannot classify the source"
+        ))
+    })?;
+    Ok(forward_source_type_from_metadata(event))
+}
+
+/// Forward a message into another channel or DM (kind 40009).
+///
+/// The note is the forwarder's own content; the original signed event is copied
+/// verbatim into the `fwd` tag. Forwarding a forward flattens to the embedded
+/// original, so forwards never nest.
+pub async fn cmd_forward_message(
+    client: &BuzzClient,
+    p: ForwardMessageParams,
+) -> Result<(), CliError> {
+    validate_hex64(&p.event_id)?;
+    let destination_uuid = parse_uuid(&p.to_channel_id)?;
+    let note = match p.note {
+        Some(ref n) => read_or_stdin(n)?,
+        None => String::new(),
+    };
+    validate_content_size(&note)?;
+
+    let fetched =
+        match fetch_signed_event(client, &p.event_id, Some(&forward_fetch_kinds())).await? {
+            Some(event) => event,
+            None => return Err(unforwardable_event_error(client, &p.event_id).await),
+        };
+
+    // Flatten: forwarding a forward forwards its embedded original, keeping
+    // forward depth at 1 (the relay rejects an embedded kind 40009).
+    let original = if event_kind_u32(&fetched) == KIND_STREAM_MESSAGE_FORWARD {
+        ForwardEnvelope::parse(&fetched)
+            .map_err(|e| {
+                CliError::Other(format!(
+                    "cannot flatten forward {}: {e}",
+                    fetched.id.to_hex()
+                ))
+            })?
+            .original
+    } else {
+        fetched
+    };
+
+    let source_uuid = event_channel_uuid(&original)?;
+    let source_type = resolve_forward_source_type(client, &source_uuid.to_string()).await?;
+
+    // Mentions in the note resolve against the destination channel — that's
+    // where the note lands. The original author is never p-tagged.
+    let mut mentions = resolve_content_mentions(client, &p.to_channel_id, &note).await;
+    let stripped = strip_code_regions(&note);
+    let uri_pubkeys = extract_nostr_uris(&stripped);
+    merge_mentions(&mut mentions, &uri_pubkeys, MENTION_CAP);
+    let mention_refs: Vec<&str> = mentions.iter().map(String::as_str).collect();
+
+    let builder = buzz_sdk::build_forward(
+        destination_uuid,
+        &original,
+        source_uuid,
+        source_type,
+        &note,
+        &mention_refs,
+    )
+    .map_err(sdk_err)?;
+
+    let event = client.sign_event(builder)?;
     let resp = client.submit_event(event).await?;
     println!("{}", normalize_write_response(&resp));
     Ok(())
@@ -812,6 +1015,21 @@ pub async fn dispatch(
             )
             .await
         }
+        MessagesCmd::Forward {
+            event,
+            to_channel,
+            note,
+        } => {
+            cmd_forward_message(
+                client,
+                ForwardMessageParams {
+                    event_id: event,
+                    to_channel_id: to_channel,
+                    note,
+                },
+            )
+            .await
+        }
         MessagesCmd::Edit { event, content } => cmd_edit_message(client, &event, &content).await,
         MessagesCmd::Delete {
             event,
@@ -876,7 +1094,11 @@ pub async fn dispatch(
 
 #[cfg(test)]
 mod tests {
-    use super::{find_root_from_tags, match_profiles_by_name, parse_member_pubkeys};
+    use super::{
+        event_channel_uuid, find_root_from_tags, forward_fetch_kinds,
+        forward_source_type_from_metadata, forwardable_kinds_list, match_profiles_by_name,
+        parse_member_pubkeys, ForwardSourceType, KIND_STREAM_MESSAGE_FORWARD,
+    };
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
     };
@@ -1163,5 +1385,79 @@ mod tests {
             profile_event(PK_VALID_A, Some("Aaron"), None),
         ];
         assert_eq!(match_profiles_by_name(&events, "Aaron").len(), 1);
+    }
+
+    // --- forward ---
+
+    const CHANNEL_UUID: &str = "11111111-1111-4111-8111-111111111111";
+
+    #[test]
+    fn forward_fetch_kinds_include_forwardables_plus_the_forward_kind() {
+        let kinds = forward_fetch_kinds();
+        for expected in [9, 40002, 45001, 45003, KIND_STREAM_MESSAGE_FORWARD] {
+            assert!(kinds.contains(&expected), "missing kind {expected}");
+        }
+        assert_eq!(forwardable_kinds_list(), "9, 40002, 45001, 45003");
+    }
+
+    #[test]
+    fn source_type_from_metadata_classifies_open_private_and_dm() {
+        let open = json!({"tags": [["d", CHANNEL_UUID], ["public"], ["t", "stream"]]});
+        assert_eq!(
+            forward_source_type_from_metadata(&open),
+            ForwardSourceType::Channel
+        );
+
+        let private = json!({"tags": [["d", CHANNEL_UUID], ["private"], ["t", "forum"]]});
+        assert_eq!(
+            forward_source_type_from_metadata(&private),
+            ForwardSourceType::Private
+        );
+
+        // `t=dm` wins over visibility — DM metadata also carries `private`.
+        let dm = json!({"tags": [["d", CHANNEL_UUID], ["private"], ["t", "dm"], ["hidden"]]});
+        assert_eq!(
+            forward_source_type_from_metadata(&dm),
+            ForwardSourceType::Dm
+        );
+    }
+
+    #[test]
+    fn source_type_from_metadata_fails_closed_without_a_public_tag() {
+        let bare = json!({"tags": [["d", CHANNEL_UUID]]});
+        assert_eq!(
+            forward_source_type_from_metadata(&bare),
+            ForwardSourceType::Private
+        );
+        assert_eq!(
+            forward_source_type_from_metadata(&json!({})),
+            ForwardSourceType::Private
+        );
+    }
+
+    fn signed_event(tags: Vec<Vec<&str>>) -> nostr::Event {
+        let tags: Vec<nostr::Tag> = tags
+            .iter()
+            .map(|parts| nostr::Tag::parse(parts.iter().copied()).expect("tag"))
+            .collect();
+        nostr::EventBuilder::new(nostr::Kind::Custom(9), "body")
+            .tags(tags)
+            .sign_with_keys(&nostr::Keys::generate())
+            .expect("sign")
+    }
+
+    #[test]
+    fn event_channel_uuid_reads_the_h_tag() {
+        let event = signed_event(vec![vec!["h", CHANNEL_UUID]]);
+        assert_eq!(
+            event_channel_uuid(&event).expect("uuid").to_string(),
+            CHANNEL_UUID
+        );
+    }
+
+    #[test]
+    fn event_channel_uuid_rejects_missing_and_malformed_h_tags() {
+        assert!(event_channel_uuid(&signed_event(vec![])).is_err());
+        assert!(event_channel_uuid(&signed_event(vec![vec!["h", "not-a-uuid"]])).is_err());
     }
 }

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -409,6 +409,29 @@ pub enum MessagesCmd {
         #[arg(long)]
         reply_to: Option<String>,
     },
+    /// Forward a message into another channel or DM
+    #[command(
+        after_help = "The note is your own text — the original message is copied verbatim into a \
+`fwd` tag, never merged into the note. --to-channel takes a channel UUID or a \
+DM UUID (DMs are channels). Forwarding a forward flattens: the embedded \
+original is forwarded instead, so forwards are never nested.\n\n\
+Examples:\n  \
+buzz messages forward --event <HEX> --to-channel <UUID>\n  \
+buzz messages forward --event <HEX> --to-channel <UUID> --note \"@alice relevant to us\"\n  \
+buzz messages forward --event <HEX> --to-channel <DM-UUID> --note -"
+    )]
+    Forward {
+        /// Event ID of the message to forward (64-char hex)
+        #[arg(long)]
+        event: String,
+        /// Destination channel or DM UUID
+        #[arg(long = "to-channel")]
+        to_channel: String,
+        /// Optional note to send with the forward — supports @mentions and
+        /// markdown. Use '-' to read from stdin.
+        #[arg(long)]
+        note: Option<String>,
+    },
     /// Edit a previously sent message
     Edit {
         /// Event ID of the message to edit (64-char hex)
@@ -1920,6 +1943,7 @@ mod tests {
             vec![
                 "delete",
                 "edit",
+                "forward",
                 "get",
                 "search",
                 "send",
@@ -2046,7 +2070,7 @@ mod tests {
             ("feed", 1),
             ("issues", 4),
             ("media", 1),
-            ("messages", 8),
+            ("messages", 9),
             ("pack", 2),
             ("patches", 4),
             ("pr", 5),

--- a/crates/buzz-core/src/forward.rs
+++ b/crates/buzz-core/src/forward.rs
@@ -1,0 +1,1253 @@
+//! Shared message-forward envelope contract (kind 40009).
+//!
+//! A forward is a root message authored by the *forwarder*: its `content` is
+//! the forwarder's optional note, and the complete signed original event is
+//! carried verbatim in a `fwd` tag. The original's text is never merged into
+//! the content, so attribution and full-text search stay intact.
+//!
+//! Both the relay validator and the SDK builder use this module so producer and
+//! consumer cannot drift: [`forward_tags`] emits the canonical tag set,
+//! [`ForwardEnvelope::parse`] reads it back, and
+//! [`ForwardEnvelope::verify_embedded`] upgrades the embedded copy from a claim
+//! to a fact by re-deriving its NIP-01 id and checking its Schnorr signature.
+
+use std::fmt;
+use std::str::FromStr;
+
+use nostr::{Event, JsonUtil};
+use uuid::Uuid;
+
+use crate::error::VerificationError;
+use crate::kind::{
+    event_kind_u32, KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_STREAM_MESSAGE,
+    KIND_STREAM_MESSAGE_V2,
+};
+use crate::verification::verify_event;
+
+/// Tag carrying the stringified JSON of the complete original signed event.
+pub const FWD_TAG: &str = "fwd";
+
+/// Tag carrying the source channel UUID and its source-type label.
+pub const FWD_SRC_TAG: &str = "fwd-src";
+
+/// NIP-18 generic-repost tag carrying the stringified original kind.
+pub const FWD_KIND_TAG: &str = "k";
+
+/// NIP-21 quote tag, emitted only for open-channel sources.
+pub const FWD_QUOTE_TAG: &str = "q";
+
+/// Maximum byte length of the [`FWD_TAG`] value (64 KiB).
+pub const FWD_MAX_BYTES: usize = 64 * 1024;
+
+/// Kinds that may be forwarded. Kind 40009 is deliberately absent: forwarding a
+/// forward flattens client-side to the embedded original, so depth is always 1.
+pub const FORWARDABLE_KINDS: &[u32] = &[
+    KIND_STREAM_MESSAGE,
+    KIND_STREAM_MESSAGE_V2,
+    KIND_FORUM_POST,
+    KIND_FORUM_COMMENT,
+];
+
+/// `fwd-src` label for a source channel with open visibility.
+pub const FWD_SRC_TYPE_CHANNEL: &str = "channel";
+
+/// `fwd-src` label for a non-open group source channel.
+pub const FWD_SRC_TYPE_PRIVATE: &str = "private";
+
+/// `fwd-src` label for a direct-message source channel.
+pub const FWD_SRC_TYPE_DM: &str = "dm";
+
+/// Visibility class of the channel a message was forwarded from.
+///
+/// The label is part of the wire contract: the relay checks it against the
+/// actual source channel row, and clients use it to pick the attribution line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForwardSourceType {
+    /// Source channel has open visibility — attribution is linkable.
+    Channel,
+    /// Source channel is a non-open group channel.
+    Private,
+    /// Source channel is a direct-message conversation.
+    Dm,
+}
+
+impl ForwardSourceType {
+    /// Canonical wire label.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Channel => FWD_SRC_TYPE_CHANNEL,
+            Self::Private => FWD_SRC_TYPE_PRIVATE,
+            Self::Dm => FWD_SRC_TYPE_DM,
+        }
+    }
+
+    /// Whether this source class permits a `q` tag (and a linkable attribution).
+    pub fn allows_quote(&self) -> bool {
+        matches!(self, Self::Channel)
+    }
+}
+
+impl fmt::Display for ForwardSourceType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ForwardSourceType {
+    type Err = ForwardError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            FWD_SRC_TYPE_CHANNEL => Ok(Self::Channel),
+            FWD_SRC_TYPE_PRIVATE => Ok(Self::Private),
+            FWD_SRC_TYPE_DM => Ok(Self::Dm),
+            other => Err(ForwardError::UnknownSourceType {
+                label: other.to_string(),
+            }),
+        }
+    }
+}
+
+/// The `q` tag reference to the original, present only for open sources.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForwardQuote {
+    /// Original event id, lowercase hex.
+    pub event_id: String,
+    /// Original author pubkey, lowercase hex.
+    pub author_pubkey: String,
+}
+
+/// A parsed kind 40009 forward envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForwardEnvelope {
+    /// The complete original event decoded from the `fwd` tag. Signature is
+    /// *not* checked by [`ForwardEnvelope::parse`] — call
+    /// [`ForwardEnvelope::verify_embedded`] for that.
+    pub original: Event,
+    /// Source channel UUID from `fwd-src`, equal to the original's `h` tag.
+    pub source_channel_id: Uuid,
+    /// Source-type label from `fwd-src`.
+    pub source_type: ForwardSourceType,
+    /// The `q` reference, present only when `source_type` is
+    /// [`ForwardSourceType::Channel`].
+    pub quote: Option<ForwardQuote>,
+    /// `imeta` tags copied verbatim from the original.
+    pub imeta: Vec<Vec<String>>,
+}
+
+/// Reasons a forward envelope is malformed.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ForwardError {
+    /// No `fwd` tag on the event.
+    #[error("missing {FWD_TAG} tag")]
+    MissingFwd,
+
+    /// More than one `fwd` tag; exactly one is allowed.
+    #[error("expected exactly one {FWD_TAG} tag, found {count}")]
+    DuplicateFwd {
+        /// Number of `fwd` tags seen.
+        count: usize,
+    },
+
+    /// The `fwd` tag value exceeds [`FWD_MAX_BYTES`].
+    #[error("{FWD_TAG} tag is {bytes} bytes, limit is {FWD_MAX_BYTES}")]
+    FwdTooLarge {
+        /// Byte length of the offending value.
+        bytes: usize,
+    },
+
+    /// The `fwd` tag value is not a parseable Nostr event.
+    #[error("{FWD_TAG} tag is not a parseable event: {reason}")]
+    UnparseableEmbedded {
+        /// Underlying parse failure.
+        reason: String,
+    },
+
+    /// The embedded event's kind is not in [`FORWARDABLE_KINDS`].
+    #[error("kind {kind} is not forwardable")]
+    KindNotForwardable {
+        /// The embedded event's kind.
+        kind: u32,
+    },
+
+    /// No `k` tag on the event.
+    #[error("missing {FWD_KIND_TAG} tag")]
+    MissingKind,
+
+    /// The `k` tag does not match the embedded event's kind.
+    #[error("{FWD_KIND_TAG} tag {declared:?} does not match embedded kind {embedded}")]
+    KindMismatch {
+        /// Value of the `k` tag.
+        declared: String,
+        /// The embedded event's actual kind.
+        embedded: u32,
+    },
+
+    /// No `fwd-src` tag on the event.
+    #[error("missing {FWD_SRC_TAG} tag")]
+    MissingSource,
+
+    /// More than one `fwd-src` tag; exactly one is allowed.
+    #[error("expected exactly one {FWD_SRC_TAG} tag, found {count}")]
+    DuplicateSource {
+        /// Number of `fwd-src` tags seen.
+        count: usize,
+    },
+
+    /// The `fwd-src` tag is missing elements or carries an invalid UUID.
+    #[error("malformed {FWD_SRC_TAG} tag: {reason}")]
+    MalformedSource {
+        /// What was wrong with the tag.
+        reason: String,
+    },
+
+    /// The `fwd-src` type label is not a known source class.
+    #[error("unknown {FWD_SRC_TAG} type {label:?}")]
+    UnknownSourceType {
+        /// The unrecognized label.
+        label: String,
+    },
+
+    /// No destination `h` tag on the outer event.
+    #[error("missing destination h tag")]
+    MissingDestination,
+
+    /// More than one destination `h` tag; exactly one is allowed so generic
+    /// NIP-29 consumers cannot scope the same signed event differently.
+    #[error("expected exactly one destination h tag, found {count}")]
+    DuplicateDestination {
+        /// Number of outer `h` tags seen.
+        count: usize,
+    },
+
+    /// The destination `h` tag is not the canonical two-element shape.
+    #[error("malformed destination h tag: {reason}")]
+    MalformedDestination {
+        /// What was wrong with the tag.
+        reason: String,
+    },
+
+    /// The embedded original carries no `h` tag, or it is not a UUID.
+    #[error("embedded event has no valid h tag")]
+    EmbeddedMissingChannel,
+
+    /// More than one `h` tag on the embedded original; its source channel must
+    /// be unambiguous.
+    #[error("expected exactly one h tag on the embedded original, found {count}")]
+    DuplicateEmbeddedChannel {
+        /// Number of embedded `h` tags seen.
+        count: usize,
+    },
+
+    /// The embedded original's `h` tag is not the canonical two-element shape.
+    #[error("malformed h tag on the embedded original: {reason}")]
+    MalformedEmbeddedChannel {
+        /// What was wrong with the tag.
+        reason: String,
+    },
+
+    /// The `fwd-src` UUID disagrees with the embedded original's `h` tag.
+    #[error("{FWD_SRC_TAG} channel {declared} does not match embedded h tag {embedded}")]
+    SourceChannelMismatch {
+        /// UUID declared in `fwd-src`.
+        declared: Uuid,
+        /// UUID found on the embedded original.
+        embedded: Uuid,
+    },
+
+    /// A `q` tag was present for a non-open source.
+    #[error("{FWD_QUOTE_TAG} tag is only allowed for {FWD_SRC_TYPE_CHANNEL} sources")]
+    QuoteNotAllowed,
+
+    /// More than one `q` tag; at most one is allowed.
+    #[error("expected at most one {FWD_QUOTE_TAG} tag, found {count}")]
+    DuplicateQuote {
+        /// Number of `q` tags seen.
+        count: usize,
+    },
+
+    /// The `q` tag is missing its id or author element.
+    #[error("malformed {FWD_QUOTE_TAG} tag: {reason}")]
+    MalformedQuote {
+        /// What was wrong with the tag.
+        reason: String,
+    },
+
+    /// The `q` tag id or author does not match the embedded original.
+    #[error("{FWD_QUOTE_TAG} tag {field} {declared:?} does not match embedded {expected:?}")]
+    QuoteMismatch {
+        /// Which element mismatched (`id` or `pubkey`).
+        field: &'static str,
+        /// Value found in the `q` tag.
+        declared: String,
+        /// Value on the embedded original.
+        expected: String,
+    },
+
+    /// A marked (`root`/`reply`) `e` tag was present. Forwards are always roots.
+    #[error("marked e tags are not allowed on a forward")]
+    MarkedETag,
+
+    /// The outer event's `imeta` tags are not a verbatim copy of the embedded
+    /// original's. Divergent outer attachments would render differently from
+    /// the embedded copy clients actually display.
+    #[error("imeta tags must be copied verbatim from the embedded original (outer {outer}, embedded {embedded})")]
+    ImetaMismatch {
+        /// Number of `imeta` tags on the outer event.
+        outer: usize,
+        /// Number of `imeta` tags on the embedded original.
+        embedded: usize,
+    },
+}
+
+impl ForwardEnvelope {
+    /// Parses the forward envelope out of a kind 40009 event's tags.
+    ///
+    /// Callers dispatch on the outer kind; this only reads the envelope tags.
+    /// Purely structural — the embedded signature and the existence/visibility
+    /// of the source channel are checked separately (see
+    /// [`ForwardEnvelope::verify_embedded`] and the relay's channel lookup).
+    pub fn parse(event: &Event) -> Result<Self, ForwardError> {
+        reject_marked_e_tags(event)?;
+        check_destination_tag(event)?;
+
+        match tag_count(event, FWD_TAG) {
+            0 => return Err(ForwardError::MissingFwd),
+            1 => {}
+            count => return Err(ForwardError::DuplicateFwd { count }),
+        }
+        let fwd = single_tag_value(event, FWD_TAG).ok_or(ForwardError::MissingFwd)?;
+
+        if fwd.len() > FWD_MAX_BYTES {
+            return Err(ForwardError::FwdTooLarge { bytes: fwd.len() });
+        }
+
+        let original = Event::from_json(fwd).map_err(|e| ForwardError::UnparseableEmbedded {
+            reason: e.to_string(),
+        })?;
+
+        let embedded_kind = event_kind_u32(&original);
+        if !FORWARDABLE_KINDS.contains(&embedded_kind) {
+            return Err(ForwardError::KindNotForwardable {
+                kind: embedded_kind,
+            });
+        }
+
+        let declared_kind =
+            single_tag_value(event, FWD_KIND_TAG).ok_or(ForwardError::MissingKind)?;
+        if declared_kind.parse::<u32>() != Ok(embedded_kind) {
+            return Err(ForwardError::KindMismatch {
+                declared: declared_kind.to_string(),
+                embedded: embedded_kind,
+            });
+        }
+
+        let (source_channel_id, source_type) = parse_source_tag(event)?;
+        let embedded_channel_id = embedded_channel_id(&original)?;
+        if source_channel_id != embedded_channel_id {
+            return Err(ForwardError::SourceChannelMismatch {
+                declared: source_channel_id,
+                embedded: embedded_channel_id,
+            });
+        }
+
+        let quote = parse_quote_tag(event, &original, source_type)?;
+
+        // The outer copy is what generic NIP-92 consumers render, so it must be
+        // byte-identical to the embedded original's — no extra, missing, or
+        // rewritten attachment metadata.
+        let imeta = imeta_tags(&original);
+        let outer_imeta = imeta_tags(event);
+        if outer_imeta != imeta {
+            return Err(ForwardError::ImetaMismatch {
+                outer: outer_imeta.len(),
+                embedded: imeta.len(),
+            });
+        }
+
+        Ok(Self {
+            original,
+            source_channel_id,
+            source_type,
+            quote,
+            imeta,
+        })
+    }
+
+    /// Re-derives the embedded original's NIP-01 id and verifies its Schnorr
+    /// signature, reusing [`verify_event`].
+    ///
+    /// CPU-bound — call via `tokio::task::spawn_blocking` in async contexts.
+    pub fn verify_embedded(&self) -> Result<(), VerificationError> {
+        verify_event(&self.original)
+    }
+}
+
+/// Builds the canonical tag set for a kind 40009 forward.
+///
+/// Emits, in order: `h` (destination), `fwd` (complete original JSON), `k`
+/// (original kind), `fwd-src` (source channel + type), `q` (open sources only),
+/// then the original's `imeta` tags verbatim. `p` tags for mentions the
+/// forwarder writes in the note are the caller's business — a forward never
+/// p-tags the original author.
+///
+/// `source_channel_id` must equal the original's own `h` tag.
+pub fn forward_tags(
+    destination_channel_id: Uuid,
+    original: &Event,
+    source_channel_id: Uuid,
+    source_type: ForwardSourceType,
+) -> Result<Vec<Vec<String>>, ForwardError> {
+    let embedded_kind = event_kind_u32(original);
+    if !FORWARDABLE_KINDS.contains(&embedded_kind) {
+        return Err(ForwardError::KindNotForwardable {
+            kind: embedded_kind,
+        });
+    }
+
+    let embedded_channel_id = embedded_channel_id(original)?;
+    if source_channel_id != embedded_channel_id {
+        return Err(ForwardError::SourceChannelMismatch {
+            declared: source_channel_id,
+            embedded: embedded_channel_id,
+        });
+    }
+
+    let embedded_json = original.as_json();
+    if embedded_json.len() > FWD_MAX_BYTES {
+        return Err(ForwardError::FwdTooLarge {
+            bytes: embedded_json.len(),
+        });
+    }
+
+    let mut tags = vec![
+        vec!["h".to_string(), destination_channel_id.to_string()],
+        vec![FWD_TAG.to_string(), embedded_json],
+        vec![FWD_KIND_TAG.to_string(), embedded_kind.to_string()],
+        vec![
+            FWD_SRC_TAG.to_string(),
+            source_channel_id.to_string(),
+            source_type.as_str().to_string(),
+        ],
+    ];
+
+    if source_type.allows_quote() {
+        tags.push(vec![
+            FWD_QUOTE_TAG.to_string(),
+            original.id.to_hex(),
+            String::new(),
+            original.pubkey.to_hex(),
+        ]);
+    }
+
+    tags.extend(imeta_tags(original));
+
+    Ok(tags)
+}
+
+/// Collects an event's `imeta` tags verbatim as raw string vectors.
+fn imeta_tags(event: &Event) -> Vec<Vec<String>> {
+    event
+        .tags
+        .iter()
+        .map(|t| t.as_slice())
+        .filter(|parts| parts.first().is_some_and(|name| name == "imeta"))
+        .map(<[String]>::to_vec)
+        .collect()
+}
+
+fn tag_count(event: &Event, name: &str) -> usize {
+    event
+        .tags
+        .iter()
+        .filter(|t| t.as_slice().first().is_some_and(|n| n == name))
+        .count()
+}
+
+/// Returns the second element of the sole tag with `name`, or `None` when the
+/// tag is absent, duplicated, or has no value element.
+fn single_tag_value<'a>(event: &'a Event, name: &str) -> Option<&'a str> {
+    let mut matches = event
+        .tags
+        .iter()
+        .map(|t| t.as_slice())
+        .filter(|parts| parts.first().is_some_and(|n| n == name));
+    let first = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+    first.get(1).map(String::as_str)
+}
+
+fn reject_marked_e_tags(event: &Event) -> Result<(), ForwardError> {
+    let marked = event.tags.iter().any(|t| {
+        let parts = t.as_slice();
+        parts.first().is_some_and(|n| n == "e")
+            && parts
+                .get(3)
+                .is_some_and(|marker| marker == "root" || marker == "reply")
+    });
+    if marked {
+        return Err(ForwardError::MarkedETag);
+    }
+    Ok(())
+}
+
+/// Returns the elements of the first `h` tag, or `None` when there is none.
+fn first_h_tag(event: &Event) -> Option<&[String]> {
+    event
+        .tags
+        .iter()
+        .map(|t| t.as_slice())
+        .find(|parts| parts.first().is_some_and(|n| n == "h"))
+}
+
+/// A forward names exactly one destination, in the canonical `["h", <value>]`
+/// shape: exactly two elements, so a trailing element cannot smuggle a second
+/// reading of the same scope past consumers that only look at element 1. Scoped
+/// to kind 40009 — the generic ingest `h` handling for other kinds is untouched.
+fn check_destination_tag(event: &Event) -> Result<(), ForwardError> {
+    match tag_count(event, "h") {
+        0 => return Err(ForwardError::MissingDestination),
+        1 => {}
+        count => return Err(ForwardError::DuplicateDestination { count }),
+    }
+
+    let parts = first_h_tag(event).ok_or(ForwardError::MissingDestination)?;
+    if parts.len() != 2 {
+        return Err(ForwardError::MalformedDestination {
+            reason: format!("expected exactly 2 elements, found {}", parts.len()),
+        });
+    }
+    Ok(())
+}
+
+/// Whether `value` is a 64-character hex string (either case).
+fn is_hex64(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+fn parse_source_tag(event: &Event) -> Result<(Uuid, ForwardSourceType), ForwardError> {
+    let count = tag_count(event, FWD_SRC_TAG);
+    match count {
+        0 => return Err(ForwardError::MissingSource),
+        1 => {}
+        count => return Err(ForwardError::DuplicateSource { count }),
+    }
+
+    let parts = event
+        .tags
+        .iter()
+        .map(|t| t.as_slice())
+        .find(|parts| parts.first().is_some_and(|n| n == FWD_SRC_TAG))
+        .ok_or(ForwardError::MissingSource)?;
+
+    let uuid = parts.get(1).ok_or_else(|| ForwardError::MalformedSource {
+        reason: "missing source channel uuid".to_string(),
+    })?;
+    let uuid = Uuid::parse_str(uuid).map_err(|_| ForwardError::MalformedSource {
+        reason: format!("invalid source channel uuid {uuid:?}"),
+    })?;
+    let label = parts.get(2).ok_or_else(|| ForwardError::MalformedSource {
+        reason: "missing source type label".to_string(),
+    })?;
+
+    Ok((uuid, label.parse()?))
+}
+
+/// The embedded original's source channel, held to the same canonical
+/// `["h", <uuid>]` shape as the destination tag.
+fn embedded_channel_id(original: &Event) -> Result<Uuid, ForwardError> {
+    match tag_count(original, "h") {
+        0 => return Err(ForwardError::EmbeddedMissingChannel),
+        1 => {}
+        count => return Err(ForwardError::DuplicateEmbeddedChannel { count }),
+    }
+
+    let parts = first_h_tag(original).ok_or(ForwardError::EmbeddedMissingChannel)?;
+    if parts.len() != 2 {
+        return Err(ForwardError::MalformedEmbeddedChannel {
+            reason: format!("expected exactly 2 elements, found {}", parts.len()),
+        });
+    }
+
+    Uuid::parse_str(&parts[1]).map_err(|_| ForwardError::EmbeddedMissingChannel)
+}
+
+fn parse_quote_tag(
+    event: &Event,
+    original: &Event,
+    source_type: ForwardSourceType,
+) -> Result<Option<ForwardQuote>, ForwardError> {
+    let count = tag_count(event, FWD_QUOTE_TAG);
+    match count {
+        0 => return Ok(None),
+        1 => {}
+        count => return Err(ForwardError::DuplicateQuote { count }),
+    }
+    if !source_type.allows_quote() {
+        return Err(ForwardError::QuoteNotAllowed);
+    }
+
+    let parts = event
+        .tags
+        .iter()
+        .map(|t| t.as_slice())
+        .find(|parts| parts.first().is_some_and(|n| n == FWD_QUOTE_TAG))
+        .ok_or_else(|| ForwardError::MalformedQuote {
+            reason: "missing quote tag".to_string(),
+        })?;
+
+    // NIP-FW pins the shape to exactly `["q", <id>, "", <pubkey>]`: no relay
+    // hint (the source is same-relay by construction) and no trailing
+    // elements, so every producer emits the identical tag.
+    if parts.len() != 4 {
+        return Err(ForwardError::MalformedQuote {
+            reason: format!("expected exactly 4 elements, found {}", parts.len()),
+        });
+    }
+    if !parts[2].is_empty() {
+        return Err(ForwardError::MalformedQuote {
+            reason: format!("relay hint must be empty, found {:?}", parts[2]),
+        });
+    }
+
+    let event_id = &parts[1];
+    let author_pubkey = &parts[3];
+    if !is_hex64(event_id) {
+        return Err(ForwardError::MalformedQuote {
+            reason: format!("event id {event_id:?} is not 64 hex characters"),
+        });
+    }
+    if !is_hex64(author_pubkey) {
+        return Err(ForwardError::MalformedQuote {
+            reason: format!("author pubkey {author_pubkey:?} is not 64 hex characters"),
+        });
+    }
+
+    let expected_id = original.id.to_hex();
+    if !event_id.eq_ignore_ascii_case(&expected_id) {
+        return Err(ForwardError::QuoteMismatch {
+            field: "id",
+            declared: event_id.to_string(),
+            expected: expected_id,
+        });
+    }
+    let expected_pubkey = original.pubkey.to_hex();
+    if !author_pubkey.eq_ignore_ascii_case(&expected_pubkey) {
+        return Err(ForwardError::QuoteMismatch {
+            field: "pubkey",
+            declared: author_pubkey.to_string(),
+            expected: expected_pubkey,
+        });
+    }
+
+    Ok(Some(ForwardQuote {
+        event_id: expected_id,
+        author_pubkey: expected_pubkey,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kind::KIND_STREAM_MESSAGE_FORWARD;
+    use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    const SOURCE_CHANNEL: &str = "11111111-1111-4111-8111-111111111111";
+    const DEST_CHANNEL: &str = "22222222-2222-4222-8222-222222222222";
+
+    fn source_id() -> Uuid {
+        Uuid::parse_str(SOURCE_CHANNEL).expect("source uuid")
+    }
+
+    fn dest_id() -> Uuid {
+        Uuid::parse_str(DEST_CHANNEL).expect("dest uuid")
+    }
+
+    fn sign(kind: u32, content: &str, tags: &[Vec<String>]) -> Event {
+        let keys = Keys::generate();
+        let tags: Vec<Tag> = tags
+            .iter()
+            .map(|parts| Tag::parse(parts.iter().map(String::as_str)).expect("tag"))
+            .collect();
+        EventBuilder::new(Kind::Custom(kind as u16), content)
+            .tags(tags)
+            .sign_with_keys(&keys)
+            .expect("sign")
+    }
+
+    fn owned(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|p| (*p).to_string()).collect()
+    }
+
+    /// A kind 9 original in the source channel with one imeta tag.
+    fn original() -> Event {
+        sign(
+            KIND_STREAM_MESSAGE,
+            "original text",
+            &[
+                owned(&["h", SOURCE_CHANNEL]),
+                owned(&["imeta", "url https://example.test/a.png", "x abc123"]),
+            ],
+        )
+    }
+
+    fn forward_from(tags: &[Vec<String>]) -> Event {
+        sign(KIND_STREAM_MESSAGE_FORWARD, "note", tags)
+    }
+
+    fn open_tags(original: &Event) -> Vec<Vec<String>> {
+        forward_tags(dest_id(), original, source_id(), ForwardSourceType::Channel)
+            .expect("build tags")
+    }
+
+    fn replace_tag(tags: &[Vec<String>], name: &str, replacement: Vec<String>) -> Vec<Vec<String>> {
+        tags.iter()
+            .map(|parts| {
+                if parts.first().map(String::as_str) == Some(name) {
+                    replacement.clone()
+                } else {
+                    parts.clone()
+                }
+            })
+            .collect()
+    }
+
+    fn drop_tag(tags: &[Vec<String>], name: &str) -> Vec<Vec<String>> {
+        tags.iter()
+            .filter(|parts| parts.first().map(String::as_str) != Some(name))
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn happy_path_round_trips_and_verifies() {
+        let original = original();
+        let tags = open_tags(&original);
+
+        assert_eq!(tags[0], owned(&["h", DEST_CHANNEL]));
+        assert_eq!(tags[2], owned(&["k", "9"]));
+        assert_eq!(
+            tags[3],
+            owned(&["fwd-src", SOURCE_CHANNEL, FWD_SRC_TYPE_CHANNEL])
+        );
+        assert!(tags.iter().all(|parts| parts[0] != "p"));
+
+        let forward = forward_from(&tags);
+        let envelope = ForwardEnvelope::parse(&forward).expect("parse");
+
+        assert_eq!(envelope.original.id, original.id);
+        assert_eq!(envelope.source_channel_id, source_id());
+        assert_eq!(envelope.source_type, ForwardSourceType::Channel);
+        assert_eq!(
+            envelope.quote,
+            Some(ForwardQuote {
+                event_id: original.id.to_hex(),
+                author_pubkey: original.pubkey.to_hex(),
+            })
+        );
+        assert_eq!(envelope.imeta.len(), 1);
+        assert_eq!(envelope.imeta[0][0], "imeta");
+        assert!(envelope.verify_embedded().is_ok());
+    }
+
+    #[test]
+    fn private_and_dm_sources_omit_the_quote_tag() {
+        let original = original();
+        for source_type in [ForwardSourceType::Private, ForwardSourceType::Dm] {
+            let tags =
+                forward_tags(dest_id(), &original, source_id(), source_type).expect("build tags");
+            assert!(tags.iter().all(|parts| parts[0] != FWD_QUOTE_TAG));
+
+            let envelope = ForwardEnvelope::parse(&forward_from(&tags)).expect("parse");
+            assert_eq!(envelope.source_type, source_type);
+            assert_eq!(envelope.quote, None);
+        }
+    }
+
+    #[test]
+    fn rejects_missing_and_duplicate_fwd_tags() {
+        let original = original();
+        let tags = open_tags(&original);
+
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&drop_tag(&tags, FWD_TAG))),
+            Err(ForwardError::MissingFwd)
+        );
+
+        let mut doubled = tags.clone();
+        doubled.push(
+            tags.iter()
+                .find(|parts| parts[0] == FWD_TAG)
+                .expect("fwd tag")
+                .clone(),
+        );
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&doubled)),
+            Err(ForwardError::DuplicateFwd { count: 2 })
+        );
+    }
+
+    #[test]
+    fn rejects_oversized_fwd_tag() {
+        let big = sign(
+            KIND_STREAM_MESSAGE,
+            &"x".repeat(FWD_MAX_BYTES + 16),
+            &[owned(&["h", SOURCE_CHANNEL])],
+        );
+
+        assert!(matches!(
+            forward_tags(dest_id(), &big, source_id(), ForwardSourceType::Channel),
+            Err(ForwardError::FwdTooLarge { .. })
+        ));
+
+        let tags = vec![
+            owned(&["h", DEST_CHANNEL]),
+            owned(&["fwd", &big.as_json()]),
+            owned(&["k", "9"]),
+            owned(&["fwd-src", SOURCE_CHANNEL, FWD_SRC_TYPE_PRIVATE]),
+        ];
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&tags)),
+            Err(ForwardError::FwdTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_unparseable_embedded_json() {
+        let original = original();
+        let tags = replace_tag(
+            &open_tags(&original),
+            FWD_TAG,
+            owned(&["fwd", "{not an event}"]),
+        );
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&tags)),
+            Err(ForwardError::UnparseableEmbedded { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_non_forwardable_embedded_kind() {
+        let inner_forward = sign(
+            KIND_STREAM_MESSAGE_FORWARD,
+            "note",
+            &[owned(&["h", SOURCE_CHANNEL])],
+        );
+
+        assert_eq!(
+            forward_tags(
+                dest_id(),
+                &inner_forward,
+                source_id(),
+                ForwardSourceType::Channel
+            ),
+            Err(ForwardError::KindNotForwardable {
+                kind: KIND_STREAM_MESSAGE_FORWARD
+            })
+        );
+
+        let tags = vec![
+            owned(&["h", DEST_CHANNEL]),
+            owned(&["fwd", &inner_forward.as_json()]),
+            owned(&["k", "40009"]),
+            owned(&["fwd-src", SOURCE_CHANNEL, FWD_SRC_TYPE_CHANNEL]),
+        ];
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&tags)),
+            Err(ForwardError::KindNotForwardable {
+                kind: KIND_STREAM_MESSAGE_FORWARD
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_missing_or_mismatched_k_tag() {
+        let original = original();
+        let tags = open_tags(&original);
+
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&drop_tag(&tags, FWD_KIND_TAG))),
+            Err(ForwardError::MissingKind)
+        );
+
+        let mismatched = replace_tag(&tags, FWD_KIND_TAG, owned(&["k", "40002"]));
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&mismatched)),
+            Err(ForwardError::KindMismatch {
+                declared: "40002".to_string(),
+                embedded: KIND_STREAM_MESSAGE,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_fwd_src_tags() {
+        let original = original();
+        let tags = open_tags(&original);
+
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&drop_tag(&tags, FWD_SRC_TAG))),
+            Err(ForwardError::MissingSource)
+        );
+
+        let no_label = replace_tag(&tags, FWD_SRC_TAG, owned(&["fwd-src", SOURCE_CHANNEL]));
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&no_label)),
+            Err(ForwardError::MalformedSource { .. })
+        ));
+
+        let bad_uuid = replace_tag(
+            &tags,
+            FWD_SRC_TAG,
+            owned(&["fwd-src", "not-a-uuid", FWD_SRC_TYPE_CHANNEL]),
+        );
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&bad_uuid)),
+            Err(ForwardError::MalformedSource { .. })
+        ));
+
+        let bad_label = replace_tag(
+            &tags,
+            FWD_SRC_TAG,
+            owned(&["fwd-src", SOURCE_CHANNEL, "secret"]),
+        );
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&bad_label)),
+            Err(ForwardError::UnknownSourceType {
+                label: "secret".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_fwd_src_uuid_that_differs_from_embedded_h_tag() {
+        let original = original();
+        let tags = replace_tag(
+            &open_tags(&original),
+            FWD_SRC_TAG,
+            owned(&["fwd-src", DEST_CHANNEL, FWD_SRC_TYPE_CHANNEL]),
+        );
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&tags)),
+            Err(ForwardError::SourceChannelMismatch {
+                declared: dest_id(),
+                embedded: source_id(),
+            })
+        );
+
+        assert_eq!(
+            forward_tags(dest_id(), &original, dest_id(), ForwardSourceType::Channel),
+            Err(ForwardError::SourceChannelMismatch {
+                declared: dest_id(),
+                embedded: source_id(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_embedded_original_without_h_tag() {
+        let orphan = sign(KIND_STREAM_MESSAGE, "no channel", &[]);
+        assert_eq!(
+            forward_tags(dest_id(), &orphan, source_id(), ForwardSourceType::Channel),
+            Err(ForwardError::EmbeddedMissingChannel)
+        );
+    }
+
+    #[test]
+    fn rejects_quote_mismatch_and_disallowed_quote() {
+        let original = original();
+        let tags = open_tags(&original);
+
+        let bad_id = replace_tag(
+            &tags,
+            FWD_QUOTE_TAG,
+            owned(&["q", &"a".repeat(64), "", &original.pubkey.to_hex()]),
+        );
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&bad_id)),
+            Err(ForwardError::QuoteMismatch { field: "id", .. })
+        ));
+
+        let bad_pubkey = replace_tag(
+            &tags,
+            FWD_QUOTE_TAG,
+            owned(&["q", &original.id.to_hex(), "", &"b".repeat(64)]),
+        );
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&bad_pubkey)),
+            Err(ForwardError::QuoteMismatch {
+                field: "pubkey",
+                ..
+            })
+        ));
+
+        let short = replace_tag(&tags, FWD_QUOTE_TAG, owned(&["q", &original.id.to_hex()]));
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&short)),
+            Err(ForwardError::MalformedQuote { .. })
+        ));
+
+        let mut doubled = tags.clone();
+        doubled.push(
+            tags.iter()
+                .find(|parts| parts[0] == FWD_QUOTE_TAG)
+                .expect("q tag")
+                .clone(),
+        );
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&doubled)),
+            Err(ForwardError::DuplicateQuote { count: 2 })
+        );
+
+        let private = replace_tag(
+            &tags,
+            FWD_SRC_TAG,
+            owned(&["fwd-src", SOURCE_CHANNEL, FWD_SRC_TYPE_PRIVATE]),
+        );
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&private)),
+            Err(ForwardError::QuoteNotAllowed)
+        );
+    }
+
+    #[test]
+    fn rejects_marked_e_tags() {
+        let original = original();
+        for marker in ["root", "reply"] {
+            let mut tags = open_tags(&original);
+            tags.push(owned(&["e", &"c".repeat(64), "", marker]));
+            assert_eq!(
+                ForwardEnvelope::parse(&forward_from(&tags)),
+                Err(ForwardError::MarkedETag)
+            );
+        }
+
+        // Unmarked e tags (quote-style references) are untouched.
+        let mut tags = open_tags(&original);
+        tags.push(owned(&["e", &"c".repeat(64)]));
+        assert!(ForwardEnvelope::parse(&forward_from(&tags)).is_ok());
+    }
+
+    /// The outer `imeta` copy is what generic NIP-92 consumers render, so it may
+    /// not diverge from the embedded original's.
+    #[test]
+    fn accepts_matching_imeta_and_rejects_divergence() {
+        let original = original();
+        let tags = open_tags(&original);
+        assert!(ForwardEnvelope::parse(&forward_from(&tags)).is_ok());
+
+        let mut extra = tags.clone();
+        extra.push(owned(&["imeta", "url https://example.test/b.png"]));
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&extra)),
+            Err(ForwardError::ImetaMismatch {
+                outer: 2,
+                embedded: 1
+            })
+        );
+
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&drop_tag(&tags, "imeta"))),
+            Err(ForwardError::ImetaMismatch {
+                outer: 0,
+                embedded: 1
+            })
+        );
+
+        let divergent = replace_tag(
+            &tags,
+            "imeta",
+            owned(&["imeta", "url https://evil.test/a.png", "x abc123"]),
+        );
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&divergent)),
+            Err(ForwardError::ImetaMismatch {
+                outer: 1,
+                embedded: 1
+            })
+        );
+    }
+
+    /// Exactly one destination and exactly one source channel — otherwise a
+    /// generic NIP-29 consumer could scope the same signed event differently.
+    #[test]
+    fn rejects_ambiguous_h_tags_on_the_outer_event() {
+        let original = original();
+        let tags = open_tags(&original);
+
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&drop_tag(&tags, "h"))),
+            Err(ForwardError::MissingDestination)
+        );
+
+        let mut doubled = tags.clone();
+        doubled.push(owned(&["h", SOURCE_CHANNEL]));
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&doubled)),
+            Err(ForwardError::DuplicateDestination { count: 2 })
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_h_tags_on_the_embedded_original() {
+        let two_channels = sign(
+            KIND_STREAM_MESSAGE,
+            "which channel?",
+            &[owned(&["h", SOURCE_CHANNEL]), owned(&["h", DEST_CHANNEL])],
+        );
+        assert_eq!(
+            forward_tags(
+                dest_id(),
+                &two_channels,
+                source_id(),
+                ForwardSourceType::Channel
+            ),
+            Err(ForwardError::DuplicateEmbeddedChannel { count: 2 })
+        );
+
+        let tags = vec![
+            owned(&["h", DEST_CHANNEL]),
+            owned(&["fwd", &two_channels.as_json()]),
+            owned(&["k", "9"]),
+            owned(&["fwd-src", SOURCE_CHANNEL, FWD_SRC_TYPE_PRIVATE]),
+        ];
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&tags)),
+            Err(ForwardError::DuplicateEmbeddedChannel { count: 2 })
+        );
+
+        let no_channel = sign(KIND_STREAM_MESSAGE, "orphan", &[]);
+        let tags = vec![
+            owned(&["h", DEST_CHANNEL]),
+            owned(&["fwd", &no_channel.as_json()]),
+            owned(&["k", "9"]),
+            owned(&["fwd-src", SOURCE_CHANNEL, FWD_SRC_TYPE_PRIVATE]),
+        ];
+        assert_eq!(
+            ForwardEnvelope::parse(&forward_from(&tags)),
+            Err(ForwardError::EmbeddedMissingChannel)
+        );
+    }
+
+    /// The `h` shape is pinned to exactly `["h", <uuid>]` on both the outer
+    /// event and the embedded original. A trailing element is otherwise
+    /// invisible to consumers that only read element 1, so two readers could
+    /// disagree about what the same signed event is scoped to.
+    #[test]
+    fn rejects_h_tags_with_trailing_elements() {
+        let original = original();
+        let tags = open_tags(&original);
+
+        // The canonical builder output still round-trips.
+        assert!(ForwardEnvelope::parse(&forward_from(&tags)).is_ok());
+
+        let trailing_destination = replace_tag(&tags, "h", owned(&["h", DEST_CHANNEL, "extra"]));
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&trailing_destination)),
+            Err(ForwardError::MalformedDestination { .. })
+        ));
+
+        let trailing_embedded = sign(
+            KIND_STREAM_MESSAGE,
+            "original text",
+            &[
+                owned(&["h", SOURCE_CHANNEL, "extra"]),
+                owned(&["imeta", "url https://example.test/a.png", "x abc123"]),
+            ],
+        );
+        assert!(matches!(
+            forward_tags(
+                dest_id(),
+                &trailing_embedded,
+                source_id(),
+                ForwardSourceType::Channel
+            ),
+            Err(ForwardError::MalformedEmbeddedChannel { .. })
+        ));
+
+        let embedded = vec![
+            owned(&["h", DEST_CHANNEL]),
+            owned(&["fwd", &trailing_embedded.as_json()]),
+            owned(&["k", "9"]),
+            owned(&["fwd-src", SOURCE_CHANNEL, FWD_SRC_TYPE_PRIVATE]),
+            owned(&["imeta", "url https://example.test/a.png", "x abc123"]),
+        ];
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&embedded)),
+            Err(ForwardError::MalformedEmbeddedChannel { .. })
+        ));
+    }
+
+    /// The `q` tag shape is pinned: exactly 4 elements, empty relay hint, hex
+    /// id and pubkey.
+    #[test]
+    fn rejects_q_tags_with_the_wrong_shape() {
+        let original = original();
+        let tags = open_tags(&original);
+        let id = original.id.to_hex();
+        let pubkey = original.pubkey.to_hex();
+
+        let trailing = replace_tag(
+            &tags,
+            FWD_QUOTE_TAG,
+            owned(&["q", &id, "", &pubkey, "extra"]),
+        );
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&trailing)),
+            Err(ForwardError::MalformedQuote { .. })
+        ));
+
+        let hinted = replace_tag(
+            &tags,
+            FWD_QUOTE_TAG,
+            owned(&["q", &id, "wss://elsewhere.test", &pubkey]),
+        );
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&hinted)),
+            Err(ForwardError::MalformedQuote { .. })
+        ));
+
+        let not_hex = replace_tag(
+            &tags,
+            FWD_QUOTE_TAG,
+            owned(&["q", &"z".repeat(64), "", &pubkey]),
+        );
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&not_hex)),
+            Err(ForwardError::MalformedQuote { .. })
+        ));
+
+        let short_pubkey = replace_tag(&tags, FWD_QUOTE_TAG, owned(&["q", &id, "", "abcd"]));
+        assert!(matches!(
+            ForwardEnvelope::parse(&forward_from(&short_pubkey)),
+            Err(ForwardError::MalformedQuote { .. })
+        ));
+
+        // The canonical builder output still round-trips.
+        assert!(ForwardEnvelope::parse(&forward_from(&tags)).is_ok());
+    }
+
+    #[test]
+    fn verify_embedded_rejects_a_tampered_original() {
+        let original = original();
+        let mut json: serde_json::Value =
+            serde_json::from_str(&original.as_json()).expect("parse json");
+        json["content"] = serde_json::Value::String("tampered".to_string());
+        let tampered = Event::from_json(json.to_string()).expect("parse event");
+
+        let tags = vec![
+            owned(&["h", DEST_CHANNEL]),
+            owned(&["fwd", &tampered.as_json()]),
+            owned(&["k", "9"]),
+            owned(&["fwd-src", SOURCE_CHANNEL, FWD_SRC_TYPE_PRIVATE]),
+            owned(&["imeta", "url https://example.test/a.png", "x abc123"]),
+        ];
+        let envelope = ForwardEnvelope::parse(&forward_from(&tags)).expect("parse");
+        assert!(matches!(
+            envelope.verify_embedded(),
+            Err(VerificationError::InvalidId { .. })
+        ));
+    }
+}

--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -431,6 +431,11 @@ pub const KIND_STREAM_MESSAGE_SCHEDULED: u32 = 40006;
 pub const KIND_STREAM_REMINDER: u32 = 40007;
 /// A diff/patch message showing file changes (unified diff format).
 pub const KIND_STREAM_MESSAGE_DIFF: u32 = 40008;
+/// A message forwarded into another channel or DM.
+///
+/// Content is the forwarder's optional note; the complete signed original is
+/// embedded in a `fwd` tag. See [`crate::forward`] for the envelope contract.
+pub const KIND_STREAM_MESSAGE_FORWARD: u32 = 40009;
 /// Canvas (shared document) for a channel.
 pub const KIND_CANVAS: u32 = 40100;
 /// System message for channel state changes (join, leave, rename, etc.).
@@ -636,6 +641,7 @@ pub const ALL_KINDS: &[u32] = &[
     KIND_STREAM_MESSAGE_SCHEDULED,
     KIND_STREAM_REMINDER,
     KIND_STREAM_MESSAGE_DIFF,
+    KIND_STREAM_MESSAGE_FORWARD,
     KIND_CANVAS,
     KIND_SYSTEM_MESSAGE,
     KIND_CHANNEL_SUMMARY,

--- a/crates/buzz-core/src/lib.rs
+++ b/crates/buzz-core/src/lib.rs
@@ -18,6 +18,8 @@ pub mod error;
 pub mod event;
 /// NIP-01 subscription filter matching.
 pub mod filter;
+/// Message-forward envelope contract shared by the relay validator and the SDK.
+pub mod forward;
 /// Git permission types — ref patterns, protection rules, policy evaluation.
 pub mod git_perms;
 /// Shared invite-link contract constants.

--- a/crates/buzz-db/src/feed.rs
+++ b/crates/buzz-db/src/feed.rs
@@ -37,7 +37,8 @@ use buzz_core::kind::{
     KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_GIT_ISSUE, KIND_GIT_PR_UPDATE, KIND_GIT_PULL_REQUEST,
     KIND_GIT_STATUS_CLOSED, KIND_GIT_STATUS_DRAFT, KIND_GIT_STATUS_MERGED, KIND_GIT_STATUS_OPEN,
     KIND_JOB_PROGRESS, KIND_JOB_REQUEST, KIND_JOB_RESULT, KIND_STREAM_MESSAGE,
-    KIND_STREAM_MESSAGE_V2, KIND_STREAM_REMINDER, KIND_TEXT_NOTE, KIND_WORKFLOW_APPROVAL_REQUESTED,
+    KIND_STREAM_MESSAGE_FORWARD, KIND_STREAM_MESSAGE_V2, KIND_STREAM_REMINDER, KIND_TEXT_NOTE,
+    KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::{CommunityId, StoredEvent};
 
@@ -103,7 +104,10 @@ fn build_mentions_query(
     qb.push(" AND m.pubkey_hex = ").push_bind(pubkey_hex);
     qb.push(" AND e.deleted_at IS NULL");
     qb.push(format!(
+        // A forward's `p` tags come only from mentions the forwarder wrote in
+        // the note, so they belong in the mentions feed like any message.
         " AND e.kind IN ({KIND_STREAM_MESSAGE}, {KIND_STREAM_MESSAGE_V2}, \
+         {KIND_STREAM_MESSAGE_FORWARD}, \
          {KIND_TEXT_NOTE}, {KIND_FORUM_POST}, {KIND_FORUM_COMMENT}, {KIND_GIT_PULL_REQUEST}, \
          {KIND_GIT_PR_UPDATE}, {KIND_GIT_ISSUE}, {KIND_GIT_STATUS_OPEN}, \
          {KIND_GIT_STATUS_MERGED}, {KIND_GIT_STATUS_CLOSED}, {KIND_GIT_STATUS_DRAFT})"
@@ -563,14 +567,21 @@ mod tests {
     #[test]
     fn mentions_query_includes_stream_message_kind() {
         use buzz_core::kind::{
-            KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_V2,
+            KIND_FORUM_COMMENT, KIND_FORUM_POST, KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_FORWARD,
+            KIND_STREAM_MESSAGE_V2,
         };
         let mention_kinds: &[u32] = &[
             KIND_STREAM_MESSAGE,
             KIND_STREAM_MESSAGE_V2,
+            KIND_STREAM_MESSAGE_FORWARD,
             KIND_FORUM_POST,
             KIND_FORUM_COMMENT,
         ];
+
+        assert!(
+            mention_kinds.contains(&KIND_STREAM_MESSAGE_FORWARD),
+            "a mention written in a forward's note must reach the mentions feed"
+        );
 
         assert!(
             mention_kinds.contains(&KIND_STREAM_MESSAGE),

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -30,10 +30,11 @@ use buzz_core::kind::{
     KIND_NIP65_RELAY_LIST_METADATA, KIND_PERSONA, KIND_PIN_LIST, KIND_PRESENCE_UPDATE,
     KIND_PRODUCT_FEEDBACK, KIND_PROFILE, KIND_REACTION, KIND_READ_STATE, KIND_REPORT,
     KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_BOOKMARKED, KIND_STREAM_MESSAGE_DIFF,
-    KIND_STREAM_MESSAGE_EDIT, KIND_STREAM_MESSAGE_PINNED, KIND_STREAM_MESSAGE_SCHEDULED,
-    KIND_STREAM_MESSAGE_V2, KIND_STREAM_REMINDER, KIND_TEAM, KIND_TEXT_NOTE, KIND_USER_STATUS,
-    KIND_WORKFLOW_DEF, KIND_WORKFLOW_TRIGGER, RELAY_ADMIN_ADD_MEMBER, RELAY_ADMIN_CHANGE_ROLE,
-    RELAY_ADMIN_REMOVE_MEMBER, RELAY_ADMIN_SET_WORKSPACE_PROFILE,
+    KIND_STREAM_MESSAGE_EDIT, KIND_STREAM_MESSAGE_FORWARD, KIND_STREAM_MESSAGE_PINNED,
+    KIND_STREAM_MESSAGE_SCHEDULED, KIND_STREAM_MESSAGE_V2, KIND_STREAM_REMINDER, KIND_TEAM,
+    KIND_TEXT_NOTE, KIND_USER_STATUS, KIND_WORKFLOW_DEF, KIND_WORKFLOW_TRIGGER,
+    RELAY_ADMIN_ADD_MEMBER, RELAY_ADMIN_CHANGE_ROLE, RELAY_ADMIN_REMOVE_MEMBER,
+    RELAY_ADMIN_SET_WORKSPACE_PROFILE,
 };
 use buzz_core::tenant::TenantContext;
 use buzz_core::verification::verify_event;
@@ -253,6 +254,9 @@ fn required_scope_for_kind(kind: u32, event: &Event) -> Result<Scope, &'static s
         | KIND_STREAM_MESSAGE_SCHEDULED
         | KIND_STREAM_REMINDER
         | KIND_STREAM_MESSAGE_DIFF
+        // A forward is an ordinary root message authored by the forwarder; the
+        // embedded original rides along in a `fwd` tag.
+        | KIND_STREAM_MESSAGE_FORWARD
         | KIND_FORUM_POST
         | KIND_FORUM_VOTE
         | KIND_FORUM_COMMENT => Ok(Scope::MessagesWrite),
@@ -476,6 +480,9 @@ pub(crate) fn requires_h_channel_scope(kind: u32) -> bool {
             | KIND_STREAM_MESSAGE_SCHEDULED
             | KIND_STREAM_REMINDER
             | KIND_STREAM_MESSAGE_DIFF
+            // A forward lands in a destination channel or DM (`h` is the
+            // destination); the source channel travels in `fwd-src`.
+            | KIND_STREAM_MESSAGE_FORWARD
             | KIND_CANVAS
             | KIND_FORUM_POST
             | KIND_FORUM_VOTE
@@ -510,15 +517,47 @@ pub(crate) async fn check_channel_membership(
     pubkey_bytes: &[u8],
     channel: Option<&buzz_db::channel::ChannelRecord>,
 ) -> Result<(), String> {
-    match state
+    let is_member = state
         .is_member_cached(tenant.community(), ch_id, pubkey_bytes)
         .await
-    {
-        Ok(true) => return Ok(()),
-        Ok(false) => {}
-        Err(e) => return Err(format!("error: database error: {e}")),
+        .map_err(|e| format!("error: database error: {e}"))?;
+    resolve_channel_read_access(tenant, state, ch_id, is_member, channel).await
+}
+
+/// Same read gate as [`check_channel_membership`], but the membership lookup
+/// goes straight to the DB instead of the 10-second positive cache.
+///
+/// Used where a stale `is_member = true` would leak data rather than merely
+/// delay a denial — the forward source-channel gate, where a revoked member
+/// could otherwise keep exfiltrating a private channel for the cache TTL.
+/// Forwards are rare relative to messages, so the extra query is cheap.
+pub(crate) async fn check_channel_membership_uncached(
+    tenant: &TenantContext,
+    state: &AppState,
+    ch_id: Uuid,
+    pubkey_bytes: &[u8],
+    channel: Option<&buzz_db::channel::ChannelRecord>,
+) -> Result<(), String> {
+    let is_member = state
+        .db
+        .is_member(tenant.community(), ch_id, pubkey_bytes)
+        .await
+        .map_err(|e| format!("error: database error: {e}"))?;
+    resolve_channel_read_access(tenant, state, ch_id, is_member, channel).await
+}
+
+/// Shared tail of the read gate: members pass, everyone else needs the channel
+/// to be open.
+async fn resolve_channel_read_access(
+    tenant: &TenantContext,
+    state: &AppState,
+    ch_id: Uuid,
+    is_member: bool,
+    channel: Option<&buzz_db::channel::ChannelRecord>,
+) -> Result<(), String> {
+    if is_member {
+        return Ok(());
     }
-    // Not a member — check if channel is open.
     let is_open = match channel {
         Some(ch) => ch.visibility == "open",
         None => state
@@ -960,6 +999,171 @@ fn validate_diff_event(event: &Event) -> Result<(), String> {
     if !has_commit {
         return Err("diff event requires a commit tag".to_string());
     }
+    Ok(())
+}
+
+/// The `fwd-src` label the source channel row actually warrants.
+///
+/// A DM is a channel with `channel_type = 'dm'`, so it is classified first;
+/// everything else splits on visibility. Keeping this derivation in one place is
+/// what lets the relay reject a spoofed label instead of trusting the client's
+/// claim about how private the source was.
+fn forward_source_type_for_channel(
+    channel: &buzz_db::channel::ChannelRecord,
+) -> buzz_core::forward::ForwardSourceType {
+    use buzz_core::forward::ForwardSourceType;
+    if channel.channel_type == "dm" {
+        ForwardSourceType::Dm
+    } else if channel.visibility == "open" {
+        ForwardSourceType::Channel
+    } else {
+        ForwardSourceType::Private
+    }
+}
+
+/// Read the forward envelope out of a `kind:40009` event, mapping every
+/// structural failure onto the standard `invalid:` rejection shape.
+fn parse_forward_envelope(
+    event: &Event,
+) -> Result<buzz_core::forward::ForwardEnvelope, IngestError> {
+    buzz_core::forward::ForwardEnvelope::parse(event)
+        .map_err(|e| IngestError::Rejected(format!("invalid: {e}")))
+}
+
+/// Require the embedded original to be an event this relay actually stored, in
+/// this community, in the channel the envelope names as its source.
+///
+/// A valid Schnorr signature only proves *someone* authored the bytes — not that
+/// they were ever published here. Without this gate, a signed event from another
+/// community (or one never published at all) could be forwarded into a channel
+/// with authentic-looking attribution. NIP-01 ids hash pubkey/kind/tags/content/
+/// created_at, so an id hit proves the embedded copy is byte-equivalent to the
+/// stored row; the stored `channel_id` is then the relay's own record of where
+/// it lived, which no client can forge.
+fn check_forward_provenance(
+    stored_original: Option<&buzz_core::StoredEvent>,
+    source_channel_id: Uuid,
+) -> Result<(), IngestError> {
+    let Some(stored) = stored_original else {
+        return Err(IngestError::Rejected(
+            "restricted: forwarded original was never published to this community".into(),
+        ));
+    };
+    if stored.channel_id != Some(source_channel_id) {
+        return Err(IngestError::Rejected(
+            "restricted: forwarded original is not stored in the fwd-src channel".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validate a `kind:40009` forward before it is stored.
+///
+/// Structural checks (tag cardinality, size cap, `k`/`fwd-src`/`q` agreement,
+/// marked `e` tags) live in [`buzz_core::forward::ForwardEnvelope::parse`]. This
+/// function adds what only the relay can know:
+///
+/// 1. the embedded original's signature is real (re-derived id + Schnorr check),
+/// 2. the original is actually stored in *this* community, in the `fwd-src`
+///    channel (see [`check_forward_provenance`]),
+/// 3. the source channel exists and its `fwd-src` label matches the row,
+/// 4. the forwarder may *read* the source — member, or the source is open.
+///
+/// Steps 2 and 4 are the laundering gate: without them the relay would happily
+/// bless a leaked private message, or a signed event from somewhere else
+/// entirely, as a signature-verified copy in a public channel.
+/// Destination gates (token scope, membership, archived, bans, imeta) are the
+/// ordinary pipeline and are not repeated here.
+async fn validate_forward_event(
+    tenant: &TenantContext,
+    state: &Arc<AppState>,
+    event: &Event,
+) -> Result<(), IngestError> {
+    let envelope = parse_forward_envelope(event)?;
+
+    // Signature verification is CPU-bound — same spawn_blocking treatment as the
+    // outer event's verify.
+    let envelope = Arc::new(envelope);
+    let envelope_for_verify = Arc::clone(&envelope);
+    match tokio::task::spawn_blocking(move || envelope_for_verify.verify_embedded()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            return Err(IngestError::Rejected(format!(
+                "invalid: forwarded original failed verification: {e}"
+            )));
+        }
+        Err(e) => {
+            error!("spawn_blocking panicked verifying forwarded original: {e}");
+            return Err(IngestError::Internal(
+                "error: internal verification error".into(),
+            ));
+        }
+    }
+
+    let stored_original = match state
+        .db
+        .get_event_by_id(tenant.community(), envelope.original.id.as_bytes())
+        .await
+    {
+        Ok(stored) => stored,
+        Err(e) => {
+            return Err(IngestError::Internal(format!(
+                "error: looking up forwarded original: {e}"
+            )));
+        }
+    };
+    check_forward_provenance(stored_original.as_ref(), envelope.source_channel_id)?;
+
+    let source_channel = match state
+        .db
+        .get_channel(tenant.community(), envelope.source_channel_id)
+        .await
+    {
+        Ok(channel) => channel,
+        Err(buzz_db::DbError::ChannelNotFound(_)) => {
+            return Err(IngestError::Rejected(
+                "invalid: forward source channel not found".into(),
+            ));
+        }
+        Err(e) => {
+            return Err(IngestError::Internal(format!(
+                "error: looking up forward source channel: {e}"
+            )));
+        }
+    };
+
+    let actual_source_type = forward_source_type_for_channel(&source_channel);
+    if actual_source_type != envelope.source_type {
+        return Err(IngestError::Rejected(format!(
+            "invalid: fwd-src type {} does not match source channel ({})",
+            envelope.source_type, actual_source_type
+        )));
+    }
+
+    // Read access to the source, checked against the forwarder's own key.
+    // Uncached on purpose: a member removed seconds ago must not be able to
+    // keep forwarding out of a private channel for the cache TTL.
+    let forwarder_bytes = event.pubkey.to_bytes().to_vec();
+    if let Err(reason) = check_channel_membership_uncached(
+        tenant,
+        state,
+        envelope.source_channel_id,
+        &forwarder_bytes,
+        Some(&source_channel),
+    )
+    .await
+    {
+        // `check_channel_membership_uncached` reports DB faults with the `error:` prefix;
+        // those are server faults, not a forbidden forward.
+        return Err(if reason.starts_with("error:") {
+            IngestError::Internal(reason)
+        } else {
+            IngestError::Rejected(
+                "restricted: cannot forward from a channel you are not a member of".into(),
+            )
+        });
+    }
+
     Ok(())
 }
 
@@ -2018,6 +2222,10 @@ async fn ingest_event_inner(
         validate_diff_event(&event).map_err(|e| IngestError::Rejected(format!("invalid: {e}")))?;
     }
 
+    if kind_u32 == KIND_STREAM_MESSAGE_FORWARD {
+        validate_forward_event(tenant, state, &event).await?;
+    }
+
     if kind_u32 == KIND_AGENT_ENGRAM {
         validate_engram_envelope(&event)
             .map_err(|e| IngestError::Rejected(format!("invalid: {e}")))?;
@@ -2559,7 +2767,7 @@ mod tests {
         KIND_MANAGED_AGENT, KIND_PERSONA, KIND_PRESENCE_UPDATE, KIND_STREAM_MESSAGE,
         KIND_STREAM_MESSAGE_DIFF, KIND_TEAM, KIND_USER_STATUS,
     };
-    use nostr::{EventBuilder, Kind};
+    use nostr::{EventBuilder, JsonUtil, Kind};
 
     /// A banned relay admin must be refused with the same wire prefix and
     /// transport status as every other durable-restriction refusal:
@@ -2891,6 +3099,7 @@ mod tests {
             KIND_NIP29_LEAVE_REQUEST,
             KIND_STREAM_MESSAGE_EDIT,
             KIND_STREAM_MESSAGE_DIFF,
+            KIND_STREAM_MESSAGE_FORWARD,
             KIND_CANVAS,
             KIND_FORUM_POST,
             KIND_FORUM_VOTE,
@@ -3141,6 +3350,403 @@ mod tests {
             ],
         );
         assert!(validate_diff_event(&event).is_err());
+    }
+
+    // -- kind:40009 message forwards -----------------------------------------
+
+    const FORWARD_SOURCE_CHANNEL: &str = "11111111-1111-4111-8111-111111111111";
+    const FORWARD_DEST_CHANNEL: &str = "22222222-2222-4222-8222-222222222222";
+
+    fn forward_source_id() -> Uuid {
+        Uuid::parse_str(FORWARD_SOURCE_CHANNEL).expect("source uuid")
+    }
+
+    fn forward_dest_id() -> Uuid {
+        Uuid::parse_str(FORWARD_DEST_CHANNEL).expect("dest uuid")
+    }
+
+    fn make_event_with_owned_tags(kind: u32, content: &str, tags: &[Vec<String>]) -> Event {
+        let borrowed: Vec<Vec<&str>> = tags
+            .iter()
+            .map(|parts| parts.iter().map(String::as_str).collect())
+            .collect();
+        let refs: Vec<&[&str]> = borrowed.iter().map(|parts| parts.as_slice()).collect();
+        make_event_with_tags(kind, content, &refs)
+    }
+
+    /// A signed kind:9 original living in the source channel.
+    fn forward_original() -> Event {
+        make_event_with_tags(
+            KIND_STREAM_MESSAGE,
+            "original text",
+            &[&["h", FORWARD_SOURCE_CHANNEL]],
+        )
+    }
+
+    fn owned_tag(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|p| (*p).to_string()).collect()
+    }
+
+    /// Canonical tag set for forwarding `original` out of an open channel.
+    fn open_forward_tags(original: &Event) -> Vec<Vec<String>> {
+        buzz_core::forward::forward_tags(
+            forward_dest_id(),
+            original,
+            forward_source_id(),
+            buzz_core::forward::ForwardSourceType::Channel,
+        )
+        .expect("build forward tags")
+    }
+
+    fn make_forward(tags: &[Vec<String>]) -> Event {
+        make_event_with_owned_tags(KIND_STREAM_MESSAGE_FORWARD, "the note", tags)
+    }
+
+    fn replace_forward_tag(
+        tags: &[Vec<String>],
+        name: &str,
+        replacement: Vec<String>,
+    ) -> Vec<Vec<String>> {
+        tags.iter()
+            .map(|parts| {
+                if parts.first().map(String::as_str) == Some(name) {
+                    replacement.clone()
+                } else {
+                    parts.clone()
+                }
+            })
+            .collect()
+    }
+
+    fn drop_forward_tag(tags: &[Vec<String>], name: &str) -> Vec<Vec<String>> {
+        tags.iter()
+            .filter(|parts| parts.first().map(String::as_str) != Some(name))
+            .cloned()
+            .collect()
+    }
+
+    /// Rejection message for a forward built from `tags`, or a panic if accepted.
+    fn forward_rejection(tags: &[Vec<String>]) -> String {
+        match parse_forward_envelope(&make_forward(tags)) {
+            Err(IngestError::Rejected(message)) => message,
+            Err(other) => panic!("expected a client rejection, got {other:?}"),
+            Ok(_) => panic!("malformed forward was accepted"),
+        }
+    }
+
+    fn channel_record(channel_type: &str, visibility: &str) -> buzz_db::channel::ChannelRecord {
+        buzz_db::channel::ChannelRecord {
+            id: forward_source_id(),
+            name: "source".to_string(),
+            channel_type: channel_type.to_string(),
+            visibility: visibility.to_string(),
+            description: None,
+            canvas: None,
+            created_by: Vec::new(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            archived_at: None,
+            deleted_at: None,
+            nip29_group_id: None,
+            topic_required: false,
+            max_members: None,
+            topic: None,
+            topic_set_by: None,
+            topic_set_at: None,
+            purpose: None,
+            purpose_set_by: None,
+            purpose_set_at: None,
+            ttl_seconds: None,
+            ttl_deadline: None,
+        }
+    }
+
+    /// A forward is an ordinary channel-scoped root message: MessagesWrite, `h`
+    /// mandatory, never global, no post-storage side effects, client-authorable.
+    #[test]
+    fn forward_kind_is_a_channel_scoped_message_write() {
+        let dummy = make_dummy_event();
+        assert_eq!(
+            required_scope_for_kind(KIND_STREAM_MESSAGE_FORWARD, &dummy).unwrap(),
+            Scope::MessagesWrite,
+        );
+        assert!(requires_h_channel_scope(KIND_STREAM_MESSAGE_FORWARD));
+        assert!(!is_global_only_kind(KIND_STREAM_MESSAGE_FORWARD));
+        assert!(!crate::handlers::side_effects::is_side_effect_kind(
+            KIND_STREAM_MESSAGE_FORWARD
+        ));
+        assert!(!buzz_core::kind::is_relay_only_kind(
+            KIND_STREAM_MESSAGE_FORWARD
+        ));
+    }
+
+    #[test]
+    fn forward_envelope_accepts_a_canonical_open_forward() {
+        let original = forward_original();
+        let envelope =
+            parse_forward_envelope(&make_forward(&open_forward_tags(&original))).expect("parse");
+
+        assert_eq!(envelope.original.id, original.id);
+        assert_eq!(envelope.source_channel_id, forward_source_id());
+        assert_eq!(
+            envelope.source_type,
+            buzz_core::forward::ForwardSourceType::Channel
+        );
+        assert_eq!(
+            envelope.quote.as_ref().map(|q| q.event_id.clone()),
+            Some(original.id.to_hex())
+        );
+        assert!(envelope.verify_embedded().is_ok());
+    }
+
+    #[test]
+    fn forward_rejects_missing_and_duplicate_fwd_tags() {
+        let tags = open_forward_tags(&forward_original());
+
+        assert!(forward_rejection(&drop_forward_tag(&tags, "fwd")).contains("missing fwd tag"));
+
+        let mut doubled = tags.clone();
+        doubled.push(
+            tags.iter()
+                .find(|parts| parts[0] == "fwd")
+                .expect("fwd tag")
+                .clone(),
+        );
+        assert!(forward_rejection(&doubled).contains("exactly one fwd tag"));
+    }
+
+    #[test]
+    fn forward_rejects_oversized_fwd_tag() {
+        let big = make_event_with_tags(
+            KIND_STREAM_MESSAGE,
+            &"x".repeat(buzz_core::forward::FWD_MAX_BYTES + 16),
+            &[&["h", FORWARD_SOURCE_CHANNEL]],
+        );
+        let tags = vec![
+            owned_tag(&["h", FORWARD_DEST_CHANNEL]),
+            owned_tag(&["fwd", &big.as_json()]),
+            owned_tag(&["k", "9"]),
+            owned_tag(&["fwd-src", FORWARD_SOURCE_CHANNEL, "private"]),
+        ];
+        assert!(forward_rejection(&tags).contains("limit is"));
+    }
+
+    #[test]
+    fn forward_rejects_unparseable_embedded_event() {
+        let tags = replace_forward_tag(
+            &open_forward_tags(&forward_original()),
+            "fwd",
+            owned_tag(&["fwd", "{not an event}"]),
+        );
+        assert!(forward_rejection(&tags).contains("not a parseable event"));
+    }
+
+    /// Forwarding a forward is flattened client-side, so depth is always 1 — an
+    /// embedded kind:40009 must never be blessed by the relay.
+    #[test]
+    fn forward_rejects_an_embedded_forward() {
+        let inner = make_event_with_tags(
+            KIND_STREAM_MESSAGE_FORWARD,
+            "note",
+            &[&["h", FORWARD_SOURCE_CHANNEL]],
+        );
+        let tags = vec![
+            owned_tag(&["h", FORWARD_DEST_CHANNEL]),
+            owned_tag(&["fwd", &inner.as_json()]),
+            owned_tag(&["k", "40009"]),
+            owned_tag(&["fwd-src", FORWARD_SOURCE_CHANNEL, "channel"]),
+        ];
+        assert!(forward_rejection(&tags).contains("is not forwardable"));
+    }
+
+    #[test]
+    fn forward_rejects_missing_or_mismatched_k_tag() {
+        let tags = open_forward_tags(&forward_original());
+
+        assert!(forward_rejection(&drop_forward_tag(&tags, "k")).contains("missing k tag"));
+
+        let mismatched = replace_forward_tag(&tags, "k", owned_tag(&["k", "40002"]));
+        assert!(forward_rejection(&mismatched).contains("does not match embedded kind"));
+    }
+
+    #[test]
+    fn forward_rejects_malformed_or_disagreeing_fwd_src() {
+        let tags = open_forward_tags(&forward_original());
+
+        assert!(
+            forward_rejection(&drop_forward_tag(&tags, "fwd-src")).contains("missing fwd-src tag")
+        );
+
+        let no_label = replace_forward_tag(
+            &tags,
+            "fwd-src",
+            owned_tag(&["fwd-src", FORWARD_SOURCE_CHANNEL]),
+        );
+        assert!(forward_rejection(&no_label).contains("missing source type label"));
+
+        let unknown_label = replace_forward_tag(
+            &tags,
+            "fwd-src",
+            owned_tag(&["fwd-src", FORWARD_SOURCE_CHANNEL, "secret"]),
+        );
+        assert!(forward_rejection(&unknown_label).contains("unknown fwd-src type"));
+
+        // A source uuid that disagrees with the embedded original's own h tag
+        // would let a forwarder claim the content came from somewhere else.
+        let wrong_uuid = replace_forward_tag(
+            &tags,
+            "fwd-src",
+            owned_tag(&["fwd-src", FORWARD_DEST_CHANNEL, "channel"]),
+        );
+        assert!(forward_rejection(&wrong_uuid).contains("does not match embedded h tag"));
+    }
+
+    #[test]
+    fn forward_rejects_quote_tags_that_lie_or_leak() {
+        let original = forward_original();
+        let tags = open_forward_tags(&original);
+
+        let bad_id = replace_forward_tag(
+            &tags,
+            "q",
+            owned_tag(&["q", &"a".repeat(64), "", &original.pubkey.to_hex()]),
+        );
+        assert!(forward_rejection(&bad_id).contains("q tag id"));
+
+        // A `q` tag on a private source would publish a link to content the
+        // destination cannot read.
+        let private = replace_forward_tag(
+            &tags,
+            "fwd-src",
+            owned_tag(&["fwd-src", FORWARD_SOURCE_CHANNEL, "private"]),
+        );
+        assert!(forward_rejection(&private).contains("only allowed for channel sources"));
+    }
+
+    /// Forwards are always thread roots in v1; a marked `e` tag would make one a
+    /// reply and split thread-counter maintenance.
+    #[test]
+    fn forward_rejects_marked_e_tags() {
+        for marker in ["root", "reply"] {
+            let mut tags = open_forward_tags(&forward_original());
+            tags.push(owned_tag(&["e", &"c".repeat(64), "", marker]));
+            assert!(forward_rejection(&tags).contains("marked e tags"));
+        }
+    }
+
+    /// The embedded copy is a claim until its signature is checked — a tampered
+    /// original must not survive verification.
+    #[test]
+    fn forward_embedded_verification_rejects_a_tampered_original() {
+        let original = forward_original();
+        let mut json: serde_json::Value =
+            serde_json::from_str(&original.as_json()).expect("parse json");
+        json["content"] = serde_json::Value::String("tampered".to_string());
+
+        let tags = vec![
+            owned_tag(&["h", FORWARD_DEST_CHANNEL]),
+            owned_tag(&["fwd", &json.to_string()]),
+            owned_tag(&["k", "9"]),
+            owned_tag(&["fwd-src", FORWARD_SOURCE_CHANNEL, "private"]),
+        ];
+        let envelope = parse_forward_envelope(&make_forward(&tags)).expect("parse");
+        assert!(envelope.verify_embedded().is_err());
+    }
+
+    /// The `fwd-src` label is checked against the actual row, so a client cannot
+    /// downgrade a private source to "channel" to get a linkable attribution.
+    #[test]
+    fn forward_source_type_is_derived_from_the_channel_row() {
+        use buzz_core::forward::ForwardSourceType;
+        assert_eq!(
+            forward_source_type_for_channel(&channel_record("stream", "open")),
+            ForwardSourceType::Channel
+        );
+        assert_eq!(
+            forward_source_type_for_channel(&channel_record("stream", "private")),
+            ForwardSourceType::Private
+        );
+        assert_eq!(
+            forward_source_type_for_channel(&channel_record("forum", "private")),
+            ForwardSourceType::Private
+        );
+        // channel_type wins over visibility: a DM is a DM however it is stored.
+        assert_eq!(
+            forward_source_type_for_channel(&channel_record("dm", "private")),
+            ForwardSourceType::Dm
+        );
+        assert_eq!(
+            forward_source_type_for_channel(&channel_record("dm", "open")),
+            ForwardSourceType::Dm
+        );
+    }
+
+    /// Rejection message from the provenance gate, or a panic if it passed.
+    fn provenance_rejection(stored: Option<&buzz_core::StoredEvent>) -> String {
+        match check_forward_provenance(stored, forward_source_id()) {
+            Err(IngestError::Rejected(message)) => message,
+            Err(other) => panic!("expected a client rejection, got {other:?}"),
+            Ok(()) => panic!("a forward with no valid provenance was accepted"),
+        }
+    }
+
+    /// A valid embedded signature only proves authorship. The relay also
+    /// requires the original to be stored *here*, in the claimed source
+    /// channel — otherwise a signed event from elsewhere could be laundered in
+    /// with authentic-looking attribution.
+    #[test]
+    fn forward_provenance_requires_the_stored_original_in_the_source_channel() {
+        let original = forward_original();
+
+        assert!(provenance_rejection(None).contains("never published to this community"));
+
+        let elsewhere = buzz_core::StoredEvent::new(original.clone(), Some(forward_dest_id()));
+        assert!(
+            provenance_rejection(Some(&elsewhere)).contains("not stored in the fwd-src channel")
+        );
+
+        let global = buzz_core::StoredEvent::new(original.clone(), None);
+        assert!(provenance_rejection(Some(&global)).contains("not stored in the fwd-src channel"));
+
+        let stored = buzz_core::StoredEvent::new(original, Some(forward_source_id()));
+        assert!(check_forward_provenance(Some(&stored), forward_source_id()).is_ok());
+    }
+
+    /// Outer `imeta` is what generic NIP-92 consumers render; it must be the
+    /// embedded original's set verbatim.
+    #[test]
+    fn forward_rejects_divergent_outer_imeta() {
+        let original = make_event_with_tags(
+            KIND_STREAM_MESSAGE,
+            "with attachment",
+            &[
+                &["h", FORWARD_SOURCE_CHANNEL],
+                &["imeta", "url https://example.test/a.png"],
+            ],
+        );
+        let tags = open_forward_tags(&original);
+
+        let mut extra = tags.clone();
+        extra.push(owned_tag(&["imeta", "url https://evil.test/b.png"]));
+        assert!(forward_rejection(&extra).contains("imeta tags must be copied verbatim"));
+
+        assert!(forward_rejection(&drop_forward_tag(&tags, "imeta"))
+            .contains("imeta tags must be copied verbatim"));
+    }
+
+    /// Exactly one destination, so a generic NIP-29 consumer cannot scope the
+    /// same signed forward into a different channel.
+    #[test]
+    fn forward_rejects_ambiguous_destination_h_tags() {
+        let tags = open_forward_tags(&forward_original());
+
+        assert!(
+            forward_rejection(&drop_forward_tag(&tags, "h")).contains("missing destination h tag")
+        );
+
+        let mut doubled = tags.clone();
+        doubled.push(owned_tag(&["h", FORWARD_SOURCE_CHANNEL]));
+        assert!(forward_rejection(&doubled).contains("exactly one destination h tag"));
     }
 
     fn make_dummy_event() -> Event {

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -4,6 +4,7 @@
 //! The caller signs: `builder.sign_with_keys(&keys)?`.
 
 use buzz_core::{
+    forward::{forward_tags, ForwardSourceType},
     kind::{
         KIND_AGENT_OBSERVER_FRAME, KIND_APPROVAL_DENY, KIND_APPROVAL_GRANT, KIND_DELETION,
         KIND_DM_ADD_MEMBER, KIND_DM_OPEN, KIND_EMOJI_SET, KIND_GIT_ISSUE, KIND_GIT_PATCH,
@@ -11,8 +12,8 @@ use buzz_core::{
         KIND_GIT_STATUS_CLOSED, KIND_GIT_STATUS_DRAFT, KIND_GIT_STATUS_MERGED,
         KIND_GIT_STATUS_OPEN, KIND_IA_ARCHIVE_REQUEST, KIND_IA_UNARCHIVE_REQUEST,
         KIND_MODERATION_BAN, KIND_MODERATION_RESOLVE_REPORT, KIND_MODERATION_TIMEOUT,
-        KIND_MODERATION_UNBAN, KIND_MODERATION_UNTIMEOUT, KIND_PRESENCE_UPDATE, KIND_USER_STATUS,
-        KIND_WORKFLOW_DEF, KIND_WORKFLOW_TRIGGER,
+        KIND_MODERATION_UNBAN, KIND_MODERATION_UNTIMEOUT, KIND_PRESENCE_UPDATE,
+        KIND_STREAM_MESSAGE_FORWARD, KIND_USER_STATUS, KIND_WORKFLOW_DEF, KIND_WORKFLOW_TRIGGER,
     },
     observer::{
         content_looks_like_nip44, OBSERVER_AGENT_TAG, OBSERVER_FRAME_CONTROL, OBSERVER_FRAME_TAG,
@@ -235,6 +236,58 @@ pub fn build_message(
     }
     imeta_tags(media_tags, &mut tags)?;
     Ok(EventBuilder::new(Kind::Custom(9), content).tags(tags))
+}
+
+/// Build a forwarded message (kind 40009).
+///
+/// The forward is a root message authored by the forwarder: `note` is the
+/// forwarder's own text (empty when they add nothing) and the complete signed
+/// `original` travels verbatim in the `fwd` tag. The original's text is never
+/// merged into the content, so attribution and full-text search stay intact.
+///
+/// - `destination_channel_id`: channel or DM UUID to forward into (DMs are
+///   ordinary channels, so one path covers both)
+/// - `original`: the complete signed event being forwarded
+/// - `source_channel_id`: the original's own channel — must equal its `h` tag
+/// - `source_type`: visibility class of the source channel; only
+///   [`ForwardSourceType::Channel`] emits the `q` back-reference
+/// - `note`: the forwarder's optional note (max 64 KiB)
+/// - `mentions`: pubkey hex strings to p-tag, from mentions in `note` only
+///   (deduped, max 50) — a forward never p-tags the original author, which
+///   would fire a false "you were mentioned" notification
+///
+/// Tag assembly (kind allowlist, source/embedded `h` agreement, the 64 KiB
+/// `fwd` cap, `q`-only-for-open, and verbatim `imeta` passthrough) is delegated
+/// to [`buzz_core::forward::forward_tags`], the shared contract the relay
+/// validates against.
+///
+/// Forwarding a forward is the caller's job to flatten: pass the *embedded*
+/// original, since kind 40009 is not itself forwardable and is rejected here.
+pub fn build_forward(
+    destination_channel_id: Uuid,
+    original: &nostr::Event,
+    source_channel_id: Uuid,
+    source_type: ForwardSourceType,
+    note: &str,
+    mentions: &[&str],
+) -> Result<EventBuilder, SdkError> {
+    check_content(note, 64 * 1024)?;
+    let raw = forward_tags(
+        destination_channel_id,
+        original,
+        source_channel_id,
+        source_type,
+    )
+    .map_err(|e| SdkError::InvalidInput(e.to_string()))?;
+
+    let mut tags: Vec<Tag> = Vec::with_capacity(raw.len() + mentions.len());
+    for parts in &raw {
+        let parts: Vec<&str> = parts.iter().map(String::as_str).collect();
+        tags.push(tag(&parts)?);
+    }
+    mention_tags(mentions, &mut tags)?;
+
+    Ok(EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE_FORWARD as u16), note).tags(tags))
 }
 
 /// Build an encrypted agent observer frame (kind 24200).
@@ -1841,7 +1894,7 @@ pub fn build_unarchive_identity_request(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nostr::{EventId, Keys};
+    use nostr::{EventId, JsonUtil, Keys};
 
     fn keys() -> Keys {
         Keys::generate()
@@ -2034,6 +2087,151 @@ mod tests {
         let cid = uuid();
         let max = "x".repeat(64 * 1024);
         assert!(build_message(cid, &max, None, &[], false, &[]).is_ok());
+    }
+
+    /// A signed kind 9 original in `cid` carrying one imeta tag.
+    fn original_message(cid: Uuid, author: &Keys) -> nostr::Event {
+        EventBuilder::new(Kind::Custom(9), "original body")
+            .tags([
+                Tag::parse(["h", &cid.to_string()]).expect("h tag"),
+                Tag::parse(["imeta", "url https://example.test/a.png", "x abc123"])
+                    .expect("imeta tag"),
+            ])
+            .sign_with_keys(author)
+            .expect("sign")
+    }
+
+    #[test]
+    fn forward_happy_path_carries_the_signed_original() {
+        let src = uuid();
+        let dest = uuid();
+        let author = keys();
+        let original = original_message(src, &author);
+
+        let ev = sign(
+            build_forward(
+                dest,
+                &original,
+                src,
+                ForwardSourceType::Channel,
+                "look at this",
+                &[],
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(ev.kind.as_u16(), 40009);
+        assert_eq!(ev.content, "look at this");
+        assert!(has_tag(&ev, "h", &dest.to_string()));
+        assert!(has_tag(&ev, "k", "9"));
+        assert_eq!(tag_values(&ev, "fwd-src"), vec![src.to_string()]);
+        assert_eq!(tag_values(&ev, "imeta").len(), 1);
+
+        // The fwd tag round-trips to the byte-identical signed original.
+        let embedded = nostr::Event::from_json(&tag_values(&ev, "fwd")[0]).expect("embedded event");
+        assert_eq!(embedded.id, original.id);
+        assert_eq!(embedded.sig, original.sig);
+
+        // The original's author is never p-tagged (no false mention notification).
+        assert!(tag_values(&ev, "p").is_empty());
+    }
+
+    #[test]
+    fn forward_without_a_note_has_empty_content() {
+        let src = uuid();
+        let original = original_message(src, &keys());
+        let ev =
+            sign(build_forward(uuid(), &original, src, ForwardSourceType::Dm, "", &[]).unwrap());
+        assert_eq!(ev.content, "");
+    }
+
+    #[test]
+    fn forward_quotes_only_open_sources() {
+        let src = uuid();
+        let original = original_message(src, &keys());
+
+        let open = sign(
+            build_forward(uuid(), &original, src, ForwardSourceType::Channel, "", &[]).unwrap(),
+        );
+        assert_eq!(tag_values(&open, "q"), vec![original.id.to_hex()]);
+
+        for source_type in [ForwardSourceType::Private, ForwardSourceType::Dm] {
+            let ev = sign(build_forward(uuid(), &original, src, source_type, "", &[]).unwrap());
+            assert!(tag_values(&ev, "q").is_empty());
+        }
+    }
+
+    #[test]
+    fn forward_p_tags_only_note_mentions() {
+        let src = uuid();
+        let author = keys();
+        let original = original_message(src, &author);
+        let mentioned = keys().public_key().to_hex();
+
+        let ev = sign(
+            build_forward(
+                uuid(),
+                &original,
+                src,
+                ForwardSourceType::Private,
+                "@bob relevant",
+                &[&mentioned, &mentioned],
+            )
+            .unwrap(),
+        );
+        assert_eq!(tag_values(&ev, "p"), vec![mentioned]);
+        assert!(!has_tag(&ev, "p", &author.public_key().to_hex()));
+    }
+
+    #[test]
+    fn forward_rejects_a_forward_as_input() {
+        let src = uuid();
+        let inner = original_message(src, &keys());
+        let forward =
+            sign(build_forward(uuid(), &inner, src, ForwardSourceType::Channel, "", &[]).unwrap());
+
+        // Flattening is the caller's job: a kind 40009 original is refused.
+        let err = build_forward(uuid(), &forward, src, ForwardSourceType::Channel, "", &[])
+            .expect_err("kind 40009 must not be forwardable");
+        match err {
+            SdkError::InvalidInput(msg) => assert!(msg.contains("40009"), "{msg}"),
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn forward_rejects_source_channel_that_differs_from_the_original() {
+        let src = uuid();
+        let original = original_message(src, &keys());
+        assert!(matches!(
+            build_forward(
+                uuid(),
+                &original,
+                uuid(),
+                ForwardSourceType::Channel,
+                "",
+                &[]
+            ),
+            Err(SdkError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn forward_note_too_large() {
+        let src = uuid();
+        let original = original_message(src, &keys());
+        let big = "x".repeat(64 * 1024 + 1);
+        assert!(matches!(
+            build_forward(
+                uuid(),
+                &original,
+                src,
+                ForwardSourceType::Channel,
+                &big,
+                &[]
+            ),
+            Err(SdkError::ContentTooLarge { .. })
+        ));
     }
 
     #[test]

--- a/crates/buzz-sdk/src/lib.rs
+++ b/crates/buzz-sdk/src/lib.rs
@@ -82,6 +82,8 @@ pub use buzz_core::channel::ChannelType as ChannelKind;
 pub use buzz_core::channel::ChannelVisibility as Visibility;
 /// Member role.
 pub use buzz_core::channel::MemberRole;
+/// Visibility class of the channel a forwarded message came from.
+pub use buzz_core::forward::ForwardSourceType;
 
 /// Errors returned by SDK builder functions.
 #[derive(Debug, thiserror::Error)]

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -73,7 +73,7 @@ fn nip98_post_header(keys: &Keys, url: &str, body: &str) -> String {
 
 async fn e2e_db_pool() -> sqlx::Pool<sqlx::Postgres> {
     let database_url = std::env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "postgres://buzz:buzz_dev@localhost:5432/buzz".to_string());
+        .unwrap_or_else(|_| "postgres://buzz:buzz_dev@localhost:5432/buzz".to_string()); // sadscan:disable np.postgres.1 -- local docker-compose dev credentials
     sqlx::postgres::PgPoolOptions::new()
         .max_connections(1)
         .connect(&database_url)
@@ -2911,5 +2911,428 @@ async fn test_nip29_relay_rejects_last_owner_self_demotion() {
             .as_deref(),
         Some("owner"),
         "the last owner must keep their role"
+    );
+}
+
+// -- kind:40009 message forwards ---------------------------------------------
+
+/// Create a channel over WebSocket with an explicit type/visibility and return
+/// its UUID. The creator becomes the channel owner (and therefore a member).
+async fn create_channel_ws(
+    client: &mut BuzzTestClient,
+    keys: &Keys,
+    channel_type: &str,
+    visibility: &str,
+) -> String {
+    let channel_uuid = uuid::Uuid::new_v4().to_string();
+    let channel_name = format!("relay-e2e-fwd-{channel_uuid}");
+
+    let event = EventBuilder::new(Kind::Custom(9007), "")
+        .tags(vec![
+            Tag::parse(["h", &channel_uuid]).unwrap(),
+            Tag::parse(["name", &channel_name]).unwrap(),
+            Tag::parse(["channel_type", channel_type]).unwrap(),
+            Tag::parse(["visibility", visibility]).unwrap(),
+        ])
+        .sign_with_keys(keys)
+        .unwrap();
+
+    let ok = client.send_event(event).await.expect("create channel");
+    assert!(
+        ok.accepted,
+        "{channel_type}/{visibility} channel creation failed: {}",
+        ok.message
+    );
+    channel_uuid
+}
+
+/// Publish a kind:9 message into `channel_id` and return the signed event.
+async fn post_forwardable_message(
+    client: &mut BuzzTestClient,
+    keys: &Keys,
+    channel_id: &str,
+    content: &str,
+) -> nostr::Event {
+    let event = EventBuilder::new(Kind::Custom(9), content)
+        .tags(vec![Tag::parse(["h", channel_id]).unwrap()])
+        .sign_with_keys(keys)
+        .unwrap();
+    let ok = client
+        .send_event(event.clone())
+        .await
+        .expect("publish original message");
+    assert!(ok.accepted, "original message rejected: {}", ok.message);
+    event
+}
+
+fn forward_tag_vec(parts: &[&str]) -> Vec<String> {
+    parts.iter().map(|p| (*p).to_string()).collect()
+}
+
+/// Sign a kind:40009 forward carrying `tags` (raw string tag parts).
+fn sign_forward(keys: &Keys, note: &str, tags: &[Vec<String>]) -> nostr::Event {
+    let nostr_tags: Vec<Tag> = tags
+        .iter()
+        .map(|parts| Tag::parse(parts.iter().map(String::as_str)).expect("forward tag"))
+        .collect();
+    EventBuilder::new(Kind::Custom(40009), note)
+        .tags(nostr_tags)
+        .sign_with_keys(keys)
+        .expect("sign forward")
+}
+
+/// Build the canonical forward tag set via the shared buzz-core builder.
+fn canonical_forward_tags(
+    destination: &str,
+    original: &nostr::Event,
+    source: &str,
+    source_type: buzz_core::forward::ForwardSourceType,
+) -> Vec<Vec<String>> {
+    buzz_core::forward::forward_tags(
+        Uuid::parse_str(destination).expect("destination uuid"),
+        original,
+        Uuid::parse_str(source).expect("source uuid"),
+        source_type,
+    )
+    .expect("build forward tags")
+}
+
+/// Happy path: forwarding an open-channel message into another open channel is
+/// accepted, and the `q` back-reference to the original survives the round trip.
+#[tokio::test]
+#[ignore]
+async fn test_forward_open_channel_to_channel_is_accepted() {
+    use buzz_core::forward::ForwardSourceType;
+
+    let url = relay_url();
+    let keys = Keys::generate();
+    let source = create_test_channel(&keys).await;
+    let destination = create_test_channel(&keys).await;
+
+    let mut client = BuzzTestClient::connect(&url, &keys)
+        .await
+        .expect("connect forwarder");
+    let original = post_forwardable_message(&mut client, &keys, &source, "forward me").await;
+
+    let tags = canonical_forward_tags(&destination, &original, &source, ForwardSourceType::Channel);
+    assert!(
+        tags.iter().any(|parts| parts[0] == "q"),
+        "an open source must carry a q back-reference"
+    );
+    let ok = client
+        .send_event(sign_forward(&keys, "worth a look", &tags))
+        .await
+        .expect("send forward");
+    client.disconnect().await.ok();
+
+    assert!(ok.accepted, "open channel forward rejected: {}", ok.message);
+}
+
+/// A DM is an ordinary channel, so the same mechanism forwards into one.
+#[tokio::test]
+#[ignore]
+async fn test_forward_open_channel_into_dm_is_accepted() {
+    use buzz_core::forward::ForwardSourceType;
+
+    let url = relay_url();
+    let keys = Keys::generate();
+    let source = create_test_channel(&keys).await;
+
+    let mut client = BuzzTestClient::connect(&url, &keys)
+        .await
+        .expect("connect forwarder");
+    let dm = create_channel_ws(&mut client, &keys, "dm", "private").await;
+    let original = post_forwardable_message(&mut client, &keys, &source, "for your eyes").await;
+
+    let tags = canonical_forward_tags(&dm, &original, &source, ForwardSourceType::Channel);
+    let ok = client
+        .send_event(sign_forward(&keys, "", &tags))
+        .await
+        .expect("send forward into DM");
+    client.disconnect().await.ok();
+
+    assert!(ok.accepted, "forward into DM rejected: {}", ok.message);
+}
+
+/// A member of a private source may forward out of it; the envelope carries no
+/// `q` tag, so no linkable reference to unreadable content is published.
+#[tokio::test]
+#[ignore]
+async fn test_forward_from_private_source_by_member_is_accepted_without_quote() {
+    use buzz_core::forward::ForwardSourceType;
+
+    let url = relay_url();
+    let keys = Keys::generate();
+    let destination = create_test_channel(&keys).await;
+
+    let mut client = BuzzTestClient::connect(&url, &keys)
+        .await
+        .expect("connect forwarder");
+    let source = create_private_channel_ws(&mut client, &keys).await;
+    let original = post_forwardable_message(&mut client, &keys, &source, "private note").await;
+
+    let tags = canonical_forward_tags(&destination, &original, &source, ForwardSourceType::Private);
+    assert!(
+        tags.iter().all(|parts| parts[0] != "q"),
+        "a private source must not emit a q tag"
+    );
+    let ok = client
+        .send_event(sign_forward(&keys, "sharing with the team", &tags))
+        .await
+        .expect("send private-source forward");
+    client.disconnect().await.ok();
+
+    assert!(
+        ok.accepted,
+        "member forwarding out of a private channel was rejected: {}",
+        ok.message
+    );
+}
+
+/// The laundering gate: a non-member of the private source cannot get the relay
+/// to bless a copy of its content, even with a valid embedded signature.
+#[tokio::test]
+#[ignore]
+async fn test_forward_from_private_source_by_non_member_is_rejected() {
+    use buzz_core::forward::ForwardSourceType;
+
+    let url = relay_url();
+    let owner_keys = Keys::generate();
+    let outsider_keys = Keys::generate();
+    let destination = create_test_channel(&outsider_keys).await;
+
+    let mut owner_client = BuzzTestClient::connect(&url, &owner_keys)
+        .await
+        .expect("connect owner");
+    let source = create_private_channel_ws(&mut owner_client, &owner_keys).await;
+    let original =
+        post_forwardable_message(&mut owner_client, &owner_keys, &source, "leaked secret").await;
+    owner_client.disconnect().await.ok();
+
+    let tags = canonical_forward_tags(&destination, &original, &source, ForwardSourceType::Private);
+    let mut outsider_client = BuzzTestClient::connect(&url, &outsider_keys)
+        .await
+        .expect("connect outsider");
+    let ok = outsider_client
+        .send_event(sign_forward(&outsider_keys, "look what I found", &tags))
+        .await
+        .expect("send laundering forward");
+    outsider_client.disconnect().await.ok();
+
+    assert!(
+        !ok.accepted,
+        "a non-member must not be able to forward private content, got: {}",
+        ok.message
+    );
+    assert!(
+        ok.message.contains("restricted:"),
+        "rejection should be a restriction, got: {}",
+        ok.message
+    );
+}
+
+/// The embedded copy is verified, not trusted: a tampered original is refused.
+#[tokio::test]
+#[ignore]
+async fn test_forward_with_tampered_embedded_original_is_rejected() {
+    let url = relay_url();
+    let keys = Keys::generate();
+    let source = create_test_channel(&keys).await;
+    let destination = create_test_channel(&keys).await;
+
+    let mut client = BuzzTestClient::connect(&url, &keys)
+        .await
+        .expect("connect forwarder");
+    let original = post_forwardable_message(&mut client, &keys, &source, "genuine text").await;
+
+    let mut json: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&original).unwrap()).unwrap();
+    json["content"] = serde_json::Value::String("words the author never wrote".to_string());
+
+    let tags = vec![
+        forward_tag_vec(&["h", &destination]),
+        forward_tag_vec(&["fwd", &json.to_string()]),
+        forward_tag_vec(&["k", "9"]),
+        forward_tag_vec(&["fwd-src", &source, "channel"]),
+        forward_tag_vec(&["q", &original.id.to_hex(), "", &original.pubkey.to_hex()]),
+    ];
+    let ok = client
+        .send_event(sign_forward(&keys, "", &tags))
+        .await
+        .expect("send tampered forward");
+    client.disconnect().await.ok();
+
+    assert!(
+        !ok.accepted,
+        "a tampered embedded original must be rejected, got: {}",
+        ok.message
+    );
+}
+
+/// The `k` tag is the NIP-18 declaration of the embedded kind; a lie is refused.
+#[tokio::test]
+#[ignore]
+async fn test_forward_with_mismatched_k_tag_is_rejected() {
+    use buzz_core::forward::ForwardSourceType;
+
+    let url = relay_url();
+    let keys = Keys::generate();
+    let source = create_test_channel(&keys).await;
+    let destination = create_test_channel(&keys).await;
+
+    let mut client = BuzzTestClient::connect(&url, &keys)
+        .await
+        .expect("connect forwarder");
+    let original = post_forwardable_message(&mut client, &keys, &source, "kind nine").await;
+
+    let tags: Vec<Vec<String>> =
+        canonical_forward_tags(&destination, &original, &source, ForwardSourceType::Channel)
+            .into_iter()
+            .map(|parts| {
+                if parts[0] == "k" {
+                    forward_tag_vec(&["k", "40002"])
+                } else {
+                    parts
+                }
+            })
+            .collect();
+    let ok = client
+        .send_event(sign_forward(&keys, "", &tags))
+        .await
+        .expect("send k-mismatch forward");
+    client.disconnect().await.ok();
+
+    assert!(
+        !ok.accepted,
+        "a k tag that disagrees with the embedded kind must be rejected, got: {}",
+        ok.message
+    );
+}
+
+/// Forwards never nest: an embedded kind:40009 is refused so depth stays 1.
+#[tokio::test]
+#[ignore]
+async fn test_forward_of_a_forward_is_rejected() {
+    use buzz_core::forward::ForwardSourceType;
+
+    let url = relay_url();
+    let keys = Keys::generate();
+    let source = create_test_channel(&keys).await;
+    let destination = create_test_channel(&keys).await;
+
+    let mut client = BuzzTestClient::connect(&url, &keys)
+        .await
+        .expect("connect forwarder");
+    let original = post_forwardable_message(&mut client, &keys, &source, "the first message").await;
+
+    // A real, accepted forward — then try to forward the forward itself.
+    let inner_tags =
+        canonical_forward_tags(&destination, &original, &source, ForwardSourceType::Channel);
+    let inner = sign_forward(&keys, "first hop", &inner_tags);
+    let ok = client
+        .send_event(inner.clone())
+        .await
+        .expect("send first-hop forward");
+    assert!(ok.accepted, "first hop rejected: {}", ok.message);
+
+    let nested = vec![
+        forward_tag_vec(&["h", &source]),
+        forward_tag_vec(&["fwd", &serde_json::to_string(&inner).unwrap()]),
+        forward_tag_vec(&["k", "40009"]),
+        forward_tag_vec(&["fwd-src", &destination, "channel"]),
+    ];
+    let ok = client
+        .send_event(sign_forward(&keys, "second hop", &nested))
+        .await
+        .expect("send nested forward");
+    client.disconnect().await.ok();
+
+    assert!(
+        !ok.accepted,
+        "forwarding a forward must be rejected, got: {}",
+        ok.message
+    );
+}
+
+/// Provenance: a validly signed original that was never published to this relay
+/// has no provenance here, so it cannot be laundered in with a real signature
+/// even when the forwarder owns both channels.
+#[tokio::test]
+#[ignore]
+async fn test_forward_of_an_unpublished_original_is_rejected() {
+    use buzz_core::forward::ForwardSourceType;
+
+    let url = relay_url();
+    let keys = Keys::generate();
+    let source = create_test_channel(&keys).await;
+    let destination = create_test_channel(&keys).await;
+
+    // Signed for the source channel but deliberately never sent to the relay.
+    let original = EventBuilder::new(Kind::Custom(9), "never published here")
+        .tags(vec![Tag::parse(["h", &source]).unwrap()])
+        .sign_with_keys(&keys)
+        .expect("sign unpublished original");
+
+    let tags = canonical_forward_tags(&destination, &original, &source, ForwardSourceType::Channel);
+    let mut client = BuzzTestClient::connect(&url, &keys)
+        .await
+        .expect("connect forwarder");
+    let ok = client
+        .send_event(sign_forward(&keys, "found this somewhere", &tags))
+        .await
+        .expect("send unpublished-original forward");
+    client.disconnect().await.ok();
+
+    assert!(
+        !ok.accepted,
+        "an original that was never published must not be forwardable, got: {}",
+        ok.message
+    );
+    assert!(
+        ok.message.contains("restricted:"),
+        "rejection should be a restriction, got: {}",
+        ok.message
+    );
+}
+
+/// The source-type label is checked against the channel row, so a forwarder
+/// cannot downgrade a private source to "channel" to win a linkable attribution.
+#[tokio::test]
+#[ignore]
+async fn test_forward_with_spoofed_source_type_is_rejected() {
+    let url = relay_url();
+    let keys = Keys::generate();
+    let destination = create_test_channel(&keys).await;
+
+    let mut client = BuzzTestClient::connect(&url, &keys)
+        .await
+        .expect("connect forwarder");
+    let source = create_private_channel_ws(&mut client, &keys).await;
+    let original = post_forwardable_message(&mut client, &keys, &source, "private original").await;
+
+    // Hand-rolled tags: the builder would never label a private source
+    // "channel", which is exactly the claim the relay must refuse.
+    let tags = vec![
+        forward_tag_vec(&["h", &destination]),
+        forward_tag_vec(&["fwd", &serde_json::to_string(&original).unwrap()]),
+        forward_tag_vec(&["k", "9"]),
+        forward_tag_vec(&["fwd-src", &source, "channel"]),
+        forward_tag_vec(&["q", &original.id.to_hex(), "", &original.pubkey.to_hex()]),
+    ];
+    let ok = client
+        .send_event(sign_forward(&keys, "", &tags))
+        .await
+        .expect("send spoofed-source forward");
+    client.disconnect().await.ok();
+
+    assert!(
+        !ok.accepted,
+        "a spoofed fwd-src type must be rejected, got: {}",
+        ok.message
+    );
+    assert!(
+        ok.message.contains("does not match source channel"),
+        "rejection should name the source-type mismatch, got: {}",
+        ok.message
     );
 }

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
         "**/hosted-communities-settings-screenshots.spec.ts",
         "**/invites-settings-screenshots.spec.ts",
         "**/messaging.spec.ts",
+        "**/forward-message.spec.ts",
         "**/custom-emoji.spec.ts",
         "**/profile-custom-emoji-status.spec.ts",
         "**/custom-emoji-ui.spec.ts",

--- a/desktop/src-tauri/src/commands/channel_window.rs
+++ b/desktop/src-tauri/src/commands/channel_window.rs
@@ -2,10 +2,11 @@ use tauri::State;
 
 use crate::{app_state::AppState, models::ChannelPageCursor, relay::query_relay};
 
-const TIMELINE_KINDS: [u32; 11] = [
+const TIMELINE_KINDS: [u32; 12] = [
     9,
     40002,
     40008,
+    buzz_core_pkg::kind::KIND_STREAM_MESSAGE_FORWARD,
     40099,
     43001,
     43002,

--- a/desktop/src-tauri/src/commands/messages.rs
+++ b/desktop/src-tauri/src/commands/messages.rs
@@ -7,14 +7,13 @@ use forum::{forum_message_from_event, forum_reply_from_event};
 
 use crate::{
     app_state::AppState,
-    events,
+    events, events_forward,
     managed_agents::{find_managed_agent_mut, load_managed_agents, ManagedAgentRecord},
     models::{
         FeedItemInfo, FeedMeta, FeedResponse, FeedSections, ForumMessageInfo, ForumPostsResponse,
-        ForumThreadReplyInfo, ForumThreadResponse, SearchResponse, SendChannelMessageResponse,
+        ForumThreadReplyInfo, ForumThreadResponse, SendChannelMessageResponse,
         ThreadRepliesResponse,
     },
-    nostr_convert,
     relay::{query_relay, submit_event, submit_event_with_keys},
 };
 
@@ -27,10 +26,11 @@ use crate::{
 /// (`p_gated_filters_authorized`) without a `#p` tag — load-bearing for the
 /// thread-subtree read, whose relay routing keys off `#e`+`depth_limit` (not
 /// kind) but still passes through the p-gate before it runs.
-const TIMELINE_KINDS: [u32; 11] = [
+const TIMELINE_KINDS: [u32; 12] = [
     9,
     40002,
     40008,
+    buzz_core_pkg::kind::KIND_STREAM_MESSAGE_FORWARD,
     40099,
     43001,
     43002,
@@ -71,6 +71,7 @@ pub async fn get_feed(
         "kinds": [
             9,
             40002,
+            buzz_core_pkg::kind::KIND_STREAM_MESSAGE_FORWARD,
             1,
             45001,
             45003,
@@ -136,74 +137,6 @@ pub async fn get_feed(
             generated_at: chrono::Utc::now().timestamp(),
         },
     })
-}
-
-fn build_search_messages_filter(
-    q: &str,
-    cap: u32,
-    channel_id: Option<&str>,
-    authors: Option<&[String]>,
-    since: Option<i64>,
-    until: Option<i64>,
-) -> serde_json::Value {
-    let mut filter = serde_json::Map::new();
-    filter.insert(
-        "kinds".to_string(),
-        serde_json::json!([9, 40002, 45001, 45003]),
-    );
-    filter.insert("search".to_string(), serde_json::json!(q.trim()));
-    // The desktop topbar is a typeahead surface. This bridge-only extension is
-    // consumed before nostr::Filter parsing on the relay, so general WS/NIP-50
-    // search remains word/lexeme-based.
-    filter.insert("search_mode".to_string(), serde_json::json!("prefix"));
-    filter.insert("limit".to_string(), serde_json::json!(cap));
-    if let Some(cid) = channel_id {
-        filter.insert("#h".to_string(), serde_json::json!([cid]));
-    }
-    // Optional operators from the desktop search parser (#2853). The relay
-    // already maps authors/since/until onto FTS; search remains never the
-    // access boundary (hits are refetched and re-authorized).
-    if let Some(authors) = authors {
-        let cleaned: Vec<&str> = authors
-            .iter()
-            .map(|a| a.trim())
-            .filter(|a| !a.is_empty())
-            .collect();
-        if !cleaned.is_empty() {
-            filter.insert("authors".to_string(), serde_json::json!(cleaned));
-        }
-    }
-    if let Some(since) = since {
-        filter.insert("since".to_string(), serde_json::json!(since));
-    }
-    if let Some(until) = until {
-        filter.insert("until".to_string(), serde_json::json!(until));
-    }
-    serde_json::Value::Object(filter)
-}
-
-#[tauri::command]
-pub async fn search_messages(
-    q: String,
-    limit: Option<u32>,
-    channel_id: Option<String>,
-    authors: Option<Vec<String>>,
-    since: Option<i64>,
-    until: Option<i64>,
-    state: State<'_, AppState>,
-) -> Result<SearchResponse, String> {
-    let cap = limit.unwrap_or(20).min(100);
-    let filter = build_search_messages_filter(
-        &q,
-        cap,
-        channel_id.as_deref(),
-        authors.as_deref(),
-        since,
-        until,
-    );
-
-    let events = query_relay(&state, &[filter]).await?;
-    Ok(nostr_convert::search_response_from_events(&events))
 }
 
 #[tauri::command]
@@ -463,7 +396,7 @@ pub async fn get_event(event_id: String, state: State<'_, AppState>) -> Result<S
         &state,
         &[serde_json::json!({
             "ids": [event_id],
-            "kinds": [0, 1, 3, 5, 7, 9, 30078, 40002, 40003, 40008, 40099, 40100, 45001, 45003, buzz_core_pkg::kind::KIND_HUDDLE_STARTED],
+            "kinds": [0, 1, 3, 5, 7, 9, 30078, 40002, 40003, 40008, buzz_core_pkg::kind::KIND_STREAM_MESSAGE_FORWARD, 40099, 40100, 45001, 45003, buzz_core_pkg::kind::KIND_HUDDLE_STARTED],
             "limit": 1
         })],
     )
@@ -489,7 +422,7 @@ async fn resolve_thread_ref(
         state,
         &[serde_json::json!({
             "ids": [parent_event_id],
-            "kinds": [9, 40002, 45001, 45003, buzz_core_pkg::kind::KIND_HUDDLE_STARTED],
+            "kinds": [9, 40002, buzz_core_pkg::kind::KIND_STREAM_MESSAGE_FORWARD, 45001, 45003, buzz_core_pkg::kind::KIND_HUDDLE_STARTED],
             "limit": 1
         })],
     )
@@ -608,6 +541,39 @@ pub async fn send_channel_message(
         root_event_id: resolved_root,
         parent_event_id,
         depth,
+        created_at: chrono::Utc::now().timestamp(),
+    })
+}
+
+/// Forward a message snapshot (kind 40009) into a destination channel or DM.
+///
+/// `note` is the forwarder's optional note (empty string when none).
+/// `forward_tags` carries the pre-composed `fwd`/`k`/`fwd-src`/`q`/`imeta`
+/// tags (see `buildForwardTags` in the desktop frontend); the builder rejects
+/// any other tag family. `mention_pubkeys` are mentions the forwarder wrote in
+/// the note. A forward is always a root message, so no thread fields apply.
+#[tauri::command]
+pub async fn forward_message(
+    channel_id: String,
+    note: String,
+    forward_tags: Vec<Vec<String>>,
+    mention_pubkeys: Option<Vec<String>>,
+    state: State<'_, AppState>,
+) -> Result<SendChannelMessageResponse, String> {
+    let channel_uuid = uuid::Uuid::parse_str(&channel_id)
+        .map_err(|_| format!("invalid channel UUID: {channel_id}"))?;
+    let mentions = mention_pubkeys.unwrap_or_default();
+    let mention_refs: Vec<&str> = mentions.iter().map(|s| s.as_str()).collect();
+
+    let builder =
+        events_forward::build_forward(channel_uuid, note.trim(), &forward_tags, &mention_refs)?;
+    let result = submit_event(builder, &state).await?;
+
+    Ok(SendChannelMessageResponse {
+        event_id: result.event_id,
+        root_event_id: None,
+        parent_event_id: None,
+        depth: 0,
         created_at: chrono::Utc::now().timestamp(),
     })
 }

--- a/desktop/src-tauri/src/commands/messages_search.rs
+++ b/desktop/src-tauri/src/commands/messages_search.rs
@@ -1,0 +1,81 @@
+use tauri::State;
+
+use crate::{app_state::AppState, models::SearchResponse, nostr_convert, relay::query_relay};
+
+fn build_search_messages_filter(
+    q: &str,
+    cap: u32,
+    channel_id: Option<&str>,
+    authors: Option<&[String]>,
+    since: Option<i64>,
+    until: Option<i64>,
+) -> serde_json::Value {
+    let mut filter = serde_json::Map::new();
+    filter.insert(
+        "kinds".to_string(),
+        serde_json::json!([
+            9,
+            40002,
+            buzz_core_pkg::kind::KIND_STREAM_MESSAGE_FORWARD,
+            45001,
+            45003
+        ]),
+    );
+    filter.insert("search".to_string(), serde_json::json!(q.trim()));
+    // The desktop topbar is a typeahead surface. This bridge-only extension is
+    // consumed before nostr::Filter parsing on the relay, so general WS/NIP-50
+    // search remains word/lexeme-based.
+    filter.insert("search_mode".to_string(), serde_json::json!("prefix"));
+    filter.insert("limit".to_string(), serde_json::json!(cap));
+    if let Some(cid) = channel_id {
+        filter.insert("#h".to_string(), serde_json::json!([cid]));
+    }
+    // Optional operators from the desktop search parser (#2853). The relay
+    // already maps authors/since/until onto FTS; search remains never the
+    // access boundary (hits are refetched and re-authorized).
+    if let Some(authors) = authors {
+        let cleaned: Vec<&str> = authors
+            .iter()
+            .map(|a| a.trim())
+            .filter(|a| !a.is_empty())
+            .collect();
+        if !cleaned.is_empty() {
+            filter.insert("authors".to_string(), serde_json::json!(cleaned));
+        }
+    }
+    if let Some(since) = since {
+        filter.insert("since".to_string(), serde_json::json!(since));
+    }
+    if let Some(until) = until {
+        filter.insert("until".to_string(), serde_json::json!(until));
+    }
+    serde_json::Value::Object(filter)
+}
+
+#[tauri::command]
+pub async fn search_messages(
+    q: String,
+    limit: Option<u32>,
+    channel_id: Option<String>,
+    authors: Option<Vec<String>>,
+    since: Option<i64>,
+    until: Option<i64>,
+    state: State<'_, AppState>,
+) -> Result<SearchResponse, String> {
+    let cap = limit.unwrap_or(20).min(100);
+    let filter = build_search_messages_filter(
+        &q,
+        cap,
+        channel_id.as_deref(),
+        authors.as_deref(),
+        since,
+        until,
+    );
+
+    let events = query_relay(&state, &[filter]).await?;
+    Ok(nostr_convert::search_response_from_events(&events))
+}
+
+#[cfg(test)]
+#[path = "messages_search_tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/commands/messages_search_tests.rs
+++ b/desktop/src-tauri/src/commands/messages_search_tests.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+#[test]
+fn search_messages_filter_requests_prefix_mode_for_topbar_typeahead() {
+    let filter = build_search_messages_filter("  pro  ", 12, Some("channel-1"), None, None, None);
+
+    assert_eq!(filter["search"], serde_json::json!("pro"));
+    assert_eq!(filter["search_mode"], serde_json::json!("prefix"));
+    assert_eq!(filter["limit"], serde_json::json!(12));
+    assert_eq!(filter["#h"], serde_json::json!(["channel-1"]));
+    assert!(filter.get("authors").is_none());
+    assert!(filter.get("since").is_none());
+    assert!(filter.get("until").is_none());
+}
+
+#[test]
+fn search_messages_filter_emits_operator_fields() {
+    let authors =
+        vec!["aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899".to_string()];
+    let filter = build_search_messages_filter(
+        "deploy",
+        20,
+        Some("channel-uuid"),
+        Some(&authors),
+        Some(1_700_000_000),
+        Some(1_700_086_400),
+    );
+
+    assert_eq!(filter["search"], serde_json::json!("deploy"));
+    assert_eq!(filter["#h"], serde_json::json!(["channel-uuid"]));
+    assert_eq!(
+        filter["authors"],
+        serde_json::json!(["aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"])
+    );
+    assert_eq!(filter["since"], serde_json::json!(1_700_000_000));
+    assert_eq!(filter["until"], serde_json::json!(1_700_086_400));
+}

--- a/desktop/src-tauri/src/commands/messages_tests.rs
+++ b/desktop/src-tauri/src/commands/messages_tests.rs
@@ -79,42 +79,6 @@ fn managed_agent_message_builder_rejects_invalid_mentions() {
     assert!(error.contains("pubkey must be a 64-character hex string"));
 }
 #[test]
-fn search_messages_filter_requests_prefix_mode_for_topbar_typeahead() {
-    let filter = build_search_messages_filter("  pro  ", 12, Some("channel-1"), None, None, None);
-
-    assert_eq!(filter["search"], serde_json::json!("pro"));
-    assert_eq!(filter["search_mode"], serde_json::json!("prefix"));
-    assert_eq!(filter["limit"], serde_json::json!(12));
-    assert_eq!(filter["#h"], serde_json::json!(["channel-1"]));
-    assert!(filter.get("authors").is_none());
-    assert!(filter.get("since").is_none());
-    assert!(filter.get("until").is_none());
-}
-
-#[test]
-fn search_messages_filter_emits_operator_fields() {
-    let authors =
-        vec!["aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899".to_string()];
-    let filter = build_search_messages_filter(
-        "deploy",
-        20,
-        Some("channel-uuid"),
-        Some(&authors),
-        Some(1_700_000_000),
-        Some(1_700_086_400),
-    );
-
-    assert_eq!(filter["search"], serde_json::json!("deploy"));
-    assert_eq!(filter["#h"], serde_json::json!(["channel-uuid"]));
-    assert_eq!(
-        filter["authors"],
-        serde_json::json!(["aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"])
-    );
-    assert_eq!(filter["since"], serde_json::json!(1_700_000_000));
-    assert_eq!(filter["until"], serde_json::json!(1_700_086_400));
-}
-
-#[test]
 fn channel_messages_before_filter_sends_before_id_the_relay_reads() {
     // The relay bridge's `extract_before_id` reads the composite tiebreak
     // from `before_id`. If this filter sent the id under any other key (an

--- a/desktop/src-tauri/src/commands/mod.rs
+++ b/desktop/src-tauri/src/commands/mod.rs
@@ -33,6 +33,7 @@ mod media_transcode;
 #[cfg(feature = "mesh-llm")]
 pub(crate) mod mesh_llm;
 mod messages;
+mod messages_search;
 mod notifications;
 mod observer_archive;
 mod os_idle;
@@ -87,6 +88,7 @@ pub use media_download::*;
 #[cfg(feature = "mesh-llm")]
 pub use mesh_llm::*;
 pub use messages::*;
+pub use messages_search::*;
 pub use notifications::*;
 pub use observer_archive::*;
 pub use os_idle::*;

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 // ── Constants ────────────────────────────────────────────────────────────────
 
 /// Maximum content size — matches buzz-sdk (64 KiB).
-const MAX_CONTENT_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_CONTENT_BYTES: usize = 64 * 1024;
 
 /// Maximum mention count — matches buzz-sdk.
 const MAX_MENTIONS: usize = 50;
@@ -26,11 +26,11 @@ const MAX_EMOJI_CHARS: usize = 64;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-fn tag(parts: Vec<&str>) -> Result<Tag, String> {
+pub(crate) fn tag(parts: Vec<&str>) -> Result<Tag, String> {
     Tag::parse(parts).map_err(|e| format!("invalid tag: {e}"))
 }
 
-fn check_content(content: &str) -> Result<(), String> {
+pub(crate) fn check_content(content: &str) -> Result<(), String> {
     if content.len() > MAX_CONTENT_BYTES {
         return Err(format!(
             "content exceeds maximum size of {} bytes (got {})",
@@ -60,7 +60,7 @@ fn thread_tags(tr: &ThreadRef) -> Result<Vec<Tag>, String> {
     }
 }
 
-fn mention_tags(mentions: &[&str]) -> Result<Vec<Tag>, String> {
+pub(crate) fn mention_tags(mentions: &[&str]) -> Result<Vec<Tag>, String> {
     if mentions.len() > MAX_MENTIONS {
         return Err(format!("too many mentions (max {MAX_MENTIONS})"));
     }

--- a/desktop/src-tauri/src/events_forward.rs
+++ b/desktop/src-tauri/src/events_forward.rs
@@ -1,0 +1,131 @@
+//! Signed-event builder for message forwarding (kind 40009).
+//!
+//! Split out of `events.rs` (which is at its file-size ceiling); follows the
+//! same pattern: validate inputs, return a `nostr::EventBuilder`, and let
+//! `relay::submit_event` sign + POST.
+
+use nostr::{EventBuilder, Kind, Tag};
+use uuid::Uuid;
+
+use crate::events::{check_content, mention_tags, tag, MAX_CONTENT_BYTES};
+
+/// Forward metadata tag families the desktop send path accepts. Everything
+/// else is rejected so this path cannot forge channel/thread/mention metadata
+/// (mirrors the `imeta_tags`/`emoji_tags` allowlist pattern in `events.rs`).
+fn forward_tags(forward_tags: &[Vec<String>], tags: &mut Vec<Tag>) -> Result<(), String> {
+    let mut fwd_count = 0usize;
+    let mut k_count = 0usize;
+    let mut src_count = 0usize;
+    for ft in forward_tags {
+        match ft.first().map(String::as_str) {
+            Some("fwd") => {
+                fwd_count += 1;
+                let embedded = ft.get(1).ok_or("fwd tag missing embedded event")?;
+                if embedded.len() > MAX_CONTENT_BYTES {
+                    return Err(format!(
+                        "embedded event exceeds maximum size of {} bytes (got {})",
+                        MAX_CONTENT_BYTES,
+                        embedded.len()
+                    ));
+                }
+            }
+            Some("k") => k_count += 1,
+            Some("fwd-src") => src_count += 1,
+            Some("q") | Some("imeta") => {}
+            other => {
+                return Err(format!(
+                    "forward tags must use fwd/k/fwd-src/q/imeta prefix (got {other:?})"
+                ));
+            }
+        }
+        let parts: Vec<&str> = ft.iter().map(String::as_str).collect();
+        tags.push(Tag::parse(parts).map_err(|e| format!("invalid forward tag: {e}"))?);
+    }
+    if fwd_count != 1 || k_count != 1 || src_count != 1 {
+        return Err(format!(
+            "forward requires exactly one fwd, k, and fwd-src tag (got {fwd_count}/{k_count}/{src_count})"
+        ));
+    }
+    Ok(())
+}
+
+/// Kind 40009 — forward a message snapshot into a channel or DM.
+///
+/// `note` is the forwarder's optional note (empty string when none);
+/// the original message rides in the `fwd` tag untouched. `mentions` are
+/// pubkeys the forwarder mentioned in the note — never the original author.
+/// Deep validation of the embedded event (id/sig recompute, source-channel
+/// access) is the relay's per-kind validator; this builder only guarantees a
+/// well-formed tag shape.
+pub fn build_forward(
+    channel_id: Uuid,
+    note: &str,
+    fwd_tags: &[Vec<String>],
+    mentions: &[&str],
+) -> Result<EventBuilder, String> {
+    check_content(note)?;
+    let mut tags = vec![tag(vec!["h", &channel_id.to_string()])?];
+    forward_tags(fwd_tags, &mut tags)?;
+    tags.extend(mention_tags(mentions)?);
+    Ok(EventBuilder::new(
+        Kind::Custom(buzz_core_pkg::kind::KIND_STREAM_MESSAGE_FORWARD as u16),
+        note,
+    )
+    .tags(tags))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr::Keys;
+
+    #[test]
+    fn forward_builder_layout_and_tag_allowlist() {
+        let channel_id = Uuid::new_v4();
+        let dest = channel_id.to_string();
+        let src = Uuid::new_v4().to_string();
+        let fwd_tags = vec![
+            vec!["fwd".to_string(), "{\"id\":\"ab\"}".to_string()],
+            vec!["k".to_string(), "9".to_string()],
+            vec!["fwd-src".to_string(), src.clone(), "channel".to_string()],
+            vec![
+                "q".to_string(),
+                "ab".to_string(),
+                String::new(),
+                "cd".to_string(),
+            ],
+            vec!["imeta".to_string(), "url https://x/y.png".to_string()],
+        ];
+        let builder = build_forward(channel_id, "a note", &fwd_tags, &[]).unwrap();
+        let keys = Keys::generate();
+        let event = builder.sign_with_keys(&keys).unwrap();
+        assert_eq!(
+            event.kind,
+            Kind::Custom(buzz_core_pkg::kind::KIND_STREAM_MESSAGE_FORWARD as u16)
+        );
+        assert_eq!(event.content, "a note");
+        let tags: Vec<Vec<String>> = event.tags.iter().map(|t| t.as_slice().to_vec()).collect();
+        assert_eq!(tags[0], vec!["h", &dest]);
+        assert_eq!(tags[1], vec!["fwd", "{\"id\":\"ab\"}"]);
+        assert_eq!(tags[2], vec!["k", "9"]);
+        assert_eq!(tags[3], vec!["fwd-src", &src, "channel"]);
+
+        // Forged non-allowlisted tags are rejected.
+        let smuggled = vec![
+            vec!["fwd".to_string(), "{}".to_string()],
+            vec!["k".to_string(), "9".to_string()],
+            vec!["fwd-src".to_string(), src.clone(), "channel".to_string()],
+            vec!["e".to_string(), "ab".to_string()],
+        ];
+        assert!(build_forward(channel_id, "", &smuggled, &[]).is_err());
+
+        // Exactly one fwd tag.
+        let doubled = vec![
+            vec!["fwd".to_string(), "{}".to_string()],
+            vec!["fwd".to_string(), "{}".to_string()],
+            vec!["k".to_string(), "9".to_string()],
+            vec!["fwd-src".to_string(), src, "channel".to_string()],
+        ];
+        assert!(build_forward(channel_id, "", &doubled, &[]).is_err());
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod commands;
 mod deep_link;
 mod event_sync;
 mod events;
+mod events_forward;
 mod huddle;
 mod managed_agents;
 mod media_proxy;
@@ -733,6 +734,7 @@ pub fn run() {
             get_feed,
             search_messages,
             send_channel_message,
+            forward_message,
             send_managed_agent_channel_message,
             has_managed_agent_channel_message_marker,
             get_forum_posts,

--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -65,7 +65,7 @@ import {
 } from "@/features/settings/ui/SettingsPanels";
 import { HuddleBar, HuddleProvider } from "@/features/huddle";
 import { useDueReminderBadgeCount } from "@/features/reminders/hooks";
-import { RemindMeLaterProvider } from "@/features/reminders/ui/RemindMeLaterProvider";
+import { MessageActionProviders } from "@/app/MessageActionProviders";
 import { useReminderNotifications } from "@/features/reminders/useReminderNotifications";
 import { AppSidebar } from "@/features/sidebar/ui/AppSidebar";
 import { requestFocusedThreadClose } from "@/features/channels/focusedThreadCloseRequest";
@@ -742,7 +742,7 @@ export function AppShell() {
           }}
         >
           <HuddleProvider>
-            <RemindMeLaterProvider pubkey={identityQuery.data?.pubkey}>
+            <MessageActionProviders pubkey={identityQuery.data?.pubkey}>
               <div
                 className="buzz-huddle-shell relative h-dvh overflow-hidden overscroll-none"
                 data-huddle-open={isHuddleDrawerOpen}
@@ -988,7 +988,7 @@ export function AppShell() {
                   />
                 </div>
               </div>
-            </RemindMeLaterProvider>
+            </MessageActionProviders>
           </HuddleProvider>
         </AppShellProvider>
       </ChannelNavigationProvider>

--- a/desktop/src/app/MessageActionProviders.tsx
+++ b/desktop/src/app/MessageActionProviders.tsx
@@ -1,0 +1,25 @@
+import type * as React from "react";
+
+import { ForwardMessageProvider } from "@/features/messages/ui/ForwardMessageProvider";
+import { RemindMeLaterProvider } from "@/features/reminders/ui/RemindMeLaterProvider";
+
+/**
+ * Composes the message-action dialog hosts (remind-me-later, forward) that
+ * every message surface under the app shell shares, keeping `AppShell`'s JSX
+ * nesting flat as hosts are added.
+ */
+export function MessageActionProviders({
+  pubkey,
+  children,
+}: {
+  pubkey?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <RemindMeLaterProvider pubkey={pubkey}>
+      <ForwardMessageProvider pubkey={pubkey}>
+        {children}
+      </ForwardMessageProvider>
+    </RemindMeLaterProvider>
+  );
+}

--- a/desktop/src/features/channels/useMessageEventProfilePubkeys.ts
+++ b/desktop/src/features/channels/useMessageEventProfilePubkeys.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import {
+  collectForwardEmbeddedPubkeys,
   collectMessageAuthorPubkeys,
   collectMessageMentionPubkeys,
   collectReactionActorPubkeys,
@@ -18,6 +19,9 @@ export function useMessageEventProfilePubkeys(
       ...new Set([
         ...collectMessageAuthorPubkeys(events, relaySelfPubkey),
         ...collectMessageMentionPubkeys(events),
+        // Forwarded rows render an embedded original: its author and mentions
+        // ride this batch instead of a per-row query.
+        ...collectForwardEmbeddedPubkeys(events),
         ...collectReactionActorPubkeys(events, relaySelfPubkey),
       ]),
     ];

--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -40,9 +40,18 @@ import {
   addReaction,
   deleteMessage,
   editMessage,
+  getEventById,
   removeReaction,
   sendChannelMessage,
 } from "@/shared/api/tauri";
+import { forwardMessage } from "@/shared/api/tauriForward";
+import {
+  buildForwardTags,
+  forwardSourceTypeForChannel,
+  getEventChannelId,
+  parseForwardEnvelope,
+  resolveForwardOriginal,
+} from "@/features/messages/lib/forwardMessage";
 import { getChannelWindowEvents } from "@/shared/api/channelWindow";
 import type { Channel, Identity, RelayEvent } from "@/shared/api/types";
 // Same .mjs the renderer uses, so the cache-update projection can't drift
@@ -65,6 +74,7 @@ import {
   CHANNEL_TIMELINE_CONTENT_KINDS,
   KIND_CHANNEL_THREAD_SUMMARY,
   KIND_STREAM_MESSAGE,
+  KIND_STREAM_MESSAGE_FORWARD,
   KIND_SYSTEM_MESSAGE,
 } from "@/shared/constants/kinds";
 
@@ -630,6 +640,83 @@ export function useSendMessageMutation(
       });
       queryClient.setQueryData(windowKey, next);
       projectChannelWindowMessages(queryClient, context.channelId);
+    },
+  });
+}
+
+/**
+ * Publish a kind-40009 forward of `message` into `destination`.
+ *
+ * The `fwd` tag must carry the COMPLETE signed original event. Timeline rows
+ * are sig-stripped, so the original is re-fetched by id — except when the
+ * message is itself a forward, whose tags already embed the complete signed
+ * original (forwarding a forward flattens to depth 1).
+ *
+ * No optimistic cache write: the forwarder stays in place and the destination
+ * channel picks the event up through its live subscription / next fetch.
+ *
+ * `senderPubkey` is the forwarder's own pubkey — the note's recipients are
+ * derived from it exactly as the ordinary send path derives them.
+ */
+export function useForwardMessageMutation(senderPubkey: string | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    { eventId: string; createdAt: number },
+    Error,
+    {
+      destination: Channel;
+      note: string;
+      /** Pubkeys the note @mentions, resolved against `destination`. */
+      mentionPubkeys?: string[];
+      message: { id: string; kind?: number; tags?: string[][] };
+    }
+  >({
+    mutationFn: async ({ destination, note, mentionPubkeys, message }) => {
+      if (destination.channelType === "forum") {
+        throw new Error("Messages cannot be forwarded into a forum.");
+      }
+
+      if (!senderPubkey) {
+        throw new Error("No identity available for sending messages.");
+      }
+
+      const original =
+        message.kind === KIND_STREAM_MESSAGE_FORWARD
+          ? (parseForwardEnvelope(message.tags ?? [])?.original ?? null)
+          : resolveForwardOriginal(await getEventById(message.id));
+      if (!original) {
+        throw new Error("This message cannot be forwarded.");
+      }
+
+      // The fwd-src label must match the source channel row; the source is
+      // the ORIGINAL's own channel (which, for a flattened re-forward, is not
+      // the channel the user is forwarding from).
+      const sourceChannelId = getEventChannelId(original);
+      const sourceChannel = queryClient
+        .getQueryData<Channel[]>(channelsQueryKey)
+        ?.find((channel) => channel.id === sourceChannelId);
+      if (!sourceChannel) {
+        throw new Error("The original message's channel is unavailable.");
+      }
+
+      const forwardTags = buildForwardTags({
+        original,
+        sourceType: forwardSourceTypeForChannel(sourceChannel),
+      });
+      // Same recipient derivation as an ordinary send: note @mentions notify,
+      // and a DM destination always p-tags its other participants.
+      const recipientPubkeys = messageMentionPubkeys(
+        destination,
+        senderPubkey,
+        mentionPubkeys,
+      );
+      return forwardMessage(
+        destination.id,
+        note.trim(),
+        forwardTags,
+        recipientPubkeys,
+      );
     },
   });
 }

--- a/desktop/src/features/messages/lib/formatTimelineMessages.test.mjs
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.test.mjs
@@ -3,7 +3,9 @@ import test from "node:test";
 import { finalizeEvent, getPublicKey } from "nostr-tools/pure";
 
 import {
+  collectForwardEmbeddedPubkeys,
   collectMessageAuthorPubkeys,
+  collectMessageProfilePubkeys,
   collectReactionActorPubkeys,
   countTopLevelTimelineRows,
   formatTimelineMessages,
@@ -654,6 +656,79 @@ test("countTopLevelTimelineRows counts huddle start rows", () => {
 
 test("huddle ended stays lifecycle-only, not a timeline row", () => {
   assert.equal(isTimelineContentEvent({ kind: KIND_HUDDLE_ENDED }), false);
+});
+
+// A forwarded row renders the embedded original inline, so the embedded
+// author and its mentions must ride the surface's batched profile request —
+// otherwise each row fires its own single-pubkey query and embedded mentions
+// never resolve to a name.
+const SOURCE_CHANNEL_ID = "b90b5d5c-2c2a-4d40-9d4a-1cb27fb4b1a2";
+const PUBKEY_C =
+  "3333333333333333333333333333333333333333333333333333333333333333";
+
+function forwardEvent(embeddedOverrides = {}, tagOverrides = null) {
+  const embedded = {
+    id: HEX64_B,
+    pubkey: PUBKEY_B.toUpperCase(),
+    created_at: 1_700_000_000,
+    kind: 9,
+    tags: [
+      ["h", SOURCE_CHANNEL_ID],
+      ["p", PUBKEY_C],
+    ],
+    content: "ping @carol",
+    sig: "ab".repeat(64),
+    ...embeddedOverrides,
+  };
+
+  return {
+    id: HEX64_A,
+    pubkey: PUBKEY_A,
+    kind: 40009,
+    created_at: 1_700_000_100,
+    content: "worth a look",
+    tags: tagOverrides ?? [
+      ["h", CHANNEL_ID],
+      ["fwd", JSON.stringify(embedded)],
+      ["k", "9"],
+      ["fwd-src", SOURCE_CHANNEL_ID, "channel"],
+    ],
+    sig: "sig",
+  };
+}
+
+test("collectForwardEmbeddedPubkeys collects the embedded author and mentions", () => {
+  assert.deepEqual(collectForwardEmbeddedPubkeys([forwardEvent()]), [
+    PUBKEY_B,
+    PUBKEY_C,
+  ]);
+});
+
+test("collectForwardEmbeddedPubkeys ignores non-forwards and malformed envelopes", () => {
+  assert.deepEqual(collectForwardEmbeddedPubkeys([streamMessage()]), []);
+  // Missing `fwd`/`fwd-src` tags: parseForwardEnvelope returns null.
+  assert.deepEqual(
+    collectForwardEmbeddedPubkeys([forwardEvent({}, [["h", CHANNEL_ID]])]),
+    [],
+  );
+  // Unparseable embedded JSON.
+  assert.deepEqual(
+    collectForwardEmbeddedPubkeys([
+      forwardEvent({}, [
+        ["h", CHANNEL_ID],
+        ["fwd", "{not json"],
+        ["fwd-src", SOURCE_CHANNEL_ID, "channel"],
+      ]),
+    ]),
+    [],
+  );
+});
+
+test("collectMessageProfilePubkeys includes forwarded-original pubkeys", () => {
+  const pubkeys = collectMessageProfilePubkeys([forwardEvent()]);
+  assert.ok(pubkeys.includes(PUBKEY_A), "forwarder");
+  assert.ok(pubkeys.includes(PUBKEY_B), "embedded author");
+  assert.ok(pubkeys.includes(PUBKEY_C), "embedded mention");
 });
 
 // Guardrail: the history fetch requests exactly CHANNEL_TIMELINE_CONTENT_KINDS,

--- a/desktop/src/features/messages/lib/formatTimelineMessages.ts
+++ b/desktop/src/features/messages/lib/formatTimelineMessages.ts
@@ -13,6 +13,7 @@ import {
   getThreadReference,
   isBroadcastReply,
 } from "@/features/messages/lib/threading";
+import { parseForwardEnvelope } from "@/features/messages/lib/forwardMessage";
 import {
   formatOwnerLabel,
   resolveUserLabel,
@@ -34,6 +35,7 @@ import {
   KIND_STREAM_MESSAGE_V2,
   KIND_STREAM_MESSAGE_EDIT,
   KIND_STREAM_MESSAGE_DIFF,
+  KIND_STREAM_MESSAGE_FORWARD,
   KIND_SYSTEM_MESSAGE,
 } from "@/shared/constants/kinds";
 import { resolveEventAuthorPubkey } from "@/shared/lib/authors";
@@ -51,6 +53,7 @@ export function isTimelineContentEvent(event: RelayEvent) {
     event.kind === KIND_STREAM_MESSAGE ||
     event.kind === KIND_STREAM_MESSAGE_V2 ||
     event.kind === KIND_STREAM_MESSAGE_DIFF ||
+    event.kind === KIND_STREAM_MESSAGE_FORWARD ||
     event.kind === KIND_SYSTEM_MESSAGE ||
     event.kind === KIND_JOB_REQUEST ||
     event.kind === KIND_JOB_ACCEPTED ||
@@ -592,13 +595,51 @@ export function collectMessageMentionPubkeys(
   return [...pubkeys];
 }
 
+/**
+ * Pubkeys the embedded original of a kind-40009 forward needs profiles for:
+ * its author plus everyone it mentions.
+ *
+ * Both render inside the forward's own timeline row, so they belong in the
+ * same batched profile request as the outer message's pubkeys — otherwise
+ * every forwarded row fires its own single-pubkey query for the author and the
+ * embedded `@mentions` never resolve to a name.
+ */
+export function collectForwardEmbeddedPubkeys(
+  events: Array<{ kind?: number; tags?: string[][] }>,
+) {
+  const pubkeys = new Set<string>();
+
+  for (const event of events) {
+    if (event.kind !== KIND_STREAM_MESSAGE_FORWARD) {
+      continue;
+    }
+
+    const original = parseForwardEnvelope(event.tags ?? [])?.original;
+    if (!original) {
+      continue;
+    }
+
+    pubkeys.add(normalizePubkey(original.pubkey));
+    for (const tag of original.tags) {
+      const pubkey = getMentionTagPubkey(tag);
+      if (pubkey) {
+        pubkeys.add(pubkey);
+      }
+    }
+  }
+
+  return [...pubkeys].filter((pubkey) => pubkey.length > 0);
+}
+
 /** Every pubkey a channel surface needs profiles for: authors (signer +
- *  attributed actor), mentions, and reaction actors, deduplicated. */
+ *  attributed actor), mentions, forwarded originals, and reaction actors,
+ *  deduplicated. */
 export function collectMessageProfilePubkeys(events: RelayEvent[]) {
   return [
     ...new Set([
       ...collectMessageAuthorPubkeys(events),
       ...collectMessageMentionPubkeys(events),
+      ...collectForwardEmbeddedPubkeys(events),
       ...collectReactionActorPubkeys(events),
     ]),
   ];

--- a/desktop/src/features/messages/lib/forwardMessage.test.mjs
+++ b/desktop/src/features/messages/lib/forwardMessage.test.mjs
@@ -1,0 +1,302 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  FORWARDABLE_SOURCE_KINDS,
+  MAX_FWD_TAG_BYTES,
+  buildForwardTags,
+  canForwardMessageKind,
+  forwardSourceTypeForChannel,
+  getEventChannelId,
+  parseForwardEnvelope,
+  resolveForwardOriginal,
+} from "./forwardMessage.ts";
+
+const SOURCE_CHANNEL = "f570339f-8f8a-4e08-a779-8d954aa44109";
+const ORIGINAL_ID =
+  "b04819ffc1f7c8ffb49c6d30b5899f470198264680d02e78894a658e30a9059f";
+const ORIGINAL_PUBKEY =
+  "953d5b1c9f0c1d4e8a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7081";
+const SIG = "ab".repeat(64);
+
+function makeOriginal(overrides = {}) {
+  return {
+    id: ORIGINAL_ID,
+    pubkey: ORIGINAL_PUBKEY,
+    created_at: 1753600000,
+    kind: 9,
+    tags: [["h", SOURCE_CHANNEL]],
+    content: "hello world",
+    sig: SIG,
+    ...overrides,
+  };
+}
+
+test("canForwardMessageKind allows the source allowlist plus 40009", () => {
+  for (const kind of [9, 40002, 45001, 45003, 40009]) {
+    assert.equal(canForwardMessageKind(kind), true, `kind ${kind}`);
+  }
+  for (const kind of [undefined, 1, 7, 40008, 40099, 39000]) {
+    assert.equal(canForwardMessageKind(kind), false, `kind ${kind}`);
+  }
+});
+
+test("forwardSourceTypeForChannel maps dm/open/closed correctly", () => {
+  assert.equal(
+    forwardSourceTypeForChannel({ channelType: "dm", visibility: "private" }),
+    "dm",
+  );
+  assert.equal(
+    forwardSourceTypeForChannel({
+      channelType: "channel",
+      visibility: "open",
+    }),
+    "channel",
+  );
+  assert.equal(
+    forwardSourceTypeForChannel({
+      channelType: "channel",
+      visibility: "private",
+    }),
+    "private",
+  );
+});
+
+test("getEventChannelId reads the h tag and rejects empty values", () => {
+  assert.equal(getEventChannelId(makeOriginal()), SOURCE_CHANNEL);
+  assert.equal(getEventChannelId({ tags: [] }), null);
+  assert.equal(getEventChannelId({ tags: [["h", ""]] }), null);
+});
+
+test("buildForwardTags emits fwd/k/fwd-src and q for open sources", () => {
+  const original = makeOriginal();
+  const tags = buildForwardTags({ original, sourceType: "channel" });
+
+  const fwd = tags.filter((tag) => tag[0] === "fwd");
+  assert.equal(fwd.length, 1);
+  const embedded = JSON.parse(fwd[0][1]);
+  // Exactly the signed NIP-01 fields, nothing local.
+  assert.deepEqual(Object.keys(embedded).sort(), [
+    "content",
+    "created_at",
+    "id",
+    "kind",
+    "pubkey",
+    "sig",
+    "tags",
+  ]);
+  assert.deepEqual(embedded, {
+    id: ORIGINAL_ID,
+    pubkey: ORIGINAL_PUBKEY,
+    created_at: 1753600000,
+    kind: 9,
+    tags: [["h", SOURCE_CHANNEL]],
+    content: "hello world",
+    sig: SIG,
+  });
+
+  assert.deepEqual(
+    tags.find((tag) => tag[0] === "k"),
+    ["k", "9"],
+  );
+  // fwd-src uuid comes from the ORIGINAL's own h tag.
+  assert.deepEqual(
+    tags.find((tag) => tag[0] === "fwd-src"),
+    ["fwd-src", SOURCE_CHANNEL, "channel"],
+  );
+  assert.deepEqual(
+    tags.find((tag) => tag[0] === "q"),
+    ["q", ORIGINAL_ID, "", ORIGINAL_PUBKEY],
+  );
+});
+
+test("buildForwardTags never leaks local-only fields into the snapshot", () => {
+  const original = makeOriginal({ localKey: "local-1", pending: true });
+  const tags = buildForwardTags({ original, sourceType: "channel" });
+  const embedded = JSON.parse(tags.find((tag) => tag[0] === "fwd")[1]);
+  assert.equal("localKey" in embedded, false);
+  assert.equal("pending" in embedded, false);
+});
+
+test("buildForwardTags omits q for private and dm sources", () => {
+  for (const sourceType of ["private", "dm"]) {
+    const tags = buildForwardTags({ original: makeOriginal(), sourceType });
+    assert.equal(
+      tags.some((tag) => tag[0] === "q"),
+      false,
+      sourceType,
+    );
+    assert.deepEqual(
+      tags.find((tag) => tag[0] === "fwd-src"),
+      ["fwd-src", SOURCE_CHANNEL, sourceType],
+    );
+  }
+});
+
+test("buildForwardTags copies imeta tags verbatim", () => {
+  const imeta = [
+    "imeta",
+    "url https://relay.example/media/abc.png",
+    "m image/png",
+    "dim 640x480",
+  ];
+  const original = makeOriginal({
+    tags: [["h", SOURCE_CHANNEL], imeta, ["p", ORIGINAL_PUBKEY]],
+  });
+  const tags = buildForwardTags({ original, sourceType: "channel" });
+  const copied = tags.filter((tag) => tag[0] === "imeta");
+  assert.equal(copied.length, 1);
+  assert.deepEqual(copied[0], imeta);
+  assert.notEqual(copied[0], imeta, "must be a copy, not the same array");
+  // Non-imeta original tags (p/h/…) must NOT be copied to the top level.
+  assert.equal(
+    tags.some((tag) => tag[0] === "p"),
+    false,
+  );
+  assert.equal(
+    tags.some((tag) => tag[0] === "h"),
+    false,
+  );
+});
+
+test("buildForwardTags rejects non-allowlisted kinds", () => {
+  assert.throws(
+    () =>
+      buildForwardTags({
+        original: makeOriginal({ kind: 40009 }),
+        sourceType: "channel",
+      }),
+    /cannot be forwarded/,
+  );
+  assert.throws(
+    () =>
+      buildForwardTags({
+        original: makeOriginal({ kind: 1 }),
+        sourceType: "channel",
+      }),
+    /cannot be forwarded/,
+  );
+});
+
+test("buildForwardTags rejects a missing signature", () => {
+  assert.throws(
+    () =>
+      buildForwardTags({
+        original: makeOriginal({ sig: "" }),
+        sourceType: "channel",
+      }),
+    /missing its signature/,
+  );
+});
+
+test("buildForwardTags rejects an original without a source channel", () => {
+  assert.throws(
+    () =>
+      buildForwardTags({
+        original: makeOriginal({ tags: [] }),
+        sourceType: "channel",
+      }),
+    /no source channel/,
+  );
+});
+
+test("buildForwardTags rejects oversize originals (64 KiB ceiling)", () => {
+  const original = makeOriginal({
+    content: "x".repeat(MAX_FWD_TAG_BYTES + 1),
+  });
+  assert.throws(
+    () => buildForwardTags({ original, sourceType: "channel" }),
+    /too large to forward/,
+  );
+});
+
+test("parseForwardEnvelope round-trips buildForwardTags output", () => {
+  const original = makeOriginal();
+  const tags = buildForwardTags({ original, sourceType: "private" });
+  const envelope = parseForwardEnvelope(tags);
+  assert.ok(envelope);
+  assert.deepEqual(envelope.original, original);
+  assert.equal(envelope.sourceChannelId, SOURCE_CHANNEL);
+  assert.equal(envelope.sourceType, "private");
+});
+
+test("parseForwardEnvelope rejects malformed tag sets", () => {
+  const good = buildForwardTags({
+    original: makeOriginal(),
+    sourceType: "channel",
+  });
+
+  // No fwd tag at all.
+  assert.equal(
+    parseForwardEnvelope(good.filter((tag) => tag[0] !== "fwd")),
+    null,
+  );
+  // Two fwd tags.
+  assert.equal(
+    parseForwardEnvelope([...good, good.find((tag) => tag[0] === "fwd")]),
+    null,
+  );
+  // Unparseable embedded JSON.
+  assert.equal(
+    parseForwardEnvelope([
+      ["fwd", "{not json"],
+      ["fwd-src", SOURCE_CHANNEL, "channel"],
+    ]),
+    null,
+  );
+  // Embedded event missing the signature field.
+  const unsigned = { ...makeOriginal() };
+  delete unsigned.sig;
+  assert.equal(
+    parseForwardEnvelope([
+      ["fwd", JSON.stringify(unsigned)],
+      ["fwd-src", SOURCE_CHANNEL, "channel"],
+    ]),
+    null,
+  );
+  // Missing fwd-src.
+  assert.equal(
+    parseForwardEnvelope(good.filter((tag) => tag[0] !== "fwd-src")),
+    null,
+  );
+  // fwd-src with an unknown visibility label.
+  assert.equal(
+    parseForwardEnvelope([
+      good.find((tag) => tag[0] === "fwd"),
+      ["fwd-src", SOURCE_CHANNEL, "public"],
+    ]),
+    null,
+  );
+});
+
+test("resolveForwardOriginal flattens a 40009 to its embedded original", () => {
+  const original = makeOriginal();
+  const forwardEvent = {
+    id: "c1".repeat(32),
+    pubkey: "d2".repeat(32),
+    created_at: 1753600100,
+    kind: 40009,
+    tags: buildForwardTags({ original, sourceType: "channel" }),
+    content: "check this out",
+    sig: "ef".repeat(64),
+  };
+  assert.deepEqual(resolveForwardOriginal(forwardEvent), original);
+});
+
+test("resolveForwardOriginal returns allowlisted events as-is, null otherwise", () => {
+  const original = makeOriginal({ kind: 45001 });
+  assert.equal(resolveForwardOriginal(original), original);
+  assert.equal(resolveForwardOriginal(makeOriginal({ kind: 40008 })), null);
+  // A 40009 with a malformed envelope cannot be re-forwarded.
+  assert.equal(
+    resolveForwardOriginal(makeOriginal({ kind: 40009, tags: [] })),
+    null,
+  );
+});
+
+test("FORWARDABLE_SOURCE_KINDS matches the relay allowlist", () => {
+  assert.deepEqual(
+    [...FORWARDABLE_SOURCE_KINDS].sort((a, b) => a - b),
+    [9, 40002, 45001, 45003],
+  );
+});

--- a/desktop/src/features/messages/lib/forwardMessage.ts
+++ b/desktop/src/features/messages/lib/forwardMessage.ts
@@ -1,0 +1,198 @@
+import type { Channel, RelayEvent } from "@/shared/api/types";
+import { KIND_STREAM_MESSAGE_FORWARD } from "@/shared/constants/kinds";
+
+/**
+ * Forward-message (kind 40009) tag composition and parsing.
+ *
+ * A forward is a snapshot: the complete signed original event rides in a
+ * single `fwd` tag, with `k` (original kind), `fwd-src` (source channel +
+ * visibility label) and — for open sources only — a NIP-18-style `q` tag.
+ * The relay re-verifies the embedded event, so everything built here must
+ * stay byte-faithful to the original.
+ */
+
+export type ForwardSourceType = "channel" | "private" | "dm";
+
+/** Kinds a forward may embed (relay allowlist). Kind 40009 itself is not
+ *  embeddable — forwarding a forward flattens to ITS embedded original. */
+export const FORWARDABLE_SOURCE_KINDS: ReadonlySet<number> = new Set([
+  9, 40002, 45001, 45003,
+]);
+
+/** Relay ceiling for the serialized embedded event (64 KiB). */
+export const MAX_FWD_TAG_BYTES = 64 * 1024;
+
+/** Whether the "Forward message…" action applies to a message of this kind. */
+export function canForwardMessageKind(kind: number | undefined): boolean {
+  if (kind === undefined) return false;
+  return (
+    FORWARDABLE_SOURCE_KINDS.has(kind) || kind === KIND_STREAM_MESSAGE_FORWARD
+  );
+}
+
+/** Map a channel row to the `fwd-src` visibility label the relay validates. */
+export function forwardSourceTypeForChannel(
+  channel: Pick<Channel, "channelType" | "visibility">,
+): ForwardSourceType {
+  if (channel.channelType === "dm") return "dm";
+  return channel.visibility === "open" ? "channel" : "private";
+}
+
+/** NIP-29 group scope (`h` tag) of an event, or null when untagged. */
+export function getEventChannelId(
+  event: Pick<RelayEvent, "tags">,
+): string | null {
+  const value = event.tags.find((tag) => tag[0] === "h")?.[1];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export type ForwardEnvelope = {
+  /** The complete signed original event embedded in the `fwd` tag. */
+  original: RelayEvent;
+  /** Source channel uuid from the `fwd-src` tag. */
+  sourceChannelId: string;
+  /** Source visibility label from the `fwd-src` tag. */
+  sourceType: ForwardSourceType;
+};
+
+function isForwardSourceType(value: unknown): value is ForwardSourceType {
+  return value === "channel" || value === "private" || value === "dm";
+}
+
+function parseEmbeddedEvent(raw: string): RelayEvent | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const candidate = parsed as Record<string, unknown>;
+  if (
+    typeof candidate.id !== "string" ||
+    typeof candidate.pubkey !== "string" ||
+    typeof candidate.created_at !== "number" ||
+    typeof candidate.kind !== "number" ||
+    typeof candidate.content !== "string" ||
+    typeof candidate.sig !== "string" ||
+    !Array.isArray(candidate.tags) ||
+    !candidate.tags.every(
+      (tag) =>
+        Array.isArray(tag) && tag.every((part) => typeof part === "string"),
+    )
+  ) {
+    return null;
+  }
+  return {
+    id: candidate.id,
+    pubkey: candidate.pubkey,
+    created_at: candidate.created_at,
+    kind: candidate.kind,
+    tags: candidate.tags as string[][],
+    content: candidate.content,
+    sig: candidate.sig,
+  };
+}
+
+/**
+ * Parse a kind-40009 tag set into its forward envelope. Returns null when the
+ * shape is malformed (missing/duplicated `fwd`, unparseable embedded event,
+ * or missing `fwd-src`) so callers can render a fallback instead of throwing.
+ */
+export function parseForwardEnvelope(
+  tags: ReadonlyArray<ReadonlyArray<string>>,
+): ForwardEnvelope | null {
+  const fwdTags = tags.filter((tag) => tag[0] === "fwd");
+  if (fwdTags.length !== 1) return null;
+  const raw = fwdTags[0][1];
+  if (typeof raw !== "string" || raw.length === 0) return null;
+
+  const original = parseEmbeddedEvent(raw);
+  if (!original) return null;
+
+  const source = tags.find((tag) => tag[0] === "fwd-src");
+  const sourceChannelId = source?.[1];
+  const sourceType = source?.[2];
+  if (
+    typeof sourceChannelId !== "string" ||
+    sourceChannelId.length === 0 ||
+    !isForwardSourceType(sourceType)
+  ) {
+    return null;
+  }
+
+  return { original, sourceChannelId, sourceType };
+}
+
+/**
+ * Resolve the event a forward of `event` must embed. Forward depth is always
+ * 1: forwarding a kind-40009 message forwards ITS embedded original
+ * (flatten); any other allowlisted kind embeds itself. Returns null when the
+ * event cannot be forwarded.
+ */
+export function resolveForwardOriginal(event: RelayEvent): RelayEvent | null {
+  if (event.kind === KIND_STREAM_MESSAGE_FORWARD) {
+    return parseForwardEnvelope(event.tags)?.original ?? null;
+  }
+  return FORWARDABLE_SOURCE_KINDS.has(event.kind) ? event : null;
+}
+
+/**
+ * Build the forward metadata tags (`fwd`, `k`, `fwd-src`, `q`, `imeta`) for a
+ * kind-40009 event. The destination `h` tag and any note-mention `p` tags are
+ * appended by the send path, not here.
+ *
+ * - `fwd-src` uuid is derived from the original's own `h` tag (the relay
+ *   rejects any mismatch, so it is never caller-supplied).
+ * - `q` is emitted only for open (`"channel"`) sources.
+ * - `imeta` tags are copied verbatim so attachments survive the hop.
+ *
+ * Throws on inputs that can never produce a relay-valid event.
+ */
+export function buildForwardTags(input: {
+  original: RelayEvent;
+  sourceType: ForwardSourceType;
+}): string[][] {
+  const { original, sourceType } = input;
+
+  if (!FORWARDABLE_SOURCE_KINDS.has(original.kind)) {
+    throw new Error(`Messages of kind ${original.kind} cannot be forwarded.`);
+  }
+  if (!original.sig) {
+    throw new Error("The original message is missing its signature.");
+  }
+  const sourceChannelId = getEventChannelId(original);
+  if (!sourceChannelId) {
+    throw new Error("The original message has no source channel.");
+  }
+
+  // Serialize exactly the signed NIP-01 fields — local-only fields
+  // (localKey, pending) must never leak into the embedded snapshot.
+  const embedded = JSON.stringify({
+    id: original.id,
+    pubkey: original.pubkey,
+    created_at: original.created_at,
+    kind: original.kind,
+    tags: original.tags,
+    content: original.content,
+    sig: original.sig,
+  });
+  if (new TextEncoder().encode(embedded).length > MAX_FWD_TAG_BYTES) {
+    throw new Error("This message is too large to forward.");
+  }
+
+  const tags: string[][] = [
+    ["fwd", embedded],
+    ["k", String(original.kind)],
+    ["fwd-src", sourceChannelId, sourceType],
+  ];
+  if (sourceType === "channel") {
+    tags.push(["q", original.id, "", original.pubkey]);
+  }
+  for (const tag of original.tags) {
+    if (tag[0] === "imeta") {
+      tags.push([...tag]);
+    }
+  }
+  return tags;
+}

--- a/desktop/src/features/messages/lib/forwardNoteMentions.test.mjs
+++ b/desktop/src/features/messages/lib/forwardNoteMentions.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  noteMayMention,
+  resolveForwardNoteMentions,
+} from "./forwardNoteMentions.ts";
+
+const ALICE =
+  "1111111111111111111111111111111111111111111111111111111111111111";
+const BOB = "2222222222222222222222222222222222222222222222222222222222222222";
+const LI = "3333333333333333333333333333333333333333333333333333333333333333";
+const ELODIE =
+  "4444444444444444444444444444444444444444444444444444444444444444";
+const ROBOT =
+  "5555555555555555555555555555555555555555555555555555555555555555";
+
+function member(pubkey, displayName) {
+  return {
+    pubkey,
+    role: "member",
+    isAgent: false,
+    joinedAt: "2026-01-01T00:00:00Z",
+    displayName,
+  };
+}
+
+const MEMBERS = [member(ALICE, "Alice"), member(BOB.toUpperCase(), "Bob")];
+const NON_ASCII_MEMBERS = [
+  member(LI, "李"),
+  member(ELODIE, "Élodie"),
+  member(ROBOT, "🤖bot"),
+];
+
+test("resolves a note mention to its destination member", () => {
+  const mentions = resolveForwardNoteMentions("hey @Alice look", MEMBERS);
+  assert.deepEqual(mentions.pubkeys, [ALICE]);
+  assert.deepEqual(mentions.names, ["Alice"]);
+  assert.deepEqual(mentions.pubkeysByName, { alice: ALICE });
+});
+
+test("member pubkeys are normalized to lowercase", () => {
+  const mentions = resolveForwardNoteMentions("@Bob ptal", MEMBERS);
+  assert.deepEqual(mentions.pubkeys, [BOB]);
+  assert.deepEqual(mentions.pubkeysByName, { bob: BOB });
+});
+
+test("matches every mentioned member, case-insensitively", () => {
+  const mentions = resolveForwardNoteMentions("@alice and @bob", MEMBERS);
+  assert.deepEqual(mentions.pubkeys.sort(), [ALICE, BOB].sort());
+  assert.equal(mentions.names.length, 2);
+});
+
+test("non-members and non-mentions resolve to nothing", () => {
+  assert.deepEqual(
+    resolveForwardNoteMentions("@carol are you there", MEMBERS).pubkeys,
+    [],
+  );
+  assert.deepEqual(
+    resolveForwardNoteMentions("Alice wrote this", MEMBERS).pubkeys,
+    [],
+  );
+});
+
+test("mentions inside code are not recipients", () => {
+  assert.deepEqual(
+    resolveForwardNoteMentions("run `@Alice --help`", MEMBERS).pubkeys,
+    [],
+  );
+  assert.deepEqual(
+    resolveForwardNoteMentions("```\n@Alice\n```", MEMBERS).pubkeys,
+    [],
+  );
+});
+
+test("empty notes and unloaded members resolve to nothing", () => {
+  assert.deepEqual(resolveForwardNoteMentions("", MEMBERS).pubkeys, []);
+  assert.deepEqual(resolveForwardNoteMentions("   ", MEMBERS).pubkeys, []);
+  assert.deepEqual(resolveForwardNoteMentions("@Alice", undefined).pubkeys, []);
+  assert.deepEqual(resolveForwardNoteMentions("@Alice", []).pubkeys, []);
+});
+
+test("members without a display name are skipped", () => {
+  assert.deepEqual(
+    resolveForwardNoteMentions("@Alice", [member(ALICE, null)]).pubkeys,
+    [],
+  );
+});
+
+test("resolves non-ASCII display names", () => {
+  assert.deepEqual(
+    resolveForwardNoteMentions("看看 @李 谢谢", NON_ASCII_MEMBERS).pubkeys,
+    [LI],
+  );
+  assert.deepEqual(
+    resolveForwardNoteMentions("@Élodie ptal", NON_ASCII_MEMBERS).pubkeys,
+    [ELODIE],
+  );
+  const robot = resolveForwardNoteMentions(
+    "@🤖bot can you look",
+    NON_ASCII_MEMBERS,
+  );
+  assert.deepEqual(robot.pubkeys, [ROBOT]);
+  assert.deepEqual(robot.names, ["🤖bot"]);
+  assert.deepEqual(robot.pubkeysByName, { "🤖bot": ROBOT });
+});
+
+test("noteMayMention gates sending on a note that could mention someone", () => {
+  assert.equal(noteMayMention("hey @Alice look"), true);
+  assert.equal(noteMayMention("@a"), true);
+  // Over-eager on purpose: a false positive only waits for members to load.
+  assert.equal(noteMayMention("mail me at bob@example.com"), true);
+});
+
+test("noteMayMention covers non-ASCII mentions", () => {
+  // `\w` would miss all three, publishing the forward with no `p` tag.
+  for (const note of ["看看 @李 谢谢", "@Élodie ptal", "@🤖bot can you look"]) {
+    assert.equal(noteMayMention(note), true);
+    assert.equal(
+      resolveForwardNoteMentions(note, NON_ASCII_MEMBERS).pubkeys.length,
+      1,
+    );
+  }
+});
+
+test("noteMayMention is false when no mention is possible", () => {
+  assert.equal(noteMayMention(""), false);
+  assert.equal(noteMayMention("ptal"), false);
+  assert.equal(noteMayMention("costs @ 5 dollars"), false);
+});

--- a/desktop/src/features/messages/lib/forwardNoteMentions.ts
+++ b/desktop/src/features/messages/lib/forwardNoteMentions.ts
@@ -1,0 +1,77 @@
+import { hasMention } from "@/features/messages/lib/hasMention";
+import type { ChannelMember } from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+export type ForwardNoteMentions = {
+  /** Normalized pubkeys to send as the note's recipients. */
+  pubkeys: string[];
+  /** Matched display names, for rendering mention chips in the preview. */
+  names: string[];
+  /** Lowercased name → pubkey, mirroring `resolveMentionProps`'s output. */
+  pubkeysByName: Record<string, string>;
+};
+
+const NO_MENTIONS: ForwardNoteMentions = {
+  pubkeys: [],
+  names: [],
+  pubkeysByName: {},
+};
+
+/**
+ * Whether the note plausibly `@mentions` someone.
+ *
+ * Deliberately cheap and over-eager (an email address counts): its only job is
+ * to decide whether sending must wait for the destination's member list, and a
+ * false positive costs a few milliseconds while that query settles, whereas a
+ * false negative publishes a mention with no `p` tag.
+ *
+ * Any non-space character counts, not `\w` — that character class is ASCII-only
+ * in JavaScript, so display names like `李`, `Élodie`, or an emoji-led agent
+ * name are mentions `resolveForwardNoteMentions` matches but a `\w` preflight
+ * would wave through unresolved.
+ */
+export function noteMayMention(note: string): boolean {
+  return /@\S/.test(note);
+}
+
+/**
+ * Resolve `@mentions` written in a forward note against the DESTINATION
+ * channel's members.
+ *
+ * The forward dialog's note is a plain textarea, so there is no autocomplete
+ * registry of picked mentions to read back the way the composer has. Matching
+ * every destination member's display name against the note reproduces the
+ * registry-free half of `useMentions().extractMentionPubkeys` — same
+ * `hasMention` matcher (code spans masked, markdown emphasis tolerated), same
+ * member-only scope — so a note mention notifies exactly the people the
+ * composer would have notified.
+ *
+ * `pubkeys` still goes through `messageMentionPubkeys` on the send path, which
+ * drops the sender and adds DM recipients.
+ */
+export function resolveForwardNoteMentions(
+  note: string,
+  members: readonly ChannelMember[] | undefined,
+): ForwardNoteMentions {
+  const trimmed = note.trim();
+  if (trimmed.length === 0 || !members || members.length === 0) {
+    return NO_MENTIONS;
+  }
+
+  const pubkeys = new Set<string>();
+  const names = new Set<string>();
+  const pubkeysByName: Record<string, string> = {};
+
+  for (const member of members) {
+    const displayName = member.displayName?.trim();
+    if (!displayName) continue;
+    const pubkey = normalizePubkey(member.pubkey);
+    if (pubkey.length === 0 || !hasMention(trimmed, displayName)) continue;
+
+    pubkeys.add(pubkey);
+    names.add(displayName);
+    pubkeysByName[displayName.toLowerCase()] = pubkey;
+  }
+
+  return { pubkeys: [...pubkeys], names: [...names], pubkeysByName };
+}

--- a/desktop/src/features/messages/ui/ForwardMessageDialog.tsx
+++ b/desktop/src/features/messages/ui/ForwardMessageDialog.tsx
@@ -1,0 +1,578 @@
+import { Check, Hash, Link2, MessageCircle, Search } from "lucide-react";
+import * as React from "react";
+import { toast } from "sonner";
+
+import {
+  useManagedAgentsQuery,
+  useRelayAgentsQuery,
+} from "@/features/agents/hooks";
+import {
+  useChannelMembersQuery,
+  useChannelsQuery,
+} from "@/features/channels/hooks";
+import { useMessageProfiles } from "@/features/channels/ui/useMessageProfiles";
+import {
+  forwardSourceTypeForChannel,
+  parseForwardEnvelope,
+  type ForwardSourceType,
+} from "@/features/messages/lib/forwardMessage";
+import {
+  noteMayMention,
+  resolveForwardNoteMentions,
+} from "@/features/messages/lib/forwardNoteMentions";
+import { buildMessageLink } from "@/features/messages/lib/messageLink";
+import { getThreadReference } from "@/features/messages/lib/threading";
+import { useMessageEmoji } from "@/features/messages/lib/useMessageEmoji";
+import { useForwardMessageMutation } from "@/features/messages/hooks";
+import { ForwardedMessageCard } from "@/features/messages/ui/ForwardedMessageCard";
+import { scoreChannelMatch } from "@/features/channels/lib/channelSearchScore";
+import { useProfileQuery, useUsersBatchQuery } from "@/features/profile/hooks";
+import { resolveChannelDisplayLabel } from "@/features/sidebar/lib/channelLabels";
+import type { Channel } from "@/shared/api/types";
+import { KIND_STREAM_MESSAGE_FORWARD } from "@/shared/constants/kinds";
+import { copyTextToClipboard } from "@/shared/lib/clipboard";
+import { cn } from "@/shared/lib/cn";
+import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+import {
+  getMentionTagPubkey,
+  resolveMentionProps,
+} from "@/shared/lib/resolveMentionNames";
+import { Button } from "@/shared/ui/button";
+import { ChooserDialogContent } from "@/shared/ui/chooser-dialog-content";
+import { Dialog } from "@/shared/ui/dialog";
+import { Markdown } from "@/shared/ui/markdown";
+import { parseImetaTags } from "@/shared/ui/markdown/parseImeta";
+import {
+  MODAL_SEARCH_INPUT_CLASS,
+  MODAL_SEARCH_SHELL_CLASS,
+} from "@/shared/ui/modalSearchStyles";
+import { Textarea } from "@/shared/ui/textarea";
+
+import type { ForwardMessageTarget } from "./ForwardMessageProvider";
+
+/**
+ * How long sending waits for the destination's member list before forwarding
+ * without mention tags — long enough for a normal round trip, short enough that
+ * a request that never settles doesn't strand the Forward button.
+ */
+const MEMBER_WAIT_LIMIT_MS = 4_000;
+
+function channelActivityTime(channel: Channel) {
+  if (!channel.lastMessageAt) return 0;
+  const timestamp = Date.parse(channel.lastMessageAt);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+type DestinationRow = {
+  channel: Channel;
+  label: string;
+};
+
+/**
+ * "Forward message…" dialog: searchable destination picker over channels AND
+ * DMs (DMs are ordinary channels with `channel_type='dm'`), an optional note,
+ * and a WYSIWYG preview of the original rendered with the same
+ * `ForwardedMessageCard` the destination timeline uses.
+ */
+export function ForwardMessageDialog({
+  currentPubkey,
+  onOpenChange,
+  open,
+  target,
+}: {
+  currentPubkey?: string;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  target: ForwardMessageTarget | null;
+}) {
+  const [query, setQuery] = React.useState("");
+  const [note, setNote] = React.useState("");
+  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+  const [highlightIndex, setHighlightIndex] = React.useState<number | null>(
+    null,
+  );
+  /** Destination whose member list took too long to load (see MEMBER_WAIT_LIMIT_MS). */
+  const [waitExpiredForId, setWaitExpiredForId] = React.useState<string | null>(
+    null,
+  );
+
+  const message = target?.message ?? null;
+  const forwardMutation = useForwardMessageMutation(currentPubkey);
+  const { nonDmChannelNames } = useChannelNavigation();
+  const channelsQuery = useChannelsQuery({ enabled: open });
+  const channels = React.useMemo(
+    () => channelsQuery.data ?? [],
+    [channelsQuery.data],
+  );
+
+  React.useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setNote("");
+      setSelectedId(null);
+      setHighlightIndex(null);
+      setWaitExpiredForId(null);
+    }
+  }, [open]);
+
+  // Destinations: joinable message surfaces only — no forums, no archived
+  // channels; DMs are always available to their participants.
+  const candidates = React.useMemo(
+    () =>
+      channels.filter(
+        (channel) =>
+          !channel.archivedAt &&
+          channel.channelType !== "forum" &&
+          (channel.isMember || channel.channelType === "dm"),
+      ),
+    [channels],
+  );
+
+  const dmParticipantPubkeys = React.useMemo(
+    () =>
+      candidates
+        .filter((channel) => channel.channelType === "dm")
+        .flatMap((channel) => channel.participantPubkeys),
+    [candidates],
+  );
+  const dmProfilesQuery = useUsersBatchQuery(dmParticipantPubkeys, {
+    enabled: open && dmParticipantPubkeys.length > 0,
+  });
+
+  const rows = React.useMemo<DestinationRow[]>(
+    () =>
+      candidates.map((channel) => ({
+        channel,
+        label:
+          channel.channelType === "dm"
+            ? resolveChannelDisplayLabel(
+                channel,
+                currentPubkey,
+                dmProfilesQuery.data?.profiles,
+              )
+            : channel.name,
+      })),
+    [candidates, currentPubkey, dmProfilesQuery.data],
+  );
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const orderedRows = React.useMemo(() => {
+    const scores = new Map<string, number>();
+    if (normalizedQuery.length > 0) {
+      for (const row of rows) {
+        const score = scoreChannelMatch(
+          { name: row.label, description: row.channel.description },
+          normalizedQuery,
+        );
+        if (score !== null) scores.set(row.channel.id, score);
+      }
+    }
+
+    const visible =
+      normalizedQuery.length === 0
+        ? [...rows]
+        : rows.filter((row) => scores.has(row.channel.id));
+
+    return visible.sort((a, b) => {
+      if (normalizedQuery.length > 0) {
+        const scoreDiff =
+          (scores.get(a.channel.id) ?? Number.POSITIVE_INFINITY) -
+          (scores.get(b.channel.id) ?? Number.POSITIVE_INFINITY);
+        if (scoreDiff !== 0) return scoreDiff;
+      }
+      const activityDiff =
+        channelActivityTime(b.channel) - channelActivityTime(a.channel);
+      if (activityDiff !== 0) return activityDiff;
+      return a.label.localeCompare(b.label, undefined, {
+        sensitivity: "base",
+      });
+    });
+  }, [normalizedQuery, rows]);
+
+  const selectedRow =
+    orderedRows.find((row) => row.channel.id === selectedId) ??
+    rows.find((row) => row.channel.id === selectedId) ??
+    null;
+
+  // Note @mentions resolve against the DESTINATION's members — the note is
+  // published into that channel, so its members are the mentionable set.
+  const destinationId = selectedRow?.channel.id ?? null;
+  const destinationMembersQuery = useChannelMembersQuery(destinationId, open);
+  const noteMentions = React.useMemo(
+    () => resolveForwardNoteMentions(note, destinationMembersQuery.data),
+    [note, destinationMembersQuery.data],
+  );
+  // The note's `p` tags are derived from those members, so submitting before
+  // they arrive would silently publish a mention that notifies nobody. Block
+  // only while the query is genuinely in flight — if it fails, the forward
+  // still goes out, just without mention tags.
+  const membersInFlight =
+    noteMayMention(note) && destinationMembersQuery.isPending;
+  // …and bound that wait the same way: a request that never settles would
+  // otherwise disable Forward forever for any note the preflight matches (an
+  // email address is enough), so past the deadline sending proceeds without
+  // mention tags exactly as it does on the error path. The deadline is recorded
+  // per destination, so picking another one waits for its members afresh.
+  React.useEffect(() => {
+    if (!membersInFlight || destinationId === null) return;
+    const timer = window.setTimeout(() => {
+      setWaitExpiredForId(destinationId);
+    }, MEMBER_WAIT_LIMIT_MS);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [destinationId, membersInFlight]);
+  const mentionsUnresolved =
+    membersInFlight && waitExpiredForId !== destinationId;
+  // Once the wait expires (or the query fails outright) sending is allowed but
+  // must not be silent — a merely slow member lookup would otherwise let a
+  // mention-bearing note publish without notifying anyone while the button
+  // still reads "Forward". The submit action says so explicitly, and reverts
+  // to a normal Forward if member data lands before the click (handleForward
+  // resolves from the data as of the click). An error only counts when there
+  // is no data at all: a failed background refetch keeps the last successful
+  // members, and handleForward WILL resolve mentions from them — the label
+  // must not promise otherwise.
+  const mentionsUnavailable =
+    noteMayMention(note) &&
+    destinationMembersQuery.data === undefined &&
+    (destinationMembersQuery.isError ||
+      (destinationMembersQuery.isPending &&
+        destinationId !== null &&
+        waitExpiredForId === destinationId));
+
+  // ── Preview (WYSIWYG: exactly what the destination will render) ──────────
+  // Forwarding a forward flattens: the preview shows ITS embedded original.
+  const previewEnvelope = React.useMemo(
+    () =>
+      message?.kind === KIND_STREAM_MESSAGE_FORWARD
+        ? parseForwardEnvelope(message.tags ?? [])
+        : null,
+    [message],
+  );
+  const previewSourceChannelId =
+    previewEnvelope?.sourceChannelId ?? target?.channelId ?? null;
+  const sourceChannel =
+    channels.find((channel) => channel.id === previewSourceChannelId) ?? null;
+  const sourceType: ForwardSourceType = sourceChannel
+    ? forwardSourceTypeForChannel(sourceChannel)
+    : (previewEnvelope?.sourceType ?? "private");
+
+  const previewPubkey = normalizePubkey(
+    previewEnvelope?.original.pubkey ??
+      message?.pubkey ??
+      message?.signerPubkey ??
+      "",
+  );
+  const previewCreatedAt =
+    previewEnvelope?.original.created_at ?? message?.createdAt ?? 0;
+  const previewContent = previewEnvelope?.original.content ?? message?.body;
+  const previewTags = previewEnvelope?.original.tags ?? message?.tags;
+
+  // Profiles the preview needs, in one batched request: everyone the original
+  // mentions — so its @mentions render as the same chips the destination
+  // timeline will show — plus a flattened original's author, whose profile the
+  // timeline row already resolved for non-forward messages.
+  const previewMentionPubkeys = React.useMemo(
+    () =>
+      (previewTags ?? [])
+        .map((tag) => getMentionTagPubkey(tag))
+        .filter((pubkey): pubkey is string => pubkey !== null),
+    [previewTags],
+  );
+  const previewProfilePubkeys = React.useMemo(
+    () =>
+      previewEnvelope && previewPubkey
+        ? [previewPubkey, ...previewMentionPubkeys]
+        : previewMentionPubkeys,
+    [previewEnvelope, previewMentionPubkeys, previewPubkey],
+  );
+  const previewProfilesQuery = useUsersBatchQuery(previewProfilePubkeys, {
+    enabled: open,
+  });
+  // The batch alone is not what the destination timeline renders from: it
+  // overlays the current profile and managed/relay agent names on top
+  // (`useMessageProfiles`), which is the only name source for an agent with no
+  // kind:0 profile. Reusing that hook keeps a preview mention of such an agent
+  // a named chip instead of plain text. Channel members are omitted — they only
+  // contribute `isAgent` flags, which neither mention chips nor the author line
+  // read.
+  const currentProfileQuery = useProfileQuery(open);
+  const managedAgentsQuery = useManagedAgentsQuery({ enabled: open });
+  const relayAgentsQuery = useRelayAgentsQuery({ enabled: open });
+  const previewProfiles = useMessageProfiles({
+    channelMembers: undefined,
+    currentProfile: currentProfileQuery.data,
+    currentPubkey,
+    managedAgents: managedAgentsQuery.data ?? [],
+    profiles: previewProfilesQuery.data?.profiles,
+    relayAgents: relayAgentsQuery.data ?? [],
+  });
+  const flattenAuthor = previewProfiles[previewPubkey];
+  const previewAuthorName = previewEnvelope
+    ? (flattenAuthor?.displayName ?? null)
+    : (message?.author ?? null);
+  const previewAuthorAvatarUrl = previewEnvelope
+    ? (flattenAuthor?.avatarUrl ?? null)
+    : (message?.avatarUrl ?? null);
+
+  const previewImetaByUrl = React.useMemo(
+    () => (previewTags ? parseImetaTags(previewTags) : undefined),
+    [previewTags],
+  );
+  const previewMentions = React.useMemo(
+    () => resolveMentionProps(previewTags, previewProfiles),
+    [previewTags, previewProfiles],
+  );
+  const { customEmoji: previewCustomEmoji } = useMessageEmoji(
+    previewContent ?? "",
+    previewTags,
+  );
+
+  const handleForward = () => {
+    if (!message || !selectedRow || forwardMutation.isPending) return;
+    if (mentionsUnresolved) return;
+    const destinationLabel =
+      selectedRow.channel.channelType === "dm"
+        ? selectedRow.label
+        : `#${selectedRow.label}`;
+    // Resolved here rather than reused from the preview memo so the recipients
+    // come from the members data as of the click.
+    const mentions = resolveForwardNoteMentions(
+      note,
+      destinationMembersQuery.data,
+    );
+    forwardMutation.mutate(
+      {
+        destination: selectedRow.channel,
+        note,
+        mentionPubkeys: mentions.pubkeys,
+        message,
+      },
+      {
+        onSuccess: () => {
+          toast.success(`Message forwarded to ${destinationLabel}`);
+          onOpenChange(false);
+        },
+        onError: (error) => {
+          toast.error(`Failed to forward message: ${error.message}`);
+        },
+      },
+    );
+  };
+
+  const handleCopyLink = () => {
+    if (!message || !target) return;
+    const { rootId } = getThreadReference(message.tags ?? []);
+    const link = buildMessageLink({
+      channelId: target.channelId,
+      messageId: message.id,
+      threadRootId: rootId,
+    });
+    copyTextToClipboard(link, "Link copied to clipboard");
+  };
+
+  const handleSearchKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (event.key === "ArrowDown" && orderedRows.length > 0) {
+      event.preventDefault();
+      setHighlightIndex((current) =>
+        current === null ? 0 : Math.min(current + 1, orderedRows.length - 1),
+      );
+      return;
+    }
+
+    if (event.key === "ArrowUp" && orderedRows.length > 0) {
+      event.preventDefault();
+      setHighlightIndex((current) =>
+        current === null ? orderedRows.length - 1 : Math.max(current - 1, 0),
+      );
+      return;
+    }
+
+    if (
+      event.key === "Enter" &&
+      !event.nativeEvent.isComposing &&
+      orderedRows.length > 0
+    ) {
+      event.preventDefault();
+      const row = orderedRows[highlightIndex ?? 0];
+      if (row) setSelectedId(row.channel.id);
+    }
+  };
+
+  if (!target || !message) {
+    return null;
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <ChooserDialogContent
+        aria-describedby={undefined}
+        data-testid="forward-message-dialog"
+        footer={
+          <>
+            <Button onClick={handleCopyLink} type="button" variant="outline">
+              <Link2 className="h-4 w-4" />
+              Copy link
+            </Button>
+            {mentionsUnavailable && (
+              <span className="ml-auto text-xs text-muted-foreground">
+                Member list unavailable — @mentions won't notify
+              </span>
+            )}
+            <Button
+              className={mentionsUnavailable ? undefined : "ml-auto"}
+              data-testid="forward-message-submit"
+              disabled={
+                !selectedRow || forwardMutation.isPending || mentionsUnresolved
+              }
+              onClick={handleForward}
+              type="button"
+            >
+              {forwardMutation.isPending
+                ? "Forwarding…"
+                : mentionsUnavailable
+                  ? "Forward without mentions"
+                  : "Forward"}
+            </Button>
+          </>
+        }
+        footerClassName="items-center gap-3"
+        title="Forward message"
+      >
+        <div className="flex flex-col gap-4">
+          <div className={cn(MODAL_SEARCH_SHELL_CLASS, "mt-0")}>
+            <label
+              className="flex min-w-0 flex-1 cursor-text items-center gap-3"
+              htmlFor="forward-destination-search"
+            >
+              <Search className="h-4 w-4 shrink-0 text-muted-foreground/55 transition-colors duration-150 ease-out group-hover/search:text-muted-foreground group-focus-within/search:text-foreground" />
+              <input
+                autoCapitalize="none"
+                autoCorrect="off"
+                className={MODAL_SEARCH_INPUT_CLASS}
+                data-testid="forward-destination-search"
+                id="forward-destination-search"
+                onChange={(event) => {
+                  setQuery(event.target.value);
+                  setHighlightIndex(null);
+                }}
+                onKeyDown={handleSearchKeyDown}
+                placeholder="Search for a channel or person"
+                spellCheck={false}
+                type="text"
+                value={query}
+              />
+            </label>
+          </div>
+
+          {orderedRows.length === 0 ? (
+            <p className="px-1 py-3 text-sm text-muted-foreground">
+              No destinations match your search.
+            </p>
+          ) : (
+            <div className="max-h-56 overflow-y-auto rounded-xl border border-border/70 bg-background/70 shadow-xs divide-y divide-border/55">
+              {orderedRows.map(({ channel, label }, index) => {
+                const isSelected = channel.id === selectedId;
+                const isHighlighted = index === highlightIndex;
+                const Icon =
+                  channel.channelType === "dm" ? MessageCircle : Hash;
+                return (
+                  <button
+                    className={cn(
+                      "flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors duration-150 ease-out focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring",
+                      isSelected
+                        ? "bg-primary/10"
+                        : isHighlighted
+                          ? "bg-muted/60"
+                          : "hover:bg-muted/40",
+                    )}
+                    data-testid={`forward-destination-${channel.id}`}
+                    key={channel.id}
+                    onClick={() => setSelectedId(channel.id)}
+                    onMouseEnter={() => setHighlightIndex(index)}
+                    type="button"
+                  >
+                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-secondary text-secondary-foreground">
+                      <Icon className="h-4 w-4" />
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                      {label}
+                    </span>
+                    {isSelected ? (
+                      <Check className="h-4 w-4 shrink-0 text-primary" />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          <Textarea
+            data-testid="forward-message-note"
+            onChange={(event) => setNote(event.target.value)}
+            placeholder="Add a message, if you'd like"
+            value={note}
+          />
+
+          {sourceType !== "channel" ? (
+            <p
+              className="text-xs text-muted-foreground"
+              data-testid="forward-privacy-notice"
+            >
+              Forwarding shares this{" "}
+              {sourceType === "dm" ? "direct message" : "private channel"}{" "}
+              content with everyone in the destination.
+            </p>
+          ) : null}
+
+          <div className="rounded-2xl border border-border/60 px-3 py-2.5">
+            <ForwardedMessageCard
+              authorAvatarUrl={previewAuthorAvatarUrl}
+              authorDisplayName={previewAuthorName}
+              note={
+                note.trim().length > 0 ? (
+                  <Markdown
+                    channelNames={nonDmChannelNames}
+                    className="max-w-full text-sm"
+                    content={note}
+                    mentionNames={
+                      noteMentions.names.length > 0
+                        ? noteMentions.names
+                        : undefined
+                    }
+                    mentionPubkeysByName={
+                      noteMentions.names.length > 0
+                        ? noteMentions.pubkeysByName
+                        : undefined
+                    }
+                  />
+                ) : undefined
+              }
+              originalCreatedAt={previewCreatedAt}
+              originalPubkey={previewPubkey}
+              sourceChannelName={
+                sourceType === "channel" ? (sourceChannel?.name ?? null) : null
+              }
+              sourceType={sourceType}
+              testId="forward-message-preview"
+            >
+              <Markdown
+                channelNames={nonDmChannelNames}
+                className="max-w-full text-sm"
+                content={previewContent ?? ""}
+                customEmoji={previewCustomEmoji}
+                imetaByUrl={previewImetaByUrl}
+                mentionNames={previewMentions.mentionNames}
+                mentionPubkeysByName={previewMentions.mentionPubkeysByName}
+              />
+            </ForwardedMessageCard>
+          </div>
+        </div>
+      </ChooserDialogContent>
+    </Dialog>
+  );
+}

--- a/desktop/src/features/messages/ui/ForwardMessageProvider.tsx
+++ b/desktop/src/features/messages/ui/ForwardMessageProvider.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+
+import type { TimelineMessage } from "@/features/messages/types";
+import { ForwardMessageDialog } from "./ForwardMessageDialog";
+
+export type ForwardMessageTarget = {
+  message: TimelineMessage;
+  /** Channel the message is being forwarded FROM (the surface it lives on). */
+  channelId: string;
+};
+
+type ForwardMessageContextValue = {
+  openForwardDialog: (target: ForwardMessageTarget) => void;
+};
+
+const ForwardMessageContext = React.createContext<ForwardMessageContextValue>({
+  openForwardDialog: () => {},
+});
+
+export function useForwardMessage() {
+  return React.useContext(ForwardMessageContext);
+}
+
+/**
+ * Hosts the "Forward message…" dialog and exposes `openForwardDialog` to any
+ * message surface below it (timeline, thread panel, DMs). Mirrors
+ * `RemindMeLaterProvider` structurally.
+ */
+export function ForwardMessageProvider({
+  pubkey,
+  children,
+}: {
+  pubkey?: string;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const [target, setTarget] = React.useState<ForwardMessageTarget | null>(null);
+
+  const openForwardDialog = React.useCallback((t: ForwardMessageTarget) => {
+    setTarget(t);
+    setOpen(true);
+  }, []);
+
+  const contextValue = React.useMemo(
+    () => ({ openForwardDialog }),
+    [openForwardDialog],
+  );
+
+  return (
+    <ForwardMessageContext.Provider value={contextValue}>
+      {children}
+      <ForwardMessageDialog
+        currentPubkey={pubkey}
+        onOpenChange={setOpen}
+        open={open}
+        target={target}
+      />
+    </ForwardMessageContext.Provider>
+  );
+}

--- a/desktop/src/features/messages/ui/ForwardedMessageCard.render.test.mjs
+++ b/desktop/src/features/messages/ui/ForwardedMessageCard.render.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ForwardedMessageCard } from "./ForwardedMessageCard.tsx";
+
+const ORIGINAL_PUBKEY =
+  "953d5b1c9f0c1d4e8a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f7081";
+
+function render(props = {}) {
+  return renderToStaticMarkup(
+    React.createElement(
+      ForwardedMessageCard,
+      {
+        authorAvatarUrl: null,
+        authorDisplayName: "Alice",
+        originalCreatedAt: 1753600000,
+        originalPubkey: ORIGINAL_PUBKEY,
+        sourceChannelName: "general",
+        sourceType: "channel",
+        testId: "forwarded-message-test",
+        ...props,
+      },
+      props.children ??
+        React.createElement("p", null, "original body text here"),
+    ),
+  );
+}
+
+test("renders attribution, author, and the quoted original body", () => {
+  const html = render();
+  assert.match(html, /data-testid="forwarded-message-test"/);
+  assert.match(html, /Forwarded from/);
+  assert.match(html, /data-testid="forwarded-from-channel"/);
+  assert.match(html, /#general/);
+  assert.match(html, /Alice/);
+  assert.match(html, /original body text here/);
+});
+
+test("renders the note above the card when present, omits it otherwise", () => {
+  const withNote = render({
+    note: React.createElement("p", null, "look at this note"),
+  });
+  assert.match(withNote, /look at this note/);
+  // Note must precede the attribution row in document order.
+  assert.ok(
+    withNote.indexOf("look at this note") < withNote.indexOf("Forwarded from"),
+  );
+
+  const withoutNote = render();
+  assert.doesNotMatch(withoutNote, /look at this note/);
+});
+
+test("open-channel attribution is a button when onOpenSource is provided", () => {
+  const linkable = render({ onOpenSource: () => {} });
+  assert.match(
+    linkable,
+    /<button[^>]*data-testid="forwarded-from-channel"[^>]*>#general/,
+  );
+
+  const plain = render();
+  assert.doesNotMatch(
+    plain,
+    /<button[^>]*data-testid="forwarded-from-channel"/,
+  );
+  assert.match(plain, /data-testid="forwarded-from-channel"/);
+});
+
+test("private and dm sources get a non-linkable generic label", () => {
+  const dm = render({ sourceType: "dm", sourceChannelName: null });
+  assert.match(dm, /data-testid="forwarded-from-private"/);
+  assert.match(dm, /Forwarded from(?:<!-- -->)?\s*a direct message/);
+  assert.doesNotMatch(dm, /forwarded-from-channel/);
+  assert.doesNotMatch(dm, /#general/);
+
+  const priv = render({ sourceType: "private", sourceChannelName: null });
+  assert.match(priv, /Forwarded from(?:<!-- -->)?\s*a private channel/);
+});
+
+test("falls back to a truncated pubkey when no profile is available", () => {
+  const html = render({ authorDisplayName: null });
+  // truncatePubkey: first 8 chars + ellipsis + last 4.
+  assert.match(html, /953d5b1c…7081/);
+});

--- a/desktop/src/features/messages/ui/ForwardedMessageCard.tsx
+++ b/desktop/src/features/messages/ui/ForwardedMessageCard.tsx
@@ -1,0 +1,223 @@
+import { Forward } from "lucide-react";
+import * as React from "react";
+
+import {
+  parseForwardEnvelope,
+  type ForwardSourceType,
+} from "@/features/messages/lib/forwardMessage";
+import { formatTime } from "@/features/messages/lib/dateFormatters";
+import { useMessageEmoji } from "@/features/messages/lib/useMessageEmoji";
+import { MessageTimestamp } from "@/features/messages/ui/MessageTimestamp";
+import type { TimelineMessage } from "@/features/messages/types";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import { useAppNavigation } from "@/app/navigation/useAppNavigation";
+import { cn } from "@/shared/lib/cn";
+import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
+import { resolveMentionProps } from "@/shared/lib/resolveMentionNames";
+import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
+import { Markdown } from "@/shared/ui/markdown";
+import { parseImetaTags } from "@/shared/ui/markdown/parseImeta";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+
+/**
+ * Presentational shell for a forwarded message: the forwarder's note (when
+ * present), an attribution row, and the quoted original. Rendered by both the
+ * timeline (via `ForwardedMessageRow`) and the forward dialog's preview so
+ * what you see in the dialog is exactly what lands in the destination.
+ */
+export function ForwardedMessageCard({
+  authorAvatarUrl,
+  authorDisplayName,
+  children,
+  note,
+  onOpenSource,
+  originalCreatedAt,
+  originalPubkey,
+  sourceChannelName,
+  sourceType,
+  testId,
+}: {
+  /** Resolved avatar URL for the original author. */
+  authorAvatarUrl?: string | null;
+  /** Resolved display name for the original author; falls back to a
+   *  truncated pubkey when no profile is available. */
+  authorDisplayName?: string | null;
+  /** Rendered markdown body of the ORIGINAL message (with its imeta map). */
+  children: React.ReactNode;
+  /** Rendered note node; omit entirely when the forwarder left no note. */
+  note?: React.ReactNode;
+  /** Jump-to-original handler; only open-channel sources are linkable. */
+  onOpenSource?: () => void;
+  originalCreatedAt: number;
+  originalPubkey: string;
+  /** Source channel name for open-channel attribution (no leading '#'). */
+  sourceChannelName?: string | null;
+  sourceType: ForwardSourceType;
+  testId?: string;
+}) {
+  const displayName =
+    authorDisplayName?.trim() || truncatePubkey(originalPubkey);
+
+  const attribution =
+    sourceType === "channel" ? (
+      <>
+        <span>Forwarded from</span>
+        {onOpenSource ? (
+          <button
+            className="cursor-pointer truncate font-medium text-muted-foreground hover:text-foreground hover:underline focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+            data-testid="forwarded-from-channel"
+            onClick={onOpenSource}
+            type="button"
+          >
+            #{sourceChannelName ?? "channel"}
+          </button>
+        ) : (
+          <span
+            className="truncate font-medium"
+            data-testid="forwarded-from-channel"
+          >
+            #{sourceChannelName ?? "channel"}
+          </span>
+        )}
+      </>
+    ) : (
+      <span data-testid="forwarded-from-private">
+        Forwarded from{" "}
+        {sourceType === "dm" ? "a direct message" : "a private channel"}
+      </span>
+    );
+
+  return (
+    <div className="flex min-w-0 flex-col gap-1" data-testid={testId}>
+      {note ? <div className="min-w-0">{note}</div> : null}
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Forward aria-hidden className="h-3.5 w-3.5 shrink-0" />
+        {attribution}
+      </div>
+      <div className="min-w-0 rounded-2xl border-l-2 border-border bg-muted/55 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <UserAvatar
+            avatarUrl={authorAvatarUrl ?? null}
+            displayName={displayName}
+            size="sm"
+            testId="forwarded-author-avatar"
+          />
+          <span className="truncate text-sm font-semibold leading-4">
+            {displayName}
+          </span>
+          <MessageTimestamp
+            createdAt={originalCreatedAt}
+            time={formatTime(originalCreatedAt)}
+          />
+        </div>
+        <div className="mt-1 min-w-0">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Timeline body for a kind-40009 event: parses the forward envelope from the
+ * event's tags and renders the shared `ForwardedMessageCard`. The embedded
+ * original's author and mentions resolve out of the surface's `profiles`
+ * lookup (see `collectForwardEmbeddedPubkeys`), never a per-row fetch.
+ * Open-channel attributions link back to the original through the same
+ * channel+messageId route message links use.
+ */
+export function ForwardedMessageRow({
+  message,
+  profiles,
+}: {
+  message: TimelineMessage;
+  profiles?: UserProfileLookup;
+}) {
+  const envelope = React.useMemo(
+    () => parseForwardEnvelope(message.tags ?? []),
+    [message.tags],
+  );
+  const original = envelope?.original ?? null;
+  const originalPubkey = original ? normalizePubkey(original.pubkey) : "";
+  const { channels, nonDmChannelNames } = useChannelNavigation();
+  const { goChannel } = useAppNavigation();
+
+  // No per-row profile query: the embedded author and the embedded original's
+  // mentions are collected into the surface's batched request by
+  // `collectForwardEmbeddedPubkeys`.
+  const authorProfile = originalPubkey ? profiles?.[originalPubkey] : undefined;
+
+  const noteMentions = React.useMemo(
+    () => resolveMentionProps(message.tags, profiles),
+    [message.tags, profiles],
+  );
+  const originalMentions = React.useMemo(
+    () => resolveMentionProps(original?.tags, profiles),
+    [original?.tags, profiles],
+  );
+  const originalImetaByUrl = React.useMemo(
+    () => (original ? parseImetaTags(original.tags) : undefined),
+    [original],
+  );
+  const { customEmoji: originalCustomEmoji } = useMessageEmoji(
+    original?.content ?? "",
+    original?.tags,
+  );
+
+  const sourceChannelId = envelope?.sourceChannelId;
+  const originalId = original?.id;
+  const handleOpenSource = React.useCallback(() => {
+    if (!sourceChannelId || !originalId) return;
+    void goChannel(sourceChannelId, { messageId: originalId });
+  }, [goChannel, originalId, sourceChannelId]);
+
+  if (!envelope || !original) {
+    // The relay validates forwards on ingest, so this only occurs for
+    // malformed events from before validation (or other clients' bugs).
+    return (
+      <p className="text-sm italic text-muted-foreground">
+        This forwarded message can't be displayed.
+      </p>
+    );
+  }
+
+  const sourceChannelName =
+    envelope.sourceType === "channel"
+      ? (channels.find((channel) => channel.id === envelope.sourceChannelId)
+          ?.name ?? null)
+      : null;
+
+  return (
+    <ForwardedMessageCard
+      authorAvatarUrl={authorProfile?.avatarUrl ?? null}
+      authorDisplayName={authorProfile?.displayName ?? null}
+      note={
+        message.body.trim().length > 0 ? (
+          <Markdown
+            channelNames={nonDmChannelNames}
+            className="max-w-full text-sm"
+            content={message.body}
+            mentionNames={noteMentions.mentionNames}
+            mentionPubkeysByName={noteMentions.mentionPubkeysByName}
+          />
+        ) : undefined
+      }
+      onOpenSource={
+        envelope.sourceType === "channel" ? handleOpenSource : undefined
+      }
+      originalCreatedAt={original.created_at}
+      originalPubkey={originalPubkey}
+      sourceChannelName={sourceChannelName}
+      sourceType={envelope.sourceType}
+      testId={`forwarded-message-${message.id}`}
+    >
+      <Markdown
+        channelNames={nonDmChannelNames}
+        className={cn("max-w-full text-sm")}
+        content={original.content}
+        customEmoji={originalCustomEmoji}
+        imetaByUrl={originalImetaByUrl}
+        mentionNames={originalMentions.mentionNames}
+        mentionPubkeysByName={originalMentions.mentionPubkeysByName}
+      />
+    </ForwardedMessageCard>
+  );
+}

--- a/desktop/src/features/messages/ui/MessageActionBar.tsx
+++ b/desktop/src/features/messages/ui/MessageActionBar.tsx
@@ -6,6 +6,7 @@ import {
   CornerUpLeft,
   EllipsisVertical,
   Flag,
+  Forward,
   Link2,
   MailCheck,
   MailOpen,
@@ -15,6 +16,7 @@ import {
 } from "lucide-react";
 import * as React from "react";
 
+import { canForwardMessageKind } from "@/features/messages/lib/forwardMessage";
 import { buildMessageLink } from "@/features/messages/lib/messageLink";
 import { EmojiPicker } from "@/features/custom-emoji/ui/EmojiPicker";
 import { useCustomEmoji } from "@/features/custom-emoji/hooks";
@@ -66,6 +68,7 @@ function MoreActionsMenu({
   onDelete,
   onEdit,
   onFollowThread,
+  onForward,
   onMarkUnread,
   onMarkRead,
   onOpenChange,
@@ -82,6 +85,7 @@ function MoreActionsMenu({
   onDelete?: (message: TimelineMessage) => void;
   onEdit?: (message: TimelineMessage) => void;
   onFollowThread?: (message: TimelineMessage) => void;
+  onForward?: (message: TimelineMessage) => void;
   onMarkUnread?: (message: TimelineMessage) => void;
   onMarkRead?: (message: TimelineMessage) => void;
   onOpenChange: (open: boolean) => void;
@@ -240,6 +244,21 @@ function MoreActionsMenu({
             </DropdownMenuItem>
           ) : null}
 
+          {onForward &&
+          hasCopyActions &&
+          channelId &&
+          canForwardMessageKind(message.kind) ? (
+            <DropdownMenuItem
+              data-testid={`forward-message-${message.id}`}
+              onClick={() => {
+                onForward(message);
+              }}
+            >
+              <Forward className="h-4 w-4" />
+              Forward message…
+            </DropdownMenuItem>
+          ) : null}
+
           {canReport || onDelete ? <DropdownMenuSeparator /> : null}
 
           {canReport ? (
@@ -371,6 +390,7 @@ export const MessageActionBar = React.memo(function MessageActionBar({
   onDelete,
   onEdit,
   onFollowThread,
+  onForward,
   onMarkUnread,
   onMarkRead,
   onReactionBadgeBurstRequest,
@@ -390,6 +410,9 @@ export const MessageActionBar = React.memo(function MessageActionBar({
   onDelete?: (message: TimelineMessage) => void;
   onEdit?: (message: TimelineMessage) => void;
   onFollowThread?: (message: TimelineMessage) => void;
+  /** Opens the "Forward message…" dialog; hidden when omitted or when the
+   *  message kind is not forwardable. */
+  onForward?: (message: TimelineMessage) => void;
   onMarkUnread?: (message: TimelineMessage) => void;
   onMarkRead?: (message: TimelineMessage) => void;
   onReactionBadgeBurstRequest?: (emoji: string) => void;
@@ -574,6 +597,7 @@ export const MessageActionBar = React.memo(function MessageActionBar({
               onDelete={onDelete}
               onEdit={onEdit}
               onFollowThread={onFollowThread}
+              onForward={onForward}
               onMarkUnread={onMarkUnread}
               onMarkRead={onMarkRead}
               onOpenChange={setIsDropdownOpen}

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -26,7 +26,10 @@ import {
 import {
   KIND_HUDDLE_STARTED,
   KIND_STREAM_MESSAGE_DIFF,
+  KIND_STREAM_MESSAGE_FORWARD,
 } from "@/shared/constants/kinds";
+import { ForwardedMessageRow } from "@/features/messages/ui/ForwardedMessageCard";
+import { useForwardMessage } from "@/features/messages/ui/ForwardMessageProvider";
 import { getConfigNudgeAuthorPubkey } from "@/features/messages/ui/configNudgeAuthPubkey";
 import { cn } from "@/shared/lib/cn";
 import { normalizePubkey } from "@/shared/lib/pubkey";
@@ -178,6 +181,14 @@ export const MessageRow = React.memo(
         });
       },
       [channelId, openReminder],
+    );
+    const { openForwardDialog } = useForwardMessage();
+    const handleForward = React.useCallback(
+      (msg: TimelineMessage) => {
+        if (!channelId) return;
+        openForwardDialog({ message: msg, channelId });
+      },
+      [channelId, openForwardDialog],
     );
     const { mentionNames, mentionPubkeysByName } = React.useMemo(
       () => resolveMentionProps(message.tags, profiles),
@@ -334,6 +345,8 @@ export const MessageRow = React.memo(
               onOpenThread={onReply}
             />
           );
+        case KIND_STREAM_MESSAGE_FORWARD:
+          return <ForwardedMessageRow message={message} profiles={profiles} />;
         default:
           {
             const waveMessage = parseWaveMessageContent(message.body);
@@ -484,6 +497,7 @@ export const MessageRow = React.memo(
           onDelete={onDelete}
           onEdit={onEdit}
           onFollowThread={onFollowThread}
+          onForward={channelId ? handleForward : undefined}
           onMarkUnread={onMarkUnread}
           onMarkRead={onMarkRead}
           onReactionBadgeBurstRequest={

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -95,7 +95,7 @@ type RawSearchResponse = {
   found: number;
 };
 
-type RawSendChannelMessageResult = {
+export type RawSendChannelMessageResult = {
   event_id: string;
   parent_event_id: string | null;
   root_event_id: string | null;

--- a/desktop/src/shared/api/tauriForward.ts
+++ b/desktop/src/shared/api/tauriForward.ts
@@ -1,0 +1,32 @@
+import { invokeTauri, type RawSendChannelMessageResult } from "./tauri";
+
+/**
+ * Publish a kind-40009 message forward into `channelId`.
+ *
+ * `note` is the forwarder's optional note ("" when none). `forwardTags` is
+ * the pre-composed `fwd`/`k`/`fwd-src`/`q`/`imeta` tag set from
+ * `buildForwardTags` — the Rust side rejects any other tag family.
+ * `mentionPubkeys` are the note's recipients; the Rust side turns them into
+ * the `p` tags that drive notifications.
+ */
+export async function forwardMessage(
+  channelId: string,
+  note: string,
+  forwardTags: string[][],
+  mentionPubkeys?: string[],
+): Promise<{ eventId: string; createdAt: number }> {
+  const response = await invokeTauri<RawSendChannelMessageResult>(
+    "forward_message",
+    {
+      channelId,
+      note,
+      forwardTags,
+      mentionPubkeys: mentionPubkeys ?? null,
+    },
+  );
+
+  return {
+    eventId: response.event_id,
+    createdAt: response.created_at,
+  };
+}

--- a/desktop/src/shared/constants/kinds.ts
+++ b/desktop/src/shared/constants/kinds.ts
@@ -20,6 +20,10 @@ export const KIND_STREAM_MESSAGE_EDIT = 40003;
 export const KIND_CHANNEL_THREAD_SUMMARY = 39005;
 export const KIND_CHANNEL_WINDOW_BOUNDS = 39006;
 export const KIND_STREAM_MESSAGE_DIFF = 40008;
+// Message forward (snapshot). Carries the complete signed original event in a
+// `fwd` tag plus `k`/`fwd-src`/`q` metadata; rendered as its own timeline row
+// authored by the forwarder. Mirror of buzz-core's KIND_STREAM_MESSAGE_FORWARD.
+export const KIND_STREAM_MESSAGE_FORWARD = 40009;
 export const KIND_REMINDER = 40007;
 export const KIND_SYSTEM_MESSAGE = 40099;
 export const KIND_JOB_REQUEST = 43001;
@@ -78,6 +82,7 @@ export const KIND_DM_VISIBILITY = 30622;
 export const CHANNEL_MESSAGE_EVENT_KINDS = [
   KIND_STREAM_MESSAGE,
   KIND_STREAM_MESSAGE_V2,
+  KIND_STREAM_MESSAGE_FORWARD,
   KIND_FORUM_POST,
   KIND_FORUM_COMMENT,
 ] as const;
@@ -126,6 +131,7 @@ export const CHANNEL_TIMELINE_CONTENT_KINDS = [
   KIND_STREAM_MESSAGE, // 9
   KIND_STREAM_MESSAGE_V2, // 40002
   KIND_STREAM_MESSAGE_DIFF, // 40008 — diff messages (own row)
+  KIND_STREAM_MESSAGE_FORWARD, // 40009 — forwarded messages (own row)
   KIND_SYSTEM_MESSAGE, // 40099 — system rows (join/leave/channel-created)
   KIND_JOB_REQUEST, // 43001
   KIND_JOB_ACCEPTED, // 43002

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -44,6 +44,7 @@ import {
   KIND_REPO_ANNOUNCEMENT,
   KIND_REPO_STATE,
   KIND_STREAM_MESSAGE_EDIT,
+  KIND_STREAM_MESSAGE_FORWARD,
   KIND_SYSTEM_MESSAGE,
   KIND_TEXT_NOTE,
   KIND_USER_STATUS,
@@ -4341,6 +4342,7 @@ const TIMELINE_KINDS = new Set([
   9,
   40002,
   40008,
+  KIND_STREAM_MESSAGE_FORWARD,
   40099,
   43001,
   43002,
@@ -11392,6 +11394,7 @@ export function maybeInstallE2eTauriMocks() {
         if (delayMs > 0) {
           await new Promise((resolve) => window.setTimeout(resolve, delayMs));
         }
+        // sadscan:disable np.generic.1 -- mock pairing fixture for the E2E bridge, not a real secret
         return "nostrpair://8f4b8db31967ce14fef970a1ff1e8eecf19a430aa1c83875e2f5be68dcac0f1a?relay=wss%3A%2F%2Frelay.example.com&secret=87d5a8cfd5807a0cb44f728b67d88d6dcb8daf99be137c158f21a50c1e913c0a&v=1";
       }
       case "cancel_pairing":

--- a/desktop/tests/e2e/forward-message.spec.ts
+++ b/desktop/tests/e2e/forward-message.spec.ts
@@ -1,0 +1,186 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAnimations } from "../helpers/animations";
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+// PR screenshots for message forwarding: the "Forward message…" entry in the
+// more-actions menu and the forward dialog (destination picker + note +
+// WYSIWYG preview). Timeline rendering of kind-40009 events is captured via
+// `just desktop-screenshot --messages` instead — no interaction needed there.
+
+const SHOTS = "test-results/forward-screenshots";
+const RANDOM_CHANNEL_ID = "9dae0116-799b-5071-a0a8-fdd30a91a35d";
+const SOURCE_MESSAGE_ID = "a1".repeat(32);
+const SOURCE_MESSAGE_CONTENT =
+  "Heads up: the beta cluster maintenance window moved to Thursday 14:00 UTC.";
+
+async function waitForMockLiveSubscription(
+  page: import("@playwright/test").Page,
+  channelName: string,
+) {
+  await expect
+    .poll(async () => {
+      return page.evaluate(
+        ({ ch }) =>
+          (
+            window as Window & {
+              __BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?: (input: {
+                channelName: string;
+              }) => boolean;
+            }
+          ).__BUZZ_E2E_HAS_MOCK_LIVE_SUBSCRIPTION__?.({ channelName: ch }) ??
+          false,
+        { ch: channelName },
+      );
+    })
+    .toBe(true);
+}
+
+/**
+ * Navigate to #general, pad the timeline with filler chatter (so the open
+ * menu overlays real messages, not the empty-channel onboarding cards), then
+ * inject Alice's source message with a known id.
+ */
+async function seedSourceMessage(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+  await waitForMockLiveSubscription(page, "general");
+
+  // Distinct, increasing createdAt values: same-second events tiebreak by id
+  // in the timeline, which would shuffle the display order.
+  const base = Math.floor(Date.now() / 1000);
+  const messages = [
+    {
+      id: "1a".repeat(32),
+      content: "Morning all — the deploy train leaves at noon.",
+      pubkey: TEST_IDENTITIES.bob.pubkey,
+      createdAt: base - 45,
+    },
+    {
+      id: "2b".repeat(32),
+      content: "CI is green on main again after the flaky retry fix.",
+      pubkey: TEST_IDENTITIES.charlie.pubkey,
+      createdAt: base - 35,
+    },
+    {
+      id: "3c".repeat(32),
+      content: "Standup notes are in the usual doc.",
+      pubkey: TEST_IDENTITIES.bob.pubkey,
+      createdAt: base - 25,
+    },
+    {
+      id: SOURCE_MESSAGE_ID,
+      content: SOURCE_MESSAGE_CONTENT,
+      pubkey: TEST_IDENTITIES.alice.pubkey,
+      createdAt: base - 15,
+    },
+  ];
+
+  for (const message of messages) {
+    await page.evaluate(({ id, content, pubkey, createdAt }) => {
+      (
+        window as Window & {
+          __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+            channelName: string;
+            content: string;
+            pubkey: string;
+            id: string;
+            createdAt: number;
+          }) => unknown;
+        }
+      ).__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        content,
+        pubkey,
+        id,
+        createdAt,
+      });
+    }, message);
+  }
+
+  const row = page.locator(`[data-message-id="${SOURCE_MESSAGE_ID}"]`);
+  await expect(row).toBeVisible({ timeout: 10_000 });
+  return row;
+}
+
+async function openMoreActionsMenu(page: import("@playwright/test").Page) {
+  const row = page.locator(`[data-message-id="${SOURCE_MESSAGE_ID}"]`);
+  await row.hover();
+  await page.getByTestId(`more-actions-${SOURCE_MESSAGE_ID}`).click();
+  await expect(page.locator('[role="menuitem"]').first()).toBeVisible({
+    timeout: 5_000,
+  });
+  return row;
+}
+
+test("captures the Forward message entry in the more-actions menu", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await seedSourceMessage(page);
+  const row = await openMoreActionsMenu(page);
+
+  const forwardItem = page.getByTestId(`forward-message-${SOURCE_MESSAGE_ID}`);
+  await expect(forwardItem).toBeVisible();
+  // Hover the entry so the shot shows it highlighted (also moves the pointer
+  // off the trigger, dismissing its tooltip).
+  await forwardItem.hover();
+
+  await waitForAnimations(page);
+
+  // Crop to the message row plus the open menu (portaled, so union the boxes).
+  const rowBox = await row.boundingBox();
+  const menuBox = await page.locator('[role="menu"]').boundingBox();
+  if (!rowBox || !menuBox) throw new Error("missing bounding boxes");
+  const viewport = page.viewportSize() ?? { width: 1280, height: 720 };
+  const pad = 16;
+  const x = Math.max(0, Math.min(rowBox.x, menuBox.x) - pad);
+  const y = Math.max(0, Math.min(rowBox.y, menuBox.y) - pad);
+  const right = Math.min(
+    viewport.width,
+    Math.max(rowBox.x + rowBox.width, menuBox.x + menuBox.width) + pad,
+  );
+  const bottom = Math.min(
+    viewport.height,
+    Math.max(rowBox.y + rowBox.height, menuBox.y + menuBox.height) + pad,
+  );
+  await page.screenshot({
+    path: `${SHOTS}/01-menu-item.png`,
+    clip: { x, y, width: right - x, height: bottom - y },
+  });
+});
+
+test.describe("forward dialog", () => {
+  // The dialog caps at 85vh; a taller viewport lets the destination list,
+  // note, and preview card all render without inner scrolling.
+  test.use({ viewport: { width: 1280, height: 960 } });
+
+  test("captures the forward dialog with destination, note, and preview", async ({
+    page,
+  }) => {
+    await installMockBridge(page);
+    await seedSourceMessage(page);
+    await openMoreActionsMenu(page);
+    await page.getByTestId(`forward-message-${SOURCE_MESSAGE_ID}`).click();
+
+    const dialog = page.getByTestId("forward-message-dialog");
+    await expect(dialog).toBeVisible();
+
+    // Pick #random as the destination and confirm the selection took.
+    await page.getByTestId(`forward-destination-${RANDOM_CHANNEL_ID}`).click();
+    await expect(page.getByTestId("forward-message-submit")).toBeEnabled();
+
+    await page
+      .getByTestId("forward-message-note")
+      .fill("Adding context: this affects Thursday's launch window.");
+
+    // Preview card renders the original message.
+    const preview = page.getByTestId("forward-message-preview");
+    await expect(preview).toBeVisible();
+    await expect(preview).toContainText("beta cluster maintenance window");
+
+    await waitForAnimations(page);
+    await dialog.screenshot({ path: `${SHOTS}/02-forward-dialog.png` });
+  });
+});

--- a/docs/nips/NIP-FW.md
+++ b/docs/nips/NIP-FW.md
@@ -1,0 +1,334 @@
+NIP-FW
+======
+
+Message Forwarding
+------------------
+
+`draft` `optional` `relay`
+
+**Depends on**: NIP-01 (basic event format), NIP-18 (reposts), NIP-29 (relay-based
+groups), NIP-42 (authentication)
+
+This NIP defines `kind:40009` message forwards — a message that carries a
+complete, independently verifiable copy of another message into a different
+channel, together with an optional note written by the forwarder. It is the
+Slack "Forward message…" primitive expressed as a Nostr event.
+
+## Motivation
+
+Buzz issue [#3264](https://github.com/block/buzz/issues/3264) asks for Slack
+parity on the single most-used sharing gesture in a chat product: take a
+message that is in the wrong place and put it in the right place, with a line
+of context. Today the only way to do that in Buzz is to copy the text by hand,
+which loses the author, the timestamp, the attachments, and any link back to
+the original.
+
+The agent case is the sharper one. Handing work off — "this is the failure the
+build agent reported, take it from here" — means moving one concrete message,
+verbatim, from where it happened to where the next actor is listening. A
+hand-retyped paste is not evidence: the recipient (human or agent) cannot tell
+whether the quoted text is what the original author actually wrote. A forward
+carries the original's signature, so the copy is a fact the relay and every
+client can check rather than a claim the forwarder makes.
+
+## Definitions
+
+- **Original**: the signed event being forwarded.
+- **Source channel**: the channel the original was posted in (its `h` tag).
+- **Destination channel**: the channel the forward is posted in. DMs are
+  ordinary channels with `channel_type = 'dm'`, so channels and DMs are the
+  same mechanism throughout this NIP.
+- **Forwarder**: the pubkey signing the `kind:40009` event.
+- **Note**: the forwarder's optional accompanying message.
+
+## Kinds
+
+| Kind | Name | Signer | Storage | Purpose |
+|------|------|--------|---------|---------|
+| `40009` | `KIND_STREAM_MESSAGE_FORWARD` | user | regular | A forwarded copy of another message |
+
+`kind:40009` is a regular (stored, append-only) event in the Buzz
+stream-messaging family, taking the next free slot after `40008`
+`KIND_STREAM_MESSAGE_DIFF`. All kinds are defined in
+`crates/buzz-core/src/kind.rs`.
+
+## Event
+
+```jsonc
+{
+  "kind": 40009,
+  "pubkey": "<forwarder_pubkey>",
+  "created_at": <unix_seconds>,
+  "content": "cc @dana — this is the failure I mentioned",
+  "tags": [
+    ["h", "9f1c8a20-6d3e-4a51-b7d2-0c5f1e884b31"],
+    ["fwd", "{\"id\":\"3b1f…\",\"pubkey\":\"a77c…\",\"created_at\":1780000000,\"kind\":40002,\"tags\":[[\"h\",\"1c2d3e4f-5a6b-7c8d-9e0f-a1b2c3d4e5f6\"],[\"imeta\",\"url https://relay.example/blossom/ab12…\",\"m image/png\",\"x ab12…\"]],\"content\":\"deploy failed: exit 137 on shard 3\",\"sig\":\"9e0d…\"}"],
+    ["k", "40002"],
+    ["fwd-src", "1c2d3e4f-5a6b-7c8d-9e0f-a1b2c3d4e5f6", "channel"],
+    ["q", "3b1f…", "", "a77c…"],
+    ["imeta", "url https://relay.example/blossom/ab12…", "m image/png", "x ab12…"],
+    ["p", "<dana_pubkey>"]
+  ],
+  "sig": "…"
+}
+```
+
+Second example — no note, private source. The `q` tag is absent and the
+`fwd-src` type label is `private`:
+
+```jsonc
+{
+  "kind": 40009,
+  "pubkey": "<forwarder_pubkey>",
+  "created_at": <unix_seconds>,
+  "content": "",
+  "tags": [
+    ["h", "9f1c8a20-6d3e-4a51-b7d2-0c5f1e884b31"],
+    ["fwd", "{\"id\":\"7c4e…\",\"pubkey\":\"b902…\",\"created_at\":1780000500,\"kind\":9,\"tags\":[[\"h\",\"44e9b1c7-2f80-4d13-8a6e-51ba7c093d2a\"]],\"content\":\"rotating the staging token now\",\"sig\":\"1af5…\"}"],
+    ["k", "9"],
+    ["fwd-src", "44e9b1c7-2f80-4d13-8a6e-51ba7c093d2a", "private"]
+  ],
+  "sig": "…"
+}
+```
+
+### `content`
+
+`content` is the forwarder's note in Buzz markdown, or the empty string when
+the forwarder adds no note.
+
+`content` SHOULD NOT contain the original's text. The original travels only
+inside the `fwd` tag. This is an attribution and search-integrity guideline
+rather than a relay-enforceable rule — a relay cannot distinguish quoted text
+from a forwarder's own words — but clients SHOULD honour it: the note is
+indexed as the forwarder's own words, and full-text search should not
+attribute the original author's sentences to the forwarder or return the same
+sentence once per forward.
+
+### Tags
+
+| Tag | Cardinality | Meaning |
+|-----|-------------|---------|
+| `h` | exactly 1 | Destination channel or DM uuid. Standard NIP-29 group scope. MUST be the canonical two-element form `["h", <uuid>]` — trailing elements are rejected. |
+| `fwd` | exactly 1 | Stringified JSON of the **complete** original signed event: `id`, `pubkey`, `created_at`, `kind`, `tags`, `content`, `sig`. Maximum 64 KiB. |
+| `k` | exactly 1 | The original's kind, stringified. MUST equal the embedded event's `kind` ([NIP-18](18.md) generic-repost convention). |
+| `fwd-src` | exactly 1 | `["fwd-src", <source_channel_uuid>, <type>]` where `type` is `channel` (open visibility), `private` (non-open group channel), or `dm` (`channel_type = 'dm'`). The uuid MUST equal the embedded original's own `h` tag, and the embedded original MUST carry exactly one canonical two-element `h` tag. |
+| `q` | 0 or 1 | `["q", <original_id>, "", <original_author_pubkey>]` — exactly 4 elements, third empty. Present **only** when `fwd-src` type is `channel`. |
+| `imeta` | 0+ | Copied verbatim from the original, preserving attachments ([NIP-92](92.md)). |
+| `p` | 0+ | Mentions the forwarder writes in the note, via the standard mention pipeline. |
+
+There is deliberately **no** bare `p` tag for the original author. A forward is
+not a mention: p-tagging the original author would fire a false "you were
+mentioned" notification on a message they did not participate in and may not be
+able to read.
+
+### Forwardable kinds
+
+The original's kind MUST be one of:
+
+| Kind | Name |
+|------|------|
+| `9` | `KIND_STREAM_MESSAGE` |
+| `40002` | `KIND_STREAM_MESSAGE_V2` |
+| `45001` | `KIND_FORUM_POST` |
+| `45003` | `KIND_FORUM_COMMENT` |
+
+An embedded original of kind `40009` MUST be rejected. Forwarding a forward
+flattens client-side: the client forwards the *embedded* original instead, so
+forward depth is always exactly 1. This keeps validation cost bounded (no
+recursive verification), keeps the 64 KiB cap meaningful (no nesting blowup),
+and keeps rendering to a single quoted card.
+
+### Threading
+
+A forward is always a **root** message. Marked `e` tags (`root` / `reply`, per
+[NIP-10](10.md)) on a `kind:40009` event MUST be rejected in v1.
+
+A forward may itself become a thread root: replies, reactions, edits of the
+note (via the existing `kind:40003` edit), and deletion by its author all work
+exactly as on any other message the forwarder owns.
+
+## Relay Behavior
+
+A relay MUST apply a per-kind validator on ingest and **fail closed** — reject
+on any doubt. Validation is what upgrades the embedded copy from a claim into a
+fact, so a relay that skips it is worse than one that rejects `kind:40009`
+outright.
+
+1. **Verifiable, present original.** Exactly one `fwd` tag, parseable as a
+   complete event. The relay recomputes the [NIP-01](01.md) event id from
+   `(pubkey, created_at, kind, tags, content)` and verifies the Schnorr `sig`,
+   reusing the same `buzz-core` verification path as the outer event (and, like
+   the outer verify, off the async executor). In addition, the relay MUST
+   confirm that the embedded original **exists in this community's event
+   store**, stored under the channel named by `fwd-src`. A forward whose
+   embedded original is unknown to the relay, or is stored under a different
+   channel, MUST be rejected (see Security Considerations → Provenance).
+2. **Kind agreement.** The `k` tag equals the embedded `kind`, and that kind is
+   in the forwardable allowlist above. Embedded `kind:40009` is rejected.
+3. **Source agreement.** The embedded original carries exactly one canonical
+   two-element `h` tag (as does the outer event — see Tags), the `fwd-src` uuid
+   equals it, the source channel row exists, and the type label
+   matches that row's actual `visibility` / `channel_type`. Mismatches are
+   rejected — a forwarder MUST NOT be able to label a private source as
+   `channel` (or the reverse).
+4. **Read access.** The forwarder (`event.pubkey`) MUST be a member of the
+   source channel, or the source channel visibility MUST be `open` — the same
+   check as the existing channel-membership gate. Without this rule the relay
+   would sign off on laundering leaked private content into a public channel:
+   the forward would be *verifiably* the original author's words, carrying the
+   relay's blessing, published by someone who never had access.
+5. **`q` scope.** A `q` tag is allowed only when the `fwd-src` type is
+   `channel`; it MUST have exactly four elements with an empty third element,
+   its id element MUST equal the embedded original's id, and its pubkey element
+   MUST equal the embedded `pubkey`.
+6. **Bounds.** The `fwd` tag value MUST be ≤ 64 KiB. Marked `e` tags are
+   rejected.
+7. **Destination gates are unchanged.** `h` scoping, group token, destination
+   membership, archived-channel, ban/timeout, and `imeta` blob verification are
+   the existing pipeline. This NIP adds no destination rules; it only requires
+   that `kind:40009` flow through them like any other stream message.
+
+Rule 7 is why copied `imeta` tags are safe: the relay re-verifies the
+referenced blobs on the forward itself. Blossom blobs are content-addressed and
+tenant-scoped, so a same-tenant copy verifies against the same hash without
+re-uploading bytes.
+
+## Snapshot Semantics
+
+A forward is a **snapshot** taken at forward time. Later edits
+(`kind:40003`) and deletions ([NIP-09](09.md)) of the original do **not**
+propagate to any forward of it.
+
+This is deliberate and matches Slack. The embedded event is signed: rewriting
+its content on a later edit would invalidate the signature and destroy the
+property that makes the copy verifiable, and there is no way to re-sign it
+without the original author's key. Propagating deletions would require the
+relay to maintain a reverse index from every event to every forward of it
+across channel boundaries, and would let a delete reach into channels the
+original author never posted in.
+
+Clients SHOULD therefore render the quoted card as of `created_at` of the
+forward, and MUST NOT present it as live state. Where a forward's `fwd-src`
+type is `channel`, the `q` tag gives a client an optional path to resolve the
+current original and surface an "edited since" affordance; this is a
+presentation choice, not a protocol requirement.
+
+## Privacy Considerations
+
+**Forwarding out of a private source republishes content.** When the source is
+a private channel or a DM, a `kind:40009` event deliberately re-publishes that
+content to the destination's members. The relay's rule 4 constrains *who* can
+do this (a member of the source) but not *where* — a member may forward into
+any channel they can post in. This mirrors Slack, and it mirrors physical
+reality: a member of a private channel can already retype anything they read
+there. What the protocol adds is attribution integrity, not confinement.
+Clients MUST make the consequence visible before the fact: when the source is
+private or a DM, the forward dialog shows a one-line notice that forwarding
+shares this content with the destination.
+
+**Source identity is not leaked by name, only by uuid.** For non-open sources
+the `q` tag is omitted and clients render "Forwarded from a private channel" /
+"Forwarded from a direct message" with no link. The embedded original,
+however, necessarily carries its own `h` tag — the source channel uuid — because
+that tag is covered by the original's signature and cannot be stripped without
+breaking verification (rule 1). A uuid is an opaque identifier: it reveals no
+channel name, topic, or member list, and it resolves to nothing for a reader
+who is not a member. Readers who *are* members of the source learn only that
+the message they can already see was forwarded.
+
+**No hidden recipients.** A forward has exactly one destination (`h`). Fan-out
+to several places is several events, each individually validated and each
+individually visible in its destination.
+
+## Security Considerations
+
+**Provenance — the embedded copy MUST be one the relay has seen.** Signature
+verification alone proves only that *some* key signed *some* event; it does not
+prove the event was ever posted in the channel the forward claims. Without a
+store lookup a forwarder could fabricate an event signed by their own key,
+label an arbitrary channel as its source, and have the relay bless it. Relays
+therefore MUST verify that the embedded original exists in the destination
+community's event store, stored in the channel named by `fwd-src`, in addition
+to verifying its NIP-01 id and Schnorr signature (relay rule 1). Forwards
+referencing an unknown original, or one scoped to a different channel, MUST be
+rejected.
+
+**Freshness — authorize against current membership.** The forwarder's read
+access to the source channel (relay rule 4) SHOULD be evaluated against current
+membership and visibility state, not against a cached or previously issued
+grant: a user removed from a private channel must not be able to forward out of
+it. A residual race remains between the authorization check and the store write
+when visibility or membership changes concurrently; that race is accepted, and
+relays MAY narrow it by re-checking access transactionally with the insert.
+
+**Tag cardinality and shape are normative.** The outer event MUST carry exactly
+one `h` tag, and the embedded original MUST carry exactly one `h` tag; anything
+else is rejected rather than resolved by picking the first. Both `h` tags MUST
+additionally be the canonical two-element shape `["h", <uuid>]`: trailing
+elements are rejected rather than ignored, because common event libraries
+preserve them and a permissive reader of `["h", <uuid>, <extra>]` could be shown
+different data than the access check evaluated. The optional `q` tag MUST be
+exactly `["q", <original_id>, "", <original_author_pubkey>]` — four elements,
+with an empty relay hint in the third position. Ambiguous multi-`h` events would
+otherwise let a forwarder present one scope to the access check and another to
+storage or to readers.
+
+**Client trust — verification lives at ingest.** Clients rely on relay-side
+ingest verification for the "this is a fact, not a claim" property, so a client
+talking to an untrusted or unverified relay inherits that relay's honesty.
+Clients SHOULD independently verify the embedded event's id and signature where
+feasible (they have the complete signed event in the `fwd` tag), and SHOULD
+present a forward whose embedded signature they cannot verify distinctly from a
+verified one rather than rendering it as an ordinary quoted message.
+
+Client-side display parsers (TypeScript, Dart) perform display-oriented
+structural parsing only: they read the tags a row needs to render and are
+deliberately more permissive than the rules above — a duplicated `fwd-src`
+resolves to its first occurrence rather than being rejected, and `h` cardinality
+and shape are not re-checked. The Tauri desktop backend is a send-side builder
+rather than a display parser: it emits the canonical two-element outer `h` and
+rejects duplicate `fwd`/`k`/`fwd-src` tags at build time, while still deferring
+embedded-event validation and provenance to the relay. Ingest-time validation in
+the relay is the single normative gate, so a client MUST NOT treat its own parse
+or build acceptance as evidence that a forward is well-formed or that its
+provenance was verified.
+
+## Relationship to Other NIPs
+
+- [NIP-18](18.md): `kind:40009` follows the generic-repost convention of
+  carrying the stringified original plus a `k` tag, but is not a repost.
+  NIP-18 reposts are author-attributed amplifications on a global timeline;
+  a forward is a new message *authored by the forwarder*, scoped to one
+  destination, with its own note, reactions, and thread.
+- [NIP-29](29.md): the reason a reference-only design fails. A `q`-tag-only
+  quote (or an `e` tag) is resolvable only by a reader who can read the
+  referenced event, and Buzz reads are scoped per `h`: members of the
+  destination generally cannot read the source channel, so a bare reference
+  renders as a dead link for exactly the audience the forward is for. Embedding
+  the signed original is what makes the content readable in the destination
+  while keeping it verifiable.
+- [NIP-10](10.md): marked `e` tags are rejected on `kind:40009` (see
+  Threading). A forward is a root; NIP-10 threading applies to its replies.
+- [NIP-92](92.md): `imeta` tags are copied verbatim so attachments survive the
+  forward.
+- [NIP-09](09.md): deleting a forward deletes the forward only, never the
+  original; deleting the original does not affect existing forwards.
+
+## Out of Scope (v1)
+
+- **Threads as destinations.** `h` names a channel; forwarding into a specific
+  thread would need a destination thread reference and conflicts with the
+  "forward is always a root" rule.
+- **Multiple destinations per forward.** One `h` per event; a client wanting
+  three destinations publishes three events.
+- **Scheduled forwards.** `kind:40006` scheduled messages are a separate
+  mechanism and are not composed with forwarding here.
+- **External [NIP-17](17.md) gift-wrapped sources or destinations.** A
+  gift-wrapped rumor is unsigned by construction, so it cannot satisfy rule 1 —
+  there is nothing to verify, and an unverifiable embedded copy is exactly the
+  hand-retyped paste this NIP replaces.
+- **Forward to a new channel.** The "forward, creating a channel for it"
+  variant discussed in
+  [#3264](https://github.com/block/buzz/issues/3264) is a channel-creation
+  flow layered on top of this event, not a change to it.

--- a/mobile/lib/features/activity/activity_provider.dart
+++ b/mobile/lib/features/activity/activity_provider.dart
@@ -66,7 +66,14 @@ class ActivityNotifier extends AsyncNotifier<HomeFeedResponse> {
       // Mentions of me on user-visible channel content.
       session.fetchHistory(
         NostrFilter(
-          kinds: const [9, 40002, 1, 45001, 45003],
+          kinds: const [
+            9,
+            40002,
+            EventKind.streamMessageForward,
+            1,
+            45001,
+            45003,
+          ],
           tags: {
             '#p': [myPk],
           },
@@ -93,12 +100,18 @@ class ActivityNotifier extends AsyncNotifier<HomeFeedResponse> {
           limit: 20,
         ),
       ),
-      // Recent DM traffic (filtered to other senders below).
+      // Recent DM traffic (filtered to other senders below). Forwards are
+      // included because a no-note forward into a DM carries no p tag for the
+      // recipient, so the mentions query above never sees it.
       if (dmChannelIds.isEmpty)
         Future.value(const <NostrEvent>[])
       else
         session.fetchHistory(
-          NostrFilter(kinds: const [9], tags: {'#h': dmChannelIds}, limit: 30),
+          NostrFilter(
+            kinds: const [9, EventKind.streamMessageForward],
+            tags: {'#h': dmChannelIds},
+            limit: 30,
+          ),
         ),
     ]);
 

--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -33,6 +33,7 @@ import 'date_formatters.dart';
 import 'day_divider.dart';
 import 'dm_channel_labels.dart';
 import 'ephemeral_channel_display.dart';
+import 'forwarded_message_quote.dart';
 import 'manage_channel_sheet.dart';
 import 'members_sheet.dart';
 import 'message_actions.dart';

--- a/mobile/lib/features/channels/channel_detail_page/message_bubble.dart
+++ b/mobile/lib/features/channels/channel_detail_page/message_bubble.dart
@@ -136,58 +136,63 @@ class _MessageBubble extends ConsumerWidget {
                             ],
                           ),
                         ),
-                      MessageContent(
-                        content: message.content,
-                        mentionNames: mentionNames,
-                        agentMentionPubkeys: agentMentionPubkeys,
-                        channelNames: channelNames,
-                        tags: message.tags,
-                        baseStyle: messageBodyTextStyle.copyWith(
-                          color: context.colors.onSurface,
-                        ),
-                        mediaCarouselTrailingOverflow: Grid.gutter,
-                        onMediaReply: allMessages == null
-                            ? null
-                            : () {
-                                if (!context.mounted) return;
-                                Navigator.of(context).push(
-                                  MaterialPageRoute<void>(
-                                    builder: (_) => ThreadDetailPage(
-                                      threadHead: message,
-                                      allMessages: allMessages!,
-                                      channelId: currentChannelId,
-                                      currentPubkey: currentPubkey,
-                                      isMember: isMember,
-                                      isArchived: isArchived,
+                      // Forwards with an empty note render only the quote card.
+                      if (message.forward == null ||
+                          message.content.trim().isNotEmpty)
+                        MessageContent(
+                          content: message.content,
+                          mentionNames: mentionNames,
+                          agentMentionPubkeys: agentMentionPubkeys,
+                          channelNames: channelNames,
+                          tags: message.tags,
+                          baseStyle: messageBodyTextStyle.copyWith(
+                            color: context.colors.onSurface,
+                          ),
+                          mediaCarouselTrailingOverflow: Grid.gutter,
+                          onMediaReply: allMessages == null
+                              ? null
+                              : () {
+                                  if (!context.mounted) return;
+                                  Navigator.of(context).push(
+                                    MaterialPageRoute<void>(
+                                      builder: (_) => ThreadDetailPage(
+                                        threadHead: message,
+                                        allMessages: allMessages!,
+                                        channelId: currentChannelId,
+                                        currentPubkey: currentPubkey,
+                                        isMember: isMember,
+                                        isArchived: isArchived,
+                                      ),
                                     ),
-                                  ),
-                                );
-                              },
-                        onMediaMore: (viewerContext, imageUrl) =>
-                            showImageActions(
-                              context: viewerContext,
+                                  );
+                                },
+                          onMediaMore: (viewerContext, imageUrl) =>
+                              showImageActions(
+                                context: viewerContext,
+                                ref: ref,
+                                message: message,
+                                channelId: currentChannelId,
+                                imageUrl: imageUrl,
+                                canManageMessage: canManageMessage,
+                                onDeleted: () {
+                                  if (viewerContext.mounted) {
+                                    Navigator.of(viewerContext).maybePop();
+                                  }
+                                },
+                              ),
+                          onChannelTap: (channelId) {
+                            openChannelLink(
+                              context: context,
                               ref: ref,
-                              message: message,
-                              channelId: currentChannelId,
-                              imageUrl: imageUrl,
-                              canManageMessage: canManageMessage,
-                              onDeleted: () {
-                                if (viewerContext.mounted) {
-                                  Navigator.of(viewerContext).maybePop();
-                                }
-                              },
-                            ),
-                        onChannelTap: (channelId) {
-                          openChannelLink(
-                            context: context,
-                            ref: ref,
-                            channelId: channelId,
-                            currentChannelId: currentChannelId,
-                          );
-                        },
-                        onMentionTap: (pubkey) =>
-                            showUserProfileSheet(context, pubkey),
-                      ),
+                              channelId: channelId,
+                              currentChannelId: currentChannelId,
+                            );
+                          },
+                          onMentionTap: (pubkey) =>
+                              showUserProfileSheet(context, pubkey),
+                        ),
+                      if (message.forward != null)
+                        ForwardedMessageQuote(forward: message.forward!),
                       if (message.reactions.isNotEmpty)
                         ReactionRow(
                           reactions: message.reactions,

--- a/mobile/lib/features/channels/forwarded_message_quote.dart
+++ b/mobile/lib/features/channels/forwarded_message_quote.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../shared/theme/theme.dart';
+import '../profile/user_cache_provider.dart';
+import 'channel.dart';
+import 'channels_provider.dart';
+import 'date_formatters.dart';
+import 'message_content.dart';
+import 'timeline_message.dart';
+
+/// Quoted rendering of a forwarded message (kind 40009): an attribution row
+/// ("Forwarded from #channel" / "a private channel" / "a direct message")
+/// followed by a bordered card with the original author, timestamp, and body.
+class ForwardedMessageQuote extends ConsumerWidget {
+  final ForwardInfo forward;
+
+  const ForwardedMessageQuote({super.key, required this.forward});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final original = forward.original;
+    final authorPk = original.pubkey.toLowerCase();
+    final authorProfile =
+        ref.watch(userCacheProvider.select((cache) => cache[authorPk])) ??
+        ref.read(userCacheProvider.notifier).get(authorPk);
+    final authorName =
+        authorProfile?.label ??
+        (original.pubkey.length >= 8
+            ? '${original.pubkey.substring(0, 8)}...'
+            : original.pubkey);
+
+    final metaStyle = context.textTheme.labelSmall?.copyWith(
+      color: context.colors.onSurfaceVariant,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: Grid.quarter),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                LucideIcons.forward,
+                size: 14,
+                color: context.colors.onSurfaceVariant,
+              ),
+              const SizedBox(width: Grid.quarter),
+              Flexible(
+                child: Text(
+                  _attributionLabel(ref),
+                  style: metaStyle,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+        Container(
+          margin: const EdgeInsets.only(top: Grid.quarter),
+          padding: const EdgeInsets.symmetric(
+            horizontal: Grid.xxs,
+            vertical: Grid.half,
+          ),
+          decoration: BoxDecoration(
+            color: context.colors.surfaceContainerHighest.withValues(
+              alpha: 0.4,
+            ),
+            borderRadius: BorderRadius.circular(Radii.md),
+            border: Border.all(color: context.colors.outlineVariant),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Flexible(
+                    child: Text(
+                      authorName,
+                      style: context.textTheme.labelMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: context.colors.onSurface,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  const SizedBox(width: Grid.xxs),
+                  Text(formatMessageTime(original.createdAt), style: metaStyle),
+                ],
+              ),
+              const SizedBox(height: Grid.quarter),
+              MessageContent(content: original.content, tags: original.tags),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _attributionLabel(WidgetRef ref) {
+    switch (forward.sourceType) {
+      case ForwardSourceType.channel:
+        final channels =
+            ref.watch(channelsProvider).asData?.value ?? const <Channel>[];
+        Channel? source;
+        for (final channel in channels) {
+          if (channel.id == forward.sourceChannelId) {
+            source = channel;
+            break;
+          }
+        }
+        return source != null && source.name.isNotEmpty
+            ? 'Forwarded from #${source.name}'
+            : 'Forwarded from a channel';
+      case ForwardSourceType.private:
+        return 'Forwarded from a private channel';
+      case ForwardSourceType.dm:
+        return 'Forwarded from a direct message';
+    }
+  }
+}

--- a/mobile/lib/features/channels/timeline_message.dart
+++ b/mobile/lib/features/channels/timeline_message.dart
@@ -113,6 +113,77 @@ class SystemEvent {
   }
 }
 
+/// Source-channel type label carried on a forward's `fwd-src` tag.
+enum ForwardSourceType {
+  /// Open-visibility channel — attribution may name and link the source.
+  channel,
+
+  /// Private (non-open) group channel — attribution stays anonymous.
+  private,
+
+  /// Direct message — attribution stays anonymous.
+  dm,
+}
+
+/// Parsed forward metadata from a kind-40009 event's tags.
+@immutable
+class ForwardInfo {
+  /// The complete original signed event, embedded in the `fwd` tag.
+  final NostrEvent original;
+
+  /// Source channel UUID from the `fwd-src` tag.
+  final String sourceChannelId;
+
+  /// Source channel type label from the `fwd-src` tag.
+  final ForwardSourceType sourceType;
+
+  const ForwardInfo({
+    required this.original,
+    required this.sourceChannelId,
+    required this.sourceType,
+  });
+
+  /// Parse forward metadata from a kind-40009 event's tags.
+  ///
+  /// Returns null when the `fwd` or `fwd-src` tags are missing or malformed,
+  /// so callers can fall back to rendering the event like a normal message.
+  static ForwardInfo? fromTags(List<List<String>> tags) {
+    String? fwdJson;
+    String? sourceChannelId;
+    String? sourceTypeLabel;
+    for (final tag in tags) {
+      if (tag.length >= 2 && tag[0] == 'fwd') fwdJson ??= tag[1];
+      if (tag.length >= 3 && tag[0] == 'fwd-src') {
+        sourceChannelId ??= tag[1];
+        sourceTypeLabel ??= tag[2];
+      }
+    }
+    if (fwdJson == null || sourceChannelId == null || sourceChannelId.isEmpty) {
+      return null;
+    }
+
+    final sourceType = switch (sourceTypeLabel) {
+      'channel' => ForwardSourceType.channel,
+      'private' => ForwardSourceType.private,
+      'dm' => ForwardSourceType.dm,
+      _ => null,
+    };
+    if (sourceType == null) return null;
+
+    try {
+      final decoded = jsonDecode(fwdJson);
+      if (decoded is! Map<String, dynamic>) return null;
+      return ForwardInfo(
+        original: NostrEvent.fromJson(decoded),
+        sourceChannelId: sourceChannelId,
+        sourceType: sourceType,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
 @immutable
 class TimelineReaction {
   final String emoji;
@@ -157,6 +228,11 @@ class TimelineMessage {
   /// Root event ID of the thread (null for top-level messages).
   final String? rootId;
 
+  /// Forward metadata for kind-40009 messages. Null for normal messages and
+  /// for forwards whose `fwd`/`fwd-src` tags failed to parse (which then
+  /// render like a normal message showing only the forwarder's note).
+  final ForwardInfo? forward;
+
   const TimelineMessage({
     required this.id,
     required this.pubkey,
@@ -170,6 +246,7 @@ class TimelineMessage {
     this.reactions = const [],
     this.parentId,
     this.rootId,
+    this.forward,
   });
 
   /// Attachment messages stay visually distinct from surrounding messages,
@@ -448,7 +525,8 @@ List<TimelineMessage> formatTimeline(
 
     if (event.kind == EventKind.streamMessage ||
         event.kind == EventKind.streamMessageV2 ||
-        event.kind == EventKind.streamMessageDiff) {
+        event.kind == EventKind.streamMessageDiff ||
+        event.kind == EventKind.streamMessageForward) {
       final edit = edits[event.id];
       final effectiveTags = edit?.tags ?? event.tags;
       // Include both notify (`p`) and reference-only (`mention`) tags —
@@ -473,6 +551,9 @@ List<TimelineMessage> formatTimeline(
           reactions: reactionsFor(event.id),
           parentId: threadRef.parentId,
           rootId: threadRef.rootId,
+          forward: event.kind == EventKind.streamMessageForward
+              ? ForwardInfo.fromTags(event.tags)
+              : null,
         ),
       );
     }

--- a/mobile/lib/features/search/search_provider.dart
+++ b/mobile/lib/features/search/search_provider.dart
@@ -136,7 +136,7 @@ class SearchNotifier extends Notifier<SearchState> {
       final session = ref.read(relaySessionProvider.notifier);
       final events = await session.fetchHistory(
         NostrFilter(
-          kinds: const [9, 40002, 45001, 45003],
+          kinds: const [9, 40002, EventKind.streamMessageForward, 45001, 45003],
           search: query,
           limit: 20,
         ),

--- a/mobile/lib/shared/relay/nostr_filters.dart
+++ b/mobile/lib/shared/relay/nostr_filters.dart
@@ -122,7 +122,7 @@ abstract final class NostrFilters {
     String? channelId,
     int limit = 20,
   }) => NostrFilter(
-    kinds: [9, 40002, 45001, 45003],
+    kinds: [9, 40002, EventKind.streamMessageForward, 45001, 45003],
     tags: channelId != null
         ? {
             '#h': [channelId],

--- a/mobile/lib/shared/relay/nostr_models.dart
+++ b/mobile/lib/shared/relay/nostr_models.dart
@@ -26,6 +26,7 @@ abstract final class EventKind {
   static const channelWindowBounds = 39006;
   static const streamMessageEdit = 40003;
   static const streamMessageDiff = 40008;
+  static const streamMessageForward = 40009;
   static const systemMessage = 40099;
   static const jobRequest = 43001;
   static const jobAccepted = 43002;
@@ -44,6 +45,7 @@ abstract final class EventKind {
   static const channelMessageEventKinds = [
     streamMessage, // 9
     streamMessageV2, // 40002
+    streamMessageForward, // 40009
     forumPost, // 45001
     forumComment, // 45003
   ];
@@ -78,6 +80,7 @@ abstract final class EventKind {
     streamMessage,
     streamMessageV2,
     streamMessageDiff,
+    streamMessageForward,
     systemMessage,
     jobRequest,
     jobAccepted,

--- a/mobile/test/features/activity/activity_provider_test.dart
+++ b/mobile/test/features/activity/activity_provider_test.dart
@@ -8,9 +8,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// Records every DM history query (`#h` filter) so tests can assert whether
-/// the DM source was fetched. All queries resolve to empty lists.
+/// the DM source was fetched, and with which kinds. All queries resolve to
+/// empty lists.
 class _RecordingSessionNotifier extends RelaySessionNotifier {
   final List<List<String>> dmQueries = [];
+  final List<List<int>> dmKinds = [];
 
   @override
   SessionState build() => const SessionState(status: SessionStatus.connected);
@@ -21,7 +23,10 @@ class _RecordingSessionNotifier extends RelaySessionNotifier {
     Duration timeout = const Duration(seconds: 8),
   }) async {
     final h = filter.tags['#h'];
-    if (h != null) dmQueries.add(h);
+    if (h != null) {
+      dmQueries.add(h);
+      dmKinds.add(filter.kinds);
+    }
     return const [];
   }
 }
@@ -83,6 +88,29 @@ void main() {
 
     expect(session.dmQueries, hasLength(1));
     expect(session.dmQueries.single, ['dm1']);
+  });
+
+  test('DM query asks for forwards too, since a no-note forward into a DM '
+      'carries no p tag for the recipient', () async {
+    final session = _RecordingSessionNotifier();
+    final channels = _LateChannelsNotifier();
+    final container = ProviderContainer(
+      overrides: [
+        relayConfigProvider.overrideWith(_FixedRelayConfigNotifier.new),
+        myPubkeyProvider.overrideWithValue('me_pk'),
+        relaySessionProvider.overrideWith(() => session),
+        channelsProvider.overrideWith(() => channels),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(activityProvider.future);
+    channels.resolve([_dmChannel('dm1')]);
+    await container.read(channelsProvider.future);
+    await container.read(activityProvider.future);
+
+    expect(session.dmKinds.single, contains(EventKind.streamMessage));
+    expect(session.dmKinds.single, contains(EventKind.streamMessageForward));
   });
 
   test('does not query DMs when the resolved channel list has none', () async {

--- a/mobile/test/features/channels/forwarded_message_quote_test.dart
+++ b/mobile/test/features/channels/forwarded_message_quote_test.dart
@@ -1,0 +1,214 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:buzz/features/channels/channel.dart';
+import 'package:buzz/features/channels/channels_provider.dart';
+import 'package:buzz/features/channels/forwarded_message_quote.dart';
+import 'package:buzz/features/channels/timeline_message.dart';
+import 'package:buzz/features/profile/user_cache_provider.dart';
+import 'package:buzz/features/profile/user_profile.dart';
+import 'package:buzz/shared/relay/relay.dart';
+
+import '../../helpers/widget_helpers.dart';
+
+final _authorPubkey = 'a' * 64;
+final _forwarderPubkey = 'b' * 64;
+
+Map<String, dynamic> _originalJson() => {
+  'id': 'c' * 64,
+  'pubkey': _authorPubkey,
+  'created_at': 1700000000,
+  'kind': 40002,
+  'tags': [
+    ['h', 'src-channel'],
+  ],
+  'content': 'the original body',
+  'sig': 'd' * 128,
+};
+
+List<List<String>> _forwardTags({String type = 'channel', String? fwdJson}) => [
+  ['h', 'dest-channel'],
+  ['fwd', fwdJson ?? jsonEncode(_originalJson())],
+  ['k', '40002'],
+  ['fwd-src', 'src-channel', type],
+];
+
+NostrEvent _forwardEvent({String note = '', List<List<String>>? tags}) =>
+    NostrEvent(
+      id: 'e' * 64,
+      pubkey: _forwarderPubkey,
+      createdAt: 1700000100,
+      kind: EventKind.streamMessageForward,
+      tags: tags ?? _forwardTags(),
+      content: note,
+      sig: 'f' * 128,
+    );
+
+Channel _sourceChannel({String visibility = 'open'}) => Channel(
+  id: 'src-channel',
+  name: 'general',
+  channelType: 'stream',
+  visibility: visibility,
+  description: '',
+  createdBy: _authorPubkey,
+  createdAt: DateTime.utc(2024),
+  memberCount: 2,
+);
+
+class _FakeChannelsNotifier extends ChannelsNotifier {
+  final List<Channel> _channels;
+  _FakeChannelsNotifier(this._channels);
+
+  @override
+  Future<List<Channel>> build() async => _channels;
+}
+
+class _FakeUserCacheNotifier extends UserCacheNotifier {
+  final Map<String, UserProfile> _users;
+  _FakeUserCacheNotifier(this._users);
+
+  @override
+  Map<String, UserProfile> build() => _users;
+}
+
+Future<void> _pumpQuote(
+  WidgetTester tester,
+  ForwardInfo forward, {
+  List<Channel> channels = const [],
+}) async {
+  await tester.pumpWidget(
+    WidgetHelpers.testable(
+      overrides: [
+        channelsProvider.overrideWith(() => _FakeChannelsNotifier(channels)),
+        userCacheProvider.overrideWith(
+          () => _FakeUserCacheNotifier({
+            _authorPubkey: UserProfile(
+              pubkey: _authorPubkey,
+              displayName: 'Alice',
+            ),
+          }),
+        ),
+      ],
+      child: ForwardedMessageQuote(forward: forward),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('ForwardInfo.fromTags', () {
+    test('parses a valid forward', () {
+      final info = ForwardInfo.fromTags(_forwardTags());
+      expect(info, isNotNull);
+      expect(info!.original.pubkey, _authorPubkey);
+      expect(info.original.content, 'the original body');
+      expect(info.original.kind, 40002);
+      expect(info.sourceChannelId, 'src-channel');
+      expect(info.sourceType, ForwardSourceType.channel);
+    });
+
+    test('parses private and dm source types', () {
+      expect(
+        ForwardInfo.fromTags(_forwardTags(type: 'private'))!.sourceType,
+        ForwardSourceType.private,
+      );
+      expect(
+        ForwardInfo.fromTags(_forwardTags(type: 'dm'))!.sourceType,
+        ForwardSourceType.dm,
+      );
+    });
+
+    test('returns null for malformed inputs', () {
+      // Unparseable JSON.
+      expect(ForwardInfo.fromTags(_forwardTags(fwdJson: 'not json')), isNull);
+      // Wrong JSON shape.
+      expect(ForwardInfo.fromTags(_forwardTags(fwdJson: '[1,2]')), isNull);
+      // Missing fields in the embedded event.
+      expect(ForwardInfo.fromTags(_forwardTags(fwdJson: '{"id":1}')), isNull);
+      // Unknown source type label.
+      expect(ForwardInfo.fromTags(_forwardTags(type: 'bogus')), isNull);
+      // Missing fwd tag entirely.
+      expect(
+        ForwardInfo.fromTags([
+          ['h', 'dest-channel'],
+          ['fwd-src', 'src-channel', 'channel'],
+        ]),
+        isNull,
+      );
+    });
+  });
+
+  group('formatTimeline forwards', () {
+    test('forward with note keeps the note and attaches forward info', () {
+      final messages = formatTimeline([_forwardEvent(note: 'check this out')]);
+      expect(messages, hasLength(1));
+      expect(messages.first.content, 'check this out');
+      expect(messages.first.pubkey, _forwarderPubkey);
+      expect(messages.first.forward, isNotNull);
+      expect(messages.first.forward!.original.content, 'the original body');
+    });
+
+    test('forward without note has empty content and forward info', () {
+      final messages = formatTimeline([_forwardEvent()]);
+      expect(messages, hasLength(1));
+      expect(messages.first.content, isEmpty);
+      expect(messages.first.forward, isNotNull);
+    });
+
+    test('malformed fwd tag falls back to a normal message', () {
+      final messages = formatTimeline([
+        _forwardEvent(
+          note: 'just the note',
+          tags: _forwardTags(fwdJson: '{broken'),
+        ),
+      ]);
+      expect(messages, hasLength(1));
+      expect(messages.first.content, 'just the note');
+      expect(messages.first.forward, isNull);
+    });
+  });
+
+  group('ForwardedMessageQuote', () {
+    testWidgets('open source shows channel name, author, and body', (
+      tester,
+    ) async {
+      final forward = ForwardInfo.fromTags(_forwardTags())!;
+      await _pumpQuote(tester, forward, channels: [_sourceChannel()]);
+
+      expect(find.text('Forwarded from #general'), findsOneWidget);
+      expect(find.text('Alice'), findsOneWidget);
+      expect(
+        find.textContaining('the original body', findRichText: true),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('unknown open source falls back to a generic label', (
+      tester,
+    ) async {
+      final forward = ForwardInfo.fromTags(_forwardTags())!;
+      await _pumpQuote(tester, forward);
+
+      expect(find.text('Forwarded from a channel'), findsOneWidget);
+    });
+
+    testWidgets('private source shows anonymous channel label', (tester) async {
+      final forward = ForwardInfo.fromTags(_forwardTags(type: 'private'))!;
+      await _pumpQuote(
+        tester,
+        forward,
+        channels: [_sourceChannel(visibility: 'private')],
+      );
+
+      expect(find.text('Forwarded from a private channel'), findsOneWidget);
+      expect(find.textContaining('#general'), findsNothing);
+    });
+
+    testWidgets('dm source shows direct-message label', (tester) async {
+      final forward = ForwardInfo.fromTags(_forwardTags(type: 'dm'))!;
+      await _pumpQuote(tester, forward);
+
+      expect(find.text('Forwarded from a direct message'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #3264

## Summary

Adds Slack-parity message forwarding: any channel or DM message can be forwarded to any other channel or DM, with an optional note, rendered as a quoted card with attribution and a link back to the source (when visible to the viewer).

## Protocol design (new kind `40009`, documented in `docs/nips/NIP-FW.md`)

- **New event kind `40009` (`KIND_STREAM_MESSAGE_FORWARD`)** — follows the repo convention that new features get new kind integers; old relays/clients fail closed.
- **NIP-18-style embedded original**: the full signed original event is carried in a `["fwd", <event JSON>]` tag, making every forward self-verifying (NIP-01 id recompute + Schnorr signature check on the relay). Works across per-channel read scoping and DMs, where a reference alone would be unreadable to recipients.
- **`content` is the forwarder's note only** — search/FTS and attribution stay honest; the original author's words are never re-attributed to the forwarder.
- **Tags**: `["h", dest]` (NIP-29 scoping), `["k", <orig kind>]`, `["fwd-src", <channel uuid>, "channel"|"private"|"dm"]`, and a NIP-18 `["q", ...]` quote tag **only when the source channel is open** (private/DM sources are not leaked). `imeta` tags are copied verbatim so media renders. No `p` tag is added for the original author (forwarding is not a mention).
- **Anti-laundering gate**: the relay verifies the *forwarder* has read access to the source channel (member, or open visibility) and that the claimed `fwd-src` label matches the actual channel row. You cannot exfiltrate a private channel's messages into a public one by fabricating tags — the embedded event must genuinely verify and the source must genuinely be readable by you.
- **Forwardable kinds allowlist** (`9`, `40002`, `45001`, `45003`); forwards-of-forwards are flattened to the innermost original (depth 1), and embedded `40009` is rejected.
- **Snapshot semantics** (Slack parity): the forward captures the original at forward time; later edits/deletes of the original do not propagate. Forwards are always root messages in the destination.

## Surfaces

| Surface | Change |
|---|---|
| `buzz-core` | `forward.rs`: envelope parse/verify, tag builder, error taxonomy (single source of truth) |
| `buzz-relay` | ingest validation: embedded-event verification under `spawn_blocking`, source-channel lookup, read-access + label checks; scope/h-tag registration |
| `buzz-db` | forwards with mentions reach the mentions feed |
| `buzz-sdk` | `build_forward(...)` typed builder |
| `buzz-cli` | `buzz messages forward --event <hex> --to-channel <uuid> [--note ...]` (sig-preserving fetch, flatten-on-reforward, fail-closed source typing) |
| Desktop | Forward action in the message action bar → destination picker dialog with note + preview → `ForwardedMessageCard` rendering (quote card, source attribution, jump-to-original when visible) |
| Mobile | `ForwardInfo` defensive tag parser + `ForwardedMessageQuote` card wired into the message bubble |
| Docs | `docs/nips/NIP-FW.md` protocol spec |

## Adversarial review

The full diff went through two adversarial review rounds plus two focused verification passes (high-effort external model). Every confirmed fixable finding was fixed in this PR:

- **Provenance (critical)**: the relay now requires the embedded original to exist in the destination community's event store, stored in the channel named by `fwd-src` — signature verification alone cannot prove a message was ever actually posted where the forward claims. Forwarding a deleted original is likewise rejected.
- Outer `imeta` must equal the embedded original's `imeta` verbatim; exactly one `h` tag on the outer event and on the embedded original; the `q` tag is pinned to its exact 4-element shape with hex validation.
- The forwarder's **source**-channel read access is checked against the database directly (bypassing the positive membership cache), so revoked members can't keep forwarding during the cache TTL.
- Kind `40009` added to every mention/notification/search surface that enumerates message kinds: desktop Home + search, pop-out channel window timeline, mobile Activity + search, ACP agent mention defaults, CLI default read/search kinds.
- Desktop: @mentions in a forward note now resolve against the destination channel and publish `p` tags; the dialog preview is fully WYSIWYG (renders the live note); forwarded-card author + embedded mention profiles ride the existing batched profile query instead of per-row requests.
- CLI: transport errors during forward-source diagnostics keep exit code 2 instead of collapsing into "not found".
- Round-2 residuals, also fixed: canonical two-element `h` tag shape enforced on outer + embedded (the `nostr` crate preserves trailing tag elements, so `["h", uuid, "extra"]` genuinely parsed before); mobile's direct-DM Activity query includes 40009; forward-note mentions resolve at submit time and the button waits for member data when the note looks mention-bearing (no more silent `p`-tag drops); the dialog preview renders embedded-original mentions and `#channel` refs identically to the timeline.
- Final-pass residuals, also fixed: the note-mention preflight is character-agnostic (`@李`, `@Élodie`, emoji-led agent names — JS `\w` is ASCII-only, so those previously bypassed the gate); the member-data wait is bounded (4s) and never silently degrades — when no member data exists (deadline expired, or the query failed before first data) the submit button explicitly reads "Forward without mentions" with a visible warning, reverting to a normal Forward the moment data arrives, so a hung request can't strand the button, a slow one can't silently drop notifications, and a failed background refetch (which keeps cached members that still resolve) doesn't show a false warning; the preview resolves mention chips and the flattened-forward author line through the same merged profile overlay as the timeline (managed/relay agents without a kind-0 profile render by name); NIP-FW now normatively specifies the two-element `["h", <uuid>]` shape and accurately describes each client's parser role (TypeScript/Dart permissive display parsers vs. the Tauri send-side builder).

Deferred as documented follow-ups (rationale in NIP-FW Security Considerations): transactional revalidate-on-insert for the residual authorization race window, client-side signature verification of embedded originals (clients currently share the platform-wide trust in relay ingest verification — this applies equally to every message kind), an E2E-bridge `forward_message` mock for submit-flow tests, and unifying the four per-platform envelope parsers (the relay's `buzz-core` validation is the single normative gate; client parsers are display-oriented, now stated explicitly in NIP-FW).

## Testing

- `just ci` green (Rust fmt/clippy/unit, desktop lint + 3802 JS tests, mobile analyze + 886 tests, builds).
- 9 new integration tests in `crates/buzz-test-client/tests/e2e_relay.rs` run against a live relay: open→channel, →DM, private source by member vs. non-member (rejected), tampered embedded event (rejected), mismatched `k` (rejected), forward-of-a-forward (flattened), spoofed `fwd-src` type (rejected), never-published original (rejected).
- Live CLI smoke test verified the exact stored event shape end-to-end.
- Desktop unit tests for the forward builder/parser (`forwardMessage.test.mjs`, card render tests); mobile widget tests for the quote card (channel/private/DM label variants, malformed-tag fallback).

Screenshots follow in a comment (per repo screenshot policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
