### PR TITLE
feat(desktop): expose canvas revision history [issue:#3086]

### DIFF
--- a/desktop/src-tauri/src/commands/canvas.rs
+++ b/desktop/src-tauri/src/commands/canvas.rs
@@ -6,6 +6,8 @@ use crate::{
     relay::{query_relay, submit_event},
 };
 
+const CANVAS_HISTORY_LIMIT: u64 = 50;
+
 /// Read the most recent canvas event (kind:40100) for a channel.
 #[tauri::command]
 pub async fn get_canvas(
@@ -39,6 +41,39 @@ pub async fn get_canvas(
         "event_id": event.id.to_hex(),
         "updated_at": event.created_at.as_secs(),
         "author": event.pubkey.to_hex(),
+    }))
+}
+
+/// Read the most recent signed canvas revisions for a channel.
+///
+/// Canvas events are append-only kind:40100 events, so the relay already
+/// retains the complete revision history. The bounded response keeps the
+/// Desktop panel predictable for heavily edited canvases while preserving the
+/// newest revision as the first item.
+#[tauri::command]
+pub async fn get_canvas_history(
+    channel_id: String,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let mut events = query_relay(
+        &state,
+        &[serde_json::json!({
+            "kinds": [40100],
+            "#h": [channel_id],
+            "limit": CANVAS_HISTORY_LIMIT
+        })],
+    )
+    .await?;
+
+    events.sort_by_key(|event| std::cmp::Reverse(event.created_at));
+
+    Ok(serde_json::json!({
+        "revisions": events.into_iter().map(|event| serde_json::json!({
+            "event_id": event.id.to_hex(),
+            "content": event.content,
+            "updated_at": event.created_at.as_secs(),
+            "author": event.pubkey.to_hex(),
+        })).collect::<Vec<_>>(),
     }))
 }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -748,6 +748,7 @@ pub fn run() {
             join_channel,
             leave_channel,
             get_canvas,
+            get_canvas_history,
             set_canvas,
             get_feed,
             search_messages,

--- a/desktop/src/features/channel-templates/useApplyTemplate.ts
+++ b/desktop/src/features/channel-templates/useApplyTemplate.ts
@@ -13,7 +13,7 @@ import { resolvePersonaRuntime } from "@/features/agents/lib/resolvePersonaRunti
 import { resolveTeamPersonas } from "@/features/agents/lib/teamPersonas";
 import { useLastRuntime } from "@/features/agents/lib/useLastRuntime";
 import { useChannelTemplatesQuery } from "@/features/channel-templates/hooks";
-import { setCanvas } from "@/shared/api/tauri";
+import { setCanvas } from "@/shared/api/tauriCanvas";
 import type { ChannelTemplate } from "@/shared/api/types";
 
 /**

--- a/desktop/src/features/channels/hooks.ts
+++ b/desktop/src/features/channels/hooks.ts
@@ -6,7 +6,6 @@ import {
   archiveChannel,
   createChannel,
   deleteChannel,
-  getCanvas,
   getChannelDetails,
   getChannelMembers,
   getChannels,
@@ -15,12 +14,16 @@ import {
   leaveChannel,
   openDm,
   removeChannelMember,
-  setCanvas,
   setChannelPurpose,
   setChannelTopic,
   unarchiveChannel,
   updateChannel,
 } from "@/shared/api/tauri";
+import {
+  getCanvas,
+  getCanvasHistory,
+  setCanvas,
+} from "@/shared/api/tauriCanvas";
 import type {
   AddChannelMembersInput,
   Channel,
@@ -638,6 +641,22 @@ export function useCanvasQuery(channelId: string | null, enabled = true) {
   });
 }
 
+export function useCanvasHistoryQuery(
+  channelId: string | null,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: ["channel-canvas-history", channelId],
+    queryFn: () => {
+      if (!channelId) {
+        return Promise.reject(new Error("No channel selected"));
+      }
+      return getCanvasHistory(channelId);
+    },
+    enabled: enabled && channelId !== null,
+  });
+}
+
 export function useSetCanvasMutation(channelId: string | null) {
   const queryClient = useQueryClient();
 
@@ -652,6 +671,9 @@ export function useSetCanvasMutation(channelId: string | null) {
       if (channelId) {
         void queryClient.invalidateQueries({
           queryKey: ["channel-canvas", channelId],
+        });
+        void queryClient.invalidateQueries({
+          queryKey: ["channel-canvas-history", channelId],
         });
       }
     },

--- a/desktop/src/features/channels/ui/ChannelCanvas.tsx
+++ b/desktop/src/features/channels/ui/ChannelCanvas.tsx
@@ -2,10 +2,13 @@ import { Pencil, Save, X } from "lucide-react";
 import * as React from "react";
 
 import {
-  useCanvasQuery,
+  useCanvasHistoryQuery,
   useSetCanvasMutation,
 } from "@/features/channels/hooks";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
 import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
+import type { CanvasRevision } from "@/shared/api/canvasTypes";
+import { resolveUserLabel } from "@/features/profile/lib/identity";
 import { Button } from "@/shared/ui/button";
 import { Markdown } from "@/shared/ui/markdown";
 import { Textarea } from "@/shared/ui/textarea";
@@ -20,12 +23,28 @@ type ChannelCanvasProps = {
   isArchived: boolean;
 };
 
+const revisionDateFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function formatRevisionTimestamp(timestamp: number) {
+  return revisionDateFormatter.format(new Date(timestamp * 1_000));
+}
+
+function isCurrentRevision(
+  revision: CanvasRevision,
+  currentRevision: CanvasRevision | null,
+) {
+  return revision.eventId === currentRevision?.eventId;
+}
+
 export function ChannelCanvas({
   channelId,
   canEdit,
   isArchived,
 }: ChannelCanvasProps) {
-  const canvasQuery = useCanvasQuery(channelId, channelId !== null);
+  const canvasQuery = useCanvasHistoryQuery(channelId, channelId !== null);
   const setCanvasMutation = useSetCanvasMutation(channelId);
   const { channels } = useChannelNavigation();
   const channelNames = React.useMemo(
@@ -34,11 +53,45 @@ export function ChannelCanvas({
   );
   const [isEditing, setIsEditing] = React.useState(false);
   const [draft, setDraft] = React.useState("");
+  const [selectedRevisionId, setSelectedRevisionId] = React.useState<
+    string | null
+  >(null);
 
-  const canvasContent = canvasQuery.data?.content ?? null;
+  const revisions = canvasQuery.data ?? [];
+  const currentRevision = revisions[0] ?? null;
+  const selectedRevision =
+    revisions.find((revision) => revision.eventId === selectedRevisionId) ??
+    currentRevision;
+  const viewingHistoricalRevision =
+    selectedRevision !== null &&
+    !isCurrentRevision(selectedRevision, currentRevision);
+  const revisionAuthors = React.useMemo(
+    () => [...new Set(revisions.map((revision) => revision.author))],
+    [revisions],
+  );
+  const profilesQuery = useUsersBatchQuery(revisionAuthors, {
+    enabled: revisionAuthors.length > 0,
+  });
+  const profiles = profilesQuery.data?.profiles;
+  const canvasContent = currentRevision?.content ?? null;
+  const displayedContent = selectedRevision?.content ?? null;
   // Defer the single large Markdown parse so opening the canvas commits the
   // surrounding chrome immediately and the heavy render reconciles after.
-  const deferredCanvasContent = React.useDeferredValue(canvasContent);
+  const deferredCanvasContent = React.useDeferredValue(displayedContent);
+
+  React.useEffect(() => {
+    if (!currentRevision) {
+      setSelectedRevisionId(null);
+      return;
+    }
+
+    if (
+      selectedRevisionId === null ||
+      !revisions.some((revision) => revision.eventId === selectedRevisionId)
+    ) {
+      setSelectedRevisionId(currentRevision.eventId);
+    }
+  }, [currentRevision, revisions, selectedRevisionId]);
 
   function handleStartEditing() {
     setDraft(canvasContent ?? "");
@@ -119,11 +172,29 @@ export function ChannelCanvas({
 
   return (
     <div className="space-y-3">
-      {canvasContent ? (
+      {selectedRevision ? (
         <div
           className="rounded-2xl border border-border/70 bg-muted/20 px-4 py-3"
           data-testid="channel-canvas-content"
         >
+          {viewingHistoricalRevision ? (
+            <div className="mb-3 flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-background/50 px-3 py-2 text-sm">
+              <span className="text-muted-foreground">
+                Viewing an earlier revision (read-only).
+              </span>
+              <Button
+                data-testid="channel-canvas-current-revision"
+                onClick={() =>
+                  setSelectedRevisionId(currentRevision?.eventId ?? null)
+                }
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                Return to current
+              </Button>
+            </div>
+          ) : null}
           <Markdown
             channelNames={channelNames}
             content={deferredCanvasContent ?? ""}
@@ -134,7 +205,70 @@ export function ChannelCanvas({
           No canvas set for this channel.
         </p>
       )}
-      {canEdit && !isArchived ? (
+      {selectedRevision && currentRevision ? (
+        <div
+          className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground"
+          data-testid="channel-canvas-current-metadata"
+        >
+          <span>Updated by</span>
+          <span className="font-medium text-foreground">
+            {resolveUserLabel({ pubkey: currentRevision.author, profiles })}
+          </span>
+          <span aria-hidden="true">·</span>
+          <time
+            dateTime={new Date(currentRevision.updatedAt * 1_000).toISOString()}
+          >
+            {formatRevisionTimestamp(currentRevision.updatedAt)}
+          </time>
+        </div>
+      ) : null}
+      {revisions.length > 1 ? (
+        <section
+          aria-label="Canvas revision history"
+          className="space-y-2 rounded-2xl border border-border/70 px-3 py-3"
+          data-testid="channel-canvas-history"
+        >
+          <h3 className="text-sm font-semibold">Revision history</h3>
+          <div className="space-y-1">
+            {revisions.map((revision) => {
+              const current = isCurrentRevision(revision, currentRevision);
+              const selected = revision.eventId === selectedRevision?.eventId;
+              return (
+                <button
+                  aria-current={selected ? "page" : undefined}
+                  className={`flex w-full items-start justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm transition-colors ${selected ? "bg-muted" : "hover:bg-muted/60"}`}
+                  data-testid={
+                    current
+                      ? "channel-canvas-revision-current"
+                      : `channel-canvas-revision-${revision.eventId}`
+                  }
+                  key={revision.eventId}
+                  onClick={() => setSelectedRevisionId(revision.eventId)}
+                  type="button"
+                >
+                  <span className="min-w-0">
+                    <span className="block font-medium">
+                      {current ? "Current revision" : "Earlier revision"}
+                    </span>
+                    <span className="block truncate text-muted-foreground">
+                      {resolveUserLabel({ pubkey: revision.author, profiles })}
+                    </span>
+                  </span>
+                  <time
+                    className="shrink-0 text-xs text-muted-foreground"
+                    dateTime={new Date(
+                      revision.updatedAt * 1_000,
+                    ).toISOString()}
+                  >
+                    {formatRevisionTimestamp(revision.updatedAt)}
+                  </time>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+      {canEdit && !isArchived && !viewingHistoricalRevision ? (
         <Button
           data-testid="channel-canvas-edit"
           onClick={handleStartEditing}

--- a/desktop/src/features/channels/ui/ChannelCanvas.tsx
+++ b/desktop/src/features/channels/ui/ChannelCanvas.tsx
@@ -201,8 +201,11 @@ export function ChannelCanvas({
           />
         </div>
       ) : (
-        <p className="text-sm text-muted-foreground">
-          No canvas set for this channel.
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="channel-canvas-history-empty"
+        >
+          No revision history yet — save the canvas to start tracking changes.
         </p>
       )}
       {selectedRevision && currentRevision ? (

--- a/desktop/src/features/onboarding/welcomeCanvas.ts
+++ b/desktop/src/features/onboarding/welcomeCanvas.ts
@@ -1,4 +1,4 @@
-import { getCanvas, setCanvas } from "@/shared/api/tauri";
+import { getCanvas, setCanvas } from "@/shared/api/tauriCanvas";
 
 export const WELCOME_CANVAS_CONTENT = `# Welcome to Buzz
 

--- a/desktop/src/shared/api/canvasTypes.ts
+++ b/desktop/src/shared/api/canvasTypes.ts
@@ -1,0 +1,23 @@
+export type CanvasResponse = {
+  content: string | null;
+  eventId: string | null;
+  updatedAt: number | null;
+  author: string | null;
+};
+
+export type CanvasRevision = {
+  eventId: string;
+  content: string;
+  updatedAt: number;
+  author: string;
+};
+
+export type SetCanvasInput = {
+  channelId: string;
+  content: string;
+};
+
+export type SetCanvasResult = {
+  ok: boolean;
+  eventId: string;
+};

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -12,7 +12,6 @@ import type {
   AddChannelMembersResult,
   BackendProviderCandidate,
   BackendProviderProbeResult,
-  CanvasResponse,
   GetHomeFeedInput,
   HomeFeedResponse,
   ManagedAgent,
@@ -26,8 +25,6 @@ import type {
   SearchMessagesInput,
   SearchMessagesResponse,
   SendChannelMessageResult,
-  SetCanvasInput,
-  SetCanvasResult,
   ThreadCursor,
   ThreadRepliesResponse,
   CreateManagedAgentInput,
@@ -240,17 +237,6 @@ type RawListRelayMembersResponse = {
   members: RawRelayMember[];
 };
 
-type RawCanvasResponse = {
-  content: string | null;
-  updated_at: number | null;
-  author: string | null;
-};
-
-type RawSetCanvasResult = {
-  ok: boolean;
-  event_id: string;
-};
-
 /** Error normalized from a rejected Tauri invocation with its wire payload. */
 export class TauriInvokeError extends Error {
   readonly payload: unknown;
@@ -405,33 +391,6 @@ export async function joinChannel(channelId: string): Promise<void> {
 
 export async function leaveChannel(channelId: string): Promise<void> {
   await invokeTauri("leave_channel", { channelId });
-}
-
-export async function getCanvas(channelId: string): Promise<CanvasResponse> {
-  const response = await invokeTauri<RawCanvasResponse>("get_canvas", {
-    channelId,
-  });
-  return {
-    content: response.content,
-    // Normalize absent keys to null: ensureWelcomeCanvas treats null as
-    // "no canvas yet", and `undefined !== null` would make every fresh
-    // channel look already-seeded.
-    updatedAt: response.updated_at ?? null,
-    author: response.author ?? null,
-  };
-}
-
-export async function setCanvas(
-  input: SetCanvasInput,
-): Promise<SetCanvasResult> {
-  const response = await invokeTauri<RawSetCanvasResult>("set_canvas", {
-    channelId: input.channelId,
-    content: input.content,
-  });
-  return {
-    ok: response.ok,
-    eventId: response.event_id,
-  };
 }
 
 export async function getHomeFeed(

--- a/desktop/src/shared/api/tauriCanvas.ts
+++ b/desktop/src/shared/api/tauriCanvas.ts
@@ -1,0 +1,68 @@
+import type {
+  CanvasRevision,
+  CanvasResponse,
+  SetCanvasInput,
+  SetCanvasResult,
+} from "./canvasTypes";
+import { invokeTauri } from "./tauri";
+
+type RawCanvasResponse = {
+  content: string | null;
+  event_id: string | null;
+  updated_at: number | null;
+  author: string | null;
+};
+
+type RawCanvasHistoryResponse = {
+  revisions: Array<{
+    event_id: string;
+    content: string;
+    updated_at: number;
+    author: string;
+  }>;
+};
+
+type RawSetCanvasResult = {
+  ok: boolean;
+  event_id: string;
+};
+
+export async function getCanvas(channelId: string): Promise<CanvasResponse> {
+  const response = await invokeTauri<RawCanvasResponse>("get_canvas", {
+    channelId,
+  });
+  return {
+    content: response.content,
+    eventId: response.event_id ?? null,
+    updatedAt: response.updated_at ?? null,
+    author: response.author ?? null,
+  };
+}
+
+export async function getCanvasHistory(
+  channelId: string,
+): Promise<CanvasRevision[]> {
+  const response = await invokeTauri<RawCanvasHistoryResponse>(
+    "get_canvas_history",
+    { channelId },
+  );
+  return response.revisions.map((revision) => ({
+    eventId: revision.event_id,
+    content: revision.content,
+    updatedAt: revision.updated_at,
+    author: revision.author,
+  }));
+}
+
+export async function setCanvas(
+  input: SetCanvasInput,
+): Promise<SetCanvasResult> {
+  const response = await invokeTauri<RawSetCanvasResult>("set_canvas", {
+    channelId: input.channelId,
+    content: input.content,
+  });
+  return {
+    ok: response.ok,
+    eventId: response.event_id,
+  };
+}

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -73,22 +73,6 @@ export type SetChannelPurposeInput = {
   purpose: string;
 };
 
-export type CanvasResponse = {
-  content: string | null;
-  updatedAt: number | null;
-  author: string | null;
-};
-
-export type SetCanvasInput = {
-  channelId: string;
-  content: string;
-};
-
-export type SetCanvasResult = {
-  ok: boolean;
-  eventId: string;
-};
-
 export type AddChannelMembersInput = {
   channelId: string;
   pubkeys: string[];

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -135,6 +135,13 @@ type MockTeamSeed = {
   personaIds: string[];
 };
 
+type MockCanvasRevisionSeed = {
+  eventId: string;
+  content: string;
+  updatedAt: number;
+  author: string;
+};
+
 type MockSearchProfileSeed = {
   pubkey: string;
   displayName: string | null;
@@ -261,6 +268,8 @@ type E2eConfig = {
     deepHistoryMessageCount?: number;
     feedReadError?: string;
     canvasReadError?: string;
+    /** Signed kind:40100 revisions returned by the mocked canvas history query. */
+    canvasHistory?: MockCanvasRevisionSeed[];
     /** Delay (ms) for `apply_workspace` so e2e tests can observe the
      *  community-switch gate. 0/undefined = instant. */
     applyCommunityDelayMs?: number;
@@ -11653,7 +11662,28 @@ export function maybeInstallE2eTauriMocks() {
           throw new Error(canvasReadError);
         }
         // Return the no-canvas success shape — content null means no canvas set.
-        return { content: null, updated_at: null, author: null };
+        return {
+          content: null,
+          event_id: null,
+          updated_at: null,
+          author: null,
+        };
+      }
+      case "get_canvas_history": {
+        const canvasReadError = activeConfig?.mock?.canvasReadError;
+        if (canvasReadError) {
+          throw new Error(canvasReadError);
+        }
+        return {
+          revisions: (activeConfig?.mock?.canvasHistory ?? []).map(
+            (revision) => ({
+              event_id: revision.eventId,
+              content: revision.content,
+              updated_at: revision.updatedAt,
+              author: revision.author,
+            }),
+          ),
+        };
       }
       // ── Local-save archive ──────────────────────────────────────────────
       // These stubs drive the LocalArchiveSettingsCard in screenshot / UI tests

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2607,10 +2607,18 @@ test("canvas shows an empty revision history before the first save", async ({
   const canvasSection = page.getByTestId("channel-canvas-section");
   await expect(
     canvasSection.getByTestId("channel-canvas-history-empty"),
-  ).toHaveText("No revision history yet — save the canvas to start tracking changes.");
+  ).toHaveText(
+    "No revision history yet — save the canvas to start tracking changes.",
+  );
   await expect(canvasSection.getByTestId("channel-canvas-edit")).toContainText(
     "Create canvas",
   );
+  if (process.env.BUZZ_CANVAS_HISTORY_SCREENSHOTS === "1") {
+    await waitForAnimations(page);
+    await page.screenshot({
+      path: "test-results/canvas-revision-history-empty.png",
+    });
+  }
 });
 
 async function seedHomeInboxMention(

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -12,6 +12,7 @@ import {
   openCreateChannelDialog,
   openNewMessagePage,
 } from "../helpers/bridge";
+import { waitForAnimations } from "../helpers/animations";
 
 const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
 const AGENTS_CHANNEL_ID = "94a444a4-c0a3-5966-ab05-530c6ddc2301";
@@ -2529,6 +2530,70 @@ test("manage channel keeps canvas near the top of the sheet", async ({
   expect(canvasBox).not.toBeNull();
   expect(nameBox).not.toBeNull();
   expect(canvasBox?.y).toBeLessThan(nameBox?.y);
+});
+
+test("canvas shows signed revision history and opens earlier revisions read-only", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    canvasHistory: [
+      {
+        eventId: "canvas-current-revision",
+        content: "# Current canvas\n\nLatest signed content.",
+        updatedAt: 1_751_353_200,
+        author: TEST_IDENTITIES.alice.pubkey,
+      },
+      {
+        eventId: "canvas-earlier-revision",
+        content: "# Earlier canvas\n\nPrevious signed content.",
+        updatedAt: 1_751_266_800,
+        author: TEST_IDENTITIES.bob.pubkey,
+      },
+    ],
+  });
+  await page.goto("/");
+  await openChannelManagement(page, "general");
+  await page.getByTestId("channel-canvas-ingress").click();
+
+  const canvasSection = page.getByTestId("channel-canvas-section");
+  await expect(
+    canvasSection.getByTestId("channel-canvas-content"),
+  ).toContainText("Latest signed content.");
+  await expect(
+    canvasSection.getByTestId("channel-canvas-current-metadata"),
+  ).toContainText("alice");
+  await expect(
+    canvasSection.getByTestId("channel-canvas-history"),
+  ).toBeVisible();
+  if (process.env.BUZZ_CANVAS_HISTORY_SCREENSHOTS === "1") {
+    await waitForAnimations(page);
+    await page.screenshot({
+      path: "test-results/canvas-revision-history-current.png",
+    });
+  }
+
+  await canvasSection
+    .getByTestId("channel-canvas-revision-canvas-earlier-revision")
+    .click();
+  await expect(
+    canvasSection.getByTestId("channel-canvas-content"),
+  ).toContainText("Previous signed content.");
+  await expect(
+    canvasSection.getByText("Viewing an earlier revision (read-only)."),
+  ).toBeVisible();
+  await expect(canvasSection.getByTestId("channel-canvas-edit")).toHaveCount(0);
+  if (process.env.BUZZ_CANVAS_HISTORY_SCREENSHOTS === "1") {
+    await waitForAnimations(page);
+    await page.screenshot({
+      path: "test-results/canvas-revision-history-earlier.png",
+    });
+  }
+
+  await canvasSection.getByTestId("channel-canvas-current-revision").click();
+  await expect(
+    canvasSection.getByTestId("channel-canvas-content"),
+  ).toContainText("Latest signed content.");
+  await expect(canvasSection.getByTestId("channel-canvas-edit")).toBeVisible();
 });
 
 async function seedHomeInboxMention(

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -2596,6 +2596,23 @@ test("canvas shows signed revision history and opens earlier revisions read-only
   await expect(canvasSection.getByTestId("channel-canvas-edit")).toBeVisible();
 });
 
+test("canvas shows an empty revision history before the first save", async ({
+  page,
+}) => {
+  await installMockBridge(page, { canvasHistory: [] });
+  await page.goto("/");
+  await openChannelManagement(page, "general");
+  await page.getByTestId("channel-canvas-ingress").click();
+
+  const canvasSection = page.getByTestId("channel-canvas-section");
+  await expect(
+    canvasSection.getByTestId("channel-canvas-history-empty"),
+  ).toHaveText("No revision history yet — save the canvas to start tracking changes.");
+  await expect(canvasSection.getByTestId("channel-canvas-edit")).toContainText(
+    "Create canvas",
+  );
+});
+
 async function seedHomeInboxMention(
   page: import("@playwright/test").Page,
   itemId: string,

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -116,6 +116,13 @@ type MockTeamSeed = {
   personaIds: string[];
 };
 
+type MockCanvasRevisionSeed = {
+  eventId: string;
+  content: string;
+  updatedAt: number;
+  author: string;
+};
+
 export type MockEngramEntry = {
   slug: string;
   body: string;
@@ -248,6 +255,8 @@ type MockBridgeOptions = {
   deepHistoryMessageCount?: number;
   feedReadError?: string;
   canvasReadError?: string;
+  /** Signed kind:40100 revisions returned by the mocked canvas history query. */
+  canvasHistory?: MockCanvasRevisionSeed[];
   /** Delay (ms) for `apply_workspace`; see e2eBridge mock config. */
   applyCommunityDelayMs?: number;
   openDmDelayMs?: number;


### PR DESCRIPTION
# Summary

Implements [#3086](https://github.com/block/buzz/issues/3086), as part of the work needed for [#3863](https://github.com/block/buzz/issues/3863).

Adds:
- current Canvas revision author and localized timestamp;
- a bounded history of signed Canvas revisions;
- read-only viewing of earlier revisions with a return-to-current control;
- a concise first-open empty state when the Canvas has no signed revisions yet;
- focused Desktop E2E coverage and screenshot evidence.

# Scope

## Included

- Query the existing signed Canvas event kind `40100` for up to 50 channel revisions.
- Show the newest revision as current and list earlier revisions by resolved profile name and timestamp.
- Open an earlier revision read-only and return to the current revision.
- Invalidate history after a Canvas save.
- Explain the empty first-open state before the first Canvas save.

## Excluded

- No diff or restore action.
- No new Nostr event kind or HTTP API.
- No command-palette/autocomplete work.
- No OEXL-specific code, matching, payments, settlement, ledger, or marketplace semantics.
- Workflow history (#2980), mention resolution (#3204), and reply placement (#3825/#3836) remain separate follow-up contributions.

# Product / Architecture Decisions

- Reuses the existing signed Canvas event path and kind `40100`; history is a read-only relay query.
- Keeps the response bounded to 50 revisions for predictable Desktop rendering.
- Earlier revisions are explicitly read-only; editing remains available only for the current revision.
- Human and agent authors use the existing profile batch lookup and identity-label resolver.
- An empty history is an expected first-open state, not an error: the panel tells the user to save the Canvas to begin tracking changes.

# User-Facing Contract

## Desktop

The Canvas panel shows:
- `Updated by <profile> · <timestamp>` for the current revision;
- a `Revision history` list with current and earlier revisions;
- `Viewing an earlier revision (read-only).` plus `Return to current` when historical content is selected;
- `No revision history yet — save the canvas to start tracking changes.` before the first save.

No restore or diff semantics are introduced.

# Verification

## Ran

- `pnpm typecheck`
- `pnpm test` — 3,870 tests passed
- `pnpm build:e2e`
- `pnpm exec playwright test tests/e2e/channels.spec.ts --project=smoke --grep 'canvas shows signed revision history' --reporter=line` — 1 passed before this follow-up
- focused Biome check on the changed Canvas component and E2E spec
- `git diff --check`
- `cargo check --manifest-path desktop/src-tauri/Cargo.toml`

The new empty-history E2E assertion is committed and ready for CI. A follow-up browser run was not possible in this clone because the dependency install is unavailable; the existing focused history test and full build evidence are recorded above.

`cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings` was attempted but could not start because the environment lacks `cmake` while compiling `audiopus_sys`. The full `just ci` gate was not run in this environment.

## Covered

The regression coverage seeds signed current and earlier revisions from two identities, verifies current metadata and history, opens the earlier revision read-only, verifies editing is unavailable, and returns to current.

The new regression seeds an empty revision list and verifies the first-open message plus the `Create canvas` action.

Desktop before/after evidence is posted in a separate screenshot comment. No private keys or relay credentials are included.

# Review Path

Suggested review order: Canvas relay command and API types, Canvas panel behavior and first-open empty state, then the focused E2E fixture and test.

# Notes For Reviewer

This is intentionally the smallest history slice for #3086. The command-palette/UI autocomplete work remains deferred to its existing issues.