### PR TITLE
refine(desktop): add sender context to thread notifications

### DIFF
--- a/desktop/src/app/useAppShellDesktopNotifications.test.mjs
+++ b/desktop/src/app/useAppShellDesktopNotifications.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  resolveThreadReplySenderName,
+  threadReplyNotificationTitle,
+} from "./useAppShellDesktopNotifications.ts";
+
+const PUBKEY = "a".repeat(64);
+
+test("thread reply title uses resolved sender name with channel", () => {
+  const senderName = resolveThreadReplySenderName(PUBKEY, {
+    displayName: "Maya",
+    nip05Handle: null,
+  });
+
+  assert.equal(senderName, "Maya");
+  assert.equal(
+    threadReplyNotificationTitle(senderName, "#design"),
+    "Maya replied in #design",
+  );
+});
+
+test("thread reply title falls back to Reply when profile is not cached", () => {
+  const senderName = resolveThreadReplySenderName(PUBKEY, undefined);
+
+  assert.equal(senderName, undefined);
+  assert.equal(
+    threadReplyNotificationTitle(senderName, "#design"),
+    "Reply in #design",
+  );
+});
+
+test("empty display name never leaks a truncated pubkey into the title", () => {
+  const senderName = resolveThreadReplySenderName(PUBKEY, {
+    displayName: "   ",
+    nip05Handle: null,
+  });
+
+  assert.equal(senderName, undefined);
+  assert.equal(threadReplyNotificationTitle(senderName, null), "Reply");
+});
+
+test("nip05 handle is used when display name is missing", () => {
+  const senderName = resolveThreadReplySenderName(PUBKEY, {
+    displayName: null,
+    nip05Handle: "maya@example.com",
+  });
+
+  assert.equal(senderName, "maya@example.com");
+  assert.equal(
+    threadReplyNotificationTitle(senderName, "#design"),
+    "maya@example.com replied in #design",
+  );
+});
+
+test("resolved sender title omits channel when channel is unresolved", () => {
+  assert.equal(threadReplyNotificationTitle("Maya", null), "Maya replied");
+});

--- a/desktop/src/app/useAppShellDesktopNotifications.ts
+++ b/desktop/src/app/useAppShellDesktopNotifications.ts
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
+
 import {
   shouldBounceForChannelNotification,
   toSearchHit,
@@ -21,7 +23,61 @@ import {
   playNotificationSound,
   resolveSlotSound,
 } from "@/features/notifications/lib/sound";
-import type { Channel, RelayEvent } from "@/shared/api/types";
+import { resolveUserLabel } from "@/features/profile/lib/identity";
+import type {
+  Channel,
+  Profile,
+  RelayEvent,
+  UserProfileSummary,
+} from "@/shared/api/types";
+import { normalizePubkey, truncatePubkey } from "@/shared/lib/pubkey";
+
+/**
+ * Resolve a sender's display name for the thread-reply toast title, mirroring
+ * the home-feed notification path (use-feed-desktop-notifications.ts): resolve
+ * via `resolveUserLabel`, then discard the truncated-pubkey fallback so a raw
+ * pubkey/npub never lands in an OS notification title.
+ *
+ * Returns `undefined` when no usable name exists (caller falls back to the
+ * bare "Reply" prefix).
+ */
+export function resolveThreadReplySenderName(
+  pubkey: string,
+  profile:
+    | Pick<UserProfileSummary, "displayName" | "nip05Handle">
+    | null
+    | undefined,
+): string | undefined {
+  if (!profile) return undefined;
+  const label = resolveUserLabel({
+    pubkey,
+    profiles: {
+      [normalizePubkey(pubkey)]: {
+        displayName: profile.displayName,
+        avatarUrl: null,
+        nip05Handle: profile.nip05Handle,
+        ownerPubkey: null,
+      },
+    },
+    preferResolvedSelfLabel: true,
+  });
+  return label !== truncatePubkey(pubkey) ? label : undefined;
+}
+
+/**
+ * Thread-reply toast title: `"{Sender} replied in #channel"` when the sender's
+ * profile is cached, otherwise today's `"Reply in #channel"` fallback. Channel
+ * label omitted when unresolved (see {@link formatNotificationTitle}).
+ */
+export function threadReplyNotificationTitle(
+  senderName: string | undefined,
+  channelLabel: string | null,
+): string {
+  return formatNotificationTitle({
+    prefix: senderName ? `${senderName} replied` : "Reply",
+    channelLabel,
+  });
+}
 
 export function useAppShellDesktopNotifications({
   channels,
@@ -40,6 +96,14 @@ export function useAppShellDesktopNotifications({
   ) => Promise<unknown>;
   pubkey?: string;
 }) {
+  // Sender names come from the shared react-query profile cache rather than a
+  // new prop from AppShell: `useUsersBatchQuery` (which backs message
+  // timelines, the home feed, and DM metadata) seeds a `["user-profile", pk]`
+  // entry for every profile it resolves, so reading it here is a pure cache
+  // hit. A miss just means the profile hasn't been fetched this session — the
+  // toast falls back to the nameless "Reply" prefix.
+  const queryClient = useQueryClient();
+
   const handleChannelNotification = React.useEffectEvent(
     (_channelId: string, event: RelayEvent) => {
       if (!shouldBounceForChannelNotification(event.tags)) return;
@@ -103,11 +167,18 @@ export function useAppShellDesktopNotifications({
       // channelLabel is "#name" for the toast title; channelName is the raw
       // name stored in the navigation target for click-through routing.
       const channelLabel = channelName ? `#${channelName}` : null;
+      const senderName = resolveThreadReplySenderName(
+        event.pubkey,
+        queryClient.getQueryData<Profile>([
+          "user-profile",
+          normalizePubkey(event.pubkey),
+        ]),
+      );
       const body = truncateNotificationBody(event.content, "New reply");
       const threadRootId = getThreadReference(event.tags).rootId ?? null;
 
       void sendDesktopNotification({
-        title: formatNotificationTitle({ prefix: "Reply", channelLabel }),
+        title: threadReplyNotificationTitle(senderName, channelLabel),
         body,
         target: {
           channelId,


### PR DESCRIPTION
## Summary

Adds sender context to desktop thread-reply notifications, changing generic titles such as `Reply · #design` to titles such as `Maya replied in #design`.

The implementation resolves display names from the existing React Query profile cache, performs no new network request, and falls back safely when a cached profile is unavailable.

## Why this slice

This is isolated presentation work: notification eligibility, read state, navigation, and deep links are unchanged. The payload already carries the sender and destination metadata; this slice makes that context visible before the user chooses where to navigate.

## Verification

- TypeScript typecheck
- 3,890 desktop unit tests passed
- New helper coverage for cached profiles, missing profiles, malformed cache values, and fallback titles
