### PR TITLE
fix(mobile): harden relay backoff and rate-limit handling

### DIFF
--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -26,6 +26,17 @@ class SessionState {
   const SessionState({required this.status, this.reconnectAttempt = 0});
 }
 
+/// A publish was refused because the relay's rate-limit window is still active.
+class RelayRateLimitedException implements Exception {
+  const RelayRateLimitedException(this.retryAfter);
+
+  final Duration retryAfter;
+
+  @override
+  String toString() =>
+      'Relay is rate-limited; retry after ${retryAfter.inMilliseconds}ms';
+}
+
 class _HistorySubscription {
   final List<NostrEvent> events = [];
   final Completer<List<NostrEvent>> completer;
@@ -78,17 +89,40 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   RelaySessionNotifier({
     http.Client? httpClient,
     RelaySocketFactory socketFactory = RelaySocket.new,
+    Random? random,
+    int Function()? rateLimitNowMs,
   }) : _httpClient = httpClient,
-       _socketFactory = socketFactory;
+       _socketFactory = socketFactory,
+       _random = random ?? Random(),
+       _rateLimitClock = Stopwatch()..start(),
+       _rateLimitNowMsOverride = rateLimitNowMs;
 
   final http.Client? _httpClient;
   final RelaySocketFactory _socketFactory;
+  final Random _random;
+  final Stopwatch _rateLimitClock;
+  final int Function()? _rateLimitNowMsOverride;
 
   static const _baseReconnectDelayMs = 1000;
   static const _maxReconnectDelayMs = 30000;
   static const _eventBatchMs = 16;
   static const _reconnectReplaySkewSeconds = 5;
   static const _maxRecentDeliveryKeys = 5000;
+
+  /// Fraction of the backoff delay randomised in each direction, so a fleet of
+  /// clients does not reconnect in lockstep after a relay blip. Mirrors
+  /// buzz-acp's `jittered_duration` (crates/buzz-acp/src/relay.rs).
+  static const _reconnectJitterRatio = 0.2;
+
+  /// How long a connection must stay up before the backoff ladder is
+  /// considered earned back and resets to base. Mirrors buzz-acp's
+  /// `STABLE_CONNECTION_SECS` (crates/buzz-acp/src/relay.rs).
+  static const _stableConnectionMs = 60000;
+
+  /// Backoff floor applied when the relay rate-limits us without a usable
+  /// `retry in Ns` hint (absent, or below 2s). Mirrors the floor in buzz-acp's
+  /// `set_rate_limit_gate`.
+  static const _minRateLimitBackoffMs = 5000;
 
   RelaySocket? _socket;
   final Map<String, _HistorySubscription> _historySubscriptions = {};
@@ -99,7 +133,10 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   Timer? _reconnectTimer;
   Timer? _flushTimer;
   Timer? _backgroundGraceTimer;
+  Timer? _stableConnectionTimer;
   int _reconnectDelayMs = _baseReconnectDelayMs;
+  Duration? _lastReconnectDelay;
+  int? _rateLimitDeadlineMs;
   int _subIdCounter = 0;
   bool _disposed = false;
   bool _paused = false;
@@ -250,6 +287,11 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     NostrEvent event, {
     Duration timeout = const Duration(seconds: 8),
   }) {
+    final retryAfter = _checkRateLimitGate();
+    if (retryAfter != null) {
+      return Future<NostrEvent>.error(RelayRateLimitedException(retryAfter));
+    }
+
     final completer = Completer<NostrEvent>();
 
     final timer = Timer(timeout, () {
@@ -275,6 +317,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   /// Send a raw message over the WebSocket without waiting for acknowledgement.
   /// Used for ephemeral events like typing indicators.
   void sendRaw(List<dynamic> payload) {
+    if (_checkRateLimitGate() != null) return;
     _socket?.send(payload);
   }
 
@@ -298,6 +341,46 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   void debugHandleSocketMessageForTest(List<dynamic> data) =>
       _handleMessage(data);
 
+  /// Current position on the reconnect backoff ladder, before jitter.
+  @visibleForTesting
+  int get debugReconnectDelayMs => _reconnectDelayMs;
+
+  /// The jittered delay most recently handed to the reconnect timer.
+  @visibleForTesting
+  Duration? get debugLastReconnectDelay => _lastReconnectDelay;
+
+  /// Whether a connection is currently accruing stability toward a backoff
+  /// ladder reset.
+  @visibleForTesting
+  bool get debugStableConnectionArmed => _stableConnectionTimer != null;
+
+  /// Remaining send-side rate-limit delay, or null when the gate is inactive.
+  @visibleForTesting
+  Duration? get debugRateLimitRemaining => _checkRateLimitGate();
+
+  /// Monotonic deadline used to verify overlapping notices preserve the max.
+  @visibleForTesting
+  int? get debugRateLimitDeadlineMs {
+    if (_checkRateLimitGate() == null) return null;
+    return _rateLimitDeadlineMs;
+  }
+
+  @visibleForTesting
+  Duration debugJitteredDelay(int baseMs) => _jitteredDelay(baseMs);
+
+  /// Run the pending reconnect attempt now instead of waiting out its delay.
+  @visibleForTesting
+  void debugFireReconnectTimer() {
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+    _runScheduledReconnect();
+  }
+
+  /// Run the stability reset the connection would reach after
+  /// [_stableConnectionMs], without waiting for wall-clock time.
+  @visibleForTesting
+  void debugCompleteStableConnection() => _onConnectionStable();
+
   @visibleForTesting
   void debugAttachSocketForTest(RelaySocket socket) {
     _socket?.dispose();
@@ -308,6 +391,9 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   /// Force a reconnect (e.g., returning from background).
   Future<void> reconnect() async {
     await _socket?.disconnect();
+    // Caller-driven reconnect: reset the ladder immediately. Unlike the
+    // automatic reconnect path this is gated by an explicit request, so it
+    // cannot spin into a hammering loop on its own.
     _reconnectDelayMs = _baseReconnectDelayMs;
     final config = ref.read(relayConfigProvider);
     await _connect(config);
@@ -322,6 +408,8 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   void _pauseNow() {
     _paused = true;
     _reconnectTimer?.cancel();
+    _stableConnectionTimer?.cancel();
+    _stableConnectionTimer = null;
     _cancelAllHistory(Exception('App moved to background'));
     _rejectAllPending(Exception('App moved to background'));
     _socket?.disconnect();
@@ -339,7 +427,10 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     if (state.status == SessionStatus.connected) return;
 
     // Cancel any in-flight reconnect backoff timer so we reconnect immediately
-    // instead of waiting for the (possibly large) exponential delay.
+    // instead of waiting for the (possibly large) exponential delay. The
+    // preceding disconnect was our own backgrounding, not relay trouble, and
+    // the user is looking at the app right now — reset the ladder immediately
+    // rather than making them wait out a delay the relay never asked for.
     _reconnectTimer?.cancel();
     _reconnectDelayMs = _baseReconnectDelayMs;
     final config = ref.read(relayConfigProvider);
@@ -375,13 +466,37 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   void _handleConnected(int generation) {
     if (_disposed || generation != _connectionGeneration) return;
     _hasConnectedOnce = true;
-    _reconnectDelayMs = _baseReconnectDelayMs;
+    // Deliberately does NOT reset the backoff ladder. A socket that dies
+    // seconds after connecting would reset it on every cycle, so the doubling
+    // never accumulates and a flapping link hammers the relay indefinitely.
+    // The ladder is only earned back once the connection proves itself stable.
+    _armStableConnectionReset();
     state = const SessionState(status: SessionStatus.connected);
     _replayLiveSubscriptions();
   }
 
+  /// Start counting down to a backoff ladder reset. Cancelled the moment the
+  /// connection drops, so only a connection that survives
+  /// [_stableConnectionMs] resets the ladder.
+  void _armStableConnectionReset() {
+    _stableConnectionTimer?.cancel();
+    _stableConnectionTimer = Timer(
+      const Duration(milliseconds: _stableConnectionMs),
+      _onConnectionStable,
+    );
+  }
+
+  void _onConnectionStable() {
+    _stableConnectionTimer?.cancel();
+    _stableConnectionTimer = null;
+    _reconnectDelayMs = _baseReconnectDelayMs;
+  }
+
   void _handleDisconnected(int generation, Object? error) {
     if (_disposed || generation != _connectionGeneration) return;
+    // The connection did not survive long enough to earn the ladder back.
+    _stableConnectionTimer?.cancel();
+    _stableConnectionTimer = null;
     _cancelAllHistory(error);
     _rejectAllPending(error);
     _eventBuffer.clear();
@@ -404,11 +519,26 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     );
 
     _reconnectTimer?.cancel();
-    _reconnectTimer = Timer(Duration(milliseconds: _reconnectDelayMs), () {
-      _reconnectDelayMs = min(_reconnectDelayMs * 2, _maxReconnectDelayMs);
-      final config = ref.read(relayConfigProvider);
-      _connect(config);
-    });
+    final delay = _jitteredDelay(_reconnectDelayMs);
+    _lastReconnectDelay = delay;
+    _reconnectTimer = Timer(delay, _runScheduledReconnect);
+  }
+
+  void _runScheduledReconnect() {
+    _reconnectDelayMs = min(_reconnectDelayMs * 2, _maxReconnectDelayMs);
+    final config = ref.read(relayConfigProvider);
+    _connect(config);
+  }
+
+  /// Randomise [baseMs] by ±[_reconnectJitterRatio] so a fleet of clients does
+  /// not reconnect in lockstep after a relay blip. The ladder position itself
+  /// stays un-jittered; jitter is applied per scheduled wait.
+  Duration _jitteredDelay(int baseMs) {
+    final factor =
+        1 -
+        _reconnectJitterRatio +
+        _random.nextDouble() * 2 * _reconnectJitterRatio;
+    return Duration(milliseconds: (baseMs * factor).round());
   }
 
   /// Replay all live subscriptions after a reconnect, with a time skew to
@@ -439,7 +569,54 @@ class RelaySessionNotifier extends Notifier<SessionState> {
         _handleClosed(data);
       case 'OK':
         _handleOk(data);
+      case 'NOTICE':
+        _handleNotice(data);
     }
+  }
+
+  /// Handle a relay NOTICE. The relay announces rate limiting this way
+  /// (`rate-limited: ...; retry in 30s`), so discarding NOTICE means never
+  /// hearing the slow-down we are provoking. A rate-limit notice arms a
+  /// send-side gate independent of the reconnect backoff ladder.
+  void _handleNotice(List<dynamic> data) {
+    if (data.length < 2 || data[1] is! String) return;
+    final message = data[1] as String;
+    debugPrint('relay NOTICE: $message');
+    if (!message.startsWith('rate-limited:')) return;
+
+    // A missing hint, or one under 2s, floors to _minRateLimitBackoffMs: a
+    // burst of low-quality hints must not drop the gate so short that the next
+    // send immediately re-triggers the limit.
+    final hintMs = _parseRetryHintMs(message) ?? 0;
+    final requested = hintMs < 2000 ? _minRateLimitBackoffMs : hintMs;
+    final deadline = _rateLimitNowMs + _jitteredDelay(requested).inMilliseconds;
+    // Take the maximum so overlapping notices cannot shorten a later deadline
+    // that is already in place. Relay hints are deliberately not clamped by
+    // the reconnect ladder's 30-second maximum.
+    _rateLimitDeadlineMs = max(_rateLimitDeadlineMs ?? 0, deadline);
+  }
+
+  /// Return the remaining gate duration, lazily clearing an expired deadline.
+  Duration? _checkRateLimitGate() {
+    final deadline = _rateLimitDeadlineMs;
+    if (deadline == null) return null;
+    final remainingMs = deadline - _rateLimitNowMs;
+    if (remainingMs > 0) return Duration(milliseconds: remainingMs);
+    _rateLimitDeadlineMs = null;
+    return null;
+  }
+
+  int get _rateLimitNowMs =>
+      _rateLimitNowMsOverride?.call() ?? _rateLimitClock.elapsedMilliseconds;
+
+  /// Parse the relay's `retry in {N}s` hint into milliseconds. Returns null
+  /// when the hint is absent or malformed. Mirrors buzz-acp's
+  /// `parse_rate_limit_retry_secs`.
+  int? _parseRetryHintMs(String message) {
+    final match = RegExp(r'retry in (\d+)').firstMatch(message);
+    if (match == null) return null;
+    final seconds = int.tryParse(match.group(1)!);
+    return seconds == null ? null : seconds * 1000;
   }
 
   void _handleEvent(List<dynamic> data) {
@@ -639,9 +816,11 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     _reconnectTimer?.cancel();
     _flushTimer?.cancel();
     _backgroundGraceTimer?.cancel();
+    _stableConnectionTimer?.cancel();
     _cancelAllHistory(null);
     _rejectAllPending(null);
     _recentDeliveryKeys.clear();
+    _rateLimitDeadlineMs = null;
     _socket?.dispose();
     _socket = null;
     _httpClient?.close();

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -321,6 +322,260 @@ void main() {
     );
   });
 
+  // ── Gap 3: reconnect backoff jitter ──────────────────────────────────────
+
+  test('jitters the scheduled reconnect delay around the ladder position', () {
+    final session = RelaySessionNotifier(random: Random(1234));
+    final container = ProviderContainer(
+      overrides: [relaySessionProvider.overrideWith(() => session)],
+    );
+    addTearDown(container.dispose);
+    container.read(relaySessionProvider);
+
+    session.debugHandleConnected();
+    session.debugHandleDisconnected();
+
+    final delay = session.debugLastReconnectDelay;
+    expect(delay, isNotNull);
+    // The ladder itself stays un-jittered at base...
+    expect(session.debugReconnectDelayMs, 1000);
+    // ...but the scheduled wait is randomised within +/-20% of it. A flat
+    // doubling schedule would land on exactly 1000ms.
+    expect(delay!.inMilliseconds, isNot(1000));
+    expect(delay.inMilliseconds, inInclusiveRange(800, 1200));
+  });
+
+  test('keeps every jittered delay within +/-20% and does not repeat', () {
+    final session = RelaySessionNotifier(random: Random(7));
+    final samples = <int>{};
+
+    for (var i = 0; i < 200; i++) {
+      final delay = session.debugJitteredDelay(8000).inMilliseconds;
+      expect(delay, inInclusiveRange(6400, 9600));
+      samples.add(delay);
+    }
+
+    // A flat (un-jittered) schedule would collapse to the single value 8000.
+    expect(samples.length, greaterThan(1));
+    expect(samples, isNot(contains(8000)));
+  });
+
+  // ── Gap 4: backoff resets on stability, not on connect ───────────────────
+
+  test('does not reset the backoff ladder on a short-lived connection', () {
+    final session = _backoffSession();
+
+    // Three connect/drop cycles that never reach the stability threshold. The
+    // ladder must keep doubling instead of snapping back to base each time.
+    session.debugHandleConnected();
+    expect(session.debugStableConnectionArmed, isTrue);
+    session.debugHandleDisconnected();
+    // Dropping before the threshold disarms the pending reset.
+    expect(session.debugStableConnectionArmed, isFalse);
+    expect(session.debugReconnectDelayMs, 1000);
+
+    session.debugFireReconnectTimer();
+    expect(session.debugReconnectDelayMs, 2000);
+
+    session.debugHandleConnected();
+    session.debugHandleDisconnected();
+    session.debugFireReconnectTimer();
+    expect(session.debugReconnectDelayMs, 4000);
+
+    session.debugHandleConnected();
+    session.debugHandleDisconnected();
+    session.debugFireReconnectTimer();
+    expect(session.debugReconnectDelayMs, 8000);
+  });
+
+  test('resets the backoff ladder once a connection proves stable', () {
+    final session = _backoffSession();
+
+    session.debugHandleConnected();
+    session.debugHandleDisconnected();
+    session.debugFireReconnectTimer();
+    session.debugHandleConnected();
+    session.debugHandleDisconnected();
+    session.debugFireReconnectTimer();
+    expect(session.debugReconnectDelayMs, 4000);
+
+    // This connection survives the stability window, earning the ladder back.
+    session.debugHandleConnected();
+    session.debugCompleteStableConnection();
+
+    expect(session.debugReconnectDelayMs, 1000);
+    expect(session.debugStableConnectionArmed, isFalse);
+  });
+
+  test('resets the backoff ladder immediately on app resume', () {
+    final session = _backoffSession();
+
+    session.debugHandleConnected();
+    session.debugHandleDisconnected();
+    session.debugFireReconnectTimer();
+    expect(session.debugReconnectDelayMs, 2000);
+
+    // Backgrounding is our own teardown, not relay trouble: a foregrounding
+    // user must not wait out a ladder the relay never asked for.
+    session.debugPauseNow();
+    session.onAppResumed();
+
+    expect(session.debugReconnectDelayMs, 1000);
+  });
+
+  // ── Gap 5: NOTICE frames feed backpressure ───────────────────────────────
+
+  test('rate-limit gate rejects publish without sending the event', () async {
+    final fixture = _recordingSession();
+    fixture.session.debugHandleMessage([
+      'NOTICE',
+      'rate-limited: quota exceeded; retry in 12s',
+    ]);
+
+    await expectLater(
+      fixture.session.publish(
+        _event(),
+        timeout: const Duration(milliseconds: 1),
+      ),
+      throwsA(
+        isA<RelayRateLimitedException>().having(
+          (error) => error.retryAfter,
+          'retryAfter',
+          greaterThan(Duration.zero),
+        ),
+      ),
+    );
+    expect(fixture.socket.sent, isEmpty);
+  });
+
+  test('rate-limit gate drops ephemeral raw sends', () {
+    final fixture = _recordingSession();
+    fixture.session.sendRaw(['EVENT', _event().toJson()]);
+    expect(fixture.socket.sent, hasLength(1));
+    fixture.socket.sent.clear();
+
+    fixture.session.debugHandleMessage([
+      'NOTICE',
+      'rate-limited: quota exceeded; retry in 12s',
+    ]);
+
+    fixture.session.sendRaw(['EVENT', _event().toJson()]);
+
+    expect(fixture.socket.sent, isEmpty);
+  });
+
+  test('rate-limit NOTICE arms a gate separate from reconnect backoff', () {
+    final session = RelaySessionNotifier(random: Random(1));
+
+    session.debugHandleMessage([
+      'NOTICE',
+      'rate-limited: quota exceeded; retry in 12s',
+    ]);
+
+    expect(session.debugRateLimitRemaining, isNotNull);
+    expect(session.debugReconnectDelayMs, 1000);
+  });
+
+  test('floors a rate-limit NOTICE without a usable hint', () {
+    final withoutHint = RelaySessionNotifier(random: Random(1));
+    withoutHint.debugHandleMessage([
+      'NOTICE',
+      'rate-limited: too many concurrent requests',
+    ]);
+    expect(
+      withoutHint.debugRateLimitRemaining!.inMilliseconds,
+      inInclusiveRange(3900, 6000),
+    );
+
+    final zeroHint = RelaySessionNotifier(random: Random(1));
+    zeroHint.debugHandleMessage([
+      'NOTICE',
+      'rate-limited: quota exceeded; retry in 0s',
+    ]);
+    expect(
+      zeroHint.debugRateLimitRemaining!.inMilliseconds,
+      inInclusiveRange(3900, 6000),
+    );
+  });
+
+  test('does not clamp a long rate-limit hint to reconnect maximum', () {
+    final session = RelaySessionNotifier(random: Random(1));
+
+    session.debugHandleMessage([
+      'NOTICE',
+      'rate-limited: quota exceeded; retry in 60s',
+    ]);
+
+    // A 30s clamp with +/-20% jitter can be at most 36s. The unclamped 60s
+    // hint is at least 48s, leaving a wide margin for test execution time.
+    expect(session.debugRateLimitRemaining!.inMilliseconds, greaterThan(40000));
+  });
+
+  test('never shortens an existing rate-limit deadline', () {
+    final session = RelaySessionNotifier(random: Random(1));
+
+    session.debugHandleMessage([
+      'NOTICE',
+      'rate-limited: quota exceeded; retry in 30s',
+    ]);
+    final longDeadline = session.debugRateLimitDeadlineMs;
+
+    session.debugHandleMessage([
+      'NOTICE',
+      'rate-limited: quota exceeded; retry in 1s',
+    ]);
+
+    expect(session.debugRateLimitDeadlineMs, longDeadline);
+  });
+
+  test('stable connection reset preserves the rate-limit deadline', () {
+    final session = RelaySessionNotifier(random: Random(1));
+    session.debugHandleMessage([
+      'NOTICE',
+      'rate-limited: quota exceeded; retry in 60s',
+    ]);
+    final deadline = session.debugRateLimitDeadlineMs;
+
+    session.debugCompleteStableConnection();
+
+    expect(session.debugReconnectDelayMs, 1000);
+    expect(session.debugRateLimitDeadlineMs, deadline);
+  });
+
+  test('lazily clears the rate-limit deadline once it expires', () {
+    var nowMs = 100;
+    final session = RelaySessionNotifier(
+      random: Random(1),
+      rateLimitNowMs: () => nowMs,
+    );
+    session.debugHandleMessage([
+      'NOTICE',
+      'rate-limited: quota exceeded; retry in 5s',
+    ]);
+    final deadline = session.debugRateLimitDeadlineMs!;
+
+    expect(session.debugRateLimitRemaining, isNotNull);
+
+    nowMs = deadline;
+
+    expect(session.debugRateLimitRemaining, isNull);
+    expect(session.debugRateLimitDeadlineMs, isNull);
+  });
+
+  test('leaves rate gate and backoff untouched for other NOTICE frames', () {
+    final session = RelaySessionNotifier(random: Random(1));
+
+    session.debugHandleMessage(['NOTICE', 'server restarting shortly']);
+    expect(session.debugReconnectDelayMs, 1000);
+    expect(session.debugRateLimitRemaining, isNull);
+
+    // Malformed NOTICE frames must not throw.
+    session.debugHandleMessage(['NOTICE']);
+    session.debugHandleMessage(['NOTICE', 42]);
+    expect(session.debugReconnectDelayMs, 1000);
+    expect(session.debugRateLimitRemaining, isNull);
+  });
+
   test(
     'live onClosed callback runs when relay closes an open subscription',
     () async {
@@ -393,7 +648,82 @@ class _ControlledRelaySocket extends RelaySocket {
   void disconnectWith(Object? error) => _disconnected(error);
 }
 
+class _RecordingRelaySocket extends RelaySocket {
+  final List<List<dynamic>> sent = [];
+
+  _RecordingRelaySocket()
+    : super(
+        wsUrl: 'wss://relay.example',
+        nsec: null,
+        onMessage: (_) {},
+        onConnected: () {},
+        onDisconnected: (_) {},
+      );
+
+  @override
+  void send(List<dynamic> payload) => sent.add(payload);
+
+  @override
+  void dispose() {}
+}
+
+class _RecordingSessionFixture {
+  final RelaySessionNotifier session;
+  final _RecordingRelaySocket socket;
+
+  _RecordingSessionFixture(this.session, this.socket);
+}
+
+_RecordingSessionFixture _recordingSession() {
+  final session = RelaySessionNotifier(random: Random(1));
+  final container = ProviderContainer(
+    overrides: [relaySessionProvider.overrideWith(() => session)],
+  );
+  addTearDown(container.dispose);
+  container.read(relaySessionProvider);
+  final socket = _RecordingRelaySocket();
+  session.debugAttachSocketForTest(socket);
+  return _RecordingSessionFixture(session, socket);
+}
+
 const _channelId = '11111111-1111-4111-8111-111111111111';
+
+/// A session whose reconnects attach a no-op socket, so the backoff ladder can
+/// be driven through real connect/drop cycles without touching the network.
+RelaySessionNotifier _backoffSession({int seed = 1}) {
+  final keychain = nostr.Keys.generate();
+  final session = RelaySessionNotifier(
+    random: Random(seed),
+    socketFactory:
+        ({
+          required wsUrl,
+          required nsec,
+          required onMessage,
+          required onConnected,
+          required onDisconnected,
+        }) => _ControlledRelaySocket(
+          wsUrl: wsUrl,
+          nsec: nsec,
+          onMessage: onMessage,
+          onConnected: onConnected,
+          onDisconnected: onDisconnected,
+        ),
+  );
+  final container = ProviderContainer(
+    overrides: [
+      relaySessionProvider.overrideWith(() => session),
+      relayConfigProvider.overrideWith(
+        () => _FakeRelayConfigNotifier(
+          baseUrl: 'https://relay.example',
+          nsec: keychain.nsec,
+        ),
+      ),
+    ],
+  );
+  addTearDown(container.dispose);
+  container.read(relaySessionProvider);
+  return session;
+}
 
 class _FakeRelayConfigNotifier extends RelayConfigNotifier {
   final String _baseUrl;


### PR DESCRIPTION
## Summary

This closes gaps 3, 4, and 5 from #3224 in the mobile relay session:

- jitter reconnect scheduling by ±20% while preserving the deterministic exponential ladder;
- reset automatic reconnect backoff only after 60 seconds of connection stability, instead of immediately after authentication; and
- parse rate-limited `NOTICE` frames into a monotonic, reconnect-independent deadline.

During an active deadline, durable `publish()` calls fail before writing an `EVENT` with a domain-specific `RelayRateLimitedException`, while ephemeral `sendRaw()` traffic such as typing indicators is dropped. The deadline honors explicit retry hints without the reconnect ladder's 30-second cap, floors absent or sub-2-second hints to 5 seconds, takes the maximum of overlapping windows, and survives reconnects until it expires or the session is disposed.

`publish()` failing promptly is a deliberate mobile divergence from the desktop and buzz-acp implementations, which wait or park work until the gate clears. A failed future preserves the existing mobile publish error path and avoids presenting a send as hung for an unbounded relay-provided window.

Randomness and monotonic time are injectable so the behavior, including the exact expiry boundary, is deterministic in tests.

### Related issue

Addresses #3224 (gaps 3, 4, and 5).

Gap 1 is covered by #3231. Gap 2 is intentionally deferred because the cited mobile timeouts span different transports and do not have one faithful desktop constant to copy.

Closest existing work:

- #3053 implements the same rate-limit feature at the `CLOSED`/REQ boundary: it owns retryable subscription replay and history pacing, while this PR adds `NOTICE` activation and application send behavior. The combined design must use one injectable `RelayRateLimitGate`, armed by both `NOTICE` and rate-limited `CLOSED` frames. If this PR lands first, #3053 should collapse both deadline paths into its gate when rebased; if #3053 lands first, this change should fold into that gate rather than retain parallel state. The shared activation policy should follow buzz-acp: absent, non-positive, or sub-2-second hints floor to 5 seconds; explicit hints are not capped; windows receive ±20% jitter; and overlaps take the later deadline.
- #3406 also edits the start of `publish()` to wait for an authenticated connection. When combined, the rate-limit check must run before `_waitUntilConnected()` so a gated send cannot trigger a new connection that bypasses the reconnect ladder. `RelayRateLimitedException` also keeps this condition distinct from #3406's generic background and connection-unavailable `StateError`s.

### Testing

Verified at exact commit `3db0ba01ee95550bb6eee7d540862fb5e86d5f5a`:

- `dart format --output=none --set-exit-if-changed .` — 302 files, 0 changed
- `flutter analyze --no-pub` — no issues
- `flutter test` — 889 passed, 1 skipped
- `git diff --check origin/main...HEAD` — clean

Fourteen new relay-session cases cover jitter bounds, stability-gated resets, publish and ephemeral-send behavior, retry-hint floors and overlap, long unclamped hints, deadline preservation across reconnect/reset, and exact-boundary expiry. Each behavior was exercised with a negative control; notably, making expiry inclusive leaves a zero-duration gate active and fails the boundary test.

No UI changed, so screenshots are not applicable.
