### PR TITLE
Open links in browser on Cmd/Ctrl+click

### DIFF
--- a/desktop/src/shared/lib/platform.test.mjs
+++ b/desktop/src/shared/lib/platform.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasPrimaryShortcutModifier } from "./platform.ts";
+
+const originalNavigator = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "navigator",
+);
+
+function withPlatform(platform, userAgent, run) {
+  Object.defineProperty(globalThis, "navigator", {
+    value: { platform, userAgent: userAgent ?? "" },
+    configurable: true,
+    writable: true,
+  });
+  try {
+    run();
+  } finally {
+    if (originalNavigator) {
+      Object.defineProperty(globalThis, "navigator", originalNavigator);
+    } else {
+      delete globalThis.navigator;
+    }
+  }
+}
+
+const mods = (overrides) => ({
+  altKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false,
+  ...overrides,
+});
+
+// ── macOS: Command is the primary modifier, Control is NOT ───────────────────
+
+test("macOS: Cmd (meta) is the primary modifier", () => {
+  withPlatform("MacIntel", "", () => {
+    assert.equal(hasPrimaryShortcutModifier(mods({ metaKey: true })), true);
+  });
+});
+
+test("macOS: Ctrl is rejected (it is a right-click / Emacs binding there)", () => {
+  withPlatform("MacIntel", "", () => {
+    assert.equal(hasPrimaryShortcutModifier(mods({ ctrlKey: true })), false);
+  });
+});
+
+test("macOS: Cmd+Ctrl together is rejected", () => {
+  withPlatform("MacIntel", "", () => {
+    assert.equal(
+      hasPrimaryShortcutModifier(mods({ metaKey: true, ctrlKey: true })),
+      false,
+    );
+  });
+});
+
+test("macOS: no modifier is not the primary modifier", () => {
+  withPlatform("MacIntel", "", () => {
+    assert.equal(hasPrimaryShortcutModifier(mods()), false);
+  });
+});
+
+// ── Windows/Linux: Control is the primary modifier, Meta is NOT ──────────────
+
+test("Windows: Ctrl is the primary modifier", () => {
+  withPlatform("Win32", "", () => {
+    assert.equal(hasPrimaryShortcutModifier(mods({ ctrlKey: true })), true);
+  });
+});
+
+test("Windows: Meta (Windows key) is not the primary modifier", () => {
+  withPlatform("Win32", "", () => {
+    assert.equal(hasPrimaryShortcutModifier(mods({ metaKey: true })), false);
+  });
+});
+
+test("Linux: Ctrl is the primary modifier, Meta+Ctrl is rejected", () => {
+  withPlatform("Linux x86_64", "X11; Linux x86_64", () => {
+    assert.equal(hasPrimaryShortcutModifier(mods({ ctrlKey: true })), true);
+    assert.equal(
+      hasPrimaryShortcutModifier(mods({ ctrlKey: true, metaKey: true })),
+      false,
+    );
+  });
+});

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -9,7 +9,6 @@ import {
   ZoomOut,
 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { openUrl } from "@tauri-apps/plugin-opener";
 import { toast } from "sonner";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
@@ -23,7 +22,6 @@ import { UserProfilePopover } from "@/features/profile/ui/UserProfilePopover";
 import { invokeTauri } from "@/shared/api/tauri";
 import { useChannelNavigation } from "@/shared/context/ChannelNavigationContext";
 import { cn } from "@/shared/lib/cn";
-import { copyTextToClipboard } from "@/shared/lib/clipboard";
 import {
   extractSupportedLinkPreviews,
   parseSupportedLinkPreview,
@@ -59,6 +57,7 @@ import {
   MarkdownCodeBlock,
   SyntaxHighlightedCode,
 } from "./markdown/CodeBlock";
+import { ExternalLinkAnchor } from "./markdown/ExternalLinkAnchor";
 import { FileCard } from "./markdown/FileCard";
 import { InlineEmojiPopover } from "./markdown/InlineEmojiPopover";
 import { MarkdownInput } from "./markdown/MarkdownInput";
@@ -108,7 +107,6 @@ import {
   visibleImageGalleryForTrigger,
 } from "./markdown/imageLightbox";
 import { MarkdownTable } from "./markdown/MarkdownTable";
-import { MaskedLinkTooltip } from "./markdown/MaskedLinkTooltip";
 import { ProgressiveImage } from "./markdown/ProgressiveImage";
 import { MessageLinkPill } from "./markdown/MessageLinkPill";
 import { renderCachedMarkdown } from "./markdown/nodeCache";
@@ -1269,85 +1267,6 @@ function ImageMosaic({ children }: { children: React.ReactNode[] }) {
     >
       {children}
     </div>
-  );
-}
-
-/**
- * An external `[text](href)` link with a custom right-click menu.
- *
- * Buzz renders inside a native webview whose default context menu has no
- * useful link actions, so a plain right-click on a link is a no-op. This adds
- * an in-app menu with "Open link" (via the OS opener, matching the anchor's
- * left-click `target="_blank"` behavior) and "Copy link" (the real href, not
- * the masked display text).
- */
-function ExternalLinkAnchor({
-  anchorProps,
-  children,
-  href,
-  isLinearLink,
-  label,
-}: {
-  anchorProps: React.ComponentPropsWithoutRef<"a">;
-  children: React.ReactNode;
-  href: string | undefined;
-  isLinearLink: boolean;
-  label: string;
-}) {
-  const [menu, setMenu] = React.useState<MediaContextMenuPosition | null>(null);
-  const closeMenu = React.useCallback(() => setMenu(null), []);
-  useDismissMediaContextMenu(Boolean(menu), closeMenu);
-
-  const anchor = (
-    <a
-      {...anchorProps}
-      className={cn(
-        "font-medium underline underline-offset-4 transition-colors",
-        isLinearLink ? "linear-link" : "text-primary hover:text-primary/80",
-      )}
-      href={href}
-      onContextMenuCapture={(event) => {
-        if (!href) return;
-        event.preventDefault();
-        setMenu({ x: event.clientX, y: event.clientY });
-      }}
-      rel="noreferrer"
-      target="_blank"
-    >
-      {children}
-    </a>
-  );
-
-  return (
-    <>
-      <MaskedLinkTooltip disabled={isLinearLink} href={href} label={label}>
-        {anchor}
-      </MaskedLinkTooltip>
-      {menu && href ? (
-        <MediaContextMenu
-          dataAttributes={["data-link-context-menu"]}
-          items={[
-            {
-              label: "Open link",
-              onSelect: () => {
-                closeMenu();
-                void openUrl(href).catch(() => {
-                  toast.error("Failed to open link");
-                });
-              },
-            },
-            {
-              label: "Copy link",
-              onSelect: () => {
-                closeMenu();
-                copyTextToClipboard(href, "Link copied to clipboard");
-              },
-            },
-          ]}
-          position={menu}
-        />
-      ) : null}
-    </>
   );
 }
 

--- a/desktop/src/shared/ui/markdown/ExternalLinkAnchor.tsx
+++ b/desktop/src/shared/ui/markdown/ExternalLinkAnchor.tsx
@@ -1,0 +1,106 @@
+import * as React from "react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { toast } from "sonner";
+
+import { cn } from "@/shared/lib/cn";
+import { copyTextToClipboard } from "@/shared/lib/clipboard";
+import { hasPrimaryShortcutModifier } from "@/shared/lib/platform";
+
+import { MaskedLinkTooltip } from "./MaskedLinkTooltip";
+import {
+  MediaContextMenu,
+  type MediaContextMenuPosition,
+  useDismissMediaContextMenu,
+} from "./MediaContextMenu";
+
+/**
+ * An external `[text](href)` link with a custom right-click menu.
+ *
+ * Buzz renders inside a native webview whose default context menu has no
+ * useful link actions, so a plain right-click on a link is a no-op. This adds
+ * an in-app menu with "Open link" (via the OS opener, matching the anchor's
+ * left-click `target="_blank"` behavior) and "Copy link" (the real href, not
+ * the masked display text).
+ */
+export function ExternalLinkAnchor({
+  anchorProps,
+  children,
+  href,
+  isLinearLink,
+  label,
+}: {
+  anchorProps: React.ComponentPropsWithoutRef<"a">;
+  children: React.ReactNode;
+  href: string | undefined;
+  isLinearLink: boolean;
+  label: string;
+}) {
+  const [menu, setMenu] = React.useState<MediaContextMenuPosition | null>(null);
+  const closeMenu = React.useCallback(() => setMenu(null), []);
+  useDismissMediaContextMenu(Boolean(menu), closeMenu);
+
+  const anchor = (
+    <a
+      {...anchorProps}
+      className={cn(
+        "font-medium underline underline-offset-4 transition-colors",
+        isLinearLink ? "linear-link" : "text-primary hover:text-primary/80",
+      )}
+      href={href}
+      onClick={(event) => {
+        if (!href) return;
+        // Primary-modifier click (Cmd on macOS, Ctrl on Windows/Linux) opens
+        // in the OS browser, matching Slack/Discord. WKWebView swallows the
+        // modifier click on a `target="_blank"` anchor — there is no tab to
+        // open into — so without this it is a dead gesture. A plain click
+        // keeps the native `target="_blank"` open-in-browser behavior.
+        if (!hasPrimaryShortcutModifier(event)) return;
+        event.preventDefault();
+        void openUrl(href).catch(() => {
+          toast.error("Failed to open link");
+        });
+      }}
+      onContextMenuCapture={(event) => {
+        if (!href) return;
+        event.preventDefault();
+        setMenu({ x: event.clientX, y: event.clientY });
+      }}
+      rel="noreferrer"
+      target="_blank"
+    >
+      {children}
+    </a>
+  );
+
+  return (
+    <>
+      <MaskedLinkTooltip disabled={isLinearLink} href={href} label={label}>
+        {anchor}
+      </MaskedLinkTooltip>
+      {menu && href ? (
+        <MediaContextMenu
+          dataAttributes={["data-link-context-menu"]}
+          items={[
+            {
+              label: "Open link",
+              onSelect: () => {
+                closeMenu();
+                void openUrl(href).catch(() => {
+                  toast.error("Failed to open link");
+                });
+              },
+            },
+            {
+              label: "Copy link",
+              onSelect: () => {
+                closeMenu();
+                copyTextToClipboard(href, "Link copied to clipboard");
+              },
+            },
+          ]}
+          position={menu}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/desktop/tests/e2e/messaging.spec.ts
+++ b/desktop/tests/e2e/messaging.spec.ts
@@ -280,6 +280,53 @@ test("supported link previews keep the message link visible", async ({
   await expectSmoothCorners(previewCard);
 });
 
+test("primary-modifier click on a message link opens it in the OS browser", async ({
+  page,
+}) => {
+  const url = `https://example.com/cmd-click-${Date.now()}`;
+
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  await page.getByTestId("message-input").fill(url);
+  await page.getByTestId("send-message").click();
+
+  const link = page
+    .getByTestId("message-row")
+    .last()
+    .getByRole("link", { exact: true, name: url });
+  await expect(link).toBeVisible();
+
+  const openedUrls = () =>
+    page.evaluate(
+      (href) =>
+        (
+          window as Window & {
+            __BUZZ_E2E_COMMAND_LOG__?: Array<{
+              command: string;
+              payload: unknown;
+            }>;
+          }
+        ).__BUZZ_E2E_COMMAND_LOG__?.filter(
+          (entry) =>
+            entry.command === "plugin:opener|open_url" &&
+            (entry.payload as { url?: string }).url === href,
+        ).length ?? 0,
+      url,
+    );
+
+  // Nothing has opened the URL yet.
+  expect(await openedUrls()).toBe(0);
+
+  // `ControlOrMeta` is Cmd on macOS and Ctrl elsewhere — exactly the platform
+  // primary modifier `hasPrimaryShortcutModifier` accepts. In a real WKWebView
+  // this gesture is otherwise swallowed; here we assert it routes to the opener.
+  await link.click({ modifiers: ["ControlOrMeta"] });
+
+  await expect.poll(openedUrls).toBe(1);
+});
+
 test("send multiple messages in sequence", async ({ page }) => {
   const ts = Date.now();
   const messages = [


### PR DESCRIPTION
## Summary
- Cmd+click (macOS) / Ctrl+click (Windows/Linux) on a message link now opens it in the OS browser, matching Slack and Discord.
- Previously this gesture was a dead no-op: Buzz renders inside a WKWebView that silently swallows the modifier-click on a `target="_blank"` anchor — there is no browser tab to open into.
- A plain (unmodified) click keeps the existing native open-in-browser behavior; the right-click "Open link" / "Copy link" menu is unchanged.

## Implementation
The link click handler routes primary-modifier clicks through the OS opener via the existing `hasPrimaryShortcutModifier` helper, which already encodes the platform rule (Cmd on macOS, Ctrl elsewhere; Ctrl is rejected on macOS since it is the right-click there).

To keep the diff small and stay under the file-size ratchet, the external link anchor was extracted out of the 2k-line `markdown.tsx` into its own `ExternalLinkAnchor.tsx` (net **-82 lines** in `markdown.tsx`).

## Validation
- New unit tests for `hasPrimaryShortcutModifier` across macOS / Windows / Linux (7 cases).
- New E2E test (`messaging.spec.ts`) that sends a link, `ControlOrMeta`-clicks it, and asserts exactly one `plugin:opener|open_url` reaches the bridge — **passing**.
- `pnpm typecheck`, `biome check`, and the file-size / px-text / pubkey guards all green; full desktop unit suite passes.
- Note: Chromium (Playwright) doesn't reproduce WKWebView's modifier-swallow, so the underlying dead-gesture root cause was confirmed by reasoning about the native webview; the fix itself is verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
