### PR TITLE
test(desktop): click visible thread collapse guide

### DIFF
--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -918,10 +918,10 @@ test("opens a single-level thread panel with inline expansion", async ({
     `[data-testid="message-thread-summary"][data-thread-head-id="${firstReplyId}"]`,
   );
   await expect(firstReplySummaryRow).toHaveCount(0);
-  const firstReplyBranchRail = threadReplies.locator(
-    `[data-testid="thread-collapse-rail"][data-thread-head-id="${firstReplyId}"]`,
+  const firstReplyBranchGuide = threadReplies.locator(
+    `[data-testid="thread-collapse-guide"][data-thread-head-id="${firstReplyId}"]`,
   );
-  await expect(firstReplyBranchRail).toHaveCount(1);
+  await expect(firstReplyBranchGuide).not.toHaveCount(0);
 
   await expect(rootSummaryRow).toContainText("18 replies");
   await expect(
@@ -941,7 +941,7 @@ test("opens a single-level thread panel with inline expansion", async ({
 
   await expectThreadReplyUnobscured(nestedReplyRow);
 
-  await firstReplyBranchRail.click();
+  await firstReplyBranchGuide.first().click();
   await expect(firstReplySummaryRow).toHaveCount(1);
   await expect(firstReplySummaryRow).toContainText("2 replies");
   await expect(


### PR DESCRIPTION
## Summary

- target the visible thread branch collapse guide in the messaging smoke test
- avoid clicking the underlying collapse rail when the guide overlaps it
- retain the existing post-click assertions that verify the two-reply branch collapses

## Context

`main` CI failed because Playwright repeatedly attempted to click the lower `thread-collapse-rail` while the matching `thread-collapse-guide` intercepted pointer events. Both controls dispatch collapse for the same branch; the guide is the actual topmost user target and is already used by `thread-unread.spec.ts`.

Failing run: https://github.com/block/buzz/actions/runs/30575425126

## Validation

- focused Playwright smoke test: 1 passed
- pre-push hooks: desktop check passed; 3,835 desktop tests passed
- `git diff --check`

## Review

Princess Donut reviewed the test-only approach and locator determinism with no blockers. Mongo review is pending.
