### PR TITLE
fix(desktop): disable JSC JIT on AVX-less Linux CPUs

### DIFF
--- a/desktop/src-tauri/src/webkit_rendering.rs
+++ b/desktop/src-tauri/src/webkit_rendering.rs
@@ -18,7 +18,9 @@
 //!
 //! * an NVIDIA GPU, the driver family behind most upstream reports; and
 //! * AppImage packaging, where linuxdeploy's AppRun hook pins `GDK_BACKEND=x11`
-//!   and the dmabuf renderer buys nothing on that XWayland path (#2338).
+//!   and the dmabuf renderer buys nothing on that XWayland path (#2338); and
+//! * an x86_64 CPU without AVX, where affected WebKitGTK 2.52 JavaScriptCore
+//!   builds can execute an AVX instruction and kill WebKitWebProcess (#3747).
 //!
 //! `--safe-rendering` is the manual escape hatch for a machine neither signal
 //! recognises; it also disables accelerated compositing, for that launch only.
@@ -38,6 +40,8 @@ const NVIDIA_PCI_VENDOR: &str = "0x10de";
 
 /// Where DRM devices advertise their PCI vendor.
 const DRM_ROOT: &str = "/sys/class/drm";
+/// Linux's processor feature inventory.
+const CPU_INFO: &str = "/proc/cpuinfo";
 
 /// Prefer shared-memory dmabuf transport. The #3654 replacement for
 /// `WEBKIT_DISABLE_DMABUF_RENDERER` on current WebKitGTK.
@@ -48,6 +52,9 @@ const FORCE_SHM: &str = "WEBKIT_DMABUF_RENDERER_FORCE_SHM";
 const DISABLE_DMABUF: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
 /// Drops accelerated compositing as well. `--safe-rendering` only.
 const DISABLE_COMPOSITING: &str = "WEBKIT_DISABLE_COMPOSITING_MODE";
+/// Disables JavaScriptCore's JIT on AVX-less x86_64 CPUs. The workaround for
+/// #3747.
+const DISABLE_JSC_JIT: &str = "JSC_useJIT";
 
 /// What the heuristic applies: force shared-memory transport without emptying
 /// the buffer mode set (#3654).
@@ -57,11 +64,9 @@ const HEURISTIC: [&str; 1] = [FORCE_SHM];
 /// omits DISABLE_DMABUF — that variable is the #3654 crash on current WebKit.
 const SAFE_VARS: [&str; 2] = [FORCE_SHM, DISABLE_COMPOSITING];
 
-/// Every variable this module may set, and therefore every variable a user
-/// assignment takes away from it. Being the same list is the invariant: nothing
-/// outside it is ever written, so a user value for any other WebKit variable is
-/// not a conflict. DISABLE_DMABUF stays owned so `=0` still stands the heuristic
-/// down for operators who need the old path or an explicit override.
+/// Every dmabuf/compositing variable this module may set, and therefore every
+/// variable a user assignment takes away from the dmabuf heuristic.
+/// `DISABLE_JSC_JIT` is an independent decision with its own user override.
 const OWNED: [&str; 3] = [FORCE_SHM, DISABLE_DMABUF, DISABLE_COMPOSITING];
 
 /// Reads one environment variable. Injected so the decision is testable without
@@ -72,9 +77,9 @@ type EnvLookup<'a> = &'a dyn Fn(&str) -> Option<OsString>;
 /// What this launch should do about its rendering environment.
 #[derive(Debug, PartialEq, Eq)]
 enum Plan {
-    /// Set each of these to `1`, then report `why`.
+    /// Apply each `(variable, value)` assignment, then report `why`.
     Apply {
-        vars: &'static [&'static str],
+        assignments: Vec<(&'static str, &'static str)>,
         why: String,
     },
     /// Change nothing, and report `why`.
