### PR TITLE
fix(desktop): allow mentioning invocable external relay agents

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -57,10 +57,16 @@ export function getMentionableAgentPubkeys({
 export function isAgentIdentityInManagedList(
   candidate: { isAgent?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
+  mentionableAgentPubkeys?: ReadonlySet<string>,
 ) {
+  const pubkey = normalizePubkey(candidate.pubkey);
   return (
     candidate.isAgent !== true ||
-    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
+    managedAgentPubkeys.has(pubkey) ||
+    // Externally-hosted agents (relay directory, kind:10100) that are
+    // invocable for the current user are legitimate mention targets even
+    // though no local managed-agent record exists for them.
+    (mentionableAgentPubkeys?.has(pubkey) ?? false)
   );
 }
 

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -246,7 +246,13 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (
+        !isAgentIdentityInManagedList(
+          candidate,
+          managedAgentPubkeys,
+          mentionableAgentPubkeys,
+        )
+      ) {
         return;
       }
       if (


### PR DESCRIPTION
## Summary

Attested agents (kind:0 with a valid NIP-OA `auth` tag) that have no local managed-agent record are hard-dropped from mention candidates in `useMentions` — `isAgentIdentityInManagedList` only passes non-agents and desktop-managed agents. Since managed-agent records are never minted from relay events (by design — no local secret), an **externally-hosted agent can never be mentioned by anyone, including its owner**, even when its kind:10100 directory entry makes it invocable for the current user.

This surfaced the moment we added an NIP-OA owner attestation to a self-hosted buzz-acp agent: it went from mentionable (as a plain member) to invisible in the picker, while remaining a channel member and answering CLI-authored mentions fine.

Fix: accept candidates that are in `mentionableAgentPubkeys` (relay-directory agents invocable for the current user — same set `shouldHideAgentFromMentions` already consults) alongside desktop-managed ones. Non-invocable directory agents stay hidden exactly as before.

### Related issue
None found — closest context is the kind:10100 invocability model in `agentAutocompleteEligibility.ts`.

### Testing
- `tsc --noEmit` clean
- Reproduced against a self-hosted relay (closed, NIP-43) with an external buzz-acp agent (`respond_to=allowlist`, kind:10100 published with `respond_to_allowlist` containing the owner): before the patch the agent never appears in the mention picker; after the patch it autocompletes and mentions dispatch end-to-end (agent replies via the harness)
- Local release build (`desktop-release-build` recipe) verified interactively on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)