### PR TITLE
fix(desktop): render RTL messages in their own direction

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
         "**/hosted-communities-settings-screenshots.spec.ts",
         "**/invites-settings-screenshots.spec.ts",
         "**/messaging.spec.ts",
+        "**/message-rtl-direction.spec.ts",
         "**/message-feedback-snapshots.spec.ts",
         "**/custom-emoji.spec.ts",
         "**/profile-custom-emoji-status.spec.ts",

--- a/desktop/src/features/messages/lib/useRichTextEditor.ts
+++ b/desktop/src/features/messages/lib/useRichTextEditor.ts
@@ -491,6 +491,13 @@ export function useRichTextEditor({
           autocorrect: "off",
           class: `${MESSAGE_MARKDOWN_CLASS} min-h-0 resize-none overflow-y-hidden border-0 bg-transparent px-0 py-0 text-sm leading-5 text-foreground shadow-none focus-visible:ring-0 caret-foreground outline-hidden max-w-none`,
           "data-testid": "message-input",
+          // The `unicode-bidi: plaintext` rule already gives each paragraph its
+          // own direction, but ProseMirror renders its own list nodes rather
+          // than the markdown components that carry `dir="auto"`, so a list
+          // typed in RTL would keep its markers and indent on the left. `auto`
+          // on the root sets `direction` from the draft's first strong
+          // character, which is what the marker side follows.
+          dir: "auto",
           spellcheck: "true",
         },
         // ArrowUp in an empty composer → edit your last message (Slack

--- a/desktop/src/shared/styles/globals/composer.css
+++ b/desktop/src/shared/styles/globals/composer.css
@@ -146,9 +146,13 @@
   margin: 0.25rem 0;
 }
 
+/* Logical, not physical: the editor root carries `dir="auto"`, so an RTL draft
+   flips `direction` and the quote bar, bullets, and their indent have to follow
+   it. With `padding-left` the markers stayed pinned to the left edge while the
+   text moved right, which renders them outside the padded area. */
 .rich-text-composer .tiptap blockquote {
-  border-left: 2px solid hsl(var(--border));
-  padding-left: 1rem;
+  border-inline-start: 2px solid hsl(var(--border));
+  padding-inline-start: 1rem;
   font-style: italic;
   color: hsl(var(--muted-foreground));
   margin: 0.25rem 0;
@@ -156,13 +160,13 @@
 
 .rich-text-composer .tiptap ul {
   list-style-type: disc;
-  padding-left: 1.5rem;
+  padding-inline-start: 1.5rem;
   margin: 0.25rem 0;
 }
 
 .rich-text-composer .tiptap ol {
   list-style-type: decimal;
-  padding-left: 1.5rem;
+  padding-inline-start: 1.5rem;
   margin: 0.25rem 0;
 }
 

--- a/desktop/src/shared/styles/globals/markdown.css
+++ b/desktop/src/shared/styles/globals/markdown.css
@@ -12,6 +12,27 @@
   --agent-icon-gap: 0.125rem;
 }
 
+/* Let every text block pick its own direction from its first strong
+   character. The app root is `ltr`, so without this an RTL message (Hebrew,
+   Arabic, …) is laid out as an LTR paragraph: it stays left-aligned, and any
+   sentence long enough to wrap breaks into the wrong visual reading order.
+
+   `unicode-bidi: plaintext` is the CSS equivalent of `dir="auto"` — it runs
+   the UAX9 P2/P3 heuristic per bidi paragraph — and `text-align: start`
+   resolves against that same per-paragraph direction, so an English
+   paragraph quoted inside an RTL message keeps its own alignment. Doing it
+   here rather than per-element also covers the composer and search preview,
+   which share `.message-markdown`.
+
+   Lists and blockquotes additionally carry `dir="auto"` in markdown.tsx:
+   `unicode-bidi` does not change the `direction` property, and the blocks
+   whose chrome flanks the text — list markers, the quote bar, and their
+   `padding-inline-start` — follow `direction`, not the bidi paragraph. */
+.message-markdown :is(p, h1, h2, h3, h4, h5, h6, li, blockquote, td, th) {
+  unicode-bidi: plaintext;
+  text-align: start;
+}
+
 .message-markdown p:empty {
   display: none;
 }

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -61,6 +61,12 @@ import {
 } from "./markdown/CodeBlock";
 import { FileCard } from "./markdown/FileCard";
 import { InlineEmojiPopover } from "./markdown/InlineEmojiPopover";
