### PR TITLE
chore(ci): bump Linux AppImage build container to ubuntu:24.04

### DIFF
--- a/.github/workflows/linux-canary.yml
+++ b/.github/workflows/linux-canary.yml
@@ -21,7 +21,7 @@ jobs:
     name: Build Linux canary
     if: github.repository == 'block/buzz'
     runs-on: ubuntu-latest
-    container: ubuntu:22.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982
+    container: ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -476,7 +476,7 @@ jobs:
     if: github.repository == 'block/buzz'
     runs-on: ubuntu-latest
     # Digest-pinned like the SHA-pinned actions below; Renovate keeps it fresh.
-    container: ubuntu:22.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982
+    container: ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
     needs: setup
     timeout-minutes: 60
     permissions:
@@ -498,7 +498,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          # Must run first: bare ubuntu:22.04 ships without curl, wget, git, or
+          # Must run first: bare ubuntu:24.04 ships without curl, wget, git, or
           # ca-certificates. activate-hermit bootstraps via curl+HTTPS (needs
           # both), and actions/checkout falls back to a REST tarball without git.
           # Running as root — no sudo needed.


### PR DESCRIPTION
## What and why

The Buzz AppImage is built on `ubuntu:22.04`, which links WebKitGTK against FreeType 2.11.1. Because `libfreetype.so.6` is on the linuxdeploy community excludelist, the bundled WebKit loads the **host's** FreeType at runtime instead of the bundled one.

FreeType 2.13.0 (released 2023-02-09) added `FT_Bool read_variable` to `FT_ColorStopIterator`, growing the struct from 16 to 20 bytes. Any host running FreeType ≥ 2.13 (Fedora 42+, Ubuntu 24.04+) has a struct-layout mismatch with the 22.04-compiled WebKit. The mismatched offsets corrupt color-stop index arithmetic inside Skia's COLRv1 renderer, producing the assertion abort in issues #2548 and #2982:

```
stl_vector.h:1123: Assertion '__n < this->size()' failed.
... colrv1_configure_skpaint(FT_Face, ...) ...
```

## Fix

Bump the build container to `ubuntu:24.04` (noble), which ships FreeType **2.13.2**. Noble's struct layout matches every crash-affected host. The ABI mismatch disappears and the crash is eliminated at root.

WebKitGTK also advances from **2.50.4** (jammy backport) to **2.52.3** (noble backport).

## Glibc floor change

| Build base | glibc floor | Oldest supported AppImage distro |
|---|---|---|
| ubuntu:22.04 (before) | 2.35 | Ubuntu 22.04 LTS, Debian 12 |
| ubuntu:24.04 (after) | 2.39 | Ubuntu 24.04 LTS, Fedora 40+ |

Ubuntu 22.04 LTS and Debian 12 users lose AppImage support. Both distributions continue to receive first-class `.deb` / `.rpm` packages, which use the system WebKit and are unaffected. The crash-affected users (Fedora 42/44, Ubuntu 24.04+) all have glibc ≥ 2.39.

## Changes

- `.github/workflows/linux-canary.yml:24` — container pin updated to `ubuntu:24.04@sha256:4fbb8e6a…`
- `.github/workflows/release.yml:479` — same container pin updated
- `.github/workflows/release.yml:501` — comment version string updated from 22.04 to 24.04

`fix-appimage.sh` and `desktop/src-tauri/**` are untouched. The #3573 fontconfig stopgap remains active; retirement is a separate follow-on PR once this fix is verified on a shipped build.

## Sequencing

`docs/linux-rendering-troubleshooting.md` (introduced in #3573) will receive a glibc-floor callout section once #3573 merges — adding it here would conflict with #3573's open branch.

Context: #2548, #2982.