### PR TITLE
fix(relay): hide DMs from recipients until the first message arrives

### DIFF
--- a/crates/buzz-db/src/channel.rs
+++ b/crates/buzz-db/src/channel.rs
@@ -656,6 +656,32 @@ pub async fn is_member(
     Ok(cnt > 0)
 }
 
+/// Like [`is_member`], but excludes `hidden_pending` DM memberships — the
+/// same rows [`get_accessible_channel_ids`] withholds. For the REQ/COUNT
+/// stale-cache repair path, so confirming membership against the DB cannot
+/// re-grant exactly the read access deferred DM visibility withholds.
+/// Explicitly hidden (non-pending) memberships still count as visible.
+pub async fn is_visible_member(
+    pool: &PgPool,
+    community_id: CommunityId,
+    channel_id: Uuid,
+    pubkey: &[u8],
+) -> Result<bool> {
+    let row = sqlx::query(
+        "SELECT COUNT(*) as cnt FROM channel_members cm \
+         JOIN channels c ON cm.community_id = c.community_id AND cm.channel_id = c.id AND c.deleted_at IS NULL \
+         WHERE cm.community_id = $1 AND cm.channel_id = $2 AND cm.pubkey = $3 \
+           AND cm.removed_at IS NULL AND NOT cm.hidden_pending",
+    )
+    .bind(community_id.as_uuid())
+    .bind(channel_id)
+    .bind(pubkey)
+    .fetch_one(pool)
+    .await?;
+    let cnt: i64 = row.try_get("cnt")?;
+    Ok(cnt > 0)
+}
+
 /// Return which of the given (channel, pubkey) combinations are active
 /// memberships, restricted to non-deleted channels — one statement for any
 /// batch size (T2b). Semantics per pair match [`is_member`].
