### PR TITLE
docs(security): document NIP-98 bridge per-request-uniqueness contract

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,6 +53,26 @@ REST endpoints authenticate via
 the client signs a `kind:27235` event containing the request URL and method.
 The relay verifies the Schnorr signature and extracts the pubkey.
 
+Bridge endpoints (`/events`, `/query`, `/count`, and other REST routes) also
+reject a reused auth event id, to close replay: a duplicate id is refused even
+if it's still inside the timestamp window. Because a NIP-98 event is
+deterministic — kind, second-granularity `created_at`, `u`/`method`/`payload`
+tags — two distinct requests to the same URL within the same wall-clock second
+sign to the same event id, and the second one gets `401 replay detected`.
+Clients that may issue more than one request per second to the same endpoint
+**must** add a random `nonce` tag to keep each auth event unique; see
+`crates/buzz-cli/src/client.rs`'s `sign_nip98` for the reference
+implementation. Bumping `created_at` instead does not work as a substitute —
+it drifts the event outside the verifier's timestamp window under sustained
+bursts.
+
+The git smart-HTTP transport (`crates/buzz-relay/src/api/git/transport.rs`) is
+a deliberate exception: Git's credential protocol signs one token and reuses
+it across a session's requests (`info/refs` GET, then the pack POST), so that
+route does not dedup by event id — it relies on the timestamp window, URL
+scoping, and HTTPS instead. Don't add id-based replay rejection there; it
+would break normal clone/push.
+
 ### Authorization — Channel Membership as the Gate
 
 Channel membership is the **only** access control mechanism. There are no

--- a/crates/buzz-auth/src/nip98_replay.rs
+++ b/crates/buzz-auth/src/nip98_replay.rs
@@ -29,6 +29,14 @@
 //! The TTL must cover the verifier's clock-skew tolerance (currently ±60s, so
 //! the window over which a duplicate event id is even plausible is 2×60 = 120s).
 //! [`DEFAULT_REPLAY_TTL_SECS`] is the floor; deployments may raise it.
+//!
+//! Keying on the event id has a client-visible consequence: a NIP-98 event is
+//! deterministic (kind, second-granularity `created_at`, `u`/`method`/`payload`
+//! tags), so two distinct same-second requests to the same URL sign to the same
+//! id and the second is rejected as a replay. Clients that may burst requests
+//! must add a random `nonce` tag per request — see `buzz-cli`'s `sign_nip98` —
+//! and see `SECURITY.md` for the documented client contract, including why the
+//! git smart-HTTP transport intentionally skips this dedup.
 
 use std::{future::Future, pin::Pin};
 


### PR DESCRIPTION
## Problem

Fixes #3489.

The HTTP bridge's NIP-98 replay guard (`crates/buzz-auth/src/nip98_replay.rs`) keys on the auth event id — correct design, but a NIP-98 auth event is fully deterministic (kind `27235`, second-granularity `created_at`, `u`/`method`/`payload` tags), so two distinct, legitimate requests to the same URL within the same wall-clock second sign to the same event id. The second one is rejected with `401 NIP-98: replay detected`.

`buzz-cli` and `buzz-acp` already avoid this with a random `nonce` tag per request (`crates/buzz-cli/src/client.rs`), but that obligation was undocumented anywhere — a third-party integrator implementing NIP-98 exactly as specified (no nonce required by the NIP itself) hits intermittent 401s under any burst/batch load with no explanation. The reporter also flagged that the "obvious" fix of bumping `created_at` instead breaks under sustained bursts, since it drifts the event outside the verifier's ±60s freshness window — nonce is the only sound fix.

## Fix

Docs only, no behavior change:
- `SECURITY.md`: extended the existing NIP-98 auth paragraph with the per-request-uniqueness requirement, the recommended nonce convention (pointing at `buzz-cli`'s `sign_nip98` as the reference), and why bumping `created_at` doesn't work.
- Documented the deliberate contrast with the git smart-HTTP transport (`crates/buzz-relay/src/api/git/transport.rs`), which intentionally reuses one signed token across a session's requests and does not dedup by event id — so nobody "fixes" that regime by mistake.
- Cross-linked both from the module doc comment in `nip98_replay.rs`, since that's where a future maintainer touching the replay guard will land first.

## Test plan
- [x] `cargo fmt -p buzz-auth --check` — clean
- Docs-only change, no runtime behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)