### PR TITLE
fix(desktop): allow linux-only media items as dead code off-linux

### DIFF
--- a/desktop/src-tauri/src/linux_media.rs
+++ b/desktop/src-tauri/src/linux_media.rs
@@ -22,17 +22,22 @@
 //! which is the backend WebKitGTK media capture is reliable on.
 
 /// The origin Tauri serves the packaged app from on Linux.
+/// Consumed only by linux-gated [`enable_media_capture`]; kept compiling on all
+/// platforms so the unit tests run everywhere.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 const PROD_ORIGIN: &str = "tauri://localhost";
 
 /// The Vite dev-server origin (`devUrl` in `tauri.conf.json`, `strictPort`
 /// 1420 in `vite.config.ts`). Only trusted in debug builds.
 #[cfg(debug_assertions)]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 const DEV_ORIGIN: &str = "http://localhost:1420";
 
 /// Whether `uri` (the webview's current document URI) is a trusted app origin
 /// allowed to use mic/camera. Matches the origin exactly or as a path prefix so
 /// `tauri://localhost.evil.com` and `http://localhost:14200` do not slip
 /// through. Pure and platform-independent so it can be unit-tested everywhere.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 fn is_trusted_media_origin(uri: &str) -> bool {
     fn matches(uri: &str, origin: &str) -> bool {
         uri == origin


### PR DESCRIPTION
Local `desktop-tauri-clippy` fails on macOS with dead-code errors for `PROD_ORIGIN`, `DEV_ORIGIN`, and `is_trusted_media_origin`, which are only used inside `#[cfg(target_os = "linux")] enable_media_capture`. The items are intentionally platform-independent so unit tests run everywhere. Added `cfg_attr` allow attribute to suppress the warnings on non-Linux targets.

Since [#3607](https://github.com/block/buzz/pull/3607), this affects all Rust developers on macOS.