### PR TITLE
Show counted working spinners throughout the sidebar

### DIFF
--- a/desktop/src/features/search/ui/SearchChannelActivityIndicator.test.mjs
+++ b/desktop/src/features/search/ui/SearchChannelActivityIndicator.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SearchChannelActivityIndicator } from "./SearchChannelActivityIndicator.tsx";
+
+const activeWorking = {
+  agentCount: 1,
+  agentNames: ["Honey"],
+  agentPubkeys: ["honey-pubkey"],
+  anchorAt: Date.now(),
+  channelId: "recent-channel",
+};
+
+describe("SearchChannelActivityIndicator", () => {
+  it("replaces an active recent timestamp with the shared working spinner", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SearchChannelActivityIndicator, {
+        channelName: "recent-channel",
+        summary: activeWorking,
+        timestampLabel: "2m ago",
+      }),
+    );
+
+    assert.match(html, /lucide-loader-circle/);
+    assert.match(html, /motion-safe:animate-spin/);
+    assert.match(html, /\binline-flex\b/);
+    assert.doesNotMatch(html, /(?:class="| )hidden(?: |")/);
+    assert.match(html, /aria-label="Honey working"/);
+    assert.doesNotMatch(html, /2m ago/);
+  });
+
+  it("keeps the activity timestamp when the recent channel is idle", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SearchChannelActivityIndicator, {
+        channelName: "recent-channel",
+        timestampLabel: "2m ago",
+      }),
+    );
+
+    assert.match(html, />2m ago</);
+    assert.doesNotMatch(html, /lucide-loader-circle/);
+  });
+});

--- a/desktop/src/features/search/ui/SearchChannelActivityIndicator.test.mjs
+++ b/desktop/src/features/search/ui/SearchChannelActivityIndicator.test.mjs
@@ -43,4 +43,23 @@ describe("SearchChannelActivityIndicator", () => {
     assert.match(html, />2m ago</);
     assert.doesNotMatch(html, /lucide-loader-circle/);
   });
+
+  it("shows the active process count inside the recent-channel spinner", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(SearchChannelActivityIndicator, {
+        channelName: "recent-channel",
+        summary: {
+          ...activeWorking,
+          agentCount: 3,
+          agentNames: ["Honey", "Fizz", "Bumble"],
+          agentPubkeys: ["honey-pubkey", "fizz-pubkey", "bumble-pubkey"],
+        },
+        timestampLabel: "2m ago",
+      }),
+    );
+
+    assert.match(html, /data-testid="channel-working-count-recent-channel"/);
+    assert.match(html, />3</);
+    assert.doesNotMatch(html, /2m ago/);
+  });
 });

--- a/desktop/src/features/search/ui/SearchChannelActivityIndicator.tsx
+++ b/desktop/src/features/search/ui/SearchChannelActivityIndicator.tsx
@@ -1,0 +1,29 @@
+import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
+import { ChannelWorkingIndicator } from "@/features/sidebar/ui/SidebarSection";
+
+export function SearchChannelActivityIndicator({
+  channelName,
+  summary,
+  timestampLabel,
+}: {
+  channelName: string;
+  summary?: ActiveChannelTurnSummary;
+  timestampLabel: string | null;
+}) {
+  if (summary) {
+    return (
+      <ChannelWorkingIndicator
+        channelName={channelName}
+        className="inline-flex text-muted-foreground/60"
+        isActive={false}
+        summary={summary}
+      />
+    );
+  }
+
+  return timestampLabel ? (
+    <span className="shrink-0 text-2xs text-muted-foreground/75">
+      {timestampLabel}
+    </span>
+  ) : null;
+}

--- a/desktop/src/features/search/ui/TopbarSearch.tsx
+++ b/desktop/src/features/search/ui/TopbarSearch.tsx
@@ -12,7 +12,9 @@ import {
   resultTestId,
   type SearchResult,
 } from "@/features/search/ui/SearchResultItem";
+import { SearchChannelActivityIndicator } from "@/features/search/ui/SearchChannelActivityIndicator";
 import { SearchPromptPlaceholder } from "@/features/search/ui/SearchPromptPlaceholder";
+import { useActiveWorkingChannelsById } from "@/features/sidebar/lib/useActiveWorkingChannelsById";
 import type { Channel, SearchHit, UserSearchResult } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
