### PR TITLE
fix(desktop): show New Project button in empty projects state

### DIFF
--- a/desktop/src/features/projects/ui/ProjectCards.tsx
+++ b/desktop/src/features/projects/ui/ProjectCards.tsx
@@ -263,7 +263,13 @@ function StatusPill({ status }: { status: string }) {
   );
 }
 
-export function EmptyState() {
+export function EmptyState({
+  onCreateProject,
+  isCreating,
+}: {
+  onCreateProject?: () => void;
+  isCreating?: boolean;
+}) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-3 px-4 py-16 text-center">
       <FolderGit2 className="h-10 w-10 text-muted-foreground/40" />
@@ -273,6 +279,17 @@ export function EmptyState() {
           Projects published to this relay will appear here.
         </p>
       </div>
+      {onCreateProject ? (
+        <Button
+          disabled={isCreating}
+          onClick={onCreateProject}
+          size="sm"
+          type="button"
+        >
+          <FolderGit2 className="h-4 w-4" />
+          New Project
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -448,7 +448,25 @@ export function ProjectsView() {
   }
 
   if (projects.length === 0) {
-    return <EmptyState />;
+    return (
+      <>
+        <CreateProjectDialog
+          isCreating={createProjectMutation.isPending}
+          onCreate={async (input) => {
+            const project = await createProjectMutation.mutateAsync(input);
+            toast.success(`Project "${project.name}" created.`);
+            handleRepositoryScopeChange("all");
+            handleFilterChange("repositories");
+          }}
+          onOpenChange={setCreateProjectOpen}
+          open={createProjectOpen}
+        />
+        <EmptyState
+          isCreating={createProjectMutation.isPending}
+          onCreateProject={() => setCreateProjectOpen(true)}
+        />
+      </>
+    );
   }
 
   const repositoryItems =


### PR DESCRIPTION
## Summary
- `EmptyState` in ProjectsView returned early without the create menu, making it impossible to create a project when the list was empty
- Added an optional `onCreateProject` prop to `EmptyState` that renders a "New Project" button, and wired it to open the existing `CreateProjectDialog`

Fixes #3470

## Testing
- Built and ran the desktop app locally
- Enabled Projects in Settings → Experiments
- Navigated to Projects with empty list — "New Project" button now appears in the empty state
<img width="1875" height="991" alt="image" src="https://github.com/user-attachments/assets/d337bfbb-e033-40b5-929a-7685e3ab811a" />