### PR TITLE
feat(desktop): auto-mention agents when replying in their threads

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -65,6 +65,7 @@ export default defineConfig({
         "**/mentions.spec.ts",
         "**/team-mentions.spec.ts",
         "**/persistent-agent-audience.spec.ts",
+        "**/reply-agent-automention.spec.ts",
         "**/relay-reconnect.spec.ts",
         "**/relay-reconnect-affordance.spec.ts",
         "**/workflows.spec.ts",

--- a/desktop/src/features/home/ui/InboxDetailPane.tsx
+++ b/desktop/src/features/home/ui/InboxDetailPane.tsx
@@ -395,10 +395,12 @@ function InboxMessageDetailPane({
       },
       agentPubkeys,
       profiles,
+      currentPubkey,
     );
   }, [
     agentPubkeys,
     capturedDefaultParentId,
+    currentPubkey,
     displayMessages,
     isDirectMessage,
     item,

--- a/desktop/src/features/home/ui/InboxDetailPane.tsx
+++ b/desktop/src/features/home/ui/InboxDetailPane.tsx
@@ -31,6 +31,7 @@ import {
   isWithinGroupingWindow,
 } from "@/features/messages/lib/messageGrouping";
 import { orderMentionPubkeysByText } from "@/features/messages/lib/orderMentionPubkeys";
+import { resolveReplyTargetAgent } from "@/features/messages/lib/replyTargetAgentMention";
 import { getThreadReference } from "@/features/messages/lib/threading";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { MessageComposer } from "@/features/messages/ui/MessageComposer";
@@ -361,6 +362,50 @@ function InboxMessageDetailPane({
     conversationId,
   );
 
+  // Auto-mention the agent whose message is being replied to. The effective
+  // target mirrors `composerParentEventId` below: the explicit sub-message
+  // reply target, else the captured default parent. DMs already p-tag every
+  // participant, so they never need the chip.
+  const replyTargetAgent = React.useMemo(() => {
+    if (!item || isDirectMessage) {
+      return null;
+    }
+    const explicitTarget =
+      displayMessages.find((message) => message.id === replyTargetId) ?? null;
+    const targetId = explicitTarget?.id ?? capturedDefaultParentId ?? item.id;
+    const targetMessage =
+      displayMessages.find((message) => message.id === targetId) ??
+      (targetId === item.id
+        ? {
+            authorLabel: item.senderLabel,
+            authorPubkey: item.item.pubkey,
+            id: item.id,
+            isAgent: undefined,
+          }
+        : null);
+    if (!targetMessage) {
+      return null;
+    }
+    return resolveReplyTargetAgent(
+      {
+        author: targetMessage.authorLabel,
+        id: targetMessage.id,
+        isAgent: targetMessage.isAgent,
+        pubkey: targetMessage.authorPubkey,
+      },
+      agentPubkeys,
+      profiles,
+    );
+  }, [
+    agentPubkeys,
+    capturedDefaultParentId,
+    displayMessages,
+    isDirectMessage,
+    item,
+    profiles,
+    replyTargetId,
+  ]);
+
   if (!item) {
     return (
       <section
@@ -674,6 +719,7 @@ function InboxMessageDetailPane({
                     "Replies are not available for this item.")
               }
               replyTarget={composerReplyTarget}
+              replyTargetAgent={replyTargetAgent}
             />
           </div>
         </div>

--- a/desktop/src/features/messages/lib/replyTargetAgentMention.test.mjs
+++ b/desktop/src/features/messages/lib/replyTargetAgentMention.test.mjs
@@ -64,6 +64,39 @@ test("absent target or pubkey resolves to null", () => {
   );
 });
 
+test("never resolves when the parent author is the current viewer", () => {
+  // Even an agent-flagged parent must not resolve when it is the viewer's
+  // own identity — replying to yourself must not @-mention yourself.
+  assert.equal(
+    resolveReplyTargetAgent(
+      { id: "evt1", pubkey: agentPubkey, author: "Fizz", isAgent: true },
+      new Set([agentPubkey]),
+      undefined,
+      agentPubkey,
+    ),
+    null,
+  );
+  assert.equal(
+    resolveReplyTargetAgent(
+      { id: "evt1", pubkey: agentPubkey, author: "Fizz", isAgent: true },
+      emptySet,
+      undefined,
+      agentPubkey.toUpperCase(),
+    ),
+    null,
+  );
+  // A different viewer still resolves normally.
+  assert.deepEqual(
+    resolveReplyTargetAgent(
+      { id: "evt1", pubkey: agentPubkey, author: "Fizz", isAgent: true },
+      emptySet,
+      undefined,
+      humanPubkey,
+    ),
+    { targetId: "evt1", pubkey: agentPubkey, displayName: "Fizz" },
+  );
+});
+
 test("normalizes uppercase pubkeys before matching", () => {
   assert.deepEqual(
     resolveReplyTargetAgent(

--- a/desktop/src/features/messages/lib/replyTargetAgentMention.test.mjs
+++ b/desktop/src/features/messages/lib/replyTargetAgentMention.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveReplyTargetAgent } from "./replyTargetAgentMention.ts";
+
+const agentPubkey = "a".repeat(64);
+const humanPubkey = "c".repeat(64);
+const emptySet = new Set();
+
+test("resolves agent via the message isAgent flag", () => {
+  assert.deepEqual(
+    resolveReplyTargetAgent(
+      { id: "evt1", pubkey: agentPubkey, author: "Fizz", isAgent: true },
+      emptySet,
+    ),
+    { targetId: "evt1", pubkey: agentPubkey, displayName: "Fizz" },
+  );
+});
+
+test("resolves agent via the known-agent pubkey set", () => {
+  assert.deepEqual(
+    resolveReplyTargetAgent(
+      { id: "evt1", pubkey: agentPubkey, author: "Fizz" },
+      new Set([agentPubkey]),
+    ),
+    { targetId: "evt1", pubkey: agentPubkey, displayName: "Fizz" },
+  );
+});
+
+test("resolves agent via the profile isAgent flag", () => {
+  assert.deepEqual(
+    resolveReplyTargetAgent({ id: "evt1", pubkey: agentPubkey }, emptySet, {
+      [agentPubkey]: {
+        displayName: "Fizz",
+        avatarUrl: null,
+        nip05Handle: null,
+        ownerPubkey: null,
+        isAgent: true,
+      },
+    }),
+    { targetId: "evt1", pubkey: agentPubkey, displayName: "Fizz" },
+  );
+});
+
+test("human reply target resolves to null", () => {
+  assert.equal(
+    resolveReplyTargetAgent(
+      { id: "evt1", pubkey: humanPubkey, author: "Fulki" },
+      new Set([agentPubkey]),
+    ),
+    null,
+  );
+});
+
+test("absent target or pubkey resolves to null", () => {
+  assert.equal(resolveReplyTargetAgent(null, emptySet), null);
+  assert.equal(resolveReplyTargetAgent(undefined, emptySet), null);
+  assert.equal(
+    resolveReplyTargetAgent(
+      { id: "evt1", author: "Fizz", isAgent: true },
+      emptySet,
+    ),
+    null,
+  );
+});
+
+test("normalizes uppercase pubkeys before matching", () => {
+  assert.deepEqual(
+    resolveReplyTargetAgent(
+      { id: "evt1", pubkey: agentPubkey.toUpperCase(), author: "Fizz" },
+      new Set([agentPubkey]),
+    ),
+    { targetId: "evt1", pubkey: agentPubkey, displayName: "Fizz" },
+  );
+});
+
+test("prefers profile display name over the message author label", () => {
+  assert.deepEqual(
+    resolveReplyTargetAgent(
+      {
+        id: "evt1",
+        pubkey: agentPubkey,
+        author: "fizz-fallback",
+        isAgent: true,
+      },
+      emptySet,
+      {
+        [agentPubkey]: {
+          displayName: "Fizz",
+          avatarUrl: null,
+          nip05Handle: null,
+          ownerPubkey: null,
+        },
+      },
+    ),
+    { targetId: "evt1", pubkey: agentPubkey, displayName: "Fizz" },
+  );
+});
+
+test("falls back to the profile name, then null without any name", () => {
+  assert.deepEqual(
+    resolveReplyTargetAgent(
+      { id: "evt1", pubkey: agentPubkey, isAgent: true },
+      emptySet,
+      {
+        [agentPubkey]: {
+          displayName: null,
+          name: "fizz",
+          avatarUrl: null,
+          nip05Handle: null,
+          ownerPubkey: null,
+        },
+      },
+    ),
+    { targetId: "evt1", pubkey: agentPubkey, displayName: "fizz" },
+  );
+  assert.equal(
+    resolveReplyTargetAgent(
+      { id: "evt1", pubkey: agentPubkey, isAgent: true },
+      emptySet,
+    ),
+    null,
+  );
+});

--- a/desktop/src/features/messages/lib/replyTargetAgentMention.ts
+++ b/desktop/src/features/messages/lib/replyTargetAgentMention.ts
@@ -1,0 +1,62 @@
+import type { UserProfileLookup } from "@/features/profile/lib/identity";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+/** Agent-authored reply target the composer should auto-mention. */
+export type ReplyTargetAgent = {
+  /** Event id of the message being replied to. */
+  targetId: string;
+  /** Agent identity pubkey (normalized lowercase hex) — the key the ACP
+   * harness gates on, not the raw signer pubkey. */
+  pubkey: string;
+  /** Name to render in the inserted `@Name` chip. */
+  displayName: string;
+};
+
+/**
+ * Resolve the effective reply target into an auto-mention descriptor, or null
+ * when the target is absent, human-authored, or unresolvable. Agent detection
+ * is layered the same way the thread panel already does it: the message's own
+ * `isAgent` flag, the known-agent pubkey set, then the profile flag.
+ */
+export function resolveReplyTargetAgent(
+  target:
+    | {
+        id: string;
+        pubkey?: string;
+        author?: string;
+        isAgent?: boolean;
+      }
+    | null
+    | undefined,
+  knownAgentPubkeys: ReadonlySet<string> | null | undefined,
+  profiles?: UserProfileLookup,
+): ReplyTargetAgent | null {
+  if (!target?.pubkey) {
+    return null;
+  }
+
+  const pubkey = normalizePubkey(target.pubkey);
+  if (!pubkey) {
+    return null;
+  }
+
+  const profile = profiles?.[pubkey];
+  const isAgent =
+    target.isAgent === true ||
+    knownAgentPubkeys?.has(pubkey) === true ||
+    profile?.isAgent === true;
+  if (!isAgent) {
+    return null;
+  }
+
+  const displayName =
+    profile?.displayName?.trim() ||
+    profile?.name?.trim() ||
+    target.author?.trim() ||
+    "";
+  if (!displayName) {
+    return null;
+  }
+
+  return { targetId: target.id, pubkey, displayName };
+}

--- a/desktop/src/features/messages/lib/replyTargetAgentMention.ts
+++ b/desktop/src/features/messages/lib/replyTargetAgentMention.ts
@@ -17,6 +17,10 @@ export type ReplyTargetAgent = {
  * when the target is absent, human-authored, or unresolvable. Agent detection
  * is layered the same way the thread panel already does it: the message's own
  * `isAgent` flag, the known-agent pubkey set, then the profile flag.
+ *
+ * A parent authored by the current viewer never resolves — replying to your
+ * own message must not @-mention yourself, even when the signed-in identity
+ * is itself agent-flagged (e.g. the app running under an agent key).
  */
 export function resolveReplyTargetAgent(
   target:
@@ -30,6 +34,7 @@ export function resolveReplyTargetAgent(
     | undefined,
   knownAgentPubkeys: ReadonlySet<string> | null | undefined,
   profiles?: UserProfileLookup,
+  currentPubkey?: string | null,
 ): ReplyTargetAgent | null {
   if (!target?.pubkey) {
     return null;
@@ -37,6 +42,10 @@ export function resolveReplyTargetAgent(
 
   const pubkey = normalizePubkey(target.pubkey);
   if (!pubkey) {
+    return null;
+  }
+
+  if (currentPubkey && normalizePubkey(currentPubkey) === pubkey) {
     return null;
   }
 

--- a/desktop/src/features/messages/ui/MessageComposer.tsx
+++ b/desktop/src/features/messages/ui/MessageComposer.tsx
@@ -53,6 +53,8 @@ import { ComposerDockToolbar } from "./ComposerDockToolbar";
 import { NonMemberMentionDialog } from "./NonMemberMentionDialog";
 import { useMentionSendFlow } from "./useMentionSendFlow";
 import { usePersistentAgentMentionHydration } from "./usePersistentAgentMentionHydration";
+import { useReplyTargetAgentMention } from "./useReplyTargetAgentMention";
+import { useComposerAutoSubmit } from "./useComposerAutoSubmit";
 import { useComposerContentState } from "./useComposerContentState";
 import { useDraftPersistLifecycle } from "./useDraftPersistSnapshot";
 
@@ -82,6 +84,7 @@ function MessageComposerImpl({
   placeholder,
   profiles,
   replyTarget = null,
+  replyTargetAgent = null,
   mediaController,
   showTopBorder = false,
   toolbarExtraActions,
@@ -155,7 +158,21 @@ function MessageComposerImpl({
     effectiveDraftKey,
     channelId,
     loadDraft: drafts.loadDraft,
-    persistDraft: drafts.persistDraft,
+    // An untouched auto-inserted reply-target mention is not an authored
+    // draft — persist it as empty (which clears the entry) so navigating
+    // away from an agent thread never strands a phantom "@Agent " draft.
+    persistDraft: (draftKey, content, draftChannelId, imeta, spoilered, refs) =>
+      drafts.persistDraft(
+        draftKey,
+        imeta.length === 0 &&
+          replyAgentMentionRef.current?.isUntouchedAutoMention()
+          ? ""
+          : content,
+        draftChannelId,
+        imeta,
+        spoilered,
+        refs,
+      ),
     getMentionRefs: mentions.getDraftMentionRefs,
     restoreMentionRefs: mentions.restoreDraftMentionRefs,
     livePendingImeta: media.pendingImeta,
@@ -261,6 +278,7 @@ function MessageComposerImpl({
       emojiAutocomplete.updateEmojiQuery(text, cursor);
 
       persistentMentionHydrationRef.current?.reconcile(text);
+      replyAgentMentionRef.current?.reconcile(text);
 
       if (text.trim().length > 0) {
         notifyTyping();
@@ -292,6 +310,15 @@ function MessageComposerImpl({
     persistentMentionHydration,
   );
   persistentMentionHydrationRef.current = persistentMentionHydration;
+
+  const replyAgentMention = useReplyTargetAgentMention({
+    isEditing: editTarget != null,
+    mentions,
+    richText,
+    target: replyTargetAgent,
+  });
+  const replyAgentMentionRef = React.useRef(replyAgentMention);
+  replyAgentMentionRef.current = replyAgentMention;
 
   const mentionSendFlow = useMentionSendFlow({
     channelId,
@@ -598,6 +625,7 @@ function MessageComposerImpl({
 
     onPreparingMentionSendChange?.(true);
     persistentMentionHydration.beginSubmit();
+    replyAgentMention.beginSubmit();
     try {
       await mentionSendFlow.sendMessageWithMentionFlow({
         capturedChannelId: channelId,
@@ -614,6 +642,7 @@ function MessageComposerImpl({
       });
     } finally {
       persistentMentionHydration.endSubmit();
+      replyAgentMention.endSubmit();
       onPreparingMentionSendChange?.(false);
     }
   }, [
@@ -636,47 +665,18 @@ function MessageComposerImpl({
     onPreparingMentionSendChange,
     audienceScope,
     persistentMentionHydration,
+    replyAgentMention,
     persistentAudience.generation,
     persistentAudience.revision,
   ]);
   submitMessageRef.current = submitMessage;
 
-  // ── Auto-submit on draft send ────────────────────────────────────────────
-  // When `autoSubmitDraftKey` is set (the user clicked "Send message" in the
-  // Drafts panel and confirmed), fire `submitMessage` once after mount so the
-  // draft is sent through the real send path (mention resolution, media, etc.).
-  //
-  // Guard: only fire when the effective draft key matches the trigger so a
-  // stale URL param on a different channel never fires a spurious send.
-  //
-  // Fires at most once per mount (empty dep array after the key check) — the
-  // `onAutoSubmitComplete` callback clears the trigger before `submitMessage`
-  // runs, preventing re-fire on re-render or back-navigation.
-  const onAutoSubmitCompleteRef = React.useRef(onAutoSubmitComplete);
-  onAutoSubmitCompleteRef.current = onAutoSubmitComplete;
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally fires once on mount only
-  React.useEffect(() => {
-    if (
-      autoSubmitDraftKey === null ||
-      autoSubmitDraftKey !== effectiveDraftKey
-    ) {
-      return;
-    }
-    // Clear the trigger BEFORE firing so any navigation from the send cannot
-    // loop back with the param still present.
-    onAutoSubmitCompleteRef.current?.();
-    // Defer by one macrotask so the draft-persist lifecycle effect (which runs
-    // synchronously after mount) has a chance to load the draft content into
-    // the Tiptap editor before we try to submit.
-    const timer = window.setTimeout(() => {
-      submitMessageRef.current();
-    }, 0);
-    return () => {
-      window.clearTimeout(timer);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // mount-only
+  useComposerAutoSubmit({
+    autoSubmitDraftKey,
+    effectiveDraftKey,
+    onAutoSubmitComplete,
+    submitMessageRef,
+  });
 
   const handleSubmit = React.useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {

--- a/desktop/src/features/messages/ui/MessageComposer.types.ts
+++ b/desktop/src/features/messages/ui/MessageComposer.types.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import type { ImetaMedia } from "@/features/messages/lib/imetaMediaMarkdown";
+import type { ReplyTargetAgent } from "@/features/messages/lib/replyTargetAgentMention";
 import type { MediaUploadController } from "@/features/messages/lib/useMediaUpload";
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
 import type { ChannelType } from "@/shared/api/types";
@@ -91,6 +92,11 @@ export type MessageComposerProps = {
     body: string;
     id: string;
   } | null;
+  /**
+   * Agent-authored effective reply target. When set, the composer auto-inserts
+   * a visible, removable `@Name` mention so the reply wakes the agent.
+   */
+  replyTargetAgent?: ReplyTargetAgent | null;
   showTopBorder?: boolean;
   toolbarExtraActions?: ReactNode;
   typingParentEventId?: string | null;

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -3,6 +3,7 @@ import { ArrowDown } from "lucide-react";
 
 import { useKnownAgentPubkeys } from "@/features/agents/useKnownAgentPubkeys";
 import { orderMentionPubkeysByText } from "@/features/messages/lib/orderMentionPubkeys";
+import { resolveReplyTargetAgent } from "@/features/messages/lib/replyTargetAgentMention";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { resolveMentionProps } from "@/shared/lib/resolveMentionNames";
 import {
@@ -310,6 +311,23 @@ export function MessageThreadPanel({
         }
       : null;
 
+  // Auto-mention the agent whose message is being replied to: the effective
+  // target is the explicit reply target, falling back to the thread head
+  // (mirrors `parentEventId` in onCaptureSendContext above). DMs already
+  // p-tag every participant, so they never need the chip.
+  const knownAgentPubkeys = useKnownAgentPubkeys();
+  const effectiveReplyTarget =
+    channel?.channelType === "dm" ? null : (replyTargetMessage ?? threadHead);
+  const replyTargetAgent = React.useMemo(
+    () =>
+      resolveReplyTargetAgent(
+        effectiveReplyTarget,
+        knownAgentPubkeys,
+        profiles,
+      ),
+    [effectiveReplyTarget, knownAgentPubkeys, profiles],
+  );
+
   const deferredThreadReplies = React.useDeferredValue(
     threadReplies,
     EMPTY_THREAD_REPLIES,
@@ -511,7 +529,6 @@ export function MessageThreadPanel({
     settleAtBottomAfterLayout,
   );
 
-  const knownAgentPubkeys = useKnownAgentPubkeys();
   const initialAgentPubkeys = React.useMemo(() => {
     if (
       !threadHead ||
@@ -881,6 +898,7 @@ export function MessageThreadPanel({
               placeholder={`Reply in thread to ${threadHead.author}`}
               profiles={profiles}
               replyTarget={composerReplyTarget}
+              replyTargetAgent={replyTargetAgent}
               typingParentEventId={threadHead.id}
               typingRootEventId={threadHead.rootId}
             />

--- a/desktop/src/features/messages/ui/MessageThreadPanel.tsx
+++ b/desktop/src/features/messages/ui/MessageThreadPanel.tsx
@@ -324,8 +324,9 @@ export function MessageThreadPanel({
         effectiveReplyTarget,
         knownAgentPubkeys,
         profiles,
+        currentPubkey,
       ),
-    [effectiveReplyTarget, knownAgentPubkeys, profiles],
+    [currentPubkey, effectiveReplyTarget, knownAgentPubkeys, profiles],
   );
 
   const deferredThreadReplies = React.useDeferredValue(

--- a/desktop/src/features/messages/ui/useComposerAutoSubmit.ts
+++ b/desktop/src/features/messages/ui/useComposerAutoSubmit.ts
@@ -1,0 +1,51 @@
+import * as React from "react";
+
+/**
+ * Auto-submit on draft send: when `autoSubmitDraftKey` is set (the user
+ * clicked "Send message" in the Drafts panel and confirmed), fire the
+ * composer's submit once after mount so the draft is sent through the real
+ * send path (mention resolution, media, etc.).
+ *
+ * Guard: only fires when the effective draft key matches the trigger so a
+ * stale URL param on a different channel never fires a spurious send.
+ *
+ * Fires at most once per mount (empty dep array after the key check) — the
+ * `onAutoSubmitComplete` callback clears the trigger before the submit runs,
+ * preventing re-fire on re-render or back-navigation.
+ */
+export function useComposerAutoSubmit({
+  autoSubmitDraftKey,
+  effectiveDraftKey,
+  onAutoSubmitComplete,
+  submitMessageRef,
+}: {
+  autoSubmitDraftKey: string | null;
+  effectiveDraftKey: string | null;
+  onAutoSubmitComplete?: () => void;
+  submitMessageRef: React.RefObject<() => void>;
+}) {
+  const onAutoSubmitCompleteRef = React.useRef(onAutoSubmitComplete);
+  onAutoSubmitCompleteRef.current = onAutoSubmitComplete;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally fires once on mount only
+  React.useEffect(() => {
+    if (
+      autoSubmitDraftKey === null ||
+      autoSubmitDraftKey !== effectiveDraftKey
+    ) {
+      return;
+    }
+    // Clear the trigger BEFORE firing so any navigation from the send cannot
+    // loop back with the param still present.
+    onAutoSubmitCompleteRef.current?.();
+    // Defer by one macrotask so the draft-persist lifecycle effect (which runs
+    // synchronously after mount) has a chance to load the draft content into
+    // the Tiptap editor before we try to submit.
+    const timer = window.setTimeout(() => {
+      submitMessageRef.current();
+    }, 0);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, []); // mount-only
+}

--- a/desktop/src/features/messages/ui/useReplyTargetAgentMention.ts
+++ b/desktop/src/features/messages/ui/useReplyTargetAgentMention.ts
@@ -1,0 +1,188 @@
+import * as React from "react";
+
+import type { ReplyTargetAgent } from "@/features/messages/lib/replyTargetAgentMention";
+import type { UseMentionsResult } from "@/features/messages/lib/useMentions";
+import type { UseRichTextEditorResult } from "@/features/messages/lib/useRichTextEditor";
+import { normalizePubkey } from "@/shared/lib/pubkey";
+
+/**
+ * Auto-insert a visible `@AgentName` mention when the composer's reply target
+ * is an agent-authored message, so plain thread replies carry the agent p-tag
+ * the ACP harness wakes on. The chip is real composer text: the user can
+ * delete it to opt out (tracked per target so it is not re-inserted), and it
+ * flows through the normal send pipeline like a hand-typed mention.
+ *
+ * Insertion never touches user-authored text — it only writes into an empty
+ * composer, or replaces a previous auto-inserted chip that is still the
+ * composer's entire content.
+ */
+export function useReplyTargetAgentMention({
+  isEditing,
+  mentions,
+  richText,
+  target,
+}: {
+  isEditing: boolean;
+  mentions: UseMentionsResult;
+  richText: UseRichTextEditorResult;
+  target: ReplyTargetAgent | null;
+}) {
+  const targetRef = React.useRef(target);
+  targetRef.current = target;
+  const isEditingRef = React.useRef(isEditing);
+  isEditingRef.current = isEditing;
+  const isRestoringRef = React.useRef(false);
+  const isSubmittingRef = React.useRef(false);
+  // Exact text of the auto-inserted chip while it is still the composer's
+  // entire content; null once the user types around it or removes it.
+  const lastInsertedTextRef = React.useRef<string | null>(null);
+  const lastInsertedTargetIdRef = React.useRef<string | null>(null);
+  const dismissedTargetIdRef = React.useRef<string | null>(null);
+
+  const insert = React.useCallback(() => {
+    const capturedTarget = targetRef.current;
+    const current = richText.getPlainTextAndCursor().text;
+    const untouchedAutoMention =
+      lastInsertedTextRef.current !== null &&
+      current === lastInsertedTextRef.current;
+
+    if (!capturedTarget) {
+      // The reply target moved off an agent. Clear the chip only while it is
+      // still the composer's entire, untouched content, and always drop the
+      // bookkeeping so stale chip text from a previous target cannot leak
+      // into later comparisons.
+      if (untouchedAutoMention) {
+        isRestoringRef.current = true;
+        richText.replacePlainTextRange(0, current.length, "");
+        isRestoringRef.current = false;
+        mentions.cancelMentionAutocomplete();
+      }
+      lastInsertedTextRef.current = null;
+      lastInsertedTargetIdRef.current = null;
+      return;
+    }
+
+    if (
+      isEditingRef.current ||
+      dismissedTargetIdRef.current === capturedTarget.targetId
+    ) {
+      return;
+    }
+
+    const present = new Set(
+      mentions.extractMentionPubkeys(current).map(normalizePubkey),
+    );
+    if (present.has(capturedTarget.pubkey)) {
+      lastInsertedTargetIdRef.current = capturedTarget.targetId;
+      return;
+    }
+
+    if (current.length > 0 && !untouchedAutoMention) {
+      return;
+    }
+
+    const displayName =
+      mentions.getMentionDisplayName(capturedTarget.pubkey) ??
+      capturedTarget.displayName;
+
+    isRestoringRef.current = true;
+    const edit = mentions.insertResolvedMention({
+      displayName,
+      pubkey: capturedTarget.pubkey,
+      isAgent: true,
+      replaceFromOffset: 0,
+      replaceToOffset: current.length,
+    });
+    richText.replacePlainTextRange(
+      edit.replaceFromOffset,
+      edit.replaceToOffset,
+      edit.insertText,
+    );
+    isRestoringRef.current = false;
+    lastInsertedTextRef.current = edit.insertText;
+    lastInsertedTargetIdRef.current = capturedTarget.targetId;
+    // Programmatic transition, not an authored query — drop any autocomplete
+    // work the editor update scheduled.
+    mentions.cancelMentionAutocomplete();
+  }, [mentions, richText]);
+
+  const reconcile = React.useCallback(
+    (text: string) => {
+      if (
+        isRestoringRef.current ||
+        isSubmittingRef.current ||
+        isEditingRef.current
+      ) {
+        return;
+      }
+      const capturedTarget = targetRef.current;
+      if (
+        !capturedTarget ||
+        lastInsertedTargetIdRef.current !== capturedTarget.targetId
+      ) {
+        return;
+      }
+      // The user typed around the chip — the content is no longer an
+      // untouched auto-mention, so target switches must not rewrite it.
+      if (
+        lastInsertedTextRef.current !== null &&
+        text !== lastInsertedTextRef.current
+      ) {
+        lastInsertedTextRef.current = null;
+      }
+      // The user removed the chip — honor the opt-out for this target.
+      const present = new Set(
+        mentions.extractMentionPubkeys(text).map(normalizePubkey),
+      );
+      if (!present.has(capturedTarget.pubkey)) {
+        dismissedTargetIdRef.current = capturedTarget.targetId;
+      }
+    },
+    [mentions.extractMentionPubkeys],
+  );
+
+  const insertRef = React.useRef(insert);
+  insertRef.current = insert;
+  const scheduleInsert = React.useCallback(
+    () => requestAnimationFrame(() => insertRef.current()),
+    [],
+  );
+
+  const targetId = target?.targetId ?? null;
+  React.useEffect(() => {
+    if (
+      dismissedTargetIdRef.current !== null &&
+      dismissedTargetIdRef.current !== targetId
+    ) {
+      dismissedTargetIdRef.current = null;
+    }
+    const frame = scheduleInsert();
+    return () => cancelAnimationFrame(frame);
+  }, [targetId, scheduleInsert]);
+
+  return {
+    beginSubmit: () => {
+      isSubmittingRef.current = true;
+    },
+    /**
+     * True while the composer's entire content is still the auto-inserted
+     * chip. Draft persistence uses this to avoid stranding a phantom
+     * "@Agent " draft when the user opens an agent thread and leaves
+     * without typing.
+     */
+    isUntouchedAutoMention: () =>
+      lastInsertedTextRef.current !== null &&
+      richText.getPlainTextAndCursor().text === lastInsertedTextRef.current,
+    endSubmit: () => {
+      isSubmittingRef.current = false;
+      // The composer was cleared by the send — re-arm so the next reply in
+      // the same thread gets the chip again.
+      lastInsertedTextRef.current = null;
+      lastInsertedTargetIdRef.current = null;
+      dismissedTargetIdRef.current = null;
+      scheduleInsert();
+    },
+    reconcile,
+    scheduleInsert,
+  };
+}

--- a/desktop/tests/e2e/reply-agent-automention.spec.ts
+++ b/desktop/tests/e2e/reply-agent-automention.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { installMockBridge } from "../helpers/bridge";
+
+const CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+const AGENT = "a".repeat(64);
+const HUMAN = "c".repeat(64);
+
+type CommandPayloadWindow = Window & {
+  __BUZZ_E2E_COMMAND_PAYLOADS__?: Array<{
+    command: string;
+    payload: unknown;
+  }>;
+  __BUZZ_E2E_EMIT_MOCK_MESSAGE__?: (input: {
+    channelName: string;
+    content: string;
+    pubkey?: string;
+  }) => { id: string };
+};
+
+async function installAgentFixtures(page: Page) {
+  await installMockBridge(page, {
+    managedAgents: [
+      {
+        pubkey: AGENT,
+        name: "Morgarita",
+        status: "running",
+        channelNames: ["general"],
+      },
+    ],
+  });
+}
+
+async function openGeneral(page: Page) {
+  await page.goto(`/#/channels/${CHANNEL_ID}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+}
+
+async function emitRootMessage(page: Page, content: string, pubkey?: string) {
+  const event = await page.evaluate(
+    ({ message, author }) =>
+      (window as CommandPayloadWindow).__BUZZ_E2E_EMIT_MOCK_MESSAGE__?.({
+        channelName: "general",
+        content: message,
+        pubkey: author,
+      }),
+    { message: content, author: pubkey },
+  );
+  if (!event) throw new Error("Mock message emitter is not installed");
+  return event;
+}
+
+async function openThread(page: Page, threadRootId: string) {
+  await page.goto(
+    `/#/channels/${CHANNEL_ID}?messageId=${threadRootId}&thread=${threadRootId}`,
+    { waitUntil: "domcontentloaded" },
+  );
+  await expect(page.getByTestId("message-thread-panel")).toBeVisible();
+}
+
+function threadInput(page: Page) {
+  return page
+    .getByTestId("thread-composer-overlay")
+    .getByTestId("message-input");
+}
+
+function sentChannelMessages(page: Page) {
+  return page.evaluate(() =>
+    ((window as CommandPayloadWindow).__BUZZ_E2E_COMMAND_PAYLOADS__ ?? [])
+      .filter((entry) => entry.command === "send_channel_message")
+      .map((entry) => entry.payload as { mentionPubkeys?: string[] }),
+  );
+}
+
+test("replying to an agent's thread auto-inserts a removable mention chip", async ({
+  page,
+}) => {
+  await installAgentFixtures(page);
+  await openGeneral(page);
+  const root = await emitRootMessage(page, "@Fulki 2", AGENT);
+
+  await openThread(page, root.id);
+
+  const input = threadInput(page);
+  await expect(input).toHaveText("@Morgarita ");
+  await expect(input.locator(".agent-mention-highlight")).toHaveCount(1);
+
+  await input.click();
+  await page.keyboard.press("End");
+  await input.pressSequentially("how about 10+6?");
+  await expect(input).toHaveText("@Morgarita how about 10+6?");
+  await input.press("Enter");
+
+  await expect
+    .poll(async () => {
+      const sends = await sentChannelMessages(page);
+      return sends.at(-1)?.mentionPubkeys ?? null;
+    })
+    .toContain(AGENT);
+});
+
+test("removing the chip opts out and it is not re-inserted", async ({
+  page,
+}) => {
+  await installAgentFixtures(page);
+  await openGeneral(page);
+  const root = await emitRootMessage(page, "@Fulki 2", AGENT);
+
+  await openThread(page, root.id);
+
+  const input = threadInput(page);
+  await expect(input).toHaveText("@Morgarita ");
+
+  // Replacing the content removes the chip — the auto-mention must respect
+  // the opt-out and stay away for this reply target.
+  await input.fill("how about 10+6?");
+  await page.waitForTimeout(250);
+  await expect(input).toHaveText("how about 10+6?");
+  await input.press("Enter");
+
+  await expect
+    .poll(async () => {
+      const sends = await sentChannelMessages(page);
+      return sends.length;
+    })
+    .toBeGreaterThan(0);
+  const sends = await sentChannelMessages(page);
+  expect(sends.at(-1)?.mentionPubkeys ?? []).not.toContain(AGENT);
+});
+
+test("human-authored thread roots get no auto-mention", async ({ page }) => {
+  await installAgentFixtures(page);
+  await openGeneral(page);
+  const root = await emitRootMessage(page, "lunch plans?", HUMAN);
+
+  await openThread(page, root.id);
+
+  const input = threadInput(page);
+  // Give the insertion scheduler a frame to (incorrectly) fire before
+  // asserting the composer stayed empty.
+  await page.waitForTimeout(250);
+  await expect(input).toHaveText("");
+});


### PR DESCRIPTION
<p align="center">
  <strong>Reply to an agent in its thread, and the agent actually answers.</strong>
</p>

---

## What is this, really?

Replying in a thread to a message written by an agent did nothing. The ACP harness only wakes on events carrying the agent's `p` tag — the relay subscription filters on `#p` (`crates/buzz-acp/src/relay.rs`) and `filter::match_event` re-checks it — while the desktop composer derived mention tags exclusively from typed `@` text. So a plain reply under an agent's message never reached the agent, and the thread went quiet unless you remembered to re-type `@AgentName` every time.

Now the composer auto-inserts a **visible, removable `@AgentName` mention chip** whenever the message you're replying to was authored by an agent. The chip is real composer text: it rides the existing send pipeline (mention extraction → `p` tag → both harness gates → managed-agent wake-up), and deleting it before sending opts out of waking the agent for that reply.

---

## Before · After

<table>
  <tr>
    <td width="50%" valign="top" align="center">
<img width="268" height="101" alt="Screenshot 2026-07-31 at 14 25 47" src="https://github.com/user-attachments/assets/4e02f8d9-d909-4044-8451-0a4aecad4cb8" />
      <br>
      <sub><strong>Before.</strong> Replying under the agent's message sends a plain reply — no mention, no answer.</sub>
    </td>
    <td width="50%" valign="top" align="center"> 
     <img width="311" height="277" alt="Screenshot 2026-07-31 at 18 44 45" src="https://github.com/user-attachments/assets/b14196aa-e50c-4656-98b9-380ce2927339" />
      <br>
      <sub><strong>After.</strong> The @mention chip is pre-filled in the thread composer; sending wakes the agent. Delete the chip to opt out.</sub>
    </td>
  </tr>
</table>

---

## How it works

- **`useReplyTargetAgentMention`** (new composer hook, modeled on the persistent-audience hydration hook) inserts the chip via the existing `insertResolvedMention` / `replacePlainTextRange` machinery. It only ever writes into an empty composer or over its own untouched chip — user-authored text and restored drafts are never touched.
- **`resolveReplyTargetAgent`** (new pure helper) decides "is this reply target an agent" with the same layered detection the thread panel already uses: message `isAgent` flag → known-agent pubkey set → profile flag. It matches on the agent *identity* pubkey (not the raw signer key), which is what `event_mentions_agent` gates on.
- Wired in **both reply surfaces**: the thread panel (effective target = explicit reply target, falling back to the thread head) and the Home inbox reply pane. DMs are skipped — they already `p`-tag every participant.
- **Opt-out sticks per target**: removing the chip marks that reply target dismissed, so it isn't re-inserted until the target changes or a reply is sent.
- **No phantom drafts**: an untouched auto-chip persists as an empty draft, so opening an agent thread and navigating away doesn't strand a `@Agent ` draft (caught by the drafts e2e suite during development).
- `useComposerAutoSubmit` is a pure extraction from `MessageComposer` to stay under the file-size ratchet.

---

## Test plan

- [x] Unit: `replyTargetAgentMention.test.mjs` — agent detection via message flag / known set / profile, human → null, pubkey normalization, display-name fallbacks (8 tests)
- [x] E2E: `reply-agent-automention.spec.ts` (registered in the smoke project) — chip auto-inserts on agent threads, sent payload carries the agent pubkey in `mentionPubkeys`, deleting the chip opts out, human-authored threads get no chip
- [x] Regression: full desktop unit suite (3878 tests), `pnpm check` (biome + file-size + px-text + pubkey guards), `tsc --noEmit`, and ~215 e2e tests across messaging / mentions / persistent-agent-audience / threads / drafts / channels / inbox
- [x] Manual: verified live against the dev server — opening a bot-authored thread pre-fills the chip, and the sent reply event carries the agent's `p` tag