### PR TITLE
huddle: linux: grant WebKit user media requests

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1085,6 +1085,7 @@ dependencies = [
  "url",
  "user-idle",
  "uuid",
+ "webkit2gtk",
  "window-vibrancy",
  "windows-sys 0.61.2",
  "zeroize",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -40,6 +40,9 @@ keyring = { version = "3.6.3", default-features = false, features = ["sync-secre
 # connection is dropped, which the plugin does immediately. Default features
 # keep the pure-Rust zbus backend, matching the plugin (no libdbus needed).
 notify-rust = "4"
+# Tauri exposes the underlying WebKitGTK view, but applications still need to
+# answer WebKit's user-media permission signal themselves on Linux.
+webkit2gtk = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSHapticFeedback"] }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -30,6 +30,8 @@ mod shutdown;
 mod templates;
 mod util;
 #[cfg(target_os = "linux")]
+mod webkit_permissions;
+#[cfg(target_os = "linux")]
 pub mod webkit_rendering;
 use app_state::{build_app_state, resolve_persisted_identity, AppState};
 use builderlab::*;
@@ -193,6 +195,13 @@ pub fn run() {
                 .on_webview_ready(|webview| {
                     if webview.label() != "main" {
                         return;
+                    }
+
+                    #[cfg(target_os = "linux")]
+                    if let Err(error) = webkit_permissions::install(&webview) {
+                        eprintln!(
+                            "buzz-desktop: failed to install WebKit media permissions: {error}"
+                        );
                     }
 
                     // macOS applies the restored geometry asynchronously. Wait

--- a/desktop/src-tauri/src/webkit_permissions.rs
+++ b/desktop/src-tauri/src/webkit_permissions.rs
@@ -1,0 +1,71 @@
+//! Linux WebKit permission integration.
+//!
+//! WebKitGTK delegates `getUserMedia` decisions to its embedding application.
+//! An unanswered `WebKitUserMediaPermissionRequest` is denied, so huddles cannot
+//! acquire a microphone unless Buzz handles the `permission-request` signal.
+
+use tauri::Webview;
+use webkit2gtk::{
+    glib::ObjectExt, PermissionRequestExt, SettingsExt, UserMediaPermissionRequest, WebViewExt,
+};
+
+/// Origins served by Buzz itself.
+///
+/// Release builds use Tauri's custom protocol. Development builds use the Vite
+/// URL declared in `tauri.conf.json`. Keep this allowlist narrow so navigating a
+/// webview away from Buzz cannot inherit microphone or camera access.
+fn is_buzz_origin(uri: &str) -> bool {
+    ["tauri://localhost", "http://localhost:1420"]
+        .iter()
+        .any(|origin| {
+            uri == *origin
+                || uri
+                    .strip_prefix(origin)
+                    .is_some_and(|rest| rest.starts_with('/'))
+        })
+}
+
+/// Enable media capture and grant only user-media requests from Buzz's own UI.
+pub fn install(webview: &Webview) -> tauri::Result<()> {
+    webview.with_webview(|platform_webview| {
+        let webview = platform_webview.inner();
+
+        if let Some(settings) = webview.settings() {
+            settings.set_enable_media_stream(true);
+        }
+
+        webview.connect_permission_request(|webview, request| {
+            let is_user_media = request.is::<UserMediaPermissionRequest>();
+            let is_trusted_uri = webview.uri().as_deref().is_some_and(is_buzz_origin);
+
+            if is_user_media && is_trusted_uri {
+                request.allow();
+                true
+            } else {
+                false
+            }
+        });
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_buzz_origin;
+
+    #[test]
+    fn accepts_release_and_development_origins() {
+        assert!(is_buzz_origin("tauri://localhost"));
+        assert!(is_buzz_origin("tauri://localhost/"));
+        assert!(is_buzz_origin("tauri://localhost/index.html"));
+        assert!(is_buzz_origin("http://localhost:1420/"));
+    }
+
+    #[test]
+    fn rejects_lookalike_and_remote_origins() {
+        assert!(!is_buzz_origin("https://example.com/"));
+        assert!(!is_buzz_origin("tauri://localhost.evil.example/"));
+        assert!(!is_buzz_origin("https://tauri.localhost/"));
+        assert!(!is_buzz_origin("http://localhost:14200/"));
+        assert!(!is_buzz_origin("http://localhost:1420.evil.example/"));
+    }
+}


### PR DESCRIPTION
## Summary

- enable WebKitGTK media-stream support when the Linux main webview is ready
- grant user-media permission requests only for Buzz's bundled UI and configured Vite development origin
- leave every other permission type and navigated origin to WebKit's default handling
- cover the trusted-origin boundary with focused unit tests

## Root cause

WebKitGTK delegates `getUserMedia` permission decisions to the embedding application. Buzz did not handle `WebKitUserMediaPermissionRequest`, so WebKit denied microphone access without showing a prompt and Linux Huddles failed with `NotAllowedError`.

## Impact

Linux users can acquire their microphone for Huddles while navigated or untrusted content remains unable to inherit user-media permission.

Closes #3495.

## Validation

- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml webkit_permissions`
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml`
- `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings`
- production-profile runtime test on Arch Linux, KDE Wayland, and WebKitGTK: Huddle microphone capture became active without the previous permission rejection
