### PR TITLE
fix(desktop): isolate AppImage external URL opener

### DIFF
--- a/desktop/scripts/appimage-xdg-open
+++ b/desktop/scripts/appimage-xdg-open
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(dirname "$(readlink -f "$0")")"
+appdir="$(readlink -f "$here/../..")"
+
+is_appdir_path() {
+  local resolved
+  resolved="$(realpath -m -- "${1:-.}" 2>/dev/null || true)"
+  [[ "$resolved" == "$appdir" || "$resolved" == "$appdir/"* ]]
+}
+
+filter_appdir_entries() {
+  local name="$1"
+  local value entry filtered=""
+  local -a entries
+
+  [[ -v "$name" ]] || return 0
+  value="${!name}"
+  IFS=: read -r -a entries <<< "$value"
+  for entry in "${entries[@]}"; do
+    if is_appdir_path "$entry"; then
+      continue
+    fi
+    [[ -z "$filtered" ]] || filtered+=":"
+    filtered+="$entry"
+  done
+
+  if [[ -n "$filtered" ]]; then
+    printf -v "$name" '%s' "$filtered"
+    export "$name"
+  else
+    unset "$name"
+  fi
+}
+
+unset_if_appdir_path() {
+  local name="$1"
+  [[ -v "$name" ]] || return 0
+  if is_appdir_path "${!name}"; then
+    unset "$name"
+  fi
+}
+
+# AppRun prepends AppDir paths to these search lists. Keep unrelated host and
+# user entries while preventing host opener processes from loading AppImage
+# libraries, modules, plugins, or data.
+for name in PATH LD_LIBRARY_PATH XDG_DATA_DIRS GIO_EXTRA_MODULES GTK_PATH \
+  QT_PLUGIN_PATH PYTHONPATH; do
+  filter_appdir_entries "$name"
+done
+
+for name in GSETTINGS_SCHEMA_DIR GTK_DATA_PREFIX GTK_EXE_PREFIX \
+  GTK_IM_MODULE_FILE GDK_PIXBUF_MODULE_FILE; do
+  unset_if_appdir_path "$name"
+done
+
+# These identify or configure the AppImage process itself, not the host opener.
+unset APPDIR APPIMAGE
+if [[ ${GDK_BACKEND-} == "x11" ]]; then
+  unset GDK_BACKEND
+fi
+
+if host_xdg_open="$(command -v xdg-open 2>/dev/null)"; then
+  exec "$host_xdg_open" "$@"
+fi
+
+exec "$here/xdg-open.appimage" "$@"

--- a/desktop/scripts/appimage-xdg-open-install.sh
+++ b/desktop/scripts/appimage-xdg-open-install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+install_appimage_xdg_open() {
+  local appdir="$1"
+  local wrapper_source="$2"
+  local xdg_open="$appdir/usr/bin/xdg-open"
+
+  if [[ ! -f "$xdg_open" ]]; then
+    echo "Error: bundled usr/bin/xdg-open not found - bundler layout changed; update fix-appimage.sh" >&2
+    return 1
+  fi
+  if [[ -e "$xdg_open.appimage" ]]; then
+    echo "Error: usr/bin/xdg-open.appimage already exists - wrapper already installed?" >&2
+    return 1
+  fi
+
+  mv "$xdg_open" "$xdg_open.appimage"
+  install -m 755 "$wrapper_source" "$xdg_open"
+}

--- a/desktop/scripts/fix-appimage.sh
+++ b/desktop/scripts/fix-appimage.sh
@@ -12,7 +12,7 @@
 # avoid appimagetool fetching one from its mutable `continuous` tag (CI pins
 # this; unset is fine for local testing).
 #
-# Root cause — three interlocking failures (upstream: https://github.com/tauri-apps/tauri/issues/15665):
+# Root cause - four interlocking failures (upstream: https://github.com/tauri-apps/tauri/issues/15665):
 #
 #  1. EGL crash: linuxdeploy bundles libwayland-client.so.0 (1.22) alongside
 #     the app. Mesa 25's libEGL calls the bundled version at runtime; the version
@@ -42,6 +42,11 @@
 #     wrong -- spawning nothing, dying on unresolved bundled libs, or spawning
 #     the system helpers -- and the window never appears.
 #
+#  4. External opener mismatch: AppRun puts the bundled xdg-open first on PATH,
+#     and opener children inherit AppImage GLib/GIO paths. On newer GNOME hosts,
+#     that mixed environment can hand the desktop a fully percent-encoded HTTPS
+#     URI instead of the original URL, so GNOME reports "No Apps Available".
+#
 # Fix: (a) remove the offending libs so the app uses the system copies (newer and
 # ABI-compatible on any distro shipping glib >= 2.72 / Ubuntu 22.04+), and
 # (b) install a launcher shim in front of the app binary that strips the
