### PR TITLE
Serialize Tauri pre-push checks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -61,17 +61,12 @@ pre-push:
       glob: ["desktop/**", "pnpm-lock.yaml"]
       exclude: ["desktop/src-tauri/**"]
       run: just desktop-test
-    desktop-tauri-clippy:
+    desktop-tauri-checks:
       # Keep local lint parity with Desktop Core CI for every path that can
-      # affect the Tauri crate or its path dependencies.
+      # affect the Tauri crate or its path dependencies. Run clippy and tests
+      # serially so parallel pre-push hooks do not contend for Cargo's lock.
       glob: ["desktop/src-tauri/**", "crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "justfile"]
-      run: just desktop-tauri-clippy
-    desktop-tauri-test:
-      # ci.yml:113 — Desktop Core triggers on `rust` OR `desktop-rust`;
-      # desktop/src-tauri path-depends on crates/buzz-core, buzz-persona,
-      # buzz-sdk, buzz-agent (desktop/src-tauri/Cargo.toml:88-91).
-      glob: ["desktop/src-tauri/**", "crates/**", "migrations/**", "schema/**", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "deny.toml", "scripts/run-tests.sh", "justfile"]
-      run: just desktop-tauri-test
+      run: just desktop-tauri-clippy && just desktop-tauri-test
     mobile-test:
       glob: ["mobile/**"]
       run: just mobile-test


### PR DESCRIPTION
## Summary

- combine Desktop Tauri clippy and tests into one pre-push command
- run clippy first, then tests
- keep unrelated pre-push commands parallel

## Why

PR #3555 added clippy as a separate command while the pre-push group uses `parallel: true`. That can start clippy and tests simultaneously against the same Cargo target directory, leaving one command waiting on Cargo's build lock and making pushes appear stalled.

Serializing only these two Cargo-heavy checks avoids lock contention while retaining the CI-equivalent clippy command and existing test coverage.

## Validation

- `lefthook validate`
- forced `desktop-tauri-checks` through Lefthook with an instrumented `just`; observed `desktop-tauri-clippy` followed by `desktop-tauri-test`
