### PR TITLE
fix(desktop): reuse managed agents on team deploy instead of force-minting

### DIFF
--- a/crates/buzz-acp/src/agents_roster.rs
+++ b/crates/buzz-acp/src/agents_roster.rs
@@ -1,0 +1,78 @@
+//! Live reload of the Buzz-managed block in `AGENTS.md` for long-running agents.
+//!
+//! Desktop regenerates the block when agents or the active community relay change.
+//! The harness injects updates into turn prompts when the managed section changes.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+const BEGIN_MARKER: &str = "<!-- BEGIN BUZZ MANAGED";
+const END_MARKER: &str = "<!-- END BUZZ MANAGED -->";
+
+static ROSTER_CACHE: Mutex<Option<HashMap<PathBuf, RosterSnapshot>>> = Mutex::new(None);
+
+#[derive(Clone, PartialEq, Eq)]
+struct RosterSnapshot {
+    content_hash: u64,
+}
+
+fn hash_bytes(bytes: &[u8]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Extract the managed section body (including markers) from `AGENTS.md` text.
+pub fn extract_managed_section(content: &str) -> Option<String> {
+    let begin = content.find(BEGIN_MARKER)?;
+    let end = content[begin..]
+        .find(END_MARKER)
+        .map(|p| p + begin + END_MARKER.len())?;
+    Some(content[begin..end].to_string())
+}
+
+fn agents_md_path(nest_dir: &Path) -> PathBuf {
+    nest_dir.join("AGENTS.md")
+}
+
+/// If the managed roster in `nest_dir/AGENTS.md` changed since the last poll for
+/// this agent process, return the fresh section for injection into the prompt.
+pub fn poll_roster_update(nest_dir: &Path) -> Option<String> {
+    let path = agents_md_path(nest_dir);
+    let content = std::fs::read_to_string(&path).ok()?;
+    let section = extract_managed_section(&content)?;
+    let digest = hash_bytes(section.as_bytes());
+
+    let mut guard = ROSTER_CACHE.lock().ok()?;
+    let map = guard.get_or_insert_with(HashMap::new);
+    let prev = map.get(&path).cloned();
+    if prev.as_ref().is_some_and(|s| s.content_hash == digest) {
+        return None;
+    }
+    map.insert(
+        path,
+        RosterSnapshot {
+            content_hash: digest,
+        },
+    );
+    prev.as_ref()?;
+    Some(format!(
+        "The Active Agents roster in AGENTS.md was updated. Use this authoritative list \
+         (names, persona labels, instance pubkeys, relay URL for the active Desktop community):\n\n{section}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_managed_section_finds_block() {
+        let md =
+            "intro\n<!-- BEGIN BUZZ MANAGED -->\n## Active Agents\n<!-- END BUZZ MANAGED -->\n";
+        let block = extract_managed_section(md).expect("block");
+        assert!(block.contains("Active Agents"));
+    }
+}

--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -32,7 +32,7 @@ When someone asks to create an agent, ask for at most two things: the agent's na
 
 Use the channel UUID from `[Context]`. Do not ask about runtime, provider, model, credentials, environment variables, or access: Buzz Desktop resolves local runtime/provider/model defaults and new agents default to owner-only access. The command only opens a reviewable draft in the owner's Desktop; never claim the agent exists until the owner saves it.
 
-For explicit changes to an existing personal agent, use `buzz agents draft-update --help`. Draft updates also require owner review and save.
+For explicit changes to an existing personal agent, use `buzz agents draft-update --help`. Prefer `--pubkey <instance-hex>` from the Active Agents table in `AGENTS.md` when multiple instances share a display name; otherwise use `--agent-name`. Draft updates also require owner review and save. The harness refreshes the managed roster block when Desktop regenerates `AGENTS.md` (community switch or agent changes).
 
 ## Communication Patterns
 
@@ -80,7 +80,7 @@ All replies and delegations — including task assignments to other agents — g
 
 1. `buzz feed get` — surface pending mentions and action items. Filter by type: `mentions`, `needs_action`, `activity`, `agent_activity`.
 2. `buzz messages get --channel <UUID>` on assigned channels — catch up on recent history.
-3. Check `AGENTS.md` in your working directory for team context.
+3. Check `AGENTS.md` in your working directory for team context. The **Relay** line and **Instance pubkey** column reflect the **currently selected Buzz Desktop community** — treat that block as authoritative for coordination, not a hardcoded local vs production URL.
 4. Check `RESEARCH/`, `GUIDES/`, `PLANS/` before searching externally. Use `buzz messages search --query "..."` for cross-channel keyword lookups.
 
 ## Workspace Layout

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(unsafe_code)]
 
 mod acp;
+mod agents_roster;
 mod config;
 mod engram_fetch;
 mod filter;

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1845,6 +1845,9 @@ pub async fn run_prompt_task(
             );
         }
 
