### PR TITLE
fix(relay): always admit Desktop WebView CORS origins

### DIFF
--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -93,7 +93,12 @@ pub struct Config {
     pub require_auth_token: bool,
     /// Comma-separated list of allowed CORS origins.
     /// If empty, permissive CORS is used (dev mode).
-    /// Example: "tauri://localhost,http://localhost:3000"
+    /// Example: "tauri://localhost,http://tauri.localhost,https://tauri.localhost,http://localhost:3000"
+    ///
+    /// First-party Desktop origins (`tauri://localhost`, `http://tauri.localhost`,
+    /// `https://tauri.localhost`) are always merged in when this list is
+    /// non-empty — Windows WebView2 uses `http://tauri.localhost`, and omitting
+    /// it produces a silent "Failed to fetch" on Join community.
     pub cors_origins: Vec<String>,
     /// Optional hex-encoded private key for the relay's signing keypair.
     /// If absent, a fresh keypair is generated at startup.
@@ -268,6 +273,25 @@ pub struct Config {
     /// Whether the configured web bundle serves Git browser routes in addition
     /// to the public invite landing page. Defaults to false.
     pub serve_git_web_gui: bool,
+}
+
+/// Lockdown mode (non-empty CORS list) must still admit the fixed Desktop
+/// WebView origins. Windows WebView2 speaks `http://tauri.localhost`;
+/// macOS/Linux use `tauri://localhost`. An empty list stays empty so
+/// permissive CORS (dev mode) is unchanged.
+fn merge_desktop_cors_origins(cors_origins: &mut Vec<String>) {
+    if cors_origins.is_empty() {
+        return;
+    }
+    for origin in [
+        "tauri://localhost",
+        "http://tauri.localhost",
+        "https://tauri.localhost",
+    ] {
+        if !cors_origins.iter().any(|existing| existing == origin) {
+            cors_origins.push(origin.to_string());
+        }
+    }
 }
 
 fn parse_bind_addr(raw: &str) -> Result<SocketAddr, ConfigError> {
@@ -606,12 +630,13 @@ impl Config {
             );
         }
 
-        let cors_origins = std::env::var("BUZZ_CORS_ORIGINS")
+        let mut cors_origins: Vec<String> = std::env::var("BUZZ_CORS_ORIGINS")
             .unwrap_or_default()
             .split(',')
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
             .collect();
+        merge_desktop_cors_origins(&mut cors_origins);
 
         let relay_private_key = std::env::var("BUZZ_RELAY_PRIVATE_KEY").ok();
 
@@ -1304,6 +1329,23 @@ mod tests {
             !config.huddle_audio_available,
             "BUZZ_HUDDLE_AUDIO_AVAILABLE=false must disable huddle audio (multi-pod deployments)"
         );
+    }
+
+    #[test]
+    fn merge_desktop_cors_origins_fills_windows_webview_origin() {
+        let mut origins = vec!["https://buzz.example.com".to_string()];
+        merge_desktop_cors_origins(&mut origins);
+        assert!(origins.contains(&"https://buzz.example.com".to_string()));
+        assert!(origins.contains(&"tauri://localhost".to_string()));
+        assert!(origins.contains(&"http://tauri.localhost".to_string()));
+        assert!(origins.contains(&"https://tauri.localhost".to_string()));
+    }
+
+    #[test]
+    fn merge_desktop_cors_origins_leaves_empty_list_for_permissive_mode() {
+        let mut origins = Vec::new();
+        merge_desktop_cors_origins(&mut origins);
+        assert!(origins.is_empty());
     }
 
     #[test]

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -10,7 +10,7 @@ BUZZ_DOMAIN=buzz.example.com
 RELAY_URL=wss://buzz.example.com
 BUZZ_MEDIA_BASE_URL=https://buzz.example.com/media
 BUZZ_MEDIA_SERVER_DOMAIN=buzz.example.com
-BUZZ_CORS_ORIGINS=https://buzz.example.com
+BUZZ_CORS_ORIGINS=https://buzz.example.com,tauri://localhost,http://tauri.localhost,https://tauri.localhost
 
 # Production defaults. Closed relay mode requires RELAY_OWNER_PUBKEY and a stable relay key.
 BUZZ_REQUIRE_AUTH_TOKEN=true


### PR DESCRIPTION
## Summary
- When `BUZZ_CORS_ORIGINS` is set, always merge `tauri://localhost`, `http://tauri.localhost`, and `https://tauri.localhost`
- Document those origins in `deploy/compose/.env.example`
- Empty allowlist (dev permissive mode) is unchanged

Windows WebView2 uses `http://tauri.localhost`. Self-host configs built from the compose example or macOS-oriented guides omit it, so Join community fails with a silent "Failed to fetch" and nothing hits the relay logs (#3490).

## Test plan
- [x] Unit tests for `merge_desktop_cors_origins` (fills Windows origin; leaves empty list alone)
- [ ] Deploy with `BUZZ_CORS_ORIGINS=https://buzz.example.com` only — OPTIONS from `http://tauri.localhost` returns ACAO
- [ ] Windows Desktop Join community against that relay succeeds

Fixes #3490

Made with [Cursor](https://cursor.com)