### PR TITLE
fix(mobile): prevent message text overlap

### DIFF
--- a/mobile/lib/features/channels/channel_detail_page/message_bubble.dart
+++ b/mobile/lib/features/channels/channel_detail_page/message_bubble.dart
@@ -33,6 +33,10 @@ class _MessageBubble extends ConsumerWidget {
         currentPubkey?.toLowerCase() == pk ||
         (profile?.ownerPubkey != null &&
             profile?.ownerPubkey == currentPubkey?.toLowerCase());
+    final hasImageGallery = hasTrailingImageGallery(
+      message.content,
+      message.tags,
+    );
 
     // Build mention names map from event p-tags.
     final userCache = ref.watch(userCacheProvider);
@@ -57,10 +61,10 @@ class _MessageBubble extends ConsumerWidget {
       child: Material(
         color: Colors.transparent,
         borderRadius: BorderRadius.circular(Radii.md),
-        // The media carousel intentionally continues through the list's trailing
-        // gutter. InkWell still clips its ink to [borderRadius], while leaving
-        // overflowing message content visible.
-        clipBehavior: Clip.none,
+        // Only galleries paint through the trailing gutter. Keep normal rows
+        // clipped so recycled list children cannot leave stale text over the
+        // following message or thread summary.
+        clipBehavior: hasImageGallery ? Clip.none : Clip.antiAlias,
         child: InkWell(
           key: ValueKey('message-row-${message.id}'),
           borderRadius: BorderRadius.circular(Radii.md),

--- a/mobile/lib/features/channels/message_content.dart
+++ b/mobile/lib/features/channels/message_content.dart
@@ -59,6 +59,12 @@ final openDownloadedFileProvider = Provider<OpenDownloadedFile>((ref) {
   };
 });
 
+/// Whether [content] ends with the multi-image gallery rendered by
+/// [MessageContent].
+bool hasTrailingImageGallery(String content, List<List<String>> tags) {
+  return _extractTrailingImageGallery(content, parseImetaTags(tags)) != null;
+}
+
 String _safeDownloadedFilename(String filename) {
   final safe = filename
       .split(RegExp(r'[/\\]'))

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -486,6 +486,10 @@ class _ThreadMessage extends ConsumerWidget {
         currentPubkey?.toLowerCase() == pk ||
         (profile?.ownerPubkey != null &&
             profile?.ownerPubkey == currentPubkey?.toLowerCase());
+    final hasImageGallery = hasTrailingImageGallery(
+      message.content,
+      message.tags,
+    );
 
     final userCache = ref.watch(userCacheProvider);
     final knownAgentPubkeys = ref.watch(mentionAgentPubkeysProvider(channelId));
@@ -515,10 +519,10 @@ class _ThreadMessage extends ConsumerWidget {
         child: Material(
           color: Colors.transparent,
           borderRadius: BorderRadius.circular(Radii.md),
-          // The media carousel intentionally continues through the list's
-          // trailing gutter. InkWell still clips its ink to [borderRadius],
-          // while leaving overflowing message content visible.
-          clipBehavior: Clip.none,
+          // Only galleries paint through the trailing gutter. Keep normal rows
+          // clipped so recycled list children cannot leave stale text over the
+          // following message or thread summary.
+          clipBehavior: hasImageGallery ? Clip.none : Clip.antiAlias,
           child: InkWell(
             key: ValueKey('thread-message-row-${message.id}'),
             borderRadius: BorderRadius.circular(Radii.md),

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -696,6 +696,16 @@ void main() {
       expect(find.text('Alice'), findsOneWidget);
       expect(find.text('alice@example.com'), findsOneWidget);
       expect(find.text('Bob'), findsOneWidget);
+      final textMessageMaterial = find
+          .ancestor(
+            of: find.byKey(const ValueKey('message-row-msg1')),
+            matching: find.byType(Material),
+          )
+          .first;
+      expect(
+        tester.widget<Material>(textMessageMaterial).clipBehavior,
+        Clip.antiAlias,
+      );
       final messageAvatars = find.byType(CircleAvatar);
       expect(messageAvatars, findsNWidgets(2));
       for (final avatar in messageAvatars.evaluate()) {


### PR DESCRIPTION
## Summary

Mobile text messages could leave stale paint over the following message or thread summary after #3370 disabled clipping on every message `Material` to support gallery overflow.

This change restores `Clip.antiAlias` for ordinary channel and thread messages while retaining `Clip.none` only when `MessageContent` detects an actual trailing multi-image gallery. That keeps gallery cards flush with the trailing gutter without exposing text-only rows to recycled-list paint bleed. A widget regression assertion verifies normal text rows are clipped; the existing gallery assertion continues to verify that galleries are not.

Manual verification: rendered the real mobile channel widget tree at the reporter's 475 px width with two thread summaries and confirmed each message and summary occupies its own row. No follow-up work is currently deferred.

### Related issue

Fixes #3491.

Duplicate search: no competing open issue or PR found; #3491 is the closest and originating report.

### Testing

- `just ci` — passed (full Rust, desktop, Tauri, web, and mobile gate; 883 mobile tests passed, 1 skipped)
- `flutter test test/features/channels/channel_detail_page_test.dart` — 52 passed
- `flutter test test/features/channels/message_content_test.dart` — 46 passed
- deterministic 475 px mobile widget render used for the after image below

| Before | After |
| --- | --- |
| Message text and reply summaries overlap. | Message text and reply summaries remain in separate rows. |
| ![Before: overlapping mobile message rows](https://raw.githubusercontent.com/techieasif/buzz/516c4320d8712a9b7399f9e9491d471647a2eb32/pr-3506--before.png) | ![After: non-overlapping mobile message rows](https://raw.githubusercontent.com/techieasif/buzz/516c4320d8712a9b7399f9e9491d471647a2eb32/pr-3506--after.png) |