### PR TITLE
fix(ci): resolve desktop Mesh revision from its manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1038,10 +1038,12 @@ jobs:
         id: mesh_rev
         run: |
           set -euo pipefail
-          REV=$(python3 -c 'import tomllib; d=tomllib.load(open("Cargo.lock", "rb")); p=next(p for p in d["package"] if p["name"] == "mesh-llm-sdk"); print(p["source"].rsplit("#", 1)[1])')
-          [[ -n "$REV" ]] || { echo "::error::could not resolve mesh-llm rev from Cargo.lock"; exit 1; }
+          # Derive the Mesh-LLM rev from desktop/src-tauri/Cargo.toml (the
+          # manifest the desktop build actually fetches), not the root
+          # Cargo.lock. See scripts/resolve-mesh-rev.sh.
+          REV=$(scripts/resolve-mesh-rev.sh)
           echo "rev=$REV" >> "$GITHUB_OUTPUT"
-          echo "short=${REV:0:7}" >> "$GITHUB_OUTPUT"
+          echo "short=$(scripts/resolve-mesh-rev.sh --short)" >> "$GITHUB_OUTPUT"
       - name: Restore mesh llama build cache
         id: llama_cache
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
@@ -1055,12 +1057,7 @@ jobs:
         run: |
           set -euo pipefail
           cargo fetch --manifest-path desktop/src-tauri/Cargo.toml
-          SHORT="$MESH_REV_SHORT"
-          MESH_ROOT=$(find "${CARGO_HOME:-$HOME/.cargo}/git/checkouts" -path "*/$SHORT" -type d -name "$SHORT" | head -1)
-          if [[ -z "$MESH_ROOT" ]]; then
-            echo "::error::mesh-llm checkout for $SHORT not found after cargo fetch"
-            exit 1
-          fi
+          MESH_ROOT=$(scripts/resolve-mesh-rev.sh --find-checkout)
           export LLAMA_STAGE_BACKEND=metal
           export LLAMA_STAGE_BUILD_DIR="$GITHUB_WORKSPACE/.cache/mesh-llama/build-stage-abi-metal"
           export CMAKE_OSX_DEPLOYMENT_TARGET=10.15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,10 +142,12 @@ jobs:
         id: mesh_rev
         run: |
           set -euo pipefail
-          REV=$(python3 -c 'import tomllib; d=tomllib.load(open("Cargo.lock", "rb")); p=next(p for p in d["package"] if p["name"] == "mesh-llm-sdk"); print(p["source"].rsplit("#", 1)[1])')
-          [[ -n "$REV" ]] || { echo "::error::could not resolve mesh-llm rev from Cargo.lock"; exit 1; }
+          # Derive the Mesh-LLM rev from desktop/src-tauri/Cargo.toml (the
+          # manifest the desktop build actually fetches), not the root
+          # Cargo.lock. See scripts/resolve-mesh-rev.sh.
+          REV=$(scripts/resolve-mesh-rev.sh)
           echo "rev=$REV" >> "$GITHUB_OUTPUT"
-          echo "short=${REV:0:7}" >> "$GITHUB_OUTPUT"
+          echo "short=$(scripts/resolve-mesh-rev.sh --short)" >> "$GITHUB_OUTPUT"
       - name: Restore mesh llama build cache
         id: llama_cache
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
@@ -159,12 +161,7 @@ jobs:
         run: |
           set -euo pipefail
           cargo fetch --manifest-path desktop/src-tauri/Cargo.toml
-          SHORT="$MESH_REV_SHORT"
-          MESH_ROOT=$(find "${CARGO_HOME:-$HOME/.cargo}/git/checkouts" -path "*/$SHORT" -type d -name "$SHORT" | head -1)
-          if [[ -z "$MESH_ROOT" ]]; then
-            echo "::error::mesh-llm checkout for $SHORT not found after cargo fetch"
-            exit 1
-          fi
+          MESH_ROOT=$(scripts/resolve-mesh-rev.sh --find-checkout)
           export LLAMA_STAGE_BACKEND=metal
           export LLAMA_STAGE_BUILD_DIR="$GITHUB_WORKSPACE/.cache/mesh-llama/build-stage-abi-metal"
           export CMAKE_OSX_DEPLOYMENT_TARGET=10.15

--- a/.github/workflows/signed-macos-canary.yml
+++ b/.github/workflows/signed-macos-canary.yml
@@ -101,10 +101,12 @@ jobs:
         id: mesh_rev
         run: |
           set -euo pipefail
-          REV=$(python3 -c 'import tomllib; d=tomllib.load(open("Cargo.lock", "rb")); p=next(p for p in d["package"] if p["name"] == "mesh-llm-sdk"); print(p["source"].rsplit("#", 1)[1])')
-          [[ -n "$REV" ]] || { echo "::error::could not resolve mesh-llm rev from Cargo.lock"; exit 1; }
+          # Derive the Mesh-LLM rev from desktop/src-tauri/Cargo.toml (the
+          # manifest the desktop build actually fetches), not the root
+          # Cargo.lock. See scripts/resolve-mesh-rev.sh.
+          REV=$(scripts/resolve-mesh-rev.sh)
           echo "rev=$REV" >> "$GITHUB_OUTPUT"