+        let agents_roster_refresh =
+            crate::agents_roster::poll_roster_update(std::path::Path::new(&ctx.cwd));
+
         crate::queue::format_prompt(
             b,
             &crate::queue::FormatPromptArgs {
@@ -1857,6 +1860,7 @@ pub async fn run_prompt_task(
                 system_prompt: ctx.system_prompt.as_deref(),
                 team_instructions: ctx.team_instructions.as_deref(),
                 agent_canvas: agent_canvas.as_deref(),
+                agents_roster_refresh: agents_roster_refresh.as_deref(),
             },
         )
     } else {

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1372,6 +1372,8 @@ pub struct FormatPromptArgs<'a> {
     /// For legacy agents it rides in the user message on every turn of the
     /// session, alongside `[Base]`/`[System]`/`[Agent Memory — core]`.
     pub agent_canvas: Option<&'a str>,
+    /// When the managed block in `AGENTS.md` changed since the prior turn.
+    pub agents_roster_refresh: Option<&'a str>,
 }
 
 /// Format the `[Base]` section for the base prompt.
@@ -1455,6 +1457,14 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
         if let Some(canvas) = args.agent_canvas {
             sections.push(canvas.to_string());
         }
+    }
+
+    if let Some(refresh) = args
+        .agents_roster_refresh
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        sections.push(format!("[Agents roster]\n{refresh}"));
     }
 
     // 2. Context hints (with a human-aware reply anchor).

--- a/crates/buzz-cli/src/agent_management.rs
+++ b/crates/buzz-cli/src/agent_management.rs
@@ -5,6 +5,7 @@ use nostr::{Event, Keys, PublicKey};
 use serde::Serialize;
 
 use crate::error::CliError;
+use crate::validate::validate_hex64;
 
 const REQUEST_KIND: &str = "agent_management_request";
 const MAX_NAME_CHARS: usize = 120;
@@ -23,6 +24,8 @@ pub struct CreateAgentDraft {
 pub struct UpdateAgentDraft {
     pub channel_id: String,
     pub agent_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_pubkey: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -158,9 +161,32 @@ pub fn build_update(
             "respond-to must be owner-only or anyone".into(),
         ));
     }
