### PR TITLE
feat(relay): raise hosted community limit to five

### DIFF
--- a/crates/buzz-db/src/relay_members.rs
+++ b/crates/buzz-db/src/relay_members.rs
@@ -376,7 +376,7 @@ pub enum TransferResult {
 /// Default maximum number of communities a single pubkey can own. Enforced at
 /// the relay layer — the authoritative layer — so that concurrent transfers or
 /// transfer-vs-create races cannot both pass a preflight count.
-pub const MAX_COMMUNITIES_PER_OWNER: i64 = 3;
+pub const MAX_COMMUNITIES_PER_OWNER: i64 = 5;
 
 /// Effective per-owner community limit for this deployment.
 ///

--- a/desktop/src/features/communities/hostedCommunityApi.ts
+++ b/desktop/src/features/communities/hostedCommunityApi.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 
 export const HOSTED_COMMUNITY_SUFFIX = "communities.buzz.xyz";
-export const HOSTED_COMMUNITY_LIMIT = 3;
+export const HOSTED_COMMUNITY_LIMIT = 5;
 export const VALID_HOSTED_COMMUNITY_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 export type BuilderlabAuth = {


### PR DESCRIPTION
## Summary
- raise the relay authoritative default community ownership limit from 3 to 5
- raise the desktop hosted-community treatment from 3 to 5
- preserve `BUZZ_MAX_COMMUNITIES_PER_OWNER` as a deployment override

## Validation
- `pnpm -r check`
- `cargo fmt --all -- --check`
- `cargo test -p buzz-db` (94 passed, 151 Postgres-dependent tests ignored)
- pre-push hooks: desktop checks/tests, Rust tests, Tauri checks (all passed; 1,995 desktop Rust tests passed)