### PR TITLE
fix(acp): acknowledge consumed owner commands in channel

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2044,6 +2044,15 @@ async fn tokio_main() -> Result<()> {
                                             sender = %buzz_event.event.pubkey.to_hex(),
                                             "shutdown command from owner — exiting gracefully"
                                         );
+                                        let thread_tags =
+                                            queue::parse_thread_tags(&buzz_event.event);
+                                        pool::post_notice(
+                                            &ctx.rest_client,
+                                            buzz_event.channel_id,
+                                            &thread_tags,
+                                            SHUTDOWN_NOTICE,
+                                        )
+                                        .await;
                                         let _ = shutdown_tx.send(());
                                         continue;
                                     }
@@ -2074,12 +2083,19 @@ async fn tokio_main() -> Result<()> {
                                             buzz_event.channel_id,
                                             ControlSignal::Cancel,
                                         );
+                                        let notice = cancel_notice(fired);
                                         if !fired {
                                             tracing::warn!(
                                                 channel_id = %buzz_event.channel_id,
                                                 "!cancel received but no in-flight task — no-op"
                                             );
                                         }
+                                        spawn_notice(
+                                            Some(&ctx.rest_client),
+                                            buzz_event.channel_id,
+                                            queue::parse_thread_tags(&buzz_event.event),
+                                            notice.to_string(),
+                                        );
                                         continue; // consume event — do NOT push to queue
                                     }
                                 }
@@ -2112,11 +2128,12 @@ async fn tokio_main() -> Result<()> {
                                             buzz_event.channel_id,
                                             ControlSignal::Rotate,
                                         );
-                                        if fired {
+                                        let invalidated = if fired {
                                             tracing::info!(
                                                 channel_id = %buzz_event.channel_id,
                                                 "!rotate received — cancelling in-flight turn and rotating session"
                                             );
+                                            0
                                         } else {
                                             let invalidated = pool.invalidate_channel_sessions(buzz_event.channel_id);
                                             tracing::info!(
@@ -2124,7 +2141,14 @@ async fn tokio_main() -> Result<()> {
                                                 invalidated,
                                                 "!rotate received — invalidated idle channel session(s)"
                                             );
-                                        }
+                                            invalidated
+                                        };
+                                        spawn_notice(
+                                            Some(&ctx.rest_client),
+                                            buzz_event.channel_id,
+                                            queue::parse_thread_tags(&buzz_event.event),
+                                            rotate_notice(fired, invalidated).to_string(),
+                                        );
                                         continue; // consume event — do NOT push to queue
                                     }
                                 }
@@ -3028,10 +3052,45 @@ fn is_auth_error(error: &acp::AcpError) -> bool {
     message.contains("Re-authenticate") || message.contains("API Error: 401")
 }
 
+const SHUTDOWN_NOTICE: &str = "Shutting down.";
+
+fn cancel_notice(turn_active: bool) -> &'static str {
+    if turn_active {
+        "Cancelled the current turn."
+    } else {
+        "Nothing to cancel — no turn in flight."
+    }
+}
+
+fn rotate_notice(turn_active: bool, invalidated_sessions: usize) -> &'static str {
+    if turn_active {
+        "Cancelled the current turn — the next one starts from a fresh session."
+    } else if invalidated_sessions > 0 {
+        "Session rotated — the next turn starts fresh."
+    } else {
+        "No session to rotate — the next turn already starts fresh."
+    }
+}
+
+/// Spawn a task that posts a user-visible notice to the relay.
+fn spawn_notice(
+    rest_client: Option<&relay::RestClient>,
+    channel_id: Uuid,
+    thread_tags: ThreadTags,
+    content: String,
+) {
+    if let Some(rest) = rest_client {
+        let rest = rest.clone();
+        tokio::spawn(async move {
+            pool::post_notice(&rest, channel_id, &thread_tags, &content).await;
+        });
+    }
+}
+
 /// Spawn a task that posts a user-visible failure notice to the relay.
 ///
 /// Shared by the hard-cap immediate dead-letter path and the retries-exhausted
