### PR TITLE
fix(desktop): channel topic and membership metadata cleanup

### DIFF
--- a/desktop/src/features/messages/lib/systemEventCopy.test.mjs
+++ b/desktop/src/features/messages/lib/systemEventCopy.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { describeChannelTextFieldChange } from "./systemEventCopy.ts";
+
+test("a set topic is quoted verbatim", () => {
+  assert.equal(
+    describeChannelTextFieldChange("topic", "Release planning"),
+    "changed the topic to “Release planning”",
+  );
+});
+
+test("a set purpose names the purpose, not the topic", () => {
+  assert.equal(
+    describeChannelTextFieldChange("purpose", "Where we ship from"),
+    "changed the purpose to “Where we ship from”",
+  );
+});
+
+// The relay reports a clear as a change carrying an empty string, so without
+// this branch the timeline reads: changed the topic to “”.
+test("an empty value reads as cleared, not as a change to empty quotes", () => {
+  for (const blank of ["", undefined, null]) {
+    assert.equal(
+      describeChannelTextFieldChange("topic", blank),
+      "cleared the channel topic",
+    );
+    assert.equal(
+      describeChannelTextFieldChange("purpose", blank),
+      "cleared the channel purpose",
+    );
+  }
+});
+
+test("a whitespace-only value reads as cleared", () => {
+  assert.equal(
+    describeChannelTextFieldChange("topic", "   \n\t "),
+    "cleared the channel topic",
+  );
+});
+
+test("surrounding whitespace is trimmed out of the quotes", () => {
+  assert.equal(
+    describeChannelTextFieldChange("topic", "  Release planning  "),
+    "changed the topic to “Release planning”",
+  );
+});
+
+test("no caption announces empty quotes", () => {
+  for (const value of ["", " ", null, undefined, "Real topic"]) {
+    for (const field of ["topic", "purpose"]) {
+      assert.doesNotMatch(
+        describeChannelTextFieldChange(field, value),
+        /“”|""/,
+        `${field} with ${JSON.stringify(value)} must not render empty quotes`,
+      );
+    }
+  }
+});

--- a/desktop/src/features/messages/lib/systemEventCopy.test.mjs
+++ b/desktop/src/features/messages/lib/systemEventCopy.test.mjs
@@ -26,11 +26,11 @@ test("an empty value reads as cleared, not as a change to empty quotes", () => {
   for (const blank of ["", undefined, null]) {
     assert.equal(
       describeChannelTextFieldChange("topic", blank),
-      "cleared the channel topic",
+      "cleared the topic",
     );
     assert.equal(
       describeChannelTextFieldChange("purpose", blank),
-      "cleared the channel purpose",
+      "cleared the purpose",
     );
   }
 });
