### PR TITLE
fix(mobile): reconnect on resume instead of trusting a stale status

### DIFF
--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -103,6 +103,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   int _subIdCounter = 0;
   bool _disposed = false;
   bool _paused = false;
+  bool _wasBackgrounded = false;
   bool _hasConnectedOnce = false;
   int _connectionGeneration = 0;
 
@@ -315,6 +316,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
 
   /// Called by the app lifecycle provider when the app goes to background.
   void onAppPaused() {
+    _wasBackgrounded = true;
     _backgroundGraceTimer?.cancel();
     _backgroundGraceTimer = Timer(const Duration(seconds: 5), _pauseNow);
   }
@@ -334,14 +336,33 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     _backgroundGraceTimer?.cancel();
     _backgroundGraceTimer = null;
 
-    // If still connected, nothing to do — the socket survived the background
-    // grace window.
-    if (state.status == SessionStatus.connected) return;
+    final wasBackgrounded = _wasBackgrounded;
+    _wasBackgrounded = false;
+
+    // Only trust a `connected` status when the app never actually left the
+    // foreground — e.g. resuming from `inactive` after a Control Centre swipe.
+    //
+    // After a real background stint the status cannot be trusted: the OS
+    // suspends the process, so the grace timer never fires and a socket torn
+    // down by the platform or carrier NAT never delivers its onDisconnected
+    // callback. The session then resumes believing it is connected, sits on a
+    // dead socket, and no events arrive until some later write happens to
+    // surface the error. Reconnecting is idempotent and replays missed events,
+    // so an occasional redundant reconnect is far cheaper than a silent stall.
+    if (!wasBackgrounded && state.status == SessionStatus.connected) return;
 
     // Cancel any in-flight reconnect backoff timer so we reconnect immediately
     // instead of waiting for the (possibly large) exponential delay.
     _reconnectTimer?.cancel();
     _reconnectDelayMs = _baseReconnectDelayMs;
+
+    if (state.status == SessionStatus.connected) {
+      // Believed-connected but unverifiable: tear the old socket down first so
+      // the replacement is not racing a half-open one.
+      unawaited(reconnect());
+      return;
+    }
+
     final config = ref.read(relayConfigProvider);
     _connect(config);
   }

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -260,6 +260,87 @@ void main() {
     expect(session.state.status, SessionStatus.disconnected);
   });
 
