### PR TITLE
feat(mobile): add signed profile editor

### DIFF
--- a/mobile/lib/features/profile/edit_profile_sheet.dart
+++ b/mobile/lib/features/profile/edit_profile_sheet.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../shared/theme/theme.dart';
+import '../../shared/widgets/avatar_image.dart';
+import 'profile_provider.dart';
+import 'user_profile.dart';
+
+const _avatarColors = [
+  (hex: '#F4B942', color: Color(0xFFF4B942)),
+  (hex: '#E66A6A', color: Color(0xFFE66A6A)),
+  (hex: '#9B72CF', color: Color(0xFF9B72CF)),
+  (hex: '#5B8DEF', color: Color(0xFF5B8DEF)),
+  (hex: '#4EAD8C', color: Color(0xFF4EAD8C)),
+];
+
+/// Open the current user's small kind:0 profile editor.
+void showEditProfileSheet(BuildContext context, {UserProfile? profile}) {
+  showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    builder: (_) => _EditProfileSheet(profile: profile),
+  );
+}
+
+/// Build a self-contained, percent-encoded SVG avatar around [emoji].
+String emojiAvatarDataUrl(String emoji, String color) {
+  final escaped = emoji
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
+  final svg =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" '
+      'viewBox="0 0 512 512"><rect width="512" height="512" rx="256" '
+      'fill="$color"/><text x="50%" y="56%" dominant-baseline="middle" '
+      'text-anchor="middle" font-size="258">$escaped</text></svg>';
+  return 'data:image/svg+xml,${Uri.encodeComponent(svg)}';
+}
+
+class _EditProfileSheet extends HookConsumerWidget {
+  const _EditProfileSheet({required this.profile});
+
+  final UserProfile? profile;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final displayNameController = useTextEditingController(
+      text: profile?.displayName ?? '',
+    );
+    final displayName = useState(profile?.displayName ?? '');
+    final emoji = useState('');
+    final colorIndex = useState(0);
+    final isSaving = useState(false);
+    final avatarUrl = emoji.value.trim().isEmpty
+        ? profile?.avatarUrl
+        : emojiAvatarDataUrl(
+            emoji.value.trim(),
+            _avatarColors[colorIndex.value].hex,
+          );
+    final initial = displayName.value.trim().isNotEmpty
+        ? displayName.value.trim()[0].toUpperCase()
+        : profile?.initial ?? '?';
+    final canSave = displayName.value.trim().isNotEmpty && !isSaving.value;
+
+    Future<void> save() async {
+      if (!canSave) return;
+      isSaving.value = true;
+      final messenger = ScaffoldMessenger.of(context);
+      try {
+        final avatarEmoji = emoji.value.trim();
+        await ref
+            .read(profileProvider.notifier)
+            .saveProfile(
+              displayName: displayName.value,
+              avatarUrl: avatarEmoji.isEmpty
+                  ? null
+                  : emojiAvatarDataUrl(
+                      avatarEmoji,
+                      _avatarColors[colorIndex.value].hex,
+                    ),
+            );
+        if (!context.mounted) return;
+        Navigator.of(context).pop();
+        messenger.showSnackBar(const SnackBar(content: Text('Profile saved')));
+      } catch (_) {
+        if (!context.mounted) return;
+        messenger.showSnackBar(
+          const SnackBar(content: Text('Unable to save profile')),
+        );
+        isSaving.value = false;
+      }
+    }
+
+    return SingleChildScrollView(
+      padding: EdgeInsets.fromLTRB(
+        Grid.gutter,
+        0,
+        Grid.gutter,
+        Grid.gutter +
+            MediaQuery.viewInsetsOf(context).bottom +
+            MediaQuery.viewPaddingOf(context).bottom,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Edit profile', style: context.textTheme.titleLarge),
+          const SizedBox(height: Grid.xs),
+          Center(
+            child: AvatarImage(
+              imageUrl: avatarUrl,
+              radius: 48,
+              backgroundColor: context.colors.primaryContainer,
+              fallback: Text(
+                initial,
+                style: context.textTheme.headlineMedium?.copyWith(
+                  color: context.colors.onPrimaryContainer,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: Grid.xs),
+          TextField(
+            autofocus: true,
+            decoration: const InputDecoration(labelText: 'Display name'),
+            textCapitalization: TextCapitalization.words,
+            textInputAction: TextInputAction.next,
+            onChanged: (value) => displayName.value = value,
+            controller: displayNameController,
+          ),
+          const SizedBox(height: Grid.twelve),
+          TextField(
+            decoration: const InputDecoration(
+              labelText: 'Avatar emoji',
+              hintText: '🐝',
+              helperText: 'Stored as an inline SVG — no image host needed.',
+            ),
+            textInputAction: TextInputAction.done,
+            onChanged: (value) => emoji.value = value,
+            onSubmitted: (_) => save(),
+          ),
+          const SizedBox(height: Grid.twelve),
+          Text('Avatar color', style: context.textTheme.labelLarge),
+          const SizedBox(height: Grid.xxs),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              for (final (index, entry) in _avatarColors.indexed)
+                Semantics(
+                  button: true,
+                  selected: colorIndex.value == index,
+                  label: 'Avatar color ${index + 1}',
+                  child: InkWell(
+                    customBorder: const CircleBorder(),
+                    onTap: () => colorIndex.value = index,
+                    child: Padding(
+                      padding: const EdgeInsets.all(Grid.half),
+                      child: Container(
+                        width: 36,
+                        height: 36,
+                        decoration: BoxDecoration(
+                          color: entry.color,
+                          shape: BoxShape.circle,
+                          border: Border.all(
+                            color: colorIndex.value == index
+                                ? context.colors.onSurface
+                                : Colors.transparent,
+                            width: 2,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: Grid.gutter),
+          SizedBox(
+            width: double.infinity,
+            height: 52,
+            child: FilledButton(
+              onPressed: canSave ? save : null,
+              child: Text(isSaving.value ? 'Saving…' : 'Save profile'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/profile/profile_provider.dart
+++ b/mobile/lib/features/profile/profile_provider.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../shared/crypto/nip_oa.dart';
 import '../../shared/relay/relay.dart';
 import 'user_cache_provider.dart';
 import 'user_profile.dart';
@@ -95,8 +96,12 @@ final profileProvider = AsyncNotifierProvider<ProfileNotifier, UserProfile?>(
   ProfileNotifier.new,
 );
 
-NostrEvent _latest(List<NostrEvent> events) =>
-    events.reduce((a, b) => a.createdAt >= b.createdAt ? a : b);
+NostrEvent _latest(List<NostrEvent> events) => events.reduce((a, b) {
+  if (a.createdAt != b.createdAt) {
+    return a.createdAt > b.createdAt ? a : b;
+  }
+  return a.id.compareTo(b.id) <= 0 ? a : b;
+});
 
 Map<String, dynamic> _metadataFrom(NostrEvent? event) {
   if (event == null) return {};
@@ -121,6 +126,7 @@ UserProfile _userProfileFromEvent(NostrEvent event) {
     avatarUrl: data.avatarUrl,
     about: data.about,
     nip05Handle: data.nip05,
+    ownerPubkey: verifiedOaOwnerPubkey(event.tags, event.pubkey),
   );
 }
 

--- a/mobile/lib/features/profile/profile_provider.dart
+++ b/mobile/lib/features/profile/profile_provider.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../shared/relay/relay.dart';
+import 'user_cache_provider.dart';
 import 'user_profile.dart';
 
 /// The current user's profile (kind:0 metadata) loaded over the relay
@@ -24,24 +26,103 @@ class ProfileNotifier extends AsyncNotifier<UserProfile?> {
     final session = ref.read(relaySessionProvider.notifier);
     final events = await session.fetchHistory(NostrFilters.profile(myPk));
     if (events.isEmpty) return null;
-    final data = ProfileData.fromEvent(events.first);
-    return UserProfile(
-      pubkey: data.pubkey,
-      displayName: data.displayName,
-      avatarUrl: data.avatarUrl,
-      about: data.about,
-      nip05Handle: data.nip05,
-    );
+    return _userProfileFromEvent(_latest(events));
   }
 
   Future<void> refresh() async {
     state = await AsyncValue.guard(_fetch);
+  }
+
+  /// Publish a kind:0 profile update with the active community identity.
+  ///
+  /// The existing JSON object is merged before signing so fields outside this
+  /// editor survive unchanged. A null [avatarUrl] preserves the current avatar.
+  Future<UserProfile> saveProfile({
+    required String displayName,
+    String? avatarUrl,
+  }) async {
+    final name = displayName.trim();
+    if (name.isEmpty) {
+      throw ArgumentError.value(
+        displayName,
+        'displayName',
+        'must not be empty',
+      );
+    }
+
+    final config = ref.read(relayConfigProvider);
+    if (config.nsec == null || config.nsec!.isEmpty) {
+      throw StateError('Cannot save profile: no signing key available');
+    }
+
+    final relay = SignedEventRelay(
+      session: ref.read(relaySessionProvider.notifier),
+      nsec: config.nsec,
+    );
+    final pubkey = relay.pubkey;
+    if (pubkey == null) {
+      throw StateError('Cannot save profile: invalid signing key');
+    }
+
+    final session = ref.read(relaySessionProvider.notifier);
+    final events = await session.fetchHistory(NostrFilters.profile(pubkey));
+    final previous = events.isEmpty ? null : _latest(events);
+    final metadata = _metadataFrom(previous);
+    metadata['display_name'] = name;
+    if (avatarUrl != null) metadata['picture'] = avatarUrl;
+
+    NostrEvent? signed;
+    await relay.submit(
+      kind: EventKind.metadata,
+      content: jsonEncode(metadata),
+      tags: previous?.tags ?? const [],
+      createdAt: _nextCreatedAt(previous),
+      onSigned: (event) => signed = event,
+    );
+    final event = signed;
+    if (event == null) {
+      throw StateError('Profile event was not signed');
+    }
+
+    final profile = _userProfileFromEvent(event);
+    state = AsyncValue.data(profile);
+    ref.read(userCacheProvider.notifier).updateProfile(profile);
+    return profile;
   }
 }
 
 final profileProvider = AsyncNotifierProvider<ProfileNotifier, UserProfile?>(
   ProfileNotifier.new,
 );
+
+NostrEvent _latest(List<NostrEvent> events) =>
+    events.reduce((a, b) => a.createdAt >= b.createdAt ? a : b);
+
+Map<String, dynamic> _metadataFrom(NostrEvent? event) {
+  if (event == null) return {};
+  final decoded = jsonDecode(event.content);
+  if (decoded is! Map<String, dynamic>) {
+    throw const FormatException('Existing profile metadata is not an object');
+  }
+  return Map<String, dynamic>.from(decoded);
+}
+
+int _nextCreatedAt(NostrEvent? previous) {
+  final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+  if (previous == null || previous.createdAt < now) return now;
+  return previous.createdAt + 1;
+}
+
+UserProfile _userProfileFromEvent(NostrEvent event) {
+  final data = ProfileData.fromEvent(event);
+  return UserProfile(
+    pubkey: data.pubkey.toLowerCase(),
+    displayName: data.displayName,
+    avatarUrl: data.avatarUrl,
+    about: data.about,
+    nip05Handle: data.nip05,
+  );
+}
 
 /// Presence status for the current user.
 ///

--- a/mobile/lib/features/profile/settings_profile_header.dart
+++ b/mobile/lib/features/profile/settings_profile_header.dart
@@ -7,6 +7,7 @@ import '../../shared/custom_emoji/custom_emoji_render.dart';
 import '../../shared/theme/theme.dart';
 import '../../shared/widgets/avatar_image.dart';
 import '../../shared/widgets/masked_avatar_badge.dart';
+import 'edit_profile_sheet.dart';
 import 'profile_provider.dart';
 import 'set_status_sheet.dart';
 import 'user_status_provider.dart';
@@ -58,6 +59,11 @@ class SettingsProfileHeader extends ConsumerWidget {
             profile?.label ?? 'Your profile',
             style: context.textTheme.titleMedium,
             textAlign: TextAlign.center,
+          ),
+          TextButton.icon(
+            onPressed: () => showEditProfileSheet(context, profile: profile),
+            icon: const Icon(LucideIcons.pencil, size: 16),
+            label: const Text('Edit profile'),
           ),
           // No placeholder copy — the badge is the affordance, so this line
           // appears only once there is an actual status to show.

--- a/mobile/lib/features/profile/user_cache_provider.dart
+++ b/mobile/lib/features/profile/user_cache_provider.dart
@@ -44,6 +44,11 @@ class UserCacheNotifier extends Notifier<Map<String, UserProfile>> {
     _batchTimer ??= Timer(const Duration(milliseconds: 50), _flushPending);
   }
 
+  /// Replace a profile immediately after the current user publishes it.
+  void updateProfile(UserProfile profile) {
+    state = {...state, profile.pubkey.toLowerCase(): profile};
+  }
+
   void _scheduleFetch(String pubkey) {
     if (state.containsKey(pubkey) || _pending.contains(pubkey)) return;
     _pending.add(pubkey);

--- a/mobile/lib/shared/relay/nostr_models.dart
+++ b/mobile/lib/shared/relay/nostr_models.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 ///
 /// Keep in sync with `desktop/src/shared/constants/kinds.ts`.
 abstract final class EventKind {
+  static const metadata = 0;
   static const note = 1;
   static const contactList = 3;
   static const deletion = 5;

--- a/mobile/test/features/profile/profile_provider_test.dart
+++ b/mobile/test/features/profile/profile_provider_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:buzz/features/profile/profile_provider.dart';
 import 'package:buzz/features/profile/user_cache_provider.dart';
@@ -6,10 +7,12 @@ import 'package:buzz/shared/relay/relay.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:nostr/nostr.dart' as nostr;
+import 'package:pointycastle/digests/sha256.dart';
 
 void main() {
   test('signs kind:0, preserves metadata, and refreshes both caches', () async {
     final keys = nostr.Keys.generate();
+    final owner = nostr.Keys.generate();
     final previous = _profileEvent(
       keys,
       content: {
@@ -20,8 +23,9 @@ void main() {
         'nip05': 'old@example.com',
         'custom': {'keep': true},
       },
-      tags: const [
-        ['x', 'keep'],
+      tags: [
+        const ['x', 'keep'],
+        _authTag(owner, keys.public),
       ],
     );
     final session = _FakeRelaySession(events: [previous]);
@@ -52,8 +56,36 @@ void main() {
 
     expect(saved.displayName, 'New Name');
     expect(saved.avatarUrl, avatar);
+    expect(saved.ownerPubkey, owner.public);
     expect(container.read(profileProvider).value, saved);
     expect(container.read(userCacheProvider)[keys.public], saved);
+    expect(
+      container.read(userCacheProvider)[keys.public]?.ownerPubkey,
+      owner.public,
+    );
+  });
+
+  test('uses the lowest event id when timestamps are equal', () async {
+    final keys = nostr.Keys.generate();
+    final first = _profileEvent(
+      keys,
+      content: {'display_name': 'First'},
+      createdAt: 1700000000,
+    );
+    final second = _profileEvent(
+      keys,
+      content: {'display_name': 'Second'},
+      createdAt: 1700000000,
+    );
+    final lower = first.id.compareTo(second.id) < 0 ? first : second;
+    final higher = identical(lower, first) ? second : first;
+    final session = _FakeRelaySession(events: [higher, lower]);
+    final container = _container(session: session, nsec: keys.nsec);
+    addTearDown(container.dispose);
+
+    final loaded = await container.read(profileProvider.future);
+
+    expect(loaded?.displayName, lower.id == first.id ? 'First' : 'Second');
   });
 
   test('keeps the loaded profile when relay publication fails', () async {
@@ -117,16 +149,29 @@ NostrEvent _profileEvent(
   nostr.Keys keys, {
   required Map<String, dynamic> content,
   List<List<String>> tags = const [],
+  int? createdAt,
 }) {
   final event = nostr.Event.from(
     kind: EventKind.metadata,
     content: jsonEncode(content),
     tags: tags,
     secretKey: nostr.Nip19.decode(payload: keys.nsec).data,
-    createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 10,
+    createdAt: createdAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000 - 10,
     verify: false,
   );
   return NostrEvent.fromJson(event.toMap());
+}
+
+List<String> _authTag(nostr.Keys owner, String agentPubkey) {
+  final input = utf8.encode('nostr:agent-auth:$agentPubkey:');
+  final digest = SHA256Digest().process(Uint8List.fromList(input));
+  final message = digest.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  return [
+    'auth',
+    owner.public,
+    '',
+    nostr.Schnorr.sign(secretKey: owner.secret, message: message),
+  ];
 }
 
 class _FakeRelaySession extends RelaySessionNotifier {

--- a/mobile/test/features/profile/profile_provider_test.dart
+++ b/mobile/test/features/profile/profile_provider_test.dart
@@ -1,0 +1,171 @@
+import 'dart:convert';
+
+import 'package:buzz/features/profile/profile_provider.dart';
+import 'package:buzz/features/profile/user_cache_provider.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+void main() {
+  test('signs kind:0, preserves metadata, and refreshes both caches', () async {
+    final keys = nostr.Keys.generate();
+    final previous = _profileEvent(
+      keys,
+      content: {
+        'name': 'old-handle',
+        'display_name': 'Old Name',
+        'picture': 'https://example.com/old.png',
+        'about': 'Still here',
+        'nip05': 'old@example.com',
+        'custom': {'keep': true},
+      },
+      tags: const [
+        ['x', 'keep'],
+      ],
+    );
+    final session = _FakeRelaySession(events: [previous]);
+    final container = _container(session: session, nsec: keys.nsec);
+    addTearDown(container.dispose);
+    await container.read(profileProvider.future);
+
+    const avatar =
+        'data:image/svg+xml,%3Csvg%3E%3Ctext%3E%F0%9F%90%9D%3C%2Ftext%3E%3C%2Fsvg%3E';
+    final saved = await container
+        .read(profileProvider.notifier)
+        .saveProfile(displayName: '  New Name  ', avatarUrl: avatar);
+
+    final published = session.published!;
+    final verified = nostr.Event.fromJson(jsonEncode(published.toJson()));
+    final metadata = jsonDecode(published.content) as Map<String, dynamic>;
+    expect(verified.isValid(), isTrue);
+    expect(published.kind, EventKind.metadata);
+    expect(published.pubkey, keys.public);
+    expect(published.tags, previous.tags);
+    expect(published.createdAt, greaterThan(previous.createdAt));
+    expect(metadata['display_name'], 'New Name');
+    expect(metadata['picture'], avatar);
+    expect(metadata['name'], 'old-handle');
+    expect(metadata['about'], 'Still here');
+    expect(metadata['nip05'], 'old@example.com');
+    expect(metadata['custom'], {'keep': true});
+
+    expect(saved.displayName, 'New Name');
+    expect(saved.avatarUrl, avatar);
+    expect(container.read(profileProvider).value, saved);
+    expect(container.read(userCacheProvider)[keys.public], saved);
+  });
+
+  test('keeps the loaded profile when relay publication fails', () async {
+    final keys = nostr.Keys.generate();
+    final previous = _profileEvent(
+      keys,
+      content: {'display_name': 'Original', 'about': 'Keep me'},
+    );
+    final session = _FakeRelaySession(
+      events: [previous],
+      publishError: Exception('relay rejected profile'),
+    );
+    final container = _container(session: session, nsec: keys.nsec);
+    addTearDown(container.dispose);
+    final original = await container.read(profileProvider.future);
+
+    await expectLater(
+      container
+          .read(profileProvider.notifier)
+          .saveProfile(displayName: 'Unsaved'),
+      throwsException,
+    );
+
+    expect(container.read(profileProvider).value, same(original));
+    expect(container.read(userCacheProvider), isEmpty);
+  });
+
+  test('fails closed without an active community signing key', () async {
+    final session = _FakeRelaySession();
+    final container = _container(session: session, nsec: null);
+    addTearDown(container.dispose);
+    await container.read(profileProvider.future);
+
+    await expectLater(
+      container
+          .read(profileProvider.notifier)
+          .saveProfile(displayName: 'No Key'),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(session.published, isNull);
+    expect(session.fetchCount, 0);
+  });
+}
+
+ProviderContainer _container({
+  required _FakeRelaySession session,
+  required String? nsec,
+}) {
+  return ProviderContainer(
+    overrides: [
+      relaySessionProvider.overrideWith(() => session),
+      relayConfigProvider.overrideWith(
+        () => _FakeRelayConfigNotifier(nsec: nsec),
+      ),
+    ],
+  );
+}
+
+NostrEvent _profileEvent(
+  nostr.Keys keys, {
+  required Map<String, dynamic> content,
+  List<List<String>> tags = const [],
+}) {
+  final event = nostr.Event.from(
+    kind: EventKind.metadata,
+    content: jsonEncode(content),
+    tags: tags,
+    secretKey: nostr.Nip19.decode(payload: keys.nsec).data,
+    createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 10,
+    verify: false,
+  );
+  return NostrEvent.fromJson(event.toMap());
+}
+
+class _FakeRelaySession extends RelaySessionNotifier {
+  _FakeRelaySession({this.events = const [], this.publishError});
+
+  final List<NostrEvent> events;
+  final Object? publishError;
+  NostrEvent? published;
+  int fetchCount = 0;
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    fetchCount++;
+    return events;
+  }
+
+  @override
+  Future<NostrEvent> publish(
+    NostrEvent event, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    published = event;
+    if (publishError case final error?) throw error;
+    return event;
+  }
+}
+
+class _FakeRelayConfigNotifier extends RelayConfigNotifier {
+  _FakeRelayConfigNotifier({required this.nsec});
+
+  final String? nsec;
+
+  @override
+  RelayConfig build() =>
+      RelayConfig(baseUrl: 'https://relay.example', nsec: nsec);
+}

--- a/mobile/test/features/profile/settings_profile_header_test.dart
+++ b/mobile/test/features/profile/settings_profile_header_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import 'package:buzz/features/profile/edit_profile_sheet.dart';
 import 'package:buzz/features/profile/profile_provider.dart';
 import 'package:buzz/features/profile/settings_profile_header.dart';
 import 'package:buzz/features/profile/user_profile.dart';
@@ -5,12 +8,23 @@ import 'package:buzz/features/profile/user_status.dart';
 import 'package:buzz/features/profile/user_status_provider.dart';
 import 'package:buzz/shared/custom_emoji/custom_emoji_provider.dart';
 import 'package:buzz/shared/widgets/masked_avatar_badge.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../../helpers/widget_helpers.dart';
 
 void main() {
+  test('builds a self-contained escaped emoji SVG avatar', () {
+    final avatar = emojiAvatarDataUrl('🐝<&', '#F4B942');
+    final svg = utf8.decode(UriData.parse(avatar).contentAsBytes());
+
+    expect(avatar, startsWith('data:image/svg+xml,'));
+    expect(svg, contains('<rect'));
+    expect(svg, contains('fill="#F4B942"'));
+    expect(svg, contains('🐝&lt;&amp;'));
+  });
+
   testWidgets('uses a bounded icon for an unresolved status shortcode', (
     tester,
   ) async {
@@ -45,6 +59,61 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets('edits and saves the current profile', (tester) async {
+    final profile = _SavingProfileNotifier();
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: [
+          profileProvider.overrideWith(() => profile),
+          userStatusProvider.overrideWith(() => _FakeUserStatusNotifier(null)),
+        ],
+        child: const SettingsProfileHeader(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'Edit profile'));
+    await tester.pumpAndSettle();
+    expect(find.text('Edit profile'), findsWidgets);
+
+    await tester.enterText(find.byType(TextField).at(0), 'New Name');
+    await tester.enterText(find.byType(TextField).at(1), '🦊');
+    await tester.tap(find.widgetWithText(FilledButton, 'Save profile'));
+    await tester.pumpAndSettle();
+
+    expect(profile.savedDisplayName, 'New Name');
+    expect(profile.savedAvatarUrl, startsWith('data:image/svg+xml,'));
+    expect(find.text('Profile saved'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Save profile'), findsNothing);
+  });
+
+  testWidgets('keeps the editor open and surfaces save failures', (
+    tester,
+  ) async {
+    final profile = _SavingProfileNotifier(
+      error: Exception('relay rejected profile'),
+    );
+    await tester.pumpWidget(
+      WidgetHelpers.testable(
+        overrides: [
+          profileProvider.overrideWith(() => profile),
+          userStatusProvider.overrideWith(() => _FakeUserStatusNotifier(null)),
+        ],
+        child: const SettingsProfileHeader(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(TextButton, 'Edit profile'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).at(0), 'Unsaved Name');
+    await tester.tap(find.widgetWithText(FilledButton, 'Save profile'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Unable to save profile'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, 'Save profile'), findsOneWidget);
+  });
 }
 
 class _FakeProfileNotifier extends ProfileNotifier {
@@ -56,8 +125,35 @@ class _FakeProfileNotifier extends ProfileNotifier {
 class _FakeUserStatusNotifier extends UserStatusNotifier {
   _FakeUserStatusNotifier(this._status);
 
-  final UserStatus _status;
+  final UserStatus? _status;
 
   @override
   Future<UserStatus?> build() async => _status;
+}
+
+class _SavingProfileNotifier extends ProfileNotifier {
+  _SavingProfileNotifier({this.error});
+
+  final Object? error;
+  String? savedDisplayName;
+  String? savedAvatarUrl;
+
+  @override
+  Future<UserProfile?> build() async =>
+      const UserProfile(pubkey: 'aabb', displayName: 'Old Name');
+
+  @override
+  Future<UserProfile> saveProfile({
+    required String displayName,
+    String? avatarUrl,
+  }) async {
+    savedDisplayName = displayName;
+    savedAvatarUrl = avatarUrl;
+    if (error case final failure?) throw failure;
+    return UserProfile(
+      pubkey: 'aabb',
+      displayName: displayName,
+      avatarUrl: avatarUrl,
+    );
+  }
 }


### PR DESCRIPTION
Adds an in-app editor for the active community identity display name and avatar. Updates are signed as Nostr kind:0 events by the phone identity, preserve unknown metadata and tags, refresh both profile caches, support inline SVG avatars, and fail closed without a signing key.

Correctness pins:
- canonical replaceable-event ordering: newest created_at, then lowest event id
- verified NIP-OA owner metadata survives cache refresh
- no hard-coded identities or assets

Validation:
- focused profile/UI/avatar tests: 13 passed
- mobile formatting, analyzer, and file-size gate: passed
- full mobile suite: 912 passed, 1 skipped, 1 pre-existing channel-scroll assertion failed at channel_detail_page_test.dart:1042 (reproduced before this correction and unrelated to the profile diff)