### PR TITLE
feat(desktop): expose text size controls in Settings

### DIFF
--- a/desktop/src/app/useWebviewZoomShortcuts.ts
+++ b/desktop/src/app/useWebviewZoomShortcuts.ts
@@ -86,15 +86,68 @@ function applyTextScale(zoomFactor: number) {
   window.localStorage.setItem(TEXT_SCALE_STORAGE_KEY, String(zoomFactor));
 }
 
-export function useWebviewZoomShortcuts() {
-  const zoomFactorRef = React.useRef(DEFAULT_ZOOM_FACTOR);
+// Reactive store so Settings UI can read and set the zoom factor alongside the
+// keyboard shortcuts. Mirrors the threadViewModePreference pattern.
+const listeners = new Set<() => void>();
+let zoomFactor = readStoredZoomFactor();
 
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): number {
+  return zoomFactor;
+}
+
+function getServerSnapshot(): number {
+  return DEFAULT_ZOOM_FACTOR;
+}
+
+function commitZoomFactor(next: number) {
+  const clamped = Math.min(
+    Math.max(roundZoomFactor(next), MIN_ZOOM_FACTOR),
+    MAX_ZOOM_FACTOR,
+  );
+  if (clamped === zoomFactor) return;
+  zoomFactor = clamped;
+  applyTextScale(clamped);
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** Read the persisted zoom factor outside of React. */
+export function getZoomFactor(): number {
+  return zoomFactor;
+}
+
+/** Set the zoom factor from UI (e.g. Settings dropdown). */
+export function setZoomFactor(next: number): void {
+  commitZoomFactor(next);
+}
+
+/** Reset the zoom factor to the default. */
+export function resetZoomFactor(): void {
+  commitZoomFactor(DEFAULT_ZOOM_FACTOR);
+}
+
+export const ZOOM_FACTOR_MIN = MIN_ZOOM_FACTOR;
+export const ZOOM_FACTOR_MAX = MAX_ZOOM_FACTOR;
+export const ZOOM_FACTOR_STEP = ZOOM_STEP;
+export const ZOOM_FACTOR_DEFAULT = DEFAULT_ZOOM_FACTOR;
+
+/** Reactive zoom factor — re-renders when keyboard shortcuts or UI change it. */
+export function useZoomFactor(): number {
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+export function useWebviewZoomShortcuts() {
   React.useLayoutEffect(() => {
     const webview = getCurrentWebview();
-    const storedZoomFactor = readStoredZoomFactor();
-
-    zoomFactorRef.current = storedZoomFactor;
-    applyTextScale(storedZoomFactor);
+    applyTextScale(zoomFactor);
 
     // Keep the webview coordinate system stable; only text should scale.
     void webview.setZoom(DEFAULT_ZOOM_FACTOR).catch((error) => {
@@ -109,15 +162,13 @@ export function useWebviewZoomShortcuts() {
 
       event.preventDefault();
 
-      const previousZoomFactor = zoomFactorRef.current;
-      const nextZoomFactor = getNextZoomFactor(action, previousZoomFactor);
+      const nextZoomFactor = getNextZoomFactor(action, zoomFactor);
 
-      if (nextZoomFactor === previousZoomFactor) {
+      if (nextZoomFactor === zoomFactor) {
         return;
       }
 
-      zoomFactorRef.current = nextZoomFactor;
-      applyTextScale(nextZoomFactor);
+      commitZoomFactor(nextZoomFactor);
     }
 
     window.addEventListener("keydown", handleKeyDown);

--- a/desktop/src/features/settings/ui/SettingsPanels.tsx
+++ b/desktop/src/features/settings/ui/SettingsPanels.tsx
@@ -14,6 +14,8 @@ import {
   MessagesSquare,
   MonitorCog,
   Moon,
+  Minus,
+  Plus,
   ShieldAlert,
   Smartphone,
   Smile,
@@ -37,6 +39,14 @@ import {
   useThreadViewMode,
   type ThreadViewMode,
 } from "@/features/channels/lib/threadViewModePreference";
+import {
+  resetZoomFactor,
+  setZoomFactor,
+  useZoomFactor,
+  ZOOM_FACTOR_MAX,
+  ZOOM_FACTOR_MIN,
+  ZOOM_FACTOR_STEP,
+} from "@/app/useWebviewZoomShortcuts";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import {
@@ -656,6 +666,7 @@ function ThemeSettingsCard() {
       )}
 
       <ThreadLayoutSetting />
+      <TextSizeSetting />
     </section>
   );
 }
@@ -735,6 +746,65 @@ function ThreadLayoutSetting() {
             </DropdownMenuRadioGroup>
           </DropdownMenuContent>
         </DropdownMenu>
+      </SettingsOptionRow>
+    </SettingsOptionGroup>
+  );
+}
+
+function TextSizeSetting() {
+  const zoomFactor = useZoomFactor();
+  const pct = Math.round(zoomFactor * 100);
+
+  return (
+    <SettingsOptionGroup className="mt-4">
+      <SettingsOptionRow>
+        <div className="min-w-0">
+          <p className="text-sm font-medium">Text size</p>
+          <p className="text-sm font-normal text-muted-foreground">
+            {pct}% — use Cmd +/- to adjust, Cmd+0 to reset
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            className="h-7 w-7 rounded-full border border-border/50 bg-muted/45 p-0 text-xs shadow-none hover:bg-muted/70"
+            data-testid="font-size-decrease"
+            disabled={zoomFactor <= ZOOM_FACTOR_MIN}
+            onClick={() => setZoomFactor(zoomFactor - ZOOM_FACTOR_STEP)}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            <Minus className="h-4 w-4" />
+          </Button>
+          <span
+            className="min-w-10 text-center text-xs font-medium tabular-nums"
+            data-testid="font-size-display"
+          >
+            {pct}%
+          </span>
+          <Button
+            className="h-7 w-7 rounded-full border border-border/50 bg-muted/45 p-0 text-xs shadow-none hover:bg-muted/70"
+            data-testid="font-size-increase"
+            disabled={zoomFactor >= ZOOM_FACTOR_MAX}
+            onClick={() => setZoomFactor(zoomFactor + ZOOM_FACTOR_STEP)}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+          <Button
+            className="h-7 rounded-full border border-border/50 bg-muted/45 px-2.5 text-xs font-medium shadow-none hover:bg-muted/70"
+            data-testid="font-size-reset"
+            disabled={zoomFactor === 1}
+            onClick={resetZoomFactor}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            Reset
+          </Button>
+        </div>
       </SettingsOptionRow>
     </SettingsOptionGroup>
   );


### PR DESCRIPTION
## Summary
- The desktop app already supported Cmd +/- / Cmd+0 text zoom (scaling the root `<html>` font-size), but it was only accessible via keyboard shortcuts
- Added a reactive store (`useZoomFactor` / `setZoomFactor` / `resetZoomFactor`) to `useWebviewZoomShortcuts` so the Settings UI can read and set the same zoom factor
- Added a "Text size" row in Settings → Appearance with - / + / Reset buttons showing the current percentage

Fixes #3938

## Testing
- Built and ran the desktop app locally
- Verified the "Text size" row appears in Settings → Appearance
- Buttons adjust the zoom and the percentage updates live
- Cmd +/- and Cmd+0 still work and stay in sync with the Settings UI
Video: https://gofile.io/d/w3cbID