### PR TITLE
fix(acp): default empty omp args to ACP mode to fix initialize timeout

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -687,7 +687,7 @@ pub(crate) fn normalize_agent_command_identity(command: &str) -> String {
 
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
-        "goose" => Some(vec!["acp".to_string()]),
+        "goose" | "omp" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,
@@ -1511,9 +1511,14 @@ mod tests {
     }
 
     #[test]
-    fn normalizes_goose_args_to_acp() {
+    fn normalizes_goose_and_omp_args_to_acp() {
         assert_eq!(normalize_agent_args("goose", Vec::new()), vec!["acp"]);
         assert_eq!(normalize_agent_args("goose", vec!["".into()]), vec!["acp"]);
+        assert_eq!(normalize_agent_args("omp", Vec::new()), vec!["acp"]);
+        assert_eq!(
+            normalize_agent_args("/opt/homebrew/bin/omp", vec!["".into()]),
+            vec!["acp"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
`buzz-acp`'s `default_agent_args` did not recognize the `omp` (Oh My Pi) command, so a managed agent configured with command `omp` and empty/absent `agent_args` launched omp's interactive mode instead of `omp acp`. The ACP `initialize` request then never received a response, and Buzz reported a breaking `agent initialize failed: Request timeout`.

Fix: map the normalized command identity `omp` to default args `["acp"]` (matching `goose`), so empty or absent args launch ACP mode. Explicit non-empty args are preserved unchanged. Single-file change in `crates/buzz-acp/src/config.rs`.

### Related issue
None found.

### Testing
- `cargo test -p buzz-acp` — 637 passed; added `normalizes_goose_and_omp_args_to_acp` covering bare `omp` and an absolute path with empty args.
- `cargo fmt --all -- --check` — clean.
- Built the desktop app and verified the bundled `buzz-acp` spawns `omp acp` and returns ACP auth methods under an empty-args launch (previously timed out).

Note: local `cargo clippy --workspace` flags pre-existing `clippy::question_mark` lints in `buzz-acp/src/{queue.rs,lib.rs}` and `buzz-agent` under the newer local toolchain (clippy 1.97.0 vs the pinned 1.88); these are unrelated to this change and out of scope.