### PR TITLE
feat: add configurable agent behavior controls

### DIFF
--- a/crates/buzz-cli/README.md
+++ b/crates/buzz-cli/README.md
@@ -45,6 +45,8 @@ buzz messages send-diff --channel <uuid> --diff - --repo https://github.com/org/
 # Channels
 buzz channels list
 buzz channels create --name "my-channel" --type stream --visibility open
+buzz channels update --channel <uuid> --agent-reply-mode inline
+buzz channels update --channel <dm-uuid> --no-dm-require-mention
 buzz channels join --channel <uuid>
 buzz channels topic --channel <uuid> --topic "New topic"
 
@@ -113,7 +115,7 @@ stored rules in `validation_error` so an owner can remove and repair them.
 | `channels` | `list` | List channels |
 | | `get` | Get channel details |
 | | `create` | Create a channel |
-| | `update` | Update channel name/description |
+| | `update` | Update channel metadata, TTL, and agent behavior policy |
 | | `topic` | Set channel topic |
 | | `purpose` | Set channel purpose |
 | | `join` | Join a channel |

--- a/crates/buzz-cli/src/commands/channels.rs
+++ b/crates/buzz-cli/src/commands/channels.rs
@@ -14,10 +14,18 @@ use crate::error::CliError;
 use crate::validate::{parse_uuid, read_or_stdin, validate_hex64, validate_uuid};
 
 fn extract_channel_metadata(e: &serde_json::Value) -> serde_json::Value {
+    let agent_reply_mode = match extract_tag_value(e, "agent_reply_mode").as_str() {
+        "inline" => "inline",
+        _ => "thread",
+    };
+    let dm_require_mention = extract_tag_value(e, "dm_require_mention") != "false";
     serde_json::json!({
         "channel_id": extract_d_tag(e),
         "name": extract_tag_value(e, "name"),
+        "channel_type": extract_tag_value(e, "t"),
         "description": extract_tag_value(e, "about"),
+        "agent_reply_mode": agent_reply_mode,
+        "dm_require_mention": dm_require_mention,
         "created_at": e.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0),
     })
 }
