### PR TITLE
feat(tracing): add PostgreSQL tracing spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,6 +1291,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,6 +886,7 @@ name = "buzz-audit"
 version = "0.1.0"
 dependencies = [
  "buzz-core",
+ "buzz-datastore-tracing",
  "chrono",
  "futures-util",
  "hex",
@@ -1001,10 +1002,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "buzz-datastore-tracing"
+version = "0.1.0"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "buzz-db"
 version = "0.1.0"
 dependencies = [
  "buzz-core",
+ "buzz-datastore-tracing",
  "chrono",
  "hex",
  "metrics",
@@ -1192,6 +1209,7 @@ dependencies = [
  "buzz-auth",
  "buzz-conformance",
  "buzz-core",
+ "buzz-datastore-tracing",
  "buzz-db",
  "buzz-media",
  "buzz-pubsub",
@@ -1288,6 +1306,7 @@ name = "buzz-search"
 version = "0.1.0"
 dependencies = [
  "buzz-core",
+ "buzz-datastore-tracing",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/buzz-dev-mcp",
     "crates/buzz-voice",
     "crates/buzz-backend-kubernetes",
+    "crates/buzz-datastore-tracing",
     "examples/countdown-bot",
 ]
 exclude = ["desktop/src-tauri"]
@@ -143,6 +144,7 @@ buzz-media = { path = "crates/buzz-media" }
 buzz-sdk = { path = "crates/buzz-sdk" }
 buzz-ws-client = { path = "crates/buzz-ws-client" }
 buzz-relay-mesh = { path = "crates/buzz-relay-mesh" }
+buzz-datastore-tracing = { path = "crates/buzz-datastore-tracing" }
 
 # CI profile — builds the relay for desktop e2e. Dependencies keep full
 # release optimization (warm from main's cache; they carry the runtime hot

--- a/crates/buzz-audit/Cargo.toml
+++ b/crates/buzz-audit/Cargo.toml
@@ -9,6 +9,7 @@ description = "Hash-chain audit log for Buzz"
 
 [dependencies]
 buzz-core = { workspace = true }
+buzz-datastore-tracing = { workspace = true }
 sqlx        = { workspace = true }
 tokio       = { workspace = true }
 serde       = { workspace = true }

--- a/crates/buzz-audit/src/service.rs
+++ b/crates/buzz-audit/src/service.rs
@@ -49,7 +49,7 @@ impl AuditService {
     /// Serialized per-community via `pg_advisory_lock`. Postgres advisory locks
     /// are session-scoped, so we acquire before the transaction and release
     /// after commit (or on any error path).
-    #[instrument(skip(self, entry), fields(action = %entry.action))]
+    #[instrument(target = "buzz_datastore", name = "audit_log", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn log(&self, entry: NewAuditEntry) -> Result<AuditEntry, AuditError> {
         let mut conn = self.pool.acquire().await?;
 
@@ -125,7 +125,7 @@ impl AuditService {
 
         audit_entry.hash = compute_hash(&audit_entry)?.to_vec();
 
-        debug!(seq, "writing audit entry");
+        debug!("writing audit entry");
 
         sqlx::query(
             r#"
@@ -156,7 +156,7 @@ impl AuditService {
     /// Reads exactly that community's chain — it can never observe another
     /// community's entries or head. Returns `Ok(false)` if the range is empty,
     /// `Ok(true)` if the segment is internally consistent.
-    #[instrument(skip(self))]
+    #[instrument(target = "buzz_datastore", name = "audit_verify_chain", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn verify_chain(
         &self,
         community: CommunityId,
@@ -208,7 +208,7 @@ impl AuditService {
     /// Returns up to `limit` entries from one community's chain starting at
     /// `from_seq`, ordered by sequence number. Scoped to `community` — never
     /// returns another community's rows.
-    #[instrument(skip(self))]
+    #[instrument(target = "buzz_datastore", name = "audit_get_entries", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_entries(
         &self,
         community: CommunityId,
@@ -274,7 +274,7 @@ mod tests {
 
     async fn test_pool() -> Option<PgPool> {
         let url = std::env::var("DATABASE_URL")
-            .unwrap_or_else(|_| "postgres://buzz:buzz_dev@localhost:5432/buzz".into());
+            .unwrap_or_else(|_| "postgres://buzz:buzz_dev@localhost:5432/buzz".into()); // sadscan:disable np.postgres.1 -- local test fixture
         PgPool::connect(&url).await.ok()
     }
 

--- a/crates/buzz-audit/src/service.rs
+++ b/crates/buzz-audit/src/service.rs
@@ -1,10 +1,11 @@
 use chrono::{DateTime, Utc};
 use futures_util::FutureExt as _;
 use sqlx::{Acquire, PgPool, Row};
-use tracing::{debug, instrument, warn};
+use tracing::{debug, warn};
 use uuid::Uuid;
 
 use buzz_core::CommunityId;
+use buzz_datastore_tracing::datastore_span;
 
 use crate::{
     action::AuditAction,
@@ -49,7 +50,11 @@ impl AuditService {
     /// Serialized per-community via `pg_advisory_lock`. Postgres advisory locks
     /// are session-scoped, so we acquire before the transaction and release
     /// after commit (or on any error path).
-    #[instrument(target = "buzz_datastore", name = "audit_log", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(
+        name = "audit_log",
+        system = "postgresql",
+        fields(action = %entry.action)
+    )]
     pub async fn log(&self, entry: NewAuditEntry) -> Result<AuditEntry, AuditError> {
         let mut conn = self.pool.acquire().await?;
 
@@ -125,7 +130,7 @@ impl AuditService {
 
         audit_entry.hash = compute_hash(&audit_entry)?.to_vec();
 
-        debug!("writing audit entry");
+        debug!(seq, "writing audit entry");
 
         sqlx::query(
             r#"
@@ -156,7 +161,11 @@ impl AuditService {
     /// Reads exactly that community's chain — it can never observe another
     /// community's entries or head. Returns `Ok(false)` if the range is empty,
     /// `Ok(true)` if the segment is internally consistent.
-    #[instrument(target = "buzz_datastore", name = "audit_verify_chain", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(
+        name = "audit_verify_chain",
+        system = "postgresql",
+        fields(from_seq = from_seq, to_seq = to_seq)
+    )]
     pub async fn verify_chain(
         &self,
         community: CommunityId,
@@ -208,7 +217,11 @@ impl AuditService {
     /// Returns up to `limit` entries from one community's chain starting at
     /// `from_seq`, ordered by sequence number. Scoped to `community` — never
     /// returns another community's rows.
-    #[instrument(target = "buzz_datastore", name = "audit_get_entries", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(
+        name = "audit_get_entries",
+        system = "postgresql",
+        fields(from_seq = from_seq, limit = limit)
+    )]
     pub async fn get_entries(
         &self,
         community: CommunityId,

--- a/crates/buzz-datastore-tracing/Cargo.toml
+++ b/crates/buzz-datastore-tracing/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "buzz-datastore-tracing"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Privacy-preserving datastore tracing policy macros for Buzz"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
+
+[dev-dependencies]
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/buzz-datastore-tracing/src/lib.rs
+++ b/crates/buzz-datastore-tracing/src/lib.rs
@@ -1,0 +1,168 @@
+//! Policy-enforcing instrumentation for logical datastore operations.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
+use syn::{
+    parenthesized, parse_macro_input, Error, Ident, ItemFn, LitStr, Result, ReturnType, Token, Type,
+};
+
+struct DatastoreArgs {
+    name: LitStr,
+    system: LitStr,
+    fields: Option<TokenStream2>,
+}
+
+impl Parse for DatastoreArgs {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let mut name = None;
+        let mut system = None;
+        let mut fields = None;
+
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            match key.to_string().as_str() {
+                "name" => {
+                    if name.is_some() {
+                        return Err(Error::new(key.span(), "duplicate `name` argument"));
+                    }
+                    input.parse::<Token![=]>()?;
+                    name = Some(input.parse()?);
+                }
+                "system" => {
+                    if system.is_some() {
+                        return Err(Error::new(key.span(), "duplicate `system` argument"));
+                    }
+                    input.parse::<Token![=]>()?;
+                    system = Some(input.parse()?);
+                }
+                "fields" => {
+                    if fields.is_some() {
+                        return Err(Error::new(key.span(), "duplicate `fields` argument"));
+                    }
+                    let content;
+                    parenthesized!(content in input);
+                    fields = Some(content.parse()?);
+                }
+                _ => {
+                    return Err(Error::new(
+                        key.span(),
+                        "expected `name`, `system`, or `fields`",
+                    ))
+                }
+            }
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(Self {
+            name: name.ok_or_else(|| Error::new(input.span(), "missing `name`"))?,
+            system: system.ok_or_else(|| Error::new(input.span(), "missing `system`"))?,
+            fields,
+        })
+    }
+}
+
+/// Instruments an async logical datastore operation according to Buzz policy.
+///
+/// PostgreSQL spans always omit function arguments, use the `buzz_datastore`
+/// target, and expose only canonical semantic fields plus explicitly supplied
+/// safe fields. An `Err` sets `otel.status_code` without inspecting the error.
+#[proc_macro_attribute]
+pub fn datastore_span(args: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as DatastoreArgs);
+    let mut function = parse_macro_input!(item as ItemFn);
+
+    if function.sig.asyncness.is_none() {
+        return Error::new_spanned(
+            function.sig.fn_token,
+            "`datastore_span` requires an async function",
+        )
+        .into_compile_error()
+        .into();
+    }
+    if args.system.value() != "postgresql" {
+        return Error::new_spanned(
+            args.system,
+            "unsupported datastore system; only `postgresql` is currently supported",
+        )
+        .into_compile_error()
+        .into();
+    }
+
+    let name = args.name;
+    let extra_fields = args.fields.map(|tokens| quote!(, #tokens));
+    function.attrs.push(syn::parse_quote!(
+        #[::tracing::instrument(
+            target = "buzz_datastore",
+            name = #name,
+            skip_all,
+            fields(
+                otel.kind = "client",
+                db.system.name = "postgresql",
+                otel.status_code = ::tracing::field::Empty
+                #extra_fields
+            )
+        )]
+    ));
+
+    let return_type: Type = match &function.sig.output {
+        ReturnType::Type(_, ty) => *ty.clone(),
+        ReturnType::Default => syn::parse_quote!(()),
+    };
+    let returns_result = match &return_type {
+        Type::Path(path) => path
+            .path
+            .segments
+            .last()
+            .is_some_and(|segment| segment.ident == "Result"),
+        _ => false,
+    };
+    let original_body = function.block;
+    let result = format_ident!("__buzz_datastore_result_7f3a9c");
+    let record_error = returns_result.then(|| {
+        quote! {
+            if #result.is_err() {
+                ::tracing::Span::current().record("otel.status_code", "ERROR");
+            }
+        }
+    });
+    function.block = Box::new(syn::parse_quote!({
+        let #result: #return_type = (async #original_body).await;
+        #record_error
+        #result
+    }));
+
+    quote!(#function).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DatastoreArgs;
+
+    #[test]
+    fn parses_safe_tracing_fields() {
+        let args: DatastoreArgs = syn::parse_str(
+            r#"name = "audit", system = "postgresql", fields(action = %entry.action, from_seq = from_seq, limit = limit)"#,
+        )
+        .expect("valid arguments");
+        assert!(args.fields.is_some());
+    }
+
+    #[test]
+    fn rejects_duplicate_arguments() {
+        for args in [
+            r#"name = "one", name = "two", system = "postgresql""#,
+            r#"name = "one", system = "postgresql", system = "postgresql""#,
+            r#"name = "one", system = "postgresql", fields(a = 1), fields(b = 2)"#,
+        ] {
+            let error = match syn::parse_str::<DatastoreArgs>(args) {
+                Ok(_) => panic!("duplicate accepted"),
+                Err(error) => error,
+            };
+            assert!(error.to_string().starts_with("duplicate `"));
+        }
+    }
+}

--- a/crates/buzz-datastore-tracing/tests/runtime.rs
+++ b/crates/buzz-datastore-tracing/tests/runtime.rs
@@ -1,0 +1,80 @@
+use buzz_datastore_tracing::datastore_span;
+use opentelemetry::trace::{SpanKind, Status, TracerProvider as _};
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+use tracing_subscriber::prelude::*;
+
+const DIRECT_ERROR: &str = "raw-secret-direct-error";
+const QUESTION_ERROR: &str = "raw-secret-question-error";
+
+fn question_path(fail: bool) -> Result<(), &'static str> {
+    if fail {
+        Err(QUESTION_ERROR)
+    } else {
+        Ok(())
+    }
+}
+
+#[datastore_span(name = "test_operation", system = "postgresql", fields(limit = limit))]
+async fn operation(
+    limit: usize,
+    direct_error: bool,
+    question_error: bool,
+) -> Result<usize, &'static str> {
+    if direct_error {
+        return Err(DIRECT_ERROR);
+    }
+    question_path(question_error)?;
+    Ok(limit)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn exports_policy_fields_without_error_or_argument_data() {
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let subscriber = tracing_subscriber::registry()
+        .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("datastore-macro-test")));
+    let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+    assert_eq!(operation(7, false, false).await, Ok(7));
+    assert_eq!(operation(8, true, false).await, Err(DIRECT_ERROR));
+    assert_eq!(operation(9, false, true).await, Err(QUESTION_ERROR));
+
+    provider.force_flush().expect("spans flush");
+    let spans = exporter.get_finished_spans().expect("exported spans");
+    assert_eq!(spans.len(), 3);
+
+    for (span, (expected_limit, expected_status)) in spans.iter().zip([
+        (7_i64, Status::Unset),
+        (8_i64, Status::error("")),
+        (9_i64, Status::error("")),
+    ]) {
+        assert_eq!(span.name, "test_operation");
+        assert_eq!(span.span_kind, SpanKind::Client);
+        assert_eq!(span.status, expected_status);
+
+        let attributes = span
+            .attributes
+            .iter()
+            .map(|attribute| (attribute.key.as_str(), attribute.value.to_string()))
+            .collect::<Vec<_>>();
+        assert!(attributes.contains(&("target", "buzz_datastore".to_owned())));
+        assert!(attributes.contains(&("db.system.name", "postgresql".to_owned())));
+        assert!(attributes.contains(&("limit", expected_limit.to_string())));
+        assert!(!attributes
+            .iter()
+            .any(|(key, _)| { matches!(*key, "direct_error" | "question_error") }));
+
+        let exported = format!("{span:?}");
+        assert!(!exported.contains(DIRECT_ERROR));
+        assert!(!exported.contains(QUESTION_ERROR));
+        assert!(span.events.iter().all(|event| {
+            !format!("{event:?}").contains(DIRECT_ERROR)
+                && !format!("{event:?}").contains(QUESTION_ERROR)
+        }));
+        if let Status::Error { description } = &span.status {
+            assert!(description.is_empty());
+        }
+    }
+}

--- a/crates/buzz-db/Cargo.toml
+++ b/crates/buzz-db/Cargo.toml
@@ -9,6 +9,7 @@ description = "Postgres event store and data access layer for Buzz"
 
 [dependencies]
 buzz-core = { workspace = true }
+buzz-datastore-tracing = { workspace = true }
 sqlx        = { workspace = true }
 tokio       = { workspace = true }
 serde       = { workspace = true }

--- a/crates/buzz-db/src/event.rs
+++ b/crates/buzz-db/src/event.rs
@@ -601,8 +601,8 @@ pub(crate) fn row_to_stored_event(row: sqlx::postgres::PgRow) -> Result<Option<S
     // Avoid the Value → String → parse round-trip: deserialize directly from the Value.
     let event: nostr::Event = match serde_json::from_value(event_json) {
         Ok(e) => e,
-        Err(_e) => {
-            tracing::warn!("failed to reconstruct event from DB row");
+        Err(e) => {
+            tracing::warn!("failed to reconstruct event from DB row: {e}");
             return Ok(None);
         }
     };

--- a/crates/buzz-db/src/event.rs
+++ b/crates/buzz-db/src/event.rs
@@ -601,8 +601,8 @@ pub(crate) fn row_to_stored_event(row: sqlx::postgres::PgRow) -> Result<Option<S
     // Avoid the Value → String → parse round-trip: deserialize directly from the Value.
     let event: nostr::Event = match serde_json::from_value(event_json) {
         Ok(e) => e,
-        Err(e) => {
-            tracing::warn!("failed to reconstruct event from DB row: {e}");
+        Err(_e) => {
+            tracing::warn!("failed to reconstruct event from DB row");
             return Ok(None);
         }
     };

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -57,6 +57,7 @@ pub mod workflow;
 pub use error::{DbError, Result};
 pub use event::{EventQuery, ReactionEventInsertOutcome, DEFAULT_MAX_PAGE_LIMIT};
 
+use buzz_datastore_tracing::datastore_span;
 use chrono::{DateTime, Utc};
 use sqlx::postgres::{PgConnection, PgPoolOptions};
 use sqlx::{Connection, PgPool, QueryBuilder, Row};
@@ -130,7 +131,11 @@ pub async fn insert_mentions(
         .into_iter()
         .filter(|pk| {
             if pk.len() != 64 || !pk.chars().all(|c| c.is_ascii_hexdigit()) {
-                tracing::debug!("skipping malformed p-tag in insert_mentions");
+                tracing::debug!(
+                    event_id = %event.id,
+                    invalid_ptag = pk,
+                    "skipping malformed p-tag in insert_mentions"
+                );
                 false
             } else {
                 true
@@ -248,7 +253,7 @@ impl ReadSession {
     /// the degraded follow-up can only observe *more* than the proof-time
     /// snapshot, never less — fresher aux rows, the same failure semantics
     /// as a request that routed to the writer to begin with.
-    #[tracing::instrument(target = "buzz_datastore", name = "read_session_query_events", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "read_session_query_events", system = "postgresql")]
     pub async fn query_events(&mut self, q: &EventQuery) -> Result<Vec<StoredEvent>> {
         let degraded = match &mut self.inner {
             ReadSessionInner::Replica { tx, writer } => {
@@ -488,7 +493,6 @@ impl UsageMetricsLeader {
     ///
     /// Bounded to 5 seconds — a blackholed connection (no RST) would otherwise
     /// stall the entire poller tick until the OS TCP timeout.
-    #[tracing::instrument(target = "buzz_datastore", name = "usage_metrics_leader_is_live", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn is_live(&mut self) -> bool {
         tokio::time::timeout(std::time::Duration::from_secs(5), self.connection.ping())
             .await
@@ -1007,7 +1011,7 @@ impl Db {
     }
 
     /// Run pending database migrations.
-    #[tracing::instrument(target = "buzz_datastore", name = "migrate", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "migrate", system = "postgresql")]
     pub async fn migrate(&self) -> Result<()> {
         migration::run_migrations(&self.pool).await
     }
@@ -1052,7 +1056,7 @@ impl Db {
     /// detached from the shared pool so a stable leader neither returns a locked
     /// session to other callers nor permanently consumes a pool slot. Dropping the
     /// guard closes the connection and releases the session-scoped lock.
-    #[tracing::instrument(target = "buzz_datastore", name = "try_lock_usage_metrics", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "try_lock_usage_metrics", system = "postgresql")]
     pub async fn try_lock_usage_metrics(
         &self,
         lock_key: i64,
@@ -1073,7 +1077,7 @@ impl Db {
 
     /// List reports for the deployment-global read-only admin plane.
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(target = "buzz_datastore", name = "admin_list_reports", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "admin_list_reports", system = "postgresql")]
     pub async fn admin_list_reports(
         &self,
         community_id: Option<Uuid>,
@@ -1100,7 +1104,7 @@ impl Db {
     }
 
     /// Fetch one report for the deployment-global read-only admin plane.
-    #[tracing::instrument(target = "buzz_datastore", name = "admin_get_report", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "admin_get_report", system = "postgresql")]
     pub async fn admin_get_report(
         &self,
         id: Uuid,
@@ -1109,7 +1113,7 @@ impl Db {
     }
 
     /// List feedback for the deployment-global read-only admin plane.
-    #[tracing::instrument(target = "buzz_datastore", name = "admin_list_feedback", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "admin_list_feedback", system = "postgresql")]
     pub async fn admin_list_feedback(
         &self,
         limit: i64,
@@ -1118,7 +1122,7 @@ impl Db {
     }
 
     /// Fetch one feedback submission for the deployment-global admin plane.
-    #[tracing::instrument(target = "buzz_datastore", name = "admin_get_feedback", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "admin_get_feedback", system = "postgresql")]
     pub async fn admin_get_feedback(
         &self,
         id: Uuid,
@@ -1127,43 +1131,43 @@ impl Db {
     }
 
     /// Return total number of communities on this relay.
-    #[tracing::instrument(target = "buzz_datastore", name = "usage_community_count", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "usage_community_count", system = "postgresql")]
     pub async fn usage_community_count(&self) -> Result<i64> {
         usage::community_count(&self.pool).await
     }
 
     /// Return per-community user counts split by human/agent.
-    #[tracing::instrument(target = "buzz_datastore", name = "usage_user_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "usage_user_counts", system = "postgresql")]
     pub async fn usage_user_counts(&self) -> Result<Vec<usage::CommunityUserCounts>> {
         usage::user_counts(&self.pool).await
     }
 
     /// Return per-community channel counts by type.
-    #[tracing::instrument(target = "buzz_datastore", name = "usage_channel_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "usage_channel_counts", system = "postgresql")]
     pub async fn usage_channel_counts(&self) -> Result<Vec<usage::CommunityChannelCount>> {
         usage::channel_counts(&self.pool).await
     }
 
     /// Return per-community kind=9 message counts.
-    #[tracing::instrument(target = "buzz_datastore", name = "usage_message_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "usage_message_counts", system = "postgresql")]
     pub async fn usage_message_counts(&self) -> Result<Vec<usage::CommunityMessageCount>> {
         usage::message_counts(&self.pool).await
     }
 
     /// Return per-community relay-member counts by role.
-    #[tracing::instrument(target = "buzz_datastore", name = "usage_relay_member_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "usage_relay_member_counts", system = "postgresql")]
     pub async fn usage_relay_member_counts(&self) -> Result<Vec<usage::CommunityMemberCount>> {
         usage::relay_member_counts(&self.pool).await
     }
 
     /// Return per-community workflow counts by status.
-    #[tracing::instrument(target = "buzz_datastore", name = "usage_workflow_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "usage_workflow_counts", system = "postgresql")]
     pub async fn usage_workflow_counts(&self) -> Result<Vec<usage::CommunityWorkflowCount>> {
         usage::workflow_counts(&self.pool).await
     }
 
     /// Return per-community git-repo counts.
-    #[tracing::instrument(target = "buzz_datastore", name = "usage_git_repo_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "usage_git_repo_counts", system = "postgresql")]
     pub async fn usage_git_repo_counts(&self) -> Result<Vec<usage::CommunityGitRepoCount>> {
         usage::git_repo_counts(&self.pool).await
     }
@@ -1171,7 +1175,7 @@ impl Db {
     /// Return per-community distinct active-user counts for a given SQL interval.
     ///
     /// `interval_sql` must be a trusted literal such as `"1 day"` or `"7 days"`.
-    #[tracing::instrument(target = "buzz_datastore", name = "usage_active_user_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "usage_active_user_counts", system = "postgresql")]
     pub async fn usage_active_user_counts(
         &self,
         interval_sql: &'static str,
@@ -1180,7 +1184,7 @@ impl Db {
     }
 
     /// Return per-community active-channel counts for a given SQL interval.
-    #[tracing::instrument(target = "buzz_datastore", name = "usage_active_channel_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "usage_active_channel_counts", system = "postgresql")]
     pub async fn usage_active_channel_counts(
         &self,
         interval_sql: &'static str,
@@ -1189,7 +1193,7 @@ impl Db {
     }
 
     /// Return all community id → host mappings.
-    #[tracing::instrument(target = "buzz_datastore", name = "usage_community_hosts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "usage_community_hosts", system = "postgresql")]
     pub async fn usage_community_hosts(&self) -> Result<Vec<usage::CommunityHost>> {
         usage::community_hosts(&self.pool).await
     }
@@ -1206,7 +1210,7 @@ impl Db {
     ///
     /// The caller owns host normalization and turns `None` into the fail-closed
     /// request/connection error. buzz-db only reads the durable host map.
-    #[tracing::instrument(target = "buzz_datastore", name = "lookup_community_by_host", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "lookup_community_by_host", system = "postgresql")]
     pub async fn lookup_community_by_host(
         &self,
         normalized_host: &str,
@@ -1236,7 +1240,7 @@ impl Db {
     }
 
     /// Returns whether a community id still exists in the active lifecycle state.
-    #[tracing::instrument(target = "buzz_datastore", name = "is_community_active", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "is_community_active", system = "postgresql")]
     pub async fn is_community_active(&self, community_id: CommunityId) -> Result<bool> {
         let active = sqlx::query_scalar::<_, bool>(
             "SELECT EXISTS(SELECT 1 FROM communities WHERE id = $1 AND archived_at IS NULL)",
@@ -1248,7 +1252,10 @@ impl Db {
     }
 
     /// Returns a community by host regardless of lifecycle state. Operator-plane only.
-    #[tracing::instrument(target = "buzz_datastore", name = "lookup_community_by_host_for_management", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(
+        name = "lookup_community_by_host_for_management",
+        system = "postgresql"
+    )]
     pub async fn lookup_community_by_host_for_management(
         &self,
         normalized_host: &str,
@@ -1270,7 +1277,7 @@ impl Db {
     ///
     /// This is an operator-plane helper, not a tenant-scoped data-plane read:
     /// callers must gate it on deployment-level operator auth before exposing it.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_communities_owned_by", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_communities_owned_by", system = "postgresql")]
     pub async fn list_communities_owned_by(
         &self,
         owner_pubkey: &str,
@@ -1316,7 +1323,7 @@ impl Db {
     /// fan out under *that* community rather than the deployment default. The
     /// community is authoritative; the host is read back for labelling only and
     /// is never used to re-derive the community.
-    #[tracing::instrument(target = "buzz_datastore", name = "lookup_community_host", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "lookup_community_host", system = "postgresql")]
     pub async fn lookup_community_host(&self, community_id: CommunityId) -> Result<Option<String>> {
         let row = sqlx::query(
             r#"
@@ -1341,7 +1348,7 @@ impl Db {
     ///
     /// Set by relay admins/owners via the kind:9033 command; the value is
     /// validated and size-capped at that write path.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_community_icon", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_community_icon", system = "postgresql")]
     pub async fn get_community_icon(&self, community_id: CommunityId) -> Result<Option<String>> {
         let row = sqlx::query(
             r#"
@@ -1362,7 +1369,7 @@ impl Db {
     }
 
     /// Sets or clears (`None`) the community's workspace icon.
-    #[tracing::instrument(target = "buzz_datastore", name = "set_community_icon", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "set_community_icon", system = "postgresql")]
     pub async fn set_community_icon(
         &self,
         community_id: CommunityId,
@@ -1387,7 +1394,7 @@ impl Db {
     /// This is the startup/config seeding path for N=1 deployments. Migrations
     /// create the schema only; deployment-specific hosts are not hardcoded into
     /// schema history.
-    #[tracing::instrument(target = "buzz_datastore", name = "ensure_configured_community", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "ensure_configured_community", system = "postgresql")]
     pub async fn ensure_configured_community(
         &self,
         normalized_host: &str,
@@ -1420,7 +1427,7 @@ impl Db {
     /// Holds a per-owner advisory lock while enforcing the ownership limit.
     /// Identical create retries return the original record; host collisions and
     /// limit failures remain distinguishable to the operator API.
-    #[tracing::instrument(target = "buzz_datastore", name = "create_community_with_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "create_community_with_owner", system = "postgresql")]
     pub async fn create_community_with_owner(
         &self,
         normalized_host: &str,
@@ -1506,7 +1513,7 @@ impl Db {
     }
 
     /// Idempotently archives a community when the asserted pubkey is its current owner.
-    #[tracing::instrument(target = "buzz_datastore", name = "archive_community_owned_by", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "archive_community_owned_by", system = "postgresql")]
     pub async fn archive_community_owned_by(
         &self,
         normalized_host: &str,
@@ -1540,7 +1547,7 @@ impl Db {
     }
 
     /// Idempotently restores a community when the asserted pubkey is its current owner.
-    #[tracing::instrument(target = "buzz_datastore", name = "unarchive_community_owned_by", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "unarchive_community_owned_by", system = "postgresql")]
     pub async fn unarchive_community_owned_by(
         &self,
         normalized_host: &str,
@@ -1573,7 +1580,7 @@ impl Db {
     ///
     /// Internal relay producers use this to derive tenant context from the row
     /// they are acting on, rather than falling back to an implicit default.
-    #[tracing::instrument(target = "buzz_datastore", name = "community_of_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "community_of_channel", system = "postgresql")]
     pub async fn community_of_channel(&self, channel_id: Uuid) -> Result<Option<CommunityId>> {
         let row = sqlx::query(
             r#"
@@ -1612,7 +1619,7 @@ impl Db {
     /// are intentionally not present rather than mapped to a default —
     /// callers MUST treat "channel-id not in map" as a coverage breach,
     /// never as "use the resolved community".
-    #[tracing::instrument(target = "buzz_datastore", name = "communities_of_channels", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "communities_of_channels", system = "postgresql")]
     pub async fn communities_of_channels(
         &self,
         channel_ids: &[Uuid],
@@ -1642,7 +1649,7 @@ impl Db {
     }
 
     /// Inserts an event. Returns `(StoredEvent, was_inserted)` — `false` on duplicate.
-    #[tracing::instrument(target = "buzz_datastore", name = "insert_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "insert_event", system = "postgresql")]
     pub async fn insert_event(
         &self,
         community_id: CommunityId,
@@ -1651,8 +1658,8 @@ impl Db {
     ) -> Result<(StoredEvent, bool)> {
         let result = event::insert_event(&self.pool, community_id, event, channel_id).await?;
         if result.1 {
-            if let Err(_e) = insert_mentions(&self.pool, community_id, event, channel_id).await {
-                tracing::warn!("mention insertion failed");
+            if let Err(e) = insert_mentions(&self.pool, community_id, event, channel_id).await {
+                tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
             }
         }
         Ok(result)
@@ -1665,7 +1672,7 @@ impl Db {
     /// callers that tolerate bounded staleness should use
     /// [`Db::query_events_routed`] instead — converting a caller is an
     /// explicit, per-callsite decision, never a change to this method.
-    #[tracing::instrument(target = "buzz_datastore", name = "query_events", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "query_events", system = "postgresql")]
     pub async fn query_events(&self, q: &EventQuery) -> Result<Vec<StoredEvent>> {
         event::query_events(&self.pool, q).await
     }
@@ -1686,7 +1693,7 @@ impl Db {
     /// unset, even covered-eligible queries stay on the writer, so merging
     /// this seam is a true no-op until the budget is configured. Every
     /// failure fails closed to the writer.
-    #[tracing::instrument(target = "buzz_datastore", name = "query_events_routed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "query_events_routed", system = "postgresql")]
     pub async fn query_events_routed(
         &self,
         path: &'static str,
@@ -1721,7 +1728,7 @@ impl Db {
     /// display page absorbs that per-row; a number derived from the rows
     /// does not. Same classification-table requirement as
     /// [`Db::query_events_routed`].
-    #[tracing::instrument(target = "buzz_datastore", name = "query_events_routed_bounded", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "query_events_routed_bounded", system = "postgresql")]
     pub async fn query_events_routed_bounded(
         &self,
         path: &'static str,
@@ -1749,7 +1756,7 @@ impl Db {
     ///
     /// Always reads from the WRITER pool — see [`Db::query_events`] for the
     /// writer-vs-routed rule.
-    #[tracing::instrument(target = "buzz_datastore", name = "count_events", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "count_events", system = "postgresql")]
     pub async fn count_events(&self, q: &EventQuery) -> Result<i64> {
         event::count_events(&self.pool, q).await
     }
@@ -1764,7 +1771,7 @@ impl Db {
     /// inflated number for up to `FENCE_STALENESS` is a different product
     /// statement than a page briefly showing a deleted row. `Bounded` ties
     /// the error to the accepted budget `B`.
-    #[tracing::instrument(target = "buzz_datastore", name = "count_events_routed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "count_events_routed", system = "postgresql")]
     pub async fn count_events_routed(&self, path: &'static str, q: &EventQuery) -> Result<i64> {
         match self.route_read(path, RoutePredicate::Bounded).await {
             RouteDecision::Replica(mut tx, _entry, reason) => {
@@ -1786,7 +1793,7 @@ impl Db {
 
     /// Return whether a creator-signed huddle-start event links a parent
     /// channel to an ephemeral huddle channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "huddle_started_link_exists", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "huddle_started_link_exists", system = "postgresql")]
     pub async fn huddle_started_link_exists(
         &self,
         community_id: CommunityId,
@@ -1809,7 +1816,7 @@ impl Db {
     /// Uses canonical NIP-16 ordering: `created_at DESC, id ASC`.
     /// This matches the write path in [`replace_addressable_event`] and handles
     /// historical duplicate survivors correctly.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_latest_global_replaceable", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_latest_global_replaceable", system = "postgresql")]
     pub async fn get_latest_global_replaceable(
         &self,
         community_id: CommunityId,
@@ -1822,7 +1829,7 @@ impl Db {
     /// Fetches a single non-deleted event by its raw ID bytes.
     ///
     /// Returns `None` if the event does not exist or has been soft-deleted.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_event_by_id", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_event_by_id", system = "postgresql")]
     pub async fn get_event_by_id(
         &self,
         community_id: CommunityId,
@@ -1832,7 +1839,7 @@ impl Db {
     }
 
     /// Fetches a single event by its raw ID bytes, **including soft-deleted rows**.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_event_by_id_including_deleted", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_event_by_id_including_deleted", system = "postgresql")]
     pub async fn get_event_by_id_including_deleted(
         &self,
         community_id: CommunityId,
@@ -1842,7 +1849,7 @@ impl Db {
     }
 
     /// Soft-deletes an event. Returns `Ok(true)` if deleted, `Ok(false)` if already deleted.
-    #[tracing::instrument(target = "buzz_datastore", name = "soft_delete_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "soft_delete_event", system = "postgresql")]
     pub async fn soft_delete_event(
         &self,
         community_id: CommunityId,
@@ -1855,7 +1862,7 @@ impl Db {
     /// when it is not newer than the deletion request.
     /// Used by NIP-09 a-tag deletion for parameterized-replaceable kinds;
     /// `deletion_created_at_secs` is the deletion event's `created_at`.
-    #[tracing::instrument(target = "buzz_datastore", name = "soft_delete_by_coordinate", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "soft_delete_by_coordinate", system = "postgresql")]
     pub async fn soft_delete_by_coordinate(
         &self,
         community_id: CommunityId,
@@ -1876,7 +1883,7 @@ impl Db {
     }
 
     /// Atomically soft-delete an event and decrement thread reply counters.
-    #[tracing::instrument(target = "buzz_datastore", name = "soft_delete_event_and_update_thread", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "soft_delete_event_and_update_thread", system = "postgresql")]
     pub async fn soft_delete_event_and_update_thread(
         &self,
         community_id: CommunityId,
@@ -1895,7 +1902,7 @@ impl Db {
     }
 
     /// Returns the most recent `created_at` for a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_last_message_at", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_last_message_at", system = "postgresql")]
     pub async fn get_last_message_at(
         &self,
         community_id: CommunityId,
@@ -1905,7 +1912,7 @@ impl Db {
     }
 
     /// Bulk-fetch the most recent `created_at` for a set of channel IDs.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_last_message_at_bulk", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_last_message_at_bulk", system = "postgresql")]
     pub async fn get_last_message_at_bulk(
         &self,
         community_id: CommunityId,
@@ -1915,7 +1922,7 @@ impl Db {
     }
 
     /// Batch-fetch non-deleted events by their raw IDs.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_events_by_ids", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_events_by_ids", system = "postgresql")]
     pub async fn get_events_by_ids(
         &self,
         community_id: CommunityId,
@@ -1931,7 +1938,7 @@ impl Db {
     /// channel pin, so no fence floor can prove insert-completeness — the
     /// covered arm is structurally unavailable. Used for FTS hit hydration,
     /// where a missing row degrades to a skipped search hit downstream.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_events_by_ids_routed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_events_by_ids_routed", system = "postgresql")]
     pub async fn get_events_by_ids_routed(
         &self,
         path: &'static str,
@@ -1957,7 +1964,7 @@ impl Db {
     }
 
     /// Exclusively claim a batch of due matcher jobs from one community.
-    #[tracing::instrument(target = "buzz_datastore", name = "claim_due_push_match_batch", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "claim_due_push_match_batch", system = "postgresql")]
     pub async fn claim_due_push_match_batch(
         &self,
         limit: i64,
@@ -1967,7 +1974,7 @@ impl Db {
     }
 
     /// Load active endpoint-enabled leases eligible for push matching.
-    #[tracing::instrument(target = "buzz_datastore", name = "active_push_match_leases", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "active_push_match_leases", system = "postgresql")]
     pub async fn active_push_match_leases(
         &self,
         community: CommunityId,
@@ -1976,7 +1983,7 @@ impl Db {
     }
 
     /// Complete matcher jobs from one claimed batch while the fence holds.
-    #[tracing::instrument(target = "buzz_datastore", name = "complete_push_match_batch", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "complete_push_match_batch", system = "postgresql")]
     pub async fn complete_push_match_batch(
         &self,
         community: CommunityId,
@@ -1987,7 +1994,7 @@ impl Db {
     }
 
     /// Release fenced matcher claims from one batch for retry.
-    #[tracing::instrument(target = "buzz_datastore", name = "retry_push_match_batch", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "retry_push_match_batch", system = "postgresql")]
     pub async fn retry_push_match_batch(
         &self,
         community: CommunityId,
@@ -1999,13 +2006,13 @@ impl Db {
     }
 
     /// Delete exhausted matcher jobs (periodic sweep, off the claim path).
-    #[tracing::instrument(target = "buzz_datastore", name = "reap_exhausted_push_matches", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "reap_exhausted_push_matches", system = "postgresql")]
     pub async fn reap_exhausted_push_matches(&self) -> Result<u64> {
         push::reap_exhausted_matches(&self.pool).await
     }
 
     /// Idempotently enqueue a wake for a matched lease and event.
-    #[tracing::instrument(target = "buzz_datastore", name = "enqueue_push_wake", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "enqueue_push_wake", system = "postgresql")]
     pub async fn enqueue_push_wake(
         &self,
         community: CommunityId,
@@ -2017,7 +2024,7 @@ impl Db {
     }
 
     /// Set-wise [`Self::enqueue_push_wake`]: one transaction per batch.
-    #[tracing::instrument(target = "buzz_datastore", name = "enqueue_push_wakes", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "enqueue_push_wakes", system = "postgresql")]
     pub async fn enqueue_push_wakes(
         &self,
         community: CommunityId,
@@ -2027,7 +2034,7 @@ impl Db {
     }
 
     /// Exclusively claim due wake jobs for one community.
-    #[tracing::instrument(target = "buzz_datastore", name = "claim_due_push_wakes", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "claim_due_push_wakes", system = "postgresql")]
     pub async fn claim_due_push_wakes(
         &self,
         community: CommunityId,
@@ -2038,7 +2045,7 @@ impl Db {
     }
 
     /// Revalidate a wake's claim, source event, and current lease before send.
-    #[tracing::instrument(target = "buzz_datastore", name = "revalidate_push_wake", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "revalidate_push_wake", system = "postgresql")]
     pub async fn revalidate_push_wake(
         &self,
         community: CommunityId,
@@ -2049,7 +2056,7 @@ impl Db {
     }
 
     /// Mark a fenced wake claim delivered.
-    #[tracing::instrument(target = "buzz_datastore", name = "complete_push_wake", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "complete_push_wake", system = "postgresql")]
     pub async fn complete_push_wake(
         &self,
         community: CommunityId,
@@ -2060,7 +2067,7 @@ impl Db {
     }
 
     /// Release a fenced wake claim for retry at the supplied time.
-    #[tracing::instrument(target = "buzz_datastore", name = "retry_push_wake", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "retry_push_wake", system = "postgresql")]
     pub async fn retry_push_wake(
         &self,
         community: CommunityId,
@@ -2072,7 +2079,7 @@ impl Db {
     }
 
     /// Mark a fenced wake claim terminally failed.
-    #[tracing::instrument(target = "buzz_datastore", name = "fail_push_wake", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "fail_push_wake", system = "postgresql")]
     pub async fn fail_push_wake(
         &self,
         community: CommunityId,
@@ -2083,7 +2090,7 @@ impl Db {
     }
 
     /// Disable an endpoint only if the specified lease generation is current.
-    #[tracing::instrument(target = "buzz_datastore", name = "disable_push_endpoint", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "disable_push_endpoint", system = "postgresql")]
     pub async fn disable_push_endpoint(
         &self,
         community: CommunityId,
@@ -2103,7 +2110,7 @@ impl Db {
 
     /// Atomically persist a validated kind:30350 event and its effective lease.
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(target = "buzz_datastore", name = "accept_push_lease_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "accept_push_lease_event", system = "postgresql")]
     pub async fn accept_push_lease_event(
         &self,
         community: CommunityId,
@@ -2126,7 +2133,7 @@ impl Db {
     }
 
     /// Atomically insert an event AND its thread metadata in a single transaction.
-    #[tracing::instrument(target = "buzz_datastore", name = "insert_event_with_thread_metadata", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "insert_event_with_thread_metadata", system = "postgresql")]
     pub async fn insert_event_with_thread_metadata(
         &self,
         community_id: CommunityId,
@@ -2143,8 +2150,8 @@ impl Db {
         )
         .await?;
         if result.1 {
-            if let Err(_e) = insert_mentions(&self.pool, community_id, event, channel_id).await {
-                tracing::warn!("mention insertion failed");
+            if let Err(e) = insert_mentions(&self.pool, community_id, event, channel_id).await {
+                tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
             }
         }
         Ok(result)
@@ -2152,7 +2159,10 @@ impl Db {
 
     /// Atomically insert a kind:7 reaction event and its reaction row.
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(target = "buzz_datastore", name = "insert_reaction_event_with_thread_metadata", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(
+        name = "insert_reaction_event_with_thread_metadata",
+        system = "postgresql"
+    )]
     pub async fn insert_reaction_event_with_thread_metadata(
         &self,
         community_id: CommunityId,
@@ -2178,8 +2188,8 @@ impl Db {
             was_inserted: true, ..
         } = &outcome
         {
-            if let Err(_e) = insert_mentions(&self.pool, community_id, event, channel_id).await {
-                tracing::warn!("mention insertion failed");
+            if let Err(e) = insert_mentions(&self.pool, community_id, event, channel_id).await {
+                tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
             }
         }
         Ok(outcome)
@@ -2187,7 +2197,7 @@ impl Db {
 
     /// Creates a new channel, bootstraps the creator as owner, and returns the record.
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(target = "buzz_datastore", name = "create_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "create_channel", system = "postgresql")]
     pub async fn create_channel(
         &self,
         community_id: CommunityId,
@@ -2215,7 +2225,7 @@ impl Db {
     ///
     /// Returns `(record, true)` if newly created, `(record, false)` if already exists.
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(target = "buzz_datastore", name = "create_channel_with_id", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "create_channel_with_id", system = "postgresql")]
     pub async fn create_channel_with_id(
         &self,
         community_id: CommunityId,
@@ -2242,7 +2252,7 @@ impl Db {
     }
 
     /// Fetches a channel record by ID.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_channel", system = "postgresql")]
     pub async fn get_channel(
         &self,
         community_id: CommunityId,
@@ -2252,7 +2262,7 @@ impl Db {
     }
 
     /// Returns the canvas content for a channel, if any.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_canvas", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_canvas", system = "postgresql")]
     pub async fn get_canvas(
         &self,
         community_id: CommunityId,
@@ -2262,7 +2272,7 @@ impl Db {
     }
 
     /// Sets or clears the canvas content for a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "set_canvas", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "set_canvas", system = "postgresql")]
     pub async fn set_canvas(
         &self,
         community_id: CommunityId,
@@ -2273,7 +2283,7 @@ impl Db {
     }
 
     /// Adds a member to a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "add_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "add_member", system = "postgresql")]
     pub async fn add_member(
         &self,
         community_id: CommunityId,
@@ -2294,7 +2304,7 @@ impl Db {
     }
 
     /// Removes a member from a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "remove_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "remove_member", system = "postgresql")]
     pub async fn remove_member(
         &self,
         community_id: CommunityId,
@@ -2306,7 +2316,7 @@ impl Db {
     }
 
     /// Returns `true` if the pubkey is an active member.
-    #[tracing::instrument(target = "buzz_datastore", name = "is_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "is_member", system = "postgresql")]
     pub async fn is_member(
         &self,
         community_id: CommunityId,
@@ -2318,7 +2328,7 @@ impl Db {
 
     /// Return the active (channel, pubkey) membership pairs among the given
     /// sets, in one statement.
-    #[tracing::instrument(target = "buzz_datastore", name = "membership_pairs", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "membership_pairs", system = "postgresql")]
     pub async fn membership_pairs(
         &self,
         community_id: CommunityId,
@@ -2329,7 +2339,7 @@ impl Db {
     }
 
     /// Returns all active members of a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_members", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_members", system = "postgresql")]
     pub async fn get_members(
         &self,
         community_id: CommunityId,
@@ -2339,7 +2349,7 @@ impl Db {
     }
 
     /// Returns active members for multiple channels in a single query.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_members_bulk", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_members_bulk", system = "postgresql")]
     pub async fn get_members_bulk(
         &self,
         community_id: CommunityId,
@@ -2349,7 +2359,7 @@ impl Db {
     }
 
     /// Get all channel IDs accessible to a pubkey.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_accessible_channel_ids", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_accessible_channel_ids", system = "postgresql")]
     pub async fn get_accessible_channel_ids(
         &self,
         community_id: CommunityId,
@@ -2359,7 +2369,7 @@ impl Db {
     }
 
     /// Lists channels, optionally filtered by visibility.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_channels", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_channels", system = "postgresql")]
     pub async fn list_channels(
         &self,
         community_id: CommunityId,
@@ -2369,7 +2379,7 @@ impl Db {
     }
 
     /// Returns full channel records for all channels a user can access.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_accessible_channels", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_accessible_channels", system = "postgresql")]
     pub async fn get_accessible_channels(
         &self,
         community_id: CommunityId,
@@ -2388,7 +2398,7 @@ impl Db {
     }
 
     /// Returns all bot-role members with their aggregated channel names in one community.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_bot_members", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_bot_members", system = "postgresql")]
     pub async fn get_bot_members(
         &self,
         community_id: CommunityId,
@@ -2397,7 +2407,7 @@ impl Db {
     }
 
     /// Bulk-fetch user records by pubkey.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_users_bulk", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_users_bulk", system = "postgresql")]
     pub async fn get_users_bulk(
         &self,
         community_id: CommunityId,
@@ -2407,7 +2417,7 @@ impl Db {
     }
 
     /// Updates a channel's name and/or description.
-    #[tracing::instrument(target = "buzz_datastore", name = "update_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "update_channel", system = "postgresql")]
     pub async fn update_channel(
         &self,
         community_id: CommunityId,
@@ -2418,7 +2428,7 @@ impl Db {
     }
 
     /// Sets the topic for a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "set_topic", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "set_topic", system = "postgresql")]
     pub async fn set_topic(
         &self,
         community_id: CommunityId,
@@ -2430,7 +2440,7 @@ impl Db {
     }
 
     /// Sets the purpose for a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "set_purpose", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "set_purpose", system = "postgresql")]
     pub async fn set_purpose(
         &self,
         community_id: CommunityId,
@@ -2442,13 +2452,13 @@ impl Db {
     }
 
     /// Archives a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "archive_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "archive_channel", system = "postgresql")]
     pub async fn archive_channel(&self, community_id: CommunityId, channel_id: Uuid) -> Result<()> {
         channel::archive_channel(&self.pool, community_id, channel_id).await
     }
 
     /// Unarchives a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "unarchive_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "unarchive_channel", system = "postgresql")]
     pub async fn unarchive_channel(
         &self,
         community_id: CommunityId,
@@ -2458,7 +2468,7 @@ impl Db {
     }
 
     /// Soft-delete a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "soft_delete_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "soft_delete_channel", system = "postgresql")]
     pub async fn soft_delete_channel(
         &self,
         community_id: CommunityId,
@@ -2468,7 +2478,7 @@ impl Db {
     }
 
     /// Returns the count of active members in a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_member_count", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_member_count", system = "postgresql")]
     pub async fn get_member_count(
         &self,
         community_id: CommunityId,
@@ -2478,7 +2488,7 @@ impl Db {
     }
 
     /// Bulk-fetch member counts for a set of channel IDs.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_member_counts_bulk", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_member_counts_bulk", system = "postgresql")]
     pub async fn get_member_counts_bulk(
         &self,
         community_id: CommunityId,
@@ -2488,7 +2498,7 @@ impl Db {
     }
 
     /// Get the active role of a pubkey in a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_member_role", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_member_role", system = "postgresql")]
     pub async fn get_member_role(
         &self,
         community_id: CommunityId,
@@ -2499,7 +2509,7 @@ impl Db {
     }
 
     /// Archive ephemeral channels whose TTL deadline has passed.
-    #[tracing::instrument(target = "buzz_datastore", name = "reap_expired_ephemeral_channels", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "reap_expired_ephemeral_channels", system = "postgresql")]
     pub async fn reap_expired_ephemeral_channels(
         &self,
     ) -> Result<Vec<channel::ReapedEphemeralChannel>> {
@@ -2507,7 +2517,7 @@ impl Db {
     }
 
     /// Query due reminders ready for delivery.
-    #[tracing::instrument(target = "buzz_datastore", name = "query_due_reminders", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "query_due_reminders", system = "postgresql")]
     pub async fn query_due_reminders(
         &self,
         now_secs: i64,
@@ -2517,7 +2527,7 @@ impl Db {
     }
 
     /// Atomically claim a due reminder for delivery (cross-pod dedup).
-    #[tracing::instrument(target = "buzz_datastore", name = "claim_due_reminder", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "claim_due_reminder", system = "postgresql")]
     pub async fn claim_due_reminder(
         &self,
         community_id: CommunityId,
@@ -2528,7 +2538,7 @@ impl Db {
     }
 
     /// Atomically claim a due reminder using a caller-supplied delivery stamp.
-    #[tracing::instrument(target = "buzz_datastore", name = "claim_due_reminder_with_stamp", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "claim_due_reminder_with_stamp", system = "postgresql")]
     pub async fn claim_due_reminder_with_stamp(
         &self,
         community_id: CommunityId,
@@ -2547,7 +2557,7 @@ impl Db {
     }
 
     /// Release a claimed due reminder after a publish failure.
-    #[tracing::instrument(target = "buzz_datastore", name = "release_due_reminder", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "release_due_reminder", system = "postgresql")]
     pub async fn release_due_reminder(
         &self,
         community_id: CommunityId,
@@ -2570,13 +2580,13 @@ impl Db {
     /// Returns `true` if a new row was inserted (first time), `false` if it
     /// already existed. Callers use the `true` return to increment
     /// `buzz_users_created_total`.
-    #[tracing::instrument(target = "buzz_datastore", name = "ensure_user", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "ensure_user", system = "postgresql")]
     pub async fn ensure_user(&self, community_id: CommunityId, pubkey: &[u8]) -> Result<bool> {
         user::ensure_user(&self.pool, community_id, pubkey).await
     }
 
     /// Get a single user record by pubkey.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_user", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_user", system = "postgresql")]
     pub async fn get_user(
         &self,
         community_id: CommunityId,
@@ -2586,7 +2596,7 @@ impl Db {
     }
 
     /// Update a user's profile fields.
-    #[tracing::instrument(target = "buzz_datastore", name = "update_user_profile", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "update_user_profile", system = "postgresql")]
     pub async fn update_user_profile(
         &self,
         community_id: CommunityId,
@@ -2609,7 +2619,7 @@ impl Db {
     }
 
     /// Look up a user by NIP-05 handle.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_user_by_nip05", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_user_by_nip05", system = "postgresql")]
     pub async fn get_user_by_nip05(
         &self,
         community_id: CommunityId,
@@ -2620,7 +2630,7 @@ impl Db {
     }
 
     /// Search users by display name, NIP-05 handle, or pubkey prefix.
-    #[tracing::instrument(target = "buzz_datastore", name = "search_users", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "search_users", system = "postgresql")]
     pub async fn search_users(
         &self,
         community_id: CommunityId,
@@ -2632,7 +2642,7 @@ impl Db {
 
     /// Atomically set agent owner — only if no owner is currently assigned.
     /// Returns Ok(true) if set, Ok(false) if an owner already exists.
-    #[tracing::instrument(target = "buzz_datastore", name = "set_agent_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "set_agent_owner", system = "postgresql")]
     pub async fn set_agent_owner(
         &self,
         community_id: CommunityId,
@@ -2643,7 +2653,7 @@ impl Db {
     }
 
     /// Get the channel_add_policy and agent_owner_pubkey for a user.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_agent_channel_policy", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_agent_channel_policy", system = "postgresql")]
     pub async fn get_agent_channel_policy(
         &self,
         community_id: CommunityId,
@@ -2653,7 +2663,7 @@ impl Db {
     }
 
     /// Check whether `actor_pubkey` is the agent owner of `target_pubkey`.
-    #[tracing::instrument(target = "buzz_datastore", name = "is_agent_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "is_agent_owner", system = "postgresql")]
     pub async fn is_agent_owner(
         &self,
         community_id: CommunityId,
@@ -2664,7 +2674,7 @@ impl Db {
     }
 
     /// Set the channel_add_policy for a user.
-    #[tracing::instrument(target = "buzz_datastore", name = "set_channel_add_policy", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "set_channel_add_policy", system = "postgresql")]
     pub async fn set_channel_add_policy(
         &self,
         community_id: CommunityId,
@@ -2675,7 +2685,7 @@ impl Db {
     }
 
     /// Find an existing DM by its participant hash.
-    #[tracing::instrument(target = "buzz_datastore", name = "find_dm_by_participants", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "find_dm_by_participants", system = "postgresql")]
     pub async fn find_dm_by_participants(
         &self,
         community_id: CommunityId,
@@ -2685,7 +2695,7 @@ impl Db {
     }
 
     /// Create or return an existing DM channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "create_dm", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "create_dm", system = "postgresql")]
     pub async fn create_dm(
         &self,
         community_id: CommunityId,
@@ -2696,7 +2706,7 @@ impl Db {
     }
 
     /// List all DMs for a user.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_dms_for_user", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_dms_for_user", system = "postgresql")]
     pub async fn list_dms_for_user(
         &self,
         community_id: CommunityId,
@@ -2708,7 +2718,7 @@ impl Db {
     }
 
     /// Open or retrieve a DM for the given participants.
-    #[tracing::instrument(target = "buzz_datastore", name = "open_dm", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "open_dm", system = "postgresql")]
     pub async fn open_dm(
         &self,
         community_id: CommunityId,
@@ -2722,7 +2732,7 @@ impl Db {
     ///
     /// The DM is not deleted — it can be restored by opening a new DM with
     /// the same participants.
-    #[tracing::instrument(target = "buzz_datastore", name = "hide_dm", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "hide_dm", system = "postgresql")]
     pub async fn hide_dm(
         &self,
         community_id: CommunityId,
@@ -2733,7 +2743,7 @@ impl Db {
     }
 
     /// Unhide a DM channel for a specific user.
-    #[tracing::instrument(target = "buzz_datastore", name = "unhide_dm", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "unhide_dm", system = "postgresql")]
     pub async fn unhide_dm(
         &self,
         community_id: CommunityId,
@@ -2744,7 +2754,7 @@ impl Db {
     }
 
     /// List the channel IDs of all DMs the given user currently has hidden.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_hidden_dms", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_hidden_dms", system = "postgresql")]
     pub async fn list_hidden_dms(
         &self,
         community_id: CommunityId,
@@ -2755,7 +2765,7 @@ impl Db {
 
     /// Insert thread metadata.
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(target = "buzz_datastore", name = "insert_thread_metadata", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "insert_thread_metadata", system = "postgresql")]
     pub async fn insert_thread_metadata(
         &self,
         community_id: CommunityId,
@@ -2806,7 +2816,7 @@ impl Db {
     /// A head fetch routed under Predicate A skips the re-run: bounded
     /// staleness (missing at most the freshest budget-window of replies) is
     /// exactly the semantic the head gate accepts.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_thread_replies", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_thread_replies", system = "postgresql")]
     pub async fn get_thread_replies(
         &self,
         community_id: CommunityId,
@@ -2881,7 +2891,7 @@ impl Db {
     }
 
     /// Fetch aggregated thread stats.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_thread_summary", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_thread_summary", system = "postgresql")]
     pub async fn get_thread_summary(
         &self,
         community_id: CommunityId,
@@ -2933,7 +2943,7 @@ impl Db {
     ///
     /// Every failure fails closed to the writer and is recorded in
     /// `buzz_db_route_decision`.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_channel_window", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_channel_window", system = "postgresql")]
     pub async fn get_channel_window_with_session(
         &self,
         community_id: CommunityId,
@@ -3099,7 +3109,7 @@ impl Db {
     }
 
     /// Look up a single thread_metadata row by event_id.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_thread_metadata_by_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_thread_metadata_by_event", system = "postgresql")]
     pub async fn get_thread_metadata_by_event(
         &self,
         community_id: CommunityId,
@@ -3109,7 +3119,7 @@ impl Db {
     }
 
     /// Decrement reply counts.
-    #[tracing::instrument(target = "buzz_datastore", name = "decrement_reply_count", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "decrement_reply_count", system = "postgresql")]
     pub async fn decrement_reply_count(
         &self,
         community_id: CommunityId,
@@ -3121,7 +3131,7 @@ impl Db {
     }
 
     /// Add (or re-activate) a reaction.
-    #[tracing::instrument(target = "buzz_datastore", name = "add_reaction", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "add_reaction", system = "postgresql")]
     pub async fn add_reaction(
         &self,
         community: CommunityId,
@@ -3144,7 +3154,7 @@ impl Db {
     }
 
     /// Soft-delete a reaction.
-    #[tracing::instrument(target = "buzz_datastore", name = "remove_reaction", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "remove_reaction", system = "postgresql")]
     pub async fn remove_reaction(
         &self,
         community: CommunityId,
@@ -3165,7 +3175,7 @@ impl Db {
     }
 
     /// Soft-delete a reaction by its source event ID.
-    #[tracing::instrument(target = "buzz_datastore", name = "remove_reaction_by_source_event_id", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "remove_reaction_by_source_event_id", system = "postgresql")]
     pub async fn remove_reaction_by_source_event_id(
         &self,
         community: CommunityId,
@@ -3175,7 +3185,7 @@ impl Db {
     }
 
     /// Look up the active reaction row for one actor + emoji + target tuple.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_active_reaction_record", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_active_reaction_record", system = "postgresql")]
     pub async fn get_active_reaction_record(
         &self,
         community: CommunityId,
@@ -3196,7 +3206,7 @@ impl Db {
     }
 
     /// Backfill the source event ID on an active reaction row.
-    #[tracing::instrument(target = "buzz_datastore", name = "set_reaction_event_id", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "set_reaction_event_id", system = "postgresql")]
     pub async fn set_reaction_event_id(
         &self,
         community: CommunityId,
@@ -3219,7 +3229,7 @@ impl Db {
     }
 
     /// Get all active reactions for an event, grouped by emoji.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_reactions", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_reactions", system = "postgresql")]
     pub async fn get_reactions(
         &self,
         community: CommunityId,
@@ -3240,7 +3250,7 @@ impl Db {
     }
 
     /// Batch-fetch emoji counts for a set of (event_id, event_created_at) pairs.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_reactions_bulk", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_reactions_bulk", system = "postgresql")]
     pub async fn get_reactions_bulk(
         &self,
         community: CommunityId,
@@ -3250,7 +3260,7 @@ impl Db {
     }
 
     /// Find events that @mention the given pubkey.
-    #[tracing::instrument(target = "buzz_datastore", name = "query_feed_mentions", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "query_feed_mentions", system = "postgresql")]
     pub async fn query_feed_mentions(
         &self,
         community: CommunityId,
@@ -3277,7 +3287,7 @@ impl Db {
     /// parameter admits community-global rows alongside channel rows, so no
     /// single channel's fence floor can prove completeness — the covered arm
     /// is structurally unavailable, not merely unchosen.
-    #[tracing::instrument(target = "buzz_datastore", name = "query_feed_mentions_routed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "query_feed_mentions_routed", system = "postgresql")]
     pub async fn query_feed_mentions_routed(
         &self,
         path: &'static str,
@@ -3333,7 +3343,7 @@ impl Db {
     }
 
     /// Find events that require action from the given pubkey.
-    #[tracing::instrument(target = "buzz_datastore", name = "query_feed_needs_action", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "query_feed_needs_action", system = "postgresql")]
     pub async fn query_feed_needs_action(
         &self,
         community: CommunityId,
@@ -3356,7 +3366,7 @@ impl Db {
     /// [`Db::query_feed_needs_action`] with replica routing — BOUNDED arm
     /// only; see [`Db::query_feed_mentions_routed`] for why the covered arm
     /// is structurally unavailable to feed queries.
-    #[tracing::instrument(target = "buzz_datastore", name = "query_feed_needs_action_routed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "query_feed_needs_action_routed", system = "postgresql")]
     pub async fn query_feed_needs_action_routed(
         &self,
         path: &'static str,
@@ -3412,7 +3422,7 @@ impl Db {
     }
 
     /// Find recent activity across accessible channels.
-    #[tracing::instrument(target = "buzz_datastore", name = "query_feed_activity", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "query_feed_activity", system = "postgresql")]
     pub async fn query_feed_activity(
         &self,
         community: CommunityId,
@@ -3426,7 +3436,7 @@ impl Db {
     /// [`Db::query_feed_activity`] with replica routing — BOUNDED arm only;
     /// see [`Db::query_feed_mentions_routed`] for why the covered arm is
     /// structurally unavailable to feed queries.
-    #[tracing::instrument(target = "buzz_datastore", name = "query_feed_activity_routed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "query_feed_activity_routed", system = "postgresql")]
     pub async fn query_feed_activity_routed(
         &self,
         path: &'static str,
@@ -3473,7 +3483,7 @@ impl Db {
 
     /// Create a new API token record.
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(target = "buzz_datastore", name = "create_api_token", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "create_api_token", system = "postgresql")]
     pub async fn create_api_token(
         &self,
         community_id: CommunityId,
@@ -3499,7 +3509,7 @@ impl Db {
 
     /// Atomic conditional INSERT with 10-token limit (per (community, owner)).
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(target = "buzz_datastore", name = "create_api_token_if_under_limit", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "create_api_token_if_under_limit", system = "postgresql")]
     pub async fn create_api_token_if_under_limit(
         &self,
         community_id: CommunityId,
@@ -3529,7 +3539,7 @@ impl Db {
     /// See [`api_token::get_api_token_by_hash_including_revoked`] for the
     /// row-44 conformance rationale — the `(community_id, token_hash)` key
     /// is enforced both by the storage UNIQUE index and by this WHERE clause.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_api_token_by_hash", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_api_token_by_hash", system = "postgresql")]
     pub async fn get_api_token_by_hash(
         &self,
         community_id: CommunityId,
@@ -3555,7 +3565,10 @@ impl Db {
     }
 
     /// Look up an API token by hash, including revoked, scoped to community.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_api_token_by_hash_including_revoked", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(
+        name = "get_api_token_by_hash_including_revoked",
+        system = "postgresql"
+    )]
     pub async fn get_api_token_by_hash_including_revoked(
         &self,
         community_id: CommunityId,
@@ -3570,7 +3583,7 @@ impl Db {
     }
 
     /// Record a token usage (update `last_used_at`), scoped to community.
-    #[tracing::instrument(target = "buzz_datastore", name = "touch_api_token", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "touch_api_token", system = "postgresql")]
     pub async fn touch_api_token(&self, community_id: CommunityId, hash: &[u8]) -> Result<()> {
         sqlx::query(
             "UPDATE api_tokens SET last_used_at = NOW() WHERE community_id = $1 AND token_hash = $2",
@@ -3592,7 +3605,7 @@ impl Db {
     }
 
     /// List all active (non-revoked) tokens in a community, newest first.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_active_tokens", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_active_tokens", system = "postgresql")]
     pub async fn list_active_tokens(&self, community_id: CommunityId) -> Result<Vec<TokenSummary>> {
         let rows = sqlx::query(
             r#"
@@ -3627,7 +3640,7 @@ impl Db {
     }
 
     /// List all tokens for a (community, owner) pair (including revoked).
-    #[tracing::instrument(target = "buzz_datastore", name = "list_tokens_by_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_tokens_by_owner", system = "postgresql")]
     pub async fn list_tokens_by_owner(
         &self,
         community_id: CommunityId,
@@ -3637,7 +3650,7 @@ impl Db {
     }
 
     /// Revoke a single token by ID, scoped to (community, owner).
-    #[tracing::instrument(target = "buzz_datastore", name = "revoke_token", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "revoke_token", system = "postgresql")]
     pub async fn revoke_token(
         &self,
         community_id: CommunityId,
@@ -3656,7 +3669,7 @@ impl Db {
     }
 
     /// Revoke all active tokens for a (community, owner) pair.
-    #[tracing::instrument(target = "buzz_datastore", name = "revoke_all_tokens", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "revoke_all_tokens", system = "postgresql")]
     pub async fn revoke_all_tokens(
         &self,
         community_id: CommunityId,
@@ -3673,7 +3686,7 @@ impl Db {
     }
 
     /// Create a new workflow.
-    #[tracing::instrument(target = "buzz_datastore", name = "create_workflow", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "create_workflow", system = "postgresql")]
     pub async fn create_workflow(
         &self,
         community_id: CommunityId,
@@ -3697,7 +3710,7 @@ impl Db {
 
     /// Insert or update a workflow using its NIP-33 `d`-tag UUID.
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(target = "buzz_datastore", name = "upsert_workflow", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "upsert_workflow", system = "postgresql")]
     pub async fn upsert_workflow(
         &self,
         community_id: CommunityId,
@@ -3722,7 +3735,7 @@ impl Db {
     }
 
     /// Fetch a single workflow by ID, scoped to its community.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_workflow", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_workflow", system = "postgresql")]
     pub async fn get_workflow(
         &self,
         community_id: CommunityId,
@@ -3732,7 +3745,7 @@ impl Db {
     }
 
     /// List workflows for a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_channel_workflows", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_channel_workflows", system = "postgresql")]
     pub async fn list_channel_workflows(
         &self,
         community_id: CommunityId,
@@ -3744,7 +3757,7 @@ impl Db {
     }
 
     /// List active, enabled workflows for a channel.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_enabled_channel_workflows", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_enabled_channel_workflows", system = "postgresql")]
     pub async fn list_enabled_channel_workflows(
         &self,
         community_id: CommunityId,
@@ -3754,7 +3767,7 @@ impl Db {
     }
 
     /// List all active, enabled schedule-triggered workflows.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_all_enabled_workflows", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_all_enabled_workflows", system = "postgresql")]
     pub async fn list_all_enabled_workflows(&self) -> Result<Vec<workflow::WorkflowRecord>> {
         workflow::list_all_enabled_workflows(&self.pool).await
     }
@@ -3767,7 +3780,7 @@ impl Db {
     /// from the scheduler scan), never client-supplied — `workflows` is keyed
     /// `(community_id, id)`, so the claim must bind both to avoid fanning
     /// across communities that share the workflow UUID.
-    #[tracing::instrument(target = "buzz_datastore", name = "claim_scheduled_workflow_fire", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "claim_scheduled_workflow_fire", system = "postgresql")]
     pub async fn claim_scheduled_workflow_fire(
         &self,
         community_id: CommunityId,
@@ -3784,7 +3797,7 @@ impl Db {
     }
 
     /// Fetch the latest claimed schedule instant for interval trigger anchoring.
-    #[tracing::instrument(target = "buzz_datastore", name = "latest_scheduled_workflow_fire", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "latest_scheduled_workflow_fire", system = "postgresql")]
     pub async fn latest_scheduled_workflow_fire(
         &self,
         community_id: CommunityId,
@@ -3794,7 +3807,7 @@ impl Db {
     }
 
     /// Attach the workflow run id created from a won scheduled-fire claim.
-    #[tracing::instrument(target = "buzz_datastore", name = "attach_scheduled_workflow_run", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "attach_scheduled_workflow_run", system = "postgresql")]
     pub async fn attach_scheduled_workflow_run(
         &self,
         community_id: CommunityId,
@@ -3813,7 +3826,7 @@ impl Db {
     }
 
     /// Delete old scheduled workflow fire claims before a retention cutoff.
-    #[tracing::instrument(target = "buzz_datastore", name = "prune_scheduled_workflow_fires_before", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "prune_scheduled_workflow_fires_before", system = "postgresql")]
     pub async fn prune_scheduled_workflow_fires_before(
         &self,
         older_than: chrono::DateTime<chrono::Utc>,
@@ -3822,7 +3835,7 @@ impl Db {
     }
 
     /// Update a workflow's name, definition, and hash.
-    #[tracing::instrument(target = "buzz_datastore", name = "update_workflow", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "update_workflow", system = "postgresql")]
     pub async fn update_workflow(
         &self,
         community_id: CommunityId,
@@ -3843,7 +3856,7 @@ impl Db {
     }
 
     /// Update a workflow's status.
-    #[tracing::instrument(target = "buzz_datastore", name = "update_workflow_status", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "update_workflow_status", system = "postgresql")]
     pub async fn update_workflow_status(
         &self,
         community_id: CommunityId,
@@ -3854,7 +3867,7 @@ impl Db {
     }
 
     /// Enable or disable a workflow.
-    #[tracing::instrument(target = "buzz_datastore", name = "set_workflow_enabled", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "set_workflow_enabled", system = "postgresql")]
     pub async fn set_workflow_enabled(
         &self,
         community_id: CommunityId,
@@ -3866,6 +3879,7 @@ impl Db {
 
     /// Disable all of an owner's workflows in a channel (SEC-006, on
     /// membership loss). Returns the number of workflows disabled.
+    #[datastore_span(name = "disable_workflows_for_owner_in_channel", system = "postgresql")]
     pub async fn disable_workflows_for_owner_in_channel(
         &self,
         community_id: CommunityId,
@@ -3882,14 +3896,14 @@ impl Db {
     }
 
     /// Delete a workflow and all its runs/approvals.
-    #[tracing::instrument(target = "buzz_datastore", name = "delete_workflow", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "delete_workflow", system = "postgresql")]
     pub async fn delete_workflow(&self, community_id: CommunityId, id: Uuid) -> Result<()> {
         workflow::delete_workflow(&self.pool, community_id, id).await
     }
 
     /// Delete a workflow only when it belongs to the provided owner.
     /// Returns the deleted workflow's `channel_id`.
-    #[tracing::instrument(target = "buzz_datastore", name = "delete_workflow_for_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "delete_workflow_for_owner", system = "postgresql")]
     pub async fn delete_workflow_for_owner(
         &self,
         community_id: CommunityId,
@@ -3901,7 +3915,7 @@ impl Db {
 
     /// Find a workflow by owner pubkey and name within a community. Used for
     /// NIP-09 a-tag deletion where the d-tag is the workflow name (not UUID).
-    #[tracing::instrument(target = "buzz_datastore", name = "find_workflow_by_owner_and_name", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "find_workflow_by_owner_and_name", system = "postgresql")]
     pub async fn find_workflow_by_owner_and_name(
         &self,
         community_id: CommunityId,
@@ -3912,7 +3926,7 @@ impl Db {
     }
 
     /// Create a new workflow run.
-    #[tracing::instrument(target = "buzz_datastore", name = "create_workflow_run", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "create_workflow_run", system = "postgresql")]
     pub async fn create_workflow_run(
         &self,
         community_id: CommunityId,
@@ -3931,7 +3945,7 @@ impl Db {
     }
 
     /// Fetch a single workflow run, scoped to its community.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_workflow_run", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_workflow_run", system = "postgresql")]
     pub async fn get_workflow_run(
         &self,
         community_id: CommunityId,
@@ -3941,7 +3955,7 @@ impl Db {
     }
 
     /// List runs for a workflow.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_workflow_runs", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_workflow_runs", system = "postgresql")]
     pub async fn list_workflow_runs(
         &self,
         community_id: CommunityId,
@@ -3952,7 +3966,7 @@ impl Db {
     }
 
     /// Update a workflow run's status.
-    #[tracing::instrument(target = "buzz_datastore", name = "update_workflow_run", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "update_workflow_run", system = "postgresql")]
     pub async fn update_workflow_run(
         &self,
         community_id: CommunityId,
@@ -3975,13 +3989,13 @@ impl Db {
     }
 
     /// Create an approval request.
-    #[tracing::instrument(target = "buzz_datastore", name = "create_approval", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "create_approval", system = "postgresql")]
     pub async fn create_approval(&self, params: workflow::CreateApprovalParams<'_>) -> Result<()> {
         workflow::create_approval(&self.pool, params).await
     }
 
     /// Fetch an approval by raw token.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_approval", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_approval", system = "postgresql")]
     pub async fn get_approval(
         &self,
         community_id: CommunityId,
@@ -3991,7 +4005,7 @@ impl Db {
     }
 
     /// Fetch an approval by its already-hashed token (no re-hashing).
-    #[tracing::instrument(target = "buzz_datastore", name = "get_approval_by_stored_hash", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_approval_by_stored_hash", system = "postgresql")]
     pub async fn get_approval_by_stored_hash(
         &self,
         community_id: CommunityId,
@@ -4001,7 +4015,7 @@ impl Db {
     }
 
     /// Fetch all approvals for a workflow run.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_run_approvals", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_run_approvals", system = "postgresql")]
     pub async fn get_run_approvals(
         &self,
         community_id: CommunityId,
@@ -4012,7 +4026,7 @@ impl Db {
     }
 
     /// Update an approval's status.
-    #[tracing::instrument(target = "buzz_datastore", name = "update_approval", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "update_approval", system = "postgresql")]
     pub async fn update_approval(
         &self,
         community_id: CommunityId,
@@ -4033,7 +4047,7 @@ impl Db {
     }
 
     /// Update an approval by its already-hashed token (no re-hashing).
-    #[tracing::instrument(target = "buzz_datastore", name = "update_approval_by_stored_hash", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "update_approval_by_stored_hash", system = "postgresql")]
     pub async fn update_approval_by_stored_hash(
         &self,
         community_id: CommunityId,
@@ -4054,7 +4068,7 @@ impl Db {
     }
 
     /// Ensures monthly partitions exist for the next N months.
-    #[tracing::instrument(target = "buzz_datastore", name = "ensure_future_partitions", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "ensure_future_partitions", system = "postgresql")]
     pub async fn ensure_future_partitions(&self, months_ahead: u32) -> Result<()> {
         partition::ensure_future_partitions(&self.pool, months_ahead).await
     }
@@ -4063,7 +4077,7 @@ impl Db {
     ///
     /// Idempotent — safe to call on every startup. No-ops when all rows are already populated.
     /// Runs a single UPDATE touching only NIP-33 rows with NULL d_tag.
-    #[tracing::instrument(target = "buzz_datastore", name = "backfill_d_tags", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "backfill_d_tags", system = "postgresql")]
     pub async fn backfill_d_tags(&self) -> Result<u64> {
         let result = sqlx::query(
             "UPDATE events \
@@ -4080,7 +4094,7 @@ impl Db {
     }
 
     /// Check if a pubkey is in the allowlist for `community`.
-    #[tracing::instrument(target = "buzz_datastore", name = "is_pubkey_allowed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "is_pubkey_allowed", system = "postgresql")]
     pub async fn is_pubkey_allowed(&self, community: CommunityId, pubkey: &[u8]) -> Result<bool> {
         let row = sqlx::query(
             "SELECT COUNT(*) as cnt FROM pubkey_allowlist WHERE community_id = $1 AND pubkey = $2",
@@ -4094,7 +4108,7 @@ impl Db {
     }
 
     /// Check if the community allowlist has any entries (i.e. is enforcement active).
-    #[tracing::instrument(target = "buzz_datastore", name = "has_allowlist_entries", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "has_allowlist_entries", system = "postgresql")]
     pub async fn has_allowlist_entries(&self, community: CommunityId) -> Result<bool> {
         let row =
             sqlx::query("SELECT COUNT(*) as cnt FROM pubkey_allowlist WHERE community_id = $1")
@@ -4106,7 +4120,7 @@ impl Db {
     }
 
     /// Add a pubkey to the community allowlist.
-    #[tracing::instrument(target = "buzz_datastore", name = "add_to_allowlist", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "add_to_allowlist", system = "postgresql")]
     pub async fn add_to_allowlist(
         &self,
         community: CommunityId,
@@ -4128,7 +4142,7 @@ impl Db {
     }
 
     /// Remove a pubkey from the community allowlist.
-    #[tracing::instrument(target = "buzz_datastore", name = "remove_from_allowlist", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "remove_from_allowlist", system = "postgresql")]
     pub async fn remove_from_allowlist(
         &self,
         community: CommunityId,
@@ -4144,7 +4158,7 @@ impl Db {
     }
 
     /// List all pubkeys in the community allowlist.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_allowlist", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_allowlist", system = "postgresql")]
     pub async fn list_allowlist(&self, community: CommunityId) -> Result<Vec<AllowlistEntry>> {
         let rows = sqlx::query(
             "SELECT pubkey, added_by, added_at, note FROM pubkey_allowlist WHERE community_id = $1 ORDER BY added_at DESC",
@@ -4173,7 +4187,7 @@ impl Db {
     /// `B`; everything else fails closed to the writer, exactly like
     /// [`Db::query_events_routed_bounded`]. Not precedent for routing other
     /// permission reads.
-    #[tracing::instrument(target = "buzz_datastore", name = "is_relay_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "is_relay_member", system = "postgresql")]
     pub async fn is_relay_member(&self, community: CommunityId, pubkey: &str) -> Result<bool> {
         let path = "relay_membership";
         match self.route_read(path, RoutePredicate::Bounded).await {
@@ -4197,7 +4211,7 @@ impl Db {
     }
 
     /// Returns the relay member record for `pubkey` in `community`, or `None` if not found.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_relay_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_relay_member", system = "postgresql")]
     pub async fn get_relay_member(
         &self,
         community: CommunityId,
@@ -4207,7 +4221,7 @@ impl Db {
     }
 
     /// Returns all relay members of `community` ordered by `created_at` ascending.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_relay_members", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_relay_members", system = "postgresql")]
     pub async fn list_relay_members(
         &self,
         community: CommunityId,
@@ -4219,7 +4233,7 @@ impl Db {
     ///
     /// Returns `true` if the row was actually inserted, `false` if the pubkey
     /// already existed in `community` (idempotent — `ON CONFLICT DO NOTHING`).
-    #[tracing::instrument(target = "buzz_datastore", name = "add_relay_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "add_relay_member", system = "postgresql")]
     pub async fn add_relay_member(
         &self,
         community: CommunityId,
@@ -4232,7 +4246,7 @@ impl Db {
 
     /// Claims relay membership via an invite and atomically persists the
     /// accepted policy version when a policy is configured.
-    #[tracing::instrument(target = "buzz_datastore", name = "claim_relay_membership", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "claim_relay_membership", system = "postgresql")]
     pub async fn claim_relay_membership(
         &self,
         community: CommunityId,
@@ -4245,7 +4259,7 @@ impl Db {
     }
 
     /// Returns whether a member has persisted acceptance evidence for a policy version.
-    #[tracing::instrument(target = "buzz_datastore", name = "has_join_policy_acceptance", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "has_join_policy_acceptance", system = "postgresql")]
     pub async fn has_join_policy_acceptance(
         &self,
         community: CommunityId,
@@ -4257,7 +4271,7 @@ impl Db {
     }
 
     /// Removes a relay member from `community` atomically, refusing to delete the owner.
-    #[tracing::instrument(target = "buzz_datastore", name = "remove_relay_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "remove_relay_member", system = "postgresql")]
     pub async fn remove_relay_member(
         &self,
         community: CommunityId,
@@ -4270,7 +4284,7 @@ impl Db {
     ///
     /// Atomic conditional delete — eliminates the TOCTOU race between a
     /// prior role read and the delete. See [`relay_members::remove_relay_member_if_role`].
-    #[tracing::instrument(target = "buzz_datastore", name = "remove_relay_member_if_role", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "remove_relay_member_if_role", system = "postgresql")]
     pub async fn remove_relay_member_if_role(
         &self,
         community: CommunityId,
@@ -4282,7 +4296,7 @@ impl Db {
     }
 
     /// Updates the role of an existing relay member in `community`. Returns `true` if updated.
-    #[tracing::instrument(target = "buzz_datastore", name = "update_relay_member_role", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "update_relay_member_role", system = "postgresql")]
     pub async fn update_relay_member_role(
         &self,
         community: CommunityId,
@@ -4293,7 +4307,7 @@ impl Db {
     }
 
     /// Ensures the owner pubkey exists with role `"owner"` in `community`. Called at startup.
-    #[tracing::instrument(target = "buzz_datastore", name = "bootstrap_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "bootstrap_owner", system = "postgresql")]
     pub async fn bootstrap_owner(&self, community: CommunityId, owner_pubkey: &str) -> Result<()> {
         relay_members::bootstrap_owner(&self.pool, community, owner_pubkey).await
     }
@@ -4308,7 +4322,7 @@ impl Db {
     /// demoting the previous owner(s) to `member`. Verifies
     /// `expected_owner_pubkey` matches the current owner inside the same
     /// transaction to prevent stale-owner races.
-    #[tracing::instrument(target = "buzz_datastore", name = "transfer_ownership", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "transfer_ownership", system = "postgresql")]
     pub async fn transfer_ownership(
         &self,
         community: CommunityId,
@@ -4328,7 +4342,7 @@ impl Db {
     ///
     /// Idempotent — uses `ON CONFLICT DO NOTHING`. Returns the number of rows
     /// inserted, or 0 if the `pubkey_allowlist` table doesn't exist.
-    #[tracing::instrument(target = "buzz_datastore", name = "backfill_from_allowlist", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "backfill_from_allowlist", system = "postgresql")]
     pub async fn backfill_from_allowlist(&self, community: CommunityId) -> Result<u64> {
         relay_members::backfill_from_allowlist(&self.pool, community).await
     }
@@ -4338,6 +4352,7 @@ impl Db {
     ///
     /// `max_uses` is `None` for unlimited or `Some(1..=10000)`.
     /// `ttl_secs` must be in the shared invite lifetime range.
+    #[datastore_span(name = "mint_relay_invite", system = "postgresql")]
     pub async fn mint_relay_invite(
         &self,
         community: CommunityId,
@@ -4349,6 +4364,7 @@ impl Db {
     }
 
     /// Delete one bounded batch of invites expired before `cutoff`.
+    #[datastore_span(name = "reap_expired_relay_invites", system = "postgresql")]
     pub async fn reap_expired_relay_invites(
         &self,
         cutoff: chrono::DateTime<chrono::Utc>,
@@ -4361,6 +4377,7 @@ impl Db {
     /// transaction with `FOR UPDATE` on the invite row.
     ///
     /// `token_hash` is the SHA-256 of the presented v2 code (32 bytes).
+    #[datastore_span(name = "claim_relay_invite", system = "postgresql")]
     pub async fn claim_relay_invite(
         &self,
         community: CommunityId,
@@ -4379,7 +4396,7 @@ impl Db {
     }
 
     /// Sidecar an accepted product-feedback event, idempotent by event id.
-    #[tracing::instrument(target = "buzz_datastore", name = "insert_product_feedback", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "insert_product_feedback", system = "postgresql")]
     pub async fn insert_product_feedback(
         &self,
         community: CommunityId,
@@ -4389,7 +4406,7 @@ impl Db {
     }
 
     /// List product feedback across the deployment, newest first.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_product_feedback", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_product_feedback", system = "postgresql")]
     pub async fn list_product_feedback(
         &self,
         limit: i64,
@@ -4398,7 +4415,7 @@ impl Db {
     }
 
     /// Insert a tenant-scoped NIP-56 report row, idempotent by report event id.
-    #[tracing::instrument(target = "buzz_datastore", name = "insert_moderation_report", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "insert_moderation_report", system = "postgresql")]
     pub async fn insert_moderation_report(
         &self,
         community: CommunityId,
@@ -4408,7 +4425,7 @@ impl Db {
     }
 
     /// List moderation reports for a community, newest first.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_moderation_reports", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_moderation_reports", system = "postgresql")]
     pub async fn list_moderation_reports(
         &self,
         community: CommunityId,
@@ -4419,7 +4436,7 @@ impl Db {
     }
 
     /// Fetch one moderation report by row id.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_moderation_report", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_moderation_report", system = "postgresql")]
     pub async fn get_moderation_report(
         &self,
         community: CommunityId,
@@ -4429,7 +4446,7 @@ impl Db {
     }
 
     /// Fetch one moderation report by signed NIP-56 report event id.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_moderation_report_by_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_moderation_report_by_event", system = "postgresql")]
     pub async fn get_moderation_report_by_event(
         &self,
         community: CommunityId,
@@ -4439,7 +4456,7 @@ impl Db {
     }
 
     /// Resolve, dismiss, or escalate an open moderation report.
-    #[tracing::instrument(target = "buzz_datastore", name = "resolve_moderation_report", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "resolve_moderation_report", system = "postgresql")]
     pub async fn resolve_moderation_report(
         &self,
         community: CommunityId,
@@ -4460,7 +4477,7 @@ impl Db {
     }
 
     /// Upsert a community ban for a member pubkey.
-    #[tracing::instrument(target = "buzz_datastore", name = "ban_community_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "ban_community_member", system = "postgresql")]
     pub async fn ban_community_member(
         &self,
         community: CommunityId,
@@ -4473,7 +4490,7 @@ impl Db {
     }
 
     /// Lift a community ban for a member pubkey.
-    #[tracing::instrument(target = "buzz_datastore", name = "unban_community_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "unban_community_member", system = "postgresql")]
     pub async fn unban_community_member(
         &self,
         community: CommunityId,
@@ -4484,7 +4501,7 @@ impl Db {
     }
 
     /// Upsert a community timeout/write-block for a member pubkey.
-    #[tracing::instrument(target = "buzz_datastore", name = "timeout_community_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "timeout_community_member", system = "postgresql")]
     pub async fn timeout_community_member(
         &self,
         community: CommunityId,
@@ -4497,7 +4514,7 @@ impl Db {
     }
 
     /// Clear a community timeout/write-block for a member pubkey.
-    #[tracing::instrument(target = "buzz_datastore", name = "untimeout_community_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "untimeout_community_member", system = "postgresql")]
     pub async fn untimeout_community_member(
         &self,
         community: CommunityId,
@@ -4508,7 +4525,7 @@ impl Db {
     }
 
     /// Fetch the active ban/timeout restriction state for enforcement hot paths.
-    #[tracing::instrument(target = "buzz_datastore", name = "moderation_restriction_state", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "moderation_restriction_state", system = "postgresql")]
     pub async fn moderation_restriction_state(
         &self,
         community: CommunityId,
@@ -4518,7 +4535,7 @@ impl Db {
     }
 
     /// Fetch the full ban/timeout row for a member pubkey.
-    #[tracing::instrument(target = "buzz_datastore", name = "get_community_ban", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "get_community_ban", system = "postgresql")]
     pub async fn get_community_ban(
         &self,
         community: CommunityId,
@@ -4528,7 +4545,7 @@ impl Db {
     }
 
     /// List currently restricted members in a community.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_community_restrictions", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_community_restrictions", system = "postgresql")]
     pub async fn list_community_restrictions(
         &self,
         community: CommunityId,
@@ -4537,7 +4554,7 @@ impl Db {
     }
 
     /// Insert a moderation audit action row.
-    #[tracing::instrument(target = "buzz_datastore", name = "insert_moderation_action", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "insert_moderation_action", system = "postgresql")]
     pub async fn insert_moderation_action(
         &self,
         community: CommunityId,
@@ -4547,7 +4564,7 @@ impl Db {
     }
 
     /// List moderation audit action rows, newest first.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_moderation_actions", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_moderation_actions", system = "postgresql")]
     pub async fn list_moderation_actions(
         &self,
         community: CommunityId,
@@ -4558,7 +4575,7 @@ impl Db {
 
     /// Return the current owner of git repo name `repo_id` in `community`, or
     /// `None` if unreserved. See [`git_repo::repo_name_owner`].
-    #[tracing::instrument(target = "buzz_datastore", name = "repo_name_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "repo_name_owner", system = "postgresql")]
     pub async fn repo_name_owner(
         &self,
         community: CommunityId,
@@ -4571,7 +4588,7 @@ impl Db {
     ///
     /// See [`git_repo::reserve_repo_name`] for the outcome semantics. The
     /// per-pubkey quota is enforced by the caller against `count_repos_for_owner`.
-    #[tracing::instrument(target = "buzz_datastore", name = "reserve_repo_name", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "reserve_repo_name", system = "postgresql")]
     pub async fn reserve_repo_name(
         &self,
         community: CommunityId,
@@ -4582,7 +4599,7 @@ impl Db {
     }
 
     /// Count git repos reserved by `owner_pubkey` in `community` (quota check).
-    #[tracing::instrument(target = "buzz_datastore", name = "count_repos_for_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "count_repos_for_owner", system = "postgresql")]
     pub async fn count_repos_for_owner(
         &self,
         community: CommunityId,
@@ -4594,7 +4611,7 @@ impl Db {
     /// Release a git repo name reservation held by `owner_pubkey` (rollback).
     ///
     /// Returns the number of rows removed (0 or 1). See [`git_repo::release_repo_name`].
-    #[tracing::instrument(target = "buzz_datastore", name = "release_repo_name", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "release_repo_name", system = "postgresql")]
     pub async fn release_repo_name(
         &self,
         community: CommunityId,
@@ -4605,14 +4622,14 @@ impl Db {
     }
 
     /// Returns `true` if `pubkey` (64-char hex) is archived in `community_id`.
-    #[tracing::instrument(target = "buzz_datastore", name = "is_archived", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "is_archived", system = "postgresql")]
     pub async fn is_archived(&self, community_id: CommunityId, pubkey: &str) -> Result<bool> {
         archived_identities::is_archived(&self.pool, community_id, pubkey).await
     }
 
     /// Archives an identity in `community_id`. Returns `true` if inserted, `false` if already archived.
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(target = "buzz_datastore", name = "archive", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "archive", system = "postgresql")]
     pub async fn archive(
         &self,
         community_id: CommunityId,
@@ -4637,13 +4654,13 @@ impl Db {
     }
 
     /// Unarchives an identity from `community_id`. Returns `true` if deleted, `false` if absent.
-    #[tracing::instrument(target = "buzz_datastore", name = "unarchive", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "unarchive", system = "postgresql")]
     pub async fn unarchive(&self, community_id: CommunityId, pubkey: &str) -> Result<bool> {
         archived_identities::unarchive(&self.pool, community_id, pubkey).await
     }
 
     /// Returns all identities archived in `community_id`, ordered by archive time ascending.
-    #[tracing::instrument(target = "buzz_datastore", name = "list_archived", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "list_archived", system = "postgresql")]
     pub async fn list_archived(
         &self,
         community_id: CommunityId,
@@ -4652,7 +4669,7 @@ impl Db {
     }
 
     /// Soft-delete NIP-29 discovery events for a channel created by a specific relay pubkey.
-    #[tracing::instrument(target = "buzz_datastore", name = "soft_delete_discovery_events", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "soft_delete_discovery_events", system = "postgresql")]
     pub async fn soft_delete_discovery_events(
         &self,
         community_id: CommunityId,
@@ -4678,7 +4695,7 @@ impl Db {
     /// Same-second ties are broken by lowest event `id` (NIP-16 deterministic ordering).
     /// Returns `(event, false)` for stale writes and duplicate IDs — callers should
     /// skip fan-out/dispatch when `was_inserted` is false.
-    #[tracing::instrument(target = "buzz_datastore", name = "replace_addressable_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "replace_addressable_event", system = "postgresql")]
     pub async fn replace_addressable_event(
         &self,
         community_id: CommunityId,
@@ -4795,8 +4812,8 @@ impl Db {
 
         // Mentions are a denormalized index — safe outside the transaction.
         // insert_event() normally handles this, but we inlined the INSERT above.
-        if let Err(_e) = crate::insert_mentions(&self.pool, community_id, event, channel_id).await {
-            tracing::warn!("mention insertion failed");
+        if let Err(e) = crate::insert_mentions(&self.pool, community_id, event, channel_id).await {
+            tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
         }
 
         Ok((
@@ -4811,6 +4828,10 @@ impl Db {
     /// Snapshot and canonical rows are compared directly rather than by
     /// timestamp: relay membership events use whole-second Nostr timestamps,
     /// and multiple mutations within one second must still be repaired.
+    #[datastore_span(
+        name = "nip43_membership_snapshot_needs_reconciliation",
+        system = "postgresql"
+    )]
     pub async fn nip43_membership_snapshot_needs_reconciliation(
         &self,
         community_id: CommunityId,
@@ -4861,7 +4882,7 @@ impl Db {
     /// prevents the stale-snapshot race where a concurrent publication reads
     /// older state and overwrites a newer snapshot by arrival order.
     ///
-    #[tracing::instrument(target = "buzz_datastore", name = "publish_nip43_membership_locked", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "publish_nip43_membership_locked", system = "postgresql")]
     pub async fn publish_nip43_membership_locked(
         &self,
         community_id: CommunityId,
@@ -4970,8 +4991,8 @@ impl Db {
 
         tx.commit().await?;
 
-        if let Err(_e) = crate::insert_mentions(&self.pool, community_id, &event, None).await {
-            tracing::warn!("mention insertion failed");
+        if let Err(e) = crate::insert_mentions(&self.pool, community_id, &event, None).await {
+            tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
         }
 
         Ok((
@@ -5002,7 +5023,7 @@ impl Db {
     /// relay-signed NIP-29 group metadata (kind 39000–39002) where the relay is the
     /// author and channel_id distinguishes groups. User-submitted NIP-33 events use
     /// this function instead, where the author's pubkey + d-tag is the natural key.
-    #[tracing::instrument(target = "buzz_datastore", name = "replace_parameterized_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+    #[datastore_span(name = "replace_parameterized_event", system = "postgresql")]
     pub async fn replace_parameterized_event(
         &self,
         community_id: CommunityId,
@@ -5208,8 +5229,8 @@ impl Db {
         tx.commit().await?;
 
         // Mentions are a denormalized index — safe outside the transaction.
-        if let Err(_e) = crate::insert_mentions(&self.pool, community_id, event, channel_id).await {
-            tracing::warn!("mention insertion failed");
+        if let Err(e) = crate::insert_mentions(&self.pool, community_id, event, channel_id).await {
+            tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
         }
 
         Ok((

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -130,11 +130,7 @@ pub async fn insert_mentions(
         .into_iter()
         .filter(|pk| {
             if pk.len() != 64 || !pk.chars().all(|c| c.is_ascii_hexdigit()) {
-                tracing::debug!(
-                    event_id = %event.id,
-                    invalid_ptag = pk,
-                    "skipping malformed p-tag in insert_mentions"
-                );
+                tracing::debug!("skipping malformed p-tag in insert_mentions");
                 false
             } else {
                 true
@@ -252,6 +248,7 @@ impl ReadSession {
     /// the degraded follow-up can only observe *more* than the proof-time
     /// snapshot, never less — fresher aux rows, the same failure semantics
     /// as a request that routed to the writer to begin with.
+    #[tracing::instrument(target = "buzz_datastore", name = "read_session_query_events", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn query_events(&mut self, q: &EventQuery) -> Result<Vec<StoredEvent>> {
         let degraded = match &mut self.inner {
             ReadSessionInner::Replica { tx, writer } => {
@@ -491,6 +488,7 @@ impl UsageMetricsLeader {
     ///
     /// Bounded to 5 seconds — a blackholed connection (no RST) would otherwise
     /// stall the entire poller tick until the OS TCP timeout.
+    #[tracing::instrument(target = "buzz_datastore", name = "usage_metrics_leader_is_live", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn is_live(&mut self) -> bool {
         tokio::time::timeout(std::time::Duration::from_secs(5), self.connection.ping())
             .await
@@ -1009,6 +1007,7 @@ impl Db {
     }
 
     /// Run pending database migrations.
+    #[tracing::instrument(target = "buzz_datastore", name = "migrate", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn migrate(&self) -> Result<()> {
         migration::run_migrations(&self.pool).await
     }
@@ -1053,6 +1052,7 @@ impl Db {
     /// detached from the shared pool so a stable leader neither returns a locked
     /// session to other callers nor permanently consumes a pool slot. Dropping the
     /// guard closes the connection and releases the session-scoped lock.
+    #[tracing::instrument(target = "buzz_datastore", name = "try_lock_usage_metrics", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn try_lock_usage_metrics(
         &self,
         lock_key: i64,
@@ -1073,6 +1073,7 @@ impl Db {
 
     /// List reports for the deployment-global read-only admin plane.
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(target = "buzz_datastore", name = "admin_list_reports", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn admin_list_reports(
         &self,
         community_id: Option<Uuid>,
@@ -1099,6 +1100,7 @@ impl Db {
     }
 
     /// Fetch one report for the deployment-global read-only admin plane.
+    #[tracing::instrument(target = "buzz_datastore", name = "admin_get_report", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn admin_get_report(
         &self,
         id: Uuid,
@@ -1107,6 +1109,7 @@ impl Db {
     }
 
     /// List feedback for the deployment-global read-only admin plane.
+    #[tracing::instrument(target = "buzz_datastore", name = "admin_list_feedback", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn admin_list_feedback(
         &self,
         limit: i64,
@@ -1115,6 +1118,7 @@ impl Db {
     }
 
     /// Fetch one feedback submission for the deployment-global admin plane.
+    #[tracing::instrument(target = "buzz_datastore", name = "admin_get_feedback", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn admin_get_feedback(
         &self,
         id: Uuid,
@@ -1123,36 +1127,43 @@ impl Db {
     }
 
     /// Return total number of communities on this relay.
+    #[tracing::instrument(target = "buzz_datastore", name = "usage_community_count", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn usage_community_count(&self) -> Result<i64> {
         usage::community_count(&self.pool).await
     }
 
     /// Return per-community user counts split by human/agent.
+    #[tracing::instrument(target = "buzz_datastore", name = "usage_user_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn usage_user_counts(&self) -> Result<Vec<usage::CommunityUserCounts>> {
         usage::user_counts(&self.pool).await
     }
 
     /// Return per-community channel counts by type.
+    #[tracing::instrument(target = "buzz_datastore", name = "usage_channel_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn usage_channel_counts(&self) -> Result<Vec<usage::CommunityChannelCount>> {
         usage::channel_counts(&self.pool).await
     }
 
     /// Return per-community kind=9 message counts.
+    #[tracing::instrument(target = "buzz_datastore", name = "usage_message_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn usage_message_counts(&self) -> Result<Vec<usage::CommunityMessageCount>> {
         usage::message_counts(&self.pool).await
     }
 
     /// Return per-community relay-member counts by role.
+    #[tracing::instrument(target = "buzz_datastore", name = "usage_relay_member_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn usage_relay_member_counts(&self) -> Result<Vec<usage::CommunityMemberCount>> {
         usage::relay_member_counts(&self.pool).await
     }
 
     /// Return per-community workflow counts by status.
+    #[tracing::instrument(target = "buzz_datastore", name = "usage_workflow_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn usage_workflow_counts(&self) -> Result<Vec<usage::CommunityWorkflowCount>> {
         usage::workflow_counts(&self.pool).await
     }
 
     /// Return per-community git-repo counts.
+    #[tracing::instrument(target = "buzz_datastore", name = "usage_git_repo_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn usage_git_repo_counts(&self) -> Result<Vec<usage::CommunityGitRepoCount>> {
         usage::git_repo_counts(&self.pool).await
     }
@@ -1160,6 +1171,7 @@ impl Db {
     /// Return per-community distinct active-user counts for a given SQL interval.
     ///
     /// `interval_sql` must be a trusted literal such as `"1 day"` or `"7 days"`.
+    #[tracing::instrument(target = "buzz_datastore", name = "usage_active_user_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn usage_active_user_counts(
         &self,
         interval_sql: &'static str,
@@ -1168,6 +1180,7 @@ impl Db {
     }
 
     /// Return per-community active-channel counts for a given SQL interval.
+    #[tracing::instrument(target = "buzz_datastore", name = "usage_active_channel_counts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn usage_active_channel_counts(
         &self,
         interval_sql: &'static str,
@@ -1176,6 +1189,7 @@ impl Db {
     }
 
     /// Return all community id → host mappings.
+    #[tracing::instrument(target = "buzz_datastore", name = "usage_community_hosts", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn usage_community_hosts(&self) -> Result<Vec<usage::CommunityHost>> {
         usage::community_hosts(&self.pool).await
     }
@@ -1192,6 +1206,7 @@ impl Db {
     ///
     /// The caller owns host normalization and turns `None` into the fail-closed
     /// request/connection error. buzz-db only reads the durable host map.
+    #[tracing::instrument(target = "buzz_datastore", name = "lookup_community_by_host", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn lookup_community_by_host(
         &self,
         normalized_host: &str,
@@ -1221,6 +1236,7 @@ impl Db {
     }
 
     /// Returns whether a community id still exists in the active lifecycle state.
+    #[tracing::instrument(target = "buzz_datastore", name = "is_community_active", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn is_community_active(&self, community_id: CommunityId) -> Result<bool> {
         let active = sqlx::query_scalar::<_, bool>(
             "SELECT EXISTS(SELECT 1 FROM communities WHERE id = $1 AND archived_at IS NULL)",
@@ -1232,6 +1248,7 @@ impl Db {
     }
 
     /// Returns a community by host regardless of lifecycle state. Operator-plane only.
+    #[tracing::instrument(target = "buzz_datastore", name = "lookup_community_by_host_for_management", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn lookup_community_by_host_for_management(
         &self,
         normalized_host: &str,
@@ -1253,6 +1270,7 @@ impl Db {
     ///
     /// This is an operator-plane helper, not a tenant-scoped data-plane read:
     /// callers must gate it on deployment-level operator auth before exposing it.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_communities_owned_by", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_communities_owned_by(
         &self,
         owner_pubkey: &str,
@@ -1298,6 +1316,7 @@ impl Db {
     /// fan out under *that* community rather than the deployment default. The
     /// community is authoritative; the host is read back for labelling only and
     /// is never used to re-derive the community.
+    #[tracing::instrument(target = "buzz_datastore", name = "lookup_community_host", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn lookup_community_host(&self, community_id: CommunityId) -> Result<Option<String>> {
         let row = sqlx::query(
             r#"
@@ -1322,6 +1341,7 @@ impl Db {
     ///
     /// Set by relay admins/owners via the kind:9033 command; the value is
     /// validated and size-capped at that write path.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_community_icon", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_community_icon(&self, community_id: CommunityId) -> Result<Option<String>> {
         let row = sqlx::query(
             r#"
@@ -1342,6 +1362,7 @@ impl Db {
     }
 
     /// Sets or clears (`None`) the community's workspace icon.
+    #[tracing::instrument(target = "buzz_datastore", name = "set_community_icon", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn set_community_icon(
         &self,
         community_id: CommunityId,
@@ -1366,6 +1387,7 @@ impl Db {
     /// This is the startup/config seeding path for N=1 deployments. Migrations
     /// create the schema only; deployment-specific hosts are not hardcoded into
     /// schema history.
+    #[tracing::instrument(target = "buzz_datastore", name = "ensure_configured_community", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn ensure_configured_community(
         &self,
         normalized_host: &str,
@@ -1398,6 +1420,7 @@ impl Db {
     /// Holds a per-owner advisory lock while enforcing the ownership limit.
     /// Identical create retries return the original record; host collisions and
     /// limit failures remain distinguishable to the operator API.
+    #[tracing::instrument(target = "buzz_datastore", name = "create_community_with_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn create_community_with_owner(
         &self,
         normalized_host: &str,
@@ -1483,6 +1506,7 @@ impl Db {
     }
 
     /// Idempotently archives a community when the asserted pubkey is its current owner.
+    #[tracing::instrument(target = "buzz_datastore", name = "archive_community_owned_by", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn archive_community_owned_by(
         &self,
         normalized_host: &str,
@@ -1516,6 +1540,7 @@ impl Db {
     }
 
     /// Idempotently restores a community when the asserted pubkey is its current owner.
+    #[tracing::instrument(target = "buzz_datastore", name = "unarchive_community_owned_by", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn unarchive_community_owned_by(
         &self,
         normalized_host: &str,
@@ -1548,6 +1573,7 @@ impl Db {
     ///
     /// Internal relay producers use this to derive tenant context from the row
     /// they are acting on, rather than falling back to an implicit default.
+    #[tracing::instrument(target = "buzz_datastore", name = "community_of_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn community_of_channel(&self, channel_id: Uuid) -> Result<Option<CommunityId>> {
         let row = sqlx::query(
             r#"
@@ -1586,6 +1612,7 @@ impl Db {
     /// are intentionally not present rather than mapped to a default —
     /// callers MUST treat "channel-id not in map" as a coverage breach,
     /// never as "use the resolved community".
+    #[tracing::instrument(target = "buzz_datastore", name = "communities_of_channels", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn communities_of_channels(
         &self,
         channel_ids: &[Uuid],
@@ -1615,6 +1642,7 @@ impl Db {
     }
 
     /// Inserts an event. Returns `(StoredEvent, was_inserted)` — `false` on duplicate.
+    #[tracing::instrument(target = "buzz_datastore", name = "insert_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn insert_event(
         &self,
         community_id: CommunityId,
@@ -1623,8 +1651,8 @@ impl Db {
     ) -> Result<(StoredEvent, bool)> {
         let result = event::insert_event(&self.pool, community_id, event, channel_id).await?;
         if result.1 {
-            if let Err(e) = insert_mentions(&self.pool, community_id, event, channel_id).await {
-                tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
+            if let Err(_e) = insert_mentions(&self.pool, community_id, event, channel_id).await {
+                tracing::warn!("mention insertion failed");
             }
         }
         Ok(result)
@@ -1637,6 +1665,7 @@ impl Db {
     /// callers that tolerate bounded staleness should use
     /// [`Db::query_events_routed`] instead — converting a caller is an
     /// explicit, per-callsite decision, never a change to this method.
+    #[tracing::instrument(target = "buzz_datastore", name = "query_events", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn query_events(&self, q: &EventQuery) -> Result<Vec<StoredEvent>> {
         event::query_events(&self.pool, q).await
     }
@@ -1657,6 +1686,7 @@ impl Db {
     /// unset, even covered-eligible queries stay on the writer, so merging
     /// this seam is a true no-op until the budget is configured. Every
     /// failure fails closed to the writer.
+    #[tracing::instrument(target = "buzz_datastore", name = "query_events_routed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn query_events_routed(
         &self,
         path: &'static str,
@@ -1691,6 +1721,7 @@ impl Db {
     /// display page absorbs that per-row; a number derived from the rows
     /// does not. Same classification-table requirement as
     /// [`Db::query_events_routed`].
+    #[tracing::instrument(target = "buzz_datastore", name = "query_events_routed_bounded", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn query_events_routed_bounded(
         &self,
         path: &'static str,
@@ -1718,6 +1749,7 @@ impl Db {
     ///
     /// Always reads from the WRITER pool — see [`Db::query_events`] for the
     /// writer-vs-routed rule.
+    #[tracing::instrument(target = "buzz_datastore", name = "count_events", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn count_events(&self, q: &EventQuery) -> Result<i64> {
         event::count_events(&self.pool, q).await
     }
@@ -1732,6 +1764,7 @@ impl Db {
     /// inflated number for up to `FENCE_STALENESS` is a different product
     /// statement than a page briefly showing a deleted row. `Bounded` ties
     /// the error to the accepted budget `B`.
+    #[tracing::instrument(target = "buzz_datastore", name = "count_events_routed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn count_events_routed(&self, path: &'static str, q: &EventQuery) -> Result<i64> {
         match self.route_read(path, RoutePredicate::Bounded).await {
             RouteDecision::Replica(mut tx, _entry, reason) => {
@@ -1753,6 +1786,7 @@ impl Db {
 
     /// Return whether a creator-signed huddle-start event links a parent
     /// channel to an ephemeral huddle channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "huddle_started_link_exists", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn huddle_started_link_exists(
         &self,
         community_id: CommunityId,
@@ -1775,6 +1809,7 @@ impl Db {
     /// Uses canonical NIP-16 ordering: `created_at DESC, id ASC`.
     /// This matches the write path in [`replace_addressable_event`] and handles
     /// historical duplicate survivors correctly.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_latest_global_replaceable", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_latest_global_replaceable(
         &self,
         community_id: CommunityId,
@@ -1787,6 +1822,7 @@ impl Db {
     /// Fetches a single non-deleted event by its raw ID bytes.
     ///
     /// Returns `None` if the event does not exist or has been soft-deleted.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_event_by_id", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_event_by_id(
         &self,
         community_id: CommunityId,
@@ -1796,6 +1832,7 @@ impl Db {
     }
 
     /// Fetches a single event by its raw ID bytes, **including soft-deleted rows**.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_event_by_id_including_deleted", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_event_by_id_including_deleted(
         &self,
         community_id: CommunityId,
@@ -1805,6 +1842,7 @@ impl Db {
     }
 
     /// Soft-deletes an event. Returns `Ok(true)` if deleted, `Ok(false)` if already deleted.
+    #[tracing::instrument(target = "buzz_datastore", name = "soft_delete_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn soft_delete_event(
         &self,
         community_id: CommunityId,
@@ -1817,6 +1855,7 @@ impl Db {
     /// when it is not newer than the deletion request.
     /// Used by NIP-09 a-tag deletion for parameterized-replaceable kinds;
     /// `deletion_created_at_secs` is the deletion event's `created_at`.
+    #[tracing::instrument(target = "buzz_datastore", name = "soft_delete_by_coordinate", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn soft_delete_by_coordinate(
         &self,
         community_id: CommunityId,
@@ -1837,6 +1876,7 @@ impl Db {
     }
 
     /// Atomically soft-delete an event and decrement thread reply counters.
+    #[tracing::instrument(target = "buzz_datastore", name = "soft_delete_event_and_update_thread", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn soft_delete_event_and_update_thread(
         &self,
         community_id: CommunityId,
@@ -1855,6 +1895,7 @@ impl Db {
     }
 
     /// Returns the most recent `created_at` for a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_last_message_at", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_last_message_at(
         &self,
         community_id: CommunityId,
@@ -1864,6 +1905,7 @@ impl Db {
     }
 
     /// Bulk-fetch the most recent `created_at` for a set of channel IDs.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_last_message_at_bulk", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_last_message_at_bulk(
         &self,
         community_id: CommunityId,
@@ -1873,6 +1915,7 @@ impl Db {
     }
 
     /// Batch-fetch non-deleted events by their raw IDs.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_events_by_ids", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_events_by_ids(
         &self,
         community_id: CommunityId,
@@ -1888,6 +1931,7 @@ impl Db {
     /// channel pin, so no fence floor can prove insert-completeness — the
     /// covered arm is structurally unavailable. Used for FTS hit hydration,
     /// where a missing row degrades to a skipped search hit downstream.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_events_by_ids_routed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_events_by_ids_routed(
         &self,
         path: &'static str,
@@ -1913,6 +1957,7 @@ impl Db {
     }
 
     /// Exclusively claim a batch of due matcher jobs from one community.
+    #[tracing::instrument(target = "buzz_datastore", name = "claim_due_push_match_batch", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn claim_due_push_match_batch(
         &self,
         limit: i64,
@@ -1922,6 +1967,7 @@ impl Db {
     }
 
     /// Load active endpoint-enabled leases eligible for push matching.
+    #[tracing::instrument(target = "buzz_datastore", name = "active_push_match_leases", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn active_push_match_leases(
         &self,
         community: CommunityId,
@@ -1930,6 +1976,7 @@ impl Db {
     }
 
     /// Complete matcher jobs from one claimed batch while the fence holds.
+    #[tracing::instrument(target = "buzz_datastore", name = "complete_push_match_batch", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn complete_push_match_batch(
         &self,
         community: CommunityId,
@@ -1940,6 +1987,7 @@ impl Db {
     }
 
     /// Release fenced matcher claims from one batch for retry.
+    #[tracing::instrument(target = "buzz_datastore", name = "retry_push_match_batch", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn retry_push_match_batch(
         &self,
         community: CommunityId,
@@ -1951,11 +1999,13 @@ impl Db {
     }
 
     /// Delete exhausted matcher jobs (periodic sweep, off the claim path).
+    #[tracing::instrument(target = "buzz_datastore", name = "reap_exhausted_push_matches", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn reap_exhausted_push_matches(&self) -> Result<u64> {
         push::reap_exhausted_matches(&self.pool).await
     }
 
     /// Idempotently enqueue a wake for a matched lease and event.
+    #[tracing::instrument(target = "buzz_datastore", name = "enqueue_push_wake", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn enqueue_push_wake(
         &self,
         community: CommunityId,
@@ -1967,6 +2017,7 @@ impl Db {
     }
 
     /// Set-wise [`Self::enqueue_push_wake`]: one transaction per batch.
+    #[tracing::instrument(target = "buzz_datastore", name = "enqueue_push_wakes", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn enqueue_push_wakes(
         &self,
         community: CommunityId,
@@ -1976,6 +2027,7 @@ impl Db {
     }
 
     /// Exclusively claim due wake jobs for one community.
+    #[tracing::instrument(target = "buzz_datastore", name = "claim_due_push_wakes", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn claim_due_push_wakes(
         &self,
         community: CommunityId,
@@ -1986,6 +2038,7 @@ impl Db {
     }
 
     /// Revalidate a wake's claim, source event, and current lease before send.
+    #[tracing::instrument(target = "buzz_datastore", name = "revalidate_push_wake", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn revalidate_push_wake(
         &self,
         community: CommunityId,
@@ -1996,6 +2049,7 @@ impl Db {
     }
 
     /// Mark a fenced wake claim delivered.
+    #[tracing::instrument(target = "buzz_datastore", name = "complete_push_wake", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn complete_push_wake(
         &self,
         community: CommunityId,
@@ -2006,6 +2060,7 @@ impl Db {
     }
 
     /// Release a fenced wake claim for retry at the supplied time.
+    #[tracing::instrument(target = "buzz_datastore", name = "retry_push_wake", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn retry_push_wake(
         &self,
         community: CommunityId,
@@ -2017,6 +2072,7 @@ impl Db {
     }
 
     /// Mark a fenced wake claim terminally failed.
+    #[tracing::instrument(target = "buzz_datastore", name = "fail_push_wake", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn fail_push_wake(
         &self,
         community: CommunityId,
@@ -2027,6 +2083,7 @@ impl Db {
     }
 
     /// Disable an endpoint only if the specified lease generation is current.
+    #[tracing::instrument(target = "buzz_datastore", name = "disable_push_endpoint", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn disable_push_endpoint(
         &self,
         community: CommunityId,
@@ -2046,6 +2103,7 @@ impl Db {
 
     /// Atomically persist a validated kind:30350 event and its effective lease.
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(target = "buzz_datastore", name = "accept_push_lease_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn accept_push_lease_event(
         &self,
         community: CommunityId,
@@ -2068,6 +2126,7 @@ impl Db {
     }
 
     /// Atomically insert an event AND its thread metadata in a single transaction.
+    #[tracing::instrument(target = "buzz_datastore", name = "insert_event_with_thread_metadata", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn insert_event_with_thread_metadata(
         &self,
         community_id: CommunityId,
@@ -2084,8 +2143,8 @@ impl Db {
         )
         .await?;
         if result.1 {
-            if let Err(e) = insert_mentions(&self.pool, community_id, event, channel_id).await {
-                tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
+            if let Err(_e) = insert_mentions(&self.pool, community_id, event, channel_id).await {
+                tracing::warn!("mention insertion failed");
             }
         }
         Ok(result)
@@ -2093,6 +2152,7 @@ impl Db {
 
     /// Atomically insert a kind:7 reaction event and its reaction row.
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(target = "buzz_datastore", name = "insert_reaction_event_with_thread_metadata", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn insert_reaction_event_with_thread_metadata(
         &self,
         community_id: CommunityId,
@@ -2118,8 +2178,8 @@ impl Db {
             was_inserted: true, ..
         } = &outcome
         {
-            if let Err(e) = insert_mentions(&self.pool, community_id, event, channel_id).await {
-                tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
+            if let Err(_e) = insert_mentions(&self.pool, community_id, event, channel_id).await {
+                tracing::warn!("mention insertion failed");
             }
         }
         Ok(outcome)
@@ -2127,6 +2187,7 @@ impl Db {
 
     /// Creates a new channel, bootstraps the creator as owner, and returns the record.
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(target = "buzz_datastore", name = "create_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn create_channel(
         &self,
         community_id: CommunityId,
@@ -2154,6 +2215,7 @@ impl Db {
     ///
     /// Returns `(record, true)` if newly created, `(record, false)` if already exists.
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(target = "buzz_datastore", name = "create_channel_with_id", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn create_channel_with_id(
         &self,
         community_id: CommunityId,
@@ -2180,6 +2242,7 @@ impl Db {
     }
 
     /// Fetches a channel record by ID.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_channel(
         &self,
         community_id: CommunityId,
@@ -2189,6 +2252,7 @@ impl Db {
     }
 
     /// Returns the canvas content for a channel, if any.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_canvas", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_canvas(
         &self,
         community_id: CommunityId,
@@ -2198,6 +2262,7 @@ impl Db {
     }
 
     /// Sets or clears the canvas content for a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "set_canvas", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn set_canvas(
         &self,
         community_id: CommunityId,
@@ -2208,6 +2273,7 @@ impl Db {
     }
 
     /// Adds a member to a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "add_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn add_member(
         &self,
         community_id: CommunityId,
@@ -2228,6 +2294,7 @@ impl Db {
     }
 
     /// Removes a member from a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "remove_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn remove_member(
         &self,
         community_id: CommunityId,
@@ -2239,6 +2306,7 @@ impl Db {
     }
 
     /// Returns `true` if the pubkey is an active member.
+    #[tracing::instrument(target = "buzz_datastore", name = "is_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn is_member(
         &self,
         community_id: CommunityId,
@@ -2250,6 +2318,7 @@ impl Db {
 
     /// Return the active (channel, pubkey) membership pairs among the given
     /// sets, in one statement.
+    #[tracing::instrument(target = "buzz_datastore", name = "membership_pairs", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn membership_pairs(
         &self,
         community_id: CommunityId,
@@ -2260,6 +2329,7 @@ impl Db {
     }
 
     /// Returns all active members of a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_members", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_members(
         &self,
         community_id: CommunityId,
@@ -2269,6 +2339,7 @@ impl Db {
     }
 
     /// Returns active members for multiple channels in a single query.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_members_bulk", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_members_bulk(
         &self,
         community_id: CommunityId,
@@ -2278,6 +2349,7 @@ impl Db {
     }
 
     /// Get all channel IDs accessible to a pubkey.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_accessible_channel_ids", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_accessible_channel_ids(
         &self,
         community_id: CommunityId,
@@ -2287,6 +2359,7 @@ impl Db {
     }
 
     /// Lists channels, optionally filtered by visibility.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_channels", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_channels(
         &self,
         community_id: CommunityId,
@@ -2296,6 +2369,7 @@ impl Db {
     }
 
     /// Returns full channel records for all channels a user can access.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_accessible_channels", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_accessible_channels(
         &self,
         community_id: CommunityId,
@@ -2314,6 +2388,7 @@ impl Db {
     }
 
     /// Returns all bot-role members with their aggregated channel names in one community.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_bot_members", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_bot_members(
         &self,
         community_id: CommunityId,
@@ -2322,6 +2397,7 @@ impl Db {
     }
 
     /// Bulk-fetch user records by pubkey.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_users_bulk", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_users_bulk(
         &self,
         community_id: CommunityId,
@@ -2331,6 +2407,7 @@ impl Db {
     }
 
     /// Updates a channel's name and/or description.
+    #[tracing::instrument(target = "buzz_datastore", name = "update_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn update_channel(
         &self,
         community_id: CommunityId,
@@ -2341,6 +2418,7 @@ impl Db {
     }
 
     /// Sets the topic for a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "set_topic", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn set_topic(
         &self,
         community_id: CommunityId,
@@ -2352,6 +2430,7 @@ impl Db {
     }
 
     /// Sets the purpose for a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "set_purpose", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn set_purpose(
         &self,
         community_id: CommunityId,
@@ -2363,11 +2442,13 @@ impl Db {
     }
 
     /// Archives a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "archive_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn archive_channel(&self, community_id: CommunityId, channel_id: Uuid) -> Result<()> {
         channel::archive_channel(&self.pool, community_id, channel_id).await
     }
 
     /// Unarchives a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "unarchive_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn unarchive_channel(
         &self,
         community_id: CommunityId,
@@ -2377,6 +2458,7 @@ impl Db {
     }
 
     /// Soft-delete a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "soft_delete_channel", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn soft_delete_channel(
         &self,
         community_id: CommunityId,
@@ -2386,6 +2468,7 @@ impl Db {
     }
 
     /// Returns the count of active members in a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_member_count", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_member_count(
         &self,
         community_id: CommunityId,
@@ -2395,6 +2478,7 @@ impl Db {
     }
 
     /// Bulk-fetch member counts for a set of channel IDs.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_member_counts_bulk", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_member_counts_bulk(
         &self,
         community_id: CommunityId,
@@ -2404,6 +2488,7 @@ impl Db {
     }
 
     /// Get the active role of a pubkey in a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_member_role", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_member_role(
         &self,
         community_id: CommunityId,
@@ -2414,6 +2499,7 @@ impl Db {
     }
 
     /// Archive ephemeral channels whose TTL deadline has passed.
+    #[tracing::instrument(target = "buzz_datastore", name = "reap_expired_ephemeral_channels", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn reap_expired_ephemeral_channels(
         &self,
     ) -> Result<Vec<channel::ReapedEphemeralChannel>> {
@@ -2421,6 +2507,7 @@ impl Db {
     }
 
     /// Query due reminders ready for delivery.
+    #[tracing::instrument(target = "buzz_datastore", name = "query_due_reminders", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn query_due_reminders(
         &self,
         now_secs: i64,
@@ -2430,6 +2517,7 @@ impl Db {
     }
 
     /// Atomically claim a due reminder for delivery (cross-pod dedup).
+    #[tracing::instrument(target = "buzz_datastore", name = "claim_due_reminder", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn claim_due_reminder(
         &self,
         community_id: CommunityId,
@@ -2440,6 +2528,7 @@ impl Db {
     }
 
     /// Atomically claim a due reminder using a caller-supplied delivery stamp.
+    #[tracing::instrument(target = "buzz_datastore", name = "claim_due_reminder_with_stamp", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn claim_due_reminder_with_stamp(
         &self,
         community_id: CommunityId,
@@ -2458,6 +2547,7 @@ impl Db {
     }
 
     /// Release a claimed due reminder after a publish failure.
+    #[tracing::instrument(target = "buzz_datastore", name = "release_due_reminder", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn release_due_reminder(
         &self,
         community_id: CommunityId,
@@ -2480,11 +2570,13 @@ impl Db {
     /// Returns `true` if a new row was inserted (first time), `false` if it
     /// already existed. Callers use the `true` return to increment
     /// `buzz_users_created_total`.
+    #[tracing::instrument(target = "buzz_datastore", name = "ensure_user", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn ensure_user(&self, community_id: CommunityId, pubkey: &[u8]) -> Result<bool> {
         user::ensure_user(&self.pool, community_id, pubkey).await
     }
 
     /// Get a single user record by pubkey.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_user", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_user(
         &self,
         community_id: CommunityId,
@@ -2494,6 +2586,7 @@ impl Db {
     }
 
     /// Update a user's profile fields.
+    #[tracing::instrument(target = "buzz_datastore", name = "update_user_profile", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn update_user_profile(
         &self,
         community_id: CommunityId,
@@ -2516,6 +2609,7 @@ impl Db {
     }
 
     /// Look up a user by NIP-05 handle.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_user_by_nip05", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_user_by_nip05(
         &self,
         community_id: CommunityId,
@@ -2526,6 +2620,7 @@ impl Db {
     }
 
     /// Search users by display name, NIP-05 handle, or pubkey prefix.
+    #[tracing::instrument(target = "buzz_datastore", name = "search_users", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn search_users(
         &self,
         community_id: CommunityId,
@@ -2537,6 +2632,7 @@ impl Db {
 
     /// Atomically set agent owner — only if no owner is currently assigned.
     /// Returns Ok(true) if set, Ok(false) if an owner already exists.
+    #[tracing::instrument(target = "buzz_datastore", name = "set_agent_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn set_agent_owner(
         &self,
         community_id: CommunityId,
@@ -2547,6 +2643,7 @@ impl Db {
     }
 
     /// Get the channel_add_policy and agent_owner_pubkey for a user.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_agent_channel_policy", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_agent_channel_policy(
         &self,
         community_id: CommunityId,
@@ -2556,6 +2653,7 @@ impl Db {
     }
 
     /// Check whether `actor_pubkey` is the agent owner of `target_pubkey`.
+    #[tracing::instrument(target = "buzz_datastore", name = "is_agent_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn is_agent_owner(
         &self,
         community_id: CommunityId,
@@ -2566,6 +2664,7 @@ impl Db {
     }
 
     /// Set the channel_add_policy for a user.
+    #[tracing::instrument(target = "buzz_datastore", name = "set_channel_add_policy", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn set_channel_add_policy(
         &self,
         community_id: CommunityId,
@@ -2576,6 +2675,7 @@ impl Db {
     }
 
     /// Find an existing DM by its participant hash.
+    #[tracing::instrument(target = "buzz_datastore", name = "find_dm_by_participants", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn find_dm_by_participants(
         &self,
         community_id: CommunityId,
@@ -2585,6 +2685,7 @@ impl Db {
     }
 
     /// Create or return an existing DM channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "create_dm", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn create_dm(
         &self,
         community_id: CommunityId,
@@ -2595,6 +2696,7 @@ impl Db {
     }
 
     /// List all DMs for a user.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_dms_for_user", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_dms_for_user(
         &self,
         community_id: CommunityId,
@@ -2606,6 +2708,7 @@ impl Db {
     }
 
     /// Open or retrieve a DM for the given participants.
+    #[tracing::instrument(target = "buzz_datastore", name = "open_dm", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn open_dm(
         &self,
         community_id: CommunityId,
@@ -2619,6 +2722,7 @@ impl Db {
     ///
     /// The DM is not deleted — it can be restored by opening a new DM with
     /// the same participants.
+    #[tracing::instrument(target = "buzz_datastore", name = "hide_dm", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn hide_dm(
         &self,
         community_id: CommunityId,
@@ -2629,6 +2733,7 @@ impl Db {
     }
 
     /// Unhide a DM channel for a specific user.
+    #[tracing::instrument(target = "buzz_datastore", name = "unhide_dm", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn unhide_dm(
         &self,
         community_id: CommunityId,
@@ -2639,6 +2744,7 @@ impl Db {
     }
 
     /// List the channel IDs of all DMs the given user currently has hidden.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_hidden_dms", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_hidden_dms(
         &self,
         community_id: CommunityId,
@@ -2649,6 +2755,7 @@ impl Db {
 
     /// Insert thread metadata.
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(target = "buzz_datastore", name = "insert_thread_metadata", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn insert_thread_metadata(
         &self,
         community_id: CommunityId,
@@ -2699,6 +2806,7 @@ impl Db {
     /// A head fetch routed under Predicate A skips the re-run: bounded
     /// staleness (missing at most the freshest budget-window of replies) is
     /// exactly the semantic the head gate accepts.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_thread_replies", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_thread_replies(
         &self,
         community_id: CommunityId,
@@ -2773,6 +2881,7 @@ impl Db {
     }
 
     /// Fetch aggregated thread stats.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_thread_summary", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_thread_summary(
         &self,
         community_id: CommunityId,
@@ -2824,6 +2933,7 @@ impl Db {
     ///
     /// Every failure fails closed to the writer and is recorded in
     /// `buzz_db_route_decision`.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_channel_window", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_channel_window_with_session(
         &self,
         community_id: CommunityId,
@@ -2989,6 +3099,7 @@ impl Db {
     }
 
     /// Look up a single thread_metadata row by event_id.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_thread_metadata_by_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_thread_metadata_by_event(
         &self,
         community_id: CommunityId,
@@ -2998,6 +3109,7 @@ impl Db {
     }
 
     /// Decrement reply counts.
+    #[tracing::instrument(target = "buzz_datastore", name = "decrement_reply_count", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn decrement_reply_count(
         &self,
         community_id: CommunityId,
@@ -3009,6 +3121,7 @@ impl Db {
     }
 
     /// Add (or re-activate) a reaction.
+    #[tracing::instrument(target = "buzz_datastore", name = "add_reaction", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn add_reaction(
         &self,
         community: CommunityId,
@@ -3031,6 +3144,7 @@ impl Db {
     }
 
     /// Soft-delete a reaction.
+    #[tracing::instrument(target = "buzz_datastore", name = "remove_reaction", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn remove_reaction(
         &self,
         community: CommunityId,
@@ -3051,6 +3165,7 @@ impl Db {
     }
 
     /// Soft-delete a reaction by its source event ID.
+    #[tracing::instrument(target = "buzz_datastore", name = "remove_reaction_by_source_event_id", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn remove_reaction_by_source_event_id(
         &self,
         community: CommunityId,
@@ -3060,6 +3175,7 @@ impl Db {
     }
 
     /// Look up the active reaction row for one actor + emoji + target tuple.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_active_reaction_record", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_active_reaction_record(
         &self,
         community: CommunityId,
@@ -3080,6 +3196,7 @@ impl Db {
     }
 
     /// Backfill the source event ID on an active reaction row.
+    #[tracing::instrument(target = "buzz_datastore", name = "set_reaction_event_id", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn set_reaction_event_id(
         &self,
         community: CommunityId,
@@ -3102,6 +3219,7 @@ impl Db {
     }
 
     /// Get all active reactions for an event, grouped by emoji.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_reactions", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_reactions(
         &self,
         community: CommunityId,
@@ -3122,6 +3240,7 @@ impl Db {
     }
 
     /// Batch-fetch emoji counts for a set of (event_id, event_created_at) pairs.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_reactions_bulk", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_reactions_bulk(
         &self,
         community: CommunityId,
@@ -3131,6 +3250,7 @@ impl Db {
     }
 
     /// Find events that @mention the given pubkey.
+    #[tracing::instrument(target = "buzz_datastore", name = "query_feed_mentions", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn query_feed_mentions(
         &self,
         community: CommunityId,
@@ -3157,6 +3277,7 @@ impl Db {
     /// parameter admits community-global rows alongside channel rows, so no
     /// single channel's fence floor can prove completeness — the covered arm
     /// is structurally unavailable, not merely unchosen.
+    #[tracing::instrument(target = "buzz_datastore", name = "query_feed_mentions_routed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn query_feed_mentions_routed(
         &self,
         path: &'static str,
@@ -3212,6 +3333,7 @@ impl Db {
     }
 
     /// Find events that require action from the given pubkey.
+    #[tracing::instrument(target = "buzz_datastore", name = "query_feed_needs_action", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn query_feed_needs_action(
         &self,
         community: CommunityId,
@@ -3234,6 +3356,7 @@ impl Db {
     /// [`Db::query_feed_needs_action`] with replica routing — BOUNDED arm
     /// only; see [`Db::query_feed_mentions_routed`] for why the covered arm
     /// is structurally unavailable to feed queries.
+    #[tracing::instrument(target = "buzz_datastore", name = "query_feed_needs_action_routed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn query_feed_needs_action_routed(
         &self,
         path: &'static str,
@@ -3289,6 +3412,7 @@ impl Db {
     }
 
     /// Find recent activity across accessible channels.
+    #[tracing::instrument(target = "buzz_datastore", name = "query_feed_activity", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn query_feed_activity(
         &self,
         community: CommunityId,
@@ -3302,6 +3426,7 @@ impl Db {
     /// [`Db::query_feed_activity`] with replica routing — BOUNDED arm only;
     /// see [`Db::query_feed_mentions_routed`] for why the covered arm is
     /// structurally unavailable to feed queries.
+    #[tracing::instrument(target = "buzz_datastore", name = "query_feed_activity_routed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn query_feed_activity_routed(
         &self,
         path: &'static str,
@@ -3348,6 +3473,7 @@ impl Db {
 
     /// Create a new API token record.
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(target = "buzz_datastore", name = "create_api_token", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn create_api_token(
         &self,
         community_id: CommunityId,
@@ -3373,6 +3499,7 @@ impl Db {
 
     /// Atomic conditional INSERT with 10-token limit (per (community, owner)).
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(target = "buzz_datastore", name = "create_api_token_if_under_limit", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn create_api_token_if_under_limit(
         &self,
         community_id: CommunityId,
@@ -3402,6 +3529,7 @@ impl Db {
     /// See [`api_token::get_api_token_by_hash_including_revoked`] for the
     /// row-44 conformance rationale — the `(community_id, token_hash)` key
     /// is enforced both by the storage UNIQUE index and by this WHERE clause.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_api_token_by_hash", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_api_token_by_hash(
         &self,
         community_id: CommunityId,
@@ -3427,6 +3555,7 @@ impl Db {
     }
 
     /// Look up an API token by hash, including revoked, scoped to community.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_api_token_by_hash_including_revoked", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_api_token_by_hash_including_revoked(
         &self,
         community_id: CommunityId,
@@ -3441,6 +3570,7 @@ impl Db {
     }
 
     /// Record a token usage (update `last_used_at`), scoped to community.
+    #[tracing::instrument(target = "buzz_datastore", name = "touch_api_token", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn touch_api_token(&self, community_id: CommunityId, hash: &[u8]) -> Result<()> {
         sqlx::query(
             "UPDATE api_tokens SET last_used_at = NOW() WHERE community_id = $1 AND token_hash = $2",
@@ -3462,6 +3592,7 @@ impl Db {
     }
 
     /// List all active (non-revoked) tokens in a community, newest first.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_active_tokens", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_active_tokens(&self, community_id: CommunityId) -> Result<Vec<TokenSummary>> {
         let rows = sqlx::query(
             r#"
@@ -3496,6 +3627,7 @@ impl Db {
     }
 
     /// List all tokens for a (community, owner) pair (including revoked).
+    #[tracing::instrument(target = "buzz_datastore", name = "list_tokens_by_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_tokens_by_owner(
         &self,
         community_id: CommunityId,
@@ -3505,6 +3637,7 @@ impl Db {
     }
 
     /// Revoke a single token by ID, scoped to (community, owner).
+    #[tracing::instrument(target = "buzz_datastore", name = "revoke_token", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn revoke_token(
         &self,
         community_id: CommunityId,
@@ -3523,6 +3656,7 @@ impl Db {
     }
 
     /// Revoke all active tokens for a (community, owner) pair.
+    #[tracing::instrument(target = "buzz_datastore", name = "revoke_all_tokens", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn revoke_all_tokens(
         &self,
         community_id: CommunityId,
@@ -3539,6 +3673,7 @@ impl Db {
     }
 
     /// Create a new workflow.
+    #[tracing::instrument(target = "buzz_datastore", name = "create_workflow", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn create_workflow(
         &self,
         community_id: CommunityId,
@@ -3562,6 +3697,7 @@ impl Db {
 
     /// Insert or update a workflow using its NIP-33 `d`-tag UUID.
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(target = "buzz_datastore", name = "upsert_workflow", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn upsert_workflow(
         &self,
         community_id: CommunityId,
@@ -3586,6 +3722,7 @@ impl Db {
     }
 
     /// Fetch a single workflow by ID, scoped to its community.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_workflow", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_workflow(
         &self,
         community_id: CommunityId,
@@ -3595,6 +3732,7 @@ impl Db {
     }
 
     /// List workflows for a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_channel_workflows", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_channel_workflows(
         &self,
         community_id: CommunityId,
@@ -3606,6 +3744,7 @@ impl Db {
     }
 
     /// List active, enabled workflows for a channel.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_enabled_channel_workflows", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_enabled_channel_workflows(
         &self,
         community_id: CommunityId,
@@ -3615,6 +3754,7 @@ impl Db {
     }
 
     /// List all active, enabled schedule-triggered workflows.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_all_enabled_workflows", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_all_enabled_workflows(&self) -> Result<Vec<workflow::WorkflowRecord>> {
         workflow::list_all_enabled_workflows(&self.pool).await
     }
@@ -3627,6 +3767,7 @@ impl Db {
     /// from the scheduler scan), never client-supplied — `workflows` is keyed
     /// `(community_id, id)`, so the claim must bind both to avoid fanning
     /// across communities that share the workflow UUID.
+    #[tracing::instrument(target = "buzz_datastore", name = "claim_scheduled_workflow_fire", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn claim_scheduled_workflow_fire(
         &self,
         community_id: CommunityId,
@@ -3643,6 +3784,7 @@ impl Db {
     }
 
     /// Fetch the latest claimed schedule instant for interval trigger anchoring.
+    #[tracing::instrument(target = "buzz_datastore", name = "latest_scheduled_workflow_fire", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn latest_scheduled_workflow_fire(
         &self,
         community_id: CommunityId,
@@ -3652,6 +3794,7 @@ impl Db {
     }
 
     /// Attach the workflow run id created from a won scheduled-fire claim.
+    #[tracing::instrument(target = "buzz_datastore", name = "attach_scheduled_workflow_run", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn attach_scheduled_workflow_run(
         &self,
         community_id: CommunityId,
@@ -3670,6 +3813,7 @@ impl Db {
     }
 
     /// Delete old scheduled workflow fire claims before a retention cutoff.
+    #[tracing::instrument(target = "buzz_datastore", name = "prune_scheduled_workflow_fires_before", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn prune_scheduled_workflow_fires_before(
         &self,
         older_than: chrono::DateTime<chrono::Utc>,
@@ -3678,6 +3822,7 @@ impl Db {
     }
 
     /// Update a workflow's name, definition, and hash.
+    #[tracing::instrument(target = "buzz_datastore", name = "update_workflow", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn update_workflow(
         &self,
         community_id: CommunityId,
@@ -3698,6 +3843,7 @@ impl Db {
     }
 
     /// Update a workflow's status.
+    #[tracing::instrument(target = "buzz_datastore", name = "update_workflow_status", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn update_workflow_status(
         &self,
         community_id: CommunityId,
@@ -3708,6 +3854,7 @@ impl Db {
     }
 
     /// Enable or disable a workflow.
+    #[tracing::instrument(target = "buzz_datastore", name = "set_workflow_enabled", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn set_workflow_enabled(
         &self,
         community_id: CommunityId,
@@ -3735,12 +3882,14 @@ impl Db {
     }
 
     /// Delete a workflow and all its runs/approvals.
+    #[tracing::instrument(target = "buzz_datastore", name = "delete_workflow", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn delete_workflow(&self, community_id: CommunityId, id: Uuid) -> Result<()> {
         workflow::delete_workflow(&self.pool, community_id, id).await
     }
 
     /// Delete a workflow only when it belongs to the provided owner.
     /// Returns the deleted workflow's `channel_id`.
+    #[tracing::instrument(target = "buzz_datastore", name = "delete_workflow_for_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn delete_workflow_for_owner(
         &self,
         community_id: CommunityId,
@@ -3752,6 +3901,7 @@ impl Db {
 
     /// Find a workflow by owner pubkey and name within a community. Used for
     /// NIP-09 a-tag deletion where the d-tag is the workflow name (not UUID).
+    #[tracing::instrument(target = "buzz_datastore", name = "find_workflow_by_owner_and_name", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn find_workflow_by_owner_and_name(
         &self,
         community_id: CommunityId,
@@ -3762,6 +3912,7 @@ impl Db {
     }
 
     /// Create a new workflow run.
+    #[tracing::instrument(target = "buzz_datastore", name = "create_workflow_run", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn create_workflow_run(
         &self,
         community_id: CommunityId,
@@ -3780,6 +3931,7 @@ impl Db {
     }
 
     /// Fetch a single workflow run, scoped to its community.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_workflow_run", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_workflow_run(
         &self,
         community_id: CommunityId,
@@ -3789,6 +3941,7 @@ impl Db {
     }
 
     /// List runs for a workflow.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_workflow_runs", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_workflow_runs(
         &self,
         community_id: CommunityId,
@@ -3799,6 +3952,7 @@ impl Db {
     }
 
     /// Update a workflow run's status.
+    #[tracing::instrument(target = "buzz_datastore", name = "update_workflow_run", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn update_workflow_run(
         &self,
         community_id: CommunityId,
@@ -3821,11 +3975,13 @@ impl Db {
     }
 
     /// Create an approval request.
+    #[tracing::instrument(target = "buzz_datastore", name = "create_approval", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn create_approval(&self, params: workflow::CreateApprovalParams<'_>) -> Result<()> {
         workflow::create_approval(&self.pool, params).await
     }
 
     /// Fetch an approval by raw token.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_approval", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_approval(
         &self,
         community_id: CommunityId,
@@ -3835,6 +3991,7 @@ impl Db {
     }
 
     /// Fetch an approval by its already-hashed token (no re-hashing).
+    #[tracing::instrument(target = "buzz_datastore", name = "get_approval_by_stored_hash", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_approval_by_stored_hash(
         &self,
         community_id: CommunityId,
@@ -3844,6 +4001,7 @@ impl Db {
     }
 
     /// Fetch all approvals for a workflow run.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_run_approvals", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_run_approvals(
         &self,
         community_id: CommunityId,
@@ -3854,6 +4012,7 @@ impl Db {
     }
 
     /// Update an approval's status.
+    #[tracing::instrument(target = "buzz_datastore", name = "update_approval", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn update_approval(
         &self,
         community_id: CommunityId,
@@ -3874,6 +4033,7 @@ impl Db {
     }
 
     /// Update an approval by its already-hashed token (no re-hashing).
+    #[tracing::instrument(target = "buzz_datastore", name = "update_approval_by_stored_hash", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn update_approval_by_stored_hash(
         &self,
         community_id: CommunityId,
@@ -3894,6 +4054,7 @@ impl Db {
     }
 
     /// Ensures monthly partitions exist for the next N months.
+    #[tracing::instrument(target = "buzz_datastore", name = "ensure_future_partitions", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn ensure_future_partitions(&self, months_ahead: u32) -> Result<()> {
         partition::ensure_future_partitions(&self.pool, months_ahead).await
     }
@@ -3902,6 +4063,7 @@ impl Db {
     ///
     /// Idempotent — safe to call on every startup. No-ops when all rows are already populated.
     /// Runs a single UPDATE touching only NIP-33 rows with NULL d_tag.
+    #[tracing::instrument(target = "buzz_datastore", name = "backfill_d_tags", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn backfill_d_tags(&self) -> Result<u64> {
         let result = sqlx::query(
             "UPDATE events \
@@ -3918,6 +4080,7 @@ impl Db {
     }
 
     /// Check if a pubkey is in the allowlist for `community`.
+    #[tracing::instrument(target = "buzz_datastore", name = "is_pubkey_allowed", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn is_pubkey_allowed(&self, community: CommunityId, pubkey: &[u8]) -> Result<bool> {
         let row = sqlx::query(
             "SELECT COUNT(*) as cnt FROM pubkey_allowlist WHERE community_id = $1 AND pubkey = $2",
@@ -3931,6 +4094,7 @@ impl Db {
     }
 
     /// Check if the community allowlist has any entries (i.e. is enforcement active).
+    #[tracing::instrument(target = "buzz_datastore", name = "has_allowlist_entries", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn has_allowlist_entries(&self, community: CommunityId) -> Result<bool> {
         let row =
             sqlx::query("SELECT COUNT(*) as cnt FROM pubkey_allowlist WHERE community_id = $1")
@@ -3942,6 +4106,7 @@ impl Db {
     }
 
     /// Add a pubkey to the community allowlist.
+    #[tracing::instrument(target = "buzz_datastore", name = "add_to_allowlist", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn add_to_allowlist(
         &self,
         community: CommunityId,
@@ -3963,6 +4128,7 @@ impl Db {
     }
 
     /// Remove a pubkey from the community allowlist.
+    #[tracing::instrument(target = "buzz_datastore", name = "remove_from_allowlist", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn remove_from_allowlist(
         &self,
         community: CommunityId,
@@ -3978,6 +4144,7 @@ impl Db {
     }
 
     /// List all pubkeys in the community allowlist.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_allowlist", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_allowlist(&self, community: CommunityId) -> Result<Vec<AllowlistEntry>> {
         let rows = sqlx::query(
             "SELECT pubkey, added_by, added_at, note FROM pubkey_allowlist WHERE community_id = $1 ORDER BY added_at DESC",
@@ -4006,6 +4173,7 @@ impl Db {
     /// `B`; everything else fails closed to the writer, exactly like
     /// [`Db::query_events_routed_bounded`]. Not precedent for routing other
     /// permission reads.
+    #[tracing::instrument(target = "buzz_datastore", name = "is_relay_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn is_relay_member(&self, community: CommunityId, pubkey: &str) -> Result<bool> {
         let path = "relay_membership";
         match self.route_read(path, RoutePredicate::Bounded).await {
@@ -4029,6 +4197,7 @@ impl Db {
     }
 
     /// Returns the relay member record for `pubkey` in `community`, or `None` if not found.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_relay_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_relay_member(
         &self,
         community: CommunityId,
@@ -4038,6 +4207,7 @@ impl Db {
     }
 
     /// Returns all relay members of `community` ordered by `created_at` ascending.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_relay_members", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_relay_members(
         &self,
         community: CommunityId,
@@ -4049,6 +4219,7 @@ impl Db {
     ///
     /// Returns `true` if the row was actually inserted, `false` if the pubkey
     /// already existed in `community` (idempotent — `ON CONFLICT DO NOTHING`).
+    #[tracing::instrument(target = "buzz_datastore", name = "add_relay_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn add_relay_member(
         &self,
         community: CommunityId,
@@ -4061,6 +4232,7 @@ impl Db {
 
     /// Claims relay membership via an invite and atomically persists the
     /// accepted policy version when a policy is configured.
+    #[tracing::instrument(target = "buzz_datastore", name = "claim_relay_membership", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn claim_relay_membership(
         &self,
         community: CommunityId,
@@ -4073,6 +4245,7 @@ impl Db {
     }
 
     /// Returns whether a member has persisted acceptance evidence for a policy version.
+    #[tracing::instrument(target = "buzz_datastore", name = "has_join_policy_acceptance", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn has_join_policy_acceptance(
         &self,
         community: CommunityId,
@@ -4084,6 +4257,7 @@ impl Db {
     }
 
     /// Removes a relay member from `community` atomically, refusing to delete the owner.
+    #[tracing::instrument(target = "buzz_datastore", name = "remove_relay_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn remove_relay_member(
         &self,
         community: CommunityId,
@@ -4096,6 +4270,7 @@ impl Db {
     ///
     /// Atomic conditional delete — eliminates the TOCTOU race between a
     /// prior role read and the delete. See [`relay_members::remove_relay_member_if_role`].
+    #[tracing::instrument(target = "buzz_datastore", name = "remove_relay_member_if_role", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn remove_relay_member_if_role(
         &self,
         community: CommunityId,
@@ -4107,6 +4282,7 @@ impl Db {
     }
 
     /// Updates the role of an existing relay member in `community`. Returns `true` if updated.
+    #[tracing::instrument(target = "buzz_datastore", name = "update_relay_member_role", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn update_relay_member_role(
         &self,
         community: CommunityId,
@@ -4117,6 +4293,7 @@ impl Db {
     }
 
     /// Ensures the owner pubkey exists with role `"owner"` in `community`. Called at startup.
+    #[tracing::instrument(target = "buzz_datastore", name = "bootstrap_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn bootstrap_owner(&self, community: CommunityId, owner_pubkey: &str) -> Result<()> {
         relay_members::bootstrap_owner(&self.pool, community, owner_pubkey).await
     }
@@ -4131,6 +4308,7 @@ impl Db {
     /// demoting the previous owner(s) to `member`. Verifies
     /// `expected_owner_pubkey` matches the current owner inside the same
     /// transaction to prevent stale-owner races.
+    #[tracing::instrument(target = "buzz_datastore", name = "transfer_ownership", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn transfer_ownership(
         &self,
         community: CommunityId,
@@ -4150,6 +4328,7 @@ impl Db {
     ///
     /// Idempotent — uses `ON CONFLICT DO NOTHING`. Returns the number of rows
     /// inserted, or 0 if the `pubkey_allowlist` table doesn't exist.
+    #[tracing::instrument(target = "buzz_datastore", name = "backfill_from_allowlist", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn backfill_from_allowlist(&self, community: CommunityId) -> Result<u64> {
         relay_members::backfill_from_allowlist(&self.pool, community).await
     }
@@ -4200,6 +4379,7 @@ impl Db {
     }
 
     /// Sidecar an accepted product-feedback event, idempotent by event id.
+    #[tracing::instrument(target = "buzz_datastore", name = "insert_product_feedback", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn insert_product_feedback(
         &self,
         community: CommunityId,
@@ -4209,6 +4389,7 @@ impl Db {
     }
 
     /// List product feedback across the deployment, newest first.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_product_feedback", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_product_feedback(
         &self,
         limit: i64,
@@ -4217,6 +4398,7 @@ impl Db {
     }
 
     /// Insert a tenant-scoped NIP-56 report row, idempotent by report event id.
+    #[tracing::instrument(target = "buzz_datastore", name = "insert_moderation_report", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn insert_moderation_report(
         &self,
         community: CommunityId,
@@ -4226,6 +4408,7 @@ impl Db {
     }
 
     /// List moderation reports for a community, newest first.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_moderation_reports", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_moderation_reports(
         &self,
         community: CommunityId,
@@ -4236,6 +4419,7 @@ impl Db {
     }
 
     /// Fetch one moderation report by row id.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_moderation_report", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_moderation_report(
         &self,
         community: CommunityId,
@@ -4245,6 +4429,7 @@ impl Db {
     }
 
     /// Fetch one moderation report by signed NIP-56 report event id.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_moderation_report_by_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_moderation_report_by_event(
         &self,
         community: CommunityId,
@@ -4254,6 +4439,7 @@ impl Db {
     }
 
     /// Resolve, dismiss, or escalate an open moderation report.
+    #[tracing::instrument(target = "buzz_datastore", name = "resolve_moderation_report", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn resolve_moderation_report(
         &self,
         community: CommunityId,
@@ -4274,6 +4460,7 @@ impl Db {
     }
 
     /// Upsert a community ban for a member pubkey.
+    #[tracing::instrument(target = "buzz_datastore", name = "ban_community_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn ban_community_member(
         &self,
         community: CommunityId,
@@ -4286,6 +4473,7 @@ impl Db {
     }
 
     /// Lift a community ban for a member pubkey.
+    #[tracing::instrument(target = "buzz_datastore", name = "unban_community_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn unban_community_member(
         &self,
         community: CommunityId,
@@ -4296,6 +4484,7 @@ impl Db {
     }
 
     /// Upsert a community timeout/write-block for a member pubkey.
+    #[tracing::instrument(target = "buzz_datastore", name = "timeout_community_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn timeout_community_member(
         &self,
         community: CommunityId,
@@ -4308,6 +4497,7 @@ impl Db {
     }
 
     /// Clear a community timeout/write-block for a member pubkey.
+    #[tracing::instrument(target = "buzz_datastore", name = "untimeout_community_member", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn untimeout_community_member(
         &self,
         community: CommunityId,
@@ -4318,6 +4508,7 @@ impl Db {
     }
 
     /// Fetch the active ban/timeout restriction state for enforcement hot paths.
+    #[tracing::instrument(target = "buzz_datastore", name = "moderation_restriction_state", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn moderation_restriction_state(
         &self,
         community: CommunityId,
@@ -4327,6 +4518,7 @@ impl Db {
     }
 
     /// Fetch the full ban/timeout row for a member pubkey.
+    #[tracing::instrument(target = "buzz_datastore", name = "get_community_ban", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn get_community_ban(
         &self,
         community: CommunityId,
@@ -4336,6 +4528,7 @@ impl Db {
     }
 
     /// List currently restricted members in a community.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_community_restrictions", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_community_restrictions(
         &self,
         community: CommunityId,
@@ -4344,6 +4537,7 @@ impl Db {
     }
 
     /// Insert a moderation audit action row.
+    #[tracing::instrument(target = "buzz_datastore", name = "insert_moderation_action", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn insert_moderation_action(
         &self,
         community: CommunityId,
@@ -4353,6 +4547,7 @@ impl Db {
     }
 
     /// List moderation audit action rows, newest first.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_moderation_actions", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_moderation_actions(
         &self,
         community: CommunityId,
@@ -4363,6 +4558,7 @@ impl Db {
 
     /// Return the current owner of git repo name `repo_id` in `community`, or
     /// `None` if unreserved. See [`git_repo::repo_name_owner`].
+    #[tracing::instrument(target = "buzz_datastore", name = "repo_name_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn repo_name_owner(
         &self,
         community: CommunityId,
@@ -4375,6 +4571,7 @@ impl Db {
     ///
     /// See [`git_repo::reserve_repo_name`] for the outcome semantics. The
     /// per-pubkey quota is enforced by the caller against `count_repos_for_owner`.
+    #[tracing::instrument(target = "buzz_datastore", name = "reserve_repo_name", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn reserve_repo_name(
         &self,
         community: CommunityId,
@@ -4385,6 +4582,7 @@ impl Db {
     }
 
     /// Count git repos reserved by `owner_pubkey` in `community` (quota check).
+    #[tracing::instrument(target = "buzz_datastore", name = "count_repos_for_owner", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn count_repos_for_owner(
         &self,
         community: CommunityId,
@@ -4396,6 +4594,7 @@ impl Db {
     /// Release a git repo name reservation held by `owner_pubkey` (rollback).
     ///
     /// Returns the number of rows removed (0 or 1). See [`git_repo::release_repo_name`].
+    #[tracing::instrument(target = "buzz_datastore", name = "release_repo_name", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn release_repo_name(
         &self,
         community: CommunityId,
@@ -4406,12 +4605,14 @@ impl Db {
     }
 
     /// Returns `true` if `pubkey` (64-char hex) is archived in `community_id`.
+    #[tracing::instrument(target = "buzz_datastore", name = "is_archived", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn is_archived(&self, community_id: CommunityId, pubkey: &str) -> Result<bool> {
         archived_identities::is_archived(&self.pool, community_id, pubkey).await
     }
 
     /// Archives an identity in `community_id`. Returns `true` if inserted, `false` if already archived.
     #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(target = "buzz_datastore", name = "archive", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn archive(
         &self,
         community_id: CommunityId,
@@ -4436,11 +4637,13 @@ impl Db {
     }
 
     /// Unarchives an identity from `community_id`. Returns `true` if deleted, `false` if absent.
+    #[tracing::instrument(target = "buzz_datastore", name = "unarchive", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn unarchive(&self, community_id: CommunityId, pubkey: &str) -> Result<bool> {
         archived_identities::unarchive(&self.pool, community_id, pubkey).await
     }
 
     /// Returns all identities archived in `community_id`, ordered by archive time ascending.
+    #[tracing::instrument(target = "buzz_datastore", name = "list_archived", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn list_archived(
         &self,
         community_id: CommunityId,
@@ -4449,6 +4652,7 @@ impl Db {
     }
 
     /// Soft-delete NIP-29 discovery events for a channel created by a specific relay pubkey.
+    #[tracing::instrument(target = "buzz_datastore", name = "soft_delete_discovery_events", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn soft_delete_discovery_events(
         &self,
         community_id: CommunityId,
@@ -4474,6 +4678,7 @@ impl Db {
     /// Same-second ties are broken by lowest event `id` (NIP-16 deterministic ordering).
     /// Returns `(event, false)` for stale writes and duplicate IDs — callers should
     /// skip fan-out/dispatch when `was_inserted` is false.
+    #[tracing::instrument(target = "buzz_datastore", name = "replace_addressable_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn replace_addressable_event(
         &self,
         community_id: CommunityId,
@@ -4590,8 +4795,8 @@ impl Db {
 
         // Mentions are a denormalized index — safe outside the transaction.
         // insert_event() normally handles this, but we inlined the INSERT above.
-        if let Err(e) = crate::insert_mentions(&self.pool, community_id, event, channel_id).await {
-            tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
+        if let Err(_e) = crate::insert_mentions(&self.pool, community_id, event, channel_id).await {
+            tracing::warn!("mention insertion failed");
         }
 
         Ok((
@@ -4656,6 +4861,7 @@ impl Db {
     /// prevents the stale-snapshot race where a concurrent publication reads
     /// older state and overwrites a newer snapshot by arrival order.
     ///
+    #[tracing::instrument(target = "buzz_datastore", name = "publish_nip43_membership_locked", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn publish_nip43_membership_locked(
         &self,
         community_id: CommunityId,
@@ -4764,8 +4970,8 @@ impl Db {
 
         tx.commit().await?;
 
-        if let Err(e) = crate::insert_mentions(&self.pool, community_id, &event, None).await {
-            tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
+        if let Err(_e) = crate::insert_mentions(&self.pool, community_id, &event, None).await {
+            tracing::warn!("mention insertion failed");
         }
 
         Ok((
@@ -4796,6 +5002,7 @@ impl Db {
     /// relay-signed NIP-29 group metadata (kind 39000–39002) where the relay is the
     /// author and channel_id distinguishes groups. User-submitted NIP-33 events use
     /// this function instead, where the author's pubkey + d-tag is the natural key.
+    #[tracing::instrument(target = "buzz_datastore", name = "replace_parameterized_event", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
     pub async fn replace_parameterized_event(
         &self,
         community_id: CommunityId,
@@ -5001,8 +5208,8 @@ impl Db {
         tx.commit().await?;
 
         // Mentions are a denormalized index — safe outside the transaction.
-        if let Err(e) = crate::insert_mentions(&self.pool, community_id, event, channel_id).await {
-            tracing::warn!(event_id = %event.id, "Failed to insert mentions: {e}");
+        if let Err(_e) = crate::insert_mentions(&self.pool, community_id, event, channel_id).await {
+            tracing::warn!("mention insertion failed");
         }
 
         Ok((

--- a/crates/buzz-db/src/replica_fence.rs
+++ b/crates/buzz-db/src/replica_fence.rs
@@ -315,6 +315,7 @@ impl ReplicaFence {
 ///
 /// This is a name-and-shape check only; it cannot detect a sabotaged
 /// function body. [`verify_floor_guard_behavior`] proves the semantics.
+#[tracing::instrument(target = "buzz_datastore", name = "replica_fence_verify_catalog", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
 pub async fn verify_floor_guard_catalog(pool: &PgPool) -> crate::Result<()> {
     // tgtype bits: 1 = ROW, 2 = BEFORE, 4 = INSERT, 16 = UPDATE, 64 = INSTEAD.
     // Required: ROW + INSERT + UPDATE set, BEFORE + INSTEAD clear.
@@ -369,6 +370,7 @@ pub async fn verify_floor_guard_catalog(pool: &PgPool) -> crate::Result<()> {
 /// `SET CONSTRAINTS ALL IMMEDIATE` makes the deferred trigger fire per
 /// statement so each adversary is observable under a savepoint; deferral to
 /// COMMIT is separately pinned by the held-transaction fixture.
+#[tracing::instrument(target = "buzz_datastore", name = "replica_fence_verify_behavior", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
 pub async fn verify_floor_guard_behavior(pool: &PgPool) -> crate::Result<()> {
     use crate::error::DbError;
 
@@ -542,6 +544,7 @@ pub enum ProbeError {
 /// The statements are separately awaited on a single pinned connection;
 /// a single SELECT would not guarantee evaluation order across the
 /// subexpressions, reopening the race this ordering exists to close.
+#[tracing::instrument(target = "buzz_datastore", name = "replica_fence_sample_writer", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
 async fn sample_writer(writer: &PgPool) -> Result<WriterSample, ProbeError> {
     let mut conn = writer.acquire().await?;
 
@@ -698,6 +701,7 @@ pub const AURORA_IDENTITY_FN: &str = "aurora_db_instance_identifier";
 /// (undefined_function, SQLSTATE 42883); transient errors surface as `Err`
 /// so the caller can retry the probe on a later request instead of caching
 /// a wrong answer.
+#[tracing::instrument(target = "buzz_datastore", name = "replica_fence_reader_supports_aurora_identity", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
 pub async fn reader_supports_aurora_identity(conn: &mut PgConnection) -> Result<bool, sqlx::Error> {
     match sqlx::query(sqlx::AssertSqlSafe(format!(
         "SELECT {AURORA_IDENTITY_FN}()"
@@ -719,6 +723,7 @@ pub async fn reader_supports_aurora_identity(conn: &mut PgConnection) -> Result<
 /// [`reader_supports_aurora_identity`] confirmed it — the function
 /// reference fails at parse time on plain Postgres). `None` when the row
 /// is missing there (migration not yet replayed): fail closed.
+#[tracing::instrument(target = "buzz_datastore", name = "replica_fence_observe_heartbeat", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
 pub async fn observe_heartbeat(
     conn: &mut PgConnection,
     aurora: bool,

--- a/crates/buzz-db/src/replica_fence.rs
+++ b/crates/buzz-db/src/replica_fence.rs
@@ -63,6 +63,8 @@ use chrono::{DateTime, Utc};
 use sqlx::{PgConnection, PgPool, Row};
 use uuid::Uuid;
 
+use buzz_datastore_tracing::datastore_span;
+
 /// Seconds of `created_at` history the commit-time floor guard tolerates.
 ///
 /// Must exceed the relay's ingest envelope (±900 s) by enough slack that a
@@ -315,7 +317,7 @@ impl ReplicaFence {
 ///
 /// This is a name-and-shape check only; it cannot detect a sabotaged
 /// function body. [`verify_floor_guard_behavior`] proves the semantics.
-#[tracing::instrument(target = "buzz_datastore", name = "replica_fence_verify_catalog", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+#[datastore_span(name = "replica_fence_verify_catalog", system = "postgresql")]
 pub async fn verify_floor_guard_catalog(pool: &PgPool) -> crate::Result<()> {
     // tgtype bits: 1 = ROW, 2 = BEFORE, 4 = INSERT, 16 = UPDATE, 64 = INSTEAD.
     // Required: ROW + INSERT + UPDATE set, BEFORE + INSTEAD clear.
@@ -370,7 +372,7 @@ pub async fn verify_floor_guard_catalog(pool: &PgPool) -> crate::Result<()> {
 /// `SET CONSTRAINTS ALL IMMEDIATE` makes the deferred trigger fire per
 /// statement so each adversary is observable under a savepoint; deferral to
 /// COMMIT is separately pinned by the held-transaction fixture.
-#[tracing::instrument(target = "buzz_datastore", name = "replica_fence_verify_behavior", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+#[datastore_span(name = "replica_fence_verify_behavior", system = "postgresql")]
 pub async fn verify_floor_guard_behavior(pool: &PgPool) -> crate::Result<()> {
     use crate::error::DbError;
 
@@ -544,7 +546,6 @@ pub enum ProbeError {
 /// The statements are separately awaited on a single pinned connection;
 /// a single SELECT would not guarantee evaluation order across the
 /// subexpressions, reopening the race this ordering exists to close.
-#[tracing::instrument(target = "buzz_datastore", name = "replica_fence_sample_writer", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
 async fn sample_writer(writer: &PgPool) -> Result<WriterSample, ProbeError> {
     let mut conn = writer.acquire().await?;
 
@@ -701,7 +702,10 @@ pub const AURORA_IDENTITY_FN: &str = "aurora_db_instance_identifier";
 /// (undefined_function, SQLSTATE 42883); transient errors surface as `Err`
 /// so the caller can retry the probe on a later request instead of caching
 /// a wrong answer.
-#[tracing::instrument(target = "buzz_datastore", name = "replica_fence_reader_supports_aurora_identity", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
+#[datastore_span(
+    name = "replica_fence_reader_supports_aurora_identity",
+    system = "postgresql"
+)]
 pub async fn reader_supports_aurora_identity(conn: &mut PgConnection) -> Result<bool, sqlx::Error> {
     match sqlx::query(sqlx::AssertSqlSafe(format!(
         "SELECT {AURORA_IDENTITY_FN}()"
@@ -723,7 +727,6 @@ pub async fn reader_supports_aurora_identity(conn: &mut PgConnection) -> Result<
 /// [`reader_supports_aurora_identity`] confirmed it — the function
 /// reference fails at parse time on plain Postgres). `None` when the row
 /// is missing there (migration not yet replayed): fail closed.
-#[tracing::instrument(target = "buzz_datastore", name = "replica_fence_observe_heartbeat", skip_all, fields(otel.kind = "client", db.system.name = "postgresql"))]
 pub async fn observe_heartbeat(
     conn: &mut PgConnection,
     aurora: bool,

--- a/crates/buzz-relay/Cargo.toml
+++ b/crates/buzz-relay/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 buzz-core = { workspace = true }
 buzz-conformance = { workspace = true }
 buzz-db = { workspace = true }
+buzz-datastore-tracing = { workspace = true }
 buzz-auth = { workspace = true }
 buzz-pubsub = { workspace = true }
 buzz-audit = { workspace = true }

--- a/crates/buzz-relay/src/handlers/command_executor.rs
+++ b/crates/buzz-relay/src/handlers/command_executor.rs
@@ -19,6 +19,7 @@ use uuid::Uuid;
 
 use buzz_core::kind::*;
 use buzz_core::tenant::{CommunityId, TenantContext};
+use buzz_datastore_tracing::datastore_span;
 use buzz_db::workflow::{ApprovalStatus, RunStatus};
 use buzz_db::DbError;
 use buzz_workflow::executor::TriggerContext;
@@ -97,12 +98,7 @@ enum PersistResult {
 /// persists without the event record. On retry, the event INSERT succeeds
 /// (no conflict), and the mutation re-executes — which is safe for idempotent
 /// operations (open_dm, hide_dm, update_approval, upsert_workflow).
-#[tracing::instrument(
-    target = "buzz_datastore",
-    name = "persist_command_event",
-    skip_all,
-    fields(otel.kind = "client", db.system.name = "postgresql")
-)]
+#[datastore_span(name = "persist_command_event", system = "postgresql")]
 async fn persist_command_event(
     state: &Arc<AppState>,
     tenant: &TenantContext,

--- a/crates/buzz-relay/src/handlers/command_executor.rs
+++ b/crates/buzz-relay/src/handlers/command_executor.rs
@@ -97,6 +97,12 @@ enum PersistResult {
 /// persists without the event record. On retry, the event INSERT succeeds
 /// (no conflict), and the mutation re-executes — which is safe for idempotent
 /// operations (open_dm, hide_dm, update_approval, upsert_workflow).
+#[tracing::instrument(
+    target = "buzz_datastore",
+    name = "persist_command_event",
+    skip_all,
+    fields(otel.kind = "client", db.system.name = "postgresql")
+)]
 async fn persist_command_event(
     state: &Arc<AppState>,
     tenant: &TenantContext,

--- a/crates/buzz-search/Cargo.toml
+++ b/crates/buzz-search/Cargo.toml
@@ -9,6 +9,7 @@ description = "Postgres full-text search for Buzz, scoped by community"
 
 [dependencies]
 buzz-core   = { workspace = true }
+buzz-datastore-tracing = { workspace = true }
 sqlx        = { workspace = true }
 uuid        = { workspace = true }
 thiserror   = { workspace = true }

--- a/crates/buzz-search/Cargo.toml
+++ b/crates/buzz-search/Cargo.toml
@@ -12,6 +12,7 @@ buzz-core   = { workspace = true }
 sqlx        = { workspace = true }
 uuid        = { workspace = true }
 thiserror   = { workspace = true }
+tracing     = { workspace = true }
 
 [dev-dependencies]
 tokio       = { workspace = true }

--- a/crates/buzz-search/src/query.rs
+++ b/crates/buzz-search/src/query.rs
@@ -8,10 +8,11 @@
 //!
 //! See conformance row 50.
 
-use buzz_core::CommunityId;
 use sqlx::{PgPool, QueryBuilder, Row};
-use tracing::Instrument;
 use uuid::Uuid;
+
+use buzz_core::CommunityId;
+use buzz_datastore_tracing::datastore_span;
 
 use crate::error::SearchError;
 
@@ -214,6 +215,7 @@ fn normalized_search_text(q: &str) -> Option<String> {
 ///
 /// `community_id = $ctx` is the first predicate and is non-negotiable. There
 /// is no code path through this function that omits it.
+#[datastore_span(name = "search", system = "postgresql")]
 pub async fn search(pool: &PgPool, query: &SearchQuery) -> Result<SearchResult, SearchError> {
     let Some(search_text) = normalized_search_text(&query.q) else {
         return Ok(SearchResult {
@@ -312,16 +314,7 @@ pub async fn search(pool: &PgPool, query: &SearchQuery) -> Result<SearchResult, 
     qb.push(" OFFSET ");
     qb.push_bind(offset);
 
-    let rows = qb
-        .build()
-        .fetch_all(pool)
-        .instrument(tracing::info_span!(
-            target: "buzz_datastore",
-            "search",
-            otel.kind = "client",
-            db.system.name = "postgresql"
-        ))
-        .await?;
+    let rows = qb.build().fetch_all(pool).await?;
 
     let mut hits = Vec::with_capacity(rows.len());
     for row in rows {

--- a/crates/buzz-search/src/query.rs
+++ b/crates/buzz-search/src/query.rs
@@ -10,6 +10,7 @@
 
 use buzz_core::CommunityId;
 use sqlx::{PgPool, QueryBuilder, Row};
+use tracing::Instrument;
 use uuid::Uuid;
 
 use crate::error::SearchError;
@@ -311,7 +312,16 @@ pub async fn search(pool: &PgPool, query: &SearchQuery) -> Result<SearchResult, 
     qb.push(" OFFSET ");
     qb.push_bind(offset);
 
-    let rows = qb.build().fetch_all(pool).await?;
+    let rows = qb
+        .build()
+        .fetch_all(pool)
+        .instrument(tracing::info_span!(
+            target: "buzz_datastore",
+            "search",
+            otel.kind = "client",
+            db.system.name = "postgresql"
+        ))
+        .await?;
 
     let mut hits = Vec::with_capacity(rows.len());
     for row in rows {


### PR DESCRIPTION
## Why
Expose PostgreSQL datastore latency within existing request traces so slow logical database operations can be identified without recording tenant data or query arguments.

## What
- Add client spans around logical PostgreSQL operations across the database facade, search, audit, replica fencing, and command persistence
- Use a dedicated `buzz_datastore` target and `db.system.name = "postgresql"` for filtering and backend classification
- Exclude health-check database calls and scrub raw identifiers and errors from newly traced paths

## Risk Assessment
Medium — this instruments frequently used datastore paths and increases trace volume when enabled, but does not change SQL execution or datastore behavior. Existing OpenTelemetry filtering controls export.

## References
- Pre-push clippy and fast unit-test hooks passed

Generated with Amp
