### PR TITLE
feat(chart): nodeSelector, tolerations, and affinity for the pairing relay deployment

### DIFF
--- a/deploy/charts/buzz/templates/pairing-relay.yaml
+++ b/deploy/charts/buzz/templates/pairing-relay.yaml
@@ -24,6 +24,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.pairingRelay.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pairingRelay.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.pairingRelay.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.relay.securityContext | nindent 8 }}
       containers:

--- a/deploy/charts/buzz/tests/pairing_relay_test.yaml
+++ b/deploy/charts/buzz/tests/pairing_relay_test.yaml
@@ -52,3 +52,75 @@ tests:
             name: BUZZ_PAIRING_RELAY_URL
             value: wss://pairing.buzz.xyz
         template: templates/deployment.yaml
+
+  - it: honors pairing relay scheduling knobs
+    set:
+      relayUrl: wss://buzz.example.com
+      ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
+      externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
+      s3.endpoint: http://minio:9000
+      s3.accessKey: a
+      s3.secretKey: s
+      pairingRelay.enabled: true
+      pairingRelay.url: wss://pairing.buzz.xyz
+      pairingRelay.nodeSelector:
+        nodegroup: infrastructure
+      pairingRelay.tolerations:
+        - key: nodegroup
+          operator: Equal
+          value: infrastructure
+          effect: NoSchedule
+      pairingRelay.affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/component: pairing-relay
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.nodegroup
+          value: infrastructure
+        documentIndex: 0
+        template: templates/pairing-relay.yaml
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: nodegroup
+            operator: Equal
+            value: infrastructure
+            effect: NoSchedule
+        documentIndex: 0
+        template: templates/pairing-relay.yaml
+      - exists:
+          path: spec.template.spec.affinity.podAntiAffinity
+        documentIndex: 0
+        template: templates/pairing-relay.yaml
+
+  - it: omits scheduling fields when knobs are unset
+    set:
+      relayUrl: wss://buzz.example.com
+      ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
+      externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
+      s3.endpoint: http://minio:9000
+      s3.accessKey: a
+      s3.secretKey: s
+      pairingRelay.enabled: true
+      pairingRelay.url: wss://pairing.buzz.xyz
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeSelector
+        documentIndex: 0
+        template: templates/pairing-relay.yaml
+      - notExists:
+          path: spec.template.spec.tolerations
+        documentIndex: 0
+        template: templates/pairing-relay.yaml
+      - notExists:
+          path: spec.template.spec.affinity
+        documentIndex: 0
+        template: templates/pairing-relay.yaml

--- a/deploy/charts/buzz/values.schema.json
+++ b/deploy/charts/buzz/values.schema.json
@@ -282,6 +282,9 @@
         },
         "podAnnotations": { "type": "object" },
         "podLabels": { "type": "object" },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" },
         "resources": { "type": "object" }
       }
     },

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -217,6 +217,9 @@ pairingRelay:
     annotations: {}
   podAnnotations: {}
   podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
   resources:
     requests:
       cpu: "50m"


### PR DESCRIPTION
## Problem

The main relay Deployment exposes `relay.nodeSelector` / `relay.tolerations` / `relay.affinity`, but `templates/pairing-relay.yaml` renders none of them — the pairing Deployment cannot be placed on dedicated/tainted node pools at all. On clusters where platform services live behind a taint (our case: a tainted `infrastructure` pool), the pairing pod is the one chart-managed workload that can't follow the rest of the release.

## Change

Adds three standard scheduling knobs under `pairingRelay`, rendered with `with` so nothing is emitted when unset (default behavior unchanged):

- `pairingRelay.nodeSelector` (default `{}`)
- `pairingRelay.tolerations` (default `[]`)
- `pairingRelay.affinity` (default `{}`)

`values.schema.json` gains the three keys (the `pairingRelay` block is `additionalProperties: false`, so they must be declared).

## Verification

`helm unittest`: two new cases in `pairing_relay_test.yaml` — knobs render into the pod spec when set; the three fields are absent when unset. Suite passes.

Related open PRs/issues: none found.