### PR TITLE
fix(desktop): show eligible cross-owner channel agents in @ mentions

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -7,10 +7,12 @@ import {
   getMentionableAgentPubkeys,
   getSharedChannelIds,
   isAgentIdentityInAllowedList,
+  isAgentIdentityReachableForMentions,
   isAgentMentionChannelType,
   relayAgentCanRespondInChannel,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
+  shouldOfferAgentIdentityForMentions,
   uniqueAutocompleteLabels,
 } from "./agentAutocompleteEligibility.ts";
 
@@ -250,6 +252,225 @@ test("isAgentIdentityInAllowedList: keeps people and only explicitly allowed age
     isAgentIdentityInAllowedList(
       { isAgent: true, pubkey: PUB_B },
       allowedAgentPubkeys,
+    ),
+    false,
+  );
+});
+
+test("isAgentIdentityReachableForMentions: keeps channel members the viewer does not manage", () => {
+  const managedAgentPubkeys = new Set([PUB_A]);
+
+  assert.equal(
+    isAgentIdentityReachableForMentions(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+      true,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentIdentityReachableForMentions(
+      { isAgent: true, isMember: false, pubkey: PUB_B },
+      managedAgentPubkeys,
+      true,
+    ),
+    false,
+  );
+  assert.equal(
+    isAgentIdentityReachableForMentions(
+      { isAgent: true, isMember: false, pubkey: PUB_A.toUpperCase() },
+      managedAgentPubkeys,
+      true,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentIdentityReachableForMentions(
+      { isAgent: false, isMember: false, pubkey: PUB_B },
+      managedAgentPubkeys,
+      true,
+    ),
+    true,
+  );
+});
+
+test("isAgentIdentityReachableForMentions: holds the member pass-through until the relay directory is ready", () => {
+  const managedAgentPubkeys = new Set([PUB_A]);
+
+  assert.equal(
+    isAgentIdentityReachableForMentions(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+      false,
+    ),
+    false,
+  );
+  // A managed agent and a human are unaffected by the directory load state.
+  assert.equal(
+    isAgentIdentityReachableForMentions(
+      { isAgent: true, isMember: true, pubkey: PUB_A },
+      managedAgentPubkeys,
+      false,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentIdentityReachableForMentions(
+      { isAgent: false, isMember: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+      false,
+    ),
+    true,
+  );
+});
+
+/**
+ * Drives the real admission check `useMentions`' `addCandidate` calls, building
+ * its pubkey sets the same way the hook does from `relayAgentsQuery.data`.
+ * `tests/e2e/mentions.spec.ts` covers the same scenarios through the composer.
+ */
+function mentionCandidateIsOffered(
+  candidate,
+  {
+    managedAgentPubkeys,
+    relayAgents,
+    sharedChannelIds,
+    relayAgentDirectoryReady = true,
+  },
+) {
+  return shouldOfferAgentIdentityForMentions({
+    candidate,
+    managedAgentPubkeys,
+    mentionableAgentPubkeys: getMentionableAgentPubkeys({
+      currentPubkey: CURRENT_PUBKEY,
+      eligibilityScope: { type: "channel", channelId: "general" },
+      managedAgentPubkeys,
+      relayAgents,
+      sharedChannelIds,
+    }),
+    directoryAgentPubkeys: new Set(
+      relayAgents.map((agent) => agent.pubkey.toLowerCase()),
+    ),
+    relayAgentDirectoryReady,
+  });
+}
+
+test("mention path offers an invocable channel bot from another install", () => {
+  const crossOwnerBot = { isAgent: true, isMember: true, pubkey: PUB_B };
+
+  assert.equal(
+    mentionCandidateIsOffered(crossOwnerBot, {
+      managedAgentPubkeys: new Set([PUB_A]),
+      relayAgents: [
+        {
+          pubkey: PUB_B,
+          respondTo: "allowlist",
+          respondToAllowlist: [CURRENT_PUBKEY],
+          channelIds: ["general"],
+        },
+      ],
+      sharedChannelIds: new Set(["general"]),
+    }),
+    true,
+  );
+  assert.equal(
+    mentionCandidateIsOffered(crossOwnerBot, {
+      managedAgentPubkeys: new Set([PUB_A]),
+      relayAgents: [
+        {
+          pubkey: PUB_B,
+          respondTo: "anyone",
+          respondToAllowlist: [],
+          channelIds: ["general"],
+        },
+      ],
+      sharedChannelIds: new Set(["general"]),
+    }),
+    true,
+  );
+});
+
+test("mention path still hides a channel bot whose directory entry excludes the viewer", () => {
+  assert.equal(
+    mentionCandidateIsOffered(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      {
+        managedAgentPubkeys: new Set([PUB_A]),
+        relayAgents: [
+          {
+            pubkey: PUB_B,
+            respondTo: "owner-only",
+            respondToAllowlist: [],
+            channelIds: ["general"],
+          },
+        ],
+        sharedChannelIds: new Set(["general"]),
+      },
+    ),
+    false,
+  );
+  assert.equal(
+    mentionCandidateIsOffered(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      {
+        managedAgentPubkeys: new Set([PUB_A]),
+        relayAgents: [
+          {
+            pubkey: PUB_B,
+            respondTo: "allowlist",
+            respondToAllowlist: [OTHER_OWNER_PUBKEY],
+            channelIds: ["general"],
+          },
+        ],
+        sharedChannelIds: new Set(["general"]),
+      },
+    ),
+    false,
+  );
+});
+
+test("mention path does not offer a channel bot while the relay directory is still loading", () => {
+  // In flight, `relayAgents` is empty: the bot is neither invocable nor
+  // directory-present, so `shouldHideAgentFromMentions` would read it as
+  // unknown-invocability and show it. Readiness is what keeps it hidden until
+  // the directory can answer.
+  assert.equal(
+    mentionCandidateIsOffered(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      {
+        managedAgentPubkeys: new Set([PUB_A]),
+        relayAgents: [],
+        sharedChannelIds: new Set(["general"]),
+        relayAgentDirectoryReady: false,
+      },
+    ),
+    false,
+  );
+  // Once ready, an empty or errored directory falls back to Option B (unknown
+  // invocability => show) rather than hiding members indefinitely.
+  assert.equal(
+    mentionCandidateIsOffered(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      {
+        managedAgentPubkeys: new Set([PUB_A]),
+        relayAgents: [],
+        sharedChannelIds: new Set(["general"]),
+        relayAgentDirectoryReady: true,
+      },
+    ),
+    true,
+  );
+});
+
+test("mention path keeps unreachable non-member agents out of the composer", () => {
+  assert.equal(
+    mentionCandidateIsOffered(
+      { isAgent: true, isMember: false, pubkey: PUB_B },
+      {
+        managedAgentPubkeys: new Set([PUB_A]),
+        relayAgents: [],
+        sharedChannelIds: new Set(["general"]),
+      },
     ),
     false,
   );

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -92,6 +92,32 @@ export function isAgentIdentityInAllowedList(
   );
 }
 
+export function isAgentIdentityReachableForMentions(
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
+  managedAgentPubkeys: ReadonlySet<string>,
+  relayAgentDirectoryReady: boolean,
+) {
+  // `managedAgentPubkeys` only ever lists agents this Desktop install runs, so
+  // it cannot decide whether a channel member is invocable — an agent owned by
+  // a teammate is absent from it no matter how its `respond_to` is configured.
+  // Members are therefore left to `shouldHideAgentFromMentions`, which reads
+  // the relay directory. Non-members keep the managed-list gate so the
+  // composer still does not offer unreachable identities.
+  //
+  // The member pass-through waits for the relay directory because
+  // `shouldHideAgentFromMentions` reads an absent directory entry as "unknown
+  // invocability => show". Without this guard, an agent whose directory entry
+  // excludes the viewer would be offered for as long as that query is in
+  // flight. While the query is still loading, readiness stays false and
+  // members stay hidden (same as pre-fix). An errored or empty directory
+  // still counts as ready, so a finished-but-empty/failed fetch degrades to
+  // Option B (show) rather than hiding members indefinitely.
+  return (
+    (candidate.isMember === true && relayAgentDirectoryReady) ||
+    isAgentIdentityInAllowedList(candidate, managedAgentPubkeys)
+  );
+}
+
 export function shouldHideAgentFromMentions({
   isAgent,
   isMember,
@@ -123,6 +149,43 @@ export function shouldHideAgentFromMentions({
   // mentionability is still loading could be hidden prematurely — keep the
   // two sets derived from the same query.
   return directoryAgentPubkeys.has(normalized);
+}
+
+/**
+ * The full mention-autocomplete admission check: reachability first, then the
+ * invocability gate. Kept here as one exported step so the composer has a
+ * single call and tests exercise the real chain instead of a copy of it.
+ */
+export function shouldOfferAgentIdentityForMentions({
+  candidate,
+  managedAgentPubkeys,
+  mentionableAgentPubkeys,
+  directoryAgentPubkeys,
+  relayAgentDirectoryReady,
+}: {
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string };
+  managedAgentPubkeys: ReadonlySet<string>;
+  mentionableAgentPubkeys: ReadonlySet<string>;
+  directoryAgentPubkeys: ReadonlySet<string>;
+  relayAgentDirectoryReady: boolean;
+}) {
+  if (
+    !isAgentIdentityReachableForMentions(
+      candidate,
+      managedAgentPubkeys,
+      relayAgentDirectoryReady,
+    )
+  ) {
+    return false;
+  }
+
+  return !shouldHideAgentFromMentions({
+    isAgent: candidate.isAgent === true,
+    isMember: candidate.isMember === true,
+    pubkey: candidate.pubkey,
+    mentionableAgentPubkeys,
+    directoryAgentPubkeys,
+  });
 }
 
 export function isAgentMentionChannelType(type?: string | null) {

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -17,9 +17,8 @@ import {
   filterCachedAgentSuggestions,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInAllowedList,
   isAgentMentionChannelType,
-  shouldHideAgentFromMentions,
+  shouldOfferAgentIdentityForMentions,
   uniqueAutocompleteLabels,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -257,16 +256,13 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInAllowedList(candidate, mentionableAgentPubkeys)) {
-        return;
-      }
       if (
-        shouldHideAgentFromMentions({
-          isAgent: candidate.isAgent === true,
-          isMember: candidate.isMember === true,
-          pubkey,
+        !shouldOfferAgentIdentityForMentions({
+          candidate: { ...candidate, pubkey },
+          managedAgentPubkeys,
           mentionableAgentPubkeys,
           directoryAgentPubkeys,
+          relayAgentDirectoryReady,
         })
       ) {
         return;
@@ -431,12 +427,14 @@ export function useMentions(
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,
     managedAgentPersonaIdsByPubkey,
+    managedAgentPubkeys,
     managedAgentsQuery.data,
     memberPubkeys,
     members,
     mentionableAgentPubkeys,
     personaNameByPubkey,
     profiles,
+    relayAgentDirectoryReady,
     relayAgentNamesByPubkey,
     relayAgentsQuery.data,
   ]);

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -250,6 +250,8 @@ test("@ trigger prioritizes channel members before runnable personas and other m
 
   const dropdown = autocomplete(page);
   await expect(dropdown).toBeVisible();
+  // alice is a channel member and a relay agent that responds to anyone, so she
+  // is invocable here even though this install does not manage her (#3809).
   await expect(dropdown.getByText("alice")).toBeVisible();
   await expect(dropdown.getByText("bob")).toBeVisible();
   await expect(dropdown.getByText("Fizz")).toBeVisible();
@@ -258,11 +260,9 @@ test("@ trigger prioritizes channel members before runnable personas and other m
   const charlieRow = dropdown.locator("button", { hasText: "charlie" });
   await expect(charlieRow.getByTestId("mention-agent-icon")).toBeVisible();
   await expect(charlieRow.getByText("not in channel")).toBeVisible();
-  await expect(
-    dropdown
-      .locator("button", { hasText: "alice" })
-      .getByText("not in channel"),
-  ).not.toBeVisible();
+  const aliceRow = dropdown.locator("button", { hasText: "alice" });
+  await expect(aliceRow.getByTestId("mention-agent-icon")).toBeVisible();
+  await expect(aliceRow.getByText("not in channel")).not.toBeVisible();
 
   const suggestions = dropdown.locator("button");
   const suggestionText = await suggestions.allInnerTexts();


### PR DESCRIPTION
## Summary

Desktop `@`-mention autocomplete dropped **cross-owner channel-member agents** because `useMentions` filtered on `isAgentIdentityInManagedList` (local install only) before `shouldHideAgentFromMentions` / `relayAgentIsSharedWithUser` could run.

This change lets **channel-member** agents through the managed-list gate **once the relay agent directory is ready**, then keeps `shouldHideAgentFromMentions` as the single invocability decision. Non-member relay-directory agents stay on the managed-list gate (preserves `mentions.spec.ts` “relay-only agents stay hidden…” policy / #3809 Expected = channel members).

Fixes #3809

Buzz channel: `7eeeb66d-80cc-4680-87c6-0d38d8d25624`

### Related issue

- https://github.com/block/buzz/issues/3809
- Duplicate search: none closer than #3809 for Desktop cross-owner mention autocomplete.

### What changed

- `isAgentIdentityReachableForMentions` — member pass-through only when `relayAgentDirectoryReady` (reuses existing predicate in `useMentions.ts`; no new readiness predicate).
- `shouldOfferAgentIdentityForMentions` — production chain (reachability → `shouldHideAgentFromMentions`) so tests cannot drift from a hand-rolled mirror; also keeps `useMentions.ts` under the 1000-line file-size ratchet (996 lines; base on `origin/main` was 999).
- Unit cases for eligible unmanaged member, directory-excluded member, loading-directory withhold, unreachable non-member.
- E2E: `alice` (default mock relay agent, member of `general`, `respond_to: anyone`, not managed by the install) now expected visible with agent icon.

### Scope / no-widening

`rg isAgentIdentityInManagedList desktop/src` → production call sites are only `useMentions.ts` and `MembersSidebar.tsx`. This PR changes the mention path only. Lookalikes (`useClassifiedMembers`, `useSearchResults`, `useNewMessageRecipients`, `ProjectsAgentPromptPage`) build their own sets / import other helpers and do **not** take the new function.

Out of scope: harness author gate, mobile/web clients, `respond_to` semantics, non-member relay-directory broadening, `linux_media.rs` macOS clippy noise.

### Testing

Attributed commit: `4e032f7d546b5f9f82fe0b4bd2051ddc782fc270`

| Recipe | Local exit @ SHA |
|--------|------------------|
| fmt-check | 0 |
| clippy | 0 |
| desktop-check | 0 |
| desktop-tauri-fmt-check | 0 |
| web-check | 0 |
| mobile-check | 0 |
| test-unit | 0 |
| desktop-test | 0 (3853 pass) |
| desktop-build | 0 |
| desktop-tauri-check | 0 |
| desktop-tauri-test | 0 |
| web-build | 0 |
| desktop-tauri-clippy | macOS lib-target dead code in `linux_media.rs` (pre-existing; reference at line 86 inside linux-only `enable_media_capture`). **Authoritative evidence: this PR’s GHA `desktop-core` → Desktop Tauri clippy on `ubuntu-latest`.** |
| mobile-test | Local red on unrelated Flutter follow-mode assert (`channel_detail_page_test.dart:1053`); **zero `mobile/**` in diff**; GHA Mobile job path-filtered out for this change. |

Also: eligibility unit suite 24 pass; `mentions.spec.ts` 49 pass including relay-only hidden policy at `:829`.

#### Second-identity smoke (recorded steps + screenshot)

At `4e032f7d5`, e2e bridge install manages only `charlie`; types `@` in `#general`:

- `alice` appears with **agent** label (not “managed by you”, not “not in channel”) — `SMOKE_ALICE_COUNT=1`
- Rows include: alice/agent, mira/agent managed by you, Fizz, charlie managed…

Screenshots: attached in issue/PR thread from `.scratch/3809-smoke/` (`cross-owner-alice-dropdown.png`).


### Dual-frame review notes (Nick-Lex / Shuri-Lex)

- **P3 (non-member relay-directory agents stay hidden):** deliberate. Matches #3809 Expected (channel members) and the existing `mentions.spec.ts` relay-only policy. Mission “and relay-directory” wording is narrowed to members only — recorded here so it is not silent.
- **P2 (directory-absent member bot offered when directory is ready/non-empty):** pre-existing Option B inside `shouldHideAgentFromMentions` (untouched). Made live for unmanaged agents by this PR. **Not tightened here** — would re-break #3809 when the directory is incomplete; recommend a follow-up issue if product wants “no entry ⇒ hidden.”
- Alice sort-order assert and local smoke temp files: non-blocking; smoke temps removed from the worktree (never committed).
