### PR TITLE
fix(desktop): stop dropping live events behind the reader clock

### DIFF
--- a/desktop/src/features/messages/hooks.ts
+++ b/desktop/src/features/messages/hooks.ts
@@ -262,19 +262,19 @@ export function useChannelSubscription(channel: Channel | null) {
   });
 
   const appendMessage = useEffectEvent((event: RelayEvent) => {
-    if (!channelId) return;
+    if (!channelId) return false;
     if (event.kind === KIND_CHANNEL_THREAD_SUMMARY) {
       // Relay-pushed live badge recount — window-store overlay only, never a
       // timeline row (mirrors the page path, where 39005 is metadata).
       const parsed = parseLiveThreadSummary(event);
-      if (!parsed) return;
+      if (!parsed) return false;
       const windowKey = channelWindowKey(channelId);
       const current =
         queryClient.getQueryData<ChannelWindowStore>(windowKey) ??
         emptyChannelWindowStore();
       const next = mergeLiveThreadSummary(current, parsed.rootId, parsed.live);
       if (next !== current) queryClient.setQueryData(windowKey, next);
-      return;
+      return false;
     }
     const isTimelineRow = CHANNEL_TIMELINE_KINDS.has(event.kind);
     const threadReference = isTimelineRow
@@ -288,9 +288,9 @@ export function useChannelSubscription(channel: Channel | null) {
           (current = []) => mergeMessages(current, event),
         );
       }
-      if (!isBroadcastReply(event.tags)) return;
+      if (!isBroadcastReply(event.tags)) return false;
     }
