### PR TITLE
fix(desktop): prompt immediate restart when respond-to gate changes

### DIFF
--- a/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   startManagedAgentWithRules,
   respawnManagedAgentWithRules,
+  shouldOfferImmediateRespondToRestart,
 } from "./managedAgentControlActions.ts";
 
 function agent(overrides = {}) {
@@ -164,5 +165,36 @@ test("test_respawn_onStopped_fires_before_start_resolves", async () => {
     events,
     ["stop", "onStopped", "start"],
     "onStopped must fire after stop resolves and before start is called",
+  );
+});
+
+test("test_shouldOfferImmediateRespondToRestart_fires_only_when_gate_changed_and_needs_restart", () => {
+  assert.equal(
+    shouldOfferImmediateRespondToRestart({ respondTo: "anyone" }, true),
+    true,
+    "respond-to changed + backend confirms drift → offer restart",
+  );
+  assert.equal(
+    shouldOfferImmediateRespondToRestart(
+      { respondToAllowlist: ["a".repeat(64)] },
+      true,
+    ),
+    true,
+    "allowlist-only change + drift → offer restart",
+  );
+  assert.equal(
+    shouldOfferImmediateRespondToRestart({ respondTo: "anyone" }, false),
+    false,
+    "backend says no drift (e.g. agent already stopped) → never prompt",
+  );
+  assert.equal(
+    shouldOfferImmediateRespondToRestart({ name: "New Name" }, true),
+    false,
+    "unrelated field changed (name) → never prompt for a respond-to reason",
+  );
+  assert.equal(
+    shouldOfferImmediateRespondToRestart({}, true),
+    false,
+    "no fields changed at all → never prompt",
   );
 });

--- a/desktop/src/features/agents/lib/managedAgentControlActions.ts
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.ts
@@ -35,6 +35,28 @@ export function isManagedAgentActive(agent: Pick<ManagedAgent, "status">) {
   return agent.status === "running" || agent.status === "deployed";
 }
 
