### PR TITLE
fix(web): send mobile invitees to the app stores, not GitHub releases

### DIFF
--- a/web/src/shared/lib/buzz-download.ts
+++ b/web/src/shared/lib/buzz-download.ts
@@ -1,12 +1,31 @@
 export const BUZZ_RELEASES_URL = "https://github.com/block/buzz/releases";
+export const BUZZ_IOS_APP_STORE_URL =
+  "https://apps.apple.com/us/app/buzz-chat-with-your-hive/id6779728271";
+export const BUZZ_ANDROID_PLAY_STORE_URL =
+  "https://play.google.com/store/apps/details?id=xyz.block.buzz.mobile";
 const BUZZ_RELEASES_API_URL =
   "https://api.github.com/repos/block/buzz/releases?per_page=10";
 const CACHE_KEY = "buzz.latestDownload.v1";
 const CACHE_TTL_MS = 60 * 60 * 1000;
 
 export type BuzzDownloadPlatform = {
-  operatingSystem: "linux" | "macos" | "windows" | "unknown";
+  operatingSystem:
+    | "linux"
+    | "macos"
+    | "windows"
+    | "ios"
+    | "android"
+    | "unknown";
   architecture: "arm64" | "x64" | "unknown";
+};
+
+// iOS and Android are supported platforms that take a store listing instead of
+// a GitHub release asset, so they resolve before the release lookup runs.
+const STORE_URLS: Partial<
+  Record<BuzzDownloadPlatform["operatingSystem"], string>
+> = {
+  ios: BUZZ_IOS_APP_STORE_URL,
+  android: BUZZ_ANDROID_PLAY_STORE_URL,
 };
 
 type GitHubRelease = {
@@ -39,6 +58,24 @@ function normalizeOperatingSystem(
   // Reject non-desktop devices before admitting desktop-looking signals.
   const isIPadDesktopMode =
     platform === "macintel" && navigatorValue.maxTouchPoints > 1;
+
+  // Phones and tablets get a store listing, so classify the two platforms the
+  // mobile app actually ships on before the catch-all below folds every
+  // non-desktop device into `unknown`. Fire tablets (kindle/silk) and ChromeOS
+  // stay `unknown` on purpose: neither is served by the Play Store listing.
+  if (!/kindle|silk|cros/.test(userAgent)) {
+    if (
+      isIPadDesktopMode ||
+      platform === "ios" ||
+      /iphone|ipad|ipod/.test(userAgent)
+    ) {
+      return "ios";
+    }
+    if (platform === "android" || /android/.test(userAgent)) {
+      return "android";
+    }
+  }
+
   const isUnsupportedDevice =
     userAgentData?.mobile === true ||
     isIPadDesktopMode ||
@@ -142,6 +179,11 @@ export function selectBuzzDownloadUrl(
 export async function resolveBuzzDownloadUrlForPlatform(
   platform: BuzzDownloadPlatform,
 ): Promise<string> {
+  const storeUrl = STORE_URLS[platform.operatingSystem];
+  if (storeUrl) {
+    return storeUrl;
+  }
+
   try {
     const cached = JSON.parse(sessionStorage.getItem(CACHE_KEY) ?? "null") as {
       expiresAt: number;

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -260,16 +260,23 @@ test("invite asks Safari users to choose their Mac download", async ({
   await context.close();
 });
 
-test("invite download falls back for mobile and non-desktop devices", async ({
+const APP_STORE_URL =
+  "https://apps.apple.com/us/app/buzz-chat-with-your-hive/id6779728271";
+const PLAY_STORE_URL =
+  "https://play.google.com/store/apps/details?id=xyz.block.buzz.mobile";
+const RELEASES_URL = "https://github.com/block/buzz/releases";
+
+test("invite download sends each non-desktop device where its app lives", async ({
   browser,
 }) => {
-  const unsupportedDevices = [
+  const nonDesktopDevices = [
     {
       name: "iPhone Safari",
       platform: "iPhone",
       userAgent:
         "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15",
       maxTouchPoints: 5,
+      expected: APP_STORE_URL,
     },
     {
       name: "iPadOS desktop mode",
@@ -277,6 +284,7 @@ test("invite download falls back for mobile and non-desktop devices", async ({
       userAgent:
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15",
       maxTouchPoints: 5,
+      expected: APP_STORE_URL,
     },
     {
       name: "Android phone",
@@ -284,16 +292,29 @@ test("invite download falls back for mobile and non-desktop devices", async ({
       userAgent:
         "Mozilla/5.0 (Linux; Android 15; Pixel 9 Pro) AppleWebKit/537.36 Mobile",
       maxTouchPoints: 5,
+      expected: PLAY_STORE_URL,
     },
+    // No store listing serves these two, so they keep the releases-page
+    // fallback: ChromeOS is not a Play Store target here, and Fire tablets
+    // ship through Amazon's Appstore.
     {
       name: "ChromeOS",
       platform: "Linux x86_64",
       userAgent: "Mozilla/5.0 (X11; CrOS x86_64 16093.68.0) AppleWebKit/537.36",
       maxTouchPoints: 0,
+      expected: RELEASES_URL,
+    },
+    {
+      name: "Fire tablet (Silk)",
+      platform: "Linux armv8l",
+      userAgent:
+        "Mozilla/5.0 (Linux; Android 9; KFMAWI) AppleWebKit/537.36 Silk/126.0 like Chrome/126.0.0.0 Safari/537.36",
+      maxTouchPoints: 5,
+      expected: RELEASES_URL,
     },
   ];
 
-  for (const device of unsupportedDevices) {
+  for (const device of nonDesktopDevices) {
     const context = await browser.newContext({ userAgent: device.userAgent });
     await context.addInitScript(({ platform, maxTouchPoints }) => {
       Object.defineProperties(navigator, {
@@ -343,7 +364,7 @@ test("invite download falls back for mobile and non-desktop devices", async ({
     await expect(
       page.getByRole("link", { name: "Download it now" }),
       device.name,
-    ).toHaveAttribute("href", "https://github.com/block/buzz/releases");
+    ).toHaveAttribute("href", device.expected);
     await context.close();
   }
 });


### PR DESCRIPTION
## Summary

An invite link opened on a phone offers `github.com/block/buzz/releases` — a list of desktop binaries. `normalizeOperatingSystem` folds every non-desktop user agent into `unknown`, `assetPattern` has no pattern for `unknown`, and `resolveBuzzDownloadUrlForPlatform` therefore falls back to the releases page.

That fallback was the right answer while there was no mobile app to point at. Both listings are live now, so this classifies iOS and Android as real platforms and resolves them straight to their store URL, ahead of the GitHub release lookup:

- iOS — `https://apps.apple.com/us/app/buzz-chat-with-your-hive/id6779728271`
- Android — `https://play.google.com/store/apps/details?id=xyz.block.buzz.mobile`

Verified both listings resolve, and that the Play Store id matches `namespace = "xyz.block.buzz.mobile"` in `mobile/android/app/build.gradle.kts`.

iPadOS in desktop mode (`MacIntel` + `maxTouchPoints > 1`) is classified as iOS rather than being discarded — the App Store listing reports iPad support. ChromeOS and Fire tablets (`kindle`/`silk`) keep the releases fallback on purpose: neither is served by the Play Store listing. Desktop detection is untouched, so macOS, Windows and Linux still resolve a release asset exactly as before, including the "which Mac do you have?" flow.

**This is the store-links half of #3357 only.** That issue also reports a blank render of the invite page on iOS Safari against a self-hosted relay. I could not reproduce that and it is not addressed here — the invite page renders the download link unconditionally, so the two symptoms do not share a cause.

### Related issue

Refs #3357 (partial — see the scope note above). No open PR touches `web/src/shared/lib/buzz-download.ts` or `web/tests/e2e/smoke.spec.ts`; #2255 is the closest, adding a "Browse releases" link to the same invite page.

### Testing

`web` package, node 22.17.1, pnpm 11.4.0.

The existing e2e case `invite download falls back for mobile and non-desktop devices` pinned the releases-page fallback for iPhone, iPadOS desktop mode, Android and ChromeOS. It now carries an expected destination per device, covers a Fire tablet too, and is renamed to `invite download sends each non-desktop device where its app lives`.

Reverting only the `buzz-download.ts` change fails it exactly as reported in the issue:

```
Error: iPhone Safari
expect(locator).toHaveAttribute(expected) failed
Expected: "https://apps.apple.com/us/app/buzz-chat-with-your-hive/id6779728271"
Received: "https://github.com/block/buzz/releases"
```

With the change, all six smoke tests pass, including the desktop download assertion and the Mac-choice dialog. `pnpm check` and `pnpm typecheck` are clean.

Platform classification was also exercised directly against real user-agent strings — iPhone Safari, iPadOS desktop mode, Android Chrome (with UA client hints) and Android Firefox (without) all classify as `ios`/`android`, while macOS, Windows, Linux, ChromeOS and Fire tablet keep their previous classification.
