### PR TITLE
fix(desktop): stop hiding repos re-announced after a deletion

### DIFF
--- a/desktop/src/features/projects/hooks.ts
+++ b/desktop/src/features/projects/hooks.ts
@@ -3,6 +3,10 @@ import * as React from "react";
 
 import { relayClient } from "@/shared/api/relayClient";
 import { getRelaySelf } from "@/features/moderation/lib/relaySelf";
+import {
+  isDeletedByA,
+  projectCoordinate,
+} from "@/features/projects/lib/projectDeletions";
 import { getCachedRelayOrigin } from "@/shared/lib/mediaUrl";
 import { signRelayEvent } from "@/shared/api/tauri";
 import { getIdentity } from "@/shared/api/tauriIdentity";
@@ -144,10 +148,6 @@ function getCloneUrls(event: RelayEvent): string[] {
   return tag ? tag.slice(1) : [];
 }
 
-function projectCoordinate(project: Pick<Project, "owner" | "dtag">): string {
-  return `${KIND_REPO_ANNOUNCEMENT}:${project.owner}:${project.dtag}`;
-}
-
 function readHiddenProjectCards(): string[] {
   if (typeof window === "undefined") {
     return [];
@@ -167,17 +167,6 @@ function readHiddenProjectCards(): string[] {
 
 function isHiddenLocally(project: Project): boolean {
   return readHiddenProjectCards().includes(projectCoordinate(project));
-}
-
-function isDeletedByA(project: Project, deletionEvents: RelayEvent[]): boolean {
-  const coordinate = projectCoordinate(project);
-  // NIP-09: a deletion is only valid when signed by the author of the
-  // referenced event — otherwise anyone could hide someone else's project.
-  return deletionEvents.some(
-    (event) =>
-      event.pubkey.toLowerCase() === project.owner.toLowerCase() &&
-      event.tags.some((tag) => tag[0] === "a" && tag[1] === coordinate),
-  );
 }
 
 /**

--- a/desktop/src/features/projects/lib/projectDeletions.test.mjs
+++ b/desktop/src/features/projects/lib/projectDeletions.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isDeletedByA, projectCoordinate } from "./projectDeletions.ts";
+
+const OWNER = "a".repeat(64);
+const OTHER = "b".repeat(64);
+
+const ANNOUNCED_AT = 1_700_000_000;
+
+function project(overrides = {}) {
+  return {
+    owner: OWNER,
+    dtag: "bitchat",
+    createdAt: ANNOUNCED_AT,
+    ...overrides,
+  };
+}
+
+function deletion({
+  pubkey = OWNER,
+  createdAt = ANNOUNCED_AT,
+  coordinate,
+} = {}) {
+  return {
+    id: "deadbeef",
+    pubkey,
+    kind: 5,
+    created_at: createdAt,
+    content: "",
+    tags: [["a", coordinate ?? projectCoordinate(project())]],
+    sig: "",
+  };
+}
+
+test("a tombstone older than the announcement does not hide it", () => {
+  // The #3760 regression: delete a repo, then announce the same dtag again.
+  // The re-announcement is newer than the tombstone, so it is live.
+  assert.equal(
+    isDeletedByA(project(), [deletion({ createdAt: ANNOUNCED_AT - 1 })]),
+    false,
+  );
+});
+
+test("a tombstone newer than the announcement hides it", () => {
+  assert.equal(
+    isDeletedByA(project(), [deletion({ createdAt: ANNOUNCED_AT + 1 })]),
+    true,
+  );
+});
+
+test("a tombstone at the announcement's own timestamp hides it", () => {
+  // NIP-09 deletes versions "up to the created_at timestamp" — inclusive.
+  assert.equal(isDeletedByA(project(), [deletion()]), true);
+});
+
+test("only the announcement author can delete it", () => {
+  assert.equal(
+    isDeletedByA(project(), [
+      deletion({ pubkey: OTHER, createdAt: ANNOUNCED_AT + 1 }),
+    ]),
+    false,
+  );
+});
+
+test("author matching stays case-insensitive", () => {
+  assert.equal(
+    isDeletedByA(project(), [
+      deletion({ pubkey: OWNER.toUpperCase(), createdAt: ANNOUNCED_AT + 1 }),
+    ]),
+    true,
+  );
+});
+
+test("a tombstone for a different coordinate is ignored", () => {
+  assert.equal(
+    isDeletedByA(project(), [
+      deletion({
+        createdAt: ANNOUNCED_AT + 1,
+        coordinate: projectCoordinate({ owner: OWNER, dtag: "other-repo" }),
+      }),
+    ]),
+    false,
+  );
+});
+
+test("a newer tombstone still hides the announcement when an older one exists", () => {
+  assert.equal(
+    isDeletedByA(project(), [
+      deletion({ createdAt: ANNOUNCED_AT - 100 }),
+      deletion({ createdAt: ANNOUNCED_AT + 100 }),
+    ]),
+    true,
+  );
+});
+
+test("projectCoordinate builds the NIP-34 repo address", () => {
+  assert.equal(
+    projectCoordinate({ owner: OWNER, dtag: "bitchat" }),
+    `30617:${OWNER}:bitchat`,
+  );
+});

--- a/desktop/src/features/projects/lib/projectDeletions.ts
+++ b/desktop/src/features/projects/lib/projectDeletions.ts
@@ -1,0 +1,44 @@
+import type { Project } from "@/features/projects/hooks";
+import type { RelayEvent } from "@/shared/api/types";
+import { KIND_REPO_ANNOUNCEMENT } from "@/shared/constants/kinds";
+
+/**
+ * The NIP-34 repo address (`30617:<owner>:<dtag>`) — the coordinate a kind:5
+ * deletion targets with an `a` tag, and the identity two forks of the same
+ * dtag are distinguished by.
+ */
+export function projectCoordinate(
+  project: Pick<Project, "owner" | "dtag">,
+): string {
+  return `${KIND_REPO_ANNOUNCEMENT}:${project.owner}:${project.dtag}`;
+}
+
+/**
+ * Whether a kind:5 tombstone in `deletionEvents` hides this repo announcement.
+ *
+ * A repo announcement is addressable (kind:30617), so its coordinate outlives
+ * any single event at it: deleting a repo and announcing the same dtag again
+ * is a legitimate recovery path, and the re-announcement is live. NIP-09
+ * scopes an `a`-tag deletion to versions "up to the `created_at` timestamp of
+ * the deletion request event" — so a tombstone only hides announcements at or
+ * older than itself, never a newer one published after it.
+ *
+ * Without that timestamp bound a single deletion hid the coordinate forever:
+ * the relay kept serving the newer announcement and git clone/push worked,
+ * but the card never rendered again for anyone (#3760).
+ */
+export function isDeletedByA(
+  project: Pick<Project, "owner" | "dtag" | "createdAt">,
+  deletionEvents: RelayEvent[],
+): boolean {
+  const coordinate = projectCoordinate(project);
+
+  return deletionEvents.some(
+    (event) =>
+      // NIP-09: a deletion is only valid when signed by the author of the
+      // referenced event — otherwise anyone could hide someone else's project.
+      event.pubkey.toLowerCase() === project.owner.toLowerCase() &&
+      event.created_at >= project.createdAt &&
+      event.tags.some((tag) => tag[0] === "a" && tag[1] === coordinate),
+  );
+}


### PR DESCRIPTION
Fixes #3760.

## Problem

`isDeletedByA` hid a project card whenever any same-author kind:5 tombstone carried its `30617:<owner>:<dtag>` coordinate, with no timestamp comparison:

```ts
event.pubkey.toLowerCase() === project.owner.toLowerCase() &&
event.tags.some((tag) => tag[0] === "a" && tag[1] === coordinate)
```

Repo announcements are addressable, so the coordinate outlives any single event at it. Deleting a repo and announcing the same dtag again is a legitimate recovery path, and NIP-09 scopes an `a`-tag deletion to versions "up to the `created_at` timestamp of the deletion request event" — a tombstone must not hide an announcement published after it.

The relay already gets this right, which is what made the failure confusing to diagnose: the newer announcement is stored, served over REQ, and clone/push works, while Desktop's Repositories list never renders the card again for anyone. Once an owner had ever deleted a project (including via Desktop's own Delete project button), no re-announcement at that coordinate could come back.

## Fix

Bound the match to `event.created_at >= project.createdAt`, keeping the existing author check. The comparison is inclusive, matching NIP-09's "up to the `created_at` timestamp".

The predicate and `projectCoordinate` move from `hooks.ts` into `lib/projectDeletions.ts`. Two reasons: the predicate was unexported and therefore untestable, and `hooks.ts` was at 997 of the 1000 lines `desktop/scripts/check-file-sizes.mjs` allows, so the fix could not have been added in place. `hooks.ts` is now 986 lines and both call sites (`fetchProjects`, `fetchProject`) are unchanged apart from the import.

I kept the `isDeletedByA` name so it still matches the issue.

## Tests

`lib/projectDeletions.test.mjs` — 8 cases covering the regression (tombstone older than the announcement no longer hides it), a newer tombstone still hiding it, and the inclusive same-timestamp boundary. The author check, case-insensitive pubkey match, and coordinate matching already worked and are pinned so a later refactor cannot quietly drop them.

Verified the suite catches the bug: with the `created_at` comparison removed, exactly one test fails — "a tombstone older than the announcement does not hide it".

## Checks

`just desktop-check`, `just desktop-typecheck`, `just desktop-test` (3827 pass), and `just desktop-build` all pass locally.

## Out of scope

The issue's second half is deliberately not addressed here, since it needs the managed-agent ownership relationship on the client and is a larger change:

- `isDeletedByA` only honors deletions whose pubkey equals the announcement author, so a relay-accepted owner-of-agent deletion (`is_agent_owner` in `validate_standard_deletion_event`) still leaves the card rendered.
- `canDelete` in `ProjectsView.tsx` gates on strict key equality via `isProjectOwnedByCurrentUser`, so a user cannot delete their own managed agent's repos from Desktop even though the relay would authorize it.

Happy to follow up on those separately if useful.

## Related PRs

Searched open PRs and issues for duplicates; found none touching `isDeletedByA` or repo-deletion filtering.
