### PR TITLE
fix(chart): require Redis at any replica count, not just replicaCount>1

### DIFF
--- a/crates/buzz-relay/src/router.rs
+++ b/crates/buzz-relay/src/router.rs
@@ -389,6 +389,11 @@ async fn readiness_handler(State(state): State<Arc<AppState>>) -> impl IntoRespo
     if pg_ok && redis_ok {
         (StatusCode::OK, Json(json!({"status": "ready"}))).into_response()
     } else {
+        tracing::warn!(
+            postgres_ok = pg_ok,
+            redis_ok = redis_ok,
+            "readiness probe failing — see which dependency is unreachable"
+        );
         (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(json!({"status": "not_ready", "postgres": pg_ok, "redis": redis_ok})),

--- a/deploy/charts/buzz/README.md
+++ b/deploy/charts/buzz/README.md
@@ -121,13 +121,13 @@ an Ingress or HTTPRoute for the pairing Service; route the public hostname to
 
 ## HA (production)
 
-`replicaCount > 1` hard-requires Redis:
+The relay requires Redis at **any** replica count, not just HA:
 
-- Redis (`redis.enabled=true`, `externalRedis.url`, or `REDIS_URL` in `existingSecret`) — for `buzz-pubsub` fan-out
+- Redis (`redis.enabled=true`, `externalRedis.url`, or `REDIS_URL` in `existingSecret`) — for `buzz-pubsub` (presence, typing, rate limiting, cache invalidation) and the NIP-98 HTTP-auth replay guard, which fails closed without it
 
 It does **not** require ReadWriteMany git storage. Git ref/object state is object-store-backed (each request hydrates an ephemeral repo from S3-compatible storage; writer serialization is the object-store pointer CAS — see `docs/git-on-object-storage.md`), and repo-name uniqueness lives in Postgres. Each replica can use its own `ReadWriteOnce` volume; no shared filesystem is needed.
 
-The chart **template-fails** if the Redis invariant is broken at `replicaCount > 1`. No silent degradation.
+The chart **template-fails** if no Redis source is configured, at any `replicaCount`. No silent degradation — a missing Redis source used to render successfully at `replicaCount=1` and then sit at a permanent, unexplained `/_readiness` 503.
 
 ### Relay autoscaling
 

--- a/deploy/charts/buzz/templates/_validate.tpl
+++ b/deploy/charts/buzz/templates/_validate.tpl
@@ -10,14 +10,6 @@ surface at template time regardless of which manifest helm renders first.
   {{- fail "relayUrl is required: set --set relayUrl=wss://your.domain" -}}
 {{- end -}}
 
-{{/* Multiple replicas require Redis, whether fixed or autoscaled. */}}
-{{- $minimumReplicas := include "buzz.minimumReplicas" . | int -}}
-{{- if gt $minimumReplicas 1 -}}
-  {{- if and (not .Values.redis.enabled) (not .Values.externalRedis.url) (not .Values.secrets.existingSecret) -}}
-    {{- fail (printf "minimum replica count %d requires Redis for buzz-pubsub. Enable redis.enabled=true, set externalRedis.url, or provide secrets.existingSecret with key REDIS_URL." $minimumReplicas) -}}
-  {{- end -}}
-{{- end -}}
-
 {{/* Multiple replicas do NOT require ReadWriteMany git storage.
 
      Git ref/object state is object-store-backed: every read and write hydrates
@@ -30,8 +22,9 @@ surface at template time regardless of which manifest helm renders first.
 
      The prior hard-fail requiring persistence.git.accessMode=ReadWriteMany was
      removed here: its stated reason ("git on-disk state must be shared across
-     replicas") is no longer true. Redis (validated above) remains the real
-     multi-pod requirement for buzz-pubsub. */}}
+     replicas") is no longer true. Redis (validated below) remains a hard
+     runtime dependency regardless of replica count — see that guard's
+     comment for why. */}}
 
 {{/* Autoscaling bounds must be coherent. */}}
 {{- if .Values.autoscaling.enabled -}}
@@ -79,6 +72,19 @@ surface at template time regardless of which manifest helm renders first.
      startup conformance probe without a reachable bucket). */}}
 {{- if not (or .Values.minio.enabled .Values.s3.endpoint .Values.secrets.existingSecret) -}}
   {{- fail "S3/object-storage source missing: enable minio.enabled=true (quickstart in-cluster), set s3.endpoint + s3.bucket + credentials, or provide secrets.existingSecret with keys BUZZ_S3_ACCESS_KEY + BUZZ_S3_SECRET_KEY. The relay runs a startup S3 conformance probe and exits if storage is unreachable." -}}