-/// dead-letter path so neither duplicates the tokio::spawn block.
+/// dead-letter path so neither duplicates the thread-tag extraction.
 fn spawn_failure_notice(
     rest_client: Option<&relay::RestClient>,
     batch: &FlushBatch,
@@ -3043,11 +3102,7 @@ fn spawn_failure_notice(
             .last()
             .map(|be| queue::parse_thread_tags(&be.event))
             .unwrap_or_default();
-        let rest = rest.clone();
-        let channel_id = batch.channel_id;
-        tokio::spawn(async move {
-            pool::post_failure_notice(&rest, channel_id, &thread_tags, &content).await;
-        });
+        spawn_notice(Some(rest), batch.channel_id, thread_tags, content);
     }
 }
 
@@ -4312,6 +4367,36 @@ mod owner_control_command_tests {
             "!rotate",
             &agent
         ));
+    }
+
+    #[test]
+    fn cancel_notices_distinguish_active_and_idle_turns() {
+        assert_eq!(cancel_notice(true), "Cancelled the current turn.");
+        assert_eq!(
+            cancel_notice(false),
+            "Nothing to cancel — no turn in flight."
+        );
+    }
+
+    #[test]
+    fn rotate_notices_distinguish_active_cached_and_empty_sessions() {
+        assert_eq!(
+            rotate_notice(true, 0),
+            "Cancelled the current turn — the next one starts from a fresh session."
+        );
+        assert_eq!(
+            rotate_notice(false, 1),
+            "Session rotated — the next turn starts fresh."
+        );
+        assert_eq!(
+            rotate_notice(false, 0),
+            "No session to rotate — the next turn already starts fresh."
+        );
+    }
+
+    #[test]
+    fn shutdown_notice_is_concise() {
+        assert_eq!(SHUTDOWN_NOTICE, "Shutting down.");
     }
 
     #[test]

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -3800,11 +3800,10 @@ pub(crate) async fn reaction_add(rest: &crate::relay::RestClient, event_id: &str
     }
 }
 
