### PR TITLE
feat(mobile): add profile editing

### DIFF
--- a/mobile/lib/features/channels/emoji_picker.dart
+++ b/mobile/lib/features/channels/emoji_picker.dart
@@ -30,6 +30,7 @@ const _sheetHeightFactor = 0.62;
 void showEmojiPicker({
   required BuildContext context,
   required void Function(String emoji) onSelect,
+  bool includeCustomEmoji = true,
 }) {
   showModalBottomSheet<void>(
     context: context,
@@ -37,6 +38,7 @@ void showEmojiPicker({
     showDragHandle: true,
     backgroundColor: context.colors.surfaceContainerHighest,
     builder: (sheetContext) => EmojiPickerSheet(
+      includeCustomEmoji: includeCustomEmoji,
       onSelect: (emoji) {
         Navigator.of(sheetContext).pop();
         onSelect(emoji);
@@ -47,13 +49,20 @@ void showEmojiPicker({
 
 class EmojiPickerSheet extends HookConsumerWidget {
   final void Function(String emoji) onSelect;
+  final bool includeCustomEmoji;
 
-  const EmojiPickerSheet({super.key, required this.onSelect});
+  const EmojiPickerSheet({
+    super.key,
+    required this.onSelect,
+    this.includeCustomEmoji = true,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final dataset = ref.watch(emojiDatasetOrEmptyProvider);
-    final customEmoji = ref.watch(customEmojiListProvider);
+    final customEmoji = includeCustomEmoji
+        ? ref.watch(customEmojiListProvider)
+        : const <CustomEmoji>[];
     final recent = ref.watch(recentEmojiProvider);
 
     final searchController = useTextEditingController();

--- a/mobile/lib/features/profile/edit_profile_sheet.dart
+++ b/mobile/lib/features/profile/edit_profile_sheet.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../../shared/relay/relay.dart';
@@ -11,12 +12,42 @@ import '../../shared/widgets/avatar_image.dart';
 import 'profile_provider.dart';
 import 'user_profile.dart';
 
+const _profileAvatarMaxDimension = 512.0;
+const _profileAvatarImageQuality = 85;
+
+typedef PickProfileAvatarImage =
+    Future<XFile?> Function({
+      required double maxWidth,
+      required double maxHeight,
+      required int imageQuality,
+    });
+
+final profileAvatarImagePickerProvider = Provider<PickProfileAvatarImage>((
+  ref,
+) {
+  final picker = ImagePicker();
+  return ({required maxWidth, required maxHeight, required imageQuality}) =>
+      picker.pickImage(
+        source: ImageSource.gallery,
+        maxWidth: maxWidth,
+        maxHeight: maxHeight,
+        imageQuality: imageQuality,
+        requestFullMetadata: false,
+      );
+});
+
 final profileAvatarPickerProvider = Provider<Future<String?> Function()>((ref) {
   return () async {
+    final image = await ref.read(profileAvatarImagePickerProvider)(
+      maxWidth: _profileAvatarMaxDimension,
+      maxHeight: _profileAvatarMaxDimension,
+      imageQuality: _profileAvatarImageQuality,
+    );
+    if (image == null) return null;
     final descriptor = await ref
         .read(mediaUploadServiceProvider)
-        .pickAndUploadImage();
-    return descriptor?.url;
+        .uploadProfileImage(image);
+    return descriptor.url;
   };
 });
 

--- a/mobile/lib/features/profile/edit_profile_sheet.dart
+++ b/mobile/lib/features/profile/edit_profile_sheet.dart
@@ -9,11 +9,19 @@ import 'package:lucide_icons_flutter/lucide_icons.dart';
 import '../../shared/relay/relay.dart';
 import '../../shared/theme/theme.dart';
 import '../../shared/widgets/avatar_image.dart';
+import '../channels/emoji_picker.dart';
 import 'profile_provider.dart';
 import 'user_profile.dart';
 
 const _profileAvatarMaxDimension = 512.0;
 const _profileAvatarImageQuality = 85;
+const _emojiAvatarColors = [
+  (hex: '#F4B942', color: Color(0xFFF4B942)),
+  (hex: '#E66A6A', color: Color(0xFFE66A6A)),
+  (hex: '#9B72CF', color: Color(0xFF9B72CF)),
+  (hex: '#5B8DEF', color: Color(0xFF5B8DEF)),
+  (hex: '#4EAD8C', color: Color(0xFF4EAD8C)),
+];
 
 typedef PickProfileAvatarImage =
     Future<XFile?> Function({
@@ -79,6 +87,14 @@ class _EditProfileSheet extends HookConsumerWidget {
     final displayName = useState(currentProfile?.displayName ?? '');
     final about = useState(currentProfile?.about ?? '');
     final avatarUrl = useState(currentProfile?.avatarUrl ?? '');
+    final initialEmojiAvatar = useMemoized(
+      () => parseEmojiAvatarDataUrl(currentProfile?.avatarUrl),
+      [currentProfile?.avatarUrl],
+    );
+    final selectedEmoji = useState(initialEmojiAvatar?.emoji);
+    final selectedEmojiColor = useState(
+      initialEmojiAvatar?.color ?? _emojiAvatarColors.first.hex,
+    );
     final isUploading = useState(false);
     final isSaving = useState(false);
     final errorMessage = useState<String?>(null);
@@ -112,12 +128,39 @@ class _EditProfileSheet extends HookConsumerWidget {
       errorMessage.value = null;
       try {
         final url = await ref.read(profileAvatarPickerProvider)();
-        if (url != null) avatarUrl.value = url;
+        if (url != null) {
+          selectedEmoji.value = null;
+          avatarUrl.value = url;
+        }
       } catch (_) {
         errorMessage.value = 'Couldn\u2019t upload that photo. Try again.';
       } finally {
         isUploading.value = false;
       }
+    }
+
+    void chooseEmoji() {
+      if (isUploading.value || isSaving.value) return;
+      showEmojiPicker(
+        context: context,
+        includeCustomEmoji: false,
+        onSelect: (emoji) {
+          selectedEmoji.value = emoji;
+          avatarUrl.value = emojiAvatarDataUrl(emoji, selectedEmojiColor.value);
+        },
+      );
+    }
+
+    void chooseEmojiColor(String color) {
+      final emoji = selectedEmoji.value;
+      if (emoji == null || isUploading.value || isSaving.value) return;
+      selectedEmojiColor.value = color;
+      avatarUrl.value = emojiAvatarDataUrl(emoji, color);
+    }
+
+    void removeAvatar() {
+      selectedEmoji.value = null;
+      avatarUrl.value = '';
     }
 
     Future<void> save() async {
@@ -208,15 +251,64 @@ class _EditProfileSheet extends HookConsumerWidget {
                               : 'Choose photo',
                         ),
                       ),
+                      TextButton.icon(
+                        onPressed: isUploading.value || isSaving.value
+                            ? null
+                            : chooseEmoji,
+                        icon: const Icon(LucideIcons.smilePlus, size: 18),
+                        label: const Text('Use emoji'),
+                      ),
                       if (avatarUrl.value.isNotEmpty)
                         TextButton(
                           onPressed: isUploading.value || isSaving.value
                               ? null
-                              : () => avatarUrl.value = '',
+                              : removeAvatar,
                           child: const Text('Remove'),
                         ),
                     ],
                   ),
+                  if (selectedEmoji.value != null) ...[
+                    const SizedBox(height: Grid.half),
+                    Semantics(
+                      label: 'Emoji avatar color',
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          for (final (index, entry)
+                              in _emojiAvatarColors.indexed)
+                            Semantics(
+                              button: true,
+                              selected: selectedEmojiColor.value == entry.hex,
+                              label: 'Avatar color ${index + 1}',
+                              child: InkWell(
+                                key: ValueKey('avatar-color-${entry.hex}'),
+                                customBorder: const CircleBorder(),
+                                onTap: () => chooseEmojiColor(entry.hex),
+                                child: Padding(
+                                  padding: const EdgeInsets.all(Grid.half),
+                                  child: Container(
+                                    width: 32,
+                                    height: 32,
+                                    decoration: BoxDecoration(
+                                      color: entry.color,
+                                      shape: BoxShape.circle,
+                                      border: Border.all(
+                                        color:
+                                            selectedEmojiColor.value ==
+                                                entry.hex
+                                            ? context.colors.onSurface
+                                            : Colors.transparent,
+                                        width: 2,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/mobile/lib/features/profile/edit_profile_sheet.dart
+++ b/mobile/lib/features/profile/edit_profile_sheet.dart
@@ -1,0 +1,244 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+import '../../shared/relay/relay.dart';
+import '../../shared/theme/theme.dart';
+import '../../shared/widgets/avatar_image.dart';
+import 'profile_provider.dart';
+import 'user_profile.dart';
+
+final profileAvatarPickerProvider = Provider<Future<String?> Function()>((ref) {
+  return () async {
+    final descriptor = await ref
+        .read(mediaUploadServiceProvider)
+        .pickAndUploadImage();
+    return descriptor?.url;
+  };
+});
+
+void showEditProfileSheet(
+  BuildContext context, {
+  required UserProfile? currentProfile,
+}) {
+  showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    builder: (_) => _EditProfileSheet(currentProfile: currentProfile),
+  );
+}
+
+class _EditProfileSheet extends HookConsumerWidget {
+  const _EditProfileSheet({required this.currentProfile});
+
+  final UserProfile? currentProfile;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final displayNameController = useTextEditingController(
+      text: currentProfile?.displayName ?? '',
+    );
+    final aboutController = useTextEditingController(
+      text: currentProfile?.about ?? '',
+    );
+    final displayName = useState(currentProfile?.displayName ?? '');
+    final about = useState(currentProfile?.about ?? '');
+    final avatarUrl = useState(currentProfile?.avatarUrl ?? '');
+    final isUploading = useState(false);
+    final isSaving = useState(false);
+    final errorMessage = useState<String?>(null);
+
+    useEffect(() {
+      void displayNameListener() =>
+          displayName.value = displayNameController.text;
+      void aboutListener() => about.value = aboutController.text;
+      displayNameController.addListener(displayNameListener);
+      aboutController.addListener(aboutListener);
+      return () {
+        displayNameController.removeListener(displayNameListener);
+        aboutController.removeListener(aboutListener);
+      };
+    }, [displayNameController, aboutController]);
+
+    final nextDisplayName = displayName.value.trim();
+    final hasChanges =
+        nextDisplayName != (currentProfile?.displayName ?? '') ||
+        avatarUrl.value.trim() != (currentProfile?.avatarUrl ?? '') ||
+        about.value.trim() != (currentProfile?.about ?? '');
+    final canSave =
+        nextDisplayName.isNotEmpty &&
+        hasChanges &&
+        !isUploading.value &&
+        !isSaving.value;
+
+    Future<void> chooseAvatar() async {
+      if (isUploading.value || isSaving.value) return;
+      isUploading.value = true;
+      errorMessage.value = null;
+      try {
+        final url = await ref.read(profileAvatarPickerProvider)();
+        if (url != null) avatarUrl.value = url;
+      } catch (_) {
+        errorMessage.value = 'Couldn\u2019t upload that photo. Try again.';
+      } finally {
+        isUploading.value = false;
+      }
+    }
+
+    Future<void> save() async {
+      if (!canSave) return;
+      isSaving.value = true;
+      errorMessage.value = null;
+      try {
+        await ref
+            .read(profileProvider.notifier)
+            .updateProfile(
+              displayName: nextDisplayName,
+              avatarUrl: avatarUrl.value,
+              about: about.value,
+            );
+        if (!context.mounted) return;
+        final messenger = ScaffoldMessenger.of(context);
+        Navigator.of(context).pop();
+        messenger.showSnackBar(const SnackBar(content: Text('Profile saved')));
+      } catch (_) {
+        errorMessage.value = 'Couldn\u2019t save your profile. Try again.';
+      } finally {
+        isSaving.value = false;
+      }
+    }
+
+    final avatarFallback = nextDisplayName.isNotEmpty
+        ? nextDisplayName.characters.first.toUpperCase()
+        : '?';
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        Grid.gutter,
+        0,
+        Grid.gutter,
+        Grid.gutter +
+            math.max(
+              MediaQuery.viewInsetsOf(context).bottom,
+              MediaQuery.viewPaddingOf(context).bottom,
+            ),
+      ),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Edit profile', style: context.textTheme.titleMedium),
+            const SizedBox(height: Grid.twelve),
+            Center(
+              child: Column(
+                children: [
+                  ClipOval(
+                    child: SizedBox.square(
+                      dimension: 96,
+                      child: ColoredBox(
+                        color: context.colors.primaryContainer,
+                        child: AvatarImageContent(
+                          imageUrl: avatarUrl.value,
+                          fallback: Center(
+                            child: Text(
+                              avatarFallback,
+                              style: context.textTheme.displaySmall?.copyWith(
+                                color: context.colors.onPrimaryContainer,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: Grid.half),
+                  Wrap(
+                    alignment: WrapAlignment.center,
+                    spacing: Grid.xxs,
+                    children: [
+                      TextButton.icon(
+                        onPressed: isUploading.value ? null : chooseAvatar,
+                        icon: isUploading.value
+                            ? const SizedBox.square(
+                                dimension: 16,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Icon(LucideIcons.imagePlus, size: 18),
+                        label: Text(
+                          isUploading.value
+                              ? 'Uploading\u2026'
+                              : 'Choose photo',
+                        ),
+                      ),
+                      if (avatarUrl.value.isNotEmpty)
+                        TextButton(
+                          onPressed: isUploading.value || isSaving.value
+                              ? null
+                              : () => avatarUrl.value = '',
+                          child: const Text('Remove'),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: Grid.xs),
+            TextField(
+              controller: displayNameController,
+              autofocus: true,
+              decoration: const InputDecoration(
+                labelText: 'Display name',
+                hintText: 'How others see you',
+              ),
+              maxLength: 80,
+              textInputAction: TextInputAction.next,
+            ),
+            const SizedBox(height: Grid.xxs),
+            TextField(
+              controller: aboutController,
+              decoration: const InputDecoration(
+                labelText: 'Bio',
+                hintText: 'A little about you',
+                alignLabelWithHint: true,
+              ),
+              minLines: 3,
+              maxLines: 5,
+              maxLength: 500,
+              textCapitalization: TextCapitalization.sentences,
+            ),
+            if (errorMessage.value case final message?)
+              Padding(
+                padding: const EdgeInsets.only(bottom: Grid.xs),
+                child: Text(
+                  message,
+                  style: context.textTheme.bodySmall?.copyWith(
+                    color: context.colors.error,
+                  ),
+                ),
+              ),
+            SizedBox(
+              width: double.infinity,
+              height: 52,
+              child: FilledButton(
+                onPressed: canSave ? save : null,
+                child: isSaving.value
+                    ? const SizedBox.square(
+                        dimension: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Save'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/profile/profile_provider.dart
+++ b/mobile/lib/features/profile/profile_provider.dart
@@ -1,10 +1,52 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../shared/relay/relay.dart';
+import 'user_cache_provider.dart';
 import 'user_profile.dart';
+
+Map<String, dynamic> mergeProfileMetadata(
+  String? currentContent, {
+  required String displayName,
+  required String avatarUrl,
+  required String about,
+}) {
+  final trimmedDisplayName = displayName.trim();
+  if (trimmedDisplayName.isEmpty) {
+    throw ArgumentError.value(displayName, 'displayName', 'must not be empty');
+  }
+
+  final metadata = <String, dynamic>{};
+  if (currentContent != null) {
+    try {
+      final decoded = jsonDecode(currentContent);
+      if (decoded is Map<String, dynamic>) metadata.addAll(decoded);
+    } catch (_) {
+      // Replace malformed metadata with a valid profile snapshot.
+    }
+  }
+
+  metadata['display_name'] = trimmedDisplayName;
+  _setOptionalProfileField(metadata, 'picture', avatarUrl);
+  _setOptionalProfileField(metadata, 'about', about);
+  return metadata;
+}
+
+void _setOptionalProfileField(
+  Map<String, dynamic> metadata,
+  String key,
+  String value,
+) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty) {
+    metadata.remove(key);
+  } else {
+    metadata[key] = trimmed;
+  }
+}
 
 /// The current user's profile (kind:0 metadata) loaded over the relay
 /// WebSocket. Returns null when no nsec is configured or when the user has
@@ -36,6 +78,69 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
 
   Future<void> refresh() async {
     state = await AsyncValue.guard(_fetch);
+  }
+
+  Future<UserProfile> updateProfile({
+    required String displayName,
+    required String avatarUrl,
+    required String about,
+  }) async {
+    final config = ref.read(relayConfigProvider);
+    final myPk = pubkeyFromNsec(config.nsec);
+    if (myPk == null) {
+      throw StateError('Cannot update profile without an active identity');
+    }
+
+    final session = ref.read(relaySessionProvider.notifier);
+    final events = await session.fetchHistory(NostrFilters.profile(myPk));
+    final currentEvent = events.isEmpty ? null : events.first;
+    final metadata = mergeProfileMetadata(
+      currentEvent?.content,
+      displayName: displayName,
+      avatarUrl: avatarUrl,
+      about: about,
+    );
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    final createdAt = currentEvent != null && currentEvent.createdAt >= now
+        ? currentEvent.createdAt + 1
+        : now;
+    if (!_isSameRelayIdentity(config)) {
+      throw StateError('Active identity changed while editing the profile');
+    }
+    final relay = SignedEventRelay(session: session, nsec: config.nsec);
+    NostrEvent? signedEvent;
+
+    await relay.submit(
+      kind: EventKind.metadata,
+      content: jsonEncode(metadata),
+      tags: currentEvent?.tags ?? const [],
+      createdAt: createdAt,
+      onSigned: (event) => signedEvent = event,
+    );
+
+    final event = signedEvent;
+    if (event == null) {
+      throw StateError('Profile event was not signed');
+    }
+    final data = ProfileData.fromEvent(event);
+    final updated = UserProfile(
+      pubkey: data.pubkey,
+      displayName: data.displayName,
+      avatarUrl: data.avatarUrl,
+      about: data.about,
+      nip05Handle: data.nip05,
+      ownerPubkey: state.value?.ownerPubkey,
+    );
+    if (_isSameRelayIdentity(config)) {
+      state = AsyncData(updated);
+      ref.read(userCacheProvider.notifier).put(updated);
+    }
+    return updated;
+  }
+
+  bool _isSameRelayIdentity(RelayConfig expected) {
+    final active = ref.read(relayConfigProvider);
+    return active.nsec == expected.nsec && active.baseUrl == expected.baseUrl;
   }
 }
 

--- a/mobile/lib/features/profile/profile_provider.dart
+++ b/mobile/lib/features/profile/profile_provider.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../shared/crypto/nip_oa.dart';
 import '../../shared/relay/relay.dart';
 import 'user_cache_provider.dart';
 import 'user_profile.dart';
@@ -66,14 +67,7 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
     final session = ref.read(relaySessionProvider.notifier);
     final events = await session.fetchHistory(NostrFilters.profile(myPk));
     if (events.isEmpty) return null;
-    final data = ProfileData.fromEvent(events.first);
-    return UserProfile(
-      pubkey: data.pubkey,
-      displayName: data.displayName,
-      avatarUrl: data.avatarUrl,
-      about: data.about,
-      nip05Handle: data.nip05,
-    );
+    return _profileFromEvent(_latestProfileEvent(events));
   }
 
   Future<void> refresh() async {
@@ -93,7 +87,7 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
 
     final session = ref.read(relaySessionProvider.notifier);
     final events = await session.fetchHistory(NostrFilters.profile(myPk));
-    final currentEvent = events.isEmpty ? null : events.first;
+    final currentEvent = events.isEmpty ? null : _latestProfileEvent(events);
     final metadata = mergeProfileMetadata(
       currentEvent?.content,
       displayName: displayName,
@@ -122,15 +116,7 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
     if (event == null) {
       throw StateError('Profile event was not signed');
     }
-    final data = ProfileData.fromEvent(event);
-    final updated = UserProfile(
-      pubkey: data.pubkey,
-      displayName: data.displayName,
-      avatarUrl: data.avatarUrl,
-      about: data.about,
-      nip05Handle: data.nip05,
-      ownerPubkey: state.value?.ownerPubkey,
-    );
+    final updated = _profileFromEvent(event);
     if (_isSameRelayIdentity(config)) {
       state = AsyncData(updated);
       ref.read(userCacheProvider.notifier).put(updated);
@@ -147,6 +133,26 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
 final profileProvider = AsyncNotifierProvider<ProfileNotifier, UserProfile?>(
   ProfileNotifier.new,
 );
+
+NostrEvent _latestProfileEvent(List<NostrEvent> events) =>
+    events.reduce((a, b) {
+      if (a.createdAt != b.createdAt) {
+        return a.createdAt > b.createdAt ? a : b;
+      }
+      return a.id.compareTo(b.id) <= 0 ? a : b;
+    });
+
+UserProfile _profileFromEvent(NostrEvent event) {
+  final data = ProfileData.fromEvent(event);
+  return UserProfile(
+    pubkey: data.pubkey,
+    displayName: data.displayName,
+    avatarUrl: data.avatarUrl,
+    about: data.about,
+    nip05Handle: data.nip05,
+    ownerPubkey: verifiedOaOwnerPubkey(event.tags, event.pubkey),
+  );
+}
 
 /// Presence status for the current user.
 ///

--- a/mobile/lib/features/profile/settings_profile_header.dart
+++ b/mobile/lib/features/profile/settings_profile_header.dart
@@ -7,6 +7,7 @@ import '../../shared/custom_emoji/custom_emoji_render.dart';
 import '../../shared/theme/theme.dart';
 import '../../shared/widgets/avatar_image.dart';
 import '../../shared/widgets/masked_avatar_badge.dart';
+import 'edit_profile_sheet.dart';
 import 'profile_provider.dart';
 import 'set_status_sheet.dart';
 import 'user_status_provider.dart';
@@ -58,6 +59,13 @@ class SettingsProfileHeader extends ConsumerWidget {
             profile?.label ?? 'Your profile',
             style: context.textTheme.titleMedium,
             textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: Grid.quarter),
+          TextButton.icon(
+            onPressed: () =>
+                showEditProfileSheet(context, currentProfile: profile),
+            icon: const Icon(LucideIcons.pencil, size: 16),
+            label: const Text('Edit profile'),
           ),
           // No placeholder copy — the badge is the affordance, so this line
           // appears only once there is an actual status to show.

--- a/mobile/lib/features/profile/user_cache_provider.dart
+++ b/mobile/lib/features/profile/user_cache_provider.dart
@@ -33,6 +33,10 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
     return null;
   }
 
+  void put(UserProfile profile) {
+    state = {...state, profile.pubkey.toLowerCase(): profile};
+  }
+
   /// Preload profiles for a list of pubkeys (e.g. channel members).
   void preload(List<String> pubkeys) {
     final uncached = pubkeys

--- a/mobile/lib/shared/relay/media_upload.dart
+++ b/mobile/lib/shared/relay/media_upload.dart
@@ -242,6 +242,19 @@ class MediaUploadService {
     );
   }
 
+  /// Converts a bounded profile image to JPEG before upload.
+  ///
+  /// Avatar callers should resize at selection time. Re-encoding here keeps
+  /// PNG and device-specific gallery formats from producing oversized uploads.
+  Future<BlobDescriptor> uploadProfileImage(XFile image) async {
+    final bytes = await image.readAsBytes();
+    final jpegBytes = await _transcodeImageToJpeg(bytes);
+    if (jpegBytes.isEmpty) {
+      throw Exception('failed to convert profile image for upload');
+    }
+    return _uploadPreparedBytes(jpegBytes, mimeType: 'image/jpeg');
+  }
+
   Future<bool> clipboardHasImage() async {
     return await _mediaUploadPlatformChannel.invokeMethod<bool>(
           _clipboardHasImageMethod,

--- a/mobile/lib/shared/relay/nostr_models.dart
+++ b/mobile/lib/shared/relay/nostr_models.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 ///
 /// Keep in sync with `desktop/src/shared/constants/kinds.ts`.
 abstract final class EventKind {
+  static const metadata = 0;
   static const note = 1;
   static const contactList = 3;
   static const deletion = 5;

--- a/mobile/lib/shared/widgets/avatar_image.dart
+++ b/mobile/lib/shared/widgets/avatar_image.dart
@@ -6,6 +6,47 @@ import 'package:flutter_svg/flutter_svg.dart';
 
 import '../relay/relay.dart';
 
+const emojiAvatarDataUrlPrefix = 'data:image/svg+xml,';
+
+@immutable
+class EmojiAvatarDescriptor {
+  final String emoji;
+  final String color;
+
+  const EmojiAvatarDescriptor({required this.emoji, required this.color});
+}
+
+/// Build the same self-contained emoji avatar format used by Desktop.
+String emojiAvatarDataUrl(String emoji, String color) {
+  if (!RegExp(r'^#[0-9a-fA-F]{6}$').hasMatch(color)) {
+    throw ArgumentError.value(color, 'color', 'must be a six-digit hex color');
+  }
+  final escaped = emoji
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
+  final svg =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" '
+      'viewBox="0 0 512 512"><rect width="512" height="512" rx="256" '
+      'fill="$color"/><text x="50%" y="56%" dominant-baseline="middle" '
+      'text-anchor="middle" font-size="258">$escaped</text></svg>';
+  return '$emojiAvatarDataUrlPrefix${Uri.encodeComponent(svg)}';
+}
+
+/// Parse emoji avatars produced by Mobile or Desktop.
+EmojiAvatarDescriptor? parseEmojiAvatarDataUrl(String? value) {
+  final url = value?.trim();
+  if (url == null || !url.startsWith(emojiAvatarDataUrlPrefix)) return null;
+
+  try {
+    final data = UriData.parse(url);
+    if (data.mimeType != 'image/svg+xml') return null;
+    return _parseEmojiAvatar(utf8.decode(data.contentAsBytes()));
+  } on FormatException {
+    return null;
+  }
+}
+
 /// A circular avatar that supports both remote URLs and inline image data.
 ///
 /// Flutter's [NetworkImage] only loads network URLs, while desktop browsers also
@@ -122,7 +163,14 @@ sealed class _AvatarSource {
       if (data.mimeType == 'image/svg+xml') {
         final Uint8List bytes = data.contentAsBytes();
         final svg = utf8.decode(bytes);
-        return _parseEmojiAvatar(svg) ?? _SvgAvatarSource(svg);
+        final emojiAvatar = _parseEmojiAvatar(svg);
+        if (emojiAvatar != null) {
+          return _EmojiAvatarSource(
+            emojiAvatar.emoji,
+            _parseHexColor(emojiAvatar.color)!,
+          );
+        }
+        return _SvgAvatarSource(svg);
       }
       return _RasterDataAvatarSource(data.contentAsBytes());
     } on FormatException {
@@ -131,12 +179,14 @@ sealed class _AvatarSource {
   }
 }
 
-_EmojiAvatarSource? _parseEmojiAvatar(String svg) {
+EmojiAvatarDescriptor? _parseEmojiAvatar(String svg) {
   final colorValue = RegExp(
     r'<rect\b[^>]*\sfill="([^"]+)"',
   ).firstMatch(svg)?[1];
   final emojiValue = RegExp(r'<text\b[^>]*>(.*?)</text>').firstMatch(svg)?[1];
-  if (colorValue == null || emojiValue == null) return null;
+  if (colorValue == null || emojiValue == null || emojiValue.isEmpty) {
+    return null;
+  }
 
   final color = _parseHexColor(colorValue);
   if (color == null) return null;
@@ -144,7 +194,7 @@ _EmojiAvatarSource? _parseEmojiAvatar(String svg) {
       .replaceAll('&gt;', '>')
       .replaceAll('&lt;', '<')
       .replaceAll('&amp;', '&');
-  return _EmojiAvatarSource(emoji, color);
+  return EmojiAvatarDescriptor(emoji: emoji, color: colorValue);
 }
 
 Color? _parseHexColor(String value) {

--- a/mobile/test/features/channels/emoji_picker_test.dart
+++ b/mobile/test/features/channels/emoji_picker_test.dart
@@ -106,6 +106,7 @@ Future<List<String>> _pumpPicker(
   required SharedPreferences prefs,
   List<CustomEmoji> customEmoji = _customEmoji,
   EmojiDataset? dataset,
+  bool includeCustomEmoji = true,
 }) async {
   final selected = <String>[];
   await tester.pumpWidget(
@@ -116,7 +117,10 @@ Future<List<String>> _pumpPicker(
         emojiDatasetOrEmptyProvider.overrideWithValue(dataset ?? _dataset),
         customEmojiListProvider.overrideWithValue(customEmoji),
       ],
-      child: EmojiPickerSheet(onSelect: selected.add),
+      child: EmojiPickerSheet(
+        includeCustomEmoji: includeCustomEmoji,
+        onSelect: selected.add,
+      ),
     ),
   );
   await tester.pumpAndSettle();
@@ -227,6 +231,23 @@ void main() {
         find.byKey(const ValueKey('emoji-tile-custom-partyparrot')),
         findsOneWidget,
       );
+    });
+
+    testWidgets('callers can limit selection to standard emoji', (
+      tester,
+    ) async {
+      await _pumpPicker(
+        tester,
+        prefs: await _prefs(),
+        includeCustomEmoji: false,
+      );
+
+      expect(find.byTooltip('Custom'), findsNothing);
+      expect(
+        find.byKey(const ValueKey('emoji-tile-custom-partyparrot')),
+        findsNothing,
+      );
+      expect(find.byKey(const ValueKey('emoji-tile-grinning')), findsOneWidget);
     });
 
     testWidgets('custom emoji sit in the same cell as native glyphs', (

--- a/mobile/test/features/profile/edit_profile_sheet_test.dart
+++ b/mobile/test/features/profile/edit_profile_sheet_test.dart
@@ -6,11 +6,18 @@ import 'package:buzz/features/profile/settings_profile_header.dart';
 import 'package:buzz/features/profile/user_profile.dart';
 import 'package:buzz/features/profile/user_status.dart';
 import 'package:buzz/features/profile/user_status_provider.dart';
+import 'package:buzz/shared/custom_emoji/custom_emoji.dart';
+import 'package:buzz/shared/custom_emoji/custom_emoji_provider.dart';
+import 'package:buzz/shared/emoji/emoji_data.dart';
+import 'package:buzz/shared/emoji/emoji_data_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
+import 'package:buzz/shared/theme/theme_provider.dart';
+import 'package:buzz/shared/widgets/avatar_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../helpers/widget_helpers.dart';
 
@@ -121,6 +128,149 @@ void main() {
     expect(find.text('Couldn\u2019t save your profile. Try again.'), findsOne);
     expect(find.text('Profile saved'), findsNothing);
   });
+
+  testWidgets('selects a standard emoji and saves it with the profile', (
+    tester,
+  ) async {
+    final profileNotifier = _RecordingProfileNotifier();
+    await _pumpProfileHeader(tester, profileNotifier: profileNotifier);
+
+    await tester.tap(find.text('Edit profile'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.widgetWithText(TextField, 'How others see you'),
+      'Emoji Alice',
+    );
+    await tester.tap(find.text('Use emoji'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('emoji-tile-custom-partyparrot')),
+      findsNothing,
+    );
+    await tester.tap(find.byKey(const ValueKey('emoji-tile-bee')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('avatar-color-#E66A6A')));
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final avatar = parseEmojiAvatarDataUrl(profileNotifier.savedAvatarUrl);
+    expect(avatar?.emoji, '🐝');
+    expect(avatar?.color, '#E66A6A');
+  });
+
+  testWidgets('restores an existing emoji and can replace it with a photo', (
+    tester,
+  ) async {
+    final profileNotifier = _RecordingProfileNotifier(
+      currentProfile: UserProfile(
+        pubkey: 'aabb',
+        displayName: 'Emoji Alice',
+        avatarUrl: emojiAvatarDataUrl('🦊', '#5B8DEF'),
+        about: 'Existing bio',
+      ),
+    );
+    await _pumpProfileHeader(
+      tester,
+      profileNotifier: profileNotifier,
+      pickedPhotoUrl: 'https://example.com/replacement.jpg',
+    );
+
+    await tester.tap(find.text('Edit profile'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('🦊'), findsWidgets);
+    expect(find.bySemanticsLabel('Emoji avatar color'), findsOneWidget);
+    await tester.tap(find.text('Choose photo'));
+    await tester.pumpAndSettle();
+    expect(find.bySemanticsLabel('Emoji avatar color'), findsNothing);
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(
+      profileNotifier.savedAvatarUrl,
+      'https://example.com/replacement.jpg',
+    );
+    expect(profileNotifier.savedAbout, 'Existing bio');
+  });
+
+  testWidgets('removes a restored emoji avatar', (tester) async {
+    final profileNotifier = _RecordingProfileNotifier(
+      currentProfile: UserProfile(
+        pubkey: 'aabb',
+        displayName: 'Emoji Alice',
+        avatarUrl: emojiAvatarDataUrl('🦊', '#5B8DEF'),
+      ),
+    );
+    await _pumpProfileHeader(tester, profileNotifier: profileNotifier);
+
+    await tester.tap(find.text('Edit profile'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Remove'));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Emoji avatar color'), findsNothing);
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+    expect(profileNotifier.savedAvatarUrl, isEmpty);
+  });
+}
+
+final _emojiDataset = EmojiDataset(
+  categories: const [
+    EmojiCategory(
+      id: 'people',
+      emoji: [
+        EmojiEntry(
+          id: 'bee',
+          name: 'Bee',
+          keywords: ['insect'],
+          native: '🐝',
+          categoryId: 'people',
+        ),
+      ],
+    ),
+  ],
+  all: const [
+    EmojiEntry(
+      id: 'bee',
+      name: 'Bee',
+      keywords: ['insect'],
+      native: '🐝',
+      categoryId: 'people',
+    ),
+  ],
+  nativeToShortcode: const {'🐝': ':bee:'},
+);
+
+Future<void> _pumpProfileHeader(
+  WidgetTester tester, {
+  required _RecordingProfileNotifier profileNotifier,
+  String? pickedPhotoUrl,
+}) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  await tester.pumpWidget(
+    WidgetHelpers.testable(
+      overrides: [
+        profileProvider.overrideWith(() => profileNotifier),
+        userStatusProvider.overrideWith(_EmptyStatusNotifier.new),
+        profileAvatarPickerProvider.overrideWithValue(
+          () async => pickedPhotoUrl,
+        ),
+        savedPrefsProvider.overrideWithValue(prefs),
+        emojiDatasetOrEmptyProvider.overrideWithValue(_emojiDataset),
+        customEmojiListProvider.overrideWithValue(const [
+          CustomEmoji(
+            shortcode: 'partyparrot',
+            url: 'https://example.test/parrot.gif',
+          ),
+        ]),
+      ],
+      child: const SettingsProfileHeader(),
+    ),
+  );
+  await tester.pumpAndSettle();
 }
 
 class _RecordingMediaUploadService extends MediaUploadService {
@@ -148,16 +298,17 @@ class _RecordingMediaUploadService extends MediaUploadService {
 }
 
 class _RecordingProfileNotifier extends ProfileNotifier {
-  _RecordingProfileNotifier({this.shouldFail = false});
+  _RecordingProfileNotifier({this.shouldFail = false, this.currentProfile});
 
   final bool shouldFail;
+  final UserProfile? currentProfile;
   String? savedDisplayName;
   String? savedAvatarUrl;
   String? savedAbout;
   int updateCalls = 0;
 
   @override
-  Future<UserProfile?> build() async => null;
+  Future<UserProfile?> build() async => currentProfile;
 
   @override
   Future<UserProfile> updateProfile({

--- a/mobile/test/features/profile/edit_profile_sheet_test.dart
+++ b/mobile/test/features/profile/edit_profile_sheet_test.dart
@@ -1,15 +1,54 @@
+import 'dart:typed_data';
+
 import 'package:buzz/features/profile/edit_profile_sheet.dart';
 import 'package:buzz/features/profile/profile_provider.dart';
 import 'package:buzz/features/profile/settings_profile_header.dart';
 import 'package:buzz/features/profile/user_profile.dart';
 import 'package:buzz/features/profile/user_status.dart';
 import 'package:buzz/features/profile/user_status_provider.dart';
+import 'package:buzz/shared/relay/relay.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
 
 import '../../helpers/widget_helpers.dart';
 
 void main() {
+  test('profile avatar selection is bounded before JPEG upload', () async {
+    double? capturedMaxWidth;
+    double? capturedMaxHeight;
+    int? capturedImageQuality;
+    final uploadService = _RecordingMediaUploadService();
+    final container = ProviderContainer(
+      overrides: [
+        profileAvatarImagePickerProvider.overrideWithValue(({
+          required maxWidth,
+          required maxHeight,
+          required imageQuality,
+        }) async {
+          capturedMaxWidth = maxWidth;
+          capturedMaxHeight = maxHeight;
+          capturedImageQuality = imageQuality;
+          return XFile.fromData(
+            Uint8List.fromList([1, 2, 3]),
+            name: 'avatar.png',
+          );
+        }),
+        mediaUploadServiceProvider.overrideWithValue(uploadService),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final url = await container.read(profileAvatarPickerProvider)();
+
+    expect(capturedMaxWidth, 512);
+    expect(capturedMaxHeight, 512);
+    expect(capturedImageQuality, 85);
+    expect(await uploadService.uploadedImage?.readAsBytes(), [1, 2, 3]);
+    expect(url, 'https://example.com/avatar.jpg');
+  });
+
   testWidgets('profile-less identity saves name, uploaded avatar, and bio', (
     tester,
   ) async {
@@ -82,6 +121,30 @@ void main() {
     expect(find.text('Couldn\u2019t save your profile. Try again.'), findsOne);
     expect(find.text('Profile saved'), findsNothing);
   });
+}
+
+class _RecordingMediaUploadService extends MediaUploadService {
+  _RecordingMediaUploadService()
+    : super(
+        baseUrl: 'https://relay.example',
+        nsec: null,
+        pickGalleryImage: () async => null,
+        pickGalleryVideo: () async => null,
+      );
+
+  XFile? uploadedImage;
+
+  @override
+  Future<BlobDescriptor> uploadProfileImage(XFile image) async {
+    uploadedImage = image;
+    return const BlobDescriptor(
+      url: 'https://example.com/avatar.jpg',
+      sha256: 'sha256',
+      size: 3,
+      type: 'image/jpeg',
+      uploaded: 1,
+    );
+  }
 }
 
 class _RecordingProfileNotifier extends ProfileNotifier {

--- a/mobile/test/features/profile/edit_profile_sheet_test.dart
+++ b/mobile/test/features/profile/edit_profile_sheet_test.dart
@@ -1,0 +1,122 @@
+import 'package:buzz/features/profile/edit_profile_sheet.dart';
+import 'package:buzz/features/profile/profile_provider.dart';
+import 'package:buzz/features/profile/settings_profile_header.dart';
+import 'package:buzz/features/profile/user_profile.dart';
+import 'package:buzz/features/profile/user_status.dart';
+import 'package:buzz/features/profile/user_status_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../helpers/widget_helpers.dart';
+
+void main() {
+  testWidgets('profile-less identity saves name, uploaded avatar, and bio', (
+    tester,
+  ) async {
+    final profileNotifier = _RecordingProfileNotifier();
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: [
+          profileProvider.overrideWith(() => profileNotifier),
+          userStatusProvider.overrideWith(_EmptyStatusNotifier.new),
+          profileAvatarPickerProvider.overrideWithValue(
+            () async => 'https://example.com/avatar.png',
+          ),
+        ],
+        child: const SettingsProfileHeader(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Your profile'), findsOneWidget);
+    await tester.tap(find.text('Edit profile'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.widgetWithText(TextField, 'How others see you'),
+      'Android Alice',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextField, 'A little about you'),
+      'Testing mobile Buzz',
+    );
+    await tester.tap(find.text('Choose photo'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(profileNotifier.savedDisplayName, 'Android Alice');
+    expect(profileNotifier.savedAvatarUrl, 'https://example.com/avatar.png');
+    expect(profileNotifier.savedAbout, 'Testing mobile Buzz');
+    expect(find.text('Edit profile'), findsOneWidget);
+    expect(find.text('Profile saved'), findsOneWidget);
+  });
+
+  testWidgets('failed save stays open and shows stable error copy', (
+    tester,
+  ) async {
+    final profileNotifier = _RecordingProfileNotifier(shouldFail: true);
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: [
+          profileProvider.overrideWith(() => profileNotifier),
+          userStatusProvider.overrideWith(_EmptyStatusNotifier.new),
+        ],
+        child: const SettingsProfileHeader(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Edit profile'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.widgetWithText(TextField, 'How others see you'),
+      'Unsaved',
+    );
+    await tester.pump();
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(profileNotifier.updateCalls, 1);
+    expect(find.text('Edit profile'), findsWidgets);
+    expect(find.text('Couldn\u2019t save your profile. Try again.'), findsOne);
+    expect(find.text('Profile saved'), findsNothing);
+  });
+}
+
+class _RecordingProfileNotifier extends ProfileNotifier {
+  _RecordingProfileNotifier({this.shouldFail = false});
+
+  final bool shouldFail;
+  String? savedDisplayName;
+  String? savedAvatarUrl;
+  String? savedAbout;
+  int updateCalls = 0;
+
+  @override
+  Future<UserProfile?> build() async => null;
+
+  @override
+  Future<UserProfile> updateProfile({
+    required String displayName,
+    required String avatarUrl,
+    required String about,
+  }) async {
+    updateCalls += 1;
+    if (shouldFail) throw Exception('raw relay failure');
+    savedDisplayName = displayName;
+    savedAvatarUrl = avatarUrl;
+    savedAbout = about;
+    return UserProfile(
+      pubkey: 'aabb',
+      displayName: displayName,
+      avatarUrl: avatarUrl,
+      about: about,
+    );
+  }
+}
+
+class _EmptyStatusNotifier extends UserStatusNotifier {
+  @override
+  Future<UserStatus?> build() async => null;
+}

--- a/mobile/test/features/profile/profile_provider_test.dart
+++ b/mobile/test/features/profile/profile_provider_test.dart
@@ -1,0 +1,260 @@
+import 'dart:convert';
+
+import 'package:buzz/features/profile/profile_provider.dart';
+import 'package:buzz/features/profile/user_profile.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+void main() {
+  group('mergeProfileMetadata', () {
+    test('preserves unexposed and unknown fields', () {
+      final merged = mergeProfileMetadata(
+        jsonEncode({
+          'name': 'legacy-name',
+          'display_name': 'Old',
+          'picture': 'https://old.example/avatar.png',
+          'about': 'Old bio',
+          'nip05': 'alice@example.com',
+          'custom': {'theme': 'bee'},
+        }),
+        displayName: '  Alice  ',
+        avatarUrl: ' https://new.example/avatar.png ',
+        about: ' Updated bio ',
+      );
+
+      expect(merged['display_name'], 'Alice');
+      expect(merged['picture'], 'https://new.example/avatar.png');
+      expect(merged['about'], 'Updated bio');
+      expect(merged['name'], 'legacy-name');
+      expect(merged['nip05'], 'alice@example.com');
+      expect(merged['custom'], {'theme': 'bee'});
+    });
+
+    test('blank optional values remove only those fields', () {
+      final merged = mergeProfileMetadata(
+        '{"display_name":"Old","picture":"old","about":"old","nip05":"kept"}',
+        displayName: 'New',
+        avatarUrl: ' ',
+        about: '',
+      );
+
+      expect(merged, {'display_name': 'New', 'nip05': 'kept'});
+    });
+
+    test('rejects an empty display name', () {
+      expect(
+        () => mergeProfileMetadata(
+          null,
+          displayName: ' ',
+          avatarUrl: '',
+          about: '',
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  test(
+    'updateProfile signs, publishes, preserves metadata, and updates state',
+    () async {
+      final keys = nostr.Keys.generate();
+      final prior = _profileEvent(
+        pubkey: keys.public,
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 10,
+        content:
+            '{"name":"legacy","display_name":"Old","nip05":"alice@example.com","custom":true}',
+        tags: const [
+          ['auth', 'owner'],
+        ],
+      );
+      final relaySession = _RecordingRelaySession(prior: prior);
+      final container = ProviderContainer(
+        overrides: [
+          relayConfigProvider.overrideWith(
+            () => _FakeRelayConfigNotifier(keys.nsec),
+          ),
+          relaySessionProvider.overrideWith(() => relaySession),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(await container.read(profileProvider.future), isA<UserProfile>());
+      final updated = await container
+          .read(profileProvider.notifier)
+          .updateProfile(
+            displayName: 'Alice',
+            avatarUrl: 'https://example.com/avatar.png',
+            about: 'Builder',
+          );
+
+      final published = relaySession.published.single;
+      final content = jsonDecode(published.content) as Map<String, dynamic>;
+      expect(published.kind, EventKind.metadata);
+      expect(published.pubkey, keys.public);
+      expect(published.sig, isNotEmpty);
+      expect(published.createdAt, prior.createdAt + 1);
+      expect(published.tags, prior.tags);
+      expect(content['display_name'], 'Alice');
+      expect(content['picture'], 'https://example.com/avatar.png');
+      expect(content['about'], 'Builder');
+      expect(content['name'], 'legacy');
+      expect(content['nip05'], 'alice@example.com');
+      expect(content['custom'], isTrue);
+      expect(updated.displayName, 'Alice');
+      expect(container.read(profileProvider).value?.displayName, 'Alice');
+    },
+  );
+
+  test(
+    'publish failure leaves the previously loaded profile unchanged',
+    () async {
+      final keys = nostr.Keys.generate();
+      final prior = _profileEvent(
+        pubkey: keys.public,
+        createdAt: 1,
+        content: '{"display_name":"Before"}',
+      );
+      final relaySession = _RecordingRelaySession(
+        prior: prior,
+        publishError: Exception('relay rejected'),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          relayConfigProvider.overrideWith(
+            () => _FakeRelayConfigNotifier(keys.nsec),
+          ),
+          relaySessionProvider.overrideWith(() => relaySession),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        (await container.read(profileProvider.future))?.displayName,
+        'Before',
+      );
+      await expectLater(
+        container
+            .read(profileProvider.notifier)
+            .updateProfile(displayName: 'After', avatarUrl: '', about: ''),
+        throwsException,
+      );
+      expect(container.read(profileProvider).value?.displayName, 'Before');
+    },
+  );
+
+  test('identity switch before signing aborts the update', () async {
+    final firstKeys = nostr.Keys.generate();
+    final secondKeys = nostr.Keys.generate();
+    late _FakeRelayConfigNotifier configNotifier;
+    final prior = _profileEvent(
+      pubkey: firstKeys.public,
+      createdAt: 1,
+      content: '{"display_name":"Before"}',
+    );
+    var fetchCount = 0;
+    final relaySession = _RecordingRelaySession(
+      prior: prior,
+      onFetch: () {
+        fetchCount += 1;
+        if (fetchCount == 2) {
+          configNotifier.update(
+            baseUrl: 'https://other-relay.example',
+            nsec: secondKeys.nsec,
+          );
+        }
+      },
+    );
+    final container = ProviderContainer(
+      overrides: [
+        relayConfigProvider.overrideWith(() {
+          configNotifier = _FakeRelayConfigNotifier(firstKeys.nsec);
+          return configNotifier;
+        }),
+        relaySessionProvider.overrideWith(() => relaySession),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      (await container.read(profileProvider.future))?.displayName,
+      'Before',
+    );
+    await expectLater(
+      container
+          .read(profileProvider.notifier)
+          .updateProfile(displayName: 'After', avatarUrl: '', about: ''),
+      throwsStateError,
+    );
+    expect(relaySession.published, isEmpty);
+  });
+}
+
+NostrEvent _profileEvent({
+  required String pubkey,
+  required int createdAt,
+  required String content,
+  List<List<String>> tags = const [],
+}) => NostrEvent(
+  id: 'prior',
+  pubkey: pubkey,
+  createdAt: createdAt,
+  kind: EventKind.metadata,
+  tags: tags,
+  content: content,
+  sig: 'sig',
+);
+
+class _FakeRelayConfigNotifier extends RelayConfigNotifier {
+  _FakeRelayConfigNotifier(this.nsec);
+
+  final String nsec;
+
+  @override
+  RelayConfig build() =>
+      RelayConfig(baseUrl: 'https://relay.example', nsec: nsec);
+}
+
+class _RecordingRelaySession extends RelaySessionNotifier {
+  _RecordingRelaySession({
+    required this.prior,
+    this.publishError,
+    this.onFetch,
+  });
+
+  final NostrEvent prior;
+  final Object? publishError;
+  final void Function()? onFetch;
+  final List<NostrEvent> published = [];
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    onFetch?.call();
+    return [prior];
+  }
+
+  @override
+  Future<NostrEvent> publish(
+    NostrEvent event, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    published.add(event);
+    if (publishError case final error?) throw error;
+    return NostrEvent(
+      id: event.id,
+      pubkey: event.pubkey,
+      createdAt: event.createdAt,
+      kind: event.kind,
+      tags: event.tags,
+      content: 'saved',
+      sig: event.sig,
+    );
+  }
+}

--- a/mobile/test/features/profile/profile_provider_test.dart
+++ b/mobile/test/features/profile/profile_provider_test.dart
@@ -1,11 +1,14 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:buzz/features/profile/profile_provider.dart';
+import 'package:buzz/features/profile/user_cache_provider.dart';
 import 'package:buzz/features/profile/user_profile.dart';
 import 'package:buzz/shared/relay/relay.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
+import 'package:pointycastle/digests/sha256.dart';
 
 void main() {
   group('mergeProfileMetadata', () {
@@ -60,14 +63,13 @@ void main() {
     'updateProfile signs, publishes, preserves metadata, and updates state',
     () async {
       final keys = nostr.Keys.generate();
+      final owner = nostr.Keys.generate();
       final prior = _profileEvent(
         pubkey: keys.public,
         createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 10,
         content:
             '{"name":"legacy","display_name":"Old","nip05":"alice@example.com","custom":true}',
-        tags: const [
-          ['auth', 'owner'],
-        ],
+        tags: [_authTag(owner, keys.public)],
       );
       final relaySession = _RecordingRelaySession(prior: prior);
       final container = ProviderContainer(
@@ -103,9 +105,47 @@ void main() {
       expect(content['nip05'], 'alice@example.com');
       expect(content['custom'], isTrue);
       expect(updated.displayName, 'Alice');
+      expect(updated.ownerPubkey, owner.public);
       expect(container.read(profileProvider).value?.displayName, 'Alice');
+      expect(
+        container.read(userCacheProvider)[keys.public]?.ownerPubkey,
+        owner.public,
+      );
     },
   );
+
+  test('uses the lowest event id when profile timestamps are equal', () async {
+    final keys = nostr.Keys.generate();
+    final lower = _profileEvent(
+      id: 'a',
+      pubkey: keys.public,
+      createdAt: 100,
+      content: '{"display_name":"Canonical"}',
+    );
+    final higher = _profileEvent(
+      id: 'b',
+      pubkey: keys.public,
+      createdAt: 100,
+      content: '{"display_name":"Noncanonical"}',
+    );
+    final relaySession = _RecordingRelaySession(
+      prior: higher,
+      history: [higher, lower],
+    );
+    final container = ProviderContainer(
+      overrides: [
+        relayConfigProvider.overrideWith(
+          () => _FakeRelayConfigNotifier(keys.nsec),
+        ),
+        relaySessionProvider.overrideWith(() => relaySession),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final profile = await container.read(profileProvider.future);
+
+    expect(profile?.displayName, 'Canonical');
+  });
 
   test(
     'publish failure leaves the previously loaded profile unchanged',
@@ -192,12 +232,13 @@ void main() {
 }
 
 NostrEvent _profileEvent({
+  String id = 'prior',
   required String pubkey,
   required int createdAt,
   required String content,
   List<List<String>> tags = const [],
 }) => NostrEvent(
-  id: 'prior',
+  id: id,
   pubkey: pubkey,
   createdAt: createdAt,
   kind: EventKind.metadata,
@@ -205,6 +246,18 @@ NostrEvent _profileEvent({
   content: content,
   sig: 'sig',
 );
+
+List<String> _authTag(nostr.Keys owner, String agentPubkey) {
+  final input = utf8.encode('nostr:agent-auth:$agentPubkey:');
+  final digest = SHA256Digest().process(Uint8List.fromList(input));
+  final message = digest.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  return [
+    'auth',
+    owner.public,
+    '',
+    nostr.Schnorr.sign(secretKey: owner.secret, message: message),
+  ];
+}
 
 class _FakeRelayConfigNotifier extends RelayConfigNotifier {
   _FakeRelayConfigNotifier(this.nsec);
@@ -219,11 +272,13 @@ class _FakeRelayConfigNotifier extends RelayConfigNotifier {
 class _RecordingRelaySession extends RelaySessionNotifier {
   _RecordingRelaySession({
     required this.prior,
+    this.history,
     this.publishError,
     this.onFetch,
   });
 
   final NostrEvent prior;
+  final List<NostrEvent>? history;
   final Object? publishError;
   final void Function()? onFetch;
   final List<NostrEvent> published = [];
@@ -237,7 +292,7 @@ class _RecordingRelaySession extends RelaySessionNotifier {
     Duration timeout = const Duration(seconds: 8),
   }) async {
     onFetch?.call();
-    return [prior];
+    return history ?? [prior];
   }
 
   @override

--- a/mobile/test/shared/relay/media_upload_test.dart
+++ b/mobile/test/shared/relay/media_upload_test.dart
@@ -425,6 +425,45 @@ void main() {
       );
     });
 
+    test('transcodes profile images to JPEG before upload', () async {
+      final transcodedBytes = Uint8List.fromList([0xff, 0xd8, 0xff, 0xd9]);
+      Uint8List? transcodeInput;
+      http.Request? capturedRequest;
+      final service = MediaUploadService(
+        baseUrl: 'https://relay.example',
+        nsec: nostr.Keys.generate().nsec,
+        httpClient: http_testing.MockClient((request) async {
+          capturedRequest = request;
+          return http.Response(
+            jsonEncode({
+              'url': 'https://relay.example/media/avatar.jpg',
+              'sha256': request.headers['X-SHA-256'],
+              'size': request.bodyBytes.length,
+              'type': 'image/jpeg',
+              'uploaded': 1,
+            }),
+            200,
+          );
+        }),
+        pickGalleryVideo: () async => null,
+        pickGalleryImage: () async => null,
+        transcodeImageToJpeg: (bytes) async {
+          transcodeInput = bytes;
+          return transcodedBytes;
+        },
+      );
+      final sourceBytes = Uint8List.fromList([1, 2, 3, 4]);
+
+      final descriptor = await service.uploadProfileImage(
+        XFile.fromData(sourceBytes, name: 'avatar.png'),
+      );
+
+      expect(transcodeInput, sourceBytes);
+      expect(capturedRequest!.headers['Content-Type'], 'image/jpeg');
+      expect(capturedRequest!.bodyBytes, transcodedBytes);
+      expect(descriptor.type, 'image/jpeg');
+    });
+
     test(
       'retries the legacy upload route when the standard route is absent',
       () async {

--- a/mobile/test/shared/widgets/avatar_image_test.dart
+++ b/mobile/test/shared/widgets/avatar_image_test.dart
@@ -18,6 +18,24 @@ void main() {
     ),
   );
 
+  test('builds and parses the Desktop-compatible emoji avatar format', () {
+    final url = emojiAvatarDataUrl('🐝<&', '#F4B942');
+    final svg = utf8.decode(UriData.parse(url).contentAsBytes());
+
+    expect(url, startsWith(emojiAvatarDataUrlPrefix));
+    expect(svg, contains('🐝&lt;&amp;'));
+    expect(parseEmojiAvatarDataUrl(url)?.emoji, '🐝<&');
+    expect(parseEmojiAvatarDataUrl(url)?.color, '#F4B942');
+  });
+
+  test('rejects unsafe colors and unrelated data images', () {
+    expect(
+      () => emojiAvatarDataUrl('🐝', 'red" onload="alert(1)'),
+      throwsArgumentError,
+    );
+    expect(parseEmojiAvatarDataUrl('data:image/png;base64,aGVsbG8='), isNull);
+  });
+
   testWidgets('renders raccoon percent-encoded SVG data avatar', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

Allow the active Mobile identity to create and update its Nostr kind-0 profile
from Settings.

The editor supports display name, avatar, and bio while preserving unexposed
profile fields and event tags. Saves are signed by the active identity,
published to its current community, and reflected locally only after relay
acceptance. If the active identity or relay changes during the edit, the save
aborts instead of publishing with stale configuration.

Profile avatars are selected at a bounded 512 by 512 resolution, converted to
JPEG, and uploaded through the authenticated media path. This avoids reverse
proxy rejection of multi-megabyte device photos without changing the
full-resolution message-attachment path.

### Related issue

N/A. This follows the post-invite profile-less identity gap discovered while
testing #3835 and the ID-search improvement in #3843.

### Testing

- Full repository `just ci`
  - workspace formatting and strict Clippy
  - repository unit suites
  - Desktop checks, full tests, production build, and Tauri checks
  - web checks and production build
  - Mobile analysis and full tests (`1,032 passed`, `1 skipped`)
- Desktop native suite: `2,003 passed`, `14 ignored`
- Desktop mixer diagnostics: `3 passed`
- Regression tests cover:
  - profile-less kind-0 creation and signed publishing;
  - existing JSON field and event-tag preservation;
  - relay rejection without optimistic saved state;
  - identity/relay changes during an edit;
  - bounded avatar selection and JPEG conversion.
- Physical HITL test on a Moto G56 against the VPS community:
  - invite-created identity saved display name and bio;
  - Desktop discovered the identity by its saved name;
  - replacement edits preserved existing profile data;
  - the original failing large photo and a second photo uploaded and persisted;
  - avatar rendered in Desktop and Mobile's home-screen header.
- VPS nginx independently recorded HTTP `200` for both revised avatar uploads;
  the immediately preceding full-resolution request reproduced HTTP `413`.

Buzz originating channel: `c26bd1cd-860c-4f0e-8b8c-54f5ac3a6a56`
