### PR TITLE
feat(desktop): add Devin as a preset ACP harness

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -1617,6 +1617,17 @@ const PRESET_HARNESSES: &[PresetHarness] = &[
             Gateway's own environment separately.",
         underlying_cli: None,
     },
+    PresetHarness {
+        id: "devin",
+        label: "Devin",
+        command: "devin",
+        args: &["acp"],
+        install_instructions_url: "https://docs.devin.ai/cli/index",
+        install_hint: "Buzz talks to Devin through the Devin CLI's ACP mode (devin acp). \
+            Install the Devin CLI from https://docs.devin.ai/cli/index and run \
+            `devin auth login` to authenticate.",
+        underlying_cli: Some("devin"),
+    },
 ];
 
 /// Return the static preset harness definitions as `HarnessDefinition` values.

--- a/desktop/src/features/settings/ui/harnessCatalogCopy.ts
+++ b/desktop/src/features/settings/ui/harnessCatalogCopy.ts
@@ -43,6 +43,8 @@ const HARNESS_DESCRIPTIONS: Record<string, string> = {
   // Sources: https://github.com/openclaw/openclaw,
   // https://docs.openclaw.ai/start/getting-started
   openclaw: "A personal AI assistant that runs on your own devices.",
+  // Source: https://docs.devin.ai/cli/index
+  devin: "Cognition's autonomous AI software engineer, connected via the Devin CLI's ACP mode.",
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds Devin (Cognition CLI agent) as a tier-2 preset ACP harness in PRESET_HARNESSES
- Devin CLI speaks ACP natively via `devin acp` — no adapter code needed
- Adds catalog description string for the desktop settings UI

### Files changed

- `desktop/src-tauri/src/managed_agents/discovery.rs` — Added PresetHarness entry
- `desktop/src/features/settings/ui/harnessCatalogCopy.ts` — Added description string

### Test plan

- [x] cargo check --manifest-path desktop/src-tauri/Cargo.toml passes
- [x] preset_ids_are_reserved_and_cannot_be_used_as_custom_ids test passes
- [x] builtin_ids_are_rejected test passes
- [ ] Manual: install Devin CLI, verify it appears in Desktop Settings > Agents catalog
- [ ] Manual: buzz-acp --agent-command devin --agent-args acp connects and responds to @mentions

Generated with [Devin](https://devin.ai)