+  test(
+    'reconnects on resume even when the status still claims connected',
+    () async {
+      // A suspended app never runs its background grace timer and never receives
+      // the socket's onDisconnected callback, so it resumes still believing it is
+      // connected while sitting on a socket the platform already tore down.
+      // Resuming must rebuild the connection rather than trust that status.
+      final sockets = <_ControlledRelaySocket>[];
+      final session = _sessionWithControlledSockets(sockets);
+      final keychain = nostr.Keys.generate();
+      final container = ProviderContainer(
+        overrides: [
+          relaySessionProvider.overrideWith(() => session),
+          relayConfigProvider.overrideWith(
+            () => _FakeRelayConfigNotifier(
+              baseUrl: 'https://relay.example',
+              nsec: keychain.nsec,
+            ),
+          ),
+          authProvider.overrideWith(() => _AuthenticatedAuthNotifier()),
+        ],
+      );
+      addTearDown(container.dispose);
+      await container.read(authProvider.future);
+      final subscription = container.listen(relaySessionProvider, (_, _) {});
+      addTearDown(subscription.close);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(sockets, hasLength(1));
+      sockets.first.connectSuccessfully();
+      expect(session.state.status, SessionStatus.connected);
+
+      // Background, then resume before the 5s grace timer fires — exactly what a
+      // screen lock does, since a suspended process cannot run timers.
+      session.onAppPaused();
+      session.onAppResumed();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        sockets,
+        hasLength(2),
+        reason: 'resume after backgrounding must rebuild the socket',
+      );
+    },
+  );
+
+  test('does not rebuild the socket when the app never backgrounded', () async {
+    // Returning from `inactive` (a Control Centre swipe, say) also calls
+    // onAppResumed, but the socket is genuinely alive — reconnecting there
+    // would churn the connection for no reason.
+    final sockets = <_ControlledRelaySocket>[];
+    final session = _sessionWithControlledSockets(sockets);
+    final keychain = nostr.Keys.generate();
+    final container = ProviderContainer(
+      overrides: [
+        relaySessionProvider.overrideWith(() => session),
+        relayConfigProvider.overrideWith(
+          () => _FakeRelayConfigNotifier(
+            baseUrl: 'https://relay.example',
+            nsec: keychain.nsec,
+          ),
+        ),
+        authProvider.overrideWith(() => _AuthenticatedAuthNotifier()),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(authProvider.future);
+    final subscription = container.listen(relaySessionProvider, (_, _) {});
+    addTearDown(subscription.close);
+    await Future<void>.delayed(Duration.zero);
+
+    sockets.first.connectSuccessfully();
+    expect(session.state.status, SessionStatus.connected);
+
+    session.onAppResumed();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(sockets, hasLength(1));
+    expect(session.state.status, SessionStatus.connected);
+  });
+
   test('delivers the same live event to each matching subscription', () async {
     final session = RelaySessionNotifier();
     final firstEvents = <NostrEvent>[];
@@ -397,6 +478,33 @@ class _AuthenticatedAuthNotifier extends AuthNotifier {
   @override
   Future<AuthState> build() async =>
       const AuthState(status: AuthStatus.authenticated);
+}
+
+/// A session whose sockets are all [_ControlledRelaySocket]s, appended to
+/// [sockets] in creation order so tests can assert how many were built.
+RelaySessionNotifier _sessionWithControlledSockets(
+  List<_ControlledRelaySocket> sockets,
+) {
+  return RelaySessionNotifier(
+    socketFactory:
+        ({
+          required wsUrl,
+          required nsec,
+          required onMessage,
+          required onConnected,
+          required onDisconnected,
+        }) {
+          final socket = _ControlledRelaySocket(
+            wsUrl: wsUrl,
+            nsec: nsec,
+            onMessage: onMessage,
+            onConnected: onConnected,
+            onDisconnected: onDisconnected,
+          );
+          sockets.add(socket);
+          return socket;
+        },
+  );
 }
 
 class _ControlledRelaySocket extends RelaySocket {


### PR DESCRIPTION
## Summary

On mobile, the relay session could come back from a real background stint believing it was still connected while sitting on a dead socket. No events arrived until some later write surfaced the error — which is why replies would appear all at once the moment the user typed something.

`onAppResumed()` returned early whenever `state.status` was already `connected`, on the assumption that a still-connected status meant the socket survived the 5-second background grace window:

```dart
// If still connected, nothing to do — the socket survived the background
// grace window.
if (state.status == SessionStatus.connected) return;
```

That assumption does not hold once the OS suspends the process. The grace timer never fires, and a socket torn down by the platform or by carrier NAT never delivers its `onDisconnected` callback, so the status is stale in exactly the case where it matters.

This change tracks whether the app *actually* backgrounded (`onAppPaused()` fired) and only trusts a `connected` status when it did not:

- **Resume from `inactive`** — a Control Centre swipe or a notification banner — never calls `onAppPaused()`, so that path keeps its live socket and gains no reconnect churn.
- **Resume after a real background stint** reconnects regardless of the reported status. When the status still claims `connected`, the old socket is torn down first via `reconnect()` so the replacement isn't racing a half-open one.

Reconnecting is idempotent and replays missed events, so an occasional redundant reconnect is far cheaper than a silent stall.

### Related issue

None found — searched open issues and PRs for existing reports of stale mobile sockets on resume.

### Testing

Two new tests in `mobile/test/shared/relay/relay_session_test.dart`, covering both directions of the condition:

- `reconnects on resume even when the status still claims connected` — the regression itself
- `does not rebuild the socket when the app never backgrounded` — guards against trading a silent stall for reconnect churn on every Control Centre swipe

Full mobile suite on the rebased branch (not just the touched file):

```
dart format --output=none --set-exit-if-changed .   →  Formatted 331 files (0 changed)
flutter analyze                                     →  No issues found! (ran in 15.8s)
flutter test                                        →  +1024 ~1: All tests passed!
```

No UI change — behaviour only.