@@ -400,6 +402,7 @@ export function TopbarSearch({
   suggestionChannels,
   variant = "bar",
 }: TopbarSearchProps) {
+  const activeWorkingByChannelId = useActiveWorkingChannelsById();
   const [isOpen, setIsOpen] = React.useState(false);
   const [selectedMenuIndex, setSelectedMenuIndex] = React.useState(0);
   const triggerRef = React.useRef<HTMLButtonElement>(null);
@@ -663,6 +666,10 @@ export function TopbarSearch({
         : result.kind === "message"
           ? formatRelativeTime(result.hit.createdAt)
           : null;
+    const activeWorking =
+      result.kind === "channel"
+        ? activeWorkingByChannelId.get(result.channel.id)
+        : undefined;
 
     return (
       <button
@@ -746,10 +753,12 @@ export function TopbarSearch({
             </span>
           )}
         </span>
-        {result.kind !== "message" && trailingLabel ? (
-          <span className="shrink-0 text-2xs text-muted-foreground/75">
-            {trailingLabel}
-          </span>
+        {result.kind === "channel" ? (
+          <SearchChannelActivityIndicator
+            channelName={result.channel.name}
+            summary={activeWorking}
+            timestampLabel={trailingLabel}
+          />
         ) : null}
       </button>
     );

--- a/desktop/src/features/sidebar/ui/SidebarSection.test.mjs
+++ b/desktop/src/features/sidebar/ui/SidebarSection.test.mjs
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { formatWorkingTooltip } from "./SidebarSection.tsx";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  ChannelMenuButton,
+  ChannelWorkingIndicator,
+  formatWorkingTooltip,
+} from "./SidebarSection.tsx";
+import { SidebarProvider } from "../../../shared/ui/sidebar.tsx";
 
 function summary(agentNames, agentCount = agentNames.length) {
   return {
@@ -13,6 +21,28 @@ function summary(agentNames, agentCount = agentNames.length) {
       (_, index) => `agent-${index}-pubkey`,
     ),
     agentNames,
+  };
+}
+
+function channel(name, channelType, visibility = "open") {
+  return {
+    id: `${channelType}-${visibility}-${name}`,
+    name,
+    channelType,
+    visibility,
+    description: "",
+    topic: null,
+    purpose: null,
+    memberCount: 2,
+    memberPubkeys: [],
+    lastMessageAt: null,
+    archivedAt: null,
+    participants: [],
+    participantPubkeys:
+      channelType === "dm" ? ["viewer-pubkey", "agent-pubkey"] : [],
+    isMember: true,
+    ttlSeconds: null,
+    ttlDeadline: null,
   };
 }
 
@@ -48,5 +78,56 @@ describe("formatWorkingTooltip", () => {
       formatWorkingTooltip(summary(["Ned"], 3)),
       "Ned and 2 agents working",
     );
+  });
+});
+
+describe("ChannelWorkingIndicator", () => {
+  it("renders a subtle spinner instead of an elapsed-time counter", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ChannelWorkingIndicator, {
+        channelName: "agent-work",
+        isActive: false,
+        summary: summary(["Ned"]),
+      }),
+    );
+
+    assert.match(html, /lucide-loader-circle/);
+    assert.match(html, /motion-safe:animate-spin/);
+    assert.match(html, /text-sidebar-foreground\/45/);
+    assert.match(html, /aria-label="Ned working"/);
+    assert.doesNotMatch(html, /tabular-nums/);
+    assert.doesNotMatch(html, />0s</);
+  });
+});
+
+describe("ChannelMenuButton", () => {
+  it("uses the spinner for every supported left-nav channel item type", () => {
+    const itemTypes = [
+      channel("general", "stream"),
+      channel("private-team", "stream", "private"),
+      channel("help-forum", "forum"),
+      channel("agent-dm", "dm", "private"),
+    ];
+
+    for (const item of itemTypes) {
+      const html = renderToStaticMarkup(
+        React.createElement(
+          SidebarProvider,
+          null,
+          React.createElement(ChannelMenuButton, {
+            activeWorking: summary(["Ned"]),
+            channel: item,
+            hasUnread: false,
+            isActive: false,
+            onSelectChannel() {},
+          }),
+        ),
+      );
+
+      assert.match(html, /lucide-loader-circle/, item.name);
+      assert.match(html, /motion-safe:animate-spin/, item.name);
+      assert.doesNotMatch(html, /tabular-nums/, item.name);
+      assert.doesNotMatch(html, />0s</, item.name);
+    }
   });
 });

