### PR TITLE
fix: wake agents for trusted workflow messages

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -257,6 +257,68 @@ async fn author_allowed(
     }
 }
 
+/// Return the workflow owner attributed by a relay-signed workflow wake.
+///
+/// The NIP-11 relay identity is the trust anchor. Marker and attribution tags
+/// alone are not trusted because any channel member can create them.
+fn trusted_workflow_actor(
+    event: &nostr::Event,
+    relay_self: Option<&nostr::PublicKey>,
+) -> Option<String> {
+    let relay_self = relay_self?;
+    if event.kind.as_u16() != KIND_STREAM_MESSAGE as u16
+        || event.pubkey != *relay_self
+        || event.verify().is_err()
+    {
+        return None;
+    }
+
+    let workflow_tags: Vec<_> = event
+        .tags
+        .iter()
+        .filter(|tag| tag.as_slice().first().map(String::as_str) == Some("buzz:workflow"))
+        .collect();
+    if workflow_tags.len() != 1 {
+        return None;
+    }
+    let workflow_values = workflow_tags[0].as_slice();
+    if workflow_values.len() != 2
+        || workflow_values[0] != "buzz:workflow"
+        || workflow_values[1] != "true"
+    {
+        return None;
+    }
+
+    let first_p = event.tags.iter().find_map(|tag| {
+        let values = tag.as_slice();
+        (values.first().map(String::as_str) == Some("p"))
+            .then(|| values.get(1).map(String::as_str))
+            .flatten()
+    })?;
+    let first_p = PublicKey::from_hex(first_p).ok()?.to_hex();
+
+    let actor_tags: Vec<_> = event
+        .tags
+        .iter()
+        .filter(|tag| tag.as_slice().first().map(String::as_str) == Some("actor"))
+        .collect();
+    if actor_tags.len() > 1 {
+        return None;
+    }
+    if let Some(actor_tag) = actor_tags.first() {
+        let values = actor_tag.as_slice();
+        if values.len() != 2 {
+            return None;
+        }
+        let actor = PublicKey::from_hex(values.get(1)?).ok()?.to_hex();
+        if actor != first_p {
+            return None;
+        }
+    }
+
+    Some(first_p)
+}
+
 /// Resolve whether `channel_id` is a DM, for the inbound author gate.
 ///
 /// Resolution order:
@@ -1343,6 +1405,15 @@ async fn tokio_main() -> Result<()> {
             .await
             .map_err(|e| anyhow::anyhow!("relay connect error: {e}"))?;
 
+    let rest_client = relay.rest_client();
+    let relay_self_pubkey = match rest_client.relay_self_pubkey().await {
+        Ok(pubkey) => Some(pubkey),
+        Err(error) => {
+            tracing::warn!(%error, "unable to validate relay NIP-11 identity; workflow wakes will fail closed");
+            None
+        }
+    };
+
     // Tell the relay background task the watermark so it can use
     // `since = watermark - 5s` on the first REQ instead of `since=now`.
     // Best-effort: a failure here is non-fatal (we just lose the startup window
@@ -1389,6 +1460,12 @@ async fn tokio_main() -> Result<()> {
         }
     }
     let owner_cache = OwnerCache::new(startup_owner.clone());
+    if startup_owner.is_some() {
+        // BUZZ_AUTH_TAG has already established that this managed agent belongs
+        // to the configured owner. Trust its own pubkey without a profile fetch
+        // when a self-owned workflow is attributed back to it.
+        owner_cache.cache_sibling(pubkey_hex.clone(), true);
+    }
 
     let mut relay_observer_control_rx = None;
     let mut relay_observer_publisher_task = None;
