### PR TITLE
docs(linux): troubleshoot GStreamer SEGV when switching communities (#3488)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -508,6 +508,10 @@ reconnects preserve pending avatar verification work):
 community-scoped data, you must add its reset to `resetCommunityState()`.**
 Failure to do so causes data from the old community to leak into the new one.
 
+On Linux, community switches can also trip a WebKit/GStreamer segfault
+(`gst_value_set_int_range_step`); see `docs/linux-rendering-troubleshooting.md`
+and #3488 — that is a host/media-stack issue, not a missing reset.
+
 Key files:
 - `desktop/src/app/App.tsx` — community key, init gate, remount boundary
 - `desktop/src/features/communities/useCommunityInit.ts` — `resetCommunityState()`, applies config to Tauri backend

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -192,7 +192,7 @@ which strips infra libraries over-bundled by linuxdeploy (they crash on
 Mesa 25+ / GLib 2.88 distros; see
 [tauri-apps/tauri#15665](https://github.com/tauri-apps/tauri/issues/15665))
 and re-signs the artifact. As a result the AppImage relies on the
-host's Wayland/GStreamer/graphics stack and requires GLib >= 2.72
+host's Wayland/GStreamer/graphics stack and requires GLib >= 2.72. Community-switch SEGVs: see docs/linux-rendering-troubleshooting.md (#3488).
 (Ubuntu 22.04 or newer). The `release-linux` job builds inside a
 `ubuntu:22.04` container for broad GLIBC compatibility.
 

--- a/docs/linux-rendering-troubleshooting.md
+++ b/docs/linux-rendering-troubleshooting.md
@@ -159,4 +159,9 @@ Segmentation fault (core dumped)
 
 **Related fixes in flight / shipped:** AppImage GStreamer registry path (#2694 / #2560), Linux notification sound as mp3 (#2804), earlier AppImage GStreamer host fixes (#2176).
 
+### When reporting #3488-style crashes
+
+Include: package type (AppImage vs deb/rpm), Buzz version, distro, whether
+`--safe-rendering` changes the outcome, and whether any channel had video/voice
+UI open. Attach the `GStreamer-CRITICAL` lines if present.
 

--- a/docs/linux-rendering-troubleshooting.md
+++ b/docs/linux-rendering-troubleshooting.md
@@ -8,6 +8,7 @@ This guide covers the most common rendering failures on Linux and how to resolve
 |---------|-------------|-----|
 | Blank or transparent window, then `SIGABRT` with `colrv1_configure_skpaint` in the output | COLRv1 color emoji font (AppImage only) | Upgrade to the latest AppImage (v0.5.2+) |
 | Blank window on startup, no crash output | dmabuf renderer incompatibility (NVIDIA or AppImage) | `WEBKIT_DISABLE_DMABUF_RENDERER=1 ./Buzz.AppImage` or `--safe-rendering` |
+| SEGV when switching communities; `gst_value_set_int_range_step` | GStreamer/WebKit media teardown on remount (#3488) | Prefer `.deb`/`.rpm`; `--safe-rendering`; clear `~/.cache/gstreamer-1.0` |
 | Blank window on any hardware, no crash output | Unknown GPU/driver combination | `--safe-rendering` flag (see below) |
 
 ---

--- a/docs/linux-rendering-troubleshooting.md
+++ b/docs/linux-rendering-troubleshooting.md
@@ -133,3 +133,29 @@ If none of the above match your situation:
 3. Try `--safe-rendering` first — if it resolves the issue, it's a WebKit rendering incompatibility and the crash log will help narrow down which driver is involved.
 
 4. File a [new issue](https://github.com/block/buzz/issues/new) with your distro, GPU, driver version, and the terminal output.
+
+## Crash (SEGV) when switching communities on Linux (#3488)
+
+**Symptoms:** Clicking another community exits the process. Journal / terminal may show:
+
+```text
+(WebKitWebProcess:…): GStreamer-CRITICAL **: gst_value_set_int_range_step: assertion 'start < end' failed
+Segmentation fault (core dumped)
+```
+
+**Likely cause:** WebKitGTK tearing down or re-initializing media (GStreamer) while the React tree remounts for a community switch (`AGENTS.md` → Community Switching). Bad or incomplete GStreamer plugin registries on AppImage / mixed host stacks trigger the assert then SEGV inside the WebKit web process.
+
+**Workarounds to try (in order):**
+
+1. Prefer the **`.deb` / `.rpm`** package over AppImage when available — native WebKit + system GStreamer.
+2. Launch with safe rendering: `./Buzz.AppImage --safe-rendering` (or set `WEBKIT_DISABLE_DMABUF_RENDERER=1`).
+3. If you still hit GStreamer assert spam, unset a stale per-user registry and retry:
+   ```bash
+   rm -rf ~/.cache/gstreamer-1.0
+   # Buzz may also keep an AppImage-scoped registry under ~/.cache/buzz/ — see #2694
+   ```
+4. Avoid leaving a channel with an in-flight video/voice attachment focused when switching communities (reduces media teardown races).
+
+**Related fixes in flight / shipped:** AppImage GStreamer registry path (#2694 / #2560), Linux notification sound as mp3 (#2804), earlier AppImage GStreamer host fixes (#2176).
+
+


### PR DESCRIPTION
## Summary
- Document the Ubuntu/Linux community-switch crash (`gst_value_set_int_range_step` → SEGV) reported in #3488.
- Index it in the linux rendering symptom table; link from AGENTS.md community-switching notes and RELEASING.md.
- List workarounds (native packages, `--safe-rendering`, clear GStreamer cache) and related open/shipped GST fixes.

## Test plan
- [ ] Read the new section against the #3488 log snippet
- [ ] Confirm links render from AGENTS.md / RELEASING.md

Does not close #3488 until a code fix lands — this unblocks users and triage.


Made with [Cursor](https://cursor.com)