### PR TITLE
Run Tauri clippy in pre-push

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -61,6 +61,11 @@ pre-push:
       glob: ["desktop/**", "pnpm-lock.yaml"]
       exclude: ["desktop/src-tauri/**"]
       run: just desktop-test
+    desktop-tauri-clippy:
+      # Keep local lint parity with Desktop Core CI for every path that can
+      # affect the Tauri crate or its path dependencies.
+      glob: ["desktop/src-tauri/**", "crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "justfile"]
+      run: just desktop-tauri-clippy
     desktop-tauri-test:
       # ci.yml:113 — Desktop Core triggers on `rust` OR `desktop-rust`;
       # desktop/src-tauri path-depends on crates/buzz-core, buzz-persona,


### PR DESCRIPTION
## Summary

- run Desktop Tauri clippy from pre-push for every path that can affect the Tauri crate
- reuse `just desktop-tauri-clippy`, keeping the local command identical to Desktop Core CI
- leave the existing Tauri test hook unchanged

## Why

PR #3553 exposed a hook gap: `cargo test` allowed an unused-import warning that CI's `clippy -D warnings` correctly rejected. Running the same recipe before push catches that class of failure locally without duplicating CI flags in Lefthook.

## Validation

- `lefthook run pre-push --command desktop-tauri-clippy --force`
- confirmed it invokes `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings`
- command passed
