### PR TITLE
feat(desktop): add a 12-hour/24-hour clock setting to Appearance

### DIFF
--- a/desktop/src/features/agents/ui/agentSessionUtils.ts
+++ b/desktop/src/features/agents/ui/agentSessionUtils.ts
@@ -1,4 +1,5 @@
 import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
+import { createClockFormatter } from "@/shared/lib/timeFormat";
 
 export function getToolString(
   record: Record<string, unknown>,
@@ -236,13 +237,12 @@ export function shortenMiddle(value: string, maxLength: number) {
   return `${value.slice(0, edgeLength)}...${value.slice(-edgeLength)}`;
 }
 
-const transcriptTimeFormat = new Intl.DateTimeFormat("en-US", {
+const formatTranscriptClockTime = createClockFormatter("en-US", {
   hour: "numeric",
-  hour12: true,
   minute: "2-digit",
 });
 
-const transcriptTitleTimeFormat = new Intl.DateTimeFormat(undefined, {
+const formatTranscriptTitleClockTime = createClockFormatter(undefined, {
   weekday: "long",
   year: "numeric",
   month: "long",
@@ -255,7 +255,7 @@ const transcriptTitleTimeFormat = new Intl.DateTimeFormat(undefined, {
 export function formatTranscriptTime(isoTimestamp: string): string | null {
   const date = new Date(isoTimestamp);
   if (Number.isNaN(date.getTime())) return null;
-  return transcriptTimeFormat.format(date);
+  return formatTranscriptClockTime(date);
 }
 
 export function formatTranscriptTimestampTitle(
@@ -263,7 +263,7 @@ export function formatTranscriptTimestampTitle(
 ): string | undefined {
   const date = new Date(isoTimestamp);
   if (Number.isNaN(date.getTime())) return isoTimestamp || undefined;
-  return transcriptTitleTimeFormat.format(date);
+  return formatTranscriptTitleClockTime(date);
 }
 
 export function formatDuration(

--- a/desktop/src/features/channels/lib/ephemeralChannel.ts
+++ b/desktop/src/features/channels/lib/ephemeralChannel.ts
@@ -1,9 +1,10 @@
 import type { Channel } from "@/shared/api/types";
+import { createClockFormatter } from "@/shared/lib/timeFormat";
 
 const relativeTimeFormatter = new Intl.RelativeTimeFormat("en-US", {
   numeric: "auto",
 });
-const absoluteTimeFormatter = new Intl.DateTimeFormat("en-US", {
+const formatAbsoluteTime = createClockFormatter("en-US", {
   month: "short",
   day: "numeric",
   hour: "numeric",
@@ -138,7 +139,7 @@ export function getEphemeralChannelDisplay(
   const remainingSeconds = resolveRemainingSeconds(channel.ttlDeadline, nowMs);
   const absoluteDeadlineLabel =
     channel.ttlDeadline && !Number.isNaN(Date.parse(channel.ttlDeadline))
-      ? absoluteTimeFormatter.format(new Date(channel.ttlDeadline))
+      ? formatAbsoluteTime(new Date(channel.ttlDeadline))
       : null;
   if (remainingSeconds === null) {
     return {

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -73,6 +73,7 @@ import { useElementWidth } from "@/shared/hooks/use-mobile";
 import { useThreadPanelWidth } from "@/shared/hooks/useThreadPanelWidth";
 import { AUXILIARY_PANEL_SINGLE_COLUMN_BREAKPOINT_PX } from "@/shared/layout/AuxiliaryPanel";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+import { useTimeFormatPreference } from "@/shared/lib/timeFormat";
 import { useChannelActivityTyping } from "./useChannelActivityTyping";
 import { useChannelAgentSessions } from "./useChannelAgentSessions";
 import { useMessageProfiles } from "./useMessageProfiles";
@@ -385,6 +386,11 @@ export function ChannelScreen({
     }
     return { personaLookup: pLookup, respondToLookup: rLookup };
   }, [managedAgentsQuery.data, personasQuery.data]);
+  // Not read inside the memo — `formatTimelineMessages` bakes each row's `time`
+  // from the module-level clock preference, so this only invalidates the cache
+  // when the user flips 12h/24h in Settings.
+  const timeFormatPreference = useTimeFormatPreference();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: timeFormatPreference invalidates the row `time` strings baked in by formatTimelineMessages
   const timelineMessages = React.useMemo(
     () =>
       formatTimelineMessages(
@@ -410,6 +416,7 @@ export function ChannelScreen({
       relaySelfPubkey,
       respondToLookup,
       resolvedMessages,
+      timeFormatPreference,
     ],
   );
   const threadSummaries: ReadonlyMap<string, ChannelWindowThreadSummary> =

--- a/desktop/src/features/home/lib/inbox.ts
+++ b/desktop/src/features/home/lib/inbox.ts
@@ -11,6 +11,7 @@ import {
   isProjectInboxItem,
 } from "@/features/home/lib/projectInbox";
 import type { TimelineReaction } from "@/features/messages/types";
+import { createClockFormatter } from "@/shared/lib/timeFormat";
 import type {
   Channel,
   FeedItem,
@@ -103,12 +104,12 @@ export type InboxGroup = {
 
 type InboxChannel = Pick<Channel, "channelType" | "id" | "name">;
 
-const listTimeFormatter = new Intl.DateTimeFormat("en-US", {
+const formatListTime = createClockFormatter("en-US", {
   hour: "numeric",
   minute: "2-digit",
 });
 
-const fullTimeFormatter = new Intl.DateTimeFormat("en-US", {
+const formatFullTime = createClockFormatter("en-US", {
   month: "short",
   day: "numeric",
   year: "numeric",
@@ -450,7 +451,7 @@ function formatInboxTimestamp(unixSeconds: number) {
   const dayDiff = diffInDays(now, date);
 
   if (dayDiff === 0) {
-    return listTimeFormatter.format(date);
+    return formatListTime(date);
   }
 
   if (dayDiff === 1) {
@@ -465,7 +466,7 @@ function formatInboxTimestamp(unixSeconds: number) {
 }
 
 export function formatInboxFullTimestamp(unixSeconds: number) {
-  return fullTimeFormatter.format(new Date(unixSeconds * 1_000));
+  return formatFullTime(new Date(unixSeconds * 1_000));
 }
 
 export function relayEventFromFeedItem(item: FeedItem): RelayEvent {

--- a/desktop/src/features/home/ui/FeedSection.tsx
+++ b/desktop/src/features/home/ui/FeedSection.tsx
@@ -18,12 +18,20 @@ import {
   KIND_REMINDER,
 } from "@/shared/constants/kinds";
 import { resolveMentionProps } from "@/shared/lib/resolveMentionNames";
+import { createClockFormatter } from "@/shared/lib/timeFormat";
 import { Button } from "@/shared/ui/button";
 import { Markdown } from "@/shared/ui/markdown";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 
 const relativeTimeFormatter = new Intl.RelativeTimeFormat("en-US", {
   numeric: "auto",
+});
+
+const formatAbsoluteFeedTime = createClockFormatter("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
 });
 
 function formatRelativeTime(unixSeconds: number) {
@@ -49,12 +57,7 @@ function formatRelativeTime(unixSeconds: number) {
     );
   }
 
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(new Date(unixSeconds * 1_000));
+  return formatAbsoluteFeedTime(new Date(unixSeconds * 1_000));
 }
 
 function feedHeadline(item: FeedItem) {

--- a/desktop/src/features/home/ui/HomeView.tsx
+++ b/desktop/src/features/home/ui/HomeView.tsx
@@ -64,6 +64,7 @@ import { KIND_REACTION } from "@/shared/constants/kinds";
 import { topChromeInset } from "@/shared/layout/chromeLayout";
 import { cn } from "@/shared/lib/cn";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+import { useTimeFormatPreference } from "@/shared/lib/timeFormat";
 import { useElementWidth } from "@/shared/hooks/use-mobile";
 import { useThreadPanelWidth } from "@/shared/hooks/useThreadPanelWidth";
 import { AUXILIARY_PANEL_SINGLE_COLUMN_BREAKPOINT_PX } from "@/shared/layout/AuxiliaryPanel";
@@ -352,7 +353,11 @@ export function HomeView({
 
     return pubkeys;
   }, [feedProfiles, communityAgentPubkeys]);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: readStateVersion invalidates the stable getChannelReadAt callback
+  // `buildInboxItems` formats its timestamp labels from the module-level clock
+  // preference, so this value only exists to invalidate the memo below (and to
+  // repaint the inline labels this view formats during render).
+  const timeFormatPreference = useTimeFormatPreference();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: readStateVersion invalidates the stable getChannelReadAt callback; timeFormatPreference invalidates the baked timestamp labels
   const inboxItems = React.useMemo(() => {
     const items = buildInboxItems({
       channels,
@@ -373,6 +378,7 @@ export function HomeView({
     getMessageReadAt,
     getThreadReadAt,
     readStateVersion,
+    timeFormatPreference,
   ]);
   const { effectiveDoneSet, markItemRead, markItemUnread } =
     useHomeInboxReadState({

--- a/desktop/src/features/home/useHomeInboxContextMessages.ts
+++ b/desktop/src/features/home/useHomeInboxContextMessages.ts
@@ -9,6 +9,7 @@ import { formatTimelineMessages } from "@/features/messages/lib/formatTimelineMe
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { Channel, RelayEvent } from "@/shared/api/types";
 import { KIND_REACTION } from "@/shared/constants/kinds";
+import { useTimeFormatPreference } from "@/shared/lib/timeFormat";
 
 type UseHomeInboxContextMessagesOptions = {
   channelMessages?: RelayEvent[];
@@ -35,6 +36,12 @@ export function useHomeInboxContextMessages({
   selectedEventId,
   selectedItem,
 }: UseHomeInboxContextMessagesOptions): InboxContextMessage[] {
+  // Clock preference is not read inside the callback — `formatTimelineMessages`
+  // and `toInboxContextMessage` bake the formatted strings from the module-level
+  // preference — so it rides along purely to invalidate those labels.
+  const timeFormatPreference = useTimeFormatPreference();
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: timeFormatPreference invalidates the baked `timeLabel`/`fullTimestampLabel` strings
   return React.useMemo(() => {
     if (!selectedItem) return [];
 
@@ -83,5 +90,6 @@ export function useHomeInboxContextMessages({
     selectedChannel,
     selectedEventId,
     selectedItem,
+    timeFormatPreference,
   ]);
 }

--- a/desktop/src/features/messages/lib/dateFormatters.ts
+++ b/desktop/src/features/messages/lib/dateFormatters.ts
@@ -1,22 +1,28 @@
 /**
  * Shared date/time formatters for the message timeline.
  *
- * - `formatTime` — short clock time ("2:34 PM"), used in message rows.
+ * - `formatTime` — short clock time ("2:34 PM", or "14:34" on a 24-hour clock),
+ *   used in message rows.
  * - `formatFullDateTime` — verbose string for tooltips
  *   ("Wednesday, April 2, 2026 at 2:34 PM").
  * - `formatDayHeading` — label for day dividers / sticky headers.
  *   Returns "Today", "Yesterday", or a date like "Monday, March 31st".
  * - `isSameDay` — compare two unix-second timestamps.
+ *
+ * Clock-bearing formatters follow the Appearance → Clock preference; see
+ * `@/shared/lib/timeFormat`.
  */
 
-const TIME_FORMATTER = new Intl.DateTimeFormat("en-US", {
+import { createClockFormatter } from "@/shared/lib/timeFormat";
+
+const formatClockTime = createClockFormatter("en-US", {
   hour: "numeric",
   minute: "2-digit",
 });
 
 const DAY_PERIOD_SUFFIX_RE = /[\s\u00a0\u202f]*(?:AM|PM)$/i;
 
-const FULL_DATE_TIME_FORMATTER = new Intl.DateTimeFormat("en-US", {
+const formatFullClockDateTime = createClockFormatter("en-US", {
   weekday: "long",
   year: "numeric",
   month: "long",
@@ -37,19 +43,22 @@ const SHORT_MONTH_FORMATTER = new Intl.DateTimeFormat("en-US", {
   month: "short",
 });
 
-/** Short clock time, e.g. "2:34 PM". */
+/** Short clock time, e.g. "2:34 PM" — or "14:34" on a 24-hour clock. */
 export function formatTime(unixSeconds: number): string {
-  return TIME_FORMATTER.format(new Date(unixSeconds * 1_000));
+  return formatClockTime(new Date(unixSeconds * 1_000));
 }
 
-/** Short clock time with the AM/PM marker removed, e.g. "2:34". */
+/**
+ * Short clock time with the AM/PM marker removed, e.g. "2:34". A 24-hour clock
+ * has no marker to strip, so such times pass through unchanged.
+ */
 export function formatTimeWithoutDayPeriod(time: string): string {
   return time.replace(DAY_PERIOD_SUFFIX_RE, "").trim();
 }
 
 /** Full date + time for tooltips, e.g. "Wednesday, April 2, 2026 at 2:34 PM". */
 export function formatFullDateTime(unixSeconds: number): string {
-  return FULL_DATE_TIME_FORMATTER.format(new Date(unixSeconds * 1_000));
+  return formatFullClockDateTime(new Date(unixSeconds * 1_000));
 }
 
 /**

--- a/desktop/src/features/messages/ui/DraftsPanel.tsx
+++ b/desktop/src/features/messages/ui/DraftsPanel.tsx
@@ -28,6 +28,7 @@ import { useIdentityQuery } from "@/shared/api/hooks";
 import { getEventById } from "@/shared/api/tauri";
 import type { Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import { createClockFormatter } from "@/shared/lib/timeFormat";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -65,7 +66,7 @@ const UNKNOWN_DRAFT_SOURCE: DraftSource = {
   label: UNKNOWN_CHANNEL_LABEL,
 };
 
-const draftTimeFormatter = new Intl.DateTimeFormat("en-US", {
+const formatDraftTime = createClockFormatter("en-US", {
   month: "short",
   day: "numeric",
   hour: "numeric",
@@ -79,9 +80,7 @@ function parseDraftTime(value: string): number {
 
 export function formatDraftCreatedAt(draft: DraftState): string {
   const time = parseDraftTime(draft.createdAt);
-  return time === 0
-    ? "Unknown time"
-    : draftTimeFormatter.format(new Date(time));
+  return time === 0 ? "Unknown time" : formatDraftTime(new Date(time));
 }
 
 function getOriginalDraftKey(draftKey: string): string {

--- a/desktop/src/features/messages/useIndependentThreadPanel.ts
+++ b/desktop/src/features/messages/useIndependentThreadPanel.ts
@@ -8,6 +8,7 @@ import type {
   RelayEvent,
   RespondToMode,
 } from "@/shared/api/types";
+import { useTimeFormatPreference } from "@/shared/lib/timeFormat";
 
 export function useIndependentThreadPanel(args: {
   activeChannel: Channel | null;
@@ -25,6 +26,11 @@ export function useIndependentThreadPanel(args: {
   respondToLookup: Map<string, RespondToMode>;
   relaySelfPubkey: string | null | undefined;
 }) {
+  // Rides in the dep list only to invalidate the `time` strings that
+  // `formatTimelineMessages` bakes from the clock preference; nothing in the
+  // callback reads it directly.
+  const timeFormatPreference = useTimeFormatPreference();
+
   // Depend on the individual fields, NOT the `args` object — callers pass a
   // fresh object literal every render, so `[args]` never memoizes and the
   // full O(replies) formatTimelineMessages + buildThreadPanelData rebuild
@@ -33,6 +39,7 @@ export function useIndependentThreadPanel(args: {
   // screen) that saturates the main thread and starves keystrokes — see
   // typing-latency.perf.ts scenario "thread68+". Mirrors the main timeline's
   // memoization of the same formatter (ChannelScreen `timelineMessages`).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: timeFormatPreference invalidates the baked `time` strings
   return React.useMemo(
     () =>
       buildIndependentThreadPanel(
@@ -66,6 +73,7 @@ export function useIndependentThreadPanel(args: {
       args.personaLookup,
       args.respondToLookup,
       args.relaySelfPubkey,
+      timeFormatPreference,
     ],
   );
 }

--- a/desktop/src/features/projects/lib/projectsViewHelpers.ts
+++ b/desktop/src/features/projects/lib/projectsViewHelpers.ts
@@ -4,6 +4,7 @@ import type {
 } from "@/features/projects/hooks";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+import { withClockOptions } from "@/shared/lib/timeFormat";
 
 export type ProjectsViewMode = "grid" | "list";
 export type ProjectsRepositoryScope = "all" | "mine" | "local";
@@ -226,14 +227,17 @@ export function relativeTime(
 }
 
 export function formatExactTimestamp(createdAt: number) {
-  return new Date(createdAt * 1_000).toLocaleString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-  });
+  return new Date(createdAt * 1_000).toLocaleString(
+    undefined,
+    withClockOptions({
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      second: "2-digit",
+    }),
+  );
 }
 
 export function projectPeople(

--- a/desktop/src/features/projects/ui/ProjectCommitDetailPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectCommitDetailPanel.tsx
@@ -9,16 +9,20 @@ import {
   type UserProfileLookup,
 } from "@/features/profile/lib/identity";
 import type { ProjectRepoCommit, ProjectRepoDiff } from "@/shared/api/types";
+import { withClockOptions } from "@/shared/lib/timeFormat";
 import { CopyCommitHashButton } from "./ProjectCommitCopyButton";
 import { ProfileIdentityButton } from "./ProjectProfileIdentity";
 import { ProjectDiffFilesPanel } from "./ProjectPullRequestFilesChangedPanel";
 import { ProjectRichContent } from "./ProjectRichContent";
 
 function commitDateLabel(timestamp: number) {
-  return new Date(timestamp * 1_000).toLocaleString(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  });
+  return new Date(timestamp * 1_000).toLocaleString(
+    undefined,
+    withClockOptions({
+      dateStyle: "medium",
+      timeStyle: "short",
+    }),
+  );
 }
 
 /**

--- a/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
@@ -32,6 +32,7 @@ import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { UserSearchResult } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { normalizePubkey } from "@/shared/lib/pubkey";
+import { withClockOptions } from "@/shared/lib/timeFormat";
 import { SyntaxHighlightedCode } from "@/shared/ui/markdown";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import {
@@ -47,12 +48,15 @@ function pluralize(count: number, singular: string) {
 
 export function formatLastChangedAt(timestamp: number | null) {
   if (!timestamp) return "—";
-  return new Date(timestamp * 1_000).toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
+  return new Date(timestamp * 1_000).toLocaleString(
+    undefined,
+    withClockOptions({
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }),
+  );
 }
 
 function formatFileSize(size: number | null) {

--- a/desktop/src/features/search/ui/SearchResultItem.tsx
+++ b/desktop/src/features/search/ui/SearchResultItem.tsx
@@ -17,6 +17,7 @@ import {
   type UserProfileLookup,
 } from "@/features/profile/lib/identity";
 import type { Channel, SearchHit, UserSearchResult } from "@/shared/api/types";
+import { createClockFormatter } from "@/shared/lib/timeFormat";
 import { Badge } from "@/shared/ui/badge";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 
@@ -189,6 +190,13 @@ function truncateContent(content: string) {
   return `${trimmed.slice(0, 177)}...`;
 }
 
+const formatAbsoluteHit = createClockFormatter("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
 function formatRelativeTime(unixSeconds: number) {
   const diff = Math.floor(Date.now() / 1_000) - unixSeconds;
 
@@ -204,12 +212,7 @@ function formatRelativeTime(unixSeconds: number) {
     return `${Math.floor(diff / (60 * 60))}h ago`;
   }
 
-  return new Intl.DateTimeFormat("en-US", {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(new Date(unixSeconds * 1_000));
+  return formatAbsoluteHit(new Date(unixSeconds * 1_000));
 }
 
 export function MessageResultBody({

--- a/desktop/src/features/settings/ui/ModerationQueueCard.tsx
+++ b/desktop/src/features/settings/ui/ModerationQueueCard.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/features/settings/lib/moderationQueue";
 import { cn } from "@/shared/lib/cn";
 import { truncatePubkey } from "@/shared/lib/pubkey";
+import { withClockOptions } from "@/shared/lib/timeFormat";
 import { Button } from "@/shared/ui/button";
 import {
   DropdownMenu,
@@ -177,12 +178,15 @@ const RESOLUTION_OPTIONS: {
 function formatTimestamp(iso: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
-  return date.toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
+  return date.toLocaleString(
+    undefined,
+    withClockOptions({
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }),
+  );
 }
 
 const SEVERITY_BADGE: Record<SeverityTier, string> = {

--- a/desktop/src/features/settings/ui/SettingsPanels.tsx
+++ b/desktop/src/features/settings/ui/SettingsPanels.tsx
@@ -37,6 +37,12 @@ import {
   type ThreadViewMode,
 } from "@/features/channels/lib/threadViewModePreference";
 import { cn } from "@/shared/lib/cn";
+import {
+  resolvesToHour12,
+  setTimeFormatPreference,
+  useTimeFormatPreference,
+  type TimeFormatPreference,
+} from "@/shared/lib/timeFormat";
 import { Button } from "@/shared/ui/button";
 import {
   DropdownMenu,
@@ -646,8 +652,102 @@ function ThemeSettingsCard() {
         </AnimatePresence>
       )}
 
+      <ClockFormatSetting />
       <ThreadLayoutSetting />
     </section>
+  );
+}
+
+const TIME_FORMAT_OPTIONS: {
+  value: TimeFormatPreference;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "system",
+    label: "System",
+    description: "Match this device's clock",
+  },
+  {
+    value: "12-hour",
+    label: "12-hour",
+    description: "Times read like 1:30 PM",
+  },
+  {
+    value: "24-hour",
+    label: "24-hour",
+    description: "Times read like 13:30",
+  },
+];
+
+/**
+ * Clock picker: 12-hour or 24-hour times across the app — message rows, inbox
+ * labels, agent transcripts, project panels, search results. Mirrors
+ * {@link ThreadLayoutSetting}'s dropdown radio group so both Appearance rows
+ * share one vocabulary.
+ */
+function ClockFormatSetting() {
+  const timeFormatPreference = useTimeFormatPreference();
+  const activeOption =
+    TIME_FORMAT_OPTIONS.find(
+      (option) => option.value === timeFormatPreference,
+    ) ?? TIME_FORMAT_OPTIONS[0];
+
+  // "System" is otherwise opaque — say which clock this device resolves to.
+  const systemClockLabel = resolvesToHour12("system") ? "12-hour" : "24-hour";
+  const description =
+    timeFormatPreference === "system"
+      ? `Match this device's clock — ${systemClockLabel} here`
+      : activeOption.description;
+
+  return (
+    <SettingsOptionGroup className="mt-8">
+      <SettingsOptionRow>
+        <div className="min-w-0">
+          <p className="text-sm font-medium">Clock</p>
+          <p className="text-sm font-normal text-muted-foreground">
+            {description}
+          </p>
+        </div>
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              className="h-7 min-w-28 justify-between gap-1.5 rounded-full border border-border/50 bg-muted/45 px-2.5 text-xs font-medium text-foreground shadow-none hover:bg-muted/70"
+              data-testid="clock-format-trigger"
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              <span className="truncate">{activeOption.label}</span>
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-72">
+            <DropdownMenuRadioGroup
+              onValueChange={(next) =>
+                setTimeFormatPreference(next as TimeFormatPreference)
+              }
+              value={timeFormatPreference}
+            >
+              {TIME_FORMAT_OPTIONS.map((option) => (
+                <DropdownMenuRadioItem
+                  data-testid={`clock-format-${option.value}`}
+                  key={option.value}
+                  value={option.value}
+                >
+                  <span className="flex min-w-0 flex-col">
+                    <span className="font-medium">{option.label}</span>
+                    <span className="text-2xs text-muted-foreground">
+                      {option.description}
+                    </span>
+                  </span>
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SettingsOptionRow>
+    </SettingsOptionGroup>
   );
 }
 

--- a/desktop/src/shared/lib/timeFormat.test.mjs
+++ b/desktop/src/shared/lib/timeFormat.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createClockFormatter,
+  getTimeFormatPreference,
+  resolvesToHour12,
+  setTimeFormatPreference,
+  withClockOptions,
+} from "./timeFormat.ts";
+
+// A fixed local wall-clock instant: 2026-04-02, 14:34 local time.
+const AFTERNOON = new Date(2026, 3, 2, 14, 34);
+// Local midnight — the case that separates an h23 cycle ("00:07") from h24
+// ("24:07"), which some locale defaults would otherwise pick.
+const MIDNIGHT = new Date(2026, 3, 2, 0, 7);
+
+function resetPreference() {
+  setTimeFormatPreference("12-hour");
+}
+
+// Runs first on purpose: nothing has called the setter yet, so this observes
+// the value the module resolved at import time (no localStorage under node).
+test("defaults to the 12-hour clock the app shipped with", () => {
+  assert.equal(getTimeFormatPreference(), "12-hour");
+});
+
+test("setTimeFormatPreference round-trips through the module", () => {
+  resetPreference();
+
+  setTimeFormatPreference("24-hour");
+  assert.equal(getTimeFormatPreference(), "24-hour");
+
+  setTimeFormatPreference("system");
+  assert.equal(getTimeFormatPreference(), "system");
+
+  resetPreference();
+  assert.equal(getTimeFormatPreference(), "12-hour");
+});
+
+test("resolvesToHour12 answers literally for explicit clocks", () => {
+  assert.equal(resolvesToHour12("12-hour"), true);
+  assert.equal(resolvesToHour12("24-hour"), false);
+});
+
+test("resolvesToHour12 defaults to the active preference", () => {
+  resetPreference();
+  assert.equal(resolvesToHour12(), true);
+
+  setTimeFormatPreference("24-hour");
+  assert.equal(resolvesToHour12(), false);
+
+  resetPreference();
+});
+
+test("resolvesToHour12 resolves `system` to a boolean, not undefined", () => {
+  // The host locale decides which one, so only assert it is a real answer —
+  // callers pass it straight into Intl options.
+  assert.equal(typeof resolvesToHour12("system"), "boolean");
+});
+
+test("withClockOptions pins h23 for 24-hour and clears any hardcoded hour12", () => {
+  const options = withClockOptions(
+    { hour: "numeric", minute: "2-digit", hour12: true },
+    false,
+  );
+
+  assert.equal(options.hour12, undefined);
+  assert.equal(options.hourCycle, "h23");
+  assert.equal(options.hour, "numeric");
+  assert.equal(options.minute, "2-digit");
+});
+
+test("withClockOptions asks for hour12 without an hourCycle for 12-hour", () => {
+  const options = withClockOptions({ hour: "numeric" }, true);
+
+  assert.equal(options.hour12, true);
+  assert.equal(options.hourCycle, undefined);
+});
+
+test("withClockOptions stays legal alongside dateStyle/timeStyle", () => {
+  // Intl throws when dateStyle/timeStyle is combined with component options
+  // like `hour`, but permits hour12/hourCycle — the commit detail panel relies
+  // on that, so assert both directions actually construct.
+  for (const hour12 of [true, false]) {
+    const options = withClockOptions(
+      { dateStyle: "medium", timeStyle: "short" },
+      hour12,
+    );
+    assert.doesNotThrow(() => new Intl.DateTimeFormat("en-US", options));
+  }
+});
+
+test("createClockFormatter renders both clocks for the same instant", () => {
+  resetPreference();
+  const formatClockTime = createClockFormatter("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  // Day-period markers use a narrow no-break space in modern ICU; normalize
+  // it (`\s` covers U+00A0 and U+202F) so the assertion stays readable.
+  const afternoon = formatClockTime(AFTERNOON).replace(/\s+/g, " ");
+  assert.equal(afternoon, "2:34 PM");
+
+  setTimeFormatPreference("24-hour");
+  assert.equal(formatClockTime(AFTERNOON), "14:34");
+
+  resetPreference();
+});
+
+test("createClockFormatter rebuilds when the preference flips back", () => {
+  resetPreference();
+  const formatClockTime = createClockFormatter("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  const first = formatClockTime(AFTERNOON);
+  setTimeFormatPreference("24-hour");
+  const second = formatClockTime(AFTERNOON);
+  resetPreference();
+  const third = formatClockTime(AFTERNOON);
+
+  assert.notEqual(first, second);
+  assert.equal(first, third);
+});
+
+test("24-hour midnight reads 00:07, never 24:07", () => {
+  setTimeFormatPreference("24-hour");
+  const formatClockTime = createClockFormatter("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  assert.equal(formatClockTime(MIDNIGHT), "00:07");
+  resetPreference();
+});
+
+test("24-hour keeps en-US date wording and only swaps the clock", () => {
+  setTimeFormatPreference("24-hour");
+  const formatFullDateTime = createClockFormatter("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  const formatted = formatFullDateTime(AFTERNOON);
+  assert.match(formatted, /Thursday, April 2, 2026/);
+  assert.match(formatted, /14:34/);
+  assert.doesNotMatch(formatted, /AM|PM/);
+
+  resetPreference();
+});

--- a/desktop/src/shared/lib/timeFormat.ts
+++ b/desktop/src/shared/lib/timeFormat.ts
@@ -1,0 +1,180 @@
+import * as React from "react";
+
+/**
+ * User preference for the clock style used everywhere the app prints a time of
+ * day — message rows, inbox labels, agent transcripts, project panels, search
+ * results.
+ *
+ * - `system` — follow the host's clock convention (what the OS locale uses).
+ * - `12-hour` — 12-hour clock with an AM/PM marker ("2:34 PM").
+ * - `24-hour` — 24-hour clock ("14:34").
+ *
+ * Persisted in localStorage. This is a device-level UI preference, not
+ * community-scoped data, so it is intentionally not reset on community switch.
+ *
+ * Defaults to `12-hour` rather than `system`: every clock in the app was
+ * hardcoded to `en-US` before this preference existed, so 12-hour is what
+ * existing installs already show. Keeping it as the default means upgrading
+ * changes nothing until the user picks a clock, and keeps rendered times
+ * deterministic in tests and screenshots regardless of host locale.
+ *
+ * Date wording stays as-is: the app pins `en-US` for month/weekday names, and
+ * this preference only overrides the hour cycle, so switching to 24-hour does
+ * not silently re-localize every date label.
+ */
+export type TimeFormatPreference = "system" | "12-hour" | "24-hour";
+
+const STORAGE_KEY = "buzz.appearance.timeFormat";
+
+/** Clock used when nothing is stored, or the stored value is unrecognized. */
+const DEFAULT_TIME_FORMAT_PREFERENCE: TimeFormatPreference = "12-hour";
+
+const listeners = new Set<() => void>();
+
+let timeFormatPreference = readStoredPreference();
+
+function parseTimeFormatPreference(
+  value: string | null | undefined,
+): TimeFormatPreference {
+  return value === "system" || value === "12-hour" || value === "24-hour"
+    ? value
+    : DEFAULT_TIME_FORMAT_PREFERENCE;
+}
+
+function readStoredPreference(): TimeFormatPreference {
+  try {
+    return parseTimeFormatPreference(
+      globalThis.localStorage?.getItem(STORAGE_KEY),
+    );
+  } catch {
+    return DEFAULT_TIME_FORMAT_PREFERENCE;
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): TimeFormatPreference {
+  return timeFormatPreference;
+}
+
+function getServerSnapshot(): TimeFormatPreference {
+  return DEFAULT_TIME_FORMAT_PREFERENCE;
+}
+
+/** Read the persisted clock preference outside of React. */
+export function getTimeFormatPreference(): TimeFormatPreference {
+  return timeFormatPreference;
+}
+
+/** Update the clock preference and notify all subscribed components. */
+export function setTimeFormatPreference(
+  preference: TimeFormatPreference,
+): void {
+  timeFormatPreference = preference;
+
+  try {
+    globalThis.localStorage?.setItem(STORAGE_KEY, preference);
+  } catch {
+    // Persistence is best-effort; the in-memory value still applies.
+  }
+
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/**
+ * The active clock preference. Components that render a time — or that memoize
+ * a formatted time string — read this so a change in Settings repaints them
+ * immediately instead of waiting for the next unrelated data update.
+ */
+export function useTimeFormatPreference(): TimeFormatPreference {
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+let cachedSystemHour12: boolean | null = null;
+
+/**
+ * Whether the host's own locale prints a 12-hour clock. Resolved from `Intl`
+ * rather than the app's pinned `en-US`, so `system` tracks the OS convention
+ * (a Swedish or German host reads as 24-hour) without changing date wording.
+ */
+function systemPrefersHour12(): boolean {
+  if (cachedSystemHour12 !== null) return cachedSystemHour12;
+
+  try {
+    const resolved = new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+    }).resolvedOptions();
+    cachedSystemHour12 =
+      resolved.hour12 ??
+      (resolved.hourCycle === "h11" || resolved.hourCycle === "h12");
+  } catch {
+    cachedSystemHour12 = true;
+  }
+
+  return cachedSystemHour12;
+}
+
+/** Resolves `system` against the host locale; `12-hour`/`24-hour` are literal. */
+export function resolvesToHour12(
+  preference: TimeFormatPreference = getTimeFormatPreference(),
+): boolean {
+  if (preference === "12-hour") return true;
+  if (preference === "24-hour") return false;
+  return systemPrefersHour12();
+}
+
+/**
+ * Overlays the resolved hour cycle onto `Intl.DateTimeFormat` options.
+ *
+ * 24-hour uses an explicit `h23` cycle so midnight prints `00:xx` rather than
+ * the `h24` (`24:xx`) some locale defaults would pick. Whichever key is unused
+ * is set to `undefined`, which `Intl` treats as absent — that also clears any
+ * `hour12` the caller had hardcoded.
+ */
+export function withClockOptions(
+  options: Intl.DateTimeFormatOptions,
+  hour12: boolean = resolvesToHour12(),
+): Intl.DateTimeFormatOptions {
+  return {
+    ...options,
+    hour12: hour12 ? true : undefined,
+    hourCycle: hour12 ? undefined : "h23",
+  };
+}
+
+/**
+ * Builds a formatter that honors the current clock preference.
+ *
+ * Drop-in replacement for a module-level `new Intl.DateTimeFormat(...)` whose
+ * `.format(date)` is called later: the underlying formatter is built once and
+ * rebuilt only when the preference flips, so hot paths (a channel timeline
+ * formatting every visible row) keep the cached instance.
+ */
+export function createClockFormatter(
+  locales: string | string[] | undefined,
+  options: Intl.DateTimeFormatOptions,
+): (date: Date) => string {
+  let formatter: Intl.DateTimeFormat | null = null;
+  let formatterHour12: boolean | null = null;
+
+  return (date: Date) => {
+    const hour12 = resolvesToHour12();
+
+    if (!formatter || formatterHour12 !== hour12) {
+      formatterHour12 = hour12;
+      formatter = new Intl.DateTimeFormat(
+        locales,
+        withClockOptions(options, hour12),
+      );
+    }
+
+    return formatter.format(date);
+  };
+}


### PR DESCRIPTION
## Summary

Every time-of-day label in the desktop app is produced by an `Intl.DateTimeFormat` pinned to `en-US`, so the app always renders `2:34 PM` and there is no way to read times on a 24-hour clock.

This adds a **Clock** row to Settings → Appearance — System / 12-hour / 24-hour — and routes every hour-bearing formatter through it.

`desktop/src/shared/lib/timeFormat.ts` owns the preference, persisted in localStorage with the same `useSyncExternalStore` shape as the existing `threadViewModePreference` and transcript preferences. It exposes two helpers, and each call site adopts whichever one fits:

| Helper | Replaces |
|---|---|
| `createClockFormatter(locale, options)` | a module-level `new Intl.DateTimeFormat(...)` whose `.format(date)` is called later |
| `withClockOptions(options)` | an inline `date.toLocaleString(undefined, {...})` |

Surfaces covered: message rows and timestamp tooltips, inbox list/detail labels, drafts, ephemeral-channel deadlines, agent transcripts, project commit/repository panels, search results, moderation queue. A scan of `desktop/src` confirms the only remaining raw hour-bearing formatter is the host-locale probe inside `timeFormat.ts` itself.

<details>
<summary>Why the default is 12-hour rather than System</summary>

Every clock in the app was hardcoded to `en-US` before this preference existed, so 12-hour is what installs already render. Keeping it as the default means upgrading changes nothing until someone picks a clock, and rendered times stay deterministic in unit tests and screenshot tests regardless of the host's locale. `System` is one click away.

Happy to flip the default to `System` if maintainers would rather it follow the OS out of the box — it's a one-line change to `DEFAULT_TIME_FORMAT_PREFERENCE`.

</details>

<details>
<summary>Hour-cycle details (h23, and why System doesn't switch locale)</summary>

- 24-hour pins `hourCycle: "h23"` rather than `hour12: false`, so midnight reads `00:07` and never `24:07`.
- `system` resolves the *host* locale's hour cycle through `Intl.DateTimeFormat(undefined, ...).resolvedOptions()` and applies only that cycle to the app's `en-US` formatters. Date wording (month and weekday names) therefore stays English — choosing a 24-hour clock does not silently re-localize every date label.
- `withClockOptions` sets whichever key is unused to `undefined`, which `Intl` treats as absent; that also clears an `hour12: true` a caller had hardcoded (the agent transcript formatter did).

</details>

<details>
<summary>How already-rendered times pick up a change</summary>

Some surfaces bake the formatted string into memoized data rather than formatting during render — `formatTimelineMessages` fills `TimelineMessage.time`, `buildInboxItems` fills the inbox timestamp labels. Those four call sites (`ChannelScreen`, `useIndependentThreadPanel`, `useHomeInboxContextMessages`, `HomeView`) now subscribe to the preference and list it as a memo dependency, each with a `biome-ignore` note since the callback doesn't read it directly — the same idiom as the existing `readStateVersion` dependency in `HomeView`. Subscribing is what makes them re-render at all; the dependency is what makes the memo recompute.

Surfaces that format during render (agent transcripts, search results, project panels, drafts, moderation queue) adopt the new clock on their next render, which in practice is as soon as you leave the Settings screen. I deliberately did **not** add an app-shell-wide subscription to force an immediate repaint: `AppShell.tsx` sits at 999 of the 1000-line budget enforced by `check-file-sizes`, and its rows are `React.memo`'d so a parent-level subscription wouldn't repaint them anyway. If maintainers want instant repaint on those surfaces too, the follow-up is to have those row components subscribe individually.

</details>

### Related issue

None found — I searched open and closed issues and PRs for "24-hour", "24h", "12-hour", "time format", "clock format", "AM/PM" and "timestamp" before starting. Design questions (default value, locale scope, mobile follow-up) are open for discussion in #3737.

### Testing

Run from `desktop/` against the pinned pnpm 11.4.0:

- `pnpm typecheck` — clean.
- `pnpm test` — **3793 passing, 0 failing** (58 suites), including 12 new cases in `src/shared/lib/timeFormat.test.mjs` and the pre-existing `dateFormatters` / `agentSessionUtils` time assertions, which still hold because the default preserves today's 12-hour output.
- `biome check .` — 1697 files, no diagnostics in any changed file (the 2 reported infos are pre-existing `useTemplate` hints in `personaCatalogRelay.test.mjs`, untouched here).
- `check-file-sizes`, `check-px-text`, `check-pubkey-truncation` — all pass.

New tests cover the default, round-tripping the setter, `system` resolving to a real boolean, `withClockOptions` (h23 pinning, clearing a hardcoded `hour12`, staying legal alongside `dateStyle`/`timeStyle`), and `createClockFormatter` rendering both clocks, rebuilding on a flip, and printing `00:07` at midnight.

Not run: the Rust half of `just ci` (this change touches no Rust) and the Playwright E2E suite. No screenshots yet — this was developed on Windows, where the hermit toolchain doesn't bootstrap, so I couldn't launch the Tauri app; the UI addition is a `SettingsOptionGroup` + dropdown radio group copied structurally from the adjacent `ThreadLayoutSetting` row. Happy to add a before/after once someone can run the app, or if a maintainer prefers I can add an E2E case around `clock-format-trigger`.

### Not included

Mobile (Flutter) has its own `DateFormat('h:mm a')` formatters under `mobile/lib/features/channels/` and its own Appearance section; this PR is desktop-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
