### PR TITLE
fix(mobile): keep agent working status live

### DIFF
--- a/mobile/lib/features/channels/agent_activity/working_bots_provider.dart
+++ b/mobile/lib/features/channels/agent_activity/working_bots_provider.dart
@@ -2,27 +2,62 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../channel_management_provider.dart';
 import '../channel_typing_provider.dart';
+import 'active_agent_turns.dart';
 
-/// Derived provider that computes which bot members in a channel are currently
-/// typing (i.e. "working"). Returns a set of lowercase pubkeys.
+typedef _WorkingBotPubkeys = ({Set<String> anywhere, Set<String> channelRoot});
+
+final _workingBotPubkeysByScopeProvider =
+    Provider.family<_WorkingBotPubkeys, String>((ref, channelId) {
+      final members = ref.watch(channelMembersProvider(channelId));
+      final activeTurns = ref.watch(activeAgentTurnsProvider);
+      final typingEntries = ref.watch(channelTypingProvider(channelId));
+      final botPubkeys = {
+        for (final member in members.asData?.value ?? const <ChannelMember>[])
+          if (member.isBot) member.pubkey.toLowerCase(),
+      };
+      final observerPubkeys = {
+        for (final turn in activeTurns)
+          if (turn.channelId == channelId &&
+              botPubkeys.contains(turn.agentPubkey.toLowerCase()))
+            turn.agentPubkey.toLowerCase(),
+      };
+
+      return (
+        anywhere: {
+          ...observerPubkeys,
+          for (final entry in typingEntries)
+            if (botPubkeys.contains(entry.pubkey.toLowerCase()))
+              entry.pubkey.toLowerCase(),
+        },
+        channelRoot: {
+          ...observerPubkeys,
+          for (final entry in typingEntries)
+            if (entry.threadHeadId == null &&
+                botPubkeys.contains(entry.pubkey.toLowerCase()))
+              entry.pubkey.toLowerCase(),
+        },
+      );
+    });
+
+/// Bot members working anywhere in a channel, including its threads.
 ///
-/// Used by both the members button badge and the members sheet to avoid
-/// duplicating the bot-typing cross-reference logic.
+/// Observer-backed turns provide lifecycle state. Typing remains a compatibility
+/// fallback for harnesses that do not publish observer frames.
+/// Used by the members badge and members sheet.
 final workingBotPubkeysProvider = Provider.family<Set<String>, String>((
   ref,
   channelId,
 ) {
-  final typingEntries = ref.watch(channelTypingProvider(channelId));
-  final membersAsync = ref.watch(channelMembersProvider(channelId));
-  final allMembers = membersAsync.asData?.value ?? const <ChannelMember>[];
+  return ref.watch(_workingBotPubkeysByScopeProvider(channelId)).anywhere;
+});
 
-  final botPubkeys = <String>{
-    for (final m in allMembers)
-      if (m.isBot) m.pubkey.toLowerCase(),
-  };
-
-  return <String>{
-    for (final e in typingEntries)
-      if (botPubkeys.contains(e.pubkey.toLowerCase())) e.pubkey.toLowerCase(),
-  };
+/// Bot members whose work belongs in the main channel activity row.
+///
+/// Thread-scoped typing stays in the thread while observer turns remain visible
+/// for their channel lifecycle.
+final channelWorkingBotPubkeysProvider = Provider.family<Set<String>, String>((
+  ref,
+  channelId,
+) {
+  return ref.watch(_workingBotPubkeysByScopeProvider(channelId)).channelRoot;
 });

--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -368,8 +368,11 @@ class ChannelDetailPage extends HookConsumerWidget {
                     ),
                   ),
           ),
-          if (!resolvedChannel.isForum && typingEntries.isNotEmpty)
-            _TypingIndicator(entries: typingEntries),
+          if (!resolvedChannel.isForum)
+            _ChannelActivityIndicator(
+              channelId: channel.id,
+              typingEntries: typingEntries,
+            ),
           if (!resolvedChannel.isForum &&
               resolvedChannel.isMember &&
               !resolvedChannel.isArchived)