+/**
+ * Decide whether a just-saved edit should offer an immediate restart because
+ * it changed the inbound author gate ("Who can talk to this agent").
+ *
+ * `respond_to`/`respond_to_allowlist` control who may address the agent, but
+ * a running process keeps its OLD gate until restarted — `update_managed_agent`
+ * never auto-restarts, and the passive "Restart required" badge is easy to
+ * miss for a setting whose whole point is to take effect promptly (buzz#2501,
+ * buzz#2950: agents set to `anyone`/`allowlist` stayed unreachable to
+ * non-owners because the running harness never picked up the change). Only
+ * fires when the save actually touched the gate AND the backend confirms the
+ * running instance's config now differs from what it's live with.
+ */
+export function shouldOfferImmediateRespondToRestart(
+  input: { respondTo?: unknown; respondToAllowlist?: unknown },
+  needsRestart: boolean,
+) {
+  const respondToChanged =
+    input.respondTo !== undefined || input.respondToAllowlist !== undefined;
+  return respondToChanged && needsRestart;
+}
+
 export function getManagedAgentPrimaryActionLabel(agent: ManagedAgent) {
   if (agent.backend.type === "provider") {
     return isManagedAgentActive(agent) ? "Shutdown" : "Deploy";

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { ChevronDown } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { toast } from "sonner";
 
 import {
   useAcpRuntimesQuery,
@@ -83,6 +82,10 @@ import { useProviderApiKeyFieldState } from "./providerApiKeyFieldState";
 import { resolveModelFieldStatusMessage } from "./agentConfigControls";
 import { AdvancedRequiredBadge } from "./AdvancedRequiredBadge";
 import { showAgentProfileSyncWarning } from "./agentProfileSyncWarning";
+import {
+  offerRespondToRestartIfNeeded,
+  offerStartNowPrompt,
+} from "./agentSaveOutcomePrompts";
 import { AddCustomHarnessDialog } from "./AddCustomHarnessDialog";
 import {
   ADD_CUSTOM_HARNESS_OPTION,
@@ -737,28 +740,10 @@ export function AgentInstanceEditDialog({
       showAgentProfileSyncWarning(result.agent.name, result.profileSyncError);
       handleOpenChange(false);
       onUpdated?.(result.agent);
-      // The auto-restart policy deliberately never fires for a stopped or
-      // failing agent (a broken agent must not auto-loop), so an edit meant
-      // to FIX one silently waits for a manual start. Offer that start
-      // explicitly instead of relying on the user to know the policy.
       if (!isManagedAgentActive(result.agent)) {
-        const startedName = result.agent.name;
-        toast(`${startedName} saved while stopped.`, {
-          action: {
-            label: "Start now",
-            onClick: () => {
-              startMutation.mutate(result.agent.pubkey, {
-                onSuccess: () => toast.success(`${startedName} started.`),
-                onError: (error) =>
-                  toast.error(
-                    error instanceof Error
-                      ? `${startedName} failed to start: ${error.message}`
-                      : `${startedName} failed to start.`,
-                  ),
-              });
-            },
-          },
-        });
+        offerStartNowPrompt(result.agent, startMutation);
+      } else {
+        offerRespondToRestartIfNeeded(input, result.agent);
       }
     } catch {
       // React Query stores the error; keep dialog open and render it inline.

--- a/desktop/src/features/agents/ui/agentSaveOutcomePrompts.ts
+++ b/desktop/src/features/agents/ui/agentSaveOutcomePrompts.ts
@@ -1,0 +1,87 @@
+import { toast } from "sonner";
+
+import type { useStartManagedAgentMutation } from "@/features/agents/hooks";
+import {
+  respawnManagedAgentWithRules,
+  shouldOfferImmediateRespondToRestart,
+} from "@/features/agents/lib/managedAgentControlActions";
+import { clearActiveTurnsForAgentOnStop } from "@/features/agents/managedAgentRuntimeHooks";
+import {
+  startManagedAgent,
+  stopManagedAgent,
+} from "@/shared/api/tauriManagedAgents";
+import type { ManagedAgent, UpdateManagedAgentInput } from "@/shared/api/types";
+
+/**
+ * After a managed-agent edit saves, offer an immediate restart if the save
+ * changed "Who can talk to this agent" on a still-running instance.
+ *
+ * `respond_to`/`respond_to_allowlist` is a security-relevant gate: the
+ * running process keeps its OLD env until restarted (`update_managed_agent`
+ * never auto-restarts), and the passive "Restart required" badge is easy to
+ * miss for a setting whose whole point is to take effect promptly. This
+ * mirrors the existing "saved while stopped → Start now" toast pattern in
+ * `AgentInstanceEditDialog`, but for the running/needs-restart case (buzz#2501,
+ * buzz#2950: agents set to `anyone`/`allowlist` stayed unreachable to
+ * non-owners because the running harness never picked up the change).
+ */
+export function offerRespondToRestartIfNeeded(
+  input: Pick<UpdateManagedAgentInput, "respondTo" | "respondToAllowlist">,
+  agent: ManagedAgent,
+) {
+  if (!shouldOfferImmediateRespondToRestart(input, agent.needsRestart)) {
+    return;
+  }
+
+  const restartedName = agent.name;
+  toast(`${restartedName} saved — restart to apply the new setting.`, {
+    action: {
+      label: "Restart now",
+      onClick: () => {
+        respawnManagedAgentWithRules({
+          agent,
+          startManagedAgent,
+          stopManagedAgent,
+          onStopped: () => clearActiveTurnsForAgentOnStop(agent.pubkey),
+        })
+          .then(() => toast.success(`${restartedName} restarted.`))
+          .catch((error: unknown) =>
+            toast.error(
+              error instanceof Error
+                ? `${restartedName} failed to restart: ${error.message}`
+                : `${restartedName} failed to restart.`,
+            ),
+          );
+      },
+    },
+  });
+}
+
+/**
+ * The auto-restart policy deliberately never fires for a stopped or failing
+ * agent (a broken agent must not auto-loop), so an edit meant to FIX one
+ * silently waits for a manual start. Offer that start explicitly instead of
+ * relying on the user to know the policy.
+ */
+export function offerStartNowPrompt(
+  agent: ManagedAgent,
+  startMutation: ReturnType<typeof useStartManagedAgentMutation>,
+) {
+  const startedName = agent.name;
+  toast(`${startedName} saved while stopped.`, {
+    action: {
+      label: "Start now",
+      onClick: () => {
+        startMutation.mutate(agent.pubkey, {
+          onSuccess: () => toast.success(`${startedName} started.`),
+          onError: (error) =>
+            toast.error(
+              error instanceof Error
+                ? `${startedName} failed to start: ${error.message}`
+                : `${startedName} failed to start.`,
+            ),
+        });
+      },
+    },
+  });
+}


### PR DESCRIPTION
## Problem

When you change "Who can talk to this agent" (`respond_to`) on an agent that's already running, Desktop writes the new setting to disk immediately and correctly — but it never restarts the running `buzz-acp` process. That process keeps enforcing the OLD permission in memory until it happens to restart on its own (an idle-based auto-restart policy, gated to 3+ minutes idle plus other conditions) or someone restarts it by hand. In the meantime, mentions from people who should now be allowed under the new setting are silently dropped, and vice versa. The only indication anything is stale is a passive "Restart required" badge — easy to miss, and especially risky for a setting whose entire point is access control (buzz#2501, buzz#2950).

## What this changes

Adds an explicit "Restart now" action to the save toast whenever the save changed the `respond_to` gate and the backend confirms the running process is now out of sync with disk — mirroring the existing "saved while stopped → Start now" toast pattern already used elsewhere in `AgentInstanceEditDialog`. The predicate driving it (`shouldOfferImmediateRespondToRestart`) is a pure function, and the restart itself reuses only existing primitives: `respawnManagedAgentWithRules`, `startManagedAgent`/`stopManagedAgent`, `clearActiveTurnsForAgentOnStop`, and the backend's already-computed `needsRestart` drift signal. No Rust/backend changes, no new IPC, no schema changes — this is purely surfacing an existing signal more assertively.

Rebased onto main's #3352 (stateless file-size ratchet replacing the static override ledger). `AgentInstanceEditDialog.tsx` was already at the line cap and can't grow further under that rule, so the pre-existing "saved while stopped → Start now" toast was extracted alongside the new restart prompt into `agentSaveOutcomePrompts.ts` (renamed from `respondToRestartPrompt.ts`) — a net line reduction at the call site instead of a net addition. No behavior change to either toast.

## Out of scope (tracked separately)
- Propagating a persona/definition-level `respond_to` edit to already-linked instances — `update_persona` only propagates avatar/display_name today.
- The Desktop mention-picker/autocomplete eligibility work — in flight on other open PRs (buzz#2987).

## Test plan
- [x] `node --import ./test-loader.mjs --experimental-strip-types --test "src/**/*.test.mjs"` — 3770/3770 pass (full desktop suite, rebased onto main @ 58d2dfc)
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` on touched files — clean
- [x] `node desktop/scripts/check-file-sizes.mjs` (base `origin/main`) — clean
- [ ] Manual verification in Desktop: edit an existing agent's "Who can talk to this agent" to Anyone/allowlist while running, confirm the "Restart now" toast appears and a non-owner can then @mention it

🤖 Written by Claude, running as an agent inside Buzz (buzz-acp) — not the Claude Code CLI.
