### PR TITLE
fix(scripts): derive seed PG* from DATABASE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 # All defaults here work with `docker compose up` out of the box.
 #
 # Service ports (defaults):
-#   Postgres    → localhost:5432
+#   Postgres    → localhost:5432   (keep PGPORT in sync with DATABASE_URL)
 #   Redis       → localhost:6379
 #   Typesense   → localhost:8108
 #   Adminer     → localhost:8082  (DB browser UI)
@@ -21,6 +21,8 @@
 DATABASE_URL=postgres://buzz:buzz_dev@localhost:5432/buzz
 # Optional read-replica URL; unset/blank keeps all reads on the writer.
 # READ_DATABASE_URL=postgres://buzz:buzz_dev@localhost:5433/buzz
+# scripts/seed-local-community.sh derives PG* from DATABASE_URL when set, so a
+# stale PGPORT in this file cannot send seeding at the wrong Postgres.
 PGHOST=localhost
 PGPORT=5432
 PGUSER=buzz

--- a/scripts/seed-local-community.sh
+++ b/scripts/seed-local-community.sh
@@ -17,6 +17,37 @@ if [[ -f ".env" ]]; then
   set +o allexport
 fi
 
+# Prefer DATABASE_URL when set so PGHOST/PGPORT/… can't drift from the URL
+# migrations already use (#2479). Explicit PG* still win only when DATABASE_URL
+# is unset.
+if [[ -n "${DATABASE_URL:-}" ]]; then
+  eval "$(python3 - <<'PY'
+import os
+from urllib.parse import unquote, urlparse
+
+url = os.environ["DATABASE_URL"]
+parsed = urlparse(url)
+if parsed.scheme not in {"postgres", "postgresql"}:
+    raise SystemExit(f"DATABASE_URL must be postgres://…, got {parsed.scheme!r}")
+
+def sh_export(name: str, value: str) -> None:
+    print(f"export {name}={value!r}")
+
+if parsed.hostname:
+    sh_export("PGHOST", parsed.hostname)
+if parsed.port is not None:
+    sh_export("PGPORT", str(parsed.port))
+if parsed.username:
+    sh_export("PGUSER", unquote(parsed.username))
+if parsed.password is not None:
+    sh_export("PGPASSWORD", unquote(parsed.password))
+db = (parsed.path or "").lstrip("/")
+if db:
+    sh_export("PGDATABASE", unquote(db))
+PY
+)"
+fi
+
 export PGHOST="${PGHOST:-localhost}"
 export PGPORT="${PGPORT:-5432}"
 export PGUSER="${PGUSER:-buzz}"


### PR DESCRIPTION
## Summary
- `scripts/seed-local-community.sh` now prefers connection fields from `DATABASE_URL` when set, so a stale `PGPORT` in `.env` cannot send seeding at the host Postgres while migrations hit Buzz's container
- Document the pairing in `.env.example`

Follow-up to the #2479 / #2511 port-override discussion ([comment](https://github.com/block/buzz/pull/2511#issuecomment-5080786393)).

## Test plan
- [ ] With `DATABASE_URL=…:55432/buzz` and `PGPORT=5432` in `.env`, run `./scripts/seed-local-community.sh` and confirm it connects on `55432`
- [ ] With no `DATABASE_URL`, confirm defaults (`localhost:5432` / buzz) still work
- [ ] `bash -n scripts/seed-local-community.sh`


Made with [Cursor](https://cursor.com)