### PR TITLE
feat(mobile): add display name editing

### DIFF
--- a/mobile/lib/features/profile/edit_profile_sheet.dart
+++ b/mobile/lib/features/profile/edit_profile_sheet.dart
@@ -1,0 +1,155 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter/services.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../shared/theme/theme.dart';
+import 'profile_provider.dart';
+import 'user_profile.dart';
+
+const _saveButtonHeight = 52.0;
+
+void showEditProfileSheet(
+  BuildContext context, {
+  required UserProfile? currentProfile,
+}) {
+  showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    builder: (_) => _EditProfileSheet(currentProfile: currentProfile),
+  );
+}
+
+class _EditProfileSheet extends HookConsumerWidget {
+  const _EditProfileSheet({required this.currentProfile});
+
+  final UserProfile? currentProfile;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final initialName = currentProfile?.displayName ?? '';
+    final controller = useTextEditingController(text: initialName);
+    final displayName = useState(initialName);
+    final isSaving = useState(false);
+    final errorMessage = useState<String?>(null);
+
+    useEffect(() {
+      void listener() {
+        displayName.value = controller.text;
+        errorMessage.value = null;
+      }
+
+      controller.addListener(listener);
+      return () => controller.removeListener(listener);
+    }, [controller]);
+
+    final trimmedName = displayName.value.trim();
+    final canSave =
+        trimmedName.isNotEmpty &&
+        trimmedName != initialName.trim() &&
+        !isSaving.value;
+
+    Future<void> handleSave() async {
+      if (!canSave) return;
+      isSaving.value = true;
+      errorMessage.value = null;
+      try {
+        await ref.read(profileProvider.notifier).updateDisplayName(trimmedName);
+        if (context.mounted) Navigator.of(context).pop();
+      } catch (_) {
+        if (!context.mounted) return;
+        errorMessage.value = 'Could not update your profile. Try again.';
+      } finally {
+        if (context.mounted) isSaving.value = false;
+      }
+    }
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        Grid.gutter,
+        0,
+        Grid.gutter,
+        Grid.gutter +
+            math.max(
+              MediaQuery.viewInsetsOf(context).bottom,
+              MediaQuery.viewPaddingOf(context).bottom,
+            ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Edit profile', style: context.textTheme.titleMedium),
+          const SizedBox(height: Grid.half),
+          Text(
+            'Choose the name people see across Buzz.',
+            style: context.textTheme.bodySmall?.copyWith(
+              color: context.colors.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: Grid.twelve),
+          TextField(
+            controller: controller,
+            autofocus: true,
+            inputFormatters: const [
+              _RuneLengthLimitingTextInputFormatter(
+                maxProfileDisplayNameLength,
+              ),
+            ],
+            textCapitalization: TextCapitalization.words,
+            textInputAction: TextInputAction.done,
+            decoration: InputDecoration(
+              labelText: 'Display name',
+              counterText:
+                  '${displayName.value.runes.length}/'
+                  '$maxProfileDisplayNameLength',
+            ),
+            onSubmitted: (_) => handleSave(),
+          ),
+          if (errorMessage.value case final message?)
+            Padding(
+              padding: const EdgeInsets.only(top: Grid.half),
+              child: Text(
+                message,
+                style: context.textTheme.bodySmall?.copyWith(
+                  color: context.colors.error,
+                ),
+              ),
+            ),
+          const SizedBox(height: Grid.gutter),
+          SizedBox(
+            width: double.infinity,
+            height: _saveButtonHeight,
+            child: FilledButton(
+              onPressed: canSave ? handleSave : null,
+              child: const Text('Save'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RuneLengthLimitingTextInputFormatter extends TextInputFormatter {
+  const _RuneLengthLimitingTextInputFormatter(this.maxLength);
+
+  final int maxLength;
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    if (newValue.text.runes.length <= maxLength) return newValue;
+
+    final text = String.fromCharCodes(newValue.text.runes.take(maxLength));
+    return TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+  }
+}

--- a/mobile/lib/features/profile/profile_provider.dart
+++ b/mobile/lib/features/profile/profile_provider.dart
@@ -1,10 +1,16 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
 
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../shared/crypto/nip_oa.dart';
 import '../../shared/relay/relay.dart';
+import 'user_cache_provider.dart';
 import 'user_profile.dart';
+
+const maxProfileDisplayNameLength = 255;
 
 /// The current user's profile (kind:0 metadata) loaded over the relay
 /// WebSocket. Returns null when no nsec is configured or when the user has
@@ -31,12 +37,104 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
       avatarUrl: data.avatarUrl,
       about: data.about,
       nip05Handle: data.nip05,
+      ownerPubkey: verifiedOaOwnerPubkey(events.first.tags, data.pubkey),
     );
   }
 
   Future<void> refresh() async {
     state = await AsyncValue.guard(_fetch);
   }
+
+  /// Publish a replacement kind-0 event while preserving the current metadata.
+  Future<void> updateDisplayName(String displayName) async {
+    final trimmedName = displayName.trim();
+    if (trimmedName.isEmpty) {
+      throw ArgumentError.value(
+        displayName,
+        'displayName',
+        'must not be blank',
+      );
+    }
+    if (trimmedName.runes.length > maxProfileDisplayNameLength) {
+      throw ArgumentError.value(
+        displayName,
+        'displayName',
+        'must be $maxProfileDisplayNameLength characters or fewer',
+      );
+    }
+
+    final operationConfig = ref.read(relayConfigProvider);
+    final myPk = ref.read(myPubkeyProvider);
+    if (myPk == null) {
+      throw StateError('Cannot update profile without a signing key');
+    }
+
+    final session = ref.read(relaySessionProvider.notifier);
+    final events = await session.fetchHistory(NostrFilters.profile(myPk));
+    _ensureRelayScope(operationConfig, myPk);
+    final currentEvent = events.firstOrNull;
+    final metadata = _metadataFrom(currentEvent);
+    metadata['display_name'] = trimmedName;
+    final createdAt = max(
+      DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      (currentEvent?.createdAt ?? -1) + 1,
+    );
+
+    NostrEvent? submittedEvent;
+    await SignedEventRelay(session: session, nsec: operationConfig.nsec).submit(
+      kind: EventKind.profileMetadata,
+      content: jsonEncode(metadata),
+      tags: currentEvent?.tags ?? const [],
+      createdAt: createdAt,
+      onSigned: (event) => submittedEvent = event,
+    );
+    _ensureRelayScope(operationConfig, myPk);
+    final confirmedEvents = await session.fetchHistory(
+      NostrFilters.profile(myPk),
+    );
+    _ensureRelayScope(operationConfig, myPk);
+    if (confirmedEvents.firstOrNull?.id != submittedEvent?.id) {
+      throw StateError('Profile update was superseded by another event');
+    }
+
+    final updated = UserProfile(
+      pubkey: myPk.toLowerCase(),
+      displayName: trimmedName,
+      avatarUrl: _stringValue(metadata, 'picture'),
+      about: _stringValue(metadata, 'about'),
+      nip05Handle: _stringValue(metadata, 'nip05'),
+      ownerPubkey: verifiedOaOwnerPubkey(currentEvent?.tags ?? const [], myPk),
+    );
+    state = AsyncData(updated);
+    ref.read(userCacheProvider.notifier).updateProfile(updated);
+  }
+
+  void _ensureRelayScope(RelayConfig operationConfig, String pubkey) {
+    final currentConfig = ref.read(relayConfigProvider);
+    if (currentConfig.baseUrl != operationConfig.baseUrl ||
+        currentConfig.nsec != operationConfig.nsec ||
+        ref.read(myPubkeyProvider) != pubkey) {
+      throw StateError('Active community changed during profile update');
+    }
+  }
+}
+
+Map<String, dynamic> _metadataFrom(NostrEvent? event) {
+  if (event == null) return {};
+
+  try {
+    final decoded = jsonDecode(event.content);
+    return decoded is Map<String, dynamic>
+        ? Map<String, dynamic>.from(decoded)
+        : {};
+  } catch (_) {
+    return {};
+  }
+}
+
+String? _stringValue(Map<String, dynamic> metadata, String key) {
+  final value = metadata[key];
+  return value is String && value.isNotEmpty ? value : null;
 }
 
 final profileProvider = AsyncNotifierProvider<ProfileNotifier, UserProfile?>(

--- a/mobile/lib/features/profile/settings_profile_header.dart
+++ b/mobile/lib/features/profile/settings_profile_header.dart
@@ -7,6 +7,7 @@ import '../../shared/custom_emoji/custom_emoji_render.dart';
 import '../../shared/theme/theme.dart';
 import '../../shared/widgets/avatar_image.dart';
 import '../../shared/widgets/masked_avatar_badge.dart';
+import 'edit_profile_sheet.dart';
 import 'profile_provider.dart';
 import 'set_status_sheet.dart';
 import 'user_status_provider.dart';
@@ -54,10 +55,26 @@ class SettingsProfileHeader extends ConsumerWidget {
             ),
           ),
           const SizedBox(height: Grid.twelve),
-          Text(
-            profile?.label ?? 'Your profile',
-            style: context.textTheme.titleMedium,
-            textAlign: TextAlign.center,
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(
+                child: Text(
+                  profile?.label ?? 'Your profile',
+                  style: context.textTheme.titleMedium,
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              IconButton(
+                onPressed: () =>
+                    showEditProfileSheet(context, currentProfile: profile),
+                tooltip: 'Edit profile',
+                visualDensity: VisualDensity.compact,
+                icon: const Icon(LucideIcons.pencil, size: 18),
+              ),
+            ],
           ),
           // No placeholder copy — the badge is the affordance, so this line
           // appears only once there is an actual status to show.

--- a/mobile/lib/features/profile/user_cache_provider.dart
+++ b/mobile/lib/features/profile/user_cache_provider.dart
@@ -12,11 +12,13 @@ import 'user_profile.dart';
 /// kind:0 batch query (NIP-01 `authors` filter) every 50ms.
 class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
   final Set<String> _pending = {};
+  final Map<String, int> _localUpdateVersions = {};
   Timer? _batchTimer;
 
   @override
   Map<String, UserProfile> build() {
     ref.watch(relayConfigProvider);
+    _localUpdateVersions.clear();
     ref.onDispose(() {
       _batchTimer?.cancel();
       _batchTimer = null;
@@ -44,6 +46,13 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
     _batchTimer ??= Timer(const Duration(milliseconds: 50), _flushPending);
   }
 
+  /// Replace a cached profile after the local user publishes new metadata.
+  void updateProfile(UserProfile profile) {
+    final pubkey = profile.pubkey.toLowerCase();
+    _localUpdateVersions[pubkey] = (_localUpdateVersions[pubkey] ?? 0) + 1;
+    state = {...state, pubkey: profile};
+  }
+
   void _scheduleFetch(String pubkey) {
     if (state.containsKey(pubkey) || _pending.contains(pubkey)) return;
     _pending.add(pubkey);
@@ -56,6 +65,9 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
 
     final pubkeys = _pending.toList();
     _pending.clear();
+    final requestVersions = {
+      for (final pubkey in pubkeys) pubkey: _localUpdateVersions[pubkey] ?? 0,
+    };
 
     try {
       final session = ref.read(relaySessionProvider.notifier);
@@ -67,6 +79,7 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
       for (final event in events) {
         final data = ProfileData.fromEvent(event);
         final pk = data.pubkey.toLowerCase();
+        if ((_localUpdateVersions[pk] ?? 0) != requestVersions[pk]) continue;
         updated[pk] = UserProfile(
           pubkey: pk,
           displayName: data.displayName,

--- a/mobile/lib/shared/relay/nostr_models.dart
+++ b/mobile/lib/shared/relay/nostr_models.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 ///
 /// Keep in sync with `desktop/src/shared/constants/kinds.ts`.
 abstract final class EventKind {
+  static const profileMetadata = 0;
   static const note = 1;
   static const contactList = 3;
   static const deletion = 5;

--- a/mobile/test/features/profile/display_name_editor_test.dart
+++ b/mobile/test/features/profile/display_name_editor_test.dart
@@ -1,0 +1,194 @@
+import 'dart:async';
+
+import 'package:buzz/features/profile/profile_provider.dart';
+import 'package:buzz/features/profile/settings_profile_header.dart';
+import 'package:buzz/features/profile/user_profile.dart';
+import 'package:buzz/features/profile/user_status_provider.dart';
+import 'package:buzz/shared/custom_emoji/custom_emoji_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../helpers/widget_helpers.dart';
+
+void main() {
+  testWidgets('opens the display-name editor with the current value', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: [
+          profileProvider.overrideWith(_FakeProfileNotifier.new),
+          userStatusProvider.overrideWith(_FakeUserStatusNotifier.new),
+          customEmojiListProvider.overrideWithValue(const []),
+        ],
+        child: const SettingsProfileHeader(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Daniel'), findsOneWidget);
+    expect(find.byTooltip('Edit profile'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Edit profile'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit profile'), findsOneWidget);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller?.text,
+      'Daniel',
+    );
+    await tester.tap(find.byType(TextField));
+    tester.testTextInput.enterText('x' * 256);
+    await tester.pump();
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller?.text.length,
+      255,
+    );
+  });
+
+  testWidgets('saves a changed display name and closes the editor', (
+    tester,
+  ) async {
+    final profile = _RecordingProfileNotifier();
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: [
+          profileProvider.overrideWith(() => profile),
+          userStatusProvider.overrideWith(_FakeUserStatusNotifier.new),
+          customEmojiListProvider.overrideWithValue(const []),
+        ],
+        child: const SettingsProfileHeader(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Edit profile'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'Daniel V');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(profile.savedDisplayName, 'Daniel V');
+    expect(find.text('Edit profile'), findsNothing);
+  });
+
+  testWidgets('keeps the draft visible when publishing fails', (tester) async {
+    final profile = _RecordingProfileNotifier(shouldFail: true);
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: [
+          profileProvider.overrideWith(() => profile),
+          userStatusProvider.overrideWith(_FakeUserStatusNotifier.new),
+          customEmojiListProvider.overrideWithValue(const []),
+        ],
+        child: const SettingsProfileHeader(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Edit profile'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'Unsaved name');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Could not update your profile. Try again.'), findsOne);
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller?.text,
+      'Unsaved name',
+    );
+  });
+
+  testWidgets('keeps a long display name within the settings header', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: [
+          profileProvider.overrideWith(_LongNameProfileNotifier.new),
+          userStatusProvider.overrideWith(_FakeUserStatusNotifier.new),
+          customEmojiListProvider.overrideWithValue(const []),
+        ],
+        child: const SettingsProfileHeader(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byTooltip('Edit profile'), findsOneWidget);
+  });
+
+  testWidgets('can be dismissed while a profile update is pending', (
+    tester,
+  ) async {
+    final profile = _PendingProfileNotifier();
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: [
+          profileProvider.overrideWith(() => profile),
+          userStatusProvider.overrideWith(_FakeUserStatusNotifier.new),
+          customEmojiListProvider.overrideWithValue(const []),
+        ],
+        child: const SettingsProfileHeader(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Edit profile'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'Daniel V');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pump();
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+
+    profile.save.completeError(Exception('relay unavailable'));
+    await tester.pump();
+
+    expect(find.text('Edit profile'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+class _FakeProfileNotifier extends ProfileNotifier {
+  @override
+  Future<UserProfile?> build() async =>
+      const UserProfile(pubkey: 'aabb', displayName: 'Daniel');
+}
+
+class _RecordingProfileNotifier extends _FakeProfileNotifier {
+  _RecordingProfileNotifier({this.shouldFail = false});
+
+  final bool shouldFail;
+  String? savedDisplayName;
+
+  @override
+  Future<void> updateDisplayName(String displayName) async {
+    if (shouldFail) throw Exception('relay unavailable');
+    savedDisplayName = displayName;
+  }
+}
+
+class _LongNameProfileNotifier extends ProfileNotifier {
+  @override
+  Future<UserProfile?> build() async => const UserProfile(
+    pubkey: 'aabb',
+    displayName:
+        'A display name long enough to exceed the available settings width',
+  );
+}
+
+class _PendingProfileNotifier extends _FakeProfileNotifier {
+  final save = Completer<void>();
+
+  @override
+  Future<void> updateDisplayName(String displayName) => save.future;
+}
+
+class _FakeUserStatusNotifier extends UserStatusNotifier {
+  @override
+  Future<Never?> build() async => null;
+}

--- a/mobile/test/features/profile/profile_provider_test.dart
+++ b/mobile/test/features/profile/profile_provider_test.dart
@@ -1,0 +1,388 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:buzz/features/profile/profile_provider.dart';
+import 'package:buzz/features/profile/user_cache_provider.dart';
+import 'package:buzz/features/profile/user_profile.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:nostr/nostr.dart' as nostr;
+import 'package:pointycastle/digests/sha256.dart';
+
+void main() {
+  test('updates the display name without discarding kind-0 metadata', () async {
+    final keys = nostr.Keys.generate();
+    final owner = nostr.Keys.generate();
+    final nsec = keys.nsec;
+    final authTag = _authTag(owner, keys.public);
+    final session = _RecordingRelaySession(keys.public, authTag);
+    final container = ProviderContainer(
+      overrides: [
+        relayConfigProvider.overrideWith(() => _FixedRelayConfigNotifier(nsec)),
+        myPubkeyProvider.overrideWithValue(keys.public),
+        relaySessionProvider.overrideWith(() => session),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(profileProvider.future);
+    await container
+        .read(profileProvider.notifier)
+        .updateDisplayName('  Daniel V  ');
+
+    final published = session.published.single;
+    final metadata = jsonDecode(published.content) as Map<String, dynamic>;
+
+    expect(published.kind, 0);
+    expect(published.createdAt, 4102444801);
+    expect(published.tags, [authTag]);
+    expect(metadata['display_name'], 'Daniel V');
+    expect(metadata['name'], 'daniel');
+    expect(metadata['picture'], 'https://example.com/avatar.png');
+    expect(metadata['about'], 'Builder');
+    expect(metadata['nip05'], 'daniel@example.com');
+    expect(metadata['custom_field'], 'keep-me');
+    expect(
+      container.read(profileProvider).requireValue?.displayName,
+      'Daniel V',
+    );
+    expect(
+      container.read(profileProvider).requireValue?.ownerPubkey,
+      owner.public,
+    );
+    expect(
+      container.read(userCacheProvider)[keys.public]?.displayName,
+      'Daniel V',
+    );
+    expect(
+      container.read(userCacheProvider)[keys.public]?.ownerPubkey,
+      owner.public,
+    );
+  });
+
+  test('rejects display names longer than the profile storage limit', () async {
+    final keys = nostr.Keys.generate();
+    final owner = nostr.Keys.generate();
+    final session = _RecordingRelaySession(
+      keys.public,
+      _authTag(owner, keys.public),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        relayConfigProvider.overrideWith(
+          () => _FixedRelayConfigNotifier(keys.nsec),
+        ),
+        myPubkeyProvider.overrideWithValue(keys.public),
+        relaySessionProvider.overrideWith(() => session),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(profileProvider.future);
+
+    await expectLater(
+      container.read(profileProvider.notifier).updateDisplayName('x' * 256),
+      throwsArgumentError,
+    );
+    expect(session.published, isEmpty);
+  });
+
+  test('does not update local state when another kind-0 event wins', () async {
+    final keys = nostr.Keys.generate();
+    final owner = nostr.Keys.generate();
+    final session = _RecordingRelaySession(
+      keys.public,
+      _authTag(owner, keys.public),
+      confirmPublished: false,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        relayConfigProvider.overrideWith(
+          () => _FixedRelayConfigNotifier(keys.nsec),
+        ),
+        myPubkeyProvider.overrideWithValue(keys.public),
+        relaySessionProvider.overrideWith(() => session),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(profileProvider.future);
+
+    await expectLater(
+      container
+          .read(profileProvider.notifier)
+          .updateDisplayName('Superseded name'),
+      throwsStateError,
+    );
+    expect(container.read(profileProvider).requireValue?.displayName, 'Daniel');
+  });
+
+  test('local update wins over an older in-flight cache fetch', () async {
+    final keys = nostr.Keys.generate();
+    final session = _PendingRelaySession();
+    final container = ProviderContainer(
+      overrides: [
+        relayConfigProvider.overrideWith(
+          () => _FixedRelayConfigNotifier(keys.nsec),
+        ),
+        relaySessionProvider.overrideWith(() => session),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(userCacheProvider.notifier).get(keys.public);
+    await Future<void>.delayed(const Duration(milliseconds: 75));
+
+    container
+        .read(userCacheProvider.notifier)
+        .updateProfile(
+          UserProfile(pubkey: keys.public, displayName: 'New name'),
+        );
+    session.history.complete([
+      NostrEvent(
+        id: 'stale-profile',
+        pubkey: keys.public,
+        createdAt: 1,
+        kind: 0,
+        tags: const [],
+        content: jsonEncode({'display_name': 'Old name'}),
+        sig: 'sig',
+      ),
+    ]);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(
+      container.read(userCacheProvider)[keys.public]?.displayName,
+      'New name',
+    );
+  });
+
+  test('uses ownership from the latest profile event only', () async {
+    final keys = nostr.Keys.generate();
+    final owner = nostr.Keys.generate();
+    final session = _RecordingRelaySession(
+      keys.public,
+      _authTag(owner, keys.public),
+      removeAuthBeforeUpdate: true,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        relayConfigProvider.overrideWith(
+          () => _FixedRelayConfigNotifier(keys.nsec),
+        ),
+        myPubkeyProvider.overrideWithValue(keys.public),
+        relaySessionProvider.overrideWith(() => session),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      (await container.read(profileProvider.future))?.ownerPubkey,
+      owner.public,
+    );
+    await container
+        .read(profileProvider.notifier)
+        .updateDisplayName('Daniel V');
+
+    expect(container.read(profileProvider).requireValue?.ownerPubkey, isNull);
+    expect(container.read(userCacheProvider)[keys.public]?.ownerPubkey, isNull);
+  });
+
+  test('repairs non-object kind-0 metadata with a display name', () async {
+    final keys = nostr.Keys.generate();
+    final owner = nostr.Keys.generate();
+    final session = _RecordingRelaySession(
+      keys.public,
+      _authTag(owner, keys.public),
+      initialContent: '[]',
+    );
+    final container = ProviderContainer(
+      overrides: [
+        relayConfigProvider.overrideWith(
+          () => _FixedRelayConfigNotifier(keys.nsec),
+        ),
+        myPubkeyProvider.overrideWithValue(keys.public),
+        relaySessionProvider.overrideWith(() => session),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(profileProvider.future);
+    await container
+        .read(profileProvider.notifier)
+        .updateDisplayName('Repaired');
+
+    expect(jsonDecode(session.published.single.content), {
+      'display_name': 'Repaired',
+    });
+  });
+
+  test('aborts when the active relay changes during the update', () async {
+    final initialKeys = nostr.Keys.generate();
+    final nextKeys = nostr.Keys.generate();
+    final session = _CommunitySwitchRelaySession(initialKeys.public);
+    final container = ProviderContainer(
+      overrides: [
+        relayConfigProvider.overrideWith(
+          () => _FixedRelayConfigNotifier(initialKeys.nsec),
+        ),
+        relaySessionProvider.overrideWith(() => session),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(profileProvider.future);
+    final update = container
+        .read(profileProvider.notifier)
+        .updateDisplayName('Wrong community');
+    await Future<void>.delayed(Duration.zero);
+
+    container
+        .read(relayConfigProvider.notifier)
+        .update(baseUrl: 'https://other-relay.example', nsec: nextKeys.nsec);
+    session.pendingUpdate.complete([session.existingProfile]);
+
+    await expectLater(update, throwsStateError);
+    expect(session.published, isEmpty);
+  });
+}
+
+class _FixedRelayConfigNotifier extends RelayConfigNotifier {
+  _FixedRelayConfigNotifier(this._nsec);
+
+  final String _nsec;
+
+  @override
+  RelayConfig build() =>
+      RelayConfig(baseUrl: 'https://relay.example', nsec: _nsec);
+}
+
+class _RecordingRelaySession extends RelaySessionNotifier {
+  _RecordingRelaySession(
+    this.pubkey,
+    this.authTag, {
+    this.confirmPublished = true,
+    this.removeAuthBeforeUpdate = false,
+    this.initialContent,
+  });
+
+  final String pubkey;
+  final List<String> authTag;
+  final bool confirmPublished;
+  final bool removeAuthBeforeUpdate;
+  final String? initialContent;
+  final List<NostrEvent> published = [];
+  int _fetchCount = 0;
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    if (confirmPublished && published.isNotEmpty) return [published.last];
+
+    _fetchCount += 1;
+    return [
+      NostrEvent(
+        id: 'existing-profile',
+        pubkey: pubkey,
+        createdAt: 4102444800,
+        kind: 0,
+        tags: removeAuthBeforeUpdate && _fetchCount > 1 ? const [] : [authTag],
+        content:
+            initialContent ??
+            jsonEncode({
+              'display_name': 'Daniel',
+              'name': 'daniel',
+              'picture': 'https://example.com/avatar.png',
+              'about': 'Builder',
+              'nip05': 'daniel@example.com',
+              'custom_field': 'keep-me',
+            }),
+        sig: 'sig',
+      ),
+    ];
+  }
+
+  @override
+  Future<NostrEvent> publish(
+    NostrEvent event, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    published.add(event);
+    return event;
+  }
+}
+
+class _PendingRelaySession extends RelaySessionNotifier {
+  final history = Completer<List<NostrEvent>>();
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) => history.future;
+}
+
+class _CommunitySwitchRelaySession extends RelaySessionNotifier {
+  _CommunitySwitchRelaySession(this.pubkey);
+
+  final String pubkey;
+  final pendingUpdate = Completer<List<NostrEvent>>();
+  final List<NostrEvent> published = [];
+  int _fetchCount = 0;
+
+  NostrEvent get existingProfile => NostrEvent(
+    id: 'existing-profile',
+    pubkey: pubkey,
+    createdAt: 1,
+    kind: 0,
+    tags: const [],
+    content: jsonEncode({'display_name': 'Daniel'}),
+    sig: 'sig',
+  );
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) {
+    _fetchCount += 1;
+    return _fetchCount == 2
+        ? pendingUpdate.future
+        : Future.value([existingProfile]);
+  }
+
+  @override
+  Future<NostrEvent> publish(
+    NostrEvent event, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    published.add(event);
+    return event;
+  }
+}
+
+List<String> _authTag(nostr.Keys owner, String agentPubkey) {
+  final preimage = utf8.encode('nostr:agent-auth:$agentPubkey:');
+  final digest = SHA256Digest().process(Uint8List.fromList(preimage));
+  final message = digest
+      .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
+      .join();
+  final signature = nostr.Schnorr.sign(
+    secretKey: owner.secret,
+    message: message,
+  );
+  return ['auth', owner.public, '', signature];
+}


### PR DESCRIPTION
## Summary

- add a display name editor to mobile Settings
- publish replacement kind-0 metadata without discarding existing fields or tags
- refresh the local profile and shared user cache only after the submitted event is confirmed as current

## Why

Mobile-created identities can appear as raw public-key prefixes because the mobile app has no way to set a display name. This adds the narrow name-editing path requested in #3356. Avatar editing and onboarding changes remain out of scope.

## Correctness

The update preserves unrelated profile metadata and NIP-OA tags. It uses a monotonic timestamp, aborts if the active community changes during the operation, and prevents stale relay or cache responses from overwriting the confirmed local profile.

Display names are trimmed and limited to 255 Unicode characters. Failed saves keep the draft available for retry.

## Verification

- `just mobile-check`
- `just mobile-test` — 895 passed, 1 skipped
- focused profile provider and widget tests — 12 passed
- local structured review — no actionable findings

Fixes #3356