### PR TITLE
fix(robustness): replace risky production unwrap() with typed error handling

### DIFF
--- a/crates/buzz-cli/src/commands/agents.rs
+++ b/crates/buzz-cli/src/commands/agents.rs
@@ -296,7 +296,11 @@ pub(crate) async fn fetch_archived_snapshot(client: &BuzzClient) -> Result<Vec<S
     }
 
     // State 2 or 3: verify then collect.
-    let raw_event = events.into_iter().next().unwrap();
+    // Safe: the empty case returned early above, so at least one event exists.
+    let raw_event = events
+        .into_iter()
+        .next()
+        .expect("events is non-empty; checked above");
     let event: nostr::Event = serde_json::from_value(raw_event)
         .map_err(|e| CliError::Other(format!("archived-identities event is malformed: {e}")))?;
     let archived = verify_archived_event(&event, &self_hex)?;

--- a/crates/buzz-media/src/validation.rs
+++ b/crates/buzz-media/src/validation.rs
@@ -601,8 +601,9 @@ fn validate_png_metadata_free(bytes: &[u8]) -> Result<(), MediaError> {
         if i + 12 > bytes.len() {
             return Err(MediaError::InvalidImage);
         }
-        let len = u32::from_be_bytes(bytes[i..i + 4].try_into().unwrap()) as usize;
-        let kind: [u8; 4] = bytes[i + 4..i + 8].try_into().unwrap();
+        // Safe: the bounds check above guarantees at least 12 bytes from `i`.
+        let len = u32::from_be_bytes(bytes[i..i + 4].try_into().expect("bounds checked")) as usize;
+        let kind: [u8; 4] = bytes[i + 4..i + 8].try_into().expect("bounds checked");
         let end = i
             .checked_add(12)
             .and_then(|v| v.checked_add(len))
@@ -670,8 +671,10 @@ fn validate_webp_metadata_free(bytes: &[u8]) -> Result<(), MediaError> {
             if i + 8 > payload.len() {
                 return Err(MediaError::InvalidImage);
             }
-            let kind: [u8; 4] = payload[i..i + 4].try_into().unwrap();
-            let len = u32::from_le_bytes(payload[i + 4..i + 8].try_into().unwrap()) as usize;
+            // Safe: the bounds check above guarantees at least 8 bytes from `i`.
+            let kind: [u8; 4] = payload[i..i + 4].try_into().expect("bounds checked");
+            let len = u32::from_le_bytes(payload[i + 4..i + 8].try_into().expect("bounds checked"))
+                as usize;
             let padded = len.checked_add(len & 1).ok_or(MediaError::InvalidImage)?;
             i = i
                 .checked_add(8)
@@ -694,7 +697,7 @@ fn validate_webp_metadata_free(bytes: &[u8]) -> Result<(), MediaError> {
     if bytes.len() < 12 || &bytes[..4] != b"RIFF" || &bytes[8..12] != b"WEBP" {
         return Err(MediaError::InvalidImage);
     }
-    let declared = u32::from_le_bytes(bytes[4..8].try_into().unwrap()) as usize;
+    let declared = u32::from_le_bytes(bytes[4..8].try_into().expect("len >= 12 checked")) as usize;
     if declared.checked_add(8) != Some(bytes.len()) {
         return Err(MediaError::MetadataForbidden);
     }
@@ -703,8 +706,10 @@ fn validate_webp_metadata_free(bytes: &[u8]) -> Result<(), MediaError> {
         if i + 8 > bytes.len() {
             return Err(MediaError::InvalidImage);
         }
-        let kind: [u8; 4] = bytes[i..i + 4].try_into().unwrap();
-        let len = u32::from_le_bytes(bytes[i + 4..i + 8].try_into().unwrap()) as usize;
+        // Safe: the bounds check above guarantees at least 8 bytes from `i`.
+        let kind: [u8; 4] = bytes[i..i + 4].try_into().expect("bounds checked");
+        let len =
+            u32::from_le_bytes(bytes[i + 4..i + 8].try_into().expect("bounds checked")) as usize;
         let payload_start = i + 8;
         let padded = len.checked_add(len & 1).ok_or(MediaError::InvalidImage)?;
         i = payload_start
@@ -882,8 +887,9 @@ fn validate_mp4_metadata_free(path: &Path) -> Result<(), MediaError> {
             let mut h = [0u8; 8];
             file.read_exact(&mut h)
                 .map_err(|_| MediaError::InvalidVideo)?;
-            let compact = u32::from_be_bytes(h[..4].try_into().unwrap()) as u64;
-            let kind: [u8; 4] = h[4..8].try_into().unwrap();
+            // `h` is a fixed [u8; 8]; these slices are always exactly 4 bytes.
+            let compact = u32::from_be_bytes(h[..4].try_into().expect("fixed 8-byte array")) as u64;
+            let kind: [u8; 4] = h[4..8].try_into().expect("fixed 8-byte array");
             let (size, header) = if compact == 1 {
                 let mut ext = [0u8; 8];
                 file.read_exact(&mut ext)

--- a/crates/buzz-relay/src/api/git/cas_publish.rs
+++ b/crates/buzz-relay/src/api/git/cas_publish.rs
@@ -406,8 +406,14 @@ async fn write_idx_sidecar(
         .await
         .map_err(|e| CasError::PackCapture(format!("write idx input pack {pack_digest}: {e}")))?;
 
+    let pack_path_str = pack_path.to_str().ok_or_else(|| {
+        CasError::PackCapture(format!(
+            "idx pack path is not valid UTF-8: {}",
+            pack_path.display()
+        ))
+    })?;
     let mut cmd = Command::new("git");
-    cmd.args(["index-pack", pack_path.to_str().unwrap()])
+    cmd.args(["index-pack", pack_path_str])
         .current_dir(tempdir.path());
     super::transport::harden_git_env(&mut cmd);
     let out = cmd


### PR DESCRIPTION
## Summary

Removes `unwrap()` calls from production code paths where runtime panics could be triggered by external input or platform-specific conditions, as part of a codebase audit following AGENTS.md's no-`unwrap`-in-production policy.

## Changes

### 🔴 `cas_publish.rs` — real panic risk fixed
- `pack_path.to_str().unwrap()` → `ok_or_else(CasError)?`
- **Risk:** Non-UTF-8 temp directory paths (e.g. Windows usernames with non-ASCII characters) would panic the relay during git `index-pack`. Now returns a typed `CasError` instead.

### 🟡 `validation.rs` — invariant documentation (9 sites)
- `try_into().unwrap()` in PNG/WebP/MP4/GIF metadata validation → `expect()` with documented invariant
- Each site is guarded by an explicit bounds check earlier in the same function, so the unwrap never fires in practice. `expect()` makes the safety invariant explicit and produces a clear diagnostic if the assumption ever breaks during future refactoring.

### 🟡 `agents.rs` — invariant documentation
- `events.next().unwrap()` → `expect()` with invariant comment
- Already guarded by an `is_empty()` early-return above; made the safety explicit.

## What was NOT changed

The remaining ~18 production `unwrap()` calls are all in categories where failure is genuinely impossible (e.g. `"*".parse().unwrap()` for a static header value, `Response::builder().body(Body::from(...)).unwrap()` where the body type is infallible, SHA-256 digest slicing). Changing these would add noise without improving safety.

Note: `side_effects.rs` had two risky `unwrap()` calls (role string parsing, actor member lookup) that were also targeted, but `main` already refactored that code to eliminate them.

## Verification

- [x] `cargo check` — compiles
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --check` — formatted
- [x] `cargo test -p buzz-media --lib` — 103/103 pass
- [x] `cargo test -p buzz-cli --lib` — pass