@@ -161,6 +169,8 @@ struct ChannelSummary {
     about: Option<String>,
     topic: Option<String>,
     purpose: Option<String>,
+    agent_reply_mode: String,
+    dm_require_mention: bool,
 }
 
 impl ChannelSummary {
@@ -176,6 +186,8 @@ impl ChannelSummary {
         let mut about: Option<String> = None;
         let mut topic: Option<String> = None;
         let mut purpose: Option<String> = None;
+        let mut agent_reply_mode = "thread".to_string();
+        let mut dm_require_mention = true;
 
         for tag in tags {
             let Some(tag_arr) = tag.as_array() else {
@@ -194,6 +206,10 @@ impl ChannelSummary {
                 "about" => about = val.map(str::to_string),
                 "topic" => topic = val.map(str::to_string),
                 "purpose" => purpose = val.map(str::to_string),
+                "agent_reply_mode" if val == Some("inline") => {
+                    agent_reply_mode = "inline".to_string();
+                }
+                "dm_require_mention" => dm_require_mention = val != Some("false"),
                 "archived" => archived = val == Some("true"),
                 _ => {}
             }
@@ -208,6 +224,8 @@ impl ChannelSummary {
             about,
             topic,
             purpose,
+            agent_reply_mode,
+            dm_require_mention,
         })
     }
 }
@@ -829,31 +847,50 @@ fn validate_ttl_seconds(secs: i64) -> Result<i32, CliError> {
         .map_err(|_| CliError::Usage(format!("--ttl is too large (max {} seconds)", i32::MAX)))
 }
 
+pub struct ChannelUpdateArgs<'a> {
+    name: Option<&'a str>,
+    description: Option<&'a str>,
+    ttl: Option<i64>,
+    no_ttl: bool,
+    agent_reply_mode: Option<&'a str>,
+    dm_require_mention: Option<bool>,
+}
+
 pub async fn cmd_update_channel(
     client: &BuzzClient,
     channel_id: &str,
-    name: Option<&str>,
-    description: Option<&str>,
-    ttl: Option<i64>,
-    no_ttl: bool,
+    updates: ChannelUpdateArgs<'_>,
 ) -> Result<(), CliError> {
     // Outer Option: None leaves TTL unchanged. Inner: Some(secs) sets it,
     // None (from --no-ttl) clears it, making the channel permanent.
-    let ttl_change: Option<Option<i32>> = match (ttl, no_ttl) {
+    let ttl_change: Option<Option<i32>> = match (updates.ttl, updates.no_ttl) {
         (Some(secs), _) => Some(Some(validate_ttl_seconds(secs)?)),
         (None, true) => Some(None),
         (None, false) => None,
     };
 
-    if name.is_none() && description.is_none() && ttl_change.is_none() {
+    if updates.name.is_none()
+        && updates.description.is_none()
+        && ttl_change.is_none()
+        && updates.agent_reply_mode.is_none()
+        && updates.dm_require_mention.is_none()
+    {
         return Err(CliError::Usage(
-            "at least one field required (--name, --description, --ttl, --no-ttl)".into(),
+            "at least one field required (--name, --description, --ttl, --no-ttl, --agent-reply-mode, --dm-require-mention, --no-dm-require-mention)".into(),
         ));
     }
     let channel_uuid = parse_uuid(channel_id)?;
 
-    let builder = buzz_sdk::build_update_channel(channel_uuid, name, description, None, ttl_change)
-        .map_err(|e| CliError::Other(format!("build_update_channel failed: {e}")))?;
+    let builder = buzz_sdk::build_update_channel(
+        channel_uuid,
+        updates.name,
+        updates.description,
+        None,
+        ttl_change,
+        updates.agent_reply_mode,
+        updates.dm_require_mention,
+    )
+    .map_err(|e| CliError::Other(format!("build_update_channel failed: {e}")))?;
 
     let event = client.sign_event(builder)?;
     let resp = client.submit_event(event).await?;
@@ -1130,14 +1167,26 @@ pub async fn dispatch(
             description,
             ttl,
             no_ttl,
+            agent_reply_mode,
+            dm_require_mention,
+            no_dm_require_mention,
         } => {
+            let dm_require_mention = match (dm_require_mention, no_dm_require_mention) {
+                (true, _) => Some(true),
+                (false, true) => Some(false),
+                (false, false) => None,
+            };
             cmd_update_channel(
                 client,
                 &channel,
-                name.as_deref(),
-                description.as_deref(),
-                ttl,
-                no_ttl,
+                ChannelUpdateArgs {
+                    name: name.as_deref(),
+                    description: description.as_deref(),
+                    ttl,
+                    no_ttl,
+                    agent_reply_mode: agent_reply_mode.as_deref(),
+                    dm_require_mention,
+                },
             )
             .await
         }

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -573,7 +573,10 @@ pub enum ChannelsCmd {
         #[arg(long, value_name = "PATH")]
         templates_file: Option<String>,
     },
-    /// Update channel name, description, or ephemeral TTL
+    /// Update channel name, description, ephemeral TTL, or agent behavior policy
+    #[command(
+        after_help = "Examples:\n  buzz channels update --channel <UUID> --name planning\n  buzz channels update --channel <UUID> --agent-reply-mode inline\n  buzz channels update --channel <DM_UUID> --no-dm-require-mention"
+    )]
     Update {
         /// Channel UUID
         #[arg(long)]
@@ -591,6 +594,19 @@ pub enum ChannelsCmd {
         /// Clear an existing TTL, making the channel permanent.
         #[arg(long)]
         no_ttl: bool,
+        /// Agent reply placement policy: thread or inline.
+        #[arg(long, value_parser = ["thread", "inline"])]
+        agent_reply_mode: Option<String>,
+        /// Require explicit @mentions to wake agents in DMs.
+        #[arg(
+            long,
+            default_value_t = false,
+            conflicts_with = "no_dm_require_mention"
+        )]
+        dm_require_mention: bool,
+        /// Allow direct messages to wake agents without explicit @mentions.
+        #[arg(long, default_value_t = false)]
+        no_dm_require_mention: bool,
     },
     /// Set the channel topic
     Topic {

--- a/crates/buzz-db/src/channel.rs
+++ b/crates/buzz-db/src/channel.rs
@@ -63,6 +63,10 @@ pub struct ChannelRecord {
     pub ttl_seconds: Option<i32>,
     /// Deadline by which a new message must arrive or the channel is auto-archived.
     pub ttl_deadline: Option<DateTime<Utc>>,
+    /// Agent reply placement policy: `"thread"` or `"inline"`.
+    pub agent_reply_mode: String,
+    /// Whether agent DMs require explicit @mentions to wake the agent.
+    pub dm_require_mention: bool,
 }
 
 /// A channel membership row as returned from the database.
@@ -153,7 +157,8 @@ pub async fn create_channel(
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
                purpose, purpose_set_by, purpose_set_at,
-               ttl_seconds, ttl_deadline
+               ttl_seconds, ttl_deadline,
+               agent_reply_mode, dm_require_mention
         FROM channels WHERE community_id = $1 AND id = $2
         "#,
     )
@@ -253,7 +258,8 @@ pub async fn create_channel_with_id(
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
                purpose, purpose_set_by, purpose_set_at,
-               ttl_seconds, ttl_deadline
+               ttl_seconds, ttl_deadline,
+               agent_reply_mode, dm_require_mention
         FROM channels WHERE community_id = $1 AND id = $2
         "#,
     )
@@ -281,7 +287,8 @@ pub async fn get_channel(
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
                purpose, purpose_set_by, purpose_set_at,
-               ttl_seconds, ttl_deadline
+               ttl_seconds, ttl_deadline,
+               agent_reply_mode, dm_require_mention
         FROM channels WHERE community_id = $1 AND id = $2 AND deleted_at IS NULL
         "#,
     )
@@ -788,7 +795,8 @@ pub async fn list_channels(
                    nip29_group_id, topic_required, max_members,
                    topic, topic_set_by, topic_set_at,
                    purpose, purpose_set_by, purpose_set_at,
-                   ttl_seconds, ttl_deadline
+                   ttl_seconds, ttl_deadline,
+                   agent_reply_mode, dm_require_mention
             FROM channels
             WHERE community_id = $1 AND deleted_at IS NULL AND visibility::text = $2
             ORDER BY created_at DESC
@@ -808,7 +816,8 @@ pub async fn list_channels(
                    nip29_group_id, topic_required, max_members,
                    topic, topic_set_by, topic_set_at,
                    purpose, purpose_set_by, purpose_set_at,
-                   ttl_seconds, ttl_deadline
+                   ttl_seconds, ttl_deadline,
+                   agent_reply_mode, dm_require_mention
             FROM channels
             WHERE community_id = $1 AND deleted_at IS NULL
             ORDER BY created_at DESC
@@ -856,7 +865,8 @@ async fn get_channel_tx(
                nip29_group_id, topic_required, max_members,
                topic, topic_set_by, topic_set_at,
                purpose, purpose_set_by, purpose_set_at,
-               ttl_seconds, ttl_deadline
+               ttl_seconds, ttl_deadline,
+               agent_reply_mode, dm_require_mention
         FROM channels WHERE community_id = $1 AND id = $2 AND deleted_at IS NULL
         "#,
     )
@@ -959,6 +969,7 @@ pub async fn get_accessible_channels(
                c.topic, c.topic_set_by, c.topic_set_at,
                c.purpose, c.purpose_set_by, c.purpose_set_at,
                c.ttl_seconds, c.ttl_deadline,
+               c.agent_reply_mode, c.dm_require_mention,
                (cm.channel_id IS NOT NULL) AS is_member
         FROM channels c
         LEFT JOIN channel_members cm
@@ -1095,6 +1106,10 @@ fn row_to_channel_record(row: sqlx::postgres::PgRow) -> Result<ChannelRecord> {
     let purpose_set_at: Option<DateTime<Utc>> = row.try_get("purpose_set_at").unwrap_or(None);
     let ttl_seconds: Option<i32> = row.try_get("ttl_seconds").unwrap_or(None);
     let ttl_deadline: Option<DateTime<Utc>> = row.try_get("ttl_deadline").unwrap_or(None);
+    let agent_reply_mode: String = row
+        .try_get("agent_reply_mode")
+        .unwrap_or_else(|_| "thread".to_string());
+    let dm_require_mention: bool = row.try_get("dm_require_mention").unwrap_or(true);
 
     Ok(ChannelRecord {
         id,
@@ -1119,6 +1134,8 @@ fn row_to_channel_record(row: sqlx::postgres::PgRow) -> Result<ChannelRecord> {
         purpose_set_at,
         ttl_seconds,
         ttl_deadline,
+        agent_reply_mode,
+        dm_require_mention,
     })
 }
 
@@ -1149,6 +1166,10 @@ pub struct ChannelUpdate {
     /// ephemeral TTL (channel becomes permanent), `Some(Some(secs))` sets it.
     /// On any change the `ttl_deadline` is reset to `NOW() + ttl_seconds`.
     pub ttl_seconds: Option<Option<i32>>,
+    /// Agent reply placement policy: `"thread"` or `"inline"`.
+    pub agent_reply_mode: Option<String>,
+    /// Whether agent DMs require explicit @mentions to wake the agent.
+    pub dm_require_mention: Option<bool>,
 }
 
 /// Updates channel metadata dynamically.
@@ -1165,6 +1186,8 @@ pub async fn update_channel(
         && updates.description.is_none()
         && updates.visibility.is_none()
         && updates.ttl_seconds.is_none()
+        && updates.agent_reply_mode.is_none()
+        && updates.dm_require_mention.is_none()
     {
         return Err(DbError::InvalidData(
             "at least one field must be provided for update".to_string(),
@@ -1175,6 +1198,13 @@ pub async fn update_channel(
         *name = buzz_core::channel::canonical_channel_name(name).to_owned();
         if name.is_empty() {
             return Err(DbError::InvalidData("channel name is required".into()));
+        }
+    }
+    if let Some(mode) = updates.agent_reply_mode.as_ref() {
+        if mode != "thread" && mode != "inline" {
+            return Err(DbError::InvalidData(
+                "agent_reply_mode must be \"thread\" or \"inline\"".into(),
+            ));
         }
     }
 
@@ -1206,6 +1236,14 @@ pub async fn update_channel(
             None => set_parts.push("ttl_deadline = NULL".to_string()),
         }
     }
+    if updates.agent_reply_mode.is_some() {
+        set_parts.push(format!("agent_reply_mode = ${param_idx}"));
+        param_idx += 1;
+    }
+    if updates.dm_require_mention.is_some() {
+        set_parts.push(format!("dm_require_mention = ${param_idx}"));
+        param_idx += 1;
+    }
     let channel_param_idx = param_idx + 1;
     let sql = format!(
         "UPDATE channels SET {}, updated_at = NOW() WHERE community_id = ${param_idx} AND id = ${channel_param_idx} AND deleted_at IS NULL",
@@ -1224,6 +1262,12 @@ pub async fn update_channel(
     }
     if let Some(ref ttl) = updates.ttl_seconds {
         q = q.bind(*ttl);
+    }
+    if let Some(ref mode) = updates.agent_reply_mode {
+        q = q.bind(mode);
+    }
+    if let Some(require_mention) = updates.dm_require_mention {
+        q = q.bind(require_mention);
     }
     q = q.bind(community_id.as_uuid());
     q = q.bind(channel_id);

--- a/crates/buzz-db/src/dm.rs
+++ b/crates/buzz-db/src/dm.rs
@@ -511,6 +511,10 @@ fn row_to_channel_record(row: sqlx::postgres::PgRow) -> Result<ChannelRecord> {
         purpose_set_at: row.try_get("purpose_set_at").unwrap_or(None),
         ttl_seconds: row.try_get("ttl_seconds").unwrap_or(None),
         ttl_deadline: row.try_get("ttl_deadline").unwrap_or(None),
+        agent_reply_mode: row
+            .try_get("agent_reply_mode")
+            .unwrap_or_else(|_| "thread".to_string()),
+        dm_require_mention: row.try_get("dm_require_mention").unwrap_or(true),
     })
 }
 

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -301,6 +301,45 @@ async fn actor_owns_any_owner_agent(
     Ok(false)
 }
 
+/// Returns `true` if `actor_bytes` is the NIP-OA owner of any active member in
+/// `members`. This is intentionally broader than [`actor_owns_any_owner_agent`]
+/// and is only used for DM agent-behavior settings, where there is no useful
+/// owner/admin role hierarchy but the owning human still needs to tune how their
+/// own agent wakes and replies.
+async fn actor_owns_any_member_agent(
+    state: &Arc<AppState>,
+    community_id: buzz_core::CommunityId,
+    members: &[buzz_db::channel::MemberRecord],
+    actor_bytes: &[u8],
+) -> anyhow::Result<bool> {
+    for member in members {
+        if state
+            .db
+            .is_agent_owner(community_id, &member.pubkey, actor_bytes)
+            .await?
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn edit_metadata_is_agent_behavior_only(event: &Event) -> bool {
+    event.tags.iter().all(|t| {
+        let k = t.kind().to_string();
+        k != "name"
+            && k != "about"
+            && k != "archived"
+            && k != "topic"
+            && k != "purpose"
+            && k != "visibility"
+            && k != "ttl"
+    }) && event.tags.iter().any(|t| {
+        let k = t.kind().to_string();
+        k == "agent_reply_mode" || k == "dm_require_mention"
+    })
+}
+
 /// Validate an admin kind event BEFORE storage.
 pub async fn validate_admin_event(
     tenant: &TenantContext,
@@ -500,6 +539,8 @@ pub async fn validate_admin_event(
                 "purpose",
                 "visibility",
                 "ttl",
+                "agent_reply_mode",
+                "dm_require_mention",
             ];
             let has_recognized = event
                 .tags
@@ -507,7 +548,7 @@ pub async fn validate_admin_event(
                 .any(|t| RECOGNIZED_TAGS.contains(&t.kind().to_string().as_str()));
             if !has_recognized {
                 return Err(anyhow::anyhow!(
-                    "kind:9002 must include at least one metadata tag (name, about, archived, topic, purpose, visibility, ttl)"
+                    "kind:9002 must include at least one metadata tag (name, about, archived, topic, purpose, visibility, ttl, agent_reply_mode, dm_require_mention)"
                 ));
             }
 
@@ -586,11 +627,48 @@ pub async fn validate_admin_event(
                 }
             }
 
-            // name/about/archived/visibility/ttl require owner/admin;
+            for t in event.tags.iter() {
+                if t.kind().to_string() == "agent_reply_mode" {
+                    match t.content() {
+                        Some("thread") | Some("inline") => {}
+                        Some(v) => {
+                            return Err(anyhow::anyhow!(
+                                "invalid agent_reply_mode value: {v} (must be \"thread\" or \"inline\")"
+                            ));
+                        }
+                        None => {
+                            return Err(anyhow::anyhow!("agent_reply_mode tag must have a value"));
+                        }
+                    }
+                }
+                if t.kind().to_string() == "dm_require_mention" {
+                    match t.content() {
+                        Some("true") | Some("false") => {}
+                        Some(v) => {
+                            return Err(anyhow::anyhow!(
+                                "invalid dm_require_mention value: {v} (must be \"true\" or \"false\")"
+                            ));
+                        }
+                        None => {
+                            return Err(anyhow::anyhow!(
+                                "dm_require_mention tag must have a value"
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // name/about/archived/visibility/ttl/agent behavior require owner/admin;
             // topic/purpose allow any member.
             let has_privileged_tag = event.tags.iter().any(|t| {
                 let k = t.kind().to_string();
-                k == "name" || k == "about" || k == "archived" || k == "visibility" || k == "ttl"
+                k == "name"
+                    || k == "about"
+                    || k == "archived"
+                    || k == "visibility"
+                    || k == "ttl"
+                    || k == "agent_reply_mode"
+                    || k == "dm_require_mention"
             });
             if has_privileged_tag {
                 let members = state.db.get_members(tenant.community(), channel_id).await?;
@@ -611,8 +689,20 @@ pub async fn validate_admin_event(
                         {
                             return Ok(());
                         }
+                        if channel.channel_type == "dm"
+                            && edit_metadata_is_agent_behavior_only(event)
+                            && actor_owns_any_member_agent(
+                                state,
+                                tenant.community(),
+                                &members,
+                                &actor_bytes,
+                            )
+                            .await?
+                        {
+                            return Ok(());
+                        }
                         Err(anyhow::anyhow!(
-                            "actor not authorized for name/about/archived/visibility/ttl changes"
+                            "actor not authorized for name/about/archived/visibility/ttl/agent behavior changes"
                         ))
                     }
                 }
@@ -1105,6 +1195,15 @@ pub async fn emit_group_discovery_events(
         if let Some(ref deadline) = channel.ttl_deadline {
             tags.push(Tag::parse(["ttl_deadline", &deadline.to_rfc3339()])?);
         }
+        tags.push(Tag::parse(["agent_reply_mode", &channel.agent_reply_mode])?);
+        tags.push(Tag::parse([
+            "dm_require_mention",
+            if channel.dm_require_mention {
+                "true"
+            } else {
+                "false"
+            },
+        ])?);
         emit_addressable_discovery_event(
             tenant,
             state,
@@ -1566,6 +1665,51 @@ async fn handle_edit_metadata(
                         channel_id,
                         serde_json::json!({
                             "type": "ttl_changed", "actor": actor_hex, "ttl_seconds": ttl_change
+                        }),
+                    )
+                    .await?;
+                }
+                "agent_reply_mode" => {
+                    state
+                        .db
+                        .update_channel(
+                            tenant.community(),
+                            channel_id,
+                            buzz_db::channel::ChannelUpdate {
+                                agent_reply_mode: Some(val.to_string()),
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
+                    emit_system_message(
+                        tenant,
+                        state,
+                        channel_id,
+                        serde_json::json!({
+                            "type": "agent_reply_mode_changed", "actor": actor_hex, "agent_reply_mode": val
+                        }),
+                    )
+                    .await?;
+                }
+                "dm_require_mention" => {
+                    let require_mention = val == "true";
+                    state
+                        .db
+                        .update_channel(
+                            tenant.community(),
+                            channel_id,
+                            buzz_db::channel::ChannelUpdate {
+                                dm_require_mention: Some(require_mention),
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
+                    emit_system_message(
+                        tenant,
+                        state,
+                        channel_id,
+                        serde_json::json!({
+                            "type": "dm_require_mention_changed", "actor": actor_hex, "dm_require_mention": require_mention
                         }),
                     )
                     .await?;
@@ -3440,5 +3584,44 @@ mod tests {
         }];
 
         assert!(actor_is_channel_owner_or_admin(&members, &actor));
+    }
+
+    #[test]
+    fn edit_metadata_agent_behavior_only_accepts_agent_policy_tags() {
+        let keys = nostr::Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9002), "")
+            .tags([
+                Tag::parse(["h", &Uuid::new_v4().to_string()]).unwrap(),
+                Tag::parse(["agent_reply_mode", "inline"]).unwrap(),
+                Tag::parse(["dm_require_mention", "false"]).unwrap(),
+            ])
+            .sign_with_keys(&keys)
+            .expect("sign");
+
+        assert!(edit_metadata_is_agent_behavior_only(&event));
+    }
+
+    #[test]
+    fn edit_metadata_agent_behavior_only_rejects_mixed_topic_or_name_update() {
+        let keys = nostr::Keys::generate();
+        let with_topic = EventBuilder::new(Kind::Custom(9002), "")
+            .tags([
+                Tag::parse(["h", &Uuid::new_v4().to_string()]).unwrap(),
+                Tag::parse(["agent_reply_mode", "inline"]).unwrap(),
+                Tag::parse(["topic", "ops"]).unwrap(),
+            ])
+            .sign_with_keys(&keys)
+            .expect("sign");
+        let with_name = EventBuilder::new(Kind::Custom(9002), "")
+            .tags([
+                Tag::parse(["h", &Uuid::new_v4().to_string()]).unwrap(),
+                Tag::parse(["dm_require_mention", "false"]).unwrap(),
+                Tag::parse(["name", "renamed"]).unwrap(),
+            ])
+            .sign_with_keys(&keys)
+            .expect("sign");
+
+        assert!(!edit_metadata_is_agent_behavior_only(&with_topic));
+        assert!(!edit_metadata_is_agent_behavior_only(&with_name));
     }
 }

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -597,7 +597,7 @@ pub fn build_leave(channel_id: Uuid) -> Result<EventBuilder, SdkError> {
     Ok(EventBuilder::new(Kind::Custom(9022), "").tags(tags))
 }
 
-/// Build a NIP-29 edit-metadata event for name/about/visibility/ttl (kind 9002).
+/// Build a NIP-29 edit-metadata event for name/about/visibility/ttl/agent behavior (kind 9002).
 ///
 /// `ttl`: outer `None` leaves it unchanged; `Some(Some(secs))` sets the
 /// ephemeral timeout; `Some(None)` clears it (emits `["ttl", ""]`).
@@ -607,10 +607,18 @@ pub fn build_update_channel(
     about: Option<&str>,
     visibility: Option<&str>,
     ttl: Option<Option<i32>>,
+    agent_reply_mode: Option<&str>,
+    dm_require_mention: Option<bool>,
 ) -> Result<EventBuilder, SdkError> {
-    if name.is_none() && about.is_none() && visibility.is_none() && ttl.is_none() {
+    if name.is_none()
+        && about.is_none()
+        && visibility.is_none()
+        && ttl.is_none()
+        && agent_reply_mode.is_none()
+        && dm_require_mention.is_none()
+    {
         return Err(SdkError::InvalidTag(
-            "at least one of name, about, visibility, or ttl must be provided".into(),
+            "at least one of name, about, visibility, ttl, agent_reply_mode, or dm_require_mention must be provided".into(),
         ));
     }
     if let Some(v) = visibility {
@@ -625,6 +633,13 @@ pub fn build_update_channel(
         .is_some_and(|name| name.trim().is_empty())
     {
         return Err(SdkError::InvalidTag("channel name is required".into()));
+    }
+    if let Some(mode) = agent_reply_mode {
+        if mode != "thread" && mode != "inline" {
+            return Err(SdkError::InvalidTag(
+                "agent_reply_mode must be \"thread\" or \"inline\"".into(),
+            ));
+        }
     }
     let mut tags = vec![tag(&["h", &channel_id.to_string()])?];
     if let Some(n) = name {
@@ -644,6 +659,15 @@ pub fn build_update_channel(
             Some(secs) => tags.push(tag(&["ttl", &secs.to_string()])?),
             None => tags.push(tag(&["ttl", ""])?),
         }
+    }
+    if let Some(mode) = agent_reply_mode {
+        tags.push(tag(&["agent_reply_mode", mode])?);
+    }
+    if let Some(require_mention) = dm_require_mention {
+        tags.push(tag(&[
+            "dm_require_mention",
+            if require_mention { "true" } else { "false" },
+        ])?);
     }
     Ok(EventBuilder::new(Kind::Custom(9002), "").tags(tags))
 }
@@ -2410,7 +2434,16 @@ mod tests {
     fn update_channel_name_and_about() {
         let cid = uuid();
         let ev = sign(
-            build_update_channel(cid, Some("new-name"), Some("new about"), None, None).unwrap(),
+            build_update_channel(
+                cid,
+                Some("new-name"),
+                Some("new about"),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap(),
         );
         assert_eq!(ev.kind.as_u16(), 9002);
         assert!(has_tag(&ev, "name", "new-name"));
@@ -2419,15 +2452,25 @@ mod tests {
 
     #[test]
     fn update_channel_strips_all_leading_hashes_from_name() {
-        let ev =
-            sign(build_update_channel(uuid(), Some("  ###new-name  "), None, None, None).unwrap());
+        let ev = sign(
+            build_update_channel(
+                uuid(),
+                Some("  ###new-name  "),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap(),
+        );
         assert!(has_tag(&ev, "name", "new-name"));
     }
 
     #[test]
     fn update_channel_rejects_hash_only_name() {
         assert!(matches!(
-            build_update_channel(uuid(), Some("  ###  "), None, None, None),
+            build_update_channel(uuid(), Some("  ###  "), None, None, None, None, None),
             Err(SdkError::InvalidTag(_))
         ));
     }
@@ -2435,8 +2478,18 @@ mod tests {
     #[test]
     fn update_channel_visibility_and_ttl() {
         let cid = uuid();
-        let ev =
-            sign(build_update_channel(cid, None, None, Some("private"), Some(Some(3600))).unwrap());
+        let ev = sign(
+            build_update_channel(
+                cid,
+                None,
+                None,
+                Some("private"),
+                Some(Some(3600)),
+                None,
+                None,
+            )
+            .unwrap(),
+        );
         assert_eq!(ev.kind.as_u16(), 9002);
         assert!(has_tag(&ev, "visibility", "private"));
         assert!(has_tag(&ev, "ttl", "3600"));
@@ -2445,7 +2498,7 @@ mod tests {
     #[test]
     fn update_channel_clears_ttl() {
         let cid = uuid();
-        let ev = sign(build_update_channel(cid, None, None, None, Some(None)).unwrap());
+        let ev = sign(build_update_channel(cid, None, None, None, Some(None), None, None).unwrap());
         assert!(has_tag(&ev, "ttl", ""));
     }
 
@@ -2453,7 +2506,27 @@ mod tests {
     fn update_channel_invalid_visibility_rejected() {
         let cid = uuid();
         assert!(matches!(
-            build_update_channel(cid, None, None, Some("secret"), None),
+            build_update_channel(cid, None, None, Some("secret"), None, None, None),
+            Err(SdkError::InvalidTag(_))
+        ));
+    }
+
+    #[test]
+    fn update_channel_agent_behavior() {
+        let cid = uuid();
+        let ev = sign(
+            build_update_channel(cid, None, None, None, None, Some("inline"), Some(false)).unwrap(),
+        );
+        assert_eq!(ev.kind.as_u16(), 9002);
+        assert!(has_tag(&ev, "agent_reply_mode", "inline"));
+        assert!(has_tag(&ev, "dm_require_mention", "false"));
+    }
+
+    #[test]
+    fn update_channel_invalid_agent_reply_mode_rejected() {
+        let cid = uuid();
+        assert!(matches!(
+            build_update_channel(cid, None, None, None, None, Some("sideways"), None),
             Err(SdkError::InvalidTag(_))
         ));
     }
@@ -2462,7 +2535,7 @@ mod tests {
     fn update_channel_no_fields_rejected() {
         let cid = uuid();
         assert!(matches!(
-            build_update_channel(cid, None, None, None, None),
+            build_update_channel(cid, None, None, None, None, None, None),
             Err(SdkError::InvalidTag(_))
         ));
     }

--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -695,6 +695,10 @@ pub struct UpdateChannelInput {
     /// Absent = leave unchanged, `null` = clear (permanent), seconds = set.
     #[serde(default, deserialize_with = "crate::util::double_option")]
     pub ttl_seconds: Option<Option<i32>>,
+    #[serde(default)]
+    pub agent_reply_mode: Option<String>,
+    #[serde(default)]
+    pub dm_require_mention: Option<bool>,
 }
 
 #[tauri::command]
@@ -709,6 +713,8 @@ pub async fn update_channel(
         input.description.as_deref(),
         input.visibility.as_deref(),
         input.ttl_seconds,
+        input.agent_reply_mode.as_deref(),
+        input.dm_require_mention,
     )?;
     submit_event(builder, &state).await?;
 

--- a/desktop/src-tauri/src/commands/channels_tests.rs
+++ b/desktop/src-tauri/src/commands/channels_tests.rs
@@ -286,6 +286,8 @@ fn starter_match_requires_open_unarchived_stream_by_normalized_name() {
         is_member: true,
         ttl_seconds: None,
         ttl_deadline: None,
+        agent_reply_mode: "thread".to_string(),
+        dm_require_mention: true,
     };
 
     assert!(is_matching_starter_channel(&channel, spec));

--- a/desktop/src-tauri/src/events.rs
+++ b/desktop/src-tauri/src/events.rs
@@ -179,7 +179,7 @@ pub fn build_leave(channel_id: Uuid) -> Result<EventBuilder, String> {
     Ok(EventBuilder::new(Kind::Custom(9022), "").tags(tags))
 }
 
-/// Kind 9002 — update channel name/description/visibility/ttl.
+/// Kind 9002 — update channel name/description/visibility/ttl/agent behavior.
 ///
 /// `ttl`: outer `None` leaves it unchanged; `Some(Some(secs))` sets the
 /// ephemeral timeout; `Some(None)` clears it (emits `["ttl", ""]`).
@@ -189,9 +189,20 @@ pub fn build_update_channel(
     about: Option<&str>,
     visibility: Option<&str>,
     ttl: Option<Option<i32>>,
+    agent_reply_mode: Option<&str>,
+    dm_require_mention: Option<bool>,
 ) -> Result<EventBuilder, String> {
-    if name.is_none() && about.is_none() && visibility.is_none() && ttl.is_none() {
-        return Err("at least one of name, about, visibility, or ttl must be provided".into());
+    if name.is_none()
+        && about.is_none()
+        && visibility.is_none()
+        && ttl.is_none()
+        && agent_reply_mode.is_none()
+        && dm_require_mention.is_none()
+    {
+        return Err(
+            "at least one of name, about, visibility, ttl, agent_reply_mode, or dm_require_mention must be provided"
+                .into(),
+        );
     }
     if let Some(v) = visibility {
         if v != "open" && v != "private" {
@@ -201,6 +212,11 @@ pub fn build_update_channel(
     let name = name.map(buzz_sdk_pkg::canonical_channel_name);
     if name.is_some_and(|name| name.trim().is_empty()) {
         return Err("channel name is required".into());
+    }
+    if let Some(mode) = agent_reply_mode {
+        if mode != "thread" && mode != "inline" {
+            return Err("agent_reply_mode must be \"thread\" or \"inline\"".into());
+        }
     }
     let mut tags = vec![tag(vec!["h", &channel_id.to_string()])?];
     if let Some(n) = name {
@@ -217,6 +233,15 @@ pub fn build_update_channel(
             Some(secs) => tags.push(tag(vec!["ttl", &secs.to_string()])?),
             None => tags.push(tag(vec!["ttl", ""])?),
         }
+    }
+    if let Some(mode) = agent_reply_mode {
+        tags.push(tag(vec!["agent_reply_mode", mode])?);
+    }
+    if let Some(require_mention) = dm_require_mention {
+        tags.push(tag(vec![
+            "dm_require_mention",
+            if require_mention { "true" } else { "false" },
+        ])?);
     }
     Ok(EventBuilder::new(Kind::Custom(9002), "").tags(tags))
 }
@@ -854,7 +879,9 @@ mod tests {
     fn channel_builders_reject_hash_only_names() {
         let channel_id = Uuid::new_v4();
         assert!(build_create_channel(channel_id, "###", "open", "stream", None, None).is_err());
-        assert!(build_update_channel(channel_id, Some("###"), None, None, None).is_err());
+        assert!(
+            build_update_channel(channel_id, Some("###"), None, None, None, None, None).is_err()
+        );
     }
     /// Builder layout regression for the NIP-IA owner-of-agent archive flow.
     /// Compares against `docs/nips/NIP-IA.md` §Vector 1.

--- a/desktop/src-tauri/src/models.rs
+++ b/desktop/src-tauri/src/models.rs
@@ -131,6 +131,8 @@ pub struct ChannelInfo {
     pub is_member: bool,
     pub ttl_seconds: Option<i32>,
     pub ttl_deadline: Option<String>,
+    pub agent_reply_mode: String,
+    pub dm_require_mention: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -157,6 +159,8 @@ pub struct ChannelDetailInfo {
     pub nip29_group_id: Option<String>,
     pub ttl_seconds: Option<i32>,
     pub ttl_deadline: Option<String>,
+    pub agent_reply_mode: String,
+    pub dm_require_mention: bool,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/desktop/src-tauri/src/nostr_convert.rs
+++ b/desktop/src-tauri/src/nostr_convert.rs
@@ -157,6 +157,11 @@ pub fn channel_info_from_event(
     // Ephemeral channel TTL — relay emits ["ttl", "<seconds>"] and ["ttl_deadline", "<iso>"].
     let ttl_seconds = first_tag_value(event, "ttl").and_then(|v| v.parse::<i32>().ok());
     let ttl_deadline = first_tag_value(event, "ttl_deadline").map(str::to_string);
+    let agent_reply_mode = match first_tag_value(event, "agent_reply_mode") {
+        Some("inline") => "inline".to_string(),
+        _ => "thread".to_string(),
+    };
+    let dm_require_mention = first_tag_value(event, "dm_require_mention") != Some("false");
 
     Ok(ChannelInfo {
         id,
@@ -175,6 +180,8 @@ pub fn channel_info_from_event(
         is_member: is_member.unwrap_or(true),
         ttl_seconds,
         ttl_deadline,
+        agent_reply_mode,
+        dm_require_mention,
     })
 }
 
@@ -237,6 +244,11 @@ pub fn channel_detail_from_event(event: &Event) -> Result<ChannelDetailInfo, Str
         nip29_group_id: None,
         ttl_seconds: first_tag_value(event, "ttl").and_then(|v| v.parse::<i32>().ok()),
         ttl_deadline: first_tag_value(event, "ttl_deadline").map(str::to_string),
+        agent_reply_mode: match first_tag_value(event, "agent_reply_mode") {
+            Some("inline") => "inline".to_string(),
+            _ => "thread".to_string(),
+        },
+        dm_require_mention: first_tag_value(event, "dm_require_mention") != Some("false"),
     })
 }
 
@@ -715,6 +727,8 @@ mod tests {
                 vec!["visibility", "private"],
                 vec!["ttl", "86400"],
                 vec!["ttl_deadline", "2026-06-11T00:00:00Z"],
+                vec!["agent_reply_mode", "inline"],
+                vec!["dm_require_mention", "false"],
             ],
         );
         let d = channel_detail_from_event(&e).unwrap();
@@ -725,6 +739,8 @@ mod tests {
         assert_eq!(d.visibility, "private");
         assert_eq!(d.ttl_seconds, Some(86400));
         assert_eq!(d.ttl_deadline.as_deref(), Some("2026-06-11T00:00:00Z"));
+        assert_eq!(d.agent_reply_mode, "inline");
+        assert!(!d.dm_require_mention);
         assert!(d.created_at.ends_with("Z"));
         assert_eq!(d.created_by, e.pubkey.to_hex());
     }

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -136,7 +136,7 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
-test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
+test("isAgentIdentityInManagedList: keeps people, current managed agents, and channel-member agents", () => {
   const managedAgentPubkeys = new Set([PUB_A]);
 
   assert.equal(
@@ -149,6 +149,13 @@ test("isAgentIdentityInManagedList: keeps people and only current managed agent 
   assert.equal(
     isAgentIdentityInManagedList(
       { isAgent: true, pubkey: PUB_A.toUpperCase() },
+      managedAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
       managedAgentPubkeys,
     ),
     true,
@@ -169,7 +176,6 @@ test("shouldHideAgentFromMentions: never hides non-agents", () => {
       isMember: false,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set([PUB_A]),
     }),
     false,
   );
@@ -182,7 +188,6 @@ test("shouldHideAgentFromMentions: shows invocable agents even when non-member",
       isMember: false,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set([PUB_A]),
-      directoryAgentPubkeys: new Set([PUB_A]),
     }),
     false,
   );
@@ -195,22 +200,20 @@ test("shouldHideAgentFromMentions: hides non-member non-invocable agents", () =>
       isMember: false,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set(),
     }),
     true,
   );
 });
 
-test("shouldHideAgentFromMentions: hides member agents with an explicit not-invocable directory entry (Fizz)", () => {
+test("shouldHideAgentFromMentions: shows member agents even with a stale not-invocable directory entry", () => {
   assert.equal(
     shouldHideAgentFromMentions({
       isAgent: true,
       isMember: true,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set([PUB_A]),
     }),
-    true,
+    false,
   );
 });
 
@@ -221,13 +224,12 @@ test("shouldHideAgentFromMentions: shows member agents with unknown invocability
       isMember: true,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set(),
     }),
     false,
   );
 });
 
-test("shouldHideAgentFromMentions: normalizes the pubkey before lookup", () => {
+test("shouldHideAgentFromMentions: normalizes the pubkey before invocable lookup", () => {
   const mixedCase = "Ab".repeat(32);
   const normalized = mixedCase.toLowerCase();
 
@@ -236,10 +238,9 @@ test("shouldHideAgentFromMentions: normalizes the pubkey before lookup", () => {
       isAgent: true,
       isMember: true,
       pubkey: mixedCase,
-      mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set([normalized]),
+      mentionableAgentPubkeys: new Set([normalized]),
     }),
-    true,
+    false,
   );
 });
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -55,11 +55,12 @@ export function getMentionableAgentPubkeys({
 }
 
 export function isAgentIdentityInManagedList(
-  candidate: { isAgent?: boolean; pubkey: string },
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
 ) {
   return (
     candidate.isAgent !== true ||
+    candidate.isMember === true ||
     managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
   );
 }
@@ -69,32 +70,22 @@ export function shouldHideAgentFromMentions({
   isMember,
   pubkey,
   mentionableAgentPubkeys,
-  directoryAgentPubkeys,
 }: {
   isAgent: boolean;
   isMember: boolean;
   pubkey: string;
   mentionableAgentPubkeys: ReadonlySet<string>;
-  directoryAgentPubkeys: ReadonlySet<string>;
 }) {
   if (!isAgent) return false;
   const normalized = normalizePubkey(pubkey);
   // Invocable => always show.
   if (mentionableAgentPubkeys.has(normalized)) return false;
+  // Channel membership is an explicit local invitation. Keep member agents
+  // mentionable even if the relay-agent directory has stale or incomplete
+  // invocability metadata for an external/self-hosted agent.
+  if (isMember) return false;
   // Non-member, non-invocable => hide (preserves prior behavior).
-  if (!isMember) return true;
-  // Member (Option B): hide only when we have an explicit not-invocable
-  // signal — a relay directory (kind:10100) entry that excludes us.
-  // Unknown invocability (not in directory) => show.
-  //
-  // NOTE: this assumes `directoryAgentPubkeys` and `mentionableAgentPubkeys`
-  // share the same source query (`relayAgentsQuery.data`), so directory
-  // presence without membership in `mentionableAgentPubkeys` is a real
-  // explicit-exclusion signal. If a future change sources the directory set
-  // from a different query, an agent that's directory-present but whose
-  // mentionability is still loading could be hidden prematurely — keep the
-  // two sets derived from the same query.
-  return directoryAgentPubkeys.has(normalized);
+  return true;
 }
 
 type AgentAutocompleteCandidate = {

--- a/desktop/src/features/channels/ui/AgentBehaviorSettings.tsx
+++ b/desktop/src/features/channels/ui/AgentBehaviorSettings.tsx
@@ -1,0 +1,89 @@
+import { cn } from "@/shared/lib/cn";
+import { Switch } from "@/shared/ui/switch";
+
+type AgentBehaviorSettingsProps = {
+  agentRepliesInThreads: boolean;
+  disabled: boolean;
+  dmRequireMention: boolean;
+  isDm: boolean;
+  onAgentRepliesInThreadsChange: (checked: boolean) => void;
+  onDmRequireMentionChange: (checked: boolean) => void;
+};
+
+function AgentBehaviorToggle({
+  checked,
+  description,
+  disabled,
+  label,
+  onCheckedChange,
+  testId,
+}: {
+  checked: boolean;
+  description: string;
+  disabled: boolean;
+  label: string;
+  onCheckedChange: (checked: boolean) => void;
+  testId: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-start justify-between gap-4 rounded-2xl border border-border/60 px-4 py-3",
+        disabled ? "cursor-not-allowed opacity-60" : "cursor-default",
+      )}
+    >
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-medium text-foreground">
+          {label}
+        </span>
+        <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+          {description}
+        </span>
+      </span>
+      <Switch
+        checked={checked}
+        data-testid={testId}
+        disabled={disabled}
+        onCheckedChange={onCheckedChange}
+      />
+    </div>
+  );
+}
+
+export function AgentBehaviorSettings({
+  agentRepliesInThreads,
+  disabled,
+  dmRequireMention,
+  isDm,
+  onAgentRepliesInThreadsChange,
+  onDmRequireMentionChange,
+}: AgentBehaviorSettingsProps) {
+  return (
+    <div className="space-y-3" data-testid="channel-management-agent-behavior">
+      <div>
+        <h4 className="text-sm font-medium text-foreground">Agent behavior</h4>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+          Controls how agents in this channel wake up and place replies.
+        </p>
+      </div>
+      <AgentBehaviorToggle
+        checked={agentRepliesInThreads}
+        description="Turn this off when agent responses should appear inline in the channel instead of opening a thread."
+        disabled={disabled}
+        label="Agents reply in threads"
+        onCheckedChange={onAgentRepliesInThreadsChange}
+        testId="channel-management-agent-replies-in-threads"
+      />
+      {isDm ? (
+        <AgentBehaviorToggle
+          checked={dmRequireMention}
+          description="Turn this off so direct messages to the agent wake it without typing its name."
+          disabled={disabled}
+          label="Require @mention in this agent DM"
+          onCheckedChange={onDmRequireMentionChange}
+          testId="channel-management-dm-require-mention"
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
+++ b/desktop/src/features/channels/ui/ChannelManagementSheet.tsx
@@ -35,8 +35,11 @@ import {
   DEFAULT_EPHEMERAL_TTL_SECONDS,
   formatTtlDuration,
 } from "@/features/channels/lib/ephemeralChannel";
+import { ownsAuthorAgent } from "@/features/profile/lib/identity";
+import { useUsersBatchQuery } from "@/features/profile/hooks";
 import type { Channel } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
+import { normalizePubkey } from "@/shared/lib/pubkey";
 import { useTheme } from "@/shared/theme/ThemeProvider";
 import { Button } from "@/shared/ui/button";
 import {
@@ -68,6 +71,7 @@ import {
   CHANNEL_FORM_FIELD_CONTROL_CLASS,
   CHANNEL_FORM_FIELD_SHELL_CLASS,
 } from "./channelFormStyles";
+import { AgentBehaviorSettings } from "./AgentBehaviorSettings";
 import { ChannelTypeSettings } from "./ChannelTypeSettings";
 import { ChannelPermissionsSettings } from "./ChannelPermissionsSettings";
 import {
@@ -140,6 +144,45 @@ export function ChannelManagementSheet({
 
   const { canDeleteChannel, canManageChannel } =
     useChannelModerationCapabilities(membersQuery.data, currentPubkey, open);
+  const dmOtherParticipantPubkeys = React.useMemo(() => {
+    if (detail?.channelType !== "dm") {
+      return [];
+    }
+
+    const normalizedCurrentPubkey = currentPubkey
+      ? normalizePubkey(currentPubkey)
+      : null;
+
+    const participantPubkeys =
+      detail.participantPubkeys?.length > 0
+        ? detail.participantPubkeys
+        : channel?.participantPubkeys?.length
+          ? channel.participantPubkeys
+          : members.map((member) => member.pubkey);
+
+    return participantPubkeys.filter(
+      (pubkey) => normalizePubkey(pubkey) !== normalizedCurrentPubkey,
+    );
+  }, [channel, currentPubkey, detail, members]);
+  const dmParticipantProfilesQuery = useUsersBatchQuery(
+    dmOtherParticipantPubkeys,
+    {
+      enabled:
+        open &&
+        detail?.channelType === "dm" &&
+        !canManageChannel &&
+        dmOtherParticipantPubkeys.length > 0,
+    },
+  );
+  const canEditOwnedAgentDm =
+    detail?.channelType === "dm" &&
+    dmOtherParticipantPubkeys.some((pubkey) =>
+      ownsAuthorAgent(
+        dmParticipantProfilesQuery.data?.profiles[normalizePubkey(pubkey)],
+        currentPubkey,
+      ),
+    );
+  const canEditChannelSettings = canManageChannel || canEditOwnedAgentDm;
   const canEditNarrative =
     canManageChannel && selfMember !== null && detail?.channelType !== "dm";
   const isArchived =
@@ -165,6 +208,10 @@ export function ChannelManagementSheet({
   const [ttlSecondsDraft, setTtlSecondsDraft] = React.useState(
     DEFAULT_EPHEMERAL_TTL_SECONDS,
   );
+  const [agentRepliesInThreadsDraft, setAgentRepliesInThreadsDraft] =
+    React.useState(true);
+  const [dmRequireMentionDraft, setDmRequireMentionDraft] =
+    React.useState(true);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = React.useState(false);
   const [isConvertingVisibility, setIsConvertingVisibility] =
@@ -202,6 +249,8 @@ export function ChannelManagementSheet({
     setIsPrivateDraft(detail.visibility === "private");
     setIsEphemeralDraft(detail.ttlSeconds !== null);
     setTtlSecondsDraft(detail.ttlSeconds ?? DEFAULT_EPHEMERAL_TTL_SECONDS);
+    setAgentRepliesInThreadsDraft(detail.agentReplyMode !== "inline");
+    setDmRequireMentionDraft(detail.dmRequireMention);
     setHasUserEditedChannelDraft(false);
     setActiveView("summary");
   }, [detail, open]);
@@ -242,16 +291,27 @@ export function ChannelManagementSheet({
   const nextTtlSeconds: number | null = isEphemeralDraft
     ? ttlSecondsDraft
     : null;
+  const resolvedChannel = detail ?? channel;
+  const nextAgentReplyMode = agentRepliesInThreadsDraft ? "thread" : "inline";
+  const currentAgentReplyMode = resolvedChannel.agentReplyMode;
+  const agentReplyModeDirty = nextAgentReplyMode !== currentAgentReplyMode;
+  const dmRequireMentionDirty =
+    resolvedChannel.channelType === "dm" &&
+    dmRequireMentionDraft !== resolvedChannel.dmRequireMention;
   const lifecycleDirty =
     nextVisibility !== currentVisibility ||
     nextTtlSeconds !== currentTtlSeconds;
 
-  const resolvedChannel = detail ?? channel;
   const nameDirty = nameDraft.trim() !== resolvedChannel.name.trim();
   const descriptionDirty =
     descriptionDraft.trim() !== resolvedChannel.description.trim();
   const isSavingChannelEdits = updateChannelDetailsMutation.isPending;
-  const hasChannelEditChanges = nameDirty || descriptionDirty || lifecycleDirty;
+  const hasChannelEditChanges =
+    nameDirty ||
+    descriptionDirty ||
+    lifecycleDirty ||
+    agentReplyModeDirty ||
+    dmRequireMentionDirty;
   const canSaveChannelEdits =
     nameDraft.trim().length > 0 &&
     hasUserEditedChannelDraft &&
@@ -270,6 +330,10 @@ export function ChannelManagementSheet({
       setDescriptionDraft(resolvedChannel.description);
       setIsEphemeralDraft(currentTtlSeconds !== null);
       setTtlSecondsDraft(currentTtlSeconds ?? DEFAULT_EPHEMERAL_TTL_SECONDS);
+      setAgentRepliesInThreadsDraft(
+        resolvedChannel.agentReplyMode !== "inline",
+      );
+      setDmRequireMentionDraft(resolvedChannel.dmRequireMention);
       setHasUserEditedChannelDraft(false);
     }
 
@@ -278,12 +342,16 @@ export function ChannelManagementSheet({
 
   async function handleSaveChannelEdits() {
     try {
-      if (nameDirty || descriptionDirty || lifecycleDirty) {
+      if (hasChannelEditChanges) {
         await updateChannelDetailsMutation.mutateAsync({
           description: descriptionDirty ? descriptionDraft.trim() : undefined,
           name: nameDirty ? nameDraft.trim() : undefined,
           ttlSeconds:
             nextTtlSeconds !== currentTtlSeconds ? nextTtlSeconds : undefined,
+          agentReplyMode: agentReplyModeDirty ? nextAgentReplyMode : undefined,
+          dmRequireMention: dmRequireMentionDirty
+            ? dmRequireMentionDraft
+            : undefined,
           visibility:
             lifecycleDirty && nextVisibility !== currentVisibility
               ? nextVisibility
@@ -354,6 +422,7 @@ export function ChannelManagementSheet({
             canEditNarrative={canEditNarrative}
             canJoin={canJoin}
             canLeave={canLeave}
+            canEditChannelSettings={canEditChannelSettings}
             canManageChannel={canManageChannel}
             canOpenCanvas={canOpenCanvas}
             canvasPreview={canvasPreview}
@@ -400,6 +469,7 @@ export function ChannelManagementSheet({
               canEditNarrative={canEditNarrative}
               canJoin={canJoin}
               canLeave={canLeave}
+              canEditChannelSettings={canEditChannelSettings}
               canManageChannel={canManageChannel}
               canOpenCanvas={canOpenCanvas}
               canvasPreview={canvasPreview}
@@ -429,7 +499,7 @@ export function ChannelManagementSheet({
         </DialogPrimitive.Portal>
       )}
 
-      {canManageChannel ? (
+      {canEditChannelSettings ? (
         <Dialog
           onOpenChange={handleEditDialogOpenChange}
           open={isEditDialogOpen}
@@ -441,68 +511,73 @@ export function ChannelManagementSheet({
             <div className="flex max-h-[85vh] flex-col">
               <DialogHeader className="shrink-0 border-b border-border/60 px-6 py-5 pr-14">
                 <DialogTitle>
-                  Edit {currentVisibility === "private" ? "private" : "public"}{" "}
-                  channel
+                  {resolvedChannel.channelType === "dm"
+                    ? "Edit DM"
+                    : `Edit ${
+                        currentVisibility === "private" ? "private" : "public"
+                      } channel`}
                 </DialogTitle>
               </DialogHeader>
 
               <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-6 py-5">
-                <div className="space-y-5">
-                  <div className="space-y-1.5">
-                    <label
-                      className="text-sm font-medium text-foreground"
-                      htmlFor="channel-name"
-                    >
-                      Name
-                    </label>
-                    <div
-                      className={cn(
-                        "flex min-h-11 items-center px-3",
-                        CHANNEL_FORM_FIELD_SHELL_CLASS,
-                      )}
-                    >
-                      <Input
+                {resolvedChannel.channelType !== "dm" ? (
+                  <div className="space-y-5">
+                    <div className="space-y-1.5">
+                      <label
+                        className="text-sm font-medium text-foreground"
+                        htmlFor="channel-name"
+                      >
+                        Name
+                      </label>
+                      <div
                         className={cn(
-                          "h-8 px-0 py-0 leading-6",
-                          CHANNEL_FORM_FIELD_CONTROL_CLASS,
+                          "flex min-h-11 items-center px-3",
+                          CHANNEL_FORM_FIELD_SHELL_CLASS,
                         )}
-                        data-testid="channel-management-name"
-                        disabled={isSavingChannelEdits}
-                        id="channel-name"
-                        onChange={(event) => {
-                          setNameDraft(event.target.value);
-                          setHasUserEditedChannelDraft(true);
-                        }}
-                        value={nameDraft}
-                      />
+                      >
+                        <Input
+                          className={cn(
+                            "h-8 px-0 py-0 leading-6",
+                            CHANNEL_FORM_FIELD_CONTROL_CLASS,
+                          )}
+                          data-testid="channel-management-name"
+                          disabled={isSavingChannelEdits}
+                          id="channel-name"
+                          onChange={(event) => {
+                            setNameDraft(event.target.value);
+                            setHasUserEditedChannelDraft(true);
+                          }}
+                          value={nameDraft}
+                        />
+                      </div>
+                    </div>
+                    <div className="space-y-1.5">
+                      <label
+                        className="text-sm font-medium text-foreground"
+                        htmlFor="channel-description"
+                      >
+                        Description
+                      </label>
+                      <div className={CHANNEL_FORM_FIELD_SHELL_CLASS}>
+                        <Textarea
+                          className={cn(
+                            "min-h-20 resize-none px-3 py-3 leading-5",
+                            CHANNEL_FORM_FIELD_CONTROL_CLASS,
+                          )}
+                          data-testid="channel-management-description"
+                          disabled={isSavingChannelEdits}
+                          id="channel-description"
+                          onChange={(event) => {
+                            setDescriptionDraft(event.target.value);
+                            setHasUserEditedChannelDraft(true);
+                          }}
+                          rows={2}
+                          value={descriptionDraft}
+                        />
+                      </div>
                     </div>
                   </div>
-                  <div className="space-y-1.5">
-                    <label
-                      className="text-sm font-medium text-foreground"
-                      htmlFor="channel-description"
-                    >
-                      Description
-                    </label>
-                    <div className={CHANNEL_FORM_FIELD_SHELL_CLASS}>
-                      <Textarea
-                        className={cn(
-                          "min-h-20 resize-none px-3 py-3 leading-5",
-                          CHANNEL_FORM_FIELD_CONTROL_CLASS,
-                        )}
-                        data-testid="channel-management-description"
-                        disabled={isSavingChannelEdits}
-                        id="channel-description"
-                        onChange={(event) => {
-                          setDescriptionDraft(event.target.value);
-                          setHasUserEditedChannelDraft(true);
-                        }}
-                        rows={2}
-                        value={descriptionDraft}
-                      />
-                    </div>
-                  </div>
-                </div>
+                ) : null}
 
                 {resolvedChannel.channelType !== "dm" ? (
                   <div
@@ -534,6 +609,21 @@ export function ChannelManagementSheet({
                     />
                   </div>
                 ) : null}
+
+                <AgentBehaviorSettings
+                  agentRepliesInThreads={agentRepliesInThreadsDraft}
+                  disabled={isSavingChannelEdits}
+                  dmRequireMention={dmRequireMentionDraft}
+                  isDm={resolvedChannel.channelType === "dm"}
+                  onAgentRepliesInThreadsChange={(checked) => {
+                    setAgentRepliesInThreadsDraft(checked);
+                    setHasUserEditedChannelDraft(true);
+                  }}
+                  onDmRequireMentionChange={(checked) => {
+                    setDmRequireMentionDraft(checked);
+                    setHasUserEditedChannelDraft(true);
+                  }}
+                />
 
                 {updateChannelDetailsMutation.error instanceof Error ? (
                   <p className="rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
@@ -581,6 +671,7 @@ type ChannelManagementPanelContentProps = {
   canEditNarrative: boolean;
   canJoin: boolean;
   canLeave: boolean;
+  canEditChannelSettings: boolean;
   canManageChannel: boolean;
   canOpenCanvas: boolean;
   canvasPreview?: string;
@@ -613,6 +704,7 @@ function ChannelManagementPanelContent({
   canEditNarrative,
   canJoin,
   canLeave,
+  canEditChannelSettings,
   canManageChannel,
   canOpenCanvas,
   canvasPreview,
@@ -747,7 +839,7 @@ function ChannelManagementPanelContent({
                   testId="channel-management-leave"
                 />
               ) : null}
-              {canManageChannel ? (
+              {canEditChannelSettings ? (
                 <ChannelQuickAction
                   icon={Pencil}
                   label="Edit"

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -179,15 +179,6 @@ export function useMentions(
       ),
     [relayAgentsQuery.data],
   );
-  const directoryAgentPubkeys = React.useMemo(
-    () =>
-      new Set(
-        (relayAgentsQuery.data ?? []).map((agent) =>
-          normalizePubkey(agent.pubkey),
-        ),
-      ),
-    [relayAgentsQuery.data],
-  );
   const sharedChannelIds = React.useMemo(
     () => getSharedChannelIds(channelsQuery.data),
     [channelsQuery.data],
@@ -255,7 +246,6 @@ export function useMentions(
           isMember: candidate.isMember === true,
           pubkey,
           mentionableAgentPubkeys,
-          directoryAgentPubkeys,
         })
       ) {
         return;
@@ -415,7 +405,6 @@ export function useMentions(
     userSearchResults,
     canSearchGlobalUsers,
     currentPubkey,
-    directoryAgentPubkeys,
     isArchivedDiscovery,
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,

--- a/desktop/src/shared/api/channelTypes.ts
+++ b/desktop/src/shared/api/channelTypes.ts
@@ -1,0 +1,109 @@
+export type ChannelType = "stream" | "forum" | "dm";
+export type ChannelVisibility = "open" | "private";
+export type ChannelRole = "owner" | "admin" | "member" | "guest" | "bot";
+export type AgentReplyMode = "thread" | "inline";
+
+export type Channel = {
+  id: string;
+  name: string;
+  channelType: ChannelType;
+  visibility: ChannelVisibility;
+  description: string;
+  topic: string | null;
+  purpose: string | null;
+  memberCount: number;
+  memberPubkeys: string[];
+  lastMessageAt: string | null;
+  archivedAt: string | null;
+  participants: string[];
+  participantPubkeys: string[];
+  isMember: boolean;
+  ttlSeconds: number | null;
+  ttlDeadline: string | null;
+  agentReplyMode: AgentReplyMode;
+  dmRequireMention: boolean;
+};
+
+export type ChannelDetail = Channel & {
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+  topicSetBy: string | null;
+  topicSetAt: string | null;
+  purposeSetBy: string | null;
+  purposeSetAt: string | null;
+  topicRequired: boolean;
+  maxMembers: number | null;
+  nip29GroupId: string | null;
+};
+
+export type ChannelMember = {
+  pubkey: string;
+  role: ChannelRole;
+  isAgent: boolean;
+  joinedAt: string;
+  displayName: string | null;
+};
+
+export type CreateChannelInput = {
+  name: string;
+  channelType: Exclude<ChannelType, "dm">;
+  visibility: ChannelVisibility;
+  description?: string;
+  ttlSeconds?: number;
+};
+
+export type OpenDmInput = {
+  pubkeys: string[];
+};
+
+export type UpdateChannelInput = {
+  channelId: string;
+  name?: string;
+  description?: string;
+  visibility?: ChannelVisibility;
+  /** Omit to leave unchanged, `null` to clear (permanent), or a positive number of seconds to set. */
+  ttlSeconds?: number | null;
+  agentReplyMode?: AgentReplyMode;
+  dmRequireMention?: boolean;
+};
+
+export type SetChannelTopicInput = {
+  channelId: string;
+  topic: string;
+};
+
+export type SetChannelPurposeInput = {
+  channelId: string;
+  purpose: string;
+};
+
+export type CanvasResponse = {
+  content: string | null;
+  updatedAt: number | null;
+  author: string | null;
+};
+
+export type SetCanvasInput = {
+  channelId: string;
+  content: string;
+};
+
+export type SetCanvasResult = {
+  ok: boolean;
+  eventId: string;
+};
+
+export type AddChannelMembersInput = {
+  channelId: string;
+  pubkeys: string[];
+  role?: Exclude<ChannelRole, "owner">;
+};
+
+export type AddChannelMembersResult = {
+  added: string[];
+  errors: Array<{
+    pubkey: string;
+    error: string;
+  }>;
+};

--- a/desktop/src/shared/api/tauriChannels.ts
+++ b/desktop/src/shared/api/tauriChannels.ts
@@ -30,6 +30,8 @@ export type RawChannel = {
   is_member?: boolean;
   ttl_seconds: number | null;
   ttl_deadline: string | null;
+  agent_reply_mode?: Channel["agentReplyMode"];
+  dm_require_mention?: boolean;
 };
 
 type RawChannelDetail = RawChannel & {
@@ -71,11 +73,13 @@ export function fromRawChannel(channel: RawChannel): Channel {
     memberPubkeys: channel.member_pubkeys ?? [],
     lastMessageAt: channel.last_message_at,
     archivedAt: channel.archived_at,
-    participants: channel.participants,
-    participantPubkeys: channel.participant_pubkeys,
+    participants: channel.participants ?? [],
+    participantPubkeys: channel.participant_pubkeys ?? [],
     isMember: channel.is_member ?? true,
     ttlSeconds: channel.ttl_seconds,
     ttlDeadline: channel.ttl_deadline,
+    agentReplyMode: channel.agent_reply_mode ?? "thread",
+    dmRequireMention: channel.dm_require_mention ?? true,
   };
 }
 

--- a/desktop/src/shared/api/types.ts
+++ b/desktop/src/shared/api/types.ts
@@ -1,107 +1,22 @@
-export type ChannelType = "stream" | "forum" | "dm";
-export type ChannelVisibility = "open" | "private";
-export type ChannelRole = "owner" | "admin" | "member" | "guest" | "bot";
-
-export type Channel = {
-  id: string;
-  name: string;
-  channelType: ChannelType;
-  visibility: ChannelVisibility;
-  description: string;
-  topic: string | null;
-  purpose: string | null;
-  memberCount: number;
-  memberPubkeys: string[];
-  lastMessageAt: string | null;
-  archivedAt: string | null;
-  participants: string[];
-  participantPubkeys: string[];
-  isMember: boolean;
-  ttlSeconds: number | null;
-  ttlDeadline: string | null;
-};
-
-export type ChannelDetail = Channel & {
-  createdBy: string;
-  createdAt: string;
-  updatedAt: string;
-  topicSetBy: string | null;
-  topicSetAt: string | null;
-  purposeSetBy: string | null;
-  purposeSetAt: string | null;
-  topicRequired: boolean;
-  maxMembers: number | null;
-  nip29GroupId: string | null;
-};
-
-export type ChannelMember = {
-  pubkey: string;
-  role: ChannelRole;
-  isAgent: boolean;
-  joinedAt: string;
-  displayName: string | null;
-};
-
-export type CreateChannelInput = {
-  name: string;
-  channelType: Exclude<ChannelType, "dm">;
-  visibility: ChannelVisibility;
-  description?: string;
-  ttlSeconds?: number;
-};
-
-export type OpenDmInput = {
-  pubkeys: string[];
-};
-
-export type UpdateChannelInput = {
-  channelId: string;
-  name?: string;
-  description?: string;
-  visibility?: ChannelVisibility;
-  /** Omit to leave unchanged, `null` to clear (permanent), or a positive number of seconds to set. */
-  ttlSeconds?: number | null;
-};
-
-export type SetChannelTopicInput = {
-  channelId: string;
-  topic: string;
-};
-
-export type SetChannelPurposeInput = {
-  channelId: string;
-  purpose: string;
-};
-
-export type CanvasResponse = {
-  content: string | null;
-  updatedAt: number | null;
-  author: string | null;
-};
-
-export type SetCanvasInput = {
-  channelId: string;
-  content: string;
-};
-
-export type SetCanvasResult = {
-  ok: boolean;
-  eventId: string;
-};
-
-export type AddChannelMembersInput = {
-  channelId: string;
-  pubkeys: string[];
-  role?: Exclude<ChannelRole, "owner">;
-};
-
-export type AddChannelMembersResult = {
-  added: string[];
-  errors: Array<{
-    pubkey: string;
-    error: string;
-  }>;
-};
+export type {
+  AddChannelMembersInput,
+  AddChannelMembersResult,
+  AgentReplyMode,
+  CanvasResponse,
+  Channel,
+  ChannelDetail,
+  ChannelMember,
+  ChannelRole,
+  ChannelType,
+  ChannelVisibility,
+  CreateChannelInput,
+  OpenDmInput,
+  SetCanvasInput,
+  SetCanvasResult,
+  SetChannelPurposeInput,
+  SetChannelTopicInput,
+  UpdateChannelInput,
+} from "./channelTypes";
 
 export type { Identity, IdentityStorage } from "./identityTypes";
 

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -599,6 +599,8 @@ type RawChannel = {
   participant_pubkeys: string[];
   ttl_seconds: number | null;
   ttl_deadline: string | null;
+  agent_reply_mode?: "thread" | "inline";
+  dm_require_mention?: boolean;
 };
 
 type RawChannelWithMembership = RawChannel & {
@@ -1404,6 +1406,8 @@ function toRawChannel(
     participant_pubkeys: [...channel.participant_pubkeys],
     ttl_seconds: channel.ttl_seconds ?? null,
     ttl_deadline: channel.ttl_deadline ?? null,
+    agent_reply_mode: channel.agent_reply_mode ?? "thread",
+    dm_require_mention: channel.dm_require_mention ?? true,
     is_member: channel.members.some(
       (member) => member.pubkey.toLowerCase() === currentPubkey,
     ),
@@ -6275,6 +6279,8 @@ async function handleUpdateChannel(
     description?: string;
     visibility?: "open" | "private";
     ttlSeconds?: number | null;
+    agentReplyMode?: "thread" | "inline";
+    dmRequireMention?: boolean;
   },
   config: E2eConfig | undefined,
 ) {
@@ -6302,6 +6308,12 @@ async function handleUpdateChannel(
           ? null
           : new Date(Date.now() + args.ttlSeconds * 1000).toISOString();
     }
+    if (args.agentReplyMode !== undefined) {
+      channel.agent_reply_mode = args.agentReplyMode;
+    }
+    if (args.dmRequireMention !== undefined) {
+      channel.dm_require_mention = args.dmRequireMention;
+    }
     touchMockChannel(channel);
     return toRawChannelDetail(channel, config);
   }
@@ -6318,6 +6330,12 @@ async function handleUpdateChannel(
   }
   if (args.ttlSeconds !== undefined) {
     tags.push(["ttl", args.ttlSeconds === null ? "" : String(args.ttlSeconds)]);
+  }
+  if (args.agentReplyMode !== undefined) {
+    tags.push(["agent_reply_mode", args.agentReplyMode]);
+  }
+  if (args.dmRequireMention !== undefined) {
+    tags.push(["dm_require_mention", args.dmRequireMention ? "true" : "false"]);
   }
   await submitSignedEvent(config, { kind: 9002, content: "", tags });
 
@@ -6347,6 +6365,9 @@ async function handleUpdateChannel(
       ttlSeconds === null
         ? null
         : new Date(Date.now() + ttlSeconds * 1000).toISOString(),
+    agent_reply_mode:
+      getTag("agent_reply_mode") === "inline" ? "inline" : "thread",
+    dm_require_mention: getTag("dm_require_mention") !== "false",
     created_at: ev?.created_at
       ? new Date(ev.created_at * 1000).toISOString()
       : new Date().toISOString(),

--- a/migrations/0025_channel_agent_behavior.sql
+++ b/migrations/0025_channel_agent_behavior.sql
@@ -1,0 +1,8 @@
+-- Persist channel-scoped agent behavior so desktop UI, CLI, and external
+-- adapters agree on reply placement and DM wake-up policy.
+
+ALTER TABLE channels
+    ADD COLUMN agent_reply_mode TEXT NOT NULL DEFAULT 'thread',
+    ADD COLUMN dm_require_mention BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD CONSTRAINT chk_channels_agent_reply_mode
+        CHECK (agent_reply_mode IN ('thread', 'inline'));


### PR DESCRIPTION
## Summary

Adds channel-scoped controls for how agents wake and place replies:

- channels can choose whether agent replies open a thread or appear inline
- agent DMs can disable the explicit `@mention` requirement
- channel-member agents remain mentionable even when relay directory
  invocability metadata is stale or incomplete

## What changed

- Persists agent behavior policy on channels:
  - `agent_reply_mode`: `thread` or `inline`
  - `dm_require_mention`: boolean
- Emits the policy in channel discovery metadata so clients and adapters see the
  same behavior.
- Allows `kind:9002` channel metadata updates for these two policy fields.
- Adds CLI support:
  - `buzz channels update --channel <uuid> --agent-reply-mode inline`
  - `buzz channels update --channel <dm-uuid> --no-dm-require-mention`
- Adds desktop channel/DM settings UI for the policy.
- Keeps channel-member agents available in mention autocomplete even if the
  agent directory record is stale or incomplete.

## Why

The previous behavior forced all agent responses into threads and required
explicit mentions even in a direct agent DM. That is too rigid for real agent
workflows:

- channel conversations may want inline agent responses
- direct messages to an agent are already scoped to that agent
- agent autocomplete should honor explicit channel membership instead of hiding
  an added agent because directory invocability metadata has not caught up

## Validation

- `. ./bin/activate-hermit && cargo fmt -p buzz-cli -p buzz-sdk -p buzz-db -p buzz-relay --check && cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --check`
- `. ./bin/activate-hermit && cargo clippy -p buzz-cli -p buzz-sdk -p buzz-db -p buzz-relay --all-targets -- -D warnings`
- `. ./bin/activate-hermit && cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings`
- `. ./bin/activate-hermit && cargo test -p buzz-sdk update_channel --lib`
- `. ./bin/activate-hermit && cargo test -p buzz-cli channels --lib`
- `. ./bin/activate-hermit && cargo test -p buzz-relay edit_metadata_agent_behavior_only --lib`
- `. ./bin/activate-hermit && cargo test --manifest-path desktop/src-tauri/Cargo.toml channel_builders_reject_hash_only_names --lib`
- `. ./bin/activate-hermit && cd desktop && pnpm typecheck`
- `. ./bin/activate-hermit && cd desktop && node --import ./test-loader.mjs --experimental-strip-types --test src/features/agents/lib/agentAutocompleteEligibility.test.mjs`

## Notes

The migration is additive and gives existing channels the current behavior by
default:

- agent replies default to `thread`
- DMs default to requiring explicit mentions