@@ -743,6 +769,11 @@ pub async fn get_members_bulk(
 ///
 /// Includes channels where the pubkey is an active member AND all open channels.
 /// Open channels must be included in REQ filter resolution.
+///
+/// Excludes `hidden_pending` DM memberships (auto-hidden at creation, awaiting
+/// the first message) so globally-scoped reads cannot surface a DM the user
+/// was never notified about. Explicitly hidden DMs remain accessible — clients
+/// filter those via the NIP-DV snapshot instead.
 pub async fn get_accessible_channel_ids(
     pool: &PgPool,
     community_id: CommunityId,
@@ -754,6 +785,7 @@ pub async fn get_accessible_channel_ids(
         FROM channel_members cm
         JOIN channels c ON cm.community_id = c.community_id AND cm.channel_id = c.id AND c.deleted_at IS NULL
         WHERE cm.community_id = $1 AND cm.pubkey = $2 AND cm.removed_at IS NULL
+          AND NOT cm.hidden_pending
         UNION
         SELECT id AS channel_id
         FROM channels

--- a/crates/buzz-db/src/dm.rs
+++ b/crates/buzz-db/src/dm.rs
@@ -98,6 +98,8 @@ pub async fn find_dm_by_participants(
 /// - `participants` must contain 2-9 entries (enforced here).
 /// - `created_by` must be one of the participants.
 /// - The operation is idempotent: same participant set -> same channel returned.
+/// - Non-creator participants start hidden (`hidden_pending`) until the first
+///   message reveals the DM ([`reveal_pending_dm_members`]).
 pub async fn create_dm(
     pool: &PgPool,
     community_id: CommunityId,
@@ -178,22 +180,31 @@ pub async fn create_dm(
     .execute(&mut *tx)
     .await?;
 
-    // Add all participants as members with role='member'.
+    // Add all participants as members with role='member'. Non-creators start
+    // hidden with `hidden_pending = TRUE` so the DM stays invisible to them
+    // until the first real message reveals it (`reveal_pending_dm_members`) —
+    // opening a DM fires on click, before anything is sent.
     for pk in participants {
+        let is_creator = *pk == created_by;
         sqlx::query(
             r#"
-            INSERT INTO channel_members (community_id, channel_id, pubkey, role, invited_by)
-            VALUES ($1, $2, $3, 'member', $4)
+            INSERT INTO channel_members
+                (community_id, channel_id, pubkey, role, invited_by, hidden_at, hidden_pending)
+            VALUES ($1, $2, $3, 'member', $4,
+                    CASE WHEN $5 THEN NULL ELSE NOW() END, NOT $5)
             ON CONFLICT (community_id, channel_id, pubkey) DO UPDATE SET
                 removed_at = NULL,
                 removed_by = NULL,
-                role = EXCLUDED.role
+                role = EXCLUDED.role,
+                hidden_at = EXCLUDED.hidden_at,
+                hidden_pending = EXCLUDED.hidden_pending
             "#,
         )
         .bind(community_id.as_uuid())
         .bind(id)
         .bind(*pk)
         .bind(created_by)
+        .bind(is_creator)
         .execute(&mut *tx)
         .await?;
     }
@@ -400,10 +411,12 @@ pub async fn hide_dm(
     channel_id: Uuid,
     pubkey: &[u8],
 ) -> Result<()> {
+    // `hidden_pending = FALSE` marks this as an explicit hide: sticky, never
+    // auto-revealed by later messages (unlike the create-time pending state).
     let result = sqlx::query(
         r#"
         UPDATE channel_members
-        SET hidden_at = NOW()
+        SET hidden_at = NOW(), hidden_pending = FALSE
         WHERE community_id = $1 AND channel_id = $2 AND pubkey = $3 AND removed_at IS NULL
         "#,
     )
@@ -435,7 +448,7 @@ pub async fn unhide_dm(
     sqlx::query(
         r#"
         UPDATE channel_members
-        SET hidden_at = NULL
+        SET hidden_at = NULL, hidden_pending = FALSE
         WHERE community_id = $1 AND channel_id = $2 AND pubkey = $3 AND removed_at IS NULL
         "#,
     )
@@ -448,9 +461,39 @@ pub async fn unhide_dm(
     Ok(())
 }
 
+/// Reveal memberships that were auto-hidden at DM creation (`hidden_pending`),
+/// returning the revealed pubkeys. Called when the first real message lands in
+/// a DM. Explicit hides have `hidden_pending = FALSE` and are left untouched,
+/// so they stay sticky across later messages.
+pub async fn reveal_pending_dm_members(
+    pool: &PgPool,
+    community_id: CommunityId,
+    channel_id: Uuid,
+) -> Result<Vec<Vec<u8>>> {
+    let rows = sqlx::query(
+        r#"
+        UPDATE channel_members
+        SET hidden_at = NULL, hidden_pending = FALSE
+        WHERE community_id = $1 AND channel_id = $2
+          AND removed_at IS NULL AND hidden_pending
+        RETURNING pubkey
+        "#,
+    )
+    .bind(community_id.as_uuid())
+    .bind(channel_id)
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|r| r.try_get::<Vec<u8>, _>("pubkey").map_err(Into::into))
+        .collect()
+}
+
 /// Return the channel IDs of all DMs the given user currently has hidden
 /// (`hidden_at IS NOT NULL`) while still being an active member. Used to build
-/// the relay-signed NIP-DV visibility snapshot.
+/// the relay-signed NIP-DV visibility snapshot. Excludes `hidden_pending`
+/// memberships: those DMs were never visible to the user, so listing them
+/// would leak the DM's existence before its first message.
 pub async fn list_hidden_dms(
     pool: &PgPool,
     community_id: CommunityId,
@@ -467,6 +510,7 @@ pub async fn list_hidden_dms(
           AND cm.pubkey = $2
           AND cm.removed_at IS NULL
           AND cm.hidden_at IS NOT NULL
+          AND NOT cm.hidden_pending
           AND c.channel_type = 'dm'
           AND c.deleted_at IS NULL
         ORDER BY cm.channel_id

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -2237,6 +2237,17 @@ impl Db {
         channel::is_member(&self.pool, community_id, channel_id, pubkey).await
     }
 
+    /// Like [`Db::is_member`], but excludes `hidden_pending` DM memberships
+    /// (deferred visibility). For read-access repair paths.
+    pub async fn is_visible_member(
+        &self,
+        community_id: CommunityId,
+        channel_id: Uuid,
+        pubkey: &[u8],
+    ) -> Result<bool> {
+        channel::is_visible_member(&self.pool, community_id, channel_id, pubkey).await
+    }
+
     /// Return the active (channel, pubkey) membership pairs among the given
     /// sets, in one statement.
     pub async fn membership_pairs(
@@ -2625,6 +2636,16 @@ impl Db {
         pubkey: &[u8],
     ) -> Result<()> {
         dm::unhide_dm(&self.pool, community_id, channel_id, pubkey).await
+    }
+
+    /// Reveal DM memberships auto-hidden at creation, returning the revealed
+    /// pubkeys. Explicit hides are left untouched.
+    pub async fn reveal_pending_dm_members(
+        &self,
+        community_id: CommunityId,
+        channel_id: Uuid,
+    ) -> Result<Vec<Vec<u8>>> {
+        dm::reveal_pending_dm_members(&self.pool, community_id, channel_id).await
     }
 
     /// List the channel IDs of all DMs the given user currently has hidden.

--- a/crates/buzz-db/src/migration.rs
+++ b/crates/buzz-db/src/migration.rs
@@ -561,7 +561,7 @@ mod tests {
         let mut migrations: Vec<_> = MIGRATOR.iter().collect();
         migrations.sort_by_key(|migration| migration.version);
 
-        assert_eq!(migrations.len(), 26);
+        assert_eq!(migrations.len(), 27);
         assert_eq!(migrations[0].version, 1);
         assert_eq!(&*migrations[0].description, "initial schema");
         assert!(migrations[0]
@@ -902,6 +902,10 @@ mod tests {
 
         let desired_schema = include_str!("../../../schema/schema.sql");
         assert!(
+            desired_schema.contains("hidden_pending BOOLEAN NOT NULL DEFAULT FALSE"),
+            "desired-state schema must carry the deferred-DM-visibility column",
+        );
+        assert!(
             desired_schema.contains("CREATE TABLE join_policy_acceptances"),
             "desired-state schema must include join-policy evidence used by invite claims",
         );
@@ -919,6 +923,18 @@ mod tests {
         assert!(heartbeat.contains("epoch"));
         assert!(heartbeat.contains("INSERT INTO replica_heartbeat (id) VALUES (1)"));
         assert!(heartbeat.contains("_operator_global_tables"));
+
+        // Deferred DM visibility (renumbered to 0027 after 0026_replica_heartbeat
+        // landed on main): additive column on channel_members marking recipients
+        // hidden until the DM's first real message. Never folded into 0001 —
+        // same brownfield checksum rule as above.
+        assert_eq!(migrations[26].version, 27);
+        let dm_hidden_pending = migrations[26].sql.as_str();
+        assert!(dm_hidden_pending.contains("ALTER TABLE channel_members"));
+        assert!(
+            dm_hidden_pending.contains("ADD COLUMN hidden_pending BOOLEAN NOT NULL DEFAULT FALSE")
+        );
+        assert!(!migrations[0].sql.as_str().contains("hidden_pending"));
     }
 
     #[test]

--- a/crates/buzz-relay/src/handlers/command_executor.rs
+++ b/crates/buzz-relay/src/handlers/command_executor.rs
@@ -404,19 +404,22 @@ async fn handle_dm_open(
             warn!(channel = %channel.id, "DM open: discovery emission failed: {e}");
         }
 
-        for participant in &all_bytes {
-            if let Err(e) = emit_membership_notification(
-                tenant,
-                state,
-                channel.id,
-                participant,
-                &self_bytes,
-                KIND_MEMBER_ADDED_NOTIFICATION,
-            )
-            .await
-            {
-                warn!("DM open: membership notification failed: {e}");
-            }
+        // Notify only the creator. Other participants were created
+        // `hidden_pending` — a kind:41010 fires on click, before any message —
+        // and get their kind:44100 when the first message reveals the DM
+        // (`reveal_pending_dm_members` in ingest). 44100s are stored globally
+        // (channel_id = None), so notifying them here would leak the empty DM.
+        if let Err(e) = emit_membership_notification(
+            tenant,
+            state,
+            channel.id,
+            &self_bytes,
+            &self_bytes,
+            KIND_MEMBER_ADDED_NOTIFICATION,
+        )
+        .await
+        {
+            warn!("DM open: membership notification failed: {e}");
         }
     } else {
         // Re-open of an existing DM cleared the caller's hidden_at; refresh
@@ -548,19 +551,21 @@ async fn handle_dm_add_member(
             warn!(channel = %new_channel.id, "DM add_member: discovery emission failed: {e}");
         }
 
-        for participant_bytes in &all_bytes {
-            if let Err(e) = emit_membership_notification(
-                tenant,
-                state,
-                new_channel.id,
-                participant_bytes,
-                &self_bytes,
-                KIND_MEMBER_ADDED_NOTIFICATION,
-            )
-            .await
-            {
-                warn!("DM add_member: membership notification failed: {e}");
-            }
+        // Adding a member mints a NEW channel (DM sets are immutable), so the
+        // same deferred-visibility rule as handle_dm_open applies: everyone
+        // but the actor is `hidden_pending` and gets their kind:44100 when the
+        // first message reveals the expanded DM.
+        if let Err(e) = emit_membership_notification(
+            tenant,
+            state,
+            new_channel.id,
+            &self_bytes,
+            &self_bytes,
+            KIND_MEMBER_ADDED_NOTIFICATION,
+        )
+        .await
+        {
+            warn!("DM add_member: membership notification failed: {e}");
         }
     }
 

--- a/crates/buzz-relay/src/handlers/count.rs
+++ b/crates/buzz-relay/src/handlers/count.rs
@@ -126,9 +126,11 @@ pub async fn handle_count(
             let db_is_member = if accessible_channels.contains(&ch_id) {
                 None
             } else {
+                // Visible-membership check: `hidden_pending` DM rows (deferred
+                // visibility) must not be repaired into read access here.
                 match state
                     .db
-                    .is_member(conn.tenant.community(), ch_id, &pubkey_bytes)
+                    .is_visible_member(conn.tenant.community(), ch_id, &pubkey_bytes)
                     .await
                 {
                     Ok(member) => Some(member),

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -2476,6 +2476,23 @@ async fn ingest_event_inner(
         });
     }
 
+    // A DM's first real message reveals memberships auto-hidden at creation
+    // (kind:41010 fires on click, before anything is sent). See
+    // `is_dm_revealing_kind` for which kinds count as a first message.
+    if crate::handlers::side_effects::is_dm_revealing_kind(kind_u32)
+        && channel_row.as_ref().is_some_and(|c| c.channel_type == "dm")
+    {
+        if let Some(ch_id) = channel_id {
+            crate::handlers::side_effects::reveal_dm_members_on_first_message(
+                tenant,
+                state,
+                ch_id,
+                &pubkey_bytes,
+            )
+            .await;
+        }
+    }
+
     if crate::handlers::side_effects::is_side_effect_kind(kind_u32) {
         if let Err(e) =
             crate::handlers::side_effects::handle_side_effects(tenant, kind_u32, &event, state)

--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -134,9 +134,11 @@ pub async fn handle_req(
         let db_is_member = if !token_allows || accessible_channels.contains(&ch_id) {
             None
         } else {
+            // Visible-membership check: `hidden_pending` DM rows (deferred
+            // visibility) must not be repaired into read access here.
             match state
                 .db
-                .is_member(conn.tenant.community(), ch_id, &pubkey_bytes)
+                .is_visible_member(conn.tenant.community(), ch_id, &pubkey_bytes)
                 .await
             {
                 Ok(member) => {

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -8,10 +8,11 @@ use uuid::Uuid;
 
 use buzz_core::kind::{
     event_kind_u32, is_parameterized_replaceable, KIND_AGENT_PROFILE, KIND_DM_VISIBILITY,
-    KIND_GIT_REPO_ANNOUNCEMENT, KIND_IA_ARCHIVED, KIND_IA_ARCHIVED_LIST, KIND_IA_UNARCHIVED,
-    KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_NIP29_GROUP_ADMINS,
-    KIND_NIP29_GROUP_MEMBERS, KIND_NIP29_GROUP_METADATA, KIND_NIP43_MEMBERSHIP_LIST, KIND_REACTION,
-    KIND_THREAD_SUMMARY,
+    KIND_GIT_REPO_ANNOUNCEMENT, KIND_HUDDLE_STARTED, KIND_IA_ARCHIVED, KIND_IA_ARCHIVED_LIST,
+    KIND_IA_UNARCHIVED, KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION,
+    KIND_NIP29_GROUP_ADMINS, KIND_NIP29_GROUP_MEMBERS, KIND_NIP29_GROUP_METADATA,
+    KIND_NIP43_MEMBERSHIP_LIST, KIND_REACTION, KIND_STREAM_MESSAGE, KIND_STREAM_MESSAGE_DIFF,
+    KIND_STREAM_MESSAGE_V2, KIND_THREAD_SUMMARY,
 };
 use buzz_core::StoredEvent;
 use buzz_db::channel::{MemberRecord, MemberRole};
@@ -890,6 +891,60 @@ pub fn emit_live_thread_summary(
         )
         .await;
     });
+}
+
+/// True for kinds that deliver a DM's first real content: text messages
+/// (9/40002), diff messages (40008), and huddle rings (48100). These are the
+/// kinds that reveal `hidden_pending` DM members. Edits, pins, scheduled
+/// requests, canvas writes, and system messages deliberately don't — none
+/// delivers a first message to the recipient.
+pub(crate) fn is_dm_revealing_kind(kind: u32) -> bool {
+    matches!(
+        kind,
+        KIND_STREAM_MESSAGE
+            | KIND_STREAM_MESSAGE_V2
+            | KIND_STREAM_MESSAGE_DIFF
+            | KIND_HUDDLE_STARTED
+    )
+}
+
+/// Reveal a DM's `hidden_pending` members after its first real message: clear
+/// the pending flag, invalidate membership caches, and emit each revealed
+/// member's deferred kind:44100 with the message author as actor. Best-effort
+/// by contract — every stored-message path that calls this must not reject the
+/// message on failure, so errors are logged here and not returned.
+pub(crate) async fn reveal_dm_members_on_first_message(
+    tenant: &TenantContext,
+    state: &Arc<AppState>,
+    channel_id: Uuid,
+    author_pubkey: &[u8],
+) {
+    match state
+        .db
+        .reveal_pending_dm_members(tenant.community(), channel_id)
+        .await
+    {
+        Ok(revealed) => {
+            for member in &revealed {
+                state.invalidate_membership(tenant, channel_id, member);
+                if let Err(e) = emit_membership_notification(
+                    tenant,
+                    state,
+                    channel_id,
+                    member,
+                    author_pubkey,
+                    KIND_MEMBER_ADDED_NOTIFICATION,
+                )
+                .await
+                {
+                    warn!(channel = %channel_id, "DM reveal: membership notification failed: {e}");
+                }
+            }
+        }
+        Err(e) => {
+            warn!(channel = %channel_id, "DM reveal failed: {e}");
+        }
+    }
 }
 
 /// Emit a relay-signed membership notification event stored globally (channel_id = None).

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -348,6 +348,20 @@ impl ActionSink for RelayActionSink {
             // 5. Post-persist side effects (fan-out, search, audit)
             //    Only if actually inserted (idempotency guard).
             if was_inserted {
+                // This insert bypasses ingest, so run the DM first-message
+                // reveal here too — a workflow message must not leave
+                // `hidden_pending` recipients unable to see a DM that now has
+                // content. Actor = the workflow owner the message is
+                // attributed to, not the relay signing key.
+                if channel.channel_type == "dm" {
+                    crate::handlers::side_effects::reveal_dm_members_on_first_message(
+                        &tenant,
+                        &state,
+                        channel_uuid,
+                        &author_pubkey_bytes,
+                    )
+                    .await;
+                }
                 let _ = dispatch_persistent_event(
                     &tenant,
                     &state,

--- a/crates/buzz-test-client/tests/e2e_nostr_interop.rs
+++ b/crates/buzz-test-client/tests/e2e_nostr_interop.rs
@@ -860,6 +860,289 @@ async fn test_dm_discovery_events_emitted() {
     client_a.disconnect().await.expect("disconnect");
 }
 
+/// True if the event carries a tag `[key, value, ...]`.
+fn has_tag(event: &nostr::Event, key: &str, value: &str) -> bool {
+    event.tags.iter().any(|t| {
+        let s = t.as_slice();
+        s.len() >= 2 && s[0] == key && s[1] == value
+    })
+}
+
+/// Query historical events of `kind` carrying single-letter tag `tag = value`,
+/// as the connected viewer. Subscribe → EOSE → close.
+async fn query_kind_by_tag(
+    client: &mut BuzzTestClient,
+    kind: u16,
+    tag: Alphabet,
+    value: &str,
+) -> Vec<nostr::Event> {
+    let sid = sub_id(&format!("query-{kind}"));
+    let filter = Filter::new()
+        .kind(Kind::Custom(kind))
+        .custom_tag(SingleLetterTag::lowercase(tag), value);
+    client
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("subscribe query");
+    let events = client
+        .collect_until_eose(&sid, Duration::from_secs(5))
+        .await
+        .expect("query EOSE");
+    client
+        .close_subscription(&sid)
+        .await
+        .expect("close query sub");
+    events
+}
+
+/// Open a `#h`-scoped kind-9 REQ on `channel_id` and report whether the relay
+/// grants it (EOSE) or denies it (CLOSED). A `#h` REQ on a channel missing
+/// from the viewer's accessible set falls to the stale-cache membership
+/// repair path, which must not resurrect deferred-visibility DM memberships.
+async fn channel_read_granted(client: &mut BuzzTestClient, channel_id: &str) -> bool {
+    let sid = sub_id("h-scope-probe");
+    let filter = Filter::new()
+        .kind(Kind::Custom(9))
+        .custom_tag(SingleLetterTag::lowercase(Alphabet::H), channel_id);
+    client
+        .subscribe(&sid, vec![filter])
+        .await
+        .expect("subscribe #h probe");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let remaining = deadline
+            .checked_duration_since(tokio::time::Instant::now())
+            .unwrap_or(Duration::ZERO);
+        assert!(!remaining.is_zero(), "no EOSE/CLOSED for #h probe");
+        match client.recv_event(remaining).await.expect("recv #h probe") {
+            RelayMessage::Eose { subscription_id } if subscription_id == sid => {
+                client
+                    .close_subscription(&sid)
+                    .await
+                    .expect("close #h probe");
+                return true;
+            }
+            RelayMessage::Closed {
+                subscription_id, ..
+            } if subscription_id == sid => {
+                return false;
+            }
+            _ => {}
+        }
+    }
+}
+
+/// A DM opened via kind:41010 must stay INVISIBLE to the recipient until the
+/// first real message arrives — clicking a person in search must not pop an
+/// empty DM window on their end.
+///
+/// Relay semantics under test:
+/// 1. On create, only the CREATOR gets the kind:44100 membership notification;
+///    the recipient's membership starts hidden, so their globally-scoped
+///    queries (44100 by `#p`, 39000/39002 discovery) exclude the DM.
+/// 2. The first kind:9 message reveals the DM: the recipient receives a live
+///    kind:44100 for the channel and discovery queries now return it.
+/// 3. An explicit hide (kind:41012) stays sticky — later messages must NOT
+///    re-reveal the DM (only the create-time pending state auto-reveals).
+#[tokio::test]
+#[ignore]
+async fn test_dm_open_invisible_to_recipient_until_first_message() {
+    let url = relay_url();
+    let keys_a = Keys::generate();
+    let keys_b = Keys::generate();
+    let b_pubkey_hex = keys_b.public_key().to_hex();
+
+    // A clicks B in search → client fires kind:41010 immediately.
+    let channel_id = create_dm(&keys_a, &b_pubkey_hex).await;
+
+    let mut client_b = BuzzTestClient::connect(&url, &keys_b)
+        .await
+        .expect("client B connect");
+
+    // Phase 1 — before any message, B must see NOTHING about this DM.
+    let notifications = query_kind_by_tag(&mut client_b, 44100, Alphabet::P, &b_pubkey_hex).await;
+    assert!(
+        !notifications.iter().any(|e| has_tag(e, "h", &channel_id)),
+        "recipient must not receive kind:44100 for a DM with no messages yet"
+    );
+    let members = query_kind_by_tag(&mut client_b, 39002, Alphabet::P, &b_pubkey_hex).await;
+    assert!(
+        !members.iter().any(|e| has_tag(e, "d", &channel_id)),
+        "recipient must not discover kind:39002 members for a message-less DM"
+    );
+    let metadata = query_kind_by_tag(&mut client_b, 39000, Alphabet::D, &channel_id).await;
+    assert!(
+        metadata.is_empty(),
+        "recipient must not read kind:39000 metadata for a message-less DM, got {}",
+        metadata.len()
+    );
+    assert!(
+        !channel_read_granted(&mut client_b, &channel_id).await,
+        "a #h REQ by a pending recipient must be denied even if they know the channel id"
+    );
+
+    // Phase 2 — the first message must reveal the DM to B, delivered live.
+    let sid_live = sub_id("dm-reveal-44100");
+    let live_filter = Filter::new().kind(Kind::Custom(44100)).custom_tag(
+        SingleLetterTag::lowercase(Alphabet::P),
+        b_pubkey_hex.as_str(),
+    );
+    client_b
+        .subscribe(&sid_live, vec![live_filter])
+        .await
+        .expect("subscribe live membership");
+    // Drain history so the recv below can only match the live reveal.
+    client_b
+        .collect_until_eose(&sid_live, Duration::from_secs(5))
+        .await
+        .expect("live membership EOSE");
+
+    send_rest_message(&keys_a, &channel_id, "first contact").await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut got_reveal = false;
+    while tokio::time::Instant::now() < deadline {
+        match client_b.recv_event(Duration::from_secs(2)).await {
+            Ok(RelayMessage::Event { event, .. })
+                if event.kind == Kind::Custom(44100) && has_tag(&event, "h", &channel_id) =>
+            {
+                got_reveal = true;
+                break;
+            }
+            Ok(_) => {}
+            Err(_) => {}
+        }
+    }
+    assert!(
+        got_reveal,
+        "recipient must receive a live kind:44100 when the first DM message lands"
+    );
+    client_b
+        .close_subscription(&sid_live)
+        .await
+        .expect("close live sub");
+
+    let members = query_kind_by_tag(&mut client_b, 39002, Alphabet::P, &b_pubkey_hex).await;
+    assert!(
+        members.iter().any(|e| has_tag(e, "d", &channel_id)),
+        "recipient must discover the DM members event after the first message"
+    );
+    let metadata = query_kind_by_tag(&mut client_b, 39000, Alphabet::D, &channel_id).await;
+    assert!(
+        !metadata.is_empty(),
+        "recipient must read the DM metadata event after the first message"
+    );
+    assert!(
+        channel_read_granted(&mut client_b, &channel_id).await,
+        "a #h REQ by the recipient must be granted after the reveal"
+    );
+
+    // Phase 3 — an explicit hide stays sticky across further messages.
+    post_signed_event(
+        &keys_b,
+        41012,
+        vec![Tag::parse(["h", &channel_id]).unwrap()],
+    )
+    .await;
+    let hidden = read_hidden_dms(&mut client_b, &b_pubkey_hex).await;
+    assert!(
+        hidden.contains(&channel_id),
+        "explicit hide must appear in B's visibility snapshot: {hidden:?}"
+    );
+
+    send_rest_message(&keys_a, &channel_id, "second message").await;
+
+    let hidden_after = read_hidden_dms(&mut client_b, &b_pubkey_hex).await;
+    assert!(
+        hidden_after.contains(&channel_id),
+        "an explicitly hidden DM must NOT resurface on later messages: {hidden_after:?}"
+    );
+
+    client_b.disconnect().await.expect("disconnect B");
+}
+
+/// A kind:40008 diff as a DM's FIRST content must reveal the DM to the
+/// recipient exactly like a kind:9 text message. Diffs are rendered timeline
+/// messages (agents open review DMs with them), so gating the reveal on text
+/// kinds alone would leave the recipient hidden from a DM that has content.
+#[tokio::test]
+#[ignore]
+async fn test_dm_first_diff_message_reveals_recipient() {
+    let url = relay_url();
+    let keys_a = Keys::generate();
+    let keys_b = Keys::generate();
+    let b_pubkey_hex = keys_b.public_key().to_hex();
+
+    let channel_id = create_dm(&keys_a, &b_pubkey_hex).await;
+
+    let mut client_b = BuzzTestClient::connect(&url, &keys_b)
+        .await
+        .expect("client B connect");
+    assert!(
+        !channel_read_granted(&mut client_b, &channel_id).await,
+        "a #h REQ by a pending recipient must be denied before any message"
+    );
+
+    // Subscribe live before the diff lands so the reveal must arrive as an
+    // event, not via history replay.
+    let sid_live = sub_id("dm-diff-reveal-44100");
+    let live_filter = Filter::new().kind(Kind::Custom(44100)).custom_tag(
+        SingleLetterTag::lowercase(Alphabet::P),
+        b_pubkey_hex.as_str(),
+    );
+    client_b
+        .subscribe(&sid_live, vec![live_filter])
+        .await
+        .expect("subscribe live membership");
+    client_b
+        .collect_until_eose(&sid_live, Duration::from_secs(5))
+        .await
+        .expect("live membership EOSE");
+
+    let mut client_a = BuzzTestClient::connect(&url, &keys_a)
+        .await
+        .expect("client A connect");
+    let diff = EventBuilder::new(
+        Kind::Custom(40008),
+        "diff --git a/f b/f\n--- a/f\n+++ b/f\n@@ -1 +1 @@\n-old\n+new\n",
+    )
+    .tags([
+        Tag::parse(["h", &channel_id]).unwrap(),
+        Tag::parse(["repo", "https://example.com/repo.git"]).unwrap(),
+        Tag::parse(["commit", "deadbeef00c0ffee"]).unwrap(),
+    ])
+    .sign_with_keys(&keys_a)
+    .expect("sign diff");
+    let ok = client_a.send_event(diff).await.expect("send diff");
+    assert!(ok.accepted, "relay rejected diff message: {}", ok.message);
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut got_reveal = false;
+    while tokio::time::Instant::now() < deadline {
+        match client_b.recv_event(Duration::from_secs(2)).await {
+            Ok(RelayMessage::Event { event, .. })
+                if event.kind == Kind::Custom(44100) && has_tag(&event, "h", &channel_id) =>
+            {
+                got_reveal = true;
+                break;
+            }
+            Ok(_) => {}
+            Err(_) => {}
+        }
+    }
+    assert!(
+        got_reveal,
+        "recipient must receive a live kind:44100 when a first diff message lands"
+    );
+    assert!(
+        channel_read_granted(&mut client_b, &channel_id).await,
+        "a #h REQ by the recipient must be granted after a diff-first reveal"
+    );
+
+    client_a.disconnect().await.expect("disconnect A");
+    client_b.disconnect().await.expect("disconnect B");
+}
+
 /// Send a non-broadcast NIP-10 reply AND a broadcast (`["broadcast","1"]`)
 /// reply, then prove the relay's real top-level rule both directions.
 ///

--- a/migrations/0027_dm_hidden_pending.sql
+++ b/migrations/0027_dm_hidden_pending.sql
@@ -1,0 +1,11 @@
+-- Defer DM visibility for recipients until the first real message.
+--
+-- Opening a DM (kind:41010) fires on click, before anything is sent. Without
+-- this flag the recipient's client immediately renders an empty DM window.
+-- Non-creator participants are now created with `hidden_at` set and
+-- `hidden_pending = TRUE`; the first stored message flips both off in a single
+-- UPDATE (race-free under concurrent first messages). Explicit user hides
+-- (kind:41012) keep `hidden_pending = FALSE` so they stay sticky and are never
+-- auto-revealed by later messages.
+ALTER TABLE channel_members
+    ADD COLUMN hidden_pending BOOLEAN NOT NULL DEFAULT FALSE;

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -140,6 +140,9 @@ CREATE TABLE channel_members (
     removed_at  TIMESTAMPTZ,
     removed_by  BYTEA,
     hidden_at   TIMESTAMPTZ,
+    -- TRUE while a DM stays hidden from a recipient who has not received a
+    -- message yet; cleared on first message or explicit kind:41012 hide.
+    hidden_pending BOOLEAN NOT NULL DEFAULT FALSE,
     PRIMARY KEY (community_id, channel_id, pubkey),
     FOREIGN KEY (community_id, channel_id)
         REFERENCES channels (community_id, id) ON DELETE CASCADE


### PR DESCRIPTION
## Problem

Clicking a person in search fires kind:41010 (DM open) immediately — before anything is typed. The relay created the DM with all participants visible, so the recipient's client received a kind:44100 member-added notification and NIP-29 discovery events (39000/39002) right away, and an empty DM window appeared on their end. The recipient should not see the DM until the first message arrives.

## Fix (relay-side, no client changes)

New `channel_members.hidden_pending` column (`migrations/0027_dm_hidden_pending.sql`, also in `schema/schema.sql`):

- **Create** (`crates/buzz-db/src/dm.rs`): non-creator DM members are inserted with `hidden_at = NOW(), hidden_pending = TRUE`. The creator stays visible. `handle_dm_open` / `handle_dm_add_member` now emit the create-time kind:44100 to the creator/actor only — 44100s are stored globally (`channel_id = NULL`), so notifying everyone leaked the empty DM. (`dm_add_member` mints a new channel — DM participant sets are immutable — so the same rule applies.)
- **Reveal** (`crates/buzz-relay/src/handlers/side_effects.rs`, called from ingest and the workflow sink): the first real message in a DM — kind:9/40002 text, kind:40008 diff, or kind:48100 huddle ring (`is_dm_revealing_kind`) — runs a single race-free `UPDATE … WHERE hidden_pending RETURNING pubkey`, then invalidates membership caches and emits each revealed member's deferred kind:44100 with the message author as actor. Best-effort: a failed reveal never rejects the stored message.
- **Read scoping** (`crates/buzz-db/src/channel.rs`): `get_accessible_channel_ids` (REQ/COUNT/HTTP-bridge scoping) excludes `hidden_pending` memberships, so pending recipients can't discover the channel via 39000/39002/44100 queries. Deliberately narrow: explicitly hidden DMs remain readable (clients filter those via the NIP-DV 30622 snapshot).
- **Sticky explicit hide**: kind:41012 sets `hidden_pending = FALSE`, so a DM the recipient explicitly hid after the first message stays hidden through later messages. `list_hidden_dms` excludes pending rows so they never leak into the NIP-DV snapshot.
- Moderation-notice DMs are unaffected: that path calls `unhide_dm` (clears both flags) right after `open_dm`.

Idempotent re-open of an existing DM early-returns before the member insert, so it never re-hides a recipient who has already seen the DM.

Review hardening (from adversarial Claude review + codex review of the change):

- The reveal gate also accepts legacy kind:40002 stream messages, so an older client's first message still reveals the DM. Edits, pins, scheduled-message requests, and canvas writes deliberately don't reveal — none delivers a first message.
- Codex found two first-message paths the original gate missed, both fixed: kind:40008 diff messages (rendered timeline content — an agent opening a review DM with a diff would have left the recipient hidden from a DM that has content), and relay-signed kind:9s inserted directly by the workflow sink (`workflow_sink.rs` bypasses ingest). The reveal now lives in a shared `reveal_dm_members_on_first_message` helper called from both ingest and the workflow sink. Scheduled messages deliver client-side through ingest, and huddle kind:48100 is creator-signed through ingest, so those paths were already covered; relay-signed kind:40099 system messages deliberately never reveal.
- New `is_visible_member` check: the REQ/COUNT stale-cache repair path previously confirmed access via raw `is_member`, which would have let a pending recipient who learned the channel UUID out-of-band read the channel. The repair path now excludes `hidden_pending` rows (explicit hides still count as visible, matching `get_accessible_channel_ids`). Covered by a `#h`-probe assertion in the e2e test, verified red without the fix.

Known narrow edge, deferred: an ACP agent recipient replays history from its membership timestamp minus 5s of skew when the deferred kind:44100 arrives; a sender clock more than ~5s slow can stamp the first message below that floor and the agent misses it (relay ingest tolerates ±900s drift). Fixing this belongs in the ACP harness (unfloored first fetch for newly discovered DM channels) — follow-up, not this relay change.

## Testing (TDD)

- New e2e test `test_dm_open_invisible_to_recipient_until_first_message` (`crates/buzz-test-client/tests/e2e_nostr_interop.rs`), written first and failing on the unfixed relay at the exact leak (recipient received the 44100 for a message-less DM). Three phases: (1) after A opens a DM, B sees no 44100/39002/39000 for it and a `#h` REQ with the known channel id is CLOSED; (2) A's first message delivers the deferred 44100 live to B, the channel becomes discoverable, and the `#h` REQ is granted; (3) B's explicit kind:41012 hide survives a second message.
- New e2e test `test_dm_first_diff_message_reveals_recipient`, also written first and failing at the missing reveal, covering the kind:40008-first path end to end. The workflow-sink call site is glue on the same helper this test exercises (a workflow-webhook e2e harness doesn't exist yet).
- Full `e2e_nostr_interop` suite passes (27/27) against the fixed relay, including the pre-existing DM discovery and NIP-DV tests.
- `just test` green; migrator test updated for migration 0027 (renumbered after `0026_replica_heartbeat` landed on main). `just ci` green except one pre-existing mobile widget-test failure (`ChannelDetailPage keeps follow mode off while a tall newest message stays visible`) that reproduces on mobile code identical to main.
- No UI changes: the desktop already keys DM appearance off the kind:44100 live subscription (`desktop/src/features/channels/useMembershipNotifications.ts`) and relay-provided channel lists, so deferring the relay events is sufficient — no screenshots needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
