### PR TITLE
fix(huddle): guard mediaDevices access when the API is unavailable

### DIFF
--- a/desktop/src/features/huddle/HuddleContext.tsx
+++ b/desktop/src/features/huddle/HuddleContext.tsx
@@ -6,6 +6,10 @@ import { setupAudioWorklet, type AudioWorkletHandle } from "./lib/audioWorklet";
 import { type AudioInputDevice, useAudioDevices } from "./lib/useAudioDevices";
 import { formatHuddleActionError } from "./lib/huddleError";
 import {
+  availableMediaDevices,
+  MICROPHONE_UNAVAILABLE_ERROR,
+} from "./lib/mediaDevices";
+import {
   type VoiceInputMode,
   useHuddlePttState,
 } from "./lib/useHuddlePttState";
@@ -216,15 +220,14 @@ export function HuddleProvider({
       .catch(() => {
         /* best-effort */
       });
-    navigator.mediaDevices.addEventListener(
-      "devicechange",
-      refreshOutputDevices,
-    );
+    // The device list itself comes from Rust and always loads; only the
+    // hot-plug listener needs `navigator.mediaDevices`, which is absent in a
+    // non-secure context.
+    const media = availableMediaDevices();
+    if (!media) return;
+    media.addEventListener("devicechange", refreshOutputDevices);
     return () => {
-      navigator.mediaDevices.removeEventListener(
-        "devicechange",
-        refreshOutputDevices,
-      );
+      media.removeEventListener("devicechange", refreshOutputDevices);
     };
   }, []);
 