+{{- end -}}
+
+{{/* Redis source must exist somewhere, at any replica count.
+     This is not just an HA/fan-out concern: the relay unconditionally wires
+     buzz-pubsub (presence, typing, rate limiting, cache invalidation) and the
+     NIP-98 HTTP-auth replay guard through Redis (state.rs), and the replay
+     guard fails closed — with no Redis it hard-fails startup or every bridge
+     request. A single-replica install with no Redis source configured has
+     always been unready in practice (redis://localhost:6379 default, nothing
+     listening); this just makes that fail at `helm install` instead of a
+     silent, permanent /_readiness 503 with no explanation in the logs. */}}
+{{- if not (or .Values.redis.enabled .Values.externalRedis.url .Values.secrets.existingSecret) -}}
+  {{- fail "Redis source missing: the relay requires Redis at any replica count (buzz-pubsub + NIP-98 replay protection). Enable redis.enabled=true, set externalRedis.url, or provide secrets.existingSecret with key REDIS_URL." -}}
 {{- end -}}
 
 {{- end -}}

--- a/deploy/charts/buzz/templates/deployment.yaml
+++ b/deploy/charts/buzz/templates/deployment.yaml
@@ -200,7 +200,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "buzz.envSecretName" . }}
                   key: REDIS_URL
-                  optional: {{ and (eq (include "buzz.minimumReplicas" . | int) 1) (not .Values.redis.enabled) (not .Values.externalRedis.url) }}
             - name: BUZZ_S3_ACCESS_KEY
               valueFrom:
                 secretKeyRef:

--- a/deploy/charts/buzz/tests/networking_test.yaml
+++ b/deploy/charts/buzz/tests/networking_test.yaml
@@ -9,6 +9,7 @@ tests:
       relayUrl: wss://buzz.example.com
       ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
       externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
       s3.endpoint: http://minio:9000
       s3.accessKey: a
       s3.secretKey: s
@@ -27,6 +28,7 @@ tests:
       relayUrl: wss://buzz.example.com
       ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
       externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
       s3.endpoint: http://minio:9000
       s3.accessKey: a
       s3.secretKey: s
@@ -43,6 +45,7 @@ tests:
       relayUrl: wss://buzz.example.com
       ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
       externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
       s3.endpoint: http://minio:9000
       s3.accessKey: a
       s3.secretKey: s
@@ -62,6 +65,7 @@ tests:
       relayUrl: wss://buzz.example.com
       ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
       externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
       s3.endpoint: http://minio:9000
       s3.accessKey: a
       s3.secretKey: s

--- a/deploy/charts/buzz/tests/secrets_test.yaml
+++ b/deploy/charts/buzz/tests/secrets_test.yaml
@@ -8,6 +8,7 @@ tests:
       relayUrl: wss://buzz.example.com
       ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
       externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
       s3.endpoint: http://minio:9000
       s3.accessKey: a
       s3.secretKey: s
@@ -29,6 +30,7 @@ tests:
       relayUrl: wss://buzz.example.com
       ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
       externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
       s3.endpoint: http://minio:9000
       s3.accessKey: a
       s3.secretKey: s
@@ -43,6 +45,7 @@ tests:
       relayUrl: wss://buzz.example.com
       ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
       externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
       s3.endpoint: http://minio:9000
       s3.accessKey: a
       s3.secretKey: s
@@ -64,6 +67,7 @@ tests:
       relayUrl: wss://buzz.example.com
       ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
       externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
       s3.endpoint: http://minio:9000
       s3.accessKey: a
       s3.secretKey: s
@@ -85,6 +89,7 @@ tests:
       relayUrl: wss://buzz.example.com
       ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
       externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
       s3.endpoint: http://minio:9000
       s3.accessKey: a
       s3.secretKey: s
@@ -105,6 +110,7 @@ tests:
       relayUrl: wss://buzz.example.com
       ownerPubkey: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
       externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
       s3.endpoint: http://minio:9000
       s3.accessKey: a
       s3.secretKey: s
@@ -126,6 +132,7 @@ tests:
       relayUrl: wss://buzz.example.com
       ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
       externalPostgresql.url: postgres://u:p@h:5432/d
+      externalRedis.url: redis://h:6379
       s3.endpoint: http://minio:9000
       s3.accessKey: a
       s3.secretKey: s

--- a/deploy/charts/buzz/tests/validation_test.yaml
+++ b/deploy/charts/buzz/tests/validation_test.yaml
@@ -29,15 +29,31 @@ tests:
       - failedTemplate:
           errorPattern: "ownerPubkey: Does not match pattern"
 
-  - it: fails when replicaCount>1 without Redis
+  - it: fails when Redis source is missing, even at replicaCount=1
     set:
       relayUrl: wss://buzz.example.com
       ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
       externalPostgresql.url: postgres://u:p@h:5432/d
+      s3.endpoint: http://minio:9000
+      s3.accessKey: a
+      s3.secretKey: s
+      replicaCount: 1
+    asserts:
+      - failedTemplate:
+          errorPattern: "Redis source missing"
+
+  - it: fails when Redis source is missing at replicaCount>1
+    set:
+      relayUrl: wss://buzz.example.com
+      ownerPubkey: "0000000000000000000000000000000000000000000000000000000000000000"
+      externalPostgresql.url: postgres://u:p@h:5432/d
+      s3.endpoint: http://minio:9000
+      s3.accessKey: a
+      s3.secretKey: s
       replicaCount: 3
     asserts:
       - failedTemplate:
