### PR TITLE
fix(desktop): delete provider-backed instances before persona cascade

### DIFF
--- a/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   startManagedAgentWithRules,
   respawnManagedAgentWithRules,
+  deleteManagedAgentsForPersonaWithRules,
 } from "./managedAgentControlActions.ts";
 
 function agent(overrides = {}) {
@@ -164,5 +165,125 @@ test("test_respawn_onStopped_fires_before_start_resolves", async () => {
     events,
     ["stop", "onStopped", "start"],
     "onStopped must fire after stop resolves and before start is called",
+  );
+});
+
+// --- deleteManagedAgentsForPersonaWithRules ---
+//
+// Contract under test: the persona cascade must abort on the first cancelled
+// or failed instance delete, so `deletePersona` is never reached with a
+// half-torn persona. Mirrors deleteProfileManagedAgentsForPersona.
+
+function personaAgent(pubkeyChar, overrides = {}) {
+  return agent({
+    pubkey: pubkeyChar.repeat(64),
+    personaId: "persona-1",
+    ...overrides,
+  });
+}
+
+test("persona cascade deletes every instance backed by that persona", async () => {
+  const deleted = [];
+  const result = await deleteManagedAgentsForPersonaWithRules({
+    persona: { id: "persona-1" },
+    managedAgents: [personaAgent("a"), personaAgent("b")],
+    channels: [],
+    relayAgents: [],
+    deleteManagedAgent: async ({ pubkey }) => {
+      deleted.push(pubkey);
+    },
+  });
+
+  assert.deepEqual(result, {});
+  assert.deepEqual(deleted, ["a".repeat(64), "b".repeat(64)]);
+});
+
+test("persona cascade ignores instances backed by other personas", async () => {
+  const deleted = [];
+  await deleteManagedAgentsForPersonaWithRules({
+    persona: { id: "persona-1" },
+    managedAgents: [
+      personaAgent("a"),
+      personaAgent("c", { personaId: "persona-2" }),
+    ],
+    channels: [],
+    relayAgents: [],
+    deleteManagedAgent: async ({ pubkey }) => {
+      deleted.push(pubkey);
+    },
+  });
+
+  assert.deepEqual(deleted, ["a".repeat(64)]);
+});
+
+test("persona cascade deletes a duplicated instance only once", async () => {
+  const deleted = [];
+  await deleteManagedAgentsForPersonaWithRules({
+    persona: { id: "persona-1" },
+    managedAgents: [personaAgent("a"), personaAgent("A"), personaAgent("a")],
+    channels: [],
+    relayAgents: [],
+    deleteManagedAgent: async ({ pubkey }) => {
+      deleted.push(pubkey);
+    },
+  });
+
+  assert.equal(deleted.length, 1, "same pubkey must not be deleted twice");
+});
+
+test("persona cascade stops at a declined orphan confirm", async () => {
+  const originalWindow = globalThis.window;
+  globalThis.window = { confirm: () => false };
+  try {
+    const deleted = [];
+    const result = await deleteManagedAgentsForPersonaWithRules({
+      persona: { id: "persona-1" },
+      // First instance is provider-deployed and in no channel, so the
+      // orphan-warning confirm is what decides the cascade.
+      managedAgents: [
+        personaAgent("a", {
+          backend: { type: "provider" },
+          backendAgentId: "remote-1",
+        }),
+        personaAgent("b"),
+      ],
+      channels: [],
+      relayAgents: [],
+      deleteManagedAgent: async ({ pubkey }) => {
+        deleted.push(pubkey);
+      },
+    });
+
+    assert.equal(result.cancelled, true, "declining must report cancelled");
+    assert.deepEqual(
+      deleted,
+      [],
+      "no instance may be deleted once the confirm is declined",
+    );
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test("persona cascade stops at the first failed instance delete", async () => {
+  const deleted = [];
+  await assert.rejects(
+    deleteManagedAgentsForPersonaWithRules({
+      persona: { id: "persona-1" },
+      managedAgents: [personaAgent("a"), personaAgent("b")],
+      channels: [],
+      relayAgents: [],
+      deleteManagedAgent: async ({ pubkey }) => {
+        if (pubkey === "a".repeat(64)) throw new Error("backend refused");
+        deleted.push(pubkey);
+      },
+    }),
+    /backend refused/,
+  );
+
+  assert.deepEqual(
+    deleted,
+    [],
+    "instances after the failure must be left untouched",
   );
 });

--- a/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.test.mjs
@@ -194,7 +194,7 @@ test("persona cascade deletes every instance backed by that persona", async () =
     },
   });
 
-  assert.deepEqual(result, {});
+  assert.deepEqual(result, { deletedCount: 2 });
   assert.deepEqual(deleted, ["a".repeat(64), "b".repeat(64)]);
 });
 
@@ -255,10 +255,57 @@ test("persona cascade stops at a declined orphan confirm", async () => {
     });
 
     assert.equal(result.cancelled, true, "declining must report cancelled");
