### PR TITLE
fix(security): migrate MCP private-key handoff to keyfile pattern

### DIFF
--- a/crates/buzz-agent/src/mcp.rs
+++ b/crates/buzz-agent/src/mcp.rs
@@ -52,13 +52,11 @@ const PASSTHROUGH_ENV: &[&str] = &[
     "GIT_ASKPASS",
     "GIT_SSH_COMMAND",
     "GIT_CONFIG_GLOBAL",
-    // Buzz identity — dev-mcp writes NOSTR_PRIVATE_KEY to a keyfile then
-    // removes it from its own env (children never see it). BUZZ_PRIVATE_KEY
-    // and BUZZ_RELAY_URL are kept for the buzz CLI. BUZZ_AUTH_TAG is a
-    // non-secret signed ownership attestation needed by portable owner-scoped
-    // CLI operations; MCP subprocesses are trusted like the agent runtime.
-    "NOSTR_PRIVATE_KEY",
-    "BUZZ_PRIVATE_KEY",
+    // Buzz identity — dev-mcp writes both NOSTR_PRIVATE_KEY and
+    // BUZZ_PRIVATE_KEY to 0600 keyfiles, then removes them from its own env.
+    // Children receive BUZZ_KEYFILE (a path, not a secret) and BUZZ_RELAY_URL.
+    // Raw private keys are never passed through to MCP subprocesses.
+    "BUZZ_KEYFILE",
     "BUZZ_RELAY_URL",
     "BUZZ_AUTH_TAG",
     // Agent display name — dev-mcp uses it as the git author name. On the

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -85,6 +85,14 @@ struct Cli {
     #[arg(long, env = "BUZZ_PRIVATE_KEY")]
     private_key: Option<String>,
 
+    /// Path to a file containing the Nostr private key (hex or nsec).
+    ///
+    /// Alternative to `--private-key` / `BUZZ_PRIVATE_KEY` that avoids putting
+    /// the key in an environment variable (which child processes can read).
+    /// If both are set, `--keyfile` takes precedence.
+    #[arg(long, env = "BUZZ_KEYFILE")]
+    keyfile: Option<String>,
+
     /// NIP-OA auth tag JSON (owner attestation). Injected into every signed event.
     #[arg(long, env = "BUZZ_AUTH_TAG")]
     auth_tag: Option<String>,
@@ -1743,6 +1751,23 @@ pub enum ModerationCmd {
     },
 }
 
+/// Read a private key from a keyfile, trimming surrounding whitespace.
+///
+/// The file should contain the key as a single line (hex or nsec). This is
+/// the keyfile pattern used by `dev-mcp` to avoid passing the raw key through
+/// environment variables visible to child processes.
+fn read_keyfile(path: &str) -> Result<String, std::io::Error> {
+    let contents = std::fs::read_to_string(path)?;
+    let trimmed = contents.trim();
+    if trimmed.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "keyfile is empty",
+        ));
+    }
+    Ok(trimmed.to_owned())
+}
+
 async fn run(cli: Cli) -> Result<(), CliError> {
     let relay_url = client::normalize_relay_url(&cli.relay);
 
@@ -1756,11 +1781,21 @@ async fn run(cli: Cli) -> Result<(), CliError> {
 
     // Auth: private key is required for all relay operations.
     // The keypair IS the identity — no tokens, no other auth.
-    let private_key_str = cli.private_key.ok_or_else(|| {
-        CliError::Auth("BUZZ_PRIVATE_KEY is required (use --private-key or set env var)".into())
-    })?;
+    //
+    // Keyfile takes precedence over the env-var/flag form so that managed
+    // subprocess environments (dev-mcp shim) can avoid exposing the raw key.
+    let private_key_str = if let Some(ref path) = cli.keyfile {
+        read_keyfile(path).map_err(|e| CliError::Auth(format!("BUZZ_KEYFILE ({path}): {e}")))?
+    } else {
+        cli.private_key.ok_or_else(|| {
+            CliError::Auth(
+                "private key is required (use --private-key, --keyfile, or set BUZZ_PRIVATE_KEY)"
+                    .into(),
+            )
+        })?
+    };
     let keys = Keys::parse(&private_key_str)
-        .map_err(|e| CliError::Key(format!("invalid BUZZ_PRIVATE_KEY: {e}")))?;
+        .map_err(|e| CliError::Key(format!("invalid private key: {e}")))?;
 
     // NIP-OA: parse and verify the auth tag if provided.
     let (auth_tag, auth_tag_json) = match cli.auth_tag {

--- a/crates/buzz-dev-mcp/src/shell.rs
+++ b/crates/buzz-dev-mcp/src/shell.rs
@@ -75,7 +75,7 @@ impl SharedState {
 fn build_bootstrap(cwd: &Path, shell_hint: &str) -> String {
     let stack = detect_stack(cwd);
     let buzz_hint =
-        if std::env::var("BUZZ_RELAY_URL").is_ok() && std::env::var("BUZZ_PRIVATE_KEY").is_ok() {
+        if std::env::var("BUZZ_RELAY_URL").is_ok() && std::env::var("BUZZ_KEYFILE").is_ok() {
             "\nBuzz relay configured. Run `buzz --help` to see available commands.\n"
         } else {
             ""
@@ -167,9 +167,13 @@ pub async fn run(
     cmd.arg(shell_arg).arg(&p.command);
     cmd.current_dir(&workdir);
     cmd.env("PATH", &state.shim.path_env);
-    // NOSTR_PRIVATE_KEY is already removed from this process's env (shim.rs).
-    // BUZZ_PRIVATE_KEY is intentionally inherited — the buzz CLI needs it.
+    // NOSTR_PRIVATE_KEY and BUZZ_PRIVATE_KEY are already removed from this
+    // process's env (shim.rs). Git helpers read from the nostr keyfile; the
+    // buzz CLI reads from the buzz keyfile via BUZZ_KEYFILE.
     for (k, v) in &state.shim.git_env {
+        cmd.env(k, v);
+    }
+    for (k, v) in &state.shim.buzz_env {
         cmd.env(k, v);
     }
     cmd.stdin(Stdio::null());

--- a/crates/buzz-dev-mcp/src/shim.rs
+++ b/crates/buzz-dev-mcp/src/shim.rs
@@ -9,16 +9,23 @@ use zeroize::Zeroize;
 /// 1. Creates a 0700 tempdir with symlinks back to our binary (multicall)
 /// 2. If `NOSTR_PRIVATE_KEY` is set: writes a 0600 keyfile, derives the pubkey,
 ///    builds ephemeral `GIT_CONFIG_*` env vars, then removes the env var
-/// 3. Prepends the shim dir to PATH
+/// 3. If `BUZZ_PRIVATE_KEY` is set: writes it to a separate 0600 keyfile and
+///    exposes the path via `BUZZ_KEYFILE` (the buzz CLI reads keyfiles), then
+///    removes `BUZZ_PRIVATE_KEY` from the process env
+/// 4. Prepends the shim dir to PATH
 ///
-/// Shell children receive `path_env`, `git_env`, and `BUZZ_PRIVATE_KEY` (for
-/// the buzz CLI). `NOSTR_PRIVATE_KEY` is removed from the process env after
-/// the keyfile is written — git helpers read from the keyfile only.
+/// Shell children receive `path_env`, `git_env`, and `buzz_env` (which carries
+/// `BUZZ_KEYFILE` + `BUZZ_RELAY_URL`). Neither `NOSTR_PRIVATE_KEY` nor
+/// `BUZZ_PRIVATE_KEY` survives in the process env after install — shell
+/// children can only read the keys from their respective keyfiles.
 /// Cleaned up on drop (TempDir).
 pub struct Shim {
     _dir: TempDir,
     pub path_env: String,
     pub git_env: Vec<(String, String)>,
+    /// Env vars for the `buzz` CLI: `BUZZ_KEYFILE` (path to the private-key
+    /// keyfile) and `BUZZ_RELAY_URL`. Does **not** contain the raw key.
+    pub buzz_env: Vec<(String, String)>,
 }
 
 impl Shim {
@@ -67,10 +74,48 @@ impl Shim {
             k.zeroize();
         }
 
+        // Same keyfile treatment for BUZZ_PRIVATE_KEY: write to a 0600 file and
+        // pass the path via BUZZ_KEYFILE, then remove the raw key from the
+        // process env so no shell child can read it.
+        let mut buzz_env = Vec::new();
+        let mut buzz_key = std::env::var("BUZZ_PRIVATE_KEY").ok();
+        std::env::remove_var("BUZZ_PRIVATE_KEY");
+        if let Some(ref key) = buzz_key {
+            if !key.is_empty() {
+                let buzz_keyfile = dir.path().join(".buzz-key");
+                match write_keyfile_atomic(&buzz_keyfile, key.as_bytes()) {
+                    Ok(()) => {
+                        if let Some(path) = buzz_keyfile.to_str() {
+                            buzz_env.push(("BUZZ_KEYFILE".to_owned(), path.to_owned()));
+                        } else {
+                            eprintln!(
+                                "buzz-dev-mcp: warning: tempdir path is not valid UTF-8; \
+                                 buzz CLI keyfile disabled"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "buzz-dev-mcp: warning: failed to write buzz keyfile ({e}); \
+                             buzz CLI auth disabled"
+                        );
+                    }
+                }
+            }
+        }
+        // Relay URL is non-secret — pass it through for the buzz CLI.
+        if let Ok(url) = std::env::var("BUZZ_RELAY_URL") {
+            buzz_env.push(("BUZZ_RELAY_URL".to_owned(), url));
+        }
+        if let Some(ref mut k) = buzz_key {
+            k.zeroize();
+        }
+
         Ok(Self {
             _dir: dir,
             path_env,
             git_env,
+            buzz_env,
         })
     }
 }

--- a/crates/buzz-dev-mcp/src/view_image.rs
+++ b/crates/buzz-dev-mcp/src/view_image.rs
@@ -296,11 +296,18 @@ fn relay_media_get_auth(url: &reqwest::Url) -> Option<String> {
     if !is_relay_media_url(url, &relay) {
         return None;
     }
-    let key = std::env::var("BUZZ_PRIVATE_KEY").ok()?;
+    // Prefer the keyfile path (set by the shim) over the raw env var, so the
+    // key is never in the environment for child processes to read.
+    let key = std::env::var("BUZZ_KEYFILE")
+        .ok()
+        .and_then(|path| std::fs::read_to_string(&path).ok())
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .or_else(|| std::env::var("BUZZ_PRIVATE_KEY").ok())?;
     let keys = match nostr::Keys::parse(&key) {
         Ok(k) => k,
         Err(e) => {
-            tracing::warn!("BUZZ_PRIVATE_KEY invalid; fetching relay media unauthenticated: {e}");
+            tracing::warn!("private key invalid; fetching relay media unauthenticated: {e}");
             return None;
         }
     };


### PR DESCRIPTION
## Summary

Previously, `BUZZ_PRIVATE_KEY` and `NOSTR_PRIVATE_KEY` were passed to MCP subprocesses via environment variables (`PASSTHROUGH_ENV` allowlist in `buzz-agent`). **Any configured MCP server could read the user's identity key from its own environment** — a known trust-boundary tradeoff documented in commit `fbce606fe`.

This PR migrates to a **keyfile pattern** so raw private keys never appear in subprocess environments.

## Changes

### `buzz-dev-mcp/src/shim.rs` — core fix
- Writes `BUZZ_PRIVATE_KEY` to a **0600 keyfile** inside the shim's 0700 tempdir (same proven pattern already used for `NOSTR_PRIVATE_KEY`)
- Exposes the path via **`BUZZ_KEYFILE`** env var to shell children
- **Removes `BUZZ_PRIVATE_KEY` from the process env** immediately after writing the keyfile
- New `Shim.buzz_env` field carries `BUZZ_KEYFILE` + `BUZZ_RELAY_URL` (relay URL is non-secret)

### `buzz-cli/src/lib.rs` — keyfile support
- New `--keyfile` flag / `BUZZ_KEYFILE` env var that reads the private key from a file
- Takes precedence over `--private-key` / `BUZZ_PRIVATE_KEY`
- **Backward compatible** — existing env-var usage still works for standalone CLI invocations

### `buzz-dev-mcp/src/view_image.rs` — media auth
- Relay media Blossom `t=get` auth now reads from `BUZZ_KEYFILE` first, falling back to `BUZZ_PRIVATE_KEY` for backward compatibility

### `buzz-dev-mcp/src/shell.rs`
- Passes `buzz_env` (`BUZZ_KEYFILE`, `BUZZ_RELAY_URL`) to shell children alongside `git_env`
- Bootstrap hint checks `BUZZ_KEYFILE` instead of `BUZZ_PRIVATE_KEY`

### `buzz-agent/src/mcp.rs` — allowlist lockdown
- **Removes** `BUZZ_PRIVATE_KEY` and `NOSTR_PRIVATE_KEY` from `PASSTHROUGH_ENV`
- **Adds** `BUZZ_KEYFILE` (a filesystem path, not a secret)
- MCP subprocesses can no longer read identity keys from their environment

## Security impact

| Before | After |
|--------|-------|
| Any MCP server can read `BUZZ_PRIVATE_KEY` from its env | MCP servers only see `BUZZ_KEYFILE` (a path) |
| Key in env = readable via `/proc/self/environ`, `env`, etc. | Key in 0600 file inside 0700 tempdir, cleaned up on exit |
| `NOSTR_PRIVATE_KEY` already keyfile-isolated | `BUZZ_PRIVATE_KEY` now also keyfile-isolated |

## Verification

- [x] `cargo check` — all 3 crates compile
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p buzz-cli -p buzz-dev-mcp -p buzz-agent --lib` — 286 passed (2 pre-existing failures on main, unrelated to this change)