-    if (!isTimelineRow && !CHANNEL_AUX_KINDS.has(event.kind)) return;
+    if (!isTimelineRow && !CHANNEL_AUX_KINDS.has(event.kind)) return false;
     if (!isTimelineRow) {
       queryClient.setQueriesData<RelayEvent[]>(
         { queryKey: ["thread-replies", channelId] },
@@ -305,7 +305,6 @@ export function useChannelSubscription(channel: Channel | null) {
     const next = mergeLiveChannelWindowEvent(current, event, isTimelineRow);
     if (next !== current) {
       queryClient.setQueryData(windowKey, next);
-      projectChannelWindowMessages(queryClient, channelId);
     }
 
     if (event.kind === KIND_SYSTEM_MESSAGE) {
@@ -328,6 +327,7 @@ export function useChannelSubscription(channel: Channel | null) {
         // Non-JSON system message — ignore.
       }
     }
+    return next !== current;
   });
 
   // Notify the relay client which channel is currently visible so its live
@@ -348,6 +348,7 @@ export function useChannelSubscription(channel: Channel | null) {
 
     let isDisposed = false;
     let cleanup: (() => Promise<void>) | undefined;
+    let shouldProjectOnFlush = false;
     const disposeReconnectListener = relayClient.subscribeToReconnects(() => {
       void refreshNewestWindow().catch((error) => {
         if (!isDisposed) {
@@ -361,11 +362,22 @@ export function useChannelSubscription(channel: Channel | null) {
     });
 
     relayClient
-      .subscribeToChannelLive(channelId, (event) => {
-        if (!isDisposed) {
-          appendMessage(event);
-        }
-      })
+      .subscribeToChannelLive(
+        channelId,
+        (event) => {
+          if (!isDisposed) {
+            shouldProjectOnFlush = appendMessage(event) || shouldProjectOnFlush;
+          }
+        },
+        {
+          onFlush: () => {
+            if (!isDisposed && shouldProjectOnFlush) {
+              projectChannelWindowMessages(queryClient, channelId);
+            }
+            shouldProjectOnFlush = false;
+          },
+        },
+      )
       .then((dispose) => {
         if (isDisposed) {
           void dispose();
@@ -394,7 +406,7 @@ export function useChannelSubscription(channel: Channel | null) {
         void cleanup();
       }
     };
-  }, [channelId, channelType]);
+  }, [channelId, channelType, queryClient]);
 }
 
 export function useSendMessageMutation(

--- a/desktop/src/shared/api/relayChannelFilters.test.mjs
+++ b/desktop/src/shared/api/relayChannelFilters.test.mjs
@@ -4,9 +4,16 @@ import test from "node:test";
 import {
   buildChannelAuxDeletionFilter,
   buildChannelAuxFilter,
+  buildChannelLiveFilter,
   buildChannelReactionAuxFilter,
   buildChannelStructuralAuxFilter,
 } from "./relayChannelFilters.ts";
+import {
+  CHANNEL_EVENT_KINDS,
+  KIND_CHANNEL_THREAD_SUMMARY,
+} from "../constants/kinds.ts";
+import { shouldPageReconnectReplay } from "./relayReconnectReplay.ts";
+import { handleRelayClosed } from "./relayClosedRecovery.ts";
 
 const CHANNEL = "36411e44-0e2d-4cfe-bd6e-567eb169db9f";
 const IDS = [
@@ -42,4 +49,90 @@ test("buildChannelStructuralAuxFilter excludes reactions", () => {
   assert.deepEqual(filter.kinds, [5, 9005, 40003]);
   assert.deepEqual(filter["#e"], IDS);
   assert.equal("#h" in filter, false);
+});
+
+test("buildChannelLiveFilter is replay-bounded without a reader-clock since", () => {
+  const filter = buildChannelLiveFilter(CHANNEL);
+
+  assert.equal("since" in filter, false);
+  assert.ok(filter.limit > 0);
+  assert.equal(shouldPageReconnectReplay(filter), true);
+  assert.deepEqual(filter["#h"], [CHANNEL]);
+  assert.deepEqual(filter.kinds, [
+    ...CHANNEL_EVENT_KINDS,
+    KIND_CHANNEL_THREAD_SUMMARY,
+  ]);
+});
+
+test("CLOSED retry pages a gap larger than the live limit from last-seen author time", async () => {
+  const originalWindow = globalThis.window;
+  const originalDateNow = Date.now;
+  let retry;
+  globalThis.window = {
+    setTimeout: (callback) => {
+      retry = callback;
+      return 1;
+    },
+    clearTimeout: () => {},
+  };
+  Date.now = () => 1_100_000;
+
+  try {
+    const liveFilter = buildChannelLiveFilter(CHANNEL);
+    const recoveredEvents = Array.from(
+      { length: liveFilter.limit + 1 },
+      (_, index) => ({
+        id: String(index).padStart(64, "0"),
+        pubkey: "a".repeat(64),
+        created_at: 1_001 + index,
+        kind: 9,
+        tags: [["h", CHANNEL]],
+        content: `recovered ${index}`,
+        sig: "b".repeat(128),
+      }),
+    );
+    const delivered = [];
+    const sentFilters = [];
+    let requestedFilter;
+    let resolveReplay;
+    const replayed = new Promise((resolve) => {
+      resolveReplay = resolve;
+    });
+    const subscription = {
+      mode: "live",
+      filter: liveFilter,
+      onEvent: (event) => delivered.push(event),
+      lastSeenCreatedAt: 1_000,
+    };
+    const subscriptions = new Map([["live-closed", subscription]]);
+
+    handleRelayClosed({
+      subscriptions,
+      subId: "live-closed",
+      message: "error: temporary relay failure",
+      sendReq: async (_subId, filter) => {
+        sentFilters.push(filter);
+      },
+      requestHistory: async (filter) => {
+        requestedFilter = filter;
+        resolveReplay();
+        return recoveredEvents;
+      },
+      replaySubscriptionEvent: (_subId, event) => delivered.push(event),
+    });
+
+    assert.equal(typeof retry, "function");
+    retry();
+    await replayed;
+    await Promise.resolve();
+
+    assert.equal(sentFilters.length, 1);
+    assert.equal(sentFilters[0], liveFilter);
+    assert.equal(requestedFilter.since, 995);
+    assert.equal(requestedFilter.limit, 500);
+    assert.equal(delivered.length, liveFilter.limit + 1);
+  } finally {
+    globalThis.window = originalWindow;
+    Date.now = originalDateNow;
+  }
 });

--- a/desktop/src/shared/api/relayChannelFilters.ts
+++ b/desktop/src/shared/api/relayChannelFilters.ts
@@ -3,6 +3,7 @@ import {
   CHANNEL_EVENT_KINDS,
   CHANNEL_TIMELINE_CONTENT_KINDS,
   HOME_MENTION_EVENT_KINDS,
+  KIND_CHANNEL_THREAD_SUMMARY,
   KIND_DELETION,
   KIND_NIP29_DELETE_EVENT,
   KIND_REACTION,
@@ -16,6 +17,29 @@ import type { RelaySubscriptionFilter } from "@/shared/api/relayClientShared";
 // a single reaction-heavy message can have many aux events.
 export const AUX_BACKFILL_CHUNK_SIZE = 100;
 export const MAX_HISTORICAL_LIMIT = 10_000;
+
+/**
+ * Live window-store subscription for an open channel.
+ *
+ * Deliberately omits `since`: deriving it from the reader's clock permanently
+ * drops accepted events whose author clock is behind. Initial replay volume is
+ * bounded with `limit: 50` instead; `limit` does not constrain future fan-out.
+ * Keep the limit above zero because `shouldPageReconnectReplay` uses that as
+ * the gate for paged reconnect recovery. The authoritative HTTP window read
+ * owns history depth, so a larger WebSocket replay only adds serialized load.
+ */
+export function buildChannelLiveFilter(
+  channelId: string,
+): RelaySubscriptionFilter {
+  return {
+    // 39005 rides only this window-store subscription — not
+    // CHANNEL_EVENT_KINDS, whose other consumers (unread tracking,
+    // timeline-cache merges) must never see summary overlays.
+    kinds: [...CHANNEL_EVENT_KINDS, KIND_CHANNEL_THREAD_SUMMARY],
+    "#h": [channelId],
+    limit: 50,
+  };
+}
 
 /**
  * Live-subscription filter for an open channel: the broad

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -9,8 +9,6 @@ import {
   KIND_STREAM_MESSAGE,
   KIND_TYPING_INDICATOR,
   KIND_USER_STATUS,
-  CHANNEL_EVENT_KINDS,
-  KIND_CHANNEL_THREAD_SUMMARY,
 } from "@/shared/constants/kinds";
 import {
   getTextPayload,
@@ -23,6 +21,7 @@ import {
   buildChannelAuxDeletionFilter,
   buildChannelFilter,
   buildChannelHistoryFilter,
+  buildChannelLiveFilter,
   buildChannelMentionFilter,
   buildGlobalStreamFilter,
 } from "@/shared/api/relayChannelFilters";
@@ -79,6 +78,8 @@ export const BACKOFF_RESET_STABLE_MS = 60_000;
  */
 const STALL_CHECK_INTERVAL_MS = 10_000;
 const STALL_IDLE_TIMEOUT_MS = 60_000;
+
+type LiveCallbacks = Partial<Record<"onFlush", () => void>>;
 
 export class RelayClient {
   private wsId: number | null = null;
@@ -356,23 +357,13 @@ export class RelayClient {
     return this.subscribe(buildChannelFilter(channelId, 50), onEvent);
   }
 
-  /** Subscribe to channel rows and aux starting now, with no history replay. */
+  /** Subscribe to channel rows and aux, with one callback per buffered flush. */
   async subscribeToChannelLive(
     channelId: string,
     onEvent: (event: RelayEvent) => void,
+    options?: LiveCallbacks,
   ) {
-    return this.subscribe(
-      {
-        // 39005 rides only this window-store subscription — not
-        // CHANNEL_EVENT_KINDS, whose other consumers (unread tracking,
-        // timeline-cache merges) must never see summary overlays.
-        kinds: [...CHANNEL_EVENT_KINDS, KIND_CHANNEL_THREAD_SUMMARY],
-        "#h": [channelId],
-        limit: 1000,
-        since: Math.floor(Date.now() / 1_000),
-      },
-      onEvent,
-    );
+    return this.subscribe(buildChannelLiveFilter(channelId), onEvent, options);
   }
 
   /**
@@ -600,6 +591,7 @@ export class RelayClient {
   private async subscribe(
     filter: RelaySubscriptionFilter,
     onEvent: (event: RelayEvent) => void,
+    options?: LiveCallbacks,
   ) {
     await this.ensureConnected();
 
@@ -622,6 +614,7 @@ export class RelayClient {
       filter,
       onEvent,
       resolveReady,
+      ...options,
     });
 
     try {
@@ -829,6 +822,8 @@ export class RelayClient {
             ["REQ", subId, filter],
             "Failed to restore relay subscription after CLOSED.",
           ),
+        requestHistory: (filter) => this.requestHistory(filter),
+        replaySubscriptionEvent: this.handleEvent.bind(this),
       });
       return;
     }
@@ -884,14 +879,19 @@ export class RelayClient {
     this.flushTimeout = null;
     const buffer = this.eventBuffer;
     this.eventBuffer = [];
+    const flushCallbacks = new Set<() => void>();
 
     // Re-lookup: subscriptions removed during batch window are intentionally skipped.
     for (const { subId, event } of buffer) {
       const subscription = this.subscriptions.get(subId);
       if (subscription?.mode === "live") {
         subscription.onEvent(event);
+        const callback = (subscription as typeof subscription & LiveCallbacks)
+          .onFlush;
+        if (callback) flushCallbacks.add(callback);
       }
     }
+    for (const callback of flushCallbacks) callback();
   }
 
   private handleEose(subId: string) {
@@ -943,7 +943,6 @@ export class RelayClient {
 
     return false;
   }
-
   private async replayLiveSubscriptions() {
     const generation = this.connectionGeneration;
     try {
@@ -951,6 +950,7 @@ export class RelayClient {
         subscriptions: this.subscriptions,
         sendRaw: (payload) => this.sendRaw(payload),
         requestHistory: (filter) => this.requestHistory(filter),
+        replaySubscriptionEvent: this.handleEvent.bind(this),
         visibleChannelId: this.visibleChannelId,
         isActive: () => this.connectionGeneration === generation,
       });

--- a/desktop/src/shared/api/relayClosedRecovery.ts
+++ b/desktop/src/shared/api/relayClosedRecovery.ts
@@ -9,10 +9,16 @@ import {
   type RelaySubscription,
   type RelaySubscriptionFilter,
 } from "@/shared/api/relayClientShared";
+import {
+  buildReconnectReplayFilter,
+  replayReconnectHistoryPages,
+  shouldPageReconnectReplay,
+} from "@/shared/api/relayReconnectReplay";
 import type { RelayEvent } from "@/shared/api/types";
 
 const RETRY_BASE_DELAY_MS = 1_000;
 const RETRY_MAX_DELAY_MS = 30_000;
+const CLOSED_REPLAY_SKEW_SECS = 5;
 
 type LiveSubscription = Extract<RelaySubscription, { mode: "live" }>;
 
@@ -27,11 +33,15 @@ export function handleRelayClosed({
   subId,
   message,
   sendReq,
+  requestHistory,
+  replaySubscriptionEvent,
 }: {
   subscriptions: Map<string, RelaySubscription>;
   subId: string;
   message: string;
   sendReq: (subId: string, filter: RelaySubscriptionFilter) => Promise<void>;
+  requestHistory?: (filter: RelaySubscriptionFilter) => Promise<RelayEvent[]>;
+  replaySubscriptionEvent?: (subId: string, event: RelayEvent) => void;
 }) {
   const subscription = subscriptions.get(subId);
   if (!subscription) return;
@@ -57,6 +67,8 @@ export function handleRelayClosed({
     subscription,
     message,
     sendReq,
+    requestHistory,
+    replaySubscriptionEvent,
   });
 }
 
@@ -66,12 +78,16 @@ function recoverLiveSubscriptionFromClosed({
   subscription,
   message,
   sendReq,
+  requestHistory,
+  replaySubscriptionEvent,
 }: {
   subscriptions: Map<string, RelaySubscription>;
   subId: string;
   subscription: LiveSubscription;
   message: string;
   sendReq: (subId: string, filter: RelaySubscriptionFilter) => Promise<void>;
+  requestHistory?: (filter: RelaySubscriptionFilter) => Promise<RelayEvent[]>;
+  replaySubscriptionEvent?: (subId: string, event: RelayEvent) => void;
 }) {
   subscription.resolveReady?.();
   subscription.resolveReady = undefined;
@@ -111,7 +127,43 @@ function recoverLiveSubscriptionFromClosed({
   subscription.closedRetryTimeout = window.setTimeout(() => {
     subscription.closedRetryTimeout = undefined;
     if (subscriptions.get(subId) !== subscription) return;
-    void sendReq(subId, subscription.filter).catch((error) => {
+    const replaySince =
+      subscription.lastSeenCreatedAt === undefined
+        ? undefined
+        : Math.max(0, subscription.lastSeenCreatedAt - CLOSED_REPLAY_SKEW_SECS);
+    const shouldPageReplay =
+      replaySince !== undefined &&
+      requestHistory !== undefined &&
+      shouldPageReconnectReplay(subscription.filter);
+
+    void (async () => {
+      await sendReq(
+        subId,
+        shouldPageReplay
+          ? subscription.filter
+          : buildReconnectReplayFilter(subscription.filter, replaySince),
+      );
+      if (!shouldPageReplay || replaySince === undefined || !requestHistory) {
+        return;
+      }
+
+      await replayReconnectHistoryPages({
+        subscription: {
+          ...subscription,
+          onEvent: (event) => {
+            if (replaySubscriptionEvent) {
+              replaySubscriptionEvent(subId, event);
+            } else {
+              subscription.onEvent(event);
+            }
+          },
+        },
+        since: replaySince,
+        until: Math.floor(Date.now() / 1_000),
+        isActive: () => subscriptions.get(subId) === subscription,
+        requestHistory,
+      });
+    })().catch((error) => {
       if (subscriptions.get(subId) !== subscription) return;
       console.error("Failed to restore closed relay subscription", error);
       recoverLiveSubscriptionFromClosed({
@@ -120,6 +172,8 @@ function recoverLiveSubscriptionFromClosed({
         subscription,
         message,
         sendReq,
+        requestHistory,
+        replaySubscriptionEvent,
       });
     });
   }, delayMs);

--- a/desktop/src/shared/api/relayReconnectReplay.ts
+++ b/desktop/src/shared/api/relayReconnectReplay.ts
@@ -122,6 +122,7 @@ export async function replayLiveSubscriptions({
   subscriptions,
   sendRaw,
   requestHistory,
+  replaySubscriptionEvent,
   now = Math.floor(Date.now() / 1_000),
   pageReplayConcurrency = RECONNECT_REPLAY_PAGE_CONCURRENCY,
   visibleChannelId = null,
@@ -134,6 +135,7 @@ export async function replayLiveSubscriptions({
   subscriptions: Map<string, RelaySubscription>;
   sendRaw: (payload: unknown[]) => Promise<void>;
   requestHistory: (filter: RelaySubscriptionFilter) => Promise<RelayEvent[]>;
+  replaySubscriptionEvent?: (subId: string, event: RelayEvent) => void;
   now?: number;
   pageReplayConcurrency?: number;
   /** Channel currently visible in the UI — its subscriptions go in the first batch. */
@@ -238,7 +240,16 @@ export async function replayLiveSubscriptions({
     pageReplayConcurrency,
     async ({ subId, subscription, replaySince }) => {
       await replayReconnectHistoryPages({
-        subscription,
+        subscription: {
+          ...subscription,
+          onEvent: (event) => {
+            if (replaySubscriptionEvent) {
+              replaySubscriptionEvent(subId, event);
+            } else {
+              subscription.onEvent(event);
+            }
+          },
+        },
         since: replaySince,
         until: now,
         isActive: () => subscriptions.get(subId) === subscription,

--- a/desktop/tests/e2e/cold-switch-longtask.perf.ts
+++ b/desktop/tests/e2e/cold-switch-longtask.perf.ts
@@ -33,9 +33,11 @@ import { installMockBridge } from "../helpers/bridge";
  * SCOPE LIMIT: this measures Chromium main-thread longtasks under throttle. It
  * does NOT measure the WKWebView compositor feel on the shipped Tauri shell —
  * that is a separate real-wheel pass.
+ * This harness observes main-thread longtasks only. It cannot observe network
+ * round trips and must never be cited as evidence that a round trip was removed.
  *
  * Run it:
- *   pnpm build && npx playwright test --config=playwright.perf.config.ts \
+ *   pnpm build:e2e && npx playwright test --config=playwright.perf.config.ts \
  *     cold-switch-longtask.perf.ts
  */
 

--- a/desktop/tests/e2e/warm-switch-markdown.perf.ts
+++ b/desktop/tests/e2e/warm-switch-markdown.perf.ts
@@ -35,9 +35,11 @@ import { installMockBridge } from "../helpers/bridge";
  * paths are jitted. 4x CPU throttle for the same reason as the cold spec —
  * absolute ms are not portable across machines, but before/after deltas on
  * the same machine are.
+ * This harness observes main-thread longtasks only. It cannot observe network
+ * round trips and must never be cited as evidence that a round trip was removed.
  *
  * Run it (from desktop/):
- *   pnpm build
+ *   pnpm build:e2e
  *   npx playwright test --config=playwright.perf.config.ts warm-switch-markdown.perf.ts
  *
  * NOTE: the perf web server reuses an existing server on :4173 — if one is


### PR DESCRIPTION
## Summary

The desktop channel live subscription derived its `since` filter from the **reader's** clock. Nostr `created_at` is author-assigned, and the relay accepts timestamps up to 900s from server time (`MAX_TIMESTAMP_DRIFT_SECS`, `crates/buzz-relay/src/handlers/ingest.rs`). Because `since` is re-applied at live fan-out (`crates/buzz-relay/src/subscription.rs` → `filters_match` → `crates/buzz-core/src/filter.rs`), a valid message from a peer whose clock is behind the reader's was dropped — silently, and for the entire lifetime of that subscription. Nothing recovered it except a reconnect or channel re-entry.

The fix removes the reader-clock `since` and bounds initial replay with `limit` instead, which does not constrain future fan-out.

Removing `since` alone would have traded one loss window for another: the `CLOSED` retry path resent the original filter unchanged, so after a backoff of up to 30s a subscription would resume with only the newest `limit` events and permanently miss anything older in the gap. This PR therefore pairs the filter change with paged recovery, deriving the resume point from `lastSeenCreatedAt` — an author timestamp the relay already accepted, which is exactly why it is safe where a reader clock is not. That machinery already existed for reconnect (`relayReconnectReplay.ts`) and is reused rather than reinvented.

Changes, all desktop TypeScript (no Rust, no relay changes):

- `relayChannelFilters.ts` — new `buildChannelLiveFilter`: no `since`, `limit: 50`. The limit must stay above zero: `shouldPageReconnectReplay` gates paged reconnect recovery on `filter.limit > 0`, so `limit: 0` would silently disable reconnect history recovery. Documented at the call site.
- `relayClientSession.ts` — `subscribeToChannelLive` uses the new builder; adds an optional per-flush callback so replay projection can be batched.
- `relayClosedRecovery.ts` — `CLOSED` retry now performs paged catch-up from `lastSeenCreatedAt - skew` when a last-seen timestamp exists. Terminal `CLOSED` handling (auth/access/filter failure) and rate-limit backoff are unchanged.
- `relayReconnectReplay.ts` — replayed events route through the buffered event path rather than bypassing it.
- `hooks.ts` — window projection is batched per relay flush and runs only when an event actually mutated the window. Without this, removing `since` would trigger up to 50 full-store flatten-and-reconcile passes on a single channel switch, since `main` projects once per event.

### Related issue

None found for this bug. Searched open and closed issues and PRs for `clock skew`, `created_at since`, `live subscription since`, `message loss subscription`, and `drops messages`.

Related but **not** duplicate: #3104 ("Desktop thread can render agent reply before triggering message under client clock skew"). Same root cause — author-assigned `created_at` under clock skew — but the opposite symptom. #3104 is about messages that arrive and sort into the wrong *position*; this PR is about messages that never arrive at all because the reader's clock acts as a delivery filter. Fixing one does not fix the other.

Adjacent instance **not** fixed here: `buildChannelMentionFilter` (`relayChannelFilters.ts`) still uses `since: Math.floor(Date.now() / 1_000)` from the reader's clock, so channel mentions from a peer with a lagging clock can be dropped the same way. It is left alone deliberately — it needs its own check on whether a bare `limit` is safe there and whether that subscription has a recovery path. Happy to fold it into this PR or file a follow-up, whichever the maintainers prefer.

### Testing

No UI change, so no screenshots.

New unit coverage in `relayChannelFilters.test.mjs`:

- the live filter has no `since` key (the regression guard for this bug)
- `limit > 0`, and `shouldPageReconnectReplay(liveFilter) === true` — pinning the coupling a future `limit: 0` would silently break
- `#h` scoping and the kinds set, including `KIND_CHANNEL_THREAD_SUMMARY`

The existing `relay-reconnect.spec.ts:216` ("reconnect backfills more missed channel messages than the live subscription limit") is the end-to-end proof for the recovery half: it injects 260 messages during a disconnect and requires the oldest to remain reachable, which fails if recovery is bounded by the live `limit`. It passes on this branch.

Local verification (Fedora 44, x86_64):

| Check | Result |
|---|---|
| `just desktop-check` (incl. file-size, px-text, pubkey-truncation gates) | pass |
| `just desktop-test` | 3804 passed, 0 failed |
| `just desktop-typecheck` | pass |
| `just desktop-build` | pass |
| `pnpm exec playwright test --project=smoke` (all 4 shards) | pass |

Two disclosures so they are not discovered in review rather than read here:

1. `just ci` does **not** go green on my machine, because of `buzz-db`'s `replica_fence::tests::fence_starts_closed_and_opens_on_advance` — a nanosecond-vs-microsecond timestamp assertion. It fails identically on unmodified `main`, and this branch changes zero `.rs` files (`git diff --name-only origin/main..HEAD | grep -c '\.rs$'` → 0), so it cannot be caused by this change. Path filtering means Rust Lint and Unit Tests do not run for a desktop-only PR anyway.
2. `relay-reconnect.spec.ts:97` ("failed initial relay dial retries automatically") flaked once under shard parallelism with `Relay state seam is not installed` — the spec's own instrumentation hook was not yet installed when it polled. It passes in isolation on both `main` and this branch, and CI runs with `retries: 2`.

Performance is unchanged, as expected — this is a correctness fix, not a latency change. Cold-switch and warm-switch longtask harnesses are at parity with `main` within run-to-run spread.
