### PR TITLE
fix(desktop): show toolbar and create menu when Projects has zero projects

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -101,6 +101,7 @@ export default defineConfig({
         "**/project-commit-detail.spec.ts",
         "**/project-inbox.spec.ts",
         "**/project-pr-review.spec.ts",
+        "**/project-empty-state.spec.ts",
         "**/persona-model-combobox-screenshots.spec.ts",
         "**/drafts-screenshots.spec.ts",
         "**/drafts-all-fix-screenshots.spec.ts",

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -447,12 +447,10 @@ export function ProjectsView() {
     );
   }
 
-  if (projects.length === 0) {
-    return <EmptyState />;
-  }
-
   const repositoryItems =
-    visibleProjects.length === 0 ? (
+    projects.length === 0 ? (
+      <EmptyState />
+    ) : visibleProjects.length === 0 ? (
       <EmptyFilteredState />
     ) : viewMode === "grid" ? (
       <div

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1067,6 +1067,8 @@ declare global {
     };
     /** Overrides the first mock repository owner for delegated-owner tests. */
     __BUZZ_E2E_PROJECT_OWNER_OVERRIDE__?: string;
+    /** Suppresses all mock project seeds for zero-projects empty-state tests. */
+    __BUZZ_E2E_HIDE_MOCK_PROJECTS__?: boolean;
     /** Project history kinds rejected with CLOSED for aggregate-query tests. */
     __BUZZ_E2E_REJECT_PROJECT_QUERY_KINDS__?: number[];
     /** Captured aggregate project-history filters for request-count assertions. */
@@ -4988,6 +4990,10 @@ function writeMockProjectBranch(
 }
 
 function buildMockProjectEvents(): RelayEvent[] {
+  if (window.__BUZZ_E2E_HIDE_MOCK_PROJECTS__) {
+    return [];
+  }
+
   const events: RelayEvent[] = [];
   const daySeconds = 86_400;
   const now = Math.floor(Date.now() / 1000);

--- a/desktop/tests/e2e/project-empty-state.spec.ts
+++ b/desktop/tests/e2e/project-empty-state.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+test("Projects view still shows the toolbar and create menu with zero projects", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "buzz-feature-overrides-v1",
+      JSON.stringify({ projects: true }),
+    );
+    window.__BUZZ_E2E_HIDE_MOCK_PROJECTS__ = true;
+  });
+  await installMockBridge(page);
+  await page.setViewportSize({ width: 1024, height: 720 });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("open-projects-view").click();
+  await page.getByRole("button", { name: "Repositories", exact: true }).click();
+
+  await expect(page.getByText("No projects yet")).toBeVisible();
+  // The create menu (and the rest of the toolbar) must still mount so the
+  // first project can be created from an empty relay.
+  await expect(page.getByTestId("projects-create-menu")).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Fixes #3504: when a relay has zero projects, `ProjectsView` early-returned `<EmptyState/>` before the header/toolbar/create-menu ever mounted, so there was no way to create the *first* project from the UI.
- Moves the `projects.length === 0` check into the repository-list slot (same pattern already used for `EmptyFilteredState`), so `projectsHeader`/`projectsNavigation` (which contains `ProjectsCreateMenu`) always render.
- Adds a `__BUZZ_E2E_HIDE_MOCK_PROJECTS__` e2e bridge override (follows the existing `*_OVERRIDE__` convention in `e2eBridge.ts`) so a zero-projects state can be simulated without touching the shared `MOCK_PROJECT_SEEDS` fixture that `project-inbox`/`project-pr-review`/`project-commit-detail` specs depend on.
- New spec `desktop/tests/e2e/project-empty-state.spec.ts` asserts the toolbar and create menu render with zero projects.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx biome check` clean on touched files
- [x] `pnpm build:e2e && npx playwright test --project=smoke -g project` — all 21 project specs pass (existing + new)