-          errorPattern: "minimum replica count 3 requires Redis"
+          errorPattern: "Redis source missing"
 
   - it: fails when ingress and httproute both enabled
     set:

--- a/deploy/charts/buzz/values.schema.json
+++ b/deploy/charts/buzz/values.schema.json
@@ -26,7 +26,7 @@
     "replicaCount": {
       "type": "integer",
       "minimum": 1,
-      "description": "Replica count for the relay Deployment. replicaCount > 1 requires Redis (for buzz-pubsub) — enforced by _validate.tpl. Git storage does NOT need ReadWriteMany: git state is object-store-backed and repo names live in Postgres, so ReadWriteOnce is fine per replica."
+      "description": "Replica count for the relay Deployment. Redis is required at any replica count (buzz-pubsub + NIP-98 replay protection) — enforced by _validate.tpl. Git storage does NOT need ReadWriteMany: git state is object-store-backed and repo names live in Postgres, so ReadWriteOnce is fine per replica."
     },
     "relayUrl": {
       "type": "string",

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -4,8 +4,10 @@
 #
 #   PRODUCTION (default) — external Postgres/Redis/S3, existingSecret
 #   refs everywhere, no chart-side autogeneration, GitOps-safe (ArgoCD/Flux).
-#   HA-ready: replicaCount >= 2 (requires Redis; git state is object-store-
-#   backed, so no ReadWriteMany volume is needed — RWO per replica is fine).
+#   Redis is required at any replica count (buzz-pubsub + NIP-98 replay
+#   protection, not just HA fan-out). HA-ready: replicaCount >= 2 (git state
+#   is object-store-backed, so no ReadWriteMany volume is needed — RWO per
+#   replica is fine).
 #
 #   QUICKSTART — bundles in-cluster Postgres + Redis + MinIO and
 #   auto-generates relay secrets via the `lookup` pattern (NOT GitOps-safe —


### PR DESCRIPTION
## Problem

Fixes #3427.

Fresh Helm install, `replicaCount: 1`, no Redis source configured. The chart's validation, `values.yaml`, `values.schema.json`, and README all state "Redis is only required for `replicaCount > 1`" — so the install renders and deploys cleanly. The pod then sits `Running 0/1` forever: `/_readiness` returns 503 and never recovers, with nothing in the logs stating Redis is the missing dependency.

That claim is wrong. The relay unconditionally wires Redis through `buzz-pubsub` (presence, typing, rate limiting, cache invalidation) and, more importantly, the NIP-98 HTTP-auth replay guard (`RedisNip98ReplayGuard` in `state.rs`), which **fails closed** with no Redis reachable. None of this is gated on replica count — a single-replica relay needs Redis exactly as much as a 3-replica one.

The actual runtime root cause: `deployment.yaml`'s `REDIS_URL` env was conditionally `optional: true` precisely when `replicaCount==1` and no Redis source was configured, so the pod started with no `REDIS_URL` at all and fell back to the relay's `redis://localhost:6379` default — nothing listening, permanent readiness failure, no explanation.

## Fix

- `deployment.yaml`: `REDIS_URL`'s `secretKeyRef` is now unconditionally required, matching `DATABASE_URL`'s existing pattern (no `optional:` flag).
- `_validate.tpl`: the Redis hard-fail guard now fires at any replica count. Moved it to the end of the guard chain (after Postgres/S3) so it doesn't change which error message an already-misconfigured install sees first — verified against every existing `validation_test.yaml` case.
- `values.yaml`, `values.schema.json`, `README.md`: corrected the "replicaCount > 1 requires Redis" framing everywhere it appeared.
- `router.rs`: added a `warn!` log line on `/_readiness` failure naming which dependency (postgres/redis) is unreachable — the JSON response body already reported this, but it wasn't visible from pod logs/events, which is what an operator actually sees first. Requested explicitly in the issue as a complementary fix regardless of which validation direction was taken.

## Test plan
- `helm unittest deploy/charts/buzz`: 9 suites / 44 tests pass. Renamed/duplicated the old `replicaCount>1` test into two (`replicaCount=1` and `>1`, both now failing on missing Redis), and added `externalRedis.url` to the `secrets_test.yaml`/`networking_test.yaml` fixtures that previously passed only because the old guard didn't fire at `replicaCount=1`.
- `helm template` against every `ci/*-values.yaml` and `tests/fixtures/*-values.yaml` fixture (all already configure Redis) — all render cleanly, matching the CI render-matrix step.
- Manually reproduced the exact bug and the fix:
  - `helm template` with `replicaCount=1` + no Redis source → now fails fast: `Error: ... Redis source missing: the relay requires Redis at any replica count...`
  - Same install with `externalRedis.url` set → renders, `REDIS_URL` is present as a required (non-optional) `secretKeyRef`.
- `cargo build -p buzz-relay --lib` and `cargo clippy -p buzz-relay --lib --all-targets -- -D warnings`: clean.
- `cargo fmt -p buzz-relay --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)