### PR TITLE
fix(ci): restore GLIBC 2.35 compatibility for deb packages

### DIFF
--- a/.github/workflows/linux-canary.yml
+++ b/.github/workflows/linux-canary.yml
@@ -18,10 +18,19 @@ permissions:
 
 jobs:
   build:
-    name: Build Linux canary
+    name: Build Linux canary (${{ matrix.target }})
     if: github.repository == 'block/buzz'
     runs-on: ubuntu-latest
-    container: ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
+    strategy:
+      matrix:
+        include:
+          - target: AppImage
+            container: ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
+            bundles: appimage
+          - target: Debian
+            container: ubuntu:22.04
+            bundles: deb
+    container: ${{ matrix.container }}
     timeout-minutes: 60
     permissions:
       contents: read
@@ -170,11 +179,12 @@ jobs:
           ./scripts/bundle-sidecars.sh
 
       - name: Build Linux Tauri app
-        run: cd desktop && pnpm tauri build --ci --bundles deb,appimage --config src-tauri/tauri.canary.conf.json
+        run: cd desktop && pnpm tauri build --ci --bundles ${{ matrix.bundles }} --config src-tauri/tauri.canary.conf.json
         env:
           CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
       - name: Fix AppImage (remove infra libs, symlink system GStreamer)
+        if: matrix.target == 'AppImage'
         # fix-appimage.sh checks for TAURI_SIGNING_PRIVATE_KEY and skips
         # re-signing when absent, so no signing env vars are needed here.
         # Repacking still runs, removing the Mesa/GLib/GStreamer conflict libs.
@@ -202,26 +212,26 @@ jobs:
           set -euo pipefail
           BUNDLE_DIR="desktop/src-tauri/target/release/bundle"
 
-          DEB=$(find "$BUNDLE_DIR/deb" -name '*.deb' -type f | head -1)
-          if [[ -z "$DEB" ]]; then
-            echo "::error::No DEB found in $BUNDLE_DIR/deb"
-            exit 1
+          if [ "${{ matrix.target }}" = "Debian" ]; then
+            DEB=$(find "$BUNDLE_DIR/deb" -name '*.deb' -type f | head -1)
+            if [[ -z "$DEB" ]]; then
+              echo "::error::No DEB found in $BUNDLE_DIR/deb"
+              exit 1
+            fi
+            echo "path=$DEB" >> "$GITHUB_OUTPUT"
+          else
+            APPIMAGE=$(find "$BUNDLE_DIR/appimage" -name '*.AppImage' -type f | head -1)
+            if [[ -z "$APPIMAGE" ]]; then
+              echo "::error::No AppImage found in $BUNDLE_DIR/appimage"
+              exit 1
+            fi
+            echo "path=$APPIMAGE" >> "$GITHUB_OUTPUT"
           fi
-          echo "deb=$DEB" >> "$GITHUB_OUTPUT"
-
-          APPIMAGE=$(find "$BUNDLE_DIR/appimage" -name '*.AppImage' -type f | head -1)
-          if [[ -z "$APPIMAGE" ]]; then
-            echo "::error::No AppImage found in $BUNDLE_DIR/appimage"
-            exit 1
-          fi
-          echo "appimage=$APPIMAGE" >> "$GITHUB_OUTPUT"
 
       - name: Upload Linux canary packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: buzz-linux-canary-${{ github.sha }}
-          path: |
-            ${{ steps.artifacts.outputs.deb }}
-            ${{ steps.artifacts.outputs.appimage }}
+          name: buzz-linux-canary-${{ matrix.target }}-${{ github.sha }}
+          path: ${{ steps.artifacts.outputs.path }}
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,7 +424,7 @@ jobs:
             ${{ steps.artifacts.outputs.sig }}
 
   release-linux:
-    name: Release Linux
+    name: Release Linux (AppImage)
     if: github.repository == 'block/buzz'
     runs-on: ubuntu-latest
     # Digest-pinned like the SHA-pinned actions below; Renovate keeps it fresh.
@@ -573,7 +573,7 @@ jobs:
           BUZZ_UPDATER_ENDPOINT: https://github.com/block/buzz/releases/download/buzz-desktop-latest/latest.json
 
       - name: Build Linux Tauri app
-        run: cd desktop && pnpm tauri build --verbose --ci --bundles deb,appimage --config src-tauri/tauri.release.conf.json
+        run: cd desktop && pnpm tauri build --verbose --ci --bundles appimage --config src-tauri/tauri.release.conf.json
         env:
           BUZZ_UPDATER_PUBLIC_KEY: ${{ secrets.BUZZ_UPDATER_PUBLIC_KEY || secrets.SPROUT_UPDATER_PUBLIC_KEY }}
           BUZZ_UPDATER_ENDPOINT: https://github.com/block/buzz/releases/download/buzz-desktop-latest/latest.json
@@ -601,13 +601,6 @@ jobs:
         id: linux-artifacts
         run: |
           BUNDLE_DIR="desktop/src-tauri/target/release/bundle"
-
-          DEB=$(find "$BUNDLE_DIR/deb" -name '*.deb' -type f | head -1)
-          if [[ -z "$DEB" ]]; then
-            echo "::error::No DEB found in $BUNDLE_DIR/deb"
-            exit 1
-          fi
-          echo "deb=$DEB" >> "$GITHUB_OUTPUT"
 
           APPIMAGE=$(find "$BUNDLE_DIR/appimage" -name '*.AppImage' -type f | head -1)
           if [[ -z "$APPIMAGE" ]]; then
@@ -647,10 +640,115 @@ jobs:
           name: desktop-release-linux-x64
           if-no-files-found: error
           path: |
