### PR TITLE
feat(desktop): make the sidebar agent-working timer glow green

### DIFF
--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -122,11 +122,9 @@ export function formatWorkingTooltip(
 
 function ChannelWorkingBadge({
   channelName,
-  isActive,
   summary,
 }: {
   channelName: string;
-  isActive: boolean;
   summary: ActiveChannelTurnSummary;
 }) {
   const now = useNow(1000);
@@ -137,12 +135,7 @@ function ChannelWorkingBadge({
 
   return (
     <span
-      className={cn(
-        "hidden max-w-32 shrink-0 truncate rounded-full px-1.5 py-0.5 text-2xs font-medium leading-none tabular-nums motion-safe:animate-pulse group-data-[collapsible=icon]:hidden sm:inline-flex",
-        isActive
-          ? "bg-sidebar-active-foreground/20 text-sidebar-active-foreground"
-          : "bg-primary/10 text-primary",
-      )}
+      className="buzz-agent-working-glow hidden max-w-32 shrink-0 truncate rounded-full bg-agent-working-bg px-1.5 py-0.5 text-2xs font-medium leading-none tabular-nums text-agent-working group-data-[collapsible=icon]:hidden sm:inline-flex"
       data-testid={`channel-working-${channelName}`}
       title={title}
     >
@@ -307,7 +300,6 @@ export function ChannelMenuButton({
       {activeWorking ? (
         <ChannelWorkingBadge
           channelName={channel.name}
-          isActive={isActive}
           summary={activeWorking}
         />
       ) : null}

--- a/desktop/src/shared/styles/globals/animations.css
+++ b/desktop/src/shared/styles/globals/animations.css
@@ -916,3 +916,31 @@
     animation: none;
   }
 }
+
+/*
+ * Sidebar agent-working badge: a green halo that breathes while an agent holds
+ * the turn. The halo carries the live signal so the elapsed label itself keeps
+ * a steady opacity — pulsing the whole chip fades the running clock out from
+ * under whoever is reading it. The resting shadow keeps the chip glowing when
+ * the animation is suppressed.
+ */
+@keyframes buzz-agent-working-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 4px 0 var(--agent-working-glow);
+  }
+  50% {
+    box-shadow: 0 0 10px 2px var(--agent-working-glow);
+  }
+}
+
+.buzz-agent-working-glow {
+  box-shadow: 0 0 6px 1px var(--agent-working-glow);
+  animation: buzz-agent-working-glow 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .buzz-agent-working-glow {
+    animation: none;
+  }
+}

--- a/desktop/src/shared/styles/globals/theme.css
+++ b/desktop/src/shared/styles/globals/theme.css
@@ -47,6 +47,12 @@
     --sidebar-accent-foreground: 234 16.02% 35.49%;
     --sidebar-border: 225 13.56% 76.86%;
     --sidebar-ring: 225 13.56% 76.86%;
+    /* Agent-working badge. ThemeProvider overwrites these per syntax theme;
+       these are the base so the badge is never colourless on the first paint
+       after an update, before the cached var map has been refreshed. */
+    --agent-working: #177232;
+    --agent-working-bg: #e2eaea;
+    --agent-working-glow: rgba(26, 127, 55, 0.38);
     /* Exact Buzz palette tokens; components consume these semantically. */
     --buzz-gradient-light-top: #e6e6b6;
     --buzz-gradient-light-bottom: #c4d0da;
@@ -113,6 +119,9 @@
     --sidebar-accent-foreground: 227 68.25% 87.65%;
     --sidebar-border: 231 15.61% 33.92%;
     --sidebar-ring: 231 15.61% 33.92%;
+    --agent-working: #3fb950;
+    --agent-working-bg: #27363c;
+    --agent-working-glow: rgba(63, 185, 80, 0.5);
   }
 
   * {

--- a/desktop/src/shared/theme/adaptive-theme.ts
+++ b/desktop/src/shared/theme/adaptive-theme.ts
@@ -285,6 +285,19 @@ export function createThemeVars(
       // Warning
       "--ui-warning": accentOrange,
       "--ui-warning-bg": overlay(accentOrange, isDark ? 0.1 : 0.08),
+
+      // Agent working — the live elapsed badge. The surface is mixed rather
+      // than overlaid so the chip stays opaque: it sits on the active sidebar
+      // row as often as on the plain one, and a translucent green over the
+      // active accent would take the accent's hue with it. The mix stays light
+      // (the chip barely leaves the surface) because the label is 11px, and
+      // every step of green in the chip costs text contrast; the halo, not the
+      // fill, is what makes the badge read as live. On light themes the green
+      // is darkened for the same reason — a mid green on a near-white chip
+      // lands under 4.5:1.
+      "--agent-working": isDark ? accentGreen : adjust(accentGreen, -0.1),
+      "--agent-working-bg": mix(primaryBg, accentGreen, isDark ? 0.1 : 0.06),
+      "--agent-working-glow": overlay(accentGreen, isDark ? 0.5 : 0.38),
     },
   };
 }

--- a/desktop/tailwind.config.js
+++ b/desktop/tailwind.config.js
@@ -101,6 +101,10 @@ export default {
           DEFAULT: "var(--ui-warning)",
           bg: "var(--ui-warning-bg)",
         },
+        "agent-working": {
+          DEFAULT: "var(--agent-working)",
+          bg: "var(--agent-working-bg)",
+        },
       },
     },
   },


