### PR TITLE
fix(desktop): point Oh My Pi preset at omp.sh

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -106,7 +106,7 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         label: "Oh My Pi",
         command: "omp",
         args: &["acp"],
-        install_instructions_url: "https://github.com/can1357/oh-my-pi",
+        install_instructions_url: "https://omp.sh/",
         install_hint: "Buzz talks to Oh My Pi through its CLI's ACP mode (omp acp).",
         underlying_cli: None,
     },


### PR DESCRIPTION
## Summary

Points the Oh My Pi preset at the `omp.sh` installation page instead of the GitHub repository.

The project serves its current installer from `omp.sh/install.sh`.

### Related issue

Extracted from the maintainer request in #3111. I found no matching open pull request in a final duplicate check.

### Testing

`https://omp.sh/` returned HTTP 200 with the installation page.

`https://omp.sh/install.sh` resolved to the current installer and returned HTTP 200.

`cargo test --manifest-path desktop/src-tauri/Cargo.toml preset_entry -- --nocapture` passed 5 tests.

`just ci` passed.

This changes metadata only, so screenshots do not apply.