### PR TITLE
fix(dev): distinguish Docker permission denied from stopped daemon (#3713)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -592,3 +592,7 @@ usage.
 - [ARCHITECTURE.md](ARCHITECTURE.md) — system design and component relationships
 - [RELEASING.md](RELEASING.md) — release process: `release-desktop`, `release-relay`, `scripts/mobile-release.sh`, candidate tags, internal builds
 - [README.md](README.md) — project overview and quick start
+
+## Local setup gotcha
+
+If `just setup` fails on Linux with Docker permission denied, fix group membership before debugging Hermit — see CONTRIBUTING.md and `scripts/lib/docker_preflight.sh`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,15 @@ We review as capacity allows — focused PRs that follow this guide move fastest
 
 ## Setting Up the Development Environment
 
+### Docker permissions (Linux)
+
+`just setup` / `scripts/dev-setup.sh` need a working `docker info`. If the
+daemon is running but you see **permission denied**, add your user to the
+`docker` group and re-login (`sudo usermod -aG docker "$USER"`), or use
+rootless Docker / Docker Desktop. The setup script classifies this separately
+from a stopped daemon (#3713).
+
+
 ### Prerequisites
 
 | Tool | Version | Notes |

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -31,8 +31,9 @@ if ! command -v docker &>/dev/null; then
   exit 1
 fi
 
-if ! docker info &>/dev/null; then
-  error "Docker daemon is not running. Start Docker Desktop and try again."
+# shellcheck source=scripts/lib/docker_preflight.sh
+source "${SCRIPT_DIR}/lib/docker_preflight.sh"
+if ! docker_preflight_or_die; then
   exit 1
 fi
 

--- a/scripts/lib/docker_preflight.sh
+++ b/scripts/lib/docker_preflight.sh
@@ -25,7 +25,7 @@ docker_preflight_classify() {
 docker_preflight_or_die() {
   local docker_info_err code
   set +e
-  docker_info_err="$(docker info 2>&1 >/dev/null)"
+  docker_info_err="$(docker info 2>&1)"
   code=$?
   set -e
 

--- a/scripts/lib/docker_preflight.sh
+++ b/scripts/lib/docker_preflight.sh
@@ -1,28 +1,53 @@
 # shellcheck shell=bash
 # Shared Docker preflight helpers for local setup scripts.
 
-# Print a human-actionable error for a failed `docker info` and return 1.
-# Captures stderr so permission-denied is not misreported as "daemon not running".
-docker_preflight_or_die() {
-  local docker_info_err
-  if docker_info_err="$(docker info 2>&1 >/dev/null)"; then
+# Classify `docker info` stderr. Prints one of: ok | permission | not_running | other
+# Usage: docker_preflight_classify "<stderr text>" <exit_code>
+docker_preflight_classify() {
+  local err="${1-}"
+  local code="${2:-1}"
+  if [[ "$code" -eq 0 ]]; then
+    printf 'ok\n'
     return 0
   fi
-
-  if printf '%s' "$docker_info_err" | grep -qiE 'permission denied|dial unix .*: connect: permission denied'; then
-    error "Docker is installed but this user cannot talk to the daemon (permission denied)."
-    error "On Linux: add your user to the docker group, then re-login:"
-    error "  sudo usermod -aG docker \"\$USER\" && newgrp docker"
-    error "Or run rootless Docker / start Docker Desktop and ensure your user can access it."
-    return 1
+  if printf '%s' "$err" | grep -qiE 'permission denied|dial unix .*: connect: permission denied'; then
+    printf 'permission\n'
+    return 0
   fi
-
-  if printf '%s' "$docker_info_err" | grep -qiE 'Cannot connect|Is the docker daemon running|connection refused'; then
-    error "Docker daemon is not running. Start Docker Desktop (or your engine) and try again."
-    return 1
+  if printf '%s' "$err" | grep -qiE 'Cannot connect|Is the docker daemon running|connection refused'; then
+    printf 'not_running\n'
+    return 0
   fi
+  printf 'other\n'
+}
 
-  error "Docker is unreachable:"
-  error "$docker_info_err"
-  return 1
+# Print a human-actionable error for a failed `docker info` and return 1.
+docker_preflight_or_die() {
+  local docker_info_err code
+  set +e
+  docker_info_err="$(docker info 2>&1 >/dev/null)"
+  code=$?
+  set -e
+
+  case "$(docker_preflight_classify "$docker_info_err" "$code")" in
+    ok)
+      return 0
+      ;;
+    permission)
+      error "Docker is installed but this user cannot talk to the daemon (permission denied)."
+      error "On Linux: add your user to the docker group, then re-login:"
+      error "  sudo usermod -aG docker \"\$USER\" && newgrp docker"
+      error "Or run rootless Docker / start Docker Desktop and ensure your user can access it."
+      return 1
+      ;;
+    not_running)
+      error "Docker daemon is not running. Start Docker Desktop (or your engine) and try again."
+      return 1
+      ;;
+    *)
+      error "Docker is unreachable:"
+      error "$docker_info_err"
+      return 1
+      ;;
+  esac
 }

--- a/scripts/lib/docker_preflight.sh
+++ b/scripts/lib/docker_preflight.sh
@@ -1,0 +1,28 @@
+# shellcheck shell=bash
+# Shared Docker preflight helpers for local setup scripts.
+
+# Print a human-actionable error for a failed `docker info` and return 1.
+# Captures stderr so permission-denied is not misreported as "daemon not running".
+docker_preflight_or_die() {
+  local docker_info_err
+  if docker_info_err="$(docker info 2>&1 >/dev/null)"; then
+    return 0
+  fi
+
+  if printf '%s' "$docker_info_err" | grep -qiE 'permission denied|dial unix .*: connect: permission denied'; then
+    error "Docker is installed but this user cannot talk to the daemon (permission denied)."
+    error "On Linux: add your user to the docker group, then re-login:"
+    error "  sudo usermod -aG docker \"\$USER\" && newgrp docker"
+    error "Or run rootless Docker / start Docker Desktop and ensure your user can access it."
+    return 1
+  fi
+
+  if printf '%s' "$docker_info_err" | grep -qiE 'Cannot connect|Is the docker daemon running|connection refused'; then
+    error "Docker daemon is not running. Start Docker Desktop (or your engine) and try again."
+    return 1
+  fi
+
+  error "Docker is unreachable:"
+  error "$docker_info_err"
+  return 1
+}

--- a/scripts/tests/docker_preflight_test.sh
+++ b/scripts/tests/docker_preflight_test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# stub error() for sourced helper
+error() { echo "error: $*" >&2; }
+# shellcheck source=scripts/lib/docker_preflight.sh
+source "${ROOT}/scripts/lib/docker_preflight.sh"
+
+assert_eq() {
+  local got="$1" want="$2" label="$3"
+  if [[ "$got" != "$want" ]]; then
+    echo "FAIL $label: got='$got' want='$want'" >&2
+    exit 1
+  fi
+  echo "ok $label"
+}
+
+assert_eq "$(docker_preflight_classify '' 0)" ok "success"
+assert_eq "$(docker_preflight_classify 'permission denied while trying to connect' 1)" permission "permission"
+assert_eq "$(docker_preflight_classify 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?' 1)" not_running "not_running"
+assert_eq "$(docker_preflight_classify 'dial unix /var/run/docker.sock: connect: permission denied' 1)" permission "dial_unix_permission"
+assert_eq "$(docker_preflight_classify 'something weird happened' 1)" other "other"
+echo "all docker_preflight tests passed"


### PR DESCRIPTION
## Summary
- `just setup` / `dev-setup.sh` used to say "Docker daemon is not running" for every `docker info` failure, including Linux **permission denied** (user not in `docker` group) — the real cause in #3713.
- Add `scripts/lib/docker_preflight.sh` with a classifiable helper + actionable group-membership hint.
- Unit tests for the classifier; CONTRIBUTING / AGENTS notes.

## Test plan
- [x] `bash scripts/tests/docker_preflight_test.sh`
- [ ] On a Linux box without docker group: confirm message mentions `usermod -aG docker`
- [ ] With daemon stopped: still says daemon not running

Closes #3713


Made with [Cursor](https://cursor.com)