### PR TITLE
fix(desktop): hide ghost caret after Shift+Enter

### DIFF
--- a/desktop/src/shared/styles/globals/composer.css
+++ b/desktop/src/shared/styles/globals/composer.css
@@ -103,6 +103,10 @@
   margin: 0;
 }
 
+.rich-text-composer .tiptap br + .ProseMirror-trailingBreak {
+  display: none;
+}
+
 .rich-text-composer .tiptap p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   float: left;


### PR DESCRIPTION
## Summary
- Hide the trailing `<br>` ProseMirror inserts after a hard break, which WebKit/Chromium renders as a stale ghost caret

Closes #3219

## Testing
- Live-local: typed text, pressed Shift+Enter twice — only one caret blinks at the real cursor position

https://github.com/user-attachments/assets/1b1f4ec2-d38f-4982-8999-fa7354d4e066