### PR TITLE
fix(mobile): preserve secure relay transport schemes

### DIFF
--- a/mobile/lib/features/pairing/pairing_provider.dart
+++ b/mobile/lib/features/pairing/pairing_provider.dart
@@ -604,9 +604,7 @@ class PairingNotifier extends Notifier<PairingState> {
     if (nsec == null || nsec.isEmpty) {
       throw const FormatException('Pairing payload missing nsec');
     }
-    final uri = Uri.parse(relayUrl);
-    final scheme = uri.scheme == 'https' ? 'wss' : 'ws';
-    final wsUrl = uri.replace(scheme: scheme).toString();
+    final wsUrl = RelayConfig(baseUrl: relayUrl).wsUrl;
 
     final socket = RelaySocket(
       wsUrl: wsUrl,

--- a/mobile/lib/shared/relay/media_auth.dart
+++ b/mobile/lib/shared/relay/media_auth.dart
@@ -125,7 +125,7 @@ class MediaGetAuthService {
 
 final mediaGetAuthServiceProvider = Provider<MediaGetAuthService>((ref) {
   final config = ref.watch(relayConfigProvider);
-  return MediaGetAuthService(baseUrl: config.baseUrl, nsec: config.nsec);
+  return MediaGetAuthService(baseUrl: config.httpUrl, nsec: config.nsec);
 });
 
 Map<String, String> mediaGetHeadersFor(WidgetRef ref, String url) {

--- a/mobile/lib/shared/relay/media_upload.dart
+++ b/mobile/lib/shared/relay/media_upload.dart
@@ -806,7 +806,7 @@ final mediaUploadServiceProvider = Provider<MediaUploadService>((ref) {
   final config = ref.watch(relayConfigProvider);
   final picker = ImagePicker();
   final service = MediaUploadService(
-    baseUrl: config.baseUrl,
+    baseUrl: config.httpUrl,
     nsec: config.nsec,
     pickGalleryImage: () => picker.pickImage(
       source: ImageSource.gallery,

--- a/mobile/lib/shared/relay/relay_provider.dart
+++ b/mobile/lib/shared/relay/relay_provider.dart
@@ -17,10 +17,25 @@ class RelayConfig {
 
   const RelayConfig({required this.baseUrl, this.nsec});
 
-  /// Derive the websocket URL from the HTTP base URL.
-  String get wsUrl {
+  /// Derive the HTTP URL while preserving the relay's TLS posture.
+  String get httpUrl => _urlForTransport(webSocket: false);
+
+  /// Derive the WebSocket URL while preserving the relay's TLS posture.
+  String get wsUrl => _urlForTransport(webSocket: true);
+
+  String _urlForTransport({required bool webSocket}) {
     final uri = Uri.parse(baseUrl);
-    final scheme = uri.scheme == 'https' ? 'wss' : 'ws';
+    final secure = switch (uri.scheme) {
+      'https' || 'wss' => true,
+      'http' || 'ws' => false,
+      _ => throw FormatException('Unsupported relay URL scheme: ${uri.scheme}'),
+    };
+    final scheme = switch ((webSocket, secure)) {
+      (true, true) => 'wss',
+      (true, false) => 'ws',
+      (false, true) => 'https',
+      (false, false) => 'http',
+    };
     return uri.replace(scheme: scheme).toString();
   }
 }
@@ -86,7 +101,7 @@ final myPubkeyProvider = Provider<String?>((ref) {
 /// through the relay WebSocket session.
 final relayClientProvider = Provider<RelayClient>((ref) {
   final config = ref.watch(relayConfigProvider);
-  final client = RelayClient(baseUrl: config.baseUrl);
+  final client = RelayClient(baseUrl: config.httpUrl);
   ref.onDispose(client.dispose);
   return client;
 });

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -133,7 +133,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     Duration timeout = const Duration(seconds: 8),
   }) async {
     final config = ref.read(relayConfigProvider);
-    final url = Uri.parse(config.baseUrl).resolve('/query').toString();
+    final url = Uri.parse(config.httpUrl).resolve('/query').toString();
     final bodyBytes = utf8.encode(
       jsonEncode(filters.map((filter) => filter.toJson()).toList()),
     );

--- a/mobile/test/shared/relay/relay_provider_test.dart
+++ b/mobile/test/shared/relay/relay_provider_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buzz/shared/relay/relay_provider.dart';
+
+void main() {
+  group('RelayConfig transport URLs', () {
+    for (final testCase in [
+      (
+        input: 'https://relay.example',
+        http: 'https://relay.example',
+        ws: 'wss://relay.example',
+      ),
+      (
+        input: 'wss://relay.example',
+        http: 'https://relay.example',
+        ws: 'wss://relay.example',
+      ),
+      (
+        input: 'http://localhost:3000',
+        http: 'http://localhost:3000',
+        ws: 'ws://localhost:3000',
+      ),
+      (
+        input: 'ws://localhost:3000',
+        http: 'http://localhost:3000',
+        ws: 'ws://localhost:3000',
+      ),
+    ]) {
+      test('projects ${testCase.input} onto HTTP and WebSocket', () {
+        final config = RelayConfig(baseUrl: testCase.input);
+
+        expect(config.httpUrl, testCase.http);
+        expect(config.wsUrl, testCase.ws);
+      });
+    }
+
+    test('rejects unsupported schemes', () {
+      final config = RelayConfig(baseUrl: 'ftp://relay.example');
+
+      expect(() => config.httpUrl, throwsFormatException);
+      expect(() => config.wsUrl, throwsFormatException);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- project HTTP/HTTPS and WS/WSS relay URLs onto the correct transport without changing stored community identity
- fix NIP-42 authentication for invite-created communities stored as `wss://`
- use HTTP projections for relay queries and media operations, and the shared WebSocket projection for pairing
- add regression coverage for all four supported schemes

## Production evidence
A fresh Android invite successfully claimed membership, then repeatedly failed NIP-42 authentication because mobile converted stored `wss://buzz.alebairos.xyz` to `ws://buzz.alebairos.xyz`. nginx redirected the socket to TLS, but the signed AUTH event retained the insecure relay tag and the relay correctly rejected it with `relay url mismatch`.

## Verification
- `flutter test`: 880 passed, 1 skipped
- `flutter analyze`: no issues
- `just mobile-check`: passed
- `git diff --check`: clean

Buzz originating channel: `c26bd1cd-860c-4f0e-8b8c-54f5ac3a6a56`