@@ -51,8 +56,9 @@
 # the variable last -- after every apprun-hook -- so any value set before it is
 # discarded (verified empirically; a runtime GST_PLUGIN_SYSTEM_PATH_1_0 passed
 # into the AppImage does not survive). No tauri.conf.json knob can do this --
-# bundle.linux.appimage only exposes bundleMediaFramework, files (copy-only, no
-# remove/symlink), and bundleXdgOpen.
+# bundle.linux.appimage only exposes bundleMediaFramework and files (copy-only,
+# no remove/symlink). External open requests also go through a small xdg-open
+# wrapper that cleans the child environment and prefers the host opener.
 
 set -euo pipefail
 
@@ -73,6 +79,7 @@ APPIMAGE_NAME="$(basename "$APPIMAGE_ABS")"
 # Locate the desktop/ directory (this script lives at desktop/scripts/).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DESKTOP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/appimage-xdg-open-install.sh"
 
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
@@ -163,6 +170,11 @@ done
 exec -a "buzz-desktop" "$here/buzz-desktop.bin" "$@"
 SHIM
 chmod +x "$APP_BIN"
+
+echo "==> Installing host xdg-open wrapper"
+install_appimage_xdg_open \
+  "$WORKDIR/squashfs-root" \
+  "$SCRIPT_DIR/appimage-xdg-open"
 
 echo "==> Repacking AppImage"
 # Pass a pinned type2 runtime when provided (CI sets APPIMAGETOOL_RUNTIME_FILE);

