### PR TITLE
fix(chart): delay relay shutdown before termination

### DIFF
--- a/deploy/charts/buzz/Chart.yaml
+++ b/deploy/charts/buzz/Chart.yaml
@@ -7,7 +7,7 @@ description: |
   PostgreSQL and Redis. Configurable for single-node evaluation
   (subcharts on) and HA production (external services, existingSecret).
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: "0.1.0"
 home: https://github.com/block/buzz
 sources:

--- a/deploy/charts/buzz/templates/deployment.yaml
+++ b/deploy/charts/buzz/templates/deployment.yaml
@@ -101,6 +101,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.relay.containerSecurityContext | nindent 12 }}
+          {{- with .Values.relay.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.relay.command }}
           command:
             {{- toYaml . | nindent 12 }}

--- a/deploy/charts/buzz/tests/render_test.yaml
+++ b/deploy/charts/buzz/tests/render_test.yaml
@@ -30,6 +30,12 @@ tests:
           path: kind
           value: Service
         template: templates/service.yaml
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value:
+            - sleep
+            - "5"
+        template: templates/deployment.yaml
       - notContains:
           path: spec.template.spec.containers[0].env
           content:

--- a/deploy/charts/buzz/values.schema.json
+++ b/deploy/charts/buzz/values.schema.json
@@ -73,6 +73,10 @@
           "items": { "type": "string" }
         },
         "ephemeralTtlOverride": { "type": "integer", "minimum": 0 },
+        "lifecycle": {
+          "type": "object",
+          "description": "Kubernetes lifecycle hooks for the relay container."
+        },
         "command": {
           "type": "array",
           "items": { "type": "string" },

--- a/deploy/charts/buzz/values.yaml
+++ b/deploy/charts/buzz/values.yaml
@@ -101,6 +101,10 @@ secrets:
 
 # ── Relay behavior ───────────────────────────────────────────────────────────
 relay:
+  lifecycle:
+    preStop:
+      exec:
+        command: ["sleep", "5"]
   bindAddr: "0.0.0.0:3000"
   maxConnections: 10000
   maxConcurrentHandlers: 1024


### PR DESCRIPTION
## Summary

- add configurable Kubernetes lifecycle hooks to the relay container
- default the relay to a 5-second `preStop` sleep so endpoints stop routing traffic before SIGTERM
- bump the Helm chart from 0.1.7 to 0.1.8 (0.1.7 was already published before this change)
- cover the default lifecycle in Helm unit tests and the values schema

### Related issue

None found. Originated in Buzz channel `b17e217e-42cf-4e23-870a-e7891703b955`, thread `095f59f58098fa98187d8c785e286df82d5ff71381cb0ce0ca6ef61c315d39a6`.

### Testing

- `helm dependency build deploy/charts/buzz`
- `helm lint deploy/charts/buzz` with production-style external service values
- `helm unittest deploy/charts/buzz` (9 suites, 45 tests)
- rendered manifest assertion: relay lifecycle is `preStop.exec.command: [sleep, "5"]` and `terminationGracePeriodSeconds` remains 60

Generated with Builderlab Expert.
