### PR TITLE
fix(release): reject clobbered macOS updater archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -890,23 +890,32 @@ jobs:
           set -euo pipefail
           BASE="https://github.com/block/buzz/releases/download/desktop-v${VERSION}"
           TRIPLES=()
+          # Parallel arrays: ARCHIVE_NAMES[i] basename claimed by ARCHIVE_PLATFORMS[i].
           ARCHIVE_NAMES=()
+          ARCHIVE_PLATFORMS=()
 
           add_triple() {
             local result="$1" platform="$2" archive="$3"
+            local i existing existing_platform
             if [[ "$result" == "success" ]]; then
               [[ -n "$archive" ]] || { echo "::error::Missing archive name for successful platform: $platform"; exit 1; }
               # macOS used to publish both arches as Buzz.app.tar.gz; the second
               # upload clobbered the first and left latest.json with one binary
               # and two incompatible signatures. Refuse that class of channel.
-              for existing in "${ARCHIVE_NAMES[@]+"${ARCHIVE_NAMES[@]}"}"; do
+              for ((i = 0; i < ${#ARCHIVE_NAMES[@]}; i++)); do
+                existing="${ARCHIVE_NAMES[$i]}"
+                existing_platform="${ARCHIVE_PLATFORMS[$i]}"
                 if [[ "$existing" == "$archive" ]]; then
-                  echo "::error::updater archive basename collision for $platform: $archive"
+                  echo "::error::updater archive basename collision: ${existing_platform} and ${platform} both claim ${archive}"
+                  echo "::error::colliding artifact urls:"
+                  echo "::error::  ${existing_platform}: ${BASE}/${existing}"
+                  echo "::error::  ${platform}: ${BASE}/${archive}"
                   echo "::error::each platform needs a unique archive name before latest.json is published"
                   exit 1
                 fi
               done
               ARCHIVE_NAMES+=("$archive")
+              ARCHIVE_PLATFORMS+=("$platform")
               TRIPLES+=("${platform}:/tmp/sigs/${platform}.sig:${BASE}/${archive}")
             fi
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -890,11 +890,23 @@ jobs:
           set -euo pipefail
           BASE="https://github.com/block/buzz/releases/download/desktop-v${VERSION}"
           TRIPLES=()
+          ARCHIVE_NAMES=()
 
           add_triple() {
             local result="$1" platform="$2" archive="$3"
             if [[ "$result" == "success" ]]; then
               [[ -n "$archive" ]] || { echo "::error::Missing archive name for successful platform: $platform"; exit 1; }
+              # macOS used to publish both arches as Buzz.app.tar.gz; the second
+              # upload clobbered the first and left latest.json with one binary
+              # and two incompatible signatures. Refuse that class of channel.
+              for existing in "${ARCHIVE_NAMES[@]+"${ARCHIVE_NAMES[@]}"}"; do
+                if [[ "$existing" == "$archive" ]]; then
+                  echo "::error::updater archive basename collision for $platform: $archive"
+                  echo "::error::each platform needs a unique archive name before latest.json is published"
+                  exit 1
+                fi
+              done
+              ARCHIVE_NAMES+=("$archive")
               TRIPLES+=("${platform}:/tmp/sigs/${platform}.sig:${BASE}/${archive}")
             fi
           }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -272,3 +272,44 @@ valid `latest.json`. The manifest covers all four platform keys
 (`darwin-aarch64`, `darwin-x86_64`, `linux-x86_64`,
 `windows-x86_64`); a missing entry usually means that platform's
 release job failed. Check the workflow run.
+
+Installed apps always fetch:
+
+`https://github.com/block/buzz/releases/download/buzz-desktop-latest/latest.json`
+
+That file may point asset URLs at the versioned `desktop-v<version>` release.
+The rolling release only needs a correct `latest.json` last; the binaries live
+on the versioned release.
+
+### Auto-updater fails on macOS (signature / install error)
+Historical releases uploaded both Apple Silicon and Intel updater archives as
+the same rolling basename (`Buzz.app.tar.gz`). The later arch clobbered the
+earlier one while `latest.json` still advertised both platform keys with
+different signatures. Intel and Apple Silicon clients then saw signature or
+install failures.
+
+Current release jobs rename those archives before publish
+(`Buzz_<version>_aarch64.app.tar.gz` and `Buzz_<version>_x64.app.tar.gz`) and
+fail the assemble job if two platforms share a basename.
+
+**Recovery for a machine that cannot auto-update today:**
+
+1. Quit Buzz.
+2. Download the matching DMG from the latest GitHub release:
+   - Apple Silicon: `Buzz_<version>_aarch64.dmg`
+   - Intel: `Buzz_<version>_x64.dmg`
+3. Replace `/Applications/Buzz.app` from the DMG and relaunch.
+4. Confirm the version under **Settings → Software Updates**.
+
+In-app update works again only after a later desktop release publishes a
+`latest.json` whose macOS URLs are the uniquely named archives above. Manual
+DMG install does not repair the old rolling `Buzz.app.tar.gz` channel by
+itself.
+
+### Settings → Software Updates states
+| UI state | Meaning |
+|----------|---------|
+| Automatic updates aren't available on this build | Build was compiled without updater secrets (dev/canary/local). Use a GitHub release DMG. |
+| Update failed: … | Updater plugin ran; download, signature, or install failed. On macOS check the channel bug above. |
+| In-app updates aren't supported on this Linux package | Non-AppImage install (for example `.deb`). Download AppImage or reinstall manually. |
+| You're on the latest version | Installed version is already the manifest version. |


### PR DESCRIPTION
## Summary
- Root cause: both macOS release jobs uploaded `Buzz.app.tar.gz` to `buzz-desktop-latest`, so arm64 clobbered Intel while `latest.json` kept both platform signatures.
- Main already renames per-arch updater archives; this fails assemble if two platforms still share a basename before `latest.json` is published.
- Documents manual DMG recovery for machines stuck on the broken channel.

## Test plan
- [x] Local bash simulation: unique names pass, duplicate basename fails
- [x] Live channel rechecked: both macOS keys still point at one `Buzz.app.tar.gz` with different signatures
- [x] Confirmed `Buzz_0.5.2_x64.dmg` exists for Intel recovery
- [ ] Next desktop release: confirm `latest.json` macOS URLs are uniquely named archives
- [ ] On Intel Mac: after next release, Settings → Software Updates can install without signature failure

## User recovery (current channel)
Install the matching DMG from https://github.com/block/buzz/releases/latest — Intel needs `Buzz_*_x64.dmg`. In-app update stays unreliable until a release ships a correct `latest.json`.
