### PR TITLE
fix(auth): bucket IPv6 connection limits by /64

### DIFF
--- a/crates/buzz-auth/src/rate_limit.rs
+++ b/crates/buzz-auth/src/rate_limit.rs
@@ -6,7 +6,7 @@
 //! ⚠️ Fixed windows allow up to 2× burst at boundaries. Upgrade to sliding
 //! window or token bucket for strict limiting.
 
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 
 use buzz_core::TenantContext;
 use nostr::PublicKey;
@@ -207,11 +207,42 @@ pub fn rate_limit_key(ctx: &TenantContext, pubkey: &PublicKey, limit_type: &Limi
     )
 }
 
-/// Redis key for IP-based rate limit: `buzz:ratelimit:ip:{ip}:conn`.
+/// Redis key for IP-based rate limit: `buzz:ratelimit:ip:{bucket}:conn`.
 ///
-/// Operator-global by design — see [`RateLimiter`] docs.
+/// Operator-global by design — see [`RateLimiter`] docs. The address is
+/// bucketed by [`ip_rate_limit_bucket`] so an IPv6 client cannot mint a fresh
+/// counter per connection.
 pub fn ip_rate_limit_key(ip: &IpAddr) -> String {
-    format!("buzz:ratelimit:ip:{}:conn", ip)
+    format!("buzz:ratelimit:ip:{}:conn", ip_rate_limit_bucket(ip))
+}
+
+/// The counter identity an address is charged against.
+///
+/// IPv4 is keyed on the full address: v4 space is scarce, addresses are
+/// commonly shared behind carrier NAT, and widening the bucket would let one
+/// abusive client deny service to everyone behind the same egress.
+///
+/// IPv6 is keyed on the `/64` prefix. A single end site is routinely delegated
+/// a `/64` or shorter (RFC 4291 §2.5.4 fixes the interface identifier at 64
+/// bits), so keying on the full `/128` lets one host rotate through 2^64
+/// source addresses and get a fresh quota for every connection — the fence
+/// would count addresses, not clients.
+///
+/// IPv4-mapped addresses (`::ffff:a.b.c.d`) are unmapped to their IPv4 form
+/// first. Masking them to `/64` would collapse every IPv4 client that arrives
+/// over a dual-stack socket into the single `::/64` bucket, turning the fence
+/// into a global limit on all IPv4 traffic.
+pub fn ip_rate_limit_bucket(ip: &IpAddr) -> String {
+    match ip {
+        IpAddr::V4(v4) => v4.to_string(),
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => v4.to_string(),
+            None => {
+                let s = v6.segments();
+                format!("{}/64", Ipv6Addr::new(s[0], s[1], s[2], s[3], 0, 0, 0, 0))
+            }
+        },
+    }
 }
 
 /// Always-allow rate limiter for unit tests.
