### PR TITLE
feat(cli): scope buzz messages search by channel, kind, and upper time bound

### DIFF
--- a/crates/buzz-cli/README.md
+++ b/crates/buzz-cli/README.md
@@ -36,6 +36,9 @@ buzz messages get --channel <uuid> --limit 20
 buzz messages thread --channel <uuid> --event <event-id>
 buzz messages search --query "architecture"
 buzz messages search --author <pubkey|npub|name> --since <unix-ts>
+buzz messages search --query "architecture" --channel <uuid>          # scope to one channel
+buzz messages search --query "architecture" --since <ts> --until <ts> # bound both ends
+buzz messages search --query "architecture" --kinds 9,45001,45003     # override default kinds
 buzz messages edit --event <event-id> --content "Updated text"
 buzz messages delete --event <event-id>
 

--- a/crates/buzz-cli/src/commands/messages.rs
+++ b/crates/buzz-cli/src/commands/messages.rs
@@ -337,11 +337,60 @@ pub async fn cmd_get_thread(
     Ok(())
 }
 
+/// Kinds searched when `--kind` is not supplied: chat, channel metadata,
+/// forum posts, and forum comments.
+const DEFAULT_SEARCH_KINDS: &[u16] = &[9, 40002, 45001, 45003];
+
+/// Build the relay filter for `messages search`.
+///
+/// Split out of [`cmd_search`] so the filter shape is testable without a
+/// relay. Omitting every optional argument produces the same object the
+/// command sent before `--channel`, `--until`, and `--kind` existed.
+fn build_search_filter(
+    query: Option<&str>,
+    author_hex: Option<&str>,
+    since: Option<i64>,
+    until: Option<i64>,
+    channel: Option<&str>,
+    kinds: &[u16],
+    limit: u32,
+) -> serde_json::Value {
+    let kind_list: Vec<u16> = if kinds.is_empty() {
+        DEFAULT_SEARCH_KINDS.to_vec()
+    } else {
+        kinds.to_vec()
+    };
+    let mut filter = serde_json::json!({
+        "kinds": kind_list,
+        "limit": limit
+    });
+    if let Some(q) = query {
+        filter["search"] = serde_json::json!(q);
+    }
+    if let Some(pk) = author_hex {
+        filter["authors"] = serde_json::json!([pk]);
+    }
+    if let Some(s) = since {
+        filter["since"] = serde_json::json!(s);
+    }
+    if let Some(u) = until {
+        filter["until"] = serde_json::json!(u);
+    }
+    if let Some(c) = channel {
+        filter["#h"] = serde_json::json!([c]);
+    }
+    filter
+}
+
+#[allow(clippy::too_many_arguments)]
 pub async fn cmd_search(
     client: &BuzzClient,
     query: Option<&str>,
     author: Option<&str>,
     since: Option<i64>,
+    until: Option<i64>,
+    channel: Option<&str>,
+    kinds: &[u16],
     limit: Option<u32>,
     format: &crate::OutputFormat,
 ) -> Result<(), CliError> {
@@ -350,6 +399,16 @@ pub async fn cmd_search(
             "at least one of --query or --author is required".into(),
         ));
     }
