### PR TITLE
fix(desktop): optional to lock builds to compiled relay

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -203,8 +203,8 @@ desktop-tauri-test: _ensure-sidecar-stubs
     cd desktop/src-tauri && cargo test
 
 # Verify compiled-flag behavior under both compile states (clean + internal).
-# Runs the observer_archive focused test twice with independently supplied
-# expected values; build.rs rerun-if-env-changed triggers recompilation.
+# Runs the focused build-policy tests with independently supplied expected
+# values; build.rs rerun-if-env-changed triggers recompilation.
 desktop-tauri-test-compiled-flags: _ensure-sidecar-stubs
     #!/usr/bin/env bash
     set -euo pipefail
@@ -215,8 +215,12 @@ desktop-tauri-test-compiled-flags: _ensure-sidecar-stubs
       BUZZ_TEST_EXPECTED_OBSERVER_ARCHIVE_DEFAULT=false \
       cargo test observer_archive_default_enabled_matches_expected -- --ignored --nocapture
     env -u BUZZ_BUILD_AUTO_CONNECT_DEFAULT_RELAY \
+      -u BUZZ_BUILD_LOCK_TO_DEFAULT_RELAY \
       BUZZ_TEST_EXPECTED_AUTO_CONNECT_DEFAULT_RELAY=false \
       cargo test compiled_flag_matches_expected -- --ignored --nocapture
+    env -u BUZZ_BUILD_LOCK_TO_DEFAULT_RELAY \
+      BUZZ_TEST_EXPECTED_LOCK_TO_DEFAULT_RELAY=false \
+      cargo test relay_lock_matches_expected -- --ignored --nocapture
     echo "=== Internal build (flags set) → expect true ==="
     BUZZ_BUILD_OBSERVER_ARCHIVE_DEFAULT=1 \
       BUZZ_TEST_EXPECTED_OBSERVER_ARCHIVE_DEFAULT=true \
@@ -224,6 +228,10 @@ desktop-tauri-test-compiled-flags: _ensure-sidecar-stubs
     BUZZ_BUILD_AUTO_CONNECT_DEFAULT_RELAY=1 \
       BUZZ_TEST_EXPECTED_AUTO_CONNECT_DEFAULT_RELAY=true \
       cargo test compiled_flag_matches_expected -- --ignored --nocapture
+    BUZZ_RELAY_URL=wss://buzz.block.builderlab.xyz \
+      BUZZ_BUILD_LOCK_TO_DEFAULT_RELAY=1 \
+      BUZZ_TEST_EXPECTED_LOCK_TO_DEFAULT_RELAY=true \
+      cargo test relay_lock_matches_expected -- --ignored --nocapture
     echo "Both compiled states verified."
 
 # Build the full desktop Tauri app locally (unsigned, for testing)

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-build = { version = "2", features = [] }
+url = "2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -3,6 +3,22 @@
 include!("src/commands/reconnect_hook_config.rs");
 
 use base64::Engine as _;
