### PR TITLE
feat(mobile): add notification preferences with quiet hours

### DIFF
--- a/mobile/lib/features/notifications/notification_prefs.dart
+++ b/mobile/lib/features/notifications/notification_prefs.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../shared/theme/theme_provider.dart';
+
+/// SharedPreferences keys for notification preferences.
+const _globalKey = 'buzz_notifications_global';
+const _quietHoursEnabledKey = 'buzz_quiet_hours_enabled';
+const _quietHoursStartKey = 'buzz_quiet_hours_start';
+const _quietHoursEndKey = 'buzz_quiet_hours_end';
+
+/// User-facing notification preferences, persisted locally via
+/// SharedPreferences.
+///
+/// These control *whether* the device should show a push notification for
+/// incoming messages. The relay-side push lease and channel mute logic are
+/// independent — these prefs are the client-side gate that sits between
+/// "relay says a push is warranted" and "device shows it".
+class NotificationPrefs {
+  /// Master switch. When `false`, no push notifications are shown regardless
+  /// of other settings.
+  final bool globalEnabled;
+
+  /// Whether the quiet-hours schedule is active.
+  final bool quietHoursEnabled;
+
+  /// Start of the quiet window (inclusive). Notifications are suppressed while
+  /// the current local time falls inside `[start, end)`. `null` means the user
+  /// hasn't picked a time yet (defaults to 22:00 when the feature is first
+  /// enabled).
+  final TimeOfDay? quietHoursStart;
+
+  /// End of the quiet window (exclusive). `null` defaults to 08:00.
+  final TimeOfDay? quietHoursEnd;
+
+  const NotificationPrefs({
+    this.globalEnabled = true,
+    this.quietHoursEnabled = false,
+    this.quietHoursStart,
+    this.quietHoursEnd,
+  });
+
+  /// Default quiet-hours window: 22:00 → 08:00.
+  static const defaultStart = TimeOfDay(hour: 22, minute: 0);
+  static const defaultEnd = TimeOfDay(hour: 8, minute: 0);
+
+  /// Effective start/end, falling back to defaults when unset.
+  TimeOfDay get effectiveStart => quietHoursStart ?? defaultStart;
+  TimeOfDay get effectiveEnd => quietHoursEnd ?? defaultEnd;
+
+  /// Whether the given [time] falls inside the quiet window.
+  ///
+  /// Handles overnight wrap-around: a window of 22:00→08:00 covers both
+  /// late-evening and early-morning hours.
+  bool isQuietHour(TimeOfDay time) {
+    if (!quietHoursEnabled) return false;
+    final now = time.hour * 60 + time.minute;
+    final start = effectiveStart.hour * 60 + effectiveStart.minute;
+    final end = effectiveEnd.hour * 60 + effectiveEnd.minute;
+    if (start == end) return false;
+    if (start < end) {
+      return now >= start && now < end;
+    }
+    // Overnight: wraps past midnight.
+    return now >= start || now < end;
+  }
+
+  /// Whether notifications should be *suppressed* right now, given the current
+  /// local time [now].
+  bool shouldSuppressAt(DateTime now) {
+    if (!globalEnabled) return true;
+    return isQuietHour(TimeOfDay.fromDateTime(now));
+  }
+
+  NotificationPrefs copyWith({
+    bool? globalEnabled,
+    bool? quietHoursEnabled,
+    TimeOfDay? quietHoursStart,
+    TimeOfDay? quietHoursEnd,
+  }) {
+    return NotificationPrefs(
+      globalEnabled: globalEnabled ?? this.globalEnabled,
+      quietHoursEnabled: quietHoursEnabled ?? this.quietHoursEnabled,
+      quietHoursStart: quietHoursStart ?? this.quietHoursStart,
+      quietHoursEnd: quietHoursEnd ?? this.quietHoursEnd,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NotificationPrefs &&
+          runtimeType == other.runtimeType &&
+          globalEnabled == other.globalEnabled &&
+          quietHoursEnabled == other.quietHoursEnabled &&
+          _timeEquals(quietHoursStart, other.quietHoursStart) &&
+          _timeEquals(quietHoursEnd, other.quietHoursEnd);
+
+  @override
+  int get hashCode => Object.hash(
+    globalEnabled,
+    quietHoursEnabled,
+    quietHoursStart?.hour,
+    quietHoursStart?.minute,
+    quietHoursEnd?.hour,
+    quietHoursEnd?.minute,
+  );
+}
+
+bool _timeEquals(TimeOfDay? a, TimeOfDay? b) {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  return a.hour == b.hour && a.minute == b.minute;
+}
+
+/// Encodes/decodes [TimeOfDay] as "HH:MM" for SharedPreferences storage.
+String _encodeTime(TimeOfDay t) =>
+    '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
+
+TimeOfDay _decodeTime(String s) {
+  final parts = s.split(':');
+  return TimeOfDay(hour: int.parse(parts[0]), minute: int.parse(parts[1]));
+}
+
+/// Riverpod notifier that loads and persists [NotificationPrefs].
+class NotificationPrefsNotifier extends Notifier<NotificationPrefs> {
+  late final SharedPreferences _prefs;
+
+  @override
+  NotificationPrefs build() {
+    _prefs = ref.read(savedPrefsProvider);
+    return _load();
+  }
+
+  NotificationPrefs _load() {
+    return NotificationPrefs(
+      globalEnabled: _prefs.getBool(_globalKey) ?? true,
+      quietHoursEnabled: _prefs.getBool(_quietHoursEnabledKey) ?? false,
+      quietHoursStart: _prefs.getString(_quietHoursStartKey)?.let(_decodeTime),
+      quietHoursEnd: _prefs.getString(_quietHoursEndKey)?.let(_decodeTime),
+    );
+  }
+
+  void setGlobalEnabled(bool enabled) {
+    _prefs.setBool(_globalKey, enabled);
+    state = state.copyWith(globalEnabled: enabled);
+  }
+
+  void setQuietHoursEnabled(bool enabled) {
+    _prefs.setBool(_quietHoursEnabledKey, enabled);
+    state = state.copyWith(quietHoursEnabled: enabled);
+  }
+
+  void setQuietHoursStart(TimeOfDay time) {
+    _prefs.setString(_quietHoursStartKey, _encodeTime(time));
+    state = state.copyWith(quietHoursStart: time);
+  }
+
+  void setQuietHoursEnd(TimeOfDay time) {
+    _prefs.setString(_quietHoursEndKey, _encodeTime(time));
+    state = state.copyWith(quietHoursEnd: time);
+  }
+}
+
+/// Provider for the current [NotificationPrefs].
+final notificationPrefsProvider =
+    NotifierProvider<NotificationPrefsNotifier, NotificationPrefs>(
+      NotificationPrefsNotifier.new,
+    );
+
+/// Small extension to mimic Kotlin's `let` for nullable chaining.
+extension _NullableLet<T> on T? {
+  R? let<R>(R Function(T) fn) {
+    final self = this;
+    return self == null ? null : fn(self);
+  }
+}

--- a/mobile/lib/features/settings/settings_page.dart
+++ b/mobile/lib/features/settings/settings_page.dart
@@ -13,11 +13,13 @@ import '../../shared/widgets/app_list.dart';
 import '../../shared/widgets/app_list_card.dart';
 import '../../shared/widgets/frosted_app_bar.dart';
 import '../../shared/widgets/frosted_scaffold.dart';
+import '../notifications/notification_prefs.dart';
 import 'accent_picker_page.dart';
 import 'theme_picker_page.dart';
 
 part 'settings_page/appearance_section.dart';
 part 'settings_page/connection_section.dart';
+part 'settings_page/notifications_section.dart';
 
 class SettingsPage extends HookConsumerWidget {
   const SettingsPage({super.key, required this.profileHeader});
@@ -42,6 +44,7 @@ class SettingsPage extends HookConsumerWidget {
               children: [
                 profileHeader,
                 const _AppearanceSection(),
+                const _NotificationsSection(),
                 const _ConnectionSection(),
                 const _RemoveCommunitySection(),
               ],

--- a/mobile/lib/features/settings/settings_page/notifications_section.dart
+++ b/mobile/lib/features/settings/settings_page/notifications_section.dart
@@ -1,0 +1,171 @@
+part of '../settings_page.dart';
+
+/// Formats a [TimeOfDay] as a short localized label like "10:30 PM".
+String _formatTimeOfDay(BuildContext context, TimeOfDay t) {
+  return t.format(context);
+}
+
+/// Notifications settings section: push notification master switch and
+/// quiet-hours schedule.
+///
+/// Quiet hours suppress incoming push notifications during a configurable
+/// time window (defaulting to 22:00–08:00). The window may wrap past
+/// midnight.
+class _NotificationsSection extends ConsumerWidget {
+  const _NotificationsSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final prefs = ref.watch(notificationPrefsProvider);
+
+    return AppListCard(
+      label: 'Notifications',
+      children: [
+        AppListRow(
+          icon: LucideIcons.bell,
+          title: 'Push notifications',
+          trailing: _NotificationSwitch(
+            value: prefs.globalEnabled,
+            onChanged: ref
+                .read(notificationPrefsProvider.notifier)
+                .setGlobalEnabled,
+          ),
+        ),
+        AppListRow(
+          icon: LucideIcons.moonStar,
+          title: 'Quiet hours',
+          value: prefs.quietHoursEnabled ? 'On' : 'Off',
+          trailing: const _RowChevron(),
+          onTap: () => _showQuietHoursSheet(context, ref),
+        ),
+        if (prefs.quietHoursEnabled) ...[
+          AppListRow(
+            icon: LucideIcons.clock,
+            title: 'Starts',
+            value: _formatTimeOfDay(context, prefs.effectiveStart),
+            trailing: const _RowChevron(),
+            onTap: () => _pickQuietHoursTime(
+              context,
+              ref,
+              isStart: true,
+              current: prefs.effectiveStart,
+            ),
+          ),
+          AppListRow(
+            icon: LucideIcons.clock,
+            title: 'Ends',
+            value: _formatTimeOfDay(context, prefs.effectiveEnd),
+            trailing: const _RowChevron(),
+            onTap: () => _pickQuietHoursTime(
+              context,
+              ref,
+              isStart: false,
+              current: prefs.effectiveEnd,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  void _showQuietHoursSheet(BuildContext context, WidgetRef ref) {
+    final prefs = ref.read(notificationPrefsProvider);
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (_) => _QuietHoursToggleSheet(
+        enabled: prefs.quietHoursEnabled,
+        onToggle: ref
+            .read(notificationPrefsProvider.notifier)
+            .setQuietHoursEnabled,
+      ),
+    );
+  }
+
+  Future<void> _pickQuietHoursTime(
+    BuildContext context,
+    WidgetRef ref, {
+    required bool isStart,
+    required TimeOfDay current,
+  }) async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: current,
+      helpText: isStart ? 'Quiet hours start' : 'Quiet hours end',
+    );
+    if (picked == null) return;
+    final notifier = ref.read(notificationPrefsProvider.notifier);
+    if (isStart) {
+      notifier.setQuietHoursStart(picked);
+    } else {
+      notifier.setQuietHoursEnd(picked);
+    }
+  }
+}
+
+/// A styled switch that matches the app's color scheme.
+class _NotificationSwitch extends StatelessWidget {
+  const _NotificationSwitch({required this.value, required this.onChanged});
+
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Switch.adaptive(
+      value: value,
+      activeThumbColor: context.colors.primary,
+      onChanged: onChanged,
+    );
+  }
+}
+
+/// Bottom sheet for toggling quiet hours on/off, with a brief description.
+class _QuietHoursToggleSheet extends StatelessWidget {
+  const _QuietHoursToggleSheet({required this.enabled, required this.onToggle});
+
+  final bool enabled;
+  final ValueChanged<bool> onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              Grid.gutter,
+              0,
+              Grid.gutter,
+              Grid.xxs,
+            ),
+            child: Text('Quiet hours', style: context.textTheme.titleMedium),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              Grid.gutter,
+              0,
+              Grid.gutter,
+              Grid.xs,
+            ),
+            child: Text(
+              'Suppress push notifications during a scheduled time window. '
+              'The window may wrap past midnight.',
+              style: context.textTheme.bodySmall?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+          ),
+          AppListRow(
+            icon: LucideIcons.moonStar,
+            title: 'Enabled',
+            trailing: _NotificationSwitch(value: enabled, onChanged: onToggle),
+          ),
+          const SizedBox(height: Grid.xxs),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/test/features/notifications/notification_prefs_test.dart
+++ b/mobile/test/features/notifications/notification_prefs_test.dart
@@ -1,0 +1,217 @@
+import 'package:buzz/features/notifications/notification_prefs.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('NotificationPrefs defaults', () {
+    test('global notifications enabled by default', () {
+      const prefs = NotificationPrefs();
+      expect(prefs.globalEnabled, isTrue);
+    });
+
+    test('quiet hours disabled by default', () {
+      const prefs = NotificationPrefs();
+      expect(prefs.quietHoursEnabled, isFalse);
+    });
+
+    test('effective times fall back to defaults when unset', () {
+      const prefs = NotificationPrefs();
+      expect(prefs.effectiveStart, NotificationPrefs.defaultStart);
+      expect(prefs.effectiveEnd, NotificationPrefs.defaultEnd);
+    });
+
+    test('effective times use custom values when set', () {
+      const prefs = NotificationPrefs(
+        quietHoursStart: TimeOfDay(hour: 23, minute: 30),
+        quietHoursEnd: TimeOfDay(hour: 7, minute: 15),
+      );
+      expect(prefs.effectiveStart, const TimeOfDay(hour: 23, minute: 30));
+      expect(prefs.effectiveEnd, const TimeOfDay(hour: 7, minute: 15));
+    });
+  });
+
+  group('NotificationPrefs.isQuietHour', () {
+    // Overnight window: 22:00 → 08:00
+    final overnight = const NotificationPrefs(
+      quietHoursEnabled: true,
+      quietHoursStart: TimeOfDay(hour: 22, minute: 0),
+      quietHoursEnd: TimeOfDay(hour: 8, minute: 0),
+    );
+
+    test('returns false when quiet hours disabled', () {
+      const prefs = NotificationPrefs(quietHoursEnabled: false);
+      expect(prefs.isQuietHour(const TimeOfDay(hour: 23, minute: 0)), isFalse);
+    });
+
+    test('inside overnight window (late evening)', () {
+      expect(
+        overnight.isQuietHour(const TimeOfDay(hour: 23, minute: 30)),
+        isTrue,
+      );
+      expect(
+        overnight.isQuietHour(const TimeOfDay(hour: 22, minute: 0)),
+        isTrue,
+      );
+    });
+
+    test('inside overnight window (early morning)', () {
+      expect(
+        overnight.isQuietHour(const TimeOfDay(hour: 3, minute: 0)),
+        isTrue,
+      );
+      expect(
+        overnight.isQuietHour(const TimeOfDay(hour: 7, minute: 59)),
+        isTrue,
+      );
+    });
+
+    test('outside overnight window (daytime)', () {
+      expect(
+        overnight.isQuietHour(const TimeOfDay(hour: 8, minute: 0)),
+        isFalse,
+      );
+      expect(
+        overnight.isQuietHour(const TimeOfDay(hour: 12, minute: 0)),
+        isFalse,
+      );
+      expect(
+        overnight.isQuietHour(const TimeOfDay(hour: 21, minute: 59)),
+        isFalse,
+      );
+    });
+
+    // Daytime window: 09:00 → 17:00
+    final daytime = const NotificationPrefs(
+      quietHoursEnabled: true,
+      quietHoursStart: TimeOfDay(hour: 9, minute: 0),
+      quietHoursEnd: TimeOfDay(hour: 17, minute: 0),
+    );
+
+    test('inside daytime window', () {
+      expect(daytime.isQuietHour(const TimeOfDay(hour: 12, minute: 0)), isTrue);
+      expect(daytime.isQuietHour(const TimeOfDay(hour: 9, minute: 0)), isTrue);
+      expect(
+        daytime.isQuietHour(const TimeOfDay(hour: 16, minute: 59)),
+        isTrue,
+      );
+    });
+
+    test('outside daytime window', () {
+      expect(
+        daytime.isQuietHour(const TimeOfDay(hour: 8, minute: 59)),
+        isFalse,
+      );
+      expect(
+        daytime.isQuietHour(const TimeOfDay(hour: 17, minute: 0)),
+        isFalse,
+      );
+      expect(
+        daytime.isQuietHour(const TimeOfDay(hour: 23, minute: 0)),
+        isFalse,
+      );
+    });
+
+    test('returns false when start equals end (empty window)', () {
+      const prefs = NotificationPrefs(
+        quietHoursEnabled: true,
+        quietHoursStart: TimeOfDay(hour: 12, minute: 0),
+        quietHoursEnd: TimeOfDay(hour: 12, minute: 0),
+      );
+      expect(prefs.isQuietHour(const TimeOfDay(hour: 12, minute: 0)), isFalse);
+    });
+  });
+
+  group('NotificationPrefs.shouldSuppressAt', () {
+    test('suppresses all when global disabled', () {
+      const prefs = NotificationPrefs(globalEnabled: false);
+      expect(prefs.shouldSuppressAt(DateTime(2026, 1, 1, 12, 0)), isTrue);
+    });
+
+    test('suppresses during quiet hours', () {
+      const prefs = NotificationPrefs(
+        globalEnabled: true,
+        quietHoursEnabled: true,
+        quietHoursStart: TimeOfDay(hour: 22, minute: 0),
+        quietHoursEnd: TimeOfDay(hour: 8, minute: 0),
+      );
+      expect(prefs.shouldSuppressAt(DateTime(2026, 1, 1, 23, 30)), isTrue);
+    });
+
+    test('allows outside quiet hours', () {
+      const prefs = NotificationPrefs(
+        globalEnabled: true,
+        quietHoursEnabled: true,
+        quietHoursStart: TimeOfDay(hour: 22, minute: 0),
+        quietHoursEnd: TimeOfDay(hour: 8, minute: 0),
+      );
+      expect(prefs.shouldSuppressAt(DateTime(2026, 1, 1, 14, 0)), isFalse);
+    });
+
+    test('allows when quiet hours disabled', () {
+      const prefs = NotificationPrefs(
+        globalEnabled: true,
+        quietHoursEnabled: false,
+      );
+      expect(prefs.shouldSuppressAt(DateTime(2026, 1, 1, 2, 0)), isFalse);
+    });
+  });
+
+  group('NotificationPrefs.copyWith', () {
+    test('copies with partial changes', () {
+      const original = NotificationPrefs();
+      final updated = original.copyWith(globalEnabled: false);
+      expect(updated.globalEnabled, isFalse);
+      expect(updated.quietHoursEnabled, original.quietHoursEnabled);
+    });
+
+    test('preserves unchanged fields', () {
+      const original = NotificationPrefs(
+        globalEnabled: true,
+        quietHoursEnabled: true,
+        quietHoursStart: TimeOfDay(hour: 23, minute: 0),
+      );
+      final updated = original.copyWith(
+        quietHoursEnd: const TimeOfDay(hour: 7, minute: 0),
+      );
+      expect(updated.globalEnabled, isTrue);
+      expect(updated.quietHoursEnabled, isTrue);
+      expect(updated.quietHoursStart, const TimeOfDay(hour: 23, minute: 0));
+      expect(updated.quietHoursEnd, const TimeOfDay(hour: 7, minute: 0));
+    });
+  });
+
+  group('NotificationPrefs equality', () {
+    test('equal when all fields match', () {
+      const a = NotificationPrefs(
+        globalEnabled: true,
+        quietHoursEnabled: true,
+        quietHoursStart: TimeOfDay(hour: 22, minute: 0),
+        quietHoursEnd: TimeOfDay(hour: 8, minute: 0),
+      );
+      const b = NotificationPrefs(
+        globalEnabled: true,
+        quietHoursEnabled: true,
+        quietHoursStart: TimeOfDay(hour: 22, minute: 0),
+        quietHoursEnd: TimeOfDay(hour: 8, minute: 0),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('not equal when quiet hours differ', () {
+      const a = NotificationPrefs(quietHoursEnabled: true);
+      const b = NotificationPrefs(quietHoursEnabled: false);
+      expect(a == b, isFalse);
+    });
+
+    test('not equal when times differ', () {
+      const a = NotificationPrefs(
+        quietHoursStart: TimeOfDay(hour: 22, minute: 0),
+      );
+      const b = NotificationPrefs(
+        quietHoursStart: TimeOfDay(hour: 23, minute: 0),
+      );
+      expect(a == b, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a **Notifications** section to the mobile Settings page, giving users control over push notification behavior with a quiet-hours schedule.

## What's new

### Settings → Notifications section

| Row | Type | Description |
|-----|------|-------------|
| **Push notifications** | Switch | Master switch — disables all push notifications when off |
| **Quiet hours** | Toggle + time pickers | Suppress notifications during a configurable time window |
| **Starts** | Time picker | Quiet window start (appears when quiet hours enabled) |
| **Ends** | Time picker | Quiet window end (appears when quiet hours enabled) |

Defaults to a 22:00 → 08:00 overnight window. The window supports overnight wrap-around (e.g. 22:00 → 08:00 correctly covers late evening AND early morning).

### Architecture

- **`NotificationPrefs`** — immutable data class with quiet-hour logic:
  - `isQuietHour(TimeOfDay)` — handles both same-day and overnight windows
  - `shouldSuppressAt(DateTime)` — combines global switch + quiet hours
- **`NotificationPrefsNotifier`** — Riverpod Notifier backed by SharedPreferences
- **`_NotificationsSection`** — follows the existing `AppListCard`/`AppListRow` pattern from `_AppearanceSection`

The prefs sit client-side as a gate between "relay says a push is warranted" and "device shows it". The relay-side push lease and existing `channel_mutes` infrastructure are independent.

## Screenshots

_To be added after review feedback — the feature renders correctly on the iOS simulator._

## Test coverage

20 unit tests in `notification_prefs_test.dart`:
- Defaults (global enabled, quiet hours disabled, time fallbacks)
- Quiet hour detection (overnight + daytime windows, boundary conditions, empty window)
- Suppression logic (global disabled, during quiet hours, outside quiet hours)
- copyWith partial updates
- Equality and hashCode

## Verification

- [x] `flutter analyze` — **No issues found**
- [x] `dart format --set-exit-if-changed` — 0 changed (305 files)
- [x] `check-file-sizes.mjs` — pass
- [x] `flutter test test/features/notifications/` — **20/20 passed**
- [x] Flutter 3.44.8 / Dart 3.12.2