### PR TITLE
fix(acp): wire BUZZ_PRIVATE_KEY and BUZZ_RELAY_URL into Hermes sessions

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -505,6 +505,12 @@ impl AcpClient {
                 // Handled by build_codex_config_env; skip here to avoid double-setting.
                 continue;
             }
+            // Buzz delivery credentials must reach Hermes even when the harness
+            // parent already carries its own copy in the inherited environment.
+            if key == "BUZZ_PRIVATE_KEY" || key == "BUZZ_RELAY_URL" {
+                cmd.env(key, value);
+                continue;
+            }
             if std::env::var_os(key).is_none() {
                 cmd.env(key, value);
             }
@@ -2922,6 +2928,36 @@ mod tests {
             "<unset>",
             "non-Hermes spawns must not receive Hermes defaults"
         );
+    }
+
+    /// Hermes must receive BUZZ delivery env from persona `extra_env` even when
+    /// the harness parent already exports the same keys.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_forces_buzz_delivery_env_onto_agent_process() {
+        const PRIVATE_KEY: &str = "BUZZ_PRIVATE_KEY";
+        const RELAY_URL: &str = "BUZZ_RELAY_URL";
+        std::env::set_var(PRIVATE_KEY, "parent-value");
+        std::env::set_var(RELAY_URL, "ws://parent.example");
+
+        let observed_key = spawn_named_and_read_child_env(
+            "hermes-acp",
+            PRIVATE_KEY,
+            &[(PRIVATE_KEY.into(), "agent-nsec".into())],
+        )
+        .await;
+        let observed_relay = spawn_named_and_read_child_env(
+            "hermes-acp",
+            RELAY_URL,
+            &[(RELAY_URL.into(), "ws://relay.example".into())],
+        )
+        .await;
+
+        std::env::remove_var(PRIVATE_KEY);
+        std::env::remove_var(RELAY_URL);
+
+        assert_eq!(observed_key, "agent-nsec");
+        assert_eq!(observed_relay, "ws://relay.example");
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use clap::ValueEnum;
 use nostr::Keys;
+use nostr::ToBech32;
 use thiserror::Error;
 use url::Url;
 use uuid::Uuid;
@@ -718,6 +719,31 @@ pub(crate) fn default_agent_env(command: &str) -> &'static [(&'static str, &'sta
     }
 }
 
+/// Buzz delivery credentials for Hermes agent subprocesses.
+///
+/// Hermes executes the Buzz CLI inside the managed ACP session process, not only
+/// through session MCP servers. Inject relay identity into the agent env so
+/// managed Hermes sessions can authenticate delivery without manual setup.
+pub(crate) fn hermes_buzz_delivery_env_vars(
+    agent_command: &str,
+    keys: &nostr::Keys,
+    relay_url: &str,
+) -> Vec<(String, String)> {
+    match normalize_agent_command_identity(agent_command).as_str() {
+        "hermes" | "hermes-agent" | "hermes-acp" => {
+            let private_key = keys
+                .secret_key()
+                .to_bech32()
+                .expect("agent secret key bech32 encoding should never fail");
+            vec![
+                ("BUZZ_PRIVATE_KEY".into(), private_key),
+                ("BUZZ_RELAY_URL".into(), relay_url.to_string()),
+            ]
+        }
+        _ => Vec::new(),
+    }
+}
+
 /// Build the `CODEX_CONFIG` environment variable that enables full outbound
 /// network access in Codex's macOS Seatbelt sandbox.
 ///
@@ -1050,6 +1076,11 @@ impl Config {
             } else {
                 false
             };
+        persona_env_vars.extend(hermes_buzz_delivery_env_vars(
+            &agent_command,
+            &keys,
+            &args.relay_url,
+        ));
 
         validate_multiple_event_handling(args.multiple_event_handling, args.dedup)?;
 
@@ -1653,6 +1684,26 @@ mod tests {
                 "non-Hermes command must have no env defaults: {command}"
             );
         }
+    }
+
+    #[test]
+    fn hermes_buzz_delivery_env_vars_injects_relay_credentials() {
+        let keys = nostr::Keys::generate();
+        let relay_url = "ws://localhost:3000";
+        let vars = hermes_buzz_delivery_env_vars("hermes-acp", &keys, relay_url);
+        assert_eq!(vars.len(), 2);
+        let map: std::collections::HashMap<_, _> = vars.into_iter().collect();
+        assert_eq!(
+            map.get("BUZZ_RELAY_URL").map(String::as_str),
+            Some(relay_url)
+        );
+        assert!(map.contains_key("BUZZ_PRIVATE_KEY"));
+    }
+
+    #[test]
+    fn hermes_buzz_delivery_env_vars_noop_for_other_runtimes() {
+        let keys = nostr::Keys::generate();
+        assert!(hermes_buzz_delivery_env_vars("goose", &keys, "ws://localhost:3000").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Hermes-specific persona env injection for `BUZZ_PRIVATE_KEY` and `BUZZ_RELAY_URL` so managed Hermes sessions can authenticate Buzz CLI delivery.
- Force-apply those env vars when spawning the agent subprocess, even when the harness parent already exports its own copies.
- Add unit coverage for env assembly and spawn precedence.

Fixes #3768

## Test plan
- [ ] `cargo test -p buzz-acp hermes_buzz spawn_forces`
- [ ] Launch a managed Hermes agent and confirm Buzz delivery succeeds without manual env injection

Made with [Cursor](https://cursor.com)