+use url::Url;
+
+fn validate_relay_origin(raw: &str) {
+    let parsed = Url::parse(raw)
+        .unwrap_or_else(|error| panic!("BUZZ_RELAY_URL must be a valid URL: {error}"));
+    if !matches!(parsed.scheme(), "ws" | "wss")
+        || parsed.host_str().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || !matches!(parsed.path(), "" | "/")
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        panic!("BUZZ_RELAY_URL must be a ws:// or wss:// origin without credentials, path, query, or fragment");
+    }
+}
 
 fn main() {
     println!("cargo:rerun-if-env-changed=BUZZ_RELAY_URL");
@@ -16,9 +32,14 @@ fn main() {
     println!("cargo:rerun-if-env-changed=BUZZ_BUILD_OBSERVER_ARCHIVE_DEFAULT");
     println!("cargo:rerun-if-env-changed=BUZZ_BUILD_AGENT_METRIC_ARCHIVE_DEFAULT");
     println!("cargo:rerun-if-env-changed=BUZZ_BUILD_AUTO_CONNECT_DEFAULT_RELAY");
+    println!("cargo:rerun-if-env-changed=BUZZ_BUILD_LOCK_TO_DEFAULT_RELAY");
     println!("cargo:rustc-check-cfg=cfg(buzz_updater_enabled)");
 
-    if let Ok(relay_url) = std::env::var("BUZZ_RELAY_URL") {
+    let build_relay_url = std::env::var("BUZZ_RELAY_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    if let Some(relay_url) = build_relay_url.as_deref() {
         println!("cargo:rustc-env=BUZZ_DESKTOP_BUILD_RELAY_URL={relay_url}");
     }
 
@@ -95,6 +116,17 @@ fn main() {
     // leave this unset and retain explicit community selection.
     if std::env::var("BUZZ_BUILD_AUTO_CONNECT_DEFAULT_RELAY").is_ok() {
         println!("cargo:rustc-env=BUZZ_DESKTOP_BUILD_AUTO_CONNECT_DEFAULT_RELAY=1");
+    }
+
+    // Presence-only release policy. Locked builds may connect only to their
+    // immutable compiled default relay. OSS builds leave this unset and retain
+    // multi-community relay selection.
+    if std::env::var("BUZZ_BUILD_LOCK_TO_DEFAULT_RELAY").is_ok() {
+        let relay_url = build_relay_url.as_deref().unwrap_or_else(|| {
+            panic!("BUZZ_BUILD_LOCK_TO_DEFAULT_RELAY requires a non-empty BUZZ_RELAY_URL")
+        });
+        validate_relay_origin(relay_url);
+        println!("cargo:rustc-env=BUZZ_DESKTOP_BUILD_LOCK_TO_DEFAULT_RELAY=1");
     }
 
     let updater_public_key = std::env::var("BUZZ_UPDATER_PUBLIC_KEY")

--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -60,9 +60,19 @@ pub fn auto_connect_default_relay_enabled() -> bool {
     option_env!("BUZZ_DESKTOP_BUILD_AUTO_CONNECT_DEFAULT_RELAY").is_some()
 }
 
+#[tauri::command]
+pub fn get_relay_connection_policy() -> Result<relay::RelayConnectionPolicy, String> {
+    relay::relay_connection_policy()
+}
+
+#[tauri::command]
+pub fn assert_relay_url_allowed(relay_url: String) -> Result<(), String> {
+    relay::ensure_relay_url_allowed(&relay_url)
+}
+
 #[cfg(test)]
 mod auto_connect_default_relay_tests {
-    use super::auto_connect_default_relay_enabled;
+    use super::{auto_connect_default_relay_enabled, relay};
 
     #[test]
     #[ignore]
@@ -71,6 +81,17 @@ mod auto_connect_default_relay_tests {
             .expect("compiled-flag test requires an expected value");
         assert_eq!(
             auto_connect_default_relay_enabled(),
+            expected == "true" || expected == "1"
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn relay_lock_matches_expected() {
+        let expected = std::env::var("BUZZ_TEST_EXPECTED_LOCK_TO_DEFAULT_RELAY")
+            .expect("compiled-flag test requires an expected value");
+        assert_eq!(
+            relay::lock_to_default_relay_enabled(),
             expected == "true" || expected == "1"
         );
     }

--- a/desktop/src-tauri/src/commands/join_policy.rs
+++ b/desktop/src-tauri/src/commands/join_policy.rs
@@ -32,6 +32,7 @@ fn join_policy_url(relay_url: &str) -> Result<Url, String> {
 /// Fetch an arbitrary relay's optional join policy through native networking.
 #[tauri::command]
 pub async fn fetch_join_policy(relay_url: String) -> Result<Option<Value>, String> {
+    crate::relay::ensure_relay_url_allowed(&relay_url)?;
     let url = join_policy_url(&relay_url)?;
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())

--- a/desktop/src-tauri/src/commands/profile.rs
+++ b/desktop/src-tauri/src/commands/profile.rs
@@ -106,6 +106,7 @@ pub async fn update_profile_at_relay(
     avatar_url: String,
     state: State<'_, AppState>,
 ) -> Result<ProfileInfo, String> {
+    crate::relay::ensure_relay_url_allowed(&relay_url)?;
     let signer = capture_expected_signer(&state, &expected_pubkey)?;
 
     let api_base_url = relay_http_base_url(&relay_url);

--- a/desktop/src-tauri/src/commands/workspace.rs
+++ b/desktop/src-tauri/src/commands/workspace.rs
@@ -52,6 +52,7 @@ pub async fn fetch_workspace_icon(
     relay_url: String,
     state: State<'_, AppState>,
 ) -> Result<Option<String>, String> {
+    relay::ensure_relay_url_allowed(&relay_url)?;
     let http_url = relay::relay_http_base_url(&relay_url);
     let Ok(response) = state
         .http_client
@@ -136,6 +137,7 @@ pub async fn apply_workspace(
         let state = app.state::<AppState>();
 
         // ── Validate before mutating ──────────────────────────────────────────
+        relay::ensure_relay_url_allowed(&relay_url)?;
         let parsed_keys = match nsec.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
             Some(nsec_trimmed) => {
                 Some(Keys::parse(nsec_trimmed).map_err(|e| format!("invalid nsec: {e}"))?)

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ mod prevent_sleep;
 mod ptt_shortcut;
 mod relay;
 mod relay_admission;
+mod relay_policy;
 mod reset;
 mod secret_store;
 mod shutdown;
@@ -719,6 +720,8 @@ pub fn run() {
             get_os_idle_seconds,
             get_default_relay_url,
             auto_connect_default_relay_enabled,
+            get_relay_connection_policy,
+            assert_relay_url_allowed,
             get_legacy_workspace_storage,
             is_shared_identity,
             get_relay_ws_url,

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -243,6 +243,7 @@ fn start_pair(
     expected_updated_at: Option<&str>,
     app: AppHandle,
 ) -> Result<ManagedAgentRuntimeStatus, String> {
+    crate::relay::ensure_relay_url_allowed(&relay_url)?;
     let state = app.state::<AppState>();
     let _transition = state
         .managed_agent_runtime_transition
@@ -400,6 +401,7 @@ async fn probe_agent_relay_access(
     record: super::ManagedAgentRecord,
     requested_relay_url: String,
 ) -> Result<(super::ManagedAgentRecord, ManagedAgentRuntimeKey, String), String> {
+    crate::relay::ensure_relay_url_allowed(&requested_relay_url)?;
     let key = ManagedAgentRuntimeKey::new(record.pubkey.clone(), &requested_relay_url)?;
     let keys = nostr::Keys::parse(record.private_key_nsec.trim())
         .map_err(|error| format!("invalid managed-agent key: {error}"))?;

--- a/desktop/src-tauri/src/native_websocket.rs
+++ b/desktop/src-tauri/src/native_websocket.rs
@@ -179,6 +179,7 @@ async fn connect(
     on_message: Channel<serde_json::Value>,
     _config: Option<serde_json::Value>,
 ) -> Result<Id, String> {
+    crate::relay::ensure_relay_url_allowed(&url)?;
     open_connection(manager.inner(), &url, on_message).await
 }
 

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -8,8 +8,11 @@ use sha2::{Digest, Sha256};
 // nostr 0.36 alias — required for cross-version bridging with buzz-sdk.
 
 use crate::app_state::AppState;
-
-const DEFAULT_RELAY_WS_URL: &str = "ws://localhost:3000";
+use crate::relay_policy::{compiled_relay_ws_url, DEFAULT_RELAY_WS_URL};
+pub use crate::relay_policy::{
+    ensure_relay_url_allowed, lock_to_default_relay_enabled, relay_connection_policy,
+    RelayConnectionPolicy,
+};
 
 // A reached-but-malformed 2xx body is NOT a connectivity failure, so this
 // message must never carry the "relay unreachable:" prefix the frontend
@@ -24,8 +27,13 @@ fn configured_env_var(name: &str) -> Option<String> {
 }
 
 pub fn relay_ws_url() -> String {
+    if lock_to_default_relay_enabled() {
+        return compiled_relay_ws_url()
+            .unwrap_or(DEFAULT_RELAY_WS_URL)
+            .to_string();
+    }
     configured_env_var("BUZZ_RELAY_URL")
-        .or_else(|| option_env!("BUZZ_DESKTOP_BUILD_RELAY_URL").map(str::to_string))
+        .or_else(|| compiled_relay_ws_url().map(str::to_string))
         .unwrap_or_else(|| DEFAULT_RELAY_WS_URL.to_string())
 }
 
@@ -42,12 +50,18 @@ fn workspace_relay_override(state: &AppState) -> Option<String> {
 /// Returns the relay WebSocket URL, checking the workspace override first.
 /// Precedence: workspace override > env vars > build-time vars > default.
 pub fn relay_ws_url_with_override(state: &AppState) -> String {
+    if lock_to_default_relay_enabled() {
+        return relay_ws_url();
+    }
     workspace_relay_override(state).unwrap_or_else(relay_ws_url)
 }
 
 /// Returns the relay HTTP API base URL, checking the workspace override first.
 /// Precedence: workspace override > env vars > build-time vars > default.
 pub fn relay_api_base_url_with_override(state: &AppState) -> String {
+    if lock_to_default_relay_enabled() {
+        return relay_api_base_url();
+    }
     match workspace_relay_override(state) {
         Some(url) => relay_http_base_url(&url),
         None => relay_api_base_url(),

--- a/desktop/src-tauri/src/relay_policy.rs
+++ b/desktop/src-tauri/src/relay_policy.rs
@@ -1,0 +1,141 @@
+use serde::Serialize;
+use url::Url;
+
+pub const DEFAULT_RELAY_WS_URL: &str = "ws://localhost:3000";
+const LOCKED_RELAY_ERROR: &str = "This Buzz build only allows its configured relay.";
+
+pub(crate) fn compiled_relay_ws_url() -> Option<&'static str> {
+    option_env!("BUZZ_DESKTOP_BUILD_RELAY_URL")
+}
+
+pub fn lock_to_default_relay_enabled() -> bool {
+    option_env!("BUZZ_DESKTOP_BUILD_LOCK_TO_DEFAULT_RELAY").is_some()
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelayConnectionPolicy {
+    pub locked_to_default_relay: bool,
+    pub default_relay_url: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RelayOrigin {
+    scheme: String,
+    host: String,
+    port: u16,
+}
+
+fn relay_origin(raw: &str) -> Result<RelayOrigin, String> {
+    let parsed = Url::parse(raw.trim()).map_err(|_| "invalid relay URL".to_string())?;
+    if !matches!(parsed.scheme(), "ws" | "wss")
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || !matches!(parsed.path(), "" | "/")
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        return Err("relay URL must be a ws:// or wss:// origin".to_string());
+    }
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "relay URL must include a host".to_string())?;
+    let port = parsed
+        .port_or_known_default()
+        .ok_or_else(|| "relay URL must include a valid port".to_string())?;
+    Ok(RelayOrigin {
+        scheme: parsed.scheme().to_string(),
+        host: host.to_ascii_lowercase(),
+        port,
+    })
+}
+
+fn ensure_relay_url_allowed_with_policy(
+    relay_url: &str,
+    locked: bool,
+    allowed_relay_url: Option<&str>,
+) -> Result<(), String> {
+    if !locked {
+        return Ok(());
+    }
+    let allowed = allowed_relay_url.ok_or_else(|| LOCKED_RELAY_ERROR.to_string())?;
+    let candidate_origin = relay_origin(relay_url).map_err(|_| LOCKED_RELAY_ERROR.to_string())?;
+    let allowed_origin = relay_origin(allowed).map_err(|_| LOCKED_RELAY_ERROR.to_string())?;
+    if candidate_origin != allowed_origin {
+        return Err(LOCKED_RELAY_ERROR.to_string());
+    }
+    Ok(())
+}
+
+pub fn ensure_relay_url_allowed(relay_url: &str) -> Result<(), String> {
+    ensure_relay_url_allowed_with_policy(
+        relay_url,
+        lock_to_default_relay_enabled(),
+        compiled_relay_ws_url(),
+    )
+}
+
+pub fn relay_connection_policy() -> Result<RelayConnectionPolicy, String> {
+    let locked = lock_to_default_relay_enabled();
+    let default_relay_url = compiled_relay_ws_url()
+        .unwrap_or(DEFAULT_RELAY_WS_URL)
+        .to_string();
+    ensure_relay_url_allowed_with_policy(&default_relay_url, locked, compiled_relay_ws_url())?;
+    Ok(RelayConnectionPolicy {
+        locked_to_default_relay: locked,
+        default_relay_url,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_relay_url_allowed_with_policy, relay_origin};
+
+    #[test]
+    fn unlocked_build_allows_any_relay_string() {
+        assert!(ensure_relay_url_allowed_with_policy("not a URL", false, None).is_ok());
+    }
+
+    #[test]
+    fn locked_build_accepts_only_the_compiled_origin() {
+        let allowed = "wss://buzz.block.builderlab.xyz";
+        assert!(ensure_relay_url_allowed_with_policy(
+            "wss://BUZZ.block.builderlab.xyz/",
+            true,
+            Some(allowed),
+        )
+        .is_ok());
+
+        for rejected in [
+            "ws://buzz.block.builderlab.xyz",
+            "wss://public.example.com",
+            "wss://public.buzz.block.builderlab.xyz",
+            "wss://buzz.block.builderlab.xyz:8443",
+            "wss://buzz.block.builderlab.xyz/path",
+            "wss://user@buzz.block.builderlab.xyz",
+            "wss://buzz.block.builderlab.xyz?redirect=public.example.com",
+        ] {
+            assert!(
+                ensure_relay_url_allowed_with_policy(rejected, true, Some(allowed)).is_err(),
+                "expected {rejected} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn locked_build_fails_closed_without_a_compiled_relay() {
+        assert!(ensure_relay_url_allowed_with_policy(
+            "wss://buzz.block.builderlab.xyz",
+            true,
+            None,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn relay_origin_requires_a_bare_websocket_origin() {
+        assert!(relay_origin("https://buzz.block.builderlab.xyz").is_err());
+        assert!(relay_origin("wss://buzz.block.builderlab.xyz/channel").is_err());
+        assert!(relay_origin("wss://buzz.block.builderlab.xyz").is_ok());
+    }
+}

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -43,6 +43,7 @@ import { ResetFailedScreen } from "@/features/onboarding/ui/ResetFailedScreen";
 import { useCommunityInit } from "@/features/communities/useCommunityInit";
 import { useNestNotifications } from "@/features/communities/useNestNotifications";
 import { useCommunities } from "@/features/communities/useCommunities";
+import { isRelayUrlAllowed } from "@/features/communities/relayPolicy";
 import {
   loadCommunityDestination,
   markPendingCommunityRestore,
@@ -304,6 +305,7 @@ function CommunityApp({
     removeCommunity,
     switchCommunity,
     reconnectCommunity,
+    relayConnectionPolicy,
   } = useCommunities();
   const communityOnboarding = useCommunityOnboarding();
   const connectingTransactionRef = useRef<string | null>(null);
@@ -342,6 +344,7 @@ function CommunityApp({
     activeCommunity,
     communityKey,
     sharedIdentity,
+    relayConnectionPolicy,
   );
 
   const transitionCommunity = useCallback(
@@ -593,7 +596,7 @@ function CommunityApp({
 }
 
 function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
-  const { activeCommunity } = useCommunities();
+  const { activeCommunity, relayConnectionPolicy } = useCommunities();
   const communityOnboarding = useCommunityOnboarding();
   const machine = useMachineOnboardingState({
     activeCommunityPubkey: activeCommunity
@@ -641,15 +644,19 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
   }, [machine.stage, postOnboardingNav]);
 
   const openAddCommunity = useCallback(
-    (payload: AddCommunityDeepLinkPayload & { requestId: string }) =>
-      activeCommunity
+    (payload: AddCommunityDeepLinkPayload & { requestId: string }) => {
+      if (!isRelayUrlAllowed(relayConnectionPolicy, payload.relayUrl)) {
+        return false;
+      }
+      return activeCommunity
         ? requestAddCommunityPrefill(payload)
         : communityOnboarding.start({
             source: "add-community",
             relayUrl: payload.relayUrl,
             communityName: payload.name,
-          }),
-    [activeCommunity, communityOnboarding.start],
+          });
+    },
+    [activeCommunity, communityOnboarding.start, relayConnectionPolicy],
   );
 
   // Deep links are captured here — above the machine-onboarding gate — not in
@@ -659,6 +666,8 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
   // still pending, and survives a relaunch in between.
   useEffect(() => {
     const unlisten = listenForDeepLinks({
+      isRelayAllowed: (relayUrl) =>
+        isRelayUrlAllowed(relayConnectionPolicy, relayUrl),
       startCommunityOnboarding: communityOnboarding.start,
       openAddCommunity,
       onAddCommunityAvailable: onAddCommunityPrefillAvailable,
@@ -666,7 +675,7 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
     return () => {
       void unlisten.then((fn) => fn());
     };
-  }, [communityOnboarding.start, openAddCommunity]);
+  }, [communityOnboarding.start, openAddCommunity, relayConnectionPolicy]);
 
   if (machine.stage === "reset-failed") return <ResetFailedScreen />;
   if (machine.stage === "keyring-locked") return <KeyringLockedScreen />;

--- a/desktop/src/features/communities/communityStorage.ts
+++ b/desktop/src/features/communities/communityStorage.ts
@@ -104,6 +104,10 @@ export function saveActiveCommunityId(id: string): boolean {
   return setLocalStorageItemWithRecovery(ACTIVE_COMMUNITY_KEY, id);
 }
 
+export function clearActiveCommunityId(): void {
+  localStorage.removeItem(ACTIVE_COMMUNITY_KEY);
+}
+
 export function normalizeRelayUrl(url: string): string {
   if (!url.startsWith("ws://") && !url.startsWith("wss://")) {
     return `wss://${url}`;

--- a/desktop/src/features/communities/relayPolicy.test.mjs
+++ b/desktop/src/features/communities/relayPolicy.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyRelayConnectionPolicy,
+  isRelayUrlAllowed,
+} from "./relayPolicy.ts";
+
+const locked = {
+  lockedToDefaultRelay: true,
+  defaultRelayUrl: "wss://buzz.block.builderlab.xyz",
+};
+
+test("locked policy compares exact normalized origins", () => {
+  assert.equal(
+    isRelayUrlAllowed(locked, "wss://BUZZ.block.builderlab.xyz/"),
+    true,
+  );
+  for (const relayUrl of [
+    "ws://buzz.block.builderlab.xyz",
+    "wss://public.example.com",
+    "wss://public.buzz.block.builderlab.xyz",
+    "wss://buzz.block.builderlab.xyz:8443",
+    "wss://buzz.block.builderlab.xyz/path",
+  ]) {
+    assert.equal(isRelayUrlAllowed(locked, relayUrl), false, relayUrl);
+  }
+});
+
+test("unrestricted policy preserves existing behavior", () => {
+  assert.equal(
+    isRelayUrlAllowed(
+      {
+        lockedToDefaultRelay: false,
+        defaultRelayUrl: "ws://localhost:3000",
+      },
+      "not a URL",
+    ),
+    true,
+  );
+});
+
+test("locked policy removes saved external communities before app mount", () => {
+  const communities = [
+    { id: "external", relayUrl: "wss://public.example.com" },
+    { id: "block", relayUrl: "wss://buzz.block.builderlab.xyz" },
+  ];
+  assert.deepEqual(
+    applyRelayConnectionPolicy(communities, "external", locked),
+    {
+      communities: [communities[1]],
+      activeId: "block",
+      changed: true,
+    },
+  );
+});
+
+test("locked policy clears state when no saved community is allowed", () => {
+  const communities = [
+    { id: "external", relayUrl: "wss://public.example.com" },
+  ];
+  assert.deepEqual(
+    applyRelayConnectionPolicy(communities, "external", locked),
+    { communities: [], activeId: null, changed: true },
+  );
+});

--- a/desktop/src/features/communities/relayPolicy.ts
+++ b/desktop/src/features/communities/relayPolicy.ts
@@ -1,0 +1,61 @@
+import type { RelayConnectionPolicy } from "@/shared/api/tauriRelayPolicy";
+import type { Community } from "./types";
+
+export const UNRESTRICTED_RELAY_CONNECTION_POLICY: RelayConnectionPolicy = {
+  lockedToDefaultRelay: false,
+  defaultRelayUrl: "ws://localhost:3000",
+};
+
+function relayOrigin(raw: string): string | null {
+  try {
+    const url = new URL(raw.trim());
+    if (
+      (url.protocol !== "ws:" && url.protocol !== "wss:") ||
+      url.username !== "" ||
+      url.password !== "" ||
+      (url.pathname !== "" && url.pathname !== "/") ||
+      url.search !== "" ||
+      url.hash !== ""
+    ) {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function isRelayUrlAllowed(
+  policy: RelayConnectionPolicy,
+  relayUrl: string,
+): boolean {
+  if (!policy.lockedToDefaultRelay) return true;
+  const candidate = relayOrigin(relayUrl);
+  const allowed = relayOrigin(policy.defaultRelayUrl);
+  return candidate !== null && allowed !== null && candidate === allowed;
+}
+
+export function applyRelayConnectionPolicy(
+  communities: Community[],
+  activeId: string | null,
+  policy: RelayConnectionPolicy,
+): { communities: Community[]; activeId: string | null; changed: boolean } {
+  if (!policy.lockedToDefaultRelay) {
+    return { communities, activeId, changed: false };
+  }
+  const allowedCommunities = communities.filter((community) =>
+    isRelayUrlAllowed(policy, community.relayUrl),
+  );
+  const nextActiveId = allowedCommunities.some(
+    (community) => community.id === activeId,
+  )
+    ? activeId
+    : (allowedCommunities[0]?.id ?? null);
+  return {
+    communities: allowedCommunities,
+    activeId: nextActiveId,
+    changed:
+      allowedCommunities.length !== communities.length ||
+      nextActiveId !== activeId,
+  };
+}

--- a/desktop/src/features/communities/relayProbe.ts
+++ b/desktop/src/features/communities/relayProbe.ts
@@ -2,6 +2,8 @@
  * Normalize a relay URL to ws(s):// form and probe reachability.
  */
 
+import { assertRelayUrlAllowed } from "@/shared/api/tauriRelayPolicy";
+
 /** Normalize a user-entered relay URL to ws(s):// form. Returns null if invalid. */
 export function normalizeRelayUrl(input: string): string | null {
   const trimmed = input.trim().replace(/\/+$/, "");
@@ -61,6 +63,7 @@ export function normalizeRelayUrl(input: string): string | null {
 export function probeRelayReachable(
   wsUrl: string,
   timeoutMs = 4000,
+  assertAllowed: (relayUrl: string) => Promise<void> = assertRelayUrlAllowed,
 ): { promise: Promise<boolean>; cancel: () => void } {
   let socket: WebSocket | null = null;
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -80,15 +83,20 @@ export function probeRelayReachable(
       resolve(result);
     }
 
-    try {
-      socket = new WebSocket(wsUrl);
-      socket.onopen = () => settle(true);
-      socket.onerror = () => settle(false);
-      socket.onclose = () => settle(false);
-      timeoutId = setTimeout(() => settle(false), timeoutMs);
-    } catch {
-      settle(false);
-    }
+    void assertAllowed(wsUrl)
+      .then(() => {
+        if (settled) return;
+        try {
+          socket = new WebSocket(wsUrl);
+          socket.onopen = () => settle(true);
+          socket.onerror = () => settle(false);
+          socket.onclose = () => settle(false);
+          timeoutId = setTimeout(() => settle(false), timeoutMs);
+        } catch {
+          settle(false);
+        }
+      })
+      .catch(() => settle(false));
   });
 
   return {

--- a/desktop/src/features/communities/ui/AddCommunityDialog.tsx
+++ b/desktop/src/features/communities/ui/AddCommunityDialog.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, ChevronRight, Link2, Plus } from "lucide-react";
 
 import type { AddCommunityPrefillRequest } from "@/features/communities/addCommunityPrefill";
 import { HostedCommunityCreateFlow } from "@/features/communities/ui/HostedCommunityCreateFlow";
+import { useCommunities } from "@/features/communities/useCommunities";
 import { useCommunityOnboarding } from "@/features/onboarding/communityOnboarding";
 import { InviteRedeemForm } from "@/features/onboarding/ui/InviteRedeemForm";
 import {
@@ -32,6 +33,7 @@ export function AddCommunityDialog({
   open,
   onOpenChange,
 }: AddCommunityDialogProps) {
+  const { relayConnectionPolicy } = useCommunities();
   const communityOnboarding = useCommunityOnboarding();
   const [mode, setMode] = React.useState<AddCommunityMode>("choose");
   const [joinError, setJoinError] = React.useState<string | null>(null);
@@ -80,6 +82,8 @@ export function AddCommunityDialog({
     },
     [communityOnboarding, handleClose, prefill?.name],
   );
+
+  if (relayConnectionPolicy.lockedToDefaultRelay) return null;
 
   const title =
     mode === "create"

--- a/desktop/src/features/communities/ui/CommunityChangeOverlay.tsx
+++ b/desktop/src/features/communities/ui/CommunityChangeOverlay.tsx
@@ -12,7 +12,8 @@ export function CommunityChangeOverlay({
   onClose,
   onUpdated,
 }: CommunityChangeOverlayProps) {
-  const { activeCommunity, updateCommunity } = useCommunities();
+  const { activeCommunity, relayConnectionPolicy, updateCommunity } =
+    useCommunities();
   const [error, setError] = React.useState<string | null>(null);
   const overlayRef = React.useRef<HTMLDivElement>(null);
 
@@ -79,7 +80,9 @@ export function CommunityChangeOverlay({
           Change community
         </h2>
         <p className="mt-2 text-sm text-muted-foreground">
-          Update your community name or relay URL.
+          {relayConnectionPolicy.lockedToDefaultRelay
+            ? "Update your community name. The relay is managed by this Buzz build."
+            : "Update your community name or relay URL."}
         </p>
         <div className="mt-6">
           <CommunityEditForm
@@ -87,6 +90,7 @@ export function CommunityChangeOverlay({
             initialRelayUrl={activeCommunity.relayUrl}
             onCancel={onClose}
             onSubmit={handleSubmit}
+            relayReadOnly={relayConnectionPolicy.lockedToDefaultRelay}
             submitLabel="Save changes"
           />
         </div>

--- a/desktop/src/features/communities/ui/CommunityEditForm.tsx
+++ b/desktop/src/features/communities/ui/CommunityEditForm.tsx
@@ -23,6 +23,7 @@ export type CommunityEditFormProps = {
   joinPolicyRequired?: boolean;
   onCancel: () => void;
   onSubmit: (name: string, relayUrl: string) => void;
+  relayReadOnly?: boolean;
   submitLabel: string;
 };
 
@@ -34,6 +35,7 @@ export function CommunityEditForm({
   joinPolicyRequired = false,
   onCancel,
   onSubmit,
+  relayReadOnly = false,
   submitLabel,
 }: CommunityEditFormProps) {
   const [name, setName] = React.useState(initialName);
@@ -59,7 +61,7 @@ export function CommunityEditForm({
   }, []);
 
   React.useEffect(() => {
-    if (!joinPolicyRequired) return;
+    if (!joinPolicyRequired || relayReadOnly) return;
 
     const normalizedUrl = normalizeRelayUrl(relayUrl);
     if (!normalizedUrl || !isJoinPolicyDiscoveryCandidate(normalizedUrl)) {
@@ -87,7 +89,7 @@ export function CommunityEditForm({
       cancelled = true;
       window.clearTimeout(timeoutId);
     };
-  }, [joinPolicyRequired, relayUrl]);
+  }, [joinPolicyRequired, relayReadOnly, relayUrl]);
 
   const handleSubmit = React.useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {
@@ -95,6 +97,10 @@ export function CommunityEditForm({
       const trimmedName = name.trim();
       if (!trimmedName) {
         setError("Please enter a community name.");
+        return;
+      }
+      if (relayReadOnly) {
+        onSubmit(trimmedName, initialRelayUrl);
         return;
       }
       const normalizedUrl = normalizeRelayUrl(relayUrl);
@@ -170,9 +176,11 @@ export function CommunityEditForm({
       agreementConfirmed,
       joinPolicy,
       joinPolicyRequired,
+      initialRelayUrl,
       name,
       onSubmit,
       policyRelayUrl,
+      relayReadOnly,
       relayUrl,
       useAnywayOverride,
     ],
@@ -219,35 +227,37 @@ export function CommunityEditForm({
         />
       </div>
 
-      <div className="space-y-1.5 text-left">
-        <label
-          className="text-sm font-medium text-foreground"
-          htmlFor="community-edit-url"
-        >
-          Community URL
-        </label>
-        <Input
-          className="h-10 bg-background"
-          disabled={isProbing}
-          id="community-edit-url"
-          onChange={(event) => {
-            setRelayUrl(event.target.value);
-            setError(null);
-            setProbeWarning(null);
-            setUseAnywayOverride(false);
-            setJoinPolicy(null);
-            setPolicyRelayUrl(null);
-            setAgeConfirmed(false);
-            setAgreementConfirmed(false);
-          }}
-          placeholder="wss://relay.example.com"
-          type="text"
-          value={relayUrl}
-        />
-      </div>
+      {!relayReadOnly ? (
+        <div className="space-y-1.5 text-left">
+          <label
+            className="text-sm font-medium text-foreground"
+            htmlFor="community-edit-url"
+          >
+            Community URL
+          </label>
+          <Input
+            className="h-10 bg-background"
+            disabled={isProbing}
+            id="community-edit-url"
+            onChange={(event) => {
+              setRelayUrl(event.target.value);
+              setError(null);
+              setProbeWarning(null);
+              setUseAnywayOverride(false);
+              setJoinPolicy(null);
+              setPolicyRelayUrl(null);
+              setAgeConfirmed(false);
+              setAgreementConfirmed(false);
+            }}
+            placeholder="wss://relay.example.com"
+            type="text"
+            value={relayUrl}
+          />
+        </div>
+      ) : null}
 
       <AnimatePresence initial={false}>
-        {joinPolicy && policyRelayUrl ? (
+        {!relayReadOnly && joinPolicy && policyRelayUrl ? (
           <motion.div
             animate={{
               height: "auto",
@@ -307,7 +317,7 @@ export function CommunityEditForm({
           disabled={
             isBusy ||
             !name.trim() ||
-            !relayUrl.trim() ||
+            (!relayReadOnly && !relayUrl.trim()) ||
             Boolean(joinPolicy?.ageAttestationRequired && !ageConfirmed) ||
             Boolean(
               joinPolicy &&
@@ -340,7 +350,7 @@ export function CommunityEditForm({
           <p className="text-center text-sm text-destructive">{error}</p>
         ) : null}
 
-        {probeWarning ? (
+        {!relayReadOnly && probeWarning ? (
           <div className="flex flex-col items-center gap-2">
             <p className="text-center text-sm text-destructive">
               {probeWarning}

--- a/desktop/src/features/communities/ui/CommunitySwitcher.tsx
+++ b/desktop/src/features/communities/ui/CommunitySwitcher.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/shared/api/useRelayConnection";
 import { writeTextToClipboard } from "@/shared/lib/clipboard";
 import { useActiveCommunityIcon } from "@/features/communities/useCommunityIcons";
+import { useCommunities } from "@/features/communities/useCommunities";
 import { EditCommunityDialog } from "./EditCommunityDialog";
 
 const CONNECTION_STATE_LABEL: Record<ConnectionState, string> = {
@@ -100,6 +101,8 @@ export function CommunitySwitcher({
   onUpdateCommunity,
   onRemoveCommunity,
 }: CommunitySwitcherProps) {
+  const { relayConnectionPolicy } = useCommunities();
+  const relayLocked = relayConnectionPolicy.lockedToDefaultRelay;
   const [editingCommunity, setEditingCommunity] =
     React.useState<Community | null>(null);
   const [dropdownOpen, setDropdownOpen] = React.useState(false);
@@ -281,18 +284,20 @@ export function CommunitySwitcher({
                 <hr className="-mx-1 my-1 h-px border-0 bg-muted" />
               </>
             ) : null}
-            <button
-              className="flex min-h-9 w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm outline-hidden transition-colors hover:bg-muted/50 focus:bg-muted/50 focus:outline-none focus-visible:bg-muted/50 focus-visible:outline-none"
-              onClick={() => {
-                setDropdownOpen(false);
-                onAddCommunity();
-              }}
-              role="menuitem"
-              type="button"
-            >
-              <Plus className="h-4 w-4" />
-              <span>Add a community</span>
-            </button>
+            {!relayLocked ? (
+              <button
+                className="flex min-h-9 w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm outline-hidden transition-colors hover:bg-muted/50 focus:bg-muted/50 focus:outline-none focus-visible:bg-muted/50 focus-visible:outline-none"
+                onClick={() => {
+                  setDropdownOpen(false);
+                  onAddCommunity();
+                }}
+                role="menuitem"
+                type="button"
+              >
+                <Plus className="h-4 w-4" />
+                <span>Add a community</span>
+              </button>
+            ) : null}
           </div>
         </PopoverContent>
       </Popover>
@@ -369,11 +374,15 @@ export function CommunitySwitcher({
             </button>
           </DropdownMenuItem>
         ))}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={onAddCommunity}>
-          <Plus className="h-4 w-4" />
-          <span>Add a community</span>
-        </DropdownMenuItem>
+        {!relayLocked ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={onAddCommunity}>
+              <Plus className="h-4 w-4" />
+              <span>Add a community</span>
+            </DropdownMenuItem>
+          </>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/desktop/src/features/communities/ui/EditCommunityDialog.tsx
+++ b/desktop/src/features/communities/ui/EditCommunityDialog.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { CommunityIconSettingsCard } from "@/features/communities/ui/CommunityIconSettingsCard";
 import { useMyRelayMembershipLookupQuery } from "@/features/community-members/hooks";
 import type { Community } from "@/features/communities/types";
+import { useCommunities } from "@/features/communities/useCommunities";
 import {
   expandTilde,
   normalizeRelayUrl,
@@ -42,6 +43,8 @@ export function EditCommunityDialog({
   canRemove,
   showIconEditor = false,
 }: EditCommunityDialogProps) {
+  const { relayConnectionPolicy } = useCommunities();
+  const relayLocked = relayConnectionPolicy.lockedToDefaultRelay;
   const [name, setName] = React.useState("");
   const [relayUrl, setRelayUrl] = React.useState("");
   const [token, setToken] = React.useState("");
@@ -73,7 +76,7 @@ export function EditCommunityDialog({
   const handleSubmit = React.useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault();
-      if (!community || !relayUrl.trim()) {
+      if (!community || (!relayLocked && !relayUrl.trim())) {
         return;
       }
 
@@ -86,9 +89,11 @@ export function EditCommunityDialog({
         updates.name = trimmedName;
       }
 
-      const normalizedUrl = normalizeRelayUrl(relayUrl.trim());
-      if (normalizedUrl !== community.relayUrl) {
-        updates.relayUrl = normalizedUrl;
+      if (!relayLocked) {
+        const normalizedUrl = normalizeRelayUrl(relayUrl.trim());
+        if (normalizedUrl !== community.relayUrl) {
+          updates.relayUrl = normalizedUrl;
+        }
       }
 
       const trimmedToken = token.trim() || undefined;
@@ -119,7 +124,16 @@ export function EditCommunityDialog({
 
       handleClose();
     },
-    [community, name, relayUrl, token, reposDir, onSave, handleClose],
+    [
+      community,
+      name,
+      relayUrl,
+      token,
+      reposDir,
+      relayLocked,
+      onSave,
+      handleClose,
+    ],
   );
 
   const handleRemove = React.useCallback(() => {
@@ -139,7 +153,9 @@ export function EditCommunityDialog({
         <DialogHeader>
           <DialogTitle>Edit Community</DialogTitle>
           <DialogDescription>
-            Update this community's name or relay URL.
+            {relayLocked
+              ? "Update this community's local settings."
+              : "Update this community's name or relay URL."}
           </DialogDescription>
         </DialogHeader>
         <form
@@ -173,21 +189,23 @@ export function EditCommunityDialog({
               value={name}
             />
           </div>
-          <div className="flex flex-col gap-1.5">
-            <label
-              className="text-sm font-medium text-foreground"
-              htmlFor="edit-ws-relay-url"
-            >
-              Relay URL
-            </label>
-            <Input
-              id="edit-ws-relay-url"
-              onChange={(e) => setRelayUrl(e.target.value)}
-              placeholder="wss://relay.example.com"
-              type="text"
-              value={relayUrl}
-            />
-          </div>
+          {!relayLocked ? (
+            <div className="flex flex-col gap-1.5">
+              <label
+                className="text-sm font-medium text-foreground"
+                htmlFor="edit-ws-relay-url"
+              >
+                Relay URL
+              </label>
+              <Input
+                id="edit-ws-relay-url"
+                onChange={(e) => setRelayUrl(e.target.value)}
+                placeholder="wss://relay.example.com"
+                type="text"
+                value={relayUrl}
+              />
+            </div>
+          ) : null}
           <div className="flex flex-col gap-1.5">
             <label
               className="text-sm font-medium text-foreground"

--- a/desktop/src/features/communities/useCommunities.tsx
+++ b/desktop/src/features/communities/useCommunities.tsx
@@ -2,20 +2,32 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
 import type { ReactNode } from "react";
+import { isTauri } from "@tauri-apps/api/core";
 
 import type { Community } from "./types";
 import {
   clearCommunityStorage,
+  clearActiveCommunityId,
   loadActiveCommunityId,
   loadCommunities,
   saveActiveCommunityId,
   saveCommunities,
 } from "./communityStorage";
+import {
+  applyRelayConnectionPolicy,
+  isRelayUrlAllowed,
+  UNRESTRICTED_RELAY_CONNECTION_POLICY,
+} from "./relayPolicy";
+import {
+  getRelayConnectionPolicy,
+  type RelayConnectionPolicy,
+} from "@/shared/api/tauriRelayPolicy";
 import { removeSelfProfileCachesForRelay } from "@/features/profile/lib/selfProfileStorage";
 import { removeChannelSnapshotForRelay } from "@/features/channels/channelSnapshot";
 import { removeMessageSnapshotsForRelay } from "@/features/messages/lib/messageSnapshot";
@@ -115,6 +127,7 @@ export function applyCommunitiesOrder(
 export type UseCommunitiesReturn = {
   communities: Community[];
   activeCommunity: Community | null;
+  relayConnectionPolicy: RelayConnectionPolicy;
   /** Counter bumped when the active community's config changes (relayUrl/token). */
   reinitKey: number;
   /** Add a community, deduplicating by relayUrl. Returns the final ID in the list. */
@@ -138,6 +151,7 @@ const CommunitiesContext = createContext<UseCommunitiesReturn | null>(null);
 
 export function CommunitiesProvider({ children }: { children: ReactNode }) {
   const value = useCommunitiesInternal();
+  if (!value) return null;
   return (
     <CommunitiesContext.Provider value={value}>
       {children}
@@ -153,15 +167,58 @@ export function useCommunities(): UseCommunitiesReturn {
   return ctx;
 }
 
-function useCommunitiesInternal(): UseCommunitiesReturn {
+function useCommunitiesInternal(): UseCommunitiesReturn | null {
   const [communities, setCommunitiesState] =
     useState<Community[]>(loadCommunities);
   const [activeId, setActiveId] = useState<string | null>(
     loadActiveCommunityId,
   );
   const [reinitKey, setReinitKey] = useState(0);
+  const [relayConnectionPolicy, setRelayConnectionPolicy] =
+    useState<RelayConnectionPolicy | null>(null);
   const communitiesRef = useRef(communities);
   communitiesRef.current = communities;
+  const relayConnectionPolicyRef = useRef(relayConnectionPolicy);
+  relayConnectionPolicyRef.current = relayConnectionPolicy;
+
+  useEffect(() => {
+    let cancelled = false;
+    const policyPromise =
+      isTauri() || import.meta.env.MODE === "e2e"
+        ? getRelayConnectionPolicy()
+        : Promise.resolve(UNRESTRICTED_RELAY_CONNECTION_POLICY);
+    void policyPromise
+      .then((policy) => {
+        if (cancelled) return;
+        const currentCommunities = communitiesRef.current;
+        const currentActiveId = loadActiveCommunityId();
+        const next = applyRelayConnectionPolicy(
+          currentCommunities,
+          currentActiveId,
+          policy,
+        );
+        if (next.changed) {
+          saveCommunities(next.communities);
+          if (next.activeId) {
+            saveActiveCommunityId(next.activeId);
+          } else {
+            clearActiveCommunityId();
+          }
+          communitiesRef.current = next.communities;
+          setCommunitiesState(next.communities);
+          setActiveId(next.activeId);
+        }
+        setRelayConnectionPolicy(policy);
+      })
+      .catch((error) => {
+        // A signed Tauri build that cannot load its compiled relay policy must
+        // not render any surface that could initiate a relay connection.
+        console.error("Failed to load relay connection policy:", error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const activeCommunity = useMemo(
     () => communities.find((w) => w.id === activeId) ?? communities[0] ?? null,
@@ -169,6 +226,10 @@ function useCommunitiesInternal(): UseCommunitiesReturn {
   );
 
   const addCommunity = useCallback((community: Community): string => {
+    const policy = relayConnectionPolicyRef.current;
+    if (!policy || !isRelayUrlAllowed(policy, community.relayUrl)) {
+      throw new Error("This Buzz build only allows its configured relay.");
+    }
     const existing = communitiesRef.current.find(
       (w) => w.relayUrl === community.relayUrl,
     );
@@ -260,6 +321,14 @@ function useCommunitiesInternal(): UseCommunitiesReturn {
         Pick<Community, "name" | "relayUrl" | "token" | "pubkey" | "reposDir">
       >,
     ): UpdateCommunityResult => {
+      const policy = relayConnectionPolicyRef.current;
+      if (
+        !policy ||
+        (updates.relayUrl !== undefined &&
+          !isRelayUrlAllowed(policy, updates.relayUrl))
+      ) {
+        throw new Error("This Buzz build only allows its configured relay.");
+      }
       const result = resolveCommunityUpdateResult(
         communitiesRef.current,
         activeId,
@@ -294,9 +363,12 @@ function useCommunitiesInternal(): UseCommunitiesReturn {
     });
   }, []);
 
+  if (!relayConnectionPolicy) return null;
+
   return {
     communities,
     activeCommunity,
+    relayConnectionPolicy,
     reinitKey,
     addCommunity,
     clearCommunities,

--- a/desktop/src/features/communities/useCommunityInit.ts
+++ b/desktop/src/features/communities/useCommunityInit.ts
@@ -10,6 +10,7 @@ import {
   getDefaultRelayUrl,
 } from "@/shared/api/tauri";
 import { getIdentity } from "@/shared/api/tauriIdentity";
+import type { RelayConnectionPolicy } from "@/shared/api/tauriRelayPolicy";
 import { clearTrayAgentActivity } from "@/shared/api/trayMenu";
 import { getOverrides } from "@/shared/features";
 import { resetMediaCaches } from "@/shared/lib/mediaUrl";
@@ -93,6 +94,7 @@ export function useCommunityInit(
   activeCommunity: Community | null,
   communityKey: string,
   isSharedIdentity: boolean,
+  relayConnectionPolicy: RelayConnectionPolicy,
 ): CommunityInitResult {
   const [result, setResult] = useState<CommunityInitResult>({
     isReady: false,
@@ -128,6 +130,7 @@ export function useCommunityInit(
           // selection even when BUZZ_RELAY_URL is overridden at runtime.
           if (
             isSharedIdentity ||
+            relayConnectionPolicy.lockedToDefaultRelay ||
             (autoConnectDefaultRelay &&
               shouldAutoConnectDefaultRelay(defaultRelayUrl))
           ) {
@@ -287,6 +290,7 @@ export function useCommunityInit(
     activeCommunity?.reposDir,
     isSharedIdentity,
     communityKey,
+    relayConnectionPolicy.lockedToDefaultRelay,
   ]);
 
   return result;

--- a/desktop/src/features/settings/ui/HostedCommunitiesSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/HostedCommunitiesSettingsCard.tsx
@@ -65,7 +65,7 @@ function relayHost(url: string | null | undefined) {
 
 export function HostedCommunitiesSettingsCard() {
   const onboarding = useCommunityOnboarding();
-  const { activeCommunity } = useCommunities();
+  const { activeCommunity, relayConnectionPolicy } = useCommunities();
   const localPubkey = useIdentityQuery().data?.pubkey ?? null;
   const [auth, setAuth] = React.useState<BuilderlabAuth | null>(null);
   const [communities, setCommunities] = React.useState<HostedCommunity[]>([]);
@@ -413,6 +413,8 @@ export function HostedCommunitiesSettingsCard() {
 
   const busy = action != null;
   const atCommunityLimit = communities.length >= MAX_COMMUNITIES;
+
+  if (relayConnectionPolicy.lockedToDefaultRelay) return null;
 
   return (
     <section className="space-y-6" data-testid="hosted-communities-settings">

--- a/desktop/src/features/sidebar/ui/CommunityRail.tsx
+++ b/desktop/src/features/sidebar/ui/CommunityRail.tsx
@@ -21,6 +21,7 @@ import * as React from "react";
 import type { Community } from "@/features/communities/types";
 import { EditCommunityDialog } from "@/features/communities/ui/EditCommunityDialog";
 import { useCommunityIcons } from "@/features/communities/useCommunityIcons";
+import { useCommunities } from "@/features/communities/useCommunities";
 import { useMyRelayMembershipLookupQuery } from "@/features/community-members/hooks";
 import {
   useCommunityUnread,
@@ -308,6 +309,7 @@ export function CommunityRail({
   onRemoveCommunity,
   onReorderCommunities,
 }: CommunityRailProps) {
+  const { relayConnectionPolicy } = useCommunities();
   const { unreadByCommunity, markCommunityRead } = useCommunityUnread(
     communities,
     activeCommunityId,
@@ -408,20 +410,22 @@ export function CommunityRail({
           ) : null}
         </DragOverlay>
       </DndContext>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            aria-label="Add community"
-            className="flex h-9 w-9 items-center justify-center rounded-2xl bg-sidebar-accent/60 text-sidebar-foreground/70 outline-hidden transition-all hover:rounded-xl hover:bg-primary/80 hover:text-primary-foreground focus:outline-none focus-visible:outline-none"
-            data-testid="community-rail-add"
-            onClick={onAddCommunity}
-            type="button"
-          >
-            <Plus className="h-4 w-4" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="right">Add community</TooltipContent>
-      </Tooltip>
+      {!relayConnectionPolicy.lockedToDefaultRelay ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              aria-label="Add community"
+              className="flex h-9 w-9 items-center justify-center rounded-2xl bg-sidebar-accent/60 text-sidebar-foreground/70 outline-hidden transition-all hover:rounded-xl hover:bg-primary/80 hover:text-primary-foreground focus:outline-none focus-visible:outline-none"
+              data-testid="community-rail-add"
+              onClick={onAddCommunity}
+              type="button"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">Add community</TooltipContent>
+        </Tooltip>
+      ) : null}
       <EditCommunityDialog
         canRemove={communities.length > 1}
         onOpenChange={(open) => {

--- a/desktop/src/shared/api/invites.test.mjs
+++ b/desktop/src/shared/api/invites.test.mjs
@@ -5,12 +5,23 @@ import { getJoinPolicy, mintInvite } from "./invites.ts";
 
 function withFetch(response, run) {
   const originalFetch = globalThis.fetch;
+  const previousWindow = globalThis.window;
+  globalThis.window = {
+    __TAURI_INTERNALS__: {
+      invoke(command, args) {
+        assert.equal(command, "assert_relay_url_allowed");
+        assert.deepEqual(args, { relayUrl: "wss://relay.example" });
+        return Promise.resolve();
+      },
+    },
+  };
   globalThis.fetch = async (url) => {
     assert.equal(url, "https://relay.example/api/join-policy");
     return response;
   };
   return Promise.resolve(run()).finally(() => {
     globalThis.fetch = originalFetch;
+    globalThis.window = previousWindow;
   });
 }
 
@@ -58,6 +69,10 @@ test("getJoinPolicy maps the native command response", async () => {
   globalThis.window = {
     __TAURI_INTERNALS__: {
       invoke(command, args) {
+        if (command === "assert_relay_url_allowed") {
+          assert.deepEqual(args, { relayUrl: "wss://relay.example" });
+          return Promise.resolve();
+        }
         assert.equal(command, "fetch_join_policy");
         assert.deepEqual(args, { relayUrl: "wss://relay.example" });
         return Promise.resolve({
@@ -104,6 +119,7 @@ function setupTauriStubs(
   globalThis.window.__TAURI_INTERNALS__ = {
     invoke: async (command, args) => {
       calls.invokeArgs.push({ command, args });
+      if (command === "assert_relay_url_allowed") return undefined;
       if (command === "get_relay_http_url") return httpBase;
       if (command === "sign_event") return JSON.stringify(authEvent);
       throw new Error(`Unexpected Tauri command: ${command}`);

--- a/desktop/src/shared/api/invites.ts
+++ b/desktop/src/shared/api/invites.ts
@@ -4,6 +4,7 @@ import {
   invokeTauri,
   signRelayEvent,
 } from "@/shared/api/tauri";
+import { assertRelayUrlAllowed } from "@/shared/api/tauriRelayPolicy";
 
 // Relay invite data layer. Both endpoints are NIP-98-authed HTTP POSTs
 // (mirrors the read path in moderation.ts, plus the payload tag the relay
@@ -132,6 +133,7 @@ export async function getJoinPolicy(
   relayWsUrl: string,
   transport: "native" | "webview",
 ): Promise<JoinPolicy | null> {
+  await assertRelayUrlAllowed(relayWsUrl);
   type RawJoinPolicy = {
     terms_markdown?: string;
     privacy_markdown?: string;
@@ -173,6 +175,7 @@ export async function acceptJoinPolicy(
   policyVersion: string,
   ageConfirmed: boolean,
 ): Promise<string> {
+  await assertRelayUrlAllowed(relayWsUrl);
   const base = relayHttpFromWs(relayWsUrl);
   const response = await fetch(
     `${base.replace(/\/+$/, "")}/api/invites/accept-policy`,
@@ -225,6 +228,7 @@ export async function claimInvite(
   code: string,
   policyReceipt?: string,
 ): Promise<ClaimResult> {
+  await assertRelayUrlAllowed(relayWsUrl);
   const base = relayHttpFromWs(relayWsUrl);
   const body = JSON.stringify({ code, policy_receipt: policyReceipt });
   const raw = await invitePost<{

--- a/desktop/src/shared/api/readOnlyRelayClient.ts
+++ b/desktop/src/shared/api/readOnlyRelayClient.ts
@@ -1,6 +1,7 @@
 import { Channel, invoke } from "@tauri-apps/api/core";
 
 import { createAuthEvent } from "@/shared/api/tauri";
+import { assertRelayUrlAllowed } from "@/shared/api/tauriRelayPolicy";
 import type { RelayEvent } from "@/shared/api/types";
 import {
   getTextPayload,
@@ -131,6 +132,7 @@ export class ReadOnlyRelayClient {
   }
 
   private async openConnection(): Promise<void> {
+    await assertRelayUrlAllowed(this.relayUrl);
     const generation = ++this.generation;
     this.onMessageChannel = new Channel<unknown>((message) => {
       void this.handleWsMessage(message, generation);

--- a/desktop/src/shared/api/tauriRelayPolicy.ts
+++ b/desktop/src/shared/api/tauriRelayPolicy.ts
@@ -1,0 +1,14 @@
+import { invokeTauri } from "@/shared/api/tauri";
+
+export type RelayConnectionPolicy = {
+  lockedToDefaultRelay: boolean;
+  defaultRelayUrl: string;
+};
+
+export function getRelayConnectionPolicy(): Promise<RelayConnectionPolicy> {
+  return invokeTauri<RelayConnectionPolicy>("get_relay_connection_policy");
+}
+
+export function assertRelayUrlAllowed(relayUrl: string): Promise<void> {
+  return invokeTauri("assert_relay_url_allowed", { relayUrl });
+}

--- a/desktop/src/shared/deep-link.ts
+++ b/desktop/src/shared/deep-link.ts
@@ -8,6 +8,7 @@ export type AddCommunityDeepLinkPayload = {
 };
 
 export interface DeepLinkDeps {
+  isRelayAllowed: (relayUrl: string) => boolean;
   startCommunityOnboarding: (input: StartCommunityOnboardingInput) => boolean;
   openAddCommunity: (
     payload: AddCommunityDeepLinkPayload & { requestId: string },
@@ -58,10 +59,18 @@ type PendingCommunityDeepLink = {
   policyReceipt: string | null;
 };
 
-function acceptPendingCommunityDeepLink(
+async function acceptPendingCommunityDeepLink(
   pending: PendingCommunityDeepLink,
   deps: DeepLinkDeps,
 ) {
+  if (!deps.isRelayAllowed(pending.relayUrl)) {
+    console.warn(
+      "Ignored a community deep link blocked by build relay policy.",
+    );
+    return invoke<boolean>("acknowledge_pending_community_deep_link", {
+      id: pending.id,
+    });
+  }
   const accepted =
     pending.kind === "add-community"
       ? deps.openAddCommunity({
@@ -77,10 +86,10 @@ function acceptPendingCommunityDeepLink(
           policyReceipt: pending.policyReceipt ?? undefined,
         });
   return accepted
-    ? invoke<boolean>("acknowledge_pending_community_deep_link", {
+    ? await invoke<boolean>("acknowledge_pending_community_deep_link", {
         id: pending.id,
       })
-    : Promise.resolve(false);
+    : false;
 }
 
 async function drainPendingCommunityDeepLinks(deps: DeepLinkDeps) {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -511,6 +511,7 @@ type E2eConfig = {
   relayHttpUrl?: string;
   relayWsUrl?: string;
   autoConnectDefaultRelay?: boolean;
+  lockToDefaultRelay?: boolean;
   identity?: TestIdentity;
 };
 
@@ -11013,6 +11014,21 @@ export function maybeInstallE2eTauriMocks() {
         return getRelayWsUrl(activeConfig);
       case "auto_connect_default_relay_enabled":
         return activeConfig?.autoConnectDefaultRelay ?? false;
+      case "get_relay_connection_policy":
+        return {
+          lockedToDefaultRelay: activeConfig?.lockToDefaultRelay ?? false,
+          defaultRelayUrl: getRelayWsUrl(activeConfig),
+        };
+      case "assert_relay_url_allowed": {
+        if (!activeConfig?.lockToDefaultRelay) return null;
+        const { relayUrl } = payload as { relayUrl: string };
+        const candidate = new URL(relayUrl).origin;
+        const allowed = new URL(getRelayWsUrl(activeConfig)).origin;
+        if (candidate !== allowed) {
+          throw new Error("This Buzz build only allows its configured relay.");
+        }
+        return null;
+      }
       case "get_legacy_workspace_storage":
         return {
           workspaces: null,

--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -33,6 +33,48 @@ async function seedCommunities(
 }
 
 test.describe("community rail", () => {
+  test("locked builds remove saved external communities and relay controls", async ({
+    page,
+  }) => {
+    await installMockBridge(page, undefined, {
+      lockToDefaultRelay: true,
+      relayWsUrl: RELAY_URL,
+      skipCommunitySeed: true,
+    });
+    await seedCommunities(page, [COMMUNITY_A, COMMUNITY_B], COMMUNITY_B.id);
+    await page.goto("/");
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          JSON.parse(
+            window.localStorage.getItem("buzz-communities") ?? "[]",
+          ).map((community: { id: string }) => community.id),
+        ),
+      )
+      .toEqual([COMMUNITY_A.id]);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.localStorage.getItem("buzz-active-community-id"),
+        ),
+      )
+      .toBe(COMMUNITY_A.id);
+    await expect(page.getByTestId("community-rail-add")).toHaveCount(0);
+
+    await page.getByTestId("sidebar-profile-avatar-button").click();
+    await page.getByTestId("community-switcher").click();
+    const menu = page.getByRole("menu", { name: "Community actions" });
+    await expect(
+      menu.getByRole("menuitem", { name: "Add a community" }),
+    ).toHaveCount(0);
+    await menu.getByRole("menuitem", { name: "Community settings" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Edit Community" }),
+    ).toBeVisible();
+    await expect(page.locator("#edit-ws-relay-url")).toHaveCount(0);
+  });
+
   test("shows the rail with multiple communities despite a stale opt-out", async ({
     page,
   }) => {

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -532,6 +532,7 @@ type BridgeOptions = {
   relayHttpUrl?: string;
   relayWsUrl?: string;
   autoConnectDefaultRelay?: boolean;
+  lockToDefaultRelay?: boolean;
   skipOnboardingSeed?: boolean;
   skipCommunitySeed?: boolean;
   /**
@@ -790,6 +791,7 @@ export async function installBridge(page: Page, options: BridgeOptions) {
       relayHttpUrl,
       relayWsUrl,
       autoConnectDefaultRelay,
+      lockToDefaultRelay,
     }) => {
       const notificationLog: Array<{
         body: string | null;
@@ -849,6 +851,8 @@ export async function installBridge(page: Page, options: BridgeOptions) {
         relayWsUrl: relayWsUrl ?? currentConfig.relayWsUrl,
         autoConnectDefaultRelay:
           autoConnectDefaultRelay ?? currentConfig.autoConnectDefaultRelay,
+        lockToDefaultRelay:
+          lockToDefaultRelay ?? currentConfig.lockToDefaultRelay,
       };
       testWindow.__BUZZ_E2E_APP_BADGE_COUNT__ = 0;
       testWindow.__BUZZ_E2E_APP_BADGE_STATE__ = "none";
@@ -872,6 +876,7 @@ export async function installBridge(page: Page, options: BridgeOptions) {
       relayHttpUrl: options.relayHttpUrl,
       relayWsUrl: options.relayWsUrl,
       autoConnectDefaultRelay: options.autoConnectDefaultRelay,
+      lockToDefaultRelay: options.lockToDefaultRelay,
     },
   );
 }
@@ -882,6 +887,7 @@ export async function installMockBridge(
   options?: {
     relayWsUrl?: string;
     autoConnectDefaultRelay?: boolean;
+    lockToDefaultRelay?: boolean;
     skipOnboardingSeed?: boolean;
     skipCommunitySeed?: boolean;
     seedPreviewFeatures?: boolean;
@@ -892,6 +898,7 @@ export async function installMockBridge(
     mock,
     relayWsUrl: options?.relayWsUrl,
     autoConnectDefaultRelay: options?.autoConnectDefaultRelay,
+    lockToDefaultRelay: options?.lockToDefaultRelay,
     skipOnboardingSeed: options?.skipOnboardingSeed,
     skipCommunitySeed: options?.skipCommunitySeed,
     seedPreviewFeatures: options?.seedPreviewFeatures,


### PR DESCRIPTION
Add an absent-by-default compile-time policy that restricts locked desktop builds to the compiled relay origin.