+    if let (Some(s), Some(u)) = (since, until) {
+        if s > u {
+            return Err(CliError::Usage(
+                "--since must not be later than --until".into(),
+            ));
+        }
+    }
+    if let Some(c) = channel {
+        crate::validate::validate_uuid(c)?;
+    }
     let limit = limit.unwrap_or(20).min(100);
 
     let author_hex = match author {
@@ -357,19 +416,15 @@ pub async fn cmd_search(
         None => None,
     };
 
-    let mut filter = serde_json::json!({
-        "kinds": [9, 40002, 45001, 45003],
-        "limit": limit
-    });
-    if let Some(q) = query {
-        filter["search"] = serde_json::json!(q);
-    }
-    if let Some(ref pk) = author_hex {
-        filter["authors"] = serde_json::json!([pk]);
-    }
-    if let Some(s) = since {
-        filter["since"] = serde_json::json!(s);
-    }
+    let filter = build_search_filter(
+        query,
+        author_hex.as_deref(),
+        since,
+        until,
+        channel,
+        kinds,
+        limit,
+    );
     let resp = client.query(&filter).await?;
     let mut events: Vec<serde_json::Value> = serde_json::from_str(&resp).unwrap_or_default();
     // The full-text path returns relevance order; a pure author/time query has
@@ -856,6 +911,9 @@ pub async fn dispatch(
             query,
             author,
             since,
+            until,
+            channel,
+            kinds,
             limit,
         } => {
             cmd_search(
@@ -863,6 +921,9 @@ pub async fn dispatch(
                 query.as_deref(),
                 author.as_deref(),
                 since,
+                until,
+                channel.as_deref(),
+                &kinds,
                 limit,
                 format,
             )
@@ -1163,5 +1224,77 @@ mod tests {
             profile_event(PK_VALID_A, Some("Aaron"), None),
         ];
         assert_eq!(match_profiles_by_name(&events, "Aaron").len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod search_filter_tests {
+    use super::build_search_filter;
+    use serde_json::json;
+
+    const UUID: &str = "0b7f9c2e-3d4a-4b1c-8e5f-6a7b8c9d0e1f";
+    const PUBKEY: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+
+    #[test]
+    fn defaults_to_the_four_message_kinds_when_no_kind_flag_is_given() {
+        let f = build_search_filter(Some("deploy"), None, None, None, None, &[], 20);
+        assert_eq!(f["kinds"], json!([9, 40002, 45001, 45003]));
+    }
+
+    #[test]
+    fn explicit_kinds_replace_the_defaults() {
+        let f = build_search_filter(Some("deploy"), None, None, None, None, &[9, 40002], 20);
+        assert_eq!(f["kinds"], json!([9, 40002]));
+    }
+
+    #[test]
+    fn channel_becomes_an_h_tag_filter() {
+        let f = build_search_filter(Some("deploy"), None, None, None, Some(UUID), &[], 20);
+        assert_eq!(f["#h"], json!([UUID]));
+    }
+
+    #[test]
+    fn no_h_key_at_all_when_channel_is_absent() {
+        let f = build_search_filter(Some("deploy"), None, None, None, None, &[], 20);
+        assert!(f.get("#h").is_none(), "unscoped search must not send #h");
+    }
+
+    #[test]
+    fn until_is_passed_through_when_present_and_absent_otherwise() {
+        let with = build_search_filter(
+            Some("deploy"),
+            None,
+            None,
+            Some(1_784_102_400),
+            None,
+            &[],
+            20,
+        );
+        assert_eq!(with["until"], json!(1_784_102_400));
+        let without = build_search_filter(Some("deploy"), None, None, None, None, &[], 20);
+        assert!(without.get("until").is_none());
+    }
+
+    #[test]
+    fn omitting_every_new_flag_reproduces_the_previous_filter_exactly() {
+        let f = build_search_filter(
+            Some("checkout"),
+            Some(PUBKEY),
+            Some(1_783_497_600),
+            None,
+            None,
+            &[],
+            20,
+        );
+        assert_eq!(
+            f,
+            json!({
+                "kinds": [9, 40002, 45001, 45003],
+                "limit": 20,
+                "search": "checkout",
+                "authors": [PUBKEY],
+                "since": 1_783_497_600
+            })
+        );
     }
 }

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -471,7 +471,7 @@ pub enum MessagesCmd {
     },
     /// Full-text search across messages
     #[command(
-        after_help = "Examples:\n  buzz messages search --query checkout\n  buzz messages search --author npub1... --since 1783497600\n  buzz messages search --author Aaron --query checkout --limit 20"
+        after_help = "Examples:\n  buzz messages search --query checkout\n  buzz messages search --author npub1... --since 1783497600\n  buzz messages search --author Aaron --query checkout --limit 20\n  buzz messages search --query deploy --channel <UUID>\n  buzz messages search --query deploy --since 1783497600 --until 1784102400\n  buzz messages search --query deploy --kinds 9,45001,45003"
     )]
     Search {
         /// Search query string (optional when --author is given)
@@ -483,6 +483,15 @@ pub enum MessagesCmd {
         /// Unix timestamp — return messages after this time
         #[arg(long)]
         since: Option<i64>,
+        /// Unix timestamp — return messages before this time
+        #[arg(long)]
+        until: Option<i64>,
+        /// Channel UUID — restrict results to one channel (from 'buzz channels list')
+        #[arg(long)]
+        channel: Option<String>,
+        /// Nostr event kinds to search (comma-separated) — defaults to chat, channel, and forum kinds
+        #[arg(long, value_delimiter = ',')]
+        kinds: Vec<u16>,
         /// Maximum number of results to return
         #[arg(long)]
         limit: Option<u32>,


### PR DESCRIPTION
## Summary

![buzz messages search scoped by channel, kind, and upper time bound](https://raw.githubusercontent.com/mvanhorn/buzz/3a192299bb82900ba9ab0a10bad79580815cf48b/pr-3561-demo.gif)

<sub>Simulated demo. Every terminal frame is verbatim captured output — the opening is this branch's parent commit rejecting `--channel` before the flags existed. No search results are shown; the filter shapes are the ones the new unit tests assert.</sub>

`buzz messages search` accepts `--query`, `--author`, `--since`, and `--limit`. It builds its relay filter with a hardcoded `kinds` array and no channel constraint, so an agent asking "what did we say about the checkout bug in #eng-relay last week" has to pull unscoped hits and filter client-side.

All three capabilities already exist on the other side of the wire:

- `SearchQuery` in `buzz-search` declares both `since` and `until` ("NIP-01 until (Unix seconds). Inclusive upper bound on `created_at`"). `--since` was reachable; `--until` was not.
- Every other channel-scoped read path in this crate already sends `"#h"` — `cmd_get_messages` (`messages.rs:277`), `cmd_thread` (`:321`), plus `channels.rs` and `workflows.rs`. Search was the one read path that could not narrow to a room.
- `SearchQuery.kinds` is `Option<Vec<i32>>`, but the CLI pinned four values.

This adds three optional flags that map onto NIP-01 filter fields the relay already honors on this exact code path:

| flag | filter field |
|---|---|
| `--channel <UUID>` | `"#h": [uuid]` |
| `--until <UNIX_SECONDS>` | `"until": n` |
| `--kinds <N,N,...>` | replaces the default `kinds` array |

`--kinds` is named to match `AGENTS.md`, which already instructs agents to "pass at least `--kinds 9,45001,45003` to scope the query" to avoid the relay p-gate. That flag did not exist yet, so the documented invocation was not previously possible.

Two guards fire locally, before any network call, matching the existing "at least one of --query or --author is required" check:

- `--since` later than `--until` returns `CliError::Usage`.
- A malformed `--channel` goes through the crate's existing `validate_uuid` rather than becoming a silent zero-hit query.

The filter construction moves into `build_search_filter` so its shape is testable without a relay. `cmd_search` calls it; behavior is otherwise unchanged.

### Related issue

None found. Searched open issues and PRs for `messages search`, `search channel`, and `search until` — no duplicates.

Closest prior art is #1665 (`feat(cli): --author and --since filters on buzz messages search`, merged), which widened this command's filter surface and stopped short of channel scope and the upper time bound. #712 (`feat(cli): add channels search`, merged) is the same shape of change one command group over.

### Testing

`cargo test -p buzz-cli` — 258 passed, 0 failed. Six new unit tests in `commands::messages::search_filter_tests` cover the filter shape without needing a relay:

- default kinds when `--kinds` is omitted → `[9, 40002, 45001, 45003]`
- explicit kinds replace the defaults
- `--channel` → `filter["#h"] == [uuid]`
- `--channel` absent → no `#h` key at all (regression guard on the existing unscoped path)
- `--until` present and absent
- **all three flags omitted → filter is byte-identical to what the command sent before**, asserted against a literal

`just fmt` and `cargo clippy -p buzz-cli --all-targets -- -D warnings` are both clean.

Local verification against the built binary:

```
$ buzz messages search --help
      --query <QUERY>      Search query string (optional when --author is given)
      --author <AUTHOR>    Filter by author: 64-char hex pubkey, npub, or display name
      --since <SINCE>      Unix timestamp — return messages after this time
      --until <UNTIL>      Unix timestamp — return messages before this time
      --channel <CHANNEL>  Channel UUID — restrict results to one channel (from 'buzz channels list')
      --kinds <KINDS>      Nostr event kinds to search (comma-separated) — defaults to chat, channel, and forum kinds
      --limit <LIMIT>      Maximum number of results to return

$ buzz messages search --query x --since 200 --until 100
{"error":"user_error","message":"--since must not be later than --until","retryable":false}

$ buzz messages search --query x --channel not-a-uuid
{"error":"user_error","message":"invalid UUID: not-a-uuid","retryable":false}
```

Both guards return before any relay connection is attempted.

No UI change. `crates/buzz-cli/README.md` documents the three flags.

---

AI was used for assistance. I wrote, ran, and reviewed the final code and tests.

