### PR TITLE
fix(desktop): make remotely hosted agents mentionable from other machines

### DIFF
--- a/desktop/src-tauri/src/commands/channels.rs
+++ b/desktop/src-tauri/src/commands/channels.rs
@@ -786,6 +786,7 @@ pub async fn add_channel_members(
     pubkeys: Vec<String>,
     role: Option<String>,
     state: State<'_, AppState>,
+    app: tauri::AppHandle,
 ) -> Result<serde_json::Value, String> {
     let uuid = parse_channel_uuid(&channel_id)?;
     let role_str = match role.as_deref() {
@@ -811,6 +812,14 @@ pub async fn add_channel_members(
             Ok(_) => added.push(pubkey.clone()),
             Err(e) => errors.push(serde_json::json!({"pubkey": pubkey, "error": e})),
         }
+    }
+
+    // A managed agent's directory entry (kind:10100) lists the channels it can
+    // be reached in, and that list is empty at start time because memberships
+    // do not exist yet. Refresh it here so the agent becomes invocable from
+    // other machines as soon as it joins a channel. No-op for non-agents.
+    for pubkey in &added {
+        crate::managed_agents::refresh_agent_directory_entry(&app, &state, pubkey).await;
     }
 
     Ok(serde_json::json!({ "added": added, "errors": errors }))

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -57,7 +57,8 @@ use huddle::{
 use managed_agents::{
     backfill_persona_snapshots, ensure_nest, list_managed_agent_runtimes,
     put_managed_agent_runtime_lifecycle, reconcile_managed_agent_runtimes,
-    restart_managed_agent_runtime, start_managed_agent_runtime, stop_managed_agent_runtime,
+    refresh_agent_directory_entries, restart_managed_agent_runtime, start_managed_agent_runtime,
+    stop_managed_agent_runtime,
     try_regenerate_nest,
 };
 #[cfg(not(feature = "mesh-llm"))]
@@ -805,6 +806,7 @@ pub fn run() {
             start_managed_agent_runtime,
             stop_managed_agent_runtime,
             restart_managed_agent_runtime,
+            refresh_agent_directory_entries,
             reconcile_managed_agent_runtimes,
             put_managed_agent_runtime_lifecycle,
             create_managed_agent,

--- a/desktop/src-tauri/src/managed_agents/agent_events.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_events.rs
@@ -22,7 +22,7 @@
 //! - any runtime field (`runtime_pid`, `last_*`, `backend_agent_id`, …) — these
 //!   mutate on every start/stop and describe transient process state.
 
-use buzz_core_pkg::kind::KIND_MANAGED_AGENT;
+use buzz_core_pkg::kind::{KIND_AGENT_PROFILE, KIND_MANAGED_AGENT};
 use nostr::{EventBuilder, Kind, Tag};
 use serde::{Deserialize, Serialize};
 
@@ -116,6 +116,90 @@ pub fn build_agent_event(record: &ManagedAgentRecord) -> Result<EventBuilder, St
     let tags =
         vec![Tag::parse(["d", record.pubkey.as_str()]).map_err(|e| format!("invalid d-tag: {e}"))?];
     Ok(EventBuilder::new(Kind::Custom(KIND_MANAGED_AGENT as u16), content).tags(tags))
+}
+
+/// Default channel-add policy carried on the agent's kind:10100 entry.
+///
+/// The relay's `handle_agent_profile` side effect requires this field and
+/// fails the whole side effect without it, so a directory entry that omits it
+/// is stored but never applied. `owner_only` matches the relay's own default,
+/// so publishing it keeps behavior unchanged.
+const DEFAULT_CHANNEL_ADD_POLICY: &str = "owner_only";
+
+/// The agent's public directory entry (kind:10100), as clients consume it.
+///
+/// Field names are snake_case on the wire: the desktop parses them through
+/// `RelayAgentInfo` (serde, snake_case) and the frontend maps them to camelCase
+/// in `fromRawRelayAgent`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentProfileEventContent {
+    pub name: String,
+    pub display_name: String,
+    pub agent_type: String,
+    pub respond_to: RespondTo,
+    pub respond_to_allowlist: Vec<String>,
+    pub channel_ids: Vec<String>,
+    pub channels: Vec<String>,
+    pub capabilities: Vec<String>,
+    pub status: String,
+    /// Required by the relay side effect; see [`DEFAULT_CHANNEL_ADD_POLICY`].
+    pub channel_add_policy: String,
+}
+
+/// Build the agent's kind:10100 directory entry.
+///
+/// This is what makes an agent reachable from *other* machines: clients
+/// discover invocable agents through `list_relay_agents`, which queries this
+/// kind, and `getMentionableAgentPubkeys` decides mentionability from
+/// `respond_to` plus `channel_ids`. Without it, an agent running on one
+/// machine cannot be mentioned from another.
+///
+/// Must be signed with the **agent's own keys** — consumers take the agent
+/// pubkey from the event author, not from the content.
+pub fn build_agent_profile_event(
+    record: &ManagedAgentRecord,
+    channel_ids: Vec<String>,
+) -> Result<EventBuilder, String> {
+    let content = AgentProfileEventContent {
+        name: record.name.clone(),
+        display_name: record.name.clone(),
+        agent_type: "agent".to_string(),
+        respond_to: record.respond_to,
+        respond_to_allowlist: record.respond_to_allowlist.clone(),
+        channels: channel_ids.clone(),
+        channel_ids,
+        capabilities: Vec::new(),
+        status: "online".to_string(),
+        channel_add_policy: DEFAULT_CHANNEL_ADD_POLICY.to_string(),
+    };
+    let json = serde_json::to_string(&content)
+        .map_err(|e| format!("failed to serialize agent profile content: {e}"))?;
+    Ok(EventBuilder::new(
+        Kind::Custom(KIND_AGENT_PROFILE as u16),
+        json,
+    ))
+}
+
+/// Collect channel ids from the agent's NIP-29 membership events (kind:39002).
+///
+/// Channels are carried in `h` tags (NIP-29 group tag), not `e` tags.
+/// Duplicates are removed while preserving first-seen order.
+pub fn channel_ids_from_membership_events(events: &[nostr::Event]) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut ids = Vec::new();
+    for event in events {
+        for tag in event.tags.iter() {
+            let slice = tag.as_slice();
+            if slice.first().map(String::as_str) == Some("h") {
+                if let Some(id) = slice.get(1).filter(|value| !value.is_empty()) {
+                    if seen.insert(id.clone()) {
+                        ids.push(id.clone());
+                    }
+                }
+            }
+        }
+    }
+    ids
 }
 
 /// Parse a kind:30177 event's content into the projection — the inbound
