### PR TITLE
fix(desktop): gate the add-member search on the relay-enforced add policy

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
         "**/workflows.spec.ts",
         "**/identity-archive.spec.ts",
         "**/identity-archive-hide.spec.ts",
+        "**/add-search-eligibility.spec.ts",
         "**/relay-connectivity.spec.ts",
         "**/unread-pill.spec.ts",
         "**/sidebar-more-unread-overlap.spec.ts",

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -207,6 +207,11 @@ pub struct RelayAgentInfo {
     pub respond_to: Option<RespondTo>,
     #[serde(default)]
     pub respond_to_allowlist: Vec<String>,
+    /// The agent's kind:10100 `channel_add_policy` declaration
+    /// (`anyone` | `owner_only` | `nobody`). Relay-enforced on
+    /// third-party adds; surfaced so pickers can mirror that enforcement.
+    #[serde(default)]
+    pub channel_add_policy: Option<String>,
 }
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ManagedAgentRecord {

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -910,7 +910,7 @@ mod tests {
     fn agents_default_sparse_agent_profiles_for_directory_parse() {
         let e = ev(
             10100,
-            r#"{"channel_add_policy":"owner-only","display_name":"Scout"}"#,
+            r#"{"channel_add_policy":"owner_only","display_name":"Scout"}"#,
             vec![],
         );
         let v = agents_from_events(std::slice::from_ref(&e));
@@ -926,6 +926,7 @@ mod tests {
         assert_eq!(parsed[0].capabilities, Vec::<String>::new());
         assert_eq!(parsed[0].status, "offline");
         assert_eq!(parsed[0].respond_to, None);
+        assert_eq!(parsed[0].channel_add_policy.as_deref(), Some("owner_only"));
     }
 
     #[test]
@@ -941,6 +942,7 @@ mod tests {
             parsed[0].respond_to,
             Some(crate::managed_agents::RespondTo::Anyone)
         );
+        assert_eq!(parsed[0].channel_add_policy, None);
     }
 
     #[test]

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -7,6 +7,7 @@ import {
   getSharedChannelIds,
   isAgentIdentityInManagedList,
   relayAgentIsSharedWithUser,
+  shouldHideAgentFromAddSearch,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
 
@@ -305,4 +306,125 @@ test("coalesceAgentAutocompleteCandidates: leaves non-agents alone", () => {
   const second = makeAgent({ pubkey: PUB_B, isAgent: false });
 
   assert.deepEqual(coalesce([first, second]), [first, second]);
+});
+
+// ── shouldHideAgentFromAddSearch: mirror relay add enforcement ─────────────
+
+function addArgs(overrides = {}) {
+  const {
+    candidate = {},
+    currentPubkey = CURRENT_PUBKEY,
+    managedAgentPubkeys = new Set(),
+    relayAgentAddPolicies = new Map(),
+  } = overrides;
+  return {
+    candidate: {
+      isAgent: true,
+      ownerPubkey: null,
+      pubkey: PUB_A,
+      ...candidate,
+    },
+    currentPubkey,
+    managedAgentPubkeys,
+    relayAgentAddPolicies,
+  };
+}
+
+function addPolicy(policy) {
+  return new Map([[PUB_A, policy]]);
+}
+
+test("shouldHideAgentFromAddSearch: never hides people", () => {
+  assert.equal(
+    shouldHideAgentFromAddSearch(addArgs({ candidate: { isAgent: false } })),
+    false,
+  );
+});
+
+test("shouldHideAgentFromAddSearch: always offers managed agents", () => {
+  assert.equal(
+    shouldHideAgentFromAddSearch(
+      addArgs({ managedAgentPubkeys: new Set([PUB_A]) }),
+    ),
+    false,
+  );
+});
+
+test("shouldHideAgentFromAddSearch: offers agents declaring add-policy anyone", () => {
+  assert.equal(
+    shouldHideAgentFromAddSearch(
+      addArgs({ relayAgentAddPolicies: addPolicy("anyone") }),
+    ),
+    false,
+  );
+});
+
+test("shouldHideAgentFromAddSearch: owner_only admits only the verified owner", () => {
+  // The relay refuses owner_only adds from anyone but the stored attested
+  // owner — the picker must mirror both directions.
+  assert.equal(
+    shouldHideAgentFromAddSearch(
+      addArgs({
+        candidate: { ownerPubkey: CURRENT_PUBKEY },
+        relayAgentAddPolicies: addPolicy("owner_only"),
+      }),
+    ),
+    false,
+  );
+  assert.equal(
+    shouldHideAgentFromAddSearch(
+      addArgs({
+        candidate: { ownerPubkey: OTHER_OWNER_PUBKEY },
+        relayAgentAddPolicies: addPolicy("owner_only"),
+      }),
+    ),
+    true,
+  );
+  assert.equal(
+    shouldHideAgentFromAddSearch(
+      addArgs({ relayAgentAddPolicies: addPolicy("owner_only") }),
+    ),
+    true,
+  );
+});
+
+test("shouldHideAgentFromAddSearch: hides nobody-policy agents from everyone including the owner", () => {
+  // Relay enforcement rejects nobody-policy adds regardless of actor.
+  assert.equal(
+    shouldHideAgentFromAddSearch(
+      addArgs({
+        candidate: { ownerPubkey: CURRENT_PUBKEY },
+        relayAgentAddPolicies: addPolicy("nobody"),
+      }),
+    ),
+    true,
+  );
+});
+
+test("shouldHideAgentFromAddSearch: hides agents with no directory entry or no declared policy", () => {
+  // No declaration, no offer — preserves #2149's stale-identity guarantee.
+  assert.equal(shouldHideAgentFromAddSearch(addArgs()), true);
+  assert.equal(
+    shouldHideAgentFromAddSearch(
+      addArgs({ relayAgentAddPolicies: addPolicy(null) }),
+    ),
+    true,
+  );
+});
+
+test("shouldHideAgentFromAddSearch: normalizes pubkeys before every comparison", () => {
+  const mixedCase = "Ab".repeat(32);
+  const normalized = mixedCase.toLowerCase();
+  assert.equal(
+    shouldHideAgentFromAddSearch(
+      addArgs({
+        candidate: {
+          ownerPubkey: CURRENT_PUBKEY.toUpperCase(),
+          pubkey: mixedCase,
+        },
+        relayAgentAddPolicies: new Map([[normalized, "owner_only"]]),
+      }),
+    ),
+    false,
+  );
 });

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -97,6 +97,67 @@ export function shouldHideAgentFromMentions({
   return directoryAgentPubkeys.has(normalized);
 }
 
+/**
+ * Hide an agent-classified add-search candidate unless the relay would
+ * accept the add.
+ *
+ * The relay enforces the agent's own kind:10100 `channel_add_policy` on
+ * third-party adds (`buzz-relay` `handlers/side_effects.rs`): `owner_only`
+ * requires the actor to be the stored attested owner, `nobody` is refused
+ * for everyone, `anyone` is allowed, and self-adds always pass. The picker
+ * mirrors the relay's *declared* policy; enforcement stays server-side, so
+ * the rare divergence (the relay enforces stored DB state, the client reads
+ * the latest published declaration) surfaces as a visible add error rather
+ * than a silent gap. One deliberate tightening:
+ * agent candidates with no directory entry stay hidden. An undeclared
+ * identity offers no proof it is a live agent anyone intended to be
+ * addable, which preserves the stale-identity suppression the managed-list
+ * gate was introduced for (#2149). Ownership uses the NIP-OA-verified
+ * `ownerPubkey` (the same value the "managed by" surface renders), so
+ * `owner_only` agents remain addable by their verified owner.
+ */
+export function shouldHideAgentFromAddSearch({
+  candidate,
+  currentPubkey,
+  managedAgentPubkeys,
+  relayAgentAddPolicies,
+}: {
+  candidate: {
+    isAgent?: boolean;
+    ownerPubkey?: string | null;
+    pubkey: string;
+  };
+  currentPubkey: string | null | undefined;
+  managedAgentPubkeys: ReadonlySet<string>;
+  relayAgentAddPolicies: ReadonlyMap<string, string | null>;
+}) {
+  if (candidate.isAgent !== true) return false;
+  const pubkey = normalizePubkey(candidate.pubkey);
+  if (managedAgentPubkeys.has(pubkey)) return false;
+  if (!relayAgentAddPolicies.has(pubkey)) return true;
+  switch (relayAgentAddPolicies.get(pubkey)) {
+    case "anyone":
+      return false;
+    case "owner_only": {
+      const ownerPubkey = candidate.ownerPubkey
+        ? normalizePubkey(candidate.ownerPubkey)
+        : null;
+      const normalizedCurrentPubkey = currentPubkey
+        ? normalizePubkey(currentPubkey)
+        : null;
+      return (
+        ownerPubkey === null ||
+        normalizedCurrentPubkey === null ||
+        ownerPubkey !== normalizedCurrentPubkey
+      );
+    }
+    // "nobody", null, or any unknown value → the relay would refuse (or
+    // the declaration is unreadable) — do not offer.
+    default:
+      return true;
+  }
+}
+
 type AgentAutocompleteCandidate = {
   pubkey?: string;
   displayName?: string | null;

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -9,7 +9,7 @@ import {
 import { attachManagedAgentToChannel } from "@/features/agents/channelAgents";
 import {
   coalesceAgentAutocompleteCandidates,
-  isAgentIdentityInManagedList,
+  shouldHideAgentFromAddSearch,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
@@ -265,6 +265,12 @@ export function MembersSidebar({
         agent,
       ]),
     );
+    const relayAgentAddPolicies = new Map(
+      (relayAgentsQuery.data ?? []).map((agent) => [
+        normalizePubkey(agent.pubkey),
+        agent.channelAddPolicy,
+      ]),
+    );
     const memberAgentLabels = new Set(
       rawMembers
         .filter((member) => member.isAgent === true || member.role === "bot")
@@ -282,7 +288,12 @@ export function MembersSidebar({
           )) ||
         memberPubkeys.has(pubkey) ||
         isArchivedDiscovery(pubkey) ||
-        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+        shouldHideAgentFromAddSearch({
+          candidate,
+          currentPubkey,
+          managedAgentPubkeys,
+          relayAgentAddPolicies,
+        })
       ) {
         return;
       }

--- a/desktop/src/features/pulse/ui/PulseView.tsx
+++ b/desktop/src/features/pulse/ui/PulseView.tsx
@@ -107,6 +107,7 @@ export function PulseView({ currentPubkey }: PulseViewProps) {
           channels: [],
           channelIds: [],
           capabilities: [],
+          channelAddPolicy: null,
           status:
             agent.status === "running" || agent.status === "deployed"
               ? "online"

--- a/desktop/src/shared/api/tauri.test.mjs
+++ b/desktop/src/shared/api/tauri.test.mjs
@@ -54,7 +54,9 @@ const { isRateLimited, resetRateLimitGate } = await import(
 
 // Import the production classifier from tauri.ts — tests must exercise the
 // real function, not a local copy, so a logic change is always caught here.
-const { applyTauriRateLimitIfNeeded } = await import("./tauri.ts");
+const { applyTauriRateLimitIfNeeded, fromRawRelayAgent } = await import(
+  "./tauri.ts"
+);
 
 function resetGate(startMs = 0) {
   pendingTimers.clear();
@@ -209,6 +211,53 @@ test("fromRawAcpRuntimeCatalogEntry env round-trips through edit payload shape",
     envValues,
     "env must round-trip: edit form must see the same values that Rust serialized",
   );
+});
+
+// ── fromRawRelayAgent: kind:10100 directory wire contract ─────────────────────
+
+// These tests pin the snake_case → camelCase field mapping for the relay
+// agent directory. A misnamed field here fails CLOSED with no error — the
+// value silently defaults and eligibility gates (add-search, mentions) hide
+// the agent app-wide — so the contract must be covered, not just reviewed.
+
+function rawRelayAgent(overrides = {}) {
+  return {
+    pubkey: "ab".repeat(32),
+    name: "Scout",
+    agent_type: "agent",
+    channels: [],
+    channel_ids: [],
+    capabilities: [],
+    status: "online",
+    ...overrides,
+  };
+}
+
+test("fromRawRelayAgent maps channel_add_policy to channelAddPolicy", () => {
+  const agent = fromRawRelayAgent(
+    rawRelayAgent({ channel_add_policy: "owner_only" }),
+  );
+  assert.equal(agent.channelAddPolicy, "owner_only");
+});
+
+test("fromRawRelayAgent defaults a missing channel_add_policy to null", () => {
+  const agent = fromRawRelayAgent(rawRelayAgent());
+  assert.equal(agent.channelAddPolicy, null);
+});
+
+test("fromRawRelayAgent maps respond_to fields and defaults them when absent", () => {
+  const declared = fromRawRelayAgent(
+    rawRelayAgent({
+      respond_to: "allowlist",
+      respond_to_allowlist: ["cd".repeat(32)],
+    }),
+  );
+  assert.equal(declared.respondTo, "allowlist");
+  assert.deepStrictEqual(declared.respondToAllowlist, ["cd".repeat(32)]);
+
+  const sparse = fromRawRelayAgent(rawRelayAgent());
+  assert.equal(sparse.respondTo, null);
+  assert.deepStrictEqual(sparse.respondToAllowlist, []);
 });
 
 // ── Teardown ──────────────────────────────────────────────────────────────────

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -113,6 +113,7 @@ type RawRelayAgent = {
   status: RelayAgent["status"];
   respond_to?: RelayAgent["respondTo"];
   respond_to_allowlist?: string[];
+  channel_add_policy?: RelayAgent["channelAddPolicy"];
 };
 export type RawManagedAgent = {
   pubkey: string;
@@ -680,7 +681,9 @@ export async function createAuthEvent(input: {
   return JSON.parse(eventJson) as RelayEvent;
 }
 
-function fromRawRelayAgent(agent: RawRelayAgent): RelayAgent {
+// Exported for tests — tauri.test.mjs covers the snake_case wire contract
+// (a silently dropped field here fails closed and hides agents app-wide).
+export function fromRawRelayAgent(agent: RawRelayAgent): RelayAgent {
   return {
     pubkey: agent.pubkey,
     name: agent.name,
@@ -691,6 +694,7 @@ function fromRawRelayAgent(agent: RawRelayAgent): RelayAgent {
     status: agent.status,
     respondTo: agent.respond_to ?? null,
     respondToAllowlist: agent.respond_to_allowlist ?? [],
+    channelAddPolicy: agent.channel_add_policy ?? null,
   };
 }
 

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -295,7 +295,11 @@ export type RelayAgent = {
   status: "online" | "away" | "offline";
   respondTo: RespondToMode | null;
   respondToAllowlist: string[];
+  /** kind:10100 `channel_add_policy` — relay-enforced on third-party adds. */
+  channelAddPolicy: ChannelAddPolicy | null;
 };
+
+export type ChannelAddPolicy = "anyone" | "owner_only" | "nobody";
 
 export type ManagedAgentRuntimeLifecycle =
   | "starting"

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -103,6 +103,7 @@ type MockRelayAgentSeed = {
   capabilities?: string[];
   respondTo?: RawRelayAgent["respond_to"];
   respondToAllowlist?: string[];
+  channelAddPolicy?: RawRelayAgent["channel_add_policy"];
   channelNames?: string[];
   channelIds?: string[];
   status?: PresenceStatus;
@@ -726,6 +727,7 @@ type RawRelayAgent = {
   status: PresenceStatus;
   respond_to?: "owner-only" | "allowlist" | "anyone";
   respond_to_allowlist?: string[];
+  channel_add_policy?: "anyone" | "owner_only" | "nobody";
 };
 
 type RawManagedAgent = {
@@ -2091,6 +2093,7 @@ function resetMockRelayAgents(config?: E2eConfig) {
       status: seed.status ?? "online",
       respond_to: seed.respondTo ?? "owner-only",
       respond_to_allowlist: seed.respondToAllowlist ?? [],
+      channel_add_policy: seed.channelAddPolicy ?? "anyone",
     });
   }
 }
@@ -2926,6 +2929,7 @@ const defaultMockRelayAgents: RawRelayAgent[] = [
     status: "online",
     respond_to: "anyone",
     respond_to_allowlist: [],
+    channel_add_policy: "anyone",
   },
   {
     pubkey: CHARLIE_PUBKEY,
@@ -2937,6 +2941,7 @@ const defaultMockRelayAgents: RawRelayAgent[] = [
     status: "away",
     respond_to: "anyone",
     respond_to_allowlist: [],
+    channel_add_policy: "anyone",
   },
 ];
 let mockRelayAgents: RawRelayAgent[] = defaultMockRelayAgents.map((agent) => ({

--- a/desktop/tests/e2e/add-search-eligibility.spec.ts
+++ b/desktop/tests/e2e/add-search-eligibility.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+// External (non-managed) relay agents in the add-member search are gated on
+// their kind:10100 `channel_add_policy` — the declaration the relay enforces
+// on third-party adds. Paired specs: the deny case proves an opted-out agent
+// never reaches the picker; the allow control proves the deny result comes
+// from the policy gate, not from a broken search or member-exclusion.
+
+const NOBODY_AGENT_PUBKEY = "77".repeat(32);
+const ANYONE_AGENT_PUBKEY = "99".repeat(32);
+
+async function openAddMemberSearch(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await page.getByTestId("channel-agents").click();
+  await page.getByTestId("channel-members-trigger").click();
+  await expect(page.getByTestId("members-sidebar")).toBeVisible();
+}
+
+test("add search: agent declaring channel_add_policy nobody is never offered", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: NOBODY_AGENT_PUBKEY,
+        name: "vega",
+        channelAddPolicy: "nobody",
+        channelNames: ["general"],
+        respondTo: "anyone",
+      },
+    ],
+  });
+  await openAddMemberSearch(page);
+  await page.getByTestId("channel-management-search-users").fill("vega");
+  await expect(
+    page.getByTestId(`channel-user-search-result-${NOBODY_AGENT_PUBKEY}`),
+  ).toHaveCount(0);
+});
+
+test("add search: control — agent declaring channel_add_policy anyone IS offered", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: ANYONE_AGENT_PUBKEY,
+        name: "lyra",
+        channelAddPolicy: "anyone",
+        channelNames: ["general"],
+        respondTo: "anyone",
+      },
+    ],
+  });
+  await openAddMemberSearch(page);
+  await page.getByTestId("channel-management-search-users").fill("lyra");
+  await expect(
+    page.getByTestId(`channel-user-search-result-${ANYONE_AGENT_PUBKEY}`),
+  ).toBeVisible();
+});

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -78,6 +78,7 @@ type MockRelayAgentSeed = {
   capabilities?: string[];
   respondTo?: "owner-only" | "allowlist" | "anyone";
   respondToAllowlist?: string[];
+  channelAddPolicy?: "anyone" | "owner_only" | "nobody";
   channelNames?: string[];
   channelIds?: string[];
   status?: "online" | "away" | "offline";


### PR DESCRIPTION
## Problem

The add-member search dropped every agent-classified candidate not in the local managed store (`isAgentIdentityInManagedList`), so external (non-desktop-managed) agents could never be offered for channel adds — even when their own declared policy explicitly allows it. The relay's actual authority for third-party adds is the agent's kind:10100 `channel_add_policy`, enforced server-side in `buzz-relay` `handlers/side_effects.rs` (`owner_only` checked against the stored attested owner, `nobody` refused for everyone, `anyone` allowed, self-adds exempt). The client never consulted it — the field wasn't even carried through the `RelayAgentInfo` conversion.

Part of the external-agents family tracked in #2987 (this surface was point-adjacent to the mentions gap); originally sketched in the #3448 discussion.

## What this changes

**Wire types:** `channel_add_policy` now flows kind:10100 content → `RelayAgentInfo` (Rust, `#[serde(default)]`) → `RawRelayAgent` → `RelayAgent.channelAddPolicy` (typed `"anyone" | "owner_only" | "nobody" | null`).

**Picker gate:** `MembersSidebar` swaps the managed-list gate for `shouldHideAgentFromAddSearch`, a predicate aligned with relay enforcement:

- managed agents: always offered (native parity, unchanged)
- external agents: offered when their declared policy is `anyone`, or `owner_only` when the viewer is the NIP-OA-verified owner (same verified `ownerPubkey` the "managed by" surface renders — same provenance as the relay's stored owner mapping)
- `nobody`: hidden from everyone including the owner (the relay refuses those adds regardless of actor)
- unknown/missing policy values: hidden (fails closed)

The change is strictly widening: nothing previously visible becomes hidden.

**One deliberate tightening:** agents with no directory entry stay hidden even though the relay — whose stored policy defaults to `anyone` — would accept the add. No declaration, no offer; this preserves the stale-identity suppression the managed-list gate was introduced for (#2149).

**Why not gate adds on mentionability:** `respond_to` and `channel_add_policy` are independent declarations with independent relay enforcement — an agent can be mentionable but refuse adds (`respond_to: anyone` + `channel_add_policy: nobody`) or addable but not mentionable (`channel_add_policy: anyone` + `respond_to: owner-only`). Each surface reads its own declaration: `respond_to` for mentions (#3676), `channel_add_policy` for adds (this PR).

Enforcement stays server-side: the picker mirrors the *declared* policy, and the rare divergence between declaration and relay-stored state (first-write-wins owner mapping, last-validated policy) surfaces as a visible add error rather than a silent gap.

## Testing

- Predicate matrix: people / managed / `anyone` / `owner_only` as owner, non-owner, unverified / `nobody` incl. owner / no directory entry / null policy / pubkey normalization (`agentAutocompleteEligibility.test.mjs`).
- Wire contract on both hops — a misnamed field anywhere in this chain fails closed and silently hides agents app-wide, so it's pinned by tests: kind:10100 content → `RelayAgentInfo` (Rust directory-parse test) and `channel_add_policy` → `channelAddPolicy` (`fromRawRelayAgent`, `tauri.test.mjs`).
- Rust side executed locally via the repo's `desktop-tauri-test` recipe: 1,890 passed / 0 failed (14 ignored), including the amended directory-parse tests.
- End-to-end (added in review): the mock bridge seeds now carry `channel_add_policy`, plus paired smoke specs (`add-search-eligibility.spec.ts`) — an agent declaring `nobody` never appears in add search; an `anyone` control proves the deny comes from the policy gate. Run locally headless (2/2 passing) and in CI's `desktop-smoke-e2e`. Full desktop unit suite 3,791/3,791, repo-wide Biome, and typecheck clean; existing e2e specs swept for assertions the seed defaults could disturb (none — detail in the test commit message).

## Out of scope (tracked separately)

- **Directory parse robustness:** `list_relay_agents` deserializes the whole kind:10100 set in one call, so one malformed profile value (e.g. a numeric field) blanks the entire agent directory for every desktop surface. Pre-existing class (`respond_to`, `capabilities` have the same shape — this PR's `Option<String>` is the most tolerant field in the struct); fixed read-side in the follow-up PR (#3866, mergeable in either order). The write-path half — nothing validates kind:10100 content before the relay persists it — belongs with #2987/#3448.
- **`owner_only` directory-only candidates:** an `owner_only` agent is offered to its owner via the user-search candidate (which carries the verified owner); directory candidates carry no verified owner and fail closed. If an owner ever reports their agent missing from add search, the fix is backend owner enrichment of `RelayAgentInfo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
