### PR TITLE
fix(mobile): allow iOS local relay access

### DIFF
--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -43,8 +43,15 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Buzz needs camera access so you can take photos to attach to messages and scan QR codes for device pairing.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Buzz connects to self-hosted relays and pairs devices on your local network.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Buzz needs photo library access so you can attach images to messages.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/mobile/test/ios_network_permissions_test.dart
+++ b/mobile/test/ios_network_permissions_test.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('iOS permits self-hosted relays on the local network', () {
+    final plist = File('ios/Runner/Info.plist').readAsStringSync();
+
+    expect(plist, contains('<key>NSLocalNetworkUsageDescription</key>'));
+    expect(plist, contains('<key>NSAllowsLocalNetworking</key>'));
+  });
+}


### PR DESCRIPTION
## What changed

- declare why Buzz needs access to the iPhone's local network
- enable the scoped App Transport Security allowance for local-network resources
- add a regression test that guards both iOS manifest entries

## Why

Self-hosted Buzz instances can advertise a pairing relay at a private-LAN WebSocket URL. Desktop can connect and render the pairing QR code, but iOS rejects the target connection before it reaches the pairing relay when the app has not declared local-network access.

This keeps ATS enabled for public connections while allowing the local resources required by self-hosted relays and device pairing.

## User impact

iPhone users can approve Buzz's local-network prompt and connect to pairing relays and self-hosted Buzz relays on their LAN.

## Validation

- `plutil -lint mobile/ios/Runner/Info.plist`
- extracted `NSLocalNetworkUsageDescription` successfully
- extracted `NSAppTransportSecurity.NSAllowsLocalNetworking` as `true`
- `git diff --check`
- added `mobile/test/ios_network_permissions_test.dart`

The full Flutter suite was not run locally because Flutter and Dart are not installed on the available Mac or NUC; CI should run the complete mobile checks.
