### PR TITLE
fix(acp): register grok preset args for grok-build runtime (#3457)

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -693,6 +693,11 @@ pub(crate) fn normalize_agent_command_identity(command: &str) -> String {
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
+        "grok" => Some(vec![
+            "agent".to_string(),
+            "--always-approve".to_string(),
+            "stdio".to_string(),
+        ]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,
@@ -1538,6 +1543,18 @@ mod tests {
     fn normalizes_goose_args_to_acp() {
         assert_eq!(normalize_agent_args("goose", Vec::new()), vec!["acp"]);
         assert_eq!(normalize_agent_args("goose", vec!["".into()]), vec!["acp"]);
+    }
+
+    #[test]
+    fn normalizes_grok_args_to_agent_always_approve_stdio() {
+        assert_eq!(
+            normalize_agent_args("grok", Vec::new()),
+            vec!["agent", "--always-approve", "stdio"]
+        );
+        assert_eq!(
+            normalize_agent_args("grok", vec!["".into()]),
+            vec!["agent", "--always-approve", "stdio"]
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -463,6 +463,11 @@ pub fn try_record_agent_command(
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
+        "grok" => Some(vec![
+            "agent".to_string(),
+            "--always-approve".to_string(),
+            "stdio".to_string(),
+        ]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -55,6 +55,26 @@ fn default_agent_command_resolves_bundled_buzz_agent() {
 }
 
 #[test]
+fn normalizes_grok_args_to_agent_always_approve_stdio() {
+    assert_eq!(
+        normalize_agent_args("grok", Vec::new()),
+        vec![
+            "agent".to_string(),
+            "--always-approve".to_string(),
+            "stdio".to_string()
+        ]
+    );
+    assert_eq!(
+        normalize_agent_args("grok", vec!["".into()]),
+        vec![
+            "agent".to_string(),
+            "--always-approve".to_string(),
+            "stdio".to_string()
+        ]
+    );
+}
+
+#[test]
 fn normalizes_claude_and_codex_args_to_empty() {
     assert_eq!(
         normalize_agent_args("claude-agent-acp", vec!["acp".into()]),


### PR DESCRIPTION
Fixes #3457.

- Registers default agent args `['agent', '--always-approve', 'stdio']` for the `grok` command identity in both `buzz-acp` (`config.rs`) and desktop managed agents discovery (`discovery.rs`).
- Prevents `grok` spawns from launching the interactive TUI mode (which hangs/fails with ENXIO) when no explicit `agent_args` are configured.
- Added unit tests for Grok argument normalization in both crates.

Signed-off-by: 1nderboi <201919958+1nderboi@users.noreply.github.com>
Co-authored-by: 1nderboi <201919958+1nderboi@users.noreply.github.com>