### PR TITLE
feat(desktop): add OpenClaw native ACP runtime

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -701,7 +701,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        | "claudecode" | "openclaw-acp" | "buzz-agent" => Some(Vec::new()),
         _ => None,
     }
 }
@@ -1573,6 +1573,10 @@ mod tests {
         );
         assert_eq!(
             normalize_agent_args("claude-agent-acp", vec!["acp".into()]),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            normalize_agent_args("openclaw-acp", vec!["acp".into()]),
             Vec::<String>::new()
         );
     }

--- a/desktop/src-tauri/src/commands/agent_auth.rs
+++ b/desktop/src-tauri/src/commands/agent_auth.rs
@@ -256,7 +256,8 @@ fn launch_terminal_auth(runtime_id: &str, method: &AcpAuthMethod) -> Result<(), 
         .ok_or_else(|| format!("{} ACP adapter is not installed", runtime.label))?;
     let fallback_command = adapter_command.1.display().to_string();
     let argv = adapter_terminal_argv(runtime.label, method, &fallback_command)?;
-    launch_visible_terminal(&argv)
+    let augmented_path = auth_command_path();
+    launch_visible_terminal(&argv, augmented_path.as_deref())
 }
 
 fn adapter_terminal_argv(
@@ -361,17 +362,13 @@ fn spawn_without_stdio(mut command: Command) -> Result<(), String> {
 }
 
 #[cfg(target_os = "macos")]
-fn launch_visible_terminal(argv: &[String]) -> Result<(), String> {
+fn launch_visible_terminal(argv: &[String], augmented_path: Option<&str>) -> Result<(), String> {
     let mut script = tempfile::Builder::new()
         .prefix("buzz-auth-")
         .suffix(".command")
         .tempfile()
         .map_err(|error| format!("failed to create terminal login script: {error}"))?;
-    writeln!(
-        script,
-        "#!/bin/sh\ntrap 'rm -f -- \"$0\"' EXIT\n{}",
-        shell_join(argv)
-    )
+    writeln!(script, "{}", terminal_shell_script(argv, augmented_path))
     .map_err(|error| format!("failed to write terminal login script: {error}"))?;
     fs::set_permissions(script.path(), fs::Permissions::from_mode(0o700))
         .map_err(|error| format!("failed to prepare terminal login script: {error}"))?;
@@ -395,8 +392,8 @@ fn launch_visible_terminal(argv: &[String]) -> Result<(), String> {
 }
 
 #[cfg(target_os = "linux")]
-fn launch_visible_terminal(argv: &[String]) -> Result<(), String> {
-    let command = shell_join(argv);
+fn launch_visible_terminal(argv: &[String], augmented_path: Option<&str>) -> Result<(), String> {
+    let command = terminal_shell_command(argv, augmented_path);
     let candidates: [(&str, &[&str]); 4] = [
         ("x-terminal-emulator", &["-e", "sh", "-lc"]),
         ("gnome-terminal", &["--", "sh", "-lc"]),
@@ -414,7 +411,7 @@ fn launch_visible_terminal(argv: &[String]) -> Result<(), String> {
 }
 
 #[cfg(target_os = "windows")]
-fn launch_visible_terminal(argv: &[String]) -> Result<(), String> {
+fn launch_visible_terminal(argv: &[String], augmented_path: Option<&str>) -> Result<(), String> {
     use std::os::windows::process::CommandExt;
 
     const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
@@ -425,6 +422,9 @@ fn launch_visible_terminal(argv: &[String]) -> Result<(), String> {
     command
         .args(windows_terminal_args(argv))
         .creation_flags(CREATE_NEW_CONSOLE);
+    if let Some(path) = augmented_path {
+        command.env("PATH", path);
+    }
     spawn_without_stdio(command)
 }
 
@@ -436,8 +436,23 @@ fn windows_terminal_args(argv: &[String]) -> Vec<String> {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-fn launch_visible_terminal(_argv: &[String]) -> Result<(), String> {
+fn launch_visible_terminal(_argv: &[String], _augmented_path: Option<&str>) -> Result<(), String> {
     Err("opening a terminal is not supported on this platform".to_string())
+}
+
+fn terminal_shell_command(argv: &[String], augmented_path: Option<&str>) -> String {
+    match augmented_path {
+        Some(path) => format!("export PATH={}; exec {}", shell_escape(path), shell_join(argv)),
+        None => format!("exec {}", shell_join(argv)),
+    }
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn terminal_shell_script(argv: &[String], augmented_path: Option<&str>) -> String {
+    format!(
+        "#!/bin/sh\ntrap 'rm -f -- \"$0\"' EXIT\n{}",
+        terminal_shell_command(argv, augmented_path)
+    )
 }
 
 fn shell_join(argv: &[String]) -> String {
@@ -462,8 +477,8 @@ fn shell_escape(arg: &str) -> String {
 mod tests {
     use super::{
         adapter_terminal_argv, append_inherited_path, is_claude_subscription_login,
-        run_buzz_acp_auth_command_with_paths, shell_escape, shell_join, uses_terminal_auth,
-        windows_terminal_args, AcpAuthMethod,
+        run_buzz_acp_auth_command_with_paths, shell_escape, shell_join, terminal_shell_script,
+        uses_terminal_auth, windows_terminal_args, AcpAuthMethod,
     };
 
     /// Windows regression: the augmented PATH there holds only Buzz-managed
@@ -569,6 +584,17 @@ mod tests {
     #[test]
     fn shell_escape_leaves_simple_args_unquoted() {
         assert_eq!(shell_escape("--claudeai"), "--claudeai");
+    }
+
+    #[test]
+    fn terminal_auth_script_exports_augmented_path() {
+        assert_eq!(
+            terminal_shell_script(
+                &["/managed/openclaw-acp".into(), "--configure-model".into()],
+                Some("/managed node/bin:/usr/bin"),
+            ),
+            "#!/bin/sh\ntrap 'rm -f -- \"$0\"' EXIT\nexport PATH='/managed node/bin:/usr/bin'; exec /managed/openclaw-acp --configure-model"
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -20,6 +20,8 @@ pub(crate) use runtime_metadata::KnownAcpRuntime;
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
+const OPENCLAW_AVATAR_URL: &str =
+    "https://raw.githubusercontent.com/openclaw/openclaw/refs/heads/main/ui/public/favicon.svg";
 const BUZZ_AGENT_AVATAR_URL: &str =
     "https://raw.githubusercontent.com/block/buzz/refs/heads/main/crates/buzz-agent/buzz-agent.png";
 fn common_binary_paths() -> &'static [PathBuf] {
@@ -174,6 +176,48 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         login_hint: Some("Run `codex login` to authenticate."),
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
         auth_probe_args: Some(&["codex", "login", "status"]),
+    },
+    KnownAcpRuntime {
+        id: "openclaw",
+        label: "OpenClaw",
+        commands: &["openclaw-acp"],
+        aliases: &[],
+        avatar_url: OPENCLAW_AVATAR_URL,
+        mcp_command: None,
+        mcp_hooks: false,
+        underlying_cli: None,
+        cli_install_commands: &[],
+        cli_install_commands_windows: &[],
+        adapter_install_commands: &["npm install -g openclaw@latest"],
+        cli_install_instructions_url: "https://docs.openclaw.ai/install",
+        adapter_install_instructions_url: "https://docs.openclaw.ai/cli/acp",
+        cli_install_hint: "",
+        adapter_install_hint:
+            "Install OpenClaw to add its self-contained native ACP runtime.",
+        skill_dir: None,
+        supports_acp_model_switching: false,
+        model_env_var: None,
+        provider_env_var: None,
+        provider_locked: false,
+        default_env: &[],
+        config_file_path: Some("~/.openclaw/openclaw.json"),
+        config_file_format: Some("json"),
+        supports_acp_native_config: false,
+        thinking_env_var: None,
+        max_tokens_env_var: None,
+        context_limit_env_var: None,
+        max_rounds_env_var: None,
+        required_normalized_fields: &[],
+        login_hint: Some(
+            "Run `openclaw-acp --configure-model` to authenticate a provider and choose a model.",
+        ),
+        auth_probe_args: Some(&[
+            "openclaw",
+            "models",
+            "status",
+            "--check",
+            "--json",
+        ]),
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -460,7 +504,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        | "claudecode" | "openclaw-acp" | "buzz-agent" => Some(Vec::new()),
         _ => None,
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/presets.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/presets.rs
@@ -158,22 +158,6 @@ pub(super) const PRESET_HARNESSES: &[PresetHarness] = &[
         install_hint: "Buzz talks to Hermes Agent through its hermes-acp command.",
         underlying_cli: None,
     },
-    PresetHarness {
-        id: "openclaw",
-        label: "OpenClaw",
-        command: "openclaw",
-        args: &["acp"],
-        install_instructions_url: "https://docs.openclaw.ai/start/getting-started",
-        install_hint: "Buzz talks to OpenClaw through its ACP mode (openclaw acp), which relies on the OpenClaw Gateway daemon. Follow the setup guide to install both.\n\n\
-            ⚠️  Execution-locus note: `openclaw acp` runs tools inside the \
-            OpenClaw Gateway daemon, not in the Desktop process. \
-            Desktop-injected BUZZ_* env vars are visible to the `openclaw` \
-            harness process itself, but do NOT automatically reach the \
-            Gateway's execution environment. If your tools or agent logic \
-            needs BUZZ_* credentials at execution time, set them on the \
-            Gateway's own environment separately.",
-        underlying_cli: None,
-    },
 ];
 
 /// Return preset definitions for the spawn/readiness registry.

--- a/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/runtime_metadata.rs
@@ -122,5 +122,24 @@ mod tests {
         );
         assert!(codex.adapter_install_instructions_url.contains("codex-acp"));
         assert!(codex.cli_install_hint.contains("Codex CLI"));
+
+        let openclaw = known_acp_runtime_exact("openclaw").unwrap();
+        assert_eq!(openclaw.commands, &["openclaw-acp"]);
+        assert_eq!(
+            openclaw.adapter_install_commands,
+            &["npm install -g openclaw@latest"]
+        );
+        assert_eq!(
+            openclaw.auth_probe_args,
+            Some(
+                &[
+                    "openclaw",
+                    "models",
+                    "status",
+                    "--check",
+                    "--json"
+                ][..]
+            )
+        );
     }
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -8,7 +8,7 @@ use super::{
     is_login_shell_path_uninit, is_safe_nvm_tag, managed_agent_avatar_url, normalize_agent_args,
     parse_semver_tag, probe_codex_acp_version, record_agent_command, refresh_login_shell_path,
     try_record_agent_command, BUZZ_AGENT_AVATAR_URL, CLAUDE_CODE_AVATAR_URL, CODEX_AVATAR_URL,
-    GOOSE_AVATAR_URL,
+    GOOSE_AVATAR_URL, OPENCLAW_AVATAR_URL,
 };
 use crate::managed_agents::AcpAvailabilityStatus;
 
@@ -79,6 +79,18 @@ fn resolves_buzz_agent_avatar() {
     assert_eq!(
         managed_agent_avatar_url("/usr/local/bin/buzz-agent"),
         Some(BUZZ_AGENT_AVATAR_URL.to_string())
+    );
+}
+
+#[test]
+fn resolves_openclaw_native_runtime() {
+    assert_eq!(
+        managed_agent_avatar_url("openclaw-acp"),
+        Some(OPENCLAW_AVATAR_URL.to_string())
+    );
+    assert_eq!(
+        normalize_agent_args("openclaw-acp", vec!["acp".into()]),
+        Vec::<String>::new()
     );
 }
 

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -393,6 +393,7 @@ impl AgentReadiness {
 /// * **claude**: a successful `claude auth status` probe.
 /// * **codex**: a successful `codex login status` probe (checks the codex
 ///   credential store — NOT `OPENAI_API_KEY`).
+/// * **openclaw**: a configured model route with usable authentication.
 /// * **unknown / custom command**: always `Ready` (no requirements known).
 ///
 /// Databricks note: `DATABRICKS_TOKEN` is `.unwrap_or_default()` in
@@ -441,6 +442,17 @@ fn collect_missing_requirements(
             rt,
         ),
         "codex" => cli_login::requirements(&["codex", "login", "status"], "run `codex login`", rt),
+        "openclaw" => cli_login::requirements(
+            &[
+                "openclaw",
+                "models",
+                "status",
+                "--check",
+                "--json",
+            ],
+            "run `openclaw-acp --configure-model`",
+            rt,
+        ),
         _ => vec![],
     }
 }

--- a/desktop/src-tauri/src/migration.rs
+++ b/desktop/src-tauri/src/migration.rs
@@ -169,6 +169,7 @@ fn run_boot_migrations_inner(app: &tauri::AppHandle, reset_completed: bool) {
     }
     migrate_persona_provider_to_runtime(app);
     reconcile_legacy_command_names(app);
+    reconcile_openclaw_native_runtime(app);
     // Fold personas.json into the unified store HERE: after the JSON-level
     // personas.json migrations above (which must see the legacy file), and
     // before every consumer of the load/save_personas shims below —
@@ -1099,6 +1100,57 @@ fn reconcile_legacy_command_names_in_file(path: &Path) {
     });
 }
 
+fn reconcile_openclaw_native_runtime_in_file(path: &Path) {
+    patch_json_records(path, |obj| {
+        let legacy_args = obj
+            .get("agent_args")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|args| args.len() == 1 && args[0].as_str() == Some("acp"));
+        if !legacy_args {
+            return false;
+        }
+
+        let command_is_legacy =
+            obj.get("agent_command").and_then(serde_json::Value::as_str) == Some("openclaw");
+        let command_override = obj
+            .get("agent_command_override")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        if command_override.is_some_and(|value| value != "openclaw") {
+            return false;
+        }
+        let override_is_legacy = command_override == Some("openclaw");
+        if !command_is_legacy && !override_is_legacy {
+            return false;
+        }
+
+        if command_is_legacy {
+            obj.insert(
+                "agent_command".to_string(),
+                serde_json::Value::String("openclaw-acp".to_string()),
+            );
+        }
+        if override_is_legacy {
+            obj.insert(
+                "agent_command_override".to_string(),
+                serde_json::Value::String("openclaw-acp".to_string()),
+            );
+        }
+        obj.insert(
+            "agent_args".to_string(),
+            serde_json::Value::Array(Vec::new()),
+        );
+        eprintln!(
+            "buzz-desktop: runtime-reconcile: {:?}: migrated OpenClaw to native ACP",
+            obj.get("name")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("?"),
+        );
+        true
+    });
+}
+
 fn reconcile_legacy_persona_runtimes_in_file(path: &Path) {
     patch_json_records(path, |obj| {
         let Some(runtime) = obj.get("runtime").and_then(|v| v.as_str()) else {
@@ -1209,6 +1261,27 @@ pub fn reconcile_legacy_command_names(app: &tauri::AppHandle) {
         let teams_dir = dir.join("agents/teams");
         if teams_dir.exists() && !teams_dir.is_symlink() {
             reconcile_legacy_team_persona_runtime_files(&teams_dir);
+        }
+    }
+}
+
+/// Upgrade the exact OpenClaw command/argument shape shipped by Buzz v0.5.2.
+///
+/// Custom commands and any non-standard arguments remain untouched.
+pub fn reconcile_openclaw_native_runtime(app: &tauri::AppHandle) {
+    let Ok(current_dir) = app.path().app_data_dir() else {
+        return;
+    };
+    let mut dirs = vec![current_dir.clone()];
+    if let Some(canonical) = canonical_dev_data_dir(&current_dir) {
+        if canonical.exists() && canonical != current_dir {
+            dirs.push(canonical);
+        }
+    }
+    for dir in dirs {
+        let path = dir.join("agents/managed-agents.json");
+        if path.exists() {
+            reconcile_openclaw_native_runtime_in_file(&path);
         }
     }
 }

--- a/desktop/src-tauri/src/migration_command_tests.rs
+++ b/desktop/src-tauri/src/migration_command_tests.rs
@@ -83,6 +83,66 @@ fn reconcile_legacy_command_names_preserves_custom_commands() {
 }
 
 #[test]
+fn reconcile_openclaw_native_runtime_rewrites_exact_shipped_shape() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agents_json(
+        dir.path(),
+        &serde_json::json!([
+            {
+                "name": "Inherited OpenClaw",
+                "agent_command": "openclaw",
+                "agent_args": ["acp"]
+            },
+            {
+                "name": "Pinned OpenClaw",
+                "agent_command": "openclaw",
+                "agent_command_override": "openclaw",
+                "agent_args": ["acp"]
+            }
+        ]),
+    );
+
+    reconcile_openclaw_native_runtime_in_file(&dir.path().join("agents/managed-agents.json"));
+
+    let records = read_agents_json(dir.path());
+    assert_eq!(records[0]["agent_command"], "openclaw-acp");
+    assert_eq!(records[0]["agent_args"], serde_json::json!([]));
+    assert_eq!(records[1]["agent_command"], "openclaw-acp");
+    assert_eq!(records[1]["agent_command_override"], "openclaw-acp");
+    assert_eq!(records[1]["agent_args"], serde_json::json!([]));
+}
+
+#[test]
+fn reconcile_openclaw_native_runtime_preserves_custom_openclaw_commands() {
+    let dir = tempfile::tempdir().unwrap();
+    let records = serde_json::json!([
+        {
+            "name": "Custom args",
+            "agent_command": "openclaw",
+            "agent_args": ["acp", "--url", "wss://example.invalid"]
+        },
+        {
+            "name": "Custom command",
+            "agent_command": "/opt/openclaw",
+            "agent_args": ["acp"]
+        },
+        {
+            "name": "Custom override",
+            "agent_command": "openclaw",
+            "agent_command_override": "my-openclaw-wrapper",
+            "agent_args": ["acp"]
+        }
+    ]);
+    write_agents_json(dir.path(), &records);
+    let path = dir.path().join("agents/managed-agents.json");
+    let before = std::fs::read_to_string(&path).unwrap();
+
+    reconcile_openclaw_native_runtime_in_file(&path);
+
+    assert_eq!(before, std::fs::read_to_string(&path).unwrap());
+}
+
+#[test]
 fn reconcile_legacy_command_names_rewrites_persona_runtime() {
     let dir = tempfile::tempdir().unwrap();
     write_personas_json(

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -77,7 +77,10 @@ with a TypeScript lookup table or an id comparison in a component.
    failure. A harness selection alone does not enable Next when the harness
    requires provider/model/credential config (e.g. buzz-agent with no
    provider). Baked build env and runtime-file config satisfy the gate. Drafts
-   intentionally do not survive an app restart.
+   intentionally do not survive an app restart. ACP runtimes may advertise
+   terminal authentication methods; setup nudges for installed but
+   unauthenticated runtimes route back to Agent runtimes so that flow remains
+   actionable.
    `onboarding-agent-defaults.spec.ts` is the acceptance gate for anything
    touching this flow or the shared renderer.
 8. **Omit the Model control only after a confirmed successful empty

--- a/desktop/src/features/onboarding/ui/RuntimeIcon.tsx
+++ b/desktop/src/features/onboarding/ui/RuntimeIcon.tsx
@@ -7,11 +7,12 @@ import { BuzzMark } from "@/shared/ui/buzz-logo/BuzzMark";
 import claudeLogoUrl from "../assets/harness-logos/claude.png?inline";
 import { RUNTIME_MARKS } from "./HarnessMarks";
 
-// Bundled logos for compiled-in runtimes (inline base64, no network fetch).
-// Monochrome marks live in RUNTIME_MARKS instead — inline SVGs that follow
-// `currentColor`, so they adapt to dark/light without bitmap filters.
-const RUNTIME_LOGOS: Record<string, string> = {
+// Bundled logos for compiled-in runtimes. Monochrome marks live in
+// RUNTIME_MARKS instead — inline SVGs that follow `currentColor`, so they
+// adapt to dark/light without bitmap filters.
+export const RUNTIME_LOGOS: Record<string, string> = {
   claude: claudeLogoUrl,
+  openclaw: "/harness-logos/openclaw.svg",
 };
 
 // Public-path logos for bundled presets. Served from /harness-logos/ at runtime.
@@ -24,7 +25,6 @@ export const PRESET_LOGOS: Record<string, string> = {
   kimi: "/harness-logos/kimi.png",
   amp: "/harness-logos/amp.png",
   hermes: "/harness-logos/hermes.png",
-  openclaw: "/harness-logos/openclaw.svg",
 };
 
 function isBuzzRuntime(runtime: AcpRuntimeCatalogEntry): boolean {

--- a/desktop/src/features/onboarding/ui/presetLogos.test.mjs
+++ b/desktop/src/features/onboarding/ui/presetLogos.test.mjs
@@ -17,7 +17,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { RUNTIME_MARKS } from "./HarnessMarks.tsx";
-import { PRESET_LOGOS } from "./RuntimeIcon.tsx";
+import { PRESET_LOGOS, RUNTIME_LOGOS } from "./RuntimeIcon.tsx";
 
 const desktopRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -78,6 +78,15 @@ test("PRESET_LOGOS has no entries for unknown presets", () => {
     unknown,
     [],
     `PRESET_LOGOS maps ids the backend does not emit as presets: ${unknown.join(", ")}`,
+  );
+});
+
+test("OpenClaw keeps its bundled logo as a compiled-in runtime", () => {
+  const logoPath = RUNTIME_LOGOS.openclaw;
+  assert.equal(logoPath, "/harness-logos/openclaw.svg");
+  assert.ok(
+    existsSync(path.join(desktopRoot, "public", logoPath)),
+    `RUNTIME_LOGOS.openclaw points at ${logoPath}, which is missing from desktop/public`,
   );
 });
 

--- a/desktop/src/shared/ui/config-nudge-attachment.test.mjs
+++ b/desktop/src/shared/ui/config-nudge-attachment.test.mjs
@@ -60,6 +60,20 @@ test("shouldOpenDoctor_regularMixedRequirements_routesToEditAgent", () => {
   );
 });
 
+test("shouldOpenDoctor_availableCliLogin_routesToAgentRuntimes", () => {
+  assert.equal(
+    shouldOpenDoctor([
+      {
+        surface: "cli_login",
+        probe_args: ["openclaw"],
+        setup_copy: "run `openclaw-acp --configure-model`",
+        availability: "available",
+      },
+    ]),
+    true,
+  );
+});
+
 // ── focusTargetForRequirement — pure function ─────────────────────────────────
 
 test("focusTargetForRequirement_envKey_returnsEnvKeyTarget", () => {

--- a/desktop/src/shared/ui/config-nudge-attachment.tsx
+++ b/desktop/src/shared/ui/config-nudge-attachment.tsx
@@ -44,10 +44,8 @@ function requirementKey(
 
 /**
  * Returns true when every requirement in the nudge is a `cli_login` surface.
- * Non-authOnly all-cli_login cards (at least one install-state row) route to
- * Agent runtimes — install/login problems can't be fixed in Edit Agent. AuthOnly cards
- * (every row is `availability === "available"`) are purely informational and
- * do not route anywhere.
+ * These cards route to Agent runtimes for both installation and ACP-advertised
+ * authentication.
  */
 function hasGitBashRequirement(
   reqs: ConfigNudgePayload["requirements"],
@@ -63,21 +61,6 @@ export function shouldOpenDoctor(
   reqs: ConfigNudgePayload["requirements"],
 ): boolean {
   return isAllCliLogin(reqs) || hasGitBashRequirement(reqs);
-}
-
-/**
- * Returns true when the card is all-cli_login AND every requirement is in the
- * `available` state (tooling installed, just needs login). In this case Agent
- * runtimes has no auth functionality and is a misleading dead-end — the card becomes
- * purely informational (no trigger, no CTA, no pointer/hover affordance).
- */
-function isAuthOnly(reqs: ConfigNudgePayload["requirements"]): boolean {
-  return (
-    reqs.length > 0 &&
-    reqs.every(
-      (r) => r.surface === "cli_login" && r.availability === "available",
-    )
-  );
 }
 
 /**
@@ -168,9 +151,6 @@ export function focusTargetForRequirement(
  * (A) Any card with a `git_bash` requirement, or one whose requirements are all
  *     install-state `cli_login`, opens Settings → Agent runtimes. A card-level
  *     Agent runtimes label in `AttachmentActions` confirms the action at rest.
- * (A-auth) A card whose requirements are all available `cli_login` surfaces is
- *     purely informational: Agent runtimes cannot authenticate a CLI, and `setup_copy`
- *     already gives the needed command.
  * (B) Other mixed cards open Edit Agent as the card-level fallback. Their rows
  *     carry inline CTAs for the matching destination: install-state `cli_login`
  *     opens Agent runtimes; `env_key` and `normalized_field` open Edit Agent. A
@@ -189,11 +169,8 @@ export function ConfigNudgeCard({
 
   const allCliLogin = isAllCliLogin(nudge.requirements);
   const opensDoctor = shouldOpenDoctor(nudge.requirements);
-  const authOnly = isAuthOnly(nudge.requirements);
   const allConfigInvalid = isAllConfigInvalid(nudge.requirements);
-  // Any card that is purely informational (auth-only or all-config-invalid)
-  // has no clickable destination — treat them the same for affordance/routing.
-  const informationalOnly = authOnly || allConfigInvalid;
+  const informationalOnly = allConfigInvalid;
 
   const openDoctor = () => {
     if (!onOpenSettings) {
@@ -357,14 +334,12 @@ function RequirementRow({
             {cliLoginMessage(requirement)}
           </span>
           {/* (B) Per-row Agent runtimes CTA — shown only on mixed cards where the
-              card-level trigger opens Edit Agent (not auth-only cards). When
+              card-level trigger opens Edit Agent. When
               allCliLogin is true the card trigger already routes to Agent runtimes; the
-              per-row button is redundant and is suppressed. Also suppressed for
-              `available` cli_login rows — Agent runtimes has no auth functionality and
-              the setup_copy already provides the exact login command.
+              per-row button is redundant and is suppressed.
               stopPropagation prevents double-fire on mixed cards where both
               card and row CTAs are visible. */}
-          {!allCliLogin && requirement.availability !== "available" && (
+          {!allCliLogin && (
             <button
               className="relative z-20 shrink-0 font-medium text-muted-foreground hover:underline"
               onClick={onOpenDoctor}

--- a/desktop/tests/e2e/harness-management.spec.ts
+++ b/desktop/tests/e2e/harness-management.spec.ts
@@ -3,8 +3,8 @@
  * catalog dialog.
  *
  * Covers:
- *  - Ready preset gets a row in "Your harnesses"; needs-setup preset does NOT
- *  - Needs-setup preset appears in the Add-harnesses catalog with status,
+ *  - Ready and one-click-install runtimes get rows in "Your harnesses"
+ *  - Needs-setup runtimes appear in the Add-harnesses catalog with status,
  *    curated description, docs link, and setup action
  *  - Catalog search filters the list
  *  - Toggling install does not reorder rows (stable order)
@@ -45,25 +45,26 @@ const HERMES_AVAILABLE = {
   source: "preset",
 } as const;
 
-/** OpenClaw preset "not_installed" + no auto-install — catalog-only. */
+/** OpenClaw builtin with its native ACP executable not installed yet. */
 const OPENCLAW_NOT_INSTALLED = {
   id: "openclaw",
   label: "OpenClaw",
   avatar_url: "",
   availability: "not_installed",
-  command: "openclaw",
+  command: "openclaw-acp",
   binary_path: null,
-  default_args: ["acp"],
+  default_args: [],
   mcp_command: null,
-  install_hint:
-    "Buzz talks to OpenClaw through its ACP mode (openclaw acp), which relies on the OpenClaw Gateway daemon. Follow the setup guide to install both.",
-  install_instructions_url: "https://docs.openclaw.ai/start/getting-started",
-  can_auto_install: false,
-  requires_external_cli: true,
+  install_hint: "Install OpenClaw to add its self-contained native ACP runtime.",
+  install_instructions_url: "https://docs.openclaw.ai/install",
+  can_auto_install: true,
+  requires_external_cli: false,
   underlying_cli_path: null,
   node_required: false,
   auth_status: { status: "unknown" },
-  source: "preset",
+  source: "builtin",
+  login_hint:
+    "Run `openclaw-acp --configure-model` to authenticate a provider and choose a model.",
 } as const;
 
 /** Cursor preset — deliberately has NO bundled logo (brand assets not
@@ -174,7 +175,7 @@ async function fillHarnessForm(
 // ── Your harnesses vs catalog split ──────────────────────────────────────────
 
 test.describe("your harnesses split", () => {
-  test("ready preset gets a row; needs-setup preset is catalog-only", async ({
+  test("ready preset and one-click-install builtin get rows", async ({
     page,
   }) => {
     await installMockBridge(page, {
@@ -189,14 +190,16 @@ test.describe("your harnesses split", () => {
       "Ready",
     );
 
-    // Needs-setup preset must NOT render a row (and thus no Install button).
-    await expect(page.getByTestId("doctor-runtime-openclaw")).toHaveCount(0);
+    await expect(page.getByTestId("doctor-runtime-openclaw")).toBeVisible();
+    await expect(page.getByTestId("doctor-runtime-status-openclaw")).toHaveText(
+      "CLI needed",
+    );
     await expect(
       page.getByTestId("doctor-runtime-install-openclaw"),
-    ).toHaveCount(0);
+    ).toBeVisible();
   });
 
-  test("needs-setup preset appears in catalog with status, description, docs and setup action", async ({
+  test("needs-setup builtin appears in catalog with status, description, docs and install action", async ({
     page,
   }) => {
     await installMockBridge(page, {
@@ -219,11 +222,9 @@ test.describe("your harnesses split", () => {
     await expect(detail).toContainText(
       "A personal AI assistant that runs on your own devices.",
     );
-    // Operational setup hint from runtime state.
-    await expect(detail).toContainText("OpenClaw Gateway daemon");
-    // Primary setup action under the header (no auto-install → setup guide).
+    await expect(detail).toContainText("self-contained native ACP runtime");
     await expect(
-      page.getByTestId("harness-catalog-setup-openclaw"),
+      page.getByTestId("harness-catalog-install-openclaw"),
     ).toBeVisible();
 
     // Technical details are visible by default.
@@ -273,8 +274,11 @@ test.describe("your harnesses split", () => {
         HERMES_AVAILABLE,
         {
           ...OPENCLAW_NOT_INSTALLED,
+          id: "claude",
+          label: "Claude Code",
+          command: "claude-agent-acp",
           availability: "adapter_outdated",
-          binary_path: "/usr/local/bin/openclaw",
+          binary_path: "/usr/local/bin/claude-agent-acp",
           can_auto_install: true,
         },
       ],
@@ -291,19 +295,19 @@ test.describe("your harnesses split", () => {
           ).filter((command) => command === "install_acp_runtime").length,
       );
 
-    await page.getByTestId("harness-catalog-list-item-openclaw").click();
+    await page.getByTestId("harness-catalog-list-item-claude").click();
     await expect(
-      page.getByTestId("harness-catalog-status-openclaw"),
+      page.getByTestId("harness-catalog-status-claude"),
     ).toHaveText("Update needed");
-    const updateButton = page.getByTestId("harness-catalog-install-openclaw");
+    const updateButton = page.getByTestId("harness-catalog-install-claude");
     await expect(updateButton).toHaveText("Update");
 
     // Cancel path: clicking Update opens the warning, no mutation fires.
     await updateButton.click();
     const dialog = page.getByRole("alertdialog");
-    await expect(dialog).toContainText("Update OpenClaw adapter?");
+    await expect(dialog).toContainText("Update Claude Code adapter?");
     await expect(dialog).toContainText(
-      "This replaces the machine-wide openclaw adapter.",
+      "This replaces the machine-wide claude-agent-acp adapter.",
     );
     // Generic runtimes must never get Codex's package copy.
     await expect(dialog).not.toContainText("codex-acp");
@@ -314,7 +318,7 @@ test.describe("your harnesses split", () => {
 
     // Confirm path: exactly one install fires after confirmation.
     await updateButton.click();
-    await page.getByTestId("harness-catalog-confirm-update-openclaw").click();
+    await page.getByTestId("harness-catalog-confirm-update-claude").click();
     await expect(page.getByRole("alertdialog")).toHaveCount(0);
     await expect.poll(installCalls).toBe(1);
     // No duplicate mutation after the flow settles.


### PR DESCRIPTION
## Summary

- replace the Gateway-backed OpenClaw preset with a first-class builtin runtime
- discover and launch the dedicated `openclaw-acp` native stdio executable with zero arguments
- install/update OpenClaw through Buzz's existing managed npm path
- check model readiness with `openclaw models status --check --json`
- route model setup through Buzz's visible ACP terminal-auth flow

There is no OpenClaw Gateway lifecycle, URL/token handling, companion node, or OpenClaw-specific process manager in Buzz.

The temporary generic split PR, https://github.com/block/buzz/pull/4238, is closed. This PR is the self-contained Buzz change and includes the generic managed-runtime contracts required by the OpenClaw registration.

## Runtime Contract

`openclaw-acp` is the native-capability marker. Its process owns the OpenClaw model loop and tools, so the dedicated agent's inherited `BUZZ_*` environment reaches permitted local tool execution and the Buzz CLI used to publish signed replies.

OpenClaw treats host-forwarded ACP prompts as non-owner ingress. Owner-only OpenClaw tools remain unavailable; exec and plugin operations use ACP permission requests and fail closed.

Older Gateway-only OpenClaw releases do not expose `openclaw-acp` and are not detected as compatible.

## Migration Contract

At startup, Buzz rewrites only the exact previously shipped OpenClaw preset shape:

- command `openclaw`
- arguments `["acp"]`
- no custom command override, or an override exactly equal to `openclaw`

That shape becomes `openclaw-acp` with zero arguments. Custom paths, custom arguments, and other user overrides remain untouched.

The visible terminal-auth launcher preserves Buzz's augmented `PATH` on macOS, Linux, and Windows so managed runtime binaries remain discoverable during authentication.

## Dependency Stack

1. https://github.com/openclaw/openclaw/pull/116394 adds the process-local approval transport while preserving Gateway decision policy.
2. https://github.com/openclaw/openclaw/pull/116678 adds the non-owner native ACP host and `openclaw-acp` executable.
3. This PR registers that executable and supplies the Buzz managed-runtime contracts it needs.

Do not ship this PR until a compatible OpenClaw release is available.

## Related Issue

- https://github.com/block/buzz/issues/4021

## Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `buzz-acp` argument normalization: 1 passed
- desktop legacy migration: 2 passed
- terminal-auth PATH propagation: 1 passed
- changed frontend runtime/logo tests: 23 passed
- exact Biome check over changed frontend files: clean
- broad desktop frontend suite: 4,128 existing tests passed and exposed one stale preset-logo assertion; the runtime logo ownership was corrected and the affected tests then passed
- Semgrep OSS, zizmor, and DCO checks: passed on `61fadb7e4cd1525ab3f3c40eb813ee78a0d7bd6d`

## Remaining Live Proof

The OpenClaw dependency stack passes focused tests and changed-surface validation. A clean Testbox has no usable OpenAI authentication, so a real Buzz mention/signed-reply round trip remains required on an authenticated Crabbox before release.
