### PR TITLE
fix(desktop): remove 880px reading cap in focus-mode thread

### DIFF
--- a/desktop/src/features/channels/lib/threadFocusLayout.ts
+++ b/desktop/src/features/channels/lib/threadFocusLayout.ts
@@ -17,16 +17,6 @@
 export const THREAD_FOCUS_SLIVER_WIDTH_PX = 72;
 
 /**
- * Max width of the centered message column inside the focus drawer.
- *
- * The drawer itself spans nearly the whole channel content area, but message
- * text set that wide is unreadable. The list and composer share this max width
- * with auto horizontal margins so the reading measure stays comfortable no
- * matter how wide the window gets.
- */
-export const THREAD_FOCUS_COLUMN_MAX_WIDTH_PX = 880;
-
-/**
  * Horizontal distance the focus drawer travels on enter/exit.
  *
  * Deliberately a fraction of the drawer's own width rather than a true slide

--- a/desktop/src/features/channels/lib/threadPanelLayout.ts
+++ b/desktop/src/features/channels/lib/threadPanelLayout.ts
@@ -1,7 +1,5 @@
 import type * as React from "react";
 
-import { THREAD_FOCUS_COLUMN_MAX_WIDTH_PX } from "@/features/channels/lib/threadFocusLayout";
-
 export type ThreadPanelLayoutProps = {
   columnMaxWidthPx?: number;
   headerLeading?: React.ReactNode;
@@ -27,7 +25,10 @@ export function getThreadPanelLayout({
 }: ThreadPanelLayoutOptions): ThreadPanelLayoutProps {
   return isFocusDrawer
     ? {
-        columnMaxWidthPx: THREAD_FOCUS_COLUMN_MAX_WIDTH_PX,
+        // Full-bleed to the drawer edge, matching split/channel/inbox views:
+        // an undefined max width drops both the reading-measure cap and the
+        // `mx-auto`/inline-gutter column treatment (see THREAD_PANEL_COLUMN_CLASS).
+        columnMaxWidthPx: undefined,
         headerLeading,
         isFocusMode: true,
         isSinglePanelView: true,


### PR DESCRIPTION
## What

Removes the 880px reading-column cap in focus-mode thread view so thread content fills the drawer edge-to-edge, matching every sibling reading surface.

Previously, focus mode capped its thread content at an 880px centered column (`mx-auto`) with a `px-10` inner gutter, producing large empty side gutters on wide drawers. The split thread view, the channel timeline, and the inbox all render the same message content full-width — the cap was unique to focus mode.

## How

- `threadPanelLayout.ts` — the focus branch of `getThreadPanelLayout` now passes `columnMaxWidthPx: undefined` instead of `THREAD_FOCUS_COLUMN_MAX_WIDTH_PX`, which is exactly what split mode already does. This drops the max-width, the `mx-auto` centering, and the `px-10` gutter. The gate flows through the message list, the composer, and the loading skeleton via the shared `hasConstrainedColumn` check, so nothing shifts when replies load in.
- `threadFocusLayout.ts` — removes the now-unused `THREAD_FOCUS_COLUMN_MAX_WIDTH_PX` constant and its import.

Net: 2 files, +4/−13.

## Verification

- `tsc --noEmit` — clean
- `biome check` on touched files — clean
- Full desktop test suite — 3870/3870 pass

## Context

Discussed in the buzz-focus-thread-width channel — the 880px cap was a deliberate reading-measure choice from #2108 but a lightly-held one (single author, never iterated, inconsistent with sibling views). Removing it for consistency and to eliminate the distracting gutters.

Opening as **draft** — a human will move it to Ready for Review.
