### PR TITLE
fix(mobile): resolve ListTile ink-splash assertion failures (4 tests)

### DIFF
--- a/mobile/lib/features/channels/channels_page/sheets.dart
+++ b/mobile/lib/features/channels/channels_page/sheets.dart
@@ -306,49 +306,54 @@ class _CreateChannelRadioGroup<T> extends StatelessWidget {
             border: Border.all(color: context.colors.outlineVariant),
             borderRadius: BorderRadius.circular(Radii.lg),
           ),
-          child: RadioGroup<T>(
-            groupValue: value,
-            onChanged: (nextValue) {
-              if (enabled && nextValue != null) {
-                onSelected(nextValue);
-              }
-            },
-            child: Column(
-              children: [
-                for (final (index, option) in options.indexed) ...[
-                  RadioListTile<T>(
-                    key: option.key,
-                    value: option.value,
-                    enabled: enabled,
-                    selected: option.value == value,
-                    controlAffinity: ListTileControlAffinity.leading,
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: Grid.xs,
-                      vertical: Grid.half,
-                    ),
-                    visualDensity: VisualDensity.standard,
-                    activeColor: context.colors.primary,
-                    title: Text(
-                      option.label,
-                      style: context.textTheme.bodyMedium?.copyWith(
-                        color: enabled
-                            ? context.colors.onSurface
-                            : context.colors.onSurface.withValues(alpha: 0.38),
-                        fontWeight: option.value == value
-                            ? FontWeight.w600
-                            : FontWeight.w400,
+          child: Material(
+            type: MaterialType.transparency,
+            child: RadioGroup<T>(
+              groupValue: value,
+              onChanged: (nextValue) {
+                if (enabled && nextValue != null) {
+                  onSelected(nextValue);
+                }
+              },
+              child: Column(
+                children: [
+                  for (final (index, option) in options.indexed) ...[
+                    RadioListTile<T>(
+                      key: option.key,
+                      value: option.value,
+                      enabled: enabled,
+                      selected: option.value == value,
+                      controlAffinity: ListTileControlAffinity.leading,
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: Grid.xs,
+                        vertical: Grid.half,
+                      ),
+                      visualDensity: VisualDensity.standard,
+                      activeColor: context.colors.primary,
+                      title: Text(
+                        option.label,
+                        style: context.textTheme.bodyMedium?.copyWith(
+                          color: enabled
+                              ? context.colors.onSurface
+                              : context.colors.onSurface.withValues(
+                                  alpha: 0.38,
+                                ),
+                          fontWeight: option.value == value
+                              ? FontWeight.w600
+                              : FontWeight.w400,
+                        ),
                       ),
                     ),
-                  ),
-                  if (index < options.length - 1)
-                    Divider(
-                      height: 1,
-                      indent: Grid.xs,
-                      endIndent: Grid.xs,
-                      color: context.colors.outlineVariant,
-                    ),
+                    if (index < options.length - 1)
+                      Divider(
+                        height: 1,
+                        indent: Grid.xs,
+                        endIndent: Grid.xs,
+                        color: context.colors.outlineVariant,
+                      ),
+                  ],
                 ],
-              ],
+              ),
             ),
           ),
         ),

--- a/mobile/lib/features/channels/compose_bar/suggestions.dart
+++ b/mobile/lib/features/channels/compose_bar/suggestions.dart
@@ -122,43 +122,46 @@ class _MentionSuggestions extends StatelessWidget {
           width: 1,
         ),
       ),
-      child: ListView.separated(
-        shrinkWrap: true,
-        padding: const EdgeInsets.symmetric(vertical: Grid.xxs),
-        itemCount: suggestions.length,
-        separatorBuilder: (_, _) => const SizedBox.shrink(),
-        itemBuilder: (context, index) {
-          final candidate = suggestions[index];
-          final name = candidate.label;
-          final avatarUrl =
-              candidate.avatarUrl ?? userCache[candidate.pubkey]?.avatarUrl;
+      child: Material(
+        type: MaterialType.transparency,
+        child: ListView.separated(
+          shrinkWrap: true,
+          padding: const EdgeInsets.symmetric(vertical: Grid.xxs),
+          itemCount: suggestions.length,
+          separatorBuilder: (_, _) => const SizedBox.shrink(),
+          itemBuilder: (context, index) {
+            final candidate = suggestions[index];
+            final name = candidate.label;
+            final avatarUrl =
+                candidate.avatarUrl ?? userCache[candidate.pubkey]?.avatarUrl;
 
-          return ListTile(
-            dense: true,
-            visualDensity: VisualDensity.compact,
-            leading: AvatarImage(
-              imageUrl: avatarUrl,
-              radius: 18,
-              backgroundColor: context.colors.primaryContainer,
-              fallback: Text(
-                name[0].toUpperCase(),
-                style: context.textTheme.labelMedium?.copyWith(
-                  color: context.colors.onPrimaryContainer,
-                  fontWeight: FontWeight.w600,
+            return ListTile(
+              dense: true,
+              visualDensity: VisualDensity.compact,
+              leading: AvatarImage(
+                imageUrl: avatarUrl,
+                radius: 18,
+                backgroundColor: context.colors.primaryContainer,
+                fallback: Text(
+                  name[0].toUpperCase(),
+                  style: context.textTheme.labelMedium?.copyWith(
+                    color: context.colors.onPrimaryContainer,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
-            ),
-            title: Text(name, style: context.textTheme.titleSmall),
-            subtitle: _MentionSuggestionInfo.build(
-              context,
-              candidate: candidate,
-              currentPubkey: currentPubkey,
-              isDmChannel: isDmChannel,
-              userCache: userCache,
-            ),
-            onTap: () => onSelect(candidate),
-          );
-        },
+              title: Text(name, style: context.textTheme.titleSmall),
+              subtitle: _MentionSuggestionInfo.build(
+                context,
+                candidate: candidate,
+                currentPubkey: currentPubkey,
+                isDmChannel: isDmChannel,
+                userCache: userCache,
+              ),
+              onTap: () => onSelect(candidate),
+            );
+          },
+        ),
       ),
     );
   }
@@ -272,29 +275,32 @@ class _ChannelSuggestions extends StatelessWidget {
           width: 1,
         ),
       ),
-      child: ListView.separated(
-        shrinkWrap: true,
-        padding: const EdgeInsets.symmetric(vertical: Grid.xxs),
-        itemCount: suggestions.length,
-        separatorBuilder: (_, _) => const SizedBox.shrink(),
-        itemBuilder: (context, index) {
-          final channel = suggestions[index];
-          return ListTile(
-            dense: true,
-            visualDensity: VisualDensity.compact,
-            horizontalTitleGap: 0,
-            leading: SizedBox.square(
-              dimension: 36,
-              child: Icon(
-                LucideIcons.hash,
-                size: 20,
-                color: context.colors.onSurfaceVariant,
+      child: Material(
+        type: MaterialType.transparency,
+        child: ListView.separated(
+          shrinkWrap: true,
+          padding: const EdgeInsets.symmetric(vertical: Grid.xxs),
+          itemCount: suggestions.length,
+          separatorBuilder: (_, _) => const SizedBox.shrink(),
+          itemBuilder: (context, index) {
+            final channel = suggestions[index];
+            return ListTile(
+              dense: true,
+              visualDensity: VisualDensity.compact,
+              horizontalTitleGap: 0,
+              leading: SizedBox.square(
+                dimension: 36,
+                child: Icon(
+                  LucideIcons.hash,
+                  size: 20,
+                  color: context.colors.onSurfaceVariant,
+                ),
               ),
-            ),
-            title: Text(channel.name, style: context.textTheme.bodyLarge),
-            onTap: () => onSelect(channel),
-          );
-        },
+              title: Text(channel.name, style: context.textTheme.bodyLarge),
+              onTap: () => onSelect(channel),
+            );
+          },
+        ),
       ),
     );
   }

--- a/mobile/lib/features/pairing/pairing_page/pairing_welcome_view.dart
+++ b/mobile/lib/features/pairing/pairing_page/pairing_welcome_view.dart
@@ -112,7 +112,7 @@ class _PairingWelcomeView extends StatelessWidget {
                           transitionBuilder: (child, animation) {
                             return SizeTransition(
                               sizeFactor: animation,
-                              axisAlignment: -1,
+                              alignment: Alignment.topCenter,
                               child: FadeTransition(
                                 opacity: animation,
                                 child: child,

--- a/mobile/lib/features/search/search_page.dart
+++ b/mobile/lib/features/search/search_page.dart
@@ -172,7 +172,7 @@ class SearchPage extends HookConsumerWidget {
                   return SizeTransition(
                     sizeFactor: curvedAnimation,
                     axis: Axis.horizontal,
-                    axisAlignment: 1,
+                    alignment: Alignment.centerRight,
                     child: FadeTransition(
                       opacity: curvedAnimation,
                       child: SlideTransition(


### PR DESCRIPTION
## Summary

Fixes 4 widget tests that were failing on main due to a Flutter framework change that promotes the "ListTile background color or ink splashes may be invisible" warning to an assertion error.

## Root cause

Recent Flutter versions assert that `ListTile` (and `RadioListTile`) must have a `Material` ancestor for ink-splash effects to render. When a `ListTile` is placed inside a `DecoratedBox` or `Container` with a background color, the assertion fires because the background hides the ink effects painted on the nearest `Material` ancestor.

## Changes

### `sheets.dart` — create channel radio options
Wrapped `RadioGroup` in `Material(type: MaterialType.transparency)` so `RadioListTile` ink effects paint on a proper Material ancestor without adding a visible layer.

**Fixes:** `channels_page_test: create channel sheet lists type and visibility radio options`

### `suggestions.dart` — mention + channel autocomplete
Wrapped both `ListView.separated` builders (mention suggestions + channel suggestions) in `Material(type: MaterialType.transparency)`.

**Fixes:** 3 `compose_bar_test` failures:
- `ComposeBar adds a selected non-member agent as a bot before sending`
- `ComposeBar does not mutate a DM when mentioning a non-member agent`
- `ComposeBar waits for current member data before adding an agent`

### Deprecated API migration (included)
`SizeTransition.axisAlignment` → `alignment` (2 sites in pairing_welcome_view.dart + search_page.dart).

## Verification

| Check | Before | After |
|-------|--------|-------|
| `flutter test` | 871 passed, **4 failed** | **875 passed**, 1 skipped, **0 failed** |
| `flutter analyze` | 2 deprecation warnings | **No issues found** |
| `dart format` | — | 0 changed (217 files) |
| `check-file-sizes.mjs` | — | pass |