### PR TITLE
fix(acp): record usage from standard ACP session/update notifications

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -4331,8 +4331,9 @@ mod tests {
         assert_eq!(usage.cumulative_output_tokens, None);
     }
 
-    /// The full dispatch path: a raw `session/update` frame must reach the
-    /// tracker through the same match arm that feeds `handle_session_update`.
+    /// Cost is the one counter the standard payload carries, so it must yield a
+    /// real per-turn delta from the second turn on. (Dispatch wiring is covered
+    /// separately by the `acp_usage_frame_dispatched_by_*` tests below.)
     #[tokio::test]
     async fn acp_usage_second_turn_produces_a_cost_delta() {
         let mut client = spawn_inert_client().await;
@@ -4401,6 +4402,70 @@ mod tests {
             "jsonrpc": "2.0", "method": "session/update"
         }));
         assert!(client.take_turn_usage().is_none());
+    }
+
+    /// A bash agent that emits one standard `usage_update` frame and then the
+    /// JSON-RPC response the read loop is waiting for. Frames are exactly what
+    /// claude-agent-acp puts on the wire.
+    const ACP_USAGE_THEN_RESPONSE: &str = concat!(
+        r#"echo '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"dispatch-s","#,
+        r#""update":{"sessionUpdate":"usage_update","used":15247,"size":200000,"#,
+        r#""cost":{"amount":0.0234,"currency":"USD"}}}}'; "#,
+        r#"echo '{"jsonrpc":"2.0","id":999,"result":{"stopReason":"end_turn"}}'; "#,
+        "sleep 5",
+    );
+
+    /// Regression guard for the routing half of the bug, on the plain read loop.
+    ///
+    /// The handler being correct is not enough — the notification has to be
+    /// handed to it. Every other ACP-usage test calls `handle_acp_usage_update`
+    /// directly, so deleting the dispatch line in `read_until_response` would
+    /// silently restore the original bug. This test drives a real frame through
+    /// the loop, so that deletion fails here.
+    #[tokio::test]
+    async fn acp_usage_frame_dispatched_by_read_until_response() {
+        let mut client = spawn_script(ACP_USAGE_THEN_RESPONSE).await;
+        client.usage.begin_turn("dispatch-s");
+
+        client
+            .read_until_response(999)
+            .await
+            .expect("agent response must arrive");
+
+        let usage = client
+            .take_turn_usage()
+            .expect("the usage frame must reach the tracker through the dispatch");
+        assert_eq!(usage.session_id, "dispatch-s");
+        assert_eq!(usage.cumulative_cost_usd, Some(0.0234));
+        assert_eq!(usage.cumulative_input_tokens, None);
+    }
+
+    /// Same regression guard on the idle-timeout read loop — the loop that
+    /// actually serves prompt turns, and a second, independent dispatch site.
+    #[tokio::test]
+    async fn acp_usage_frame_dispatched_by_idle_timeout_loop() {
+        let mut client = spawn_script(ACP_USAGE_THEN_RESPONSE).await;
+        client.usage.begin_turn("dispatch-s");
+
+        let max_dur = std::time::Duration::from_secs(30);
+        let hard_deadline = tokio::time::Instant::now() + max_dur;
+        client
+            .read_until_response_with_idle_timeout(
+                "dispatch-s",
+                999,
+                std::time::Duration::from_secs(10),
+                hard_deadline,
+                max_dur,
+            )
+            .await
+            .expect("agent response must arrive");
+
+        let usage = client
+            .take_turn_usage()
+            .expect("the usage frame must reach the tracker through the dispatch");
+        assert_eq!(usage.session_id, "dispatch-s");
+        assert_eq!(usage.cumulative_cost_usd, Some(0.0234));
+        assert_eq!(usage.cumulative_input_tokens, None);
     }
 
     #[test]

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -206,11 +206,12 @@ pub struct AcpClient {
     /// outside of a goose-native turn — the read loop's steer arm is
     /// disabled in that case.
     steer_rx: Option<tokio::sync::mpsc::Receiver<crate::pool::SteerRequest>>,
-    /// Usage tracker — accumulates cumulative token counts from
-    /// `_goose/unstable/session/update` notifications and computes per-turn
-    /// deltas. Both goose and buzz-agent emit this notification; goose gates
-    /// on client capability advertisement, buzz-agent emits unconditionally.
-    goose_usage: UsageTracker,
+    /// Usage tracker — accumulates cumulative counters from `usage_update`
+    /// notifications and computes per-turn deltas. Fed by both wire formats:
+    /// `_goose/unstable/session/update` (goose gates on client capability
+    /// advertisement, buzz-agent emits unconditionally) and the core ACP
+    /// `session/update` (claude-agent-acp, codex-acp).
+    usage: UsageTracker,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -549,7 +550,7 @@ impl AcpClient {
             active_run_id: None,
             steering_supported: false,
             steer_rx: None,
-            goose_usage: UsageTracker::default(),
+            usage: UsageTracker::default(),
         })
     }
 
