### PR TITLE
test(relay): give trace_context_lookup test a per-statement unique target (#3929)

### DIFF
--- a/crates/buzz-relay/src/telemetry.rs
+++ b/crates/buzz-relay/src/telemetry.rs
@@ -480,6 +480,15 @@ mod tests {
                 .with_filter(tracing_subscriber::filter::LevelFilter::OFF),
         );
 
+        // `tracing` caches callsite *interest* globally per static callsite, not
+        // per-subscriber (see issue #3929): if a parallel test poisoned this
+        // callsite's cached interest while a different subscriber was active,
+        // `enabled!` consults that stale cache and a thread-local `with_default`
+        // filter is bypassed. Use a target literal unique to this test statement
+        // (suffixed by source line) so no other test's callsite can have poisoned
+        // this assertion's cached interest — removing the shared state instead of
+        // serializing around it. `enabled!` requires a compile-time literal, so
+        // this is an inline `concat!`, not a runtime `format!`.
         tracing::subscriber::with_default(subscriber, || {
             assert!(context_lookup
                 .dispatch
@@ -487,7 +496,7 @@ mod tests {
                 .and_then(tracing::dispatcher::WeakDispatch::upgrade)
                 .is_some());
             assert!(!tracing::enabled!(
-                target: "trace_context_lookup_filter_test",
+                target: concat!("trace_context_lookup_filter_test_L", line!()),
                 tracing::Level::ERROR
             ));
         });


### PR DESCRIPTION
## Summary

Fixes the intermittent failure of `telemetry::tests::trace_context_lookup_does_not_enable_callsites` under the parallel `buzz-relay` lib suite (#3929). The failure is pre-existing on unmodified `main` (not introduced by any open PR) and never fires when the test is run filtered or standalone.

## Root cause

`tracing` caches callsite *interest* **globally per static callsite**, not per-subscriber. The test installs a `TraceContextLookup` layer with `LevelFilter::OFF` via a thread-local `with_default`, then asserts the callsite is **not** enabled with `tracing::enabled!`.

When the full lib suite runs in parallel, another test can register a global default dispatcher and evaluate the same static callsite — caching its interest as `always` while a *different* subscriber is active. Because that cached interest outlives the other test's subscriber, the thread-local filter is bypassed when this test later runs, and `tracing::enabled!` returns `true`. Rebuild/re-registration order depends on parallel scheduling, so whether the poison lands before this test is a race.

## Fix (direction 2 — remove the shared state)

The reporter proposed three directions; this takes **(2)** — a per-run/unique callsite target so no other test can have poisoned this assertion's cached interest — rather than serializing around the shared state with a lock.

The assertion now targets a callsite unique to this test statement: `concat!("trace_context_lookup_filter_test_L", line!())`. `tracing::enabled!` requires a compile-time literal target, so this is an inline `concat!`/`line!` rather than a runtime `format!`. Since the callsite is distinct from every other target in the suite, no other test's subscriber activity can poison its cached interest, so the thread-local `LevelFilter::OFF` is always consulted.

This is a test-only change — no production behavior is altered.

## Verification

- Focused: `trace_context_lookup_does_not_enable_callsites` passes.
- `telemetry::` module: 7/7 pass.
- Full `cargo test -p buzz-relay --lib`: `trace_context_lookup_does_not_enable_callsites ... ok`. The suite still reports `793 passed; 9 failed; 35 ignored` — identical to clean-main baseline; the 9 failures are the pre-existing, unrelated `api::media` / `api::admin` panics and are unaffected by this change.
