### PR TITLE
feat(mobile): add native adaptive iPad workspace

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -495,7 +495,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
@@ -631,7 +631,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -683,7 +683,7 @@
 				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -84,5 +84,12 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 </dict>
 </plist>

--- a/mobile/lib/features/activity/activity_page.dart
+++ b/mobile/lib/features/activity/activity_page.dart
@@ -44,7 +44,9 @@ part 'activity_page/status_views.dart';
 /// navigation. Row taps deep-link to the represented message (oldest unread
 /// for grouped conversations) rather than just opening the channel.
 class ActivityPage extends HookConsumerWidget {
-  const ActivityPage({super.key});
+  const ActivityPage({super.key, this.title = 'Activity'});
+
+  final String title;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -286,7 +288,7 @@ class ActivityPage extends HookConsumerWidget {
       appBar: FrostedAppBar(
         gradient: context.appColors.topSectionGradient,
         automaticallyImplyLeading: false,
-        title: const Text('Activity'),
+        title: Text(title),
         titleStyle: headerTitleStyle,
         actions: [
           _FilterMenuButton(

--- a/mobile/lib/features/agents/agents_page.dart
+++ b/mobile/lib/features/agents/agents_page.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../shared/theme/theme.dart';
+import '../../shared/widgets/avatar_image.dart';
+import '../../shared/widgets/buzz_loading_indicator.dart';
+import '../../shared/widgets/frosted_app_bar.dart';
+import '../../shared/widgets/frosted_scaffold.dart';
+import '../channels/mentions/mention_candidates.dart';
+import '../channels/mentions/mention_candidates_provider.dart';
+import '../profile/presence_cache_provider.dart';
+import '../profile/profile_provider.dart';
+import '../profile/user_cache_provider.dart';
+import '../profile/user_profile.dart';
+import '../profile/user_profile_sheet.dart';
+
+/// Read-only mobile directory for agents advertised by the current community.
+class AgentsPage extends HookConsumerWidget {
+  const AgentsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final agentsAsync = ref.watch(agentDirectoryProvider);
+    final owners = ref.watch(agentOwnersProvider).asData?.value ?? const {};
+    final profiles = ref.watch(userCacheProvider);
+    final presence = ref.watch(presenceCacheProvider);
+    final currentPubkey = ref.watch(profileProvider).asData?.value?.pubkey;
+    final agents = agentsAsync.asData?.value ?? const <AgentDirectoryEntry>[];
+    final pubkeys = agents.map((agent) => agent.pubkey).toSet().toList()
+      ..sort();
+    final pubkeysKey = pubkeys.join(',');
+
+    useEffect(() {
+      if (pubkeys.isEmpty) return null;
+      ref.read(userCacheProvider.notifier).preload(pubkeys);
+      ref.read(presenceCacheProvider.notifier).track(pubkeys);
+      return null;
+    }, [pubkeysKey]);
+
+    return FrostedScaffold(
+      key: const Key('agents-page'),
+      appBar: const FrostedAppBar(
+        automaticallyImplyLeading: false,
+        title: Text('Agents'),
+      ),
+      body: Padding(
+        padding: EdgeInsets.only(top: frostedAppBarHeight(context)),
+        child: agentsAsync.when(
+          loading: () => const Center(
+            child: BuzzLoadingIndicator(
+              size: 40,
+              semanticLabel: 'Loading agents',
+            ),
+          ),
+          error: (_, _) => _AgentsStatus(
+            icon: LucideIcons.circleAlert,
+            message: 'Could not load agents.',
+            actionLabel: 'Retry',
+            onAction: () => ref.invalidate(agentDirectoryProvider),
+          ),
+          data: (rawAgents) {
+            final agentsByPubkey = {
+              for (final agent in rawAgents) agent.pubkey: agent,
+            };
+            final visibleAgents = agentsByPubkey.values.toList()
+              ..sort((a, b) {
+                final aName =
+                    profiles[a.pubkey]?.label ?? a.displayName ?? a.pubkey;
+                final bName =
+                    profiles[b.pubkey]?.label ?? b.displayName ?? b.pubkey;
+                return aName.toLowerCase().compareTo(bName.toLowerCase());
+              });
+
+            if (visibleAgents.isEmpty) {
+              return const _AgentsStatus(
+                icon: LucideIcons.bot,
+                message: 'No agents are advertising in this community yet.',
+              );
+            }
+
+            return ListView.separated(
+              padding: const EdgeInsets.fromLTRB(
+                Grid.gutter,
+                Grid.xxs,
+                Grid.gutter,
+                Grid.gutter,
+              ),
+              itemCount: visibleAgents.length,
+              separatorBuilder: (_, _) => const Divider(height: 1),
+              itemBuilder: (context, index) {
+                final agent = visibleAgents[index];
+                final profile = profiles[agent.pubkey];
+                final owner = owners[agent.pubkey] ?? profile?.ownerPubkey;
+                final ownerLabel = owner == null
+                    ? 'Community agent'
+                    : currentPubkey != null &&
+                          owner.toLowerCase() == currentPubkey.toLowerCase()
+                    ? 'Managed by you'
+                    : 'Externally managed';
+
+                return _AgentRow(
+                  agent: agent,
+                  profile: profile,
+                  ownerLabel: ownerLabel,
+                  presence: presence[agent.pubkey] ?? 'offline',
+                  onTap: () => showUserProfileSheet(context, agent.pubkey),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _AgentRow extends StatelessWidget {
+  const _AgentRow({
+    required this.agent,
+    required this.profile,
+    required this.ownerLabel,
+    required this.presence,
+    required this.onTap,
+  });
+
+  final AgentDirectoryEntry agent;
+  final UserProfile? profile;
+  final String ownerLabel;
+  final String presence;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final name =
+        profile?.label ?? agent.displayName ?? _shortPubkey(agent.pubkey);
+    final handle = profile?.nip05Handle?.trim();
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(vertical: Grid.half),
+      leading: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          AvatarImage(
+            imageUrl: profile?.avatarUrl,
+            radius: Grid.gutter,
+            backgroundColor: context.colors.primaryContainer,
+            fallback: Text(
+              profile?.initial ?? name.characters.first.toUpperCase(),
+              style: context.textTheme.labelLarge?.copyWith(
+                color: context.colors.onPrimaryContainer,
+              ),
+            ),
+          ),
+          Positioned(
+            right: -1,
+            bottom: -1,
+            child: Container(
+              width: 10,
+              height: 10,
+              decoration: BoxDecoration(
+                color: _presenceColor(context, presence),
+                shape: BoxShape.circle,
+                border: Border.all(color: context.colors.surface, width: 2),
+              ),
+            ),
+          ),
+        ],
+      ),
+      title: Text(name, maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: Text(
+        handle == null || handle.isEmpty ? ownerLabel : '$handle · $ownerLabel',
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: const Icon(LucideIcons.chevronRight, size: 18),
+      onTap: onTap,
+    );
+  }
+}
+
+class _AgentsStatus extends StatelessWidget {
+  const _AgentsStatus({
+    required this.icon,
+    required this.message,
+    this.actionLabel,
+    this.onAction,
+  });
+
+  final IconData icon;
+  final String message;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(Grid.gutter),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: Grid.xl, color: context.colors.onSurfaceVariant),
+            const SizedBox(height: Grid.xs),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: context.textTheme.bodyMedium?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+            if (actionLabel != null && onAction != null) ...[
+              const SizedBox(height: Grid.xs),
+              TextButton(onPressed: onAction, child: Text(actionLabel!)),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _shortPubkey(String pubkey) =>
+    pubkey.length <= 8 ? pubkey : '${pubkey.substring(0, 8)}…';
+
+Color _presenceColor(BuildContext context, String presence) =>
+    switch (presence) {
+      'online' => context.appColors.success,
+      'away' => context.appColors.warning,
+      _ => context.colors.outline,
+    };

--- a/mobile/lib/features/channels/channels_page.dart
+++ b/mobile/lib/features/channels/channels_page.dart
@@ -234,16 +234,7 @@ class ChannelsPage extends HookConsumerWidget {
         // branded gradient, the way desktop paints it across the sidebar. Null
         // under every other theme, leaving the default frosted fill.
         gradient: context.appColors.topSectionGradient,
-        leading: _CommunityIndicator(
-          onTap: () {
-            ref.invalidate(communityIconProvider);
-            showModalBottomSheet<void>(
-              context: context,
-              showDragHandle: true,
-              builder: (_) => const _CommunitySwitcherSheet(),
-            );
-          },
-        ),
+        leading: const CommunitySwitcherButton(),
         title: const SizedBox.shrink(),
         actions: [
           ProfileAvatar(

--- a/mobile/lib/features/channels/channels_page/body.dart
+++ b/mobile/lib/features/channels/channels_page/body.dart
@@ -40,7 +40,7 @@ class _ChannelsBody extends StatelessWidget {
             child: CustomScrollView(
               slivers: [
                 SliverToBoxAdapter(child: SizedBox(height: barHeight)),
-                _SliverChannelsList(
+                ChannelDirectorySliver(
                   channels: loadedChannels,
                   currentPubkey: currentPubkey,
                   onSelectChannel: onSelectChannel,
@@ -62,15 +62,21 @@ class _ChannelsBody extends StatelessWidget {
   }
 }
 
-class _SliverChannelsList extends HookConsumerWidget {
+/// Collapsible channel and direct-message sections shared by phone and iPad.
+class ChannelDirectorySliver extends HookConsumerWidget {
   final List<Channel> channels;
   final String? currentPubkey;
   final Future<void> Function(Channel channel) onSelectChannel;
+  final String directMessagesLabel;
+  final String? selectedChannelId;
 
-  const _SliverChannelsList({
+  const ChannelDirectorySliver({
+    super.key,
     required this.channels,
     required this.currentPubkey,
     required this.onSelectChannel,
+    this.directMessagesLabel = 'DMs',
+    this.selectedChannelId,
   });
 
   @override
@@ -212,6 +218,7 @@ class _SliverChannelsList extends HookConsumerWidget {
                 mutedChannelIds: mutedChannelIds,
                 currentPubkey: currentPubkey,
                 emptyLabel: '',
+                selectedChannelId: selectedChannelId,
                 onSelectChannel: onSelectChannel,
               ),
             // User-defined sections for stream channels, in user-defined order.
@@ -286,6 +293,7 @@ class _SliverChannelsList extends HookConsumerWidget {
                 onMoveDown: () => ref
                     .read(channelSectionsProvider.notifier)
                     .moveSectionDown(section.id),
+                selectedChannelId: selectedChannelId,
                 onSelectChannel: onSelectChannel,
                 onMarkChannelRead: (channel) {
                   final ts = dateTimeToUnixSeconds(channel.lastMessageAt);
@@ -316,10 +324,11 @@ class _SliverChannelsList extends HookConsumerWidget {
               mutedChannelIds: mutedChannelIds,
               currentPubkey: currentPubkey,
               emptyLabel: 'No stream channels yet',
+              selectedChannelId: selectedChannelId,
               onSelectChannel: onSelectChannel,
             ),
             _ChannelSection(
-              title: 'DMs',
+              title: directMessagesLabel,
               icon: LucideIcons.messagesSquare,
               showTopDivider: true,
               expanded: dmsExpanded.value,
@@ -330,6 +339,7 @@ class _SliverChannelsList extends HookConsumerWidget {
               mutedChannelIds: mutedChannelIds,
               currentPubkey: currentPubkey,
               emptyLabel: 'No direct messages yet',
+              selectedChannelId: selectedChannelId,
               onSelectChannel: onSelectChannel,
             ),
           ],

--- a/mobile/lib/features/channels/channels_page/channel_tile.dart
+++ b/mobile/lib/features/channels/channels_page/channel_tile.dart
@@ -5,6 +5,7 @@ class _ChannelTile extends ConsumerWidget {
   final int? unreadCount;
   final bool isUnread;
   final bool isMuted;
+  final bool selected;
   final String? currentPubkey;
   final VoidCallback onTap;
 
@@ -22,17 +23,27 @@ class _ChannelTile extends ConsumerWidget {
     required this.currentPubkey,
     required this.onTap,
     this.isMuted = false,
+    this.selected = false,
     this.onMarkRead,
     this.sectionId,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final foreground = selected
+        ? context.colors.onPrimaryContainer
+        : context.colors.onSurface;
+
     return InkWell(
       borderRadius: BorderRadius.circular(Radii.md),
       onTap: onTap,
       onLongPress: () => _showChannelActions(context, ref),
-      child: Padding(
+      child: Ink(
+        key: ValueKey('channel-tile-${channel.id}'),
+        decoration: BoxDecoration(
+          color: selected ? context.colors.primaryContainer : null,
+          borderRadius: BorderRadius.circular(Radii.md),
+        ),
         padding: const EdgeInsets.only(
           left: _kChannelSectionInset,
           right: _kChannelSectionInset,
@@ -50,7 +61,7 @@ class _ChannelTile extends ConsumerWidget {
                     : Icon(
                         channelIcon(channel),
                         size: _kChannelIconSize,
-                        color: context.colors.onSurface,
+                        color: foreground,
                       ),
               ),
             ),
@@ -67,7 +78,7 @@ class _ChannelTile extends ConsumerWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: contentListTitleTextStyle.copyWith(
-                      color: context.colors.onSurface,
+                      color: foreground,
                       fontWeight: isUnread ? FontWeight.w700 : FontWeight.w400,
                     ),
                   ),

--- a/mobile/lib/features/channels/channels_page/community.dart
+++ b/mobile/lib/features/channels/channels_page/community.dart
@@ -461,10 +461,9 @@ Future<void> _confirmRemoveCommunity(
   }
 }
 
-class _CommunityIndicator extends ConsumerWidget {
-  final VoidCallback onTap;
-
-  const _CommunityIndicator({required this.onTap});
+/// Community identity button shared by the phone header and tablet sidebar.
+class CommunitySwitcherButton extends ConsumerWidget {
+  const CommunitySwitcherButton({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -474,7 +473,14 @@ class _CommunityIndicator extends ConsumerWidget {
     final name = activeCommunity?.name;
 
     return GestureDetector(
-      onTap: onTap,
+      onTap: () {
+        ref.invalidate(communityIconProvider);
+        showModalBottomSheet<void>(
+          context: context,
+          showDragHandle: true,
+          builder: (_) => const _CommunitySwitcherSheet(),
+        );
+      },
       behavior: HitTestBehavior.opaque,
       child: Row(
         mainAxisSize: MainAxisSize.min,

--- a/mobile/lib/features/channels/channels_page/quick_actions_launcher.dart
+++ b/mobile/lib/features/channels/channels_page/quick_actions_launcher.dart
@@ -5,38 +5,79 @@ const _kQuickActionsTabMotionCurve = Cubic(0.77, 0, 0.175, 1);
 const _kQuickActionsHiddenOverlap = Grid.half;
 const _kQuickActionsHiddenScale = 0.8;
 
-/// Places the channel quick-actions button beside mobile navigation.
-///
-/// The button remains available only on Home and moves behind the navigation
-/// bar when another destination is selected.
+/// Explicit placement geometry for [ChannelQuickActionsLauncher].
+class ChannelQuickActionsPlacement {
+  final double rightInset;
+  final double closedBottomInset;
+  final double openBottomInset;
+  final double hiddenHorizontalOffset;
+
+  const ChannelQuickActionsPlacement._({
+    required this.rightInset,
+    required this.closedBottomInset,
+    required this.openBottomInset,
+    required this.hiddenHorizontalOffset,
+  });
+
+  /// Aligns the launcher beside a centered floating bottom navigation bar.
+  factory ChannelQuickActionsPlacement.besideBottomNavigation({
+    required double screenWidth,
+    required double navigationBarHeight,
+    required double navigationBarBottomGap,
+    required double navigationBarWidth,
+    required double systemBottomInset,
+    required double rightInset,
+  }) {
+    final navigationBottomInset = max(
+      systemBottomInset,
+      navigationBarBottomGap,
+    );
+    final verticalCentering = (navigationBarHeight - _kMorphClosedSize) / 2;
+    final closedBottomInset = navigationBottomInset + verticalCentering;
+    final navigationBarRight = (screenWidth + navigationBarWidth) / 2;
+    final launcherRight = screenWidth - rightInset;
+
+    return ChannelQuickActionsPlacement._(
+      rightInset: rightInset,
+      closedBottomInset: closedBottomInset,
+      openBottomInset:
+          closedBottomInset +
+          navigationBarHeight +
+          Grid.xxs -
+          verticalCentering,
+      hiddenHorizontalOffset:
+          navigationBarRight - launcherRight - _kQuickActionsHiddenOverlap,
+    );
+  }
+
+  /// Anchors the launcher to the bottom-trailing corner of its content pane.
+  factory ChannelQuickActionsPlacement.bottomTrailing({
+    required double systemBottomInset,
+    double bottomGap = Grid.gutter,
+    double rightInset = Grid.gutter,
+  }) {
+    final closedBottomInset = max(systemBottomInset, bottomGap);
+    return ChannelQuickActionsPlacement._(
+      rightInset: rightInset,
+      closedBottomInset: closedBottomInset,
+      openBottomInset: closedBottomInset + _kMorphClosedSize + Grid.xxs,
+      hiddenHorizontalOffset: 0,
+    );
+  }
+}
+
+/// Places and transitions the channel quick-actions button within its pane.
 class ChannelQuickActionsLauncher extends HookConsumerWidget {
-  /// Whether the launcher should be visible beside the navigation bar.
+  /// Whether the launcher should be visible on the current destination.
   final bool visible;
 
-  /// Height of the navigation bar used to vertically center the closed button.
-  final double navigationBarHeight;
+  /// Placement supplied by the navigation shell that owns the surrounding UI.
+  final ChannelQuickActionsPlacement placement;
 
-  /// Space between the navigation bar and the bottom safe area.
-  final double navigationBarBottomGap;
-
-  /// Full width of the navigation bar, including its inner edge padding.
-  final double navigationBarWidth;
-
-  /// Bottom system inset used by the navigation bar's [SafeArea].
-  final double systemBottomInset;
-
-  /// Distance between the launcher and the right edge of the screen.
-  final double rightInset;
-
-  /// Creates a launcher aligned with the supplied navigation geometry.
   const ChannelQuickActionsLauncher({
     super.key,
     required this.visible,
-    required this.navigationBarHeight,
-    required this.navigationBarBottomGap,
-    required this.navigationBarWidth,
-    required this.systemBottomInset,
-    required this.rightInset,
+    required this.placement,
   });
 
   @override
@@ -44,21 +85,7 @@ class ChannelQuickActionsLauncher extends HookConsumerWidget {
     final currentPubkey = ref.watch(currentPubkeyProvider);
     final quickActionsOpen = useState(false);
     final reducedMotion = MediaQuery.of(context).disableAnimations;
-    final navigationBottomInset = systemBottomInset > navigationBarBottomGap
-        ? systemBottomInset
-        : navigationBarBottomGap;
-    final closedBottomInset =
-        navigationBottomInset + ((navigationBarHeight - _kMorphClosedSize) / 2);
-    final openLift =
-        navigationBarHeight +
-        Grid.xxs -
-        ((navigationBarHeight - _kMorphClosedSize) / 2);
     final effectiveOpen = visible && quickActionsOpen.value;
-    final screenWidth = MediaQuery.sizeOf(context).width;
-    final navigationBarRight = (screenWidth + navigationBarWidth) / 2;
-    final launcherRight = screenWidth - rightInset;
-    final hiddenHorizontalOffset =
-        navigationBarRight - launcherRight - _kQuickActionsHiddenOverlap;
 
     useEffect(() {
       if (!visible && quickActionsOpen.value) {
@@ -130,8 +157,10 @@ class ChannelQuickActionsLauncher extends HookConsumerWidget {
               ? Duration.zero
               : _kQuickActionsTabMotionDuration,
           curve: _kQuickActionsTabMotionCurve,
-          right: rightInset,
-          bottom: closedBottomInset + (effectiveOpen ? openLift : 0),
+          right: placement.rightInset,
+          bottom: effectiveOpen
+              ? placement.openBottomInset
+              : placement.closedBottomInset,
           child: IgnorePointer(
             ignoring: !visible,
             child: ExcludeSemantics(
@@ -148,7 +177,10 @@ class ChannelQuickActionsLauncher extends HookConsumerWidget {
                   opacity: 1 - hiddenProgress,
                   child: Transform.translate(
                     key: const Key('channel-quick-actions-transform'),
-                    offset: Offset(hiddenHorizontalOffset * hiddenProgress, 0),
+                    offset: Offset(
+                      placement.hiddenHorizontalOffset * hiddenProgress,
+                      0,
+                    ),
                     child: Transform.scale(
                       key: const Key('channel-quick-actions-scale'),
                       scale:
@@ -160,7 +192,7 @@ class ChannelQuickActionsLauncher extends HookConsumerWidget {
                 ),
                 child: _MorphingQuickActionsButton(
                   open: effectiveOpen,
-                  openEdgeOffset: rightInset - Grid.gutter,
+                  openEdgeOffset: placement.rightInset - Grid.gutter,
                   onToggle: () =>
                       quickActionsOpen.value = !quickActionsOpen.value,
                   onSelected: (action) => unawaited(selectQuickAction(action)),

--- a/mobile/lib/features/channels/channels_page/sections.dart
+++ b/mobile/lib/features/channels/channels_page/sections.dart
@@ -11,6 +11,7 @@ class _CustomChannelSection extends StatelessWidget {
   final bool isFirst;
   final bool isLast;
   final bool showTopDivider;
+  final String? selectedChannelId;
   final VoidCallback onToggle;
   final VoidCallback onRename;
   final VoidCallback onDelete;
@@ -30,6 +31,7 @@ class _CustomChannelSection extends StatelessWidget {
     required this.isFirst,
     required this.isLast,
     required this.showTopDivider,
+    required this.selectedChannelId,
     required this.onToggle,
     required this.onRename,
     required this.onDelete,
@@ -68,6 +70,7 @@ class _CustomChannelSection extends StatelessWidget {
                   isUnread: unreadChannelIds.contains(channel.id),
                   isMuted: mutedChannelIds.contains(channel.id),
                   currentPubkey: currentPubkey,
+                  selected: channel.id == selectedChannelId,
                   onTap: () => onSelectChannel(channel),
                   onMarkRead: () => onMarkChannelRead(channel),
                   sectionId: section.id,
@@ -290,6 +293,7 @@ class _ChannelSection extends StatelessWidget {
   final Set<String> mutedChannelIds;
   final String? currentPubkey;
   final String emptyLabel;
+  final String? selectedChannelId;
   final Future<void> Function(Channel channel) onSelectChannel;
 
   const _ChannelSection({
@@ -304,6 +308,7 @@ class _ChannelSection extends StatelessWidget {
     required this.mutedChannelIds,
     required this.currentPubkey,
     required this.emptyLabel,
+    required this.selectedChannelId,
     required this.onSelectChannel,
   });
 
@@ -347,6 +352,7 @@ class _ChannelSection extends StatelessWidget {
                     isUnread: unreadChannelIds.contains(channel.id),
                     isMuted: mutedChannelIds.contains(channel.id),
                     currentPubkey: currentPubkey,
+                    selected: channel.id == selectedChannelId,
                     onTap: () => onSelectChannel(channel),
                     onMarkRead: null,
                     sectionId: null,
@@ -444,14 +450,17 @@ class _SectionHeader extends StatelessWidget {
               ),
             ),
             const SizedBox(width: _kChannelLabelGap),
-            Text(
-              label,
-              style: contentListTitleTextStyle.copyWith(
-                color: sectionColor,
-                fontWeight: FontWeight.w600,
+            Expanded(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: contentListTitleTextStyle.copyWith(
+                  color: sectionColor,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ),
-            const Spacer(),
             _SectionChevron(expanded: expanded, color: sectionColor),
           ],
         ),

--- a/mobile/lib/features/home/home_page.dart
+++ b/mobile/lib/features/home/home_page.dart
@@ -10,8 +10,16 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import '../../shared/theme/theme.dart';
 import '../../shared/widgets/mobile_tab_footer_backdrop.dart';
 import '../activity/activity_page.dart';
+import '../agents/agents_page.dart';
+import '../channels/channel.dart';
+import '../channels/channel_detail_page.dart';
 import '../channels/channels_page.dart';
+import '../channels/channels_provider.dart';
+import '../profile/profile_avatar.dart';
+import '../profile/profile_provider.dart';
 import '../search/search_page.dart';
+
+part 'tablet_workspace_sidebar.dart';
 
 class HomePage extends HookConsumerWidget {
   const HomePage({required this.settingsPageBuilder, super.key});
@@ -28,20 +36,82 @@ class HomePage extends HookConsumerWidget {
   static const double _tabDestinationHorizontalPadding = Grid.sm;
   static const double _tabIconSize = 22;
   static const double _fabClearance = _tabBarHeight + _tabBarBottomGap;
+  static const double _tabletBreakpoint = 600;
+  static const double _tabletRailWidth = Grid.xxxl;
+  static const double _workspaceSidebarWidth = 280;
+  static const double _workspaceDividerWidth = 1;
+  static const double _workspaceContentMinWidth = 420;
+  static const double _workspaceSidebarBreakpoint =
+      _workspaceSidebarWidth +
+      _workspaceDividerWidth +
+      _workspaceContentMinWidth;
+  static const double _tabletContentMaxWidth = 840;
+  static const double _tabletQuickActionClearance = 56 + Grid.gutter;
   static const Duration _tabIconWeightDuration = Duration(milliseconds: 120);
 
-  static const _destinations = [
+  static const _phoneDestinations = [
     _HomeDestination(
+      pageIndex: 0,
       icon: LucideIcons.house300,
       selectedIcon: LucideIcons.house500,
       label: 'Home',
     ),
     _HomeDestination(
+      pageIndex: 1,
       icon: LucideIcons.inbox300,
       selectedIcon: LucideIcons.inbox500,
       label: 'Activity',
     ),
     _HomeDestination(
+      pageIndex: 3,
+      icon: LucideIcons.search300,
+      selectedIcon: LucideIcons.search500,
+      label: 'Search',
+    ),
+  ];
+
+  static const _tabletDestinations = [
+    _HomeDestination(
+      pageIndex: 0,
+      icon: LucideIcons.house300,
+      selectedIcon: LucideIcons.house500,
+      label: 'Home',
+    ),
+    _HomeDestination(
+      pageIndex: 1,
+      icon: LucideIcons.inbox300,
+      selectedIcon: LucideIcons.inbox500,
+      label: 'Activity',
+    ),
+    _HomeDestination(
+      pageIndex: 2,
+      icon: LucideIcons.bot,
+      selectedIcon: LucideIcons.bot,
+      label: 'Agents',
+    ),
+    _HomeDestination(
+      pageIndex: 3,
+      icon: LucideIcons.search300,
+      selectedIcon: LucideIcons.search500,
+      label: 'Search',
+    ),
+  ];
+
+  static const _workspaceDestinations = [
+    _HomeDestination(
+      pageIndex: 1,
+      icon: LucideIcons.inbox300,
+      selectedIcon: LucideIcons.inbox500,
+      label: 'Inbox',
+    ),
+    _HomeDestination(
+      pageIndex: 2,
+      icon: LucideIcons.bot,
+      selectedIcon: LucideIcons.bot,
+      label: 'Agents',
+    ),
+    _HomeDestination(
+      pageIndex: 3,
       icon: LucideIcons.search300,
       selectedIcon: LucideIcons.search500,
       label: 'Search',
@@ -50,19 +120,73 @@ class HomePage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final tabIndex = useState(0);
+    final selectedPageIndex = useState(0);
+    final selectedChannelId = useState<String?>(null);
+    final channels = ref.watch(channelsProvider).asData?.value;
+    Channel? selectedChannel;
+    for (final channel in channels ?? const <Channel>[]) {
+      if (channel.id != selectedChannelId.value) continue;
+      selectedChannel = channel;
+      break;
+    }
+    final windowSize = MediaQuery.sizeOf(context);
+    final tabletWindow = windowSize.width >= HomePage._tabletBreakpoint;
     final systemBottomInset = MediaQuery.paddingOf(context).bottom;
-    final navigationBarWidth = _floatingTabBarWidth(
-      MediaQuery.sizeOf(context).width,
-      _destinations.length,
-    );
 
     final pages = [
       ChannelsPage(settingsPageBuilder: settingsPageBuilder),
       const ActivityPage(),
+      tabletWindow ? const AgentsPage() : const SizedBox.shrink(),
       const SearchPage(),
     ];
 
+    void selectDestination(int pageIndex) {
+      if (pageIndex == selectedPageIndex.value &&
+          selectedChannelId.value == null) {
+        return;
+      }
+      unawaited(HapticFeedback.selectionClick());
+      selectedChannelId.value = null;
+      selectedPageIndex.value = pageIndex;
+    }
+
+    Future<void> selectChannel(Channel channel) async {
+      if (selectedChannelId.value == channel.id) return;
+      unawaited(HapticFeedback.selectionClick());
+      selectedChannelId.value = channel.id;
+    }
+
+    if (tabletWindow) {
+      return Scaffold(
+        backgroundColor: context.colors.surface,
+        // Keep navigation and Home quick actions anchored above the keyboard.
+        resizeToAvoidBottomInset: false,
+        body: _TabletHomeShell(
+          selectedPageIndex: selectedPageIndex.value,
+          selectedChannel: selectedChannel,
+          onDestinationSelected: selectDestination,
+          onChannelSelected: selectChannel,
+          settingsPageBuilder: settingsPageBuilder,
+          railDestinations: _tabletDestinations,
+          workspaceDestinations: _workspaceDestinations,
+          pages: pages,
+        ),
+      );
+    }
+
+    final compactPageIndex =
+        _phoneDestinations.any(
+          (destination) => destination.pageIndex == selectedPageIndex.value,
+        )
+        ? selectedPageIndex.value
+        : 0;
+    final selectedDestinationIndex = _phoneDestinations.indexWhere(
+      (destination) => destination.pageIndex == compactPageIndex,
+    );
+    final navigationBarWidth = _floatingTabBarWidth(
+      windowSize.width,
+      _phoneDestinations.length,
+    );
     return Scaffold(
       backgroundColor: Colors.transparent,
       // Keep the floating navigation and Home quick actions anchored while the
@@ -76,11 +200,11 @@ class HomePage extends HookConsumerWidget {
             Positioned.fill(child: ColoredBox(color: context.colors.surface)),
             Positioned.fill(
               child: MediaQuery(
-                data: _mediaQueryWithFloatingTabBarClearance(
+                data: _mediaQueryWithBottomClearance(
                   context,
                   HomePage._fabClearance,
                 ),
-                child: IndexedStack(index: tabIndex.value, children: pages),
+                child: IndexedStack(index: compactPageIndex, children: pages),
               ),
             ),
             Align(
@@ -93,25 +217,28 @@ class HomePage extends HookConsumerWidget {
             ),
             Positioned.fill(
               child: ChannelQuickActionsLauncher(
-                visible: tabIndex.value == 0,
-                navigationBarHeight: HomePage._tabBarHeight,
-                navigationBarBottomGap: HomePage._tabBarBottomGap,
-                navigationBarWidth: navigationBarWidth,
-                systemBottomInset: systemBottomInset,
-                rightInset: Grid.sm,
+                visible: compactPageIndex == 0,
+                placement: ChannelQuickActionsPlacement.besideBottomNavigation(
+                  screenWidth: windowSize.width,
+                  navigationBarHeight: HomePage._tabBarHeight,
+                  navigationBarBottomGap: HomePage._tabBarBottomGap,
+                  navigationBarWidth: navigationBarWidth,
+                  systemBottomInset: systemBottomInset,
+                  rightInset: Grid.sm,
+                ),
               ),
             ),
           ],
         ),
       ),
-      bottomNavigationBar: _FloatingTabBar(
-        selectedIndex: tabIndex.value,
-        onDestinationSelected: (i) {
-          if (i == tabIndex.value) return;
-          unawaited(HapticFeedback.selectionClick());
-          tabIndex.value = i;
-        },
-        destinations: _destinations,
+      bottomNavigationBar: KeyedSubtree(
+        key: const Key('mobile-navigation-bar'),
+        child: _FloatingTabBar(
+          selectedIndex: selectedDestinationIndex,
+          onDestinationSelected: (index) =>
+              selectDestination(_phoneDestinations[index].pageIndex),
+          destinations: _phoneDestinations,
+        ),
       ),
     );
   }
@@ -136,7 +263,7 @@ double _floatingTabBarWidth(double screenWidth, int destinationCount) {
       (HomePage._tabBarInnerInset * 2);
 }
 
-MediaQueryData _mediaQueryWithFloatingTabBarClearance(
+MediaQueryData _mediaQueryWithBottomClearance(
   BuildContext context,
   double clearance,
 ) {
@@ -151,12 +278,202 @@ MediaQueryData _mediaQueryWithFloatingTabBarClearance(
   );
 }
 
+class _TabletHomeShell extends StatelessWidget {
+  final int selectedPageIndex;
+  final Channel? selectedChannel;
+  final ValueChanged<int> onDestinationSelected;
+  final Future<void> Function(Channel channel) onChannelSelected;
+  final WidgetBuilder settingsPageBuilder;
+  final List<_HomeDestination> railDestinations;
+  final List<_HomeDestination> workspaceDestinations;
+  final List<Widget> pages;
+
+  const _TabletHomeShell({
+    required this.selectedPageIndex,
+    required this.selectedChannel,
+    required this.onDestinationSelected,
+    required this.onChannelSelected,
+    required this.settingsPageBuilder,
+    required this.railDestinations,
+    required this.workspaceDestinations,
+    required this.pages,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.colors;
+    final windowWidth = MediaQuery.sizeOf(context).width;
+    final showWorkspaceSidebar =
+        windowWidth >= HomePage._workspaceSidebarBreakpoint;
+    final selectedDestinationIndex = railDestinations.indexWhere(
+      (destination) => destination.pageIndex == selectedPageIndex,
+    );
+    final workspacePageIndex = selectedPageIndex == 0 ? 1 : selectedPageIndex;
+    final workspaceDestinationIndex = workspaceDestinations.indexWhere(
+      (destination) => destination.pageIndex == workspacePageIndex,
+    );
+
+    return Row(
+      children: [
+        if (showWorkspaceSidebar)
+          _TabletWorkspaceSidebar(
+            selectedPageIndex: workspacePageIndex,
+            selectedChannelId: selectedChannel?.id,
+            onDestinationSelected: onDestinationSelected,
+            onChannelSelected: onChannelSelected,
+            settingsPageBuilder: settingsPageBuilder,
+            destinations: workspaceDestinations,
+          )
+        else
+          _TabletNavigationRail(
+            selectedIndex: selectedDestinationIndex,
+            onDestinationSelected: (index) =>
+                onDestinationSelected(railDestinations[index].pageIndex),
+            destinations: railDestinations,
+          ),
+        VerticalDivider(
+          width: HomePage._workspaceDividerWidth,
+          thickness: HomePage._workspaceDividerWidth,
+          color: colorScheme.outlineVariant.withValues(alpha: 0.45),
+        ),
+        Expanded(
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(
+                maxWidth: HomePage._tabletContentMaxWidth,
+              ),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final paneSize = constraints.biggest;
+                  final systemBottomInset = MediaQuery.paddingOf(
+                    context,
+                  ).bottom;
+                  final paneMediaQuery = _mediaQueryWithBottomClearance(
+                    context,
+                    HomePage._tabletQuickActionClearance,
+                  ).copyWith(size: paneSize);
+
+                  return MediaQuery(
+                    data: paneMediaQuery,
+                    child: SizedBox.expand(
+                      key: const Key('tablet-page-content'),
+                      child: Stack(
+                        fit: StackFit.expand,
+                        children: [
+                          if (showWorkspaceSidebar)
+                            IndexedStack(
+                              index: workspaceDestinationIndex,
+                              children: const [
+                                ActivityPage(title: 'Inbox'),
+                                AgentsPage(),
+                                SearchPage(),
+                              ],
+                            )
+                          else
+                            IndexedStack(
+                              index: selectedPageIndex,
+                              children: pages,
+                            ),
+                          if (selectedChannel case final channel?)
+                            Positioned.fill(
+                              child: ChannelDetailPage(
+                                key: ValueKey('tablet-channel-${channel.id}'),
+                                channel: channel,
+                              ),
+                            ),
+                          Positioned.fill(
+                            child: ChannelQuickActionsLauncher(
+                              visible:
+                                  selectedChannel == null &&
+                                  (showWorkspaceSidebar
+                                      ? workspacePageIndex == 1
+                                      : selectedPageIndex == 0),
+                              placement:
+                                  ChannelQuickActionsPlacement.bottomTrailing(
+                                    systemBottomInset: systemBottomInset,
+                                  ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TabletNavigationRail extends StatelessWidget {
+  const _TabletNavigationRail({
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+    required this.destinations,
+  });
+
+  final int selectedIndex;
+  final ValueChanged<int> onDestinationSelected;
+  final List<_HomeDestination> destinations;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.colors;
+
+    return ColoredBox(
+      color: colorScheme.surfaceContainerLow,
+      child: SafeArea(
+        right: false,
+        child: NavigationRail(
+          key: const Key('tablet-navigation-rail'),
+          selectedIndex: selectedIndex,
+          onDestinationSelected: onDestinationSelected,
+          minWidth: HomePage._tabletRailWidth,
+          groupAlignment: -0.72,
+          labelType: NavigationRailLabelType.all,
+          backgroundColor: colorScheme.surfaceContainerLow,
+          indicatorColor: colorScheme.primaryContainer,
+          selectedIconTheme: IconThemeData(
+            color: colorScheme.onPrimaryContainer,
+            size: HomePage._tabIconSize,
+          ),
+          unselectedIconTheme: IconThemeData(
+            color: colorScheme.onSurfaceVariant,
+            size: HomePage._tabIconSize,
+          ),
+          selectedLabelTextStyle: context.textTheme.labelMedium?.copyWith(
+            color: colorScheme.onSurface,
+            fontWeight: FontWeight.w600,
+          ),
+          unselectedLabelTextStyle: context.textTheme.labelMedium?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+            fontWeight: FontWeight.w500,
+          ),
+          destinations: [
+            for (final destination in destinations)
+              NavigationRailDestination(
+                icon: Icon(destination.icon),
+                selectedIcon: Icon(destination.selectedIcon),
+                label: Text(destination.label),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _HomeDestination {
+  final int pageIndex;
   final IconData icon;
   final IconData selectedIcon;
   final String label;
 
   const _HomeDestination({
+    required this.pageIndex,
     required this.icon,
     required this.selectedIcon,
     required this.label,

--- a/mobile/lib/features/home/tablet_workspace_sidebar.dart
+++ b/mobile/lib/features/home/tablet_workspace_sidebar.dart
@@ -1,0 +1,312 @@
+part of 'home_page.dart';
+
+class _TabletWorkspaceSidebar extends ConsumerWidget {
+  const _TabletWorkspaceSidebar({
+    required this.selectedPageIndex,
+    required this.selectedChannelId,
+    required this.onDestinationSelected,
+    required this.onChannelSelected,
+    required this.settingsPageBuilder,
+    required this.destinations,
+  });
+
+  final int selectedPageIndex;
+  final String? selectedChannelId;
+  final ValueChanged<int> onDestinationSelected;
+  final Future<void> Function(Channel channel) onChannelSelected;
+  final WidgetBuilder settingsPageBuilder;
+  final List<_HomeDestination> destinations;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final channelsAsync = ref.watch(channelsProvider);
+    final profile = ref.watch(profileProvider).asData?.value;
+    final currentPubkey = profile?.pubkey;
+    final colorScheme = context.colors;
+
+    return SizedBox(
+      key: const Key('tablet-workspace-sidebar'),
+      width: HomePage._workspaceSidebarWidth,
+      child: ColoredBox(
+        color: colorScheme.surfaceContainerLow,
+        child: SafeArea(
+          right: false,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Padding(
+                padding: EdgeInsets.fromLTRB(
+                  Grid.twelve,
+                  Grid.twelve,
+                  Grid.xs,
+                  Grid.xxs,
+                ),
+                child: CommunitySwitcherButton(),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: Grid.xxs),
+                child: Column(
+                  children: [
+                    for (final destination in destinations)
+                      _TabletSidebarDestinationTile(
+                        destination: destination,
+                        selected:
+                            selectedChannelId == null &&
+                            destination.pageIndex == selectedPageIndex,
+                        onTap: () =>
+                            onDestinationSelected(destination.pageIndex),
+                      ),
+                  ],
+                ),
+              ),
+              Divider(
+                height: Grid.xs,
+                indent: Grid.xs,
+                endIndent: Grid.xs,
+                color: colorScheme.outlineVariant.withValues(alpha: 0.72),
+              ),
+              Expanded(
+                child: channelsAsync.when(
+                  loading: () => const _TabletDirectoryStatus(loading: true),
+                  error: (_, _) => _TabletDirectoryStatus(
+                    onRetry: () =>
+                        ref.read(channelsProvider.notifier).refresh(),
+                  ),
+                  data: (channels) => channels.isEmpty
+                      ? const _TabletDirectoryStatus()
+                      : CustomScrollView(
+                          slivers: [
+                            ChannelDirectorySliver(
+                              channels: channels,
+                              currentPubkey: currentPubkey,
+                              directMessagesLabel: 'Direct Messages',
+                              selectedChannelId: selectedChannelId,
+                              onSelectChannel: onChannelSelected,
+                            ),
+                          ],
+                        ),
+                ),
+              ),
+              Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  key: const Key('tablet-profile-footer'),
+                  onTap: () => Navigator.of(
+                    context,
+                  ).push(MaterialPageRoute<void>(builder: settingsPageBuilder)),
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(
+                      Grid.twelve,
+                      Grid.twelve,
+                      Grid.xs,
+                      Grid.twelve,
+                    ),
+                    child: Row(
+                      children: [
+                        const ProfileAvatar(showPresence: true),
+                        const SizedBox(width: Grid.half + Grid.quarter),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                profile?.label ?? 'Your profile',
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: context.textTheme.labelLarge?.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              if (profile?.nip05Handle case final handle?)
+                                Text(
+                                  handle,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: context.textTheme.bodySmall?.copyWith(
+                                    color: colorScheme.onSurfaceVariant,
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                        Icon(
+                          LucideIcons.settings,
+                          size: 18,
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TabletSidebarDestinationTile extends StatelessWidget {
+  const _TabletSidebarDestinationTile({
+    required this.destination,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final _HomeDestination destination;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = context.colors;
+    final foreground = selected
+        ? colorScheme.onPrimaryContainer
+        : colorScheme.onSurfaceVariant;
+
+    return Material(
+      color: selected ? colorScheme.primaryContainer : Colors.transparent,
+      borderRadius: BorderRadius.circular(Radii.md),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        key: ValueKey('tablet-destination-${destination.label}'),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: Grid.twelve,
+            vertical: Grid.xxs,
+          ),
+          child: Row(
+            children: [
+              Icon(
+                selected ? destination.selectedIcon : destination.icon,
+                size: HomePage._tabIconSize,
+                color: foreground,
+              ),
+              const SizedBox(width: Grid.xxs),
+              Expanded(
+                child: Text(
+                  destination.label,
+                  style: context.textTheme.labelLarge?.copyWith(
+                    color: foreground,
+                    fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TabletDirectoryStatus extends StatelessWidget {
+  const _TabletDirectoryStatus({this.loading = false, this.onRetry});
+
+  final bool loading;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.only(bottom: Grid.xs),
+      children: [
+        const _TabletDirectorySectionLabel(
+          icon: LucideIcons.hash,
+          label: 'Channels',
+        ),
+        if (!loading)
+          Padding(
+            padding: const EdgeInsets.only(
+              left: 50,
+              right: Grid.xs,
+              bottom: Grid.xxs,
+            ),
+            child: Text(
+              onRetry == null ? 'No channels yet' : 'Could not load channels',
+              style: context.textTheme.bodySmall?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+          ),
+        const _TabletDirectorySectionLabel(
+          icon: LucideIcons.messagesSquare,
+          label: 'Direct Messages',
+        ),
+        if (loading)
+          Padding(
+            padding: const EdgeInsets.only(left: 50, top: Grid.xxs),
+            child: Text(
+              'Loading conversations…',
+              style: context.textTheme.bodySmall?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+          )
+        else if (onRetry != null)
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Padding(
+              padding: const EdgeInsets.only(left: 50),
+              child: TextButton(onPressed: onRetry, child: const Text('Retry')),
+            ),
+          )
+        else
+          Padding(
+            padding: const EdgeInsets.only(left: 50, right: Grid.xs),
+            child: Text(
+              'No direct messages yet',
+              style: context.textTheme.bodySmall?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _TabletDirectorySectionLabel extends StatelessWidget {
+  const _TabletDirectorySectionLabel({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        Grid.gutter,
+        Grid.twelve,
+        Grid.gutter,
+        Grid.xxs,
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 22,
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Icon(icon, size: 18, color: context.colors.primary),
+            ),
+          ),
+          const SizedBox(width: Grid.xxs),
+          Expanded(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: contentListTitleTextStyle.copyWith(
+                color: context.colors.primary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/test/features/channels/channels_page_test.dart
+++ b/mobile/test/features/channels/channels_page_test.dart
@@ -34,6 +34,7 @@ void main() {
     Map<String, String?> communityIcons = const {},
     ValueChanged<String>? onCommunityIconLoad,
     TextScaler textScaler = TextScaler.noScaling,
+    Widget? home,
   }) {
     return ProviderScope(
       overrides: [
@@ -60,21 +61,27 @@ void main() {
           ),
           child: child!,
         ),
-        home: const Stack(
-          children: [
-            ChannelsPage(settingsPageBuilder: _buildSettingsPage),
-            Positioned.fill(
-              child: ChannelQuickActionsLauncher(
-                visible: true,
-                navigationBarHeight: 60,
-                navigationBarBottomGap: 12,
-                navigationBarWidth: 218,
-                systemBottomInset: 0,
-                rightInset: 16,
-              ),
+        home:
+            home ??
+            Stack(
+              children: [
+                const ChannelsPage(settingsPageBuilder: _buildSettingsPage),
+                Positioned.fill(
+                  child: ChannelQuickActionsLauncher(
+                    visible: true,
+                    placement:
+                        ChannelQuickActionsPlacement.besideBottomNavigation(
+                          screenWidth: 800,
+                          navigationBarHeight: 60,
+                          navigationBarBottomGap: 12,
+                          navigationBarWidth: 218,
+                          systemBottomInset: 0,
+                          rightInset: 16,
+                        ),
+                  ),
+                ),
+              ],
             ),
-          ],
-        ),
       ),
     );
   }
@@ -144,6 +151,47 @@ void main() {
     final sectionTitle = tester.widget<Text>(find.text('Channels'));
     expect(sectionTitle.style?.fontSize, contentListTitleTextStyle.fontSize);
     expect(sectionTitle.style?.fontWeight, FontWeight.w600);
+  });
+
+  testWidgets('highlights a selected tablet channel without shifting labels', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildTestable(
+        overrides: [
+          channelsProvider.overrideWith(() => _FakeNotifier(testChannels)),
+        ],
+        home: Material(
+          child: CustomScrollView(
+            slivers: [
+              ChannelDirectorySliver(
+                channels: testChannels,
+                currentPubkey: 'aabb',
+                selectedChannelId: '1',
+                directMessagesLabel: 'Direct Messages',
+                onSelectChannel: (_) async {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final selectedTile = tester.widget<Ink>(
+      find.byKey(const ValueKey('channel-tile-1')),
+    );
+    final context = tester.element(
+      find.byKey(const ValueKey('channel-tile-1')),
+    );
+    expect(
+      (selectedTile.decoration as BoxDecoration).color,
+      Theme.of(context).colorScheme.primaryContainer,
+    );
+    expect(
+      tester.getTopLeft(find.text('general')).dx,
+      closeTo(tester.getTopLeft(find.text('Alice')).dx, 0.01),
+    );
   });
 
   testWidgets('keeps the last channel above the floating tab bar', (
@@ -655,11 +703,15 @@ void main() {
               Positioned.fill(
                 child: ChannelQuickActionsLauncher(
                   visible: visible,
-                  navigationBarHeight: 60,
-                  navigationBarBottomGap: 12,
-                  navigationBarWidth: 218,
-                  systemBottomInset: 0,
-                  rightInset: 16,
+                  placement:
+                      ChannelQuickActionsPlacement.besideBottomNavigation(
+                        screenWidth: 800,
+                        navigationBarHeight: 60,
+                        navigationBarBottomGap: 12,
+                        navigationBarWidth: 218,
+                        systemBottomInset: 0,
+                        rightInset: 16,
+                      ),
                 ),
               ),
             ],

--- a/mobile/test/features/home/home_page_test.dart
+++ b/mobile/test/features/home/home_page_test.dart
@@ -1,5 +1,8 @@
-import 'package:buzz/features/home/home_page.dart';
+import 'package:buzz/features/channels/channel.dart';
 import 'package:buzz/features/channels/channels_page.dart';
+import 'package:buzz/features/channels/channels_provider.dart';
+import 'package:buzz/features/channels/mentions/mention_candidates_provider.dart';
+import 'package:buzz/features/home/home_page.dart';
 import 'package:buzz/shared/theme/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -8,11 +11,16 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  Future<Widget> buildHome() async {
+  Future<Widget> buildHome({List<Channel>? channels}) async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
     return ProviderScope(
-      overrides: [savedPrefsProvider.overrideWithValue(prefs)],
+      overrides: [
+        savedPrefsProvider.overrideWithValue(prefs),
+        agentDirectoryProvider.overrideWith((ref) async => const []),
+        if (channels != null)
+          channelsProvider.overrideWith(() => _FakeChannelsNotifier(channels)),
+      ],
       child: MaterialApp(
         theme: AppTheme.light(),
         home: const HomePage(settingsPageBuilder: _buildSettingsPage),
@@ -20,9 +28,17 @@ void main() {
     );
   }
 
+  void useSurfaceSize(WidgetTester tester, Size size) {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = size;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+  }
+
   testWidgets('shows icon-only navigation and an aligned quick action', (
     tester,
   ) async {
+    useSurfaceSize(tester, const Size(390, 844));
     await tester.pumpWidget(await buildHome());
     await tester.pump();
 
@@ -38,7 +54,7 @@ void main() {
     final launcherSize = tester.getSize(
       find.byType(ChannelQuickActionsLauncher),
     );
-    expect(launcherSize.width, 800);
+    expect(launcherSize.width, 390);
     expect(launcherSize.height, greaterThan(0));
     final motionRect = tester.getRect(
       find.byKey(const Key('channel-quick-actions-motion')),
@@ -49,8 +65,8 @@ void main() {
     final quickActionRect = tester.getRect(quickAction);
     expect(quickActionRect.left, greaterThanOrEqualTo(0));
     expect(quickActionRect.top, greaterThanOrEqualTo(0));
-    expect(quickActionRect.right, lessThanOrEqualTo(800));
-    expect(quickActionRect.bottom, lessThanOrEqualTo(600));
+    expect(quickActionRect.right, lessThanOrEqualTo(390));
+    expect(quickActionRect.bottom, lessThanOrEqualTo(844));
     final homeDestinationRect = tester.getRect(find.bySemanticsLabel('Home'));
     expect(
       quickActionRect.center.dy,
@@ -61,6 +77,7 @@ void main() {
   testWidgets('gives selection haptics only when the tab changes', (
     tester,
   ) async {
+    useSurfaceSize(tester, const Size(390, 844));
     final hapticCalls = <MethodCall>[];
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform, (call) async {
@@ -98,6 +115,7 @@ void main() {
   testWidgets('scales and fades the quick action as tabs change', (
     tester,
   ) async {
+    useSurfaceSize(tester, const Size(390, 844));
     await tester.pumpWidget(await buildHome());
     await tester.pump();
 
@@ -135,6 +153,184 @@ void main() {
     expect(scale(), closeTo(1, 0.001));
     expect(opacity(), closeTo(1, 0.001));
   });
+
+  testWidgets('keeps compact navigation in a narrow iPad split view', (
+    tester,
+  ) async {
+    useSurfaceSize(tester, const Size(599, 1024));
+    await tester.pumpWidget(await buildHome());
+    await tester.pump();
+
+    expect(find.byKey(const Key('mobile-navigation-bar')), findsOneWidget);
+    expect(find.byKey(const Key('tablet-navigation-rail')), findsNothing);
+  });
+
+  testWidgets('uses rail navigation in a medium tablet window', (tester) async {
+    useSurfaceSize(tester, const Size(650, 1024));
+    await tester.pumpWidget(await buildHome());
+    await tester.pump();
+
+    expect(find.byKey(const Key('tablet-navigation-rail')), findsOneWidget);
+    expect(find.byKey(const Key('tablet-workspace-sidebar')), findsNothing);
+    expect(find.byKey(const Key('mobile-navigation-bar')), findsNothing);
+  });
+
+  testWidgets('reserves 420 points before exposing the workspace sidebar', (
+    tester,
+  ) async {
+    useSurfaceSize(tester, const Size(700, 1024));
+    await tester.pumpWidget(await buildHome());
+    await tester.pump();
+
+    expect(find.byKey(const Key('tablet-navigation-rail')), findsOneWidget);
+    expect(find.byKey(const Key('tablet-workspace-sidebar')), findsNothing);
+
+    tester.view.physicalSize = const Size(701, 1024);
+    await tester.pump();
+
+    expect(find.byKey(const Key('tablet-navigation-rail')), findsNothing);
+    expect(find.byKey(const Key('tablet-workspace-sidebar')), findsOneWidget);
+  });
+
+  testWidgets('shows the complete workspace sidebar on iPad', (tester) async {
+    useSurfaceSize(tester, const Size(768, 1024));
+    await tester.pumpWidget(await buildHome());
+    await tester.pump();
+
+    final sidebar = find.byKey(const Key('tablet-workspace-sidebar'));
+    expect(sidebar, findsOneWidget);
+    expect(find.byKey(const Key('tablet-navigation-rail')), findsNothing);
+    expect(find.byKey(const Key('mobile-navigation-bar')), findsNothing);
+    for (final label in [
+      'Inbox',
+      'Agents',
+      'Channels',
+      'Direct Messages',
+      'Community',
+      'Your profile',
+    ]) {
+      expect(
+        find.descendant(of: sidebar, matching: find.text(label)),
+        findsOneWidget,
+      );
+    }
+    expect(find.text('Home'), findsNothing);
+    expect(find.text('Activity'), findsNothing);
+    expect(find.byKey(const Key('tablet-profile-footer')), findsOneWidget);
+
+    final labelColumn = tester
+        .getTopLeft(find.descendant(of: sidebar, matching: find.text('Inbox')))
+        .dx;
+    for (final label in [
+      'Community',
+      'Agents',
+      'Channels',
+      'Direct Messages',
+      'Your profile',
+    ]) {
+      final labelFinder = find.descendant(
+        of: sidebar,
+        matching: find.text(label),
+      );
+      expect(tester.getTopLeft(labelFinder).dx, closeTo(labelColumn, 0.01));
+    }
+
+    await tester.tap(
+      find.descendant(of: sidebar, matching: find.text('Agents')),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('agents-page')), findsOneWidget);
+  });
+
+  testWidgets('opens a selected channel beside the iPad sidebar', (
+    tester,
+  ) async {
+    useSurfaceSize(tester, const Size(1194, 834));
+    final channel = Channel(
+      id: 'general',
+      name: 'general',
+      channelType: 'stream',
+      visibility: 'open',
+      description: 'General discussion',
+      createdBy: 'owner',
+      createdAt: DateTime(2026),
+      memberCount: 4,
+      isMember: true,
+    );
+    await tester.pumpWidget(await buildHome(channels: [channel]));
+    await tester.pump();
+
+    final sidebar = find.byKey(const Key('tablet-workspace-sidebar'));
+    await tester.tap(
+      find.descendant(of: sidebar, matching: find.text('general')),
+    );
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('tablet-channel-general')),
+      findsOneWidget,
+    );
+    final selectedTile = tester.widget<Ink>(
+      find.byKey(const ValueKey('channel-tile-general')),
+    );
+    expect((selectedTile.decoration as BoxDecoration).color, isNotNull);
+  });
+
+  testWidgets('opens settings from the pinned iPad profile footer', (
+    tester,
+  ) async {
+    useSurfaceSize(tester, const Size(768, 1024));
+    await tester.pumpWidget(await buildHome());
+    await tester.pump();
+
+    await tester.tap(find.byKey(const Key('tablet-profile-footer')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('settings-page')), findsOneWidget);
+  });
+
+  testWidgets('keeps content and quick actions inside an iPad landscape pane', (
+    tester,
+  ) async {
+    useSurfaceSize(tester, const Size(1194, 834));
+    await tester.pumpWidget(await buildHome());
+    await tester.pump();
+
+    expect(find.byKey(const Key('tablet-workspace-sidebar')), findsOneWidget);
+    expect(find.byKey(const Key('tablet-navigation-rail')), findsNothing);
+
+    final contentRect = tester.getRect(
+      find.byKey(const Key('tablet-page-content')),
+    );
+    expect(contentRect.width, 840);
+    expect(contentRect.left, greaterThan(200));
+    expect(contentRect.right, lessThan(1194));
+
+    final quickAction = find.byTooltip('Create or start conversation');
+    final closedRect = tester.getRect(quickAction);
+    expect(contentRect.contains(closedRect.topLeft), isTrue);
+    expect(contentRect.contains(closedRect.bottomRight), isTrue);
+
+    await tester.tap(quickAction);
+    await tester.pumpAndSettle();
+
+    final openRect = tester.getRect(
+      find.byKey(const Key('quick-actions-surface')),
+    );
+    expect(openRect.left, greaterThan(contentRect.left));
+    expect(openRect.right, lessThan(contentRect.right));
+  });
 }
 
-Widget _buildSettingsPage(BuildContext context) => const SizedBox.shrink();
+Widget _buildSettingsPage(BuildContext context) =>
+    const SizedBox(key: Key('settings-page'));
+
+class _FakeChannelsNotifier extends ChannelsNotifier {
+  _FakeChannelsNotifier(this.channels);
+
+  final List<Channel> channels;
+
+  @override
+  Future<List<Channel>> build() async => channels;
+}


### PR DESCRIPTION
## Summary

- make the Flutter iOS target universal and declare the four supported iPad orientations while retaining the existing iPhone orientation set
- choose the navigation shell from available width: the existing compact phone UI below 600 points, a navigation rail at medium widths, and a 280-point workspace sidebar once 420 points remain for content
- compose the expanded sidebar from the existing community, channel, DM, unread, profile, presence, and agent providers; channel selection opens in the adjacent detail pane
- keep wide content readable at an 840-point maximum and move Home quick actions to the active pane without changing compact placement

### Related issue

None found after searching open issues and PRs for iPad, tablet, and split-view support.

### UI review

| Before | After | Why |
| --- | --- | --- |
| The iOS target was iPhone-only. | The same app target now supports iPhone and iPad. | Ship one universal app without creating a second client or navigation model. |
| Home used the compact floating tab shell at every supported width. | Widths below 600 points keep that shell; medium widths use a rail; widths of 701 points or more use the full workspace sidebar. | Preserve iPhone and narrow Split View behavior while using tablet space deliberately. |
| Channels, DMs, agents, and profile controls were not available together as a tablet workspace. | The sidebar exposes provider-backed Inbox, Agents, Search, Channels, DMs, community switching, and the pinned profile/settings footer. | Make high-frequency navigation visible without duplicating relay queries or state. |
| Opening a channel replaced the directory. | The selected channel opens beside the directory and receives a restrained selected-row treatment. | Support master/detail scanning and fast conversation switching. |

![Adaptive iPad workspace with representative provider-backed data](https://raw.githubusercontent.com/amadad/buzz/bc303672b3d7aa852028ff2244ce0afdd55c5e1e/ipad-workspace-landscape.png)

The screenshot uses a temporary provider fixture for representative community, channel, DM, and profile data; no fixture or preview entry point is included in this change.

### Testing

- `dart format --output=none --set-exit-if-changed .` — 310 files, 0 changed
- `flutter analyze` — no issues
- `flutter test` — 914 passed, 1 skipped, 0 failed
- `node mobile/scripts/check-file-sizes.mjs` — passed
- `flutter build ios --simulator --debug --no-codesign` — built `Buzz.app`
- built app metadata — `UIDeviceFamily = [1, 2]`; existing iPhone orientations retained; portrait, upside-down portrait, landscape left, and landscape right enabled for iPad
- adaptive widget coverage — 390×844 phone, 599×1024 narrow Split View, 650×1024 rail, 700/701-point sidebar boundary, 768×1024 portrait, and 1194×834 landscape

An Android binary build was not run because the verification hosts do not have an Android SDK; the shared Flutter code is covered by the analyzer and widget/full test suites above.
