### PR TITLE
docs(readme): clarify which release asset to download per platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,19 @@ New to Buzz? Pick the path that matches you.
 
 ### I just want to try the app
 
-Grab a packaged build from the [latest release](https://github.com/block/buzz/releases/latest) — macOS (`.dmg`), Linux (`.AppImage` / `.deb`), or Windows (`.exe`). Install it like any other app.
+Grab a packaged build from the [latest release](https://github.com/block/buzz/releases/latest):
+
+| Platform | File |
+|---|---|
+| macOS (Apple Silicon) | `Buzz_<version>_aarch64.dmg` |
+| macOS (Intel) | `Buzz_<version>_x64.dmg` |
+| Linux (x86_64) | `Buzz_<version>_amd64.AppImage` or `Buzz_<version>_amd64.deb` |
+| Windows (x64) | `Buzz_<version>_x64-setup_alpha-unsigned.exe` |
+
+On a Mac, check the Apple menu > About This Mac: "Apple M1/M2/M3/M4" means Apple Silicon, "Intel" means x64.
+
+The Windows build is not code-signed, so SmartScreen will show "Windows protected your PC" on first launch. Click **More info**, then **Run anyway**.
+
 
 By default the app connects to `ws://localhost:3000`. To point it at a relay you're running or one someone shared with you, set `BUZZ_RELAY_URL` before launching, or switch the relay from inside the app. If you don't have a relay yet, follow **Build & run from source** below to stand one up locally.
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ Grab a packaged build from the [latest release](https://github.com/block/buzz/re
 | Linux (x86_64) | `Buzz_<version>_amd64.AppImage` or `Buzz_<version>_amd64.deb` |
 | Windows (x64) | `Buzz_<version>_x64-setup_alpha-unsigned.exe` |
 
-On a Mac, check the Apple menu > About This Mac: "Apple M1/M2/M3/M4" means Apple Silicon, "Intel" means x64.
+On a Mac, check the Apple menu > About This Mac: "Chip: Apple …" means Apple Silicon; "Processor: Intel …" means Intel.
 
-The Windows build is not code-signed, so SmartScreen will show "Windows protected your PC" on first launch. Click **More info**, then **Run anyway**.
+The Windows build is not code-signed, so SmartScreen may show "Windows protected your PC" on first launch. If available, click **More info**, then **Run anyway**.
 
 
 By default the app connects to `ws://localhost:3000`. To point it at a relay you're running or one someone shared with you, set `BUZZ_RELAY_URL` before launching, or switch the relay from inside the app. If you don't have a relay yet, follow **Build & run from source** below to stand one up locally.


### PR DESCRIPTION
## Summary

The "I just want to try the app" section names platforms generically (macOS `.dmg`, Linux `.AppImage` / `.deb`, Windows `.exe`), but the release publishes five assets, including two separate macOS builds. A first-time user on a Mac has no way to tell whether they need `aarch64` or `x64`, and nothing sets expectations for the SmartScreen warning on the unsigned Windows build.

This replaces that sentence with a platform-to-filename table, a one-line note on how to check which Mac you have, and a note that the Windows build is unsigned and what the warning looks like.

Filenames use `<version>` rather than `0.5.0` so the table doesn't go stale each release.

### Related issue

None found. Searched open issues and PRs for README/download/install topics.

### Testing

Docs-only change, no code paths touched. Verified the table and paragraph breaks render correctly in GitHub's markdown preview.