### PR TITLE
feat(acp): add native Buzz reply delivery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -955,7 +955,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p desktop/src-tauri/binaries
-          for bin in buzz-acp buzz-agent buzz-dev-mcp git-credential-nostr buzz; do
+          for bin in buzz-acp buzz-agent buzz-dev-mcp buzz-native-mcp git-credential-nostr buzz; do
             touch "desktop/src-tauri/binaries/${bin}-${TARGET}.exe"
           done
       - name: Clippy (workspace)
@@ -1030,6 +1030,7 @@ jobs:
           touch "desktop/src-tauri/binaries/buzz-acp-$TARGET"
           touch "desktop/src-tauri/binaries/buzz-agent-$TARGET"
           touch "desktop/src-tauri/binaries/buzz-dev-mcp-$TARGET"
+          touch "desktop/src-tauri/binaries/buzz-native-mcp-$TARGET"
           touch "desktop/src-tauri/binaries/git-credential-nostr-$TARGET"
           touch "desktop/src-tauri/binaries/buzz-$TARGET"
       # Mesh rev is derived from Cargo.lock so a dependency bump needs no

--- a/Justfile
+++ b/Justfile
@@ -155,7 +155,7 @@ _ensure-sidecar-stubs:
     set -euo pipefail
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
     mkdir -p desktop/src-tauri/binaries
-    for bin in buzz-acp buzz-agent buzz-dev-mcp git-credential-nostr buzz; do
+    for bin in buzz-acp buzz-agent buzz-dev-mcp buzz-native-mcp git-credential-nostr buzz; do
         touch "desktop/src-tauri/binaries/${bin}-${TARGET}"
     done
 
@@ -237,6 +237,7 @@ desktop-release-build target="aarch64-apple-darwin":
     touch "desktop/src-tauri/binaries/buzz-acp-$TARGET"
     touch "desktop/src-tauri/binaries/buzz-agent-$TARGET"
     touch "desktop/src-tauri/binaries/buzz-dev-mcp-$TARGET"
+    touch "desktop/src-tauri/binaries/buzz-native-mcp-$TARGET"
     touch "desktop/src-tauri/binaries/git-credential-nostr-$TARGET"
     touch "desktop/src-tauri/binaries/buzz-$TARGET"
     pnpm install
@@ -478,7 +479,7 @@ desktop-standalone *ARGS: _ensure-sidecar-stubs
     cargo build -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p buzz-cli -p git-credential-nostr
     TARGET=$(rustc -vV | sed -n 's|host: ||p')
     TARGET_DIR=$(cargo metadata --format-version 1 --no-deps | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).target_directory")
-    for bin in buzz-acp buzz-agent buzz-dev-mcp git-credential-nostr buzz; do
+    for bin in buzz-acp buzz-agent buzz-dev-mcp buzz-native-mcp git-credential-nostr buzz; do
         cp "${TARGET_DIR}/debug/${bin}" "desktop/src-tauri/binaries/${bin}-${TARGET}"
         chmod +x "desktop/src-tauri/binaries/${bin}-${TARGET}"
     done

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -1,15 +1,28 @@
 # buzz-acp
 
