### PR TITLE
fix(desktop): keep channel-member agents mentionable without a local managed list

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -246,7 +246,16 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      // The managed-list guard only applies to NON-member identities: it
+      // exists to drop stale/ghost agent identities surfaced by discovery,
+      // but an agent owned by ANOTHER user is never in this install's
+      // managed list, and as a relay-confirmed channel member it must stay
+      // mentionable. Member-agent visibility is owned by
+      // shouldHideAgentFromMentions below (invocable / directory-exclusion).
+      if (
+        candidate.isMember !== true &&
+        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+      ) {
         return;
       }
       if (

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -96,6 +96,16 @@ type MockManagedAgentRuntimeSeed = {
   lifecycle?: MockManagedAgentRuntimeRow["lifecycle"];
 };
 
+/** A channel member with role "bot" that is NOT in the local managed-agent
+ *  list nor the kind:10100 relay agent directory — models an agent owned by
+ *  another community member, as seen from this install. */
+type MockChannelBotMemberSeed = {
+  pubkey: string;
+  name: string;
+  channelNames?: string[];
+  channelIds?: string[];
+};
+
 type MockRelayAgentSeed = {
   pubkey: string;
   name: string;
@@ -225,6 +235,9 @@ type E2eConfig = {
       mcp?: MockCommandAvailability;
     };
     managedAgents?: MockManagedAgentSeed[];
+    /** Channel members with role "bot" owned by another user: never in the
+     *  managed list, never in the kind:10100 directory. */
+    channelBotMembers?: MockChannelBotMemberSeed[];
     /** Per agent+relay runtime rows for the pair-scoped lifecycle commands
      *  (`list/start/stop/restart_managed_agent_runtime`). */
     managedAgentRuntimes?: MockManagedAgentRuntimeSeed[];
@@ -2123,6 +2136,35 @@ function resetMockManagedAgents(config?: E2eConfig) {
       is_agent: true,
       has_profile_event: true,
     });
+    for (const channel of mockChannels) {
+      const isSeedChannel =
+        seed.channelIds?.includes(channel.id) ||
+        seed.channelNames?.includes(channel.name);
+      if (
+        !isSeedChannel ||
+        channel.members.some((member) => member.pubkey === seed.pubkey)
+      ) {
+        continue;
+      }
+
+      channel.members.push({
+        pubkey: seed.pubkey,
+        role: "bot",
+        is_agent: true,
+        joined_at: new Date().toISOString(),
+        display_name: seed.name,
+      });
+      syncMockChannel(channel);
+      touchMockChannel(channel);
+    }
+  }
+
+  // Foreign bot members: channel membership only — deliberately NOT added to
+  // mockManagedAgents, mockRelayAgents, or mockProfiles, so the client sees
+  // exactly what it sees for an agent owned by another community member.
+  for (const seed of config?.mock?.channelBotMembers ?? []) {
+    applyMockDisplayName(seed.pubkey, seed.name);
+    mockAgentPubkeys.add(seed.pubkey);
     for (const channel of mockChannels) {
       const isSeedChannel =
         seed.channelIds?.includes(channel.id) ||

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -24,6 +24,8 @@ const ALLOWLIST_RELAY_AGENT_PUBKEY =
   "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 const DELAYED_RELAY_AGENT_PUBKEY =
   "9999999999999999999999999999999999999999999999999999999999999999";
+const FOREIGN_MEMBER_AGENT_PUBKEY =
+  "7777777777777777777777777777777777777777777777777777777777777777";
 const CASEY_PROFILE_PUBKEY =
   "1111111111111111111111111111111111111111111111111111111111111111";
 const PROFILE_ONLY_AGENT_PUBKEY =
@@ -209,7 +211,9 @@ test("@ trigger prioritizes channel members before runnable personas and other m
 
   const dropdown = autocomplete(page);
   await expect(dropdown).toBeVisible();
-  await expect(dropdown.getByText("alice")).toHaveCount(0);
+  // alice is a channel member AND a directory agent with respond_to
+  // "anyone" — invocable, so she stays mentionable like any other member.
+  await expect(dropdown.getByText("alice")).toBeVisible();
   await expect(dropdown.getByText("bob")).toBeVisible();
   await expect(dropdown.getByText("Fizz")).toBeVisible();
   await expect(dropdown.getByText("charlie")).toBeVisible();
@@ -847,6 +851,62 @@ test("relay-only agents stay hidden from channel mentions even when allowlisted"
   await input.fill("@quinn");
 
   await expect(autocomplete(page)).toHaveCount(0);
+});
+
+test("channel-member agents owned by another user stay mentionable", async ({
+  page,
+}) => {
+  // vera is a channel member with role "bot" but is NOT in this install's
+  // managed-agent list nor the kind:10100 relay directory — exactly what an
+  // agent deployed by another community member looks like from this client.
+  await installMockBridge(page, {
+    channelBotMembers: [
+      {
+        pubkey: FOREIGN_MEMBER_AGENT_PUBKEY,
+        name: "vera",
+        channelNames: ["general"],
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@vera");
+
+  const dropdown = autocomplete(page);
+  await expect(dropdown.getByText("vera")).toBeVisible();
+  await expect(dropdown.getByTestId("mention-agent-icon")).toBeVisible();
+
+  await input.press("Enter");
+  await page.keyboard.type(" ping");
+  await page.getByTestId("send-message").click();
+
+  const mentionChip = page
+    .getByTestId("message-row")
+    .last()
+    .locator("[data-mention].agent-mention-highlight", { hasText: "vera" });
+  await expect(mentionChip).toBeVisible();
+
+  // The mention must resolve to a real p-tag on the wire, not just render.
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const events = (
+          window as Window & {
+            __BUZZ_E2E_SIGNED_EVENTS__?: Array<{
+              content: string;
+              tags: string[][];
+            }>;
+          }
+        ).__BUZZ_E2E_SIGNED_EVENTS__;
+        return (
+          events?.find((event) => event.content.includes("ping"))?.tags ?? []
+        );
+      }),
+    )
+    .toContainEqual(["p", FOREIGN_MEMBER_AGENT_PUBKEY]);
 });
 
 test("mentioning an in-channel stopped managed agent starts it before sending", async ({

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -61,6 +61,16 @@ type MockManagedAgentSeed = {
   respondToAllowlist?: string[];
 };
 
+/** A channel member with role "bot" that is NOT in the local managed-agent
+ *  list nor the kind:10100 relay agent directory — models an agent owned by
+ *  another community member, as seen from this install. */
+type MockChannelBotMemberSeed = {
+  pubkey: string;
+  name: string;
+  channelNames?: string[];
+  channelIds?: string[];
+};
+
 type MockSearchProfileSeed = {
   pubkey: string;
   displayName: string | null;
@@ -211,6 +221,9 @@ type MockBridgeOptions = {
     mcp?: MockCommandAvailability;
   };
   managedAgents?: MockManagedAgentSeed[];
+  /** Channel members with role "bot" owned by another user: never in the
+   *  managed list, never in the kind:10100 directory. */
+  channelBotMembers?: MockChannelBotMemberSeed[];
   /** Per agent+relay runtime rows for pair-scoped lifecycle commands. */
   managedAgentRuntimes?: Array<{
     pubkey: string;


### PR DESCRIPTION
Fixes #3671

## Problem

On desktop, an agent owned by another user is never mentionable — even as a member of the same channel, even when the viewer is on its `respond_to` allowlist. The managed-list guard in `useMentions.addCandidate` runs before `shouldHideAgentFromMentions` and drops every agent identity not in the **local** managed list. Since `getMentionableAgentPubkeys` seeds with `managedAgentPubkeys`, every agent surviving the guard is already "invocable", so `shouldHideAgentFromMentions` returns `false` on its first line, always — its documented member branch ("Option B": member + unknown invocability ⇒ show) is unreachable dead code. The mobile client implements the same pipeline without the pre-gate and behaves correctly; see the issue for the full analysis.

## Change

- `useMentions.ts`: the managed-list ghost-guard now only applies to **non-member** candidates. Member-agent visibility is decided by `shouldHideAgentFromMentions`, which already encodes the intended policy (invocable ⇒ show; directory-present-but-excluding ⇒ hide; unknown ⇒ show).
- `e2eBridge.ts` / `tests/helpers/bridge.ts`: new `channelBotMembers` mock seed — a channel member with role `bot` that is deliberately absent from the managed list, the kind:10100 directory, and profiles, i.e. exactly what another owner's agent looks like from this install.
- `mentions.spec.ts`: new regression test — with an empty managed list, a foreign member bot appears in the `@` dropdown (with the agent icon) and the signed event carries `["p", <agent>]`, pinning the wire-level behavior. Verified to fail without the src change and pass with it.
- One existing expectation updated: the prioritization test pinned `alice` — a **channel member** and directory agent with `respond_to: "anyone"` — as hidden. That expectation captured the regression itself (she is invocable and a member); she is now asserted visible.

Not changed: `MembersSidebar` add-member search keeps the unfiltered guard — its candidates are non-members by construction. The pinned "relay-only agents stay hidden from channel mentions even when allowlisted" behavior is unchanged (those candidates are non-members).

## Testing

- `biome check` clean on the four touched files; `tsc --noEmit` clean.
- Desktop unit tests: 3781 pass, 0 fail.
- E2E (`mentions.spec.ts`, smoke project): all tests pass with this change except "groups member additions and joins with hidden names in the standard tooltip", which is flaky independently of this branch — it also fails intermittently (1 in 3 repeats) on unmodified `origin/main` on the same machine, and touches join system messages, not mention autocomplete.
- The new regression test was verified in both directions: it fails with the src change reverted and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
