### PR TITLE
fix(desktop): keep cross-owned invocable agents in mention autocomplete

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -162,6 +162,48 @@ test("isAgentIdentityInManagedList: keeps people and only current managed agent 
   );
 });
 
+test("isAgentIdentityInManagedList: keeps cross-owned agents the current user can invoke (#3125)", () => {
+  const managedAgentPubkeys = new Set([PUB_A]);
+  const invocableAgentPubkeys = new Set([PUB_A, PUB_B]);
+
+  // Another owner's agent whose allowlist/anyone policy admits us: keep.
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+      invocableAgentPubkeys,
+    ),
+    true,
+  );
+  // Case-insensitive on the invocable set too.
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey: PUB_B.toUpperCase() },
+      managedAgentPubkeys,
+      invocableAgentPubkeys,
+    ),
+    true,
+  );
+  // Stale identity: neither managed nor invocable — still dropped (#2149).
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey: PUB_C },
+      managedAgentPubkeys,
+      invocableAgentPubkeys,
+    ),
+    false,
+  );
+  // People are never gated.
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: false, pubkey: PUB_C },
+      managedAgentPubkeys,
+      invocableAgentPubkeys,
+    ),
+    true,
+  );
+});
+
 test("shouldHideAgentFromMentions: never hides non-agents", () => {
   assert.equal(
     shouldHideAgentFromMentions({

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -54,13 +54,26 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
+const EMPTY_PUBKEY_SET: ReadonlySet<string> = new Set();
+
 export function isAgentIdentityInManagedList(
   candidate: { isAgent?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
+  // The managed list is only authoritative for the CURRENT user's concrete
+  // agent identities (stale-duplicate suppression, #2149). A cross-owned
+  // agent that is invocable by the current user — respond_to "anyone" in a
+  // shared channel, or an allowlist naming us — must stay mentionable, or
+  // the downstream invocability check is unreachable (#3125). Callers that
+  // gate mention candidates pass `mentionableAgentPubkeys`; callers that
+  // genuinely want managed-only (e.g. add-member search) omit it.
+  invocableAgentPubkeys: ReadonlySet<string> = EMPTY_PUBKEY_SET,
 ) {
+  if (candidate.isAgent !== true) {
+    return true;
+  }
+  const normalized = normalizePubkey(candidate.pubkey);
   return (
-    candidate.isAgent !== true ||
-    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
+    managedAgentPubkeys.has(normalized) || invocableAgentPubkeys.has(normalized)
   );
 }
 

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -246,7 +246,13 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (
+        !isAgentIdentityInManagedList(
+          candidate,
+          managedAgentPubkeys,
+          mentionableAgentPubkeys,
+        )
+      ) {
         return;
       }
       if (


### PR DESCRIPTION
## Why

Fixes #3125 (also the root of the cross-machine flavor reported in #3204 / #3277 / #2508 / #2349 when the agent is owned by another user).

The managed-list gate added in #2149 runs **before** `shouldHideAgentFromMentions` in mention autocomplete, so an agent owned by another user is discarded even when its `respond_to` policy explicitly admits the current user. The downstream invocability logic is unreachable for cross-owned agents: the mention never resolves, the published event carries no agent `p` tag, and ACP is never woken.

Reproduced on a self-hosted relay: owner's client resolves the agent fine; an allowlisted second user's `@Agent` stays plain text.

## What

- `isAgentIdentityInManagedList` gains an optional `invocableAgentPubkeys` parameter and admits candidates present in either set. The mention path passes `mentionableAgentPubkeys` (already "managed ∪ relay agents shared with me" via `getMentionableAgentPubkeys`), so:
  - cross-owned agent, allowlist names me / `respond_to: anyone` in a shared channel → **kept**, falls through to the existing eligibility check;
  - stale identity (neither managed nor invocable) → **still dropped**, preserving the duplicate suppression #2149 introduced;
  - people → never gated (unchanged).
- The add-member search in `MembersSidebar` intentionally keeps managed-only semantics via the defaulted parameter.
- Unit tests for the new behavior incl. case-insensitivity and the stale-identity case.

`pnpm test` (3672 pass) and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)