@@ -1547,7 +1624,7 @@ async fn tokio_main() -> Result<()> {
             .unwrap_or_else(|_| std::path::PathBuf::from("/"))
             .to_string_lossy()
             .to_string(),
-        rest_client: relay.rest_client(),
+        rest_client: rest_client.clone(),
         channel_info: pool::ChannelInfoResolver::new(channel_info_map, relay.rest_client()),
         context_message_limit: config.context_message_limit,
         max_turns_per_session: config.max_turns_per_session,
@@ -2142,8 +2219,12 @@ async fn tokio_main() -> Result<()> {
                             // launched by the same human). Allowlist adds the
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
+                            let effective_author = trusted_workflow_actor(
+                                &buzz_event.event,
+                                relay_self_pubkey.as_ref(),
+                            )
+                            .unwrap_or_else(|| buzz_event.event.pubkey.to_hex());
                             {
-                                let author = buzz_event.event.pubkey.to_hex();
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
@@ -2152,7 +2233,7 @@ async fn tokio_main() -> Result<()> {
                                 let allowed = author_allowed(
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
-                                    &author,
+                                    &effective_author,
                                     is_dm,
                                     &owner_cache,
                                     &ctx.rest_client,
@@ -2161,7 +2242,8 @@ async fn tokio_main() -> Result<()> {
                                 if !allowed {
                                     tracing::debug!(
                                         channel_id = %buzz_event.channel_id,
-                                        author = %buzz_event.event.pubkey.to_hex(),
+                                        author = %effective_author,
+                                        envelope_author = %buzz_event.event.pubkey.to_hex(),
                                         mode = %config.respond_to,
                                         is_dm,
                                         "inbound author gate — dropping event"
@@ -2180,7 +2262,7 @@ async fn tokio_main() -> Result<()> {
                             };
                             // Capture author pubkey before queue.push() moves
                             // buzz_event.event (needed for mode gate below).
-                            let author_hex = buzz_event.event.pubkey.to_hex();
+                            let author_hex = effective_author;
                             let event_id_hex = buzz_event.event.id.to_hex();
                             // Clone for the non-cancelling steer fork, which
                             // needs the event to render the steer body. The
@@ -4420,6 +4502,26 @@ mod owner_cache_tests {
 mod author_gate_tests {
     use super::*;
 
+    fn workflow_event(
+        relay: &nostr::Keys,
+        owner: &nostr::PublicKey,
+        actor: Option<&nostr::PublicKey>,
+        marker_count: usize,
+    ) -> nostr::Event {
+        let mut tags = Vec::new();
+        if let Some(actor) = actor {
+            tags.push(nostr::Tag::parse(["actor", &actor.to_hex()]).unwrap());
+        }
+        tags.push(nostr::Tag::parse(["p", &owner.to_hex()]).unwrap());
+        for _ in 0..marker_count {
+            tags.push(nostr::Tag::parse(["buzz:workflow", "true"]).unwrap());
+        }
+        nostr::EventBuilder::new(nostr::Kind::Custom(KIND_STREAM_MESSAGE as u16), "wake")
+            .tags(tags)
+            .sign_with_keys(relay)
+            .unwrap()
+    }
+
     /// A `RestClient` for tests. The author-gate decisions exercised here all
     /// resolve from the owner pubkey or sibling cache before any HTTP call, so
     /// this client is never actually used to make a request.
@@ -4444,6 +4546,87 @@ mod author_gate_tests {
         cache.cache_sibling(STRANGER.into(), false);
         cache.cache_sibling(EXTERNAL.into(), false);
         cache
+    }
+
+    #[tokio::test]
+    async fn trusted_relay_workflow_owned_by_self_passes_owner_only_gate() {
+        let relay = nostr::Keys::generate();
+        let agent = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let event = workflow_event(&relay, &agent.public_key(), Some(&agent.public_key()), 1);
+        let actor = trusted_workflow_actor(&event, Some(&relay.public_key())).unwrap();
+        let cache = OwnerCache::new(Some(owner.public_key().to_hex()));
+        cache.cache_sibling(agent.public_key().to_hex(), true);
+
+        assert!(
+            author_allowed(
+                &RespondTo::OwnerOnly,
+                &HashSet::new(),
+                &actor,
+                false,
+                &cache,
+                &dummy_rest_client(),
+            )
+            .await
+        );
+    }
+
+    #[test]
+    fn workflow_attribution_requires_trusted_relay_and_unambiguous_tags() {
+        let relay = nostr::Keys::generate();
+        let impostor = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let other = nostr::Keys::generate();
+
+        let valid = workflow_event(&relay, &owner.public_key(), Some(&owner.public_key()), 1);
+        assert_eq!(
+            trusted_workflow_actor(&valid, Some(&relay.public_key())),
+            Some(owner.public_key().to_hex())
+        );
+        assert_eq!(
+            trusted_workflow_actor(&valid, Some(&impostor.public_key())),
+            None
+        );
+
+        let legacy = workflow_event(&relay, &owner.public_key(), None, 1);
+        assert_eq!(
+            trusted_workflow_actor(&legacy, Some(&relay.public_key())),
+            Some(owner.public_key().to_hex())
+        );
+
+        let missing_marker =
+            workflow_event(&relay, &owner.public_key(), Some(&owner.public_key()), 0);
+        assert_eq!(
+            trusted_workflow_actor(&missing_marker, Some(&relay.public_key())),
+            None
+        );
+
+        let mut tampered = valid.clone();
+        tampered.content.push_str(" tampered");
+        assert_eq!(
+            trusted_workflow_actor(&tampered, Some(&relay.public_key())),
+            None
+        );
+
+        let forged = workflow_event(&impostor, &owner.public_key(), Some(&owner.public_key()), 1);
+        assert_eq!(
+            trusted_workflow_actor(&forged, Some(&relay.public_key())),
+            None
+        );
+
+        let duplicate_marker =
+            workflow_event(&relay, &owner.public_key(), Some(&owner.public_key()), 2);
+        assert_eq!(
+            trusted_workflow_actor(&duplicate_marker, Some(&relay.public_key())),
+            None
+        );
+
+        let mismatched_actor =
+            workflow_event(&relay, &owner.public_key(), Some(&other.public_key()), 1);
+        assert_eq!(
+            trusted_workflow_actor(&mismatched_actor, Some(&relay.public_key())),
+            None
+        );
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -259,6 +259,26 @@ fn unix_now_secs() -> u64 {
 }
 
 impl RestClient {
+    /// Fetch and validate the relay signing identity published in its NIP-11
+    /// information document.
+    pub async fn relay_self_pubkey(&self) -> Result<nostr::PublicKey, RelayError> {
+        let url = format!("{}/", self.base_url.trim_end_matches('/'));
+        let response = self
+            .http
+            .get(&url)
+            .header(reqwest::header::ACCEPT, "application/nostr+json")
+            .send()
+            .await
+            .map_err(|e| RelayError::Http(format!("failed to fetch relay info: {e}")))?
+            .error_for_status()
+            .map_err(|e| RelayError::Http(format!("relay info request failed: {e}")))?;
+        let document: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| RelayError::Http(format!("invalid relay info document: {e}")))?;
+        parse_relay_self_pubkey(&document)
+    }
+
     /// Sign a NIP-98 HTTP Auth event (kind:27235) for the given method/URL/body.
     ///
     /// Returns the `Authorization: Nostr <base64>` header value (without the
@@ -434,6 +454,20 @@ impl RestClient {
         }
         serde_json::from_str(&text).map_err(|e| RelayError::Http(e.to_string()))
     }
+}
+
+fn parse_relay_self_pubkey(document: &serde_json::Value) -> Result<nostr::PublicKey, RelayError> {
+    let self_hex = document
+        .get("self")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| RelayError::Http("relay info document missing 'self' field".into()))?;
+    if self_hex.len() != 64 || !self_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(RelayError::Http(format!(
+            "relay 'self' field is not a valid 64-hex pubkey: {self_hex}"
+        )));
+    }
+    nostr::PublicKey::from_hex(self_hex)
+        .map_err(|e| RelayError::Http(format!("invalid relay 'self' pubkey: {e}")))
 }
 
 /// Events the harness cares about.
@@ -4007,6 +4041,20 @@ async fn wait_for_any_ok(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn relay_self_pubkey_parses_valid_and_uppercase_hex() {
+        let expected = nostr::Keys::generate().public_key();
+        let upper = expected.to_hex().to_ascii_uppercase();
+        let parsed = parse_relay_self_pubkey(&serde_json::json!({"self": upper})).unwrap();
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn relay_self_pubkey_rejects_missing_or_invalid_self() {
+        assert!(parse_relay_self_pubkey(&serde_json::json!({})).is_err());
+        assert!(parse_relay_self_pubkey(&serde_json::json!({"self": "not-a-pubkey"})).is_err());
+    }
 
     #[test]
     fn relay_ws_to_http_plain() {

--- a/crates/buzz-relay/src/workflow_sink.rs
+++ b/crates/buzz-relay/src/workflow_sink.rs
@@ -252,12 +252,14 @@ impl ActionSink for RelayActionSink {
 
             // 3. Build kind:9 Nostr event
             //    - Signed by relay keypair (event.pubkey = relay pubkey)
-            //    - `p` tag attributes the message to the workflow owner
+            //    - `actor` and first `p` tag attribute the message to the workflow owner
             //    - `h` tag scopes to the channel (NIP-29, canonical UUID)
             //    - `buzz:workflow` tag prevents recursive workflow triggering
             //    - one `p` tag per `@Name` that resolves to a channel member,
             //      so mentioned agents are woken (wake is `p`-tag gated)
             let mut tags = vec![
+                Tag::parse(["actor", &author_pubkey_hex])
+                    .map_err(|e| ActionSinkError::EventBuild(format!("actor tag: {e}")))?,
                 Tag::parse(["p", &author_pubkey_hex])
                     .map_err(|e| ActionSinkError::EventBuild(format!("p tag: {e}")))?,
                 Tag::parse(["h", &channel_id_canonical])
@@ -698,6 +700,17 @@ mod integration_tests {
             .filter(|t| t.as_slice().first().map(|s| s.as_str()) == Some("p"))
             .filter_map(|t| t.as_slice().get(1).map(|s| s.as_str()))
             .collect();
+
+        let actor_tag_targets: Vec<&str> = stored
+            .event
+            .tags
+            .iter()
+            .filter(|t| t.as_slice().first().map(|s| s.as_str()) == Some("actor"))
+            .filter_map(|t| t.as_slice().get(1).map(|s| s.as_str()))
+            .collect();
+
+        assert_eq!(actor_tag_targets, vec![author_hex.as_str()]);
+        assert_eq!(p_tag_targets.first().copied(), Some(author_hex.as_str()));
 
         assert!(
             p_tag_targets.contains(&author_hex.as_str()),


### PR DESCRIPTION
## Summary
- pin the relay signing identity from NIP-11 before trusting workflow attribution
- route relay-signed workflow owners through the existing owner-only/allowlist gate
- add explicit workflow actor tags while retaining legacy first-p attribution
- cache the managed agent self-identity for self-owned workflows

## Security
Workflow tags alone are never trusted. Admission requires a valid event signed by the relay pubkey published in NIP-11; attributed actors still pass the existing author and DM gates.

## Verification
- `cargo test -p buzz-acp --no-fail-fast` (653 unit + 9 lifecycle tests)
- `cargo test -p buzz-relay --lib ...` (792 passed, 35 ignored; 9 DB-dependent tests and one isolated telemetry-global-state test filtered)
- isolated telemetry test passes on its own

Originating Buzz channel: `343d10ae-c948-4e32-9f16-56a367dc3a7d`