-          echo "short=${REV:0:7}" >> "$GITHUB_OUTPUT"
+          echo "short=$(scripts/resolve-mesh-rev.sh --short)" >> "$GITHUB_OUTPUT"
 
       - name: Restore mesh llama build cache
         id: llama_cache
@@ -120,11 +122,7 @@ jobs:
         run: |
           set -euo pipefail
           cargo fetch --manifest-path desktop/src-tauri/Cargo.toml
-          MESH_ROOT=$(find "${CARGO_HOME:-$HOME/.cargo}/git/checkouts" -path "*/$MESH_REV_SHORT" -type d -name "$MESH_REV_SHORT" | head -1)
-          if [[ -z "$MESH_ROOT" ]]; then
-            echo "::error::mesh-llm checkout for $MESH_REV_SHORT not found after cargo fetch"
-            exit 1
-          fi
+          MESH_ROOT=$(scripts/resolve-mesh-rev.sh --find-checkout)
           export LLAMA_STAGE_BACKEND=metal
           export LLAMA_STAGE_BUILD_DIR="$GITHUB_WORKSPACE/.cache/mesh-llama/build-stage-abi-metal"
           export CMAKE_OSX_DEPLOYMENT_TARGET=10.15

--- a/scripts/resolve-mesh-rev.sh
+++ b/scripts/resolve-mesh-rev.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Single source of truth for the Mesh-LLM git revision the desktop macOS build
+# actually fetches. Used identically by ci.yml, release.yml, and
+# signed-macos-canary.yml.
+#
+# Why derive from desktop/src-tauri/Cargo.toml and NOT the root Cargo.lock:
+# the desktop crate is `exclude`d from the root Cargo workspace and pins its own
+# Mesh-LLM git `rev` in desktop/src-tauri/Cargo.toml. The macOS build runs
+# `cargo fetch --manifest-path desktop/src-tauri/Cargo.toml`, which checks out
+# THAT rev. The root Cargo.lock carries buzz-relay's separate Mesh pin (a
+# different SHA), so resolving from it makes CI hunt a checkout that was never
+# created ("mesh-llm checkout for <short> not found"). This resolver reads the
+# desktop manifest — the manifest the fetch uses — and fails loudly on any
+# inconsistency so a bad pin is a clear error, not a mysterious CI miss.
+#
+# Usage:
+#   resolve-mesh-rev.sh                 # print the full 40-char rev
+#   resolve-mesh-rev.sh --short         # print the 7-char short rev
+#   resolve-mesh-rev.sh --find-checkout # print the cargo git checkout path,
+#                                       #   failing loudly if it is absent
+#
+# Manifest path is overridable via MESH_MANIFEST (used by the tests).
+
+fail() {
+  echo "::error::resolve-mesh-rev: $*" >&2
+  exit 1
+}
+
+manifest="${MESH_MANIFEST:-desktop/src-tauri/Cargo.toml}"
+
+mode="rev"
+case "${1:-}" in
+  "") mode="rev" ;;
+  --short) mode="short" ;;
+  --find-checkout) mode="find" ;;
+  *) fail "unknown argument: $1 (expected --short or --find-checkout)" ;;
+esac
+
+[[ -f "$manifest" ]] || fail "manifest not found: $manifest"
+
+# Non-comment dependency lines that reference the Mesh-LLM git repository.
+# (Portable to bash 3.2 — no `mapfile`.)
+dep_lines=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && dep_lines+=("$line")
+done < <(grep -E 'Mesh-LLM/mesh-llm\.git' "$manifest" | grep -vE '^[[:space:]]*#' || true)
+[[ ${#dep_lines[@]} -gt 0 ]] \
+  || fail "no Mesh-LLM git dependency found in $manifest"
+
+revs=()
+for line in "${dep_lines[@]}"; do
+  rev="$(sed -nE 's/.*[^a-zA-Z0-9_]rev[[:space:]]*=[[:space:]]*"([0-9a-fA-F]{7,40})".*/\1/p' <<<"$line")"
+  [[ -n "$rev" ]] \
+    || fail "Mesh-LLM git dependency without an explicit rev in $manifest: ${line}"
+  revs+=("$rev")
+done
+
+unique=()
+while IFS= read -r r; do
+  [[ -n "$r" ]] && unique+=("$r")
+done < <(printf '%s\n' "${revs[@]}" | sort -u)
+if [[ ${#unique[@]} -ne 1 ]]; then
+  fail "inconsistent Mesh-LLM revs across desktop dependencies (${unique[*]}) — pin every Mesh-LLM dependency in $manifest to the same rev"
+fi
+
+rev="${unique[0]}"
+short="${rev:0:7}"
+
+case "$mode" in
+  rev) printf '%s\n' "$rev" ;;
+  short) printf '%s\n' "$short" ;;
+  find)
+    root="${CARGO_HOME:-$HOME/.cargo}/git/checkouts"
+    [[ -d "$root" ]] \
+      || fail "cargo git checkouts dir missing ($root) — run 'cargo fetch --manifest-path $manifest' before resolving the checkout"
+    path="$(find "$root" -path "*/$short" -type d -name "$short" 2>/dev/null | head -1)"
+    [[ -n "$path" ]] \
+      || fail "Mesh-LLM checkout for $short not found under $root — 'cargo fetch --manifest-path $manifest' did not create it"
+    printf '%s\n' "$path"
+    ;;
+esac

--- a/scripts/test-resolve-mesh-rev.sh
+++ b/scripts/test-resolve-mesh-rev.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deterministic, offline tests for resolve-mesh-rev.sh. Covers success, mixed
+# rev failure, missing rev/dependency failure, and absent checkout failure.
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$here/resolve-mesh-rev.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+die() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# Expect the script to exit non-zero for a bad input.
+expect_fail() {
+  local desc="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    die "$desc — expected failure but the resolver succeeded"
+  fi
+}
+
+REV="c441ea7f328692b18b7f49ad819c7b1a603cbdcb"
+SHORT="c441ea7"
+
+# --- success: consistent revs across several deps (+ a decoy comment) --------
+cat >"$tmp/consistent.toml" <<EOF
+[dependencies]
+# comment mentioning Mesh-LLM/mesh-llm.git that is not a real dependency
+mesh-llm-sdk = { git = "https://github.com/Mesh-LLM/mesh-llm.git", rev = "$REV", package = "mesh-llm-sdk" }
+mesh-llm-node = { git = "https://github.com/Mesh-LLM/mesh-llm.git", rev = "$REV", package = "mesh-llm-node" }
+serde = "1"
+EOF
+
+got="$(MESH_MANIFEST="$tmp/consistent.toml" "$script")"
+[[ "$got" == "$REV" ]] || die "consistent rev: expected $REV, got $got"
+got="$(MESH_MANIFEST="$tmp/consistent.toml" "$script" --short)"
+[[ "$got" == "$SHORT" ]] || die "consistent short: expected $SHORT, got $got"
+
+# --- failure: mixed revs -----------------------------------------------------
+cat >"$tmp/mixed.toml" <<EOF
+mesh-llm-sdk = { git = "https://github.com/Mesh-LLM/mesh-llm.git", rev = "$REV" }
+mesh-llm-node = { git = "https://github.com/Mesh-LLM/mesh-llm.git", rev = "0000000000000000000000000000000000000000" }
+EOF
+expect_fail "mixed revs" env MESH_MANIFEST="$tmp/mixed.toml" "$script"
+
+# --- failure: a Mesh dep with no rev ----------------------------------------
+cat >"$tmp/missing-rev.toml" <<EOF
+mesh-llm-sdk = { git = "https://github.com/Mesh-LLM/mesh-llm.git", package = "mesh-llm-sdk" }
+EOF
+expect_fail "missing rev" env MESH_MANIFEST="$tmp/missing-rev.toml" "$script"
+
+# --- failure: no Mesh dependency at all -------------------------------------
+cat >"$tmp/none.toml" <<EOF
+serde = "1"
+EOF
+expect_fail "no dependency" env MESH_MANIFEST="$tmp/none.toml" "$script"
+
+# --- failure: absent checkout ------------------------------------------------
+expect_fail "absent checkout" \
+  env MESH_MANIFEST="$tmp/consistent.toml" CARGO_HOME="$tmp/empty-cargo" "$script" --find-checkout
+
+# --- success: --find-checkout locates an existing checkout -------------------
+mkdir -p "$tmp/cargo/git/checkouts/mesh-llm-abcd1234/$SHORT"
+found="$(MESH_MANIFEST="$tmp/consistent.toml" CARGO_HOME="$tmp/cargo" "$script" --find-checkout)"
+[[ "$found" == *"/$SHORT" ]] || die "find-checkout: expected a path ending in /$SHORT, got $found"
+
+echo "resolve-mesh-rev: ALL TESTS PASSED"


### PR DESCRIPTION
## Problem

The macOS workflows fetch Mesh-LLM using `desktop/src-tauri/Cargo.toml`, but derive the expected checkout revision from the root `Cargo.lock`. Those are independent dependency graphs: the root lockfile tracks the relay's Mesh pin, which can differ from the desktop manifest revision. When they diverge, CI searches for a checkout that `cargo fetch --manifest-path desktop/src-tauri/Cargo.toml` never created.

## Solution

- Resolve the Mesh revision directly from `desktop/src-tauri/Cargo.toml`.
- Fail loudly if Mesh dependencies omit a revision or use inconsistent revisions.
- Centralize checkout discovery for CI, release, and signed macOS canary workflows.
- Add deterministic offline tests for successful resolution and all failure modes.

This changes CI/tooling only. It does not update Mesh or alter product code.

## Validation

- `scripts/test-resolve-mesh-rev.sh`
- Bash syntax checks for both scripts
- Real manifest revision resolution
- YAML parsing for all three modified workflows
- Full `CHECK_FILE_SIZES_BASE=upstream/main just ci`

The explicit file-size base was used because this checkout's `origin` is a downstream mirror; the exact upstream base was used for the comparison.

No matching open upstream issue or pull request was found. This contribution is independent of #3655.
