### PR TITLE
fix(desktop): expand ancestors of nested thread replies on panel open (#3799)

### DIFF
--- a/desktop/src/features/channels/lib/threadReplyUnreadCounts.test.mjs
+++ b/desktop/src/features/channels/lib/threadReplyUnreadCounts.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { computeThreadReplyUnreadCounts } from "./threadReplyUnreadCounts.ts";
+import {
+  computeThreadReplyUnreadCounts,
+  unionScopeMessages,
+} from "./threadReplyUnreadCounts.ts";
 
 // Open thread "root":
 //   root(100)
@@ -176,4 +179,56 @@ test("computeThreadReplyUnreadCounts_forcedUnread_relightsReadDescendant", () =>
   });
   assert.equal(counts.get("a"), 1); // a1 forced unread
   assert.equal(counts.has("b"), false); // b subtree still read
+});
+
+// --- block/buzz#3799 (scope-b): depth-2+ replies outside the channel window ---
+
+test("unionScopeMessages dedupes by id and preserves order", () => {
+  const windowMessages = [
+    { id: "a", createdAt: 1, parentId: null },
+    { id: "b", createdAt: 2, parentId: null },
+  ];
+  const extras = [
+    { id: "b", createdAt: 2, parentId: null },
+    { id: "c", createdAt: 3, parentId: null },
+  ];
+  assert.deepEqual(
+    unionScopeMessages(windowMessages, extras).map((m) => m.id),
+    ["a", "b", "c"],
+  );
+  // Empty extras return the input reference unchanged (memo-friendly).
+  assert.equal(unionScopeMessages(windowMessages, []), windowMessages);
+});
+
+test("computeThreadReplyUnreadCounts with scoped union counts a depth-2 reply outside the channel window (#3799)", () => {
+  // Read-line 550: b2(600) is unread but lives ONLY in the open thread's
+  // fetched reply set (threadReplyEvents) — the channel-window projection
+  // never materialized it. The hook must union the scope before computing,
+  // or collapsed b renders badge-less and the reply is invisible (#3799).
+  const windowMessages = fixture().filter((m) => m.id !== "b2");
+  const openThreadExtras = [{ id: "b2", createdAt: 600, parentId: "b1" }];
+  const counts = computeThreadReplyUnreadCounts({
+    timelineMessages: unionScopeMessages(windowMessages, openThreadExtras),
+    subtreeReplyIds: ROOT_SUBTREE,
+    visibleReplyIds: ["a", "b"],
+    expandedReplyIds: new Set(),
+    getReadAt: uniformReadAt(550),
+  });
+  assert.equal(counts.get("b"), 1); // b2
+  assert.equal(counts.has("a"), false); // a1(400) read at 550
+});
+
+test("computeThreadReplyUnreadCounts without the union misses the window-external reply (documents #3799 pre-fix)", () => {
+  // Baseline negative control: feeding only the channel-window projection
+  // yields a zero badge for b even though b2 is unread — exactly the bug
+  // shape. The union above is the fix; this pins the before/after contrast.
+  const windowMessages = fixture().filter((m) => m.id !== "b2");
+  const counts = computeThreadReplyUnreadCounts({
+    timelineMessages: windowMessages,
+    subtreeReplyIds: ROOT_SUBTREE,
+    visibleReplyIds: ["a", "b"],
+    expandedReplyIds: new Set(),
+    getReadAt: uniformReadAt(550),
+  });
+  assert.equal(counts.has("b"), false);
 });

--- a/desktop/src/features/channels/lib/threadReplyUnreadCounts.ts
+++ b/desktop/src/features/channels/lib/threadReplyUnreadCounts.ts
@@ -25,6 +25,29 @@ import type { TimelineMessage } from "@/features/messages/types";
  * @param isForcedUnread Session-local OR-overlay: a reply forced unread this
  *   session counts regardless of its marker (per-message mark-unread).
  */
