### PR TITLE
fix(acp): classify 'Authentication required' as non-retryable auth error (#3831)

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2366,6 +2366,7 @@ async fn tokio_main() -> Result<()> {
                     &mut respawn_tasks,
                     observer.clone(),
                     Some(&ctx.rest_client),
+                    Some((&presence_publisher, &presence_keys)),
                 ) == LoopAction::Exit
                 {
                     break;
@@ -3066,6 +3067,7 @@ fn handle_prompt_result(
     respawn_tasks: &mut tokio::task::JoinSet<()>,
     observer: Option<observer::ObserverHandle>,
     rest_client: Option<&relay::RestClient>,
+    presence: Option<(&relay::RelayEventPublisher, &nostr::Keys)>,
 ) -> LoopAction {
     let before = pool.task_map().len();
     let agent_index = result.agent.index;
@@ -3165,6 +3167,31 @@ fn handle_prompt_result(
                     and then re-send."
                     .to_string();
                 spawn_failure_notice(rest_client, &batch, content);
+                // Auth tokens don't self-repair between heartbeats, and without this the
+                // presence heartbeat keeps publishing "online" while every subsequent
+                // mention dead-letters — the UI keeps showing the agent as available during
+                // a guaranteed outage. Flip presence to offline (best-effort, non-blocking)
+                // so the UI reflects the real state instead. Mirrors the shutdown flip.
+                if let Some((publisher, keys)) = presence {
+                    if config.presence_enabled {
+                        let publisher = publisher.clone();
+                        let keys = keys.clone();
+                        tokio::spawn(async move {
+                            match tokio::time::timeout(
+                                Duration::from_secs(2),
+                                publish_presence(&publisher, &keys, "offline"),
+                            )
+                            .await
+                            {
+                                Ok(Ok(_)) => tracing::info!("presence set to offline after auth dead-letter"),
+                                Ok(Err(e)) => {
+                                    tracing::warn!("failed to set offline presence after auth dead-letter: {e}")
+                                }
+                                Err(_) => tracing::warn!("auth dead-letter offline presence timed out"),
+                            }
+                        });
+                    }
+                }
             } else if let Some(dead) = queue.requeue(batch) {
                 let reason = match &result.outcome {
                     PromptOutcome::Timeout(TimeoutKind::Idle) => "the turn timed out".to_string(),
@@ -5354,6 +5381,7 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             Some(observer.clone()),
             None,
+            None,
         );
 
         let turn_errors: Vec<_> = observer
@@ -5519,6 +5547,7 @@ mod error_outcome_emission_tests {
                 &mut respawn_tasks,
                 Some(observer.clone()),
                 None,
+                None,
             );
             let events = observer.snapshot();
             let turn_error = events.iter().find(|e| e.kind == "turn_error").unwrap();
@@ -5607,6 +5636,7 @@ mod error_outcome_emission_tests {
                 &mut crash_history,
                 &respawn_tx,
                 &mut respawn_tasks,
+                None,
                 None,
                 None,
             );
@@ -5714,6 +5744,7 @@ mod error_outcome_emission_tests {
                 &mut respawn_tasks,
                 None,
                 None,
+                None,
             );
             (
                 queue.pending_channels(),
@@ -5804,6 +5835,7 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
             None,
         );
 
@@ -5897,6 +5929,7 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
             None,
         );
 
@@ -6012,6 +6045,7 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
             None,
         );
 
@@ -6144,6 +6178,7 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
             None,
         );
 
@@ -6344,6 +6379,7 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             None,
             None,
+            None,
         );
 
         // The batch must not be requeued: pending_channels returns 0.
@@ -6427,6 +6463,7 @@ mod error_outcome_emission_tests {
             &mut crash_history,
             &respawn_tx,
             &mut respawn_tasks,
+            None,
             None,
             None,
         );

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3025,7 +3025,9 @@ fn is_auth_error(error: &acp::AcpError) -> bool {
     let acp::AcpError::AgentError { message, .. } = error else {
         return false;
     };
-    message.contains("Re-authenticate") || message.contains("API Error: 401")
+    message.contains("Re-authenticate")
+        || message.contains("API Error: 401")
+        || message.contains("Authentication required")
 }
 
 /// Spawn a task that posts a user-visible failure notice to the relay.
@@ -6223,6 +6225,23 @@ mod error_outcome_emission_tests {
         assert!(
             is_auth_error(&e),
             "API Error: 401 variant must be classified as auth error"
+        );
+    }
+
+    #[test]
+    fn is_auth_error_matches_authentication_required_message() {
+        // Reporter-observed subprocess message (claude-agent-acp 0.63.0, buzz
+        // #3831): expired subscription credential surfaces as a bare
+        // "Authentication required" with code -32000. Without this variant the
+        // immediate dead-letter + re-auth notice never fires and every mention
+        // burns ~10 retries before dead-lettering.
+        let e = acp::AcpError::AgentError {
+            code: -32000,
+            message: "Authentication required".to_string(),
+        };
+        assert!(
+            is_auth_error(&e),
+            "Authentication required variant must be classified as auth error"
         );
     }
 


### PR DESCRIPTION
Fixes #3831

## Problem
Expired Claude subscription credentials surface from `claude-agent-acp` as a bare AgentError:

    Agent reported error (code -32000): Authentication required

`is_auth_error()` only matched the two variants PR #2751 added (`Re-authenticate`, `API Error: 401`), so this third variant fell into the generic `queue.requeue()` path. Every mention burned ~10 retry slots over a long backoff before dead-lettering — while presence kept the agent `online` and nothing told the user the agent was effectively dead. The reporter (#3831) had a container `Up`, socket connected, and no signal for hours after credential expiry.

## Root cause
`crates/buzz-acp/src/lib.rs` `is_auth_error()` pattern-match missed the subprocess's bare-credential message.

## Fix (narrow, +1 arm)
Add `message.contains("Authentication required")` alongside the two existing arms in `is_auth_error()`. Now the expired-credential case hits the existing immediate dead-letter + in-channel re-auth notice path (`post_failure_notice`), so each failed mention surfaces where the user is already looking.

Precision bar preserved (per the fn's doc-comment): the matched token is a subprocess **credential hand**, not a generic failure string. Adjacent tests prove no over-classification — transient/transport (`Io`, `WriteTimeout`) and non-auth `AgentError` (usage-credit) variants remain `false`.

## Not in scope (deliberately)
- Presence/away-after-N-errors (reporter option A) — separate, larger policy change.
- Non-zero exit / unhealthy signal to the container runtime (option C) — separate.

Both are listed as follow-ups on #3831; this PR closes the silent-failure root for the documented message variant.

## Test
- `is_auth_error_matches_authentication_required_message` — **fail-first** (red on `origin/main` before the fix, green after).
- Existing `is_auth_error_*` (reauthenticate / 401 / reject-non-auth / reject-transport) all pass.
- Full `cargo test -p buzz-acp --lib` green (650/650 serially; 2 keepalive/idle timers are pre-existing flakes under parallel load, unrelated — pass in isolation on clean `origin/main`).
- `cargo clippy -p buzz-acp --lib` clean.

DCO `--signoff` present. No changeset (repo FILE-SIZE/no-changeset convention).
