### PR TITLE
fix(compose): allow overriding S3 endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,7 +87,8 @@ RELAY_URL=ws://localhost:3000
 # -----------------------------------------------------------------------------
 # The local MinIO container is reachable from host processes at localhost:9000.
 # Path style keeps the bucket in the URL path and is required by this local DNS
-# setup. Use `virtual` only when the provider requires bucket-as-subdomain URLs.
+# setup. Use `virtual` only when the provider requires bucket-as-subdomain URLs
+# (for example, real S3 endpoints rather than local MinIO).
 BUZZ_S3_ENDPOINT=http://localhost:9000
 BUZZ_S3_ACCESS_KEY=buzz_dev
 BUZZ_S3_SECRET_KEY=buzz_dev_secret

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ A Rust workspace of focused crates. Single source of truth: the relay. See [ARCH
 <summary><strong>Configuration</strong> (env vars, defaults work for local dev)</summary>
 
 All defaults work out of the box. Override via `.env`. Full reference in [`.env.example`](.env.example).
+For local MinIO, keep `BUZZ_S3_ADDRESSING_STYLE=path`; real S3-style providers may require `virtual` bucket-subdomain addressing instead.
 
 </details>
 

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -32,8 +32,9 @@ POSTGRES_PASSWORD=CHANGE_ME_RANDOM_PASSWORD
 REDIS_PASSWORD=CHANGE_ME_RANDOM_PASSWORD
 BUZZ_S3_ACCESS_KEY=CHANGE_ME_RANDOM_ACCESS_KEY
 BUZZ_S3_SECRET_KEY=CHANGE_ME_RANDOM_SECRET_KEY
-# Override this for external S3-compatible storage; the default targets the
-# bundled MinIO service.
+# Compose reads this from `.env`; override it for external S3-compatible
+# storage instead of editing `compose.yml`. The default targets the bundled
+# MinIO service.
 BUZZ_S3_ENDPOINT=http://minio:9000
 BUZZ_S3_BUCKET=buzz-media
 # Bundled MinIO uses path-style URLs. External S3-compatible providers may

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -32,8 +32,12 @@ POSTGRES_PASSWORD=CHANGE_ME_RANDOM_PASSWORD
 REDIS_PASSWORD=CHANGE_ME_RANDOM_PASSWORD
 BUZZ_S3_ACCESS_KEY=CHANGE_ME_RANDOM_ACCESS_KEY
 BUZZ_S3_SECRET_KEY=CHANGE_ME_RANDOM_SECRET_KEY
+# Override this for external S3-compatible storage; the default targets the
+# bundled MinIO service.
+BUZZ_S3_ENDPOINT=http://minio:9000
 BUZZ_S3_BUCKET=buzz-media
-# Bundled MinIO uses path-style URLs; deploy/compose/compose.yml pins this.
+# Bundled MinIO uses path-style URLs. External S3-compatible providers may
+# require virtual addressing.
 BUZZ_S3_ADDRESSING_STYLE=path
 
 # Optional host ports. Base compose publishes the relay directly on BUZZ_HTTP_PORT.

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -38,11 +38,13 @@ keypair.
   migrations.
 - The stack uses Postgres, Redis, MinIO, and a git data volume because
   those are real Buzz dependencies today. Minimal mode can simplify this later.
-- The bundled Compose stack fixes the relay endpoint to `http://minio:9000` and
-  `BUZZ_S3_ADDRESSING_STYLE=path`: Docker DNS resolves `minio`, not
-  `<bucket>.minio`. It is not configurable for an external S3 provider through
-  `.env`; use the Helm chart or a custom Compose configuration for providers
-  such as new Railway Storage Buckets that require `virtual` addressing.
+- The bundled Compose stack defaults `BUZZ_S3_ENDPOINT` to
+  `http://minio:9000` and `BUZZ_S3_ADDRESSING_STYLE=path`: Docker DNS resolves
+  `minio`, not `<bucket>.minio`. Keep `path` for bundled MinIO; check your
+  provider's addressing requirements before copying that default to real S3,
+  R2, or another S3-compatible service. Set both variables in `.env` when
+  pointing the relay at an external provider that requires a different endpoint
+  or `virtual` addressing.
 
 Run `./run.sh backup-hint` for the backup checklist.
 

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -11,9 +11,9 @@ services:
       BUZZ_METRICS_PORT: "9102"
       DATABASE_URL: postgres://${POSTGRES_USER:-buzz}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-buzz}
       REDIS_URL: redis://:${REDIS_PASSWORD:?set REDIS_PASSWORD}@redis:6379
-      BUZZ_S3_ENDPOINT: http://minio:9000
+      BUZZ_S3_ENDPOINT: ${BUZZ_S3_ENDPOINT:-http://minio:9000}
       # Docker DNS resolves `minio`, not arbitrary `<bucket>.minio` hosts.
-      BUZZ_S3_ADDRESSING_STYLE: path
+      BUZZ_S3_ADDRESSING_STYLE: ${BUZZ_S3_ADDRESSING_STYLE:-path}
       BUZZ_S3_ACCESS_KEY: ${BUZZ_S3_ACCESS_KEY:?set BUZZ_S3_ACCESS_KEY}
       BUZZ_S3_SECRET_KEY: ${BUZZ_S3_SECRET_KEY:?set BUZZ_S3_SECRET_KEY}
       BUZZ_S3_BUCKET: ${BUZZ_S3_BUCKET:-buzz-media}


### PR DESCRIPTION
## Summary

- Honor `BUZZ_S3_ENDPOINT` from compose `.env`, defaulting to bundled MinIO.
- Honor `BUZZ_S3_ADDRESSING_STYLE` from `.env`, defaulting to `path` for bundled MinIO.
- Document both variables in the compose example and README.

Fixes #3794

## Validation

- `git diff --check`
- `docker compose --env-file .env config` with `.env` copied from `.env.example` renders `BUZZ_S3_ENDPOINT: http://minio:9000` and `BUZZ_S3_ADDRESSING_STYLE: path`.
- `BUZZ_S3_ENDPOINT=https://example.r2.cloudflarestorage.com BUZZ_S3_ADDRESSING_STYLE=virtual docker compose --env-file .env config` renders the external endpoint and `virtual` addressing.