@@ -310,6 +341,57 @@ mod tests {
         // IP fence stays operator-global — no community in the key.
         let ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
         assert_eq!(ip_rate_limit_key(&ip), "buzz:ratelimit:ip:192.168.1.1:conn");
+    }
+
+    #[test]
+    fn ipv6_addresses_in_one_slash_64_share_a_counter() {
+        // The fence counts clients, not addresses. An end site holding a /64
+        // must not mint a fresh quota by rotating its interface identifier —
+        // it has 2^64 of them.
+        let a = IpAddr::V6("2001:db8:1:2::1".parse::<Ipv6Addr>().unwrap());
+        let b = IpAddr::V6("2001:db8:1:2:dead:beef:cafe:1".parse::<Ipv6Addr>().unwrap());
+        assert_eq!(ip_rate_limit_key(&a), ip_rate_limit_key(&b));
+        assert_eq!(
+            ip_rate_limit_key(&a),
+            "buzz:ratelimit:ip:2001:db8:1:2::/64:conn"
+        );
+    }
+
+    #[test]
+    fn distinct_ipv6_prefixes_keep_separate_counters() {
+        // Bucketing must not over-block: two different end sites stay independent.
+        let a = IpAddr::V6("2001:db8:1:2::1".parse::<Ipv6Addr>().unwrap());
+        let b = IpAddr::V6("2001:db8:1:3::1".parse::<Ipv6Addr>().unwrap());
+        assert_ne!(ip_rate_limit_key(&a), ip_rate_limit_key(&b));
+    }
+
+    #[test]
+    fn ipv4_mapped_addresses_are_not_collapsed() {
+        // ::ffff:a.b.c.d arrives on dual-stack sockets. Masking these to /64
+        // would put every IPv4 client in one bucket — a global IPv4 limit, and
+        // a self-inflicted outage rather than a fence.
+        let mapped_a = IpAddr::V6("::ffff:192.168.1.1".parse::<Ipv6Addr>().unwrap());
+        let mapped_b = IpAddr::V6("::ffff:203.0.113.9".parse::<Ipv6Addr>().unwrap());
+        assert_ne!(ip_rate_limit_key(&mapped_a), ip_rate_limit_key(&mapped_b));
+
+        // A mapped address charges the same counter as its native v4 form, so a
+        // client cannot double its quota by switching socket family.
+        let native = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+        assert_eq!(ip_rate_limit_key(&mapped_a), ip_rate_limit_key(&native));
+    }
+
+    #[test]
+    fn ipv6_bucket_key_is_lowercase() {
+        // Same idempotence invariant the pubkey key holds: uppercase hex would
+        // split one logical client across two Redis rows → double quota.
+        let ip = IpAddr::V6("2001:DB8:AB:CD::1".parse::<Ipv6Addr>().unwrap());
+        let key = ip_rate_limit_key(&ip);
+        for c in key.chars() {
+            assert!(
+                !c.is_ascii_uppercase(),
+                "ip rate-limit key {key} must be all-lowercase ASCII"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`ip_rate_limit_key` keyed the per-IP connection fence on the full address:

```rust
format!("buzz:ratelimit:ip:{}:conn", ip)
```

For IPv6 that is a `/128`. RFC 4291 §2.5.4 fixes the interface identifier at 64 bits, and end sites are routinely delegated a `/64` or shorter, so one host can rotate through 2^64 source addresses and charge a different Redis counter on every connection. The fence counts addresses, not clients.

This is the pre-auth edge control — `check_ip_connection` runs before host to community resolution completes (and instead of it when resolution fails), so unlike the pubkey-keyed limits there is no authenticated identity downstream that re-checks it. It is the only thing standing between an unauthenticated peer and connection-slot exhaustion.

Trace: `ip_rate_limit_key` (`crates/buzz-auth/src/rate_limit.rs:213`) → `check_ip_connection` (`crates/buzz-pubsub/src/rate_limiter.rs:118`) → `run_rate_limit` fixed-window. No prefix normalization anywhere in the chain.

## Fix

Bucket IPv6 on the `/64` prefix via a new `ip_rate_limit_bucket`.

IPv4 deliberately keeps the full address. v4 space is scarce and commonly shared behind carrier NAT, so widening that bucket would let one abusive client deny service to everyone behind the same egress — the opposite failure.

## The IPv4-mapped trap

`::ffff:a.b.c.d` arrives on dual-stack sockets. Masking those to `/64` like any other v6 address would place **every** IPv4 client into the single `::/64` bucket, silently converting a per-client fence into a global cap on all IPv4 traffic — a self-inflicted outage strictly worse than the bug being fixed. They are unmapped to their v4 form first, which also means a client cannot double its quota by switching socket family. There is a test pinning both directions.

## Tests

Five cases in `rate_limit.rs`, all infra-free:

- two addresses in one `/64` share a counter (the regression)
- distinct `/64`s stay independent (guards against over-blocking)
- v4-mapped addresses do not collapse together, and match their native v4 key
- the existing IPv4 key format is unchanged
- the key stays lowercase, matching the invariant `rate_limit_key` already holds

Verified the suite catches the bug: reverting `ip_rate_limit_bucket` to `ip.to_string()` fails exactly the `/64` and v4-mapped tests.

## Operational note

IPv6 keys change shape, so counters in flight at deploy are orphaned. They expire with the rate-limit window (seconds) and no migration is needed.

## Checks

`just fmt-check`, `just clippy` (clean), and `just test-unit` (all six suites) pass locally. `buzz-pubsub` is unaffected — the public signature is unchanged.

## Scope

Found while auditing `buzz-auth`. Two other candidate findings from that pass are deliberately **not** included, since both turned out to be working as designed:

- the inert scope grant in `verify_auth_event` — `SECURITY.md` states channel membership is the only access-control mechanism and there are no capability taxonomies, so the scope layer is intentionally not a gate;
- NIP-98 body binding — `api/bridge.rs` already enforces a `require_payload` check before verification, and `api/git/transport.rs` documents its `body: None` as a considered trade-off.

Happy to open an issue on either if maintainers see it differently.

## Related

Searched open PRs and issues; nothing touches IP rate limiting. #3633 (`feat(auth): add provider-neutral authorization contract`) also lives in `buzz-auth` but only in `lib.rs` and a new `provider/` module, so there is no overlap with `rate_limit.rs`.