-ACP harness that connects AI agents to Buzz. The harness listens for @mentions on the relay, prompts your agent, and the agent replies using the Buzz CLI.
+ACP harness that connects AI agents to Buzz. The harness listens for @mentions
+on the relay, prompts your agent, and publishes replies through a host-side Buzz
+tool.
 
 ```
 Buzz Relay ──WS──→ buzz-acp ──stdio──→ Your Agent
-                                               │
-                                          Buzz CLI
-                                       (send_message, etc.)
+                       │                    │
+                       └──── native MCP ────┘
+                         (threaded replies)
 ```
 
 Supports any agent that speaks [ACP](https://agentclientprotocol.com/) over stdio: **goose**, **codex** (via [codex-acp](https://github.com/agentclientprotocol/codex-acp)), and **claude code** (via [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp)).
+
+The host-side `reply_to_current_thread` MCP tool keeps the Nostr signing
+identity outside sandboxed agent tool containers and returns the signed event
+ID as delivery proof. Developer-capable agents may still use the Buzz CLI for
+broader operations.
+
+For stream-channel turns, `buzz-acp` also captures ACP
+`agent_message_chunk` output. If a turn ends normally and no agent-authored
+message appeared in that channel during the turn, the harness publishes the
+captured text as a threaded fallback. The duplicate-suppression check fails
+closed, and the fallback is disabled for DMs and forum channels.
 
 ## Prerequisites
 
@@ -62,7 +75,9 @@ export GOOSE_MODE=auto
 buzz-acp
 ```
 
-That's it. The harness spawns `goose acp`, connects to the relay, discovers channels, and starts listening. When someone @mentions the agent, goose receives the message and can reply using the Buzz CLI that the harness configures automatically.
+That's it. The harness spawns `goose acp`, connects to the relay, discovers
+channels, and starts listening. When someone @mentions the agent, goose
+receives the message and can reply through the native Buzz MCP sidecar.
 
 ## Running with Codex
 

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -211,6 +211,12 @@ pub struct AcpClient {
     /// deltas. Both goose and buzz-agent emit this notification; goose gates
     /// on client capability advertisement, buzz-agent emits unconditionally.
     goose_usage: UsageTracker,
+    /// Text emitted through `agent_message_chunk` during the current turn.
+    ///
+    /// Buzz owns delivery for ACP runtimes that cannot reach the Buzz CLI
+    /// (for example, a Docker-backed Hermes terminal). The pool consumes this
+    /// buffer after a successful turn and may publish it as a safety-net reply.
+    turn_message: String,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -550,6 +556,7 @@ impl AcpClient {
             steering_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
+            turn_message: String::new(),
         })
     }
 
@@ -751,6 +758,9 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
+        // Never allow text from a failed or cancelled prior turn to leak into
+        // the next turn's delivery fallback.
+        self.turn_message.clear();
         let params = build_prompt_params(session_id, prompt_blocks);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
@@ -894,6 +904,13 @@ impl AcpClient {
     /// Idempotent — safe to call when `steer_rx` is already `None`.
     pub fn clear_steer_rx(&mut self) {
         self.steer_rx = None;
+    }
+
+    /// Take the text streamed by the agent during the most recent turn.
+    ///
+    /// The buffer is cleared even when the caller elects not to publish it.
+    pub fn take_turn_message(&mut self) -> String {
+        std::mem::take(&mut self.turn_message)
     }
 
     /// Returns `true` if no steer receiver is currently installed.
@@ -1715,6 +1732,7 @@ impl AcpClient {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::info!(target: "acp::stream", "{text}");
+                    self.turn_message.push_str(text);
                 }
                 false
             }
@@ -3433,6 +3451,25 @@ mod tests {
         AcpClient::spawn("cat", &[], &[], false)
             .await
             .expect("spawn cat as inert client")
+    }
+
+    #[tokio::test]
+    async fn agent_message_chunks_accumulate_and_take_clears() {
+        let mut client = spawn_inert_client().await;
+        for text in ["first ", "second"] {
+            let update = serde_json::json!({
+                "params": {
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": { "type": "text", "text": text }
+                    }
+                }
+            });
+            let _ = client.handle_session_update(&update);
+        }
+
+        assert_eq!(client.take_turn_message(), "first second");
+        assert_eq!(client.take_turn_message(), "");
     }
 
     /// Build a `session/update` JSON-RPC notification carrying a

--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -4,6 +4,8 @@ You are operating inside the Buzz platform — a Nostr-based messaging platform 
 
 The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`. Exit codes: 0 ok, 1 user error, 2 network, 3 auth, 4 other. Output is structured JSON.
 
+When the ACP session exposes `reply_to_current_thread`, prefer that host-side tool for an ordinary reply to the triggering Buzz conversation. Copy the channel UUID and reply destination from the current `[Context]`; a successful result returns the signed event ID as delivery proof. Use the CLI for broader Buzz operations.
+
 | Group | Key commands |
 |-------|-------------|
 | `buzz agents` | `draft-create`, `draft-update` |

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1351,6 +1351,7 @@ pub async fn run_prompt_task(
         PromptSource::Channel(channel_id) => Some(*channel_id),
         PromptSource::Heartbeat => None,
     };
+    let turn_started_secs = nostr::Timestamp::now().as_secs();
     let turn_started_at = chrono::Utc::now().to_rfc3339();
     agent.acp.set_observer_context(observer::context_for_turn(
         observer_channel_id,
@@ -2061,6 +2062,14 @@ pub async fn run_prompt_task(
                             Some(buzz_core::agent_turn_metric::StopReason::EndTurn),
                         )
                         .await;
+                        let final_text = agent.acp.take_turn_message();
+                        publish_turn_fallback_if_needed(
+                            &ctx,
+                            batch.as_ref(),
+                            &final_text,
+                            turn_started_secs,
+                        )
+                        .await;
                         send_prompt_result(
                             &result_tx,
                             &turn_id,
@@ -2123,6 +2132,17 @@ pub async fn run_prompt_task(
                 Some(core_stop),
             )
             .await;
+
+            let final_text = agent.acp.take_turn_message();
+            if stop_reason == StopReason::EndTurn {
+                publish_turn_fallback_if_needed(
+                    &ctx,
+                    batch.as_ref(),
+                    &final_text,
+                    turn_started_secs,
+                )
+                .await;
+            }
 
             send_prompt_result(
                 &result_tx,
@@ -3063,6 +3083,182 @@ fn requeue_batch_if_queue(ctx: &PromptContext, batch: Option<FlushBatch>) -> Opt
     match ctx.dedup_mode {
         DedupMode::Queue => batch,
         DedupMode::Drop => None,
+    }
+}
+
+/// Publish the ACP agent's streamed final text when the turn produced no Buzz
+/// message of its own.
+///
+/// This is the host-side delivery safety net for sandboxed runtimes: the agent
+/// never needs the Buzz binary or signing key in its tool container. A
+/// channel-scoped self-message query suppresses the fallback when the agent
+/// already used either the native Buzz MCP tool or the CLI during this turn.
+/// Only stream channels are eligible; DMs and forum channels require different
+/// message/encryption semantics and deliberately fail closed.
+async fn publish_turn_fallback_if_needed(
+    ctx: &PromptContext,
+    batch: Option<&FlushBatch>,
+    content: &str,
+    turn_started_secs: u64,
+) {
+    use nostr::{Alphabet, SingleLetterTag};
+
+    let content = content.trim();
+    if content.is_empty() {
+        return;
+    }
+    let Some(batch) = batch else {
+        return;
+    };
+    let Some(last_event) = batch.events.last() else {
+        return;
+    };
+
+    let Some(channel_info) = ctx.channel_info.resolve(batch.channel_id).await else {
+        tracing::warn!(
+            target: "pool::fallback_reply",
+            channel = %batch.channel_id,
+            "channel type unavailable — refusing to auto-publish ACP text"
+        );
+        return;
+    };
+    if channel_info.channel_type != "stream" {
+        tracing::debug!(
+            target: "pool::fallback_reply",
+            channel = %batch.channel_id,
+            channel_type = %channel_info.channel_type,
+            "auto-publish is limited to stream channels"
+        );
+        return;
+    }
+
+    let h_tag = SingleLetterTag::lowercase(Alphabet::H);
+    let filter = nostr::Filter::new()
+        .kind(nostr::Kind::Custom(
+            buzz_core::kind::KIND_STREAM_MESSAGE as u16,
+        ))
+        .author(ctx.agent_keys.public_key())
+        .custom_tags(h_tag, [batch.channel_id.to_string()])
+        .since(nostr::Timestamp::from(turn_started_secs))
+        .limit(1);
+
+    match tokio::time::timeout(
+        Duration::from_secs(3),
+        ctx.rest_client.query(std::slice::from_ref(&filter)),
+    )
+    .await
+    {
+        Ok(Ok(value)) if value.as_array().is_some_and(|events| !events.is_empty()) => {
+            tracing::info!(
+                target: "pool::fallback_reply",
+                channel = %batch.channel_id,
+                "agent already published during this turn — suppressing fallback"
+            );
+            return;
+        }
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => {
+            // Duplicate prevention takes precedence over delivery. If Buzz
+            // cannot prove that the turn was silent, it must not guess.
+            tracing::warn!(
+                target: "pool::fallback_reply",
+                channel = %batch.channel_id,
+                "duplicate-suppression query failed: {error} — refusing fallback"
+            );
+            return;
+        }
+        Err(_) => {
+            tracing::warn!(
+                target: "pool::fallback_reply",
+                channel = %batch.channel_id,
+                "duplicate-suppression query timed out — refusing fallback"
+            );
+            return;
+        }
+    }
+
+    let thread_tags = crate::queue::parse_thread_tags(&last_event.event);
+    let reply_anchor = thread_tags
+        .root_event_id
+        .unwrap_or_else(|| last_event.event.id.to_hex());
+    let Ok(reply_event_id) = nostr::EventId::from_hex(&reply_anchor) else {
+        tracing::warn!(
+            target: "pool::fallback_reply",
+            anchor = %reply_anchor,
+            "invalid reply anchor — refusing fallback"
+        );
+        return;
+    };
+    let thread_ref = buzz_sdk::ThreadRef {
+        root_event_id: reply_event_id,
+        parent_event_id: reply_event_id,
+    };
+    let builder = match buzz_sdk::build_message(
+        batch.channel_id,
+        content,
+        Some(&thread_ref),
+        &[],
+        false,
+        &[],
+    ) {
+        Ok(builder) => builder,
+        Err(error) => {
+            tracing::warn!(
+                target: "pool::fallback_reply",
+                channel = %batch.channel_id,
+                "failed to build fallback message: {error}"
+            );
+            return;
+        }
+    };
+
+    let builder = match ctx.rest_client.auth_tag_json.as_deref() {
+        Some(raw) => match buzz_sdk::nip_oa::parse_auth_tag(raw) {
+            Ok(tag) => builder.tags([tag]),
+            Err(error) => {
+                tracing::warn!(
+                    target: "pool::fallback_reply",
+                    "invalid harness auth tag — refusing fallback: {error}"
+                );
+                return;
+            }
+        },
+        None => builder,
+    };
+    let event = match builder.sign_with_keys(&ctx.agent_keys) {
+        Ok(event) => event,
+        Err(error) => {
+            tracing::warn!(
+                target: "pool::fallback_reply",
+                "failed to sign fallback message: {error}"
+            );
+            return;
+        }
+    };
+    let event_id = event.id.to_hex();
+
+    match tokio::time::timeout(
+        Duration::from_secs(10),
+        ctx.rest_client.submit_event(&event),
+    )
+    .await
+    {
+        Ok(Ok(_)) => tracing::info!(
+            target: "pool::fallback_reply",
+            channel = %batch.channel_id,
+            event_id = %event_id,
+            "published ACP final text through Buzz fallback"
+        ),
+        Ok(Err(error)) => tracing::error!(
+            target: "pool::fallback_reply",
+            channel = %batch.channel_id,
+            "fallback publish failed: {error}"
+        ),
+        Err(_) => tracing::error!(
+            target: "pool::fallback_reply",
+            channel = %batch.channel_id,
+            "fallback publish timed out"
+        ),
     }
 }
 

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent_management;
 mod client;
 mod commands;
 mod error;
+pub mod native;
 mod validate;
 
 use clap::{Parser, Subcommand};

--- a/crates/buzz-cli/src/native.rs
+++ b/crates/buzz-cli/src/native.rs
@@ -1,0 +1,127 @@
+//! Host-side Buzz operations for ACP/MCP integrations.
+//!
+//! These helpers intentionally do not print to stdout: MCP servers use stdout
+//! for their protocol transport. Authentication stays in the host-side process
+//! environment and is never handed to the model or its tool container.
+
+use nostr::{EventId, Keys};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::client::{normalize_relay_url, BuzzClient};
+
+/// Delivery proof returned by [`reply_from_env`].
+#[derive(Debug, Clone, Serialize)]
+pub struct NativeReplyReceipt {
+    /// Signed Nostr event ID accepted for delivery.
+    pub event_id: String,
+    /// Channel that received the reply.
+    pub channel_id: String,
+}
+
+/// Publish a stream-channel reply using host-side Buzz credentials.
+///
+/// Credentials are read from `BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, and the
+/// optional `BUZZ_AUTH_TAG`. `reply_to` is the immediate parent; `thread_root`
+/// may be supplied for a nested reply and otherwise defaults to `reply_to`.
+pub async fn reply_from_env(
+    channel_id: &str,
+    content: &str,
+    reply_to: &str,
+    thread_root: Option<&str>,
+    mention_pubkeys: &[String],
+) -> Result<NativeReplyReceipt, String> {
+    let channel_id =
+        Uuid::parse_str(channel_id).map_err(|error| format!("invalid channel UUID: {error}"))?;
+    if content.trim().is_empty() {
+        return Err("message content must not be empty".into());
+    }
+    let parent_event_id =
+        EventId::from_hex(reply_to).map_err(|error| format!("invalid reply event ID: {error}"))?;
+    let root_event_id = match thread_root {
+        Some(root) => {
+            EventId::from_hex(root).map_err(|error| format!("invalid thread root ID: {error}"))?
+        }
+        None => parent_event_id,
+    };
+
+    let relay_url = std::env::var("BUZZ_RELAY_URL")
+        .map_err(|_| "BUZZ_RELAY_URL is not configured for the native Buzz tool".to_string())?;
+    let private_key = std::env::var("BUZZ_PRIVATE_KEY")
+        .map_err(|_| "BUZZ_PRIVATE_KEY is not configured for the native Buzz tool".to_string())?;
+    let keys =
+        Keys::parse(&private_key).map_err(|error| format!("invalid BUZZ_PRIVATE_KEY: {error}"))?;
+
+    let auth_tag_json = std::env::var("BUZZ_AUTH_TAG")
+        .ok()
+        .filter(|value| !value.is_empty());
+    let auth_tag = match auth_tag_json.as_deref() {
+        Some(raw) => {
+            let tag = buzz_sdk::nip_oa::parse_auth_tag(raw)
+                .map_err(|error| format!("BUZZ_AUTH_TAG is malformed: {error}"))?;
+            buzz_sdk::nip_oa::verify_auth_tag(raw, &keys.public_key())
+                .map_err(|error| format!("BUZZ_AUTH_TAG verification failed: {error}"))?;
+            Some(tag)
+        }
+        None => None,
+    };
+
+    let client = BuzzClient::new(
+        normalize_relay_url(&relay_url),
+        keys,
+        auth_tag,
+        auth_tag_json,
+    )
+    .map_err(|error| error.to_string())?;
+    let thread_ref = buzz_sdk::ThreadRef {
+        root_event_id,
+        parent_event_id,
+    };
+    let mentions: Vec<&str> = mention_pubkeys.iter().map(String::as_str).collect();
+    let builder = buzz_sdk::build_message(
+        channel_id,
+        content,
+        Some(&thread_ref),
+        &mentions,
+        false,
+        &[],
+    )
+    .map_err(|error| format!("failed to build Buzz reply: {error}"))?;
+    let event = client
+        .sign_event(builder)
+        .map_err(|error| error.to_string())?;
+    let event_id = event.id.to_hex();
+    client
+        .submit_event(event)
+        .await
+        .map_err(|error| error.to_string())?;
+
+    Ok(NativeReplyReceipt {
+        event_id,
+        channel_id: channel_id.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn rejects_invalid_routing_before_reading_credentials() {
+        let error = reply_from_env("not-a-uuid", "hello", &"a".repeat(64), None, &[])
+            .await
+            .expect_err("invalid channel must fail");
+        assert!(error.contains("invalid channel UUID"));
+
+        let error = reply_from_env(
+            "5508fd33-ed7e-46c0-9950-8a3a76a51779",
+            "hello",
+            "not-an-event",
+            None,
+            &[],
+        )
+        .await
+        .expect_err("invalid reply target must fail");
+        assert!(error.contains("invalid reply event ID"));
+    }
+}

--- a/crates/buzz-dev-mcp/Cargo.toml
+++ b/crates/buzz-dev-mcp/Cargo.toml
@@ -13,6 +13,10 @@ path = "src/lib.rs"
 name = "buzz-dev-mcp"
 path = "src/main.rs"
 
+[[bin]]
+name = "buzz-native-mcp"
+path = "src/native_main.rs"
+
 [dependencies]
 buzz-cli = { path = "../buzz-cli" }
 git-credential-nostr = { path = "../git-credential-nostr" }

--- a/crates/buzz-dev-mcp/src/lib.rs
+++ b/crates/buzz-dev-mcp/src/lib.rs
@@ -10,6 +10,7 @@ use rmcp::{
 use std::path::Path;
 use std::sync::Arc;
 
+mod native_reply;
 mod paths;
 mod read_file;
 mod rg;
@@ -25,6 +26,47 @@ struct DevMcp {
     state: Arc<shell::SharedState>,
     todos: Arc<todo::TodoState>,
     tool_router: ToolRouter<DevMcp>,
+}
+
+#[derive(Clone)]
+struct NativeBuzzMcp {
+    tool_router: ToolRouter<NativeBuzzMcp>,
+}
+
+#[tool_router]
+impl NativeBuzzMcp {
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(
+        name = "reply_to_current_thread",
+        description = "Publish a Buzz reply through the host-side harness. Use the channel UUID and reply destination supplied in the current Buzz prompt. Returns the signed Nostr event ID as delivery proof. Buzz credentials stay outside the agent's tool container."
+    )]
+    async fn reply_to_current_thread(
+        &self,
+        Parameters(params): Parameters<native_reply::ReplyParams>,
+    ) -> Result<String, ErrorData> {
+        native_reply::run(params).await
+    }
+}
+
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for NativeBuzzMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(rmcp::model::Implementation::new(
+                "buzz-native-mcp",
+                env!("CARGO_PKG_VERSION"),
+            ))
+            .with_instructions(
+                "Use reply_to_current_thread for the human-visible result of a Buzz-triggered \
+                 turn. Copy channel_id and reply_to exactly from the current prompt context. \
+                 A successful result contains the signed event ID and is delivery proof.",
+            )
+    }
 }
 
 #[tool_router]
@@ -69,6 +111,17 @@ impl DevMcp {
         Parameters(p): Parameters<view_image::ViewImageParams>,
     ) -> Result<CallToolResult, ErrorData> {
         view_image::run(&self.state, p).await
+    }
+
+    #[tool(
+        name = "reply_to_current_thread",
+        description = "Publish a Buzz reply through the host-side harness. Use the channel UUID and reply destination supplied in the current Buzz prompt. Returns the signed Nostr event ID as delivery proof."
+    )]
+    async fn reply_to_current_thread(
+        &self,
+        Parameters(params): Parameters<native_reply::ReplyParams>,
+    ) -> Result<String, ErrorData> {
+        native_reply::run(params).await
     }
 
     #[tool(
@@ -175,6 +228,12 @@ async fn async_main(cmd: String) -> Result<(), Box<dyn std::error::Error>> {
         .with_writer(std::io::stderr)
         .with_ansi(false)
         .init();
+
+    if cmd == "buzz-native-mcp" {
+        let service = NativeBuzzMcp::new().serve(stdio()).await?;
+        service.waiting().await?;
+        return Ok(());
+    }
 
     let cwd = std::env::current_dir()?;
     let shim = shim::Shim::install()?;

--- a/crates/buzz-dev-mcp/src/native_main.rs
+++ b/crates/buzz-dev-mcp/src/native_main.rs
@@ -1,0 +1,3 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    buzz_dev_mcp::run()
+}

--- a/crates/buzz-dev-mcp/src/native_reply.rs
+++ b/crates/buzz-dev-mcp/src/native_reply.rs
@@ -1,0 +1,38 @@
+use rmcp::ErrorData;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReplyParams {
+    /// Channel UUID from the current Buzz prompt context.
+    pub channel_id: String,
+    /// Reply text to publish.
+    #[schemars(length(min = 1, max = 65536))]
+    pub content: String,
+    /// Event ID supplied as the current prompt's reply destination.
+    pub reply_to: String,
+    /// Thread root for nested agent-to-agent replies. Omit for ordinary
+    /// human-facing replies, where `reply_to` is already the root.
+    #[serde(default)]
+    pub thread_root: Option<String>,
+    /// Exact hex public keys to notify. Names alone are not accepted.
+    #[serde(default)]
+    #[schemars(length(max = 50))]
+    pub mention_pubkeys: Vec<String>,
+}
+
+pub async fn run(params: ReplyParams) -> Result<String, ErrorData> {
+    let receipt = buzz_cli::native::reply_from_env(
+        &params.channel_id,
+        &params.content,
+        &params.reply_to,
+        params.thread_root.as_deref(),
+        &params.mention_pubkeys,
+    )
+    .await
+    .map_err(|error| ErrorData::internal_error(error, None))?;
+
+    serde_json::to_string(&receipt)
+        .map_err(|error| ErrorData::internal_error(error.to_string(), None))
+}

--- a/crates/sprig/src/main.rs
+++ b/crates/sprig/src/main.rs
@@ -36,8 +36,8 @@ fn dispatch() -> Result<(), String> {
                 ))
             }
         },
