### PR TITLE
fix(release): preserve main in desktop PR body

### DIFF
--- a/scripts/prepare-desktop-release.sh
+++ b/scripts/prepare-desktop-release.sh
@@ -71,7 +71,7 @@ cat >"$body" <<EOF
 - **Previous desktop release:** \`$previous_tag\`
 - **Proposed immutable tag:** \`desktop-v$version\`
 
-This PR must be **squash merged** only after the Desktop Release Candidate check passes. The branch must remain based directly on current `main`; stale base, payload drift, incomplete notes, or an unauthorized merge produce no tag.
+This PR must be **squash merged** only after the Desktop Release Candidate check passes. The branch must remain based directly on current \`main\`; stale base, payload drift, incomplete notes, or an unauthorized merge produce no tag.
 
 The checked-in changelog accounts for every non-merge commit in the release range. Publication remains bound to the immutable candidate tag.
 EOF

--- a/scripts/test-release-ref-contract.sh
+++ b/scripts/test-release-ref-contract.sh
@@ -64,6 +64,11 @@ grep -Fq 'git/refs' "$auto_tag"
 grep -Fq 'TAG_PREFIX="desktop-v"' "$auto_tag"
 grep -Fq 'target_sha=${{ github.event.pull_request.merge_commit_sha }}' "$auto_tag"
 grep -Fq 'scripts/verify-desktop-release-merge.sh' "$auto_tag"
+grep -Fq 'current \`main\`' "$repo_root/scripts/prepare-desktop-release.sh"
+if grep -Fq 'current `main`' "$repo_root/scripts/prepare-desktop-release.sh"; then
+  echo "desktop release PR body contains executable command substitution" >&2
+  exit 1
+fi
 "$repo_root/scripts/test-desktop-release-authorization.sh"
 if rg -q 'rule-suites|desktop-release-bypass-authorized|MERGED_BY' \
   "$repo_root/scripts/verify-desktop-release-merge.sh" \


### PR DESCRIPTION
## Summary
- escape the Markdown backticks around `main` in the desktop release PR body
- prevent the shell from executing `main` as command substitution
- lock the heredoc contract into the release-ref test

## Verification
- `scripts/test-release-ref-contract.sh`
- `bash -n scripts/prepare-desktop-release.sh scripts/test-release-ref-contract.sh`
- `git diff --check origin/main...HEAD`

This is a follow-up to the cosmetic PR-body issue observed on #3972. It does not modify that frozen release candidate.
