### PR TITLE
fix(push): update gateway release contract

### DIFF
--- a/deploy/charts/buzz-push-gateway/tests/release-contract.sh
+++ b/deploy/charts/buzz-push-gateway/tests/release-contract.sh
@@ -8,16 +8,18 @@ auto_path = Path('.github/workflows/auto-tag-on-release-pr-merge.yml')
 publish_path = Path('.github/workflows/push-gateway-helm-chart.yml')
 auto_text = auto_path.read_text()
 publish_text = publish_path.read_text()
-# Parse first, then pin the cross-workflow strings whose agreement makes this a
-# reachable lane rather than an orphan publisher.
+# Parse first, then pin the tag producer and consumer strings whose agreement
+# makes this a reachable lane rather than an orphan publisher.
 yaml.safe_load(auto_text)
 yaml.safe_load(publish_text)
 for needle in (
     'push-chart-release/*)',
     'VERSION="${BRANCH#push-chart-release/}"',
     'TAG_PREFIX="push-chart-v"',
-    'DISPATCH="push-gateway-helm-chart"',
-    'push-gateway-helm-chart) WORKFLOW="push-gateway-helm-chart.yml"',
+    '- name: Create and push tag',
+    'TAG: ${{ steps.release.outputs.tag }}',
+    'refs/tags/$TAG',
+    '-f sha="$TARGET_SHA"',
 ):
     assert needle in auto_text, f'missing auto-tag gateway chart contract: {needle}'
 for needle in (


### PR DESCRIPTION
### What changed?

Updated the push gateway chart release contract to assert the live tag-based release path. The test now pins the `Create and push tag` step, its resolved tag input, the `refs/tags/$TAG` destination, and the target SHA passed to GitHub.

### Why?

[Commit `0b297edbd`](https://github.com/block/buzz/commit/0b297edbdf6757459ead48fb61fcfeac50f736fc) replaced direct workflow dispatch with GitHub App-authored tags, but the contract test continued requiring the deleted dispatch code. That stale assertion broke chart validation on main and in [run 30594012619](https://github.com/block/buzz/actions/runs/30594012619).

The push gateway workflow runs only when its chart path or workflow file changes, so this contract may otherwise remain unexercised for long periods. Its `publish` job requires `validate`, which currently prevents `push-chart-v*` releases until this test is fixed. The chart remains at `0.1.0`, and `push-chart-v0.1.0` already exists.

Originating Buzz channel: `e241d25e-05da-4b94-a3a4-faa41f4aec31`.

### How is it tested?

Updated test:

- [`release-contract.sh`](https://github.com/block/buzz/blob/main/deploy/charts/buzz-push-gateway/tests/release-contract.sh)

The fixed contract and shell syntax checks pass locally. Mutation checks independently break all four new tag-creation needles, delete the complete tag-creation step, and spot-check the existing tag-prefix and publisher-trigger needles. Every mutation fails, and every restored contract passes.