-        // buzz-dev-mcp also handles its own multicall names: rg, tree,
-        // buzz, git-credential-nostr, and git-sign-nostr.
+        // buzz-dev-mcp also handles buzz-native-mcp and its helper multicall
+        // names: rg, tree, buzz, git-credential-nostr, and git-sign-nostr.
         _ => buzz_dev_mcp::run().map_err(|e| e.to_string()),
     }
 }
@@ -46,8 +46,8 @@ fn print_usage() {
     println!(
         "Sprig — all-in-one Buzz ACP harness, agent, and developer MCP\n\n\
 Sprig is a multicall binary. Invoke it through one of the personality names:\n\n\
-  buzz-acp       ACP harness\n  buzz-agent     ACP-compliant agent\n  buzz-dev-mcp   Developer MCP server\n\n\
+  buzz-acp       ACP harness\n  buzz-agent     ACP-compliant agent\n  buzz-dev-mcp   Developer MCP server\n  buzz-native-mcp  Least-privilege Buzz reply MCP server\n\n\
 Developer MCP helper names are also supported: rg, tree, buzz, git-credential-nostr, git-sign-nostr.\n\n\
-Installers can create links with:\n  ln -s sprig buzz-acp\n  ln -s sprig buzz-agent\n  ln -s sprig buzz-dev-mcp"
+Installers can create links with:\n  ln -s sprig buzz-acp\n  ln -s sprig buzz-agent\n  ln -s sprig buzz-dev-mcp\n  ln -s sprig buzz-native-mcp"
     );
 }

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -76,7 +76,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         commands: &["goose"],
         aliases: &[],
         avatar_url: GOOSE_AVATAR_URL,
