### PR TITLE
fix(desktop): run Vite directly in Tauri dev command

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "xyz.block.buzz.app",
   "build": {
     "beforeDevCommand": {
-      "script": "exec ./node_modules/.bin/vite",
+      "script": "node ./node_modules/vite/bin/vite.js",
       "cwd": "..",
       "wait": false
     },


### PR DESCRIPTION
## Summary

Runs Vite through its Node entry point in Tauri's default `beforeDevCommand`.

The current command relies on the POSIX `exec` shell builtin, which is unavailable under Windows `cmd.exe`. Direct Tauri development commands that read `desktop/src-tauri/tauri.conf.json` therefore fail before the app starts. Calling Vite's published Node entry point is portable without changing how Vite starts on macOS or Linux.

The `just` recipes that start Tauri provide a generated config from `scripts/instance-env.sh`; #3534 covers that path. `just desktop-dev` already calls `pnpm exec vite` directly and is not affected.

### Related issue

Extracted from the maintainer request in #2506. Complements #3534.

### Testing

`node ./node_modules/vite/bin/vite.js --version` returned `vite/8.0.16 darwin-arm64 node-v24.15.0`.

`pnpm --dir desktop check` passed.

`just ci` passed.

A Windows smoke test was not available locally. This changes configuration only, so screenshots do not apply.
