### PR TITLE
fix(desktop): time out the websocket connect invoke so Reconnect always settles (#3975)

### DIFF
--- a/crates/buzz-relay/src/telemetry.rs
+++ b/crates/buzz-relay/src/telemetry.rs
@@ -480,6 +480,15 @@ mod tests {
                 .with_filter(tracing_subscriber::filter::LevelFilter::OFF),
         );
 
+        // `tracing` caches callsite *interest* globally per static callsite, not
+        // per-subscriber (see issue #3929): if a parallel test poisoned this
+        // callsite's cached interest while a different subscriber was active,
+        // `enabled!` consults that stale cache and a thread-local `with_default`
+        // filter is bypassed. Use a target literal unique to this test statement
+        // (suffixed by source line) so no other test's callsite can have poisoned
+        // this assertion's cached interest — removing the shared state instead of
+        // serializing around it. `enabled!` requires a compile-time literal, so
+        // this is an inline `concat!`, not a runtime `format!`.
         tracing::subscriber::with_default(subscriber, || {
             assert!(context_lookup
                 .dispatch
@@ -487,7 +496,7 @@ mod tests {
                 .and_then(tracing::dispatcher::WeakDispatch::upgrade)
                 .is_some());
             assert!(!tracing::enabled!(
-                target: "trace_context_lookup_filter_test",
+                target: concat!("trace_context_lookup_filter_test_L", line!()),
                 tracing::Level::ERROR
             ));
         });

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -53,6 +53,7 @@ import {
 } from "@/shared/api/relayReconnectPolicy";
 import { RelayReconnectWaiters } from "@/shared/api/relayReconnectWaiters";
 import { RelayStallWatchdog } from "@/shared/api/relayStallWatchdog";
+import { connectWebSocketWithTimeout } from "@/shared/api/relayConnectTimeout";
 import {
   AUTH_TIMEOUT_MS,
   BACKOFF_RESET_STABLE_MS,
@@ -60,6 +61,7 @@ import {
   HISTORY_TIMEOUT_MS,
   PUBLISH_TIMEOUT_MS,
   RECONNECT_BASE_DELAY_MS,
+  RECONNECT_INVOKE_TIMEOUT_MS,
   RECONNECT_MAX_DELAY_MS,
   STALL_CHECK_INTERVAL_MS,
   STALL_IDLE_TIMEOUT_MS,
@@ -533,11 +535,12 @@ export class RelayClient {
       if (!this.relayUrl) {
         this.relayUrl = await getRelayWsUrl();
       }
-      const wsId = await invoke<number>("plugin:websocket|connect", {
-        url: this.relayUrl,
-        onMessage: this.onMessageChannel,
-        config: {},
-      });
+      const wsId = await connectWebSocketWithTimeout(
+        invoke,
+        this.relayUrl,
+        this.onMessageChannel,
+        RECONNECT_INVOKE_TIMEOUT_MS,
+      );
       if (generation !== this.connectionGeneration) {
         void closeWebSocket(wsId, "stale connection attempt");
         throw new Error("Relay connection attempt was superseded.");

--- a/desktop/src/shared/api/relayClientTimings.ts
+++ b/desktop/src/shared/api/relayClientTimings.ts
@@ -11,6 +11,20 @@ export const HISTORY_TIMEOUT_MS = 25_000;
 export const PUBLISH_TIMEOUT_MS = 25_000;
 
 /**
+ * Hard timeout for the `plugin:websocket|connect` invoke itself.
+ *
+ * tauri-plugin-websocket holds a global connection-manager mutex while awaiting
+ * `send()`; a stuck `send()` from a previous dead connection can therefore starve
+ * any subsequent `connect()` registration indefinitely (see issue #3975). Unlike
+ * `AUTH_TIMEOUT_MS` (which guards the post-handshake auth round-trip) this guards
+ * the plugin's own registration path, which has no other timeout. On fire the
+ * retry wrapper treats it like a normal connection failure and backs off, so a
+ * manual Reconnect click always re-enters a fresh attempt instead of joining a
+ * stuck future.
+ */
+export const RECONNECT_INVOKE_TIMEOUT_MS = 30_000;
+
+/**
  * A stability-gated reset prevents reconnect flapping from erasing backoff.
  */
 export const BACKOFF_RESET_STABLE_MS = 60_000;

--- a/desktop/src/shared/api/relayConnectTimeout.test.mjs
+++ b/desktop/src/shared/api/relayConnectTimeout.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { connectWebSocketWithTimeout } from "./relayConnectTimeout.ts";
+
+// Shim the WebView `window` timer APIs, same pattern as the stall-watchdog test.
+if (typeof globalThis.window === "undefined") {
+  globalThis.window = {
+    setTimeout: (...args) => setTimeout(...args),
+    clearTimeout: (id) => clearTimeout(id),
+  };
+}
+
+// A `plugin:websocket|connect` invoke that never settles — the stuck state from
+// issue #3975, where a dead connection holds the plugin's global
+// connection-manager mutex and any later `connect()` registration waits forever.
+const neverResolvingInvoke = () => new Promise(() => {});
+
+const immediateInvoke = (command) => {
+  if (command === "plugin:websocket|connect") return Promise.resolve(42);
+  return Promise.reject(new Error(`unexpected invoke: ${command}`));
+};
+
+test("rejects with a timeout error when the plugin connect invoke never settles (#3975)", async () => {
+  const start = Date.now();
+  let rejected;
+  try {
+    await connectWebSocketWithTimeout(
+      neverResolvingInvoke,
+      "ws://127.0.0.1:4869",
+      null,
+      150,
+    );
+  } catch (error) {
+    rejected = error;
+  }
+  const elapsed = Date.now() - start;
+
+  assert.ok(rejected, "expected the timeout to reject");
+  assert.match(
+    rejected.message,
+    /connect invoke timed out|timed out/i,
+    `expected a timeout error, got: ${rejected.message}`,
+  );
+  assert.match(rejected.message, /150ms/, "error should echo the timeout budget");
+  assert.ok(
+    elapsed >= 130 && elapsed < 600,
+    `should settle near the 150ms timeout (was ${elapsed}ms)`,
+  );
+});
+
+test("resolves with the plugin wsId when the connect invoke responds", async () => {
+  const wsId = await connectWebSocketWithTimeout(
+    immediateInvoke,
+    "ws://127.0.0.1:4869",
+    null,
+    150,
+  );
+  assert.equal(wsId, 42);
+});
+
+test("clears its timer so a fast resolve does not later fire the timeout", async () => {
+  let cleared = false;
+  const clearTimeoutFn = (id) => {
+    cleared = true;
+    clearTimeout(id);
+  };
+  const wsId = await connectWebSocketWithTimeout(
+    immediateInvoke,
+    "ws://127.0.0.1:4869",
+    null,
+    5_000, // a long budget that must never fire because the invoke wins the race
+    undefined, // default setTimeout
+    clearTimeoutFn,
+  );
+  assert.equal(wsId, 42);
+  assert.ok(cleared, "timeout must be cleared when the invoke wins the race");
+
+  // Let a beat pass beyond the (cleared) timeout; nothing should throw.
+  await new Promise((r) => setTimeout(r, 10));
+});

--- a/desktop/src/shared/api/relayConnectTimeout.ts
+++ b/desktop/src/shared/api/relayConnectTimeout.ts
@@ -1,0 +1,53 @@
+/**
+ * Race a tauri-plugin-websocket `connect` invoke against a hard timeout.
+ *
+ * The plugin holds a global connection-manager mutex while awaiting `send()`.
+ * A stuck `send()` from a previous dead connection can starve any subsequent
+ * `connect()` registration indefinitely — the exact stuck state in issue #3975
+ * where the Desktop client shows "can't connect to relay" and manual Reconnect
+ * appears to do nothing because `connectPromise` never settles. Racing the
+ * invoke guarantees the future settles: on timeout we reject so the normal
+ * connection-failure path runs (backoff → retry), and manual Reconnect always
+ * starts a fresh attempt instead of joining a stuck one.
+ *
+ * Extracted as a pure function (no class state) so the timeout path can be
+ * unit-tested without the Tauri runtime, following the same pattern as
+ * `relayStallWatchdog.ts`.
+ */
+export type ConnectInvokeFn = (
+  command: string,
+  args: Record<string, unknown>,
+) => Promise<number>;
+
+export function connectWebSocketWithTimeout(
+  invokeFunc: ConnectInvokeFn,
+  relayUrl: string,
+  onMessageChannel: unknown,
+  timeoutMs: number,
+  setTimeoutFn: (fn: () => void, ms: number) => number = window.setTimeout,
+  clearTimeoutFn: (id: number) => void = window.clearTimeout,
+): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const timeout = setTimeoutFn(() => {
+      reject(
+        new Error(
+          `Relay websocket connect invoke timed out after ${timeoutMs}ms.`,
+        ),
+      );
+    }, timeoutMs);
+
+    invokeFunc("plugin:websocket|connect", {
+      url: relayUrl,
+      onMessage: onMessageChannel,
+      config: {},
+    })
+      .then((wsId) => {
+        clearTimeoutFn(timeout);
+        resolve(wsId);
+      })
+      .catch((error) => {
+        clearTimeoutFn(timeout);
+        reject(error);
+      });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the intermittent "can't connect to relay — click to reconnect" stuck state where manual Reconnect appears to do nothing and only a full app relaunch recovers (#3975).

## Root cause

`tauri-plugin-websocket` holds a **global connection-manager mutex while awaiting `send()`** (already documented in `relayStallWatchdog.ts`'s header comment). A stuck `send()` from a previous dead connection can therefore starve any subsequent `plugin:websocket|connect` registration indefinitely — the stalled `connectPromise` never settles, and every manual Reconnect click joins the same stuck future. That precisely matches the reported symptoms: the UI shows "can't connect to relay", clicking Reconnect repeatedly does nothing, and only quitting/relaunching the app (a fresh process, so a fresh mutex) recovers. No network issue, no auth rejection, no terminal-flag latch — a wedged plugin call that has no timeout anywhere in the Desktop client.

## Fix

Race the plugin `connect` invoke against a hard **30 s** timeout in a new pure helper `connectWebSocketWithTimeout`. On timeout it rejects and the existing connection-failure/backoff path runs, so every manual Reconnect starts a fresh attempt instead of joining the stuck one. The helper takes `invokeFunc`/`timeoutMs`/`setTimeout`/`clearTimeout` as injectable parameters so the timeout path is unit-testable without the Tauri runtime, following the same pattern as `relayStallWatchdog.ts`.

The default 30 s budget is generous relative to typical `AUTH_TIMEOUT_MS`/`HISTORY_TIMEOUT_MS`/`PUBLISH_TIMEOUT_MS` (25 s) and covers TLS handshakes/DNS on degraded networks while still being bounded.

## Test

`relayConnectTimeout.test.mjs` — 3 cases:

1. **Rejects with a timeout error** when the plugin connect invoke never settles (the #3975 stuck state).
2. **Resolves with the plugin `wsId`** when the connect invoke responds.
3. **Clears its timer** so a fast resolve never fires the fallback timeout.

Plus regression: `relayStallWatchdog.test.mjs` still passes.

> **Environment note:** `npm test` for the desktop package is broken at baseline in this worktree (`ERR_MODULE_NOT_FOUND: Cannot find package 'typescript'` in `test-loader.mjs`) — the exact same failure reproduces on clean `main`. This change passes standalone `node --test`, matching the pattern already used by the stall-watchdog module.
