### PR TITLE
fix(acp): default Claude-runtime agents out of inheriting operator claude.ai connectors

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -711,9 +711,23 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
 /// startup budget (see block/buzz#3355). Skip that unrelated global startup
 /// by default; an operator or persona can still opt back in by setting the
 /// variable explicitly.
+///
+/// Claude: a Buzz-managed Claude agent otherwise inherits the operator's
+/// claude.ai account connectors (Gmail, Drive, HubSpot, ClickUp, etc.) into
+/// the agent's tool surface — connectors the operator wired up for their own
+/// use, now reachable from a shared community agent. Default those off so the
+/// connector surface is opt-in, mirroring the Hermes isolation above.
+/// `ENABLE_CLAUDEAI_MCP_SERVERS` is honored by Claude Code from v2.1.63
+/// (older builds ignore the unknown variable); it governs the claude.ai
+/// *connector* path only, not file-configured MCP servers (`.mcp.json` /
+/// user-scope `mcpServers`). An operator or persona re-enables connectors by
+/// setting the variable explicitly.
 pub(crate) fn default_agent_env(command: &str) -> &'static [(&'static str, &'static str)] {
     match normalize_agent_command_identity(command).as_str() {
         "hermes" | "hermes-agent" | "hermes-acp" => &[("HERMES_ACP_SKIP_CONFIGURED_MCP", "1")],
+        "claude-agent-acp" | "claude-code-acp" | "claude-code" | "claudecode" => {
+            &[("ENABLE_CLAUDEAI_MCP_SERVERS", "false")]
+        }
         _ => &[],
     }
 }
@@ -1647,10 +1661,36 @@ mod tests {
                 "unexpected env defaults for {command}"
             );
         }
-        for command in ["goose", "codex-acp", "claude-agent-acp", "buzz-agent", ""] {
+        for command in ["goose", "codex-acp", "buzz-agent", ""] {
             assert!(
                 default_agent_env(command).is_empty(),
-                "non-Hermes command must have no env defaults: {command}"
+                "non-Hermes command must have no Hermes env defaults: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn default_agent_env_recognizes_claude_identities() {
+        for command in [
+            "claude-agent-acp",
+            "claude-code-acp",
+            "claude-code",
+            "claudecode",
+            "Claude Code",
+            "/usr/local/bin/claude-code-acp",
+            r"C:\Users\test\AppData\Roaming\npm\claude-code-acp.cmd",
+        ] {
+            assert_eq!(
+                default_agent_env(command),
+                &[("ENABLE_CLAUDEAI_MCP_SERVERS", "false")],
+                "unexpected env defaults for {command}"
+            );
+        }
+        for command in ["goose", "codex-acp", "hermes-acp", "buzz-agent", ""] {
+            assert_ne!(
+                default_agent_env(command),
+                &[("ENABLE_CLAUDEAI_MCP_SERVERS", "false")],
+                "non-Claude command must not get Claude env defaults: {command}"
             );
         }
     }


### PR DESCRIPTION
## Summary

Extends the per-runtime env-default mechanism introduced in #3420 to the Claude runtime. A Buzz-managed Claude agent currently inherits the operator's claude.ai **account connectors** (Gmail, Drive, HubSpot, ClickUp, etc.) straight into the agent's tool surface. Those connectors were wired up by the operator for their own use; once the agent is placed in a community and its inbound gate is opened past `owner-only`, that same connector surface is reachable from a shared agent.

This sets `ENABLE_CLAUDEAI_MCP_SERVERS=false` as a per-runtime default for the Claude command identities, exactly mirroring how #3420 defaults `HERMES_ACP_SKIP_CONFIGURED_MCP=1` for Hermes: the connector surface becomes opt-in rather than inherited-by-default. Nothing else changes.

## Why this is the same shape as #3420

`default_agent_env()` already establishes the pattern: per-runtime env defaults, applied in `AcpClient::spawn` **only when the operator has not set the variable** (the `std::env::var_os(key).is_none()` guard). So an operator or persona that wants the connectors keeps them by setting `ENABLE_CLAUDEAI_MCP_SERVERS=true` in the parent env or persona `extra_env` — the default never overrides an explicit choice. This is the identical escape-hatch semantics Hermes gets today.

## Scope — deliberately narrow, and honest about it

- `ENABLE_CLAUDEAI_MCP_SERVERS` is honored by Claude Code from **v2.1.63**. Older builds ignore the unknown variable (same tolerance the existing `GOOSE_SCHEDULER_DISABLED_ENV` line relies on), so this is safe across versions — a no-op on old, effective on new. **Operator note:** that also means on Claude Code < 2.1.63 the default has no effect and those installs keep the current inherit-connectors behavior — self-hosters need Claude Code ≥ 2.1.63 for this isolation default to actually take hold.
- It governs the **claude.ai connector path only**. File-configured MCP servers (`.mcp.json`, user-scope `mcpServers` in `~/.claude.json`) are a **separate** inheritance path this PR does **not** close. Fully isolating those needs `--strict-mcp-config` + `--mcp-config`, whose interaction with ACP session-provided MCP servers I have not verified end-to-end, so I've left it out rather than assert behavior I can't stand behind. Happy to follow up in a separate PR if maintainers want it.

## Test

Adds `default_agent_env_recognizes_claude_identities`, mirroring the existing Hermes test. Both env tests pass; `cargo fmt -p buzz-acp -- --check` is clean.

## Sources for the env var
- Claude Code issue #29506 (ENABLE_CLAUDEAI_MCP_SERVERS)
- Claude Code v2.1.63 release notes

Context: I self-hosted Buzz for a community, opened the agent's inbound gate to run a real greeter, and noticed the Claude runtime inherits the operator's connectors with no per-runtime isolation while Hermes now has exactly that. This brings the Claude runtime in line with the precedent #3420 set.

