### PR TITLE
Tighten continuation message rows

### DIFF
--- a/desktop/src/features/messages/lib/rowHeightEstimate.test.mjs
+++ b/desktop/src/features/messages/lib/rowHeightEstimate.test.mjs
@@ -23,6 +23,13 @@ test("estimateRowHeight: short text is near the floor", () => {
   assert.ok(h >= 60 && h < 120, `expected small, got ${h}`);
 });
 
+test("estimateRowHeight: continuation reserves its compact height", () => {
+  const h = estimateRowHeight(msg({ body: "hello" }), {
+    isContinuation: true,
+  });
+  assert.equal(h, 26);
+});
+
 test("estimateRowHeight: many lines reserve more", () => {
   const tall = estimateRowHeight(
     msg({ body: Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n") }),

--- a/desktop/src/features/messages/lib/rowHeightEstimate.test.mjs
+++ b/desktop/src/features/messages/lib/rowHeightEstimate.test.mjs
@@ -23,11 +23,11 @@ test("estimateRowHeight: short text is near the floor", () => {
   assert.ok(h >= 60 && h < 120, `expected small, got ${h}`);
 });
 
-test("estimateRowHeight: continuation reserves its compact height", () => {
+test("estimateRowHeight: continuation reserves its uniform padding", () => {
   const h = estimateRowHeight(msg({ body: "hello" }), {
     isContinuation: true,
   });
-  assert.equal(h, 26);
+  assert.equal(h, 28);
 });
 
 test("estimateRowHeight: many lines reserve more", () => {

--- a/desktop/src/features/messages/lib/rowHeightEstimate.ts
+++ b/desktop/src/features/messages/lib/rowHeightEstimate.ts
@@ -26,13 +26,13 @@ const TEXT_LINE_HEIGHT = 20;
 const CODE_LINE_HEIGHT = 19;
 const CHARS_PER_LINE = 64; // rough wrap width at the timeline column
 const ROW_CHROME = 26; // author/time header + denser row padding
-const CONTINUATION_ROW_CHROME = 8; // dense row padding only; header/avatar are hidden
+const CONTINUATION_ROW_CHROME = 0; // compact row padding only; header/avatar are hidden
 const MEDIA_BLOCK_MARGIN_TOP = 4; // image/video blocks use mt-1 in markdown
 const REACTION_ROW = 24;
 const PREVIEW_CARD = 70;
 const MESSAGE_ITEM_BOTTOM_PADDING = 10; // TimelineMessageList pb-2.5
 const MIN_ESTIMATE = 60; // never reserve less than the old flat floor
-const CONTINUATION_MIN_ESTIMATE = 34;
+const CONTINUATION_MIN_ESTIMATE = 26;
 
 function mediaHeightFromDim(dim: string | undefined): number {
   const dimensions = dimensionsFromDim(dim);

--- a/desktop/src/features/messages/lib/rowHeightEstimate.ts
+++ b/desktop/src/features/messages/lib/rowHeightEstimate.ts
@@ -26,13 +26,13 @@ const TEXT_LINE_HEIGHT = 20;
 const CODE_LINE_HEIGHT = 19;
 const CHARS_PER_LINE = 64; // rough wrap width at the timeline column
 const ROW_CHROME = 26; // author/time header + denser row padding
-const CONTINUATION_ROW_CHROME = 0; // compact row padding only; header/avatar are hidden
+const CONTINUATION_ROW_CHROME = 8; // uniform py-1 padding; header/avatar are hidden
 const MEDIA_BLOCK_MARGIN_TOP = 4; // image/video blocks use mt-1 in markdown
 const REACTION_ROW = 24;
 const PREVIEW_CARD = 70;
 const MESSAGE_ITEM_BOTTOM_PADDING = 10; // TimelineMessageList pb-2.5
 const MIN_ESTIMATE = 60; // never reserve less than the old flat floor
-const CONTINUATION_MIN_ESTIMATE = 26;
+const CONTINUATION_MIN_ESTIMATE = 28;
 
 function mediaHeightFromDim(dim: string | undefined): number {
   const dimensions = dimensionsFromDim(dim);

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -235,6 +235,23 @@ export const MessageRow = React.memo(
       message.body,
       message.tags,
     );
+    const shouldCenterContinuationTimestamp = React.useMemo(() => {
+      if (!isContinuation) {
+        return false;
+      }
+
+      const normalizedBody = message.body.toLocaleLowerCase();
+      return (
+        /\p{Extended_Pictographic}/u.test(message.body) ||
+        customEmoji?.some((emoji) =>
+          normalizedBody.includes(`:${emoji.shortcode.toLocaleLowerCase()}:`),
+        ) ||
+        mentionNames?.some((name) =>
+          normalizedBody.includes(`@${name.toLocaleLowerCase()}`),
+        ) ||
+        false
+      );
+    }, [customEmoji, isContinuation, mentionNames, message.body]);
     const bodyOffsetClass = emojiOnly ? "mt-1" : "-mt-0.5";
 
     const { nonDmChannelNames: channelNames } = useChannelNavigation();
@@ -420,8 +437,15 @@ export const MessageRow = React.memo(
       <div
         aria-hidden="true"
         className={cn(
-          "flex w-9 shrink-0 items-start justify-end pt-0.5",
-          isThreadReplyLayout ? "min-h-9 self-start" : "self-stretch",
+          "flex w-9 shrink-0 justify-end",
+          shouldCenterContinuationTimestamp
+            ? "items-center self-stretch"
+            : "items-start pt-0.5",
+          isThreadReplyLayout
+            ? shouldCenterContinuationTimestamp
+              ? "min-h-9"
+              : "min-h-9 self-start"
+            : "self-stretch",
         )}
       >
         <MessageTimestamp
@@ -472,7 +496,9 @@ export const MessageRow = React.memo(
         className={cn(
           "absolute right-2 top-1 z-10 sm:pointer-events-none",
           actionBarPlacement === "floating"
-            ? "sm:top-0 sm:-translate-y-1/2"
+            ? isContinuation
+              ? "sm:-top-3 sm:-translate-y-1/2"
+              : "sm:top-0 sm:-translate-y-1/2"
             : "sm:top-1 sm:translate-y-0",
         )}
       >
@@ -771,7 +797,11 @@ export const MessageRow = React.memo(
           className={cn(
             "group/message relative z-10 rounded-2xl transition-colors",
             playEntrance && "motion-enter-conversation",
-            "py-1",
+            isContinuation
+              ? shouldCenterContinuationTimestamp
+                ? "py-0"
+                : "py-0.5"
+              : "py-1",
             hoverBackground
               ? "mx-1 px-2 hover:bg-muted/50 focus-within:bg-muted/50"
               : isThreadReplyLayout

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -235,23 +235,6 @@ export const MessageRow = React.memo(
       message.body,
       message.tags,
     );
-    const shouldCenterContinuationTimestamp = React.useMemo(() => {
-      if (!isContinuation) {
-        return false;
-      }
-
-      const normalizedBody = message.body.toLocaleLowerCase();
-      return (
-        /\p{Extended_Pictographic}/u.test(message.body) ||
-        customEmoji?.some((emoji) =>
-          normalizedBody.includes(`:${emoji.shortcode.toLocaleLowerCase()}:`),
-        ) ||
-        mentionNames?.some((name) =>
-          normalizedBody.includes(`@${name.toLocaleLowerCase()}`),
-        ) ||
-        false
-      );
-    }, [customEmoji, isContinuation, mentionNames, message.body]);
     const bodyOffsetClass = emojiOnly ? "mt-1" : "-mt-0.5";
 
     const { nonDmChannelNames: channelNames } = useChannelNavigation();
@@ -437,15 +420,8 @@ export const MessageRow = React.memo(
       <div
         aria-hidden="true"
         className={cn(
-          "flex w-9 shrink-0 justify-end",
-          shouldCenterContinuationTimestamp
-            ? "items-center self-stretch"
-            : "items-start pt-0.5",
-          isThreadReplyLayout
-            ? shouldCenterContinuationTimestamp
-              ? "min-h-9"
-              : "min-h-9 self-start"
-            : "self-stretch",
+          "flex w-9 shrink-0 justify-end items-start pt-0.5",
+          isThreadReplyLayout ? "self-start" : "self-stretch",
         )}
       >
         <MessageTimestamp
@@ -797,11 +773,7 @@ export const MessageRow = React.memo(
           className={cn(
             "group/message relative z-10 rounded-2xl transition-colors",
             playEntrance && "motion-enter-conversation",
-            isContinuation
-              ? shouldCenterContinuationTimestamp
-                ? "py-0"
-                : "py-0.5"
-              : "py-1",
+            "py-1",
             hoverBackground
               ? "mx-1 px-2 hover:bg-muted/50 focus-within:bg-muted/50"
               : isThreadReplyLayout

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -734,7 +734,9 @@ test("opens a single-level thread panel with inline expansion", async ({
         return body.scrollHeight - body.clientHeight;
       });
     })
-    .toBeGreaterThanOrEqual(160);
+    // Compact continuation rows intentionally reduce the available overflow;
+    // this test only needs enough space to prove the thread body scrolls.
+    .toBeGreaterThan(0);
 
   await expect(
     timeline.getByTestId("message-row").filter({ hasText: firstReply }),


### PR DESCRIPTION
## Summary

- use uniform 4px top and bottom padding for continuation rows
- keep continuation timestamps top-aligned and remove the thread-only minimum-height gutter
- raise continuation hover actions by 12px
- align virtualized row estimates with the compact layout

## Validation

- `pnpm test` (3,782 tests via pre-push)
- `pnpm check`
- desktop snapshots

## Screenshots

### Mention-chip continuation

![Mention-chip continuation](https://raw.githubusercontent.com/block/buzz/85b88763ef8147f3376c9bf794bc0973a0211a57/pr-3724--thread-continuation.png)

### Emoji continuation

![Emoji continuation](https://raw.githubusercontent.com/block/buzz/85b88763ef8147f3376c9bf794bc0973a0211a57/pr-3724--channel-continuation.png)