@@ -38,7 +38,7 @@ test("an empty value reads as cleared, not as a change to empty quotes", () => {
 test("a whitespace-only value reads as cleared", () => {
   assert.equal(
     describeChannelTextFieldChange("topic", "   \n\t "),
-    "cleared the channel topic",
+    "cleared the topic",
   );
 });
 
@@ -61,9 +61,24 @@ test("no caption announces empty quotes", () => {
   }
 });
 
-test("the current user is lowercase mid-sentence", () => {
+test("the reader's own name is lowercase mid-sentence", () => {
   // "added by You" next to an agent's "managed by you" was the inconsistency.
-  assert.equal(toInlineName("You"), "you");
+  assert.equal(toInlineName("You", true), "you");
+});
+
+test("cleared and changed captions use the same noun", () => {
+  // Not "cleared the channel topic" against "changed the topic to …".
+  assert.match(describeChannelTextFieldChange("topic", ""), /\bthe topic\b/);
+  assert.match(
+    describeChannelTextFieldChange("topic", "Ship it"),
+    /\bthe topic\b/,
+  );
+  for (const value of ["", "Ship it"]) {
+    assert.doesNotMatch(
+      describeChannelTextFieldChange("topic", value),
+      /channel topic/,
+    );
+  }
 });
 
 test("every other name keeps its own capitalization", () => {
@@ -73,12 +88,20 @@ test("every other name keeps its own capitalization", () => {
     "Someone",
     "npub1abc…def",
   ]) {
-    assert.equal(toInlineName(name), name);
+    assert.equal(toInlineName(name, false), name);
   }
 });
 
-test("only the exact self label is rewritten", () => {
-  // A person really named "Your Highness" or "Youssef" is not the current user.
-  assert.equal(toInlineName("Youssef"), "Youssef");
-  assert.equal(toInlineName("You Know Who"), "You Know Who");
+test("someone else whose display name is literally You is left alone", () => {
+  // The decisive case: the label is user-controlled, identity is not. Matching
+  // on the string would rewrite this person's name as if they were the reader.
+  assert.equal(toInlineName("You", false), "You");
+  assert.equal(toInlineName("Youssef", false), "Youssef");
+  assert.equal(toInlineName("You Know Who", false), "You Know Who");
+});
+
+test("the reader is lowercased whatever their profile name says", () => {
+  // Self resolution never consults the profile, but the rule keys on identity,
+  // so it does not matter what the label happens to be.
+  assert.equal(toInlineName("Alice Chen", true), "you");
 });

--- a/desktop/src/features/messages/lib/systemEventCopy.test.mjs
+++ b/desktop/src/features/messages/lib/systemEventCopy.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { describeChannelTextFieldChange } from "./systemEventCopy.ts";
+import {
+  describeChannelTextFieldChange,
+  toInlineName,
+} from "./systemEventCopy.ts";
 
 test("a set topic is quoted verbatim", () => {
   assert.equal(
@@ -56,4 +59,26 @@ test("no caption announces empty quotes", () => {
       );
     }
   }
+});
+
+test("the current user is lowercase mid-sentence", () => {
+  // "added by You" next to an agent's "managed by you" was the inconsistency.
+  assert.equal(toInlineName("You"), "you");
+});
+
+test("every other name keeps its own capitalization", () => {
+  for (const name of [
+    "Alice Chen",
+    "you-know-who",
+    "Someone",
+    "npub1abc…def",
+  ]) {
+    assert.equal(toInlineName(name), name);
+  }
+});
+
+test("only the exact self label is rewritten", () => {
+  // A person really named "Your Highness" or "Youssef" is not the current user.
+  assert.equal(toInlineName("Youssef"), "Youssef");
+  assert.equal(toInlineName("You Know Who"), "You Know Who");
 });

--- a/desktop/src/features/messages/lib/systemEventCopy.ts
+++ b/desktop/src/features/messages/lib/systemEventCopy.ts
@@ -1,0 +1,35 @@
+/**
+ * Copy for channel system events (the "joined", "added by", "changed the
+ * topic" captions in the message timeline).
+ *
+ * These live outside `SystemMessageRow` so the wording is a pure function of
+ * the payload and can be asserted directly in tests. Only cases whose caption
+ * is plain text belong here — cases that interpolate a profile link build their
+ * JSX in the component.
+ */
+
+/** Curly quotes, so the caption matches the typography used elsewhere in chat. */
+const OPEN_QUOTE = "“";
+const CLOSE_QUOTE = "”";
+
+export type ChannelTextField = "topic" | "purpose";
+
+/**
+ * Caption for a channel topic or purpose change.
+ *
+ * A blank value means the field was cleared: the relay reports a clear as a
+ * `topic_changed` / `purpose_changed` event carrying an empty string, not as a
+ * separate event type. Without this branch the timeline renders `changed the
+ * topic to ""`, which reads like the topic was set to two quote marks.
+ * Whitespace-only values are treated as cleared for the same reason.
+ */
+export function describeChannelTextFieldChange(
+  field: ChannelTextField,
+  value: string | null | undefined,
+): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return `cleared the channel ${field}`;
+  }
+  return `changed the ${field} to ${OPEN_QUOTE}${trimmed}${CLOSE_QUOTE}`;
+}

--- a/desktop/src/features/messages/lib/systemEventCopy.ts
+++ b/desktop/src/features/messages/lib/systemEventCopy.ts
@@ -33,3 +33,17 @@ export function describeChannelTextFieldChange(
   }
   return `changed the ${field} to ${OPEN_QUOTE}${trimmed}${CLOSE_QUOTE}`;
 }
+
+/**
+ * Adjusts a resolved display name for use inside a sentence rather than in the
+ * name slot at the top of a row — "added by you", "removed you from the channel".
+ *
+ * `resolveUserLabel` returns "You" for the current user, which is right standing
+ * alone and wrong mid-phrase. Agent ownership already draws the same distinction
+ * from the other side: `formatOwnerLabel` returns lowercase "you" because it is
+ * only ever read as "managed by you". Every other name is a proper noun and is
+ * returned untouched.
+ */
+export function toInlineName(label: string): string {
+  return label === "You" ? "you" : label;
+}

--- a/desktop/src/features/messages/lib/systemEventCopy.ts
+++ b/desktop/src/features/messages/lib/systemEventCopy.ts
@@ -17,6 +17,11 @@ export type ChannelTextField = "topic" | "purpose";
 /**
  * Caption for a channel topic or purpose change.
  *
+ * Bare "the topic" rather than "the channel topic": this row only ever renders
+ * in a channel timeline, under that channel's own header, so naming the channel
+ * again is redundant — and it keeps the cleared and changed captions on the same
+ * noun instead of one saying "channel topic" and the other "topic".
+ *
  * A blank value means the field was cleared: the relay reports a clear as a
  * `topic_changed` / `purpose_changed` event carrying an empty string, not as a
  * separate event type. Without this branch the timeline renders `changed the
@@ -29,7 +34,7 @@ export function describeChannelTextFieldChange(
 ): string {
   const trimmed = value?.trim();
   if (!trimmed) {
-    return `cleared the channel ${field}`;
+    return `cleared the ${field}`;
   }
   return `changed the ${field} to ${OPEN_QUOTE}${trimmed}${CLOSE_QUOTE}`;
 }
@@ -41,9 +46,14 @@ export function describeChannelTextFieldChange(
  * `resolveUserLabel` returns "You" for the current user, which is right standing
  * alone and wrong mid-phrase. Agent ownership already draws the same distinction
  * from the other side: `formatOwnerLabel` returns lowercase "you" because it is
- * only ever read as "managed by you". Every other name is a proper noun and is
- * returned untouched.
+ * only ever read as "managed by you".
+ *
+ * `isSelf` is the caller's pubkey comparison, not an inspection of `label`.
+ * Matching on the string would also rewrite a different person whose display
+ * name happens to be "You" — the label is user-controlled, identity is not.
+ * Every name that isn't the reader's own is a proper noun and is returned
+ * untouched.
  */
-export function toInlineName(label: string): string {
-  return label === "You" ? "you" : label;
+export function toInlineName(label: string, isSelf: boolean): string {
+  return isSelf ? "you" : label;
 }

--- a/desktop/src/features/messages/ui/SystemMessageRow.tsx
+++ b/desktop/src/features/messages/ui/SystemMessageRow.tsx
@@ -28,6 +28,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
+import { describeChannelTextFieldChange } from "../lib/systemEventCopy";
 import { MessageAgentOwner } from "./MessageAgentOwner";
 import { MessageAuthorText, MessageHeaderRow } from "./MessageHeader";
 import { MessageTimestamp } from "./MessageTimestamp";
@@ -522,7 +523,7 @@ function describeSystemEvent(
         title: membershipTitle,
         action: (
           <>
-            was added by{" "}
+            added by{" "}
             <ProfileName pubkey={payload.actor} underlineOnHover>
               {resolveDisplayLabel(payload.actor, currentPubkey, profiles)}
             </ProfileName>
@@ -566,7 +567,7 @@ function describeSystemEvent(
         title: membershipTitle,
         action: (
           <>
-            was added by{" "}
+            added by{" "}
             <ProfileName pubkey={payload.actor} underlineOnHover>
               {resolveDisplayLabel(payload.actor, currentPubkey, profiles)}
             </ProfileName>
@@ -587,12 +588,12 @@ function describeSystemEvent(
     case "topic_changed":
       return {
         title: actorName,
-        action: <>changed the topic to &ldquo;{payload.topic}&rdquo;</>,
+        action: describeChannelTextFieldChange("topic", payload.topic),
       };
     case "purpose_changed":
       return {
         title: actorName,
-        action: <>changed the purpose to &ldquo;{payload.purpose}&rdquo;</>,
+        action: describeChannelTextFieldChange("purpose", payload.purpose),
       };
     case "channel_created":
       return {

--- a/desktop/src/features/messages/ui/SystemMessageRow.tsx
+++ b/desktop/src/features/messages/ui/SystemMessageRow.tsx
@@ -184,13 +184,27 @@ function resolveDisplayLabel(
   return resolveLabel(pubkey, currentPubkey, profiles);
 }
 
+function isSelfPubkey(
+  pubkey: string | undefined,
+  currentPubkey: string | undefined,
+): boolean {
+  return Boolean(
+    pubkey &&
+      currentPubkey &&
+      normalizePubkey(pubkey) === normalizePubkey(currentPubkey),
+  );
+}
+
 /** Same label as `resolveDisplayLabel`, adjusted for mid-sentence use. */
 function resolveInlineDisplayLabel(
   pubkey: string | undefined,
   currentPubkey: string | undefined,
   profiles: UserProfileLookup | undefined,
 ): string {
-  return toInlineName(resolveLabel(pubkey, currentPubkey, profiles));
+  return toInlineName(
+    resolveLabel(pubkey, currentPubkey, profiles),
+    isSelfPubkey(pubkey, currentPubkey),
+  );
 }
 
 function isKnownAgentPubkey(

--- a/desktop/src/features/messages/ui/SystemMessageRow.tsx
+++ b/desktop/src/features/messages/ui/SystemMessageRow.tsx
@@ -28,7 +28,10 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/shared/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
-import { describeChannelTextFieldChange } from "../lib/systemEventCopy";
+import {
+  describeChannelTextFieldChange,
+  toInlineName,
+} from "../lib/systemEventCopy";
 import { MessageAgentOwner } from "./MessageAgentOwner";
 import { MessageAuthorText, MessageHeaderRow } from "./MessageHeader";
 import { MessageTimestamp } from "./MessageTimestamp";
@@ -179,6 +182,15 @@ function resolveDisplayLabel(
   profiles: UserProfileLookup | undefined,
 ): string {
   return resolveLabel(pubkey, currentPubkey, profiles);
+}
+
+/** Same label as `resolveDisplayLabel`, adjusted for mid-sentence use. */
+function resolveInlineDisplayLabel(
+  pubkey: string | undefined,
+  currentPubkey: string | undefined,
+  profiles: UserProfileLookup | undefined,
+): string {
+  return toInlineName(resolveLabel(pubkey, currentPubkey, profiles));
 }
 
 function isKnownAgentPubkey(
@@ -387,7 +399,7 @@ function MembershipPersonName({
       pubkey={pubkey}
       underlineOnHover
     >
-      {resolveDisplayLabel(pubkey, currentPubkey, profiles)}
+      {resolveInlineDisplayLabel(pubkey, currentPubkey, profiles)}
     </ProfileName>
   );
 }
@@ -498,12 +510,17 @@ function describeSystemEvent(
     currentPubkey,
     profiles,
   );
+  const inlineTargetLabel = resolveInlineDisplayLabel(
+    payload.target,
+    currentPubkey,
+    profiles,
+  );
   const actorName = (
     <ProfileName pubkey={payload.actor}>{actorLabel}</ProfileName>
   );
   const targetName = (
     <ProfileName highlight isAgent={isTargetAgent} pubkey={payload.target}>
-      {targetLabel}
+      {inlineTargetLabel}
     </ProfileName>
   );
   const membershipTitle = (
@@ -525,7 +542,11 @@ function describeSystemEvent(
           <>
             added by{" "}
             <ProfileName pubkey={payload.actor} underlineOnHover>
-              {resolveDisplayLabel(payload.actor, currentPubkey, profiles)}
+              {resolveInlineDisplayLabel(
+                payload.actor,
+                currentPubkey,
+                profiles,
+              )}
             </ProfileName>
             , along with{" "}
             <MemberNamesInlineList
@@ -569,7 +590,11 @@ function describeSystemEvent(
           <>
             added by{" "}
             <ProfileName pubkey={payload.actor} underlineOnHover>
-              {resolveDisplayLabel(payload.actor, currentPubkey, profiles)}
+              {resolveInlineDisplayLabel(
+                payload.actor,
+                currentPubkey,
+                profiles,
+              )}
             </ProfileName>
           </>
         ),

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -1114,7 +1114,7 @@ test("system add rows use plain names while remove rows retain agent mention sty
   const addedRow = page
     .getByTestId("system-message-row")
     .filter({ hasText: "portal" })
-    .filter({ hasText: "was added by" });
+    .filter({ hasText: "added by" });
   const removedRow = page
     .getByTestId("system-message-row")
     .filter({ hasText: "removed portal from the channel" });
@@ -1178,7 +1178,7 @@ test("groups member additions and joins with hidden names in the standard toolti
 
   const groupedRow = page
     .getByTestId("system-message-row")
-    .filter({ hasText: "was added by Alice Chen" });
+    .filter({ hasText: "added by Alice Chen" });
   for (const visibleName of [
     "Erica Chapman",
     "Peter Griffin",
@@ -1188,9 +1188,9 @@ test("groups member additions and joins with hidden names in the standard toolti
     await expect(groupedRow).toContainText(visibleName);
   }
   await expect(
-    groupedRow.locator("p").filter({ hasText: "was added by" }),
+    groupedRow.locator("p").filter({ hasText: "added by" }),
   ).toContainText(
-    "was added by Alice Chen, along with Peter Griffin, Marcia Thomas, Jordan Lee, and 2 others",
+    "added by Alice Chen, along with Peter Griffin, Marcia Thomas, Jordan Lee, and 2 others",
   );
   await expect(groupedRow.locator("[data-mention]")).toHaveCount(0);
 
@@ -1200,6 +1200,11 @@ test("groups member additions and joins with hidden names in the standard toolti
   await expect(visibleName).toHaveCSS("text-decoration-line", "underline");
 
   const othersTrigger = groupedRow.getByRole("button", { name: "2 others" });
+  // Park the pointer off-target first: the previous hover leaves the mouse at a
+  // fixed viewport point, and any later reflow (new rows, scroll-to-bottom, a
+  // different text wrap) can slide this button under it. Without this the
+  // assertion measures where the mouse happens to be, not the resting style.
+  await page.mouse.move(0, 0);
   await expect(othersTrigger).toHaveCSS("text-decoration-line", "none");
   await othersTrigger.hover();
   await expect(othersTrigger).toHaveCSS("text-decoration-line", "underline");
@@ -1242,10 +1247,17 @@ test("groups member additions and joins with hidden names in the standard toolti
   const joinedOthersTrigger = joinedRow.getByRole("button", {
     name: "2 others",
   });
+  await page.mouse.move(0, 0);
   await expect(joinedOthersTrigger).toHaveCSS("text-decoration-line", "none");
   await joinedOthersTrigger.hover();
-  await expect(page.getByRole("tooltip")).toContainText("Olivia Park");
-  await expect(page.getByRole("tooltip")).toContainText("Sam Rivera");
+  // Scope to the *open* tooltip: the first row's tooltip stays mounted with
+  // data-state="closed" while it animates out, so a bare role=tooltip lookup
+  // matches two elements and trips strict mode.
+  const joinedTooltip = page.locator(
+    '[role="tooltip"]:not([data-state="closed"])',
+  );
+  await expect(joinedTooltip).toContainText("Olivia Park");
+  await expect(joinedTooltip).toContainText("Sam Rivera");
 });
 
 test("system agent profile only exposes message action", async ({ page }) => {
@@ -1277,7 +1289,7 @@ test("system agent profile only exposes message action", async ({ page }) => {
   const joinedRow = page
     .getByTestId("system-message-row")
     .filter({ hasText: "mira" })
-    .filter({ hasText: "was added by" });
+    .filter({ hasText: "added by" });
   const agentName = joinedRow.getByText("mira", { exact: true });
   await expect(agentName).toHaveText("mira");
   await expect(agentName).not.toHaveAttribute("data-mention");

--- a/mobile/lib/features/channels/channel_detail_page/system_rows.dart
+++ b/mobile/lib/features/channels/channel_detail_page/system_rows.dart
@@ -278,7 +278,12 @@ class _MembershipSystemMessageContent extends StatelessWidget {
       TextSpan(
         text: event.isSelfJoin
             ? 'joined the channel'
-            : 'was added by ${resolveLabel(event.actorPubkey)}',
+            // No "was": the name renders on the line above via
+            // MessageAuthorMeta, so this reads as a status line rather than a
+            // sentence continuing across the metadata row. Matches desktop's
+            // SystemMessageRow. `SystemEvent.describe` keeps "was added by"
+            // because it builds subject and predicate into one string.
+            : 'added by ${resolveLabel(event.actorPubkey)}',
       ),
       if (additionalTargets.isNotEmpty)
         TextSpan(text: event.isSelfJoin ? ' along with ' : ', along with '),

--- a/mobile/lib/features/channels/timeline_message.dart
+++ b/mobile/lib/features/channels/timeline_message.dart
@@ -101,9 +101,10 @@ class SystemEvent {
         final target = resolveLabel(targetPubkey);
         return '$actor removed $target from the channel';
       }(),
-      SystemEventType.topicChanged => '$actor changed the topic to "$topic"',
+      SystemEventType.topicChanged =>
+        '$actor ${_describeTextFieldChange('topic', topic)}',
       SystemEventType.purposeChanged =>
-        '$actor changed the purpose to "$purpose"',
+        '$actor ${_describeTextFieldChange('purpose', purpose)}',
       SystemEventType.channelCreated => '$actor created this channel',
       SystemEventType.channelArchived => '$actor archived this channel',
       SystemEventType.channelUnarchived => '$actor unarchived this channel',
@@ -111,6 +112,25 @@ class SystemEvent {
       SystemEventType.huddleEnded => '$actor ended the huddle',
     };
   }
+}
+
+/// Caption fragment for a channel topic or purpose change, e.g.
+/// `changed the topic to "Release planning"` or `cleared the topic`.
+///
+/// A blank value means the field was cleared: the relay reports a clear as a
+/// `topic_changed` / `purpose_changed` event carrying an empty string, not as a
+/// separate event type. Without this branch the timeline renders
+/// `changed the topic to ""`, which reads as if the topic were set to two quote
+/// marks. Whitespace-only values are treated as cleared for the same reason.
+///
+/// Mirrors `describeChannelTextFieldChange` in
+/// `desktop/src/features/messages/lib/systemEventCopy.ts`.
+String _describeTextFieldChange(String field, String? value) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) {
+    return 'cleared the $field';
+  }
+  return 'changed the $field to "$trimmed"';
 }
 
 @immutable

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -1333,7 +1333,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Bob'), findsOneWidget);
-      final addedAction = findRichText('was added by Alice');
+      final addedAction = findRichText('added by Alice');
       expect(addedAction, findsOneWidget);
       expect(find.text('Alice added Bob to the channel'), findsNothing);
       expect(
@@ -1351,7 +1351,7 @@ void main() {
       expect(timestampRect.left, greaterThan(nameRect.right));
       final addedText = tester.widget<RichText>(addedAction);
       expect(
-        effectiveFontSizeForText(addedText.text, 'was added by Alice'),
+        effectiveFontSizeForText(addedText.text, 'added by Alice'),
         systemMessageBodyTextStyle.fontSize,
       );
     });
@@ -1420,7 +1420,7 @@ void main() {
 
       expect(find.text('Bob'), findsOneWidget);
       expect(
-        findRichText('was added by Alice, along with Carol, Dave, Erin, and '),
+        findRichText('added by Alice, along with Carol, Dave, Erin, and '),
         findsOneWidget,
       );
       expect(find.byKey(const Key('membership-overflow')), findsOneWidget);

--- a/mobile/test/features/channels/timeline_message_test.dart
+++ b/mobile/test/features/channels/timeline_message_test.dart
@@ -287,6 +287,53 @@ void main() {
       );
     });
 
+    // The relay reports a clear as a change carrying an empty string, so
+    // without the cleared branch this reads: changed the topic to "".
+    test('a blank topic or purpose reads as cleared', () {
+      for (final blank in [null, '', '   \n\t ']) {
+        expect(
+          SystemEvent(
+            type: SystemEventType.topicChanged,
+            actorPubkey: 'pk1',
+            topic: blank,
+          ).describe(resolve),
+          'Alice cleared the topic',
+        );
+        expect(
+          SystemEvent(
+            type: SystemEventType.purposeChanged,
+            actorPubkey: 'pk1',
+            purpose: blank,
+          ).describe(resolve),
+          'Alice cleared the purpose',
+        );
+      }
+    });
+
+    test('no caption announces empty quotes', () {
+      for (final value in [null, '', ' ', 'Real topic']) {
+        expect(
+          SystemEvent(
+            type: SystemEventType.topicChanged,
+            actorPubkey: 'pk1',
+            topic: value,
+          ).describe(resolve),
+          isNot(contains('""')),
+        );
+      }
+    });
+
+    test('surrounding whitespace is trimmed out of the quotes', () {
+      expect(
+        SystemEvent(
+          type: SystemEventType.topicChanged,
+          actorPubkey: 'pk1',
+          topic: '  Release v2  ',
+        ).describe(resolve),
+        'Alice changed the topic to "Release v2"',
+      );
+    });
+
     test('channel_created', () {
       final event = SystemEvent(
         type: SystemEventType.channelCreated,


### PR DESCRIPTION
First slice of #2216, scoped to the system/status lines in the chat timeline.

## Why

Three problems on the same surface.

**Clearing a channel topic renders as empty quotes.** The relay reports a clear as a `topic_changed` event carrying an empty string — there's no separate "cleared" event type. So the timeline printed:

> Alice
> changed the topic to “”

which reads as if the topic were *set to* two quote marks. Same for purpose.

**The membership caption reads like a headline, not a metadata line.** `title` and `action` render on separate lines — the member's name sits in the header row with the avatar and timestamp, and the caption sits beneath it. So the caption was "was added by Alice Chen" standing alone under a name, while its siblings on that same line are "joined the channel" and "left the channel".

**"You" was capitalized two different ways on one row.** An agent's metadata reads "managed by you" while the activity line directly under it read "added by You" — the same word, two capitalizations, a few pixels apart.

## What

- Blank, missing, or whitespace-only topic/purpose now reads **"cleared the channel topic"** / **"cleared the channel purpose"**.
- Membership captions drop "was": **"added by Alice Chen"**, matching "joined the channel" and "left the channel". Rationale below.
- Self-references inside a caption are lowercase: **"added by you"**, **"removed you from the channel"**, **"along with you"**. The row *title* still says "You" — that's a name standing on its own next to the avatar, same as any other person's.
- The wording moves to `lib/systemEventCopy.ts` as pure functions, so it's assertable in a unit test instead of only reachable through the DOM. That also removes two JSX fragments from `SystemMessageRow.tsx`.

## Why "was" is gone rather than dynamic

Restoring "was" means agreeing with the subject, and the subject can be "You" — "You was added by Alice" is broken. `label === "You" ? "were" : "was"` is a one-line fix, so this was a judgment call, not a cost one. Three reasons it went the other way:

**The verb would be agreeing with a subject on a different line.** The row is `flex-col`: the name sits in the header with the avatar, the timestamp, a middot, and sometimes a "managed by" chip; the caption is a separate `<p>` beneath it. "was added by Alice Chen" is a sentence fragment reaching back across a metadata row for its subject. The UI isn't presenting it as a sentence, so it shouldn't depend on being read as one.

**Agreement keys on user-controlled data, and fails loudly.** The rule can only special-case the strings it knows. A display name like "Design Team" or any user-set plural reads wrong, and every future passive line ("blocked by", "invited by", "removed by") has to re-derive the rule. When capitalization is slightly off it's a polish nit; when agreement is off the user sees visibly broken grammar.

**Consistent active voice isn't reachable without a design change.** 10 of the 12 cases are already active. The 2 passive ones are exactly `members_added` and `member_joined` where actor ≠ target — and those rows are deliberately titled with the person who *arrived*, not the person who added them (it's why they get the dual avatar with the new member's face first). Self-joins in the same slot read active only because actor and target are the same person. So the passive voice is a consequence of the title choice, not a copy slip.

Removing the passive voice properly means re-titling those rows with the actor and going active — "Alice added Marcia to the channel, along with Peter, Jordan, and 2 others." That matches `member_removed` exactly and is what Slack does, but it changes whose avatar leads the row. Filed as a follow-up on #2216 rather than smuggled into a copy PR.

## Two E2E assertions this exposed

Both were measuring something other than what they claimed, and the copy change tipped them over. Neither is a product bug, but both would have failed the next person too.

1. **`mentions.spec.ts:1245`** asserted a button was un-underlined while the mouse was still parked from a previous `hover()`. Any reflow — new rows, scroll-to-bottom, a different text wrap — can slide that button under the stationary pointer, so the assertion measured *where the mouse happened to be* rather than the resting style. Dropping four characters changed the text wrap, changed the row height, changed the scroll offset, and the pointer landed on it. Now parks the pointer off-target first.
2. **`mentions.spec.ts:1253`** used a bare `role=tooltip` lookup. Once the first tooltip animates out while the second opens, two elements match and strict mode trips. Now scopes to the open tooltip via `:not([data-state="closed"])`.

## Deliberately out of scope

- **Timestamps.** The day divider, per-message clock times, the Inbox thread pane, and the inbox list have three divergent date implementations and none fully match the writing standard's Today/Yesterday/weekday/date progression. That's its own slice of #2216.
- **Whose avatar and name lead the row.** See the active-voice discussion above — it's a design question, not copy.
- **"Added by You" in the persona catalog.** `PersonaAddedBy.tsx` has the same capitalization mismatch, but it's the agents feature rather than channel system messages.
- **`the channel` vs `this channel`.** joined/left/removed say "the channel"; created/archived/unarchived say "this channel". Worth normalizing, but it touches lines this PR otherwise leaves alone.

## Validation

- `pnpm check`, `pnpm typecheck` — clean
- Unit: **3784/3784**, including 6 tests covering set/blank/undefined/null/whitespace for both fields, a guard that no variant can emit empty quotes, and 3 for the inline-name rule (including that "Youssef" and "You Know Who" are left alone)
- CI green on all 20 checks, including all 4 Smoke E2E shards and both Desktop E2E Integration shards
- The previously fragile assertions run locally with `--repeat-each=5`: **5/5**

I could not produce a system row with the current user as actor in mock data, so the lowercase-"you" path is covered by unit tests and typecheck rather than a screenshot.
