### PR TITLE
fix: agent config panel resolves Claude MCP paths from CLAUDE_CONFIG_DIR

### DIFF
--- a/desktop/src-tauri/src/managed_agents/config_bridge/claude.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/claude.rs
@@ -1,10 +1,13 @@
+use std::path::{Path, PathBuf};
+
 use super::types::{ExtensionEntry, RuntimeFileConfig};
 
-/// Read Claude Code config from `~/.claude/settings.json` and `~/.claude.json`.
-pub(super) fn read_config_file() -> Option<RuntimeFileConfig> {
-    let home = dirs::home_dir()?;
-    let settings_path = home.join(".claude").join("settings.json");
-    let mcp_path = home.join(".claude.json");
+/// Read Claude Code config from `settings.json` and `.claude.json`, resolved
+/// against `config_dir` (the agent's effective `CLAUDE_CONFIG_DIR`, if set) or
+/// `~/.claude`/`~` otherwise. Passing the correct `config_dir` for an isolated
+/// agent is what keeps this from reading the operator's personal config.
+pub(super) fn read_config_file(config_dir: Option<&Path>) -> Option<RuntimeFileConfig> {
+    let (settings_path, mcp_path) = claude_config_paths(config_dir)?;
 
     let settings = read_json_file(&settings_path);
     let mcp_config = read_json_file(&mcp_path);
@@ -26,7 +29,7 @@ pub(super) fn read_config_file() -> Option<RuntimeFileConfig> {
         cfg.extra = super::schema_walker::extract_config_fields(s, skip);
     }
 
-    // MCP servers from ~/.claude.json
+    // MCP servers from mcp_path (~/.claude.json, or <CLAUDE_CONFIG_DIR>/.claude.json)
     let mut extensions = Vec::new();
     if let Some(ref mc) = mcp_config {
         if let Some(servers) = mc.get("mcpServers").and_then(|v| v.as_object()) {
@@ -42,6 +45,24 @@ pub(super) fn read_config_file() -> Option<RuntimeFileConfig> {
     cfg.extensions = extensions;
 
     Some(cfg)
+}
+
+/// Resolve `(settings.json, .claude.json)` for `config_dir`. When
+/// `config_dir` is `Some` (an explicit `CLAUDE_CONFIG_DIR`), both files live
+/// directly under it — matching Claude Code's own resolution, which replaces
+/// `~/.claude` *and* moves the top-level `.claude.json` inside it. Otherwise
+/// falls back to the default `~/.claude/settings.json` + `~/.claude.json`.
+pub(super) fn claude_config_paths(config_dir: Option<&Path>) -> Option<(PathBuf, PathBuf)> {
+    match config_dir {
+        Some(dir) => Some((dir.join("settings.json"), dir.join(".claude.json"))),
+        None => {
+            let home = dirs::home_dir()?;
+            Some((
+                home.join(".claude").join("settings.json"),
+                home.join(".claude.json"),
+            ))
+        }
+    }
 }
 
 fn read_json_file(path: &std::path::Path) -> Option<serde_json::Value> {
@@ -60,6 +81,47 @@ fn json_string(val: &serde_json::Value, key: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn config_dir_override_reads_settings_and_mcp_from_isolated_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("settings.json"),
+            r#"{"model": "isolated-model"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join(".claude.json"),
+            r#"{"mcpServers": {"isolated-server": {"command": "foo"}}}"#,
+        )
+        .unwrap();
+
+        let cfg = read_config_file(Some(dir.path())).expect("config read from isolated dir");
+        assert_eq!(cfg.model.as_deref(), Some("isolated-model"));
+        assert_eq!(cfg.extensions.len(), 1);
+        assert_eq!(cfg.extensions[0].name, "isolated-server");
+    }
+
+    #[test]
+    fn config_dir_override_does_not_leak_operator_home_config() {
+        // An isolated agent's CLAUDE_CONFIG_DIR pointing at an empty directory
+        // must never fall back to reading the operator's ~/.claude.json, even
+        // when the isolated dir has no files of its own yet.
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = read_config_file(Some(dir.path()));
+        assert!(
+            cfg.is_none(),
+            "empty isolated dir must not surface any config"
+        );
+    }
+
+    #[test]
+    fn claude_config_paths_nests_both_files_under_explicit_config_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let (settings_path, mcp_path) = claude_config_paths(Some(dir.path())).unwrap();
+        assert_eq!(settings_path, dir.path().join("settings.json"));
+        assert_eq!(mcp_path, dir.path().join(".claude.json"));
+    }
 
     /// Parse a settings JSON string into a RuntimeFileConfig using the same
     /// logic as read_config_file but without touching the filesystem.

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader.rs
@@ -20,7 +20,13 @@ pub(crate) fn read_config_surface(
         .map(|m| m.id)
         .and_then(|id| match id {
             "goose" => super::goose::read_config_file().map(|c| (c, true)),
-            "claude" => super::claude::read_config_file().map(|c| (c, true)),
+            "claude" => super::claude::read_config_file(
+                record
+                    .env_vars
+                    .get("CLAUDE_CONFIG_DIR")
+                    .map(std::path::Path::new),
+            )
+            .map(|c| (c, true)),
             "codex" => super::codex::read_config_file().map(|c| (c, true)),
             "buzz-agent" => super::buzz_agent::read_config_file().map(|c| (c, true)),
             _ => None,
@@ -167,7 +173,8 @@ pub(crate) fn read_config_surface(
     let config_file_path = runtime_meta
         .and_then(|m| m.config_file_path)
         .map(resolve_tilde);
-    let mcp_config_file_path = runtime_meta.and_then(mcp_config_file_path_for_runtime);
+    let mcp_config_file_path =
+        runtime_meta.and_then(|m| mcp_config_file_path_for_runtime(m, record));
     let extensions = file_config.extensions.clone();
 
     let sources = ConfigSourceReport {
@@ -213,12 +220,22 @@ pub(crate) fn read_config_surface(
     }
 }
 
-fn mcp_config_file_path_for_runtime(runtime: &KnownAcpRuntime) -> Option<String> {
+fn mcp_config_file_path_for_runtime(
+    runtime: &KnownAcpRuntime,
+    record: &ManagedAgentRecord,
+) -> Option<String> {
     match runtime.id {
         "goose" => {
             super::goose::goose_config_path().map(|path| path.to_string_lossy().into_owned())
         }
-        "claude" => Some(resolve_tilde("~/.claude.json")),
+        "claude" => {
+            let config_dir = record
+                .env_vars
+                .get("CLAUDE_CONFIG_DIR")
+                .map(std::path::Path::new);
+            super::claude::claude_config_paths(config_dir)
+                .map(|(_, mcp_path)| mcp_path.to_string_lossy().into_owned())
+        }
         "codex" => {
             super::codex::codex_config_path().map(|path| path.to_string_lossy().into_owned())
         }

--- a/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/config_bridge/reader_tests.rs
@@ -198,6 +198,44 @@ fn claude_surface_uses_mcp_config_path_not_settings_path() {
 }
 
 #[test]
+fn claude_surface_honors_per_agent_config_dir_override() {
+    // An agent isolated via CLAUDE_CONFIG_DIR must read its own settings/MCP
+    // config from that directory, not the operator's ~/.claude — both for the
+    // extensions list and for the "From config file (…)" attribution path.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("settings.json"),
+        r#"{"model": "isolated-model"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join(".claude.json"),
+        r#"{"mcpServers": {"isolated-server": {"command": "foo"}}}"#,
+    )
+    .unwrap();
+
+    let mut record = test_record();
+    record.env_vars.insert(
+        "CLAUDE_CONFIG_DIR".to_string(),
+        dir.path().display().to_string(),
+    );
+    let runtime = &KnownAcpRuntime {
+        id: "claude",
+        config_file_path: Some("~/.claude/settings.json"),
+        ..*test_runtime()
+    };
+
+    let surface = read_config_surface(&record, Some(runtime), None, None);
+
+    assert_eq!(surface.extensions.len(), 1);
+    assert_eq!(surface.extensions[0].name, "isolated-server");
+    assert_eq!(
+        surface.sources.mcp_config_file_path.as_deref(),
+        Some(dir.path().join(".claude.json").to_string_lossy().as_ref())
+    );
+}
+
+#[test]
 fn record_model_overrides_file_model() {
     let mut record = test_record();
     record.model = Some("explicit-model".to_string());


### PR DESCRIPTION
## Summary

- The agent config panel's MCP server list and "From config file (…)" attribution for the `claude` runtime always read `~/.claude/settings.json` + `~/.claude.json`, ignoring an agent's own `CLAUDE_CONFIG_DIR`.
- An agent given its own `CLAUDE_CONFIG_DIR` (to isolate it from the operator's personal Claude Code config) genuinely spawns isolated — but the panel kept showing the operator's MCP servers, which reads as "the isolation didn't work" and is alarming when the personal config has mail/drive/database connectors.

## Fix

- `claude::read_config_file` now takes an optional `config_dir` and resolves both `settings.json` and `.claude.json` under it when given (matching Claude Code's own `CLAUDE_CONFIG_DIR` resolution, which relocates both files together) — falling back to `~/.claude/settings.json` + `~/.claude.json` otherwise.
- `reader::mcp_config_file_path_for_runtime` resolves the same way for the panel's file-attribution path.
- Both call sites pull `CLAUDE_CONFIG_DIR` from the agent's own `record.env_vars`.

## Why this scope

The confirmed root cause (and the issue title) is specifically the per-agent `CLAUDE_CONFIG_DIR` override — the most common way to isolate an agent today. Threading the fully layered effective env (global defaults + persona + per-agent) through would require widening `read_config_surface`'s signature across ~25 call sites for a case the issue doesn't demonstrate a concrete repro for; happy to follow up if that's wanted.

## Test plan

- [x] Added unit tests in `claude.rs`: isolated `CLAUDE_CONFIG_DIR` reads settings/MCP servers from that dir; an empty isolated dir does not fall back to `~/.claude.json`; `claude_config_paths` nests both files under an explicit dir.
- [x] Added a `reader_tests.rs` test asserting `read_config_surface` surfaces MCP extensions and the `mcp_config_file_path` from the per-agent `CLAUDE_CONFIG_DIR`, not the default.
- [x] `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib managed_agents::config_bridge` — 84 passed, 0 failed.
- [x] `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets` — clean.
- [x] `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)