### PR TITLE
fix(chart): route /pair to the pairing relay in default HTTPRoute and Ingress rules

### DIFF
--- a/deploy/charts/buzz/templates/httproute.yaml
+++ b/deploy/charts/buzz/templates/httproute.yaml
@@ -17,6 +17,22 @@ spec:
     {{- if .Values.httproute.rules }}
     {{- toYaml .Values.httproute.rules | nindent 4 }}
     {{- else }}
+    {{- if .Values.pairingRelay.enabled }}
+    {{- /* NIP-AB device pairing: clients resolve the pairing relay from the
+         NIP-11 `pairing_relay_url`, falling back to the legacy `/pair` path
+         on the main relay URL. Both conventions land on this host, so the
+         default route must peel `/pair` off to the pairing sidecar — the
+         main relay serves no `/pair` route and would 404 mobile pairing.
+         Gateway API prefers the most specific path match, so rule order is
+         cosmetic. */}}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /pair
+      backendRefs:
+        - name: {{ include "buzz.fullname" . }}-pairing
+          port: {{ .Values.pairingRelay.service.port }}
+    {{- end }}
     - matches:
         - path:
             type: PathPrefix

--- a/deploy/charts/buzz/templates/ingress.yaml
+++ b/deploy/charts/buzz/templates/ingress.yaml
@@ -39,5 +39,18 @@ spec:
                 port:
                   number: {{ $svcPort }}
           {{- end }}
+          {{- if $.Values.pairingRelay.enabled }}
+          {{- /* Same reason as the HTTPRoute default rules: the legacy client
+               fallback is `/pair` on the relay host, and the main relay 404s
+               it. Longest-path matching sends `/pair` here, everything else
+               to the relay. */}}
+          - path: /pair
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}-pairing
+                port:
+                  number: {{ $.Values.pairingRelay.service.port }}
+          {{- end }}
     {{- end }}
 {{- end }}

--- a/deploy/charts/buzz/tests/networking_test.yaml
+++ b/deploy/charts/buzz/tests/networking_test.yaml
@@ -77,3 +77,78 @@ tests:
           path: kind
           value: HTTPRoute
         template: templates/httproute.yaml
+      - notContains:
+          path: spec.rules
+          content:
+            matches:
+              - path:
+                  type: PathPrefix
+                  value: /pair
+            backendRefs:
+              - name: RELEASE-NAME-buzz-pairing
+                port: 5000
+        template: templates/httproute.yaml
+
+  - it: HTTPRoute default rules route /pair to the pairing relay when enabled
+    set:
+      relayUrl: wss://buzz.example.com
+      ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
+      externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
+      s3.endpoint: http://minio:9000
+      s3.accessKey: a
+      s3.secretKey: s
+      httproute.enabled: true
+      httproute.parentRefs:
+        - name: my-gateway
+          namespace: gateway-system
+      pairingRelay.enabled: true
+      pairingRelay.url: wss://pairing.example.com
+    asserts:
+      - contains:
+          path: spec.rules
+          content:
+            matches:
+              - path:
+                  type: PathPrefix
+                  value: /pair
+            backendRefs:
+              - name: RELEASE-NAME-buzz-pairing
+                port: 5000
+        template: templates/httproute.yaml
+      - contains:
+          path: spec.rules
+          content:
+            matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - name: RELEASE-NAME-buzz
+                port: 3000
+        template: templates/httproute.yaml
+
+  - it: Ingress default host routes /pair to the pairing relay when enabled
+    set:
+      relayUrl: wss://buzz.example.com
+      ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
+      externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
+      s3.endpoint: http://minio:9000
+      s3.accessKey: a
+      s3.secretKey: s
+      ingress.enabled: true
+      pairingRelay.enabled: true
+      pairingRelay.url: wss://pairing.example.com
+    asserts:
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /pair
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-buzz-pairing
+                port:
+                  number: 5000
+        template: templates/ingress.yaml


### PR DESCRIPTION
## Problem

With `pairingRelay.enabled: true`, the chart deploys the `buzz-pair-relay` sidecar and its Service — but neither the default HTTPRoute rules nor the chart-managed Ingress route anything to it. Mobile pairing then fails for every chart user who relies on the chart's own ingress objects:

1. Desktop probes NIP-11 for `pairing_relay_url`; operators who route ingress themselves may not have a `/pair` route either way, but chart-managed ingress users get the default `/` → relay rule only.
2. Whether the advertised URL is `wss://<host>/pair` or the client falls back to the legacy `/pair` convention, the request lands on the main relay, which serves no `/pair` route (`router.rs`) → **WebSocket upgrade 404, pairing dead**.

This is the Helm-chart sibling of #2734 / #3291 (same gap in `deploy/compose`).

## Fix

When `pairingRelay.enabled`:
- **HTTPRoute** (default rules branch only — explicit `httproute.rules` stay untouched): add a `PathPrefix /pair` rule → `<fullname>-pairing:<port>`. Gateway API prefers the most specific match, so ordering is cosmetic.
- **Ingress**: append a `/pair` Prefix path → the pairing Service on every rendered host (longest-path matching peels it off the relay's `/`).

The pair relay itself ignores the request path (`buzz-pair-relay/src/lib.rs`: "Routes only /pair to this sidecar… The relay does not enforce path restrictions"), so no rewrite filter is needed.

## Verification

- `helm unittest`: three new cases in `networking_test.yaml` (no `/pair` rule when disabled; HTTPRoute default rules gain `/pair` + keep `/`; Ingress default host gains `/pair`). Suite passes.
- Running in production at `wss://buzz.yugalabs.io` (chart 0.1.6, ArgoCD + Envoy Gateway, equivalent route defined out-of-chart): NIP-11 advertises `wss://buzz.yugalabs.io/pair`, WS upgrade on `/pair` returns 101, iOS pairing completes.

Related open PRs/issues: #2734, #3291 (compose-side; this PR is chart-side — none found targeting the chart).