-/// Best-effort: post a visible failure notice (kind:9) to a channel after a
-/// batch is dead-lettered. Replies into the thread of `thread_tags` when the
-/// triggering event was threaded. Errors are logged and swallowed — the
-/// notice must never take down the main loop.
-pub(crate) async fn post_failure_notice(
+/// Best-effort: post a visible notice (kind:9) to a channel. Replies into the
+/// thread of `thread_tags` when the triggering event was threaded. Errors are
+/// logged and swallowed — the notice must never take down the main loop.
+pub(crate) async fn post_notice(
     rest: &crate::relay::RestClient,
     channel_id: Uuid,
     thread_tags: &ThreadTags,
@@ -3826,21 +3825,21 @@ pub(crate) async fn post_failure_notice(
         match buzz_sdk::build_message(channel_id, content, thread_ref.as_ref(), &[], false, &[]) {
             Ok(b) => b,
             Err(e) => {
-                tracing::warn!(channel = %channel_id, "failure notice: build failed: {e}");
+                tracing::warn!(channel = %channel_id, "notice: build failed: {e}");
                 return;
             }
         };
     let event = match builder.sign_with_keys(&rest.keys) {
         Ok(e) => e,
         Err(e) => {
-            tracing::warn!(channel = %channel_id, "failure notice: sign failed: {e}");
+            tracing::warn!(channel = %channel_id, "notice: sign failed: {e}");
             return;
         }
     };
     match tokio::time::timeout(Duration::from_secs(5), rest.submit_event(&event)).await {
         Ok(Ok(_)) => {}
-        Ok(Err(e)) => tracing::warn!(channel = %channel_id, "failure notice failed: {e}"),
-        Err(_) => tracing::warn!(channel = %channel_id, "failure notice timed out"),
+        Ok(Err(e)) => tracing::warn!(channel = %channel_id, "notice failed: {e}"),
+        Err(_) => tracing::warn!(channel = %channel_id, "notice timed out"),
     }
 }
 


### PR DESCRIPTION
# Summary

Implements the acknowledgement-only slice of [#3711](https://github.com/block/buzz/issues/3711), as part of the ordered workstream tracked by [#3863](https://github.com/block/buzz/issues/3863).

Adds:
- visible channel acknowledgements when an owner consumes `!cancel`, `!rotate`, or `!shutdown`;
- state-specific wording for active, idle, cached-session, and empty-session cases;
- focused ACP regression tests.

No desktop UI changed, so no screenshots are included.

# Scope

## Included

- `!cancel` publishes either `Cancelled the current turn.` or `Nothing to cancel — no turn in flight.`
- `!rotate` publishes the active-turn, cached-idle, or empty-session acknowledgement defined in #3711.
- `!shutdown` publishes `Shutting down.` before the shutdown signal is sent.
- Notices remain channel-scoped, threaded kind-9 events.

## Excluded

- Slash-command autocomplete and command-palette work (#2528).
- Agent role descriptions (#2699).
- Canvas revision history (#3086).
- Structured job handoff cards (#2932).
- The native signed extension panel work described in the follow-up handoff.
- OEXL matching, payments, acceptance, ledger, settlement, or `/bounty` logic.
- New HTTP APIs, new Buzz event kinds, or broad UI redesign.

# Product / Architecture Decisions

- Generalized the existing failure-notice publishing path from `post_failure_notice` to `post_notice`.
- Reused the existing `ThreadTags` and kind-9 channel-notice path used by failure notices and the owner `!model` acknowledgement path.
- Shutdown awaits the notice publish attempt before sending the shutdown signal; cancel and rotate use the existing best-effort spawned notice pattern.
- Buzz remains responsible for channel visibility and auditability. No OEXL-specific protocol or settlement semantics were added.

# User-Facing Contract

| Command | Situation | Notice |
| --- | --- | --- |
| `!rotate` | Turn active | `Cancelled the current turn — the next one starts from a fresh session.` |
| `!rotate` | Cached session, idle | `Session rotated — the next turn starts fresh.` |
| `!rotate` | No cached session | `No session to rotate — the next turn already starts fresh.` |
| `!cancel` | Turn active | `Cancelled the current turn.` |
| `!cancel` | Idle | `Nothing to cancel — no turn in flight.` |
| `!shutdown` | Any | `Shutting down.` |

# Verification

## Ran

- `cargo test -p buzz-acp owner_control_command_tests` — 6 passed.
- `rustfmt --edition 2021 crates/buzz-acp/src/lib.rs crates/buzz-acp/src/pool.rs --check` — passed.
- `cargo clippy -p buzz-acp --all-targets -- -D warnings` — passed.
- `./scripts/run-tests.sh unit` — `buzz-core` (237 passed) and `buzz-auth` (45 passed) completed before the broader run was stopped during a local `buzz-cli` compile stall.

## Not completed locally

- The whole-workspace `just fmt-check` / `just clippy` / `just test-unit` / `just ci` sequence was not completed because the first-run workspace formatter/toolchain stalled in the local environment. The focused ACP gates above passed; CI should provide the full repository gate.

## Covered

- Active and idle `!cancel`.
- Active, cached-idle, and empty `!rotate`.
- `!shutdown` acknowledgement.
- Notice text and helper delegation remain isolated from desktop/mobile UI.

# Review Path

1. `crates/buzz-acp/src/pool.rs` notice helper generalization.
2. `crates/buzz-acp/src/lib.rs` owner-command acknowledgement sequencing.
3. Focused owner-control regression tests.

# Notes For Reviewer

This is intentionally the smallest channel-notice contribution for #3711 and the first ordered contribution in #3863. Command-palette/autocomplete presentation remains deferred to its separate UI work. No desktop UI changed, and no OEXL-specific code or settlement semantics were added.