-        mcp_command: None,
+        mcp_command: Some("buzz-native-mcp"),
         mcp_hooks: false,
         underlying_cli: Some("goose"),
         cli_install_commands: &["curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash"],
@@ -110,7 +110,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         commands: &["claude-agent-acp", "claude-code-acp"],
         aliases: &["claude-code", "claudecode"],
         avatar_url: CLAUDE_CODE_AVATAR_URL,
-        mcp_command: None,
+        mcp_command: Some("buzz-native-mcp"),
         mcp_hooks: false,
         underlying_cli: Some("claude"),
         cli_install_commands: &["curl -fsSL https://claude.ai/install.sh | bash"],
@@ -1514,7 +1514,7 @@ fn preset_catalog_entry(
         command,
         binary_path,
         default_args,
-        mcp_command: None,
+        mcp_command: Some("buzz-native-mcp".to_string()),
         model_env_var: None,
         provider_env_var: None,
         thinking_env_var: None,
@@ -1781,9 +1781,9 @@ pub fn discover_acp_runtimes_from(
                 command,
                 binary_path,
                 default_args,
-                // Custom harnesses are plain ACP — no MCP sidecar, no env-var
-                // model switching, no thinking knobs.
-                mcp_command: None,
+                // Custom ACP harnesses receive only the least-privilege native
+                // Buzz reply sidecar; they get no developer shell tools.
+                mcp_command: Some("buzz-native-mcp".to_string()),
                 model_env_var: None,
                 provider_env_var: None,
                 thinking_env_var: None,

--- a/desktop/src-tauri/src/managed_agents/runtime/process.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/process.rs
@@ -22,6 +22,8 @@ pub(crate) const KNOWN_AGENT_BINARIES: &[&str] = &[
     // invocations — not listed here.
     "buzz-dev-mcp",
     "buzz_dev_mcp",
+    "buzz-native-mcp",
+    "buzz_native_mcp",
 ];
 
 /// Script interpreters that may host managed agent wrappers (e.g. npm shims).

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -104,10 +104,10 @@ fn codex_has_mcp_command() {
 }
 
 #[test]
-fn goose_has_no_mcp_hooks() {
+fn goose_has_native_buzz_mcp() {
     let p = known_acp_runtime("goose").expect("should resolve");
     assert!(!p.mcp_hooks);
-    assert_eq!(p.mcp_command, None);
+    assert_eq!(p.mcp_command, Some("buzz-native-mcp"));
 }
 
 #[test]

--- a/desktop/src-tauri/src/migration.rs
+++ b/desktop/src-tauri/src/migration.rs
@@ -1008,9 +1008,8 @@ fn reconcile_mcp_commands_in_file(path: &Path) {
         if current == expected {
             return false;
         }
-        // Only fix values that are clearly stale (empty or a removed binary).
-        // Leave user-customized values untouched.
-        if !current.is_empty() && current != "buzz-mcp-server" {
+        // Rewrite only empty/stale/Buzz-managed values; preserve custom MCPs.
+        if !["", "buzz-mcp-server", "buzz-native-mcp", "buzz-dev-mcp"].contains(&current) {
             return false;
         }
         eprintln!(

--- a/desktop/src-tauri/src/migration_tests.rs
+++ b/desktop/src-tauri/src/migration_tests.rs
@@ -627,7 +627,7 @@ fn rename_provider_to_runtime_preserves_existing_runtime_over_provider() {
 }
 
 #[test]
-fn reconcile_mcp_commands_clears_stale_buzz_mcp_server() {
+fn reconcile_mcp_commands_replaces_stale_server_with_native_buzz_mcp() {
     let dir = tempfile::tempdir().unwrap();
     write_agents_json(
         dir.path(),
@@ -639,7 +639,7 @@ fn reconcile_mcp_commands_clears_stale_buzz_mcp_server() {
     );
     reconcile_mcp_commands_in_file(&dir.path().join("agents/managed-agents.json"));
     let records = read_agents_json(dir.path());
-    assert_eq!(records[0]["mcp_command"], "");
+    assert_eq!(records[0]["mcp_command"], "buzz-native-mcp");
 }
 
 #[test]
@@ -720,8 +720,8 @@ fn reconcile_mcp_commands_handles_mixed_agents() {
     );
     reconcile_mcp_commands_in_file(&dir.path().join("agents/managed-agents.json"));
     let records = read_agents_json(dir.path());
-    assert_eq!(records[0]["mcp_command"], "");
-    assert_eq!(records[1]["mcp_command"], "");
+    assert_eq!(records[0]["mcp_command"], "buzz-native-mcp");
+    assert_eq!(records[1]["mcp_command"], "buzz-native-mcp");
     assert_eq!(records[2]["mcp_command"], "my-custom-mcp");
     assert_eq!(records[3]["mcp_command"], "buzz-dev-mcp");
 }
@@ -729,8 +729,9 @@ fn reconcile_mcp_commands_handles_mixed_agents() {
 #[test]
 fn reconcile_mcp_commands_resolves_persona_runtime_over_stale_snapshot() {
     // The frozen snapshot is buzz-agent (wants buzz-dev-mcp), but the linked
-    // persona's runtime is goose (wants no mcp). The reconcile must follow the
-    // EFFECTIVE harness (persona-wins) and clear the stale buzz-mcp-server.
+    // persona's runtime is goose (wants the native Buzz MCP). The reconcile
+    // must follow the EFFECTIVE harness (persona-wins) and replace the stale
+    // buzz-mcp-server.
     let dir = tempfile::tempdir().unwrap();
     write_agents_json(
         dir.path(),
@@ -747,7 +748,7 @@ fn reconcile_mcp_commands_resolves_persona_runtime_over_stale_snapshot() {
     );
     reconcile_mcp_commands_in_file(&dir.path().join("agents/managed-agents.json"));
     let records = read_agents_json(dir.path());
-    assert_eq!(records[0]["mcp_command"], "");
+    assert_eq!(records[0]["mcp_command"], "buzz-native-mcp");
 }
 
 #[test]
@@ -769,8 +770,8 @@ fn reconcile_mcp_commands_sees_team_dir_runtime_edit_same_launch() {
             "mcp_command": ""
         }]),
     );
-    // Pre-edit launch state: persona runtime is goose (no mcp_command). A
-    // reader running against this stale file derives the empty goose value.
+    // Pre-edit launch state: persona runtime is goose (native Buzz MCP). A
+    // reader running against this stale file derives that goose value.
     write_personas_json(
         dir.path(),
         &serde_json::json!([{"id": "p1", "runtime": "goose"}]),
@@ -778,7 +779,7 @@ fn reconcile_mcp_commands_sees_team_dir_runtime_edit_same_launch() {
     reconcile_mcp_commands_in_file(&dir.path().join("agents/managed-agents.json"));
     assert_eq!(
         read_agents_json(dir.path())[0]["mcp_command"],
-        "",
+        "buzz-native-mcp",
         "reader-before-writer would see only the stale goose runtime"
     );
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -56,6 +56,7 @@
       "binaries/buzz-acp",
       "binaries/buzz-agent",
       "binaries/buzz-dev-mcp",
+      "binaries/buzz-native-mcp",
       "binaries/git-credential-nostr",
       "binaries/buzz"
     ],

--- a/scripts/build-sprig.sh
+++ b/scripts/build-sprig.sh
@@ -7,6 +7,7 @@
 #   buzz-agent     link to sprig (ACP-compliant agent)
 #   buzz-dev-mcp   link to sprig (developer MCP server; also dispatches
 #                    rg/tree/buzz/git-credential-nostr/git-sign-nostr)
+#   buzz-native-mcp link to sprig (least-privilege Buzz reply MCP server)
 #
 # Usage:
 #   ./scripts/build-sprig.sh [version] [target]
@@ -35,6 +36,7 @@
 #   buzz-acp
 #   buzz-agent
 #   buzz-dev-mcp
+#   buzz-native-mcp
 #   README.md
 #   sprig.json        { version, git_sha, target, binaries: [{name, sha256, size}] }
 
@@ -59,7 +61,7 @@ else
 fi
 
 BUNDLE_BIN="sprig"
-COMMANDS=(buzz-acp buzz-agent buzz-dev-mcp)
+COMMANDS=(buzz-acp buzz-agent buzz-dev-mcp buzz-native-mcp)
 
 echo "==> Building Sprig v${VERSION} for ${TARGET}"
 echo "    git_sha=${GIT_SHA}"
@@ -146,6 +148,7 @@ Commands:
 - `buzz-dev-mcp` — Developer MCP server (shell, str_replace, todo) and
   multicall entrypoint for `rg`, `tree`, `buzz`, `git-credential-nostr`,
   `git-sign-nostr`.
+- `buzz-native-mcp` — Least-privilege host-side Buzz reply tool for ACP agents.
 
 See `sprig.json` for SHA-256s, sizes, target, and source git SHA.
 

--- a/scripts/bundle-sidecars.sh
+++ b/scripts/bundle-sidecars.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SIDECARS=(buzz-acp buzz-agent buzz-dev-mcp git-credential-nostr buzz)
+SIDECARS=(buzz-acp buzz-agent buzz-dev-mcp buzz-native-mcp git-credential-nostr buzz)
 HOST=$(rustc -vV | sed -n 's|host: ||p')
 TARGET=${1:-$HOST}
 BINARIES_DIR="desktop/src-tauri/binaries"


### PR DESCRIPTION
## Summary

- add a host-side, least-privilege `reply_to_current_thread` MCP tool for ACP runtimes
- keep Nostr credentials and event signing outside sandboxed agent containers
- auto-publish successful ACP stream turns when no Buzz event was emitted, with duplicate suppression and fail-closed behavior
- wire the native sidecar through known, preset, and custom ACP harnesses plus desktop/Sprig packaging

## Safety

- native-only MCP exposes reply delivery without developer shell tools
- fallback is limited to stream channels; DMs and forums fail closed
- relay query errors/timeouts suppress fallback to prevent duplicate posts
- existing custom MCP commands are preserved by migration reconciliation

## Validation

- `just ci`
- workspace fmt and clippy
- full Rust crate and Desktop Tauri suites
- desktop/web checks and production builds
- Flutter analysis and 906 mobile tests

Originating Buzz channel: `5508fd33-ed7e-46c0-9950-8a3a76a51779`