### PR TITLE
Add channel-owned agent response policy

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -50,6 +50,14 @@ The harness discovers channels by querying the relay with the agent's authentica
 
 By default, the harness discovers only channels the agent is a **member** of (`GET /api/channels?member=true`). When the agent is added to a new channel, the membership notification subscription auto-subscribes to it.
 
+Channel owners can set **Agent replies** to **Only @mentions** or **Every
+message** in channel settings. The relay publishes the authoritative policy in
+channel metadata and all connected ACP harnesses replace that channel's
+subscription without a restart. This controls delivery for every agent member;
+each agent's `RespondTo` author gate still decides who is allowed to trigger it.
+New and migrated channels default to mention-only. A harness connected to an
+older relay with no policy tag preserves its local mention rule.
+
 **Private channels** require explicit membership. The relay doesn't yet have a REST/event API for managing channel members — this is a known gap. For now, use `create_channel` via the Buzz CLI to create new channels (the creator is automatically a member).
 
 ## Quick Start (goose)

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -488,6 +488,20 @@ pub struct ChannelFilter {
     pub require_mention: bool,
 }
 
+/// Apply a channel-owned response policy to a resolved agent subscription.
+///
+/// When present, the channel-owned policy overrides the agent's local mention
+/// rule in either direction. `None` preserves the local rule for compatibility
+/// with relays that predate channel-owned response policy metadata.
+pub fn apply_agent_response_policy(
+    filter: &mut ChannelFilter,
+    policy: Option<buzz_core::channel::AgentResponsePolicy>,
+) {
+    if let Some(policy) = policy {
+        filter.require_mention = policy == buzz_core::channel::AgentResponsePolicy::Mentions;
+    }
+}
+
 #[derive(Debug)]
 pub struct Config {
     pub keys: Keys,
@@ -1908,6 +1922,42 @@ mod tests {
         let result = resolve_channel_filters(&config, &[ch], &rules);
         let f = result.get(&ch).unwrap();
         assert!(!f.require_mention, "most permissive (false) should win");
+    }
+
+    #[test]
+    fn channel_all_policy_relaxes_mention_filter() {
+        let mut filter = ChannelFilter {
+            kinds: Some(vec![1]),
+            require_mention: true,
+        };
+        apply_agent_response_policy(
+            &mut filter,
+            Some(buzz_core::channel::AgentResponsePolicy::All),
+        );
+        assert!(!filter.require_mention);
+    }
+
+    #[test]
+    fn channel_mentions_policy_overrides_explicit_local_all_rule() {
+        let mut filter = ChannelFilter {
+            kinds: Some(vec![1]),
+            require_mention: false,
+        };
+        apply_agent_response_policy(
+            &mut filter,
+            Some(buzz_core::channel::AgentResponsePolicy::Mentions),
+        );
+        assert!(filter.require_mention);
+    }
+
+    #[test]
+    fn missing_channel_policy_preserves_local_rule_for_older_relays() {
+        let mut filter = ChannelFilter {
+            kinds: Some(vec![1]),
+            require_mention: false,
+        };
+        apply_agent_response_policy(&mut filter, None);
+        assert!(!filter.require_mention);
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1471,7 +1471,12 @@ async fn tokio_main() -> Result<()> {
         }
     };
 
-    let channel_filters = config::resolve_channel_filters(&config, &channel_ids, &rules);
+    let mut channel_filters = config::resolve_channel_filters(&config, &channel_ids, &rules);
+    for (channel_id, filter) in &mut channel_filters {
+        if let Some(channel_info) = channel_info_map.get(channel_id) {
+            config::apply_agent_response_policy(filter, channel_info.agent_response_policy);
+        }
+    }
     if channel_filters.is_empty() {
         tracing::warn!("no channel subscriptions resolved — agent will sit idle");
     }
@@ -1964,10 +1969,20 @@ async fn tokio_main() -> Result<()> {
                                     // stripped for a legitimately re-added channel.
                                     removed_channels.remove(&ch);
 
-                                    if subscribed_channel_ids.contains(&ch) {
-                                        tracing::debug!(channel_id = %ch, "membership notification: channel already subscribed");
-                                    } else if let Some(filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules) {
-                                        tracing::info!(channel_id = %ch, "membership notification: subscribing to new channel");
+                                    if let Some(mut filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules) {
+                                        if let Some(channel_info) = ctx.channel_info.refresh(ch).await {
+                                            config::apply_agent_response_policy(
+                                                &mut filter,
+                                                channel_info.agent_response_policy,
+                                            );
+                                        }
+                                        let was_subscribed = subscribed_channel_ids.contains(&ch);
+                                        tracing::info!(
+                                            channel_id = %ch,
+                                            was_subscribed,
+                                            require_mention = filter.require_mention,
+                                            "membership notification: refreshing channel subscription"
+                                        );
                                         if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
                                             tracing::warn!("failed to subscribe to new channel {ch}: {e}");
                                         } else {
@@ -4642,6 +4657,7 @@ mod author_gate_tests {
                 relay::ChannelInfo {
                     name: "dm".into(),
                     channel_type: "dm".into(),
+                    agent_response_policy: Some(buzz_core::channel::AgentResponsePolicy::Mentions),
                 },
             ),
             (
@@ -4649,6 +4665,7 @@ mod author_gate_tests {
                 relay::ChannelInfo {
                     name: "stream".into(),
                     channel_type: "stream".into(),
+                    agent_response_policy: Some(buzz_core::channel::AgentResponsePolicy::Mentions),
                 },
             ),
         ]);
@@ -4665,6 +4682,7 @@ mod author_gate_tests {
             relay::ChannelInfo {
                 name: "unknown".into(),
                 channel_type: "unknown".into(),
+                agent_response_policy: Some(buzz_core::channel::AgentResponsePolicy::Mentions),
             },
         )]);
         assert!(

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -469,6 +469,7 @@ impl ChannelInfoResolver {
                     PromptChannelInfo {
                         name: info.name,
                         channel_type: info.channel_type,
+                        agent_response_policy: info.agent_response_policy,
                     },
                 ))
             })
@@ -489,6 +490,18 @@ impl ChannelInfoResolver {
             return Some(info);
         }
 
