### PR TITLE
fix(desktop): render projects header and create menu at zero projects

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -107,6 +107,7 @@ export default defineConfig({
         "**/project-commit-detail.spec.ts",
         "**/project-inbox.spec.ts",
         "**/project-issue-comments.spec.ts",
+        "**/projects-empty-state.spec.ts",
         "**/project-pr-review.spec.ts",
         "**/persona-model-combobox-screenshots.spec.ts",
         "**/drafts-screenshots.spec.ts",

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -592,9 +592,10 @@ export function ProjectsView() {
     );
   }
 
-  if (projects.length === 0) {
-    return <EmptyState />;
-  }
+  // Zero projects still renders the full chrome — the create menu lives in the
+  // toolbar, so returning early here would leave no way to create the first
+  // project from the UI.
+  const hasProjects = projects.length > 0;
 
   const projectItems =
     visibleProjects.length === 0 ? (
@@ -850,7 +851,9 @@ export function ProjectsView() {
           </div>
           <div className="mx-auto w-full max-w-6xl">
             <div className="w-full min-w-0 pb-4 pt-4">
-              {filter === "all" ? (
+              {!hasProjects ? (
+                <EmptyState />
+              ) : filter === "all" ? (
                 <ProjectsOverviewPanel
                   metadata={
                     <ProjectsOverviewRail

--- a/desktop/tests/e2e/projects-empty-state.spec.ts
+++ b/desktop/tests/e2e/projects-empty-state.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+import { FEATURE_OVERRIDES_STORAGE_KEY } from "../helpers/features";
+
+const DEFAULT_MOCK_PUBKEY = "deadbeef".repeat(8);
+// Locally hiding the seeded project and repository announcements is the only
+// mock-bridge path to a zero-project relay.
+const ALL_MOCK_PROJECT_COORDINATES = [
+  `30621:${DEFAULT_MOCK_PUBKEY}:buzz`,
+  `30617:${DEFAULT_MOCK_PUBKEY}:buzz`,
+  `30617:${TEST_IDENTITIES.alice.pubkey}:relay-tools`,
+  `30617:${TEST_IDENTITIES.bob.pubkey}:design-system`,
+];
+
+async function openEmptyProjectsView(page: import("@playwright/test").Page) {
+  // Both overrides must land before the app mounts: projects is a preview
+  // feature, and the hidden-card list is read while fetching projects.
+  await page.addInitScript(
+    ({ coordinates, featureOverridesStorageKey }) => {
+      window.localStorage.setItem(
+        featureOverridesStorageKey,
+        JSON.stringify({ projects: true }),
+      );
+      window.localStorage.setItem(
+        "buzz.projects.hidden-cards.v1",
+        JSON.stringify(coordinates),
+      );
+    },
+    {
+      coordinates: ALL_MOCK_PROJECT_COORDINATES,
+      featureOverridesStorageKey: FEATURE_OVERRIDES_STORAGE_KEY,
+    },
+  );
+  await installMockBridge(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("open-projects-view").click();
+}
+
+test("projects header and create menu stay mounted with zero projects", async ({
+  page,
+}) => {
+  await openEmptyProjectsView(page);
+
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Projects" }),
+  ).toBeVisible();
+  await expect(page.getByText("No projects yet")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Repositories", exact: true }),
+  ).toBeVisible();
+
+  // The regression: the create menu was unreachable until a project already
+  // existed, so the first project could never be created from the UI.
+  await page.getByTestId("projects-create-menu").hover();
+  await page.getByRole("menuitem", { name: "Project" }).click();
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+  await expect(page.getByTestId("create-project-name")).toBeVisible();
+});
+
+test("empty state replaces only the content area on every filter", async ({
+  page,
+}) => {
+  await openEmptyProjectsView(page);
+
+  for (const filter of ["Repositories", "Pull Requests", "Issues"]) {
+    await page.getByRole("button", { name: filter, exact: true }).click();
+    await expect(page.getByText("No projects yet")).toBeVisible();
+    await expect(page.getByTestId("projects-create-menu")).toBeVisible();
+  }
+});


### PR DESCRIPTION
Fixes #3504.

## Problem

`ProjectsView` returned `<EmptyState />` before constructing the page header, toolbar, and `<ProjectsCreateMenu />`. On a relay with zero projects, the UI therefore hid the only control capable of creating the first project.

## Fix

- Remove the early return.
- Render `<EmptyState />` in the normal content slot when `projects.length === 0`.
- Keep the Projects header, filter toolbar, and `+` create menu mounted for every project count.
- Add focused Playwright coverage for the create flow and for preserving the page chrome across filters.

## Scope

This is intentionally a three-file regression fix. It does not change empty-state copy, add another CTA, or modify project deletion/tombstone behavior. Broader related implementations are tracked in #4118 and #5205.

Unhiding the create menu also exposes its **Issue** and **Pull Request** items when there are no projects. Their existing dialogs already handle an empty project list by disabling submission until a project is available.

## Current-main adaptation

The branch is rebased onto current `main`. The E2E setup now:

- uses `FEATURE_OVERRIDES_STORAGE_KEY` rather than a versioned string literal;
- hides the seeded kind `30621` project announcement as well as the kind `30617` repository announcements;
- selects the current **Project** create-menu item name; and
- preserves the existing project smoke-test entries in `playwright.config.ts`.

## Verification

- Biome check on the three touched files
- `pnpm typecheck`
- `pnpm build:e2e`
- `pnpm exec playwright test --project=smoke tests/e2e/projects-empty-state.spec.ts` — **2 passed**

The two focused tests verify:

1. The header, empty state, toolbar, and create menu remain mounted with zero projects, and **Project** opens the existing create dialog.
2. The empty state replaces only the content area across Repositories, Pull Requests, and Issues filters.