--- a/mobile/lib/features/channels/channel_detail_page/app_bar.dart
+++ b/mobile/lib/features/channels/channel_detail_page/app_bar.dart
@@ -19,28 +19,50 @@ double _dmAppBarTitleContentHeight(BuildContext context) {
   return textHeight > 30 ? textHeight : 30;
 }
 
-class _TypingIndicator extends ConsumerWidget {
-  final List<TypingEntry> entries;
+class _ChannelActivityIndicator extends ConsumerWidget {
+  final String channelId;
+  final List<TypingEntry> typingEntries;
 
-  const _TypingIndicator({required this.entries});
+  const _ChannelActivityIndicator({
+    required this.channelId,
+    required this.typingEntries,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final userCache = ref.watch(userCacheProvider);
-    final names = entries.map((e) {
-      final profile =
-          userCache[e.pubkey.toLowerCase()] ??
-          ref.read(userCacheProvider.notifier).get(e.pubkey.toLowerCase());
-      return profile?.label ?? shortPubkey(e.pubkey);
-    }).toList();
-    final text = switch (names.length) {
-      1 => '${names[0]} is typing…',
-      2 => '${names[0]} and ${names[1]} are typing…',
-      _ => '${names[0]} and ${names.length - 1} others are typing…',
+    final normalizedWorking = {
+      for (final pubkey in ref.watch(
+        channelWorkingBotPubkeysProvider(channelId),
+      ))
+        pubkey.toLowerCase(),
     };
+    final typingPubkeys = <String>[];
+    final seenTyping = <String>{};
+    for (final entry in typingEntries) {
+      final pubkey = entry.pubkey.toLowerCase();
+      if (normalizedWorking.contains(pubkey) || !seenTyping.add(pubkey)) {
+        continue;
+      }
+      typingPubkeys.add(pubkey);
+    }
+    final orderedPubkeys = [...normalizedWorking, ...typingPubkeys];
+    if (orderedPubkeys.isEmpty) return const SizedBox.shrink();
 
-    final visibleEntries = entries.take(3).toList();
-    final avatarCount = visibleEntries.length;
+    String labelFor(String pubkey) {
+      final profile =
+          userCache[pubkey] ?? ref.read(userCacheProvider.notifier).get(pubkey);
+      return profile?.label ?? shortPubkey(pubkey);
+    }
+
+    final workingNames = normalizedWorking.map(labelFor).toList();
+    final typingNames = typingPubkeys.map(labelFor).toList();
+    final text = [
+      if (workingNames.isNotEmpty) _activityLabel(workingNames, 'working'),
+      if (typingNames.isNotEmpty) _activityLabel(typingNames, 'typing'),
+    ].join(' · ');
+    final visiblePubkeys = orderedPubkeys.take(3).toList();
+    final avatarCount = visiblePubkeys.length;
 
     return Container(
       width: double.infinity,
@@ -59,7 +81,7 @@ class _TypingIndicator extends ConsumerWidget {
                   Positioned(
                     left: i * 12.0,
                     child: SmallAvatar(
-                      pubkey: visibleEntries[i].pubkey,
+                      pubkey: visiblePubkeys[i],
                       userCache: userCache,
                     ),
                   ),
@@ -69,7 +91,7 @@ class _TypingIndicator extends ConsumerWidget {
           const SizedBox(width: Grid.xxs),
           Flexible(
             child: Text(
-              text,
+              '$text…',
               style: context.textTheme.labelSmall?.copyWith(
                 color: context.colors.outline,
                 fontStyle: FontStyle.italic,
@@ -82,6 +104,13 @@ class _TypingIndicator extends ConsumerWidget {
     );
   }
 }
+
+String _activityLabel(List<String> names, String action) =>
+    switch (names.length) {
+      1 => '${names[0]} is $action',
+      2 => '${names[0]} and ${names[1]} are $action',
+      _ => '${names[0]} and ${names.length - 1} others are $action',
+    };
 
 class _MembersButton extends ConsumerWidget {
   final String channelId;

--- a/mobile/test/features/channels/agent_activity/working_bots_provider_test.dart
+++ b/mobile/test/features/channels/agent_activity/working_bots_provider_test.dart
@@ -1,0 +1,89 @@
+import 'package:buzz/features/channels/agent_activity/active_agent_turns.dart';
+import 'package:buzz/features/channels/agent_activity/working_bots_provider.dart';
+import 'package:buzz/features/channels/channel_management_provider.dart';
+import 'package:buzz/features/channels/channel_typing_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+const _channelId = 'channel-a';
+
+void main() {
+  test(
+    'combines observer turns with bot-typing fallback for one channel',
+    () async {
+      final now = DateTime.utc(2026, 7, 30);
+      final container = ProviderContainer(
+        overrides: [
+          activeAgentTurnsProvider.overrideWithValue([
+            ActiveAgentTurn(
+              agentPubkey: 'observer-bot',
+              channelId: _channelId,
+              turnId: 'turn-a',
+              startedAt: now,
+              lastActivityAt: now,
+            ),
+            ActiveAgentTurn(
+              agentPubkey: 'other-channel-bot',
+              channelId: 'channel-b',
+              turnId: 'turn-b',
+              startedAt: now,
+              lastActivityAt: now,
+            ),
+            ActiveAgentTurn(
+              agentPubkey: 'human',
+              channelId: _channelId,
+              turnId: 'turn-c',
+              startedAt: now,
+              lastActivityAt: now,
+            ),
+          ]),
+          channelTypingProvider(_channelId).overrideWith(
+            () => _FakeTypingNotifier([
+              const TypingEntry(pubkey: 'typing-bot', expiresAtMs: 1),
+              const TypingEntry(
+                pubkey: 'thread-bot',
+                threadHeadId: 'thread-1',
+                expiresAtMs: 1,
+              ),
+              const TypingEntry(pubkey: 'human', expiresAtMs: 1),
+            ]),
+          ),
+          channelMembersProvider(_channelId).overrideWith(
+            (ref) async => [
+              _member('observer-bot', 'bot'),
+              _member('typing-bot', 'bot'),
+              _member('thread-bot', 'bot'),
+              _member('other-channel-bot', 'bot'),
+              _member('human', 'member'),
+            ],
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(channelMembersProvider(_channelId).future);
+
+      expect(container.read(workingBotPubkeysProvider(_channelId)), {
+        'observer-bot',
+        'typing-bot',
+        'thread-bot',
+      });
+      expect(container.read(channelWorkingBotPubkeysProvider(_channelId)), {
+        'observer-bot',
+        'typing-bot',
+      });
+    },
+  );
+}
+
+ChannelMember _member(String pubkey, String role) =>
+    ChannelMember(pubkey: pubkey, role: role, joinedAt: DateTime.utc(2026));
+
+class _FakeTypingNotifier extends ChannelTypingNotifier {
+  _FakeTypingNotifier(this.entries) : super(_channelId);
+
+  final List<TypingEntry> entries;
+
+  @override
+  List<TypingEntry> build() => entries;
+}

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+import 'package:buzz/features/channels/agent_activity/active_agent_turns.dart';
 import 'package:buzz/features/channels/channel.dart';
 import 'package:buzz/features/channels/channel_detail_page.dart';
 import 'package:buzz/features/channels/channel_management_provider.dart';
@@ -46,6 +47,11 @@ final _testChannel = Channel(
   memberCount: 5,
   isMember: true,
 );
+
+final _mutableActiveTurnsProvider =
+    NotifierProvider<_MutableActiveTurnsNotifier, List<ActiveAgentTurn>>(
+      _MutableActiveTurnsNotifier.new,
+    );
 
 NostrEvent _textMsg({
   required String id,
@@ -139,6 +145,9 @@ NostrEvent _edit({
 Widget _buildTestable({
   required List<NostrEvent> messages,
   List<TypingEntry> typing = const [],
+  List<ActiveAgentTurn> activeTurns = const [],
+  bool mutableActiveTurns = false,
+  VoidCallback? onPageBuild,
   Map<String, UserProfile> users = const {},
   List<ChannelMember> members = const [],
   Channel? channel,
@@ -169,6 +178,11 @@ Widget _buildTestable({
       channelTypingProvider(
         _channelId,
       ).overrideWith(() => _FakeTypingNotifier(typing)),
+      activeAgentTurnsProvider.overrideWith(
+        (ref) => mutableActiveTurns
+            ? ref.watch(_mutableActiveTurnsProvider)
+            : activeTurns,
+      ),
       userCacheProvider.overrideWith(() => _FakeUserCacheNotifier(users)),
       profileProvider.overrideWith(() => _FakeProfileNotifier()),
       channelsProvider.overrideWith(() => fakeChannelsNotifier),
@@ -209,11 +223,16 @@ Widget _buildTestable({
         child: child!,
       ),
       navigatorObservers: navigatorObservers,
-      home: ChannelDetailPage(
-        channel: resolvedChannel,
-        initialMessageId: initialMessageId,
-        initialThreadRootId: initialThreadRootId,
-      ),
+      home: onPageBuild == null
+          ? ChannelDetailPage(
+              channel: resolvedChannel,
+              initialMessageId: initialMessageId,
+              initialThreadRootId: initialThreadRootId,
+            )
+          : _CountingChannelDetailPage(
+              channel: resolvedChannel,
+              onBuild: onPageBuild,
+            ),
     ),
   );
 }
@@ -1732,7 +1751,135 @@ void main() {
     });
   });
 
-  group('Typing indicator', () {
+  group('Channel activity indicator', () {
+    testWidgets('keeps an observer-backed bot visibly working', (tester) async {
+      final now = DateTime.utc(2026, 7, 30);
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: const [],
+          typing: [
+            TypingEntry(
+              pubkey: 'alice',
+              expiresAtMs: now.millisecondsSinceEpoch,
+            ),
+          ],
+          activeTurns: [
+            ActiveAgentTurn(
+              agentPubkey: 'kunst',
+              channelId: _channelId,
+              turnId: 'turn-1',
+              startedAt: now,
+              lastActivityAt: now,
+            ),
+          ],
+          members: [ChannelMember(pubkey: 'kunst', role: 'bot', joinedAt: now)],
+          users: const {
+            'kunst': UserProfile(pubkey: 'kunst', displayName: 'Kunst'),
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Kunst is working · Alice is typing…'), findsOneWidget);
+      expect(find.textContaining('Kunst is typing'), findsNothing);
+    });
+
+    testWidgets('labels bot typing as a working fallback', (tester) async {
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: const [],
+          typing: [
+            TypingEntry(
+              pubkey: 'kunst',
+              expiresAtMs: DateTime.now().millisecondsSinceEpoch + 8000,
+            ),
+          ],
+          members: [
+            ChannelMember(
+              pubkey: 'kunst',
+              role: 'bot',
+              joinedAt: DateTime(2025),
+            ),
+          ],
+          users: const {
+            'kunst': UserProfile(pubkey: 'kunst', displayName: 'Kunst'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Kunst is working…'), findsOneWidget);
+      expect(find.text('Kunst is typing…'), findsNothing);
+    });
+
+    testWidgets('does not surface thread-only bot typing in the channel row', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: const [],
+          typing: [
+            TypingEntry(
+              pubkey: 'kunst',
+              threadHeadId: 'thread-1',
+              expiresAtMs: DateTime.now().millisecondsSinceEpoch + 8000,
+            ),
+          ],
+          members: [
+            ChannelMember(
+              pubkey: 'kunst',
+              role: 'bot',
+              joinedAt: DateTime(2025),
+            ),
+          ],
+          users: const {
+            'kunst': UserProfile(pubkey: 'kunst', displayName: 'Kunst'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Kunst is working'), findsNothing);
+    });
+
+    testWidgets('contains active-turn rebuilds within the activity row', (
+      tester,
+    ) async {
+      var pageBuilds = 0;
+      final now = DateTime.utc(2026, 7, 30);
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: const [],
+          mutableActiveTurns: true,
+          onPageBuild: () => pageBuilds += 1,
+          members: [ChannelMember(pubkey: 'kunst', role: 'bot', joinedAt: now)],
+          users: const {
+            'kunst': UserProfile(pubkey: 'kunst', displayName: 'Kunst'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+      final settledPageBuilds = pageBuilds;
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(_CountingChannelDetailPage)),
+      );
+
+      container.read(_mutableActiveTurnsProvider.notifier).setTurns([
+        ActiveAgentTurn(
+          agentPubkey: 'kunst',
+          channelId: _channelId,
+          turnId: 'turn-1',
+          startedAt: now,
+          lastActivityAt: now,
+        ),
+      ]);
+      await tester.pump();
+
+      expect(find.text('Kunst is working…'), findsOneWidget);
+      expect(pageBuilds, settledPageBuilds);
+    });
+
     testWidgets('shows single typer', (tester) async {
       await tester.pumpWidget(
         _buildTestable(
@@ -2264,6 +2411,28 @@ class _ReconnectingRelaySession extends RelaySessionNotifier {
 
   void connect() {
     state = const SessionState(status: SessionStatus.connected);
+  }
+}
+
+class _MutableActiveTurnsNotifier extends Notifier<List<ActiveAgentTurn>> {
+  @override
+  List<ActiveAgentTurn> build() => const [];
+
+  void setTurns(List<ActiveAgentTurn> turns) => state = turns;
+}
+
+class _CountingChannelDetailPage extends ChannelDetailPage {
+  final VoidCallback onBuild;
+
+  const _CountingChannelDetailPage({
+    required super.channel,
+    required this.onBuild,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    onBuild();
+    return super.build(context, ref);
   }
 }
 


### PR DESCRIPTION
## Summary

Stacked on #3324.

- include #3324's observer-backed active turns in the existing channel-scoped working-bot provider
- keep bot typing as the compatibility fallback for harnesses without observer telemetry
- replace the typing-only channel row with one activity row that labels bots as **working**, humans as **typing**, and deduplicates a bot reported by both signals
- keep thread-scoped typing out of the main channel row while preserving it for the channel-wide members badge and sheet
- contain five-second liveness updates within the activity row instead of rebuilding the full message page
- reuse #3324's existing completion, error, and liveness pruning instead of introducing another timer or run-state model

### Related issue

Follow-up to #3324. This is intentionally based on `kennylopez-android-agent-live-updates` so it can be reviewed and merged into that PR without duplicating its active-turn implementation.

### UI review

| Before | After | Why |
| --- | --- | --- |
| Agent status depended on kind `20002` typing entries and disappeared after the eight-second mobile TTL when typing refreshes were delayed. | Observer-backed turns keep the agent labeled **working** for the turn lifecycle; typing remains a fallback. | The ACP observer lifecycle, not typing animation, owns whether an agent is working. |
| Bots and people both appeared as “typing.” | Bots render as **working** while people remain **typing**. | Distinguishes execution from human composition without adding a second status surface. |
| Observer and typing signals could describe the same agent independently. | The activity row renders that agent once and can combine it with human typing. | Keep one channel-scoped projection and avoid duplicate avatars/copy. |

![Kunst working while Alice types](https://raw.githubusercontent.com/amadad/buzz/1b1b9ea1a9da6aa7b9794a3d3fe73ce90426602c/mobile-agent-working-status.png)

The screenshot uses an observer-only agent turn plus human typing in a temporary provider fixture with the production channel activity widget and bundled Inter/Lucide fonts; no fixture or golden is committed.

### Testing

- regression tests failed before the implementation for observer-only work and bot-working copy
- `dart format --output=none --set-exit-if-changed .` — 311 files, 0 changed
- `flutter analyze` — no issues
- `flutter test` — 903 passed, 1 skipped, 0 failed
- `CHECK_FILE_SIZES_BASE=HEAD node mobile/scripts/check-file-sizes.mjs` — passed
- focused provider coverage verifies channel scoping, bot membership, observer turns, channel-root versus thread typing, fallback, and deduplication
- focused widget coverage verifies observer-only working status, mixed working/typing copy, bot typing fallback, thread isolation, existing human typing copy, and activity-row-only rebuilds

No native files change in this follow-up. A local iOS binary build was not run because the available verification Mac has Command Line Tools but not Xcode; #3324's current native/mobile CI is green.
