### PR TITLE
fix(desktop): replace legacy AppImage buzz wrapper

### DIFF
--- a/desktop/src-tauri/src/managed_agents/nest.rs
+++ b/desktop/src-tauri/src/managed_agents/nest.rs
@@ -356,7 +356,11 @@ pub fn cli_link_name(is_dev: bool) -> &'static str {
 ///
 /// On every boot: replaces any existing symlink unconditionally (the `buzz` /
 /// `buzz-dev` name is our namespace), creates a new one if absent, and leaves
-/// regular files alone to avoid clobbering a user-compiled binary.
+/// regular files alone to avoid clobbering a user-compiled binary. The one
+/// regular-file exception is the legacy Linux AppImage GUI launcher formerly
+/// installed as `~/.local/bin/buzz`: that wrapper shadows the bundled headless
+/// CLI and silently no-ops agent-facing commands like `buzz messages send`, so
+/// production boots migrate it to the real CLI symlink.
 ///
 /// Non-fatal: callers should ignore errors — the symlink is a convenience
 /// for human Terminal use; agents find the CLI via PATH augmentation.
@@ -371,20 +375,38 @@ pub fn ensure_cli_symlink(exe_parent: &Path, is_dev: bool) -> Result<(), String>
         .ok_or("cannot resolve home directory")?
         .join(".local")
         .join("bin");