@@ -96,13 +101,18 @@ pub fn apply() -> Result<(), String> {
         std::env::args_os(),
         &|key| std::env::var_os(key),
         Path::new(DRM_ROOT),
+        std::env::consts::ARCH,
+        Path::new(CPU_INFO),
     ) {
-        Plan::Apply { vars, why } => {
-            for var in vars {
+        Plan::Apply { assignments, why } => {
+            for (var, value) in &assignments {
                 // Safe here and only here — see the doc comment above.
-                std::env::set_var(var, "1");
+                std::env::set_var(var, value);
             }
-            let applied: Vec<String> = vars.iter().map(|var| format!("{var}=1")).collect();
+            let applied: Vec<String> = assignments
+                .iter()
+                .map(|(var, value)| format!("{var}={value}"))
+                .collect();
             eprintln!("buzz-desktop: {} — {why}", applied.join(" "));
             Ok(())
         }
@@ -114,75 +124,111 @@ pub fn apply() -> Result<(), String> {
     }
 }
 
-/// The whole decision, as a pure function of argv, the environment, and the DRM
-/// device tree.
+/// The whole decision, as a function of injected argv, environment, platform,
+/// and Linux hardware inventory paths.
 fn plan(
     args: impl IntoIterator<Item = impl AsRef<OsStr>>,
     env: EnvLookup<'_>,
     drm_root: &Path,
+    arch: &str,
+    cpu_info: &Path,
 ) -> Plan {
     let safe_rendering = args
         .into_iter()
         .any(|arg| arg.as_ref() == OsStr::new(SAFE_RENDERING));
     let user_set = user_set(env);
 
-    if !user_set.is_empty() {
-        // A user who has assigned one of these has taken over the decision, so
-        // the heuristic stands down wholesale — writing the *other* variable
-        // behind their back would be exactly the surprise they opted out of.
-        return match safe_rendering {
-            // Two incompatible answers to one question, and no basis for
-            // picking: honouring the flag would overwrite configuration the
-            // user typed, honouring the environment would silently ignore a
-            // rescue flag from a user whose app does not start.
-            true => Plan::Fatal {
-                diagnostic: conflict(&user_set),
-            },
-            false => {
-                let mut why = format!("{} set in the environment", describe(&user_set));
-                // Older docs told people to export DISABLE_DMABUF=1; on current
-                // WebKitGTK that empties the transport and SIGSEGVs (#3654).
-                // Leave the takeover alone, but point survivors at FORCE_SHM.
-                if user_set
-                    .iter()
-                    .any(|(key, value)| *key == DISABLE_DMABUF && value.as_os_str() != "0")
-                {
-                    why.push_str(&format!(
-                        "; warning: {DISABLE_DMABUF} (other than =0) empties the \
-                         transport on current WebKitGTK and SIGSEGVs — prefer \
-                         {FORCE_SHM}=1 (see #3654)"
-                    ));
-                }
-                Plan::Leave { why }
-            }
+    if !user_set.is_empty() && safe_rendering {
+        // Two incompatible answers to one question, and no basis for picking:
+        // honouring the flag would overwrite configuration the user typed,
+        // honouring the environment would silently ignore a rescue flag from a
+        // user whose app does not start.
+        return Plan::Fatal {
+            diagnostic: conflict(&user_set),
         };
     }
+
+    let mut assignments = Vec::new();
+    let mut reasons = Vec::new();
 
     if safe_rendering {
-        return Plan::Apply {
-            vars: &SAFE_VARS,
-            why: format!("{SAFE_RENDERING} requested, this launch only"),
-        };
+        push_vars(&mut assignments, &SAFE_VARS);
+        reasons.push(format!("{SAFE_RENDERING} requested, this launch only"));
+    } else if user_set.is_empty() {
+        let signals = [
+            (nvidia_gpu(drm_root), "NVIDIA GPU"),
+            (env("APPIMAGE").is_some(), "AppImage"),
+        ];
+        let hits: Vec<&str> = signals
+            .iter()
+            .filter_map(|(hit, label)| hit.then_some(*label))
+            .collect();
+        if !hits.is_empty() {
+            push_vars(&mut assignments, &HEURISTIC);
+            reasons.push(hits.join(", "));
+        }
+    } else {
+        let mut why = format!("{} set in the environment", describe(&user_set));
+        // Older docs told people to export DISABLE_DMABUF=1; on current
+        // WebKitGTK that empties the transport and SIGSEGVs (#3654).
+        // Leave the takeover alone, but point survivors at FORCE_SHM.
+        if user_set
+            .iter()
+            .any(|(key, value)| *key == DISABLE_DMABUF && value.as_os_str() != "0")
+        {
+            why.push_str(&format!(
+                "; warning: {DISABLE_DMABUF} (other than =0) empties the \
+                 transport on current WebKitGTK and SIGSEGVs — prefer \
+                 {FORCE_SHM}=1 (see #3654)"
+            ));
+        }
+        reasons.push(why);
     }
 
-    let signals = [
-        (nvidia_gpu(drm_root), "NVIDIA GPU"),
-        (env("APPIMAGE").is_some(), "AppImage"),
-    ];
-    let hits: Vec<&str> = signals
-        .iter()
-        .filter_map(|(hit, label)| hit.then_some(*label))
-        .collect();
+    if env(DISABLE_JSC_JIT).is_some() {
+        reasons.push(format!("{DISABLE_JSC_JIT} set in the environment"));
+    } else if avx_available(arch, cpu_info) == Some(false) {
+        assignments.push((DISABLE_JSC_JIT, "0"));
+        reasons.push("x86_64 CPU does not advertise AVX".to_string());
+    }
 
-    match hits.is_empty() {
+    match assignments.is_empty() {
         true => Plan::Leave {
-            why: "no NVIDIA GPU and not an AppImage".to_string(),
+            why: match reasons.is_empty() {
+                true => "no NVIDIA GPU, not an AppImage, and no AVX-less x86_64 CPU detected"
+                    .to_string(),
+                false => reasons.join("; "),
+            },
         },
         false => Plan::Apply {
-            vars: &HEURISTIC,
-            why: hits.join(", "),
+            assignments,
+            why: reasons.join("; "),
         },
     }
+}
+
+fn push_vars(assignments: &mut Vec<(&'static str, &'static str)>, vars: &[&'static str]) {
+    for var in vars {
+        assignments.push((var, "1"));
+    }
+}
+
+/// Whether an x86_64 CPU advertises AVX. Unknown architecture or unreadable /
+/// malformed CPU data produces no decision rather than disabling the JIT.
+fn avx_available(arch: &str, cpu_info: &Path) -> Option<bool> {
+    if arch != "x86_64" {
+        return None;
+    }
+
+    let cpu_info = std::fs::read_to_string(cpu_info).ok()?;
+    cpu_info.lines().find_map(|line| {
+        let (key, features) = line.split_once(':')?;
+        key.trim().eq_ignore_ascii_case("flags").then(|| {
+            features
+                .split_ascii_whitespace()
+                .any(|feature| feature.eq_ignore_ascii_case("avx"))
+        })
+    })
 }
 
 /// Owned variables the environment already carries, keyed by name.

--- a/desktop/src-tauri/src/webkit_rendering/tests.rs
+++ b/desktop/src-tauri/src/webkit_rendering/tests.rs
@@ -33,10 +33,26 @@ fn env_from(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<OsString> {
     }
 }
 
-/// The variables a plan would set, or `None` for a plan that sets nothing.
-fn applied(plan: &Plan) -> Option<&[&str]> {
+fn cpu_info(features: &str) -> tempfile::NamedTempFile {
+    let file = tempfile::NamedTempFile::new().expect("cpu info");
+    std::fs::write(file.path(), format!("processor : 0\nflags : {features}\n"))
+        .expect("cpu features");
+    file
+}
+
+fn test_plan(
+    args: impl IntoIterator<Item = impl AsRef<OsStr>>,
+    env: EnvLookup<'_>,
+    drm_root: &Path,
+) -> Plan {
+    let cpu_info = cpu_info("sse sse2 avx avx2");
+    plan(args, env, drm_root, "x86_64", cpu_info.path())
+}
+
+/// The assignments a plan would apply, or `None` for a plan that changes nothing.
+fn applied(plan: &Plan) -> Option<&[(&str, &str)]> {
     match plan {
-        Plan::Apply { vars, .. } => Some(vars),
+        Plan::Apply { assignments, .. } => Some(assignments),
         _ => None,
     }
 }
@@ -46,12 +62,9 @@ fn applied(plan: &Plan) -> Option<&[&str]> {
 #[test]
 fn test_nvidia_gpu_forces_shared_memory_dmabuf_transport() {
     let drm = drm(&["0x10de"]);
-    let plan = plan(NO_ARGS, &env_from(&[]), drm.path());
+    let plan = test_plan(NO_ARGS, &env_from(&[]), drm.path());
 
-    assert_eq!(
-        applied(&plan),
-        Some(&["WEBKIT_DMABUF_RENDERER_FORCE_SHM"][..])
-    );
+    assert_eq!(applied(&plan), Some(&[(FORCE_SHM, "1")][..]));
     let Plan::Apply { why, .. } = &plan else {
         unreachable!()
     };
@@ -65,8 +78,8 @@ fn test_an_nvidia_gpu_alongside_another_vendor_still_counts() {
     let drm = drm(&["0x8086", "0x10de"]);
 
     assert_eq!(
-        applied(&plan(NO_ARGS, &env_from(&[]), drm.path())),
-        Some(&["WEBKIT_DMABUF_RENDERER_FORCE_SHM"][..])
+        applied(&test_plan(NO_ARGS, &env_from(&[]), drm.path())),
+        Some(&[(FORCE_SHM, "1")][..])
     );
 }
 
@@ -75,8 +88,8 @@ fn test_the_vendor_id_match_ignores_case() {
     let drm = drm(&["0x10DE"]);
 
     assert_eq!(
-        applied(&plan(NO_ARGS, &env_from(&[]), drm.path())),
-        Some(&["WEBKIT_DMABUF_RENDERER_FORCE_SHM"][..])
+        applied(&test_plan(NO_ARGS, &env_from(&[]), drm.path())),
+        Some(&[(FORCE_SHM, "1")][..])
     );
 }
 
@@ -86,12 +99,9 @@ fn test_an_appimage_launch_forces_shared_memory_dmabuf_transport() {
     // #2338's reporter (Intel Mesa under the AppRun's pinned XWayland backend).
     let drm = drm(&["0x8086"]);
     let env = env_from(&[("APPIMAGE", "/home/u/Buzz.AppImage")]);
-    let plan = plan(NO_ARGS, &env, drm.path());
+    let plan = test_plan(NO_ARGS, &env, drm.path());
 
-    assert_eq!(
-        applied(&plan),
-        Some(&["WEBKIT_DMABUF_RENDERER_FORCE_SHM"][..])
-    );
+    assert_eq!(applied(&plan), Some(&[(FORCE_SHM, "1")][..]));
     let Plan::Apply { why, .. } = &plan else {
         unreachable!()
     };
@@ -103,7 +113,7 @@ fn test_a_plain_non_nvidia_launch_changes_nothing() {
     let drm = drm(&["0x8086", "0x1002"]);
 
     assert!(matches!(
-        plan(NO_ARGS, &env_from(&[]), drm.path()),
+        test_plan(NO_ARGS, &env_from(&[]), drm.path()),
         Plan::Leave { .. }
     ));
 }
@@ -116,7 +126,7 @@ fn test_an_unreadable_drm_tree_is_not_treated_as_a_hit() {
     let missing = std::path::Path::new("/nonexistent/class/drm");
 
     assert!(matches!(
-        plan(NO_ARGS, &env_from(&[]), missing),
+        test_plan(NO_ARGS, &env_from(&[]), missing),
         Plan::Leave { .. }
     ));
 }
@@ -132,8 +142,8 @@ fn test_a_device_without_a_vendor_file_is_skipped_not_fatal() {
     std::fs::write(device.join("vendor"), "0x10de\n").expect("vendor");
 
     assert_eq!(
-        applied(&plan(NO_ARGS, &env_from(&[]), root.path())),
-        Some(&["WEBKIT_DMABUF_RENDERER_FORCE_SHM"][..])
+        applied(&test_plan(NO_ARGS, &env_from(&[]), root.path())),
+        Some(&[(FORCE_SHM, "1")][..])
     );
 }
 
@@ -145,7 +155,7 @@ fn test_a_user_set_variable_disables_the_heuristic_wholesale() {
     // dmabuf renderer *on*, on a machine the heuristic would have opted out.
     let drm = drm(&["0x10de"]);
     let env = env_from(&[(DISABLE_DMABUF, "0")]);
-    let plan = plan(NO_ARGS, &env, drm.path());
+    let plan = test_plan(NO_ARGS, &env, drm.path());
 
     let Plan::Leave { why } = &plan else {
         panic!("a user assignment must not be overwritten: {plan:?}");
@@ -159,7 +169,7 @@ fn test_a_user_set_force_shm_also_stands_the_heuristic_down() {
     // whole decision away, same as the older DISABLE_DMABUF takeover.
     let drm = drm(&["0x10de"]);
     let env = env_from(&[(FORCE_SHM, "1")]);
-    let plan = plan(NO_ARGS, &env, drm.path());
+    let plan = test_plan(NO_ARGS, &env, drm.path());
 
     let Plan::Leave { why } = &plan else {
         panic!("a user FORCE_SHM assignment must not be overwritten: {plan:?}");
@@ -171,7 +181,7 @@ fn test_a_user_set_force_shm_also_stands_the_heuristic_down() {
 fn test_user_set_disable_dmabuf_one_warns_about_the_crashy_var() {
     let drm = drm(&["0x10de"]);
     let env = env_from(&[(DISABLE_DMABUF, "1")]);
-    let plan = plan(NO_ARGS, &env, drm.path());
+    let plan = test_plan(NO_ARGS, &env, drm.path());
 
     let Plan::Leave { why } = &plan else {
         panic!("expected Leave: {plan:?}");
@@ -187,7 +197,7 @@ fn test_an_empty_assignment_is_still_a_user_assignment() {
     let env = env_from(&[(DISABLE_DMABUF, "")]);
 
     assert!(matches!(
-        plan(NO_ARGS, &env, drm.path()),
+        test_plan(NO_ARGS, &env, drm.path()),
         Plan::Leave { .. }
     ));
 }
@@ -201,7 +211,7 @@ fn test_a_user_set_compositing_variable_also_stands_the_heuristic_down() {
     let env = env_from(&[(DISABLE_COMPOSITING, "1")]);
 
     assert!(matches!(
-        plan(NO_ARGS, &env, drm.path()),
+        test_plan(NO_ARGS, &env, drm.path()),
         Plan::Leave { .. }
     ));
 }
@@ -214,16 +224,11 @@ fn test_safe_rendering_applies_the_safest_set_without_any_hardware_signal() {
     // must not depend on either one.
     let drm = drm(&["0x8086"]);
     let args = ["buzz://channel/1", SAFE_RENDERING];
-    let plan = plan(args, &env_from(&[]), drm.path());
+    let plan = test_plan(args, &env_from(&[]), drm.path());
 
     assert_eq!(
         applied(&plan),
-        Some(
-            &[
-                "WEBKIT_DMABUF_RENDERER_FORCE_SHM",
-                "WEBKIT_DISABLE_COMPOSITING_MODE"
-            ][..]
-        )
+        Some(&[(FORCE_SHM, "1"), (DISABLE_COMPOSITING, "1")][..])
     );
 }
 
@@ -232,7 +237,7 @@ fn test_an_unrelated_flag_is_not_mistaken_for_safe_rendering() {
     let drm = drm(&["0x8086"]);
 
     assert!(matches!(
-        plan(["--safe-renderingX"], &env_from(&[]), drm.path()),
+        test_plan(["--safe-renderingX"], &env_from(&[]), drm.path()),
         Plan::Leave { .. }
     ));
 }
@@ -241,7 +246,7 @@ fn test_an_unrelated_flag_is_not_mistaken_for_safe_rendering() {
 fn test_safe_rendering_against_a_user_set_variable_is_fatal_not_guessed() {
     let drm = drm(&["0x8086"]);
     let env = env_from(&[(DISABLE_DMABUF, "0")]);
-    let plan = plan([SAFE_RENDERING], &env, drm.path());
+    let plan = test_plan([SAFE_RENDERING], &env, drm.path());
 
     let Plan::Fatal { diagnostic } = &plan else {
         panic!("the flag and the environment disagree; neither may be guessed: {plan:?}");
@@ -270,9 +275,87 @@ fn test_a_non_utf8_user_assignment_is_reported_not_ignored() {
             false => None,
         };
 
-        let Plan::Fatal { diagnostic } = plan([SAFE_RENDERING], &env, drm.path()) else {
+        let Plan::Fatal { diagnostic } = test_plan([SAFE_RENDERING], &env, drm.path()) else {
             panic!("a non-UTF-8 assignment is still a user assignment");
         };
         assert!(diagnostic.contains(DISABLE_DMABUF), "{diagnostic}");
     }
+}
+
+// ── JavaScriptCore AVX fallback ─────────────────────────────────────────────
+
+#[test]
+fn test_avx_absent_disables_the_jsc_jit() {
+    let drm = drm(&["0x8086"]);
+    let cpu_info = cpu_info("sse sse2 ssse3");
+    let plan = plan(
+        NO_ARGS,
+        &env_from(&[]),
+        drm.path(),
+        "x86_64",
+        cpu_info.path(),
+    );
+
+    assert_eq!(applied(&plan), Some(&[(DISABLE_JSC_JIT, "0")][..]));
+}
+
+#[test]
+fn test_avx_present_leaves_the_jsc_jit_unchanged() {
+    let drm = drm(&["0x8086"]);
+    let cpu_info = cpu_info("sse sse2 avx avx2");
+
+    assert!(matches!(
+        plan(
+            NO_ARGS,
+            &env_from(&[]),
+            drm.path(),
+            "x86_64",
+            cpu_info.path(),
+        ),
+        Plan::Leave { .. }
+    ));
+}
+
+#[test]
+fn test_a_user_set_jsc_jit_value_is_never_overwritten() {
+    let drm = drm(&["0x8086"]);
+    let cpu_info = cpu_info("sse sse2");
+    let env = env_from(&[(DISABLE_JSC_JIT, "1")]);
+
+    assert!(matches!(
+        plan(NO_ARGS, &env, drm.path(), "x86_64", cpu_info.path()),
+        Plan::Leave { .. }
+    ));
+}
+
+#[test]
+fn test_non_x86_and_unreadable_cpu_data_do_not_disable_the_jit() {
+    let drm = drm(&["0x8086"]);
+    let cpu_info = cpu_info("sse sse2");
+    let missing = Path::new("/nonexistent/proc/cpuinfo");
+
+    assert!(matches!(
+        plan(
+            NO_ARGS,
+            &env_from(&[]),
+            drm.path(),
+            "aarch64",
+            cpu_info.path(),
+        ),
+        Plan::Leave { .. }
+    ));
+    assert!(matches!(
+        plan(NO_ARGS, &env_from(&[]), drm.path(), "x86_64", missing),
+        Plan::Leave { .. }
+    ));
+}
+
+#[test]
+fn test_avx_fallback_applies_even_when_dmabuf_is_user_owned() {
+    let drm = drm(&["0x10de"]);
+    let cpu_info = cpu_info("sse sse2");
+    let env = env_from(&[(DISABLE_DMABUF, "0")]);
+    let plan = plan(NO_ARGS, &env, drm.path(), "x86_64", cpu_info.path());
+
+    assert_eq!(applied(&plan), Some(&[(DISABLE_JSC_JIT, "0")][..]));
 }

--- a/docs/linux-rendering-troubleshooting.md
+++ b/docs/linux-rendering-troubleshooting.md
@@ -7,8 +7,36 @@ This guide covers the most common rendering failures on Linux and how to resolve
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
 | Blank or transparent window, then `SIGABRT` with `colrv1_configure_skpaint` in the output | COLRv1 color emoji font (AppImage only) | Upgrade to the latest AppImage (v0.5.2+) |
+| Window disappears and `WebKitWebProcess` reports `SIGILL` on an older x86_64 CPU | WebKitGTK 2.52 JavaScriptCore emits AVX instructions on a CPU without AVX | Buzz automatically sets `JSC_useJIT=0`; set it manually when running an older build |
 | Blank window on startup / SIGSEGV when switching workspaces | dmabuf renderer incompatibility (NVIDIA or AppImage) | Prefer `WEBKIT_DMABUF_RENDERER_FORCE_SHM=1` (shipped automatically) or `--safe-rendering`. Do **not** set `WEBKIT_DISABLE_DMABUF_RENDERER=1` on current WebKitGTK — see [#3654](https://github.com/block/buzz/issues/3654). On Debian/Ubuntu with the proprietary NVIDIA driver the crash can persist (distro WebKit patch) — [#3654](https://github.com/block/buzz/issues/3654) stays open for that path. |
 | Blank window on any hardware, no crash output | Unknown GPU/driver combination | `--safe-rendering` flag (see below) |
+
+---
+
+## Crash: `WebKitWebProcess` `SIGILL` on an AVX-less CPU
+
+**Affected hardware:** Older x86_64 CPUs that do not advertise the AVX feature, when used with affected WebKitGTK 2.52 builds. Issue [#3747](https://github.com/block/buzz/issues/3747).
+
+**Symptom:** Buzz starts and its WebKit child process exits with `SIGILL` (illegal instruction), often at an AVX `vmovaps` instruction in JavaScriptCore.
+
+**Automatic fix:** On Linux x86_64 only, Buzz reads `/proc/cpuinfo`, finds a `flags` line, and checks its whitespace-separated feature tokens for `avx`. If the line is found and `avx` is absent, Buzz sets `JSC_useJIT=0` before WebKit starts. Other architectures, AVX-capable CPUs, and missing, unreadable, or malformed CPU information leave JavaScriptCore unchanged. An explicitly provided `JSC_useJIT` value, including an empty value, is always preserved.
+
+**Support diagnostic:** Run this command in the same environment where Buzz is launched:
+
+```bash
+flags=$(awk -F: 'tolower($1) ~ /^[[:space:]]*flags[[:space:]]*$/ { print $2; exit }' /proc/cpuinfo 2>/dev/null)
+if [ -z "$flags" ]; then
+  echo "AVX status unknown: no readable flags line"
+elif printf '%s\n' "$flags" | grep -qiw avx; then
+  echo "AVX present: Buzz leaves JSC unchanged"
+else
+  echo "AVX absent: Buzz automatically sets JSC_useJIT=0"
+fi
+```
+
+`AVX absent` confirms the automatic fallback applies in current builds. `AVX present` means this workaround is not selected. `AVX status unknown` means Buzz also leaves JSC unchanged because it cannot safely determine that AVX is missing.
+
+**Manual workaround for older builds:** Launch with `JSC_useJIT=0 buzz-desktop`, or prefix the AppImage command, for example `JSC_useJIT=0 ./Buzz.AppImage`. Current builds do not overwrite any user-provided `JSC_useJIT` setting, so this explicit workaround and other deliberate values remain in effect.
 
 ---
 


### PR DESCRIPTION
## Summary

Rebased onto current `main` after #4505 switched dmabuf workarounds to `WEBKIT_DMABUF_RENDERER_FORCE_SHM=1`.

- Disable JavaScriptCore JIT only when an x86_64 Linux CPU has readable `/proc/cpuinfo` feature data without AVX (`JSC_useJIT=0`).
- Preserve explicit `JSC_useJIT` configuration (including empty values) and keep the JSC decision independent of dmabuf / `--safe-rendering` heuristics.
- Retain current main dmabuf behavior: heuristic and `--safe-rendering` use `WEBKIT_DMABUF_RENDERER_FORCE_SHM`, not `WEBKIT_DISABLE_DMABUF_RENDERER`.
- Document the WebKitGTK 2.52 `SIGILL` workaround in `docs/linux-rendering-troubleshooting.md`.

### Related issue

Fixes #3747

### Testing

- [x] `rustfmt --edition 2021 --check desktop/src-tauri/src/webkit_rendering.rs desktop/src-tauri/src/webkit_rendering/tests.rs`
- [x] `git diff --check`
- [x] Standalone `cargo test` harness for `webkit_rendering` (21 tests: AVX absent/present, user override, non-x86, unreadable cpuinfo, dmabuf/JSC independence, FORCE_SHM regressions)
- [ ] `cargo test --manifest-path desktop/src-tauri/Cargo.toml webkit_rendering --lib` *(blocked in this environment: GTK/WebKit dev packages unavailable)*