### PR TITLE
ci: survive cold mesh-llm cache — clone locked rev when cargo fetch leaves no checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1040,8 +1040,10 @@ jobs:
           set -euo pipefail
           REV=$(python3 -c 'import tomllib; d=tomllib.load(open("Cargo.lock", "rb")); p=next(p for p in d["package"] if p["name"] == "mesh-llm-sdk"); print(p["source"].rsplit("#", 1)[1])')
           [[ -n "$REV" ]] || { echo "::error::could not resolve mesh-llm rev from Cargo.lock"; exit 1; }
+          URL=$(python3 -c 'import tomllib; d=tomllib.load(open("Cargo.lock", "rb")); p=next(p for p in d["package"] if p["name"] == "mesh-llm-sdk"); print(p["source"].split("+", 1)[1].split("?", 1)[0].split("#", 1)[0])')
           echo "rev=$REV" >> "$GITHUB_OUTPUT"
           echo "short=${REV:0:7}" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
       - name: Restore mesh llama build cache
         id: llama_cache
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
@@ -1052,14 +1054,22 @@ jobs:
         if: steps.llama_cache.outputs.cache-hit != 'true'
         env:
           MESH_REV_SHORT: ${{ steps.mesh_rev.outputs.short }}
+          MESH_REV: ${{ steps.mesh_rev.outputs.rev }}
+          MESH_URL: ${{ steps.mesh_rev.outputs.url }}
         run: |
           set -euo pipefail
           cargo fetch --manifest-path desktop/src-tauri/Cargo.toml
           SHORT="$MESH_REV_SHORT"
           MESH_ROOT=$(find "${CARGO_HOME:-$HOME/.cargo}/git/checkouts" -path "*/$SHORT" -type d -name "$SHORT" | head -1)
           if [[ -z "$MESH_ROOT" ]]; then
-            echo "::error::mesh-llm checkout for $SHORT not found after cargo fetch"
-            exit 1
+            # cargo fetch fills git/db but creates checkouts lazily at build
+            # time, so a cold runner (fresh fork, evicted rust-cache) has no
+            # checkout dir — clone the locked rev directly instead of failing.
+            echo "no cargo checkout for $SHORT; cloning $MESH_URL at $MESH_REV"
+            MESH_ROOT="$RUNNER_TEMP/mesh-llm-$SHORT"
+            git init -q "$MESH_ROOT"
+            git -C "$MESH_ROOT" fetch -q --depth 1 "$MESH_URL" "$MESH_REV"
+            git -C "$MESH_ROOT" checkout -q FETCH_HEAD
           fi
           export LLAMA_STAGE_BACKEND=metal
           export LLAMA_STAGE_BUILD_DIR="$GITHUB_WORKSPACE/.cache/mesh-llama/build-stage-abi-metal"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,8 +144,10 @@ jobs:
           set -euo pipefail
           REV=$(python3 -c 'import tomllib; d=tomllib.load(open("Cargo.lock", "rb")); p=next(p for p in d["package"] if p["name"] == "mesh-llm-sdk"); print(p["source"].rsplit("#", 1)[1])')
           [[ -n "$REV" ]] || { echo "::error::could not resolve mesh-llm rev from Cargo.lock"; exit 1; }
+          URL=$(python3 -c 'import tomllib; d=tomllib.load(open("Cargo.lock", "rb")); p=next(p for p in d["package"] if p["name"] == "mesh-llm-sdk"); print(p["source"].split("+", 1)[1].split("?", 1)[0].split("#", 1)[0])')
           echo "rev=$REV" >> "$GITHUB_OUTPUT"
           echo "short=${REV:0:7}" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
       - name: Restore mesh llama build cache
         id: llama_cache
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
@@ -156,14 +158,22 @@ jobs:
         if: steps.llama_cache.outputs.cache-hit != 'true'
         env:
           MESH_REV_SHORT: ${{ steps.mesh_rev.outputs.short }}
+          MESH_REV: ${{ steps.mesh_rev.outputs.rev }}
+          MESH_URL: ${{ steps.mesh_rev.outputs.url }}
         run: |
           set -euo pipefail
           cargo fetch --manifest-path desktop/src-tauri/Cargo.toml
           SHORT="$MESH_REV_SHORT"
           MESH_ROOT=$(find "${CARGO_HOME:-$HOME/.cargo}/git/checkouts" -path "*/$SHORT" -type d -name "$SHORT" | head -1)
           if [[ -z "$MESH_ROOT" ]]; then