+    assert.equal(
+      result.deletedCount,
+      0,
+      "nothing was deleted before the abort",
+    );
     assert.deepEqual(
       deleted,
       [],
       "no instance may be deleted once the confirm is declined",
+    );
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test("a declined confirm does not undo instances already deleted", async () => {
+  // The aborting instance is deliberately NOT first: a local instance deletes
+  // with no prompt, then the provider instance's confirm is declined. The
+  // earlier delete is permanent, so the cascade must report it rather than let
+  // it vanish silently behind a cancelled persona delete.
+  const originalWindow = globalThis.window;
+  globalThis.window = { confirm: () => false };
+  try {
+    const deleted = [];
+    const result = await deleteManagedAgentsForPersonaWithRules({
+      persona: { id: "persona-1" },
+      managedAgents: [
+        personaAgent("a"),
+        personaAgent("b", {
+          backend: { type: "provider" },
+          backendAgentId: "remote-1",
+        }),
+        personaAgent("c"),
+      ],
+      channels: [],
+      relayAgents: [],
+      deleteManagedAgent: async ({ pubkey }) => {
+        deleted.push(pubkey);
+      },
+    });
+
+    assert.equal(result.cancelled, true);
+    assert.deepEqual(
+      deleted,
+      ["a".repeat(64)],
+      "the local instance ahead of the declined one is already gone",
+    );
+    assert.equal(
+      result.deletedCount,
+      1,
+      "deletedCount must surface the partial teardown so the caller can report it",
     );
   } finally {
     globalThis.window = originalWindow;

--- a/desktop/src/features/agents/lib/managedAgentControlActions.ts
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.ts
@@ -1,5 +1,6 @@
 import { sendChannelMessage } from "@/shared/api/tauri";
 import type {
+  AgentPersona,
   Channel,
   ManagedAgent,
   PresenceLookup,
@@ -138,6 +139,48 @@ export async function stopManagedAgentWithRules({
   }
 
   await stopManagedAgent(agent.pubkey);
+  return {};
+}
+
+/**
+ * Delete every managed-agent instance backed by `persona`, applying the same
+ * per-agent rules as {@link deleteManagedAgentWithRules} — including the
+ * orphan-warning confirm for provider deployments.
+ *
+ * Callers must run this to completion *before* deleting the persona itself:
+ * `delete_persona` refuses to cascade over a provider-deployed instance, so a
+ * persona whose instances are still deployed cannot be deleted at all.
+ *
+ * Contract, shared with `deleteProfileManagedAgentsForPersona` in
+ * `features/profile/ui/UserProfilePanelDeletion.ts`: abort the persona cascade
+ * on the first cancelled or failed instance delete, so a declined confirm or a
+ * backend error never leaves a half-torn persona. That variant additionally
+ * removes each agent from its channels between deletes, which is why the two
+ * loops are kept separate rather than parameterized — keep both in step.
+ */
+export async function deleteManagedAgentsForPersonaWithRules({
+  persona,
+  managedAgents,
+  ...context
+}: {
+  persona: Pick<AgentPersona, "id">;
+  managedAgents: readonly ManagedAgent[];
+  deleteManagedAgent: DeleteManagedAgent;
+} & ManagedAgentActionContext): Promise<ManagedAgentActionResult> {
+  // Dedup by pubkey so a list carrying the same instance twice cannot delete it
+  // twice — mirrors the profile variant's Map for the same reason.
+  const agentsByPubkey = new Map<string, ManagedAgent>();
+  for (const agent of managedAgents) {
+    if (agent.personaId === persona.id) {
+      agentsByPubkey.set(normalizePubkey(agent.pubkey), agent);
+    }
+  }
+
+  for (const agent of agentsByPubkey.values()) {
+    const result = await deleteManagedAgentWithRules({ agent, ...context });
+    if (result.cancelled) return result;
+  }
+
   return {};
 }
 

--- a/desktop/src/features/agents/lib/managedAgentControlActions.ts
+++ b/desktop/src/features/agents/lib/managedAgentControlActions.ts
@@ -152,11 +152,21 @@ export async function stopManagedAgentWithRules({
  * persona whose instances are still deployed cannot be deleted at all.
  *
  * Contract, shared with `deleteProfileManagedAgentsForPersona` in
- * `features/profile/ui/UserProfilePanelDeletion.ts`: abort the persona cascade
- * on the first cancelled or failed instance delete, so a declined confirm or a
- * backend error never leaves a half-torn persona. That variant additionally
- * removes each agent from its channels between deletes, which is why the two
- * loops are kept separate rather than parameterized — keep both in step.
+ * `features/profile/ui/UserProfilePanelDeletion.ts`: stop the cascade at the
+ * first cancelled or failed instance delete, so the persona is not deleted on
+ * top of a partial teardown.
+ *
+ * Aborting stops *further* deletes — it cannot undo the ones that already ran,
+ * and instance deletes are not reversible. Instances are visited in
+ * `managedAgents` order and only provider-deployed ones prompt, so a local
+ * instance ahead of a declined provider instance is already gone by the time
+ * the user cancels. `deletedCount` reports how many were destroyed precisely so
+ * the caller can tell the user about that partial state instead of silently
+ * keeping the persona.
+ *
+ * The profile variant additionally removes each agent from its channels between
+ * deletes, which is why the two loops are kept separate rather than
+ * parameterized — keep both in step.
  */
 export async function deleteManagedAgentsForPersonaWithRules({
   persona,
@@ -166,7 +176,9 @@ export async function deleteManagedAgentsForPersonaWithRules({
   persona: Pick<AgentPersona, "id">;
   managedAgents: readonly ManagedAgent[];
   deleteManagedAgent: DeleteManagedAgent;
-} & ManagedAgentActionContext): Promise<ManagedAgentActionResult> {
+} & ManagedAgentActionContext): Promise<
+  ManagedAgentActionResult & { deletedCount: number }
+> {
   // Dedup by pubkey so a list carrying the same instance twice cannot delete it
   // twice — mirrors the profile variant's Map for the same reason.
   const agentsByPubkey = new Map<string, ManagedAgent>();
@@ -176,12 +188,14 @@ export async function deleteManagedAgentsForPersonaWithRules({
     }
   }
 
+  let deletedCount = 0;
   for (const agent of agentsByPubkey.values()) {
     const result = await deleteManagedAgentWithRules({ agent, ...context });
-    if (result.cancelled) return result;
+    if (result.cancelled) return { ...result, deletedCount };
+    deletedCount += 1;
   }
 
-  return {};
+  return { deletedCount };
 }
 
 export async function deleteManagedAgentWithRules({

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -402,8 +402,19 @@ export function AgentsView() {
             ).length
           }
           onConfirm={(persona) => {
-            void personas.handleDelete(persona);
+            void personas.handleDelete(
+              persona,
+              agents.handleDeleteInstancesForPersona,
+            );
           }}
+          providerInstanceCount={
+            (agents.managedAgents ?? []).filter(
+              (a) =>
+                a.personaId === personas.personaToDelete?.id &&
+                a.backend.type === "provider" &&
+                a.backendAgentId,
+            ).length
+          }
           onOpenChange={(open) => {
             if (!open) {
               personas.setPersonaToDelete(null);

--- a/desktop/src/features/agents/ui/PersonaDeleteDialog.test.mjs
+++ b/desktop/src/features/agents/ui/PersonaDeleteDialog.test.mjs
@@ -32,3 +32,30 @@ test("no instances → no archival claim (nothing is archived)", () => {
 test("null persona keeps the generic fallback", () => {
   assert.equal(personaDeleteDescription(null, 2), "Delete this agent.");
 });
+
+// Provider-hosted instances are removed from the provider as part of the
+// cascade — destructive beyond this machine, so the dialog must say so before
+// the confirm rather than promising a purely local delete.
+
+test("provider-hosted instances are disclosed (singular)", () => {
+  const copy = personaDeleteDescription(persona, 2, 1);
+  assert.match(copy, /1 of them is hosted by a provider/);
+  assert.match(copy, /removed from that provider/);
+});
+
+test("provider-hosted instances are disclosed (plural)", () => {
+  const copy = personaDeleteDescription(persona, 3, 2);
+  assert.match(copy, /2 of them are hosted by a provider/);
+});
+
+test("no provider instances → no provider claim", () => {
+  const copy = personaDeleteDescription(persona, 2, 0);
+  assert.doesNotMatch(copy, /provider/i);
+});
+
+test("provider disclosure defaults off for existing callers", () => {
+  assert.equal(
+    personaDeleteDescription(persona, 2),
+    personaDeleteDescription(persona, 2, 0),
+  );
+});

--- a/desktop/src/features/agents/ui/PersonaDeleteDialog.test.mjs
+++ b/desktop/src/features/agents/ui/PersonaDeleteDialog.test.mjs
@@ -33,19 +33,33 @@ test("null persona keeps the generic fallback", () => {
   assert.equal(personaDeleteDescription(null, 2), "Delete this agent.");
 });
 
-// Provider-hosted instances are removed from the provider as part of the
-// cascade — destructive beyond this machine, so the dialog must say so before
-// the confirm rather than promising a purely local delete.
+// Provider-hosted instances are NOT torn down by this cascade — delete_managed_agent
+// never contacts the provider, and force_remote_delete only bypasses the backend's
+// orphan guard. The dialog must say the deployment survives, because the failure it
+// prevents is a user believing their billed infrastructure was removed when it wasn't.
 
-test("provider-hosted instances are disclosed (singular)", () => {
+test("provider-hosted instances are disclosed as surviving (singular)", () => {
   const copy = personaDeleteDescription(persona, 2, 1);
   assert.match(copy, /1 of them is hosted by a provider/);
-  assert.match(copy, /removed from that provider/);
+  assert.match(copy, /not torn down/);
+  assert.match(copy, /until you remove it at the provider/);
 });
 
-test("provider-hosted instances are disclosed (plural)", () => {
+test("provider-hosted instances are disclosed as surviving (plural)", () => {
   const copy = personaDeleteDescription(persona, 3, 2);
   assert.match(copy, /2 of them are hosted by a provider/);
+  assert.match(copy, /not torn down/);
+});
+
+test("never claims the provider deployment is removed", () => {
+  // Regression guard: an earlier draft promised "will also be removed from that
+  // provider", which contradicts the orphan-warning confirm shown moments later
+  // in the same flow and would hide ongoing provider spend.
+  for (const count of [1, 2, 5]) {
+    const copy = personaDeleteDescription(persona, count + 1, count);
+    assert.doesNotMatch(copy, /removed from that provider/);
+    assert.doesNotMatch(copy, /will also be removed/);
+  }
 });
 
 test("no provider instances → no provider claim", () => {

--- a/desktop/src/features/agents/ui/PersonaDeleteDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDeleteDialog.tsx
@@ -16,6 +16,8 @@ type PersonaDeleteDialogProps = {
   persona: AgentPersona | null;
   /** Number of managed-agent instances backed by this persona. Omit or pass 0 to suppress the instance-count sentence. */
   instanceCount?: number;
+  /** How many of those instances are provider-hosted. Omit or pass 0 to suppress the provider-removal sentence. */
+  providerInstanceCount?: number;
   onConfirm: (persona: AgentPersona) => void;
   onOpenChange: (open: boolean) => void;
 };
@@ -26,10 +28,15 @@ type PersonaDeleteDialogProps = {
  * cascade-deleted, each one's identity is also archived on the relay
  * (NIP-IA), and that durable side effect must be disclosed before the
  * destructive confirm — matching the direct agent-delete dialog.
+ *
+ * Provider-hosted instances are removed from the provider as part of the same
+ * cascade, which is destructive beyond this machine, so it is disclosed
+ * separately rather than folded into the archival sentence.
  */
 export function personaDeleteDescription(
   persona: AgentPersona | null,
   instanceCount: number,
+  providerInstanceCount = 0,
 ): string {
   if (!persona) {
     return "Delete this agent.";
@@ -41,13 +48,21 @@ export function personaDeleteDescription(
     instanceCount === 1
       ? "Also deletes 1 agent instance and archives its identity on the relay, so it no longer appears in member lists or mention suggestions."
       : `Also deletes ${instanceCount} agent instances and archives their identities on the relay, so they no longer appear in member lists or mention suggestions.`;
-  return `Delete ${persona.displayName}. ${cascade}`;
+  if (providerInstanceCount === 0) {
+    return `Delete ${persona.displayName}. ${cascade}`;
+  }
+  const provider =
+    providerInstanceCount === 1
+      ? "1 of them is hosted by a provider and will also be removed from that provider."
+      : `${providerInstanceCount} of them are hosted by a provider and will also be removed from that provider.`;
+  return `Delete ${persona.displayName}. ${cascade} ${provider}`;
 }
 
 export function PersonaDeleteDialog({
   open,
   persona,
   instanceCount = 0,
+  providerInstanceCount = 0,
   onConfirm,
   onOpenChange,
 }: PersonaDeleteDialogProps) {
@@ -57,7 +72,11 @@ export function PersonaDeleteDialog({
         <AlertDialogHeader>
           <AlertDialogTitle>Delete agent?</AlertDialogTitle>
           <AlertDialogDescription>
-            {personaDeleteDescription(persona, instanceCount)}
+            {personaDeleteDescription(
+              persona,
+              instanceCount,
+              providerInstanceCount,
+            )}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/desktop/src/features/agents/ui/PersonaDeleteDialog.tsx
+++ b/desktop/src/features/agents/ui/PersonaDeleteDialog.tsx
@@ -29,9 +29,13 @@ type PersonaDeleteDialogProps = {
  * (NIP-IA), and that durable side effect must be disclosed before the
  * destructive confirm — matching the direct agent-delete dialog.
  *
- * Provider-hosted instances are removed from the provider as part of the same
- * cascade, which is destructive beyond this machine, so it is disclosed
- * separately rather than folded into the archival sentence.
+ * Provider-hosted instances are disclosed separately because the cascade does
+ * NOT tear them down. `delete_managed_agent` stops the local process, drops the
+ * record and key, and tombstones/archives the identity — it never contacts the
+ * provider, and `force_remote_delete` only bypasses the backend's orphan guard.
+ * Provider teardown is a future `undeploy` operation (see the note in
+ * `managed_agents/runtime.rs`), so the remote deployment keeps running and
+ * keeps costing money. Saying otherwise would be worse than saying nothing.
  */
 export function personaDeleteDescription(
   persona: AgentPersona | null,
@@ -53,8 +57,8 @@ export function personaDeleteDescription(
   }
   const provider =
     providerInstanceCount === 1
-      ? "1 of them is hosted by a provider and will also be removed from that provider."
-      : `${providerInstanceCount} of them are hosted by a provider and will also be removed from that provider.`;
+      ? "1 of them is hosted by a provider: the remote deployment is not torn down and keeps running until you remove it at the provider."
+      : `${providerInstanceCount} of them are hosted by a provider: those remote deployments are not torn down and keep running until you remove them at the provider.`;
   return `Delete ${persona.displayName}. ${cascade} ${provider}`;
 }
 

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -25,6 +25,7 @@ import { removeChannelMember } from "@/shared/api/tauri";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import {
   deleteManagedAgentWithRules,
+  deleteManagedAgentsForPersonaWithRules,
   isManagedAgentActive,
   startManagedAgentWithRules,
   stopManagedAgentWithRules,
@@ -303,6 +304,24 @@ export function useManagedAgentActions() {
     }
   }
 
+  /**
+   * Delete every instance backed by `persona`, so a following `deletePersona`
+   * cascade has no provider-deployed instance left to refuse. Throws if any
+   * instance delete fails and reports `cancelled` if the user declines an
+   * orphan-warning confirm; callers must not delete the persona in either case.
+   */
+  async function handleDeleteInstancesForPersona(persona: AgentPersona) {
+    const channels = await getChannelsForAction();
+    return deleteManagedAgentsForPersonaWithRules({
+      persona,
+      managedAgents,
+      channels,
+      deleteManagedAgent: deleteMutation.mutateAsync,
+      presenceLookup: managedPresenceQuery.data,
+      relayAgents: relayAgentsQuery.data ?? [],
+    });
+  }
+
   async function handleToggleStartOnAppLaunch(
     pubkey: string,
     startOnAppLaunch: boolean,
@@ -425,6 +444,7 @@ export function useManagedAgentActions() {
     handleStartPersona,
     handleStop,
     handleDelete,
+    handleDeleteInstancesForPersona,
     handleToggleStartOnAppLaunch,
     handleAddedToChannel,
     handleBulkStopRunning,

--- a/desktop/src/features/agents/ui/useManagedAgentActions.ts
+++ b/desktop/src/features/agents/ui/useManagedAgentActions.ts
@@ -309,6 +309,13 @@ export function useManagedAgentActions() {
    * cascade has no provider-deployed instance left to refuse. Throws if any
    * instance delete fails and reports `cancelled` if the user declines an
    * orphan-warning confirm; callers must not delete the persona in either case.
+   *
+   * Unlike `handleDelete` for a single instance, this does not call
+   * `removeAgentFromAllChannels`. That is deliberate: it preserves the
+   * pre-existing behaviour of the persona cascade, which `delete_persona` only
+   * ever tombstoned and archived, so this fix does not quietly widen the blast
+   * radius of a persona delete beyond making it succeed. The profile variant
+   * does clean up channels — see `deleteProfileManagedAgentsForPersona`.
    */
   async function handleDeleteInstancesForPersona(persona: AgentPersona) {
     const channels = await getChannelsForAction();

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -284,9 +284,27 @@ export function usePersonaActions() {
     }
   }
 
-  async function handleDelete(persona: AgentPersona) {
+  /**
+   * `deleteInstances` must tear down the persona's managed-agent instances
+   * first: `delete_persona` refuses to cascade over a provider-deployed
+   * instance, so without it deleting such a persona fails outright. It is a
+   * required parameter rather than an internal call because the instance
+   * context lives in `useManagedAgentActions`, and requiring it keeps a caller
+   * from silently reintroducing the unguarded delete.
+   */
+  async function handleDelete(
+    persona: AgentPersona,
+    deleteInstances: (
+      persona: AgentPersona,
+    ) => Promise<{ cancelled?: boolean }>,
+  ) {
     clearFeedback("library");
     try {
+      // Abort the cascade if the user declined a confirm; a throw here skips
+      // the persona delete for the same reason.
+      const instances = await deleteInstances(persona);
+      if (instances.cancelled) return;
+
       await deletePersonaMutation.mutateAsync(persona.id);
       setPersonaNoticeMessage(`Deleted ${persona.displayName}.`);
       setPersonaToDelete(null);

--- a/desktop/src/features/agents/ui/usePersonaActions.ts
+++ b/desktop/src/features/agents/ui/usePersonaActions.ts
@@ -296,14 +296,26 @@ export function usePersonaActions() {
     persona: AgentPersona,
     deleteInstances: (
       persona: AgentPersona,
-    ) => Promise<{ cancelled?: boolean }>,
+    ) => Promise<{ cancelled?: boolean; deletedCount?: number }>,
   ) {
     clearFeedback("library");
     try {
       // Abort the cascade if the user declined a confirm; a throw here skips
       // the persona delete for the same reason.
       const instances = await deleteInstances(persona);
-      if (instances.cancelled) return;
+      if (instances.cancelled) {
+        // Cancelling stops further deletes but cannot undo the ones that
+        // already ran, and the dialog has closed itself by now. Say so —
+        // otherwise an instance destroyed by a flow the user cancelled
+        // disappears with no feedback at all.
+        const deleted = instances.deletedCount ?? 0;
+        if (deleted > 0) {
+          setPersonaNoticeMessage(
+            `Deleted ${deleted} agent instance${deleted === 1 ? "" : "s"}; kept ${persona.displayName} because you cancelled.`,
+          );
+        }
+        return;
+      }
 
       await deletePersonaMutation.mutateAsync(persona.id);
       setPersonaNoticeMessage(`Deleted ${persona.displayName}.`);

--- a/desktop/src/features/agents/ui/usePersonaActionsDelete.test.mjs
+++ b/desktop/src/features/agents/ui/usePersonaActionsDelete.test.mjs
@@ -1,0 +1,300 @@
+/**
+ * Ordering regression tests for the AgentsView persona delete
+ * (`usePersonaActions.handleDelete`).
+ *
+ * Same invariant as the profile panel's
+ * `UserProfilePanelPersonaDelete.test.mjs`, on the other surface that deletes
+ * a persona: `delete_persona` must not be reached while any provider-deployed
+ * instance is still alive. The backend cascade refuses to delete one, so the
+ * persona delete fails outright and the user is stuck with a persona they
+ * cannot remove.
+ *
+ * `handleDelete` takes its instance teardown as a required parameter, so a
+ * caller cannot skip it without a type error — that much the compiler already
+ * guards. What the compiler cannot see is the body: whether the teardown is
+ * awaited *before* `delete_persona`, and whether a cancelled or failed
+ * teardown actually aborts. Those three are what this file pins.
+ *
+ * The real hook is mounted (react-dom/client + act) over a real QueryClient
+ * and the real CommunitiesProvider, with Tauri IPC intercepted at
+ * `__TAURI_INTERNALS__.invoke` by command name — so `delete_persona` is
+ * observed where the production code actually issues it, not at a stub in
+ * between. The instance teardown is the injected fake, which is exactly the
+ * seam under test.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// ── Minimal DOM shim ─────────────────────────────────────────────────────────
+// react-dom/client needs a container element and a document; node has neither.
+// The harness renders null, so no real node operations are exercised. Mirrors
+// the shim in addCustomHarness.test.mjs, plus the localStorage
+// CommunitiesProvider reads on mount.
+
+class ElementShim {
+  constructor() {
+    this.children = [];
+    this.childNodes = [];
+    this.nodeType = 1;
+    this.nodeName = "DIV";
+    this.tagName = "DIV";
+    this.namespaceURI = "http://www.w3.org/1999/xhtml";
+  }
+  get ownerDocument() {
+    return globalThis.document;
+  }
+  addEventListener() {}
+  removeEventListener() {}
+  appendChild(child) {
+    this.children.push(child);
+    this.childNodes.push(child);
+    return child;
+  }
+  removeChild(child) {
+    this.children = this.children.filter((current) => current !== child);
+    this.childNodes = this.childNodes.filter((current) => current !== child);
+    return child;
+  }
+  insertBefore(child) {
+    return this.appendChild(child);
+  }
+  contains(target) {
+    return this === target;
+  }
+}
+
+globalThis.document = {
+  activeElement: null,
+  addEventListener() {},
+  createElement: () => new ElementShim(),
+  get defaultView() {
+    return globalThis.window;
+  },
+  nodeType: 9,
+  removeEventListener() {},
+};
+
+const localStorageShim = (() => {
+  const store = new Map();
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => store.set(key, String(value)),
+    removeItem: (key) => store.delete(key),
+  };
+})();
+
+Object.defineProperty(globalThis, "window", {
+  configurable: true,
+  value: {
+    addEventListener() {},
+    document: globalThis.document,
+    event: undefined,
+    HTMLIFrameElement: ElementShim,
+    localStorage: localStorageShim,
+    removeEventListener() {},
+  },
+});
+globalThis.localStorage = localStorageShim;
+globalThis.HTMLElement = ElementShim;
+globalThis.Node = ElementShim;
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// ── Tauri IPC mock ───────────────────────────────────────────────────────────
+// @tauri-apps/api/core calls window.__TAURI_INTERNALS__.invoke(cmd, args).
+// Intercepting here catches `delete_persona` at the real call site rather than
+// at a stubbed mutation, and lets the persona-delete command land in the same
+// log as the injected teardown. `onInvoke` is reassigned per mount.
+//
+// It must hang off the window shim above, not just globalThis: the shim is a
+// distinct object, so an internals stub installed only on globalThis is
+// invisible to @tauri-apps/api and every command silently fails to dispatch.
+const OWNER_PUBKEY = "1f".repeat(32);
+
+/**
+ * Per-command responses. The hook's queries run for real once IPC dispatches,
+ * so each command answers in its true shape — `get_identity` in particular
+ * returns an object, not an empty array. Returning a blanket `[]` here makes
+ * `identityQuery.data.pubkey` undefined and crashes the mount inside a
+ * `useMemo`, which looks like a product bug but is purely a stub artefact.
+ * Anything unlisted resolves to undefined, which every consumer already
+ * guards with `?.` or `?? []`.
+ */
+const IPC_RESPONSES = {
+  get_identity: {
+    pubkey: OWNER_PUBKEY,
+    display_name: "Owner",
+    lost: false,
+    locked: false,
+    reset_failed: false,
+  },
+  list_personas: [],
+  list_managed_agents: [],
+  list_acp_runtimes: [],
+};
+
+let onInvoke = async (cmd) => IPC_RESPONSES[cmd];
+const tauriInternals = {
+  invoke: (cmd, args) => onInvoke(cmd, args),
+  transformCallback: (callback) => callback,
+};
+globalThis.__TAURI_INTERNALS__ = tauriInternals;
+globalThis.window.__TAURI_INTERNALS__ = tauriInternals;
+
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { CommunitiesProvider } from "@/features/communities/useCommunities.tsx";
+import { usePersonaActions } from "./usePersonaActions.ts";
+
+const PERSONA = { id: "persona-1", displayName: "Scout" };
+
+/**
+ * Mount the real hook. `deleteInstances` stands in for
+ * `handleDeleteInstancesForPersona`; every Tauri command and every teardown
+ * boundary lands in one ordered log, which is what the assertions read.
+ */
+async function mountPersonaActions({ deleteInstances }) {
+  const calls = [];
+  const control = {};
+
+  onInvoke = async (cmd) => {
+    // The hook's queries fire reads on mount; logging only the destructive
+    // command keeps the log to the sequence under test.
+    if (cmd === "delete_persona") calls.push("delete_persona");
+    return IPC_RESPONSES[cmd];
+  };
+
+  function Harness() {
+    control.hook = usePersonaActions();
+    return null;
+  }
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const root = createRoot(new ElementShim());
+  await act(async () => {
+    root.render(
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(
+          CommunitiesProvider,
+          null,
+          React.createElement(Harness),
+        ),
+      ),
+    );
+  });
+
+  return {
+    calls,
+    delete: async (persona = PERSONA) => {
+      await act(async () => {
+        await control.hook.handleDelete(persona, async (target) => {
+          calls.push("teardown:start");
+          const result = await deleteInstances(target);
+          calls.push("teardown:end");
+          return result;
+        });
+      });
+    },
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+    },
+  };
+}
+
+// ── The ordering invariant ───────────────────────────────────────────────────
+
+test("the persona is deleted only after instance teardown completes", async () => {
+  const harness = await mountPersonaActions({
+    deleteInstances: async () => ({ deletedCount: 2 }),
+  });
+  await harness.delete();
+
+  assert.deepEqual(harness.calls, [
+    "teardown:start",
+    "teardown:end",
+    "delete_persona",
+  ]);
+
+  await harness.unmount();
+});
+
+test("teardown is awaited, not merely started, before delete_persona", async () => {
+  // A teardown that resolves on a later tick: if the persona delete were
+  // issued without awaiting it, delete_persona would land between the two
+  // teardown markers rather than after both.
+  const harness = await mountPersonaActions({
+    deleteInstances: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return { deletedCount: 1 };
+    },
+  });
+  await harness.delete();
+
+  assert.deepEqual(harness.calls, [
+    "teardown:start",
+    "teardown:end",
+    "delete_persona",
+  ]);
+
+  await harness.unmount();
+});
+
+// ── Aborts must not fall through to the persona delete ───────────────────────
+
+test("a cancelled teardown never deletes the persona", async () => {
+  const harness = await mountPersonaActions({
+    deleteInstances: async () => ({ cancelled: true, deletedCount: 0 }),
+  });
+  await harness.delete();
+
+  assert.equal(
+    harness.calls.includes("delete_persona"),
+    false,
+    "cancelling must abort the persona delete, not proceed without the teardown",
+  );
+
+  await harness.unmount();
+});
+
+test("a partial teardown the user cancelled still blocks the persona delete", async () => {
+  // The dangerous shape: some instances are already destroyed, so it is
+  // tempting to "finish the job". A provider-deployed instance may be among
+  // the survivors, and delete_persona would refuse the cascade anyway.
+  const harness = await mountPersonaActions({
+    deleteInstances: async () => ({ cancelled: true, deletedCount: 3 }),
+  });
+  await harness.delete();
+
+  assert.equal(harness.calls.includes("delete_persona"), false);
+
+  await harness.unmount();
+});
+
+test("a failed teardown never deletes the persona", async () => {
+  const harness = await mountPersonaActions({
+    deleteInstances: async () => {
+      throw new Error("backend refused");
+    },
+  });
+  // handleDelete reports failures through its error-message state rather than
+  // rejecting, so the absence of delete_persona is the only observable proof
+  // it aborted.
+  await harness.delete();
+
+  assert.equal(
+    harness.calls.includes("delete_persona"),
+    false,
+    "a throw mid-teardown must not fall through to the persona delete",
+  );
+
+  await harness.unmount();
+});

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -608,6 +608,12 @@ export function UserProfilePanel({
       }
 
       try {
+        // Instances first: delete_persona refuses to cascade over a
+        // provider-deployed instance, so the persona delete fails outright
+        // unless they are torn down. Matches the built-in path above.
+        const instances = await deleteManagedAgentsForPersona(personaToConfirm);
+        if (instances.cancelled) return;
+
         await deletePersonaMutation.mutateAsync(personaToConfirm.id);
         toast.success(`Deleted ${personaToConfirm.displayName}.`);
         setPersonaToDelete(null);
@@ -618,7 +624,7 @@ export function UserProfilePanel({
         );
       }
     },
-    [deletePersonaMutation.mutateAsync, onClose],
+    [deleteManagedAgentsForPersona, deletePersonaMutation.mutateAsync, onClose],
   );
 
   // Count of managed-agent instances backed by the persona being deleted.
@@ -628,6 +634,19 @@ export function UserProfilePanel({
       personaToDelete
         ? (managedAgentsQuery.data ?? []).filter(
             (a) => a.personaId === personaToDelete.id,
+          ).length
+        : 0,
+    [managedAgentsQuery.data, personaToDelete],
+  );
+
+  const personaDeleteProviderInstanceCount = React.useMemo(
+    () =>
+      personaToDelete
+        ? (managedAgentsQuery.data ?? []).filter(
+            (a) =>
+              a.personaId === personaToDelete.id &&
+              a.backend.type === "provider" &&
+              a.backendAgentId,
           ).length
         : 0,
     [managedAgentsQuery.data, personaToDelete],
@@ -945,6 +964,7 @@ export function UserProfilePanel({
             : null
         }
         instanceCount={personaDeleteInstanceCount}
+        providerInstanceCount={personaDeleteProviderInstanceCount}
         isPending={
           createPersonaMutation.isPending ||
           updatePersonaMutation.isPending ||

--- a/desktop/src/features/profile/ui/UserProfilePanel.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePanel.tsx
@@ -69,6 +69,7 @@ import {
 import { AgentConfigurationFocusedView } from "@/features/profile/ui/UserProfilePanelAgentDetails";
 import { UserProfileAgentSettingsMenuSlot } from "@/features/profile/ui/UserProfileAgentActions";
 import { useProfileAgentDeletion } from "@/features/profile/ui/UserProfilePanelDeletion";
+import { useProfilePersonaDelete } from "@/features/profile/ui/UserProfilePanelPersonaDelete";
 import { useProfileFieldBuckets } from "@/features/profile/ui/UserProfilePanelFields";
 import { submitProfilePersonaDialog } from "@/features/profile/ui/UserProfilePanelPersonaSubmit";
 import {
@@ -179,8 +180,6 @@ export function UserProfilePanel({
   const [addToChannelOpen, setAddToChannelOpen] = React.useState(false);
   const [personaDialogState, setPersonaDialogState] =
     React.useState<PersonaDialogState | null>(null);
-  const [personaToDelete, setPersonaToDelete] =
-    React.useState<AgentPersona | null>(null);
   const [personaToExportSnapshot, setPersonaToExportSnapshot] =
     React.useState<AgentPersona | null>(null);
   const [cardMintTarget, setCardMintTarget] =
@@ -419,6 +418,19 @@ export function UserProfilePanel({
       relayAgents: relayAgentsQuery.data,
     });
 
+  const {
+    personaToDelete,
+    setPersonaToDelete,
+    instanceCount: personaDeleteInstanceCount,
+    providerInstanceCount: personaDeleteProviderInstanceCount,
+    handleConfirmDeletePersona,
+  } = useProfilePersonaDelete({
+    deleteManagedAgentsForPersona,
+    deletePersona: deletePersonaMutation.mutateAsync,
+    managedAgents: managedAgentsQuery.data,
+    onClose,
+  });
+
   const createManagedAgentForPersona = React.useCallback(
     async (personaToStart: AgentPersona) => {
       const runtimes = await availableRuntimesForStart(availableRuntimesQuery);
@@ -597,60 +609,8 @@ export function UserProfilePanel({
     onClose,
     resolvedPersona,
     setPersonaActiveMutation.mutateAsync,
+    setPersonaToDelete,
   ]);
-
-  const handleConfirmDeletePersona = React.useCallback(
-    async (personaToConfirm: AgentPersona) => {
-      if (personaToConfirm.sourceTeam) {
-        toast.error("This agent is managed by a team.");
-        setPersonaToDelete(null);
-        return;
-      }
-
-      try {
-        // Instances first: delete_persona refuses to cascade over a
-        // provider-deployed instance, so the persona delete fails outright
-        // unless they are torn down. Matches the built-in path above.
-        const instances = await deleteManagedAgentsForPersona(personaToConfirm);
-        if (instances.cancelled) return;
-
-        await deletePersonaMutation.mutateAsync(personaToConfirm.id);
-        toast.success(`Deleted ${personaToConfirm.displayName}.`);
-        setPersonaToDelete(null);
-        onClose();
-      } catch (error) {
-        toast.error(
-          error instanceof Error ? error.message : "Failed to delete agent.",
-        );
-      }
-    },
-    [deleteManagedAgentsForPersona, deletePersonaMutation.mutateAsync, onClose],
-  );
-
-  // Count of managed-agent instances backed by the persona being deleted.
-  // Shown in the confirm dialog so the user knows what will be cascade-deleted.
-  const personaDeleteInstanceCount = React.useMemo(
-    () =>
-      personaToDelete
-        ? (managedAgentsQuery.data ?? []).filter(
-            (a) => a.personaId === personaToDelete.id,
-          ).length
-        : 0,
-    [managedAgentsQuery.data, personaToDelete],
-  );
-
-  const personaDeleteProviderInstanceCount = React.useMemo(
-    () =>
-      personaToDelete
-        ? (managedAgentsQuery.data ?? []).filter(
-            (a) =>
-              a.personaId === personaToDelete.id &&
-              a.backend.type === "provider" &&
-              a.backendAgentId,
-          ).length
-        : 0,
-    [managedAgentsQuery.data, personaToDelete],
-  );
 
   const handleAddedToChannel = React.useCallback(
     (channel: Channel, result: AttachManagedAgentToChannelResult) => {

--- a/desktop/src/features/profile/ui/UserProfilePanelDeletion.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelDeletion.ts
@@ -134,6 +134,17 @@ export async function deleteProfileManagedAgent(
   return result;
 }
 
+/**
+ * Delete every managed-agent instance backed by `persona`, removing each one
+ * from its channels as it goes.
+ *
+ * Contract, shared with `deleteManagedAgentsForPersonaWithRules` in
+ * `features/agents/lib/managedAgentControlActions.ts`: abort the persona
+ * cascade on the first cancelled or failed instance delete, so a declined
+ * confirm or a backend error never leaves a half-torn persona. This variant
+ * exists separately because its channel cleanup is interleaved per instance —
+ * keep both in step.
+ */
 export async function deleteProfileManagedAgentsForPersona(
   persona: AgentPersona,
   context: DeleteProfileManagedAgentsForPersonaContext,

--- a/desktop/src/features/profile/ui/UserProfilePanelDeletion.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelDeletion.ts
@@ -143,7 +143,9 @@ export async function deleteProfileManagedAgent(
  * first cancelled or failed instance delete, so the persona is not deleted on
  * top of a partial teardown. Aborting stops *further* deletes; it cannot undo
  * instances already destroyed, since only provider-deployed instances prompt
- * and any local instance visited earlier is already gone.
+ * and any local instance visited earlier is already gone. `deletedCount`
+ * reports how many were destroyed so the caller can tell the user about that
+ * partial state instead of silently keeping the persona.
  *
  * This variant exists separately because its channel cleanup is interleaved per
  * instance — keep both in step.
@@ -151,7 +153,7 @@ export async function deleteProfileManagedAgent(
 export async function deleteProfileManagedAgentsForPersona(
   persona: AgentPersona,
   context: DeleteProfileManagedAgentsForPersonaContext,
-): Promise<ManagedAgentActionResult> {
+): Promise<ManagedAgentActionResult & { deletedCount: number }> {
   const { managedAgents, selectedAgent, ...deleteContext } = context;
   const agentsByPubkey = new Map<string, ManagedAgent>();
 
@@ -165,10 +167,12 @@ export async function deleteProfileManagedAgentsForPersona(
     agentsByPubkey.set(selectedAgent.pubkey, selectedAgent);
   }
 
+  let deletedCount = 0;
   for (const agent of agentsByPubkey.values()) {
     const result = await deleteProfileManagedAgent(agent, deleteContext);
-    if (result.cancelled) return result;
+    if (result.cancelled) return { ...result, deletedCount };
+    deletedCount += 1;
   }
 
-  return {};
+  return { deletedCount };
 }

--- a/desktop/src/features/profile/ui/UserProfilePanelDeletion.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelDeletion.ts
@@ -139,11 +139,14 @@ export async function deleteProfileManagedAgent(
  * from its channels as it goes.
  *
  * Contract, shared with `deleteManagedAgentsForPersonaWithRules` in
- * `features/agents/lib/managedAgentControlActions.ts`: abort the persona
- * cascade on the first cancelled or failed instance delete, so a declined
- * confirm or a backend error never leaves a half-torn persona. This variant
- * exists separately because its channel cleanup is interleaved per instance —
- * keep both in step.
+ * `features/agents/lib/managedAgentControlActions.ts`: stop the cascade at the
+ * first cancelled or failed instance delete, so the persona is not deleted on
+ * top of a partial teardown. Aborting stops *further* deletes; it cannot undo
+ * instances already destroyed, since only provider-deployed instances prompt
+ * and any local instance visited earlier is already gone.
+ *
+ * This variant exists separately because its channel cleanup is interleaved per
+ * instance — keep both in step.
  */
 export async function deleteProfileManagedAgentsForPersona(
   persona: AgentPersona,

--- a/desktop/src/features/profile/ui/UserProfilePanelPersonaDelete.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelPersonaDelete.test.mjs
@@ -1,0 +1,399 @@
+/**
+ * Ordering regression tests for the profile panel's persona delete.
+ *
+ * The invariant, and the bug this pins: a provider-backed instance must never
+ * be left for `delete_persona`'s cascade to deal with. The backend cascade
+ * refuses to delete a provider-deployed instance, so a persona that still has
+ * one cannot be deleted at all — the call fails and the user is stuck. The fix
+ * is ordering: the frontend tears every instance down through
+ * `delete_managed_agent` (which prompts and passes `forceRemoteDelete`) and
+ * only then calls `delete_persona`, by which point the cascade has nothing
+ * provider-backed left to refuse.
+ *
+ * `managedAgentControlActions.test.mjs` covers the cascade helper in isolation
+ * — that it visits the right instances and stops on a cancel or a failure.
+ * What it cannot see is the ordering: a caller that ignored `cancelled` and
+ * deleted the persona anyway, or one that deleted the persona first, passes
+ * every one of those tests. That seam is here.
+ *
+ * The real hook is mounted (react-dom/client + act) over the real
+ * `deleteProfileManagedAgentsForPersona` cascade and the real
+ * `deleteManagedAgentWithRules` rules, so only the two backend leaves
+ * (`delete_managed_agent`, `delete_persona`) and the channel cleanup are
+ * faked. Every call lands in one ordered log, which is what the assertions
+ * read — the order is the property under test, not the counts.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// ── Minimal DOM shim ─────────────────────────────────────────────────────────
+// react-dom/client needs a container element and a document; node has neither.
+// The harness renders null, so no real node operations are exercised. Mirrors
+// the shim in features/agents/ui/addCustomHarness.test.mjs, plus a `confirm`
+// the tests swap — the orphan-warning prompt is what decides a cancelled
+// cascade, and `deleteManagedAgentWithRules` reads it off `window`.
+
+class ElementShim {
+  constructor() {
+    this.children = [];
+    this.childNodes = [];
+    this.nodeType = 1;
+    this.nodeName = "DIV";
+    this.tagName = "DIV";
+    this.namespaceURI = "http://www.w3.org/1999/xhtml";
+  }
+  get ownerDocument() {
+    return globalThis.document;
+  }
+  addEventListener() {}
+  removeEventListener() {}
+  appendChild(child) {
+    this.children.push(child);
+    this.childNodes.push(child);
+    return child;
+  }
+  removeChild(child) {
+    this.children = this.children.filter((current) => current !== child);
+    this.childNodes = this.childNodes.filter((current) => current !== child);
+    return child;
+  }
+  insertBefore(child) {
+    return this.appendChild(child);
+  }
+  contains(target) {
+    return this === target;
+  }
+}
+
+globalThis.document = {
+  activeElement: null,
+  addEventListener() {},
+  createElement: () => new ElementShim(),
+  get defaultView() {
+    return globalThis.window;
+  },
+  nodeType: 9,
+  removeEventListener() {},
+};
+Object.defineProperty(globalThis, "window", {
+  configurable: true,
+  value: {
+    addEventListener() {},
+    // Replaced per test. Defaulting to a throw keeps a test that forgets to
+    // set it from silently passing on an unprompted path.
+    confirm: () => {
+      throw new Error("window.confirm called without a test-supplied answer");
+    },
+    document: globalThis.document,
+    event: undefined,
+    HTMLIFrameElement: ElementShim,
+    removeEventListener() {},
+  },
+});
+globalThis.HTMLElement = ElementShim;
+globalThis.Node = ElementShim;
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+
+import { deleteProfileManagedAgentsForPersona } from "./UserProfilePanelDeletion.ts";
+import { useProfilePersonaDelete } from "./UserProfilePanelPersonaDelete.ts";
+
+const PERSONA = { id: "persona-1", displayName: "Scout" };
+
+function instance(pubkeyChar, overrides = {}) {
+  return {
+    pubkey: pubkeyChar.repeat(64),
+    name: "Scout instance",
+    personaId: PERSONA.id,
+    relayUrl: "ws://localhost:3000",
+    acpCommand: "buzz-acp",
+    agentCommand: "goose",
+    agentArgs: [],
+    mcpCommand: "",
+    turnTimeoutSeconds: 320,
+    idleTimeoutSeconds: null,
+    maxTurnDurationSeconds: null,
+    parallelism: 1,
+    systemPrompt: null,
+    model: "hf://demo/model.gguf",
+    envVars: {},
+    status: "stopped",
+    pid: null,
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    lastStartedAt: null,
+    lastStoppedAt: null,
+    lastExitCode: null,
+    lastError: null,
+    logPath: null,
+    startOnAppLaunch: false,
+    backend: { type: "local" },
+    backendAgentId: null,
+    respondTo: "owner-only",
+    respondToAllowlist: [],
+    ...overrides,
+  };
+}
+
+/** An instance actually deployed to a provider — what the cascade refuses. */
+function providerInstance(pubkeyChar) {
+  return instance(pubkeyChar, {
+    backend: { type: "provider" },
+    backendAgentId: `remote-${pubkeyChar}`,
+  });
+}
+
+/**
+ * Mount the real hook over the real cascade. `deleteManagedAgent` and
+ * `deletePersona` are the only faked backend calls; both append to `calls`, so
+ * the log records the true interleaving the production code produced.
+ *
+ * No channels and no relay agents means every provider-backed instance
+ * resolves to no channel and hits the orphan-warning confirm, which is the
+ * branch a persona delete actually takes: `useProfileAgentDeletion` passes
+ * `skipRemoteDeleteConfirm` only for a single-instance delete, never for the
+ * persona cascade.
+ */
+async function mountPersonaDelete({
+  managedAgents,
+  confirm = () => true,
+  deleteManagedAgent = async () => {},
+}) {
+  const calls = [];
+  const control = {};
+  globalThis.window.confirm = (message) => {
+    calls.push({ op: "confirm", message });
+    return confirm(message);
+  };
+
+  function Harness() {
+    control.hook = useProfilePersonaDelete({
+      deleteManagedAgentsForPersona: (persona) =>
+        deleteProfileManagedAgentsForPersona(persona, {
+          channels: [],
+          deleteManagedAgent: async (input) => {
+            calls.push({
+              op: "delete_managed_agent",
+              pubkey: input.pubkey,
+              forceRemoteDelete: input.forceRemoteDelete,
+            });
+            return deleteManagedAgent(input);
+          },
+          managedAgents,
+          presenceLookup: null,
+          relayAgents: [],
+          removeAgentFromAllChannels: async (pubkey) => {
+            calls.push({ op: "remove_from_channels", pubkey });
+          },
+        }),
+      deletePersona: async (id) => {
+        calls.push({ op: "delete_persona", id });
+      },
+      managedAgents,
+      onClose: () => {
+        calls.push({ op: "close_panel" });
+      },
+    });
+    return null;
+  }
+
+  const container = new ElementShim();
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(Harness));
+  });
+
+  return {
+    calls,
+    confirmDelete: async (persona = PERSONA) => {
+      await act(async () => {
+        await control.hook.handleConfirmDeletePersona(persona);
+      });
+    },
+    hook: () => control.hook,
+    setPersonaToDelete: async (persona) => {
+      await act(async () => {
+        control.hook.setPersonaToDelete(persona);
+      });
+    },
+    unmount: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+    },
+  };
+}
+
+const ops = (calls) => calls.map((call) => call.op);
+const indexOfOp = (calls, op) => calls.findIndex((call) => call.op === op);
+
+// ── The ordering invariant ───────────────────────────────────────────────────
+
+test("every provider-backed instance is deleted before delete_persona runs", async () => {
+  // Deliberately mixed and provider-last: the cascade must finish ALL of them,
+  // not just the ones it happens to reach before the first local instance.
+  const harness = await mountPersonaDelete({
+    managedAgents: [
+      providerInstance("a"),
+      instance("b"),
+      providerInstance("c"),
+    ],
+  });
+  await harness.confirmDelete();
+
+  const personaDeleteAt = indexOfOp(harness.calls, "delete_persona");
+  assert.notEqual(personaDeleteAt, -1, "the persona must actually be deleted");
+
+  const providerDeletes = harness.calls
+    .map((call, index) => ({ call, index }))
+    .filter(({ call }) => call.op === "delete_managed_agent")
+    .filter(({ call }) => call.forceRemoteDelete === true);
+
+  assert.deepEqual(
+    providerDeletes.map(({ call }) => call.pubkey),
+    ["a".repeat(64), "c".repeat(64)],
+    "both provider-deployed instances must be torn down by the instance path",
+  );
+  for (const { call, index } of providerDeletes) {
+    assert.ok(
+      index < personaDeleteAt,
+      `provider instance ${call.pubkey.slice(0, 4)} was still alive when delete_persona ran — the backend cascade would have refused it`,
+    );
+  }
+
+  await harness.unmount();
+});
+
+test("delete_persona is the last backend call, after every instance", async () => {
+  const harness = await mountPersonaDelete({
+    managedAgents: [providerInstance("a"), instance("b")],
+  });
+  await harness.confirmDelete();
+
+  assert.deepEqual(ops(harness.calls), [
+    // Provider instance: orphan warning, forced delete, channel cleanup.
+    "confirm",
+    "delete_managed_agent",
+    "remove_from_channels",
+    // Local instance: no prompt.
+    "delete_managed_agent",
+    "remove_from_channels",
+    // Only now is the persona safe to delete.
+    "delete_persona",
+    "close_panel",
+  ]);
+
+  await harness.unmount();
+});
+
+test("a provider-backed instance is deleted with forceRemoteDelete", async () => {
+  // Without the force flag the backend's own orphan guard rejects the delete,
+  // the instance survives, and the persona delete that follows hits exactly
+  // the cascade refusal this ordering exists to avoid.
+  const harness = await mountPersonaDelete({
+    managedAgents: [providerInstance("a"), instance("b")],
+  });
+  await harness.confirmDelete();
+
+  const deletes = harness.calls.filter(
+    (call) => call.op === "delete_managed_agent",
+  );
+  assert.equal(deletes[0].forceRemoteDelete, true, "provider instance forces");
+  assert.equal(
+    deletes[1].forceRemoteDelete,
+    undefined,
+    "a local instance must not force — it has no remote deployment to orphan",
+  );
+
+  await harness.unmount();
+});
+
+// ── Aborts must not fall through to the persona delete ───────────────────────
+
+test("declining the provider orphan warning never deletes the persona", async () => {
+  const harness = await mountPersonaDelete({
+    managedAgents: [providerInstance("a"), instance("b")],
+    confirm: () => false,
+  });
+  await harness.confirmDelete();
+
+  assert.equal(
+    indexOfOp(harness.calls, "delete_persona"),
+    -1,
+    "cancelling the cascade must abort the persona delete, not proceed without it",
+  );
+  assert.deepEqual(ops(harness.calls), ["confirm"]);
+
+  await harness.unmount();
+});
+
+test("a failed instance delete never deletes the persona", async () => {
+  const harness = await mountPersonaDelete({
+    managedAgents: [providerInstance("a"), instance("b")],
+    deleteManagedAgent: async () => {
+      throw new Error("backend refused");
+    },
+  });
+  // The hook reports failures through a toast rather than rejecting, so the
+  // absence of delete_persona is the only observable proof it aborted.
+  await harness.confirmDelete();
+
+  assert.equal(
+    indexOfOp(harness.calls, "delete_persona"),
+    -1,
+    "a throw mid-cascade must not fall through to the persona delete",
+  );
+
+  await harness.unmount();
+});
+
+test("a team-managed persona deletes nothing at all", async () => {
+  const harness = await mountPersonaDelete({
+    managedAgents: [providerInstance("a")],
+  });
+  await harness.confirmDelete({ ...PERSONA, sourceTeam: "team-1" });
+
+  assert.deepEqual(
+    harness.calls,
+    [],
+    "the team guard must run before the cascade, not after it destroys instances",
+  );
+
+  await harness.unmount();
+});
+
+// ── The counts the confirm dialog discloses ──────────────────────────────────
+
+test("providerInstanceCount counts only instances deployed to a provider", async () => {
+  const harness = await mountPersonaDelete({
+    managedAgents: [
+      providerInstance("a"),
+      instance("b"),
+      // Configured for a provider but never deployed: no remote deployment
+      // exists, so warning about one would be false.
+      instance("c", { backend: { type: "provider" }, backendAgentId: null }),
+      instance("d", { personaId: "persona-2" }),
+    ],
+  });
+  await harness.setPersonaToDelete(PERSONA);
+
+  assert.equal(harness.hook().instanceCount, 3, "excludes other personas");
+  assert.equal(harness.hook().providerInstanceCount, 1);
+
+  await harness.unmount();
+});
+
+test("both counts are zero while no persona is pending deletion", async () => {
+  const harness = await mountPersonaDelete({
+    managedAgents: [providerInstance("a")],
+  });
+
+  assert.equal(harness.hook().instanceCount, 0);
+  assert.equal(harness.hook().providerInstanceCount, 0);
+
+  await harness.unmount();
+});

--- a/desktop/src/features/profile/ui/UserProfilePanelPersonaDelete.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelPersonaDelete.ts
@@ -1,0 +1,113 @@
+import * as React from "react";
+import { toast } from "sonner";
+
+import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
+import type { deleteProfileManagedAgentsForPersona } from "@/features/profile/ui/UserProfilePanelDeletion";
+
+type DeleteManagedAgentsForPersona = (
+  persona: AgentPersona,
+) => ReturnType<typeof deleteProfileManagedAgentsForPersona>;
+
+type UseProfilePersonaDeleteInput = {
+  deleteManagedAgentsForPersona: DeleteManagedAgentsForPersona;
+  deletePersona: (id: string) => Promise<unknown>;
+  managedAgents?: readonly ManagedAgent[];
+  onClose: () => void;
+};
+
+/**
+ * Confirm-and-delete state for a persona in the profile panel: the pending
+ * persona, the two instance counts the confirm dialog discloses, and the
+ * confirmed-delete handler.
+ *
+ * Split out of `UserProfilePanel` to keep that component under the desktop
+ * file-size ratchet, and kept beside `UserProfilePanelDeletion` because it is
+ * the same concern — that module owns the cascade, this one owns the dialog
+ * state driving it.
+ */
+export function useProfilePersonaDelete({
+  deleteManagedAgentsForPersona,
+  deletePersona,
+  managedAgents,
+  onClose,
+}: UseProfilePersonaDeleteInput) {
+  const [personaToDelete, setPersonaToDelete] =
+    React.useState<AgentPersona | null>(null);
+
+  // Instances backed by the persona being deleted, shown in the confirm dialog
+  // so the user knows what the cascade takes with it.
+  const instanceCount = React.useMemo(
+    () =>
+      personaToDelete
+        ? (managedAgents ?? []).filter(
+            (a) => a.personaId === personaToDelete.id,
+          ).length
+        : 0,
+    [managedAgents, personaToDelete],
+  );
+
+  // Only instances actually deployed to a provider — the same condition the
+  // backend rejects on and under which `deleteManagedAgentWithRules` forces —
+  // so the dialog does not warn about a provider that was never involved.
+  const providerInstanceCount = React.useMemo(
+    () =>
+      personaToDelete
+        ? (managedAgents ?? []).filter(
+            (a) =>
+              a.personaId === personaToDelete.id &&
+              a.backend.type === "provider" &&
+              a.backendAgentId,
+          ).length
+        : 0,
+    [managedAgents, personaToDelete],
+  );
+
+  const handleConfirmDeletePersona = React.useCallback(
+    async (personaToConfirm: AgentPersona) => {
+      if (personaToConfirm.sourceTeam) {
+        toast.error("This agent is managed by a team.");
+        setPersonaToDelete(null);
+        return;
+      }
+
+      try {
+        // Instances first: delete_persona refuses to cascade over a
+        // provider-deployed instance, so the persona delete fails outright
+        // unless they are torn down.
+        const instances = await deleteManagedAgentsForPersona(personaToConfirm);
+        if (instances.cancelled) {
+          // Cancelling stops further deletes but cannot undo the ones that
+          // already ran. Say so — otherwise an instance destroyed by a flow the
+          // user cancelled disappears with no feedback, on a path that toasts
+          // every other outcome.
+          if (instances.deletedCount > 0) {
+            toast.warning(
+              `Deleted ${instances.deletedCount} agent instance${
+                instances.deletedCount === 1 ? "" : "s"
+              }; kept ${personaToConfirm.displayName} because you cancelled.`,
+            );
+          }
+          return;
+        }
+
+        await deletePersona(personaToConfirm.id);
+        toast.success(`Deleted ${personaToConfirm.displayName}.`);
+        setPersonaToDelete(null);
+        onClose();
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Failed to delete agent.",
+        );
+      }
+    },
+    [deleteManagedAgentsForPersona, deletePersona, onClose],
+  );
+
+  return {
+    personaToDelete,
+    setPersonaToDelete,
+    instanceCount,
+    providerInstanceCount,
+    handleConfirmDeletePersona,
+  };
+}

--- a/desktop/src/features/profile/ui/UserProfilePersonaDialogs.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePersonaDialogs.tsx
@@ -26,6 +26,7 @@ export function UserProfilePersonaDialogs({
   personaDialogState,
   personaToDelete,
   personaToExportSnapshot,
+  providerInstanceCount,
   resolvedPersona,
   runtimes,
   runtimesLoading,
@@ -47,6 +48,8 @@ export function UserProfilePersonaDialogs({
   personaDialogState: PersonaDialogState | null;
   personaToDelete: AgentPersona | null;
   personaToExportSnapshot: AgentPersona | null;
+  /** How many of those instances are provider-hosted. */
+  providerInstanceCount: number;
   resolvedPersona: AgentPersona | undefined;
   runtimes: AcpRuntimeCatalogEntry[];
   runtimesLoading: boolean;
@@ -89,6 +92,7 @@ export function UserProfilePersonaDialogs({
         }}
         open={personaToDelete !== null}
         persona={personaToDelete}
+        providerInstanceCount={providerInstanceCount}
       />
       {personaToExportSnapshot ? (
         <UserProfileSnapshotExportDialog


### PR DESCRIPTION
## Summary

Fixes #3771.

Deleting a persona whose managed-agent instances are provider-deployed always
failed. `delete_persona`
(`desktop/src-tauri/src/commands/personas/mod.rs:113`) takes only `(id, app)` —
there is no force parameter — and it hard-rejects the cascade when any target
is remote-deployed, via `collect_remote_deployed`
(`mod.rs:81`, matching `backend != Local && backend_agent_id.is_some()`):

> persona {id} has provider-deployed agent instances (…); delete those agent instances first

Both persona-delete call sites went straight to `deletePersona` without
touching instances first, so they hit that rejection every time:

- `desktop/src/features/agents/ui/usePersonaActions.ts` — `handleDelete`
- `desktop/src/features/profile/ui/UserProfilePanel.tsx` — `handleConfirmDeletePersona`

The confirm dialog made it worse by promising the cascade unconditionally, so
the user saw a promise immediately followed by a refusal.

## The fix

Delete the persona's instances first, so the cascade finds nothing left to
refuse. `delete_managed_agent` already has the escape hatch this needs —
`force_remote_delete: Option<bool>`
(`desktop/src-tauri/src/commands/agents.rs:1276`) — and the frontend already
wraps it in the right ritual: `deleteManagedAgentWithRules` sends `!shutdown`,
presents the orphan-warning confirm, and only then passes
`forceRemoteDelete: true`.

New `deleteManagedAgentsForPersonaWithRules` in
`features/agents/lib/managedAgentControlActions.ts` loops a persona's instances
through that per-agent function. Contract: **stop the persona cascade at the
first cancelled or failed instance delete**, so the persona itself is never
removed while instances remain. Instances already deleted when the abort fires
stay deleted — the cascade bounds the damage rather than unwinding it, and it
reports `deletedCount` so the caller can tell the user about that partial
state. Instances are deduplicated by normalized pubkey so a list carrying the
same instance twice cannot delete it twice.

Provider deployments are never force-deleted silently — every one goes through
the existing orphan-warning confirm, and declining it stops the whole cascade.

The delete dialog now calls out the provider-hosted instances in the cascade as
their own sentence rather than folding them into the relay-archival one. The
count is scoped to instances that are actually deployed
(`backend.type === "provider" && backendAgentId`), matching both the condition
the backend rejects on and the condition under which
`deleteManagedAgentWithRules` forces. Deleting removes the local management
record and its key, tombstones the agent's relay record, and archives its relay
identity — it does not tear down the provider deployment. There is no undeploy
operation today (`commands/agents.rs:455`), so the remote infrastructure keeps
running until it is removed at the provider, and the dialog now says so,
matching the orphan-warning confirm the same flow shows.

**The backend guard is deliberately left alone.** Its comment states the
invariant: the rejection is a runtime guard, and a compromised IPC caller must
not be able to orphan a live remote deployment. Adding a force flag to
`delete_persona` would weaken that for no gain, since the frontend can do the
instance deletion explicitly, behind the orphan-warning confirm, rather than
have the backend bypass its own invariant.

## On the two loops

`features/profile/ui/UserProfilePanelDeletion.ts` has its own
persona-instance loop (`deleteProfileManagedAgentsForPersona`) and this PR
leaves it in place rather than sharing one implementation. Its extra work is
interleaved per instance — it removes each agent from its channels between
deletes — so sharing the loop would mean giving the generic helper a per-agent
callback parameter, and parameterizing a working delete path to save ~20 lines
seemed the worse trade. Both loops now carry a cross-reference comment naming
the other and the shared abort contract, so drift is visible to a reader.

Happy to consolidate them if maintainers would prefer that.

One deliberate asymmetry: the agents-side cascade does not remove instances
from their channels, while the profile variant does. That preserves the
pre-existing behaviour of the persona cascade — `delete_persona` only ever
tombstoned and archived — so this fix does not quietly widen what deleting a
persona does beyond making it succeed.

## A note on the call signature

`usePersonaActions.handleDelete` now takes the instance-teardown function as a
**required** parameter, supplied by `AgentsView`, which already holds both the
persona and managed-agent hooks. That hook is also mounted app-wide by
`RequestedAgentCreateDialogs`, which never deletes anything, so wiring four new
queries into it to serve one button seemed wrong. Making the parameter required
rather than optional is deliberate: TypeScript now refuses a call that skips
instance teardown, instead of silently degrading back to the bug this PR fixes.

## Tests

11 new, all passing.

Cascade (`managedAgentControlActions.test.mjs`):
- deletes every instance backed by the persona
- ignores instances backed by other personas
- deletes a duplicated pubkey only once
- **stops at a declined orphan confirm** — zero instances deleted
- **stops at the first failed instance delete** — later instances untouched
- **a declined confirm does not undo earlier deletes** — the aborting instance
  is deliberately not first, so the partial teardown is pinned rather than
  hidden by test ordering

The abort tests assert that instances after the stopping point are never
touched, and that `deletedCount` reports the ones already destroyed.

Dialog copy (`PersonaDeleteDialog.test.mjs`): singular and plural provider
disclosure, no provider claim when the count is zero, and parity with the
previous output for callers that don't pass the new argument.

Verified locally at the pushed commit: **full desktop suite 3846 passed, 0
failed**; `just desktop-check` exits 0 (biome, the file-size ratchet,
`check:px-text`, `check:pubkey-truncation`); `just desktop-build`
(`tsc && vite build`) succeeds; and `desktop-tauri-check`, `desktop-tauri-test`
and `desktop-tauri-test-compiled-flags` all pass. `desktop-tauri-clippy` fails
locally on macOS with three `dead_code` errors in
`src-tauri/src/linux_media.rs` — a file this PR does not touch, in a module
whose code is live on the Linux runner CI uses; this PR changes no Rust.

**Not covered:** there is no E2E test driving the rendered dialog against a
live provider deployment — the confirm path is exercised at the unit level with
a stubbed `window.confirm`, not through the real dialog. I also could not
verify against an actual provider-backed agent, so the claim that the cascade
now succeeds rests on the traced code path rather than on a reproduction. A
maintainer with a provider deployment to hand could confirm that end to end
quickly.

## Related

- Fixes #3771.
- Closest existing PR: none found. Open PRs matching persona/delete/cascade
  terms are #3532 (persona pack skill validation) and #3392 (relay workflow
  delete); neither touches this path.


