### PR TITLE
ci(acp): add a command-neutral acceptance probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
         run: scripts/test-mobile-worktree-overrides.sh
       - name: File size ratchet unit tests
         run: node --test scripts/check-file-sizes-core.test.mjs
+      - name: ACP command acceptance contract
+        run: scripts/test-agent-harness-acceptance.sh
 
   rust-lint:
     name: Rust Lint

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -23,6 +23,26 @@ cargo build --release -p buzz-acp
 export PATH="$PWD/target/release:$PATH"
 ```
 
+## Validate an ACP command
+
+The repository includes a command-neutral acceptance probe for ACP adapters. It
+starts the supplied executable through `buzz-acp models` and requires successful
+`initialize` and `session/new` responses with the expected structured output.
+No relay, Buzz identity, or deployment configuration is involved.
+
+```bash
+./scripts/agent-harness-acceptance.sh \
+  --agent-command /path/to/acp-adapter \
+  --agent-arg serve \
+  --agent-arg "value with spaces" \
+  --timeout 15
+```
+
+Repeat `--agent-arg` to preserve exact argument boundaries. The timeout applies
+to the ACP handshake and accepts an integer from 1 to 300 seconds. Exit code 2
+means the supplied executable is missing; other probe or contract failures use
+exit code 1.
+
 ## Generating Keys
 
 Each agent needs a Nostr keypair — this is the agent's identity in Buzz. Use `buzz-admin` to generate one:

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -179,6 +179,15 @@ pub struct ModelsArgs {
     #[command(flatten)]
     pub agent: AuthAgentArgs,
 
+    /// One argument passed to the agent binary. Repeat to preserve argument
+    /// boundaries, including spaces and commas.
+    #[arg(long = "agent-arg", action = clap::ArgAction::Append)]
+    pub additional_agent_args: Vec<String>,
+
+    /// Maximum seconds for ACP initialize plus session/new.
+    #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u64).range(1..=300))]
+    pub timeout: u64,
+
     /// Output structured JSON instead of human-readable text.
     #[arg(long)]
     pub json: bool,
@@ -1560,6 +1569,33 @@ mod tests {
     fn normalizes_goose_args_to_acp() {
         assert_eq!(normalize_agent_args("goose", Vec::new()), vec!["acp"]);
         assert_eq!(normalize_agent_args("goose", vec!["".into()]), vec!["acp"]);
+    }
+
+    #[test]
+    fn models_args_preserve_repeated_argument_boundaries_and_timeout() {
+        let args = ModelsArgs::parse_from([
+            "buzz-acp models",
+            "--agent-command",
+            "custom-acp",
+            "--agent-args",
+            "",
+            "--agent-arg",
+            "serve",
+            "--agent-arg",
+            "two words",
+            "--agent-arg",
+            "comma,value",
+            "--timeout",
+            "17",
+        ]);
+
+        assert_eq!(args.agent.agent_command, "custom-acp");
+        assert_eq!(args.agent.agent_args, vec![""]);
+        assert_eq!(
+            args.additional_agent_args,
+            vec!["serve", "two words", "comma,value"]
+        );
+        assert_eq!(args.timeout, 17);
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4691,7 +4691,10 @@ async fn run_authenticate(args: AuthenticateArgs) -> Result<()> {
 async fn run_models(args: ModelsArgs) -> Result<()> {
     use acp::{extract_model_config_options, extract_model_state};
 
-    let agent_args = config::normalize_agent_args(&args.agent.agent_command, args.agent.agent_args);
+    let mut raw_agent_args = args.agent.agent_args;
+    raw_agent_args.extend(args.additional_agent_args);
+    let agent_args = config::normalize_agent_args(&args.agent.agent_command, raw_agent_args);
+    let models_timeout = Duration::from_secs(args.timeout);
     let cwd = std::env::current_dir()
         .unwrap_or_else(|_| std::path::PathBuf::from("/"))
         .to_string_lossy()
@@ -4710,7 +4713,7 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
 
     // Initialize + session/new under a timeout. Client is owned above,
     // so shutdown() runs on all paths (success, error, timeout).
-    let protocol_result = tokio::time::timeout(MODELS_TIMEOUT, async {
+    let protocol_result = tokio::time::timeout(models_timeout, async {
         let init = client.initialize().await?;
         let session = client.session_new_full(&cwd, vec![], None, None).await?;
         Ok::<_, acp::AcpError>((init, session))
@@ -4726,7 +4729,7 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
         }
         Err(_) => {
             client.shutdown().await;
-            eprintln!("error: agent timed out ({MODELS_TIMEOUT:?})");
+            eprintln!("error: agent timed out ({models_timeout:?})");
             std::process::exit(1);
         }
     };

--- a/scripts/agent-harness-acceptance.sh
+++ b/scripts/agent-harness-acceptance.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --agent-command <executable> [--agent-arg <value>]... [--timeout <seconds>]" >&2
+}
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+agent_command=""
+agent_args=()
+agent_arg_count=0
+timeout_seconds=10
+
+while (($# > 0)); do
+  case "$1" in
+    --agent-command)
+      (($# >= 2)) || { usage; exit 64; }
+      agent_command=$2
+      shift 2
+      ;;
+    --agent-arg)
+      (($# >= 2)) || { usage; exit 64; }
+      agent_args+=("$2")
+      agent_arg_count=$((agent_arg_count + 1))
+      shift 2
+      ;;
+    --timeout)
+      (($# >= 2)) || { usage; exit 64; }
+      timeout_seconds=$2
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 64
+      ;;
+  esac
+done
+
+if [[ -z "$agent_command" ]]; then
+  echo "Missing required --agent-command" >&2
+  usage
+  exit 64
+fi
+
+if [[ ! "$timeout_seconds" =~ ^[0-9]+$ ]] || ((timeout_seconds < 1 || timeout_seconds > 300)); then
+  echo "--timeout must be an integer from 1 to 300 seconds" >&2
+  exit 64
+fi
+
+buzz_acp_bin=${BUZZ_ACP_BIN:-"$repo_root/target/debug/buzz-acp"}
+if [[ -n "${BUZZ_ACP_BIN:-}" ]]; then
+  if [[ ! -x "$buzz_acp_bin" ]]; then
+    echo "FAIL buzz-acp: BUZZ_ACP_BIN is not executable: $buzz_acp_bin" >&2
+    exit 1
+  fi
+else
+  (
+    cd "$repo_root"
+    cargo build -p buzz-acp
+  )
+fi
+
+if [[ "$agent_command" == */* ]]; then
+  if [[ ! -x "$agent_command" ]]; then
+    echo "MISSING: agent command is not executable: $agent_command" >&2
+    exit 2
+  fi
+elif ! command -v "$agent_command" >/dev/null 2>&1; then
+  echo "MISSING: agent command was not found on PATH: $agent_command" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL jq: required to validate structured ACP probe output" >&2
+  exit 1
+fi
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+output="$tmp_dir/output.json"
+error_output="$tmp_dir/stderr"
+
+probe_args=(
+  models
+  --agent-command "$agent_command"
+  --agent-args ""
+  --timeout "$timeout_seconds"
+  --json
+)
+if ((agent_arg_count > 0)); then
+  for agent_arg in "${agent_args[@]}"; do
+    probe_args+=(--agent-arg "$agent_arg")
+  done
+fi
+
+echo "PROBE: $agent_command ($agent_arg_count args, ${timeout_seconds}s timeout)"
+if ! "$buzz_acp_bin" "${probe_args[@]}" >"$output" 2>"$error_output"; then
+  echo "FAIL: ACP initialize/session-new probe failed" >&2
+  sed 's/^/  /' "$error_output" >&2
+  exit 1
+fi
+
+if [[ ! -s "$output" ]] || ! jq -e '
+  (.agent | type == "object")
+  and (.agent.name | type == "string")
+  and (.agent.version | type == "string")
+  and (.stable.configOptions | type == "array")
+' "$output" >/dev/null; then
+  echo "FAIL: probe returned an unexpected JSON contract" >&2
+  sed 's/^/  /' "$output" >&2
+  exit 1
+fi
+
+agent_name=$(jq -r '.agent.name' "$output")
+agent_version=$(jq -r '.agent.version' "$output")
+echo "PASS: ACP initialize + session/new ($agent_name $agent_version)"

--- a/scripts/test-agent-harness-acceptance.sh
+++ b/scripts/test-agent-harness-acceptance.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+acceptance="$repo_root/scripts/agent-harness-acceptance.sh"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$tmp_dir/bin/custom-acp"
+chmod +x "$tmp_dir/bin/custom-acp"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'printf "<%s>\\n" "$@" >"$CALL_LOG"' \
+  'printf "%s\\n" '\''{"agent":{"name":"fixture","version":"1.0"},"stable":{"configOptions":[]},"unstable":null}'\''' \
+  >"$tmp_dir/fake-buzz-acp"
+chmod +x "$tmp_dir/fake-buzz-acp"
+
+CALL_LOG="$tmp_dir/calls" \
+BUZZ_ACP_BIN="$tmp_dir/fake-buzz-acp" \
+  "$acceptance" \
+    --agent-command "$tmp_dir/bin/custom-acp" \
+    --agent-arg serve \
+    --agent-arg "two words" \
+    --agent-arg "comma,value" \
+    --timeout 17 \
+    >"$tmp_dir/success.out"
+
+printf '%s\n' \
+  '<models>' \
+  "<--agent-command>" \
+  "<$tmp_dir/bin/custom-acp>" \
+  '<--agent-args>' \
+  '<>' \
+  '<--timeout>' \
+  '<17>' \
+  '<--json>' \
+  '<--agent-arg>' \
+  '<serve>' \
+  '<--agent-arg>' \
+  '<two words>' \
+  '<--agent-arg>' \
+  '<comma,value>' \
+  >"$tmp_dir/expected-calls"
+cmp "$tmp_dir/expected-calls" "$tmp_dir/calls"
+grep -Fq "PASS: ACP initialize + session/new (fixture 1.0)" "$tmp_dir/success.out"
+
+set +e
+BUZZ_ACP_BIN="$tmp_dir/fake-buzz-acp" \
+  "$acceptance" --agent-command "$tmp_dir/bin/missing-acp" \
+  >"$tmp_dir/missing.out" 2>"$tmp_dir/missing.err"
+missing_status=$?
+set -e
+if [[ $missing_status -ne 2 ]]; then
+  echo "expected missing prerequisite exit 2, got $missing_status" >&2
+  exit 1
+fi
+grep -Fq "MISSING" "$tmp_dir/missing.err"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "%s\\n" '\''{"unexpected":true}'\''' \
+  >"$tmp_dir/bad-buzz-acp"
+chmod +x "$tmp_dir/bad-buzz-acp"
+
+set +e
+BUZZ_ACP_BIN="$tmp_dir/bad-buzz-acp" \
+  "$acceptance" --agent-command "$tmp_dir/bin/custom-acp" \
+  >"$tmp_dir/bad.out" 2>"$tmp_dir/bad.err"
+bad_status=$?
+set -e
+if [[ $bad_status -ne 1 ]]; then
+  echo "expected protocol-contract failure exit 1, got $bad_status" >&2
+  exit 1
+fi
+grep -Fq "unexpected JSON contract" "$tmp_dir/bad.err"
+
+set +e
+BUZZ_ACP_BIN="$tmp_dir/fake-buzz-acp" \
+  "$acceptance" --agent-command "$tmp_dir/bin/custom-acp" --timeout 0 \
+  >"$tmp_dir/timeout.out" 2>"$tmp_dir/timeout.err"
+timeout_status=$?
+set -e
+if [[ $timeout_status -ne 64 ]]; then
+  echo "expected timeout validation exit 64, got $timeout_status" >&2
+  exit 1
+fi
+grep -Fq -- "--timeout must be an integer" "$tmp_dir/timeout.err"
+
+echo "ACP command acceptance contract passed"


### PR DESCRIPTION
## Summary

Adds a command-neutral acceptance probe for ACP executables. Callers provide the executable and repeatable arguments explicitly; Buzz verifies that the command completes ACP `initialize` and `session/new` through `buzz-acp models` within a bounded timeout.

The contract depends only on the public ACP process boundary. It does not assume a particular runtime, host, relay, private key, deployment topology, or lifecycle manager.

## What changed

- Adds `scripts/agent-harness-acceptance.sh` with required `--agent-command`, repeatable `--agent-arg`, and configurable `--timeout` options.
- Extends `buzz-acp models` with additive `--agent-arg` and `--timeout` options while preserving the existing positional argument behavior.
- Preserves argument boundaries exactly, including spaces and commas.
- Adds `scripts/test-agent-harness-acceptance.sh`, backed by a synthetic ACP command and fake `buzz-acp`, so CI validates success and failure behavior without installing any external runtime.
- Wires the synthetic contract test into the existing GitHub Actions quick script checks.
- Documents the public invocation in `crates/buzz-acp/README.md`.

The earlier unrelated `ARCHITECTURE.md` protocol-limit correction and named runtime presets are intentionally not part of this revision.

## Why

An external ACP implementation should be testable against Buzz without adding runtime-specific discovery, installation, credentials, machine assumptions, or deployment policy to this repository. This probe gives adapter authors a stable executable contract while keeping those concerns with the caller.

## Validation

- `bash -n scripts/agent-harness-acceptance.sh scripts/test-agent-harness-acceptance.sh`
- `scripts/test-agent-harness-acceptance.sh`
- `cargo test -p buzz-acp`
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- Real synthetic ACP handshake through the built `buzz-acp`, including arguments containing spaces and commas
- `just ci`

The full `just ci` gate passed on 2026-08-13, including the current Rust, desktop/Tauri, web, and mobile checks, tests, and builds.

Rebuilt as one signed commit on `upstream/main` at `a96af8952`.
