### PR TITLE
feat(cli): emit verified signed message events

### DIFF
--- a/crates/buzz-cli/README.md
+++ b/crates/buzz-cli/README.md
@@ -33,6 +33,7 @@ buzz messages send --channel <uuid> --content "Hello"
 buzz messages send --channel <uuid> --content "Reply" --reply-to <event-id> --broadcast
 buzz messages send --channel <uuid> --content - < message.md   # read body from stdin
 buzz messages get --channel <uuid> --limit 20
+buzz messages get --channel <uuid> --include-signatures
 buzz messages thread --channel <uuid> --event <event-id>
 buzz messages search --query "architecture"
 buzz messages search --author <pubkey|npub|name> --since <unix-ts>
@@ -90,6 +91,14 @@ buzz repos protect remove --id my-repo --ref refs/heads/main
 # Pipe to jq
 buzz channels list | jq '.[].name'
 ```
+
+`messages get`, `messages thread`, and `messages search` omit event signatures
+by default. Pass `--include-signatures` when a downstream system must verify
+authorship. The CLI verifies each event id and Schnorr signature before emitting
+the complete `{id,pubkey,kind,content,created_at,tags,sig}` envelope; a malformed
+or unverifiable relay event makes the command fail. This complete envelope is
+preserved even with the global `--format compact` option because a partial event
+cannot be verified.
 
 `protect set` replaces every existing rule for the exact ref pattern. Any
 constraint omitted from the command is removed. `protect list` reports malformed

--- a/crates/buzz-cli/TESTING.md
+++ b/crates/buzz-cli/TESTING.md
@@ -215,13 +215,22 @@ echo 'Body with `backticks` and $vars stays literal.' \
 # messages get
 buzz messages get --channel "$CHANNEL_ID" | jq .
 buzz messages get --channel "$CHANNEL_ID" --limit 5 | jq .
+# Opt-in proof mode verifies each relay event before returning its full signed
+# envelope. The default read above remains sig-stripped.
+buzz messages get --channel "$CHANNEL_ID" --include-signatures \
+  | jq -e 'all(.[]; has("id") and has("pubkey") and has("kind") and
+    has("content") and has("created_at") and has("tags") and has("sig"))'
 
 # messages thread
 buzz messages thread --channel "$CHANNEL_ID" --event "$EVENT_ID" | jq .
+buzz messages thread --channel "$CHANNEL_ID" --event "$EVENT_ID" \
+  --include-signatures | jq -e 'all(.[]; has("sig"))'
 
 # messages search
 buzz messages search --query "Hello" | jq .
 buzz messages search --query "CLI test" --limit 5 | jq .
+buzz messages search --query "Hello" --include-signatures \
+  | jq -e 'all(.[]; has("sig"))'
 
 # messages edit
 buzz messages edit --event "$EVENT_ID" --content "Edited by CLI test" | jq .

--- a/crates/buzz-cli/src/client.rs
+++ b/crates/buzz-cli/src/client.rs
@@ -1321,6 +1321,44 @@ pub fn normalize_events(events: &[serde_json::Value]) -> String {
     serde_json::to_string(&normalized).unwrap_or_default()
 }
 
+/// Verify and normalize raw event JSON into a complete signed Nostr envelope.
+///
+/// Unlike [`normalize_events`], this path fails closed when any event is
+/// malformed or its id/signature does not verify. The selected fields are the
+/// complete NIP-01 event needed by an external verifier; relay-only projection
+/// fields are intentionally omitted.
+pub fn normalize_verified_events(events: &[serde_json::Value]) -> Result<String, CliError> {
+    let mut normalized = Vec::with_capacity(events.len());
+    for raw in events {
+        let event_id = raw
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("<unknown>");
+        let event = serde_json::from_value::<nostr::Event>(raw.clone()).map_err(|error| {
+            CliError::Other(format!(
+                "relay returned malformed signed event {event_id}: {error}"
+            ))
+        })?;
+        event.verify().map_err(|error| {
+            CliError::Other(format!(
+                "relay returned unverifiable signed event {event_id}: {error}"
+            ))
+        })?;
+
+        normalized.push(serde_json::json!({
+            "id": raw.get("id").cloned().unwrap_or(serde_json::Value::Null),
+            "pubkey": raw.get("pubkey").cloned().unwrap_or(serde_json::Value::Null),
+            "kind": raw.get("kind").cloned().unwrap_or(serde_json::Value::Null),
+            "content": raw.get("content").cloned().unwrap_or(serde_json::Value::Null),
+            "created_at": raw.get("created_at").cloned().unwrap_or(serde_json::Value::Null),
+            "tags": raw.get("tags").cloned().unwrap_or(serde_json::Value::Null),
+            "sig": raw.get("sig").cloned().unwrap_or(serde_json::Value::Null),
+        }));
+    }
+    serde_json::to_string(&normalized)
+        .map_err(|error| CliError::Other(format!("failed to serialize signed events: {error}")))
+}
+
 /// Extract the d-tag value from a Nostr event JSON object.
 pub fn extract_d_tag(event: &serde_json::Value) -> String {
     event

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -2,7 +2,9 @@ use buzz_sdk::{DeleteMessageOptions, DiffMeta, ThreadRef, VoteDirection};
 use nostr::PublicKey;
 use uuid::Uuid;
 
-use crate::client::{normalize_events, normalize_write_response, BuzzClient};
+use crate::client::{
+    normalize_events, normalize_verified_events, normalize_write_response, BuzzClient,
+};
 use crate::error::CliError;
 use crate::validate::{
     infer_language, parse_event_id, parse_uuid, read_or_stdin, truncate_diff,
@@ -239,7 +241,17 @@ fn parse_member_pubkeys(event: &serde_json::Value) -> Vec<String> {
         .collect()
 }
 
-fn format_events(normalized: &str, format: &crate::OutputFormat) -> String {
+fn format_events(
+    normalized: &str,
+    format: &crate::OutputFormat,
+    include_signatures: bool,
+) -> String {
+    // A signature without pubkey/kind/tags/content/created_at cannot be
+    // verified. Preserve the complete envelope even when the global compact
+    // format was requested rather than emitting misleading partial proof.
+    if include_signatures {
+        return normalized.to_string();
+    }
     match format {
         crate::OutputFormat::Compact => {
             let events: Vec<serde_json::Value> =
@@ -260,6 +272,24 @@ fn format_events(normalized: &str, format: &crate::OutputFormat) -> String {
     }
 }
 
+fn render_events(
+    events: &[serde_json::Value],
+    format: &crate::OutputFormat,
+    include_signatures: bool,
+) -> Result<String, CliError> {
+    let normalized = if include_signatures {
+        normalize_verified_events(events)?
+    } else {
+        normalize_events(events)
+    };
+    Ok(format_events(&normalized, format, include_signatures))
+}
+
+pub struct MessageOutputOptions<'a> {
+    pub format: &'a crate::OutputFormat,
+    pub include_signatures: bool,
+}
+
 pub async fn cmd_get_messages(
     client: &BuzzClient,
     channel_id: &str,
@@ -267,7 +297,7 @@ pub async fn cmd_get_messages(
     before: Option<i64>,
     since: Option<i64>,
     kinds: Option<&str>,
-    format: &crate::OutputFormat,
+    output: MessageOutputOptions<'_>,
 ) -> Result<(), CliError> {
     validate_uuid(channel_id)?;
     let limit = limit.unwrap_or(50).min(200);
@@ -296,8 +326,10 @@ pub async fn cmd_get_messages(
     let resp = client.query(&filter).await?;
     let mut events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
     events.sort_by_key(|e| e.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0));
-    let normalized = normalize_events(&events);
-    println!("{}", format_events(&normalized, format));
+    println!(
+        "{}",
+        render_events(&events, output.format, output.include_signatures)?
+    );
     Ok(())
 }
 
@@ -307,7 +339,7 @@ pub async fn cmd_get_thread(
     event_id: &str,
     limit: Option<u32>,
     depth_limit: Option<u32>,
-    format: &crate::OutputFormat,
+    output: MessageOutputOptions<'_>,
 ) -> Result<(), CliError> {
     validate_uuid(channel_id)?;
     validate_hex64(event_id)?;
@@ -332,8 +364,10 @@ pub async fn cmd_get_thread(
     let resp = client.query_multi(&[reply_filter, root_filter]).await?;
     let mut events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
     events.sort_by_key(|e| e.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0));
-    let normalized = normalize_events(&events);
-    println!("{}", format_events(&normalized, format));
+    println!(
+        "{}",
+        render_events(&events, output.format, output.include_signatures)?
+    );
     Ok(())
 }
 
@@ -343,7 +377,7 @@ pub async fn cmd_search(
     author: Option<&str>,
     since: Option<i64>,
     limit: Option<u32>,
-    format: &crate::OutputFormat,
+    output: MessageOutputOptions<'_>,
 ) -> Result<(), CliError> {
     if query.is_none() && author.is_none() {
         return Err(CliError::Usage(
@@ -379,8 +413,10 @@ pub async fn cmd_search(
             std::cmp::Reverse(e.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0))
         });
     }
-    let normalized = normalize_events(&events);
-    println!("{}", format_events(&normalized, format));
+    println!(
+        "{}",
+        render_events(&events, output.format, output.include_signatures)?
+    );
     Ok(())
 }
 
@@ -834,6 +870,7 @@ pub async fn dispatch(
             before,
             since,
             kinds,
+            include_signatures,
         } => {
             cmd_get_messages(
                 client,
@@ -842,7 +879,10 @@ pub async fn dispatch(
                 before,
                 since,
                 kinds.as_deref(),
-                format,
+                MessageOutputOptions {
+                    format,
+                    include_signatures,
+                },
             )
             .await
         }
@@ -851,12 +891,27 @@ pub async fn dispatch(
             event,
             limit,
             depth_limit,
-        } => cmd_get_thread(client, &channel, &event, limit, depth_limit, format).await,
+            include_signatures,
+        } => {
+            cmd_get_thread(
+                client,
+                &channel,
+                &event,
+                limit,
+                depth_limit,
+                MessageOutputOptions {
+                    format,
+                    include_signatures,
+                },
+            )
+            .await
+        }
         MessagesCmd::Search {
             query,
             author,
             since,
             limit,
+            include_signatures,
         } => {
             cmd_search(
                 client,
@@ -864,7 +919,10 @@ pub async fn dispatch(
                 author.as_deref(),
                 since,
                 limit,
-                format,
+                MessageOutputOptions {
+                    format,
+                    include_signatures,
+                },
             )
             .await
         }
@@ -876,10 +934,11 @@ pub async fn dispatch(
 
 #[cfg(test)]
 mod tests {
-    use super::{find_root_from_tags, match_profiles_by_name, parse_member_pubkeys};
+    use super::{find_root_from_tags, match_profiles_by_name, parse_member_pubkeys, render_events};
     use buzz_sdk::mentions::{
         extract_at_mentions_with_known, extract_at_names, match_names_to_profiles, MentionProfile,
     };
+    use nostr::{EventBuilder, Keys, Kind};
     use serde_json::json;
 
     const ID_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -891,6 +950,64 @@ mod tests {
     const PK_VALID_A: &str = "35c18ae273fccfaf80d629e20e7f8721b90499379addff533054acc2504c12b4";
     const PK_VALID_B: &str = "c6237ef84fa537c78dcee78efd2d4e59f728859c7f194da42ac51ededfa0be05";
     const PK_VALID_C: &str = "f4a42a97e594b77bdbd8ee35191c8b28a94a4cb871d96f32921558275421fb68";
+
+    fn signed_message(content: &str) -> serde_json::Value {
+        let event = EventBuilder::new(Kind::TextNote, content)
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        serde_json::to_value(event).unwrap()
+    }
+
+    #[test]
+    fn default_message_output_remains_signature_stripped() {
+        let output = render_events(
+            &[signed_message("hello")],
+            &crate::OutputFormat::Json,
+            false,
+        )
+        .unwrap();
+        let events: Vec<serde_json::Value> = serde_json::from_str(&output).unwrap();
+
+        assert!(events[0].get("sig").is_none());
+        assert_eq!(events[0]["content"], "hello");
+    }
+
+    #[test]
+    fn signature_output_is_complete_verified_and_not_compacted() {
+        let mut raw = signed_message("owner says go");
+        raw["relay_projection_only"] = json!("not part of the signed envelope");
+
+        let output = render_events(&[raw], &crate::OutputFormat::Compact, true).unwrap();
+        let events: Vec<serde_json::Value> = serde_json::from_str(&output).unwrap();
+        let event = &events[0];
+
+        for field in [
+            "id",
+            "pubkey",
+            "kind",
+            "content",
+            "created_at",
+            "tags",
+            "sig",
+        ] {
+            assert!(event.get(field).is_some(), "missing signed field {field}");
+        }
+        assert!(event.get("relay_projection_only").is_none());
+
+        let typed: nostr::Event = serde_json::from_value(event.clone()).unwrap();
+        typed.verify().unwrap();
+    }
+
+    #[test]
+    fn signature_output_rejects_tampering_without_echoing_content() {
+        let mut raw = signed_message("original");
+        raw["content"] = json!("sensitive-tampered-content");
+
+        let error = render_events(&[raw], &crate::OutputFormat::Json, true).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("unverifiable signed event"));
+        assert!(!message.contains("sensitive-tampered-content"));
+    }
 
     #[test]
     fn root_marker_wins_over_reply_marker() {

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -435,7 +435,7 @@ pub enum MessagesCmd {
     },
     /// Retrieve messages from a channel
     #[command(
-        after_help = "Examples:\n  buzz messages get --channel <UUID>\n  buzz messages get --channel <UUID> --limit 50 --kinds 1,1984"
+        after_help = "Examples:\n  buzz messages get --channel <UUID>\n  buzz messages get --channel <UUID> --limit 50 --kinds 1,1984\n  buzz messages get --channel <UUID> --include-signatures"
     )]
     Get {
         /// Channel UUID
@@ -453,6 +453,9 @@ pub enum MessagesCmd {
         /// Comma-separated event kinds to filter (e.g. 1,1984)
         #[arg(long)]
         kinds: Option<String>,
+        /// Verify and include the complete signed Nostr event envelope
+        #[arg(long, default_value_t = false)]
+        include_signatures: bool,
     },
     /// Get a message thread (replies to a root message)
     Thread {
@@ -468,6 +471,9 @@ pub enum MessagesCmd {
         /// Maximum reply nesting depth to include
         #[arg(long)]
         depth_limit: Option<u32>,
+        /// Verify and include the complete signed Nostr event envelope
+        #[arg(long, default_value_t = false)]
+        include_signatures: bool,
     },
     /// Full-text search across messages
     #[command(
@@ -486,6 +492,9 @@ pub enum MessagesCmd {
         /// Maximum number of results to return
         #[arg(long)]
         limit: Option<u32>,
+        /// Verify and include the complete signed Nostr event envelope
+        #[arg(long, default_value_t = false)]
+        include_signatures: bool,
     },
     /// Upvote or downvote a forum post
     Vote {


### PR DESCRIPTION
## What changed

Adds opt-in `--include-signatures` output to `buzz messages get`, `messages thread`, and `messages search`. The default output remains unchanged and signature-stripped.

Proof mode:

- parses every relay result as a complete NIP-01 event;
- verifies both the event id and Schnorr signature before output;
- emits exactly `{id,pubkey,kind,content,created_at,tags,sig}`;
- fails closed on malformed or unverifiable events without echoing message content in the error;
- preserves the complete envelope even with global `--format compact`, because a partial event cannot be independently verified.

## Why

The relay `/query` response contains signed events, but every agent-facing `buzz messages` read currently strips `sig`. A downstream approval broker therefore cannot distinguish a real owner-authored command from agent prose or a forged JSON object. The opt-in envelope allows an external verifier to bind an action to a cryptographically signed Buzz event without exposing any private key or changing normal chat reads.

No matching issue or PR was found.

## Security

This adds only the public event signature. It does not read or emit `BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`, HTTP authorization headers, provider credentials, or other environment values. Relay-only projection fields are omitted. Existing event tags are preserved because they are part of the signed NIP-01 preimage.

## Verification

- `cargo test -p buzz-cli` — 253 passed
- `cargo clippy -p buzz-cli --all-targets -- -D warnings`
- `cargo fmt --all`
- `git diff --check`