### PR TITLE
fix(desktop): resolve mentions from channel members [issue:#3204]

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,6 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,9 +245,6 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
-        return;
-      }
       if (
         shouldHideAgentFromMentions({
           isAgent: candidate.isAgent === true,
@@ -420,7 +416,6 @@ export function useMentions(
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,
     managedAgentPersonaIdsByPubkey,
-    managedAgentPubkeys,
     managedAgentsQuery.data,
     memberPubkeys,
     members,

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -258,6 +258,33 @@ test("@ includes channel-member agents that are not locally managed", async ({
   await expect(row.getByText("not in channel")).toHaveCount(0);
 });
 
+test("@ hides channel-member agents when the viewer is outside their allowlist", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: PROFILE_ONLY_AGENT_PUBKEY,
+        name: "mira",
+        channelNames: ["general"],
+        respondTo: "allowlist",
+        respondToAllowlist: [TEST_IDENTITIES.alice.pubkey],
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@mi");
+
+  await expect(autocomplete(page)).not.toBeVisible();
+  await expect(
+    page.getByTestId(`mention-suggestion-${PROFILE_ONLY_AGENT_PUBKEY}`),
+  ).toHaveCount(0);
+});
+
 test("thread autocomplete keeps multiple long names readable in a narrow panel", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -241,6 +241,23 @@ test("@ trigger prioritizes channel members before runnable personas and other m
   expect(fizzIndex).toBeLessThan(charlieIndex);
 });
 
+test("@ includes channel-member agents that are not locally managed", async ({
+  page,
+}) => {
+  await installMockBridge(page);
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@mi");
+
+  const row = autocomplete(page).locator("button", { hasText: "mira" });
+  await expect(row).toBeVisible();
+  await expect(row.getByTestId("mention-agent-icon")).toBeVisible();
+  await expect(row.getByText("not in channel")).toHaveCount(0);
+});
+
 test("thread autocomplete keeps multiple long names readable in a narrow panel", async ({
   page,
 }) => {


### PR DESCRIPTION
# Summary

Implements issue #3204 as the next separate contribution in the #3863 handoff workstream.

The mention picker was applying a local-managed-agent gate to every agent candidate, including agents already present in the current channel. That made a remote or otherwise non-local channel member impossible to mention, while unrelated local persona rows could appear instead.

# Scope

## Included

- Removes the local-managed-agent requirement from channel-member mention candidates.
- Keeps the existing invocability and archived-identity checks for non-member agent candidates.
- Preserves channel membership on the candidate, so a channel-member agent is not labeled “not in channel” and can be selected with the correct pubkey.
- Adds a focused E2E regression covering a profile-backed agent that is a member of #general but is not locally managed.

## Excluded

- No new relay/API or Nostr event kind.
- No change to agent deployment or persona-minting behavior (#3639 remains separate).
- No change to the DM recipient picker.
- No command-palette/autocomplete redesign beyond correcting this existing mention candidate source.
- No OEXL-specific code, matching, outcome contracts, payments, ledger state, or settlement semantics.

# Product / Architecture Decisions

- Channel membership remains the authoritative source for candidates already in the open channel.
- Local managed agents and explicitly invocable relay agents retain their existing non-member behavior.
- Existing duplicate-name disambiguation, profile labels, archived filtering, and p-tag extraction are reused unchanged.

# User-Facing Contract

In a channel composer, @ now offers agent identities that are current members of that channel even when their runtime is hosted on another machine or is not represented in this Desktop’s local managed-agent list. Those rows are shown as channel members rather than “not in channel.” Non-member, non-invocable agent rows remain hidden.

# Verification

## Ran

- Focused Biome check on useMentions.ts and mentions.spec.ts
- node --import ./test-loader.mjs --experimental-strip-types --test src/features/agents/lib/agentAutocompleteEligibility.test.mjs (18 passed)
- git diff --check

## Added

- desktop/tests/e2e/mentions.spec.ts: channel-member, non-local agent is visible and not labeled “not in channel.”

The full Playwright browser run and TypeScript build were attempted but could not complete in this environment because the temporary checkout’s Vite/Node dependency loader stalled while reading vite.config.ts; this is an environment/toolchain limitation, not a test assertion failure.

# UI Evidence

This changes autocomplete behavior, not layout or styling. A screenshot/recording could not be captured because the local browser build was blocked by the dependency-loader issue described above; the regression is represented in the focused E2E spec for maintainers to run in CI.

# Review Path

1. desktop/src/features/messages/lib/useMentions.ts
2. desktop/tests/e2e/mentions.spec.ts

# Notes For Reviewer

This is an independent branch and PR, not stacked on the workflow-history or Canvas-history contributions. It deliberately does not address the adjacent persona duplication, DM recipient, or command-palette workstreams.