### PR TITLE
mobile: don't downgrade wss:// relay URLs to plaintext ws://

### DIFF
--- a/mobile/lib/shared/relay/relay_provider.dart
+++ b/mobile/lib/shared/relay/relay_provider.dart
@@ -17,10 +17,18 @@ class RelayConfig {
 
   const RelayConfig({required this.baseUrl, this.nsec});
 
-  /// Derive the websocket URL from the HTTP base URL.
+  /// Derive the websocket URL from the base URL.
+  ///
+  /// A base that is already `ws`/`wss` (e.g. an invite-joined community's
+  /// `wss://` relay) passes through unchanged — mapping it to `ws` would be a
+  /// silent TLS downgrade that also fails against TLS-only relays.
   String get wsUrl {
     final uri = Uri.parse(baseUrl);
-    final scheme = uri.scheme == 'https' ? 'wss' : 'ws';
+    final scheme = switch (uri.scheme) {
+      'https' || 'wss' => 'wss',
+      'http' || 'ws' => 'ws',
+      _ => uri.scheme,
+    };
     return uri.replace(scheme: scheme).toString();
   }
 }

--- a/mobile/test/shared/relay/relay_provider_test.dart
+++ b/mobile/test/shared/relay/relay_provider_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buzz/shared/relay/relay_provider.dart';
+
+void main() {
+  group('RelayConfig.wsUrl', () {
+    test('maps http-family schemes to their websocket equivalent', () {
+      expect(
+        const RelayConfig(baseUrl: 'https://relay.example').wsUrl,
+        'wss://relay.example',
+      );
+      expect(
+        const RelayConfig(baseUrl: 'http://localhost:3000').wsUrl,
+        'ws://localhost:3000',
+      );
+    });
+
+    test('passes ws-family schemes through without downgrading', () {
+      // An invite-joined community stores relayUrl as wss://…; downgrading it to
+      // plaintext ws:// is a TLS downgrade and fails against TLS-only relays.
+      expect(
+        const RelayConfig(baseUrl: 'wss://relay.example').wsUrl,
+        'wss://relay.example',
+      );
+      expect(
+        const RelayConfig(baseUrl: 'ws://localhost:3000').wsUrl,
+        'ws://localhost:3000',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`RelayConfig.wsUrl` derived the WebSocket scheme with
`uri.scheme == 'https' ? 'wss' : 'ws'`, which mapped **every** non-`https`
scheme — including `wss` — to plaintext `ws`. A base URL that was already
`wss://` got silently downgraded to `ws://`.

Invite-joined communities store their relay as `wss://…`, so for invited
members the relay connection lost transport encryption and, against relays
that only accept TLS, failed to connect at all — the community was unusable
for them.

## Change

Derive the scheme explicitly:

- `https` / `wss` → `wss`
- `http` / `ws` → `ws`
- any other scheme passes through unchanged (fail loudly rather than silently
  pick plaintext)

`http`→`ws` and `https`→`wss` behavior is unchanged; the only fix is that an
already-secure `wss://` base is no longer downgraded.

## Tests

New unit test for `RelayConfig.wsUrl`: http-family schemes map to their
WebSocket equivalent, and ws-family schemes (`ws`/`wss`) pass through without
downgrading. The `wss://` case fails on the old ternary and passes on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