-    fs::create_dir_all(&local_bin).map_err(|e| format!("create {}: {e}", local_bin.display()))?;
+
+    ensure_cli_symlink_in_local_bin(&local_bin, &buzz_bin, is_dev)
+}
+
+#[cfg(unix)]
+fn ensure_cli_symlink_in_local_bin(
+    local_bin: &Path,
+    buzz_bin: &Path,
+    is_dev: bool,
+) -> Result<(), String> {
+    fs::create_dir_all(local_bin).map_err(|e| format!("create {}: {e}", local_bin.display()))?;
 
     let link = local_bin.join(cli_link_name(is_dev));
     match link.symlink_metadata() {
         Ok(meta) if meta.file_type().is_symlink() => {
             let _ = fs::remove_file(&link);
-            create_symlink(&buzz_bin, &link)
+            create_symlink(buzz_bin, &link)
+                .map_err(|e| format!("symlink {}: {e}", link.display()))?;
+        }
+        Ok(meta)
+            if meta.file_type().is_file() && !is_dev && is_legacy_appimage_gui_wrapper(&link) =>
+        {
+            fs::remove_file(&link).map_err(|e| format!("remove {}: {e}", link.display()))?;
+            create_symlink(buzz_bin, &link)
                 .map_err(|e| format!("symlink {}: {e}", link.display()))?;
         }
         Ok(_) => {
-            // Regular file or directory — don't clobber.
+            // Regular user files/directories are preserved; only the known legacy
+            // AppImage GUI wrapper above is migrated.
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            create_symlink(&buzz_bin, &link)
+            create_symlink(buzz_bin, &link)
                 .map_err(|e| format!("symlink {}: {e}", link.display()))?;
         }
         Err(e) => {
@@ -393,6 +415,18 @@ pub fn ensure_cli_symlink(exe_parent: &Path, is_dev: bool) -> Result<(), String>
     }
 
     Ok(())
+}
+
+#[cfg(unix)]
+fn is_legacy_appimage_gui_wrapper(path: &Path) -> bool {
+    let Ok(script) = fs::read_to_string(path) else {
+        return false;
+    };
+
+    script.len() <= 16 * 1024
+        && script.contains("BUZZ_APPIMAGE")
+        && script.contains("buzz-browser")
+        && script.contains("exec \"$APPIMAGE\" \"$@\"")
 }
 
 /// No-op on non-Unix platforms — symlink management is macOS/Linux only.

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -340,41 +340,39 @@ fn cli_link_name_dev_is_buzz_dev() {
 }
 
 #[cfg(unix)]
-#[test]
-fn ensure_cli_symlink_creates_symlink_prod() {
+fn cli_symlink_fixture() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
     let tmp = tempfile::tempdir().unwrap();
     let exe_parent = tmp.path().join("MacOS");
     fs::create_dir(&exe_parent).unwrap();
-    fs::write(exe_parent.join("buzz"), "binary").unwrap();
+    let buzz_bin = exe_parent.join("buzz");
+    fs::write(&buzz_bin, "binary").unwrap();
 
     let local_bin = tmp.path().join("local_bin");
-    fs::create_dir_all(&local_bin).unwrap();
+    (tmp, local_bin, buzz_bin)
+}
 
-    // Prod link name is "buzz"; simulate the symlink creation path.
+#[cfg(unix)]
+#[test]
+fn ensure_cli_symlink_creates_symlink_prod() {
+    let (_tmp, local_bin, buzz_bin) = cli_symlink_fixture();
+
+    ensure_cli_symlink_in_local_bin(&local_bin, &buzz_bin, false).unwrap();
+
     let link = local_bin.join(cli_link_name(false));
-    std::os::unix::fs::symlink(exe_parent.join("buzz"), &link).unwrap();
     assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
-    assert_eq!(fs::read_link(&link).unwrap(), exe_parent.join("buzz"));
+    assert_eq!(fs::read_link(&link).unwrap(), buzz_bin);
 }
 
 #[cfg(unix)]
 #[test]
 fn ensure_cli_symlink_creates_symlink_dev() {
-    let tmp = tempfile::tempdir().unwrap();
-    let exe_parent = tmp.path().join("MacOS");
-    fs::create_dir(&exe_parent).unwrap();
-    fs::write(exe_parent.join("buzz"), "binary").unwrap();
+    let (_tmp, local_bin, buzz_bin) = cli_symlink_fixture();
 
-    let local_bin = tmp.path().join("local_bin");
-    fs::create_dir_all(&local_bin).unwrap();
-
-    // Dev link must be "buzz-dev", never "buzz".
-    assert_eq!(cli_link_name(true), "buzz-dev");
+    ensure_cli_symlink_in_local_bin(&local_bin, &buzz_bin, true).unwrap();
 
     let link = local_bin.join(cli_link_name(true));
-    std::os::unix::fs::symlink(exe_parent.join("buzz"), &link).unwrap();
     assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
-    assert_eq!(fs::read_link(&link).unwrap(), exe_parent.join("buzz"));
+    assert_eq!(fs::read_link(&link).unwrap(), buzz_bin);
     // Prod link must not exist — the two builds don't touch each other.
     assert!(!local_bin.join("buzz").exists());
 }
@@ -382,13 +380,13 @@ fn ensure_cli_symlink_creates_symlink_dev() {
 #[cfg(unix)]
 #[test]
 fn ensure_cli_symlink_does_not_clobber_regular_file_prod() {
-    let tmp = tempfile::tempdir().unwrap();
-    let local_bin = tmp.path().join("local_bin");
+    let (_tmp, local_bin, buzz_bin) = cli_symlink_fixture();
     fs::create_dir_all(&local_bin).unwrap();
     let link = local_bin.join(cli_link_name(false));
     fs::write(&link, "user-installed binary").unwrap();
 
-    // Regular files are preserved — the Ok(_) branch skips them.
+    ensure_cli_symlink_in_local_bin(&local_bin, &buzz_bin, false).unwrap();
+
     assert!(link.symlink_metadata().unwrap().file_type().is_file());
     assert_eq!(fs::read_to_string(&link).unwrap(), "user-installed binary");
 }
@@ -396,18 +394,68 @@ fn ensure_cli_symlink_does_not_clobber_regular_file_prod() {
 #[cfg(unix)]
 #[test]
 fn ensure_cli_symlink_does_not_clobber_regular_file_dev() {
-    let tmp = tempfile::tempdir().unwrap();
-    let local_bin = tmp.path().join("local_bin");
+    let (_tmp, local_bin, buzz_bin) = cli_symlink_fixture();
     fs::create_dir_all(&local_bin).unwrap();
     let link = local_bin.join(cli_link_name(true));
     fs::write(&link, "user-installed buzz-dev binary").unwrap();
 
-    // Regular files at the dev path are also preserved.
+    ensure_cli_symlink_in_local_bin(&local_bin, &buzz_bin, true).unwrap();
+
     assert!(link.symlink_metadata().unwrap().file_type().is_file());
     assert_eq!(
         fs::read_to_string(&link).unwrap(),
         "user-installed buzz-dev binary"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn ensure_cli_symlink_replaces_legacy_prod_appimage_wrapper() {
+    let (_tmp, local_bin, buzz_bin) = cli_symlink_fixture();
+    fs::create_dir_all(&local_bin).unwrap();
+    let link = local_bin.join(cli_link_name(false));
+    fs::write(
+        &link,
+        r#"#!/usr/bin/env bash
+# Launch Buzz with a clean browser handoff for OAuth / external links.
+set -euo pipefail
+
+APPIMAGE="${BUZZ_APPIMAGE:-$HOME/Applications/Buzz.AppImage}"
+if [[ ! -e "$APPIMAGE" ]]; then
+  echo "buzz: AppImage not found at $APPIMAGE" >&2
+  exit 1
+fi
+
+export BROWSER="${HOME}/.local/bin/buzz-browser"
+
+exec "$APPIMAGE" "$@"
+"#,
+    )
+    .unwrap();
+
+    ensure_cli_symlink_in_local_bin(&local_bin, &buzz_bin, false).unwrap();
+
+    assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+    assert_eq!(fs::read_link(&link).unwrap(), buzz_bin);
+}
+
+#[cfg(unix)]
+#[test]
+fn ensure_cli_symlink_preserves_legacy_wrapper_name_for_dev() {
+    let (_tmp, local_bin, buzz_bin) = cli_symlink_fixture();
+    fs::create_dir_all(&local_bin).unwrap();
+    let link = local_bin.join(cli_link_name(true));
+    let wrapper = r#"#!/usr/bin/env bash
+APPIMAGE="${BUZZ_APPIMAGE:-$HOME/Applications/Buzz.AppImage}"
+export BROWSER="${HOME}/.local/bin/buzz-browser"
+exec "$APPIMAGE" "$@"
+"#;
+    fs::write(&link, wrapper).unwrap();
+
+    ensure_cli_symlink_in_local_bin(&local_bin, &buzz_bin, true).unwrap();
+
+    assert!(link.symlink_metadata().unwrap().file_type().is_file());
+    assert_eq!(fs::read_to_string(&link).unwrap(), wrapper);
 }
 
 fn make_persona(id: &str, display_name: &str) -> AgentDefinition {


### PR DESCRIPTION
## Summary
- migrate the known legacy Linux AppImage GUI launcher at `~/.local/bin/buzz` to the bundled headless CLI symlink on desktop startup
- preserve unrelated regular files and the dev `buzz-dev` link name behavior
- add regression coverage for creating CLI symlinks, preserving user files, and replacing the legacy AppImage wrapper

Closes #3471.

## Test plan
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --check`
- `git diff --check`
- Attempted: `cargo test --manifest-path desktop/src-tauri/Cargo.toml managed_agents::nest` (blocked in this container because no system C compiler/linker toolchain is installed; `sudo` requires a password, and the Hermit clang fallback cannot link glibc Rust build scripts due missing `libgcc_s`/glibc linker support)
