### PR TITLE
fix(acp): clarify pool worker startup errors

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3752,7 +3752,7 @@ async fn shutdown_agent_pool(pool: &mut AgentPool) {
 }
 
 struct PoolStartup {
-    agents: u32,
+    worker_count: u32,
     command: String,
     args: Vec<String>,
     extra_env: Vec<(String, String)>,
@@ -3764,7 +3764,7 @@ struct PoolStartup {
 impl PoolStartup {
     fn from_config(config: &Config, observer: Option<observer::ObserverHandle>) -> Self {
         Self {
-            agents: config.agents,
+            worker_count: config.agents,
             command: config.agent_command.clone(),
             args: config.agent_args.clone(),
             extra_env: config.persona_env_vars.clone(),
@@ -3779,10 +3779,11 @@ async fn initialize_agent_pool(
     startup: &PoolStartup,
     mut shutdown: Option<watch::Receiver<()>>,
 ) -> Result<AgentPool> {
-    // One agent failing to start must not kill the whole pool.
+    // One harness worker failing to start must not kill the whole pool.
     // Attempt each spawn under a 60-second timeout; a partial pool is valid.
-    let mut agent_slots: Vec<Option<OwnedAgent>> = Vec::with_capacity(startup.agents as usize);
-    for i in 0..startup.agents as usize {
+    let mut agent_slots: Vec<Option<OwnedAgent>> =
+        Vec::with_capacity(startup.worker_count as usize);
+    for i in 0..startup.worker_count as usize {
         let spawn_result = AcpClient::spawn(
             &startup.command,
             &startup.args,
@@ -3843,19 +3844,22 @@ async fn initialize_agent_pool(
                         }));
                     }
                     Ok(Err(e)) => {
-                        tracing::error!(agent = i, "agent initialize failed: {e}");
+                        tracing::error!(worker = i, "ACP harness worker initialize failed: {e}");
                         acp.shutdown().await;
                         agent_slots.push(None);
                     }
                     Err(_) => {
-                        tracing::error!(agent = i, "agent timed out during init (60s)");
+                        tracing::error!(
+                            worker = i,
+                            "ACP harness worker timed out during init (60s)"
+                        );
                         acp.shutdown().await;
                         agent_slots.push(None);
                     }
                 }
             }
             Err(e) => {
-                tracing::error!(agent = i, "agent failed to spawn: {e}");
+                tracing::error!(worker = i, "ACP harness worker failed to spawn: {e}");
                 agent_slots.push(None);
             }
         }
@@ -3863,15 +3867,15 @@ async fn initialize_agent_pool(
     let live_count = agent_slots.iter().filter(|slot| slot.is_some()).count();
     if live_count == 0 {
         return Err(anyhow::anyhow!(
-            "all {} agents failed to start — cannot continue",
-            startup.agents
+            "all {} ACP harness workers failed to start — cannot continue",
+            startup.worker_count
         ));
     }
-    if live_count < startup.agents as usize {
+    if live_count < startup.worker_count as usize {
         tracing::warn!(
-            "started {}/{} agents — continuing with reduced pool",
+            "started {}/{} ACP harness workers — continuing with reduced pool",
             live_count,
-            startup.agents
+            startup.worker_count
         );
     }
     tracing::info!("agent_pool_ready agents={}", live_count);
@@ -4231,6 +4235,34 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
             env
         },
     }]
+}
+
+#[cfg(test)]
+mod pool_startup_diagnostic_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn all_failed_workers_are_not_reported_as_separate_buzz_agents() {
+        let startup = PoolStartup {
+            worker_count: 2,
+            command: "buzz-acp-nonexistent-test-command".to_string(),
+            args: vec![],
+            extra_env: vec![],
+            has_generated_codex_config: false,
+            model: None,
+            observer: None,
+        };
+
+        let error = match initialize_agent_pool(&startup, None).await {
+            Ok(_) => panic!("a nonexistent harness command must fail every worker"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "all 2 ACP harness workers failed to start — cannot continue"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Clarifies ACP pool-startup diagnostics so a pool worker is not reported as a separate configured Buzz agent.

When one configured agent starts a pool of `BUZZ_ACP_AGENTS=N` harness subprocesses, the previous errors labeled each pool index as `agent=N` and reported `all N agents failed`. That reads like a workspace-wide failure even though the count belongs to one agent's local harness pool.

## Problem and reproduction

Configure one agent with a pool size greater than one and a harness command that fails during startup. For example, with two workers, the aggregate failure previously ended with:

```text
all 2 agents failed to start — cannot continue
```

Per-slot startup failures also used a structured `agent=N` field. Together, those diagnostics made one misconfigured agent look like several independent Buzz agents had failed.

## Root cause

`PoolStartup::agents` is populated from `Config::agents`, which is the `BUZZ_ACP_AGENTS` harness-pool size. At this boundary, each index identifies a subprocess slot inside one configured agent, not a separate user-facing Buzz agent. The same noun was therefore being used for two different concepts.

## Implementation

- rename the internal startup count from `agents` to `worker_count`
- report startup failures with `worker=N` and `ACP harness worker` wording
- report zero-live-worker and reduced-pool outcomes as ACP harness workers
- add a regression test that starts a two-worker pool with a nonexistent command and checks the aggregate diagnostic

Successful initialization events and the existing `agent_pool_ready agents=N` marker are intentionally unchanged. They may be consumed as structured log/readiness contracts, and changing them is not required to fix the misleading failure path.

The outer configured agent name is not available to `initialize_agent_pool`, so this patch does not add identity plumbing solely for the diagnostic. The containing process/log still identifies the configured agent; this change makes the count and per-slot indices unambiguous within that log.

## Scope and risk

This changes diagnostics and an internal field name only. It does not change:

- pool sizing or `BUZZ_ACP_AGENTS`
- process spawning, initialization, timeout, shutdown, or retry behavior
- ACP protocol messages or observer event payloads
- successful-start/readiness log markers

## Related issue

Closes #3338.

No competing implementation was found after checking linked PRs and searching open PRs by issue number, diagnostic wording, and the affected source path before publication.

## Testing

Verified from base `052174a148f9f6bcbb2b5a1d20ce0317645e49f8` at candidate head `91d722e905d87d6b32ec3a6928fcbd11bf45fad4` in a clean Linux environment:

- `cargo fmt --all -- --check`
- `cargo test -p buzz-acp all_failed_workers_are_not_reported_as_separate_buzz_agents -- --nocapture`
- `cargo test -p buzz-acp`: 650 unit tests and 9 integration tests passed
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`

The regression test was run against the pre-fix behavior first. It failed with:

```text
left:  "all 2 agents failed to start — cannot continue"
right: "all 2 ACP harness workers failed to start — cannot continue"
```

It passes with this patch.