--- a/desktop/scripts/test-appimage-xdg-open.sh
+++ b/desktop/scripts/test-appimage-xdg-open.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$script_dir/appimage-xdg-open-install.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+appdir="$workdir/App Dir"
+appdir_alias="$workdir/AppDir-alias"
+host_bin="$workdir/host bin"
+tool_bin="$workdir/tool-bin"
+capture_dir="$workdir/capture"
+mkdir -p "$appdir/usr/bin" "$host_bin" "$tool_bin" "$capture_dir"
+ln -s "$appdir" "$appdir_alias"
+
+cat > "$appdir/usr/bin/xdg-open" <<'CAPTURE_OPENER'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$CAPTURE_DIR/args"
+env | LC_ALL=C sort > "$CAPTURE_DIR/env"
+CAPTURE_OPENER
+chmod +x "$appdir/usr/bin/xdg-open"
+cp "$appdir/usr/bin/xdg-open" "$host_bin/xdg-open"
+
+url='https://example.com/auth/login?returnTo=http%3A%2F%2F127.0.0.1%3A1234%2Fcallback&state=safe-test'
+contaminated_env=(
+  "PATH=$appdir_alias/usr/bin:$host_bin:/usr/bin:/bin"
+  "CAPTURE_DIR=$capture_dir"
+  "APPDIR=$appdir"
+  "APPIMAGE=$workdir/Buzz.AppImage"
+  "LD_LIBRARY_PATH=$appdir_alias/usr/lib:/host/lib"
+  "XDG_DATA_DIRS=$appdir_alias/usr/share:/host/share one:/host/share-two"
+  "GIO_EXTRA_MODULES=$appdir/usr/lib/gio/modules:/host/gio"
+  "GTK_PATH=$appdir/usr/lib/gtk:/host/gtk"
+  "QT_PLUGIN_PATH=$appdir/usr/plugins:/host/qt"
+  "PYTHONPATH=$appdir/usr/python:/host/python"
+  "GSETTINGS_SCHEMA_DIR=$appdir/usr/share/glib-2.0/schemas"
+  "GTK_DATA_PREFIX=$appdir/usr"
+  "GTK_EXE_PREFIX=$appdir/usr"
+  "GTK_IM_MODULE_FILE=$appdir/usr/lib/gtk.immodules"
+  "GDK_PIXBUF_MODULE_FILE=$appdir/usr/lib/gdk-pixbuf.loaders"
+  "GDK_BACKEND=x11"
+)
+
+# Before installation, packaged PATH resolves the bundled opener and every
+# AppRun value reaches it. This assertion proves the fixture detects the bug.
+env "${contaminated_env[@]}" xdg-open "$url"
+[[ "$(<"$capture_dir/args")" == "$url" ]]
+grep -Fqx "APPDIR=$appdir" "$capture_dir/env"
+grep -Fqx "XDG_DATA_DIRS=$appdir_alias/usr/share:/host/share one:/host/share-two" \
+  "$capture_dir/env"
+rm -f "$capture_dir/args" "$capture_dir/env"
+
+install_appimage_xdg_open "$appdir" "$script_dir/appimage-xdg-open"
+[[ -x "$appdir/usr/bin/xdg-open" ]]
+[[ -x "$appdir/usr/bin/xdg-open.appimage" ]]
+cmp "$script_dir/appimage-xdg-open" "$appdir/usr/bin/xdg-open"
+
+# Exercise the installed boundary through the same packaged PATH lookup.
+env "${contaminated_env[@]}" xdg-open "$url"
+[[ "$(<"$capture_dir/args")" == "$url" ]]
+
+for variable in APPDIR APPIMAGE GSETTINGS_SCHEMA_DIR GTK_DATA_PREFIX \
+  GTK_EXE_PREFIX GTK_IM_MODULE_FILE GDK_PIXBUF_MODULE_FILE GDK_BACKEND; do
+  if grep -q "^$variable=" "$capture_dir/env"; then
+    echo "expected $variable to be unset" >&2
+    exit 1
+  fi
+done
+
+grep -Fqx "LD_LIBRARY_PATH=/host/lib" "$capture_dir/env"
+grep -Fqx "XDG_DATA_DIRS=/host/share one:/host/share-two" "$capture_dir/env"
+grep -Fqx "GIO_EXTRA_MODULES=/host/gio" "$capture_dir/env"
+grep -Fqx "GTK_PATH=/host/gtk" "$capture_dir/env"
+grep -Fqx "QT_PLUGIN_PATH=/host/qt" "$capture_dir/env"
+grep -Fqx "PYTHONPATH=/host/python" "$capture_dir/env"
+grep -Fqx "PATH=$host_bin:/usr/bin:/bin" "$capture_dir/env"
+
+# Host-owned single paths and backend choices must survive cleanup.
+rm -f "$capture_dir/args" "$capture_dir/env"
+env "${contaminated_env[@]}" \
+  GTK_DATA_PREFIX=/host/gtk-data \
+  GTK_EXE_PREFIX=/host/gtk-exe \
+  GTK_IM_MODULE_FILE=/host/gtk.immodules \
+  GDK_PIXBUF_MODULE_FILE=/host/gdk-pixbuf.loaders \
+  GSETTINGS_SCHEMA_DIR=/host/schemas \
+  GDK_BACKEND=wayland \
+  xdg-open "$url"
+for expected in \
+  'GTK_DATA_PREFIX=/host/gtk-data' \
+  'GTK_EXE_PREFIX=/host/gtk-exe' \
+  'GTK_IM_MODULE_FILE=/host/gtk.immodules' \
+  'GDK_PIXBUF_MODULE_FILE=/host/gdk-pixbuf.loaders' \
+  'GSETTINGS_SCHEMA_DIR=/host/schemas' \
+  'GDK_BACKEND=wayland'; do
+  grep -Fqx "$expected" "$capture_dir/env"
+done
+
+# If no host opener exists, the retained bundled opener remains executable.
+rm -f "$capture_dir/args" "$capture_dir/env"
+ln -s /usr/bin/bash "$tool_bin/bash"
+ln -s /usr/bin/dirname "$tool_bin/dirname"
+ln -s /usr/bin/env "$tool_bin/env"
+ln -s /usr/bin/readlink "$tool_bin/readlink"
+ln -s /usr/bin/realpath "$tool_bin/realpath"
+ln -s /usr/bin/sort "$tool_bin/sort"
+PATH="$appdir_alias/usr/bin:$tool_bin" CAPTURE_DIR="$capture_dir" \
+  "$appdir/usr/bin/xdg-open" "$url"
+[[ "$(<"$capture_dir/args")" == "$url" ]]
+
+printf 'appimage-xdg-open integration tests passed\n'


### PR DESCRIPTION
## Summary
- route Linux AppImage external-open requests through a clean host `xdg-open` environment
- preserve URL bytes and host-owned path/settings entries while removing only AppDir-derived contamination
- retain the bundled opener as a fallback and test the real AppImage post-processing installation boundary

### Related issue
Closes #3814

### Testing
- `bash -n desktop/scripts/appimage-xdg-open desktop/scripts/appimage-xdg-open-install.sh desktop/scripts/test-appimage-xdg-open.sh desktop/scripts/fix-appimage.sh`
- `bash desktop/scripts/test-appimage-xdg-open.sh`
- `git diff --check`

This change only affects Linux AppImage post-processing; macOS, Windows, `.deb`, and `.rpm` paths are unchanged. The focused fixture covers exact URL preservation, AppDir environment cleanup, host-setting preservation, paths with spaces and symlink aliases, production wrapper installation, and bundled fallback. A full release AppImage rebuild and live cross-distribution matrix were not run locally.