### PR TITLE
feat(protocol): define signed channel panel manifest

### DIFF
--- a/crates/buzz-core/src/lib.rs
+++ b/crates/buzz-core/src/lib.rs
@@ -30,6 +30,8 @@ pub mod network;
 pub mod observer;
 /// NIP-AB device pairing — crypto primitives, message types, and errors.
 pub mod pairing;
+/// Signed, channel-scoped extension-panel manifest types.
+pub mod panel;
 /// Presence status types shared across crates.
 pub mod presence;
 /// Canonical relay runtime identities.
@@ -42,6 +44,7 @@ pub mod verification;
 pub use error::VerificationError;
 pub use event::StoredEvent;
 pub use nostr::{Event, EventId, Filter, Keys, Kind, PublicKey};
+pub use panel::{PanelManifest, PanelManifestError};
 pub use presence::PresenceStatus;
 pub use tenant::{normalize_host, CommunityId, TenantContext};
 pub use verification::verify_event;

--- a/crates/buzz-core/src/panel.rs
+++ b/crates/buzz-core/src/panel.rs
@@ -1,0 +1,476 @@
+//! Signed, channel-scoped extension-panel manifest types.
+//!
+//! The manifest is a generic projection contract. It does not assign a Nostr
+//! event kind or decide which integration owns a field; transport and domain
+//! semantics remain outside `buzz-core`.
+
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::Url;
+use uuid::Uuid;
+
+/// Current signed panel-manifest schema version.
+pub const PANEL_MANIFEST_SCHEMA_VERSION: u16 = 1;
+/// Maximum serialized UTF-8 manifest size, leaving room for an event envelope.
+pub const MAX_PANEL_MANIFEST_BYTES: usize = 32 * 1024;
+/// Maximum number of sections in a manifest.
+pub const MAX_PANEL_SECTIONS: usize = 32;
+/// Maximum number of fields in one section.
+pub const MAX_PANEL_FIELDS_PER_SECTION: usize = 64;
+/// Maximum number of links in one section.
+pub const MAX_PANEL_LINKS_PER_SECTION: usize = 32;
+/// Maximum number of source-event references in a manifest.
+pub const MAX_PANEL_SOURCE_EVENTS: usize = 64;
+
+const MAX_PANEL_ID_BYTES: usize = 128;
+const MAX_PANEL_LABEL_BYTES: usize = 256;
+const MAX_PANEL_VALUE_BYTES: usize = 4_096;
+
+/// Validation failures for a [`PanelManifest`].
+#[derive(Debug, Error)]
+pub enum PanelManifestError {
+    /// The JSON was not a manifest object or contained an unknown field.
+    #[error("invalid panel manifest JSON: {0}")]
+    Json(#[from] serde_json::Error),
+    /// A decoded manifest violated the bounded contract.
+    #[error("invalid panel manifest: {0}")]
+    Invalid(String),
+}
+
+/// A generic, read-only projection of signed channel state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct PanelManifest {
+    /// Exact schema version understood by this client.
+    pub schema_version: u16,
+    /// Stable identifier for this panel within its channel.
+    pub panel_id: String,
+    /// Canonical UUID of the channel that owns this projection.
+    pub channel_id: String,
+    /// Short human-readable panel title.
+    pub title: String,
+    /// Optional plain-text context for the panel.
+    pub description: Option<String>,
+    /// Overall panel status.
+    pub status: PanelStatus,
+    /// Unix timestamp in seconds for the latest source update.
+    pub updated_at: u64,
+    /// Structured sections rendered by the client.
+    pub sections: Vec<PanelSection>,
+    /// Signed source-event references supporting the projection.
+    pub source_events: Vec<PanelSourceEvent>,
+}
+
+/// Bounded status vocabulary shared by a panel and its sections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PanelStatus {
+    /// Work has not started.
+    Pending,
+    /// Work is in progress.
+    Active,
+    /// Work completed successfully.
+    Complete,
+    /// Work needs an external decision or intervention.
+    Blocked,
+    /// Work failed.
+    Failed,
+    /// The projection may no longer reflect current source state.
+    Stale,
+    /// The source exists but is not currently available to the reader.
+    Unavailable,
+}
+
+/// One named section of a panel.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct PanelSection {
+    /// Stable section identifier within the manifest.
+    pub id: String,
+    /// Short section heading.
+    pub title: String,
+    /// Current section status.
+    pub status: PanelStatus,
+    /// Human-readable fields in display order.
+    pub fields: Vec<PanelField>,
+    /// Typed links back to source events or an external HTTPS destination.
+    pub links: Vec<PanelLink>,
+}
+
+/// One label/value pair in a section.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct PanelField {
+    /// Short field label.
+    pub label: String,
+    /// Plain-text field value.
+    pub value: String,
+    /// Allowlisted rendering hint.
+    pub presentation: PanelPresentation,
+}
+
+/// Safe presentation hints understood by the renderer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PanelPresentation {
+    /// Normal proportional text.
+    Text,
+    /// Text that benefits from fixed-width glyphs.
+    Monospace,
+    /// Unix seconds rendered as a localized timestamp.
+    Timestamp,
+    /// A value that should receive semantic status treatment.
+    Status,
+}
+
+/// A typed link from a panel to a source event or external destination.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct PanelLink {
+    /// Short action label.
+    pub label: String,
+    /// Kind of destination the client should resolve.
+    pub target: PanelLinkTarget,
+    /// Source event for a Buzz-native destination.
+    pub source_event_id: Option<String>,
+    /// External destination. Only `https:` is permitted for this target.
+    pub uri: Option<String>,
+}
+
+/// Allowlisted link destinations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PanelLinkTarget {
+    /// A channel Canvas revision.
+    Canvas,
+    /// A workflow definition or run.
+    Workflow,
+    /// A structured job handoff/result.
+    Handoff,
+    /// A channel thread.
+    Thread,
+    /// A raw signed event.
+    Event,
+    /// A user-activated external HTTPS destination.
+    External,
+}
+
+/// A signed event reference supporting the panel projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct PanelSourceEvent {
+    /// Lowercase 64-character event id.
+    pub event_id: String,
+    /// Nostr event kind.
+    pub kind: u32,
+    /// Channel containing the source event.
+    pub channel_id: String,
+    /// Short provenance label shown to the reader.
+    pub label: String,
+}
+
+impl PanelManifest {
+    /// Decode and validate a JSON manifest, including size limits.
+    pub fn from_json(input: &str) -> Result<Self, PanelManifestError> {
+        if input.len() > MAX_PANEL_MANIFEST_BYTES {
+            return Err(PanelManifestError::Invalid(format!(
+                "serialized content exceeds {MAX_PANEL_MANIFEST_BYTES} bytes"
+            )));
+        }
+
+        let manifest: Self = serde_json::from_str(input)?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    /// Validate the manifest's structural, size, and identifier constraints.
+    pub fn validate(&self) -> Result<(), PanelManifestError> {
+        if self.schema_version != PANEL_MANIFEST_SCHEMA_VERSION {
+            return invalid(format!(
+                "unsupported schema version {}",
+                self.schema_version
+            ));
+        }
+
+        validate_identifier("panelId", &self.panel_id, MAX_PANEL_ID_BYTES)?;
+        validate_channel_id("channelId", &self.channel_id)?;
+        validate_text("title", &self.title, MAX_PANEL_LABEL_BYTES, true)?;
+        if let Some(description) = &self.description {
+            validate_text("description", description, MAX_PANEL_VALUE_BYTES, false)?;
+        }
+
+        if self.updated_at == 0 {
+            return invalid("updatedAt must be a positive Unix timestamp");
+        }
+        if self.sections.len() > MAX_PANEL_SECTIONS {
+            return invalid(format!("sections exceeds maximum of {MAX_PANEL_SECTIONS}"));
+        }
+        if self.source_events.len() > MAX_PANEL_SOURCE_EVENTS {
+            return invalid(format!(
+                "sourceEvents exceeds maximum of {MAX_PANEL_SOURCE_EVENTS}"
+            ));
+        }
+        if self.source_events.is_empty() {
+            return invalid("sourceEvents must contain at least one signed source");
+        }
+
+        let mut section_ids = HashSet::with_capacity(self.sections.len());
+        for section in &self.sections {
+            validate_identifier("section.id", &section.id, MAX_PANEL_ID_BYTES)?;
+            validate_text("section.title", &section.title, MAX_PANEL_LABEL_BYTES, true)?;
+            if !section_ids.insert(&section.id) {
+                return invalid(format!("duplicate section id `{}`", section.id));
+            }
+            if section.fields.len() > MAX_PANEL_FIELDS_PER_SECTION {
+                return invalid(format!(
+                    "section `{}` fields exceeds maximum of {MAX_PANEL_FIELDS_PER_SECTION}",
+                    section.id
+                ));
+            }
+            if section.links.len() > MAX_PANEL_LINKS_PER_SECTION {
+                return invalid(format!(
+                    "section `{}` links exceeds maximum of {MAX_PANEL_LINKS_PER_SECTION}",
+                    section.id
+                ));
+            }
+
+            let mut field_labels = HashSet::with_capacity(section.fields.len());
+            for field in &section.fields {
+                validate_text("field.label", &field.label, MAX_PANEL_LABEL_BYTES, true)?;
+                validate_text("field.value", &field.value, MAX_PANEL_VALUE_BYTES, false)?;
+                if !field_labels.insert(&field.label) {
+                    return invalid(format!(
+                        "duplicate field label `{}` in section `{}`",
+                        field.label, section.id
+                    ));
+                }
+            }
+
+            for link in &section.links {
+                validate_text("link.label", &link.label, MAX_PANEL_LABEL_BYTES, true)?;
+                validate_link(link)?;
+            }
+        }
+
+        let mut source_event_ids = HashSet::with_capacity(self.source_events.len());
+        for source in &self.source_events {
+            validate_event_id("sourceEvents.eventId", &source.event_id)?;
+            validate_channel_id("sourceEvents.channelId", &source.channel_id)?;
+            if source.channel_id != self.channel_id {
+                return invalid(format!(
+                    "source event `{}` belongs to another channel",
+                    source.event_id
+                ));
+            }
+            validate_text(
+                "sourceEvents.label",
+                &source.label,
+                MAX_PANEL_LABEL_BYTES,
+                true,
+            )?;
+            if !source_event_ids.insert(&source.event_id) {
+                return invalid(format!("duplicate source event id `{}`", source.event_id));
+            }
+        }
+
+        let serialized = serde_json::to_vec(self)?;
+        if serialized.len() > MAX_PANEL_MANIFEST_BYTES {
+            return invalid(format!(
+                "serialized content exceeds {MAX_PANEL_MANIFEST_BYTES} bytes"
+            ));
+        }
+        Ok(())
+    }
+
+    /// Validate that the manifest is scoped to the reader's current channel.
+    pub fn validate_for_channel(&self, channel_id: Uuid) -> Result<(), PanelManifestError> {
+        self.validate()?;
+        if self.channel_id != channel_id.to_string() {
+            return invalid("manifest channel does not match the current channel");
+        }
+        Ok(())
+    }
+}
+
+fn validate_link(link: &PanelLink) -> Result<(), PanelManifestError> {
+    match link.target {
+        PanelLinkTarget::External => {
+            if link.source_event_id.is_some() {
+                return invalid("external links cannot carry a source event id");
+            }
+            let Some(uri) = link.uri.as_deref() else {
+                return invalid("external links require a URI");
+            };
+            let parsed = Url::parse(uri)
+                .map_err(|_| PanelManifestError::Invalid("external URI is invalid".into()))?;
+            if parsed.scheme() != "https" || parsed.host_str().is_none() {
+                return invalid("external links require an HTTPS URI with a host");
+            }
+        }
+        _ => {
+            let Some(source_event_id) = link.source_event_id.as_deref() else {
+                return invalid("Buzz-native links require a source event id");
+            };
+            validate_event_id("link.sourceEventId", source_event_id)?;
+            if link.uri.is_some() {
+                return invalid("Buzz-native links cannot carry an arbitrary URI");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_channel_id(field: &str, value: &str) -> Result<(), PanelManifestError> {
+    let parsed = Uuid::parse_str(value)
+        .map_err(|_| PanelManifestError::Invalid(format!("{field} is not a UUID")))?;
+    if parsed.to_string() != value {
+        return invalid(format!("{field} must use canonical lowercase UUID form"));
+    }
+    Ok(())
+}
+
+fn validate_event_id(field: &str, value: &str) -> Result<(), PanelManifestError> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return invalid(format!("{field} must be lowercase 64-character hex"));
+    }
+    Ok(())
+}
+
+fn validate_identifier(
+    field: &str,
+    value: &str,
+    max_bytes: usize,
+) -> Result<(), PanelManifestError> {
+    validate_text(field, value, max_bytes, true)?;
+    if !value.is_ascii() {
+        return invalid(format!("{field} must contain ASCII characters only"));
+    }
+    Ok(())
+}
+
+fn validate_text(
+    field: &str,
+    value: &str,
+    max_bytes: usize,
+    require_non_empty: bool,
+) -> Result<(), PanelManifestError> {
+    if require_non_empty && value.is_empty() {
+        return invalid(format!("{field} must not be empty"));
+    }
+    if value.len() > max_bytes {
+        return invalid(format!("{field} exceeds maximum of {max_bytes} bytes"));
+    }
+    if value.chars().any(char::is_control) {
+        return invalid(format!("{field} must not contain control characters"));
+    }
+    Ok(())
+}
+
+fn invalid<T>(message: impl Into<String>) -> Result<T, PanelManifestError> {
+    Err(PanelManifestError::Invalid(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CHANNEL_ID: &str = "00000000-0000-4000-8000-000000000001";
+
+    fn valid_manifest() -> PanelManifest {
+        PanelManifest {
+            schema_version: PANEL_MANIFEST_SCHEMA_VERSION,
+            panel_id: "panel".into(),
+            channel_id: CHANNEL_ID.into(),
+            title: "Panel".into(),
+            description: Some("A projection".into()),
+            status: PanelStatus::Active,
+            updated_at: 1_760_000_000,
+            sections: vec![PanelSection {
+                id: "section".into(),
+                title: "Section".into(),
+                status: PanelStatus::Active,
+                fields: vec![PanelField {
+                    label: "State".into(),
+                    value: "Active".into(),
+                    presentation: PanelPresentation::Status,
+                }],
+                links: vec![PanelLink {
+                    label: "Source".into(),
+                    target: PanelLinkTarget::Event,
+                    source_event_id: Some("1".repeat(64)),
+                    uri: None,
+                }],
+            }],
+            source_events: vec![PanelSourceEvent {
+                event_id: "1".repeat(64),
+                kind: 43004,
+                channel_id: CHANNEL_ID.into(),
+                label: "Result".into(),
+            }],
+        }
+    }
+
+    #[test]
+    fn fixture_round_trips_and_validates() {
+        let input = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../docs/fixtures/signed-channel-panel.json"
+        ));
+        let manifest = PanelManifest::from_json(input).expect("fixture must validate");
+        assert_eq!(manifest.schema_version, 1);
+        assert_eq!(manifest.source_events.len(), 2);
+    }
+
+    #[test]
+    fn valid_manifest_validates_for_current_channel() {
+        let manifest = valid_manifest();
+        assert!(manifest
+            .validate_for_channel(Uuid::parse_str(CHANNEL_ID).expect("channel id"))
+            .is_ok());
+    }
+
+    #[test]
+    fn unknown_schema_version_is_rejected() {
+        let mut manifest = valid_manifest();
+        manifest.schema_version = 2;
+        assert!(manifest.validate().is_err());
+    }
+
+    #[test]
+    fn cross_channel_manifest_is_rejected() {
+        let manifest = valid_manifest();
+        assert!(manifest.validate_for_channel(Uuid::new_v4()).is_err());
+    }
+
+    #[test]
+    fn unsafe_external_link_is_rejected() {
+        let mut manifest = valid_manifest();
+        manifest.sections[0].links = vec![PanelLink {
+            label: "Remote".into(),
+            target: PanelLinkTarget::External,
+            source_event_id: None,
+            uri: Some("javascript:alert(1)".into()),
+        }];
+        assert!(manifest.validate().is_err());
+    }
+
+    #[test]
+    fn duplicate_section_ids_are_rejected() {
+        let mut manifest = valid_manifest();
+        manifest.sections.push(manifest.sections[0].clone());
+        assert!(manifest.validate().is_err());
+    }
+
+    #[test]
+    fn unknown_json_fields_are_rejected() {
+        let mut value = serde_json::to_value(valid_manifest()).expect("serialize");
+        value["unexpected"] = serde_json::Value::Bool(true);
+        assert!(PanelManifest::from_json(&value.to_string()).is_err());
+    }
+}

--- a/docs/fixtures/signed-channel-panel.json
+++ b/docs/fixtures/signed-channel-panel.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": 1,
+  "panelId": "exchange-outcome-demo",
+  "channelId": "00000000-0000-4000-8000-000000000001",
+  "title": "Documentation marker",
+  "description": "A bounded, read-only operational projection.",
+  "status": "active",
+  "updatedAt": 1760000000,
+  "sections": [
+    {
+      "id": "provider-pool",
+      "title": "Provider pool",
+      "status": "active",
+      "fields": [
+        {
+          "label": "Ferris",
+          "value": "Rust · available",
+          "presentation": "text"
+        },
+        {
+          "label": "Sable",
+          "value": "Security · available",
+          "presentation": "text"
+        },
+        {
+          "label": "Prism",
+          "value": "Frontend · available",
+          "presentation": "text"
+        },
+        {
+          "label": "Gauge",
+          "value": "Testing · available",
+          "presentation": "text"
+        },
+        {
+          "label": "Ledger",
+          "value": "Database · available",
+          "presentation": "text"
+        },
+        {
+          "label": "Hook",
+          "value": "Integration · available",
+          "presentation": "text"
+        }
+      ],
+      "links": []
+    },
+    {
+      "id": "outcome",
+      "title": "Outcome",
+      "status": "active",
+      "fields": [
+        {
+          "label": "Request",
+          "value": "Add a bounded documentation marker",
+          "presentation": "text"
+        },
+        {
+          "label": "Match",
+          "value": "Ferris selected",
+          "presentation": "status"
+        },
+        {
+          "label": "Evidence",
+          "value": "Patch hash and validation result",
+          "presentation": "monospace"
+        },
+        {
+          "label": "Decision",
+          "value": "Awaiting buyer acceptance",
+          "presentation": "status"
+        },
+        {
+          "label": "Settlement",
+          "value": "Pending acceptance",
+          "presentation": "status"
+        }
+      ],
+      "links": []
+    }
+  ],
+  "sourceEvents": [
+    {
+      "eventId": "1111111111111111111111111111111111111111111111111111111111111111",
+      "kind": 43001,
+      "channelId": "00000000-0000-4000-8000-000000000001",
+      "label": "Outcome request"
+    },
+    {
+      "eventId": "2222222222222222222222222222222222222222222222222222222222222222",
+      "kind": 43004,
+      "channelId": "00000000-0000-4000-8000-000000000001",
+      "label": "Evidence result"
+    }
+  ]
+}

--- a/docs/signed-channel-extension-panel.md
+++ b/docs/signed-channel-extension-panel.md
@@ -1,0 +1,220 @@
+# Signed channel extension panel
+
+Status: design proposal for [#3863](https://github.com/block/buzz/issues/3863).
+
+This document is the contract slice of the panel work. It defines the generic
+projection that a later Desktop implementation may render. It does not add a
+relay event kind, a new HTTP endpoint, an integration adapter, or a panel to
+the client.
+
+## Product boundary
+
+A panel is a compact, read-only projection of signed Buzz state in the current
+channel. It is not a second source of truth and it does not become a workflow,
+acceptance, accounting, or settlement authority.
+
+Buzz owns:
+
+- panel placement and rendering;
+- community and channel permission checks;
+- signature and source-event provenance;
+- bounded parsing and fail-closed behavior; and
+- fallback links to the source Canvas, workflow, handoff, or thread.
+
+An integration owns:
+
+- domain semantics and policy;
+- matching, acceptance, and dispute decisions;
+- accounting and settlement; and
+- external credentials and execution.
+
+The contract deliberately uses generic sections and fields. A panel may be
+useful for an exchange, an incident, a deployment, or another workflow without
+Buzz learning that domain's rules.
+
+## View-model contract
+
+The transport envelope remains an open decision for maintainers. The first
+contract slice defines the content that a verified, channel-scoped source event
+or adapter must provide:
+
+```text
+PanelManifest
+├── schemaVersion       integer, currently 1
+├── panelId             stable identifier within the channel
+├── channelId           canonical channel UUID
+├── title               short human-readable title
+├── description         optional plain-text context
+├── status              pending | active | complete | blocked | failed |
+│                       stale | unavailable
+├── updatedAt           Unix seconds
+├── sections[]
+│   ├── id              stable within the manifest
+│   ├── title           short section heading
+│   ├── status          same bounded status vocabulary
+│   ├── fields[]
+│   │   ├── label       short plain-text label
+│   │   ├── value       plain-text value
+│   │   └── presentation text | monospace | timestamp | status
+│   └── links[]
+│       ├── label       short action label
+│       ├── target      canvas | workflow | handoff | thread | event | external
+│       ├── sourceEventId  optional 64-character event id
+│       └── uri         optional, only for an external HTTPS destination
+└── sourceEvents[]
+    ├── eventId         64-character event id
+    ├── kind            unsigned event kind
+    ├── channelId       canonical channel UUID
+    └── label            short provenance label
+```
+
+The wire representation is JSON with the same names and types. Objects MUST
+not contain unknown fields, and a client MUST reject a manifest whose
+`schemaVersion` is not exactly `1`. Additive fields belong to a later schema
+version; clients must not guess how to render an unknown version.
+
+### Field rules
+
+- All identifiers are ASCII strings with explicit length limits. `panelId` and
+  section ids are at most 128 bytes; labels and titles are at most 256 bytes;
+  field values and descriptions are at most 4,096 bytes.
+- `channelId` is a canonical lowercase UUID. Every source event must carry the
+  same channel id as the manifest.
+- `eventId` and `sourceEventId` are lowercase 64-character hexadecimal event
+  ids. A link that points to a Buzz object uses a source event reference rather
+  than an arbitrary URL.
+- `presentation` is an allowlist, not a CSS class or renderer name. Unknown
+  hints fall back to `text` only when the schema version is known; unknown
+  required enum values reject the manifest.
+- `status` is conveyed by text and a semantic badge. Color is supplemental and
+  must never be the only status signal.
+- `external` links require an `https:` URI. The renderer does not fetch the URI,
+  execute its contents, or embed it in an iframe.
+- Sections, fields, links, and source events are bounded collections. A
+  proposed first implementation caps them at 32, 64, 32, and 64 items
+  respectively, and caps the UTF-8 manifest content at 32 KiB. These limits
+  keep the payload below the relay's 65,536-byte frame limit with room for the
+  signed event envelope.
+
+## Signature and provenance
+
+The panel may only be built from a verified Nostr event or from events already
+verified by the relay and returned through the authenticated query path. A
+future transport adapter must preserve the original signed event id and kind;
+it must not replace source events with an unsigned integration response.
+
+Before display, the client or adapter MUST:
+
+1. resolve the current community from the configured relay and the current
+   channel from the route/context;
+2. require normal channel membership for the current reader;
+3. verify that the manifest channel id equals the current channel id;
+4. verify every source event reference is channel-local and was obtained from
+   the same community;
+5. verify the event id/signature when the raw signed event is available; and
+6. reject malformed, oversized, stale-by-policy, or cross-channel data.
+
+The panel displays source-event ids as inspectable provenance and offers a
+deep link back to the source event. It must not infer authorship, acceptance,
+settlement, or correctness from a presentation status alone.
+
+## Transport decision still required
+
+This proposal intentionally does not reserve a new event kind. Existing source
+events cover several useful cases:
+
+| Source | Existing kind | What it can provide |
+| --- | ---: | --- |
+| Canvas revision | 40100 | channel document and author/timestamp provenance |
+| Job request/result | 43001–43006 | requested outcome, progress, result, or failure |
+| Workflow run | 46001–46012 | trigger, step, approval, and terminal status |
+| Thread/message | 9 / 40002 | conversation context and acknowledgements |
+
+None of these alone is a generic panel manifest. Maintainers should choose
+between composing a projection from those source events and registering one
+new signed, channel-scoped manifest event. The eventual event choice must be
+documented and tested before the Desktop panel PR. This contract PR must not
+silently overload kind 9, Canvas, or workflow events with a second meaning.
+
+Regardless of transport, all writes remain ordinary signed Nostr events and
+must use the existing relay authorization, persistence, query, fan-out, audit,
+and community-scoping paths. No bespoke HTTP API is part of this proposal.
+
+## Desktop surface contract
+
+The renderer PR should use the existing channel auxiliary-panel shell and make
+the panel discoverable from the current channel. It should preserve reading,
+threading, and composing in the channel instead of replacing the timeline.
+
+Required states:
+
+- loading: the panel location is stable while the source query resolves;
+- empty: no panel projection is available, with a link to the channel's source
+  Canvas or thread when one exists;
+- ready: title, overall status, sections, last update, attribution, and source
+  links are visible without raw JSON;
+- stale: the last update is visible and the panel explains that the projection
+  may no longer describe current source events;
+- unavailable: the reader lacks access or the source cannot be resolved;
+- invalid: malformed or unknown-version data is rejected with a concise error
+  and a source-event fallback where possible.
+
+The panel must remain usable in a narrow window. Headings and status badges use
+semantic accessibility labels; source links are keyboard-focusable; status is
+not communicated by color alone; and the raw manifest is available only as an
+explicit inspection affordance, never as the primary presentation.
+
+## Security boundary
+
+The panel MUST NOT:
+
+- execute JavaScript, WebAssembly, provider code, or arbitrary HTML;
+- embed remote pages, iframes, plugins, or webviews;
+- read another channel or community because a manifest names it;
+- display private provider, buyer, credential, or integration data not present
+  in an authorized source event;
+- upload local files or scan a working directory;
+- call matching, acceptance, payment, accounting, or settlement APIs; or
+- turn a visual status into an authorization or business decision.
+
+Unknown schemas, invalid signatures, cross-channel references, oversized
+payloads, unsupported link schemes, and malformed identifiers all fail closed.
+
+## Deterministic fixture
+
+`docs/fixtures/signed-channel-panel.json` is a non-secret manifest fixture for
+parser and renderer tests. It describes a small provider-and-deliverable
+workflow using generic Buzz fields. It is not an OEXL integration, does not
+contain credentials, and is not intended to be published to a live relay.
+
+Tests that need a signed event should sign this content with an ephemeral test
+key inside the test process. No private key belongs in the fixture or the
+repository.
+
+## Verification matrix for follow-up implementation
+
+The protocol and Desktop slices should cover at least:
+
+- valid version-1 manifest round-trip;
+- unknown schema version rejection;
+- malformed JSON, duplicate/unknown required fields, and oversized content;
+- invalid event id/signature and a source event from another channel;
+- unsupported status, presentation hint, and link scheme;
+- loading, empty, ready, stale, unavailable, and invalid rendering;
+- human and agent authorship attribution;
+- keyboard navigation and screen-reader labels; and
+- narrow-window layout without hiding the source-event fallback.
+
+## Explicit non-goals
+
+- OEXL matching, pricing, acceptance, dispute, accounting, payments, or
+  settlement inside Buzz;
+- an OEXL-specific mode or marketplace dashboard;
+- replacing Canvases, workflows, jobs, threads, or the activity feed;
+- a generic third-party plugin runtime;
+- arbitrary remote UI; and
+- a Desktop implementation in this contract PR.
+
+The next PR may render this generic contract in the existing channel panel. An
+integration adapter should follow only if maintainers want a stable adapter
+surface after the transport and rendering contracts are accepted.


### PR DESCRIPTION
# Summary

Part 1 of [#3863](https://github.com/block/buzz/issues/3863): defines the generic signed channel extension-panel contract before the Desktop renderer or integration adapter work.

Adds:
- typed `buzz-core` `PanelManifest` types with schema/version, channel scoping, provenance, bounded sections, statuses, and typed links;
- fail-closed validation for unknown schemas, unknown fields, malformed identifiers, cross-channel references, oversized payloads, and unsafe external links;
- a deterministic non-secret fixture and contract documentation.

This is the Part 1 design/contract PR. No desktop UI changed, so no screenshots are included.

# Scope

## Included

- Generic read-only panel view-model types in `buzz-core`.
- Explicit community/channel and signed source-event provenance boundaries.
- Allowlisted status, presentation, and link target vocabularies.
- Bounded payload and collection sizes.
- Loading/empty/stale/unavailable/invalid state requirements for the follow-up renderer.
- Deterministic fixture data for tests; no live relay or integration connection.

## Excluded

- Desktop panel rendering and channel-panel navigation.
- A new Nostr event kind or final transport envelope; maintainers should choose this before Part 2.
- Any new HTTP API, remote JavaScript, HTML injection, iframe, plugin, or webview execution.
- OEXL matching, pricing, acceptance, disputes, accounting, payments, settlement, or credentials.
- Replacement of Canvases, workflows, jobs, threads, or the activity feed.

# Product / Architecture Decisions

- The manifest is a generic projection, not a second source of truth or domain authority.
- Existing Canvas (40100), job (43001–43006), workflow (46001–46012), and message/thread events remain authoritative source candidates.
- This PR intentionally does not overload kind 9, Canvas, or workflow events and does not reserve a new kind. Transport selection is an explicit maintainer decision for the next slice.
- Buzz owns placement, permission checks, provenance, bounded parsing, fail-closed behavior, and source-event fallback. Integrations own domain semantics and external execution.
- External links are user-activated HTTPS destinations only; the renderer never fetches or executes them.

# User-Facing Contract

A version-1 manifest contains:

- stable panel and channel identifiers;
- title, description, overall status, and update time;
- ordered sections with status, plain-text fields, and allowlisted presentation hints;
- typed links to Canvas, workflow, handoff, thread, event, or HTTPS sources; and
- signed source-event references.

Unknown schema versions, malformed or cross-channel data, invalid signatures, unsupported link schemes, and oversized payloads fail closed. The follow-up Desktop PR must render semantic statuses without relying on color alone and must preserve a source-event fallback.

# Verification

## Ran

- `cargo test -p buzz-core` — 244 unit tests and 2 doc tests passed.
- `cargo test -p buzz-core panel` — 7 panel contract tests passed.
- `cargo clippy -p buzz-core --all-targets -- -D warnings` — passed.
- `rustfmt --edition 2021 crates/buzz-core/src/panel.rs crates/buzz-core/src/lib.rs --check` — passed.
- `jq empty docs/fixtures/signed-channel-panel.json` — passed.
- `git diff --cached --check` — passed.

## Not run

- `just ci` and Desktop checks are deferred to the implementation PR because this Part 1 slice contains no Desktop changes.

# Review Path

1. `crates/buzz-core/src/panel.rs` — type and validation contract.
2. `docs/signed-channel-extension-panel.md` — security boundary and transport decision.
3. `docs/fixtures/signed-channel-panel.json` — deterministic non-secret fixture.

# Notes For Reviewer

This PR is intentionally Part 1 of #3863. Please review the manifest shape, source-event/provenance rules, payload bounds, and the unresolved transport-kind choice before the Desktop panel PR. The fixture uses OEXL-shaped labels only as deterministic test data; no OEXL-specific code or settlement semantics were added.

The next contribution can be a read-only Desktop rendering PR after the contract and transport decision are accepted.