### PR TITLE
docs(env): note that / and /repos need BUZZ_SERVE_GIT_WEB_GUI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,10 +54,16 @@ RELAY_URL=ws://localhost:3000
 # Stable relay signing key. Set this in dev if you want REST-created forum posts
 # to keep resolving to the original author across relay restarts.
 # BUZZ_RELAY_PRIVATE_KEY=<32-byte hex private key>
-# Optional: path to the web UI dist directory. When set, the relay serves
-# the web frontend at / for browser requests. Leave unset for local dev
-# (use `just web` for Vite HMR instead).
+# Optional: path to the web UI dist directory. When set, the relay serves the
+# invite landing bundle, so /invite/{code} works for browser requests. Leave
+# unset for local dev (use `just web` for Vite HMR instead).
 # BUZZ_WEB_DIR=./web/dist
+# Serving the bundle at / and /repos/... additionally requires the flag below;
+# without it those paths answer with the NIP-11 document instead of the SPA.
+# Set to `true` or `1` to expose the bundled Git repository browser. Has no
+# effect unless BUZZ_WEB_DIR is set. Defaults to false; invite routes do not
+# depend on this flag.
+# BUZZ_SERVE_GIT_WEB_GUI=true
 
 # Shared Redis-backed admission limits. Defaults shown below; each value must
 # be a positive integer.

--- a/.env.example
+++ b/.env.example
@@ -58,8 +58,9 @@ RELAY_URL=ws://localhost:3000
 # invite landing bundle, so /invite/{code} works for browser requests. Leave
 # unset for local dev (use `just web` for Vite HMR instead).
 # BUZZ_WEB_DIR=./web/dist
-# Serving the bundle at / and /repos/... additionally requires the flag below;
-# without it those paths answer with the NIP-11 document instead of the SPA.
+# Serving the bundle at / and /repos/... additionally requires
+# BUZZ_SERVE_GIT_WEB_GUI; without it those paths answer with the NIP-11
+# document instead of the SPA.
 # Set to `true` or `1` to expose the bundled Git repository browser. Has no
 # effect unless BUZZ_WEB_DIR is set. Defaults to false; invite routes do not
 # depend on this flag.


### PR DESCRIPTION
## Summary

The `BUZZ_WEB_DIR` comment in `.env.example` says that setting it makes the relay serve "the web frontend at `/` for browser requests". Setting it alone does not do that, so anyone following the file ends up with a relay that answers `/` with JSON and concludes the web bundle is broken.

What the code actually does — `crates/buzz-relay/src/router.rs`:

```rust
fn should_serve_spa(path: &str, serve_git_web_gui: bool) -> bool {
    is_invite_landing_path(path) || (serve_git_web_gui && is_git_web_gui_path(path))
}

fn is_git_web_gui_path(path: &str) -> bool {
    path == "/" || path == "/repos" || path.starts_with("/repos/")
}
```

`nip11_or_ws_handler` gates its `Accept: text/html` branch for `/` on the same flag, and `serve_git_web_gui` is read from `BUZZ_SERVE_GIT_WEB_GUI` in `crates/buzz-relay/src/config.rs` with `.unwrap_or(false)`. So with only `BUZZ_WEB_DIR` set, a browser requesting `/` gets the NIP-11 document.

`/invite/{code}` **does** work with `BUZZ_WEB_DIR` alone, since `is_invite_landing_path` is checked unconditionally. The comment now says that, and documents `BUZZ_SERVE_GIT_WEB_GUI` — which `.env.example` did not mention at all.

The wording follows the table already in `TESTING.md`, which describes both variables correctly today; this only brings `.env.example` in line with it.

### Related issue

Fixes #3815. No open PR touches these lines — #3777 also edits `.env.example`, but adds `BUZZ_ADMIN_WEB_DIR` in a different section.

### Testing

Documentation only; no code changes, so no behaviour to test. The claim is verified against the repository's own unit test rather than by reasoning alone — `crates/buzz-relay/src/router.rs` contains:

```rust
#[test]
fn invite_is_always_served_but_git_gui_requires_opt_in() {
    assert!(should_serve_spa("/invite/payload.mac", false));
    assert!(!should_serve_spa("/", false));
    assert!(!should_serve_spa("/repos/example", false));
    assert!(should_serve_spa("/", true));
    assert!(should_serve_spa("/repos/example", true));
}
```

That test is exactly the behaviour the old comment contradicted.
