### PR TITLE
Fix provider deploy config parity

### DIFF
--- a/desktop/src-tauri/src/commands/agents_deploy.rs
+++ b/desktop/src-tauri/src/commands/agents_deploy.rs
@@ -88,6 +88,9 @@ pub(super) fn build_deploy_payload(
     let effective_model = cfg.model.value;
     let effective_provider = cfg.provider.value;
     let effective_prompt = cfg.system_prompt.value;
+    let teams = crate::managed_agents::load_teams(app).unwrap_or_default();
+    let team_instructions =
+        crate::managed_agents::spawn_hash::effective_team_instructions(record, &teams);
 
     Ok(deploy_payload_json(
         record,
@@ -98,6 +101,7 @@ pub(super) fn build_deploy_payload(
         effective_model,
         effective_provider,
         effective_prompt,
+        team_instructions,
         merged_env,
     ))
 }
@@ -111,6 +115,7 @@ pub(super) fn deploy_payload_json(
     effective_model: Option<String>,
     effective_provider: Option<String>,
     effective_prompt: Option<String>,
+    team_instructions: Option<String>,
     merged_env: std::collections::BTreeMap<String, String>,
 ) -> serde_json::Value {
     serde_json::json!({
@@ -121,9 +126,9 @@ pub(super) fn deploy_payload_json(
         "agent_command": &record.agent_command,
         "agent_args": &record.agent_args,
         "system_prompt": effective_prompt,
+        "team_instructions": team_instructions,
         "model": effective_model,
         "provider": effective_provider,
-        "turn_timeout_seconds": record.turn_timeout_seconds,
         "idle_timeout_seconds": record.idle_timeout_seconds,
         "max_turn_duration_seconds": record.max_turn_duration_seconds,
         "parallelism": record.parallelism,

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -435,6 +435,7 @@ fn deploy_payload_carries_the_full_behavioral_quad() {
         Some("gpt-x".to_string()),
         Some("openai".to_string()),
         None,
+        Some("Current team instructions".to_string()),
         std::collections::BTreeMap::new(),
     );
 
@@ -444,4 +445,6 @@ fn deploy_payload_carries_the_full_behavioral_quad() {
     assert_eq!(payload["model"], "gpt-x");
     assert_eq!(payload["provider"], "openai");
     assert_eq!(payload["relay_url"], "wss://relay.example");
+    assert_eq!(payload["team_instructions"], "Current team instructions");
+    assert!(payload.get("turn_timeout_seconds").is_none());
 }


### PR DESCRIPTION
## Summary

- stop sending the deprecated `turn_timeout_seconds` compatibility field to external providers
- resolve the agent's current team with the existing local-spawn helper
- include trimmed live `team_instructions` in provider deploy payloads
- extend the existing payload regression test

## Root cause

Provider deployment serialized a stale timeout field that local spawn intentionally ignores and did not cross the team-instruction boundary, so provider-backed agents could diverge from local runtime behavior.

## Checks

- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`
- `git diff --check HEAD^`

The full `cargo test --manifest-path desktop/src-tauri/Cargo.toml` and `just ci` gates require the documented Linux GTK/WebKit build packages. This managed container lacks them and prohibits sudo; draft PR CI is the remaining full gate.

Companion VPS controller PR: https://github.com/OthmaneN/super-coach/pull/17