-            ${{ steps.linux-artifacts.outputs.deb }}
             ${{ steps.linux-artifacts.outputs.appimage }}
             ${{ steps.linux-artifacts.outputs.archive }}
             ${{ steps.linux-artifacts.outputs.sig }}
+
+  release-linux-deb:
+    name: Release Linux (Debian)
+    if: github.repository == 'block/buzz'
+    runs-on: ubuntu-latest
+    container: ubuntu:22.04
+    needs: setup
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Install system dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30
+          apt-get install -y --no-install-recommends \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            -o DPkg::Lock::Timeout=120 \
+            build-essential \
+            ca-certificates \
+            curl \
+            desktop-file-utils \
+            file \
+            git \
+            libasound2-dev \
+            libayatana-appindicator3-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf \
+            pkg-config \
+            squashfs-tools \
+            wget \
+            xdg-utils
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ needs.setup.outputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Mark workspace safe for git (containerized job)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Verify tag-bound release source
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+        run: scripts/verify-release-ref.sh desktop-v "$VERSION"
+
+      - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: desktop/src-tauri
+          lookup-only: true
+
+      - name: Install desktop dependencies
+        run: just desktop-install-ci
+
+      - name: Patch version
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+        run: |
+          cd desktop && node scripts/set-version-from-tag.mjs "$VERSION"
+          cd src-tauri && cargo update --workspace
+
+      - name: Build sidecars
+        run: |
+          cargo build --release -p buzz-acp -p buzz-agent -p buzz-dev-mcp -p git-credential-nostr -p buzz-cli
+          ./scripts/bundle-sidecars.sh
+
+      - name: Build Linux Tauri app
+        run: cd desktop && pnpm tauri build --verbose --ci --bundles deb --config src-tauri/tauri.release.conf.json
+        env:
+          CMAKE_POLICY_VERSION_MINIMUM: "3.5"
+
+      - name: Locate Linux build artifacts
+        id: linux-artifacts
+        run: |
+          BUNDLE_DIR="desktop/src-tauri/target/release/bundle"
+
+          DEB=$(find "$BUNDLE_DIR/deb" -name '*.deb' -type f | head -1)
+          if [[ -z "$DEB" ]]; then
+            echo "::error::No DEB found in $BUNDLE_DIR/deb"
+            exit 1
+          fi
+          echo "deb=$DEB" >> "$GITHUB_OUTPUT"
+
+      - name: Stage Linux release artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: desktop-release-linux-deb
+          if-no-files-found: error
+          path: |
+            ${{ steps.linux-artifacts.outputs.deb }}
 
   release-windows:
     name: Release Windows
@@ -784,10 +882,11 @@ jobs:
       needs.release.result == 'success' &&
       needs.release-macos-x64.result == 'success' &&
       needs.release-linux.result == 'success' &&
+      needs.release-linux-deb.result == 'success' &&
       needs.release-windows.result == 'success' &&
       github.ref == format('refs/tags/desktop-v{0}', needs.setup.outputs.version)
     runs-on: ubuntu-latest
-    needs: [setup, release, release-macos-x64, release-linux, release-windows]
+    needs: [setup, release, release-macos-x64, release-linux, release-linux-deb, release-windows]
     timeout-minutes: 10
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
PR #3602 resolved the rendering-related `colrv1_configure_skpaint` crash (issues #2548 and #2982) on newer host distributions (like Ubuntu 24.04+ and Fedora 40+) by bumping the Linux AppImage build container to `ubuntu:24.04`. This ensured that the bundled WebKitGTK in the AppImage matched the `FT_ColorStopIterator` layout changes introduced in FreeType 2.13+.

However, upgrading the build container to `ubuntu:24.04` had the unintended side effect of raising the minimum GLIBC floor of the entire build pipeline to 2.39. As a result, the generated `.deb` packages (which were compiled inside the same container) now require `GLIBC_2.38` or higher, breaking installations on stable distributions such as **Ubuntu 22.04 LTS** (GLIBC 2.35) and **Debian 12** (GLIBC 2.36).

Because `.deb` packages do not bundle WebKitGTK (they use the system's `libwebkit2gtk` package), they are completely unaffected by the FreeType struct mismatch. The system-provided WebKitGTK is already compiled against the system-provided FreeType layout. Thus, there is no technical requirement to compile `.deb` packages on Ubuntu 24.04.

By splitting the Linux build environments, we can restore first-class support for Ubuntu 22.04 LTS and Debian 12 via the `.deb` package while fully preserving the AppImage fixes for newer hosts.

### Solution

- **Split Linux Build Pipelines**:
  - **`.github/workflows/linux-canary.yml`**: Refactored the `build` job to use a `strategy.matrix` separating target platforms.
    - `AppImage` is built in `ubuntu:24.04` to maintain FreeType 2.13+ layout compatibility.
    - `Debian` is built in `ubuntu:22.04` to restore the GLIBC 2.35 floor.
    - Updated steps (`tauri build`, `fix-appimage.sh` gating, artifact collection, and uploading) to be matrix-aware.
  - **`.github/workflows/release.yml`**: 
    - Isolated the existing `release-linux` job to only build `appimage` on `ubuntu:24.04`.
    - Added a new `release-linux-deb` job running on `ubuntu:22.04` to compile the `deb` package only.
    - Updated the `assemble-manifest` job to wait for both `release-linux` and `release-linux-deb` before completing the release draft.

### References

- Resolves the compatibility regression introduced in [PR #3602]

### Validation

- The workflows have been validated by running them on a fork:
  - The `AppImage` matrix job successfully compiled the AppImage package on `ubuntu:24.04`.
  - The `Debian` matrix job successfully compiled the `.deb` package on `ubuntu:22.04`.
  - The generated `.deb` package was downloaded and verified to install and launch without GLIBC errors on an Ubuntu 22.04 LTS system (GLIBC 2.35).
