### PR TITLE
fix(catalog): update Amp tagline

### DIFF
--- a/desktop/src/features/settings/ui/harnessCatalogCopy.ts
+++ b/desktop/src/features/settings/ui/harnessCatalogCopy.ts
@@ -36,7 +36,7 @@ const HARNESS_DESCRIPTIONS: Record<string, string> = {
   // https://moonshotai.github.io/kimi-cli/en/
   kimi: "A terminal coding agent for software development and command-line tasks.",
   // Sources: https://ampcode.com, https://ampcode.com/manual
-  amp: "A coding agent for your terminal and editor.",
+  amp: "The coding agent and development environment that runs anywhere and everywhere.",
   // Sources: https://github.com/NousResearch/hermes-agent,
   // https://hermes-agent.nousresearch.com/docs/
   hermes: "A general-purpose AI agent from Nous Research.",


### PR DESCRIPTION
## Summary

Update Amp's runtime catalog description to use its current tagline:

> The coding agent and development environment that runs anywhere and everywhere.

### Related issue

N/A. This follows the Amp description update in https://github.com/block/buzz/pull/3758.

### Testing

* `pnpm -C desktop check`
* `pnpm -C desktop typecheck`
* `pnpm -C desktop test` (3,835 passed)

No screenshot is included because this changes only the catalog description text. It does not change layout or interaction behavior.