### PR TITLE
fix(desktop): disable backdrop-blur on Linux for perf

### DIFF
--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -14,6 +14,7 @@ import { PoofBurstProvider } from "@/shared/ui/PoofBurstProvider";
 import { Toaster } from "@/shared/ui/sonner";
 import { TooltipProvider } from "@/shared/ui/tooltip";
 import { recoverLocalStorageQuotaOnStartup } from "@/shared/lib/localStorageQuota";
+import { isLinuxPlatform } from "@/shared/lib/platform";
 
 type E2eWindow = Window & {
   __BUZZ_E2E__?: unknown;
@@ -108,9 +109,16 @@ async function installE2eBridgeIfConfigured() {
   maybeInstallE2eTauriMocks();
 }
 
+function tagPlatformClass() {
+  if (isLinuxPlatform()) {
+    document.documentElement.classList.add("platform-linux");
+  }
+}
+
 async function bootstrap() {
   resetDevWebviewStateFromUrl();
   configureDevE2eBridgeFromUrl();
+  tagPlatformClass();
   recoverLocalStorageQuotaOnStartup();
   await installE2eBridgeIfConfigured();
   await migrateLegacyCommunityStorageBeforeRender();

--- a/desktop/src/shared/styles/globals/motion.css
+++ b/desktop/src/shared/styles/globals/motion.css
@@ -117,3 +117,9 @@
 ::view-transition-new(root) {
   animation: none;
 }
+
+/* Linux WebKitGTK has no GPU-accelerated backdrop-filter — disable it. */
+.platform-linux * {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}


### PR DESCRIPTION
## Summary
Linux WebKitGTK has no GPU-accelerated `backdrop-filter`. With 16+ backdrop-blur layers visible (header, composer, action bars, thread panel), each frame re-blurs all backdrops in software, blocking the main thread — causing sluggish UI and slow loading. Tag `<html>` with `platform-linux` at boot and neutralize `backdrop-filter` on Linux, falling back to the opaque `bg-*` colors every blur element already carries.

### Related issue
Fixes #3328

### Testing
Verified on Arch Linux + Hyprland: app was sluggish with 30 messages in #general. After reload with the fix, UI is responsive. macOS/Windows unaffected (no `platform-linux` class added).

<img width="800" height="402" alt="screenrecording-2026-07-29_20-42-51" src="https://github.com/user-attachments/assets/226c984c-e2a8-4c18-9640-424c36582cc5" />