### PR TITLE
fix(web): reject incomplete relay queries before EOSE

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -263,7 +263,7 @@ desktop-e2e-pre-push: _ensure-migrations
     cd {{desktop_dir}} && pnpm build:e2e && pnpm exec playwright test --only-changed=origin/main
 
 # Run all checks suitable for CI / pre-push (no infra needed)
-ci: check test-unit desktop-test desktop-build desktop-tauri-check desktop-tauri-test web-build mobile-test
+ci: check test-unit desktop-test desktop-build desktop-tauri-check desktop-tauri-test web-test web-build mobile-test
 
 # ─── Test ─────────────────────────────────────────────────────────────────────
 
@@ -587,6 +587,10 @@ web-fix:
 # Run web TypeScript checks
 web-typecheck:
     cd {{web_dir}} && pnpm typecheck
+
+# Run web unit tests
+web-test:
+    cd {{web_dir}} && pnpm test:unit
 
 # Build web frontend assets
 web-build:

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit",
     "check:file-sizes": "node ./scripts/check-file-sizes.mjs",
     "check:pubkey-truncation": "node ./scripts/check-pubkey-truncation.mjs",
+    "test:unit": "node --test \"tests/unit/**/*.test.ts\"",
     "lint": "biome lint .",
     "check": "biome check . && pnpm check:file-sizes && pnpm check:pubkey-truncation",
     "format": "biome format --write .",

--- a/web/src/shared/lib/nostr-client.ts
+++ b/web/src/shared/lib/nostr-client.ts
@@ -6,10 +6,7 @@
  */
 
 import { makeAuthEvent } from "nostr-tools/nip42";
-import {
-  type SignedNostrEvent,
-  signNostrEvent,
-} from "@/shared/lib/nostr-signer";
+import { type SignedNostrEvent, signNostrEvent } from "./nostr-signer.ts";
 
 export interface NostrFilter {
   ids?: string[];
@@ -24,6 +21,19 @@ export interface NostrFilter {
 export type NostrEvent = SignedNostrEvent;
 
 const QUERY_TIMEOUT_MS = 10_000;
+
+/**
+ * The relay disconnected before confirming the query was complete with EOSE.
+ *
+ * Any events received before this error are an incomplete prefix and must not
+ * be treated as a successful query result.
+ */
+export class NostrClosedBeforeEoseError extends Error {
+  constructor() {
+    super("Relay closed the connection before EOSE; results are incomplete.");
+    this.name = "NostrClosedBeforeEoseError";
+  }
+}
 
 /**
  * Open a WebSocket to `wsUrl`, authenticate via NIP-42 if challenged,
@@ -167,8 +177,8 @@ export function queryEvents(
     ws.addEventListener("close", () => {
       if (!settled) {
         settled = true;
-        clearTimeout(timeout);
-        resolve(events);
+        cleanup();
+        reject(new NostrClosedBeforeEoseError());
       }
     });
   });

--- a/web/tests/unit/nostr-client.test.ts
+++ b/web/tests/unit/nostr-client.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  NostrClosedBeforeEoseError,
+  queryEvents,
+} from "../../src/shared/lib/nostr-client.ts";
+
+class FakeWebSocket extends EventTarget {
+  static last: FakeWebSocket | undefined;
+  readonly sent: string[] = [];
+  readonly url: string;
+
+  constructor(url: string) {
+    super();
+    this.url = url;
+    FakeWebSocket.last = this;
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {}
+}
+
+test("queryEvents rejects when the socket closes before EOSE", async () => {
+  const realWebSocket = globalThis.WebSocket;
+  Object.defineProperty(globalThis, "WebSocket", {
+    configurable: true,
+    value: FakeWebSocket,
+  });
+
+  try {
+    const query = queryEvents("ws://relay.test", { kinds: [1] });
+    const socket = FakeWebSocket.last;
+    assert.ok(socket, "queryEvents constructed a WebSocket");
+
+    socket.dispatchEvent(new Event("open"));
+    socket.dispatchEvent(new Event("close"));
+
+    await assert.rejects(query, NostrClosedBeforeEoseError);
+  } finally {
+    Object.defineProperty(globalThis, "WebSocket", {
+      configurable: true,
+      value: realWebSocket,
+    });
+    FakeWebSocket.last = undefined;
+  }
+});


### PR DESCRIPTION
## Summary

- reject relay queries when the WebSocket closes before EOSE instead of returning an incomplete event prefix as a successful result
- expose a typed `NostrClosedBeforeEoseError` for callers
- add a real WebSocket lifecycle regression test and run web unit tests from `just ci`

### Related issue

N/A. No matching open issue or pull request was found.

### Testing

- `CHECK_FILE_SIZES_BASE=upstream/main just ci`
- `pnpm -C web test:unit`

No UI changes; screenshots are not applicable.
