### PR TITLE
refine(desktop): simplify sidebar unread signals

### DIFF
--- a/desktop/src/app/AppShell.tsx
+++ b/desktop/src/app/AppShell.tsx
@@ -330,6 +330,7 @@ export function AppShell() {
     unreadChannelIds,
     unreadChannelCounts,
     highPriorityUnreadChannelIds,
+    threadOnlyUnreadChannelIds,
     unreadChannelNotificationCount,
     getEffectiveTimestamp: getChannelReadAt,
     getOwnTimestamp: getOwnReadAt,
@@ -355,7 +356,6 @@ export function AppShell() {
     onThreadReplyDesktopNotification: handleThreadReplyDesktopNotification,
     followedRootIds,
   });
-
   const getThreadReadAt = React.useCallback(
     (rootId: string, channelId?: string | null) => {
       const threadReadAt = getOwnReadAt(`thread:${rootId}`);
@@ -910,6 +910,7 @@ export function AppShell() {
                             selectedView={selectedView}
                             unreadChannelIds={unreadChannelIds}
                             unreadChannelCounts={unreadChannelCounts}
+                            threadOnlyUnreadChannelIds={threadOnlyUnreadChannelIds}
                             mutedChannelIds={mutedChannelIds}
                             onMuteChannel={muteChannel}
                             onUnmuteChannel={unmuteChannel}

--- a/desktop/src/features/channels/unreadChannelCounts.ts
+++ b/desktop/src/features/channels/unreadChannelCounts.ts
@@ -5,6 +5,8 @@ export type ObservedUnreadEvent = {
   createdAt: number;
   rootId: string | null;
   highPriority: boolean;
+  isDm: boolean;
+  isThreadedReply: boolean;
   countsTowardBadge: boolean;
   countsTowardAppBadge: boolean;
 };
@@ -23,6 +25,8 @@ export function makeObservedUnreadEvent(input: {
     createdAt: input.createdAt,
     rootId: input.rootId,
     highPriority: input.highPriority,
+    isDm,
+    isThreadedReply: input.isThreadedReply,
     countsTowardBadge: isDm || input.isThreadedReply || input.highPriority,
     countsTowardAppBadge:
       isDm || (!input.isThreadedReply && input.highPriority),
@@ -118,6 +122,39 @@ export function countUnreadHighPriorityObservedEvents(
     if (readAt === null || event.createdAt > readAt) count += 1;
   }
   return count;
+}
+
+/**
+ * A badge event whose only reason for counting is a threaded reply: not a DM
+ * and not a mention/broadcast. A mention inside a thread is high-priority and
+ * is intentionally excluded — it keeps the solid numeric badge.
+ */
+export function isThreadOnlyBadgeObservedEvent(
+  event: ObservedUnreadEvent,
+): boolean {
+  return event.isThreadedReply === true && !event.isDm && !event.highPriority;
+}
+
+/**
+ * True when at least one badge-counting event is unread and ALL unread
+ * badge-counting events are thread-only — i.e. the channel's numeric badge is
+ * entirely explained by replies invisible in the channel scroll, so the
+ * sidebar can demote it to the thread-glyph badge.
+ */
+export function unreadBadgeObservedEventsAreThreadOnly(
+  eventsById: ReadonlyMap<string, ObservedUnreadEvent> | undefined,
+  getReadAt: (event: ObservedUnreadEvent) => number | null,
+): boolean {
+  if (!eventsById) return false;
+  let sawThreadOnly = false;
+  for (const event of eventsById.values()) {
+    if (!event.countsTowardBadge) continue;
+    const readAt = getReadAt(event);
+    if (readAt !== null && event.createdAt <= readAt) continue;
+    if (!isThreadOnlyBadgeObservedEvent(event)) return false;
+    sawThreadOnly = true;
+  }
+  return sawThreadOnly;
 }
 
 export function observedUnreadEventReadAt(

--- a/desktop/src/features/channels/unreadReadMarker.test.mjs
+++ b/desktop/src/features/channels/unreadReadMarker.test.mjs
@@ -7,8 +7,11 @@ import {
   countUnreadBadgeObservedEvents,
   countUnreadHighPriorityObservedEvents,
   countUnreadObservedEvents,
+  isThreadOnlyBadgeObservedEvent,
+  makeObservedUnreadEvent,
   observedUnreadEventReadAt,
   recordObservedUnreadEvent,
+  unreadBadgeObservedEventsAreThreadOnly,
 } from "./unreadChannelCounts.ts";
 import {
   addThreadActivityItems,
@@ -487,4 +490,128 @@ test("addThreadActivityItems keeps newest items when input is newest-first", () 
   assert.equal(result.items.length, 100);
   assert.equal(result.items[0].id, "reply-1");
   assert.equal(result.items.at(-1).id, "reply-100");
+});
+
+function observedEvent({
+  id,
+  createdAt,
+  channelType = "stream",
+  isThreadedReply = false,
+  highPriority = false,
+  rootId = null,
+}) {
+  return makeObservedUnreadEvent({
+    id,
+    createdAt,
+    rootId,
+    highPriority,
+    channelType,
+    isThreadedReply,
+  });
+}
+
+test("thread-only classification: plain thread reply qualifies", () => {
+  const event = observedEvent({
+    id: "reply",
+    createdAt: 10,
+    isThreadedReply: true,
+    rootId: "root",
+  });
+  assert.equal(isThreadOnlyBadgeObservedEvent(event), true);
+});
+
+test("thread-only classification: thread reply that is also a mention does not qualify", () => {
+  const event = observedEvent({
+    id: "mention-reply",
+    createdAt: 10,
+    isThreadedReply: true,
+    highPriority: true,
+    rootId: "root",
+  });
+  assert.equal(isThreadOnlyBadgeObservedEvent(event), false);
+});
+
+test("thread-only classification: DM reply does not qualify", () => {
+  const event = observedEvent({
+    id: "dm-reply",
+    createdAt: 10,
+    channelType: "dm",
+    isThreadedReply: true,
+    rootId: "root",
+  });
+  assert.equal(isThreadOnlyBadgeObservedEvent(event), false);
+});
+
+test("channel is thread-only when every unread badge event is a plain thread reply", () => {
+  const events = new Map([
+    [
+      "r1",
+      observedEvent({
+        id: "r1",
+        createdAt: 10,
+        isThreadedReply: true,
+        rootId: "root",
+      }),
+    ],
+    [
+      "r2",
+      observedEvent({
+        id: "r2",
+        createdAt: 20,
+        isThreadedReply: true,
+        rootId: "root",
+      }),
+    ],
+  ]);
+  assert.equal(
+    unreadBadgeObservedEventsAreThreadOnly(events, () => null),
+    true,
+  );
+});
+
+test("channel is not thread-only when an unread mention coexists with thread replies", () => {
+  const events = new Map([
+    [
+      "r1",
+      observedEvent({
+        id: "r1",
+        createdAt: 10,
+        isThreadedReply: true,
+        rootId: "root",
+      }),
+    ],
+    ["m1", observedEvent({ id: "m1", createdAt: 20, highPriority: true })],
+  ]);
+  assert.equal(
+    unreadBadgeObservedEventsAreThreadOnly(events, () => null),
+    false,
+  );
+});
+
+test("channel is not thread-only once its thread replies are read", () => {
+  const events = new Map([
+    [
+      "r1",
+      observedEvent({
+        id: "r1",
+        createdAt: 10,
+        isThreadedReply: true,
+        rootId: "root",
+      }),
+    ],
+  ]);
+  assert.equal(
+    unreadBadgeObservedEventsAreThreadOnly(events, () => 10),
+    false,
+  );
+});
+
+// Forced-unread channels record no observed events (the unread derivation
+// short-circuits before the classifier); with no events the classifier must
+// report not-thread-only so the solid badge treatment is kept.
+test("channel without observed events (forced-unread) is not thread-only", () => {
+  assert.equal(
+    unreadBadgeObservedEventsAreThreadOnly(undefined, () => null),
+    false,
+  );
 });

--- a/desktop/src/features/channels/useUnreadChannels.ts
+++ b/desktop/src/features/channels/useUnreadChannels.ts
@@ -10,11 +10,12 @@ import {
   countUnreadHighPriorityObservedEvents,
   countUnreadObservedEvents,
   makeObservedUnreadEvent,
-  mapsEqual,
   observedUnreadEventReadAt,
   recordObservedUnreadEvent,
+  unreadBadgeObservedEventsAreThreadOnly,
   type ObservedUnreadEvent,
 } from "@/features/channels/unreadChannelCounts";
+import { useStableMap, useStableSet } from "@/shared/hooks/useStableReference";
 import { useReadState } from "@/features/channels/readState/useReadState";
 import { makeRootIdStore } from "@/features/channels/unreadRootIdStore";
 import {
@@ -123,14 +124,6 @@ export function resolveChannelReadMarker(
 
 export function resolveObservedUnreadRootId(tags: string[][]): string | null {
   return isBroadcastReply(tags) ? null : getThreadReference(tags).rootId;
-}
-
-function setsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
-  if (a.size !== b.size) return false;
-  for (const item of a) {
-    if (!b.has(item)) return false;
-  }
-  return true;
 }
 
 export function useUnreadChannels(
@@ -831,6 +824,7 @@ export function useUnreadChannels(
         return {
           unreadChannelIds: new Set<string>(),
           highPriorityUnreadChannelIds: new Set<string>(),
+          threadOnlyUnreadChannelIds: new Set<string>(),
           unreadChannelCounts: new Map<string, number>(),
           unreadChannelNotificationCount: 0,
         };
@@ -838,6 +832,7 @@ export function useUnreadChannels(
 
       const unread = new Set<string>();
       const highPriority = new Set<string>();
+      const threadOnly = new Set<string>();
       const counts = new Map<string, number>();
       let unreadChannelNotificationCount = 0;
 
@@ -878,6 +873,18 @@ export function useUnreadChannels(
           readAtForObservedEvent,
         );
         counts.set(channel.id, badgeCount);
+        if (
+          unreadBadgeObservedEventsAreThreadOnly(
+            observedEvents,
+            readAtForObservedEvent,
+          )
+        ) {
+          // Every unread badge event is a plain thread reply — the sidebar
+          // demotes the badge to the thread glyph. Forced-unread channels
+          // never reach here (they continue above) so they keep the solid
+          // badge.
+          threadOnly.add(channel.id);
+        }
         unreadChannelNotificationCount += countUnreadAppBadgeObservedEvents(
           observedEvents,
           readAtForObservedEvent,
@@ -901,6 +908,7 @@ export function useUnreadChannels(
       return {
         unreadChannelIds: unread,
         highPriorityUnreadChannelIds: highPriority,
+        threadOnlyUnreadChannelIds: threadOnly,
         unreadChannelCounts: counts,
         unreadChannelNotificationCount,
       };
@@ -914,37 +922,16 @@ export function useUnreadChannels(
       readStateVersion,
     ]);
 
-  // Stabilize Set references: only replace when contents actually change,
-  // so downstream memos don't re-run on every render when sets are equal.
-  const prevUnreadRef = React.useRef<ReadonlySet<string>>(new Set());
-  const prevHighPriorityRef = React.useRef<ReadonlySet<string>>(new Set());
-  const prevUnreadCountsRef = React.useRef<ReadonlyMap<string, number>>(
-    new Map(),
-  );
-
-  const unreadChannelIds = setsEqual(
-    rawUnread.unreadChannelIds,
-    prevUnreadRef.current,
-  )
-    ? prevUnreadRef.current
-    : rawUnread.unreadChannelIds;
-  prevUnreadRef.current = unreadChannelIds;
-
-  const highPriorityUnreadChannelIds = setsEqual(
+  // Stabilize Set/Map references: only replace when contents actually
+  // change, so downstream memos don't re-run when contents are equal.
+  const unreadChannelIds = useStableSet(rawUnread.unreadChannelIds);
+  const highPriorityUnreadChannelIds = useStableSet(
     rawUnread.highPriorityUnreadChannelIds,
-    prevHighPriorityRef.current,
-  )
-    ? prevHighPriorityRef.current
-    : rawUnread.highPriorityUnreadChannelIds;
-  prevHighPriorityRef.current = highPriorityUnreadChannelIds;
-
-  const unreadChannelCounts = mapsEqual(
-    rawUnread.unreadChannelCounts,
-    prevUnreadCountsRef.current,
-  )
-    ? prevUnreadCountsRef.current
-    : rawUnread.unreadChannelCounts;
-  prevUnreadCountsRef.current = unreadChannelCounts;
+  );
+  const threadOnlyUnreadChannelIds = useStableSet(
+    rawUnread.threadOnlyUnreadChannelIds,
+  );
+  const unreadChannelCounts = useStableMap(rawUnread.unreadChannelCounts);
   const unreadChannelNotificationCount =
     rawUnread.unreadChannelNotificationCount;
 
@@ -994,6 +981,7 @@ export function useUnreadChannels(
     unreadChannelIds,
     unreadChannelCounts,
     highPriorityUnreadChannelIds,
+    threadOnlyUnreadChannelIds,
     unreadChannelNotificationCount,
     markAllChannelsRead,
     markChannelRead,

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -108,6 +108,7 @@ type AppSidebarProps = {
     | "projects";
   unreadChannelCounts: ReadonlyMap<string, number>;
   unreadChannelIds: ReadonlySet<string>;
+  threadOnlyUnreadChannelIds: ReadonlySet<string>;
   communities: Community[];
   onAddCommunity: (community: Community) => void;
   onAddCommunityOpenChange?: (open: boolean) => void;
@@ -195,6 +196,7 @@ export function AppSidebar({
   selectedView,
   unreadChannelCounts,
   unreadChannelIds,
+  threadOnlyUnreadChannelIds,
   communities,
   onAddCommunity,
   onAddCommunityOpenChange,
@@ -650,6 +652,7 @@ export function AppSidebar({
                       title="Starred"
                       unreadChannelCounts={unreadChannelCounts}
                       unreadChannelIds={unreadChannelIds}
+                      threadOnlyUnreadChannelIds={threadOnlyUnreadChannelIds}
                       mutedChannelIds={mutedChannelIds}
                       onMuteChannel={onMuteChannel}
                       onUnmuteChannel={onUnmuteChannel}
@@ -684,6 +687,7 @@ export function AppSidebar({
                         selectedChannelId={selectedChannelId}
                         unreadChannelCounts={unreadChannelCounts}
                         unreadChannelIds={unreadChannelIds}
+                        threadOnlyUnreadChannelIds={threadOnlyUnreadChannelIds}
                         sections={channelSections}
                         assignments={channelAssignments}
                         isFirst={idx === 0}
@@ -755,6 +759,7 @@ export function AppSidebar({
                       title="Channels"
                       unreadChannelCounts={unreadChannelCounts}
                       unreadChannelIds={unreadChannelIds}
+                      threadOnlyUnreadChannelIds={threadOnlyUnreadChannelIds}
                       sections={channelSections}
                       assignments={channelAssignments}
                       onAssignChannel={assignChannel}
@@ -794,6 +799,7 @@ export function AppSidebar({
                       title="Forums"
                       unreadChannelCounts={unreadChannelCounts}
                       unreadChannelIds={unreadChannelIds}
+                      threadOnlyUnreadChannelIds={threadOnlyUnreadChannelIds}
                       mutedChannelIds={mutedChannelIds}
                       onMuteChannel={onMuteChannel}
                       onUnmuteChannel={onUnmuteChannel}

--- a/desktop/src/features/sidebar/ui/AppSidebarPinnedHeader.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebarPinnedHeader.tsx
@@ -1,6 +1,7 @@
 import { Activity, Bot, FolderGit2, Inbox, Zap } from "lucide-react";
 
 import { TopbarSearch } from "@/features/search/ui/TopbarSearch";
+import { cn } from "@/shared/lib/cn";
 import { FeatureGate } from "@/shared/features";
 import type { Channel, SearchHit } from "@/shared/api/types";
 import {
@@ -98,6 +99,11 @@ export function AppSidebarPrimaryMenu({
       <SidebarMenu className="pb-2">
         <SidebarMenuItem>
           <SidebarMenuButton
+            className={cn(
+              selectedView !== "home" &&
+                homeBadgeCount > 0 &&
+                "font-semibold text-sidebar-foreground hover:text-sidebar-foreground",
+            )}
             isActive={selectedView === "home"}
             onClick={onSelectHome}
             tooltip="Inbox"
@@ -108,7 +114,7 @@ export function AppSidebarPrimaryMenu({
           </SidebarMenuButton>
           {homeBadgeCount > 0 ? (
             <SidebarMenuBadge
-              className="right-2 rounded-full bg-primary/15 px-1.5 text-2xs text-primary peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
+              className="right-2 rounded-full bg-primary px-1.5 text-2xs font-semibold tabular-nums text-primary-foreground peer-data-[active=true]/menu-button:bg-sidebar-active-foreground/20 peer-data-[active=true]/menu-button:text-sidebar-active-foreground"
               data-testid="sidebar-home-count"
             >
               {Math.min(homeBadgeCount, 99)}

--- a/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
+++ b/desktop/src/features/sidebar/ui/CustomChannelSection.tsx
@@ -360,6 +360,7 @@ export function ChannelGroupSection({
   title,
   unreadChannelCounts,
   unreadChannelIds,
+  threadOnlyUnreadChannelIds,
   sections,
   assignments,
   onAssignChannel,
@@ -408,6 +409,7 @@ export function ChannelGroupSection({
   title: string;
   unreadChannelCounts: ReadonlyMap<string, number>;
   unreadChannelIds: ReadonlySet<string>;
+  threadOnlyUnreadChannelIds?: ReadonlySet<string>;
   hasUnread?: boolean;
   onMarkAllRead?: () => void;
   sections?: ChannelSection[];
@@ -440,6 +442,9 @@ export function ChannelGroupSection({
                       channel={channel}
                       activeWorking={activeWorkingByChannelId?.get(channel.id)}
                       hasUnread={unreadChannelIds.has(channel.id)}
+                      hasThreadOnlyUnread={threadOnlyUnreadChannelIds?.has(
+                        channel.id,
+                      )}
                       unreadCount={unreadChannelCounts.get(channel.id) ?? 0}
                       isMuted={mutedChannelIds?.has(channel.id)}
                       isActive={
@@ -453,6 +458,9 @@ export function ChannelGroupSection({
                     channel={channel}
                     activeWorking={activeWorkingByChannelId?.get(channel.id)}
                     hasUnread={unreadChannelIds.has(channel.id)}
+                    hasThreadOnlyUnread={threadOnlyUnreadChannelIds?.has(
+                      channel.id,
+                    )}
                     unreadCount={unreadChannelCounts.get(channel.id) ?? 0}
                     isMuted={mutedChannelIds?.has(channel.id)}
                     isActive={
@@ -550,6 +558,7 @@ export function CustomChannelSection({
   selectedChannelId,
   unreadChannelCounts,
   unreadChannelIds,
+  threadOnlyUnreadChannelIds,
   sections,
   assignments,
   isFirst,
@@ -587,6 +596,7 @@ export function CustomChannelSection({
   selectedChannelId: string | null;
   unreadChannelCounts: ReadonlyMap<string, number>;
   unreadChannelIds: ReadonlySet<string>;
+  threadOnlyUnreadChannelIds?: ReadonlySet<string>;
   sections: ChannelSection[];
   assignments: Record<string, string>;
   isFirst: boolean;
@@ -743,6 +753,9 @@ export function CustomChannelSection({
                                   channel.id,
                                 )}
                                 hasUnread={unreadChannelIds.has(channel.id)}
+                                hasThreadOnlyUnread={threadOnlyUnreadChannelIds?.has(
+                                  channel.id,
+                                )}
                                 unreadCount={
                                   unreadChannelCounts.get(channel.id) ?? 0
                                 }

--- a/desktop/src/features/sidebar/ui/SidebarSection.tsx
+++ b/desktop/src/features/sidebar/ui/SidebarSection.tsx
@@ -82,19 +82,30 @@ function UnreadCountBadge({
   );
 }
 
-function UnreadDotBadge({
+/**
+ * Relevant unread thread activity renders as a dot: the unread lives in a
+ * thread, not the main timeline, so the channel row must not promise a new
+ * top-level message the way the solid numeric badge does. The count stays in
+ * the accessible name; visually the dot survives opening the channel until
+ * the thread itself is read.
+ */
+function ThreadUnreadDot({
   channelName,
   className,
+  count,
 }: {
   channelName: string;
   className?: string;
+  count: number;
 }) {
   return (
     <span
       className={cn("h-2 w-2 shrink-0 rounded-full bg-primary", className)}
-      data-testid={`channel-unread-dot-${channelName}`}
+      data-testid={`channel-thread-unread-${channelName}`}
     >
-      <span className="sr-only">unread</span>
+      <span className="sr-only">
+        {count} unread thread {count === 1 ? "reply" : "replies"}
+      </span>
     </span>
   );
 }
@@ -250,6 +261,7 @@ export function ChannelMenuButton({
   label,
   isActive,
   hasUnread,
+  hasThreadOnlyUnread,
   unreadCount = 0,
   activeWorking,
   isMuted,
@@ -261,6 +273,7 @@ export function ChannelMenuButton({
   label?: string;
   isActive: boolean;
   hasUnread: boolean;
+  hasThreadOnlyUnread?: boolean;
   unreadCount?: number;
   activeWorking?: ActiveChannelTurnSummary;
   isMuted?: boolean;
@@ -321,15 +334,22 @@ export function ChannelMenuButton({
           )}
         />
       ) : null}
-      {hasUnread && !isActive && channel.channelType !== "dm" ? (
-        unreadCount > 0 ? (
-          <UnreadCountBadge
+      {hasUnread &&
+      !isActive &&
+      channel.channelType !== "dm" &&
+      unreadCount > 0 ? (
+        hasThreadOnlyUnread ? (
+          <ThreadUnreadDot
             channelName={channel.name}
             className="ml-auto"
             count={unreadCount}
           />
         ) : (
-          <UnreadDotBadge channelName={channel.name} className="ml-auto" />
+          <UnreadCountBadge
+            channelName={channel.name}
+            className="ml-auto"
+            count={unreadCount}
+          />
         )
       ) : null}
     </SidebarMenuButton>
@@ -349,6 +369,7 @@ export function SidebarSection({
   selectedChannelId,
   title,
   testId,
+  threadOnlyUnreadChannelIds,
   unreadChannelCounts,
   unreadChannelIds,
   onHideDm,
@@ -373,6 +394,7 @@ export function SidebarSection({
   selectedChannelId: string | null;
   title: string;
   testId: string;
+  threadOnlyUnreadChannelIds?: ReadonlySet<string>;
   unreadChannelCounts: ReadonlyMap<string, number>;
   unreadChannelIds: ReadonlySet<string>;
   onHideDm?: (channelId: string) => void;
@@ -442,6 +464,9 @@ export function SidebarSection({
                       activeWorking={activeWorkingByChannelId?.get(channel.id)}
                       dmParticipants={dmParticipantsByChannelId?.[channel.id]}
                       hasUnread={unreadChannelIds.has(channel.id)}
+                      hasThreadOnlyUnread={threadOnlyUnreadChannelIds?.has(
+                        channel.id,
+                      )}
                       unreadCount={unreadChannelCounts.get(channel.id) ?? 0}
                       isMuted={mutedChannelIds?.has(channel.id)}
                       isActive={

--- a/desktop/tests/e2e/badge.spec.ts
+++ b/desktop/tests/e2e/badge.spec.ts
@@ -105,7 +105,9 @@ test("regular message bolds inactive channel without numeric badge", async ({
     "600",
   );
   await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
-  await expect(page.getByTestId("channel-unread-dot-random")).toBeVisible();
+  // Channel-level unread is bold-only: no dot, no count. Dots are reserved
+  // for relevant unread thread activity.
+  await expect(page.getByTestId("channel-unread-dot-random")).toHaveCount(0);
   await waitForBadgeState(page, withDotOnlyBadge(baselineBadge));
 });
 
@@ -190,7 +192,10 @@ test("numeric badge increments for interested thread reply in inactive channel",
     { parentEventId: rootEventId, pubkey: TEST_IDENTITIES.alice.pubkey },
   );
 
-  await expect(page.getByTestId("channel-unread-random")).toBeVisible();
+  // A plain thread reply (no mention, not a DM) renders the demoted
+  // thread-glyph badge instead of the solid numeric badge.
+  await expect(page.getByTestId("channel-thread-unread-random")).toBeVisible();
+  await expect(page.getByTestId("channel-unread-random")).toHaveCount(0);
   await waitForBadgeState(page, withAdditionalBadgeCount(baselineBadge, 1));
 });
 

--- a/desktop/tests/e2e/channel-sort.spec.ts
+++ b/desktop/tests/e2e/channel-sort.spec.ts
@@ -38,6 +38,7 @@ function streamNames(page: Page) {
         .filter(
           (id) =>
             !id.startsWith("channel-unread") &&
+            !id.startsWith("channel-thread-unread") &&
             !id.startsWith("channel-working") &&
             !id.startsWith("channel-dm-count"),
         )
@@ -138,6 +139,7 @@ test.describe("per-group channel sort", () => {
           .filter(
             (id) =>
               !id.startsWith("channel-unread") &&
+              !id.startsWith("channel-thread-unread") &&
               !id.startsWith("channel-working"),
           )
           .map((id) => id.replace(/^channel-/, "")),

--- a/desktop/tests/e2e/thread-unread.spec.ts
+++ b/desktop/tests/e2e/thread-unread.spec.ts
@@ -747,11 +747,13 @@ test.describe("thread unread indicator", () => {
     await page.getByTestId("channel-general").click();
     await expect(page.getByTestId("chat-title")).toHaveText("general");
 
-    // The crux: leave general. The unopened thread reply should still keep a
-    // numeric channel sidebar badge until the thread itself is read.
+    // The crux: leave general. The unopened thread reply should still keep
+    // the thread-unread dot until the thread itself is read.
     await page.getByTestId("channel-random").click();
     await expect(page.getByTestId("chat-title")).toHaveText("random");
-    await expect(page.getByTestId("channel-unread-general")).toBeVisible();
+    await expect(
+      page.getByTestId("channel-thread-unread-general"),
+    ).toBeVisible();
   });
 
   // Regression guard for the all-replies window: when the loaded window holds


### PR DESCRIPTION
## Summary

Simplifies desktop sidebar unread signals into a smaller, destination-aware system:

- New channel-level messages bold the channel name without a dot or count.
- Relevant unread thread activity uses a dot that survives opening the channel until the thread is handled.
- Mentions and DMs keep their existing numeric unread treatment.
- Inbox uses a solid count and bold label when unread activity is present.
- Muted activity remains suppressed.

This retains the existing unread classification and per-thread read frontiers; the change is primarily derivation plumbing and rendering, with no new route or surface.

## Why this slice

This is the lowest-risk part of the notification redesign: it removes competing sidebar indicators while preserving the existing data model and deep-link behavior. It also provides the state Kenny's proposed hover preview or a future Threads view can consume later.

## Verification

- TypeScript typecheck
- 3,892 desktop unit tests passed
- 25 targeted Playwright tests passed (`badge`, `channel-sort`, and `thread-unread`)