+import {
+  MarkdownBlockquote,
+  MarkdownListItem,
+  MarkdownOrderedList,
+  MarkdownUnorderedList,
+} from "./markdown/directionalBlocks";
 import { MarkdownInput } from "./markdown/MarkdownInput";
 import {
   MediaContextMenu,
@@ -1355,9 +1361,6 @@ function createMarkdownComponents(
   interactive = true,
   mediaInset = false,
 ): Components {
-  const listItemClassName = "[&_p]:inline";
-  const listClassName = "space-y-1 pl-6 marker:text-muted-foreground/80";
-
   function MarkdownAnchor({
     children,
     href,
@@ -1496,11 +1499,7 @@ function createMarkdownComponents(
       </SpoilerInline>
     ),
     a: MarkdownAnchor,
-    blockquote: ({ children }) => (
-      <blockquote className="border-l-2 border-border pl-4 italic text-muted-foreground [&>*:first-child]:mt-0 [&>*+*]:mt-2">
-        {children}
-      </blockquote>
-    ),
+    blockquote: MarkdownBlockquote,
     br: () => <br />,
     code: ({ children, className, ...props }: React.ComponentProps<"code">) => {
       const rawCode = String(children);
@@ -1608,10 +1607,8 @@ function createMarkdownComponents(
       );
     },
     input: MarkdownInput,
-    li: ({ children }) => <li className={listItemClassName}>{children}</li>,
-    ol: ({ children }) => (
-      <ol className={cn("list-decimal", listClassName)}>{children}</ol>
-    ),
+    li: MarkdownListItem,
+    ol: MarkdownOrderedList,
     p: ({ children }) => {
       // Detect media-only paragraphs (images + <br> from remarkBreaks).
       // Multi-image: render as a compact, count-aware mosaic. Two images split
@@ -1661,9 +1658,7 @@ function createMarkdownComponents(
         {children}
       </th>
     ),
-    ul: ({ children }) => (
-      <ul className={cn("list-disc", listClassName)}>{children}</ul>
-    ),
+    ul: MarkdownUnorderedList,
     mention: function MarkdownMention({
       children,
     }: {

--- a/desktop/src/shared/ui/markdown/directionalBlocks.tsx
+++ b/desktop/src/shared/ui/markdown/directionalBlocks.tsx
@@ -28,12 +28,13 @@ export function MarkdownBlockquote({
   );
 }
 
+// Deliberately no `dir` here: `dir="auto"` on the list skips any descendant
+// that carries its own `dir`, so marking items too leaves the list with no
+// strong character to read and it falls back to `ltr` — markers and indent
+// stranded on the left. Items still get their own text direction from the
+// `unicode-bidi: plaintext` rule; the list owns the marker side for all of them.
 export function MarkdownListItem({ children }: { children?: React.ReactNode }) {
-  return (
-    <li dir="auto" className={ITEM_CLASS}>
-      {children}
-    </li>
-  );
+  return <li className={ITEM_CLASS}>{children}</li>;
 }
 
 export function MarkdownOrderedList({

--- a/desktop/src/shared/ui/markdown/directionalBlocks.tsx
+++ b/desktop/src/shared/ui/markdown/directionalBlocks.tsx
@@ -1,0 +1,61 @@
+import type * as React from "react";
+
+import { cn } from "@/shared/lib/cn";
+
+// The markdown blocks whose chrome flanks the text — list markers, the quote
+// bar, and the inline padding that clears them — and so must carry `dir="auto"`
+// rather than lean on the `unicode-bidi: plaintext` rule in
+// styles/globals/markdown.css. That rule resolves each bidi paragraph's
+// direction for the text itself, but leaves the `direction` property alone, and
+// marker side plus `padding-inline-start` follow `direction`. Without the
+// attribute an RTL message (Hebrew, Arabic, …) renders right-aligned text with
+// its bullets and quote bar stranded on the far side of the block.
+
+const ITEM_CLASS = "[&_p]:inline";
+const LIST_CLASS = "space-y-1 ps-6 marker:text-muted-foreground/80";
+const QUOTE_CLASS =
+  "border-s-2 border-border ps-4 italic text-muted-foreground [&>*:first-child]:mt-0 [&>*+*]:mt-2";
+
+export function MarkdownBlockquote({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
+  return (
+    <blockquote dir="auto" className={QUOTE_CLASS}>
+      {children}
+    </blockquote>
+  );
+}
+
+export function MarkdownListItem({ children }: { children?: React.ReactNode }) {
+  return (
+    <li dir="auto" className={ITEM_CLASS}>
+      {children}
+    </li>
+  );
+}
+
+export function MarkdownOrderedList({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
+  return (
+    <ol dir="auto" className={cn("list-decimal", LIST_CLASS)}>
+      {children}
+    </ol>
+  );
+}
+
+export function MarkdownUnorderedList({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
+  return (
+    <ul dir="auto" className={cn("list-disc", LIST_CLASS)}>
+      {children}
+    </ul>
+  );
+}

--- a/desktop/tests/e2e/message-rtl-direction.spec.ts
+++ b/desktop/tests/e2e/message-rtl-direction.spec.ts
@@ -1,0 +1,179 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+// Regression cover for RTL message direction. The app root is `ltr`, so before
+// the fix every block inherited it: a Hebrew message rendered as an LTR
+// paragraph — left-aligned, and long enough to wrap it broke into the wrong
+// visual reading order. Blocks whose chrome flanks the text (list markers, the
+// quote bar) additionally need `direction` itself flipped, not just the bidi
+// paragraph, or the markers strand on the far side of right-aligned text.
+//
+// These assert on layout facts rather than CSS declarations: line-box edges for
+// alignment, and which physical side the inline padding resolved to. A rule
+// that stops applying — or gets overridden downstream — fails here even if the
+// stylesheet still contains it.
+
+const CHANNEL = "general";
+
+const HEBREW_PARAGRAPH =
+  "שאלה טובה — ויש חדשות טובות וחצי. זה משפט ארוך מספיק כדי להישבר לשתי שורות לפחות בתוך הבועה הזאת.";
+const ENGLISH_PARAGRAPH =
+  "An English paragraph inside the same message keeps its own direction.";
+const HEBREW_MESSAGE = [
+  HEBREW_PARAGRAPH,
+  "",
+  "- פריט ראשון ברשימה בעברית",
+  "- פריט שני",
+  "",
+  "> ציטוט בעברית",
+  "",
+  ENGLISH_PARAGRAPH,
+].join("\n");
+
+type Edges = { left: number; right: number }[];
+
+// A paragraph is right-flush (RTL) when its line boxes share a right edge and
+// vary on the left, and left-flush (LTR) when the reverse holds. One-line
+// paragraphs cannot show this, so callers pass text long enough to wrap.
+function isFlush(edges: Edges, side: "left" | "right") {
+  if (edges.length < 2) throw new Error("need a wrapped paragraph to compare");
+  const spread = (values: number[]) =>
+    Math.max(...values) - Math.min(...values);
+  const flush = edges.map((edge) => edge[side]);
+  const ragged = edges.map((edge) => edge[side === "left" ? "right" : "left"]);
+  return spread(flush) <= 1 && spread(ragged) > 1;
+}
+
+async function paragraphEdges(page: Page, text: string): Promise<Edges> {
+  return page.evaluate((needle) => {
+    const paragraph = [
+      ...document.querySelectorAll<HTMLElement>(".message-markdown p"),
+    ].find((node) => node.textContent?.includes(needle.slice(0, 24)));
+    if (!paragraph)
+      throw new Error(`no rendered paragraph matching: ${needle}`);
+    const range = document.createRange();
+    range.selectNodeContents(paragraph);
+    return [...range.getClientRects()].map((rect) => ({
+      left: Math.round(rect.left),
+      right: Math.round(rect.right),
+    }));
+  }, text);
+}
+
+async function emitHebrewMessage(page: Page) {
+  await page.waitForFunction(
+    () => typeof window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__ === "function",
+  );
+  await page.evaluate(
+    ({ channelName, content }) => {
+      window.__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({ channelName, content });
+    },
+    { channelName: CHANNEL, content: HEBREW_MESSAGE },
+  );
+  await expect(page.getByTestId("message-timeline")).toContainText("פריט שני");
+}
+
+test.describe("RTL message direction", () => {
+  test.beforeEach(async ({ page }) => {
+    await installMockBridge(page);
+    await page.setViewportSize({ width: 900, height: 700 });
+    await page.goto("/");
+    await page.getByTestId(`channel-${CHANNEL}`).click();
+    await expect(page.getByTestId("message-timeline")).toBeVisible();
+  });
+
+  test("a Hebrew paragraph renders right-flush and an English one stays left-flush", async ({
+    page,
+  }) => {
+    await emitHebrewMessage(page);
+
+    expect(isFlush(await paragraphEdges(page, HEBREW_PARAGRAPH), "right")).toBe(
+      true,
+    );
+
+    // Same message, opposite script: per-block resolution, not one direction
+    // stamped on the whole message.
+    const english = await paragraphEdges(page, ENGLISH_PARAGRAPH);
+    expect(english[0].left).toBeLessThan(english[0].right);
+    expect(
+      await page.evaluate((needle) => {
+        const paragraph = [
+          ...document.querySelectorAll<HTMLElement>(".message-markdown p"),
+        ].find((node) => node.textContent?.includes(needle.slice(0, 24)));
+        return paragraph ? getComputedStyle(paragraph).unicodeBidi : null;
+      }, ENGLISH_PARAGRAPH),
+    ).toBe("plaintext");
+  });
+
+  test("Hebrew list markers and the quote bar move to the right edge", async ({
+    page,
+  }) => {
+    await emitHebrewMessage(page);
+
+    const chrome = await page.evaluate((marker) => {
+      // Scope to our own message: `general` ships with seeded English content,
+      // so an unscoped `.message-markdown ul` can match somebody else's list.
+      const body = [
+        ...document.querySelectorAll<HTMLElement>(".message-markdown"),
+      ].find((node) => node.textContent?.includes(marker));
+      if (!body) throw new Error("no rendered body for the Hebrew message");
+      const list = body.querySelector<HTMLElement>("ul");
+      const quote = body.querySelector<HTMLElement>("blockquote");
+      if (!list || !quote) throw new Error("missing list or blockquote");
+      const listStyle = getComputedStyle(list);
+      const quoteStyle = getComputedStyle(quote);
+      return {
+        listDirection: listStyle.direction,
+        listPaddingLeft: Number.parseFloat(listStyle.paddingLeft),
+        listPaddingRight: Number.parseFloat(listStyle.paddingRight),
+        quoteDirection: quoteStyle.direction,
+        quoteBorderLeft: Number.parseFloat(quoteStyle.borderLeftWidth),
+        quoteBorderRight: Number.parseFloat(quoteStyle.borderRightWidth),
+      };
+    }, "פריט שני");
+
+    expect(chrome.listDirection).toBe("rtl");
+    expect(chrome.listPaddingRight).toBeGreaterThan(chrome.listPaddingLeft);
+    expect(chrome.quoteDirection).toBe("rtl");
+    expect(chrome.quoteBorderRight).toBeGreaterThan(chrome.quoteBorderLeft);
+  });
+
+  test("the composer follows the draft's own script", async ({ page }) => {
+    const editor = page.getByTestId("message-input");
+    const direction = () =>
+      editor.evaluate((node) => getComputedStyle(node).direction);
+
+    await editor.click();
+    await page.keyboard.type(HEBREW_PARAGRAPH);
+    await expect.poll(direction).toBe("rtl");
+
+    await page.keyboard.press("ControlOrMeta+A");
+    await page.keyboard.press("Backspace");
+    await page.keyboard.type(ENGLISH_PARAGRAPH);
+    await expect.poll(direction).toBe("ltr");
+  });
+
+  test("a Hebrew list typed in the composer indents from the right", async ({
+    page,
+  }) => {
+    const editor = page.getByTestId("message-input");
+    await editor.click();
+    await page.keyboard.type("- פריט ראשון ברשימה");
+
+    await expect
+      .poll(() =>
+        editor.evaluate((node) => {
+          const list = node.querySelector<HTMLElement>("ul, ol");
+          if (!list) return null;
+          const style = getComputedStyle(list);
+          return (
+            Number.parseFloat(style.paddingInlineStart) > 0 &&
+            Number.parseFloat(style.paddingRight) >
+              Number.parseFloat(style.paddingLeft)
+          );
+        }),
+      )
+      .toBe(true);
+  });
+});


### PR DESCRIPTION
Duplicate search: none found — no open or closed PR or issue in `block/buzz` covers RTL / bidi / text direction (searched `rtl`, `bidi`, `hebrew`, `arabic`, `right-to-left`).

## Problem

Message markdown has no direction handling — `grep` for `dir="auto"`, `rtl`, or `unicode-bidi` across `desktop/src` returns nothing. Every block therefore inherits `ltr` from the app root, so an RTL message (Hebrew, Arabic, …) is laid out as an LTR paragraph: it stays left-aligned, and any sentence long enough to wrap breaks into the wrong visual reading order. The reader has to reassemble the sentence across lines.

Reported by a Hebrew-speaking user reading agent replies in a DM.

## Fix

**`unicode-bidi: plaintext` + `text-align: start`** on the text blocks under `.message-markdown`. This is the CSS equivalent of `dir="auto"`: it runs the UAX9 P2/P3 heuristic per bidi paragraph, and `text-align: start` resolves against that same per-paragraph direction — so an English paragraph quoted inside an RTL message keeps its own alignment. Scoping it to the shared class also covers the composer and the search preview for free.

**Lists and blockquotes need more.** `unicode-bidi` does not touch the `direction` property, and the chrome that flanks the text — list markers, the quote bar, and the inline padding that clears them — follows `direction`, not the bidi paragraph. Left alone they strand their bullets and quote bar on the far side of right-aligned text. Those blocks carry an explicit `dir="auto"` and switch from physical `pl-*` / `border-l-*` to logical `ps-*` / `border-s-*`.

They move to `markdown/directionalBlocks.tsx` so `markdown.tsx` stays under the file-size ratchet, which it may not grow past. `markdown.tsx` goes 2012 → 2007 lines.

## Verification

Measured line-box geometry in **WebKit** — the engine behind the app's Tauri webview — rather than eyeballing a capture. A Hebrew paragraph's line boxes:

| | line boxes | meaning |
|---|---|---|
| before | `[21,423]`, `[21,366]` | left-flush, ragged right |
| after | `[39,441]`, `[92,441]` | right-flush, ragged left ✅ |

Then end-to-end through `just desktop-screenshot` with an injected Hebrew message — before/after captures are in the comment below.

## Regression test

`desktop/tests/e2e/message-rtl-direction.spec.ts` (registered in the `smoke` project) covers all four behaviours: Hebrew paragraph right-flush, English paragraph in the same message left-flush, list markers and quote bar on the right, and the composer following the draft's own script.

It asserts layout facts — line-box edges, and which physical side the inline padding and border resolved to — rather than CSS declarations, so a rule that stops applying or gets overridden downstream still fails. Verified load-bearing: against the pre-fix tree all four fail; with the fix all four pass.

Writing it caught a defect the screenshots had hidden. `dir="auto"` skips descendants carrying their own `dir` when searching for a strong character, so marking both `<ul>` and `<li>` left the list with nothing to read and it fell back to `ltr`. The per-item `dir` moved each marker — which is why the capture looked correct — while the list's own `ps-6` indent stayed on the left. Fixed by dropping `dir` from `<li>`.

## Checks

- `pnpm test` — 3870 pass, 0 fail
- `pnpm exec playwright test --project=smoke message-rtl-direction` — 4 pass
- `pnpm typecheck` — clean
- `pnpm check:file-sizes`, `check:px-text`, `check:pubkey-truncation` — pass
- `biome check` on the touched files — clean (`biome check .` has pre-existing failures on `main`, untouched here)

Scope note: I ran the desktop gate, not full `just ci`. The change is desktop-only (CSS + TSX) and touches no Rust, web, or mobile code.

## Not covered

Message header chrome (author, timestamp, action icons) and the row layout stay LTR. That is a larger layout change and is deliberately out of scope — this PR is only about the message text reading correctly.
