### PR TITLE
fix(desktop): cfg-gate Linux media origin helpers

### DIFF
--- a/desktop/src-tauri/src/linux_media.rs
+++ b/desktop/src-tauri/src/linux_media.rs
@@ -22,22 +22,21 @@
 //! which is the backend WebKitGTK media capture is reliable on.
 
 /// The origin Tauri serves the packaged app from on Linux.
-/// Consumed only by linux-gated [`enable_media_capture`]; kept compiling on all
-/// platforms so the unit tests run everywhere.
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[cfg(any(target_os = "linux", test))]
 const PROD_ORIGIN: &str = "tauri://localhost";
 
 /// The Vite dev-server origin (`devUrl` in `tauri.conf.json`, `strictPort`
 /// 1420 in `vite.config.ts`). Only trusted in debug builds.
-#[cfg(debug_assertions)]
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[cfg(all(any(target_os = "linux", test), debug_assertions))]
 const DEV_ORIGIN: &str = "http://localhost:1420";
 
 /// Whether `uri` (the webview's current document URI) is a trusted app origin
 /// allowed to use mic/camera. Matches the origin exactly or as a path prefix so
 /// `tauri://localhost.evil.com` and `http://localhost:14200` do not slip
-/// through. Pure and platform-independent so it can be unit-tested everywhere.
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+/// through. Pure and platform-independent so it can be unit-tested everywhere;
+/// cfg-gated to Linux + tests so non-Linux lib builds (which never call it)
+/// stay clean under `-D warnings`.
+#[cfg(any(target_os = "linux", test))]
 fn is_trusted_media_origin(uri: &str) -> bool {
     fn matches(uri: &str, origin: &str) -> bool {
         uri == origin


### PR DESCRIPTION
## Summary

Fixes non-Linux Tauri clippy failures from Linux media-capture origin helpers that are only used by Linux-specific code.

## What changed

- `PROD_ORIGIN`, `DEV_ORIGIN`, and `is_trusted_media_origin()` now compile only on Linux or in tests.
- Existing Linux behavior is unchanged.
- The existing unit tests still compile and run on non-Linux platforms.

## Why

The desktop Tauri workspace clippy gate compiles the desktop lib target on macOS. The Linux media helper functions are not called in that target, so clippy reports them as dead code. Gating them to Linux plus tests keeps cross-platform validation clean without weakening the Linux media-capture checks.

## Validation

- `. ./bin/activate-hermit && just desktop-tauri-fmt-check`
- `. ./bin/activate-hermit && just desktop-tauri-clippy`
- `. ./bin/activate-hermit && cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib linux_media::tests`

Rebased onto `upstream/main` at `a96af8952` on 2026-08-13.