### PR TITLE
refactor(desktop): consolidate type ramp to 6 prose sizes + 1 mono

### DIFF
--- a/desktop/tailwind.config.js
+++ b/desktop/tailwind.config.js
@@ -2,15 +2,34 @@
 export default {
   theme: {
     extend: {
-      // Sub-`text-xs` ramp for meta text (timestamps, count badges, tracking
-      // labels) and tiny glyphs. Defined in rem so Cmd +/- zoom — which scales
-      // the root <html> font-size — keeps scaling them. Do NOT reintroduce
-      // arbitrary `text-[…rem]` / `text-[…px]` literals; the px-text guard
-      // rejects them. Stock scale picks up from here: xs (12px), sm (14px)…
+      // Consolidated type ramp: 6 prose sizes + 1 mono. Every text class in
+      // the app compiles onto one of these steps:
+      //
+      //   Meta 12 (xs) · Body 14 (sm) · Title 18 (lg) · Section 24 (2xl) ·
+      //   Page 30 (3xl) · Display 40 (title) · Key 36 (nsec-key, mono)
+      //
+      // Legacy class names are remapped here instead of rewritten at every
+      // call site: the sub-12 meta band (3xs 8px, badge 10px, 2xs 11px) folds
+      // up to Meta 12, `text-base` (16px) folds down to Body 14, `text-xl`
+      // (20px) folds down to Title 18, and `text-4xl` (36px) / `text-5xl`
+      // (48px) fold to Display 40. Defined in rem so Cmd +/- zoom — which
+      // scales the root <html> font-size — keeps scaling them. Do NOT
+      // reintroduce arbitrary `text-[…rem]` / `text-[…px]` literals; the
+      // px-text guard rejects them.
       fontSize: {
-        "2xs": "0.6875rem", // 11px — meta-text workhorse (timestamps, badges)
-        "3xs": "0.5rem", // 8px — tiny glyphs / micro labels
-        badge: "0.625rem", // 10px — compact status badges
+        // Meta 12 — timestamps, count badges, tracking labels, tiny glyphs.
+        // Aliases of the stock `text-xs` step.
+        "2xs": "0.75rem",
+        "3xs": "0.75rem",
+        badge: "0.75rem",
+        // Body 14 — folds the old 16px body/description step down one clean
+        // step below its 18px header. Matches stock `text-sm` exactly.
+        base: ["0.875rem", { lineHeight: "1.25rem" }],
+        // Title 18 — folds the old 20px step onto stock `text-lg`.
+        xl: ["1.125rem", { lineHeight: "1.75rem" }],
+        // Display 40 — the single large display step (was 36/40/48).
+        "4xl": ["2.5rem", { lineHeight: "1.15" }],
+        "5xl": ["2.5rem", { lineHeight: "1.15" }],
         // 40px — onboarding page titles (tightened tracking for large display type)
         title: ["2.5rem", { lineHeight: "1.15", letterSpacing: "-0.02em" }],
         // 36px — the backup-step private key, shown large in monospace

--- a/desktop/tests/e2e/agents.spec.ts
+++ b/desktop/tests/e2e/agents.spec.ts
@@ -723,9 +723,11 @@ test("moves agent actions into an overflow menu in a narrow view", async ({
   });
 
   await expect(page.getByTestId("agent-defaults-button")).toBeVisible();
+  // One line of the page description: text-base is Body 14 on the
+  // consolidated ramp, whose line-height is 1.25rem (20px).
   await expect(
     page.getByText("Set up and manage your agents.", { exact: true }),
-  ).toHaveJSProperty("scrollHeight", 24);
+  ).toHaveJSProperty("scrollHeight", 20);
 
   await page.getByTestId("agents-page-content").evaluate((element) => {
     (element as HTMLElement).style.width = "600px";


### PR DESCRIPTION
## Summary

Consolidates the desktop app's 13 in-use text sizes into a single 7-step type ramp — **6 prose sizes + 1 mono** — by remapping the size tokens in `desktop/tailwind.config.js`. Existing class names compile onto the new steps, so **no component files are touched**.

Proposed and evidenced by @jmarr with before/after captures of the running app: [buzz-typeramp-diffs.zip](https://buzz.block.builderlab.xyz/media/474a9d3a5f7e314d22ce6cad8aee6f2f5ba667fff09be19c964fd4e7ecaad9ef.zip) (13 settings screens + 5 daily-driver surfaces, captured through the Playwright e2e harness at commit `4253688` with the token remap as the only variable).

## The ramp

| Role       | px | Token          | Replaces (old px) |
|------------|---:|----------------|-------------------|
| Display    | 40 | `text-title` (+ `text-4xl`/`text-5xl` aliases) | 36, 40, 48 |
| Key (mono) | 36 | `text-nsec-key`| unchanged         |
| Page       | 30 | `text-3xl`     | 30                |
| Section    | 24 | `text-2xl`     | 24                |
| Title      | 18 | `text-lg` (+ `text-xl` alias) | 18, 20 |
| Body       | 14 | `text-sm` (+ `text-base` alias) | 14, **16** |
| Meta       | 12 | `text-xs` (+ `text-2xs`/`text-3xs`/`text-badge` aliases) | 8, 10, 11, 12 |

The net visible change is two moves:
- **16→14** — descriptions and small semibold card/section titles fold down to Body, sitting one clean step below their 18px headers.
- **sub-12→12** — the meta band (timestamps, labels, count badges) lifts to Meta 12.

Body 14 and Meta 12 carry ~95% of all text (987 `text-sm` + 597 `text-xs` call sites), so most screens barely move. Every remaining prose step is ≥1.17×, most ≥1.25×.

## Why remap tokens instead of rewriting call sites

One file, one owner, zero churn across ~1,800 call sites. Legacy names (`text-2xs`, `text-badge`, `text-base`, `text-xl`, `text-4xl`, `text-5xl`) become documented aliases of their ramp step; call sites can migrate to canonical names incrementally without any visual change.

## Verification

- `pnpm build` (tsc + vite) ✅
- `pnpm typecheck` ✅
- `pnpm check` (biome + file-sizes + px-text guard + pubkey-truncation) ✅
- `pnpm test` — 3835/3835 pass ✅
- Compiled CSS inspected: `.text-2xs`/`.text-3xs`/`.text-badge` → 0.75rem, `.text-base` → 0.875rem, `.text-xl` → 1.125rem, `.text-4xl`/`.text-5xl` → 2.5rem, and rem-based sizing preserved so Cmd +/- zoom still scales everything.

Screenshots in the linked zip are light theme; dark theme uses identical sizes so the deltas are the same.
