### PR TITLE
Preserve owner p tag for self-authored engrams

### DIFF
--- a/crates/buzz-core/src/engram.rs
+++ b/crates/buzz-core/src/engram.rs
@@ -467,6 +467,9 @@ pub fn build_event(
 
     EventBuilder::new(Kind::Custom(KIND_AGENT_ENGRAM as u16), ciphertext)
         .tags(tags)
+        // NIP-AE requires `p` as the owner address even when owner == agent.
+        // rust-nostr otherwise strips author-matching `p` tags while signing.
+        .allow_self_tagging()
         .custom_created_at(nostr::Timestamp::from(created_at))
         .sign_with_keys(agent_keys)
         .map_err(|e| EngramError::Sign(e.to_string()))
@@ -829,6 +832,54 @@ mod tests {
         .unwrap();
         assert_eq!(decoded_agent, decoded);
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn build_event_addresses_self_and_cross_owner_with_one_p_tag() {
+        let agent = keys_from_hex(SECKEY_A);
+        let other_owner = keys_from_hex(SECKEY_O);
+        let body = Body::Memory {
+            slug: "mem/example".into(),
+            value: Some("owner-addressing-control".into()),
+        };
+
+        for owner in [agent.public_key(), other_owner.public_key()] {
+            let event = build_event(&agent, &owner, &body, 1_700_000_000).unwrap();
+            let p_values: Vec<_> = event
+                .tags
+                .iter()
+                .filter(|tag| tag.kind().to_string() == "p")
+                .filter_map(|tag| tag.content().map(str::to_owned))
+                .collect();
+
+            assert_eq!(p_values, vec![owner.to_hex()]);
+        }
+    }
+
+    #[test]
+    fn validate_and_decrypt_rejects_wrong_owner_p_tag() {
+        let agent = keys_from_hex(SECKEY_A);
+        let owner = keys_from_hex(SECKEY_O);
+        let wrong_owner = Keys::generate();
+        let body = Body::Memory {
+            slug: "mem/example".into(),
+            value: Some("wrong-owner-control".into()),
+        };
+        let event = build_event(&agent, &owner.public_key(), &body, 1_700_000_000).unwrap();
+
+        let err = validate_and_decrypt(
+            &event,
+            &agent.public_key(),
+            &wrong_owner.public_key(),
+            agent.secret_key(),
+            &owner.public_key(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            EngramError::InvalidEnvelope(ref message) if message == "p tag != expected_owner"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Root cause

Self-authored agent-engram events passed through tag normalization without preserving the owner `p` tag. The relay envelope requires exactly one `p` tag, so otherwise-valid self-owner memory writes were rejected with `agent-engram event must have exactly one p tag (got 0)`.

## Narrow fix

Preserve the owner `p` tag while normalizing self-authored engram tags. The reviewed change is limited to `crates/buzz-core/src/engram.rs` (51 insertions).

## Impact

Self-owner memory writes retain the required owner address while cross-owner behavior and unrelated event handling remain unchanged.

## Validation receipt

- Reviewed diff SHA-256: `b3fd1d655e5ed1b153d42c04c74fcdc8de6cc8786896df0a22b1d3c319ec745b`
- `cargo fmt`: passed
- `buzz-core`: 234 unit tests + 2 doc tests passed
- Clippy with warnings denied: passed
- Relay envelope controls: 12/12 passed

These checks were completed against the reviewed artifact before publication.

## Buzz provenance

- Channel: `5dec9298-aa5e-4532-9b5e-11c1b195b117`
- Thread root: `078de6f4714a3acaadd439201c04973914f5a9b99ed49a2cd78573c805bdd8c1`