### PR TITLE
fix(compose): restore mobile pairing sidecar

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -12,6 +12,12 @@ BUZZ_MEDIA_BASE_URL=https://buzz.example.com/media
 BUZZ_MEDIA_SERVER_DOMAIN=buzz.example.com
 BUZZ_CORS_ORIGINS=https://buzz.example.com
 
+# Optional NIP-AB pairing sidecar. Start it with `--profile pairing`, then
+# expose only its `/pair` route through a TLS reverse proxy. Never advertise
+# this URL before the sidecar and proxy route are healthy.
+# BUZZ_PAIRING_RELAY_URL=wss://buzz.example.com/pair
+BUZZ_PAIR_RELAY_PORT=5000
+
 # Production defaults. Closed relay mode requires RELAY_OWNER_PUBKEY and a stable relay key.
 BUZZ_REQUIRE_AUTH_TOKEN=true
 BUZZ_REQUIRE_RELAY_MEMBERSHIP=true

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -46,6 +46,21 @@ services:
     networks:
       - buzz-net
 
+  # Optional stateless NIP-AB transport for pairing a device that is not yet a
+  # relay member. The host port is loopback-only; a TLS reverse proxy must
+  # expose only /pair. Enable explicitly with `--profile pairing`.
+  pairing-relay:
+    profiles: ["pairing"]
+    image: ${BUZZ_IMAGE:-ghcr.io/block/buzz:main}
+    entrypoint: ["/usr/local/bin/buzz-pair-relay"]
+    environment:
+      BUZZ_PAIR_RELAY_BIND_ADDR: 0.0.0.0:5000
+    ports:
+      - "127.0.0.1:${BUZZ_PAIR_RELAY_PORT:-5000}:5000"
+    restart: unless-stopped
+    networks:
+      - buzz-net
+
   postgres:
     image: postgres:17-alpine
     environment:


### PR DESCRIPTION
## What changed

- add an opt-in `pairing` Compose profile that runs `buzz-pair-relay` from the pinned relay image
- bind the sidecar to loopback with a configurable host port
- document the pairing relay URL and port in the Compose environment example

## Why

Desktop QR pairing advertises `/pair`, but the local Compose stack did not run the pairing relay. Mobile clients therefore reached an HTTP 404 instead of a WebSocket upgrade. The profile is opt-in and does not alter the default relay stack.

## Validation

- `cargo test -p buzz-pair-relay` — 51 integration tests passed
- `docker compose ... --profile pairing config --quiet`
- rendered service list includes `pairing-relay`
- `git diff --check`