+    let agent_pubkey = draft
+        .agent_pubkey
+        .map(|value| required(value, "agent pubkey", 64))
+        .transpose()?;
+    if agent_pubkey.is_some() {
+        if let Some(ref pk) = agent_pubkey {
+            validate_hex64(pk).map_err(|_| {
+                CliError::Usage("agent pubkey must be a 64-character hex string".into())
+            })?;
+        }
+    }
+    let agent_name_trimmed = draft.agent_name.trim();
+    if agent_pubkey.is_none() && agent_name_trimmed.is_empty() {
+        return Err(CliError::Usage(
+            "provide --agent-name or --pubkey for the target instance".into(),
+        ));
+    }
+    let agent_name = if agent_name_trimmed.is_empty() {
+        String::new()
+    } else {
+        required(draft.agent_name, "agent name", MAX_NAME_CHARS)?
+    };
     let request = UpdateAgentDraft {
         channel_id: channel_id.clone(),
-        agent_name: required(draft.agent_name, "agent name", MAX_NAME_CHARS)?,
+        agent_name,
+        agent_pubkey,
         display_name: optional(draft.display_name, "display name")?,
         system_prompt: draft
             .system_prompt
@@ -241,6 +267,33 @@ mod tests {
     }
 
     #[test]
+    fn update_accepts_pubkey_without_name() {
+        let agent = Keys::generate();
+        let owner = Keys::generate();
+        let pubkey = agent.public_key().to_hex();
+        let built = build_update(
+            &agent,
+            &owner.public_key(),
+            UpdateAgentDraft {
+                channel_id: CHANNEL.into(),
+                agent_name: String::new(),
+                agent_pubkey: Some(pubkey.clone()),
+                display_name: None,
+                system_prompt: Some("New instructions.".into()),
+                runtime: None,
+                provider: None,
+                model: None,
+                respond_to: None,
+            },
+        )
+        .unwrap();
+
+        let payload: serde_json::Value = decrypt_observer_payload(&owner, &built.event).unwrap();
+        assert_eq!(payload["payload"]["request"]["agentPubkey"], pubkey);
+        assert_eq!(payload["payload"]["request"]["agentName"], "");
+    }
+
+    #[test]
     fn update_requires_a_change() {
         let error = build_update(
             &Keys::generate(),
@@ -248,6 +301,7 @@ mod tests {
             UpdateAgentDraft {
                 channel_id: CHANNEL.into(),
                 agent_name: "Scout".into(),
+                agent_pubkey: None,
                 display_name: None,
                 system_prompt: None,
                 runtime: None,

--- a/crates/buzz-cli/src/commands/agents.rs
+++ b/crates/buzz-cli/src/commands/agents.rs
@@ -46,6 +46,7 @@ pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), Cli
         AgentsCmd::DraftUpdate {
             channel,
             agent_name,
+            pubkey,
             display_name,
             system_prompt,
             runtime,
@@ -54,12 +55,18 @@ pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), Cli
             respond_to,
         } => {
             let owner = require_owner(client)?;
+            if agent_name.is_none() && pubkey.is_none() {
+                return Err(CliError::Usage(
+                    "provide --agent-name or --pubkey for the target instance".into(),
+                ));
+            }
             let built = build_update(
                 client.keys(),
                 &owner,
                 UpdateAgentDraft {
                     channel_id: channel,
-                    agent_name,
+                    agent_name: agent_name.unwrap_or_default(),
+                    agent_pubkey: pubkey,
                     display_name,
                     system_prompt: system_prompt.map(|v| read_or_stdin(&v)).transpose()?,
                     runtime,

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -275,9 +275,12 @@ pub enum AgentsCmd {
         /// Current channel UUID
         #[arg(long)]
         channel: String,
-        /// Current name of the personal agent to update
+        /// Current display name of the personal agent (omit when using --pubkey)
         #[arg(long)]
-        agent_name: String,
+        agent_name: Option<String>,
+        /// Managed instance pubkey (preferred when several instances share a persona name)
+        #[arg(long)]
+        pubkey: Option<String>,
         #[arg(long)]
         display_name: Option<String>,
         /// Replacement instructions; use '-' to read from stdin

--- a/desktop/src-tauri/src/managed_agents/nest.rs
+++ b/desktop/src-tauri/src/managed_agents/nest.rs
@@ -558,7 +558,7 @@ pub fn render_dynamic_section(
             .to_string()
     } else {
         let mut table =
-            "## Active Agents\n\n| Name | Persona | How to address |\n|------|---------|----------------|"
+            "## Active Agents\n\n| Name | Persona | Instance pubkey | How to address |\n|------|---------|-----------------|----------------|"
                 .to_string();
         for agent in agents {
             let role = agent
@@ -569,7 +569,10 @@ pub fn render_dynamic_section(
                 .unwrap_or("—");
             let name = escape_md_cell(&agent.name);
             let role_escaped = escape_md_cell(role);
-            table.push_str(&format!("\n| {name} | {role_escaped} | @{name} |"));
+            let pubkey = escape_md_cell(&agent.pubkey);
+            table.push_str(&format!(
+                "\n| {name} | {role_escaped} | `{pubkey}` | @{name} |"
+            ));
         }
         table
     };

--- a/desktop/src-tauri/src/managed_agents/nest/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/nest/tests.rs
@@ -510,8 +510,8 @@ fn test_render_dynamic_section_with_agents() {
     let personas = vec![make_persona("p1", "Builder")];
     let agents = vec![make_agent("Kit", Some("p1"))];
     let output = render_dynamic_section(&personas, &agents, "ws://example.com:3000");
-    assert!(output.contains("| Kit | Builder | @Kit |"));
-    assert!(output.contains("| Name | Persona | How to address |"));
+    assert!(output.contains("| Kit | Builder | `` | @Kit |"));
+    assert!(output.contains("| Name | Persona | Instance pubkey | How to address |"));
     assert!(output.contains("## Workspace"));
 }
 
@@ -526,7 +526,7 @@ fn test_render_dynamic_section_agent_no_persona() {
     let personas = vec![make_persona("p1", "Builder")];
     let agents = vec![make_agent("Scout", Some("nonexistent"))];
     let output = render_dynamic_section(&personas, &agents, "ws://example.com:3000");
-    assert!(output.contains("| Scout | — | @Scout |"));
+    assert!(output.contains("| Scout | — | `` | @Scout |"));
 }
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/nest_skill.md
+++ b/desktop/src-tauri/src/managed_agents/nest_skill.md
@@ -39,6 +39,13 @@ buzz agents draft-update --channel <uuid> --agent-name "Current name" \
   --system-prompt "Updated instructions"
 ```
 
+When several managed instances share a persona name, prefer the **Instance pubkey** from the Active Agents table in `AGENTS.md`:
+
+```bash
+buzz agents draft-update --channel <uuid> --pubkey <64-hex-instance-pubkey> \
+  --system-prompt "Updated instructions"
+```
+
 Run `buzz agents draft-update --help` for optional runtime, provider, model, rename, and access changes. Prefer these CLI commands over any legacy MCP agent-management tools.
 
 ## Git Repositories

--- a/desktop/src/features/agents/agentManagement.test.mjs
+++ b/desktop/src/features/agents/agentManagement.test.mjs
@@ -90,6 +90,64 @@ test("uses an agent's current name, never an internal profile ID", () => {
   assert.deepEqual(parseAgentManagementRequest(payload), payload);
 });
 
+test("uses instance pubkey when display name is ambiguous", () => {
+  const pubkey = "a".repeat(64);
+  const payload = {
+    type: AGENT_MANAGEMENT_REQUEST,
+    action: "update",
+    requestId: "request-pk",
+    request: {
+      channelId: CHANNEL_ID,
+      agentPubkey: pubkey,
+      systemPrompt: "Updated.",
+    },
+  };
+
+  assert.deepEqual(parseAgentManagementRequest(payload), {
+    ...payload,
+    request: { ...payload.request, agentName: "" },
+  });
+});
+
+test("findPersonaAgentInChannel: returns instance already in channel", async () => {
+  const { findPersonaAgentInChannel } = await import("./agentReuse.ts");
+  const PUB_A = "a".repeat(64);
+  const agent = {
+    id: "agent-1",
+    pubkey: PUB_A,
+    agentCommand: "goose",
+    status: "running",
+    personaId: "persona-1",
+    systemPrompt: null,
+    updatedAt: "2026-01-15T00:00:00Z",
+  };
+  const channelMembers = new Set([PUB_A]);
+  assert.equal(
+    findPersonaAgentInChannel([agent], "persona-1", channelMembers)?.id,
+    "agent-1",
+  );
+});
+
+test("findPersonaAgentInChannel: excludes agent not in channel", async () => {
+  const { findPersonaAgentInChannel } = await import("./agentReuse.ts");
+  const PUB_A = "a".repeat(64);
+  const PUB_B = "b".repeat(64);
+  const agent = {
+    id: "agent-1",
+    pubkey: PUB_A,
+    agentCommand: "goose",
+    status: "running",
+    personaId: "persona-1",
+    systemPrompt: null,
+    updatedAt: "2026-01-15T00:00:00Z",
+  };
+  const channelMembers = new Set([PUB_B]);
+  assert.equal(
+    findPersonaAgentInChannel([agent], "persona-1", channelMembers),
+    undefined,
+  );
+});
+
 test("allows agents to update only personal, editable profiles", () => {
   assert.equal(
     requestTargetsEditablePersona({ isBuiltIn: false, sourceTeam: null }),

--- a/desktop/src/features/agents/agentManagement.ts
+++ b/desktop/src/features/agents/agentManagement.ts
@@ -24,6 +24,8 @@ export type AgentManagementUpdateRequest = {
   request: {
     channelId: string;
     agentName: string;
+    /** When set, targets the managed instance by pubkey (preferred over name). */
+    agentPubkey?: string;
     displayName?: string;
     systemPrompt?: string;
     runtime?: string;
@@ -97,6 +99,7 @@ export function parseAgentManagementRequest(
     !hasOnlyKeys(request, [
       "channelId",
       "agentName",
+      "agentPubkey",
       "displayName",
       "systemPrompt",
       "runtime",
@@ -105,7 +108,7 @@ export function parseAgentManagementRequest(
       "respondTo",
     ]) ||
     !isText(request.channelId) ||
-    !isText(request.agentName)
+    (!isText(request.agentName) && !isText(request.agentPubkey))
   ) {
     return null;
   }
@@ -128,7 +131,10 @@ export function parseAgentManagementRequest(
     requestId: payload.requestId,
     request: {
       channelId: request.channelId,
-      agentName: request.agentName,
+      agentName: isText(request.agentName) ? request.agentName : "",
+      ...(isText(request.agentPubkey)
+        ? { agentPubkey: request.agentPubkey.trim() }
+        : {}),
       ...changes,
     },
   };

--- a/desktop/src/features/agents/agentReuse.ts
+++ b/desktop/src/features/agents/agentReuse.ts
@@ -59,6 +59,20 @@ export function findReusablePersonaAgent(
   return pickPreferredManagedAgent(candidates);
 }
 
+/** Instance of this persona already a member of the channel — attach, do not mint. */
+export function findPersonaAgentInChannel(
+  agents: ManagedAgent[],
+  personaId: string,
+  channelMemberPubkeys: ReadonlySet<string>,
+): ManagedAgent | undefined {
+  const candidates = agents.filter(
+    (agent) =>
+      agent.personaId === personaId &&
+      channelMemberPubkeys.has(normalizePubkey(agent.pubkey)),
+  );
+  return pickPreferredManagedAgent(candidates);
+}
+
 export function findReusableGenericAgent(
   agents: ManagedAgent[],
   command: string,

--- a/desktop/src/features/agents/channelAgents.ts
+++ b/desktop/src/features/agents/channelAgents.ts
@@ -1,5 +1,6 @@
 import {
   commandsMatch,
+  findPersonaAgentInChannel,
   findReusableGenericAgent,
   findReusablePersonaAgent,
   pickPreferredManagedAgent,
@@ -76,7 +77,7 @@ export type CreateChannelManagedAgentInput = {
   respondTo?: RespondToMode;
   /** Hex pubkeys for allowlist mode. */
   respondToAllowlist?: string[];
-  /** Skip reuse logic and always create a fresh agent instance. */
+  /** Skip reuse logic and always create a fresh agent instance. Reserved for deliberate multi-instance deploys; team-to-channel attach uses reuse + in-channel dedup instead. */
   forceNewInstance?: boolean;
 };
 
@@ -265,6 +266,25 @@ export async function provisionChannelManagedAgent(
     throw new Error("Agent name is required.");
   }
 
+  if (
+    input.personaId &&
+    context?.managedAgents &&
+    context.channelMemberPubkeys
+  ) {
+    const alreadyInChannel = findPersonaAgentInChannel(
+      context.managedAgents,
+      input.personaId,
+      context.channelMemberPubkeys,
+    );
+    if (alreadyInChannel) {
+      return {
+        agent: alreadyInChannel,
+        created: false,
+        runtimeId: input.runtime.id,
+      };
+    }
+  }
+
   // Smart reuse: if a managed agent with the same personaId already exists
   // and is not already in this channel, attach it instead of creating a new one.
   if (
@@ -418,19 +438,34 @@ export async function createChannelManagedAgents(
   const channelMemberPubkeys = new Set(
     members.map((m) => normalizePubkey(m.pubkey)),
   );
-  const context = { managedAgents, channelMemberPubkeys };
 
   // Sequential loop: each agent must be fully created and its relay membership
   // written before the next starts. Concurrent writes to the replaceable
   // kind:39002 membership event cause last-write-wins data loss.
   const successes: CreateChannelManagedAgentResult[] = [];
   const failures: CreateChannelManagedAgentBatchFailure[] = [];
+  let context = {
+    managedAgents,
+    channelMemberPubkeys,
+  };
 
   for (let i = 0; i < inputs.length; i++) {
     const input = inputs[i];
     try {
       const result = await createChannelManagedAgent(channelId, input, context);
       successes.push(result);
+      if (result.agent?.pubkey) {
+        context = {
+          managedAgents: context.managedAgents.some(
+            (a) => a.pubkey === result.agent.pubkey,
+          )
+            ? context.managedAgents
+            : [...context.managedAgents, result.agent],
+          channelMemberPubkeys: new Set(context.channelMemberPubkeys).add(
+            normalizePubkey(result.agent.pubkey),
+          ),
+        };
+      }
     } catch (error) {
       failures.push({
         kind: input.personaId ? "persona" : "generic",

--- a/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
+++ b/desktop/src/features/agents/ui/AddTeamToChannelDialog.tsx
@@ -148,8 +148,6 @@ export function AddTeamToChannelDialog({
           model: persona.model ?? undefined,
           personaId: persona.id,
           teamId: team.id,
-          // One persona can be deployed under multiple teams with different instructions.
-          forceNewInstance: true,
           role,
         };
       });

--- a/desktop/src/features/agents/useAgentManagement.ts
+++ b/desktop/src/features/agents/useAgentManagement.ts
@@ -142,13 +142,25 @@ export function useAgentManagement() {
 
   const matchingPersonas = React.useMemo(() => {
     if (request?.action !== "update") return [];
+    const pubkey = request.request.agentPubkey?.trim().toLowerCase();
+    if (pubkey) {
+      const instance = (managedAgentsQuery.data ?? []).find(
+        (agent) => agent.pubkey.trim().toLowerCase() === pubkey,
+      );
+      if (!instance?.personaId) return [];
+      return (personasQuery.data ?? []).filter(
+        (persona) =>
+          persona.id === instance.personaId &&
+          requestTargetsEditablePersona(persona),
+      );
+    }
     const target = request.request.agentName.trim().toLocaleLowerCase();
     return (personasQuery.data ?? []).filter(
       (persona) =>
         persona.displayName.trim().toLocaleLowerCase() === target &&
         requestTargetsEditablePersona(persona),
     );
-  }, [personasQuery.data, request]);
+  }, [managedAgentsQuery.data, personasQuery.data, request]);
   const currentPersona =
     matchingPersonas.length === 1 ? matchingPersonas[0] : undefined;
 
@@ -287,7 +299,7 @@ export function useAgentManagement() {
       return "More than one personal agent has that name. Rename it in Agents, then ask the agent again.";
     }
     if (!currentPersona) {
-      return "Agents can only update a personal agent profile by its current name.";
+      return "Agents can only update a personal agent profile by its current name or instance pubkey.";
     }
     return null;
   }, [currentPersona, error, matchingPersonas.length, request]);


### PR DESCRIPTION
## Summary

Fixes #3639.

**Deploy team to channel** always passed `forceNewInstance: true` for every persona, which bypassed `findReusablePersonaAgent()` in `provisionChannelManagedAgent()` and minted a fresh Nostr keypair on each deploy — even when the same persona was already attached to the channel with a running managed instance.

This PR:

1. **Removes `forceNewInstance: true`** from `AddTeamToChannelDialog.tsx` so team deploy follows the same reuse path as single-agent deploy.
2. **Adds `findPersonaAgentInChannel()`** and short-circuits provisioning when the persona is already in-channel (no mint, no duplicate member attach).
3. **Refreshes batch deploy context** after each attach so subsequent personas in the same team deploy see updated channel membership.
4. **Adds `buzz agents draft-update --pubkey`** for disambiguation when multiple agents share a display name (#2423 mitigation).
5. **Adds harness roster refresh** (`agents_roster.rs`) so the ACP pool picks up managed-agent block changes without restart.
6. **Documents Instance pubkey** in the nest `AGENTS.md` table for operator clarity.

### Root cause (confirmed on `origin/main`)

```tsx
// AddTeamToChannelDialog.tsx (main)
forceNewInstance: true,  // ← bypasses reuse for every persona
```

### Live reproduction (ai-advantage community)

Repeated **Deploy team to channel** on the same team/channel grew channel bot membership from 12 distinct running instances to ~24 pubkeys with duplicate display names. Manual cleanup via `buzz channels remove-member` for stale pubkeys restored 12 canonical instances.

### Related issues

| Issue | Relationship |
|-------|--------------|
| #3639 | Primary — this PR fixes the team-deploy mint bypass |
| #2648 | Second-install mint on same machine — **not fixed here** |
| #2973 | Archive failure leaves ghost channel members — workaround unchanged |
| #2423 | `--pubkey` draft-update mitigation included |
| #3204 | Agent picker confusion worsened by duplicates — scope boundary |
| #2910 | Same-owner team-deploy collision — improved by reuse, not fully deduped server-side |

### Out of scope

- Backend dedup in `create_managed_agent` by `persona_id`
- Agent picker filtering by running state (#3204)
- Archive/remove-member UX (#2973)

## Testing

Verified locally on branch `fix/team-deploy-agent-reuse` (rebased on latest `origin/main`):

| Command | Result |
|---------|--------|
| `cargo test -p buzz-cli agent_management` | 4 passed |
| `cargo test -p buzz-acp --lib extract_managed` | 1 passed |
| `cargo clippy -p buzz-cli -p buzz-acp -- -D warnings` | pass |
| `node --test desktop/src/features/agents/agentManagement.test.mjs` | 10 passed |
| `cargo test --manifest-path desktop/src-tauri/Cargo.toml nest::tests` | 42 passed |
| `just desktop-tauri-fmt` | pass |

### Manual test plan

- [ ] Deploy a team to a channel once → N agents created (one per persona)
- [ ] Deploy the **same team to the same channel** again → **no new keypairs**, existing instances reused
- [ ] Channel member list shows one pubkey per persona display name
- [ ] `buzz agents draft-update --pubkey <hex> --name "…"` targets the correct agent when names collide
