### PR TITLE
fix(desktop): strip Windows extended-path prefix before git clone

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1026,6 +1026,7 @@ dependencies = [
  "chrono",
  "ctrlc",
  "dirs",
+ "dunce",
  "earshot",
  "ed25519-dalek",
  "flate2",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -58,6 +58,7 @@ user-idle = { version = "0.6", default-features = false }
 atomic-write-file = "0.3"
 anyhow = "1"
 dirs = "6"
+dunce = "1"
 tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-deep-link = "2"
 tauri-plugin-opener = "2"

--- a/desktop/src-tauri/src/commands/project_git_workflow.rs
+++ b/desktop/src-tauri/src/commands/project_git_workflow.rs
@@ -8,7 +8,7 @@ use super::project_git_exec::{
 };
 use super::project_repo_paths::{
     canonical_repos_roots, canonicalize_repos_root, default_repos_root_candidates,
-    find_local_repo_dir, local_repo_candidates,
+    find_local_repo_dir, local_repo_candidates, strip_extended_path_prefix,
 };
 use crate::app_state::AppState;
 use crate::managed_agents::{load_managed_agents, spawn_key_refusal};
@@ -425,7 +425,7 @@ pub(crate) fn clone_project_repository_blocking(
         .into_iter()
         .next()
         .ok_or_else(|| "Could not derive a directory name for the repository.".to_string())?;
-    let repo_dir = repos_root.join(repo_name);
+    let repo_dir = strip_extended_path_prefix(&repos_root.join(repo_name));
     if repo_dir.exists() {
         return Err(format!(
             "{} already exists but is not a git checkout.",

--- a/desktop/src-tauri/src/commands/project_repo_paths.rs
+++ b/desktop/src-tauri/src/commands/project_repo_paths.rs
@@ -137,7 +137,7 @@ pub(crate) fn find_local_repo_dir(
                     .map(|url| checkout_origin_matches(&candidate_path, &repos_root, url))
                     .unwrap_or(true)
             {
-                return Ok(Some(candidate_path));
+                return Ok(Some(strip_extended_path_prefix(&candidate_path)));
             }
         }
     }
@@ -170,6 +170,16 @@ pub(crate) fn canonicalize_repos_root(
     Ok(repos_root)
 }
 
+/// Strip the Windows extended-length path prefix (`\\?\`) that
+/// `PathBuf::canonicalize()` adds on Windows. Git for Windows rejects
+/// `\\?\`-prefixed destinations, so canonical paths must be cleaned before
+/// being passed to the git CLI.
+pub(crate) fn strip_extended_path_prefix(
+    path: &std::path::Path,
+) -> std::path::PathBuf {
+    dunce::simplified(path).to_path_buf()
+}
+
 pub(crate) fn canonical_repos_roots(
     repos_dir: Option<&str>,
 ) -> Result<Vec<std::path::PathBuf>, String> {
@@ -189,4 +199,16 @@ pub(crate) fn canonical_repos_roots(
         return Err("reposDir is not accessible".to_string());
     }
     Ok(roots)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_extended_path_prefix;
+    use std::path::PathBuf;
+
+    #[test]
+    fn strip_extended_path_prefix_leaves_normal_path_untouched() {
+        let path = PathBuf::from("/home/james/.buzz/REPOS/owner--repo");
+        assert_eq!(strip_extended_path_prefix(&path), path);
+    }
 }


### PR DESCRIPTION
## Summary
- `PathBuf::canonicalize()` on Windows returns paths with the `\\?\` extended-length prefix, which Git for Windows rejects with `Invalid argument`
- Use `dunce::simplified()` to strip the prefix at the two git CLI boundaries before passing paths to git

Fixes #3707

## Testing
- `cargo test --lib -- project_repo_paths` passes
- `cargo clippy --lib` clean
- Needs Windows verification: clone a project repo via Buzz Desktop