### PR TITLE
fix(desktop): accept npub or hex pubkey when adding members

### DIFF
--- a/desktop/src/features/channels/ui/ChannelMemberInviteCard.tsx
+++ b/desktop/src/features/channels/ui/ChannelMemberInviteCard.tsx
@@ -1,6 +1,7 @@
 import { Search, UserPlus, X } from "lucide-react";
 import * as React from "react";
 
+import { parsePubkeyInput } from "@/shared/lib/nostrUtils";
 import { truncatePubkey } from "@/shared/lib/pubkey";
 import { PubKey } from "@/shared/ui/PubKey";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
@@ -105,6 +106,35 @@ export function ChannelMemberInviteCard({
     ],
   );
 
+  // Someone without a kind:0 profile on the relay is invisible to user
+  // search — let the caller paste their npub or hex pubkey directly instead.
+  const directInvitee = React.useMemo<UserSearchResult | null>(() => {
+    const pubkey = parsePubkeyInput(deferredInviteQuery);
+    if (
+      pubkey === null ||
+      memberPubkeys.has(pubkey) ||
+      selectedInviteePubkeys.has(pubkey) ||
+      (userSearchQuery.data ?? []).some(
+        (user) => user.pubkey.toLowerCase() === pubkey,
+      )
+    ) {
+      return null;
+    }
+    return {
+      pubkey,
+      displayName: null,
+      avatarUrl: null,
+      nip05Handle: null,
+      ownerPubkey: null,
+      isAgent: false,
+    };
+  }, [
+    deferredInviteQuery,
+    memberPubkeys,
+    selectedInviteePubkeys,
+    userSearchQuery.data,
+  ]);
+
   React.useEffect(() => {
     if (!open) {
       setInviteQuery("");
@@ -161,7 +191,7 @@ export function ChannelMemberInviteCard({
               disabled={isPending}
               id="channel-management-search-users"
               onChange={(event) => setInviteQuery(event.target.value)}
-              placeholder="Search people and agents"
+              placeholder="Search people, or paste a public key"
               value={inviteQuery}
             />
           </div>
@@ -217,12 +247,41 @@ export function ChannelMemberInviteCard({
           ) : null}
           {deferredInviteQuery.length > 0 ? (
             <div className="border-t border-border/70 px-2 py-2">
-              {userSearchQuery.isLoading ? (
+              {userSearchQuery.isLoading && !directInvitee ? (
                 <p className="px-2 py-1 text-sm text-muted-foreground">
                   Searching…
                 </p>
-              ) : inviteSearchResults.length > 0 ? (
+              ) : inviteSearchResults.length > 0 || directInvitee ? (
                 <div className="max-h-44 space-y-1 overflow-y-auto">
+                  {directInvitee ? (
+                    <button
+                      className="flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground"
+                      data-testid={`channel-direct-invite-${directInvitee.pubkey}`}
+                      onClick={() => {
+                        setSelectedInvitees((current) => [
+                          ...current,
+                          directInvitee,
+                        ]);
+                        setInviteQuery("");
+                      }}
+                      type="button"
+                    >
+                      <div className="flex min-w-0 items-center gap-2">
+                        <UserAvatar
+                          avatarUrl={null}
+                          displayName={truncatePubkey(directInvitee.pubkey)}
+                          size="xs"
+                        />
+                        <p className="truncate text-sm font-medium leading-5">
+                          {truncatePubkey(directInvitee.pubkey)}
+                        </p>
+                        <span className="shrink-0 text-xs text-muted-foreground">
+                          by public key
+                        </span>
+                      </div>
+                      <span className="text-xs text-muted-foreground">Add</span>
+                    </button>
+                  ) : null}
                   {inviteSearchResults.map((result) => (
                     <button
                       className="flex w-full items-center justify-between rounded-md px-2.5 py-1.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground"

--- a/desktop/src/features/community-members/ui/AddMemberDialog.tsx
+++ b/desktop/src/features/community-members/ui/AddMemberDialog.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/features/community-members/hooks";
 import type { RelayMemberRole } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import { parsePubkeyInput } from "@/shared/lib/nostrUtils";
 import { Button } from "@/shared/ui/button";
 import {
   Dialog,
@@ -16,8 +17,6 @@ import {
   DialogTitle,
 } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
-
-const PUBKEY_REGEX = /^[0-9a-f]{64}$/;
 
 const ROLE_OPTIONS: Array<{ value: RelayMemberRole; label: string }> = [
   { value: "member", label: "Member" },
@@ -38,8 +37,8 @@ export function AddMemberDialog({
   const [pubkey, setPubkey] = React.useState("");
   const [role, setRole] = React.useState<RelayMemberRole>("member");
 
-  const normalizedPubkey = pubkey.trim().toLowerCase();
-  const isValidPubkey = PUBKEY_REGEX.test(normalizedPubkey);
+  const normalizedPubkey = parsePubkeyInput(pubkey);
+  const isValidPubkey = normalizedPubkey !== null;
   const isAlreadyMember =
     isValidPubkey &&
     !addMutation.isPending &&
@@ -62,7 +61,7 @@ export function AddMemberDialog({
   }
 
   function handleAdd() {
-    if (!canAdd) return;
+    if (!canAdd || normalizedPubkey === null) return;
     addMutation.mutate(
       { pubkey: normalizedPubkey, role },
       {
@@ -109,15 +108,14 @@ export function AddMemberDialog({
                     autoCorrect="off"
                     data-testid="member-pubkey-input"
                     id="member-pubkey"
-                    maxLength={64}
                     onChange={(e) => setPubkey(e.target.value)}
-                    placeholder="64-character hex pubkey"
+                    placeholder="npub1… or 64-character hex pubkey"
                     spellCheck={false}
                     value={pubkey}
                   />
                   {pubkey.trim().length > 0 && !isValidPubkey ? (
                     <p className="text-xs text-destructive">
-                      Must be exactly 64 lowercase hex characters.
+                      Must be an npub1… key or 64 hex characters.
                     </p>
                   ) : null}
                   {isAlreadyMember ? (

--- a/desktop/src/shared/lib/nostrUtils.ts
+++ b/desktop/src/shared/lib/nostrUtils.ts
@@ -23,6 +23,34 @@ export function safeNpub(pubkey: string): string | null {
   }
 }
 
+const HEX_PUBKEY_REGEX = /^[0-9a-f]{64}$/;
+
+/**
+ * Parse user-entered public key input — either a 64-character hex pubkey or
+ * a bech32 `npub1…` string — into a lowercase hex pubkey. Returns null for
+ * anything else (does NOT throw — intended for live form validation).
+ *
+ * The input is trimmed first; surrounding whitespace from copy-paste is
+ * tolerated.
+ */
+export function parsePubkeyInput(input: string): string | null {
+  const trimmed = input.trim().toLowerCase();
+  if (HEX_PUBKEY_REGEX.test(trimmed)) {
+    return trimmed;
+  }
+  if (trimmed.startsWith("npub1")) {
+    try {
+      const decoded = decode(trimmed);
+      if (decoded.type === "npub") {
+        return decoded.data;
+      }
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
 /**
  * Decode a bech32 nsec string and derive the matching npub. Returns null if
  * the input is not a syntactically valid `nsec1…` (does NOT throw — this is

--- a/desktop/src/shared/lib/parsePubkeyInput.test.mjs
+++ b/desktop/src/shared/lib/parsePubkeyInput.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { parsePubkeyInput } from "./nostrUtils.ts";
+
+const HEX = "ea9b4d7a7a78a3e3729e5568b14d764d4962be0e1f20f749bcf8d9dbbf9a9328";
+const NPUB = "npub1a2d567n60z37xu57245tzntkf4yk90swrus0wjdulrvah0u6jv5qusyp60";
+
+describe("parsePubkeyInput", () => {
+  it("accepts a lowercase 64-char hex pubkey", () => {
+    assert.equal(parsePubkeyInput(HEX), HEX);
+  });
+
+  it("lowercases an uppercase hex pubkey", () => {
+    assert.equal(parsePubkeyInput(HEX.toUpperCase()), HEX);
+  });
+
+  it("decodes an npub to its hex pubkey", () => {
+    assert.equal(parsePubkeyInput(NPUB), HEX);
+  });
+
+  it("tolerates surrounding whitespace from copy-paste", () => {
+    assert.equal(parsePubkeyInput(`  ${NPUB}\n`), HEX);
+    assert.equal(parsePubkeyInput(` ${HEX} `), HEX);
+  });
+
+  it("rejects an npub with a corrupted checksum", () => {
+    assert.equal(parsePubkeyInput(`${NPUB.slice(0, -1)}q`), null);
+  });
+
+  it("rejects other bech32 entities such as nsec", () => {
+    assert.equal(
+      parsePubkeyInput(
+        "nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5",
+      ),
+      null,
+    );
+  });
+
+  it("rejects hex of the wrong length", () => {
+    assert.equal(parsePubkeyInput(HEX.slice(0, 63)), null);
+    assert.equal(parsePubkeyInput(`${HEX}0`), null);
+  });
+
+  it("rejects non-hex non-npub input", () => {
+    assert.equal(parsePubkeyInput(""), null);
+    assert.equal(parsePubkeyInput("alice"), null);
+    assert.equal(parsePubkeyInput(`z${HEX.slice(1)}`), null);
+  });
+});


### PR DESCRIPTION
## Problem

Two member-add surfaces in Buzz Desktop made it impossible to add someone by their public key:

- **Relay members** (Settings → Invites → Add Member): the pubkey field only accepted a 64-character hex string and rejected `npub1…` input — the format most users actually have on hand.
- **Channel members** (Add members picker): search-only. User search matches kind:0 profile events, so an identity with no profile on the relay (e.g. a freshly generated client keypair) could not be invited at all.

## Fix

- New `parsePubkeyInput` helper in `shared/lib/nostrUtils.ts`: parses trimmed input as 64-char hex or bech32 `npub1…` (via nostr-tools nip19) into a lowercase hex pubkey; returns `null` otherwise. Unit tests cover hex, uppercase hex, npub, whitespace tolerance, bad checksum, nsec rejection, and wrong-length input.
- **AddMemberDialog** now accepts either form; placeholder and validation copy updated; `maxLength` removed so a pasted npub isn't truncated.
- **ChannelMemberInviteCard** now shows an "add by public key" row when the query parses as a pubkey that isn't already a member, already selected, or present in search results — profile-less identities can be invited directly.

## Validation

- `pnpm typecheck` — clean
- `pnpm test` — 3783 pass
- `pnpm check` (biome + file-size/px-text/pubkey-truncation checks) — clean

Internal tracking: AGNTOPS-364