### PR TITLE
fix(desktop): parse the relay agent directory leniently

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1076,6 +1076,7 @@ dependencies = [
  "security-framework 3.7.0",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_yaml",
  "sha2 0.11.0",
  "sherpa-onnx",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -84,6 +84,9 @@ opus = "0.3"
 neteq = { version = "0.8", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Names the failing field path in directory-parse skip warns (already in the
+# tree as a transitive dep).
+serde_path_to_error = "0.1"
 serde_yaml = "0.9"
 toml = "0.8"
 nostr = { version = "0.44", features = ["nip44", "nip49"] }

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -1068,12 +1068,92 @@ pub async fn list_relay_agents(state: State<'_, AppState>) -> Result<Vec<RelayAg
         .get("agents")
         .cloned()
         .unwrap_or_else(|| serde_json::json!([]));
-    serde_json::from_value(agents).map_err(|e| format!("agent parse failed: {e}"))
+    Ok(parse_relay_agents(agents))
+}
+
+/// Parse the agent directory leniently: entries that fail to deserialize are
+/// logged and skipped instead of failing the whole set.
+///
+/// Kind:10100 content is free-form JSON under each agent author's control,
+/// and the relay persists the event even when its own side-effect validation
+/// fails — so one profile with a mistyped field (e.g. a numeric
+/// `channel_add_policy`) must not blank the entire directory for every
+/// surface that mounts `list_relay_agents`.
+fn parse_relay_agents(agents: serde_json::Value) -> Vec<RelayAgentInfo> {
+    let serde_json::Value::Array(items) = agents else {
+        return Vec::new();
+    };
+    items
+        .into_iter()
+        .filter_map(|item| {
+            let pubkey_hint = item
+                .get("pubkey")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("<missing pubkey>")
+                .to_owned();
+            match serde_json::from_value::<RelayAgentInfo>(item) {
+                Ok(agent) => Some(agent),
+                Err(e) => {
+                    tracing::warn!(
+                        "list_relay_agents: skipping unparseable agent profile ({pubkey_hint}): {e}"
+                    );
+                    None
+                }
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── parse_relay_agents ────────────────────────────────────────────────────
+
+    fn directory_entry(name: &str) -> serde_json::Value {
+        serde_json::json!({
+            "pubkey": "ab".repeat(32),
+            "name": name,
+            "agent_type": "agent",
+            "channels": [],
+            "capabilities": [],
+            "status": "online",
+        })
+    }
+
+    #[test]
+    fn parse_relay_agents_parses_valid_entries() {
+        let parsed = parse_relay_agents(serde_json::json!([
+            directory_entry("Scout"),
+            directory_entry("Rover"),
+        ]));
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].name, "Scout");
+        assert_eq!(parsed[1].name, "Rover");
+    }
+
+    #[test]
+    fn parse_relay_agents_skips_malformed_entries_and_keeps_the_rest() {
+        // One profile with a mistyped field (respond_to must be a string enum)
+        // must not blank the directory — the other agents still parse.
+        let mut poisoned = directory_entry("Broken");
+        poisoned["respond_to"] = serde_json::json!(123);
+
+        let parsed = parse_relay_agents(serde_json::json!([
+            directory_entry("Scout"),
+            poisoned,
+            directory_entry("Rover"),
+        ]));
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].name, "Scout");
+        assert_eq!(parsed[1].name, "Rover");
+    }
+
+    #[test]
+    fn parse_relay_agents_returns_empty_for_non_array_input() {
+        assert!(parse_relay_agents(serde_json::json!(null)).is_empty());
+        assert!(parse_relay_agents(serde_json::json!({})).is_empty());
+    }
 
     // ── is_npm_global_install ─────────────────────────────────────────────────
 

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -1092,7 +1092,10 @@ fn parse_relay_agents(agents: serde_json::Value) -> Vec<RelayAgentInfo> {
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or("<missing pubkey>")
                 .to_owned();
-            match serde_json::from_value::<RelayAgentInfo>(item) {
+            // serde_path_to_error names the offending field (e.g.
+            // `channel_add_policy: invalid type: integer`) so operators can
+            // spot schema drift from the warn alone.
+            match serde_path_to_error::deserialize::<_, RelayAgentInfo>(item) {
                 Ok(agent) => Some(agent),
                 Err(e) => {
                     tracing::warn!(

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -1083,7 +1083,8 @@ fn parse_relay_agents(agents: serde_json::Value) -> Vec<RelayAgentInfo> {
     let serde_json::Value::Array(items) = agents else {
         return Vec::new();
     };
-    items
+    let total = items.len();
+    let parsed: Vec<RelayAgentInfo> = items
         .into_iter()
         .filter_map(|item| {
             let pubkey_hint = item
@@ -1101,7 +1102,17 @@ fn parse_relay_agents(agents: serde_json::Value) -> Vec<RelayAgentInfo> {
                 }
             }
         })
-        .collect()
+        .collect();
+    // One aggregate line per query so a poisoned directory is visible at a
+    // glance without counting per-entry warns.
+    let skipped = total - parsed.len();
+    if skipped > 0 {
+        tracing::warn!(
+            "list_relay_agents: kept {kept} of {total} agent profiles, skipped {skipped} unparseable",
+            kept = parsed.len()
+        );
+    }
+    parsed
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

`list_relay_agents` deserialized the whole kind:10100 directory in a single `serde_json::from_value` call, so one profile with a mistyped field — e.g. a numeric `respond_to` or `channel_add_policy` — failed the entire query. Kind:10100 content is free-form JSON under each agent author's control, and the relay persists the event even when its own side-effect validation fails (`handlers/ingest.rs` logs and keeps it), so any authenticated publisher could blank the agent directory for every desktop client. The failure is app-wide and looks like a product bug: `useRelayAgentsQuery` mounts on ~14 always-live surfaces (mentions, members bar, add-member search, profile popovers, search, pulse).

## What this changes

Parse per-entry instead: malformed profiles are logged (`tracing::warn!` with the offending pubkey) and skipped; the rest of the directory survives. Same pattern as `custom_harnesses.rs` (per-file warn-and-skip). Output is unchanged for any directory that parses today; error results now come only from the relay query itself. Verified against all `useRelayAgentsQuery` consumers — the two that touch the error path use it only as a readiness signal and a dialog message, so fewer errors is strictly safe.

## Testing

Unit tests on the extracted `parse_relay_agents` helper: valid entries parse; a poisoned entry (`"respond_to": 123`) is skipped while its neighbors survive; non-array input returns empty.

Executed locally via `just desktop-tauri-test`: full suite 2,017 passed / 0 failed (14 ignored), including the three `parse_relay_agents` tests.

## Related

The write-path half of this root cause — nothing validates kind:10100 content shape before it is persisted — is tracked in the external-agent threads (#2987; #3448 fixes the CLI's clobbering writer). This is the read-side defense. Surfaced during review of #3864 (which adds one more field riding this parse); mergeable in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