@@ -225,6 +309,54 @@ mod tests {
         let keys = nostr::Keys::generate();
         let event = builder.sign_with_keys(&keys).unwrap();
         assert_eq!(event.kind.as_u16() as u32, KIND_MANAGED_AGENT);
+    }
+
+    #[test]
+    fn build_agent_profile_event_produces_directory_entry() {
+        let channels = vec!["chan-a".to_string(), "chan-b".to_string()];
+        let builder = build_agent_profile_event(&sample_agent(), channels.clone()).unwrap();
+        let keys = nostr::Keys::generate();
+        let event = builder.sign_with_keys(&keys).unwrap();
+
+        assert_eq!(event.kind.as_u16() as u32, KIND_AGENT_PROFILE);
+
+        let parsed: serde_json::Value = serde_json::from_str(&event.content).unwrap();
+        assert_eq!(parsed["agent_type"], "agent");
+        assert_eq!(parsed["channel_ids"][0], "chan-a");
+        assert_eq!(parsed["channels"][1], "chan-b");
+        // The relay side effect rejects entries without this field.
+        assert_eq!(parsed["channel_add_policy"], DEFAULT_CHANNEL_ADD_POLICY);
+        // Wire format must stay snake_case for `RelayAgentInfo`.
+        assert!(parsed.get("respond_to").is_some());
+        assert!(parsed.get("respondTo").is_none());
+    }
+
+    #[test]
+    fn channel_ids_from_membership_events_collects_h_tags_once() {
+        let keys = nostr::Keys::generate();
+        let make = |tags: Vec<Vec<&str>>| {
+            let parsed: Vec<nostr::Tag> = tags
+                .into_iter()
+                .map(|tag| nostr::Tag::parse(tag).unwrap())
+                .collect();
+            EventBuilder::new(Kind::Custom(39002), "")
+                .tags(parsed)
+                .sign_with_keys(&keys)
+                .unwrap()
+        };
+
+        let events = vec![
+            make(vec![vec!["h", "chan-a"], vec!["p", "someone"]]),
+            // Duplicate must collapse; `e` tags are not channel references.
+            make(vec![vec!["h", "chan-a"], vec!["e", "chan-ignored"]]),
+            make(vec![vec!["h", "chan-b"]]),
+            make(vec![vec!["h", ""]]),
+        ];
+
+        assert_eq!(
+            channel_ids_from_membership_events(&events),
+            vec!["chan-a".to_string(), "chan-b".to_string()]
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/managed_agents/agent_events.rs
+++ b/desktop/src-tauri/src/managed_agents/agent_events.rs
@@ -182,7 +182,11 @@ pub fn build_agent_profile_event(
 
 /// Collect channel ids from the agent's NIP-29 membership events (kind:39002).
 ///
-/// Channels are carried in `h` tags (NIP-29 group tag), not `e` tags.
+/// kind:39002 is addressable: the channel id is the event's `d` tag, and the
+/// members are `p` tags. This mirrors how `get_channels` resolves a user's
+/// channels. (Message events scope channels with `h` tags — a different kind,
+/// a different tag.)
+///
 /// Duplicates are removed while preserving first-seen order.
 pub fn channel_ids_from_membership_events(events: &[nostr::Event]) -> Vec<String> {
     let mut seen = std::collections::BTreeSet::new();
@@ -190,7 +194,7 @@ pub fn channel_ids_from_membership_events(events: &[nostr::Event]) -> Vec<String
     for event in events {
         for tag in event.tags.iter() {
             let slice = tag.as_slice();
-            if slice.first().map(String::as_str) == Some("h") {
+            if slice.first().map(String::as_str) == Some("d") {
                 if let Some(id) = slice.get(1).filter(|value| !value.is_empty()) {
                     if seen.insert(id.clone()) {
                         ids.push(id.clone());
@@ -332,7 +336,7 @@ mod tests {
     }
 
     #[test]
-    fn channel_ids_from_membership_events_collects_h_tags_once() {
+    fn channel_ids_from_membership_events_collects_d_tags_once() {
         let keys = nostr::Keys::generate();
         let make = |tags: Vec<Vec<&str>>| {
             let parsed: Vec<nostr::Tag> = tags
@@ -346,11 +350,12 @@ mod tests {
         };
 
         let events = vec![
-            make(vec![vec!["h", "chan-a"], vec!["p", "someone"]]),
-            // Duplicate must collapse; `e` tags are not channel references.
-            make(vec![vec!["h", "chan-a"], vec!["e", "chan-ignored"]]),
-            make(vec![vec!["h", "chan-b"]]),
-            make(vec![vec!["h", ""]]),
+            make(vec![vec!["d", "chan-a"], vec!["p", "someone"]]),
+            // Duplicate must collapse; `h`/`e` tags are not the channel id on
+            // kind:39002 — only `d` is.
+            make(vec![vec!["d", "chan-a"], vec!["h", "chan-ignored"]]),
+            make(vec![vec!["d", "chan-b"]]),
+            make(vec![vec!["d", ""]]),
         ];
 
         assert_eq!(

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -404,7 +404,7 @@ async fn probe_agent_relay_access(
     let keys = nostr::Keys::parse(record.private_key_nsec.trim())
         .map_err(|error| format!("invalid managed-agent key: {error}"))?;
     let api_base = crate::relay::relay_http_base_url(&key.relay_url);
-    tokio::time::timeout(
+    let memberships = tokio::time::timeout(
         std::time::Duration::from_secs(10),
         crate::relay::query_relay_at_with_keys(
             state,
@@ -416,7 +416,65 @@ async fn probe_agent_relay_access(
     )
     .await
     .map_err(|_| "relay access probe timed out".to_string())??;
+
+    // The probe already carries everything the directory entry needs, so
+    // refresh it here rather than issuing a second membership query.
+    publish_agent_directory_entry(state, &record, &api_base, &keys, &memberships).await;
+
     Ok((record, key, requested_relay_url))
+}
+
+/// Refresh the agent's kind:10100 directory entry on `api_base`.
+///
+/// Other machines discover invocable agents exclusively through this kind, so
+/// without it an agent hosted here cannot be @-mentioned anywhere else. Kept
+/// best-effort: a failure is logged and never blocks the agent from starting,
+/// since the agent is fully functional locally either way.
+async fn publish_agent_directory_entry(
+    state: &AppState,
+    record: &super::ManagedAgentRecord,
+    api_base: &str,
+    keys: &nostr::Keys,
+    memberships: &[nostr::Event],
+) {
+    let channel_ids = super::agent_events::channel_ids_from_membership_events(memberships);
+    let builder = match super::agent_events::build_agent_profile_event(record, channel_ids) {
+        Ok(builder) => builder,
+        Err(error) => {
+            tracing::warn!(
+                agent = %record.pubkey,
+                %error,
+                "failed to build agent directory entry (kind:10100)"
+            );
+            return;
+        }
+    };
+    let event = match builder.sign_with_keys(keys) {
+        Ok(event) => event,
+        Err(error) => {
+            tracing::warn!(
+                agent = %record.pubkey,
+                %error,
+                "failed to sign agent directory entry (kind:10100)"
+            );
+            return;
+        }
+    };
+    if let Err(error) = crate::relay::submit_signed_event_with_keys_at(
+        &event,
+        state,
+        api_base,
+        keys,
+        record.auth_tag.as_deref(),
+    )
+    .await
+    {
+        tracing::warn!(
+            agent = %record.pubkey,
+            %error,
+            "failed to publish agent directory entry (kind:10100)"
+        );
+    }
 }
 
 /// Build the `Failed` status row for a probe failure whose requested relay URL

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::Ordering;
 
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager, State};
 
 use super::{
     agent_readiness, append_log_marker, current_instance_id, find_managed_agent_mut,
@@ -422,6 +422,57 @@ async fn probe_agent_relay_access(
     publish_agent_directory_entry(state, &record, &api_base, &keys, &memberships).await;
 
     Ok((record, key, requested_relay_url))
+}
+
+/// Minimum gap between directory refreshes for the same agent.
+///
+/// The refresh is cheap (one query + one replaceable event) but the callers
+/// are UI-driven and can fire on every channel switch, so throttle per agent.
+const DIRECTORY_REFRESH_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Last directory refresh per agent pubkey, for [`DIRECTORY_REFRESH_MIN_INTERVAL`].
+static DIRECTORY_REFRESH_AT: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, std::time::Instant>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+fn directory_refresh_due(agent_pubkey: &str) -> bool {
+    let Ok(mut seen) = DIRECTORY_REFRESH_AT.lock() else {
+        return true;
+    };
+    let now = std::time::Instant::now();
+    match seen.get(agent_pubkey) {
+        Some(last) if now.duration_since(*last) < DIRECTORY_REFRESH_MIN_INTERVAL => false,
+        _ => {
+            seen.insert(agent_pubkey.to_string(), now);
+            true
+        }
+    }
+}
+
+/// Refresh the directory entry of every locally managed agent.
+///
+/// Only the machine holding an agent's key can sign its entry, so when someone
+/// *else* adds our agent to a channel we never learn about it through
+/// `add_channel_members`. This command lets the UI ask for a refresh at points
+/// where a stale entry would be visible — the agent would otherwise stay
+/// unmentionable in that channel until its next restart.
+///
+/// Throttled per agent and best-effort: safe to call liberally.
+#[tauri::command]
+pub async fn refresh_agent_directory_entries(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let Ok(records) = load_managed_agents(&app) else {
+        return Ok(());
+    };
+    for record in records {
+        if !directory_refresh_due(&record.pubkey) {
+            continue;
+        }
+        refresh_agent_directory_entry(&app, &state, &record.pubkey.clone()).await;
+    }
+    Ok(())
 }
 
 /// Refresh a locally managed agent's kind:10100 directory entry after its

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -424,6 +424,59 @@ async fn probe_agent_relay_access(
     Ok((record, key, requested_relay_url))
 }
 
+/// Refresh a locally managed agent's kind:10100 directory entry after its
+/// channel membership changed.
+///
+/// The entry published at start time is necessarily channel-less: kind:39002
+/// memberships do not exist until the harness first connects, so the start-time
+/// snapshot is empty for a freshly created agent. An entry that lists no
+/// channels makes the agent non-invocable for `respond_to: anyone`, so it must
+/// be refreshed once memberships actually exist — otherwise the directory
+/// advertises the agent as unreachable.
+///
+/// No-op for pubkeys that are not locally managed agents; only this machine
+/// holds their keys and may sign on their behalf. Best-effort throughout.
+pub(crate) async fn refresh_agent_directory_entry(
+    app: &AppHandle,
+    state: &AppState,
+    agent_pubkey: &str,
+) {
+    let normalized = agent_pubkey.trim().to_lowercase();
+    let Ok(records) = load_managed_agents(app) else {
+        return;
+    };
+    let Some(record) = records
+        .into_iter()
+        .find(|record| record.pubkey.trim().to_lowercase() == normalized)
+    else {
+        return;
+    };
+    let Ok(keys) = nostr::Keys::parse(record.private_key_nsec.trim()) else {
+        return;
+    };
+    let api_base = crate::relay::relay_http_base_url(&record.relay_url);
+    let memberships = match crate::relay::query_relay_at_with_keys(
+        state,
+        &api_base,
+        &[serde_json::json!({"kinds": [39002], "#p": [record.pubkey]})],
+        &keys,
+        record.auth_tag.as_deref(),
+    )
+    .await
+    {
+        Ok(events) => events,
+        Err(error) => {
+            tracing::warn!(
+                agent = %record.pubkey,
+                %error,
+                "failed to read memberships while refreshing the agent directory entry"
+            );
+            return;
+        }
+    };
+    publish_agent_directory_entry(state, &record, &api_base, &keys, &memberships).await;
+}
+
 /// Refresh the agent's kind:10100 directory entry on `api_base`.
 ///
 /// Other machines discover invocable agents exclusively through this kind, so

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -555,9 +555,25 @@ pub async fn submit_event_with_keys(
 }
 
 /// POST an already-signed event using the same explicit identity for NIP-98.
+///
+/// Targets the currently active community. Use
+/// [`submit_signed_event_with_keys_at`] when the event belongs to a specific
+/// relay — a managed agent can run on a community other than the active one.
 pub async fn submit_signed_event_with_keys(
     event: &nostr::Event,
     state: &AppState,
+    keys: &Keys,
+    auth_tag: Option<&str>,
+) -> Result<SubmitEventResponse, String> {
+    let api_base = relay_api_base_url_with_override(state);
+    submit_signed_event_with_keys_at(event, state, &api_base, keys, auth_tag).await
+}
+
+/// POST an already-signed event to an explicit relay API base URL.
+pub async fn submit_signed_event_with_keys_at(
+    event: &nostr::Event,
+    state: &AppState,
+    api_base_url: &str,
     keys: &Keys,
     auth_tag: Option<&str>,
 ) -> Result<SubmitEventResponse, String> {
@@ -565,7 +581,7 @@ pub async fn submit_signed_event_with_keys(
         return Err("signed event does not match the publishing identity".to_string());
     }
     crate::relay_admission::wait_for_rate_limit().await;
-    let url = format!("{}/events", relay_api_base_url_with_override(state));
+    let url = format!("{}/events", api_base_url);
     let body_bytes = event.as_json().into_bytes();
     crate::egress_guard::assert_no_key_backup_bytes(&body_bytes, "signed event submit (keys)")?;
     let auth_header = build_nip98_auth_header_for_keys(keys, &Method::POST, &url, &body_bytes)?;

--- a/desktop/src/features/agents/hooks.ts
+++ b/desktop/src/features/agents/hooks.ts
@@ -35,6 +35,7 @@ import {
   installAcpRuntime,
   listManagedAgents,
   listRelayAgents,
+  refreshAgentDirectoryEntries,
   saveCustomHarness,
   updateManagedAgent,
 } from "@/shared/api/tauri";
@@ -323,7 +324,14 @@ export function useManagedAgentPrereqsQuery(
 export function useRelayAgentsQuery(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: relayAgentsQueryKey,
-    queryFn: listRelayAgents,
+    // Republish our own agents' entries before reading the directory: a
+    // membership change made from another device cannot reach them any other
+    // way, and a stale entry makes the agent unmentionable. Throttled in the
+    // backend and never fatal — a failure just means we read the directory as-is.
+    queryFn: async () => {
+      await refreshAgentDirectoryEntries().catch(() => {});
+      return listRelayAgents();
+    },
     staleTime: 30_000,
     // Relay agent profiles (kind:10100) are near-static and the backing
     // `list_relay_agents` command is an unfiltered relay query for the whole

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -162,6 +162,52 @@ test("isAgentIdentityInManagedList: keeps people and only current managed agent 
   );
 });
 
+test("isAgentIdentityInManagedList: keeps relay-directory agents this client can invoke", () => {
+  const managedAgentPubkeys = new Set([PUB_A]);
+  const mentionableAgentPubkeys = new Set([PUB_A, PUB_B]);
+
+  // Hosted on another machine, but advertised as invocable by the relay
+  // directory (kind:10100) — must survive so the mention picker can offer it.
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+      mentionableAgentPubkeys,
+    ),
+    true,
+  );
+
+  // Case-insensitive, same as the locally managed path.
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey: PUB_B.toUpperCase() },
+      managedAgentPubkeys,
+      mentionableAgentPubkeys,
+    ),
+    true,
+  );
+
+  // Neither local nor invocable => still dropped.
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey: PUB_C },
+      managedAgentPubkeys,
+      mentionableAgentPubkeys,
+    ),
+    false,
+  );
+
+  // People are never filtered by this gate.
+  assert.equal(
+    isAgentIdentityInManagedList(
+      { isAgent: false, pubkey: PUB_C },
+      managedAgentPubkeys,
+      mentionableAgentPubkeys,
+    ),
+    true,
+  );
+});
+
 test("shouldHideAgentFromMentions: never hides non-agents", () => {
   assert.equal(
     shouldHideAgentFromMentions({

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -352,3 +352,74 @@ test("coalesceAgentAutocompleteCandidates: leaves non-agents alone", () => {
 
   assert.deepEqual(coalesce([first, second]), [first, second]);
 });
+
+test("relayAgentIsSharedWithUser: channel membership beats a stale directory entry", () => {
+  // The agent joined a channel we are in, but its host has not republished the
+  // directory entry yet — the common case right after creating an agent.
+  const staleAgent = {
+    pubkey: PUB_A,
+    respondTo: "anyone",
+    respondToAllowlist: [],
+    channelIds: [],
+  };
+
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      staleAgent,
+      new Set(["general"]),
+      CURRENT_PUBKEY,
+    ),
+    false,
+  );
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      staleAgent,
+      new Set(["general"]),
+      CURRENT_PUBKEY,
+      new Set([PUB_A]),
+    ),
+    true,
+  );
+});
+
+test("relayAgentIsSharedWithUser: presence does not override owner-only", () => {
+  const ownerOnly = {
+    pubkey: PUB_A,
+    respondTo: "owner-only",
+    respondToAllowlist: [],
+    channelIds: [],
+  };
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      ownerOnly,
+      new Set(["general"]),
+      CURRENT_PUBKEY,
+      new Set([PUB_A]),
+    ),
+    false,
+  );
+});
+
+test("getMentionableAgentPubkeys: includes agents present in the open channel", () => {
+  const result = getMentionableAgentPubkeys({
+    currentPubkey: CURRENT_PUBKEY,
+    managedAgentPubkeys: [],
+    relayAgents: [
+      {
+        pubkey: PUB_A,
+        respondTo: "anyone",
+        respondToAllowlist: [],
+        channelIds: [],
+      },
+      {
+        pubkey: PUB_B,
+        respondTo: "owner-only",
+        respondToAllowlist: [],
+        channelIds: [],
+      },
+    ],
+    sharedChannelIds: new Set(["general"]),
+    presentChannelPubkeys: new Set([PUB_A, PUB_B]),
+  });
+  assert.deepEqual(result, new Set([PUB_A]));
+});

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -54,13 +54,32 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
+/**
+ * Keep non-agent identities, plus agent identities this client can actually
+ * invoke.
+ *
+ * An agent is invocable when it runs locally (`managedAgentPubkeys`) **or**
+ * when the relay directory advertises it as reachable for us — that second set
+ * is what `getMentionableAgentPubkeys` computes from kind:10100 entries.
+ *
+ * Without `mentionableAgentPubkeys` this drops every agent hosted on another
+ * machine before {@link shouldHideAgentFromMentions} can apply the finer
+ * directory rules, which makes remotely hosted agents impossible to mention.
+ * The parameter is optional so existing callers that only care about locally
+ * managed agents keep their previous behavior.
+ */
 export function isAgentIdentityInManagedList(
   candidate: { isAgent?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
+  mentionableAgentPubkeys?: ReadonlySet<string>,
 ) {
+  if (candidate.isAgent !== true) {
+    return true;
+  }
+  const normalized = normalizePubkey(candidate.pubkey);
   return (
-    candidate.isAgent !== true ||
-    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
+    managedAgentPubkeys.has(normalized) ||
+    mentionableAgentPubkeys?.has(normalized) === true
   );
 }
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -9,10 +9,36 @@ export function getSharedChannelIds(channels: readonly Channel[] | undefined) {
   );
 }
 
+/**
+ * Whether this client may @-mention `agent`.
+ *
+ * `allowlist` is decided by the list alone — it is channel-independent.
+ *
+ * `anyone` means "any member of a channel I am in", which is true as soon as
+ * the agent and the reader share a channel. Two independent signals establish
+ * that, and either is sufficient:
+ *
+ * 1. `presentChannelPubkeys` — the agent appears in the membership of a
+ *    channel we are in. This comes from data the client already holds and is
+ *    correct the moment the agent joins.
+ * 2. `agent.channelIds` — the agent's own directory entry. Only the machine
+ *    holding the agent's key can update it, so it lags whenever someone else
+ *    changes the agent's channels, and is empty for an agent that has not
+ *    republished since starting.
+ *
+ * Relying on (2) alone made an agent's visibility depend on whether its host
+ * happened to refresh in time, which is not something a reader can observe or
+ * influence. (1) is authoritative for the reader's own channels; (2) still
+ * covers shared channels whose membership we have not loaded.
+ */
 export function relayAgentIsSharedWithUser(
-  agent: Pick<RelayAgent, "channelIds" | "respondTo" | "respondToAllowlist">,
+  agent: Pick<
+    RelayAgent,
+    "channelIds" | "pubkey" | "respondTo" | "respondToAllowlist"
+  >,
   sharedChannelIds: ReadonlySet<string>,
   currentPubkey?: string | null,
+  presentChannelPubkeys?: ReadonlySet<string>,
 ) {
   const normalizedCurrentPubkey = currentPubkey
     ? normalizePubkey(currentPubkey)
@@ -24,8 +50,12 @@ export function relayAgentIsSharedWithUser(
       .includes(normalizedCurrentPubkey);
   }
 
+  if (agent.respondTo !== "anyone") {
+    return false;
+  }
+
   return (
-    agent.respondTo === "anyone" &&
+    presentChannelPubkeys?.has(normalizePubkey(agent.pubkey)) === true ||
     agent.channelIds.some((channelId) => sharedChannelIds.has(channelId))
   );
 }
@@ -35,18 +65,32 @@ export function getMentionableAgentPubkeys({
   managedAgentPubkeys,
   relayAgents,
   sharedChannelIds,
+  presentChannelPubkeys,
 }: {
   currentPubkey?: string | null;
   managedAgentPubkeys: Iterable<string>;
   relayAgents: readonly RelayAgent[] | undefined;
   sharedChannelIds: ReadonlySet<string>;
+  /**
+   * Pubkeys the client can see in the membership of channels it is in —
+   * typically the open channel's member list. See
+   * {@link relayAgentIsSharedWithUser} for why this outranks the directory.
+   */
+  presentChannelPubkeys?: ReadonlySet<string>;
 }) {
   const pubkeys = new Set(
     [...managedAgentPubkeys].map((pubkey) => normalizePubkey(pubkey)),
   );
 
   for (const agent of relayAgents ?? []) {
-    if (relayAgentIsSharedWithUser(agent, sharedChannelIds, currentPubkey)) {
+    if (
+      relayAgentIsSharedWithUser(
+        agent,
+        sharedChannelIds,
+        currentPubkey,
+        presentChannelPubkeys,
+      )
+    ) {
       pubkeys.add(normalizePubkey(agent.pubkey));
     }
   }

--- a/desktop/src/features/agents/ui/RespondToField.tsx
+++ b/desktop/src/features/agents/ui/RespondToField.tsx
@@ -222,9 +222,22 @@ export function CreateAgentRespondToField({
       {mode === "anyone" ? accessWarning : null}
       {mode === "owner-only" ? (
         <p className="text-xs text-muted-foreground">
-          Only you can send instructions.
+          Only you can send instructions. The agent stays out of everyone else's
+          @-mention suggestions.
         </p>
       ) : null}
+      {mode === "anyone" ? (
+        <p className="text-xs text-muted-foreground">
+          Anyone you share a channel with can @-mention the agent, including
+          from their own devices. Add it to a channel first — outside your
+          shared channels it stays invisible to them.
+        </p>
+      ) : null}
+      <p className="text-xs text-muted-foreground">
+        The agent runs on the computer that started it, and only that computer
+        can update where it can be reached. Others reach it over the relay, so
+        it answers only while that computer is awake and the app is open.
+      </p>
       {mode === "allowlist" ? (
         <AllowlistPicker
           allowlist={allowlist}

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -246,7 +246,13 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (
+        !isAgentIdentityInManagedList(
+          candidate,
+          managedAgentPubkeys,
+          mentionableAgentPubkeys,
+        )
+      ) {
         return;
       }
       if (

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -192,6 +192,14 @@ export function useMentions(
     () => getSharedChannelIds(channelsQuery.data),
     [channelsQuery.data],
   );
+  // Membership of the channel we are composing in. An agent present here is
+  // reachable for us right now, regardless of what its directory entry says —
+  // see `relayAgentIsSharedWithUser`.
+  const presentChannelPubkeys = React.useMemo(
+    () =>
+      new Set((members ?? []).map((member) => normalizePubkey(member.pubkey))),
+    [members],
+  );
   const mentionableAgentPubkeys = React.useMemo(
     () =>
       getMentionableAgentPubkeys({
@@ -199,10 +207,12 @@ export function useMentions(
         managedAgentPubkeys,
         relayAgents: relayAgentsQuery.data,
         sharedChannelIds,
+        presentChannelPubkeys,
       }),
     [
       currentPubkey,
       managedAgentPubkeys,
+      presentChannelPubkeys,
       relayAgentsQuery.data,
       sharedChannelIds,
     ],

--- a/desktop/src/shared/api/tauri.ts
+++ b/desktop/src/shared/api/tauri.ts
@@ -827,6 +827,19 @@ export async function changeRelayMemberRole(
   await invokeTauri("change_relay_member_role", { targetPubkey, newRole });
 }
 
+/**
+ * Ask the backend to republish the directory entry of every locally managed
+ * agent.
+ *
+ * Only the machine holding an agent's key can sign its entry, so a membership
+ * change made from another device never reaches it on its own. Throttled and
+ * best-effort on the Rust side, so calling it before reading the directory is
+ * cheap.
+ */
+export async function refreshAgentDirectoryEntries(): Promise<void> {
+  await invokeTauri("refresh_agent_directory_entries");
+}
+
 export async function listRelayAgents(): Promise<RelayAgent[]> {
   return (await invokeTauri<RawRelayAgent[]>("list_relay_agents")).map(
     fromRawRelayAgent,


### PR DESCRIPTION
## Related work

Reported in #3277, #2950, #2987 and #2603. Client-side fixes for the same
symptom are proposed in #2605, #2893, #3292, #3472 and #3676 — this PR differs
in also publishing kind:10100, without which the directory those fixes read
from stays empty (see #3277 for relay-layer confirmation). The Rust half here
is separable and can be rebased on top of whichever client-side fix maintainers
prefer.

## Problem

An agent hosted on one machine cannot be @-mentioned from another. This makes the
"run an agent on a always-on box, talk to it from your laptop" setup impossible,
and the failure is silent: the agent shows up in the member list with a presence
dot, but never appears in mention autocomplete and never answers.

Three independent causes, each sufficient on its own.

**1. Remote agents were filtered out before the directory rules ran.**

`useMentions` adds relay-directory agents as candidates with `isAgent: true`, and
the very next filter — `isAgentIdentityInManagedList` — dropped every agent not in
`managedAgentPubkeys`, i.e. not running locally. `shouldHideAgentFromMentions`,
which implements the actual directory rules, could never be reached for a remote
agent. The two are contradictory: one path adds them, the next removes them.

**2. Nothing published kind:10100.**

`list_relay_agents` queries kind:10100 and `getMentionableAgentPubkeys` derives
mentionability from it, but no code path in the desktop or the harness ever wrote
that kind. The directory is empty in every deployment, so the discovery path it
backs is dead code in practice.

**3. `respond_to: anyone` was decided from a source only the agent's host can write.**

`anyone` means "any member of a channel I am in". The check asked the agent's own
directory entry whether it shares a channel with the reader — but only the machine
holding the agent's key can update that entry. It is empty for an agent that has
not republished since starting, and stale whenever someone else changes the agent's
channels. Visibility therefore depended on whether a third party's laptop happened
to refresh in time.

## Changes

- Pass the already-computed `mentionableAgentPubkeys` into
  `isAgentIdentityInManagedList` so directory-advertised agents survive the gate.
  The parameter is optional; `MembersSidebar`, where restricting to locally managed
  agents is intended, is unchanged.
- Publish the agent's kind:10100 entry from `probe_agent_relay_access`, which
  already runs per (agent, community) on start and already queries the agent's
  kind:39002 memberships — no extra round trip, and it is signed with the agent's
  own keys as consumers expect.
- Refresh that entry when the agent joins a channel, and on directory reads
  (throttled per agent), so it does not stay channel-less after creation.
- Accept the open channel's membership as an equally valid signal for `anyone`.
  The client already holds it and it is correct the moment the agent joins;
  the directory entry remains as the second source. `owner-only` and `allowlist`
  are unaffected — presence in a channel never widens who may instruct an agent.
- Document the behavior where users choose it, under "Who can send instructions".

### kind:10100 carries two contracts

Worth flagging for review. The client reads `name`, `respond_to` and `channel_ids`
from this kind, while the relay's `handle_agent_profile` requires
`channel_add_policy` and fails the whole side effect without it:

```
ERROR Side effect failed: kind:10100 missing channel_add_policy field
```

So an entry written for the client is rejected by the relay, and vice versa. This
is likely why the directory was never populated. The entry here satisfies both,
publishing `owner_only` — the relay's own default, so behavior is unchanged. A
cleaner fix is to split the concerns, but that is a protocol change and out of
scope here.

## Testing

- `desktop`: 3889 unit tests pass, including new cases for the eligibility gate,
  membership-beats-stale-directory, and that presence never overrides `owner-only`.
- `desktop/src-tauri`: `agent_events` 11/11, covering the entry shape,
  `channel_add_policy`, snake_case wire format, and channel-id extraction.
- `cargo clippy --all-targets -- -D warnings` clean; `biome check` clean.
- Verified end to end on a self-hosted relay across two machines: an agent running
  on a Mac mini is mentionable and answers from a second laptop, under both
  `anyone` and `allowlist`, while `owner-only` stays private.

## Note on kind:39002

`channel_ids` are read from the `d` tag. `AGENTS.md` says channels use `h` tags,
which holds for message events but not for membership events — kind:39002 is
addressable and carries the channel in `d`, the same shape `get_channels` relies
on. Calling it out because the guidance reads as universal and cost me a debugging
cycle.
