### PR TITLE
fix(desktop): detect Kimi Code in its default install path

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -38,6 +38,7 @@ fn common_binary_paths() -> &'static [PathBuf] {
             paths.extend([
                 home.join(".local/share/mise/shims"),
                 home.join(".local/bin"),
+                home.join(".kimi-code/bin"),
                 home.join(".volta/bin"),
                 home.join(".asdf/shims"),
                 home.join(".bun/bin"),


### PR DESCRIPTION
## Summary

By default on linux kimi is installed at `~/.kimi-code/bin/kimi` and this was not detected automatically. This now fixes it by adding this path to the detection 

### Related issue

 N/A

### Testing

Before it did not appear / did not detect. Now it does :)
