### PR TITLE
fix(desktop): keep the agent relay authority unnormalized at spawn

### DIFF
--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -445,6 +445,17 @@ pub(crate) fn configure_runtime_cli(
     }
 }
 
+/// The relay URL a spawned agent actually connects to.
+///
+/// Authority-preserving by contract: only whitespace and a trailing root slash
+/// are trimmed. The host is never rewritten, because the relay derives each
+/// connection's tenant from the request authority. See the call site in
+/// `spawn_agent_child` for why the canonical (normalized) pair URL must not be
+/// used here.
+fn agent_connect_relay_url(workspace_relay_url: &str) -> String {
+    workspace_relay_url.trim().trim_end_matches('/').to_string()
+}
+
 /// Spawn an agent process without holding any locks on records or runtimes.
 /// Returns the child process and log path on success. The caller is responsible
 /// for updating `ManagedAgentRecord` fields and inserting into the runtimes map.
@@ -545,9 +556,23 @@ pub fn spawn_agent_child(
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| effective_command.clone());
 
-    // The caller supplies the explicit canonical pair relay. This is the only
-    // relay this child may connect to, regardless of the record/workspace default.
-    let effective_relay_url = runtime_key.relay_url.clone();
+    // The caller supplies the explicit pair relay. This is the only relay this
+    // child may connect to, regardless of the record/workspace default.
+    //
+    // Deliberately NOT `runtime_key.relay_url`: that field is canonicalized by
+    // `normalize_relay_url`, which folds every loopback host to `127.0.0.1` so a
+    // pair spelled `localhost` and one spelled `127.0.0.1` collapse to a single
+    // runtime identity. Tenant host-binding resolves the community from the
+    // request authority, where `localhost:3000` and `127.0.0.1:3000` are
+    // distinct communities — so handing the canonical form to the child makes
+    // every managed agent on a local relay authenticate into a different tenant
+    // than its owner, discover zero channels, and sit idle looking healthy.
+    // `relay::relay_http_base_url` already guards this for HTTP; the guard is
+    // useless if the value reaching it was rewritten here first.
+    //
+    // Identity stays canonical (dedup, `runtime_id`, log paths); the connection
+    // keeps the caller's authority.
+    let effective_relay_url = agent_connect_relay_url(relay_url);
 
     // Augment PATH for DMG launches so child processes can find:
     //   - bundled CLI via ~/.local/bin symlink

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -1314,3 +1314,59 @@ fn restart_eligible_false_when_orphan_has_no_drift() {
 fn restart_eligible_false_when_non_orphan_has_no_drift() {
     assert!(!super::restart_eligible(false, false, false));
 }
+
+// ── agent_connect_relay_url tests ───────────────────────────────────────
+//
+// Tenant host-binding resolves a community from the request authority, so
+// `localhost:3000` and `127.0.0.1:3000` are different communities. The URL
+// handed to a spawned agent must therefore preserve the authority the
+// workspace uses. `ManagedAgentRuntimeKey` canonicalizes loopback hosts to
+// `127.0.0.1` for identity/dedup; feeding that canonical form to the child
+// stranded every managed agent on a local relay in an empty tenant, where it
+// discovered zero channels and idled while looking healthy.
+
+#[test]
+fn connect_url_preserves_localhost_authority() {
+    // The regression: must NOT come back as ws://127.0.0.1:3000.
+    assert_eq!(
+        super::agent_connect_relay_url("ws://localhost:3000"),
+        "ws://localhost:3000"
+    );
+}
+
+#[test]
+fn connect_url_preserves_ipv4_loopback_authority() {
+    assert_eq!(
+        super::agent_connect_relay_url("ws://127.0.0.1:3000"),
+        "ws://127.0.0.1:3000"
+    );
+}
+
+#[test]
+fn connect_url_differs_from_canonical_key_for_localhost() {
+    // Pins the actual invariant: identity canonicalizes, connection does not.
+    let key =
+        crate::managed_agents::ManagedAgentRuntimeKey::new("a".repeat(64), "ws://localhost:3000")
+            .expect("valid key");
+    assert_eq!(key.relay_url, "ws://127.0.0.1:3000");
+    assert_ne!(
+        super::agent_connect_relay_url("ws://localhost:3000"),
+        key.relay_url
+    );
+}
+
+#[test]
+fn connect_url_trims_whitespace_and_trailing_slash() {
+    assert_eq!(
+        super::agent_connect_relay_url("  ws://localhost:3000/  "),
+        "ws://localhost:3000"
+    );
+}
+
+#[test]
+fn connect_url_leaves_remote_host_untouched() {
+    assert_eq!(
+        super::agent_connect_relay_url("wss://relay.example.com"),
+        "wss://relay.example.com"
+    );
+}


### PR DESCRIPTION
## Summary

Desktop-managed agents on a self-hosted relay authenticate into a **different tenant than their owner**, discover zero channels, and sit idle while reporting healthy:

```
INFO buzz_acp: buzz-acp starting: relay=ws://127.0.0.1:3000 ...
INFO buzz_acp: discovered 0 channel(s)
WARN buzz_acp: no channel subscriptions resolved — agent will sit idle
```

`spawn_agent_child` derived the child's `BUZZ_RELAY_URL` from `runtime_key.relay_url`. `ManagedAgentRuntimeKey::new` canonicalizes that field via `buzz_core::relay::normalize_relay_url`, which folds every loopback host to `127.0.0.1` so a pair spelled `localhost` and one spelled `127.0.0.1` collapse to a single runtime identity. That is correct for *identity* and wrong for *connecting*: the relay resolves each connection's tenant from the request authority, and under row-zero host binding `localhost:3000` and `127.0.0.1:3000` are distinct communities.

So a desktop on `ws://localhost:3000` writes its channels, owner row and events into the `localhost:3000` community, while every agent it spawns connects to `ws://127.0.0.1:3000` and finds an empty one. Fail-closed tenancy then correctly gives those agents nothing, and `buzz-acp`'s kind:39002 discovery legitimately returns zero — so nothing errors and it reads as a broken agent rather than a tenant split.

`relay::relay_http_base_url` already documents and tests this exact invariant:

> Tenant host-binding keys off the HTTP Host/authority. The desktop must **not** rewrite localhost to 127.0.0.1, or local dev HTTP calls target a different unmapped community than the WebSocket URL.

That guard was defeated upstream — it received a value this code had already rewritten. The git-credential-nostr HTTP base is derived from the same variable, so it was mis-scoped too.

## The change

Route the child's relay URL through a named, authority-preserving helper instead of the canonical pair URL. Only whitespace and a trailing root slash are trimmed; the host is never rewritten.

Identity stays canonical — dedup, `runtime_id`, log paths are all unchanged. Only the connection keeps the caller's spelling. Remote hosts are unaffected, since normalization only ever rewrote loopback.

### Related issues

This implements **suggested fix 3** from #3283 ("Don't canonicalize the relay URL handed to spawned harnesses — pass through the community URL the app itself uses"), and addresses the launcher half of #3505, #2444 and #2641. Four independent reports of the same trap.

I went with 3 rather than the alternatives deliberately:

- **1 — normalize loopback in tenant resolution.** Changes tenancy semantics for every deployment to fix a dev-only symptom. Too broad for this.
- **2 — seed only the canonical loopback host.** Fixes the default `just dev` path but not a user who types `localhost` into the community dialog, which is the actual reproduction here.
- **4 — warn on zero-discovery mismatch.** Complementary and worth doing, but a diagnostic, not a fix.

The seeding contradiction #3283 describes still stands — `seed-local-community.sh` continues to register four loopback spellings as four isolated tenants, so anything else that canonicalizes a host before a tenant lookup can hit the same class of bug. **I would not close #3283 on this PR**; the agent symptom is fixed, the underlying "one host = one community" vs "localhost == 127.0.0.1" contradiction is not.

## Testing

- 5 new regression tests in `managed_agents::runtime::tests`, including one pinning the invariant directly: `ManagedAgentRuntimeKey::new(.., "ws://localhost:3000")` canonicalizes to `127.0.0.1` **and** must differ from the connect URL. Whitespace/trailing-slash trimming and remote-host passthrough are covered.
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib` — **2008 passed, 0 failed**, 14 ignored.
- `just desktop-tauri-clippy` (`-D warnings`) and `just desktop-tauri-fmt` clean.

Reproduced the original failure on macOS with Colima against a self-hosted relay: four managed agents (3× `claude-agent-acp`, 1× `codex-acp`) all logged `discovered 0 channel(s)` while the desktop had 4 channels and 89 events in the `localhost:3000` tenant, confirmed by `SELECT` on `communities` / `channels` / `events`.

**Limits of the verification, stated plainly:** the new tests pin the helper's contract, not that `spawn_agent_child` calls it — that path needs an `AppHandle` and isn't unit-testable, so a future edit to the call site would not fail the suite. Closing that properly needs a seam around spawn-env construction, which felt out of scope for a one-line behavioral fix; happy to add it if maintainers prefer. I also verified the fix only by unit test and inspection rather than end-to-end, because unblocking my own instance required aligning both sides onto `127.0.0.1`, and demonstrating the `localhost` path again would mean recreating the split.