+        let info = fetch_channel_info(channel_id, &self.rest_client).await?;
+        if let Ok(mut cache) = self.cache.write() {
+            cache.insert(channel_id, info.clone());
+        }
+        Some(info)
+    }
+
+    /// Refetch channel metadata and replace the cached value.
+    ///
+    /// Membership notifications use this after channel policy changes so a
+    /// running harness can replace its mention filter without restarting.
+    pub async fn refresh(&self, channel_id: Uuid) -> Option<PromptChannelInfo> {
         let info = fetch_channel_info(channel_id, &self.rest_client).await?;
         if let Ok(mut cache) = self.cache.write() {
             cache.insert(channel_id, info.clone());
@@ -2336,10 +2349,20 @@ pub(crate) async fn fetch_channel_info(
                 let ev = events.first()?;
                 let tags = ev.get("tags")?.as_array()?;
                 let mut name = None;
+                let mut agent_response_policy = None;
                 for tag in tags {
                     if let Some(arr) = tag.as_array() {
                         if arr.first().and_then(|v| v.as_str()) == Some("name") {
                             name = arr.get(1).and_then(|v| v.as_str());
+                        }
+                        if arr.first().and_then(|v| v.as_str()) == Some("agent_response") {
+                            agent_response_policy = match arr.get(1).and_then(|v| v.as_str()) {
+                                Some("mentions") => {
+                                    Some(buzz_core::channel::AgentResponsePolicy::Mentions)
+                                }
+                                Some("all") => Some(buzz_core::channel::AgentResponsePolicy::All),
+                                _ => None,
+                            };
                         }
                     }
                 }
@@ -2347,6 +2370,7 @@ pub(crate) async fn fetch_channel_info(
                 Some(PromptChannelInfo {
                     name: name.unwrap_or(UNKNOWN_CHANNEL_NAME).to_string(),
                     channel_type,
+                    agent_response_policy,
                 })
             }
             Ok(Err(e)) => {

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -995,6 +995,7 @@ pub struct ContextMessage {
 pub struct PromptChannelInfo {
     pub name: String,
     pub channel_type: String,
+    pub agent_response_policy: Option<buzz_core::channel::AgentResponsePolicy>,
 }
 
 /// Minimal profile fields needed to label users in ACP prompts.
@@ -2976,6 +2977,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "engineering".into(),
             channel_type: "stream".into(),
+            agent_response_policy: Some(buzz_core::channel::AgentResponsePolicy::Mentions),
         };
 
         let prompt = format_prompt(
@@ -3007,6 +3009,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "DM".into(),
             channel_type: "dm".into(),
+            agent_response_policy: Some(buzz_core::channel::AgentResponsePolicy::Mentions),
         };
 
         let prompt = format_prompt(
@@ -3117,6 +3120,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "DM".into(),
             channel_type: "dm".into(),
+            agent_response_policy: Some(buzz_core::channel::AgentResponsePolicy::Mentions),
         };
         let ctx = ConversationContext::Dm {
             messages: vec![ContextMessage {
@@ -3373,6 +3377,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "DM".into(),
             channel_type: "dm".into(),
+            agent_response_policy: Some(buzz_core::channel::AgentResponsePolicy::Mentions),
         };
         // Thread context fetched (as the fetch path does for DM replies).
         let ctx = ConversationContext::Thread {
@@ -3430,6 +3435,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "DM".into(),
             channel_type: "dm".into(),
+            agent_response_policy: Some(buzz_core::channel::AgentResponsePolicy::Mentions),
         };
 
         // No context fetched — hints only.
@@ -3925,6 +3931,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "DM".into(),
             channel_type: "dm".into(),
+            agent_response_policy: Some(buzz_core::channel::AgentResponsePolicy::Mentions),
         };
 
         let prompt = format_prompt(
@@ -3988,6 +3995,7 @@ mod tests {
         let ci = PromptChannelInfo {
             name: "DM".into(),
             channel_type: "dm".into(),
+            agent_response_policy: Some(buzz_core::channel::AgentResponsePolicy::Mentions),
         };
 
         let prompt = format_prompt(

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -127,12 +127,14 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::config::ChannelFilter;
+use buzz_core::channel::AgentResponsePolicy;
 
 /// Metadata about a channel, populated at discovery time.
 #[derive(Debug, Clone)]
 pub struct ChannelInfo {
     pub name: String,
     pub channel_type: String,
+    pub agent_response_policy: Option<AgentResponsePolicy>,
 }
 
 pub(crate) fn channel_type_from_tags(tags: &[serde_json::Value]) -> String {
@@ -172,7 +174,7 @@ pub(crate) fn merge_discovered_channels(
     channel_uuids: Vec<Uuid>,
     meta_events: &serde_json::Value,
 ) -> HashMap<Uuid, ChannelInfo> {
-    let mut meta_map: HashMap<Uuid, (String, String)> = HashMap::new();
+    let mut meta_map: HashMap<Uuid, (String, String, Option<AgentResponsePolicy>)> = HashMap::new();
     let mut archived: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
     if let Some(arr) = meta_events.as_array() {
         for ev in arr {
@@ -183,6 +185,7 @@ pub(crate) fn merge_discovered_channels(
             let mut d_val = None;
             let mut name = None;
             let mut is_archived = false;
+            let mut agent_response_policy = None;
             for tag in tags {
                 if let Some(arr) = tag.as_array() {
                     match arr.first().and_then(|v| v.as_str()) {
@@ -190,6 +193,13 @@ pub(crate) fn merge_discovered_channels(
                         Some("name") => name = arr.get(1).and_then(|v| v.as_str()),
                         Some("archived") => {
                             is_archived = arr.get(1).and_then(|v| v.as_str()) == Some("true")
+                        }
+                        Some("agent_response") => {
+                            agent_response_policy = match arr.get(1).and_then(|v| v.as_str()) {
+                                Some("mentions") => Some(AgentResponsePolicy::Mentions),
+                                Some("all") => Some(AgentResponsePolicy::All),
+                                _ => None,
+                            };
                         }
                         _ => {}
                     }
@@ -203,7 +213,7 @@ pub(crate) fn merge_discovered_channels(
                     }
                     let ch_name = name.unwrap_or("unknown").to_string();
                     let ch_type = channel_type_from_tags(tags);
-                    meta_map.insert(uuid, (ch_name, ch_type));
+                    meta_map.insert(uuid, (ch_name, ch_type, agent_response_policy));
                 }
             }
         }
@@ -214,10 +224,17 @@ pub(crate) fn merge_discovered_channels(
         if archived.contains(&uuid) {
             continue;
         }
-        let (name, channel_type) = meta_map
+        let (name, channel_type, agent_response_policy) = meta_map
             .remove(&uuid)
-            .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
-        map.insert(uuid, ChannelInfo { name, channel_type });
+            .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string(), None));
+        map.insert(
+            uuid,
+            ChannelInfo {
+                name,
+                channel_type,
+                agent_response_policy,
+            },
+        );
     }
     map
 }
@@ -4088,6 +4105,7 @@ mod tests {
         let channel = Uuid::new_v4();
         let map = merge_discovered_channels(vec![channel], &serde_json::json!([]));
         assert_eq!(map[&channel].channel_type, "unknown");
+        assert_eq!(map[&channel].agent_response_policy, None);
     }
 
     #[test]
@@ -4096,6 +4114,36 @@ mod tests {
         let meta = serde_json::json!([meta_event(channel, "dm", &["t", "dm"])]);
         let map = merge_discovered_channels(vec![channel], &meta);
         assert_eq!(map[&channel].channel_type, "dm");
+    }
+
+    #[test]
+    fn merge_discovered_channels_reads_agent_response_policy() {
+        let channel = Uuid::new_v4();
+        let meta = serde_json::json!([meta_event(
+            channel,
+            "agent-room",
+            &["agent_response", "all"]
+        )]);
+        let map = merge_discovered_channels(vec![channel], &meta);
+        assert_eq!(
+            map[&channel].agent_response_policy,
+            Some(AgentResponsePolicy::All)
+        );
+    }
+
+    #[test]
+    fn merge_discovered_channels_reads_mentions_policy() {
+        let channel = Uuid::new_v4();
+        let meta = serde_json::json!([meta_event(
+            channel,
+            "agent-room",
+            &["agent_response", "mentions"]
+        )]);
+        let map = merge_discovered_channels(vec![channel], &meta);
+        assert_eq!(
+            map[&channel].agent_response_policy,
+            Some(AgentResponsePolicy::Mentions)
+        );
     }
 
     #[test]

--- a/crates/buzz-cli/src/commands/channels.rs
+++ b/crates/buzz-cli/src/commands/channels.rs
@@ -836,6 +836,7 @@ pub async fn cmd_update_channel(
     description: Option<&str>,
     ttl: Option<i64>,
     no_ttl: bool,
+    agent_response: Option<&str>,
 ) -> Result<(), CliError> {
     // Outer Option: None leaves TTL unchanged. Inner: Some(secs) sets it,
     // None (from --no-ttl) clears it, making the channel permanent.
@@ -845,15 +846,23 @@ pub async fn cmd_update_channel(
         (None, false) => None,
     };
 
-    if name.is_none() && description.is_none() && ttl_change.is_none() {
+    if name.is_none() && description.is_none() && ttl_change.is_none() && agent_response.is_none() {
         return Err(CliError::Usage(
-            "at least one field required (--name, --description, --ttl, --no-ttl)".into(),
+            "at least one field required (--name, --description, --ttl, --no-ttl, --agent-response)"
+                .into(),
         ));
     }
     let channel_uuid = parse_uuid(channel_id)?;
 
-    let builder = buzz_sdk::build_update_channel(channel_uuid, name, description, None, ttl_change)
-        .map_err(|e| CliError::Other(format!("build_update_channel failed: {e}")))?;
+    let builder = buzz_sdk::build_update_channel(
+        channel_uuid,
+        name,
+        description,
+        None,
+        ttl_change,
+        agent_response,
+    )
+    .map_err(|e| CliError::Other(format!("build_update_channel failed: {e}")))?;
 
     let event = client.sign_event(builder)?;
     let resp = client.submit_event(event).await?;
@@ -1130,6 +1139,7 @@ pub async fn dispatch(
             description,
             ttl,
             no_ttl,
+            agent_response,
         } => {
             cmd_update_channel(
                 client,
@@ -1138,6 +1148,9 @@ pub async fn dispatch(
                 description.as_deref(),
                 ttl,
                 no_ttl,
+                agent_response
+                    .as_ref()
+                    .map(crate::AgentResponsePolicy::as_str),
             )
             .await
         }

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -132,6 +132,32 @@ impl std::fmt::Display for ChannelVisibility {
 }
 
 #[derive(Clone, clap::ValueEnum)]
+pub enum AgentResponsePolicy {
+    #[value(name = "mentions")]
+    Mentions,
+    #[value(name = "all")]
+    All,
+}
+
+impl AgentResponsePolicy {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Mentions => "mentions",
+            Self::All => "all",
+        }
+    }
+}
+
+impl std::fmt::Display for AgentResponsePolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Mentions => write!(f, "mentions"),
+            Self::All => write!(f, "all"),
+        }
+    }
+}
+
+#[derive(Clone, clap::ValueEnum)]
 pub enum PresenceStatus {
     #[value(name = "online")]
     Online,
@@ -570,7 +596,7 @@ pub enum ChannelsCmd {
         #[arg(long, value_name = "PATH")]
         templates_file: Option<String>,
     },
-    /// Update channel name, description, or ephemeral TTL
+    /// Update channel settings
     Update {
         /// Channel UUID
         #[arg(long)]
@@ -588,6 +614,10 @@ pub enum ChannelsCmd {
         /// Clear an existing TTL, making the channel permanent.
         #[arg(long)]
         no_ttl: bool,
+        /// Agent response behavior for the channel. `all` delivers untagged
+        /// messages to every agent member; `mentions` keeps mention filtering.
+        #[arg(long, value_enum)]
+        agent_response: Option<AgentResponsePolicy>,
     },
     /// Set the channel topic
     Topic {

--- a/crates/buzz-core/src/channel.rs
+++ b/crates/buzz-core/src/channel.rs
@@ -67,6 +67,46 @@ pub enum ChannelType {
     Workflow,
 }
 
+/// Whether agents in a channel receive only explicit mentions or every message.
+///
+/// This is channel-owned policy. Agent-specific author gates still decide who
+/// is allowed to start a turn after a message reaches the harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentResponsePolicy {
+    /// Agents receive messages that explicitly mention their public key.
+    Mentions,
+    /// Agents receive every subscribed message, including untagged messages.
+    All,
+}
+
+impl AgentResponsePolicy {
+    /// Canonical string representation used by the database and Nostr tags.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Mentions => "mentions",
+            Self::All => "all",
+        }
+    }
+}
+
+impl fmt::Display for AgentResponsePolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for AgentResponsePolicy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "mentions" => Ok(Self::Mentions),
+            "all" => Ok(Self::All),
+            other => Err(format!("unknown agent response policy: {other:?}")),
+        }
+    }
+}
+
 impl ChannelType {
     /// Canonical string representation (matches DB enum and Nostr tags).
     pub fn as_str(&self) -> &'static str {
@@ -180,7 +220,9 @@ impl FromStr for MemberRole {
 
 #[cfg(test)]
 mod tests {
-    use super::canonical_channel_name;
+    use std::str::FromStr;
+
+    use super::{canonical_channel_name, AgentResponsePolicy};
 
     #[test]
     fn channel_names_trim_whitespace_and_drop_all_leading_hashes() {
@@ -194,5 +236,19 @@ mod tests {
         assert_eq!(canonical_channel_name("# #"), "");
         assert_eq!(canonical_channel_name("### ###"), "");
         assert_eq!(canonical_channel_name("channel#topic"), "channel#topic");
+    }
+
+    #[test]
+    fn agent_response_policy_round_trips_canonical_values() {
+        assert_eq!(
+            AgentResponsePolicy::from_str("mentions").unwrap(),
+            AgentResponsePolicy::Mentions
+        );
+        assert_eq!(
+            AgentResponsePolicy::from_str("all").unwrap(),
+            AgentResponsePolicy::All
+        );
+        assert_eq!(AgentResponsePolicy::All.as_str(), "all");
+        assert!(AgentResponsePolicy::from_str("sometimes").is_err());
     }
 }

--- a/crates/buzz-db/src/channel.rs
+++ b/crates/buzz-db/src/channel.rs
@@ -14,7 +14,7 @@ use buzz_core::CommunityId;
 // Re-export the canonical enum definitions from buzz-core.
 // These live in core (zero I/O deps) so the SDK can share them
 // without pulling in sqlx/tokio.
-pub use buzz_core::channel::{ChannelType, ChannelVisibility, MemberRole};
+pub use buzz_core::channel::{AgentResponsePolicy, ChannelType, ChannelVisibility, MemberRole};
 
 /// A channel row as returned from the database.
 #[derive(Debug, Clone)]
@@ -63,6 +63,8 @@ pub struct ChannelRecord {
     pub ttl_seconds: Option<i32>,
     /// Deadline by which a new message must arrive or the channel is auto-archived.
     pub ttl_deadline: Option<DateTime<Utc>>,
+    /// Whether agents receive mentions only or every message in this channel.
+    pub agent_response_policy: String,
 }
 
 /// A channel membership row as returned from the database.
@@ -153,7 +155,7 @@ pub async fn create_channel(
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
                purpose, purpose_set_by, purpose_set_at,
-               ttl_seconds, ttl_deadline
+               ttl_seconds, ttl_deadline, agent_response_policy
         FROM channels WHERE community_id = $1 AND id = $2
         "#,
     )
@@ -253,7 +255,7 @@ pub async fn create_channel_with_id(
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
                purpose, purpose_set_by, purpose_set_at,
-               ttl_seconds, ttl_deadline
+               ttl_seconds, ttl_deadline, agent_response_policy
         FROM channels WHERE community_id = $1 AND id = $2
         "#,
     )
@@ -281,7 +283,7 @@ pub async fn get_channel(
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
                purpose, purpose_set_by, purpose_set_at,
-               ttl_seconds, ttl_deadline
+               ttl_seconds, ttl_deadline, agent_response_policy
         FROM channels WHERE community_id = $1 AND id = $2 AND deleted_at IS NULL
         "#,
     )
@@ -788,7 +790,7 @@ pub async fn list_channels(
                    nip29_group_id, topic_required, max_members,
                    topic, topic_set_by, topic_set_at,
                    purpose, purpose_set_by, purpose_set_at,
-                   ttl_seconds, ttl_deadline
+                   ttl_seconds, ttl_deadline, agent_response_policy
             FROM channels
             WHERE community_id = $1 AND deleted_at IS NULL AND visibility::text = $2
             ORDER BY created_at DESC
@@ -808,7 +810,7 @@ pub async fn list_channels(
                    nip29_group_id, topic_required, max_members,
                    topic, topic_set_by, topic_set_at,
                    purpose, purpose_set_by, purpose_set_at,
-                   ttl_seconds, ttl_deadline
+                   ttl_seconds, ttl_deadline, agent_response_policy
             FROM channels
             WHERE community_id = $1 AND deleted_at IS NULL
             ORDER BY created_at DESC
@@ -856,7 +858,7 @@ async fn get_channel_tx(
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
                purpose, purpose_set_by, purpose_set_at,
-               ttl_seconds, ttl_deadline
+               ttl_seconds, ttl_deadline, agent_response_policy
         FROM channels WHERE community_id = $1 AND id = $2 AND deleted_at IS NULL
         "#,
     )
@@ -958,7 +960,7 @@ pub async fn get_accessible_channels(
                c.nip29_group_id, c.topic_required, c.max_members,
                c.topic, c.topic_set_by, c.topic_set_at,
                c.purpose, c.purpose_set_by, c.purpose_set_at,
-               c.ttl_seconds, c.ttl_deadline,
+               c.ttl_seconds, c.ttl_deadline, c.agent_response_policy,
                (cm.channel_id IS NOT NULL) AS is_member
         FROM channels c
         LEFT JOIN channel_members cm
@@ -1095,6 +1097,9 @@ fn row_to_channel_record(row: sqlx::postgres::PgRow) -> Result<ChannelRecord> {
     let purpose_set_at: Option<DateTime<Utc>> = row.try_get("purpose_set_at").unwrap_or(None);
     let ttl_seconds: Option<i32> = row.try_get("ttl_seconds").unwrap_or(None);
     let ttl_deadline: Option<DateTime<Utc>> = row.try_get("ttl_deadline").unwrap_or(None);
+    let agent_response_policy: String = row
+        .try_get("agent_response_policy")
+        .unwrap_or_else(|_| AgentResponsePolicy::Mentions.as_str().to_string());
 
     Ok(ChannelRecord {
         id,
@@ -1119,6 +1124,7 @@ fn row_to_channel_record(row: sqlx::postgres::PgRow) -> Result<ChannelRecord> {
         purpose_set_at,
         ttl_seconds,
         ttl_deadline,
+        agent_response_policy,
     })
 }
 
@@ -1149,6 +1155,8 @@ pub struct ChannelUpdate {
     /// ephemeral TTL (channel becomes permanent), `Some(Some(secs))` sets it.
     /// On any change the `ttl_deadline` is reset to `NOW() + ttl_seconds`.
     pub ttl_seconds: Option<Option<i32>>,
+    /// New agent response policy (`"mentions"`/`"all"`), or `None` to leave unchanged.
+    pub agent_response_policy: Option<String>,
 }
 
 /// Updates channel metadata dynamically.
@@ -1165,6 +1173,7 @@ pub async fn update_channel(
         && updates.description.is_none()
         && updates.visibility.is_none()
         && updates.ttl_seconds.is_none()
+        && updates.agent_response_policy.is_none()
     {
         return Err(DbError::InvalidData(
             "at least one field must be provided for update".to_string(),
@@ -1176,6 +1185,11 @@ pub async fn update_channel(
         if name.is_empty() {
             return Err(DbError::InvalidData("channel name is required".into()));
         }
+    }
+    if let Some(policy) = updates.agent_response_policy.as_deref() {
+        policy
+            .parse::<AgentResponsePolicy>()
+            .map_err(DbError::InvalidData)?;
     }
 
     // Build SET clause dynamically — only include fields that are provided.
@@ -1206,6 +1220,10 @@ pub async fn update_channel(
             None => set_parts.push("ttl_deadline = NULL".to_string()),
         }
     }
+    if updates.agent_response_policy.is_some() {
+        set_parts.push(format!("agent_response_policy = ${param_idx}"));
+        param_idx += 1;
+    }
     let channel_param_idx = param_idx + 1;
     let sql = format!(
         "UPDATE channels SET {}, updated_at = NOW() WHERE community_id = ${param_idx} AND id = ${channel_param_idx} AND deleted_at IS NULL",
@@ -1224,6 +1242,9 @@ pub async fn update_channel(
     }
     if let Some(ref ttl) = updates.ttl_seconds {
         q = q.bind(*ttl);
+    }
+    if let Some(ref policy) = updates.agent_response_policy {
+        q = q.bind(policy);
     }
     q = q.bind(community_id.as_uuid());
     q = q.bind(channel_id);

--- a/crates/buzz-db/src/dm.rs
+++ b/crates/buzz-db/src/dm.rs
@@ -511,6 +511,7 @@ fn row_to_channel_record(row: sqlx::postgres::PgRow) -> Result<ChannelRecord> {
         purpose_set_at: row.try_get("purpose_set_at").unwrap_or(None),
         ttl_seconds: row.try_get("ttl_seconds").unwrap_or(None),
         ttl_deadline: row.try_get("ttl_deadline").unwrap_or(None),
+        agent_response_policy: "mentions".to_string(),
     })
 }
 

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -560,7 +560,7 @@ mod tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 25);
+        assert_eq!(migrations.len(), 26);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]
@@ -899,11 +899,18 @@ mod tests {
             .contains("CREATE INDEX relay_invites_expires_at_idx ON relay_invites (expires_at)"));
         assert!(!relay_invites.contains("_operator_global_tables"));
 
+        assert_eq!(migrations[25].version, 26);
+        let agent_response = migrations[25].sql.as_str();
+        assert!(agent_response.contains("ADD COLUMN agent_response_policy"));
+        assert!(agent_response.contains("DEFAULT 'mentions'"));
+        assert!(agent_response.contains("IN ('mentions', 'all')"));
+
         let desired_schema = include_str!("../../../schema/schema.sql");
         assert!(
             desired_schema.contains("CREATE TABLE join_policy_acceptances"),
             "desired-state schema must include join-policy evidence used by invite claims",
         );
+        assert!(desired_schema.contains("agent_response_policy"));
     }
 
     #[test]

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -500,6 +500,7 @@ pub async fn validate_admin_event(
                 "purpose",
                 "visibility",
                 "ttl",
+                "agent_response",
             ];
             let has_recognized = event
                 .tags
@@ -507,7 +508,7 @@ pub async fn validate_admin_event(
                 .any(|t| RECOGNIZED_TAGS.contains(&t.kind().to_string().as_str()));
             if !has_recognized {
                 return Err(anyhow::anyhow!(
-                    "kind:9002 must include at least one metadata tag (name, about, archived, topic, purpose, visibility, ttl)"
+                    "kind:9002 must include at least one metadata tag (name, about, archived, topic, purpose, visibility, ttl, agent_response)"
                 ));
             }
 
@@ -586,11 +587,33 @@ pub async fn validate_admin_event(
                 }
             }
 
-            // name/about/archived/visibility/ttl require owner/admin;
+            // Validate the channel-owned agent response policy before storage.
+            for t in event.tags.iter() {
+                if t.kind().to_string() == "agent_response" {
+                    match t.content() {
+                        Some("mentions") | Some("all") => {}
+                        Some(v) => {
+                            return Err(anyhow::anyhow!(
+                                "invalid agent_response value: {v} (must be \"mentions\" or \"all\")"
+                            ));
+                        }
+                        None => {
+                            return Err(anyhow::anyhow!("agent_response tag must have a value"));
+                        }
+                    }
+                }
+            }
+
+            // name/about/archived/visibility/ttl/agent_response require owner/admin;
             // topic/purpose allow any member.
             let has_privileged_tag = event.tags.iter().any(|t| {
                 let k = t.kind().to_string();
-                k == "name" || k == "about" || k == "archived" || k == "visibility" || k == "ttl"
+                k == "name"
+                    || k == "about"
+                    || k == "archived"
+                    || k == "visibility"
+                    || k == "ttl"
+                    || k == "agent_response"
             });
             if has_privileged_tag {
                 let members = state.db.get_members(tenant.community(), channel_id).await?;
@@ -612,7 +635,7 @@ pub async fn validate_admin_event(
                             return Ok(());
                         }
                         Err(anyhow::anyhow!(
-                            "actor not authorized for name/about/archived/visibility/ttl changes"
+                            "actor not authorized for name/about/archived/visibility/ttl/agent_response changes"
                         ))
                     }
                 }
@@ -1105,6 +1128,10 @@ pub async fn emit_group_discovery_events(
         if let Some(ref deadline) = channel.ttl_deadline {
             tags.push(Tag::parse(["ttl_deadline", &deadline.to_rfc3339()])?);
         }
+        tags.push(Tag::parse([
+            "agent_response",
+            &channel.agent_response_policy,
+        ])?);
         emit_addressable_discovery_event(
             tenant,
             state,
@@ -1437,6 +1464,7 @@ async fn handle_edit_metadata(
         extract_h_tag_channel(event).ok_or_else(|| anyhow::anyhow!("missing h tag"))?;
     let actor_bytes = event.pubkey.to_bytes().to_vec();
     let actor_hex = hex::encode(&actor_bytes);
+    let mut agent_response_changed = false;
 
     for tag in event.tags.iter() {
         let key = tag.kind().to_string();
@@ -1570,6 +1598,29 @@ async fn handle_edit_metadata(
                     )
                     .await?;
                 }
+                "agent_response" => {
+                    state
+                        .db
+                        .update_channel(
+                            tenant.community(),
+                            channel_id,
+                            buzz_db::channel::ChannelUpdate {
+                                agent_response_policy: Some(val.to_string()),
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
+                    agent_response_changed = true;
+                    emit_system_message(
+                        tenant,
+                        state,
+                        channel_id,
+                        serde_json::json!({
+                            "type": "agent_response_changed", "actor": actor_hex, "policy": val
+                        }),
+                    )
+                    .await?;
+                }
                 "archived" => {
                     match val {
                         "true" => {
@@ -1648,6 +1699,30 @@ async fn handle_edit_metadata(
 
     if let Err(e) = emit_group_discovery_events(tenant, state, channel_id).await {
         warn!(channel = %channel_id, error = %e, "NIP-29 group discovery emission failed");
+    }
+
+    if agent_response_changed {
+        // ACP harnesses keep a global membership subscription alive. Reusing
+        // this notification gives every connected agent a durable signal to
+        // refetch metadata and replace its channel subscription immediately.
+        for member in state.db.get_members(tenant.community(), channel_id).await? {
+            if let Err(e) = emit_membership_notification(
+                tenant,
+                state,
+                channel_id,
+                &member.pubkey,
+                &actor_bytes,
+                KIND_MEMBER_ADDED_NOTIFICATION,
+            )
+            .await
+            {
+                warn!(
+                    channel = %channel_id,
+                    error = %e,
+                    "agent-response resubscribe notification failed"
+                );
+            }
+        }
     }
 
     Ok(())

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -597,7 +597,7 @@ pub fn build_leave(channel_id: Uuid) -> Result<EventBuilder, SdkError> {
     Ok(EventBuilder::new(Kind::Custom(9022), "").tags(tags))
 }
 
-/// Build a NIP-29 edit-metadata event for name/about/visibility/ttl (kind 9002).
+/// Build a NIP-29 edit-metadata event for channel settings (kind 9002).
 ///
 /// `ttl`: outer `None` leaves it unchanged; `Some(Some(secs))` sets the
 /// ephemeral timeout; `Some(None)` clears it (emits `["ttl", ""]`).
@@ -607,16 +607,30 @@ pub fn build_update_channel(
     about: Option<&str>,
     visibility: Option<&str>,
     ttl: Option<Option<i32>>,
+    agent_response: Option<&str>,
 ) -> Result<EventBuilder, SdkError> {
-    if name.is_none() && about.is_none() && visibility.is_none() && ttl.is_none() {
+    if name.is_none()
+        && about.is_none()
+        && visibility.is_none()
+        && ttl.is_none()
+        && agent_response.is_none()
+    {
         return Err(SdkError::InvalidTag(
-            "at least one of name, about, visibility, or ttl must be provided".into(),
+            "at least one of name, about, visibility, ttl, or agent_response must be provided"
+                .into(),
         ));
     }
     if let Some(v) = visibility {
         if v != "open" && v != "private" {
             return Err(SdkError::InvalidTag(
                 "visibility must be \"open\" or \"private\"".into(),
+            ));
+        }
+    }
+    if let Some(policy) = agent_response {
+        if policy != "mentions" && policy != "all" {
+            return Err(SdkError::InvalidTag(
+                "agent_response must be \"mentions\" or \"all\"".into(),
             ));
         }
     }
@@ -644,6 +658,9 @@ pub fn build_update_channel(
             Some(secs) => tags.push(tag(&["ttl", &secs.to_string()])?),
             None => tags.push(tag(&["ttl", ""])?),
         }
+    }
+    if let Some(policy) = agent_response {
+        tags.push(tag(&["agent_response", policy])?);
     }
     Ok(EventBuilder::new(Kind::Custom(9002), "").tags(tags))
 }
@@ -2410,7 +2427,8 @@ mod tests {
     fn update_channel_name_and_about() {
         let cid = uuid();
         let ev = sign(
-            build_update_channel(cid, Some("new-name"), Some("new about"), None, None).unwrap(),
+            build_update_channel(cid, Some("new-name"), Some("new about"), None, None, None)
+                .unwrap(),
         );
         assert_eq!(ev.kind.as_u16(), 9002);
         assert!(has_tag(&ev, "name", "new-name"));
@@ -2419,15 +2437,16 @@ mod tests {
 
     #[test]
     fn update_channel_strips_all_leading_hashes_from_name() {
-        let ev =
-            sign(build_update_channel(uuid(), Some("  ###new-name  "), None, None, None).unwrap());
+        let ev = sign(
+            build_update_channel(uuid(), Some("  ###new-name  "), None, None, None, None).unwrap(),
+        );
         assert!(has_tag(&ev, "name", "new-name"));
     }
 
     #[test]
     fn update_channel_rejects_hash_only_name() {
         assert!(matches!(
-            build_update_channel(uuid(), Some("  ###  "), None, None, None),
+            build_update_channel(uuid(), Some("  ###  "), None, None, None, None),
             Err(SdkError::InvalidTag(_))
         ));
     }
@@ -2435,8 +2454,9 @@ mod tests {
     #[test]
     fn update_channel_visibility_and_ttl() {
         let cid = uuid();
-        let ev =
-            sign(build_update_channel(cid, None, None, Some("private"), Some(Some(3600))).unwrap());
+        let ev = sign(
+            build_update_channel(cid, None, None, Some("private"), Some(Some(3600)), None).unwrap(),
+        );
         assert_eq!(ev.kind.as_u16(), 9002);
         assert!(has_tag(&ev, "visibility", "private"));
         assert!(has_tag(&ev, "ttl", "3600"));
@@ -2445,7 +2465,7 @@ mod tests {
     #[test]
     fn update_channel_clears_ttl() {
         let cid = uuid();
-        let ev = sign(build_update_channel(cid, None, None, None, Some(None)).unwrap());
+        let ev = sign(build_update_channel(cid, None, None, None, Some(None), None).unwrap());
         assert!(has_tag(&ev, "ttl", ""));
     }
 
@@ -2453,7 +2473,18 @@ mod tests {
     fn update_channel_invalid_visibility_rejected() {
         let cid = uuid();
         assert!(matches!(
-            build_update_channel(cid, None, None, Some("secret"), None),
+            build_update_channel(cid, None, None, Some("secret"), None, None),
+            Err(SdkError::InvalidTag(_))
+        ));
+    }
+
+    #[test]
+    fn update_channel_agent_response_policy() {
+        let cid = uuid();
+        let ev = sign(build_update_channel(cid, None, None, None, None, Some("all")).unwrap());
+        assert!(has_tag(&ev, "agent_response", "all"));
+        assert!(matches!(
+            build_update_channel(cid, None, None, None, None, Some("sometimes")),
             Err(SdkError::InvalidTag(_))
         ));
     }
@@ -2462,7 +2493,7 @@ mod tests {
     fn update_channel_no_fields_rejected() {
         let cid = uuid();
         assert!(matches!(
-            build_update_channel(cid, None, None, None, None),
+            build_update_channel(cid, None, None, None, None, None),
             Err(SdkError::InvalidTag(_))
         ));
     }

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -695,6 +695,9 @@ pub struct UpdateChannelInput {
     /// Absent = leave unchanged, `null` = clear (permanent), seconds = set.
     #[serde(default, deserialize_with = "crate::util::double_option")]
     pub ttl_seconds: Option<Option<i32>>,
+    /// Absent leaves the setting unchanged; valid values are `mentions` and `all`.
+    #[serde(default)]
+    pub agent_response: Option<String>,
 }
 
 #[tauri::command]
@@ -709,6 +712,7 @@ pub async fn update_channel(
         input.description.as_deref(),
         input.visibility.as_deref(),
         input.ttl_seconds,
+        input.agent_response.as_deref(),
     )?;
     submit_event(builder, &state).await?;
 

--- a/desktop/src-tauri/src/commands/channels_tests.rs
+++ b/desktop/src-tauri/src/commands/channels_tests.rs
@@ -286,6 +286,7 @@ fn starter_match_requires_open_unarchived_stream_by_normalized_name() {
         is_member: true,
         ttl_seconds: None,
         ttl_deadline: None,
+        agent_response_policy: "mentions".to_string(),
     };
 
     assert!(is_matching_starter_channel(&channel, spec));

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -13,7 +13,7 @@ use buzz_core_pkg::kind::{KIND_IA_ARCHIVE_REQUEST, KIND_IA_UNARCHIVE_REQUEST};
 use nostr::{EventBuilder, EventId, Kind, Tag};
 use uuid::Uuid;
 
-// ── Constants ────────────────────────────────────────────────────────────────
+mod channel_policy;
 
 /// Maximum content size — matches buzz-sdk (64 KiB).
 const MAX_CONTENT_BYTES: usize = 64 * 1024;
@@ -179,19 +179,17 @@ pub fn build_leave(channel_id: Uuid) -> Result<EventBuilder, String> {
     Ok(EventBuilder::new(Kind::Custom(9022), "").tags(tags))
 }
 
-/// Kind 9002 — update channel name/description/visibility/ttl.
-///
-/// `ttl`: outer `None` leaves it unchanged; `Some(Some(secs))` sets the
-/// ephemeral timeout; `Some(None)` clears it (emits `["ttl", ""]`).
+/// Kind 9002 — update channel settings.
 pub fn build_update_channel(
     channel_id: Uuid,
     name: Option<&str>,
     about: Option<&str>,
     visibility: Option<&str>,
     ttl: Option<Option<i32>>,
+    agent_response: Option<&str>,
 ) -> Result<EventBuilder, String> {
-    if name.is_none() && about.is_none() && visibility.is_none() && ttl.is_none() {
-        return Err("at least one of name, about, visibility, or ttl must be provided".into());
+    if (name, about, visibility, ttl, agent_response) == (None, None, None, None, None) {
+        return Err("provide at least one channel setting".into());
     }
     if let Some(v) = visibility {
         if v != "open" && v != "private" {
@@ -218,6 +216,7 @@ pub fn build_update_channel(
             None => tags.push(tag(vec!["ttl", ""])?),
         }
     }
+    channel_policy::push_agent_response_tag(&mut tags, agent_response)?;
     Ok(EventBuilder::new(Kind::Custom(9002), "").tags(tags))
 }
 
@@ -854,7 +853,7 @@ mod tests {
     fn channel_builders_reject_hash_only_names() {
         let channel_id = Uuid::new_v4();
         assert!(build_create_channel(channel_id, "###", "open", "stream", None, None).is_err());
-        assert!(build_update_channel(channel_id, Some("###"), None, None, None).is_err());
+        assert!(build_update_channel(channel_id, Some("###"), None, None, None, None).is_err());
     }
     /// Builder layout regression for the NIP-IA owner-of-agent archive flow.
     /// Compares against `docs/nips/NIP-IA.md` §Vector 1.

--- a/desktop/src-tauri/src/events/channel_policy.rs
+++ b/desktop/src-tauri/src/events/channel_policy.rs
@@ -1,0 +1,15 @@
+use nostr::Tag;
+
+pub(super) fn push_agent_response_tag(
+    tags: &mut Vec<Tag>,
+    policy: Option<&str>,
+) -> Result<(), String> {
+    let Some(policy) = policy else {
+        return Ok(());
+    };
+    if !matches!(policy, "mentions" | "all") {
+        return Err("agent_response must be \"mentions\" or \"all\"".into());
+    }
+    tags.push(Tag::parse(vec!["agent_response", policy]).map_err(|e| format!("invalid tag: {e}"))?);
+    Ok(())
+}

--- a/desktop/src-tauri/src/models.rs
+++ b/desktop/src-tauri/src/models.rs
@@ -129,6 +129,8 @@ pub struct ChannelInfo {
     pub is_member: bool,
     pub ttl_seconds: Option<i32>,
     pub ttl_deadline: Option<String>,
+    #[serde(default = "default_agent_response_policy")]
+    pub agent_response_policy: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -155,6 +157,12 @@ pub struct ChannelDetailInfo {
     pub nip29_group_id: Option<String>,
     pub ttl_seconds: Option<i32>,
     pub ttl_deadline: Option<String>,
+    #[serde(default = "default_agent_response_policy")]
+    pub agent_response_policy: String,
+}
+
+fn default_agent_response_policy() -> String {
+    "mentions".to_string()
 }
 
 #[derive(Serialize, Deserialize)]

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -1,11 +1,6 @@
 //! Nostr event → desktop model converters.
 //!
-//! These pure functions translate raw Nostr protocol events into the
-//! model types expected by the Tauri frontend commands.
-//!
-//! All converters here are I/O-free and deterministic — they take owned
-//! or borrowed events and return models. This makes them trivially
-//! testable with hand-crafted events (see the `tests` module below).
+//! Pure, deterministic conversions keep protocol parsing testable without I/O.
 
 use std::collections::{BTreeSet, HashMap};
 
@@ -14,6 +9,7 @@ use serde_json::{json, Value};
 
 use crate::models::*;
 
+mod channel_policy;
 mod user_search;
 pub use user_search::{
     list_user_search_results, rank_user_search_results, search_users_from_events,
@@ -157,6 +153,7 @@ pub fn channel_info_from_event(
     // Ephemeral channel TTL — relay emits ["ttl", "<seconds>"] and ["ttl_deadline", "<iso>"].
     let ttl_seconds = first_tag_value(event, "ttl").and_then(|v| v.parse::<i32>().ok());
     let ttl_deadline = first_tag_value(event, "ttl_deadline").map(str::to_string);
+    let agent_response_policy = channel_policy::from_event(event);
 
     Ok(ChannelInfo {
         id,
@@ -175,6 +172,7 @@ pub fn channel_info_from_event(
         is_member: is_member.unwrap_or(true),
         ttl_seconds,
         ttl_deadline,
+        agent_response_policy,
     })
 }
 
@@ -237,6 +235,7 @@ pub fn channel_detail_from_event(event: &Event) -> Result<ChannelDetailInfo, Str
         nip29_group_id: None,
         ttl_seconds: first_tag_value(event, "ttl").and_then(|v| v.parse::<i32>().ok()),
         ttl_deadline: first_tag_value(event, "ttl_deadline").map(str::to_string),
+        agent_response_policy: channel_policy::from_event(event),
     })
 }
 

--- a/desktop/src-tauri/src/nostr_convert/channel_policy.rs
+++ b/desktop/src-tauri/src/nostr_convert/channel_policy.rs
@@ -1,0 +1,41 @@
+use nostr::Event;
+
+pub(super) fn from_event(event: &Event) -> String {
+    event
+        .tags
+        .iter()
+        .find_map(|tag| match tag.as_slice() {
+            [name, value, ..]
+                if name == "agent_response" && matches!(value.as_str(), "mentions" | "all") =>
+            {
+                Some(value.clone())
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| "mentions".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    use super::from_event;
+
+    fn event(policy: Option<&str>) -> nostr::Event {
+        let mut tags = vec![Tag::parse(["d", "channel-id"]).unwrap()];
+        if let Some(policy) = policy {
+            tags.push(Tag::parse(["agent_response", policy]).unwrap());
+        }
+        EventBuilder::new(Kind::Custom(39000), "")
+            .tags(tags)
+            .sign_with_keys(&Keys::generate())
+            .unwrap()
+    }
+
+    #[test]
+    fn reads_valid_policy_and_defaults_invalid_or_missing_values() {
+        assert_eq!(from_event(&event(Some("all"))), "all");
+        assert_eq!(from_event(&event(Some("sometimes"))), "mentions");
+        assert_eq!(from_event(&event(None)), "mentions");
+    }
+}

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -114,6 +114,13 @@ with a TypeScript lookup table or an id comparison in a component.
     published or removed. A queued update must stay visibly queued, and the
     catalog itself must render only relay-confirmed publications — never an
     optimistic local persona.
+11. **Mention delivery can be channel-owned.** A channel's NIP-29 metadata may
+    carry `agent_response=mentions|all`, which authoritatively sets the ACP
+    mention filter for every agent member. This policy is edited with channel
+    settings and propagated by the relay; do not model it as a managed-agent
+    env override. Missing metadata preserves legacy local behavior for older
+    relays. Per-agent `RespondTo` author gates remain authoritative after
+    delivery and must never be weakened by a channel setting.
 
 ## The tests that enforce this
 

--- a/desktop/src/features/channels/lib/agentResponsePolicy.ts
+++ b/desktop/src/features/channels/lib/agentResponsePolicy.ts
@@ -1,0 +1,9 @@
+import type { AgentResponsePolicy } from "@/shared/api/types";
+
+export function agentResponseEmoji(policy: AgentResponsePolicy): string {
+  return policy === "all" ? "💬" : "🏷️";
+}
+
+export function agentResponseLabel(policy: AgentResponsePolicy): string {
+  return policy === "all" ? "Every message" : "Only @mentions";
+}

--- a/desktop/src/features/channels/ui/ChannelAgentResponseSettings.tsx
+++ b/desktop/src/features/channels/ui/ChannelAgentResponseSettings.tsx
@@ -1,0 +1,88 @@
+import { AtSign, ChevronDown, MessagesSquare } from "lucide-react";
+
+import {
+  agentResponseEmoji,
+  agentResponseLabel,
+} from "@/features/channels/lib/agentResponsePolicy";
+import type { AgentResponsePolicy } from "@/shared/api/types";
+import { Button } from "@/shared/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
+import { cn } from "@/shared/lib/cn";
+
+export function ChannelAgentResponseSettings({
+  disabled,
+  onPolicyChange,
+  policy,
+  testIdPrefix,
+}: {
+  disabled?: boolean;
+  onPolicyChange: (policy: AgentResponsePolicy) => void;
+  policy: AgentResponsePolicy;
+  testIdPrefix: string;
+}) {
+  const policyLabel = `${agentResponseEmoji(policy)} ${agentResponseLabel(policy)}`;
+
+  return (
+    <div
+      className={cn(
+        "flex min-h-12 items-center justify-between gap-4 rounded-xl border border-input bg-background px-3 py-3",
+        disabled && "opacity-50",
+      )}
+      data-testid={`${testIdPrefix}-agent-response-container`}
+    >
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-foreground">Agent replies</div>
+        <div className="text-xs text-muted-foreground">
+          Applies to every agent in this channel
+        </div>
+      </div>
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            aria-label={`Agent replies: ${policyLabel}`}
+            className="-mr-2.5 ml-auto h-9 w-fit justify-end px-2.5 text-right text-sm font-medium text-foreground hover:bg-muted/50"
+            data-testid={`${testIdPrefix}-agent-response`}
+            disabled={disabled}
+            type="button"
+            variant="ghost"
+          >
+            <span className="text-right">{policyLabel}</span>
+            <ChevronDown className="size-4 shrink-0 text-muted-foreground/70" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          onCloseAutoFocus={(event) => event.preventDefault()}
+          style={{ minWidth: "var(--radix-dropdown-menu-trigger-width)" }}
+        >
+          <DropdownMenuRadioGroup
+            onValueChange={(value) =>
+              onPolicyChange(value === "all" ? "all" : "mentions")
+            }
+            value={policy}
+          >
+            <DropdownMenuRadioItem
+              data-testid={`${testIdPrefix}-agent-response-option-mentions`}
+              value="mentions"
+            >
+              <AtSign className="mr-2 size-4" />
+              🏷️ Only @mentions
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem
+              data-testid={`${testIdPrefix}-agent-response-option-all`}
+              value="all"
+            >
+              <MessagesSquare className="mr-2 size-4" />💬 Every message
+            </DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/desktop/src/features/channels/ui/ChannelAgentResponseSummaryRow.tsx
+++ b/desktop/src/features/channels/ui/ChannelAgentResponseSummaryRow.tsx
@@ -1,0 +1,102 @@
+import {
+  AtSign,
+  ChevronDown,
+  LoaderCircle,
+  MessagesSquare,
+} from "lucide-react";
+
+import {
+  agentResponseEmoji,
+  agentResponseLabel,
+} from "@/features/channels/lib/agentResponsePolicy";
+import type { AgentResponsePolicy } from "@/shared/api/types";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
+
+export function ChannelAgentResponseSummaryRow({
+  canManage,
+  isPending,
+  onPolicyChange,
+  policy,
+}: {
+  canManage: boolean;
+  isPending: boolean;
+  onPolicyChange: (policy: AgentResponsePolicy) => void;
+  policy: AgentResponsePolicy;
+}) {
+  const status = `${agentResponseEmoji(policy)} ${agentResponseLabel(policy)}`;
+  const content = (
+    <>
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted/60">
+        <MessagesSquare className="h-4 w-4 text-muted-foreground" />
+      </span>
+      <span className="min-w-0 flex-1 text-left">
+        <span className="block text-xs font-medium text-foreground">
+          Agent replies
+        </span>
+        <span className="mt-0.5 block truncate text-sm text-muted-foreground">
+          {status}
+        </span>
+      </span>
+    </>
+  );
+
+  if (!canManage) {
+    return (
+      <div
+        className="flex w-full items-center gap-3 px-4 py-3"
+        data-testid="channel-management-agent-response-summary"
+      >
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <button
+          aria-label={`Agent replies: ${status}`}
+          className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/40 disabled:cursor-wait disabled:opacity-60"
+          data-testid="channel-management-agent-response-summary"
+          disabled={isPending}
+          type="button"
+        >
+          {content}
+          {isPending ? (
+            <LoaderCircle className="h-4 w-4 shrink-0 animate-spin text-muted-foreground" />
+          ) : (
+            <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          onValueChange={(value) =>
+            onPolicyChange(value === "all" ? "all" : "mentions")
+          }
+          value={policy}
+        >
+          <DropdownMenuRadioItem
+            data-testid="channel-management-agent-response-summary-option-mentions"
+            value="mentions"
+          >
+            <AtSign className="mr-2 size-4" />
+            🏷️ Only @mentions
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem
+            data-testid="channel-management-agent-response-summary-option-all"
+            value="all"
+          >
+            <MessagesSquare className="mr-2 size-4" />💬 Every message
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
+++ b/desktop/src/features/channels/ui/ChannelBrowserDialog.tsx
@@ -10,6 +10,10 @@ import {
 
 import type { Channel } from "@/shared/api/types";
 import {
+  agentResponseEmoji,
+  agentResponseLabel,
+} from "@/features/channels/lib/agentResponsePolicy";
+import {
   canonicalChannelName,
   channelNamesMatch,
 } from "@/features/channels/lib/canonicalChannelName";
@@ -794,6 +798,13 @@ function ChannelCard({
               #
             </span>
             <p className="min-w-0 truncate text-base font-medium tracking-tight">
+              <span
+                aria-label={`Agent replies: ${agentResponseLabel(channel.agentResponsePolicy)}`}
+                className="mr-1"
+                role="img"
+              >
+                {agentResponseEmoji(channel.agentResponsePolicy)}
+              </span>
               {channel.name}
             </p>
             {channel.archivedAt ? (

--- a/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
+++ b/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
@@ -35,7 +35,7 @@ import {
   DEFAULT_EPHEMERAL_TTL_SECONDS,
   formatTtlDuration,
 } from "@/features/channels/lib/ephemeralChannel";
-import type { Channel } from "@/shared/api/types";
+import type { AgentResponsePolicy, Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { useTheme } from "@/shared/theme/ThemeProvider";
 import { Button } from "@/shared/ui/button";
@@ -70,6 +70,7 @@ import {
 } from "./channelFormStyles";
 import { ChannelTypeSettings } from "./ChannelTypeSettings";
 import { ChannelPermissionsSettings } from "./ChannelPermissionsSettings";
+import { ChannelAgentResponseSettings } from "./ChannelAgentResponseSettings";
 import {
   ChannelHero,
   ChannelQuickAction,
@@ -165,6 +166,8 @@ export function ChannelManagementSheet({
   const [ttlSecondsDraft, setTtlSecondsDraft] = React.useState(
     DEFAULT_EPHEMERAL_TTL_SECONDS,
   );
+  const [agentResponseDraft, setAgentResponseDraft] =
+    React.useState<AgentResponsePolicy>("mentions");
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = React.useState(false);
   const [isConvertingVisibility, setIsConvertingVisibility] =
@@ -202,6 +205,7 @@ export function ChannelManagementSheet({
     setIsPrivateDraft(detail.visibility === "private");
     setIsEphemeralDraft(detail.ttlSeconds !== null);
     setTtlSecondsDraft(detail.ttlSeconds ?? DEFAULT_EPHEMERAL_TTL_SECONDS);
+    setAgentResponseDraft(detail.agentResponsePolicy);
     setHasUserEditedChannelDraft(false);
     setActiveView("summary");
   }, [detail, open]);
@@ -236,6 +240,8 @@ export function ChannelManagementSheet({
 
   const currentVisibility = detail?.visibility ?? channel.visibility;
   const currentTtlSeconds = detail?.ttlSeconds ?? null;
+  const currentAgentResponse =
+    detail?.agentResponsePolicy ?? channel.agentResponsePolicy;
   const nextVisibility: "open" | "private" = isPrivateDraft
     ? "private"
     : "open";
@@ -251,7 +257,9 @@ export function ChannelManagementSheet({
   const descriptionDirty =
     descriptionDraft.trim() !== resolvedChannel.description.trim();
   const isSavingChannelEdits = updateChannelDetailsMutation.isPending;
-  const hasChannelEditChanges = nameDirty || descriptionDirty || lifecycleDirty;
+  const agentResponseDirty = agentResponseDraft !== currentAgentResponse;
+  const hasChannelEditChanges =
+    nameDirty || descriptionDirty || lifecycleDirty || agentResponseDirty;
   const canSaveChannelEdits =
     nameDraft.trim().length > 0 &&
     hasUserEditedChannelDraft &&
@@ -270,6 +278,7 @@ export function ChannelManagementSheet({
       setDescriptionDraft(resolvedChannel.description);
       setIsEphemeralDraft(currentTtlSeconds !== null);
       setTtlSecondsDraft(currentTtlSeconds ?? DEFAULT_EPHEMERAL_TTL_SECONDS);
+      setAgentResponseDraft(currentAgentResponse);
       setHasUserEditedChannelDraft(false);
     }
 
@@ -278,7 +287,7 @@ export function ChannelManagementSheet({
 
   async function handleSaveChannelEdits() {
     try {
-      if (nameDirty || descriptionDirty || lifecycleDirty) {
+      if (hasChannelEditChanges) {
         await updateChannelDetailsMutation.mutateAsync({
           description: descriptionDirty ? descriptionDraft.trim() : undefined,
           name: nameDirty ? nameDraft.trim() : undefined,
@@ -288,6 +297,7 @@ export function ChannelManagementSheet({
             lifecycleDirty && nextVisibility !== currentVisibility
               ? nextVisibility
               : undefined,
+          agentResponse: agentResponseDirty ? agentResponseDraft : undefined,
         });
       }
 
@@ -531,6 +541,15 @@ export function ChannelManagementSheet({
                       }
                       testIdPrefix="channel-management"
                       visibility={isPrivateDraft ? "private" : "open"}
+                    />
+                    <ChannelAgentResponseSettings
+                      disabled={isSavingChannelEdits}
+                      onPolicyChange={(policy) => {
+                        setAgentResponseDraft(policy);
+                        setHasUserEditedChannelDraft(true);
+                      }}
+                      policy={agentResponseDraft}
+                      testIdPrefix="channel-management"
                     />
                   </div>
                 ) : null}

--- a/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
+++ b/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
@@ -71,6 +71,7 @@ import {
 import { ChannelTypeSettings } from "./ChannelTypeSettings";
 import { ChannelPermissionsSettings } from "./ChannelPermissionsSettings";
 import { ChannelAgentResponseSettings } from "./ChannelAgentResponseSettings";
+import { ChannelAgentResponseSummaryRow } from "./ChannelAgentResponseSummaryRow";
 import {
   ChannelHero,
   ChannelQuickAction,
@@ -98,6 +99,20 @@ type ChannelManagementSheetProps = {
   open: boolean;
   transparentChrome?: boolean;
 };
+
+function agentResponseUpdateErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (
+    message.includes("must include at least one metadata tag") ||
+    (message.includes("agent_response") && message.includes("recognized"))
+  ) {
+    return "This relay does not support agent reply settings yet";
+  }
+  if (message.includes("not authorized")) {
+    return "Only channel owners and admins can change agent replies";
+  }
+  return `Could not update agent replies: ${message}`;
+}
 
 export function ChannelManagementSheet({
   animateSplitEnter = false,
@@ -327,6 +342,21 @@ export function ChannelManagementSheet({
     }
   }
 
+  async function handleAgentResponseChange(policy: AgentResponsePolicy) {
+    if (policy === currentAgentResponse) {
+      return;
+    }
+    try {
+      await updateChannelDetailsMutation.mutateAsync({ agentResponse: policy });
+      setAgentResponseDraft(policy);
+      toast.success(
+        `Agent replies: ${policy === "all" ? "every message" : "mentions only"}`,
+      );
+    } catch (error) {
+      toast.error(agentResponseUpdateErrorMessage(error));
+    }
+  }
+
   return (
     <DialogPrimitive.Root
       modal={!isSplitLayout}
@@ -366,6 +396,7 @@ export function ChannelManagementSheet({
             canLeave={canLeave}
             canManageChannel={canManageChannel}
             canOpenCanvas={canOpenCanvas}
+            isAgentResponsePending={updateChannelDetailsMutation.isPending}
             canvasPreview={canvasPreview}
             canvasQuery={canvasQuery}
             channelId={channelId}
@@ -385,6 +416,7 @@ export function ChannelManagementSheet({
             membersError={membersQuery.error}
             onOpenChange={handlePanelOpenChange}
             resolvedChannel={resolvedChannel}
+            onAgentResponseChange={handleAgentResponseChange}
             setActiveView={setActiveView}
             setIsEditDialogOpen={setIsEditDialogOpen}
             unarchiveChannelMutation={unarchiveChannelMutation}
@@ -412,6 +444,7 @@ export function ChannelManagementSheet({
               canLeave={canLeave}
               canManageChannel={canManageChannel}
               canOpenCanvas={canOpenCanvas}
+              isAgentResponsePending={updateChannelDetailsMutation.isPending}
               canvasPreview={canvasPreview}
               canvasQuery={canvasQuery}
               channelId={channelId}
@@ -431,6 +464,7 @@ export function ChannelManagementSheet({
               membersError={membersQuery.error}
               onOpenChange={handlePanelOpenChange}
               resolvedChannel={resolvedChannel}
+              onAgentResponseChange={handleAgentResponseChange}
               setActiveView={setActiveView}
               setIsEditDialogOpen={setIsEditDialogOpen}
               unarchiveChannelMutation={unarchiveChannelMutation}
@@ -602,6 +636,7 @@ type ChannelManagementPanelContentProps = {
   canLeave: boolean;
   canManageChannel: boolean;
   canOpenCanvas: boolean;
+  isAgentResponsePending: boolean;
   canvasPreview?: string;
   canvasQuery: { isLoading: boolean };
   channelId: string | null;
@@ -620,6 +655,7 @@ type ChannelManagementPanelContentProps = {
   memberCount: number;
   membersError: unknown;
   onOpenChange: (open: boolean) => void;
+  onAgentResponseChange: (policy: AgentResponsePolicy) => Promise<void>;
   resolvedChannel: Channel;
   setActiveView: React.Dispatch<React.SetStateAction<"summary" | "canvas">>;
   setIsEditDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -634,6 +670,7 @@ function ChannelManagementPanelContent({
   canLeave,
   canManageChannel,
   canOpenCanvas,
+  isAgentResponsePending,
   canvasPreview,
   canvasQuery,
   channelId,
@@ -652,6 +689,7 @@ function ChannelManagementPanelContent({
   memberCount,
   membersError,
   onOpenChange,
+  onAgentResponseChange,
   resolvedChannel,
   setActiveView,
   setIsEditDialogOpen,
@@ -860,6 +898,16 @@ function ChannelManagementPanelContent({
                 testId="channel-management-member-count"
                 value={`${memberCount}`}
               />
+              {resolvedChannel.channelType !== "dm" ? (
+                <ChannelAgentResponseSummaryRow
+                  canManage={canManageChannel}
+                  isPending={isAgentResponsePending}
+                  onPolicyChange={(policy) => {
+                    void onAgentResponseChange(policy);
+                  }}
+                  policy={resolvedChannel.agentResponsePolicy}
+                />
+              ) : null}
               {isArchived ? (
                 <InfoFieldRow
                   icon={Archive}

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -18,6 +18,10 @@ import {
 import { ChannelContextMenuItems } from "@/features/sidebar/ui/ChannelContextMenu";
 import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
 import { formatElapsed } from "@/features/agents/ui/agentSessionUtils";
+import {
+  agentResponseEmoji,
+  agentResponseLabel,
+} from "@/features/channels/lib/agentResponsePolicy";
 import { getEphemeralChannelDisplay } from "@/features/channels/lib/ephemeralChannel";
 import { EphemeralChannelBadge } from "@/features/channels/ui/EphemeralChannelBadge";
 import {
@@ -270,6 +274,14 @@ export function ChannelMenuButton({
 }) {
   const resolvedLabel = label ?? channel.name;
   const ephemeralDisplay = getEphemeralChannelDisplay(channel);
+  const responsePolicy =
+    channel.channelType === "dm" ? null : channel.agentResponsePolicy;
+  const responseEmoji = responsePolicy
+    ? agentResponseEmoji(responsePolicy)
+    : null;
+  const tooltip = responsePolicy
+    ? `${resolvedLabel} · Agent replies: ${agentResponseLabel(responsePolicy)}`
+    : resolvedLabel;
 
   return (
     <SidebarMenuButton
@@ -286,7 +298,7 @@ export function ChannelMenuButton({
       data-testid={`channel-${channel.name}`}
       isActive={isActive}
       onClick={() => onSelectChannel(channel.id)}
-      tooltip={resolvedLabel}
+      tooltip={tooltip}
       type="button"
     >
       <SidebarChannelIcon
@@ -295,6 +307,11 @@ export function ChannelMenuButton({
         presenceStatus={presenceStatus}
       />
       <span className="min-w-0 flex-1 truncate" data-sidebar-row-label>
+        {responseEmoji ? (
+          <span aria-hidden="true" className="mr-1">
+            {responseEmoji}
+          </span>
+        ) : null}
         {resolvedLabel}
       </span>
       {ephemeralDisplay ? (

--- a/desktop/src/shared/api/tauriChannels.ts
+++ b/desktop/src/shared/api/tauriChannels.ts
@@ -30,6 +30,7 @@ export type RawChannel = {
   is_member?: boolean;
   ttl_seconds: number | null;
   ttl_deadline: string | null;
+  agent_response_policy?: "mentions" | "all";
 };
 
 type RawChannelDetail = RawChannel & {
@@ -76,6 +77,7 @@ export function fromRawChannel(channel: RawChannel): Channel {
     isMember: channel.is_member ?? true,
     ttlSeconds: channel.ttl_seconds,
     ttlDeadline: channel.ttl_deadline,
+    agentResponsePolicy: channel.agent_response_policy ?? "mentions",
   };
 }
 

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -1,7 +1,7 @@
 export type ChannelType = "stream" | "forum" | "dm";
 export type ChannelVisibility = "open" | "private";
+export type AgentResponsePolicy = "mentions" | "all";
 export type ChannelRole = "owner" | "admin" | "member" | "guest" | "bot";
-
 export type Channel = {
   id: string;
   name: string;
@@ -19,8 +19,8 @@ export type Channel = {
   isMember: boolean;
   ttlSeconds: number | null;
   ttlDeadline: string | null;
+  agentResponsePolicy: AgentResponsePolicy;
 };
-
 export type ChannelDetail = Channel & {
   createdBy: string;
   createdAt: string;
@@ -33,7 +33,6 @@ export type ChannelDetail = Channel & {
   maxMembers: number | null;
   nip29GroupId: string | null;
 };
-
 export type ChannelMember = {
   pubkey: string;
   role: ChannelRole;
@@ -61,6 +60,7 @@ export type UpdateChannelInput = {
   visibility?: ChannelVisibility;
   /** Omit to leave unchanged, `null` to clear (permanent), or a positive number of seconds to set. */
   ttlSeconds?: number | null;
+  agentResponse?: AgentResponsePolicy;
 };
 
 export type SetChannelTopicInput = {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -555,6 +555,7 @@ type RawChannel = {
   participant_pubkeys: string[];
   ttl_seconds: number | null;
   ttl_deadline: string | null;
+  agent_response_policy: "mentions" | "all";
 };
 
 type RawChannelWithMembership = RawChannel & {
@@ -1345,6 +1346,7 @@ function toRawChannel(
     participant_pubkeys: [...channel.participant_pubkeys],
     ttl_seconds: channel.ttl_seconds ?? null,
     ttl_deadline: channel.ttl_deadline ?? null,
+    agent_response_policy: channel.agent_response_policy ?? "mentions",
     is_member: channel.members.some(
       (member) => member.pubkey.toLowerCase() === currentPubkey,
     ),
@@ -1395,6 +1397,7 @@ function createMockChannel(
     | "participants"
     | "ttl_seconds"
     | "ttl_deadline"
+    | "agent_response_policy"
   > & {
     created_minutes_ago: number;
     members: RawChannelMember[];
@@ -1402,6 +1405,7 @@ function createMockChannel(
     participants?: string[];
     ttl_seconds?: number | null;
     ttl_deadline?: string | null;
+    agent_response_policy?: "mentions" | "all";
     updated_minutes_ago?: number;
   },
 ): MockChannel {
@@ -1414,6 +1418,7 @@ function createMockChannel(
     participants: [...(seed.participants ?? [])],
     ttl_seconds: seed.ttl_seconds ?? null,
     ttl_deadline: seed.ttl_deadline ?? null,
+    agent_response_policy: seed.agent_response_policy ?? "mentions",
     updated_at: isoMinutesAgo(
       seed.updated_minutes_ago ?? seed.created_minutes_ago,
     ),
@@ -5368,6 +5373,8 @@ async function handleGetChannels(config: E2eConfig | undefined) {
         participant_pubkeys: pTags,
         ttl_seconds: getTag("ttl") ? Number(getTag("ttl")) : null,
         ttl_deadline: getTag("ttl_deadline") ?? null,
+        agent_response_policy:
+          getTag("agent_response") === "all" ? "all" : "mentions",
         is_member: memberSet.has(channelId),
       };
     })
@@ -5909,6 +5916,7 @@ async function handleCreateChannel(
     archived_at: null,
     ttl_seconds: args.ttlSeconds ?? null,
     ttl_deadline: ttlDeadline,
+    agent_response_policy: "mentions",
     created_at: ev.created_at
       ? new Date(ev.created_at * 1000).toISOString()
       : new Date().toISOString(),
@@ -6007,6 +6015,7 @@ async function handleOpenDm(
     archived_at: null,
     ttl_seconds: null,
     ttl_deadline: null,
+    agent_response_policy: "mentions",
     created_at: ev?.created_at
       ? new Date(ev.created_at * 1000).toISOString()
       : new Date().toISOString(),
@@ -6078,6 +6087,8 @@ async function handleGetChannelDetails(
       : null,
     ttl_seconds: getTag("ttl") ? Number(getTag("ttl")) : null,
     ttl_deadline: getTag("ttl_deadline") ?? null,
+    agent_response_policy:
+      getTag("agent_response") === "all" ? "all" : "mentions",
     created_at: ev?.created_at
       ? new Date(ev.created_at * 1000).toISOString()
       : new Date().toISOString(),
@@ -6131,6 +6142,7 @@ async function handleUpdateChannel(
     description?: string;
     visibility?: "open" | "private";
     ttlSeconds?: number | null;
+    agentResponse?: "mentions" | "all";
   },
   config: E2eConfig | undefined,
 ) {
@@ -6158,6 +6170,9 @@ async function handleUpdateChannel(
           ? null
           : new Date(Date.now() + args.ttlSeconds * 1000).toISOString();
     }
+    if (args.agentResponse !== undefined) {
+      channel.agent_response_policy = args.agentResponse;
+    }
     touchMockChannel(channel);
     return toRawChannelDetail(channel, config);
   }
@@ -6174,6 +6189,9 @@ async function handleUpdateChannel(
   }
   if (args.ttlSeconds !== undefined) {
     tags.push(["ttl", args.ttlSeconds === null ? "" : String(args.ttlSeconds)]);
+  }
+  if (args.agentResponse !== undefined) {
+    tags.push(["agent_response", args.agentResponse]);
   }
   await submitSignedEvent(config, { kind: 9002, content: "", tags });
 
@@ -6203,6 +6221,8 @@ async function handleUpdateChannel(
       ttlSeconds === null
         ? null
         : new Date(Date.now() + ttlSeconds * 1000).toISOString(),
+    agent_response_policy:
+      getTag("agent_response") === "all" ? "all" : "mentions",
     created_at: ev?.created_at
       ? new Date(ev.created_at * 1000).toISOString()
       : new Date().toISOString(),

--- a/desktop/tests/e2e/channel-controls.spec.ts
+++ b/desktop/tests/e2e/channel-controls.spec.ts
@@ -345,4 +345,35 @@ test.describe("channel controls", () => {
       page.getByRole("dialog", { name: "Edit public channel" }),
     ).toBeVisible();
   });
+
+  test("11 — agent reply policy persists and updates the channel emoji", async ({
+    page,
+  }) => {
+    await installMockBridge(page);
+    await openManagementSheet(page);
+    await openEditDialog(page);
+
+    const policy = page.getByTestId("channel-management-agent-response");
+    await expect(policy).toHaveAccessibleName(
+      "Agent replies: 🏷️ Only @mentions",
+    );
+    await policy.click();
+    await page
+      .getByTestId("channel-management-agent-response-option-all")
+      .click();
+    await expect(policy).toHaveAccessibleName(
+      "Agent replies: 💬 Every message",
+    );
+    await page.getByTestId("channel-management-save-changes").click();
+
+    await expect(
+      page.getByRole("dialog", { name: /Edit (?:public|private) channel/ }),
+    ).toHaveCount(0);
+    await expect(page.getByTestId("channel-general")).toContainText("💬");
+
+    await openEditDialog(page);
+    await expect(
+      page.getByTestId("channel-management-agent-response"),
+    ).toHaveAccessibleName("Agent replies: 💬 Every message");
+  });
 });

--- a/desktop/tests/e2e/channel-controls.spec.ts
+++ b/desktop/tests/e2e/channel-controls.spec.ts
@@ -351,29 +351,26 @@ test.describe("channel controls", () => {
   }) => {
     await installMockBridge(page);
     await openManagementSheet(page);
-    await openEditDialog(page);
 
-    const policy = page.getByTestId("channel-management-agent-response");
-    await expect(policy).toHaveAccessibleName(
+    const summaryPolicy = page.getByTestId(
+      "channel-management-agent-response-summary",
+    );
+    await expect(summaryPolicy).toHaveAccessibleName(
       "Agent replies: 🏷️ Only @mentions",
     );
-    await policy.click();
+    await summaryPolicy.click();
     await page
-      .getByTestId("channel-management-agent-response-option-all")
+      .getByTestId("channel-management-agent-response-summary-option-all")
       .click();
-    await expect(policy).toHaveAccessibleName(
+    await expect(summaryPolicy).toHaveAccessibleName(
       "Agent replies: 💬 Every message",
     );
-    await page.getByTestId("channel-management-save-changes").click();
-
-    await expect(
-      page.getByRole("dialog", { name: /Edit (?:public|private) channel/ }),
-    ).toHaveCount(0);
     await expect(page.getByTestId("channel-general")).toContainText("💬");
 
     await openEditDialog(page);
-    await expect(
-      page.getByTestId("channel-management-agent-response"),
-    ).toHaveAccessibleName("Agent replies: 💬 Every message");
+    const policy = page.getByTestId("channel-management-agent-response");
+    await expect(policy).toHaveAccessibleName(
+      "Agent replies: 💬 Every message",
+    );
   });
 });

--- a/desktop/tests/e2e/integration.spec.ts
+++ b/desktop/tests/e2e/integration.spec.ts
@@ -485,6 +485,10 @@ test("manage sheet updates channel details through the relay", async ({
   await expect(
     editDialog.getByTestId("channel-management-purpose"),
   ).toHaveCount(0);
+  await editDialog.getByTestId("channel-management-agent-response").click();
+  await page
+    .getByTestId("channel-management-agent-response-option-all")
+    .click();
   await editDialog.getByTestId("channel-management-save-changes").click();
   await expect(editDialog).toHaveCount(0);
 
@@ -519,6 +523,9 @@ test("manage sheet updates channel details through the relay", async ({
   await expect(
     reopenedEditDialog.getByTestId("channel-management-purpose"),
   ).toHaveCount(0);
+  await expect(
+    reopenedEditDialog.getByTestId("channel-management-agent-response"),
+  ).toContainText("Every message");
 });
 
 test("manage sheet archive and unarchive survives a reload through the relay", async ({

--- a/migrations/0026_channel_agent_response_policy.sql
+++ b/migrations/0026_channel_agent_response_policy.sql
@@ -1,0 +1,7 @@
+-- Per-channel agent response policy. Mention-only preserves the existing
+-- behavior for every current channel; owners/admins may opt a channel into
+-- delivering untagged messages to all agent members.
+ALTER TABLE channels
+    ADD COLUMN agent_response_policy TEXT NOT NULL DEFAULT 'mentions',
+    ADD CONSTRAINT channels_agent_response_policy_check
+        CHECK (agent_response_policy IN ('mentions', 'all'));

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -95,6 +95,8 @@ CREATE TABLE channels (
     participant_hash BYTEA,
     ttl_seconds     INT,
     ttl_deadline    TIMESTAMPTZ,
+    agent_response_policy TEXT NOT NULL DEFAULT 'mentions'
+        CHECK (agent_response_policy IN ('mentions', 'all')),
     PRIMARY KEY (community_id, id),
     CONSTRAINT chk_channels_id_not_nil CHECK (id <> '00000000-0000-0000-0000-000000000000'::uuid)
 );


### PR DESCRIPTION
## Summary

- add a channel-owned `mentions` / `all` agent-response policy to channel metadata and persistence
- make ACP subscriptions refresh live when owners or admins change the policy, while preserving author gates and old-relay read fallback behavior
- expose the setting through the CLI and desktop UI, including clear channel indicators
- show the current policy in Channel details and let owners/admins change it there without opening the full Edit dialog
- keep the Channel details control read-only for members who cannot manage the channel, with explicit errors for permissions and unsupported relay versions

## Why

Agent response behavior was runtime-local, so channel owners could not opt selected channels into untagged agent replies without broad per-agent overrides. This makes the channel policy authoritative for every agent member and keeps existing channels mention-only by default.

The Channel details panel is also the natural place to understand the current behavior. The policy is now visible alongside Name, Type, Visibility, and Members, and authorized users can change it directly from that panel.

## Impact

- existing and new channels default to `mentions`
- owners and admins can select `all` to deliver untagged channel messages to agent members
- running agents refresh their channel subscriptions without a restart
- older relays remain readable through the existing local-rule fallback, but changing the channel-owned policy requires the relay changes in this PR to be deployed
- the desktop UI reports an unsupported relay or insufficient permissions instead of showing only a generic save failure

## Validation

- `cargo test -p buzz-sdk update_channel`
- `cargo test -p buzz-acp agent_response`
- `cargo test -p buzz-db migration::tests::embedded_migrator_contains_consolidated_initial_schema`
- workspace and desktop formatting/clippy checks pass
- desktop frontend: 3,769 tests pass
- desktop Rust: 1,850 tests pass
- desktop production build passes
- mobile format/analyze passes
- focused Playwright test passes for changing the policy in Channel details, updating the channel indicator, and syncing the Edit dialog
- Computer Use verified the Channel details control changes from `Only @mentions` to `Every message` and persists in the seeded Buzz environment

`just ci` reaches the mobile test stage but is currently blocked by an unrelated existing assertion in `mobile/test/features/channels/channel_detail_page_test.dart` (`keeps follow mode off while a tall newest message stays visible`). This branch does not modify mobile files; the failure reproduces when that test is run alone.