-            echo "::error::mesh-llm checkout for $SHORT not found after cargo fetch"
-            exit 1
+            # cargo fetch fills git/db but creates checkouts lazily at build
+            # time, so a cold runner (fresh fork, evicted rust-cache) has no
+            # checkout dir — clone the locked rev directly instead of failing.
+            echo "no cargo checkout for $SHORT; cloning $MESH_URL at $MESH_REV"
+            MESH_ROOT="$RUNNER_TEMP/mesh-llm-$SHORT"
+            git init -q "$MESH_ROOT"
+            git -C "$MESH_ROOT" fetch -q --depth 1 "$MESH_URL" "$MESH_REV"
+            git -C "$MESH_ROOT" checkout -q FETCH_HEAD
           fi
           export LLAMA_STAGE_BACKEND=metal
           export LLAMA_STAGE_BUILD_DIR="$GITHUB_WORKSPACE/.cache/mesh-llama/build-stage-abi-metal"

--- a/.github/workflows/signed-macos-canary.yml
+++ b/.github/workflows/signed-macos-canary.yml
@@ -103,8 +103,10 @@ jobs:
           set -euo pipefail
           REV=$(python3 -c 'import tomllib; d=tomllib.load(open("Cargo.lock", "rb")); p=next(p for p in d["package"] if p["name"] == "mesh-llm-sdk"); print(p["source"].rsplit("#", 1)[1])')
           [[ -n "$REV" ]] || { echo "::error::could not resolve mesh-llm rev from Cargo.lock"; exit 1; }
+          URL=$(python3 -c 'import tomllib; d=tomllib.load(open("Cargo.lock", "rb")); p=next(p for p in d["package"] if p["name"] == "mesh-llm-sdk"); print(p["source"].split("+", 1)[1].split("?", 1)[0].split("#", 1)[0])')
           echo "rev=$REV" >> "$GITHUB_OUTPUT"
           echo "short=${REV:0:7}" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
 
       - name: Restore mesh llama build cache
         id: llama_cache
@@ -117,13 +119,21 @@ jobs:
         if: steps.llama_cache.outputs.cache-hit != 'true'
         env:
           MESH_REV_SHORT: ${{ steps.mesh_rev.outputs.short }}
+          MESH_REV: ${{ steps.mesh_rev.outputs.rev }}
+          MESH_URL: ${{ steps.mesh_rev.outputs.url }}
         run: |
           set -euo pipefail
           cargo fetch --manifest-path desktop/src-tauri/Cargo.toml
           MESH_ROOT=$(find "${CARGO_HOME:-$HOME/.cargo}/git/checkouts" -path "*/$MESH_REV_SHORT" -type d -name "$MESH_REV_SHORT" | head -1)
           if [[ -z "$MESH_ROOT" ]]; then
-            echo "::error::mesh-llm checkout for $MESH_REV_SHORT not found after cargo fetch"
-            exit 1
+            # cargo fetch fills git/db but creates checkouts lazily at build
+            # time, so a cold runner (fresh fork, evicted rust-cache) has no
+            # checkout dir — clone the locked rev directly instead of failing.
+            echo "no cargo checkout for $MESH_REV_SHORT; cloning $MESH_URL at $MESH_REV"
+            MESH_ROOT="$RUNNER_TEMP/mesh-llm-$MESH_REV_SHORT"
+            git init -q "$MESH_ROOT"
+            git -C "$MESH_ROOT" fetch -q --depth 1 "$MESH_URL" "$MESH_REV"
+            git -C "$MESH_ROOT" checkout -q FETCH_HEAD
           fi
           export LLAMA_STAGE_BACKEND=metal
           export LLAMA_STAGE_BUILD_DIR="$GITHUB_WORKSPACE/.cache/mesh-llama/build-stage-abi-metal"


### PR DESCRIPTION
## Summary

`cargo fetch` populates `~/.cargo/git/db` but materializes `git/checkouts` lazily at build time. The "Build mesh llama native libraries" step probes `git/checkouts` right after `cargo fetch`, so on any runner without a warm rust-cache — a fresh fork, an evicted cache, a new runner image — the probe comes up empty and the job hard-fails with `mesh-llm checkout for <rev> not found after cargo fetch`. This repo's CI rarely sees it because its caches stay warm, but forks hit it deterministically (we did, on ours, on every macOS Desktop Build until this patch).

**Fix:** when no checkout exists, clone the Cargo.lock-pinned rev directly into `RUNNER_TEMP` — the URL is parsed from the same lockfile entry as the rev, so a mesh-llm dependency bump still needs no lockstep workflow edit. The warm-cache fast path is unchanged. Applied to the three workflows sharing the block: `ci.yml`, `release.yml`, `signed-macos-canary.yml`.

Proven on our fork: the previously-failing cold macOS job went green exercising the fallback end-to-end (flaukowski/kannaka-buzz#3).

## Test plan

- Cold path exercised end-to-end on a fork with no caches: macOS Desktop Build passes via the fallback clone.
- Warm path unchanged (fallback only runs when the `find` probe is empty).
- URL/rev extraction verified against `Cargo.lock` (`git+https://github.com/Mesh-LLM/mesh-llm.git?tag=v0.73.1#43103c5c…` → `https://github.com/Mesh-LLM/mesh-llm.git`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)