### PR TITLE
fix(mobile): queue publishes through reconnect

### DIFF
--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -56,6 +56,13 @@ class _PendingEvent {
   _PendingEvent({required this.completer, required this.timeout});
 }
 
+class _QueuedEvent {
+  final NostrEvent event;
+  final _PendingEvent pending;
+
+  _QueuedEvent({required this.event, required this.pending});
+}
+
 class _BufferedEvent {
   final String subId;
   final NostrEvent event;
@@ -93,6 +100,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   RelaySocket? _socket;
   final Map<String, _HistorySubscription> _historySubscriptions = {};
   final Map<String, _LiveSubscription> _liveSubscriptions = {};
+  final Map<String, _QueuedEvent> _queuedEvents = {};
   final Map<String, _PendingEvent> _pendingEvents = {};
   final List<_BufferedEvent> _eventBuffer = [];
   final Set<String> _recentDeliveryKeys = {};
@@ -105,24 +113,23 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   bool _paused = false;
   bool _hasConnectedOnce = false;
   int _connectionGeneration = 0;
+  int? _connectionFingerprint;
 
   @override
   SessionState build() {
-    final config = ref.watch(relayConfigProvider);
-    final authState = ref.watch(authProvider);
-
-    // Reset disposed flag — build() may re-run on the same Notifier instance
-    // after a provider dependency changes (e.g. auth completing).
     _disposed = false;
 
     ref.onDispose(_dispose);
+    ref.listen(relayConfigProvider, (_, config) {
+      _syncConnection(config, ref.read(authProvider));
+    });
+    ref.listen(authProvider, (_, authState) {
+      _syncConnection(ref.read(relayConfigProvider), authState);
+    });
 
-    // Auto-connect when authenticated and we have a signing key (NIP-42 AUTH).
-    final isAuthenticated = authState.value?.status == AuthStatus.authenticated;
-    if (isAuthenticated && config.nsec != null) {
-      // Schedule connection after build completes.
-      Future.microtask(() => _connect(config));
-    }
+    final config = ref.read(relayConfigProvider);
+    final authState = ref.read(authProvider);
+    Future.microtask(() => _syncConnection(config, authState));
 
     return const SessionState(status: SessionStatus.disconnected);
   }
@@ -250,10 +257,25 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     NostrEvent event, {
     Duration timeout = const Duration(seconds: 8),
   }) {
+    if (_disposed) {
+      return Future.error(StateError('Relay session is disposed'));
+    }
+    if (_paused) {
+      return Future.error(StateError('Cannot publish while app is paused'));
+    }
+    if (_queuedEvents.containsKey(event.id) ||
+        _pendingEvents.containsKey(event.id)) {
+      return Future.error(
+        StateError('Event ${event.id} is already awaiting publication'),
+      );
+    }
+
     final completer = Completer<NostrEvent>();
 
     final timer = Timer(timeout, () {
-      final pending = _pendingEvents.remove(event.id);
+      final pending =
+          _queuedEvents.remove(event.id)?.pending ??
+          _pendingEvents.remove(event.id);
       if (pending != null && !pending.completer.isCompleted) {
         pending.completer.completeError(
           TimeoutException(
@@ -263,12 +285,10 @@ class RelaySessionNotifier extends Notifier<SessionState> {
       }
     });
 
-    _pendingEvents[event.id] = _PendingEvent(
-      completer: completer,
-      timeout: timer,
-    );
+    final pending = _PendingEvent(completer: completer, timeout: timer);
 
-    _socket?.send(['EVENT', event.toJson()]);
+    _queuedEvents[event.id] = _QueuedEvent(event: event, pending: pending);
+    _flushQueuedEvents();
     return completer.future;
   }
 
@@ -323,6 +343,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     _paused = true;
     _reconnectTimer?.cancel();
     _cancelAllHistory(Exception('App moved to background'));
+    _rejectAllQueued(Exception('App moved to background'));
     _rejectAllPending(Exception('App moved to background'));
     _socket?.disconnect();
     state = const SessionState(status: SessionStatus.disconnected);
@@ -344,6 +365,35 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     _reconnectDelayMs = _baseReconnectDelayMs;
     final config = ref.read(relayConfigProvider);
     _connect(config);
+  }
+
+  void _syncConnection(RelayConfig config, AsyncValue<AuthState> authState) {
+    if (_disposed) return;
+    final authStatus = authState.value?.status;
+    if (authStatus == AuthStatus.unknown || authState.isLoading) return;
+
+    if (authStatus == AuthStatus.authenticated && config.nsec != null) {
+      final fingerprint = Object.hash(config.wsUrl, config.nsec);
+      if (_connectionFingerprint == fingerprint &&
+          _socket != null &&
+          state.status != SessionStatus.disconnected) {
+        return;
+      }
+      _connectionFingerprint = fingerprint;
+      _reconnectTimer?.cancel();
+      _connect(config);
+      return;
+    }
+
+    _connectionFingerprint = null;
+    _connectionGeneration++;
+    _reconnectTimer?.cancel();
+    _socket?.dispose();
+    _socket = null;
+    _cancelAllHistory(Exception('Relay session is not authenticated'));
+    _rejectAllQueued(Exception('Relay session is not authenticated'));
+    _rejectAllPending(Exception('Relay session is not authenticated'));
+    state = const SessionState(status: SessionStatus.disconnected);
   }
 
   Future<void> _connect(RelayConfig config) async {
@@ -377,6 +427,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     _hasConnectedOnce = true;
     _reconnectDelayMs = _baseReconnectDelayMs;
     state = const SessionState(status: SessionStatus.connected);
+    _flushQueuedEvents();
     _replayLiveSubscriptions();
   }
 
@@ -389,6 +440,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     _flushTimer = null;
     if (error is RelayAuthRejectedException) {
       _reconnectTimer?.cancel();
+      _rejectAllQueued(error);
       state = const SessionState(status: SessionStatus.disconnected);
       return;
     }
@@ -644,13 +696,40 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     _pendingEvents.clear();
   }
 
+  void _flushQueuedEvents() {
+    if (state.status != SessionStatus.connected) return;
+    final socket = _socket;
+    if (socket == null || socket.state != SocketState.connected) return;
+
+    for (final entry in _queuedEvents.entries.toList()) {
+      final queued = entry.value;
+      if (!socket.trySend(['EVENT', queued.event.toJson()])) return;
+      _queuedEvents.remove(entry.key);
+      _pendingEvents[entry.key] = queued.pending;
+    }
+  }
+
+  void _rejectAllQueued(Object? error) {
+    for (final entry in _queuedEvents.values) {
+      entry.pending.timeout.cancel();
+      if (!entry.pending.completer.isCompleted) {
+        entry.pending.completer.completeError(
+          error ?? Exception('Connection lost before event was sent'),
+        );
+      }
+    }
+    _queuedEvents.clear();
+  }
+
   void _dispose() {
     _disposed = true;
+    _connectionFingerprint = null;
     _connectionGeneration++;
     _reconnectTimer?.cancel();
     _flushTimer?.cancel();
     _backgroundGraceTimer?.cancel();
     _cancelAllHistory(null);
+    _rejectAllQueued(null);
     _rejectAllPending(null);
     _recentDeliveryKeys.clear();
     _socket?.dispose();

--- a/mobile/lib/shared/relay/relay_socket.dart
+++ b/mobile/lib/shared/relay/relay_socket.dart
@@ -118,7 +118,18 @@ class RelaySocket {
 
   /// Send a raw JSON array over the websocket.
   void send(List<dynamic> payload) {
-    _channel?.sink.add(jsonEncode(payload));
+    trySend(payload);
+  }
+
+  /// Send only when a channel is available.
+  ///
+  /// Required-delivery callers use the result to wait for the next
+  /// authenticated connection instead of silently dropping the payload.
+  bool trySend(List<dynamic> payload) {
+    final channel = _channel;
+    if (channel == null) return false;
+    channel.sink.add(jsonEncode(payload));
+    return true;
   }
 
   /// Gracefully close the connection.

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -245,6 +245,96 @@ void main() {
     expect(session.state.status, SessionStatus.connected);
   });
 
+  test('publishes once after a replacement socket authenticates', () async {
+    final sockets = <_ControlledRelaySocket>[];
+    final keychain = nostr.Keys.generate();
+    final session = RelaySessionNotifier(
+      socketFactory:
+          ({
+            required wsUrl,
+            required nsec,
+            required onMessage,
+            required onConnected,
+            required onDisconnected,
+          }) {
+            final socket = _ControlledRelaySocket(
+              wsUrl: wsUrl,
+              nsec: nsec,
+              onMessage: onMessage,
+              onConnected: onConnected,
+              onDisconnected: onDisconnected,
+            );
+            sockets.add(socket);
+            return socket;
+          },
+    );
+    final config = _FakeRelayConfigNotifier(
+      baseUrl: 'https://old.example',
+      nsec: keychain.nsec,
+    );
+    final container = ProviderContainer(
+      overrides: [
+        relaySessionProvider.overrideWith(() => session),
+        relayConfigProvider.overrideWith(() => config),
+        authProvider.overrideWith(() => _AuthenticatedAuthNotifier()),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(authProvider.future);
+    final subscription = container.listen(relaySessionProvider, (_, _) {});
+    addTearDown(subscription.close);
+    await Future<void>.delayed(Duration.zero);
+
+    final published = session.publish(
+      _event(),
+      timeout: const Duration(seconds: 1),
+    );
+    expect(sockets.single.sent, isEmpty);
+
+    config.update(baseUrl: 'https://new.example', nsec: keychain.nsec);
+    await Future<void>.delayed(Duration.zero);
+    expect(sockets, hasLength(2));
+
+    sockets.first.connectSuccessfully();
+    expect(sockets.first.sent, isEmpty);
+    expect(sockets.last.sent, isEmpty);
+
+    sockets.last.connectSuccessfully();
+    expect(sockets.last.sent, [
+      ['EVENT', _event().toJson()],
+    ]);
+
+    sockets.last.receive(['OK', _event().id, true, '']);
+    expect((await published).id, _event().id);
+  });
+
+  test('queued publish fails explicitly when app pauses', () async {
+    final session = RelaySessionNotifier();
+    final container = ProviderContainer(
+      overrides: [relaySessionProvider.overrideWith(() => session)],
+    );
+    addTearDown(container.dispose);
+    container.read(relaySessionProvider);
+
+    final published = session.publish(
+      _event(),
+      timeout: const Duration(seconds: 1),
+    );
+    final expectation = expectLater(
+      published,
+      throwsA(
+        isA<Exception>().having(
+          (error) => error.toString(),
+          'message',
+          contains('background'),
+        ),
+      ),
+    );
+
+    session.debugPauseNow();
+    await expectation;
+  });
+
   test('does not schedule reconnects after background disconnect', () {
     final session = RelaySessionNotifier();
     final container = ProviderContainer(
@@ -402,6 +492,9 @@ class _AuthenticatedAuthNotifier extends AuthNotifier {
 class _ControlledRelaySocket extends RelaySocket {
   final void Function() _connected;
   final void Function(Object? error) _disconnected;
+  final void Function(List<dynamic> message) _message;
+  final List<List<dynamic>> sent = [];
+  SocketState _fakeState = SocketState.disconnected;
 
   _ControlledRelaySocket({
     required super.wsUrl,
@@ -410,17 +503,36 @@ class _ControlledRelaySocket extends RelaySocket {
     required super.onConnected,
     required super.onDisconnected,
   }) : _connected = onConnected,
-       _disconnected = onDisconnected;
+       _disconnected = onDisconnected,
+       _message = onMessage;
+
+  @override
+  SocketState get state => _fakeState;
 
   @override
   Future<void> connect() async {}
 
   @override
+  bool trySend(List<dynamic> payload) {
+    if (_fakeState != SocketState.connected) return false;
+    sent.add(payload);
+    return true;
+  }
+
+  @override
   void dispose() {}
 
-  void connectSuccessfully() => _connected();
+  void connectSuccessfully() {
+    _fakeState = SocketState.connected;
+    _connected();
+  }
 
-  void disconnectWith(Object? error) => _disconnected(error);
+  void disconnectWith(Object? error) {
+    _fakeState = SocketState.disconnected;
+    _disconnected(error);
+  }
+
+  void receive(List<dynamic> message) => _message(message);
 }
 
 const _channelId = '11111111-1111-4111-8111-111111111111';


### PR DESCRIPTION
## Summary
Queue required EVENT publishes until the replacement WebSocket has authenticated instead of silently dropping a send during connection handoff. Keep config/auth changes inside one relay-session lifecycle so an in-flight pre-send event survives the socket replacement, while sent-but-unacknowledged events still fail explicitly on disconnect.

### Related issue
No upstream duplicate found. Local operational bug: source Brief #16705.

### Testing
- bin/just mobile-check
- flutter test test/shared/relay/relay_session_test.dart test/features/channels/send_message_provider_test.dart (17 passed)
- Regression replaces the first socket, publishes during the handoff, authenticates the second socket, verifies one EVENT frame, and resolves its OK acknowledgment.

Real iPhone proof remains pending an installable build containing this commit.