### PR TITLE
fix(acp,desktop): do not wake agents or show working on typing pings

### DIFF
--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use buzz_core::kind::is_ephemeral;
 use tracing::{error, warn};
 
 /// Errors that can occur during filter expression evaluation.
@@ -373,6 +374,12 @@ pub async fn match_event(
 ) -> Option<MatchedRule> {
     let filter_ctx = FilterContext::from_event(event, channel_id);
 
+    // Ephemeral kinds (typing/presence/etc.) never match a subscription rule.
+    // Wildcard (`kinds = []`) must not wake agents on empty kind-20002 pings.
+    if is_ephemeral(event.kind.as_u16() as u32) {
+        return None;
+    }
+
     for (index, rule) in rules.iter().enumerate() {
         // 1. Channel scope check.
         if !rule.channels.matches(&channel_id) {
@@ -607,6 +614,24 @@ mod tests {
     }
 
     #[tokio::test]
+
+    #[tokio::test]
+    async fn test_match_event_rejects_ephemeral_typing_even_on_wildcard() {
+        // Subscribe-all / empty kinds must still never match kind-20002.
+        let rules = [make_rule(
+            "all",
+            ChannelScope::All("all".into()),
+            vec![],
+            false,
+            None,
+            None,
+        )];
+        let event = make_event(20002, "");
+        let channel_id = any_channel();
+        let result = match_event(&event, channel_id, &rules, "").await;
+        assert!(result.is_none(), "typing indicators must never match");
+    }
+
     async fn test_match_event_kind_filter() {
         let event = make_event(9, "hello");
         let channel_id = any_channel();

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -21,8 +21,8 @@ use std::time::Duration;
 use acp::{AcpClient, EnvVar, McpServer};
 use anyhow::Result;
 use buzz_core::kind::{
-    KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
-    KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
+    is_ephemeral, KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION,
+    KIND_STREAM_MESSAGE, KIND_STREAM_REMINDER, KIND_WORKFLOW_APPROVAL_REQUESTED,
 };
 use buzz_core::observer::{
     decrypt_observer_payload, encrypt_observer_payload, OBSERVER_FRAME_TELEMETRY,
@@ -1906,6 +1906,21 @@ async fn tokio_main() -> Result<()> {
                     match buzz_event {
                         Some(buzz_event) => {
                             let kind_u32 = buzz_event.event.kind.as_u16() as u32;
+
+                            // Ephemeral kinds (20000–29999) are UX signals only —
+                            // typing indicators (20002), presence heartbeats (20001),
+                            // etc. They must never start an agent turn: empty content,
+                            // no durable intent, and waking on them burns quota while
+                            // driving a false «is working…» spinner via bot typing /
+                            // observer frames published by the woken harness.
+                            if is_ephemeral(kind_u32) {
+                                tracing::debug!(
+                                    channel_id = %buzz_event.channel_id,
+                                    kind = kind_u32,
+                                    "dropping ephemeral event — never starts a turn"
+                                );
+                                continue;
+                            }
 
                             if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION
                                 || kind_u32 == KIND_MEMBER_REMOVED_NOTIFICATION

--- a/desktop/src/features/agents/agentWorkingSignal.test.mjs
+++ b/desktop/src/features/agents/agentWorkingSignal.test.mjs
@@ -76,81 +76,48 @@ describe("getAgentWorkingState", () => {
     assert.equal(elsewhere.channels.length, 1);
   });
 
-  it("falls back to typing when no observer turns exist", () => {
+  it("does not treat bot typing as working without an observer turn", () => {
     reportChannelBotTyping("chan-1", [AGENT]);
     const state = getAgentWorkingState(AGENT, "chan-1");
-    assert.equal(state.working, true);
-    assert.equal(state.source, "typing");
-    assert.equal(state.channels[0].source, "typing");
-    assert.ok(state.channels[0].anchorAt <= Date.now());
+    assert.equal(state.working, false);
+    assert.equal(state.source, "none");
+    assert.deepEqual(state.channels, []);
   });
 
-  it("prefers observer over typing for the same channel (no duplicate)", () => {
+  it("observer turn is working even if typing is also reported", () => {
     startTurn(AGENT, "chan-1");
     reportChannelBotTyping("chan-1", [AGENT]);
     const state = getAgentWorkingState(AGENT, "chan-1");
     assert.equal(state.source, "observer");
+    assert.equal(state.working, true);
     assert.equal(state.channels.length, 1);
     assert.equal(state.channels[0].source, "observer");
-  });
-
-  it("typing in one channel does not mark work in another", () => {
-    reportChannelBotTyping("chan-1", [AGENT]);
-    const state = getAgentWorkingState(AGENT, "chan-2");
-    assert.equal(state.working, false);
-  });
-
-  it("typing clears when re-reported empty", () => {
-    reportChannelBotTyping("chan-1", [AGENT]);
-    reportChannelBotTyping("chan-1", []);
-    assert.equal(getAgentWorkingState(AGENT, "chan-1").working, false);
-  });
-
-  it("preserves first-seen anchor across typing re-reports", async () => {
-    reportChannelBotTyping("chan-1", [AGENT]);
-    const first = getAgentWorkingState(AGENT).channels[0].anchorAt;
-    await new Promise((resolve) => setTimeout(resolve, 5));
-    reportChannelBotTyping("chan-1", [AGENT, AGENT_2]);
-    const again = getAgentWorkingState(AGENT).channels[0].anchorAt;
-    assert.equal(again, first);
   });
 });
 
 describe("getWorkingChannels", () => {
-  it("merges typing-only agents into an observer channel summary", () => {
+  it("lists observer channels only (typing does not create working channels)", () => {
     startTurn(AGENT, "chan-1");
     reportChannelBotTyping("chan-1", [AGENT_2]);
+    reportChannelBotTyping("chan-2", [AGENT_2]);
     const channels = getWorkingChannels();
     assert.equal(channels.length, 1);
     assert.equal(channels[0].source, "observer");
-    assert.equal(channels[0].agentCount, 2);
+    assert.equal(channels[0].channelId, "chan-1");
     assert.deepEqual(
       new Set(channels[0].agentPubkeys),
-      new Set([AGENT, AGENT_2]),
-    );
-  });
-
-  it("adds typing-only channels with a typing source", () => {
-    startTurn(AGENT, "chan-1");
-    reportChannelBotTyping("chan-2", [AGENT_2]);
-    const channels = getWorkingChannels();
-    assert.deepEqual(
-      channels.map((c) => [c.channelId, c.source]),
-      [
-        ["chan-1", "observer"],
-        ["chan-2", "typing"],
-      ],
+      new Set([AGENT]),
     );
   });
 });
 
 describe("getWorkingAgentPubkeysForChannel", () => {
-  it("unions observer and typing agents for the channel", () => {
+  it("returns observer agents only for the channel", () => {
     startTurn(AGENT, "chan-1");
     reportChannelBotTyping("chan-1", [AGENT_2]);
     assert.deepEqual(
       new Set(getWorkingAgentPubkeysForChannel("chan-1")),
-      new Set([AGENT, AGENT_2]),
+      new Set([AGENT]),
     );
     assert.deepEqual(getWorkingAgentPubkeysForChannel("chan-2"), []);
     assert.deepEqual(getWorkingAgentPubkeysForChannel(null), []);
@@ -189,18 +156,18 @@ describe("subscription and caching", () => {
     }
   });
 
-  it("notifies on typing changes but not on identical re-reports", () => {
+  it("typing reports no longer flip working state", () => {
     let notified = 0;
     const unsubscribe = subscribeAgentWorkingSignal(() => {
       notified += 1;
     });
     try {
       reportChannelBotTyping("chan-1", [AGENT]);
-      assert.equal(notified, 1);
-      reportChannelBotTyping("chan-1", [AGENT]);
-      assert.equal(notified, 1);
+      // May notify for registry bookkeeping, but working stays false.
+      assert.equal(getAgentWorkingState(AGENT, "chan-1").working, false);
       reportChannelBotTyping("chan-1", []);
-      assert.equal(notified, 2);
+      assert.equal(getAgentWorkingState(AGENT, "chan-1").working, false);
+      assert.ok(notified >= 0);
     } finally {
       unsubscribe();
     }
@@ -220,9 +187,13 @@ describe("subscription and caching", () => {
     }
   });
 
-  it("resetAgentWorkingSignal clears typing state", () => {
+  it("resetAgentWorkingSignal leaves working idle", () => {
     reportChannelBotTyping("chan-1", [AGENT]);
+    startTurn(AGENT, "chan-1");
     resetAgentWorkingSignal();
+    // reset only clears typing registry; observer store is separate.
+    // working may still be true from active turns store — clear that too.
+    resetActiveAgentTurnsStore();
     assert.equal(getAgentWorkingState(AGENT, "chan-1").working, false);
   });
 });

--- a/desktop/src/features/agents/agentWorkingSignal.ts
+++ b/desktop/src/features/agents/agentWorkingSignal.ts
@@ -14,14 +14,17 @@ import {
  * Every surface that shows a working affordance (sidebar channel badges,
  * profile badges, agent rows, composer activity bar, activity panel header,
  * future thread ingresses) should read from this module instead of picking
- * one of the underlying pipes. The rule is:
+ * one of the underlying pipes.
  *
- *   1. Observer-derived active turns (kind 24200 → activeAgentTurnsStore)
- *      are the primary signal — they carry channel scope and a start anchor.
- *   2. Bot typing indicators (kind 20002, mirrored into this module by the
- *      channel typing hooks) are the fallback for agents whose observer
- *      stream is absent for that scope (e.g. remote harness without relay
- *      observer, or frames not yet arrived).
+ * Working = observer-derived active turns only (kind 24200 →
+ * activeAgentTurnsStore). Those frames are emitted when a real harness turn
+ * is running on a contentful event (kind 9 / other subscribed kinds).
+ *
+ * Bot typing indicators (kind 20002) are intentionally NOT a working signal.
+ * Typing is empty UX ephemera — humans type while composing, and harnesses
+ * may emit typing while already working. Folding typing into "is working…"
+ * produced false spinners on empty typing pings and double-counted real turns.
+ * Human/bot "is typing…" chrome still reads typing entries directly.
  *
  * Scope rule: with a channelId, "working" means working in that channel;
  * without one, "working" means any active work in any channel (the
@@ -99,9 +102,9 @@ export function subscribeAgentWorkingSignal(listener: () => void) {
 }
 
 /**
- * Mirror the current bot typing pubkeys for a channel into the signal.
- * Call with the full current set (empty array clears the channel). First-seen
- * timestamps are preserved across re-reports so elapsed anchors stay stable.
+ * Legacy no-op input path retained for call sites that still mirror bot typing.
+ * Typing is no longer folded into the working signal (observer turns only).
+ * Call sites may keep reporting; entries are ignored for `working` state.
  */
 export function reportChannelBotTyping(
   channelId: string,
@@ -142,21 +145,6 @@ function computeAgentWorkingState(
     anchorAt: turn.anchorAt,
     source: "observer" as const,
   }));
-  const observerChannelIds = new Set(turns.map((turn) => turn.channelId));
-
-  for (const [typingChannelId, entries] of typingByChannel) {
-    if (observerChannelIds.has(typingChannelId)) {
-      continue;
-    }
-    const since = entries.get(key);
-    if (since !== undefined) {
-      channels.push({
-        channelId: typingChannelId,
-        anchorAt: since,
-        source: "typing",
-      });
-    }
-  }
 
   if (channels.length === 0) {
     return IDLE_STATE;
@@ -168,13 +156,8 @@ function computeAgentWorkingState(
     channelId === null
       ? channels
       : channels.filter((channel) => channel.channelId === channelId);
-  const source: AgentWorkingSource = scoped.some(
-    (channel) => channel.source === "observer",
-  )
-    ? "observer"
-    : scoped.length > 0
-      ? "typing"
-      : "none";
+  const source: AgentWorkingSource =
+    scoped.length > 0 ? "observer" : "none";
 
   return { working: source !== "none", source, channels };
 }
@@ -201,10 +184,8 @@ export function getAgentWorkingState(
 }
 
 /**
- * All channels with agent work in progress, aggregated across agents and
- * merged observer-primary: typing-only agents fold into an existing observer
- * summary; channels with only typing get a typing-sourced summary anchored to
- * first-seen typing.
+ * All channels with agent work in progress, aggregated across agents from
+ * observer-derived active turns only.
  */
 export function getWorkingChannels(): WorkingChannelSummary[] {
   if (channelsCache) {
@@ -214,43 +195,6 @@ export function getWorkingChannels(): WorkingChannelSummary[] {
   const byChannel = new Map<string, WorkingChannelSummary>();
   for (const summary of getActiveTurnsByChannel()) {
     byChannel.set(summary.channelId, { ...summary, source: "observer" });
-  }
-
-  for (const [channelId, entries] of typingByChannel) {
-    const existing = byChannel.get(channelId);
-    if (existing) {
-      const known = new Set(
-        existing.agentPubkeys.map((pubkey) => normalizePubkey(pubkey)),
-      );
-      const merged = [...existing.agentPubkeys];
-      for (const pubkey of entries.keys()) {
-        if (!known.has(pubkey)) {
-          merged.push(pubkey);
-        }
-      }
-      if (merged.length !== existing.agentPubkeys.length) {
-        byChannel.set(channelId, {
-          ...existing,
-          agentPubkeys: merged,
-          agentCount: merged.length,
-        });
-      }
-      continue;
-    }
-
-    let anchorAt = Number.POSITIVE_INFINITY;
-    for (const since of entries.values()) {
-      if (since < anchorAt) {
-        anchorAt = since;
-      }
-    }
-    byChannel.set(channelId, {
-      channelId,
-      anchorAt,
-      agentCount: entries.size,
-      agentPubkeys: [...entries.keys()],
-      source: "typing",
-    });
   }
 
   const result = [...byChannel.values()].sort((a, b) =>
@@ -263,8 +207,8 @@ export function getWorkingChannels(): WorkingChannelSummary[] {
 const EMPTY_PUBKEYS: string[] = [];
 
 /**
- * Normalized pubkeys of every agent working in the given channel
- * (observer turns ∪ typing fallback). Stable while subscribed.
+ * Normalized pubkeys of every agent with an observer-backed active turn in
+ * the given channel. Stable while subscribed.
  */
 export function getWorkingAgentPubkeysForChannel(
   channelId: string | null | undefined,
@@ -283,12 +227,6 @@ export function getWorkingAgentPubkeysForChannel(
     }
     for (const pubkey of summary.agentPubkeys) {
       merged.add(normalizePubkey(pubkey));
-    }
-  }
-  const typing = typingByChannel.get(channelId);
-  if (typing) {
-    for (const pubkey of typing.keys()) {
-      merged.add(pubkey);
     }
   }
   const result = merged.size === 0 ? EMPTY_PUBKEYS : [...merged].sort();

--- a/desktop/src/features/channels/ui/ChannelPane.tsx
+++ b/desktop/src/features/channels/ui/ChannelPane.tsx
@@ -402,29 +402,19 @@ export const ChannelPane = React.memo(function ChannelPane({
   const canDropInMainColumn =
     hasMainComposerOverlay && !isComposerDisabled && !isSinglePanelView;
   const hasTypingActivity = typingPubkeys.length > 0;
-  // Unified working set for the composer bar: observer-derived turns primary,
-  // bot typing fallback (both folded together by agentWorkingSignal). This is
-  // what makes the bar show for an agent whose observer stream is live but
-  // whose typing signal never arrives — and vice versa.
+  // Unified working set for the composer bar: observer-derived active turns
+  // only (real harness turn on a contentful event). Typing is not a working
+  // signal — see agentWorkingSignal.
   const composerWorkingBotPubkeys = useChannelWorkingAgentPubkeys(
     activeChannel?.id ?? null,
   );
   const hasComposerBotActivity = composerWorkingBotPubkeys.length > 0;
   const hasComposerBottomActivity = hasComposerBotActivity || hasTypingActivity;
-  const threadComposerBotTypingPubkeys = React.useMemo(() => {
-    if (!openThreadHeadId) return [];
-    return botTypingEntries
-      .filter((entry) => entry.threadHeadId === openThreadHeadId)
-      .map((entry) => entry.pubkey)
-      .filter(
-        (pubkey, index, all) =>
-          all.findIndex(
-            (candidate) => candidate.toLowerCase() === pubkey.toLowerCase(),
-          ) === index,
-      );
-  }, [botTypingEntries, openThreadHeadId]);
+  // Thread composer "is working" uses the same observer-backed set as the
+  // channel composer. Bot typing alone must not light the working spinner.
+  const threadComposerWorkingBotPubkeys = composerWorkingBotPubkeys;
   const hasThreadComposerBotActivity =
-    threadComposerBotTypingPubkeys.length > 0;
+    threadComposerWorkingBotPubkeys.length > 0;
   const directMessageIntro = React.useMemo(
     () =>
       buildDirectMessageIntro({
@@ -894,7 +884,7 @@ export const ChannelPane = React.memo(function ChannelPane({
                       onOpenAgentSession={onOpenAgentSession}
                       openAgentSessionPubkey={openAgentSessionPubkey}
                       profiles={profiles}
-                      workingBotPubkeys={threadComposerBotTypingPubkeys}
+                      workingBotPubkeys={threadComposerWorkingBotPubkeys}
                       variant="inline"
                     />
                   ) : null


### PR DESCRIPTION
## Summary
Stops empty typing indicators (kind `20002`) from waking agents and from lighting the false «is working…» spinner.

## Changes
### Harness (`buzz-acp`)
- Drop **all ephemeral kinds** (`20000–29999`, including typing `20002` and presence `20001`) before an event can enter the turn queue.
- `match_event` hard-rejects ephemeral kinds even when rules use wildcard/`kinds = []` (subscribe-all).
- Unit test: wildcard rule does not match kind-20002.

### UI (desktop)
- «is working…» is driven **only** by observer-derived active turns (kind `24200` / real harness turn on contentful events).
- Bot typing is no longer a working fallback.
- Thread composer activity bar uses the same observer-backed working set.

## Why
While a human types, the client publishes empty kind-20002 heartbeats. If those reach the harness (wildcard/all subscriptions, or any path that does not filter ephemera), each ping starts a turn → quota burn + bot typing/observer frames → UI shows «Overseer is working…» with no real message.

## Verify
```bash
cargo test -p buzz-acp test_match_event_rejects_ephemeral_typing
cd desktop && npm test -- src/features/agents/agentWorkingSignal.test.mjs
```
Manual: type in a channel/thread with an idle agent — no harness wake and no «is working…» until a real kind-9 (or other contentful) turn.

## Context
Buzz channel `general`, thread root `32d19d8b8d8f4865f21eb8a800f64c62c4d9ea6aefebe4cb857186839c41bd60`.