@@ -758,7 +759,7 @@ impl AcpClient {
         // Mark the usage tracker as in-flight for this turn BEFORE sending the
         // prompt so that any setup notifications recorded earlier are not
         // misattributed to this turn.
-        self.goose_usage.begin_turn(session_id);
+        self.usage.begin_turn(session_id);
 
         self.last_prompt_id = Some(self.next_id);
         let id = self.next_id;
@@ -851,17 +852,17 @@ impl AcpClient {
     }
 
     /// Consume and return the per-turn usage record computed from the most
-    /// recent `_goose/unstable/session/update` notification.
+    /// recent `usage_update` notification, in either wire format.
     ///
-    /// Returns `None` if no usage update arrived since the last call (i.e.
-    /// the harness did not emit one for this turn, or this is not a goose
-    /// agent). Must be called at most once per turn; subsequent calls return
-    /// `None` until the next `usage_update` notification is recorded.
+    /// Returns `None` if no usage update arrived since the last call — the
+    /// harness did not emit one for this turn, or the ones it emitted carried
+    /// no counter NIP-AM can publish. Must be called at most once per turn;
+    /// subsequent calls return `None` until the next notification is recorded.
     ///
     /// Intended for consumption by `publish_agent_turn_metric` in `pool.rs` to
     /// publish a kind 44200 NIP-AM event.
     pub fn take_turn_usage(&mut self) -> Option<TurnUsage> {
-        self.goose_usage.take()
+        self.usage.take()
     }
 
     /// Install a per-turn steer request channel for goose-native
@@ -1215,6 +1216,7 @@ impl AcpClient {
             if let Some(method) = msg.get("method").and_then(|v| v.as_str()) {
                 match method {
                     "session/update" => {
+                        self.handle_acp_usage_update(&msg);
                         let _ = self.handle_session_update(&msg);
                     }
                     "_goose/unstable/session/update" => {
@@ -1654,6 +1656,7 @@ impl AcpClient {
                     if let Some(method) = msg.get("method").and_then(|v| v.as_str()) {
                         match method {
                             "session/update" => {
+                                self.handle_acp_usage_update(&msg);
                                 if self.handle_session_update(&msg) {
                                     let activity_now = Instant::now();
                                     idle_deadline = activity_now + idle_timeout;
@@ -1815,7 +1818,9 @@ impl AcpClient {
     /// notification is best-effort observability data, not a protocol
     /// requirement. Failures are logged at debug level.
     fn handle_goose_usage_update(&mut self, msg: &serde_json::Value) {
-        use crate::usage::{GooseSessionUpdateNotification, GooseSessionUpdateVariant};
+        use crate::usage::{
+            GooseSessionUpdateNotification, GooseSessionUpdateVariant, UsageSnapshot,
+        };
         let params = match msg.get("params") {
             Some(p) => p,
             None => {
@@ -1841,13 +1846,60 @@ impl AcpClient {
                         cached = payload.accumulated_cached_input_tokens,
                         "goose usage update"
                     );
-                    self.goose_usage.record(&notif.session_id, payload);
+                    self.usage
+                        .record(&notif.session_id, &UsageSnapshot::from(payload));
                 }
             }
             Err(e) => {
                 tracing::debug!(
                     target: "acp::usage",
                     "_goose/unstable/session/update: deserialization error: {e}"
+                );
+            }
+        }
+    }
+
+    /// Parse a standard ACP `session/update` notification and, when it carries
+    /// the `usage_update` variant, record the usage snapshot in the per-session
+    /// tracker.
+    ///
+    /// This is the counterpart to [`Self::handle_goose_usage_update`] for the
+    /// harnesses that speak only core ACP (claude-agent-acp, codex-acp). Without
+    /// it their usage notifications are parsed for display and then dropped, so
+    /// `UsageTracker::take` returns `None` at turn completion and no kind 44200
+    /// metric is ever published.
+    ///
+    /// The standard payload has no cumulative token split, so only the
+    /// cumulative cost survives into the snapshot; harnesses that report neither
+    /// (codex-acp sends a bare `{used, size}`) are dropped by `record`.
+    ///
+    /// Silently ignores malformed input and non-`usage_update` variants — every
+    /// other `session/update` flows through `handle_session_update`, and this
+    /// path must never interfere with it.
+    fn handle_acp_usage_update(&mut self, msg: &serde_json::Value) {
+        use crate::usage::{AcpSessionUpdateNotification, AcpSessionUpdateVariant, UsageSnapshot};
+        let Some(params) = msg.get("params") else {
+            return;
+        };
+        match serde_json::from_value::<AcpSessionUpdateNotification>(params.clone()) {
+            Ok(notif) => {
+                if let AcpSessionUpdateVariant::UsageUpdate(payload) = &notif.update {
+                    tracing::debug!(
+                        target: "acp::usage",
+                        session_id = %notif.session_id,
+                        used = payload.used,
+                        size = payload.size,
+                        cost = ?payload.cost.as_ref().map(|c| c.amount),
+                        "acp usage update"
+                    );
+                    self.usage
+                        .record(&notif.session_id, &UsageSnapshot::from(payload));
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    target: "acp::usage",
+                    "session/update: usage deserialization error: {e}"
                 );
             }
         }
@@ -4177,7 +4229,7 @@ mod tests {
         assert!(client.take_turn_usage().is_none(), "starts empty");
 
         // begin_turn before sending the prompt — mirrors the real call flow.
-        client.goose_usage.begin_turn("s1");
+        client.usage.begin_turn("s1");
         let msg = goose_usage_update_msg("s1", 1000, 200, Some(0.01));
         client.handle_goose_usage_update(&msg);
 
@@ -4187,8 +4239,8 @@ mod tests {
         assert_eq!(usage.session_id, "s1");
         assert_eq!(usage.turn_seq, 1);
         assert!(!usage.delta_reliable, "first turn must be unreliable");
-        assert_eq!(usage.cumulative_input_tokens, 1000);
-        assert_eq!(usage.cumulative_output_tokens, 200);
+        assert_eq!(usage.cumulative_input_tokens, Some(1000));
+        assert_eq!(usage.cumulative_output_tokens, Some(200));
         assert_eq!(usage.cumulative_cost_usd, Some(0.01));
 
         // Second take must be None.
@@ -4202,11 +4254,11 @@ mod tests {
     async fn goose_usage_second_turn_delta_reliable() {
         let mut client = spawn_inert_client().await;
         // Turn 1.
-        client.goose_usage.begin_turn("s2");
+        client.usage.begin_turn("s2");
         client.handle_goose_usage_update(&goose_usage_update_msg("s2", 1000, 200, None));
         let _ = client.take_turn_usage();
         // Turn 2.
-        client.goose_usage.begin_turn("s2");
+        client.usage.begin_turn("s2");
         client.handle_goose_usage_update(&goose_usage_update_msg("s2", 1800, 450, None));
         let usage = client.take_turn_usage().expect("turn 2 usage");
         assert!(usage.delta_reliable);
@@ -4229,6 +4281,125 @@ mod tests {
             "params": { "oops": true }
         });
         client.handle_goose_usage_update(&bad2);
+        assert!(client.take_turn_usage().is_none());
+    }
+
+    // ── Standard ACP usage notifications ──────────────────────────────────
+
+    /// A `session/update` notification exactly as claude-agent-acp emits it.
+    fn acp_usage_update_msg(session_id: &str, used: u64, cost: Option<f64>) -> serde_json::Value {
+        let mut update = serde_json::json!({
+            "sessionUpdate": "usage_update",
+            "used": used,
+            "size": 200000u64,
+        });
+        if let Some(c) = cost {
+            update["cost"] = serde_json::json!({ "amount": c, "currency": "USD" });
+        }
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": session_id,
+                "update": update
+            }
+        })
+    }
+
+    /// Regression: harnesses that speak only core ACP (claude-agent-acp,
+    /// codex-acp) send `usage_update` over `session/update`, not over the goose
+    /// extension. Before this path existed the notification was parsed for
+    /// display and dropped, `take_turn_usage` returned `None` on every turn, and
+    /// no kind 44200 metric was ever published for those agents.
+    #[tokio::test]
+    async fn acp_usage_notification_recorded_and_take_returns_usage() {
+        let mut client = spawn_inert_client().await;
+        assert!(client.take_turn_usage().is_none(), "starts empty");
+
+        client.usage.begin_turn("acp-1");
+        client.handle_acp_usage_update(&acp_usage_update_msg("acp-1", 15_247, Some(0.0234)));
+
+        let usage = client
+            .take_turn_usage()
+            .expect("standard ACP usage_update must reach the tracker");
+        assert_eq!(usage.session_id, "acp-1");
+        assert_eq!(usage.turn_seq, 1);
+        assert_eq!(usage.cumulative_cost_usd, Some(0.0234));
+        // The standard payload has no cumulative token split: `used` is a
+        // context snapshot, which NIP-AM must not receive as a token count.
+        assert_eq!(usage.cumulative_input_tokens, None);
+        assert_eq!(usage.cumulative_output_tokens, None);
+    }
+
+    /// The full dispatch path: a raw `session/update` frame must reach the
+    /// tracker through the same match arm that feeds `handle_session_update`.
+    #[tokio::test]
+    async fn acp_usage_second_turn_produces_a_cost_delta() {
+        let mut client = spawn_inert_client().await;
+        client.usage.begin_turn("acp-2");
+        client.handle_acp_usage_update(&acp_usage_update_msg("acp-2", 10_000, Some(0.10)));
+        let _ = client.take_turn_usage();
+
+        client.usage.begin_turn("acp-2");
+        client.handle_acp_usage_update(&acp_usage_update_msg("acp-2", 18_000, Some(0.25)));
+        let usage = client.take_turn_usage().expect("turn 2 usage");
+        assert!(usage.delta_reliable, "baseline observed, nothing decreased");
+        let cost = usage.turn_cost_usd.expect("cost delta");
+        assert!(
+            (cost - 0.15).abs() < 1e-9,
+            "expected a 0.15 cost delta, got {cost}"
+        );
+        assert_eq!(usage.turn_input_tokens, None, "tokens stay unknown");
+    }
+
+    /// claude-agent-acp interleaves bare `{used, size}` notifications (context
+    /// changes) with the ones that carry cost. Those carry nothing NIP-AM can
+    /// publish and must not overwrite the cost baseline.
+    #[tokio::test]
+    async fn acp_context_only_notification_does_not_clobber_the_cost_baseline() {
+        let mut client = spawn_inert_client().await;
+        client.usage.begin_turn("acp-3");
+        client.handle_acp_usage_update(&acp_usage_update_msg("acp-3", 10_000, Some(0.10)));
+        let _ = client.take_turn_usage();
+
+        client.usage.begin_turn("acp-3");
+        // Context-only frame: no cost, so nothing to record.
+        client.handle_acp_usage_update(&acp_usage_update_msg("acp-3", 4_000, None));
+        assert!(
+            client.take_turn_usage().is_none(),
+            "a counter-free notification must not produce a publishable metric"
+        );
+
+        // The baseline from turn 1 must have survived intact.
+        client.usage.begin_turn("acp-3");
+        client.handle_acp_usage_update(&acp_usage_update_msg("acp-3", 12_000, Some(0.30)));
+        let usage = client.take_turn_usage().expect("turn 3 usage");
+        let cost = usage.turn_cost_usd.expect("cost delta");
+        assert!(
+            (cost - 0.20).abs() < 1e-9,
+            "delta must be measured from the 0.10 baseline, got {cost}"
+        );
+    }
+
+    /// Malformed or non-usage `session/update` frames must be ignored without
+    /// disturbing the tracker — every other variant flows to
+    /// `handle_session_update`.
+    #[tokio::test]
+    async fn acp_non_usage_session_update_is_ignored() {
+        let mut client = spawn_inert_client().await;
+        client.usage.begin_turn("acp-4");
+        client.handle_acp_usage_update(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "acp-4",
+                "update": { "sessionUpdate": "agent_message_chunk",
+                            "content": { "text": "hi" } }
+            }
+        }));
+        client.handle_acp_usage_update(&serde_json::json!({
+            "jsonrpc": "2.0", "method": "session/update"
+        }));
         assert!(client.take_turn_usage().is_none());
     }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -6251,6 +6251,90 @@ mod tests {
         );
     }
 
+    /// A cost-only turn — what every standard-ACP harness produces, since the
+    /// protocol carries no cumulative token split. Each token field must reach
+    /// the wire as null. A zero here would be read by a token-usage calculator
+    /// as "this turn consumed nothing" instead of "unknown".
+    #[test]
+    fn test_build_turn_metric_counts_cost_only_turn_nulls_every_token_field() {
+        let usage = crate::usage::TurnUsage {
+            session_id: "sess-acp".to_string(),
+            turn_seq: 2,
+            delta_reliable: true,
+            turn_input_tokens: None,
+            turn_output_tokens: None,
+            turn_total_tokens: None,
+            turn_cost_usd: Some(0.15),
+            cumulative_input_tokens: None,
+            cumulative_output_tokens: None,
+            cumulative_total_tokens: None,
+            cumulative_cost_usd: Some(0.25),
+            model: None,
+        };
+
+        let (turn, cumulative) = crate::pool::build_turn_metric_counts(&usage);
+        let turn_json = serde_json::to_value(turn.as_ref().expect("turn counts present")).unwrap();
+        let cum_json =
+            serde_json::to_value(cumulative.as_ref().expect("cumulative counts present")).unwrap();
+
+        for (label, json) in [("turn", &turn_json), ("cumulative", &cum_json)] {
+            for field in ["inputTokens", "outputTokens", "totalTokens"] {
+                assert!(
+                    json[field].is_null(),
+                    "{label}.{field} must be null for a harness that reports no tokens, got {}",
+                    json[field]
+                );
+            }
+        }
+
+        // The one counter the standard payload does carry must survive.
+        assert_eq!(turn_json["costUsd"], serde_json::json!(0.15));
+        assert_eq!(cum_json["costUsd"], serde_json::json!(0.25));
+    }
+
+    /// The same turn as a complete NIP-AM payload: it must pass validation and
+    /// serialize with explicit nulls. `TokenCounts` carries no
+    /// `skip_serializing_if` on the four counters, so a consumer sees the key
+    /// with a null value rather than an absent key.
+    #[test]
+    fn test_cost_only_payload_validates_and_serializes_tokens_as_null() {
+        use buzz_core::agent_turn_metric::{AgentTurnMetricPayload, TokenCounts};
+
+        let counts = |cost: f64| {
+            Some(TokenCounts {
+                input_tokens: None,
+                output_tokens: None,
+                total_tokens: None,
+                cost_usd: Some(cost),
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+            })
+        };
+        let payload = AgentTurnMetricPayload {
+            harness: "claude-agent-acp".to_string(),
+            model: None,
+            channel_id: None,
+            session_id: Some("sess-acp".to_string()),
+            turn_id: Some("turn-2".to_string()),
+            turn_seq: Some(2),
+            timestamp: "2026-08-03T10:00:00.000Z".to_string(),
+            turn: counts(0.15),
+            cumulative: counts(0.25),
+            delta_reliable: true,
+            stop_reason: Some(buzz_core::agent_turn_metric::StopReason::EndTurn),
+        };
+
+        payload
+            .validate()
+            .expect("a cost-only payload is valid NIP-AM");
+
+        let json = serde_json::to_value(&payload).unwrap();
+        assert!(json["cumulative"]["inputTokens"].is_null());
+        assert!(json["cumulative"]["outputTokens"].is_null());
+        assert_eq!(json["cumulative"]["costUsd"], serde_json::json!(0.25));
+        assert_eq!(json["harness"], serde_json::json!("claude-agent-acp"));
+    }
+
     fn make_prompt_context_no_owner() -> PromptContext {
         let agent_keys = nostr::Keys::generate();
         make_prompt_context_impl(&agent_keys, None)

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -3603,10 +3603,10 @@ fn acp_stop_to_core(r: &StopReason) -> buzz_core::agent_turn_metric::StopReason 
 ///
 /// - `turn` is `None` when `delta_reliable` is false; otherwise it carries the
 ///   per-turn i/o/total/cost deltas for this turn.
-/// - `cumulative` always carries the session-aggregate i/o/cost totals.
-///   `total_tokens` is `Some` only when the session accumulated a genuine
-///   provider-reported total on every turn — never derived from i/o sums
-///   (NIP-AM MUST NOT).
+/// - `cumulative` always carries whichever session-aggregate counters the
+///   harness reported; each is null when it did not. `total_tokens` is `Some`
+///   only when the session accumulated a genuine provider-reported total on
+///   every turn — never derived from i/o sums (NIP-AM MUST NOT).
 pub(crate) fn build_turn_metric_counts(
     usage: &crate::usage::TurnUsage,
 ) -> (
@@ -3635,8 +3635,10 @@ pub(crate) fn build_turn_metric_counts(
         None
     };
     let cumulative_counts = Some(TokenCounts {
-        input_tokens: Some(usage.cumulative_input_tokens),
-        output_tokens: Some(usage.cumulative_output_tokens),
+        // `None` for harnesses whose wire format has no cumulative token split
+        // (standard ACP). NIP-AM publishes that as null — never as zero.
+        input_tokens: usage.cumulative_input_tokens,
+        output_tokens: usage.cumulative_output_tokens,
         // Present when every turn in the session reported a genuine provider
         // total. None when the session has never emitted one or any turn lacked
         // one. Never derived from input+output (NIP-AM MUST NOT).
@@ -3650,8 +3652,9 @@ pub(crate) fn build_turn_metric_counts(
 
 /// Best-effort: build and publish a `kind:44200` NIP-AM agent turn metric event.
 ///
-/// Does nothing when `usage` is `None` (goose emitted no usage notification
-/// for this turn) or when `owner_pubkey` is unconfigured (no NIP-AO identity).
+/// Does nothing when `usage` is `None` (the harness emitted no usage
+/// notification for this turn, or none carrying a counter NIP-AM can publish)
+/// or when `owner_pubkey` is unconfigured (no NIP-AO identity).
 /// Errors are logged at WARN and never surface to the caller — metric
 /// publishing must never fail a turn.
 async fn publish_agent_turn_metric(
@@ -6022,8 +6025,8 @@ mod tests {
             turn_output_tokens: Some(50),
             turn_total_tokens: None,
             turn_cost_usd: None,
-            cumulative_input_tokens: 100,
-            cumulative_output_tokens: 50,
+            cumulative_input_tokens: Some(100),
+            cumulative_output_tokens: Some(50),
             cumulative_total_tokens: None,
             cumulative_cost_usd: None,
             model: None,
@@ -6056,8 +6059,8 @@ mod tests {
             turn_output_tokens: Some(80),
             turn_total_tokens: None,
             turn_cost_usd: Some(0.001),
-            cumulative_input_tokens: 200,
-            cumulative_output_tokens: 80,
+            cumulative_input_tokens: Some(200),
+            cumulative_output_tokens: Some(80),
             cumulative_total_tokens: None,
             cumulative_cost_usd: Some(0.001),
             model: None,
@@ -6091,8 +6094,8 @@ mod tests {
             turn_output_tokens: Some(20),
             turn_total_tokens: None,
             turn_cost_usd: None,
-            cumulative_input_tokens: 150,
-            cumulative_output_tokens: 70,
+            cumulative_input_tokens: Some(150),
+            cumulative_output_tokens: Some(70),
             cumulative_total_tokens: None,
             cumulative_cost_usd: None,
             model: None,
@@ -6126,8 +6129,8 @@ mod tests {
             turn_output_tokens: None,
             turn_total_tokens: None,
             turn_cost_usd: None,
-            cumulative_input_tokens: 400,
-            cumulative_output_tokens: 100,
+            cumulative_input_tokens: Some(400),
+            cumulative_output_tokens: Some(100),
             cumulative_total_tokens: None,
             cumulative_cost_usd: None,
             model: None,
@@ -6158,8 +6161,8 @@ mod tests {
             turn_output_tokens: Some(30),
             turn_total_tokens: Some(130), // genuine per-turn total
             turn_cost_usd: None,
-            cumulative_input_tokens: 500,
-            cumulative_output_tokens: 120,
+            cumulative_input_tokens: Some(500),
+            cumulative_output_tokens: Some(120),
             cumulative_total_tokens: Some(620), // genuine cumulative total
             cumulative_cost_usd: None,
             model: None,
@@ -6205,8 +6208,8 @@ mod tests {
             turn_output_tokens: Some(60),
             turn_total_tokens: None, // provider did not supply a total
             turn_cost_usd: None,
-            cumulative_input_tokens: 200,
-            cumulative_output_tokens: 60,
+            cumulative_input_tokens: Some(200),
+            cumulative_output_tokens: Some(60),
             cumulative_total_tokens: None, // session has no total
             cumulative_cost_usd: None,
             model: None,

--- a/crates/buzz-acp/src/usage.rs
+++ b/crates/buzz-acp/src/usage.rs
@@ -404,6 +404,15 @@ impl UsageTracker {
     /// 3. **In-flight for another session** (`in_flight_session == Some(other)`):
     ///    ignored entirely — touching this session's baseline while another is
     ///    in-flight would undercount this session's next published delta.
+    ///
+    /// `pending` is replaced wholesale, so a frame reporting fewer counters than
+    /// its predecessor narrows the record. That is safe because a session is
+    /// served by exactly one wire format: goose only sends the extension because
+    /// we ask for it (`_meta.goose.customNotifications` in
+    /// `build_client_capabilities`), and the ACP-native harnesses never send it.
+    /// Should a harness ever emit both formats within one turn, a cost-only
+    /// standard frame would blank the token counters of a preceding goose frame,
+    /// and this would need to merge per counter instead of replacing.
     pub(crate) fn record(&mut self, session_id: &str, snapshot: &UsageSnapshot) {
         if !snapshot.has_any_counter() {
             // Nothing NIP-AM can carry. Returning early also protects the
@@ -1439,6 +1448,104 @@ mod tests {
         assert!(
             (d - 0.20).abs() < 1e-9,
             "delta must run from the surviving 0.10 baseline, got {d}"
+        );
+    }
+
+    /// claude-agent-acp emits several `usage_update` frames per turn. As on the
+    /// goose path, the last one wins on cumulative values, the delta is measured
+    /// from the previous *published* turn rather than an intermediate frame, and
+    /// `turn_seq` advances once per publish.
+    #[test]
+    fn acp_multiple_notifications_in_one_turn_last_one_wins() {
+        let mut tracker = UsageTracker::default();
+        tracker.begin_turn("acp-multi");
+        tracker.record("acp-multi", &acp_snapshot(Some(0.10)));
+        let t1 = tracker.take().expect("turn 1");
+        assert_eq!(t1.turn_seq, 1);
+
+        tracker.begin_turn("acp-multi");
+        tracker.record("acp-multi", &acp_snapshot(Some(0.18)));
+        tracker.record("acp-multi", &acp_snapshot(Some(0.30)));
+        let usage = tracker.take().expect("turn 2");
+
+        assert_eq!(usage.cumulative_cost_usd, Some(0.30), "last frame wins");
+        let d = usage.turn_cost_usd.expect("cost delta");
+        assert!(
+            (d - 0.20).abs() < 1e-9,
+            "delta must run from the 0.10 baseline, not the 0.18 intermediate; got {d}"
+        );
+        assert_eq!(usage.turn_seq, 2, "seq advances per publish, not per frame");
+    }
+
+    /// A cumulative cost that goes backwards is a reset or a harness bug. Per
+    /// NIP-AM the whole `turn` object is nulled, not just the cost.
+    #[test]
+    fn acp_cost_decrease_nulls_all_turn_fields() {
+        let mut tracker = UsageTracker::default();
+        tracker.begin_turn("acp-back");
+        tracker.record("acp-back", &acp_snapshot(Some(0.50)));
+        let _ = tracker.take();
+
+        tracker.begin_turn("acp-back");
+        tracker.record("acp-back", &acp_snapshot(Some(0.20)));
+        let usage = tracker.take().expect("turn 2");
+
+        assert!(!usage.delta_reliable, "a cost decrease is not reliable");
+        assert!(usage.turn_cost_usd.is_none());
+        assert!(usage.turn_input_tokens.is_none());
+        assert!(usage.turn_output_tokens.is_none());
+        // The cumulative snapshot is still reported as observed.
+        assert_eq!(usage.cumulative_cost_usd, Some(0.20));
+    }
+
+    /// A late frame for session B while session A is in-flight must not touch
+    /// B's committed baseline — doing so would undercount B's next delta.
+    /// Mirrors the goose-path regression on cross-session corruption.
+    #[test]
+    fn acp_notification_for_other_session_while_in_flight_is_ignored() {
+        let mut tracker = UsageTracker::default();
+        // Establish a baseline for B, then leave it idle.
+        tracker.begin_turn("acp-b");
+        tracker.record("acp-b", &acp_snapshot(Some(0.10)));
+        let _ = tracker.take();
+
+        // A is in-flight; a straggler frame for B arrives.
+        tracker.begin_turn("acp-a");
+        tracker.record("acp-b", &acp_snapshot(Some(0.90)));
+        assert!(
+            tracker.pending.is_none(),
+            "a frame for another session must not become A's pending record"
+        );
+
+        // B's next real turn still measures from 0.10, not from the straggler.
+        tracker.begin_turn("acp-b");
+        tracker.record("acp-b", &acp_snapshot(Some(0.25)));
+        let usage = tracker.take().expect("B turn 2");
+        let d = usage.turn_cost_usd.expect("cost delta");
+        assert!(
+            (d - 0.15).abs() < 1e-9,
+            "B's baseline must be untouched by the straggler; got {d}"
+        );
+    }
+
+    /// Frames that arrive before any `begin_turn` (session setup) advance the
+    /// baseline but must not produce a publishable record for the next turn.
+    #[test]
+    fn acp_setup_notification_before_begin_turn_advances_baseline_only() {
+        let mut tracker = UsageTracker::default();
+        tracker.record("acp-setup", &acp_snapshot(Some(0.05)));
+        assert!(
+            tracker.pending.is_none(),
+            "no turn in flight → nothing publishable"
+        );
+
+        tracker.begin_turn("acp-setup");
+        tracker.record("acp-setup", &acp_snapshot(Some(0.12)));
+        let usage = tracker.take().expect("first real turn");
+        let d = usage.turn_cost_usd.expect("cost delta");
+        assert!(
+            (d - 0.07).abs() < 1e-9,
+            "the setup frame must have seeded the baseline; got {d}"
         );
     }
 

--- a/crates/buzz-acp/src/usage.rs
+++ b/crates/buzz-acp/src/usage.rs
@@ -1,14 +1,25 @@
 //! Usage tracking for NIP-AM agent turn metrics.
 //!
-//! Agents that support usage reporting emit a `_goose/unstable/session/update`
-//! notification (with `sessionUpdate: "usage_update"`) at the end of every
-//! turn.  Both goose and buzz-agent use this same wire format.  The payload
-//! carries session-cumulative token counts from which we derive per-turn
-//! deltas.
+//! Agents report usage at the end of every turn through one of two wire
+//! formats, both normalized into a [`UsageSnapshot`] before tracking:
+//!
+//! * **goose / buzz-agent** — a `_goose/unstable/session/update` notification
+//!   (with `sessionUpdate: "usage_update"`) carrying session-cumulative token
+//!   counts and an optional cumulative cost.
+//! * **standard ACP** — a core `session/update` notification carrying the
+//!   `usage_update` variant. Agents built on the ACP SDK (claude-agent-acp,
+//!   codex-acp) speak only this one. It reports `used`/`size` (a *context
+//!   window* snapshot, not a running total) and an optional cumulative
+//!   `cost` — the protocol has no cumulative input/output token split, so
+//!   those counters stay unknown for these harnesses.
+//!
+//! Unknown counters are `None` end to end and reach the wire as JSON `null`.
+//! NIP-AM is explicit that a null must never be recorded or summed as zero, so
+//! nothing here substitutes a default for a counter the harness did not send.
 //!
 //! # Delta computation
 //!
-//! Because goose only reports cumulative counters, the per-turn counts are
+//! Because harnesses only report cumulative counters, the per-turn counts are
 //! computed as `current − previous`. Three cases require special handling per
 //! NIP-AM:
 //!
@@ -19,7 +30,7 @@
 //! 3. **Session restart** (caller supplies a new `session_id` not seen
 //!    before): treated as case 1 — fresh baseline, no delta for this turn.
 //!
-//! Goose may emit **multiple** `usage_update` notifications per turn. The
+//! A harness may emit **multiple** `usage_update` notifications per turn. The
 //! tracker handles this correctly: the committed baseline (and `turn_seq`)
 //! advance only when `take()` is called (i.e. at publish time), never on
 //! individual notifications. Within a turn all notifications measure their
@@ -106,6 +117,141 @@ pub(crate) struct UsageUpdatePayload {
     pub model: Option<String>,
 }
 
+/// Wire-format deserialization for a standard ACP `session/update` params
+/// object.
+///
+/// Method: `session/update` (ACP core — *not* the goose extension)
+/// Shape (camelCase on the wire):
+/// ```json
+/// {
+///   "sessionId": "...",
+///   "update": {
+///     "sessionUpdate": "usage_update",
+///     "used": 15247,
+///     "size": 200000,
+///     "cost": { "amount": 0.0234, "currency": "USD" }
+///   }
+/// }
+/// ```
+///
+/// Agents built on the ACP SDK emit this instead of the goose extension.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AcpSessionUpdateNotification {
+    pub session_id: String,
+    pub update: AcpSessionUpdateVariant,
+}
+
+/// Discriminated union over the ACP `SessionUpdate` variants. Only
+/// `usage_update` carries usage; everything else is handled elsewhere.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(tag = "sessionUpdate", rename_all = "snake_case")]
+pub(crate) enum AcpSessionUpdateVariant {
+    UsageUpdate(AcpUsageUpdatePayload),
+    #[serde(other)]
+    Other,
+}
+
+/// The standard ACP `usage_update` payload (`UsageUpdate` in the ACP schema).
+///
+/// Every field is optional here even though the schema requires `used` and
+/// `size`: a usage notification is best-effort observability data, and a
+/// harness that omits a field should still contribute whatever it did send.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AcpUsageUpdatePayload {
+    /// Tokens currently in context. This is a **context-window snapshot**, not
+    /// a cumulative counter — it falls as often as it rises (compaction), so it
+    /// must never be diffed into a per-turn token count. Logged only.
+    #[serde(default)]
+    pub used: u64,
+    /// Total context window size in tokens. Logged only.
+    #[serde(default)]
+    pub size: u64,
+    /// Cumulative session cost. The only counter in the standard payload that
+    /// NIP-AM can consume.
+    #[serde(default)]
+    pub cost: Option<AcpCost>,
+}
+
+/// The ACP `Cost` object.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub(crate) struct AcpCost {
+    /// Total cumulative cost for the session.
+    pub amount: f64,
+    /// ISO 4217 currency code. Retained for logging and for a future
+    /// non-USD guard; NIP-AM `costUsd` is USD by definition.
+    #[allow(dead_code)]
+    pub currency: String,
+}
+
+/// A harness-agnostic cumulative usage snapshot — the single input to
+/// [`UsageTracker::record`].
+///
+/// Each counter is independently optional: `None` means "this harness did not
+/// report it", which NIP-AM requires be published as `null` rather than `0`.
+/// goose and buzz-agent fill the token counters; standard-ACP harnesses fill
+/// only `cost_usd`.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct UsageSnapshot {
+    /// Session-cumulative input tokens, cache reads folded in.
+    pub input_tokens: Option<u64>,
+    /// Session-cumulative output tokens.
+    pub output_tokens: Option<u64>,
+    /// Session-cumulative provider-reported total tokens. Never derived by
+    /// summing input and output (NIP-AM forbids it).
+    pub total_tokens: Option<u64>,
+    /// Session-cumulative estimated cost in USD.
+    pub cost_usd: Option<f64>,
+    /// Effective model id for this turn.
+    pub model: Option<String>,
+}
+
+impl UsageSnapshot {
+    /// Whether the harness reported at least one counter NIP-AM can carry.
+    ///
+    /// Notifications that fail this test are dropped by `record`: NIP-AM
+    /// forbids publishing a metric whose counters are all unknown, and an
+    /// empty snapshot must not overwrite a baseline built from real ones.
+    /// Standard-ACP harnesses emit exactly such counter-free notifications —
+    /// claude-agent-acp sends a bare `{used, size}` on context-window changes.
+    fn has_any_counter(&self) -> bool {
+        self.input_tokens.is_some()
+            || self.output_tokens.is_some()
+            || self.total_tokens.is_some()
+            || self.cost_usd.is_some()
+    }
+}
+
+impl From<&UsageUpdatePayload> for UsageSnapshot {
+    fn from(p: &UsageUpdatePayload) -> Self {
+        Self {
+            input_tokens: Some(p.accumulated_input_tokens),
+            output_tokens: Some(p.accumulated_output_tokens),
+            total_tokens: p.accumulated_total_tokens,
+            cost_usd: p.accumulated_cost,
+            model: p.model.clone(),
+        }
+    }
+}
+
+impl From<&AcpUsageUpdatePayload> for UsageSnapshot {
+    fn from(p: &AcpUsageUpdatePayload) -> Self {
+        Self {
+            // The standard payload has no cumulative token split. `used` is a
+            // context snapshot and `size` a window size; neither is a running
+            // total, so both stay out of the tracker.
+            input_tokens: None,
+            output_tokens: None,
+            total_tokens: None,
+            cost_usd: p.cost.as_ref().map(|c| c.amount),
+            // The standard payload carries no model id; `pool.rs` publishes
+            // `model: null` for these harnesses.
+            model: None,
+        }
+    }
+}
+
 /// Per-session normalization state: the last cumulative snapshot we saw.
 #[derive(Debug, Clone)]
 struct SessionState {
@@ -116,9 +262,11 @@ struct SessionState {
     published_seq: u64,
     /// Cumulative input tokens at the end of the LAST PUBLISHED turn.
     /// Advanced only on publish (i.e. in `take()`), not on every notification.
-    last_input: u64,
+    /// `None` when the harness does not report token counters at all.
+    last_input: Option<u64>,
     /// Cumulative output tokens at the end of the LAST PUBLISHED turn.
-    last_output: u64,
+    /// `None` when the harness does not report token counters at all.
+    last_output: Option<u64>,
     /// Cumulative cost at the end of the LAST PUBLISHED turn.
     last_cost: Option<f64>,
     /// Cumulative total tokens at the end of the LAST PUBLISHED turn.
@@ -151,10 +299,12 @@ pub struct TurnUsage {
     /// Per-turn cost delta (`current − previous`); `None` when unreliable or
     /// either snapshot is missing.
     pub turn_cost_usd: Option<f64>,
-    /// Session-cumulative input tokens as reported by goose at end of turn.
-    pub cumulative_input_tokens: u64,
-    /// Session-cumulative output tokens as reported by goose at end of turn.
-    pub cumulative_output_tokens: u64,
+    /// Session-cumulative input tokens as reported at end of turn; `None` when
+    /// the harness does not report token counters (standard ACP).
+    pub cumulative_input_tokens: Option<u64>,
+    /// Session-cumulative output tokens as reported at end of turn; `None` when
+    /// the harness does not report token counters (standard ACP).
+    pub cumulative_output_tokens: Option<u64>,
     /// Session-cumulative genuine provider total tokens as reported by buzz-agent;
     /// `None` when the session has never emitted one or any turn lacked one.
     pub cumulative_total_tokens: Option<u64>,
@@ -163,6 +313,26 @@ pub struct TurnUsage {
     /// Effective model id for this turn (maps to NIP-AM `model`). `None` if the
     /// harness did not include the model in its usage notification.
     pub model: Option<String>,
+}
+
+/// Per-turn delta for a cumulative counter.
+///
+/// `None` when either snapshot is absent — unknown, which NIP-AM publishes as
+/// null — or when the counter went backwards (the caller nulls the whole turn
+/// object in that case; this guard only keeps the subtraction from wrapping).
+fn delta(current: Option<u64>, previous: Option<u64>) -> Option<u64> {
+    match (current, previous) {
+        (Some(c), Some(p)) if c >= p => Some(c - p),
+        _ => None,
+    }
+}
+
+/// Whether a cumulative counter went backwards between two snapshots.
+///
+/// A counter absent on either side is unknown, not a decrease — a harness that
+/// never reports tokens must not be treated as one whose tokens reset.
+fn decreased<T: PartialOrd>(current: Option<T>, previous: Option<T>) -> bool {
+    matches!((current, previous), (Some(c), Some(p)) if c < p)
 }
 
 /// Tracks per-session cumulative usage state across turns.
@@ -175,8 +345,8 @@ pub struct TurnUsage {
 ///    notifications that arrive *before* the first `begin_turn` (e.g. during
 ///    `session/new` setup) will still update the cumulative baseline but will
 ///    NOT produce a publishable record.
-/// 2. **`record(session_id, payload)`** — called for each
-///    `_goose/unstable/session/update` notification. When in-flight, updates
+/// 2. **`record(session_id, snapshot)`** — called for each `usage_update`
+///    notification, in either wire format. When in-flight, updates
 ///    `pending` with the latest cumulative values and a delta measured from
 ///    the committed baseline (end of the previous published turn). Multiple
 ///    notifications per turn are fine — the last one wins and `turn_seq` stays
@@ -234,11 +404,20 @@ impl UsageTracker {
     /// 3. **In-flight for another session** (`in_flight_session == Some(other)`):
     ///    ignored entirely — touching this session's baseline while another is
     ///    in-flight would undercount this session's next published delta.
-    pub(crate) fn record(&mut self, session_id: &str, payload: &UsageUpdatePayload) {
-        let current_input = payload.accumulated_input_tokens;
-        let current_output = payload.accumulated_output_tokens;
-        let current_cost = payload.accumulated_cost;
-        let current_total = payload.accumulated_total_tokens;
+    pub(crate) fn record(&mut self, session_id: &str, snapshot: &UsageSnapshot) {
+        if !snapshot.has_any_counter() {
+            // Nothing NIP-AM can carry. Returning early also protects the
+            // committed baseline: standard-ACP harnesses interleave bare
+            // `{used, size}` notifications with the ones that carry cost, and
+            // treating those as a snapshot would wipe the cost baseline and
+            // make the next turn's delta unreliable.
+            return;
+        }
+
+        let current_input = snapshot.input_tokens;
+        let current_output = snapshot.output_tokens;
+        let current_cost = snapshot.cost_usd;
+        let current_total = snapshot.total_tokens;
 
         // Determine whether this session is currently in-flight so we know
         // whether to set `pending`. We compute the delta regardless so that
@@ -256,29 +435,28 @@ impl UsageTracker {
                     // *published* seq — constant for all notifications in this
                     // turn, advanced only on publish.
                     let seq = prev.published_seq + 1;
-                    // Token counter decrease → unreliable delta.
-                    if current_input < prev.last_input || current_output < prev.last_output {
+                    // A counter that went *backwards* is a reset or a harness
+                    // bug. NIP-AM: negative delta ⇒ delta_reliable false and
+                    // every turn field nulled — not just the counter at fault.
+                    // A counter absent on either side is merely unknown, which
+                    // is field-local and leaves the others reliable.
+                    let any_decreased = decreased(current_input, prev.last_input)
+                        || decreased(current_output, prev.last_output)
+                        || decreased(current_cost, prev.last_cost);
+                    if any_decreased {
                         (false, None, None, None, seq)
                     } else {
-                        let di = current_input - prev.last_input;
-                        let dout = current_output - prev.last_output;
-                        // Cost delta: only when both snapshots have cost.
-                        // A cost *decrease* is also unreliable (NIP-AM: negative
-                        // delta ⇒ delta_reliable false, null all turn fields).
-                        let (dc, cost_reliable) = match (current_cost, prev.last_cost) {
-                            (Some(c), Some(p)) if c >= p => (Some(c - p), true),
-                            (Some(_), Some(_)) => {
-                                // Both present but current < prev — counter decreased.
-                                (None, false)
-                            }
-                            _ => (None, true), // absent on either side: null cost, reliable tokens
+                        let dc = match (current_cost, prev.last_cost) {
+                            (Some(c), Some(p)) => Some(c - p),
+                            _ => None,
                         };
-                        if cost_reliable {
-                            (true, Some(di), Some(dout), dc, seq)
-                        } else {
-                            // Cost decrease overrides the whole record to unreliable.
-                            (false, None, None, None, seq)
-                        }
+                        (
+                            true,
+                            delta(current_input, prev.last_input),
+                            delta(current_output, prev.last_output),
+                            dc,
+                            seq,
+                        )
                     }
                 }
             };
@@ -309,7 +487,7 @@ impl UsageTracker {
                 cumulative_output_tokens: current_output,
                 cumulative_total_tokens: current_total,
                 cumulative_cost_usd: current_cost,
-                model: payload.model.clone(),
+                model: snapshot.model.clone(),
             });
         } else if self.in_flight_session.is_none() {
             // Not in-flight at all: advance the committed baseline so the next
@@ -396,8 +574,11 @@ mod tests {
         assert_eq!(p.accumulated_cached_input_tokens, 0);
     }
 
-    fn payload(input: u64, output: u64, cost: Option<f64>) -> UsageUpdatePayload {
-        UsageUpdatePayload {
+    /// A goose-shaped payload, normalized the way the production handler does.
+    /// Building the wire struct (rather than a `UsageSnapshot` literal) keeps
+    /// these tests exercising the goose → snapshot conversion.
+    fn payload(input: u64, output: u64, cost: Option<f64>) -> UsageSnapshot {
+        UsageSnapshot::from(&UsageUpdatePayload {
             used: input + output,
             context_limit: 200_000,
             accumulated_input_tokens: input,
@@ -406,11 +587,11 @@ mod tests {
             accumulated_cost: cost,
             accumulated_total_tokens: None,
             model: None,
-        }
+        })
     }
 
-    fn payload_no_context(input: u64, output: u64, cost: Option<f64>) -> UsageUpdatePayload {
-        UsageUpdatePayload {
+    fn payload_no_context(input: u64, output: u64, cost: Option<f64>) -> UsageSnapshot {
+        UsageSnapshot::from(&UsageUpdatePayload {
             used: 0,
             context_limit: 0,
             accumulated_input_tokens: input,
@@ -419,7 +600,7 @@ mod tests {
             accumulated_cost: cost,
             accumulated_total_tokens: None,
             model: None,
-        }
+        })
     }
 
     // ── Turn scoping: setup notifications must not pollute the first real turn ─
@@ -495,7 +676,7 @@ mod tests {
         let a1 = tracker.take().expect("A turn 1");
         assert_eq!(a1.turn_seq, 1);
         assert!(!a1.delta_reliable, "first turn is unreliable");
-        assert_eq!(a1.cumulative_input_tokens, 1000);
+        assert_eq!(a1.cumulative_input_tokens, Some(1000));
 
         // ── B is now in-flight; A late notification arrives ──
         tracker.begin_turn("sess-b");
@@ -528,8 +709,8 @@ mod tests {
              late cross-session advance (500)"
         );
         assert_eq!(a2.turn_output_tokens, Some(150));
-        assert_eq!(a2.cumulative_input_tokens, 2000);
-        assert_eq!(a2.cumulative_output_tokens, 250);
+        assert_eq!(a2.cumulative_input_tokens, Some(2000));
+        assert_eq!(a2.cumulative_output_tokens, Some(250));
     }
 
     // ── Delta computation: non-happy paths ─────────────────────────────────
@@ -551,8 +732,8 @@ mod tests {
         assert!(usage.turn_output_tokens.is_none());
         assert!(usage.turn_cost_usd.is_none());
         // Cumulative is still populated.
-        assert_eq!(usage.cumulative_input_tokens, 1000);
-        assert_eq!(usage.cumulative_output_tokens, 200);
+        assert_eq!(usage.cumulative_input_tokens, Some(1000));
+        assert_eq!(usage.cumulative_output_tokens, Some(200));
         assert_eq!(usage.cumulative_cost_usd, Some(0.01));
     }
 
@@ -608,8 +789,8 @@ mod tests {
         assert!(usage.turn_output_tokens.is_none());
         assert!(usage.turn_cost_usd.is_none());
         // Cumulative values are unaffected.
-        assert_eq!(usage.cumulative_input_tokens, 1500);
-        assert_eq!(usage.cumulative_output_tokens, 350);
+        assert_eq!(usage.cumulative_input_tokens, Some(1500));
+        assert_eq!(usage.cumulative_output_tokens, Some(350));
         assert_eq!(usage.cumulative_cost_usd, Some(0.05));
     }
 
@@ -680,8 +861,8 @@ mod tests {
         // cost delta: 0.018 - 0.01 = 0.008 (floating-point; use approx check)
         let dc = usage.turn_cost_usd.expect("cost delta present");
         assert!((dc - 0.008).abs() < 1e-9, "cost delta: {dc}");
-        assert_eq!(usage.cumulative_input_tokens, 1800);
-        assert_eq!(usage.cumulative_output_tokens, 450);
+        assert_eq!(usage.cumulative_input_tokens, Some(1800));
+        assert_eq!(usage.cumulative_output_tokens, Some(450));
     }
 
     #[test]
@@ -718,8 +899,8 @@ mod tests {
         let usage = tracker.take().expect("turn 2");
 
         // Cumulative from the last notification.
-        assert_eq!(usage.cumulative_input_tokens, 2000);
-        assert_eq!(usage.cumulative_output_tokens, 250);
+        assert_eq!(usage.cumulative_input_tokens, Some(2000));
+        assert_eq!(usage.cumulative_output_tokens, Some(250));
         // Delta is from committed baseline (1000, 100) → (2000, 250) = 1000/150.
         assert_eq!(usage.turn_input_tokens, Some(1000));
         assert_eq!(usage.turn_output_tokens, Some(150));
@@ -852,17 +1033,17 @@ mod tests {
         tracker.begin_turn("buzz-s1");
         let notif1: GooseSessionUpdateNotification = serde_json::from_value(raw1).expect("deser");
         if let GooseSessionUpdateVariant::UsageUpdate(p) = notif1.update {
-            tracker.record("buzz-s1", &p);
+            tracker.record("buzz-s1", &UsageSnapshot::from(&p));
         }
         let t1 = tracker.take().expect("turn 1");
         assert!(!t1.delta_reliable, "first turn: unreliable");
-        assert_eq!(t1.cumulative_input_tokens, 300);
+        assert_eq!(t1.cumulative_input_tokens, Some(300));
 
         // Turn 2 — delta reliable.
         tracker.begin_turn("buzz-s1");
         let notif2: GooseSessionUpdateNotification = serde_json::from_value(raw2).expect("deser");
         if let GooseSessionUpdateVariant::UsageUpdate(p) = notif2.update {
-            tracker.record("buzz-s1", &p);
+            tracker.record("buzz-s1", &UsageSnapshot::from(&p));
         }
         let t2 = tracker.take().expect("turn 2");
         assert!(t2.delta_reliable, "second turn: reliable");
@@ -907,8 +1088,8 @@ mod tests {
         output: u64,
         cost: Option<f64>,
         model: Option<&str>,
-    ) -> UsageUpdatePayload {
-        UsageUpdatePayload {
+    ) -> UsageSnapshot {
+        UsageSnapshot::from(&UsageUpdatePayload {
             used: input + output,
             context_limit: 200_000,
             accumulated_input_tokens: input,
@@ -917,7 +1098,7 @@ mod tests {
             accumulated_cost: cost,
             accumulated_total_tokens: None,
             model: model.map(str::to_string),
-        }
+        })
     }
 
     #[test]
@@ -961,7 +1142,7 @@ mod tests {
         // And it should produce a TurnUsage with model = None.
         let mut tracker = UsageTracker::default();
         tracker.begin_turn("sess-goose-compat");
-        tracker.record("sess-goose-compat", &payload);
+        tracker.record("sess-goose-compat", &UsageSnapshot::from(&payload));
         let usage = tracker.take().expect("pending");
         assert!(
             usage.model.is_none(),
@@ -971,8 +1152,8 @@ mod tests {
 
     // ── accumulatedTotalTokens: field-local delta, session poisoning ───────
 
-    fn payload_with_total(input: u64, output: u64, total: Option<u64>) -> UsageUpdatePayload {
-        UsageUpdatePayload {
+    fn payload_with_total(input: u64, output: u64, total: Option<u64>) -> UsageSnapshot {
+        UsageSnapshot::from(&UsageUpdatePayload {
             used: input + output,
             context_limit: 200_000,
             accumulated_input_tokens: input,
@@ -981,7 +1162,7 @@ mod tests {
             accumulated_cost: None,
             accumulated_total_tokens: total,
             model: None,
-        }
+        })
     }
 
     #[test]
@@ -1104,7 +1285,7 @@ mod tests {
         // And it must flow through the tracker correctly.
         let mut tracker = UsageTracker::default();
         tracker.begin_turn("sess-goose-nototal");
-        tracker.record("sess-goose-nototal", &payload);
+        tracker.record("sess-goose-nototal", &UsageSnapshot::from(&payload));
         let usage = tracker.take().expect("pending");
         assert!(
             usage.cumulative_total_tokens.is_none(),
@@ -1131,5 +1312,154 @@ mod tests {
             "absent baseline total → turn total null even when current has a total"
         );
         assert_eq!(usage.cumulative_total_tokens, Some(250));
+    }
+
+    // ── Standard ACP wire format ──────────────────────────────────────────
+
+    /// The exact frame claude-agent-acp puts on the wire must deserialize.
+    /// A field-name drift here is invisible at runtime — `record` never sees
+    /// the payload and the harness silently stops publishing metrics.
+    #[test]
+    fn acp_usage_update_deserializes_from_the_wire_shape() {
+        let notif: AcpSessionUpdateNotification = serde_json::from_value(serde_json::json!({
+            "sessionId": "sess-acp",
+            "update": {
+                "sessionUpdate": "usage_update",
+                "used": 15_247,
+                "size": 200_000,
+                "cost": { "amount": 0.0234, "currency": "USD" },
+            }
+        }))
+        .expect("standard ACP usage_update must deserialize");
+        assert_eq!(notif.session_id, "sess-acp");
+        let AcpSessionUpdateVariant::UsageUpdate(p) = notif.update else {
+            panic!("expected the usage_update variant");
+        };
+        assert_eq!(p.used, 15_247);
+        assert_eq!(p.size, 200_000);
+        assert_eq!(p.cost.as_ref().map(|c| c.amount), Some(0.0234));
+    }
+
+    /// Non-usage variants must deserialize into `Other` rather than erroring —
+    /// every `session/update` frame passes through this parse.
+    #[test]
+    fn acp_non_usage_variant_deserializes_as_other() {
+        let notif: AcpSessionUpdateNotification = serde_json::from_value(serde_json::json!({
+            "sessionId": "sess-acp",
+            "update": { "sessionUpdate": "agent_message_chunk",
+                        "content": { "text": "hello" } }
+        }))
+        .expect("non-usage variants must not fail the parse");
+        assert!(matches!(notif.update, AcpSessionUpdateVariant::Other));
+    }
+
+    /// The standard payload carries no cumulative token split. Mapping `used`
+    /// into a token counter would be wrong — it is a context snapshot that
+    /// falls on compaction — so the snapshot leaves tokens unknown.
+    #[test]
+    fn acp_snapshot_carries_cost_only() {
+        let p = AcpUsageUpdatePayload {
+            used: 15_247,
+            size: 200_000,
+            cost: Some(AcpCost {
+                amount: 0.0234,
+                currency: "USD".to_string(),
+            }),
+        };
+        assert_eq!(
+            UsageSnapshot::from(&p),
+            UsageSnapshot {
+                input_tokens: None,
+                output_tokens: None,
+                total_tokens: None,
+                cost_usd: Some(0.0234),
+                model: None,
+            }
+        );
+    }
+
+    fn acp_snapshot(cost: Option<f64>) -> UsageSnapshot {
+        UsageSnapshot::from(&AcpUsageUpdatePayload {
+            used: 10_000,
+            size: 200_000,
+            cost: cost.map(|amount| AcpCost {
+                amount,
+                currency: "USD".to_string(),
+            }),
+        })
+    }
+
+    /// A cost-only harness still produces usable per-turn metrics: the cost
+    /// delta is reliable from the second turn on, and the token fields stay
+    /// null rather than being reported as zero (NIP-AM).
+    #[test]
+    fn acp_cost_only_second_turn_delta_is_reliable_with_null_tokens() {
+        let mut tracker = UsageTracker::default();
+
+        tracker.begin_turn("acp-s1");
+        tracker.record("acp-s1", &acp_snapshot(Some(0.10)));
+        let t1 = tracker.take().expect("turn 1");
+        assert!(!t1.delta_reliable, "first turn has no baseline");
+        assert_eq!(t1.cumulative_cost_usd, Some(0.10));
+
+        tracker.begin_turn("acp-s1");
+        tracker.record("acp-s1", &acp_snapshot(Some(0.25)));
+        let t2 = tracker.take().expect("turn 2");
+        assert!(t2.delta_reliable, "baseline observed, nothing decreased");
+        let d = t2.turn_cost_usd.expect("cost delta");
+        assert!((d - 0.15).abs() < 1e-9, "expected 0.15, got {d}");
+        assert_eq!(t2.turn_input_tokens, None);
+        assert_eq!(t2.turn_output_tokens, None);
+        assert_eq!(t2.cumulative_input_tokens, None);
+        assert_eq!(t2.cumulative_output_tokens, None);
+    }
+
+    /// A snapshot with no NIP-AM counter at all is dropped: it must neither
+    /// produce a publishable record (NIP-AM forbids an all-null metric) nor
+    /// overwrite the baseline that real snapshots established.
+    #[test]
+    fn counter_free_snapshot_is_dropped_and_preserves_the_baseline() {
+        let mut tracker = UsageTracker::default();
+
+        tracker.begin_turn("acp-s2");
+        tracker.record("acp-s2", &acp_snapshot(Some(0.10)));
+        let _ = tracker.take();
+
+        tracker.begin_turn("acp-s2");
+        tracker.record("acp-s2", &acp_snapshot(None));
+        assert!(
+            tracker.take().is_none(),
+            "no counters → nothing to publish for this turn"
+        );
+
+        tracker.begin_turn("acp-s2");
+        tracker.record("acp-s2", &acp_snapshot(Some(0.30)));
+        let t3 = tracker.take().expect("turn 3");
+        let d = t3.turn_cost_usd.expect("cost delta");
+        assert!(
+            (d - 0.20).abs() < 1e-9,
+            "delta must run from the surviving 0.10 baseline, got {d}"
+        );
+    }
+
+    /// A harness that reports tokens must keep working exactly as before when
+    /// a counter it never sends is absent — absence is field-local and must not
+    /// mark the record unreliable.
+    #[test]
+    fn absent_counter_does_not_make_the_record_unreliable() {
+        let mut tracker = UsageTracker::default();
+        tracker.begin_turn("mixed");
+        tracker.record("mixed", &payload(1000, 200, None));
+        let _ = tracker.take();
+
+        tracker.begin_turn("mixed");
+        tracker.record("mixed", &payload(1800, 450, None));
+        let usage = tracker.take().expect("turn 2");
+        assert!(
+            usage.delta_reliable,
+            "a never-reported cost must not flip delta_reliable"
+        );
+        assert_eq!(usage.turn_input_tokens, Some(800));
+        assert!(usage.turn_cost_usd.is_none());
     }
 }


### PR DESCRIPTION
## Summary

NIP-AM turn metrics (kind 44200) are only ever published for goose and buzz-agent. Agents running a harness that speaks core ACP — `claude-agent-acp`, `codex-acp` — never publish one, and nothing anywhere says so.

Found while debugging an empty local turn-metric archive: the `owner_p` / `[44200]` save subscription was active for three days against a fleet of `claude-agent-acp` agents and archived zero events.

There are two independent breaks on the emit path, and both fail silently.

**1 — Routing.** `UsageTracker::record` has a single call site, reached only from the `_goose/unstable/session/update` match arm (`acp.rs`). Standard ACP agents send `usage_update` as a variant inside a core `session/update`, which lands in `handle_session_update`, is used for display, and is dropped.

**2 — Payload shape.** `UsageUpdatePayload` requires `accumulatedInputTokens` and `accumulatedOutputTokens`. The ACP `UsageUpdate` schema has neither — it carries `used`, `size` and an optional `cost` object — so even a correctly routed notification fails deserialization.

Both paths log at `debug`. `take_turn_usage` then returns `None` at turn completion and `publish_agent_turn_metric` early-returns without logging, so the failure produces no warning at any level: the agent logs look completely healthy.

### What this changes

Both wire formats normalize into a `UsageSnapshot` whose counters are independently optional, fed from a new `handle_acp_usage_update` on the `session/update` arm.

Token counters become `Option` end to end. The standard ACP payload has no cumulative token split — `used` is a context-window snapshot that falls on compaction, not a running total — so mapping it into a token counter would be wrong. Those fields stay null, which is what NIP-AM asks for ("a null MUST NOT be recorded or summed as zero"). The cumulative `cost` the standard payload does carry now produces real per-turn deltas.

A snapshot with no NIP-AM counter at all is dropped, for two reasons: NIP-AM forbids publishing an all-null metric, and `claude-agent-acp` interleaves bare `{used, size}` frames on context changes that would otherwise wipe the cost baseline and make the next delta unreliable.

The goose path is behaviourally unchanged — its snapshots fill every counter, so the delta and reliability rules resolve exactly as before. The `goose_usage` field is renamed to `usage`, since it is no longer goose-specific.

### Known gap

`codex-acp` sends `{used, size}` with no `cost`, so it still publishes nothing — its wire format exposes no counter NIP-AM can carry. Closing that needs a protocol-level addition (cumulative token counters in `UsageUpdate`, or a `_meta` extension), which felt out of scope here.

### Related issue

None found — searched open and closed issues/PRs for `usage_update`, `44200` and NIP-AM metric reports.

### Testing

`cargo test -p buzz-acp --lib` — 667 pass, 0 fail (18 new).
`cargo clippy --workspace --all-targets -- -D warnings` — clean.
`cargo fmt --all` — clean.

**Dispatch regression (the routing half of the bug).** Verified by mutation: deleting either `self.handle_acp_usage_update(&msg);` line makes exactly these two fail, and nothing else.

- `acp_usage_frame_dispatched_by_read_until_response`
- `acp_usage_frame_dispatched_by_idle_timeout_loop`

Both spawn an agent that emits a real `session/update` usage frame followed by the awaited JSON-RPC response, and drive it through the actual read loop rather than calling the handler directly.

**Cost-only wire shape** — what every standard-ACP harness now produces:

- `test_build_turn_metric_counts_cost_only_turn_nulls_every_token_field` — every token field null, cost preserved.
- `test_cost_only_payload_validates_and_serializes_tokens_as_null` — the assembled payload passes `validate()` and serializes tokens as explicit JSON `null`, never `0`.

**Tracker semantics on the ACP path**, mirroring the invariants already covered for goose:

- `acp_multiple_notifications_in_one_turn_last_one_wins`
- `acp_cost_decrease_nulls_all_turn_fields`
- `acp_notification_for_other_session_while_in_flight_is_ignored`
- `acp_setup_notification_before_begin_turn_advances_baseline_only`
- `acp_context_only_notification_does_not_clobber_the_cost_baseline`
- `counter_free_snapshot_is_dropped_and_preserves_the_baseline`
- `absent_counter_does_not_make_the_record_unreliable`

**Wire contract:**

- `acp_usage_update_deserializes_from_the_wire_shape`
- `acp_non_usage_variant_deserializes_as_other`
- `acp_non_usage_session_update_is_ignored`
- `acp_snapshot_carries_cost_only`
- `acp_usage_notification_recorded_and_take_returns_usage`
- `acp_usage_second_turn_produces_a_cost_delta`
- `acp_cost_only_second_turn_delta_is_reliable_with_null_tokens`

No UI change.
