### PR TITLE
feat(desktop): discover public Relay agents from registry

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ mod nostr_bind;
 pub mod nostr_convert;
 mod prevent_sleep;
 mod ptt_shortcut;
+mod public_relay_agents;
 mod relay;
 mod relay_admission;
 mod reset;
@@ -54,6 +55,7 @@ use managed_agents::{
 };
 #[cfg(not(feature = "mesh-llm"))]
 use mesh_llm_stubs::*;
+use public_relay_agents::list_public_relay_agents;
 #[cfg(all(feature = "mesh-llm", target_os = "macos"))]
 use shutdown::{hard_exit_after_mesh_shutdown, relaunch_after_mesh_shutdown};
 use shutdown::{is_restart_request, shut_down_app};
@@ -790,6 +792,7 @@ pub fn run() {
             get_relay_self,
             resolve_oa_owner,
             list_relay_agents,
+            list_public_relay_agents,
             list_managed_agents,
             list_managed_agent_runtimes,
             start_managed_agent_runtime,

--- a/desktop/src-tauri/src/public_relay_agents.rs
+++ b/desktop/src-tauri/src/public_relay_agents.rs
@@ -1,0 +1,311 @@
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+const PUBLIC_RELAY_AGENTS_REGISTRY_VERSION: u32 = 1;
+const PUBLIC_RELAY_AGENTS_FILE: &str = "public-relay-agents.json";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PublicRelayAgentRegistry {
+    version: u32,
+    agents: Vec<PublicRelayAgentRegistration>,
+}
+
+/// Lifecycle state written by the local public Relay Agent provisioner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PublicRelayAgentState {
+    Provisioning,
+    Active,
+    Failed,
+}
+
+/// Non-secret public Agent metadata projected into the Desktop app-data directory.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PublicRelayAgentRegistration {
+    pub id: String,
+    pub name: String,
+    pub pubkey: String,
+    pub channel_ids: Vec<String>,
+    pub state: PublicRelayAgentState,
+    pub enabled: bool,
+}
+
+fn public_relay_agents_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(app
+        .path()
+        .app_data_dir()
+        .map_err(|error| format!("failed to resolve app data dir: {error}"))?
+        .join("agents")
+        .join(PUBLIC_RELAY_AGENTS_FILE))
+}
+
+fn valid_agent_id(id: &str) -> bool {
+    let mut chars = id.chars();
+    matches!(chars.next(), Some(first) if first.is_ascii_lowercase() || first.is_ascii_digit())
+        && chars.all(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+        })
+}
+
+fn valid_hex_pubkey(pubkey: &str) -> bool {
+    pubkey.len() == 64 && pubkey.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn validate_registration(
+    registration: &mut PublicRelayAgentRegistration,
+    ids: &mut HashSet<String>,
+    pubkeys: &mut HashSet<String>,
+) -> Result<(), String> {
+    registration.id = registration.id.trim().to_string();
+    if registration.id.is_empty() {
+        return Err("public relay agent id must not be empty".to_string());
+    }
+    if !valid_agent_id(&registration.id) {
+        return Err(format!(
+            "invalid public relay agent id '{}': expected lowercase slug",
+            registration.id
+        ));
+    }
+    if !ids.insert(registration.id.clone()) {
+        return Err(format!(
+            "duplicate public relay agent id: {}",
+            registration.id
+        ));
+    }
+
+    registration.name = registration.name.trim().to_string();
+    if registration.name.is_empty() {
+        return Err(format!(
+            "public relay agent '{}' name must not be empty",
+            registration.id
+        ));
+    }
+
+    registration.pubkey = registration.pubkey.trim().to_ascii_lowercase();
+    if !valid_hex_pubkey(&registration.pubkey) {
+        return Err(format!(
+            "public relay agent '{}' pubkey must be 64 hexadecimal characters",
+            registration.id
+        ));
+    }
+    if !pubkeys.insert(registration.pubkey.clone()) {
+        return Err(format!(
+            "duplicate public relay agent pubkey: {}",
+            registration.pubkey
+        ));
+    }
+
+    let mut channel_ids = HashSet::new();
+    registration.channel_ids = registration
+        .channel_ids
+        .drain(..)
+        .map(|channel_id| channel_id.trim().to_string())
+        .filter(|channel_id| !channel_id.is_empty())
+        .filter(|channel_id| channel_ids.insert(channel_id.clone()))
+        .collect();
+    if registration.channel_ids.is_empty() {
+        return Err(format!(
+            "public relay agent '{}' must declare at least one channel",
+            registration.id
+        ));
+    }
+
+    Ok(())
+}
+
+fn load_public_relay_agents_from_path(
+    path: &Path,
+) -> Result<Vec<PublicRelayAgentRegistration>, String> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read public relay agent registry: {error}"))?;
+    let mut registry: PublicRelayAgentRegistry = serde_json::from_str(&content)
+        .map_err(|error| format!("failed to parse public relay agent registry: {error}"))?;
+    if registry.version != PUBLIC_RELAY_AGENTS_REGISTRY_VERSION {
+        return Err(format!(
+            "unsupported public relay agent registry version {}",
+            registry.version
+        ));
+    }
+
+    let mut ids = HashSet::new();
+    let mut pubkeys = HashSet::new();
+    for registration in &mut registry.agents {
+        validate_registration(registration, &mut ids, &mut pubkeys)?;
+    }
+
+    Ok(registry.agents)
+}
+
+/// Loads the fixed public Relay Agent registry projection for this Desktop app.
+#[tauri::command]
+pub fn list_public_relay_agents(
+    app: AppHandle,
+) -> Result<Vec<PublicRelayAgentRegistration>, String> {
+    load_public_relay_agents_from_path(&public_relay_agents_path(&app)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_registry(path: &std::path::Path, value: &str) {
+        std::fs::write(path, value).expect("write registry fixture");
+    }
+
+    #[test]
+    fn missing_registry_returns_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let result =
+            load_public_relay_agents_from_path(&dir.path().join("missing.json")).expect("load");
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn valid_registry_normalizes_pubkey_and_deduplicates_channels() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("public-relay-agents.json");
+        write_registry(
+            &path,
+            &format!(
+                r#"{{
+                  "version": 1,
+                  "agents": [{{
+                    "id": "product",
+                    "name": "Product Agent",
+                    "pubkey": "{}",
+                    "channelIds": ["channel-a", "channel-a", "channel-b"],
+                    "state": "active",
+                    "enabled": true
+                  }}]
+                }}"#,
+                "A".repeat(64),
+            ),
+        );
+
+        let result = load_public_relay_agents_from_path(&path).expect("valid registry");
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].pubkey, "a".repeat(64));
+        assert_eq!(result[0].channel_ids, vec!["channel-a", "channel-b"]);
+    }
+
+    #[test]
+    fn unsupported_version_fails_loudly() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("public-relay-agents.json");
+        write_registry(&path, r#"{"version":2,"agents":[]}"#);
+
+        let error = load_public_relay_agents_from_path(&path).expect_err("version must fail");
+
+        assert!(error.contains("unsupported public relay agent registry version 2"));
+    }
+
+    #[test]
+    fn duplicate_id_and_pubkey_fail_loudly() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("public-relay-agents.json");
+        write_registry(
+            &path,
+            &format!(
+                r#"{{
+                  "version": 1,
+                  "agents": [
+                    {{
+                      "id": "one",
+                      "name": "One",
+                      "pubkey": "{}",
+                      "channelIds": ["channel-a"],
+                      "state": "active",
+                      "enabled": true
+                    }},
+                    {{
+                      "id": "one",
+                      "name": "Two",
+                      "pubkey": "{}",
+                      "channelIds": ["channel-b"],
+                      "state": "active",
+                      "enabled": true
+                    }}
+                  ]
+                }}"#,
+                "a".repeat(64),
+                "b".repeat(64),
+            ),
+        );
+
+        let id_error = load_public_relay_agents_from_path(&path).expect_err("duplicate id");
+        assert!(id_error.contains("duplicate public relay agent id: one"));
+
+        write_registry(
+            &path,
+            &format!(
+                r#"{{
+                  "version": 1,
+                  "agents": [
+                    {{
+                      "id": "one",
+                      "name": "One",
+                      "pubkey": "{}",
+                      "channelIds": ["channel-a"],
+                      "state": "active",
+                      "enabled": true
+                    }},
+                    {{
+                      "id": "two",
+                      "name": "Two",
+                      "pubkey": "{}",
+                      "channelIds": ["channel-b"],
+                      "state": "active",
+                      "enabled": true
+                    }}
+                  ]
+                }}"#,
+                "a".repeat(64),
+                "a".repeat(64),
+            ),
+        );
+
+        let pubkey_error = load_public_relay_agents_from_path(&path).expect_err("duplicate pubkey");
+        assert!(pubkey_error.contains("duplicate public relay agent pubkey"));
+    }
+
+    #[test]
+    fn empty_identity_fields_and_channels_are_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("public-relay-agents.json");
+        write_registry(
+            &path,
+            &format!(
+                r#"{{
+                  "version": 1,
+                  "agents": [{{
+                    "id": " ",
+                    "name": "Product Agent",
+                    "pubkey": "{}",
+                    "channelIds": [],
+                    "state": "active",
+                    "enabled": true
+                  }}]
+                }}"#,
+                "a".repeat(64),
+            ),
+        );
+
+        let error = load_public_relay_agents_from_path(&path).expect_err("invalid record");
+
+        assert!(error.contains("id must not be empty"));
+    }
+}

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -34,6 +34,7 @@ import {
   getRuntimeFileConfig,
   installAcpRuntime,
   listManagedAgents,
+  listPublicRelayAgents,
   listRelayAgents,
   saveCustomHarness,
   updateManagedAgent,
@@ -105,6 +106,7 @@ export type {
 } from "@/features/agents/channelAgents";
 
 export const relayAgentsQueryKey = ["relay-agents"] as const;
+export const publicRelayAgentsQueryKey = ["public-relay-agents"] as const;
 export const managedAgentsQueryKey = ["managed-agents"] as const;
 export const personasQueryKey = ["personas"] as const;
 export const acpRuntimesQueryKey = ["acp-runtimes"] as const;
@@ -336,6 +338,16 @@ export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
     refetchInterval: 5 * 60_000,
     refetchIntervalInBackground: false,
     enabled: options?.enabled,
+  });
+}
+
+export function usePublicRelayAgentsQuery(options?: { enabled?: boolean }) {
+  return useQuery({
+    enabled: options?.enabled ?? true,
+    queryKey: publicRelayAgentsQueryKey,
+    queryFn: listPublicRelayAgents,
+    staleTime: 0,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -136,13 +136,15 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
-test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
+test("isAgentIdentityInManagedList: keeps people, channel members, and known agent identities", () => {
   const managedAgentPubkeys = new Set([PUB_A]);
+  const relayAgentPubkeys = new Set([PUB_C]);
 
   assert.equal(
     isAgentIdentityInManagedList(
       { isAgent: false, pubkey: PUB_B },
       managedAgentPubkeys,
+      relayAgentPubkeys,
     ),
     true,
   );
@@ -150,13 +152,31 @@ test("isAgentIdentityInManagedList: keeps people and only current managed agent 
     isAgentIdentityInManagedList(
       { isAgent: true, pubkey: PUB_A.toUpperCase() },
       managedAgentPubkeys,
+      relayAgentPubkeys,
     ),
     true,
   );
   assert.equal(
     isAgentIdentityInManagedList(
-      { isAgent: true, pubkey: PUB_B },
+      { isAgent: true, isMember: true, pubkey: PUB_B },
       managedAgentPubkeys,
+      relayAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey: PUB_C.toUpperCase() },
+      managedAgentPubkeys,
+      relayAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey: PUB_D },
+      managedAgentPubkeys,
+      relayAgentPubkeys,
     ),
     false,
   );

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -55,12 +55,16 @@ export function getMentionableAgentPubkeys({
 }
 
 export function isAgentIdentityInManagedList(
-  candidate: { isAgent?: boolean; pubkey: string },
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
+  relayAgentPubkeys: ReadonlySet<string> = new Set(),
 ) {
+  const normalized = normalizePubkey(candidate.pubkey);
   return (
     candidate.isAgent !== true ||
-    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
+    candidate.isMember === true ||
+    managedAgentPubkeys.has(normalized) ||
+    relayAgentPubkeys.has(normalized)
   );
 }
 

--- a/desktop/src/features/agents/lib/externalRelayAgents.test.mjs
+++ b/desktop/src/features/agents/lib/externalRelayAgents.test.mjs
@@ -1,0 +1,351 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildChannelAgentFallbacks,
+  selectVisibleExternalRelayAgents,
+} from "./externalRelayAgents.ts";
+
+const CURRENT_PUBKEY = "a".repeat(64);
+const LOCAL_PUBKEY = "b".repeat(64);
+
+function relayAgent({
+  pubkey,
+  name,
+  status = "offline",
+  channelIds = ["general"],
+  respondTo = "allowlist",
+  respondToAllowlist = [CURRENT_PUBKEY],
+}) {
+  return {
+    pubkey,
+    name,
+    agentType: "coding",
+    channels: ["poc-delivery"],
+    channelIds,
+    capabilities: ["messages"],
+    status,
+    respondTo,
+    respondToAllowlist,
+  };
+}
+
+test("selectVisibleExternalRelayAgents filters local and inaccessible agents, deduplicates, and sorts by status then name", () => {
+  const techPubkey = "1".repeat(64);
+  const result = selectVisibleExternalRelayAgents({
+    currentPubkey: CURRENT_PUBKEY,
+    managedAgentPubkeys: [LOCAL_PUBKEY.toUpperCase()],
+    sharedChannelIds: new Set(["general"]),
+    relayAgents: [
+      relayAgent({
+        pubkey: "5".repeat(64),
+        name: "QA",
+        status: "offline",
+      }),
+      relayAgent({
+        pubkey: techPubkey,
+        name: "Tech",
+        status: "online",
+      }),
+      relayAgent({
+        pubkey: "3".repeat(64),
+        name: "Coding",
+        status: "away",
+      }),
+      relayAgent({
+        pubkey: "4".repeat(64),
+        name: "CR",
+        status: "online",
+      }),
+      relayAgent({
+        pubkey: "2".repeat(64),
+        name: "Product",
+        status: "online",
+      }),
+      relayAgent({
+        pubkey: techPubkey.toUpperCase(),
+        name: "Tech duplicate",
+        status: "offline",
+      }),
+      relayAgent({
+        pubkey: LOCAL_PUBKEY,
+        name: "Local managed agent",
+        status: "online",
+      }),
+      relayAgent({
+        pubkey: "6".repeat(64),
+        name: "Unshared agent",
+        status: "online",
+        channelIds: ["other"],
+        respondTo: "anyone",
+        respondToAllowlist: [],
+      }),
+      relayAgent({
+        pubkey: "7".repeat(64),
+        name: "Owner-only agent",
+        status: "online",
+        respondTo: "owner-only",
+        respondToAllowlist: [],
+      }),
+    ],
+  });
+
+  assert.deepEqual(
+    result.map((agent) => agent.name),
+    ["CR", "Product", "Tech", "Coding", "QA"],
+  );
+});
+
+test("selectVisibleExternalRelayAgents keeps an explicitly allowlisted agent outside shared channels", () => {
+  const result = selectVisibleExternalRelayAgents({
+    currentPubkey: CURRENT_PUBKEY.toUpperCase(),
+    managedAgentPubkeys: [],
+    sharedChannelIds: new Set(["general"]),
+    relayAgents: [
+      relayAgent({
+        pubkey: "8".repeat(64),
+        name: "Allowlisted",
+        channelIds: ["other"],
+        respondToAllowlist: [CURRENT_PUBKEY],
+      }),
+    ],
+  });
+
+  assert.deepEqual(
+    result.map((agent) => agent.name),
+    ["Allowlisted"],
+  );
+});
+
+test("selectVisibleExternalRelayAgents falls back to shared channel bots missing from the Relay agent directory", () => {
+  const fallbackPubkey = "9".repeat(64);
+  const explicitlyRestrictedPubkey = "c".repeat(64);
+  const result = selectVisibleExternalRelayAgents({
+    currentPubkey: CURRENT_PUBKEY,
+    managedAgentPubkeys: [],
+    sharedChannelIds: new Set(["general"]),
+    relayAgents: [
+      relayAgent({
+        pubkey: explicitlyRestrictedPubkey,
+        name: "Restricted directory agent",
+        respondTo: "owner-only",
+        respondToAllowlist: [],
+      }),
+    ],
+    channelAgents: [
+      relayAgent({
+        pubkey: fallbackPubkey,
+        name: "Channel-only agent",
+        respondTo: null,
+        respondToAllowlist: [],
+      }),
+      relayAgent({
+        pubkey: explicitlyRestrictedPubkey,
+        name: "Restricted channel member",
+        respondTo: null,
+        respondToAllowlist: [],
+      }),
+    ],
+  });
+
+  assert.deepEqual(
+    result.map((agent) => agent.name),
+    ["Channel-only agent"],
+  );
+});
+
+test("buildChannelAgentFallbacks aggregates bot memberships and live presence", () => {
+  const botPubkey = "d".repeat(64);
+  const result = buildChannelAgentFallbacks({
+    channels: [
+      { id: "general", name: "General" },
+      { id: "delivery", name: "Delivery" },
+    ],
+    membersByChannelId: {
+      general: [
+        {
+          pubkey: botPubkey,
+          displayName: "Product Agent",
+          role: "bot",
+          isAgent: true,
+        },
+        {
+          pubkey: "e".repeat(64),
+          displayName: "Human",
+          role: "member",
+          isAgent: false,
+        },
+        {
+          pubkey: "f".repeat(64),
+          displayName: null,
+          role: "bot",
+          isAgent: true,
+        },
+      ],
+      delivery: [
+        {
+          pubkey: botPubkey.toUpperCase(),
+          displayName: "Product Agent",
+          role: "bot",
+          isAgent: true,
+        },
+      ],
+    },
+    presence: { [botPubkey]: "online" },
+  });
+
+  assert.deepEqual(result, [
+    {
+      pubkey: botPubkey,
+      name: "Product Agent",
+      agentType: "external",
+      channels: ["General", "Delivery"],
+      channelIds: ["general", "delivery"],
+      capabilities: [],
+      status: "online",
+      respondTo: null,
+      respondToAllowlist: [],
+    },
+  ]);
+});
+
+test("buildChannelAgentFallbacks treats a registered member as an agent only in explicitly registered channels", () => {
+  const registeredPubkey = "a1".repeat(32);
+  const result = buildChannelAgentFallbacks({
+    channels: [
+      { id: "allowed", name: "Allowed" },
+      { id: "other", name: "Other" },
+    ],
+    membersByChannelId: {
+      allowed: [
+        {
+          pubkey: registeredPubkey.toUpperCase(),
+          displayName: "Stale Relay Name",
+          role: "member",
+          isAgent: false,
+        },
+      ],
+      other: [
+        {
+          pubkey: registeredPubkey,
+          displayName: "Stale Relay Name",
+          role: "member",
+          isAgent: false,
+        },
+      ],
+    },
+    presence: { [registeredPubkey]: "online" },
+    registrations: [
+      {
+        id: "research",
+        name: "Research Agent",
+        pubkey: registeredPubkey,
+        channelIds: ["allowed"],
+        state: "active",
+        enabled: true,
+      },
+    ],
+  });
+
+  assert.deepEqual(result, [
+    {
+      pubkey: registeredPubkey,
+      name: "Research Agent",
+      agentType: "external",
+      channels: ["Allowed"],
+      channelIds: ["allowed"],
+      capabilities: [],
+      status: "online",
+      respondTo: null,
+      respondToAllowlist: [],
+      registryState: "active",
+    },
+  ]);
+});
+
+test("buildChannelAgentFallbacks keeps unregistered members as people and forces failed registrations offline", () => {
+  const failedPubkey = "b1".repeat(32);
+  const humanPubkey = "c1".repeat(32);
+  const disabledPubkey = "d1".repeat(32);
+  const provisioningPubkey = "e1".repeat(32);
+  const result = buildChannelAgentFallbacks({
+    channels: [{ id: "allowed", name: "Allowed" }],
+    membersByChannelId: {
+      allowed: [
+        {
+          pubkey: failedPubkey,
+          displayName: "Old failed name",
+          role: "member",
+          isAgent: false,
+        },
+        {
+          pubkey: humanPubkey,
+          displayName: "Human",
+          role: "member",
+          isAgent: false,
+        },
+        {
+          pubkey: disabledPubkey,
+          displayName: "Disabled",
+          role: "member",
+          isAgent: false,
+        },
+        {
+          pubkey: provisioningPubkey,
+          displayName: "Provisioning",
+          role: "member",
+          isAgent: false,
+        },
+      ],
+    },
+    presence: {
+      [failedPubkey]: "online",
+      [humanPubkey]: "online",
+      [disabledPubkey]: "online",
+      [provisioningPubkey]: "online",
+    },
+    registrations: [
+      {
+        id: "failed",
+        name: "Failed Agent",
+        pubkey: failedPubkey,
+        channelIds: ["allowed"],
+        state: "failed",
+        enabled: true,
+      },
+      {
+        id: "disabled",
+        name: "Disabled Agent",
+        pubkey: disabledPubkey,
+        channelIds: ["allowed"],
+        state: "active",
+        enabled: false,
+      },
+      {
+        id: "provisioning",
+        name: "Provisioning Agent",
+        pubkey: provisioningPubkey,
+        channelIds: ["allowed"],
+        state: "provisioning",
+        enabled: true,
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    result.map(({ name, pubkey, registryState, status }) => ({
+      name,
+      pubkey,
+      registryState,
+      status,
+    })),
+    [
+      {
+        name: "Failed Agent",
+        pubkey: failedPubkey,
+        registryState: "failed",
+        status: "offline",
+      },
+    ],
+  );
+});

--- a/desktop/src/features/agents/lib/externalRelayAgents.ts
+++ b/desktop/src/features/agents/lib/externalRelayAgents.ts
@@ -1,0 +1,153 @@
+import type {
+  ChannelMember,
+  PresenceLookup,
+  PublicRelayAgentRegistration,
+  RelayAgent,
+} from "@/shared/api/types";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+import { relayAgentIsSharedWithUser } from "./agentAutocompleteEligibility";
+
+const STATUS_RANK: Record<RelayAgent["status"], number> = {
+  online: 0,
+  away: 1,
+  offline: 2,
+};
+
+export function buildChannelAgentFallbacks({
+  channels,
+  membersByChannelId,
+  presence,
+  registrations = [],
+}: {
+  channels: readonly { id: string; name: string }[];
+  membersByChannelId: Record<
+    string,
+    | readonly Pick<
+        ChannelMember,
+        "displayName" | "isAgent" | "pubkey" | "role"
+      >[]
+    | undefined
+  >;
+  presence: PresenceLookup | undefined;
+  registrations?: readonly PublicRelayAgentRegistration[];
+}): RelayAgent[] {
+  const agentsByPubkey = new Map<string, RelayAgent>();
+  const registrationsByPubkey = new Map(
+    registrations.map((registration) => [
+      normalizePubkey(registration.pubkey),
+      registration,
+    ]),
+  );
+
+  for (const channel of channels) {
+    for (const member of membersByChannelId[channel.id] ?? []) {
+      const pubkey = normalizePubkey(member.pubkey);
+      const registration = registrationsByPubkey.get(pubkey);
+      const isVisibleRegistration =
+        registration?.enabled === true &&
+        (registration.state === "active" || registration.state === "failed") &&
+        registration.channelIds.includes(channel.id);
+      if (member.role !== "bot" && !member.isAgent && !isVisibleRegistration) {
+        continue;
+      }
+
+      const name = isVisibleRegistration
+        ? registration.name.trim()
+        : member.displayName?.trim();
+      if (!name) continue;
+
+      const existing = agentsByPubkey.get(pubkey);
+      if (existing) {
+        if (!existing.channelIds.includes(channel.id)) {
+          existing.channelIds.push(channel.id);
+          existing.channels.push(channel.name);
+        }
+        continue;
+      }
+
+      agentsByPubkey.set(pubkey, {
+        pubkey,
+        name,
+        agentType: "external",
+        channels: [channel.name],
+        channelIds: [channel.id],
+        capabilities: [],
+        status:
+          isVisibleRegistration && registration.state === "failed"
+            ? "offline"
+            : (presence?.[pubkey] ?? "offline"),
+        respondTo: null,
+        respondToAllowlist: [],
+        ...(isVisibleRegistration
+          ? {
+              registryState:
+                registration.state === "failed"
+                  ? ("failed" as const)
+                  : ("active" as const),
+            }
+          : {}),
+      });
+    }
+  }
+
+  return [...agentsByPubkey.values()];
+}
+
+export function selectVisibleExternalRelayAgents({
+  channelAgents,
+  currentPubkey,
+  managedAgentPubkeys,
+  relayAgents,
+  sharedChannelIds,
+}: {
+  channelAgents?: readonly RelayAgent[];
+  currentPubkey?: string | null;
+  managedAgentPubkeys: Iterable<string>;
+  relayAgents: readonly RelayAgent[] | undefined;
+  sharedChannelIds: ReadonlySet<string>;
+}): RelayAgent[] {
+  const managedPubkeys = new Set(
+    [...managedAgentPubkeys].map((pubkey) => normalizePubkey(pubkey)),
+  );
+  const agentsByPubkey = new Map<string, RelayAgent>();
+  const directoryPubkeys = new Set(
+    (relayAgents ?? []).map((agent) => normalizePubkey(agent.pubkey)),
+  );
+
+  for (const agent of relayAgents ?? []) {
+    const pubkey = normalizePubkey(agent.pubkey);
+    if (
+      managedPubkeys.has(pubkey) ||
+      agentsByPubkey.has(pubkey) ||
+      !relayAgentIsSharedWithUser(agent, sharedChannelIds, currentPubkey)
+    ) {
+      continue;
+    }
+    agentsByPubkey.set(pubkey, agent);
+  }
+
+  for (const agent of channelAgents ?? []) {
+    const pubkey = normalizePubkey(agent.pubkey);
+    if (
+      managedPubkeys.has(pubkey) ||
+      directoryPubkeys.has(pubkey) ||
+      agentsByPubkey.has(pubkey)
+    ) {
+      continue;
+    }
+    agentsByPubkey.set(pubkey, agent);
+  }
+
+  return [...agentsByPubkey.values()].sort((left, right) => {
+    const statusOrder = STATUS_RANK[left.status] - STATUS_RANK[right.status];
+    if (statusOrder !== 0) return statusOrder;
+
+    const nameOrder = left.name.localeCompare(right.name);
+    if (nameOrder !== 0) return nameOrder;
+
+    return normalizePubkey(left.pubkey).localeCompare(
+      normalizePubkey(right.pubkey),
+    );
+  });
+}

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -21,6 +21,7 @@ import { TeamDeleteDialog } from "./TeamDeleteDialog";
 import { TeamDialog } from "./TeamDialog";
 import { TeamsSection } from "./TeamsSection";
 import { UnifiedAgentsSection } from "./UnifiedAgentsSection";
+import { ExternalRelayAgentsSection } from "./ExternalRelayAgentsSection";
 import { useManagedAgentActions } from "./useManagedAgentActions";
 import { usePersonaActions } from "./usePersonaActions";
 import { useTeamActions } from "./useTeamActions";
@@ -199,6 +200,15 @@ export function AgentsView() {
               onDeletePersona={personas.openDelete}
               onImportSnapshotFile={(fileBytes, fileName) => {
                 void personas.handleImportSnapshotFile(fileBytes, fileName);
+              }}
+            />
+
+            <ExternalRelayAgentsSection
+              agents={agents.externalRelayAgents}
+              error={agents.externalRelayAgentsError}
+              isLoading={agents.isExternalRelayAgentsLoading}
+              onOpenProfile={(pubkey) => {
+                openProfilePanel?.(pubkey);
               }}
             />
 

--- a/desktop/src/features/agents/ui/ExternalRelayAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/ExternalRelayAgentsSection.tsx
@@ -1,0 +1,113 @@
+import { getPresenceLabel } from "@/features/presence/lib/presence";
+import { PresenceDot } from "@/features/presence/ui/PresenceBadge";
+import { useUserProfileQuery } from "@/features/profile/hooks";
+import type { RelayAgent } from "@/shared/api/types";
+import { Badge } from "@/shared/ui/badge";
+import { IdentityCardSkeleton } from "@/shared/ui/identity-card-skeleton";
+import { SectionHeader } from "@/shared/ui/PageHeader";
+
+import { AgentIdentityCard } from "./AgentIdentityCard";
+
+const EXTERNAL_AGENT_CARD_GRID_CLASS =
+  "mx-auto grid w-full max-w-[996px] grid-cols-[repeat(auto-fill,minmax(220px,240px))] justify-center gap-3";
+
+type ExternalRelayAgentsSectionProps = {
+  agents: RelayAgent[];
+  error: Error | null;
+  isLoading: boolean;
+  onOpenProfile: (pubkey: string) => void;
+};
+
+export function ExternalRelayAgentsSection({
+  agents,
+  error,
+  isLoading,
+  onOpenProfile,
+}: ExternalRelayAgentsSectionProps) {
+  if (!isLoading && !error && agents.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="relative space-y-4" data-testid="external-relay-agents">
+      <SectionHeader
+        action={
+          !isLoading && !error ? (
+            <Badge variant="outline">{agents.length}</Badge>
+          ) : null
+        }
+        className="mx-auto w-full max-w-[996px]"
+        description="Agents hosted outside this Mac that you can interact with through the Relay."
+        title="Relay agents"
+      />
+
+      {error ? (
+        <p
+          className="mx-auto w-full max-w-[996px] rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+          role="alert"
+        >
+          Could not load Relay agents: {error.message}
+        </p>
+      ) : null}
+
+      {isLoading ? (
+        <div className={EXTERNAL_AGENT_CARD_GRID_CLASS}>
+          <IdentityCardSkeleton footerSubtitleWidthClass="w-20" />
+          <IdentityCardSkeleton footerSubtitleWidthClass="w-24" />
+          <IdentityCardSkeleton footerSubtitleWidthClass="w-16" />
+        </div>
+      ) : null}
+
+      {!isLoading && !error ? (
+        <div className={EXTERNAL_AGENT_CARD_GRID_CLASS}>
+          {agents.map((agent) => (
+            <ExternalRelayAgentCard
+              agent={agent}
+              key={agent.pubkey.toLowerCase()}
+              onOpenProfile={onOpenProfile}
+            />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function ExternalRelayAgentCard({
+  agent,
+  onOpenProfile,
+}: {
+  agent: RelayAgent;
+  onOpenProfile: (pubkey: string) => void;
+}) {
+  const profileQuery = useUserProfileQuery(agent.pubkey);
+  const channelCount = agent.channelIds.length;
+
+  return (
+    <AgentIdentityCard
+      ariaLabel={`${agent.name} Relay agent profile`}
+      avatarUrl={profileQuery.data?.avatarUrl}
+      dataTestId={`external-relay-agent-${agent.pubkey}`}
+      label={agent.name}
+      modelLabel={`External · ${
+        agent.registryState === "failed" ? "Runner failed · " : ""
+      }${channelCount} channel${channelCount === 1 ? "" : "s"}`}
+      onClick={() => onOpenProfile(agent.pubkey)}
+      statusBadge={
+        <Badge
+          className="mt-1 w-fit gap-1.5 normal-case tracking-normal"
+          variant={
+            agent.status === "online"
+              ? "success"
+              : agent.status === "away"
+                ? "warning"
+                : "secondary"
+          }
+        >
+          <PresenceDot className="h-2 w-2" status={agent.status} />
+          {getPresenceLabel(agent.status)}
+        </Badge>
+      }
+    />
+  );
+}

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useQueries } from "@tanstack/react-query";
 
 import {
   type AttachManagedAgentToChannelResult,
@@ -6,6 +7,7 @@ import {
   useCreateManagedAgentMutation,
   useManagedAgentLogQuery,
   useManagedAgentsQuery,
+  usePublicRelayAgentsQuery,
   useRelayAgentsQuery,
   useSetManagedAgentStartOnAppLaunchMutation,
   useStartManagedAgentMutation,
@@ -21,8 +23,14 @@ import type {
   CreateManagedAgentResponse,
   ManagedAgent,
 } from "@/shared/api/types";
-import { removeChannelMember } from "@/shared/api/tauri";
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { getChannelMembers, removeChannelMember } from "@/shared/api/tauri";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+import { getSharedChannelIds } from "../lib/agentAutocompleteEligibility";
+import {
+  buildChannelAgentFallbacks,
+  selectVisibleExternalRelayAgents,
+} from "../lib/externalRelayAgents";
 import {
   deleteManagedAgentWithRules,
   isManagedAgentActive,
@@ -38,7 +46,9 @@ import {
 
 export function useManagedAgentActions() {
   const { globalConfig } = useGlobalAgentConfig();
+  const identityQuery = useIdentityQuery();
   const relayAgentsQuery = useRelayAgentsQuery();
+  const publicRelayAgentsQuery = usePublicRelayAgentsQuery();
   const managedAgentsQuery = useManagedAgentsQuery();
   const [shouldLoadChannels, setShouldLoadChannels] = React.useState(false);
   const channelsQuery = useChannelsQuery({ enabled: shouldLoadChannels });
@@ -94,6 +104,108 @@ export function useManagedAgentActions() {
     () => new Set(managedAgents.map((agent) => agent.pubkey)),
     [managedAgents],
   );
+
+  const sharedChannelIds = React.useMemo(
+    () => getSharedChannelIds(channelsQuery.data),
+    [channelsQuery.data],
+  );
+
+  const sharedChannels = React.useMemo(
+    () =>
+      (channelsQuery.data ?? []).filter(
+        (channel) => channel.isMember && channel.archivedAt === null,
+      ),
+    [channelsQuery.data],
+  );
+
+  const channelMemberQueries = useQueries({
+    queries: sharedChannels.map((channel) => ({
+      queryKey: ["channels", channel.id, "members"] as const,
+      queryFn: () => getChannelMembers(channel.id),
+      staleTime: 30_000,
+    })),
+  });
+
+  const channelAgentPubkeys = React.useMemo(
+    () => [
+      ...new Set([
+        ...channelMemberQueries.flatMap((query) =>
+          (query.data ?? [])
+            .filter((member) => member.role === "bot" || member.isAgent)
+            .map((member) => normalizePubkey(member.pubkey)),
+        ),
+        ...(publicRelayAgentsQuery.data ?? [])
+          .filter(
+            (registration) =>
+              registration.enabled &&
+              (registration.state === "active" ||
+                registration.state === "failed") &&
+              registration.channelIds.some((channelId) =>
+                sharedChannelIds.has(channelId),
+              ),
+          )
+          .map((registration) => normalizePubkey(registration.pubkey)),
+      ]),
+    ],
+    [channelMemberQueries, publicRelayAgentsQuery.data, sharedChannelIds],
+  );
+
+  const externalPresenceQuery = usePresenceQuery(channelAgentPubkeys);
+
+  const channelAgents = React.useMemo(() => {
+    const membersByChannelId = Object.fromEntries(
+      sharedChannels.map((channel, index) => [
+        channel.id,
+        channelMemberQueries[index]?.data,
+      ]),
+    );
+    return buildChannelAgentFallbacks({
+      channels: sharedChannels,
+      membersByChannelId,
+      presence: externalPresenceQuery.data,
+      registrations: publicRelayAgentsQuery.data,
+    });
+  }, [
+    channelMemberQueries,
+    externalPresenceQuery.data,
+    publicRelayAgentsQuery.data,
+    sharedChannels,
+  ]);
+
+  const externalRelayAgents = React.useMemo(
+    () =>
+      selectVisibleExternalRelayAgents({
+        channelAgents,
+        currentPubkey: identityQuery.data?.pubkey,
+        managedAgentPubkeys: managedPubkeys,
+        relayAgents: relayAgentsQuery.data,
+        sharedChannelIds,
+      }),
+    [
+      channelAgents,
+      identityQuery.data?.pubkey,
+      managedPubkeys,
+      relayAgentsQuery.data,
+      sharedChannelIds,
+    ],
+  );
+
+  const externalRelayAgentsError =
+    externalRelayAgents.length === 0
+      ? ([
+          relayAgentsQuery.error,
+          publicRelayAgentsQuery.error,
+          channelsQuery.error,
+          ...channelMemberQueries.map((query) => query.error),
+        ].find((error): error is Error => error instanceof Error) ?? null)
+      : null;
+
+  const isExternalRelayAgentsLoading =
+    externalRelayAgents.length === 0 &&
+    (relayAgentsQuery.isLoading ||
+      publicRelayAgentsQuery.isLoading ||
+      channelsQuery.isLoading ||
+      channelMemberQueries.some((query) => query.isLoading));
 
   const managedPubkeyList = React.useMemo(
     () => managedAgents.map((agent) => agent.pubkey),
@@ -404,6 +516,9 @@ export function useManagedAgentActions() {
     managedPresenceQuery,
     managedAgents,
     managedPubkeys,
+    externalRelayAgents,
+    externalRelayAgentsError,
+    isExternalRelayAgentsLoading,
     channelIdToName,
     channelsByPubkey,
     isPending,
@@ -429,6 +544,9 @@ export function useManagedAgentActions() {
     handleAddedToChannel,
     handleBulkStopRunning,
     refetchManagedAgents: () => void managedAgentsQuery.refetch(),
-    refetchRelayAgents: () => void relayAgentsQuery.refetch(),
+    refetchRelayAgents: () => {
+      void relayAgentsQuery.refetch();
+      void publicRelayAgentsQuery.refetch();
+    },
   };
 }

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -58,6 +58,7 @@ import {
 import { EditRespondToDialog } from "./EditRespondToDialog";
 import { useMembersSidebarActions } from "./useMembersSidebarActions";
 import { useMembersSidebarModeration } from "./useMembersSidebarModeration";
+import { shouldRefreshMembersOnOpen } from "./membersSidebarRefresh";
 const MEMBER_ADD_RESULT_LIMIT = 50;
 const MEMBER_SEARCH_MIN_QUERY_LENGTH = 2;
 const MEMBER_ROW_INSET_DIVIDER_CLASS =
@@ -155,6 +156,14 @@ export function MembersSidebar({
   >(() => new Set());
   const identityQuery = useIdentityQuery();
   const membersQuery = useChannelMembersQuery(channelId, open);
+  const wasOpenRef = React.useRef(false);
+  React.useEffect(() => {
+    const shouldRefresh = shouldRefreshMembersOnOpen(open, wasOpenRef.current);
+    wasOpenRef.current = open;
+    if (shouldRefresh && channelId) {
+      void membersQuery.refetch();
+    }
+  }, [channelId, membersQuery.refetch, open]);
   const addMembersMutation = useAddChannelMembersMutation(channelId);
   const changeRoleMutation = useMutation({
     mutationFn: async ({ pubkey, role }: { pubkey: string; role: string }) => {
@@ -272,6 +281,11 @@ export function MembersSidebar({
         .filter((label): label is string => Boolean(label)),
     );
     const managedAgentPubkeys = new Set(managedAgentsByPubkey.keys());
+    const relayAgentPubkeys = new Set(
+      (relayAgentsQuery.data ?? []).map((agent) =>
+        normalizePubkey(agent.pubkey),
+      ),
+    );
 
     const addCandidate = (candidate: AddMemberSearchCandidate) => {
       const pubkey = normalizePubkey(candidate.pubkey);
@@ -282,7 +296,11 @@ export function MembersSidebar({
           )) ||
         memberPubkeys.has(pubkey) ||
         isArchivedDiscovery(pubkey) ||
-        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+        !isAgentIdentityInManagedList(
+          candidate,
+          managedAgentPubkeys,
+          relayAgentPubkeys,
+        )
       ) {
         return;
       }

--- a/desktop/src/features/channels/ui/membersSidebarRefresh.test.mjs
+++ b/desktop/src/features/channels/ui/membersSidebarRefresh.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldRefreshMembersOnOpen } from "./membersSidebarRefresh.ts";
+
+test("shouldRefreshMembersOnOpen refreshes exactly when the sidebar opens", () => {
+  assert.equal(shouldRefreshMembersOnOpen(false, false), false);
+  assert.equal(shouldRefreshMembersOnOpen(true, false), true);
+  assert.equal(shouldRefreshMembersOnOpen(true, true), false);
+  assert.equal(shouldRefreshMembersOnOpen(false, true), false);
+});

--- a/desktop/src/features/channels/ui/membersSidebarRefresh.ts
+++ b/desktop/src/features/channels/ui/membersSidebarRefresh.ts
@@ -1,0 +1,3 @@
+export function shouldRefreshMembersOnOpen(open: boolean, wasOpen: boolean) {
+  return open && !wasOpen;
+}

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -53,9 +53,7 @@ export type PersonaMentionTarget = {
   displayName: string;
   persona: AgentPersona;
 };
-type UseMentionsOptions = {
-  channelType?: ChannelType | null;
-};
+type UseMentionsOptions = { channelType?: ChannelType | null };
 function formatSearchUserDisplayName(user: UserSearchResult) {
   return user.displayName?.trim() || user.nip05Handle?.trim() || null;
 }
@@ -240,13 +238,18 @@ export function useMentions(
   );
   const mentionCandidates = React.useMemo<MentionCandidate[]>(() => {
     const candidatesByPubkey = new Map<string, MentionCandidate>();
-
     const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
       const pubkey = normalizePubkey(candidate.pubkey);
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (
+        !isAgentIdentityInManagedList(
+          candidate,
+          managedAgentPubkeys,
+          directoryAgentPubkeys,
+        )
+      ) {
         return;
       }
       if (
@@ -265,7 +268,6 @@ export function useMentions(
         candidatesByPubkey.set(pubkey, { ...candidate, pubkey });
         return;
       }
-
       candidatesByPubkey.set(pubkey, {
         ...current,
         avatarUrl: current.avatarUrl ?? candidate.avatarUrl ?? null,
@@ -330,7 +332,6 @@ export function useMentions(
             : null,
       });
     }
-
     for (const agent of relayAgentsQuery.data ?? []) {
       const pubkey = normalizePubkey(agent.pubkey);
       addCandidate({
@@ -345,7 +346,6 @@ export function useMentions(
         isAgent: true,
       });
     }
-
     for (const agent of managedAgentsQuery.data ?? []) {
       addCandidate({
         kind: "identity",

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -13,6 +13,7 @@ import type {
   HomeFeedResponse,
   ManagedAgent,
   ManagedAgentBackend,
+  PublicRelayAgentRegistration,
   RelayAgent,
   RelayMember,
   RelayMemberRole,
@@ -857,6 +858,14 @@ export async function changeRelayMemberRole(
 export async function listRelayAgents(): Promise<RelayAgent[]> {
   return (await invokeTauri<RawRelayAgent[]>("list_relay_agents")).map(
     fromRawRelayAgent,
+  );
+}
+
+export async function listPublicRelayAgents(): Promise<
+  PublicRelayAgentRegistration[]
+> {
+  return invokeTauri<PublicRelayAgentRegistration[]>(
+    "list_public_relay_agents",
   );
 }
 

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -295,6 +295,16 @@ export type RelayAgent = {
   status: "online" | "away" | "offline";
   respondTo: RespondToMode | null;
   respondToAllowlist: string[];
+  registryState?: "active" | "failed";
+};
+
+export type PublicRelayAgentRegistration = {
+  id: string;
+  name: string;
+  pubkey: string;
+  channelIds: string[];
+  state: "provisioning" | "active" | "failed";
+  enabled: boolean;
 };
 
 export type ManagedAgentRuntimeLifecycle =

--- a/docs/superpowers/plans/2026-07-29-external-relay-agents.md
+++ b/docs/superpowers/plans/2026-07-29-external-relay-agents.md
@@ -1,0 +1,145 @@
+# External Relay Agents Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Display invocable external Relay agents in a separate read-only section of the v0.5.0 Desktop Agents page.
+
+**Architecture:** Derive external agents from the existing Relay agent query with a pure normalized selector, excluding local managed identities. Render the result with a focused read-only card section that only opens existing profile panels.
+
+**Tech Stack:** React 19, TypeScript, TanStack Query, Tauri v2, Node test runner, Tailwind CSS.
+
+## Global Constraints
+
+- Keep the application version at v0.5.0.
+- Do not persist Relay agents into the Desktop managed-agent store.
+- Do not introduce runtime-control actions for external agents.
+- Reuse current Relay sharing and allowlist eligibility semantics.
+- Do not expose private keys, environment variables, external logs, or work directories.
+
+---
+
+### Task 1: Select visible external Relay agents
+
+**Files:**
+- Create: `desktop/src/features/agents/lib/externalRelayAgents.ts`
+- Create: `desktop/src/features/agents/lib/externalRelayAgents.test.mjs`
+
+**Interfaces:**
+- Consumes: `RelayAgent`, `relayAgentIsSharedWithUser`, and normalized managed pubkeys.
+- Produces:
+
+```ts
+export function selectVisibleExternalRelayAgents(input: {
+  currentPubkey?: string | null;
+  managedAgentPubkeys: Iterable<string>;
+  relayAgents: readonly RelayAgent[] | undefined;
+  sharedChannelIds: ReadonlySet<string>;
+}): RelayAgent[]
+```
+
+- [ ] **Step 1: Write the failing selector test**
+
+Create fixtures for one local managed agent, Product/Tech/Coding/CR/QA as eligible Relay agents, one unshared agent, and a duplicate uppercase pubkey. Assert that only the five eligible external agents remain and are sorted by status then name.
+
+- [ ] **Step 2: Run the selector test and verify RED**
+
+Run:
+
+```bash
+node --import ./test-loader.mjs --experimental-strip-types --test src/features/agents/lib/externalRelayAgents.test.mjs
+```
+
+Expected: failure because `externalRelayAgents.ts` does not exist.
+
+- [ ] **Step 3: Implement the selector**
+
+Normalize managed and Relay pubkeys, reuse `relayAgentIsSharedWithUser`, retain the first normalized Relay identity, and apply deterministic status/name sorting.
+
+- [ ] **Step 4: Run the selector test and verify GREEN**
+
+Run the Step 2 command.
+
+Expected: all selector tests pass.
+
+### Task 2: Render the read-only Relay section
+
+**Files:**
+- Create: `desktop/src/features/agents/ui/ExternalRelayAgentsSection.tsx`
+- Modify: `desktop/src/features/agents/ui/useManagedAgentActions.ts`
+- Modify: `desktop/src/features/agents/ui/AgentsView.tsx`
+
+**Interfaces:**
+- Consumes: `RelayAgent[]`, loading/error state, and `onOpenProfile(pubkey)`.
+- Produces:
+
+```ts
+export function ExternalRelayAgentsSection(props: {
+  agents: readonly RelayAgent[];
+  error: Error | null;
+  isLoading: boolean;
+  onOpenProfile: (pubkey: string) => void;
+}): React.ReactNode
+```
+
+- [ ] **Step 1: Extend `useManagedAgentActions`**
+
+Read the current identity, calculate active shared channel IDs, call `selectVisibleExternalRelayAgents`, and return `externalRelayAgents` without modifying existing managed-agent actions.
+
+- [ ] **Step 2: Add the read-only section component**
+
+Render a heading, description, loading skeleton, inline error, and one `AgentIdentityCard` per external agent. Use the existing user-profile query for avatars and an informational status badge. Do not pass any action menu or runtime control.
+
+- [ ] **Step 3: Insert the section into `AgentsView`**
+
+Render it after `UnifiedAgentsSection` and before `TeamsSection`. Pass Relay query state and the existing profile-panel opener.
+
+- [ ] **Step 4: Type-check**
+
+Run:
+
+```bash
+pnpm typecheck
+```
+
+Expected: TypeScript exits 0.
+
+### Task 3: Regression and release verification
+
+**Files:**
+- Verify all files changed in Tasks 1–2.
+
+**Interfaces:**
+- Consumes: completed selector and UI section.
+- Produces: a verified v0.5.0 release app.
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+node --import ./test-loader.mjs --experimental-strip-types --test \
+  src/features/agents/lib/externalRelayAgents.test.mjs \
+  src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+```
+
+- [ ] **Step 2: Run the full Desktop test suite**
+
+```bash
+node --import ./test-loader.mjs --experimental-strip-types --test "src/**/*.test.mjs"
+```
+
+Expected: zero failures.
+
+- [ ] **Step 3: Build the v0.5.0 app**
+
+```bash
+pnpm tauri build --features mesh-llm --target aarch64-apple-darwin --bundles app
+```
+
+Expected: `Buzz.app` is produced and `CFBundleShortVersionString` is `0.5.0`.
+
+- [ ] **Step 4: Install with a recoverable backup**
+
+Back up the current `/Applications/Buzz.app`, sign the local release with Hardened Runtime and the repository entitlements, install it, and run strict `codesign` verification.
+
+- [ ] **Step 5: Verify runtime acceptance**
+
+Open the Agents page and confirm Product, Tech, Coding, CR, and QA appear under `Relay agents`, with no local runtime controls. Recheck Relay health, five Runner processes, main-channel membership, and history.

--- a/docs/superpowers/plans/2026-07-29-public-relay-agent-registry.md
+++ b/docs/superpowers/plans/2026-07-29-public-relay-agent-registry.md
@@ -424,11 +424,12 @@ Use a temporary PoC root and executable fake `buzz`, `buzz-local`, and `start-ag
 
 1. no `--channel` exits `2` and creates nothing;
 2. invalid Channel fails before identity generation;
-3. successful create writes a `0600` identity, non-secret Agent config, workdir, `provisioning -> active` registry transition, member-role calls, Desktop projection, and start call;
-4. only repeated `--channel` values are joined;
-5. second Channel failure removes the first Channel and cleans local artifacts;
-6. Runner failure retains identity/membership and writes `state: "failed"`;
-7. identical rerun and `resume-public-agent --id` do not rotate identity.
+3. protected or out-of-root workdirs and system prompt files fail before identity generation;
+4. successful create writes a `0600` identity, non-secret Agent config, workdir, `provisioning -> active` registry transition, member-role calls, Desktop projection, and start call;
+5. only repeated `--channel` values are joined;
+6. second Channel failure removes the first Channel and cleans local artifacts;
+7. Runner failure retains identity/membership and writes `state: "failed"`;
+8. identical rerun and `resume-public-agent --id` do not rotate identity.
 
 - [ ] **Step 2: Run provisioner tests and verify RED**
 
@@ -453,7 +454,7 @@ Accept:
 --system-prompt-file <path>  # optional
 ```
 
-Validate every Channel with owner credentials using `buzz channels get --channel <uuid>` before `buzz-admin generate-key`. Normalize paths and reject the home directory, `/`, the PoC root, identity/config roots, and paths outside the PoC unless the explicit override is an already existing non-sensitive directory.
+Validate every Channel with owner credentials using `buzz channels get --channel <uuid>` before `buzz-admin generate-key`. Normalize paths and reject the home directory, `/`, the PoC root, all paths under `platform/`, and every workdir outside the PoC. System prompt files must also remain inside the PoC and outside `platform/env/`.
 
 - [ ] **Step 4: Implement provisioning and rollback**
 

--- a/docs/superpowers/plans/2026-07-29-public-relay-agent-registry.md
+++ b/docs/superpowers/plans/2026-07-29-public-relay-agent-registry.md
@@ -1,0 +1,746 @@
+# Public Relay Agent Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Buzz Desktop v0.5.0 display registered public Relay Agents while keeping their Relay and Channel role as `member`, and provide idempotent local commands that create, configure, authorize, start, resume, and supervise future public Agents only in explicitly named Channels.
+
+**Architecture:** The PoC deployment owns a versioned `platform/agents/public-agents.json` registry and atomically projects a sanitized copy into the Buzz app-data directory. A new Tauri read-only command loads that projection; the React Agents view merges registered `member` identities with kind `10100` Relay Agents and live Channel membership. Node-based deployment utilities own validation and state transitions, while the existing shell supervisor discovers Runner IDs from the registry instead of a fixed five-role list.
+
+**Tech Stack:** Rust/Tauri 2, TypeScript/React 19, TanStack Query, Node.js ESM and `node:test`, Bash, jq, tmux, Buzz CLI, buzz-admin, buzz-acp.
+
+## Global Constraints
+
+- Stay on Buzz v0.5.0; do not roll back.
+- Keep current Product, Tech, Coding, CR, and QA public/private identities and work directories unchanged.
+- Keep Relay and Channel role `member`; do not publish synthetic kind `10100` events.
+- `create-public-agent` requires one or more explicit `--channel` arguments and joins no other Channel.
+- Default runtime is local Claude Code through the existing custom Provider, `respond_to=anyone`, owner-only DM boundary, and an isolated work directory.
+- Registry files must contain no private key, `nsec`, Provider API Key, token, or copied environment secret.
+- Identity files remain separate and mode `0600`.
+- The deployment source registry is `platform/agents/public-agents.json`.
+- The Desktop projection is `~/Library/Application Support/xyz.block.buzz.app/agents/public-relay-agents.json`.
+- The PoC `platform/` directory is outside the `vendor/buzz` Git repository; Git commits cover Desktop source and documentation, while platform changes are verified in place.
+
+---
+
+### Task 1: Tauri Public Registry Reader
+
+**Files:**
+- Create: `desktop/src-tauri/src/public_relay_agents.rs`
+- Modify: `desktop/src-tauri/src/lib.rs`
+- Modify: `desktop/src/shared/api/types.ts`
+- Modify: `desktop/src/shared/api/tauri.ts`
+- Modify: `desktop/src/features/agents/hooks.ts`
+
+**Interfaces:**
+- Produces Rust command: `list_public_relay_agents(app: tauri::AppHandle) -> Result<Vec<PublicRelayAgentRegistration>, String>`.
+- Produces TypeScript type: `PublicRelayAgentRegistration`.
+- Produces frontend API: `listPublicRelayAgents(): Promise<PublicRelayAgentRegistration[]>`.
+- Produces query hook: `usePublicRelayAgentsQuery()`.
+
+- [ ] **Step 1: Write Rust tests for missing, valid, and invalid registry files**
+
+Add tests around a pure path-based loader:
+
+```rust
+#[test]
+fn missing_registry_returns_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    assert_eq!(load_public_relay_agents_from_path(&dir.path().join("missing.json")).unwrap(), vec![]);
+}
+
+#[test]
+fn valid_registry_normalizes_pubkeys_and_rejects_no_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("public-relay-agents.json");
+    std::fs::write(
+        &path,
+        r#"{"version":1,"agents":[{"id":"product","name":"Product Agent","pubkey":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","channelIds":["channel-a"],"state":"active","enabled":true}]}"#,
+    ).unwrap();
+    let agents = load_public_relay_agents_from_path(&path).unwrap();
+    assert_eq!(agents[0].pubkey, "a".repeat(64));
+}
+
+#[test]
+fn invalid_version_and_duplicate_identity_fail_loudly() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("public-relay-agents.json");
+    std::fs::write(&path, r#"{"version":2,"agents":[]}"#).unwrap();
+    let version_error = load_public_relay_agents_from_path(&path).unwrap_err();
+    assert!(version_error.contains("unsupported public relay agent registry version 2"));
+
+    std::fs::write(
+        &path,
+        format!(
+            r#"{{"version":1,"agents":[
+              {{"id":"one","name":"One","pubkey":"{}","channelIds":["channel-a"],"state":"active","enabled":true}},
+              {{"id":"one","name":"Two","pubkey":"{}","channelIds":["channel-b"],"state":"active","enabled":true}}
+            ]}}"#,
+            "a".repeat(64),
+            "b".repeat(64),
+        ),
+    ).unwrap();
+    let duplicate_error = load_public_relay_agents_from_path(&path).unwrap_err();
+    assert!(duplicate_error.contains("duplicate public relay agent id: one"));
+}
+```
+
+- [ ] **Step 2: Run the focused Rust tests and verify RED**
+
+Run:
+
+```bash
+. ./bin/activate-hermit
+cargo test --manifest-path desktop/src-tauri/Cargo.toml public_relay_agents
+```
+
+Expected: compilation fails because the module and loader do not exist.
+
+- [ ] **Step 3: Implement the minimal Rust registry module**
+
+Define:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublicRelayAgentRegistration {
+    pub id: String,
+    pub name: String,
+    pub pubkey: String,
+    pub channel_ids: Vec<String>,
+    pub state: PublicRelayAgentState,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PublicRelayAgentState {
+    Provisioning,
+    Active,
+    Failed,
+}
+```
+
+The loader must:
+
+- return an empty vector only when the file does not exist;
+- require `version == 1`;
+- trim IDs/names, lowercase and validate 64-character hex pubkeys;
+- require non-empty, unique IDs, pubkeys, and Channel lists;
+- de-duplicate Channel IDs while preserving order;
+- reject unknown states through serde;
+- never create or rewrite the file.
+
+Resolve the command path through `app.path().app_data_dir()?.join("agents/public-relay-agents.json")`. Register the module and command in `lib.rs`.
+
+- [ ] **Step 4: Run Rust tests and verify GREEN**
+
+Run:
+
+```bash
+. ./bin/activate-hermit
+cargo test --manifest-path desktop/src-tauri/Cargo.toml public_relay_agents
+```
+
+Expected: all `public_relay_agents` tests pass.
+
+- [ ] **Step 5: Add the TypeScript bridge and query**
+
+Add the matching camel-case type to `types.ts`, call `invokeTauri("list_public_relay_agents")` in `tauri.ts`, and add:
+
+```ts
+export const publicRelayAgentsQueryKey = ["public-relay-agents"] as const;
+
+export function usePublicRelayAgentsQuery(options?: { enabled?: boolean }) {
+  return useQuery({
+    enabled: options?.enabled ?? true,
+    queryKey: publicRelayAgentsQueryKey,
+    queryFn: listPublicRelayAgents,
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+  });
+}
+```
+
+- [ ] **Step 6: Run formatter, typecheck, and focused Rust tests**
+
+Run:
+
+```bash
+. ./bin/activate-hermit
+cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --check
+cd desktop
+pnpm typecheck
+pnpm test -- --test-name-pattern public
+```
+
+Expected: commands exit zero.
+
+- [ ] **Step 7: Commit the backend reader**
+
+```bash
+git add desktop/src-tauri/src/public_relay_agents.rs desktop/src-tauri/src/lib.rs desktop/src/shared/api/types.ts desktop/src/shared/api/tauri.ts desktop/src/features/agents/hooks.ts
+git commit -s -m "feat(desktop): read public relay agent registry"
+```
+
+---
+
+### Task 2: Merge Registered Members into the Desktop Agents View
+
+**Files:**
+- Modify: `desktop/src/features/agents/lib/externalRelayAgents.test.mjs`
+- Modify: `desktop/src/features/agents/lib/externalRelayAgents.ts`
+- Modify: `desktop/src/features/agents/ui/useManagedAgentActions.ts`
+- Modify: `desktop/src/features/agents/ui/ExternalRelayAgentsSection.tsx`
+- Preserve and integrate: `desktop/src/features/agents/ui/AgentsView.tsx`
+
+**Interfaces:**
+- Consumes: `PublicRelayAgentRegistration[]` from Task 1.
+- Changes: `buildChannelAgentFallbacks({ channels, membersByChannelId, presence, registrations })`.
+- Produces: `RelayAgent[]` where registered `member` identities are included only for matching registry and live Channel membership.
+
+- [ ] **Step 1: Add failing behavior tests**
+
+Add literal cases proving:
+
+```js
+test("registered member is an agent only in an explicitly registered shared channel", () => {
+  const result = buildChannelAgentFallbacks({
+    channels: [
+      { id: "allowed", name: "Allowed" },
+      { id: "other", name: "Other" },
+    ],
+    membersByChannelId: {
+      allowed: [{ pubkey: "a".repeat(64), displayName: "Relay profile", role: "member", isAgent: false }],
+      other: [{ pubkey: "a".repeat(64), displayName: "Relay profile", role: "member", isAgent: false }],
+    },
+    registrations: [{
+      id: "research",
+      name: "Research Agent",
+      pubkey: "a".repeat(64),
+      channelIds: ["allowed"],
+      state: "active",
+      enabled: true,
+    }],
+    presence: { ["a".repeat(64)]: "online" },
+  });
+  assert.deepEqual(result.map(({ name, channelIds }) => ({ name, channelIds })), [
+    { name: "Research Agent", channelIds: ["allowed"] },
+  ]);
+});
+
+test("unregistered member remains a person and failed registration is offline", () => {
+  const failedPubkey = "b".repeat(64);
+  const humanPubkey = "c".repeat(64);
+  const result = buildChannelAgentFallbacks({
+    channels: [{ id: "allowed", name: "Allowed" }],
+    membersByChannelId: {
+      allowed: [
+        { pubkey: failedPubkey, displayName: "Old name", role: "member", isAgent: false },
+        { pubkey: humanPubkey, displayName: "Human", role: "member", isAgent: false },
+      ],
+    },
+    registrations: [{
+      id: "failed",
+      name: "Failed Agent",
+      pubkey: failedPubkey,
+      channelIds: ["allowed"],
+      state: "failed",
+      enabled: true,
+    }],
+    presence: { [failedPubkey]: "online", [humanPubkey]: "online" },
+  });
+  assert.deepEqual(
+    result.map(({ name, pubkey, status }) => ({ name, pubkey, status })),
+    [{ name: "Failed Agent", pubkey: failedPubkey, status: "offline" }],
+  );
+});
+```
+
+Also retain the existing bot fallback, kind `10100` de-duplication, local-managed exclusion, access filtering, and sort tests.
+
+- [ ] **Step 2: Run the focused JS test and verify RED**
+
+Run:
+
+```bash
+cd desktop
+pnpm test -- src/features/agents/lib/externalRelayAgents.test.mjs
+```
+
+Expected: failure because `registrations` is ignored and `member` is filtered out.
+
+- [ ] **Step 3: Implement minimal registration-aware merging**
+
+Build a normalized registration map. For each Channel member:
+
+- retain the existing `role === "bot" || isAgent` fallback;
+- otherwise require an enabled registration in `active` or `failed`;
+- require the registration `channelIds` to contain the current Channel;
+- use the registration name as the authoritative local display name;
+- force `failed` status to `offline`;
+- keep `respondTo: null` because registry membership does not invent Relay policy.
+
+In `useManagedAgentActions`:
+
+- call `usePublicRelayAgentsQuery`;
+- include registered pubkeys relevant to shared Channels in the presence query;
+- pass registrations to the fallback builder;
+- include registry query failures in the Relay Agents error aggregation;
+- refetch the registry alongside Relay Agent refresh.
+
+- [ ] **Step 4: Run the focused JS test and verify GREEN**
+
+Run:
+
+```bash
+cd desktop
+pnpm test -- src/features/agents/lib/externalRelayAgents.test.mjs
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 5: Refine the Relay Agent card state copy**
+
+Render `failed` registrations as offline through the resulting `RelayAgent`. Keep the card read-only and do not add start/stop controls owned by the external Runner.
+
+- [ ] **Step 6: Run Desktop tests and typecheck**
+
+Run:
+
+```bash
+cd desktop
+pnpm test -- src/features/agents/lib/externalRelayAgents.test.mjs src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+pnpm typecheck
+pnpm check
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 7: Commit the Desktop merge**
+
+```bash
+git add desktop/src/features/agents/lib/externalRelayAgents.test.mjs desktop/src/features/agents/lib/externalRelayAgents.ts desktop/src/features/agents/ui/useManagedAgentActions.ts desktop/src/features/agents/ui/ExternalRelayAgentsSection.tsx desktop/src/features/agents/ui/AgentsView.tsx
+git commit -s -m "feat(desktop): show registered relay members as agents"
+```
+
+---
+
+### Task 3: Deployment Registry Core and Atomic Desktop Projection
+
+**Files:**
+- Create: `platform/lib/public-agent-registry.mjs`
+- Create: `platform/tests/public-agent-registry.test.mjs`
+- Create: `platform/agents/public-agents.json`
+
+**Interfaces:**
+- Produces: `loadRegistry(path)`, `validateRegistry(value)`, `upsertAgent(registry, agent)`, `projectDesktopRegistry(registry)`, `writeJsonAtomic(path, value)`, and `syncDesktopRegistry({ registryPath, desktopPath })`.
+
+- [ ] **Step 1: Write failing Node registry tests**
+
+Use `node:test` and temporary directories. Cover:
+
+- missing source registry returns `{ version: 1, agents: [] }`;
+- duplicate ID, duplicate pubkey, empty Channels, invalid state, and secret-like fields are rejected;
+- identical upsert is idempotent and conflicting upsert fails;
+- Desktop projection omits `configPath`, `workdir`, `source`, model, and prompt path;
+- atomic sync leaves valid JSON and mode `0600`.
+
+Example assertion:
+
+```js
+assert.deepEqual(projectDesktopRegistry(registry), {
+  version: 1,
+  agents: [{
+    id: "product",
+    name: "Product Agent",
+    pubkey: "a".repeat(64),
+    channelIds: ["channel-a"],
+    state: "active",
+    enabled: true,
+  }],
+});
+```
+
+- [ ] **Step 2: Run registry tests and verify RED**
+
+Run:
+
+```bash
+node --test platform/tests/public-agent-registry.test.mjs
+```
+
+Expected: module-not-found failure.
+
+- [ ] **Step 3: Implement the registry core**
+
+Use Node built-ins only. `writeJsonAtomic` must create the parent directory, write a mode-`0600` temporary file in that directory, `fsync`, rename, and leave no temp file. Reject any object key matching `/private|secret|token|api.?key|nsec/i`.
+
+- [ ] **Step 4: Run registry tests and verify GREEN**
+
+Run:
+
+```bash
+node --test platform/tests/public-agent-registry.test.mjs
+```
+
+Expected: all registry tests pass.
+
+- [ ] **Step 5: Create the initial versioned empty registry**
+
+Write:
+
+```json
+{
+  "version": 1,
+  "agents": []
+}
+```
+
+The live five-Agent migration occurs only in Task 6 after dynamic supervisor tests pass.
+
+- [ ] **Step 6: Record local verification**
+
+Because `platform/` is outside `vendor/buzz` Git, do not stage these files in the Buzz commit. Preserve the test command and output in the final delivery evidence.
+
+---
+
+### Task 4: Idempotent Create and Resume Commands
+
+**Files:**
+- Create: `platform/lib/public-agent-provisioner.mjs`
+- Create: `platform/bin/create-public-agent`
+- Create: `platform/bin/resume-public-agent`
+- Create: `platform/tests/public-agent-provisioner.test.mjs`
+
+**Interfaces:**
+- Produces CLI contract from the approved Spec.
+- Consumes the Task 3 registry core.
+- Executes external tools through an injected `run(command, args, options)` boundary so tests exercise real filesystem behavior with deterministic fake Relay commands.
+
+- [ ] **Step 1: Write failing provisioner tests**
+
+Use a temporary PoC root and executable fake `buzz`, `buzz-local`, and `start-agent` commands. Test:
+
+1. no `--channel` exits `2` and creates nothing;
+2. invalid Channel fails before identity generation;
+3. successful create writes a `0600` identity, non-secret Agent config, workdir, `provisioning -> active` registry transition, member-role calls, Desktop projection, and start call;
+4. only repeated `--channel` values are joined;
+5. second Channel failure removes the first Channel and cleans local artifacts;
+6. Runner failure retains identity/membership and writes `state: "failed"`;
+7. identical rerun and `resume-public-agent --id` do not rotate identity.
+
+- [ ] **Step 2: Run provisioner tests and verify RED**
+
+Run:
+
+```bash
+node --test platform/tests/public-agent-provisioner.test.mjs
+```
+
+Expected: module-not-found failure.
+
+- [ ] **Step 3: Implement argument parsing and preflight validation**
+
+Accept:
+
+```text
+--id <slug>
+--name <display-name>
+--channel <uuid>  # repeatable and required
+--model <model>   # optional
+--workdir <path>  # optional
+--system-prompt-file <path>  # optional
+```
+
+Validate every Channel with owner credentials using `buzz channels get --channel <uuid>` before `buzz-admin generate-key`. Normalize paths and reject the home directory, `/`, the PoC root, identity/config roots, and paths outside the PoC unless the explicit override is an already existing non-sensitive directory.
+
+- [ ] **Step 4: Implement provisioning and rollback**
+
+- Generate the identity with `buzz-local run --rm --no-deps --entrypoint /usr/local/bin/buzz-admin relay generate-key`.
+- Keep the private key only in `platform/env/identities/<id>.env` mode `0600`.
+- Write `platform/agents/<id>/agent.env` without the private key; `start-agent` sources the identity separately.
+- Register the Relay member with `buzz-admin add-member --role member`.
+- Add each Channel member using the owner identity and `buzz channels add-member --role member`.
+- Roll back partial Channel additions with `buzz channels remove-member`.
+- On pre-Runner failure remove the newly added Relay member only when this invocation created it.
+- On Runner failure retain identity, configuration and memberships, then mark `failed`.
+- On success verify the tmux pane and Relay membership before marking `active`.
+
+- [ ] **Step 5: Implement resume semantics**
+
+`resume-public-agent --id <id>` must require an existing `failed` or `active` registry record, verify identity/config/workdir/Channel membership, repair missing `member` memberships, start the Runner, and set `active` only after verification.
+
+- [ ] **Step 6: Run provisioner tests and verify GREEN**
+
+Run:
+
+```bash
+node --test platform/tests/public-agent-provisioner.test.mjs
+```
+
+Expected: all provisioner tests pass with no secret values in captured output.
+
+- [ ] **Step 7: Verify executable modes and help output**
+
+Run:
+
+```bash
+chmod 700 platform/bin/create-public-agent platform/bin/resume-public-agent
+platform/bin/create-public-agent --help
+platform/bin/resume-public-agent --help
+```
+
+Expected: help exits zero; scripts are owner-executable and do not print credentials.
+
+---
+
+### Task 5: Registry-Driven Runner Supervisor
+
+**Files:**
+- Create: `platform/bin/list-public-agent-ids`
+- Modify: `platform/bin/agents-up`
+- Modify: `platform/bin/agents-status`
+- Modify: `platform/bin/start-agent`
+- Modify: `platform/tests/agent-role-scripts.sh`
+- Create: `platform/tests/public-agent-supervisor.test.mjs`
+
+**Interfaces:**
+- Produces: `list-public-agent-ids [--startable]`.
+- Changes: `start-agent <id>` resolves `configPath`, `workdir`, and identity path from the registry.
+- Changes: `agents-up` and `agents-status` enumerate registry records.
+
+- [ ] **Step 1: Write failing supervisor behavior tests**
+
+Run copied scripts inside a temporary PoC with a fixture registry containing one enabled active Agent, one enabled failed Agent, and one disabled Agent. Fake tmux and buzz-acp. Assert:
+
+- `list-public-agent-ids --startable` returns active and failed enabled IDs only;
+- `start-agent research` sources the configured identity separately and launches in the configured workdir;
+- an ID absent from the registry exits `2`;
+- `agents-up` creates windows only for startable IDs;
+- `agents-status` reports each registered startable ID and returns failure when a pane is dead.
+
+- [ ] **Step 2: Run supervisor tests and verify RED**
+
+Run:
+
+```bash
+node --test platform/tests/public-agent-supervisor.test.mjs
+```
+
+Expected: failure because the list helper is absent and scripts are hardcoded.
+
+- [ ] **Step 3: Implement registry discovery**
+
+`list-public-agent-ids` imports the registry core, validates the source registry, and prints one validated slug per line. Shell callers read with `while IFS= read -r id`; no whitespace-split `ROLES` variable remains.
+
+- [ ] **Step 4: Refactor start and status scripts**
+
+`start-agent` must:
+
+- resolve registry metadata without `eval`;
+- require the identity/config/workdir;
+- source config and identity with automatic export;
+- unset transient Claude Provider overrides exactly as the existing script does;
+- launch the existing `platform/bin/buzz-acp`.
+
+`agents-up` and `agents-status` must preserve `buzz-local-agents` and per-ID tmux windows.
+
+- [ ] **Step 5: Run supervisor and existing role tests**
+
+Run:
+
+```bash
+node --test platform/tests/public-agent-supervisor.test.mjs
+bash platform/tests/agent-role-scripts.sh
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Run shell syntax checks**
+
+Run:
+
+```bash
+bash -n platform/bin/agents-up platform/bin/agents-status platform/bin/agents-down platform/bin/start-agent platform/bin/list-public-agent-ids
+```
+
+Expected: exit zero.
+
+---
+
+### Task 6: Migrate the Existing Five Agents Without Identity Drift
+
+**Files:**
+- Create: `platform/bin/migrate-public-agents`
+- Create: `platform/tests/migrate-public-agents.test.mjs`
+- Modify at runtime: `platform/agents/public-agents.json`
+- Create at runtime: Desktop projection in the Buzz app-data directory
+
+**Interfaces:**
+- Produces: `migrate-public-agents --dry-run` and `migrate-public-agents --apply`.
+- Consumes existing identity files, Agent configs, worktrees, and the two approved Channel UUIDs.
+
+- [ ] **Step 1: Write a failing migration fixture test**
+
+Fixture five identities and directories. Assert dry-run performs no writes; apply creates five `source: "builtin"` records using existing public keys, paths, and exactly:
+
+```text
+c1829c53-70f5-446d-b4d5-305d4a76088a
+304753ff-3464-4389-a29b-de80766d921b
+```
+
+Assert no identity file content or modification time changes.
+
+- [ ] **Step 2: Run migration test and verify RED**
+
+Run:
+
+```bash
+node --test platform/tests/migrate-public-agents.test.mjs
+```
+
+Expected: module or command missing.
+
+- [ ] **Step 3: Implement migration and collision checks**
+
+Read public keys only. Refuse if an ID maps to a different public key, a public key maps to a different ID, a required worktree/config/identity is missing, or either Channel is absent. Project the sanitized Desktop registry atomically.
+
+- [ ] **Step 4: Run migration test and verify GREEN**
+
+Run:
+
+```bash
+node --test platform/tests/migrate-public-agents.test.mjs
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Snapshot live identity and Runner state**
+
+Capture only non-secret data:
+
+```bash
+for id in product tech coding cr qa; do
+  awk -F= '/^PUBLIC_KEY=/ {print FILENAME ":" $2}' "platform/env/identities/$id.env"
+done
+platform/bin/agents-status
+```
+
+Do not print identity private keys or Agent environment files.
+
+- [ ] **Step 6: Apply the live migration**
+
+Run:
+
+```bash
+platform/bin/migrate-public-agents --dry-run
+platform/bin/migrate-public-agents --apply
+```
+
+Then compare the five public keys and workdir paths with the pre-migration snapshot.
+
+- [ ] **Step 7: Restart through the dynamic supervisor**
+
+Run:
+
+```bash
+platform/bin/agents-down
+platform/bin/agents-up
+platform/bin/agents-status
+```
+
+Expected: all five registered windows are running with unchanged IDs and public keys.
+
+---
+
+### Task 7: Full Verification, Desktop Build, Installation, and Live Acceptance
+
+**Files:**
+- Modify only if a verified failure requires a regression fix.
+- Build artifact: `desktop/src-tauri/target/release/bundle/macos/Buzz.app` or the repository-defined equivalent.
+- Install target: `/Applications/Buzz.app`.
+
+**Interfaces:**
+- Consumes all prior tasks.
+- Produces the locally installed v0.5.0 Desktop and live acceptance evidence.
+
+- [ ] **Step 1: Run all platform tests**
+
+Run:
+
+```bash
+node --test platform/tests/public-agent-registry.test.mjs platform/tests/public-agent-provisioner.test.mjs platform/tests/public-agent-supervisor.test.mjs platform/tests/migrate-public-agents.test.mjs
+bash platform/tests/agent-role-scripts.sh
+```
+
+Expected: zero failures.
+
+- [ ] **Step 2: Run Desktop focused and full gates**
+
+Run:
+
+```bash
+. ./bin/activate-hermit
+cargo test --manifest-path desktop/src-tauri/Cargo.toml public_relay_agents
+cd desktop
+pnpm test
+pnpm typecheck
+pnpm check
+pnpm build
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 3: Scan registries and output for secrets**
+
+Use a scanner that reports keys and paths, never values. Fail on fields matching `private`, `secret`, `token`, `apiKey`, `nsec`, `BUZZ_PRIVATE_KEY`, or `ANTHROPIC_API_KEY` in either registry.
+
+- [ ] **Step 4: Build the Desktop application**
+
+Run the repository-supported macOS Tauri build from the Hermit environment:
+
+```bash
+cd desktop
+pnpm tauri:build
+```
+
+Expected: a Buzz v0.5.0 `.app` bundle is produced.
+
+- [ ] **Step 5: Install without a restart loop**
+
+Before replacing `/Applications/Buzz.app`, stop the application once, copy the verified bundle, apply the same local ad-hoc signing method used by the current installation, then launch once. Confirm there is only one Buzz process and no LaunchAgent repeatedly relaunching it.
+
+- [ ] **Step 6: Verify the Desktop registry and UI**
+
+Confirm the runtime projection has five sanitized entries. Open Agents and verify Product, Tech, Coding, CR, and QA are shown in Relay agents; inspect each card’s Channel count and online state.
+
+- [ ] **Step 7: Verify Relay and Channel compatibility**
+
+For both approved Channels:
+
+- query current members and confirm all five public keys have role `member`;
+- Mention one Agent from the local Desktop and receive a reply;
+- retain the previously verified official v0.5.0 LAN-client compatibility by making no `bot` role change.
+
+- [ ] **Step 8: Exercise future registration without persisting a test Agent**
+
+Run no-side-effect negative cases:
+
+```bash
+platform/bin/create-public-agent --id missing-channel --name "Missing Channel"
+platform/bin/create-public-agent --id invalid-channel --name "Invalid Channel" --channel 00000000-0000-0000-0000-000000000000
+```
+
+Expected: both fail before identity creation. Do not create a live sixth Agent unless the user supplies its intended name and Channel.
+
+- [ ] **Step 9: Review and commit final Desktop changes**
+
+Run `git diff --check`, inspect all staged paths, and commit only reviewed Buzz files:
+
+```bash
+git add desktop docs/superpowers/plans/2026-07-29-public-relay-agent-registry.md
+git commit -s -m "feat: register public relay agents"
+```
+
+Do not stage unrelated files.

--- a/docs/superpowers/specs/2026-07-29-external-relay-agents-design.md
+++ b/docs/superpowers/specs/2026-07-29-external-relay-agents-design.md
@@ -1,0 +1,99 @@
+# External Relay Agents in Desktop Agents
+
+## Context
+
+Buzz Desktop v0.5.0 currently renders the Agents page from `list_managed_agents`, which is the current Mac's local control-plane store. The five PoC agents run independently through `buzz-acp`, have separate identities and work directories, and are represented in Relay agent profiles and channel membership rather than the Desktop managed-agent store.
+
+The result is correct runtime isolation but incomplete visibility: the agents work in channels and mentions yet do not appear in the Agents page.
+
+## Goal
+
+Show external Relay agents that the current Desktop identity can interact with in a distinct, read-only section of the Agents page.
+
+## Non-goals
+
+- Do not import external identities into `managed-agents.json`.
+- Do not expose private keys, Runner paths, environment variables, or external logs.
+- Do not add start, stop, restart, delete, edit, auto-start, or model controls.
+- Do not change Relay membership, agent allowlists, channel membership, or the five PoC Runner processes.
+- Do not change the application version from v0.5.0.
+
+## Approaches considered
+
+### A. Separate read-only Relay section — selected
+
+Use the existing Relay agent query, filter it with the same current-user interaction rules as message mentions, exclude locally managed pubkeys, and render the remainder below the local agent library.
+
+This preserves the control boundary and makes the five PoC agents discoverable.
+
+### B. Import external agents as managed agents — rejected
+
+Writing external identities into the Desktop store would imply local key custody and process ownership. Desktop could then duplicate or stop externally managed Runner processes.
+
+### C. Treat external agents as remotely manageable — deferred
+
+A remote control plane would need explicit capability negotiation, authenticated Runner control, audit events, and failure semantics. Relay presence alone is not sufficient authority.
+
+## Architecture
+
+`useManagedAgentActions` already loads all required inputs:
+
+- `managedAgentsQuery`: local instances that Desktop may control.
+- `relayAgentsQuery`: Relay profile/directory entries.
+- `channelsQuery`: active channels visible to the current identity.
+
+The hook will also read the current Desktop identity and call a pure selector:
+
+```ts
+selectVisibleExternalRelayAgents({
+  currentPubkey,
+  managedAgentPubkeys,
+  relayAgents,
+  sharedChannelIds,
+})
+```
+
+The selector will:
+
+1. Normalize pubkeys.
+2. Reuse `relayAgentIsSharedWithUser` so the Agents page and mention menu agree on eligibility.
+3. Exclude pubkeys present in the local managed-agent set.
+4. Deduplicate Relay entries by normalized pubkey.
+5. Sort `online`, then `away`, then `offline`, and sort equal statuses by display name.
+
+The Agents page will pass the selected list to a focused `ExternalRelayAgentsSection` component.
+
+## UI behavior
+
+- Heading: `Relay agents`
+- Description: `Agents running outside this Desktop. Status and channel sharing are read-only here.`
+- Each card displays the Relay profile name, avatar when available, `External · N channels`, and its Relay status.
+- Clicking a card opens the existing profile panel.
+- There are no card action menus or runtime buttons.
+- The section is hidden when the query has completed with no eligible external agents.
+- While loading, the section shows a small card skeleton.
+- Query failures render an inline error inside the section without breaking local agent management.
+
+## Security boundary
+
+The UI is informational. It consumes public Relay agent metadata already used by channels and mentions. No local managed-agent record is created, and no external control command is introduced.
+
+## Tests
+
+The pure selector must prove:
+
+- eligible external agents are returned;
+- local managed agents are excluded case-insensitively;
+- unshared or non-invocable Relay entries are excluded;
+- duplicate Relay profiles collapse by normalized pubkey;
+- status and name sorting is deterministic.
+
+TypeScript checking and the full Desktop test suite must pass. The release build must remain v0.5.0, and the installed app must be verified with the five live PoC agents visible under `Relay agents`.
+
+## Acceptance criteria
+
+1. Product, Tech, Coding, CR, and QA appear in the Desktop Agents page.
+2. Their status and channel count are visible.
+3. They do not expose local start, stop, edit, delete, model, key, or log controls.
+4. Existing local agents remain unchanged and are not duplicated.
+5. Channel membership, mentions, Relay history, and Runner processes remain unchanged.

--- a/docs/superpowers/specs/2026-07-29-public-relay-agent-registry-design.md
+++ b/docs/superpowers/specs/2026-07-29-public-relay-agent-registry-design.md
@@ -1,0 +1,291 @@
+# Buzz v0.5.0 公共 Relay Agent 注册与运行架构设计
+
+日期：2026-07-29
+
+## 1. 背景与问题
+
+当前本地 PoC 中有五个通过 `buzz-acp` 接入 Relay 的公共基础 Agent。它们需要同时满足两类客户端：
+
+- 局域网成员使用官方 Buzz Desktop v0.5.0 时，可以在指定 Channel 中 Mention 并与 Agent 交互。
+- 本机使用定制 Buzz Desktop v0.5.0 时，可以在 Agents 模块中看到这些 Agent 的身份和在线状态。
+
+Relay 侧若把成员角色设为 `bot`，本机定制版容易识别，但官方 v0.5.0 的 Mention 候选不完整；若设为 `member`，官方客户端可以 Mention，但当前本机定制版无法把它们识别为 Relay Agent。Relay 中又没有这五个 Agent 的 kind `10100` 声明事件，因此仅依赖 Relay 事件或 Channel 角色都无法同时满足两类客户端。
+
+本设计增加一份由部署工具维护的本地公共 Agent 注册表。Relay 继续使用兼容性最好的 `member` 角色，定制 Desktop 通过注册表补充 Agent 身份判断。注册新 Agent 时，由同一条命令完成身份生成、显式 Channel 授权、Runner 配置、注册表同步和启动验证。
+
+## 2. 目标
+
+1. 保持 Buzz Desktop、Relay 和 `buzz-acp` 在 v0.5.0，不回退版本。
+2. 现有五个 Agent 保持原公钥、私钥、工作目录、Channel 成员关系和运行行为。
+3. 官方 v0.5.0 客户端仍可在指定 Channel 中 Mention 并与公共 Agent 交互。
+4. 本机定制 Desktop 的 Agents 模块能显示已注册的公共 Relay Agent。
+5. 新增公共 Agent 无需重新打包 Desktop。
+6. 新 Agent 必须显式指定一个或多个 Channel，只加入指定 Channel。
+7. 默认完成身份生成、Claude Code ACP 配置、隔离工作目录创建和 Runner 启动。
+8. 注册表、日志和 Desktop 数据中不保存身份私钥或 Provider API Key。
+
+## 3. 非目标
+
+- 不把 Relay 改造成 Agent Runtime 或模型 Provider。
+- 不让公共 Agent 自动加入全部现有或未来 Channel。
+- 不向 Agent 授予主干合并、生产发布、Docker Socket 或敏感目录访问能力。
+- 不要求局域网其他成员安装定制 Desktop；官方客户端只保证 Channel 内 Mention 与交互能力。
+- 本阶段不引入企业身份、Secret Manager、高可用或跨主机 Runner 调度。
+
+## 4. 核心决策
+
+### 4.1 双层注册表
+
+部署侧以以下文件作为唯一事实源：
+
+`platform/agents/public-agents.json`
+
+Desktop 使用以下运行时镜像：
+
+`~/Library/Application Support/xyz.block.buzz.app/agents/public-relay-agents.json`
+
+部署注册表包含启动 Runner 所需的非敏感元数据；Desktop 镜像只保留展示和身份匹配字段。更新过程先校验完整内容，再通过临时文件和原子重命名替换目标文件，避免 Desktop 读取到半写入 JSON。
+
+### 4.2 Relay 成员角色保持 `member`
+
+所有公共 Agent 在指定 Channel 中都使用 `member` 角色。注册表只帮助本机定制 Desktop 识别 Agent，不改变 Relay 权限模型，也不发布伪造的 kind `10100` 事件。
+
+### 4.3 显式 Channel 授权
+
+创建命令必须至少出现一次 `--channel`。命令不会读取“默认 Channel”，不会自动扩散到其他 Channel，也不会在未来新建 Channel 时自动加入。
+
+### 4.4 一条命令完成注册和启动
+
+对外入口为：
+
+```text
+platform/bin/create-public-agent \
+  --id research \
+  --name "Research Agent" \
+  --channel <channel-uuid> \
+  [--channel <channel-uuid>] \
+  [--model <model>] \
+  [--workdir <absolute-or-poc-relative-path>] \
+  [--system-prompt-file <path>]
+```
+
+默认值：
+
+- Provider：本机已配置的 Claude Code 自定义 Provider。
+- Model：当前公共 Agent 使用的默认模型。
+- `respond_to`：`anyone`。
+- 私信边界：仅允许部署 Owner，其他私信拒绝。
+- 工作目录：`deployment/buzz-local-poc/runner-workspaces/public/<agent-id>`。
+- System Prompt：由命令生成包含公共协作边界的最小模板。
+
+命令不得复制、输出或写入 Provider API Key；Runner 继承现有的安全凭据解析方式。
+
+## 5. 数据模型
+
+### 5.1 部署注册表
+
+```json
+{
+  "version": 1,
+  "agents": [
+    {
+      "id": "product",
+      "name": "Product Agent",
+      "pubkey": "<64-char-hex-pubkey>",
+      "channelIds": [
+        "<channel-uuid>"
+      ],
+      "configPath": "platform/agents/product/agent.env",
+      "workdir": "worktrees/product",
+      "state": "active",
+      "enabled": true,
+      "source": "builtin"
+    }
+  ]
+}
+```
+
+字段约束：
+
+- `id`：稳定、唯一、可用于文件名和 tmux window 名的 slug。
+- `name`：Desktop 和 Channel 中显示的名称。
+- `pubkey`：Nostr 十六进制公钥，不保存私钥。
+- `channelIds`：非空、去重后的显式 Channel UUID 列表。
+- `configPath`：PoC 根目录内的 Runner 非敏感配置路径。
+- `workdir`：隔离工作目录。
+- `state`：`provisioning`、`active` 或 `failed`。
+- `enabled`：动态 supervisor 是否应启动该 Agent。
+- `source`：`builtin` 表示迁移的现有五个 Agent，`public` 表示后续创建。
+
+### 5.2 Desktop 镜像
+
+```json
+{
+  "version": 1,
+  "agents": [
+    {
+      "id": "product",
+      "name": "Product Agent",
+      "pubkey": "<64-char-hex-pubkey>",
+      "channelIds": [
+        "<channel-uuid>"
+      ],
+      "state": "active",
+      "enabled": true
+    }
+  ]
+}
+```
+
+Desktop 镜像不包含私钥、凭据、工作目录、Runner 配置路径或 System Prompt 路径。
+
+身份私钥继续独立保存在 `platform/env/identities/<agent-id>.env`，权限为 `0600`。
+
+## 6. Desktop 读取与合并
+
+Tauri 后端增加只读命令，从应用数据目录读取 `agents/public-relay-agents.json`：
+
+- 文件不存在时返回空列表。
+- JSON 格式、版本或字段无效时返回可诊断错误，不影响本地 Managed Agents。
+- 不允许前端传入任意文件路径。
+
+Agents 模块将三类数据合并：
+
+1. 本地 Managed Agents；
+2. Relay kind `10100` Agent；
+3. 当前 Channel 成员中，公钥存在于本地注册表且注册表包含该 Channel 的公共 Agent。
+
+合并以公钥为稳定键，Relay kind `10100` 数据优先于本地注册表展示字段，避免重复卡片。本地注册表条目仅在以下条件全部满足时进入当前 Channel 的 Agent 列表：
+
+- `enabled` 为 `true`；
+- `state` 为 `active` 或 `failed`；
+- 注册表包含当前 Channel；
+- Relay 当前成员列表也包含该公钥。
+
+`active` 条目按实时连接信息显示在线或离线；`failed` 条目始终显示为离线并保留诊断入口。普通 `member` 若不在注册表中，仍按人员处理。
+
+页面进入、窗口重新聚焦及现有 Agent/Channel 刷新动作会重新读取注册表，因此新增 Agent 后无需重新构建或重启 Desktop。
+
+## 7. 创建流程
+
+`create-public-agent` 按以下顺序执行：
+
+1. 解析参数，拒绝缺失 `--id`、`--name` 或 `--channel`。
+2. 校验 `id` 格式和唯一性；若已存在则进入幂等检查，不生成第二份身份。
+3. 向 Relay 校验所有 Channel 均存在，并确认当前部署 Owner 有添加成员的权限。
+4. 校验可选工作目录和 System Prompt 文件；拒绝敏感目录、越界路径及不可读文件。
+5. 生成 Nostr 身份，把私钥写入权限为 `0600` 的独立 identity 文件。
+6. 创建隔离工作目录、Agent 配置和 System Prompt；配置 Claude Code ACP、模型、`respond_to=anyone` 及私信 Owner 边界。
+7. 在部署注册表中写入 `provisioning` 条目，并同步 Desktop 镜像。
+8. 依次将 Agent 加入每个显式 Channel，角色固定为 `member`。
+9. 通过动态 supervisor 启动对应 `buzz-acp` Runner。
+10. 验证 Runner 进程存活、Relay 连接建立且 Channel 成员关系完整。
+11. 将状态原子更新为 `active`，再次同步 Desktop 镜像并输出非敏感摘要。
+
+创建过程中不把 Agent 加入参数之外的 Channel。
+
+## 8. 失败、回滚与幂等
+
+### 8.1 Relay 写入前失败
+
+删除本次新建的配置、工作目录和身份文件，并从注册表移除 `provisioning` 条目，不留下 Relay 成员关系。
+
+### 8.2 部分 Channel 加入失败
+
+撤销本次已经成功添加的 Channel 成员关系，再清理本地新建内容。若撤销失败，命令明确列出残留 Channel 并返回失败，不把状态标记为 `active`。
+
+### 8.3 Runner 启动或连接验证失败
+
+保留身份、配置和已确认的 Channel 成员关系，状态改为 `failed`。这样不会因自动清理造成身份漂移，也便于修复配置后恢复：
+
+```text
+platform/bin/resume-public-agent --id research
+```
+
+恢复命令重新校验注册表、身份、配置、显式 Channel 成员关系并启动 Runner；成功后状态改为 `active`。
+
+### 8.4 重复执行
+
+- 相同 `id` 且名称、公钥、Channel 和路径一致：只补齐缺失步骤并验证，不重复生成身份。
+- 相同 `id` 但关键参数冲突：拒绝执行，要求使用独立的更新流程。
+- 公钥已被其他 `id` 使用：拒绝执行。
+
+## 9. 动态 Runner Supervisor
+
+`agents-up`、`agents-status` 和 `start-agent` 从部署注册表发现 Agent，替代固定的五角色列表：
+
+- `agents-up` 启动所有 `enabled=true` 且状态为 `active` 或 `failed` 的条目。
+- `start-agent <id>` 校验注册表后只启动指定 Agent。
+- `agents-status` 按注册表报告配置、tmux window、进程和 Relay 连接状态。
+- `agents-down` 继续关闭本 PoC 的 Agent tmux session，但状态文件不被删除。
+
+每个 Agent 使用独立 tmux window、身份文件、配置目录和工作目录。Supervisor 不读取注册表之外的目录来“猜测” Agent，避免残留文件被意外启动。
+
+## 10. 现有五个 Agent 迁移
+
+迁移脚本把 Product、Tech、Coding、CR、QA 写入注册表：
+
+- 沿用现有公钥和 identity 文件；
+- 沿用现有 `platform/agents/<role>/agent.env`；
+- 沿用现有 `worktrees/<role>`；
+- 显式记录当前两个 Channel；
+- `source` 设为 `builtin`；
+- 不重新生成身份，不更改 Channel 角色，不重建工作目录。
+
+迁移后先以 dry-run 比较原固定清单和注册表解析结果，再切换动态 supervisor。五个 Runner 全部重新连接并完成 Mention/回复冒烟测试后，才删除脚本中的固定角色分支。
+
+## 11. 安全边界
+
+- 注册表和 Desktop 镜像不得包含 `nsec`、私钥、API Key、Token 或完整环境变量。
+- identity 文件必须为 `0600`；包含身份目录的父目录不得对其他用户开放写权限。
+- CLI 输出只显示 Agent ID、名称、公钥、Channel、状态和非敏感路径。
+- 工作目录默认位于专用 Runner 根目录；自定义路径必须通过拒绝列表和规范化路径校验。
+- Runner 不获得 Docker Socket、生产凭据、敏感用户目录或主干合并/发布权限。
+- Channel 授权以 Relay 实际结果为准，本地注册表不能提升 Relay 权限。
+- Desktop Tauri 命令只读取固定应用数据文件，不接受路径参数。
+
+## 12. 测试策略
+
+### 12.1 单元测试
+
+- 注册表 schema、版本、重复 ID/公钥、空 Channel 和状态校验。
+- Desktop 合并逻辑：注册 member 被识别，未注册 member 保持人员，Channel 不匹配不显示，kind `10100` 去重且优先。
+- Desktop 缺文件、损坏 JSON、未知版本时的降级。
+- CLI 参数解析、路径校验、镜像投影和敏感字段扫描。
+
+### 12.2 集成测试
+
+- 无 `--channel` 时创建被拒绝且无本地或 Relay 副作用。
+- Channel 无效或 Owner 无权限时，在身份生成前失败。
+- 多 Channel 中途失败时回滚已添加成员。
+- Runner 启动失败时保留身份和成员关系并标记 `failed`。
+- `resume-public-agent` 可把修复后的 Agent 恢复为 `active`。
+- 重复执行相同命令不产生第二身份或重复成员。
+
+### 12.3 回归与冒烟测试
+
+- 现有五个 Agent 公钥、私钥文件、工作目录保持不变。
+- 五个 Runner 均在线。
+- 本机定制 Desktop Agents 模块显示五个公共 Relay Agent。
+- 官方 v0.5.0 局域网客户端在两个指定 Channel 中都能 Mention 并收到回复。
+- 新 Agent 只出现在显式指定的 Channel。
+- 新增 Agent 后不重新打包 Desktop 即可显示。
+- 注册表、Desktop 镜像和命令输出通过敏感信息扫描。
+
+## 13. 验收标准
+
+满足以下全部条件才视为完成：
+
+1. `create-public-agent` 缺少 Channel 时无副作用地失败。
+2. 无效或无权限 Channel 不产生身份、配置、工作目录、注册表条目或 Relay 残留。
+3. 创建成功后 Agent 以 `member` 身份只加入指定 Channel。
+4. 本机定制 Desktop 把已注册成员显示为 Relay Agent；未注册成员仍显示为人员。
+5. `active` 与 `failed` 状态在 Desktop 中可区分，失败 Agent 显示离线。
+6. 现有五个 Agent 身份和工作目录不变，均可 Mention、回复并由动态 supervisor 管理。
+7. 局域网官方 v0.5.0 客户端仍能与五个 Agent 交互。
+8. 注册表和 Desktop 镜像不含任何私钥或 Provider 凭据。
+9. 后续新增公共基础 Agent 不需要修改或重新打包 Desktop。
+
+## 14. 兼容性边界
+
+本方案解决的是本机定制 Desktop 的 Agent 展示，以及官方 v0.5.0 客户端的 Channel Mention/交互兼容性。局域网其他成员使用的官方 Desktop 不会读取本机注册表，因此不承诺在其独立 Agents 模块中展示外部 Relay Agent；其受支持路径是从已授权 Channel 中 Mention 并交互。

--- a/docs/superpowers/specs/2026-07-29-public-relay-agent-registry-design.md
+++ b/docs/superpowers/specs/2026-07-29-public-relay-agent-registry-design.md
@@ -65,7 +65,7 @@ platform/bin/create-public-agent \
   --channel <channel-uuid> \
   [--channel <channel-uuid>] \
   [--model <model>] \
-  [--workdir <absolute-or-poc-relative-path>] \
+  [--workdir <poc-relative-path>] \
   [--system-prompt-file <path>]
 ```
 
@@ -240,6 +240,7 @@ platform/bin/resume-public-agent --id research
 - identity 文件必须为 `0600`；包含身份目录的父目录不得对其他用户开放写权限。
 - CLI 输出只显示 Agent ID、名称、公钥、Channel、状态和非敏感路径。
 - 工作目录默认位于专用 Runner 根目录；自定义路径必须通过拒绝列表和规范化路径校验。
+- 自定义工作目录必须位于 PoC 根目录内且不得位于 `platform/` 下；system prompt 文件不得逃逸 PoC 根目录，也不得读取 `platform/env/`。
 - Runner 不获得 Docker Socket、生产凭据、敏感用户目录或主干合并/发布权限。
 - Channel 授权以 Relay 实际结果为准，本地注册表不能提升 Relay 权限。
 - Desktop Tauri 命令只读取固定应用数据文件，不接受路径参数。


### PR DESCRIPTION
## Summary

Add Desktop support for public agents that run on an external/private Relay and are declared in a deployment-managed registry.

- read `agents/public-relay-agents.json` through a fixed-path, read-only Tauri command
- merge registered Relay members into the Agents view without changing Relay membership roles
- keep registered agents available in channel member lists and @mention suggestions
- show active/failed and online/offline state while preserving locally managed agent actions
- document the explicit-channel registration and runner lifecycle design

### Why

Buzz Desktop currently discovers locally managed agents, while Relay-hosted runners can remain ordinary `member` entries for compatibility. That leaves those agents invisible in the Agents module and inconsistently eligible for @mentions. The registry supplies the missing local classification metadata without changing the Relay authorization model or publishing synthetic agent declaration events.

### Impact

The new behavior is opt-in: installations without the registry file keep the existing behavior. Registry reads are constrained to the application data directory, malformed entries are rejected, channel scope remains explicit, and unregistered Relay members continue to be treated as people.

### Related issue

N/A — no matching open issue or PR was found for "relay agent registry" or "external relay agent".

### Testing

- Desktop test suite: 3728/3728 passing
- `pnpm typecheck`
- `pnpm check`
- Rust public Relay registry tests: 5/5 passing
- local v0.5.0 release build, signature, and entitlement verification
- local five-runner Relay smoke test: all five agents visible and online
- Desktop @mention round trip returned `DESKTOP_REGISTRY_OK`

Draft note: this changes Desktop behavior and needs maintainer review of the registry contract and UX before merge.