+/**
+ * Union the channel-window timeline with extra messages (e.g. the open
+ * thread's fetched replies) by id. Needed because fresh depth-2+ replies
+ * materialize in `threadRepliesKey` before the channel-window projection
+ * re-materializes from the event store (block/buzz#3799 scope-b): without
+ * this union the descendant-aware unread subtree walk never sees them and a
+ * collapsed ancestor row renders badge-less.
+ */
+export function unionScopeMessages(
+  timelineMessages: TimelineMessage[],
+  extraMessages: readonly TimelineMessage[],
+): TimelineMessage[] {
+  if (extraMessages.length === 0) {
+    return timelineMessages;
+  }
+  const seen = new Set(timelineMessages.map((message) => message.id));
+  const additions = extraMessages.filter((message) => !seen.has(message.id));
+  if (additions.length === 0) {
+    return timelineMessages;
+  }
+  return [...timelineMessages, ...additions];
+}
+
 export function computeThreadReplyUnreadCounts(params: {
   timelineMessages: TimelineMessage[];
   subtreeReplyIds: Iterable<string>;

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/features/messages/lib/timelineLoadingState";
 import { useFetchOlderMessages } from "@/features/messages/useFetchOlderMessages";
 import { useIndependentThreadPanel } from "@/features/messages/useIndependentThreadPanel";
+import { useThreadPanelInitialExpansion } from "@/features/messages/useThreadPanelInitialExpansion";
 import { useThreadReplies } from "@/features/messages/useThreadReplies";
 import { useChannelTyping } from "@/features/messages/useChannelTyping";
 import type { TimelineMessage } from "@/features/messages/types";
@@ -433,6 +434,23 @@ export function ChannelScreen({
     messages: timelineMessages,
     onSearchHit: handleFindSearchHit,
   });
+  // block/buzz#3799: seed the panel's initial expansion from the ancestors of
+  // any depth-2+ reply so an agent reply anchored to a *non-latest* message
+  // renders on first paint instead of hiding inside a collapsed summary row.
+  useThreadPanelInitialExpansion({
+    activeChannel,
+    threadReplyEvents,
+    openThreadHeadId: effectiveOpenThreadHeadId,
+    setExpandedThreadReplyIds,
+    currentPubkey,
+    currentAvatarUrl: currentProfile?.avatarUrl ?? null,
+    profiles: messageProfiles,
+    members: channelMembers,
+    personaLookup,
+    respondToLookup,
+    relaySelfPubkey,
+    ownerProfiles: messageOwnerProfiles,
+  });
   const threadPanelData = useIndependentThreadPanel({
     activeChannel,
     channelEvents: resolvedMessages,
@@ -471,6 +489,7 @@ export function ChannelScreen({
     threadReplyTargetId,
     expandedThreadReplyIds,
     openThreadMessages: threadPanelData.visibleReplies,
+    activeThreadMessages: threadPanelData.messages,
     getChannelReadAt,
     getMessageReadAt,
     markChannelUnread,

--- a/desktop/src/features/channels/ui/useChannelUnreadState.ts
+++ b/desktop/src/features/channels/ui/useChannelUnreadState.ts
@@ -6,7 +6,10 @@ import {
   buildRepliesByRootId,
   collectReplyDescendantIds,
 } from "@/features/channels/lib/subtreeCreatedAt";
-import { computeThreadReplyUnreadCounts } from "@/features/channels/lib/threadReplyUnreadCounts";
+import {
+  computeThreadReplyUnreadCounts,
+  unionScopeMessages,
+} from "@/features/channels/lib/threadReplyUnreadCounts";
 import { computeThreadBadgeCounts } from "@/features/channels/lib/threadBadgeCounts";
 import {
   useStableArrayShallow,
@@ -34,6 +37,7 @@ type UseChannelUnreadStateOptions = {
   threadReplyTargetId: string | null;
   expandedThreadReplyIds: ReadonlySet<string>;
   openThreadMessages?: MainTimelineEntry[];
+  activeThreadMessages?: TimelineMessage[];
   getChannelReadAt: (channelId: string) => number | null;
   getMessageReadAt: (messageId: string) => number | null;
   markChannelUnread: (channelId: string) => void;
@@ -62,6 +66,7 @@ export function useChannelUnreadState({
   threadReplyTargetId,
   expandedThreadReplyIds,
   openThreadMessages,
+  activeThreadMessages,
   getChannelReadAt,
   getMessageReadAt,
   markChannelUnread,
@@ -140,6 +145,22 @@ export function useChannelUnreadState({
     () => buildDirectReplyIdsByParentId(timelineMessages),
     [timelineMessages],
   );
+  // block/buzz#3799 (scope-b): build one *widened* id-tree over the
+  // channel-window timeline ∪ the open thread's fetched message set, so the
+  // per-row subtree-unread walk reaches a fresh depth-2+ reply that lives
+  // only in `threadRepliesKey` while the channel-window projection lags.
+  // Kept separate from directReplyIdsByParentId because it is consumed only
+  // by threadReplyUnreadCounts; the other memoized readers stay window-scoped.
+  const widenedDirectReplyIdsByParentId = React.useMemo(() => {
+    if (!activeThreadMessages || activeThreadMessages.length === 0) {
+      return directReplyIdsByParentId;
+    }
+    const seen = new Set(timelineMessages.map((m) => m.id));
+    const additions = activeThreadMessages.filter((m) => !seen.has(m.id));
+    if (additions.length === 0) return directReplyIdsByParentId;
+    const unioned = [...timelineMessages, ...additions];
+    return buildDirectReplyIdsByParentId(unioned);
+  }, [activeThreadMessages, directReplyIdsByParentId, timelineMessages]);
   const repliesByRootId = React.useMemo(
     () => buildRepliesByRootId(timelineMessages),
     [timelineMessages],
@@ -152,6 +173,11 @@ export function useChannelUnreadState({
     (messageId: string) =>
       collectReplyDescendantIds(messageId, directReplyIdsByParentId),
     [directReplyIdsByParentId],
+  );
+  const getReplyDescendantIdsForMessageWidened = React.useCallback(
+    (messageId: string) =>
+      collectReplyDescendantIds(messageId, widenedDirectReplyIdsByParentId),
+    [widenedDirectReplyIdsByParentId],
   );
   const createdAtByMessageId = React.useMemo(
     () => buildCreatedAtByMessageId(timelineMessages),
@@ -307,13 +333,22 @@ export function useChannelUnreadState({
   // unread descendant with no separate expanded-subtree gate. readStateVersion
   // is an intentional recompute trigger so the counts re-read after any marker
   // advances.
+  // block/buzz#3799 (scope-b): the scope must be the UNION of the channel
+  // window projection and the open thread's fetched message set — a fresh
+  // depth-2+ reply may live only in `threadRepliesKey` while the window
+  // projection lags, and without it the collapsed ancestor row's badge is 0.
+  const threadUnreadScope = React.useMemo(
+    () => unionScopeMessages(timelineMessages, activeThreadMessages ?? []),
+    [timelineMessages, activeThreadMessages],
+  );
   // biome-ignore lint/correctness/useExhaustiveDependencies: readStateVersion and forcedUnreadVersion are intentional recompute triggers
   const threadReplyUnreadCounts = React.useMemo(
     () =>
       openThreadHeadId
         ? computeThreadReplyUnreadCounts({
-            timelineMessages,
-            subtreeReplyIds: getReplyDescendantIdsForMessage(openThreadHeadId),
+            timelineMessages: threadUnreadScope,
+            subtreeReplyIds:
+              getReplyDescendantIdsForMessageWidened(openThreadHeadId),
             visibleReplyIds: threadMessages.map((entry) => entry.message.id),
             expandedReplyIds: expandedThreadReplyIds,
             getReadAt: getMessageReadAt,
@@ -324,10 +359,10 @@ export function useChannelUnreadState({
     [
       openThreadHeadId,
       threadMessages,
-      timelineMessages,
+      threadUnreadScope,
       getMessageReadAt,
       expandedThreadReplyIds,
-      getReplyDescendantIdsForMessage,
+      getReplyDescendantIdsForMessageWidened,
       currentPubkey,
       isMsgForcedUnread,
       readStateVersion,

--- a/desktop/src/features/messages/lib/threadPanel.test.mjs
+++ b/desktop/src/features/messages/lib/threadPanel.test.mjs
@@ -8,6 +8,7 @@ import {
   buildThreadPanelDataFromIndex,
   buildThreadPanelIndex,
   buildThreadSummaryFromVisibleEntries,
+  computeInitialExpandedReplyIds,
   hasNestedThreadBranches,
   shouldRenderUnreadDivider,
 } from "./threadPanel.ts";
@@ -700,4 +701,212 @@ test("buildMainTimelineEntries merges local knowledge over the relay floor", () 
     entry.summary?.participants.map((participant) => participant.id),
     ["relay", "local"],
   );
+});
+
+// --- block/buzz#3799: missing replies in thread view after non-latest anchor ---
+
+test("computeInitialExpandedReplyIds expands the ancestor chain of a depth-2 reply", () => {
+  // Geometry from block/buzz#3799: A is the thread head; the user's own B is
+  // a depth-1 child; then an agent anchors its reply R to B (depth 2).
+  // Without auto-expansion the panel renders B as a collapsed summary row and
+  // R is invisible — the exact reported bug.
+  const root = message({ id: "a", createdAt: 1 });
+  const b = message({
+    id: "b",
+    createdAt: 2,
+    parentId: "a",
+    rootId: "a",
+    depth: 1,
+    tags: [["e", "a", "", "reply"]],
+  });
+  const r = message({
+    id: "r",
+    createdAt: 3,
+    parentId: "b",
+    rootId: "a",
+    depth: 2,
+    tags: [
+      ["e", "a", "", "root"],
+      ["e", "b", "", "reply"],
+    ],
+  });
+
+  assert.deepEqual(
+    [...computeInitialExpandedReplyIds([root, b, r], "a")].sort(),
+    ["b"],
+  );
+});
+
+test("computeInitialExpandedReplyIds keeps depth-1-only threads collapsed", () => {
+  // No depth-2 reply present → nothing to expand, preserving the LP4
+  // open-at-level contract for ordinary threads.
+  const root = message({ id: "a", createdAt: 1 });
+  const b = message({
+    id: "b",
+    createdAt: 2,
+    parentId: "a",
+    rootId: "a",
+    depth: 1,
+    tags: [["e", "a", "", "reply"]],
+  });
+  const c = message({
+    id: "c",
+    createdAt: 3,
+    parentId: "a",
+    rootId: "a",
+    depth: 1,
+    tags: [["e", "a", "", "reply"]],
+  });
+
+  assert.deepEqual([...computeInitialExpandedReplyIds([root, b, c], "a")], []);
+});
+
+test("computeInitialExpandedReplyIds scoped to unread depth-2 replies expands only their chains", () => {
+  // Two branches: b (has depth-2 reply r1, unread) and d (has depth-2 reply
+  // r2, already read). Because the helper takes no second unread set, the
+  // caller scopes by filtering the message list first (per the helper doc):
+  // only b should be auto-expanded.
+  const root = message({ id: "a", createdAt: 1 });
+  const b = message({
+    id: "b",
+    createdAt: 2,
+    parentId: "a",
+    rootId: "a",
+    depth: 1,
+  });
+  const r1 = message({
+    id: "r1",
+    createdAt: 3,
+    parentId: "b",
+    rootId: "a",
+    depth: 2,
+  });
+  const d = message({
+    id: "d",
+    createdAt: 4,
+    parentId: "a",
+    rootId: "a",
+    depth: 1,
+  });
+  const r2 = message({
+    id: "r2",
+    createdAt: 5,
+    parentId: "d",
+    rootId: "a",
+    depth: 2,
+  });
+  const unreadDepth2Plus = [root, b, r1, d, r2].filter(
+    (m) => m.depth < 2 || m.id === "r1",
+  );
+
+  assert.deepEqual(
+    [...computeInitialExpandedReplyIds(unreadDepth2Plus, "a")].sort(),
+    ["b"],
+  );
+});
+
+test("computeInitialExpandedReplyIds handles a depth-3 reply by pinning every intermediate parent", () => {
+  // Chain a → b (d1) → c (d2) → r (d3): both b and c must be expanded for r
+  // to render. Iterative chains should not stop at the first ancestor.
+  const root = message({ id: "a", createdAt: 1 });
+  const b = message({
+    id: "b",
+    createdAt: 2,
+    parentId: "a",
+    rootId: "a",
+    depth: 1,
+  });
+  const c = message({
+    id: "c",
+    createdAt: 3,
+    parentId: "b",
+    rootId: "a",
+    depth: 2,
+  });
+  const r = message({
+    id: "r",
+    createdAt: 4,
+    parentId: "c",
+    rootId: "a",
+    depth: 3,
+  });
+
+  assert.deepEqual(
+    [...computeInitialExpandedReplyIds([root, b, c, r], "a")].sort(),
+    ["b", "c"],
+  );
+});
+
+test("computeInitialExpandedReplyIds tolerates cycles and missing parents without hanging", () => {
+  // Malformed event graphs (cycle b↔c, or a reply whose parent is absent)
+  // must not hang the panel — the hop bound and the already-pinned early-exit
+  // cap the walk. The head id is never added to the expansion set.
+  const root = message({ id: "a", createdAt: 1 });
+  const b = message({
+    id: "b",
+    createdAt: 2,
+    parentId: "c",
+    rootId: "a",
+    depth: 2,
+  });
+  const c = message({
+    id: "c",
+    createdAt: 3,
+    parentId: "b",
+    rootId: "a",
+    depth: 2,
+  });
+  const orphan = message({
+    id: "r",
+    createdAt: 4,
+    parentId: "missing",
+    rootId: "a",
+    depth: 2,
+  });
+
+  const expanded = computeInitialExpandedReplyIds([root, b, c, orphan], "a");
+  assert.ok(
+    !expanded.has("a"),
+    "thread head must never be in the expansion set",
+  );
+  // Cycle terminates because revisiting an already-pinned ancestor breaks the
+  // walk; the missing parent terminates because messageById lookup fails.
+  assert.ok(expanded.size <= 3);
+});
+
+test("buildThreadPanelData with computed initial expansion surfaces a depth-2 reply under a collapsed depth-1 branch (#3799 regression)", () => {
+  // End-to-end geometry: panel opens with the initial expansion computed
+  // from the present message set. The depth-2 reply R under B must land in
+  // visibleReplies immediately, not require a manual expand click.
+  const root = message({ id: "a", createdAt: 1 });
+  const b = message({
+    id: "b",
+    createdAt: 2,
+    parentId: "a",
+    rootId: "a",
+    depth: 1,
+  });
+  const r = message({
+    id: "r",
+    createdAt: 3,
+    parentId: "b",
+    rootId: "a",
+    depth: 2,
+    tags: [
+      ["e", "a", "", "root"],
+      ["e", "b", "", "reply"],
+    ],
+  });
+  const messages = [root, b, r];
+  const initialExpanded = computeInitialExpandedReplyIds(messages, "a");
+
+  const panel = buildThreadPanelData(messages, "a", "a", initialExpanded);
+
+  assert.deepEqual(
+    panel.visibleReplies.map((entry) => entry.message.id),
+    ["b", "r"],
+  );
+  // B's branch is expanded, so it renders as live rows (summary=null), not
+  // as a collapsed MessageThreadSummaryRow.
+  assert.equal(panel.visibleReplies[0].summary, null);
 });

--- a/desktop/src/features/messages/lib/threadPanel.ts
+++ b/desktop/src/features/messages/lib/threadPanel.ts
@@ -357,6 +357,61 @@ function appendExpandedReplies(params: {
   }
 }
 
+/**
+ * Initial ancestor-expansion set for a freshly opened thread panel.
+ *
+ * The panel starts with `expandedReplyIds = ∅`, so a depth-1 child that has
+ * any descendant renders as a collapsed `MessageThreadSummaryRow` and every
+ * deeper reply under it is omitted from `visibleReplies`. That collapse is
+ * correct for long-standing branches the user has already seen, but it
+ * silently hides depth-2+ replies the user has NOT seen (the classic case:
+ * an agent anchors a reply to a *non-latest* thread message — parent=B,
+ * depth=2 — after the viewer last read the thread; see block/buzz#3799).
+ *
+ * This helper names the minimal set of intermediate ancestors that must
+ * start expanded so depth-2+ replies are visible at open. It does NOT
+ * force-expand every reply (the LP4 open-at-level contract for manual
+ * drilling is preserved); it only un-collapses exactly the intermediate
+ * parents that otherwise would swallow a descendant's first paint. Every
+ * depth-2+ reply present expands its chain. (Callers that want to scope the
+ * seed to a subset — e.g. only currently-unread replies — can filter
+ * `messages` before calling rather than passing a second set here.)
+ */
+export function computeInitialExpandedReplyIds(
+  messages: TimelineMessage[],
+  openThreadHeadId: string,
+): Set<string> {
+  const messageById = new Map(messages.map((message) => [message.id, message]));
+  const expanded = new Set<string>();
+
+  for (const message of messages) {
+    // We only care about replies nested at depth >= 2. A depth-1 child is
+    // always reachable via appendExpandedReplies regardless of expansion
+    // state, so only deeper branches can be hidden by the collapse.
+    if (message.depth < 2) {
+      continue;
+    }
+
+    // Walk ancestors from the reply up to (but not including) the thread
+    // head, adding each intermediate id. Stops on missing parents, on
+    // already-pinned chains, or after a hop bound to keep malformed event
+    // graphs from hanging the panel.
+    let ancestorId = message.parentId;
+    let hops = 0;
+    const maxHops = messages.length + 1;
+    while (ancestorId && ancestorId !== openThreadHeadId && hops < maxHops) {
+      if (expanded.has(ancestorId)) {
+        break;
+      }
+      expanded.add(ancestorId);
+      ancestorId = messageById.get(ancestorId)?.parentId ?? null;
+      hops += 1;
+    }
+  }
+
+  return expanded;
+}
+
 function buildVisibleThreadReplies(params: {
   openThreadHeadId: string;
   directChildrenByParentId: Map<string, TimelineMessage[]>;

--- a/desktop/src/features/messages/useThreadPanelInitialExpansion.ts
+++ b/desktop/src/features/messages/useThreadPanelInitialExpansion.ts
@@ -1,0 +1,119 @@
+import * as React from "react";
+
+import { formatTimelineMessages } from "@/features/messages/lib/formatTimelineMessages";
+import { computeInitialExpandedReplyIds } from "@/features/messages/lib/threadPanel";
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import type {
+  Channel,
+  ChannelMember,
+  RelayEvent,
+  RespondToMode,
+} from "@/shared/api/types";
+
+type UseThreadPanelInitialExpansionOptions = {
+  activeChannel: Channel | null;
+  threadReplyEvents: RelayEvent[];
+  openThreadHeadId: string | null;
+  setExpandedThreadReplyIds: React.Dispatch<React.SetStateAction<Set<string>>>;
+  currentPubkey: string | undefined;
+  currentAvatarUrl: string | null;
+  profiles: UserProfileLookup | undefined;
+  members: ChannelMember[] | undefined;
+  personaLookup: Map<string, string>;
+  respondToLookup: Map<string, RespondToMode>;
+  relaySelfPubkey: string | null | undefined;
+  ownerProfiles: UserProfileLookup | undefined;
+};
+
+/**
+ * Seeds the thread panel's initial ancestor expansion (block/buzz#3799).
+ *
+ * A thread panel opened on a thread whose subtree already contains depth-2+
+ * replies (the classic "agent replied to a *non-latest* thread message"
+ * case) would otherwise start with an empty expansion set and swallow those
+ * replies inside a collapsed depth-1 summary row — invisible in the UI even
+ * though the relay delivers them. This effect unions the ancestors of every
+ * depth-2+ reply present into the expansion set, once per opened head, so
+ * they render on the first paint. Manual expand/collapse afterwards still
+ * wins because the union never removes ids. Kept out of ChannelScreen.tsx
+ * to respect the desktop file-size ratchet.
+ */
+export function useThreadPanelInitialExpansion({
+  activeChannel,
+  threadReplyEvents,
+  openThreadHeadId,
+  setExpandedThreadReplyIds,
+  currentPubkey,
+  currentAvatarUrl,
+  profiles,
+  members,
+  personaLookup,
+  respondToLookup,
+  relaySelfPubkey,
+  ownerProfiles,
+}: UseThreadPanelInitialExpansionOptions) {
+  const seededHeadRef = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    if (!openThreadHeadId) {
+      seededHeadRef.current = null;
+      return;
+    }
+    if (seededHeadRef.current === openThreadHeadId) {
+      return;
+    }
+    if (threadReplyEvents.length === 0) {
+      return;
+    }
+    const formatted = formatTimelineMessages(
+      threadReplyEvents,
+      activeChannel,
+      currentPubkey,
+      currentAvatarUrl,
+      profiles,
+      members,
+      personaLookup,
+      respondToLookup,
+      relaySelfPubkey,
+      ownerProfiles,
+    );
+    const seed = computeInitialExpandedReplyIds(formatted, openThreadHeadId);
+    if (seed.size === 0) {
+      seededHeadRef.current = openThreadHeadId;
+      return;
+    }
+    setExpandedThreadReplyIds((current) => {
+      // Idempotent: if every seed id is already expanded (e.g. the relay
+      // delivered the replies between open and fetch resolution), bail with
+      // the identity reference so React skips the re-render.
+      let allPresent = true;
+      for (const id of seed) {
+        if (!current.has(id)) {
+          allPresent = false;
+          break;
+        }
+      }
+      if (allPresent) {
+        return current;
+      }
+      const next = new Set(current);
+      for (const id of seed) {
+        next.add(id);
+      }
+      return next;
+    });
+    seededHeadRef.current = openThreadHeadId;
+  }, [
+    activeChannel,
+    currentAvatarUrl,
+    currentPubkey,
+    members,
+    openThreadHeadId,
+    ownerProfiles,
+    personaLookup,
+    profiles,
+    relaySelfPubkey,
+    respondToLookup,
+    setExpandedThreadReplyIds,
+    threadReplyEvents,
+  ]);
+}


### PR DESCRIPTION
## Problem

When an agent (or any replier) anchors a reply to a *non-latest* thread message — e.g. parent=B where the viewer's open thread has A as head and B as a depth-1 child — a fresh depth-2 reply delivered by the relay is **not rendered** in the thread panel and produces **no visible signal**. The two underlying surfaces:

| Surface | Root cause | Consequence |
|---|---|---|
| render | The panel opens with an empty `expandedThreadReplyIds` set (`ChannelScreen.tsx`). A depth-1 child that has any descendant renders as a collapsed `MessageThreadSummaryRow` and every deeper reply under it is omitted from `visibleReplies` (`threadPanel.ts` `appendExpandedReplies`). | The new depth-2 reply is present in `threadRepliesKey` but invisible in the panel. |
| badge | `computeThreadReplyUnreadCounts` (`useChannelUnreadState.ts`) builds its input set from the **channel-window projection only**. A fresh depth-2 reply that lives only in the `threadRepliesKey` cache isn't in that window, so the descendant-aware subtree walk never reaches it. | The collapsed ancestor row's unread badge stays `0`. |

Both are the same logical bug at two stages: the open thread's fetched reply set (`[head, ...replyEvents]`) is richer than the channel-window projection that seeds the panel state, and neither surface reconciled against it.

## Fix

Two tightly-scoped changes, each with independent regression coverage:

- **scope-a — expand ancestors at open.** New `computeInitialExpandedReplyIds` (pure, in `threadPanel.ts`) computes the minimal set of intermediate ancestors of every depth-≥2 reply in the fetched thread set. New `useThreadPanelInitialExpansion` hook (extracted out of `ChannelScreen.tsx` to respect the desktop file-size ratchet) seeds `expandedThreadReplyIds` once per opened head by unioning those ancestors in — the seed never removes ids and never re-runs after the user manually collapses/expands. Idempotent (bails with the identity reference when the seed is already a subset of the live set).
- **scope-b — union the message set into the unread badge.** New `unionScopeMessages` (pure, in `threadReplyUnreadCounts.ts`). `useChannelUnreadState` now feeds `computeThreadReplyUnreadCounts` a union of the channel-window projection and the open thread's full fetched message set via a *widened* `directReplyIdsByParentId` memo consumed **only** by this badge path — all other unread readers stay window-scoped, matching the existing per-message read-state contract.

## Verification

- `threadPanel.test.mjs`: **6 new cases** — open-with-seed surfaces the depth-2 reply; depth-1-only threads stay collapsed; unread-scoped filtering expands only the unread branch; depth-3 chain pins every intermediate parent; cycles/missing parents tolerated without hanging; `buildThreadPanelData` integration with the seed.
- `threadReplyUnreadCounts.test.mjs`: **3 new cases** — `unionScopeMessages` dedup/order/reference-preservation; a depth-2 reply outside the window is counted against its collapsed ancestor (the fix); and a negative control documenting that, without the union, the same scenario yields `unreadDescendantCount = 0`.
- **Full desktop suite: 3879/3879 green.**
- `pnpm check` (biome lint+format, file-size ratchet, px-text, pubkey-truncation): clean.

## Manual test

1. Open a channel with an existing thread A. Send a reply B to A (depth-1). Open a second session and have an agent (or another account) reply to **B** (depth-2), not to A and not to the latest thread message.
2. In the first session, open the thread panel for A. **Before** this fix: B renders as a collapsed summary row; the agent's reply is invisible; B carries no unread badge. **After**: B is pre-expanded; the agent's reply renders in place; B carries an unread badge while collapsed from any prior manual collapse.

Affected surface: desktop web thread panel only. No protocol, relay, storage, or key changes.

Fixes #3799