--- a/desktop/src/features/sidebar/ui/SidebarSection.test.mjs
+++ b/desktop/src/features/sidebar/ui/SidebarSection.test.mjs
@@ -96,12 +96,30 @@ describe("ChannelWorkingIndicator", () => {
     assert.match(html, /text-sidebar-foreground\/45/);
     assert.match(html, /aria-label="Ned working"/);
     assert.doesNotMatch(html, /tabular-nums/);
+    assert.doesNotMatch(html, /channel-working-count-agent-work/);
     assert.doesNotMatch(html, />0s</);
+  });
+
+  it("centers the active process count inside the spinner when multiple are working", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ChannelWorkingIndicator, {
+        channelName: "agent-work",
+        isActive: false,
+        summary: summary(["Ned", "Bart", "Carl"]),
+      }),
+    );
+
+    assert.match(html, /lucide-loader-circle/);
+    assert.match(html, /data-testid="channel-working-count-agent-work"/);
+    assert.match(html, /aria-hidden="true"/);
+    assert.match(html, /text-3xs/);
+    assert.match(html, /tabular-nums/);
+    assert.match(html, />3</);
   });
 });
 
 describe("ChannelMenuButton", () => {
-  it("uses the spinner for every supported left-nav channel item type", () => {
+  it("uses the counted spinner for every supported left-nav channel item type", () => {
     const itemTypes = [
       channel("general", "stream"),
       channel("private-team", "stream", "private"),
@@ -115,7 +133,7 @@ describe("ChannelMenuButton", () => {
           SidebarProvider,
           null,
           React.createElement(ChannelMenuButton, {
-            activeWorking: summary(["Ned"]),
+            activeWorking: summary(["Ned", "Bart", "Carl"]),
             channel: item,
             hasUnread: false,
             isActive: false,
@@ -126,7 +144,13 @@ describe("ChannelMenuButton", () => {
 
       assert.match(html, /lucide-loader-circle/, item.name);
       assert.match(html, /motion-safe:animate-spin/, item.name);
-      assert.doesNotMatch(html, /tabular-nums/, item.name);
+      assert.match(
+        html,
+        new RegExp(`channel-working-count-${item.name}`),
+        item.name,
+      );
+      assert.match(html, /tabular-nums/, item.name);
+      assert.match(html, />3</, item.name);
       assert.doesNotMatch(html, />0s</, item.name);
     }
   });

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -121,10 +121,12 @@ export function formatWorkingTooltip(
 
 export function ChannelWorkingIndicator({
   channelName,
+  className,
   isActive,
   summary,
 }: {
   channelName: string;
+  className?: string;
   isActive: boolean;
   summary: ActiveChannelTurnSummary;
 }) {
@@ -138,6 +140,7 @@ export function ChannelWorkingIndicator({
         isActive
           ? "text-sidebar-active-foreground/65"
           : "text-sidebar-foreground/45",
+        className,
       )}
       data-testid={`channel-working-${channelName}`}
       role="status"

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -5,6 +5,7 @@ import {
   CircleDot,
   FileText,
   Hash,
+  LoaderCircle,
   Lock,
   X,
 } from "lucide-react";
@@ -17,7 +18,6 @@ import {
 
 import { ChannelContextMenuItems } from "@/features/sidebar/ui/ChannelContextMenu";
 import type { ActiveChannelTurnSummary } from "@/features/agents/activeAgentTurnsStore";
-import { formatElapsed } from "@/features/agents/ui/agentSessionUtils";
 import { getEphemeralChannelDisplay } from "@/features/channels/lib/ephemeralChannel";
 import { EphemeralChannelBadge } from "@/features/channels/ui/EphemeralChannelBadge";
 import {
@@ -27,7 +27,6 @@ import {
 } from "@/features/profile/ui/ProfileAvatarWithStatus";
 import type { Channel, PresenceStatus } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
-import { useNow } from "@/shared/lib/useNow";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -120,7 +119,7 @@ export function formatWorkingTooltip(
   return `${leadName} and ${formatAgentCount(remainingAgentCount)} working`;
 }
 
-function ChannelWorkingBadge({
+export function ChannelWorkingIndicator({
   channelName,
   isActive,
   summary,
@@ -129,24 +128,25 @@ function ChannelWorkingBadge({
   isActive: boolean;
   summary: ActiveChannelTurnSummary;
 }) {
-  const now = useNow(1000);
-  const elapsed = formatElapsed(now - summary.anchorAt);
-  const label =
-    summary.agentCount > 1 ? `${elapsed} (${summary.agentCount})` : elapsed;
   const title = formatWorkingTooltip(summary);
 
   return (
     <span
+      aria-label={title}
       className={cn(
-        "hidden max-w-32 shrink-0 truncate rounded-full px-1.5 py-0.5 text-2xs font-medium leading-none tabular-nums motion-safe:animate-pulse group-data-[collapsible=icon]:hidden sm:inline-flex",
+        "hidden size-5 shrink-0 items-center justify-center group-data-[collapsible=icon]:hidden sm:inline-flex",
         isActive
-          ? "bg-sidebar-active-foreground/20 text-sidebar-active-foreground"
-          : "bg-primary/10 text-primary",
+          ? "text-sidebar-active-foreground/65"
+          : "text-sidebar-foreground/45",
       )}
       data-testid={`channel-working-${channelName}`}
+      role="status"
       title={title}
     >
-      {label}
+      <LoaderCircle
+        aria-hidden="true"
+        className="size-3.5 motion-safe:animate-spin"
+      />
     </span>
   );
 }
@@ -305,7 +305,7 @@ export function ChannelMenuButton({
         />
       ) : null}
       {activeWorking ? (
-        <ChannelWorkingBadge
+        <ChannelWorkingIndicator
           channelName={channel.name}
           isActive={isActive}
           summary={activeWorking}

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -136,7 +136,7 @@ export function ChannelWorkingIndicator({
     <span
       aria-label={title}
       className={cn(
-        "hidden size-5 shrink-0 items-center justify-center group-data-[collapsible=icon]:hidden sm:inline-flex",
+        "relative hidden size-5 shrink-0 items-center justify-center group-data-[collapsible=icon]:hidden sm:inline-flex",
         isActive
           ? "text-sidebar-active-foreground/65"
           : "text-sidebar-foreground/45",
@@ -150,6 +150,15 @@ export function ChannelWorkingIndicator({
         aria-hidden="true"
         className="size-3.5 motion-safe:animate-spin"
       />
+      {summary.agentCount > 1 ? (
+        <span
+          aria-hidden="true"
+          className="absolute inset-0 flex items-center justify-center text-3xs font-semibold leading-none tabular-nums"
+          data-testid={`channel-working-count-${channelName}`}
+        >
+          {summary.agentCount}
+        </span>
+      ) : null}
     </span>
   );
 }

--- a/desktop/tests/e2e/active-turn-resilience.spec.ts
+++ b/desktop/tests/e2e/active-turn-resilience.spec.ts
@@ -128,6 +128,12 @@ test.describe("active turn badge resilience", () => {
     const engineeringBadge = page.getByTestId("channel-working-engineering");
     await expect(generalBadge).toBeVisible({ timeout: 5_000 });
     await expect(engineeringBadge).toBeVisible();
+    await expect(page.getByTestId("channel-working-count-general")).toHaveText(
+      "2",
+    );
+    await expect(
+      page.getByTestId("channel-working-count-engineering"),
+    ).toHaveCount(0);
 
     // Simulate the all-at-once relay drop: no further frames, advance the clock
     // past both thresholds. This fires several real prune ticks; shouldPausePrune


### PR DESCRIPTION
## Summary

- replace elapsed-time working badges with the shared subtle spinner across standard channels, custom Spaces, forums, and DMs
- show the same working spinner in Recents
- center a tiny concurrent-process count inside the spinner when more than one agent is active
- preserve accessible status labels and reduced-motion behavior

## Why

Working status was inconsistent across left-nav surfaces: DMs showed a spinner while other channel rows and Recents retained counters or timestamps. The shared indicator now expresses the same state everywhere without shifting row layout.

## Validation

- `just ci`
- full desktop unit suite: 3,775 tests passed
- rendered Playwright regression: `active-turn-resilience.spec.ts` passed with two active agents in one channel and one in another
- visual sidebar review at 256×720
- pre-push desktop check and unit-test hooks passed at `b4b6ee26c8e329d65a469b74508f054ee4ee8de0`

## Buzz context

[Originating conversation](buzz://message?channel=f92eb581-ec91-4035-9cf6-ff6ea004018b&id=49bab110982e750f2bae2124835d02e34ff6c0d03a9e71ac9a03fc8112f09a0f&thread=2ed894d544f2d7b5dc28cbb729575702c27c735195b0edeffebd81a2ff5c2cd6)