### PR DESCRIPTION
## What

The elapsed-time badge on a sidebar channel row — the one that counts up while an agent holds the turn — now reads green with a soft halo that breathes, instead of a mauve chip that pulsed its own opacity.

## Why

Two things were off:

- The badge used `text-primary` / `bg-primary/10`, the same accent as everything else accented in the sidebar. "An agent is working in this channel" did not read at a glance.
- `animate-pulse` fades the entire chip, so the running clock dimmed out from under whoever was reading it every two seconds.

Moving the live signal into the halo lets the label hold a steady opacity for the whole cycle.

## How

Three theme-derived tokens back it, following the existing `--ui-warning` pattern in `adaptive-theme.ts`, so the badge tracks the active syntax theme's own green rather than hardcoding one:

- `--agent-working` — label colour
- `--agent-working-bg` — chip surface
- `--agent-working-glow` — halo

The chip surface is a `mix()` rather than a translucent `overlay()` so it stays opaque. This badge sits on the active sidebar row as often as on a plain one, and a translucent green over the active accent would take the accent's hue with it. That also let the `isActive` colour branch — and the prop — go away.

The mix is deliberately light. The label is 11px (`text-2xs`), and every step of green in the chip costs text contrast; on light themes the green is darkened for the same reason.

## Contrast

Measured label-on-chip, sRGB relative luminance:

| theme | ratio | |
|---|---|---|
| Macchiato (dark) | **4.92:1** | clears WCAG AA for small text |
| Latte (light) | **4.93:1** | clears WCAG AA for small text |

For reference, the treatment this replaces measured 3.88:1 on light themes, so light mode gets better here rather than worse.

Base values are also set in `theme.css` for both `:root` and `.dark`, so the badge is never colourless on the first paint after an update — before `ThemeProvider`'s cached var map has been refreshed. They match what `createThemeVars` computes for the default Latte/Macchiato themes.

`prefers-reduced-motion: reduce` stops the animation and keeps the resting glow.

## Testing

```
just desktop-check      # exit 0
just desktop-typecheck  # exit 0
just desktop-test       # 3834 pass, 0 fail
just desktop-build      # exit 0
```

Visual verification was done against the built stylesheet in headless Chromium — the badge markup rendered on both sidebar surfaces and on the active row, in both themes — since the E2E mock bridge has no way to seed an active agent turn. The contrast ratios above were computed from the values `createThemeVars` actually returns for each theme, not from the static fallbacks.