### PR TITLE
fix(desktop): add opencode to default_agent_args for ACP support

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -465,7 +465,7 @@ pub fn try_record_agent_command(
 
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
-        "goose" => Some(vec!["acp".to_string()]),
+        "goose" | "opencode" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,


### PR DESCRIPTION
## Summary

The `default_agent_args` function was missing the `opencode` command identity. When a user selects the built-in OpenCode harness without specifying custom arguments, the agent launches without the required `acp` argument. This causes the ACP initialize to time out after 60 seconds.

Fixes #3660

## Root cause

`default_agent_args` in `desktop/src-tauri/src/managed_agents/discovery.rs` maps command names to their default ACP arguments. OpenCode needs `["acp"]` like Goose, but it was not listed — so `normalize_agent_args` returned an empty arg list when no user-defined args were stored on the record.

Normalization path when args are empty and no custom harness definition exists:
```
normalize_agent_args("opencode", []) → default_agent_args("opencode") → None → returns []
```

## Fix

Added `"opencode" => Some(vec!["acp".to_string()])` to `default_agent_args`.

## Testing

```
cargo check --workspace   # compiles cleanly
```