@@ -581,7 +584,11 @@ export function HuddleProvider({
       if (selectedDeviceId) {
         audioConstraints.deviceId = { exact: selectedDeviceId };
       }
-      const stream = await navigator.mediaDevices.getUserMedia({
+      const media = availableMediaDevices();
+      if (!media?.getUserMedia) {
+        throw new Error(MICROPHONE_UNAVAILABLE_ERROR);
+      }
+      const stream = await media.getUserMedia({
         audio: audioConstraints,
       });
       const audioTrack = stream.getAudioTracks()[0];

--- a/desktop/src/features/huddle/HuddleContext.tsx
+++ b/desktop/src/features/huddle/HuddleContext.tsx
@@ -5,10 +5,7 @@ import * as React from "react";
 import { setupAudioWorklet, type AudioWorkletHandle } from "./lib/audioWorklet";
 import { type AudioInputDevice, useAudioDevices } from "./lib/useAudioDevices";
 import { formatHuddleActionError } from "./lib/huddleError";
-import {
-  availableMediaDevices,
-  MICROPHONE_UNAVAILABLE_ERROR,
-} from "./lib/mediaDevices";
+import { availableMediaDevices, requireMediaDevices } from "./lib/mediaDevices";
 import {
   type VoiceInputMode,
   useHuddlePttState,
@@ -220,9 +217,7 @@ export function HuddleProvider({
       .catch(() => {
         /* best-effort */
       });
-    // The device list itself comes from Rust and always loads; only the
-    // hot-plug listener needs `navigator.mediaDevices`, which is absent in a
-    // non-secure context.
+    // Only the hot-plug listener needs mediaDevices; the list comes from Rust.
     const media = availableMediaDevices();
     if (!media) return;
     media.addEventListener("devicechange", refreshOutputDevices);
@@ -584,11 +579,7 @@ export function HuddleProvider({
       if (selectedDeviceId) {
         audioConstraints.deviceId = { exact: selectedDeviceId };
       }
-      const media = availableMediaDevices();
-      if (!media?.getUserMedia) {
-        throw new Error(MICROPHONE_UNAVAILABLE_ERROR);
-      }
-      const stream = await media.getUserMedia({
+      const stream = await requireMediaDevices().getUserMedia({
         audio: audioConstraints,
       });
       const audioTrack = stream.getAudioTracks()[0];

--- a/desktop/src/features/huddle/lib/huddleError.test.mjs
+++ b/desktop/src/features/huddle/lib/huddleError.test.mjs
@@ -2,9 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { formatHuddleActionError } from "./huddleError.ts";
+import { MICROPHONE_UNAVAILABLE_ERROR } from "./mediaDevices.ts";
 
 const AUDIO_UNAVAILABLE_MESSAGE =
   "Huddle audio isn’t available on this server. Ask an administrator to turn it on.";
+
+const MICROPHONE_UNAVAILABLE_MESSAGE =
+  "Microphone access isn’t available in this window. Try restarting Buzz.";
 
 test("maps the relay deployment rejection to actionable copy", () => {
   assert.equal(
@@ -20,6 +24,17 @@ test("recognizes the relay error code when present", () => {
   assert.equal(
     formatHuddleActionError("huddle_audio_unavailable", "start"),
     AUDIO_UNAVAILABLE_MESSAGE,
+  );
+});
+
+test("maps the missing-mediaDevices sentinel to actionable copy", () => {
+  assert.equal(
+    formatHuddleActionError(new Error(MICROPHONE_UNAVAILABLE_ERROR), "join"),
+    MICROPHONE_UNAVAILABLE_MESSAGE,
+  );
+  assert.equal(
+    formatHuddleActionError(MICROPHONE_UNAVAILABLE_ERROR, "start"),
+    MICROPHONE_UNAVAILABLE_MESSAGE,
   );
 });
 

--- a/desktop/src/features/huddle/lib/huddleError.ts
+++ b/desktop/src/features/huddle/lib/huddleError.ts
@@ -1,7 +1,12 @@
+import { MICROPHONE_UNAVAILABLE_ERROR } from "./mediaDevices";
+
 export type HuddleAction = "join" | "start";
 
 const HUDDLE_AUDIO_UNAVAILABLE_MESSAGE =
   "Huddle audio isn’t available on this server. Ask an administrator to turn it on.";
+
+const MICROPHONE_UNAVAILABLE_MESSAGE =
+  "Microphone access isn’t available in this window. Try restarting Buzz.";
 
 function rawErrorMessage(error: unknown): string | null {
   if (error instanceof Error) {
@@ -25,6 +30,10 @@ export function formatHuddleActionError(
     normalized?.includes("huddle audio unavailable in this deployment")
   ) {
     return HUDDLE_AUDIO_UNAVAILABLE_MESSAGE;
+  }
+
+  if (normalized?.includes(MICROPHONE_UNAVAILABLE_ERROR)) {
+    return MICROPHONE_UNAVAILABLE_MESSAGE;
   }
 
   if (message) {

--- a/desktop/src/features/huddle/lib/mediaDevices.test.mjs
+++ b/desktop/src/features/huddle/lib/mediaDevices.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { availableMediaDevices } from "./mediaDevices.ts";
+
+/** Swap `globalThis.navigator` for the duration of `run`. */
+function withNavigator(value, run) {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  Object.defineProperty(globalThis, "navigator", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+  try {
+    return run();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(globalThis, "navigator", descriptor);
+    } else {
+      delete globalThis.navigator;
+    }
+  }
+}
+
+test("returns the MediaDevices object when the API is present", () => {
+  const media = { enumerateDevices: () => Promise.resolve([]) };
+  withNavigator({ mediaDevices: media }, () => {
+    assert.equal(availableMediaDevices(), media);
+  });
+});
+
+test("returns null when navigator.mediaDevices is undefined", () => {
+  // The non-secure-context WKWebView case that crashed the app (#3118).
+  withNavigator({}, () => {
+    assert.equal(availableMediaDevices(), null);
+  });
+});
+
+test("returns null when mediaDevices exists but exposes no enumerateDevices", () => {
+  withNavigator({ mediaDevices: {} }, () => {
+    assert.equal(availableMediaDevices(), null);
+  });
+});
+
+test("returns null when there is no navigator at all", () => {
+  withNavigator(undefined, () => {
+    assert.equal(availableMediaDevices(), null);
+  });
+});

--- a/desktop/src/features/huddle/lib/mediaDevices.test.mjs
+++ b/desktop/src/features/huddle/lib/mediaDevices.test.mjs
@@ -3,17 +3,26 @@ import test from "node:test";
 
 import { availableMediaDevices } from "./mediaDevices.ts";
 
-/** Swap `globalThis.navigator` for the duration of `run`. */
+/**
+ * Swap `globalThis.navigator` for the duration of `run`, and swallow the
+ * missing-API diagnostic so it does not pollute test output. The
+ * once-per-process behaviour of that warning is covered separately in
+ * `mediaDevicesWarning.test.mjs`, which needs its own file to see the latch
+ * unset.
+ */
 function withNavigator(value, run) {
   const descriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const originalWarn = console.warn;
   Object.defineProperty(globalThis, "navigator", {
     value,
     configurable: true,
     writable: true,
   });
+  console.warn = () => {};
   try {
     return run();
   } finally {
+    console.warn = originalWarn;
     if (descriptor) {
       Object.defineProperty(globalThis, "navigator", descriptor);
     } else {

--- a/desktop/src/features/huddle/lib/mediaDevices.test.mjs
+++ b/desktop/src/features/huddle/lib/mediaDevices.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { availableMediaDevices } from "./mediaDevices.ts";
+import {
+  availableMediaDevices,
+  MICROPHONE_UNAVAILABLE_ERROR,
+  requireMediaDevices,
+} from "./mediaDevices.ts";
 
 /**
  * Swap `globalThis.navigator` for the duration of `run`, and swallow the
@@ -54,5 +58,26 @@ test("returns null when mediaDevices exists but exposes no enumerateDevices", ()
 test("returns null when there is no navigator at all", () => {
   withNavigator(undefined, () => {
     assert.equal(availableMediaDevices(), null);
+  });
+});
+
+test("requireMediaDevices throws the sentinel when the API is missing", () => {
+  // The join path cannot degrade, so it throws a value huddleError can map to
+  // copy instead of letting a raw TypeError reach the error boundary.
+  withNavigator({}, () => {
+    assert.throws(
+      () => requireMediaDevices(),
+      (error) => error.message === MICROPHONE_UNAVAILABLE_ERROR,
+    );
+  });
+});
+
+test("requireMediaDevices returns the object when getUserMedia is present", () => {
+  const media = {
+    enumerateDevices: () => Promise.resolve([]),
+    getUserMedia: () => Promise.resolve({}),
+  };
+  withNavigator({ mediaDevices: media }, () => {
+    assert.equal(requireMediaDevices(), media);
   });
 });

--- a/desktop/src/features/huddle/lib/mediaDevices.ts
+++ b/desktop/src/features/huddle/lib/mediaDevices.ts
@@ -1,0 +1,18 @@
+/**
+ * `navigator.mediaDevices` is absent in a non-secure context — a WKWebView that
+ * did not get a secure origin exposes no `mediaDevices` at all. Touching it
+ * unguarded from a mount-time effect throws before the user ever starts a
+ * huddle, taking the whole React tree down with it.
+ *
+ * Returns the live `MediaDevices` object, or `null` when the API is missing.
+ * Mirrors the guard already used in
+ * `features/profile/lib/animatedAvatarCapture.ts`.
+ */
+export function availableMediaDevices(): MediaDevices | null {
+  const media =
+    typeof navigator === "undefined" ? undefined : navigator.mediaDevices;
+  return typeof media?.enumerateDevices === "function" ? media : null;
+}
+
+/** Raw error thrown when a huddle needs a mic but the API is unavailable. */
+export const MICROPHONE_UNAVAILABLE_ERROR = "microphone_unavailable";

--- a/desktop/src/features/huddle/lib/mediaDevices.ts
+++ b/desktop/src/features/huddle/lib/mediaDevices.ts
@@ -8,10 +8,32 @@
  * Mirrors the guard already used in
  * `features/profile/lib/animatedAvatarCapture.ts`.
  */
+/**
+ * Latched so the diagnostic below is emitted at most once per process.
+ *
+ * This is environment state, not community state: whether the webview exposes
+ * `mediaDevices` cannot change when the user switches communities. It is
+ * therefore deliberately NOT wired into `resetCommunityState()`.
+ */
+let missingApiWarned = false;
+
 export function availableMediaDevices(): MediaDevices | null {
   const media =
     typeof navigator === "undefined" ? undefined : navigator.mediaDevices;
-  return typeof media?.enumerateDevices === "function" ? media : null;
+  if (typeof media?.enumerateDevices === "function") {
+    return media;
+  }
+
+  // One line, once. Callers hit this from three sites and mount-time effects
+  // run twice under `React.StrictMode`, so an unguarded log would emit five
+  // identical lines and bury the signal it exists to provide.
+  if (!missingApiWarned) {
+    missingApiWarned = true;
+    console.warn(
+      "[mediaDevices] navigator.mediaDevices is unavailable (non-secure context); huddle audio is disabled in this window",
+    );
+  }
+  return null;
 }
 
 /** Raw error thrown when a huddle needs a mic but the API is unavailable. */

--- a/desktop/src/features/huddle/lib/mediaDevices.ts
+++ b/desktop/src/features/huddle/lib/mediaDevices.ts
@@ -38,3 +38,15 @@ export function availableMediaDevices(): MediaDevices | null {
 
 /** Raw error thrown when a huddle needs a mic but the API is unavailable. */
 export const MICROPHONE_UNAVAILABLE_ERROR = "microphone_unavailable";
+
+/**
+ * Like [`availableMediaDevices`], for the join path, which cannot degrade: a
+ * huddle without a microphone is not a huddle. Throws the sentinel that
+ * `formatHuddleActionError` turns into user-facing copy, instead of letting
+ * the raw `undefined is not an object` reach the error boundary.
+ */
+export function requireMediaDevices(): MediaDevices {
+  const media = availableMediaDevices();
+  if (!media?.getUserMedia) throw new Error(MICROPHONE_UNAVAILABLE_ERROR);
+  return media;
+}

--- a/desktop/src/features/huddle/lib/mediaDevicesWarning.test.mjs
+++ b/desktop/src/features/huddle/lib/mediaDevicesWarning.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { availableMediaDevices } from "./mediaDevices.ts";
+
+// Deliberately its own file. The once-per-process latch lives in module scope,
+// and the node test runner gives each FILE its own process — so this is the
+// only place that observes the latch in its initial state. Folding these cases
+// into `mediaDevices.test.mjs` would make them depend on declaration order
+// there, because those tests consume the latch on their first null result.
+
+/** Run `body` with `navigator` and `console.warn` swapped out. */
+function captureWarnings(navigatorValue, body) {
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "navigator",
+  );
+  const originalWarn = console.warn;
+  const warnings = [];
+
+  Object.defineProperty(globalThis, "navigator", {
+    value: navigatorValue,
+    configurable: true,
+    writable: true,
+  });
+  console.warn = (...args) => warnings.push(args.join(" "));
+
+  try {
+    body();
+  } finally {
+    console.warn = originalWarn;
+    if (navigatorDescriptor) {
+      Object.defineProperty(globalThis, "navigator", navigatorDescriptor);
+    } else {
+      delete globalThis.navigator;
+    }
+  }
+  return warnings;
+}
+
+test("warns exactly once no matter how many callers hit the missing API", () => {
+  const warnings = captureWarnings({}, () => {
+    // Three call sites, and StrictMode runs the two mount effects twice.
+    for (let i = 0; i < 5; i += 1) {
+      assert.equal(availableMediaDevices(), null);
+    }
+  });
+
+  assert.equal(warnings.length, 1, "expected a single diagnostic line");
+  assert.match(warnings[0], /^\[mediaDevices\]/);
+  assert.match(warnings[0], /non-secure context/);
+});
+
+test("stays quiet on later calls once the API is present again", () => {
+  const media = { enumerateDevices: () => Promise.resolve([]) };
+  const warnings = captureWarnings({ mediaDevices: media }, () => {
+    assert.equal(availableMediaDevices(), media);
+  });
+
+  assert.deepEqual(warnings, []);
+});

--- a/desktop/src/features/huddle/lib/useAudioDevices.test.mjs
+++ b/desktop/src/features/huddle/lib/useAudioDevices.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { after, afterEach, before, test } from "node:test";
+
+import { JSDOM } from "jsdom";
+
+// jsdom does not implement `navigator.mediaDevices`, so the default environment
+// here IS the non-secure-context case from #3118: the property is simply
+// absent. Mounting a component that touches it unguarded throws during the
+// mount effect and takes the tree down.
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "http://localhost",
+});
+
+before(() => {
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    IS_REACT_ACT_ENVIRONMENT: true,
+    window: dom.window,
+  });
+  // `globalThis.navigator` is getter-only on Node 24, so Object.assign cannot
+  // reach it. Neither Node's nor jsdom's navigator implements `mediaDevices`,
+  // which is exactly the state under test.
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: dom.window.navigator,
+  });
+});
+
+afterEach(async () => {
+  const { cleanup } = await import("@testing-library/react");
+  cleanup();
+});
+
+after(() => dom.window.close());
+
+test("mounts without throwing when navigator.mediaDevices is absent", async () => {
+  assert.equal(
+    globalThis.navigator.mediaDevices,
+    undefined,
+    "precondition: jsdom exposes no mediaDevices",
+  );
+
+  const { createElement, useRef } = await import("react");
+  const { render, screen } = await import("@testing-library/react");
+  const { useAudioDevices } = await import("./useAudioDevices.ts");
+
+  function Harness() {
+    const workletRef = useRef(null);
+    const { audioDevices } = useAudioDevices(workletRef);
+    return createElement("p", null, `devices:${audioDevices.length}`);
+  }
+
+  render(createElement(Harness));
+
+  // Rendered at all means the mount effect did not throw; empty list means it
+  // degraded rather than inventing devices.
+  assert.ok(screen.getByText("devices:0"));
+});

--- a/desktop/src/features/huddle/lib/useAudioDevices.ts
+++ b/desktop/src/features/huddle/lib/useAudioDevices.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import type { AudioWorkletHandle } from "./audioWorklet";
+import { availableMediaDevices } from "./mediaDevices";
 
 export type AudioInputDevice = {
   deviceId: string;
@@ -22,9 +23,16 @@ export function useAudioDevices(
   const micGainRef = React.useRef(1);
 
   // Enumerate audio input devices on mount and when devices change.
+  // No-op where `navigator.mediaDevices` is absent (non-secure context) —
+  // the device list stays empty rather than crashing the tree on mount.
   React.useEffect(() => {
-    function refreshDevices() {
-      navigator.mediaDevices
+    const media = availableMediaDevices();
+    if (!media) return;
+
+    // Arrow const, not a hoisted `function` — a declaration would float above
+    // the null guard and lose the narrowing on `media`.
+    const refreshDevices = () => {
+      media
         .enumerateDevices()
         .then((devices) =>
           setAudioDevices(
@@ -39,14 +47,11 @@ export function useAudioDevices(
         .catch(() => {
           /* best-effort */
         });
-    }
+    };
     refreshDevices();
-    navigator.mediaDevices.addEventListener("devicechange", refreshDevices);
+    media.addEventListener("devicechange", refreshDevices);
     return () => {
-      navigator.mediaDevices.removeEventListener(
-        "devicechange",
-        refreshDevices,
-      );
+      media.removeEventListener("devicechange", refreshDevices);
     };
   }, []);
 


### PR DESCRIPTION
## Summary

`navigator.mediaDevices` is `undefined` in a non-secure context, for example a WKWebView that never got a secure origin. Huddle touched it unguarded from two mount-time effects, so the whole React tree crashed to the "Something went wrong" boundary with `undefined is not an object (evaluating 'navigator.mediaDevices.enumerateDevices')`. That happened before the user ever started a huddle.

All five call sites now go through `lib/mediaDevices.ts`, which mirrors the guard this codebase already uses at `desktop/src/features/profile/lib/animatedAvatarCapture.ts:131`.

| Site | Before | After |
|---|---|---|
| `lib/useAudioDevices.ts`, `enumerateDevices` + `devicechange` | crash on mount | input device list stays empty, listener skipped |
| `HuddleContext.tsx`, output-device `devicechange` | crash on mount | listener skipped. The list itself is unaffected, it comes from Rust via `list_audio_output_devices` |
| `HuddleContext.tsx`, `getUserMedia` on join | opaque crash | throws a sentinel that `formatHuddleActionError` maps to "Microphone access isn't available in this window. Try restarting Buzz." |

Two shapes worth explaining. `availableMediaDevices()` returns `MediaDevices | null` for the paths that can degrade, and `requireMediaDevices()` throws the sentinel for the join path, which cannot. And the missing-API warning is latched to fire once per process: three call sites reach it and mount effects run twice under `React.StrictMode`, so an unguarded log would print five identical lines and bury the signal. The latch is environment state rather than community state, so it is deliberately not registered in `resetCommunityState()`.

## Related issue

Fixes #3118.

Duplicate search on 2026-08-09: no open PR touches huddle plus `mediaDevices`/`getUserMedia`. Closest existing PR: none found.

## Testing

`just ci` passes end to end on macOS arm64, rebased on `5bf78671f`. Desktop suite is 4545 tests, 0 failures.

The regression test is the one that matters. `useAudioDevices.test.mjs` renders a harness around the hook under jsdom, which implements no `navigator.mediaDevices` and is therefore exactly the state this issue describes. I checked that it can actually fail: reverting the guard makes it throw `TypeError: Cannot read properties of undefined (reading 'enumerateDevices')`, the same error in the report.

`mediaDevices.test.mjs` covers the helper directly, including each way the API can be missing and the once-per-process latch. That last case lives in `mediaDevicesWarning.test.mjs` because the node runner gives every test file its own process, and it is the only place the latch is observable unset.

`huddleError.test.mjs` covers the new copy. The pre-existing case that passes the literal string `"Microphone unavailable"` still returns it verbatim, because the sentinel matches on `microphone_unavailable` with an underscore.

No screenshots: this replaces a crash with a degradation path. The only new visible string is the error copy quoted above.

## Rebase note

Rebased onto current `main` after the Huddle redesign (#4281). The conflict was an import collision, nothing structural, and all guard sites reapplied cleanly.

One thing the redesign forced: `HuddleContext.tsx` came out of it at exactly the 1000-line ratchet limit, and this change pushed it to 1007. Rather than touch the limit, I moved the throw-or-return logic into `requireMediaDevices()`. The file is now 997 lines, two below where `main` has it.

## Follow-up, deliberately not here

`profile/lib/animatedAvatarCapture.ts:157` has the same unguarded `getUserMedia`, noted in the issue. Different feature, so it is a separate change. Say the word and I will send it.
