### PR TITLE
fix(buzz-acp): never deliver ephemeral events to agent subprocesses

### DIFF
--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -373,6 +373,26 @@ pub async fn match_event(
 ) -> Option<MatchedRule> {
     let filter_ctx = FilterContext::from_event(event, channel_id);
 
+    // Ephemeral events (kind 20000–29999) are never delivered to the agent,
+    // regardless of any subscription rule that might otherwise admit them.
+    //
+    // When an agent runs `subscribe=all` (or a wildcard `Config` rule, or an
+    // `All` mode with no explicit `BUZZ_ACP_KINDS` allowlist) with no curated
+    // kind list, these events would otherwise wake the agent subprocess on
+    // every keystroke: a human composing one message emits dozens of typing
+    // indicators (kind 20002) and presence updates (kind 20001), each of
+    // which starts a model turn at cost per keystroke and flashes Desktop's
+    // "agent is typing" badge. Observer frames (kind 24200) are caller-local
+    // telemetry on the same channel and belong to the same exclusion.
+    //
+    // Per the design intent behind `SubscribeMode::All`, agents want all
+    // *actionable* kinds, not ambient per-keystroke noise — which these
+    // ephemeral events are. Failing closed here (never wake on any ephemeral
+    // kind) keeps the wildcard subscription safe to use.
+    if buzz_core::kind::is_ephemeral(event.kind.as_u16() as u32) {
+        return None;
+    }
+
     for (index, rule) in rules.iter().enumerate() {
         // 1. Channel scope check.
         if !rule.channels.matches(&channel_id) {
@@ -679,6 +699,44 @@ mod tests {
 
         let result = match_event(&event, channel_id, &rules, "").await;
         assert!(result.is_none());
+    }
+
+    /// #3649: ephemeral events (kind 20000–29999 — typing, presence, observer
+    /// frames) must never wake an agent subprocess, even when a wildcard rule
+    /// would otherwise admit them. A `subscribe=all` agent sees the whole
+    /// event stream; without a guard, each keystroke fires a model turn.
+    #[tokio::test]
+    async fn test_match_event_ephemeral_never_wakes_agent_on_wildcard() {
+        let channel_id = any_channel();
+        // A wildcard rule (empty kinds = match any kind) — the shape an
+        // `All` subscription with no curated list resolves to.
+        let rules = vec![make_rule(
+            "all-kinds",
+            ChannelScope::All("all".into()),
+            vec![], // wildcard: no kind filter
+            false,
+            None,
+            None,
+        )];
+
+        // Typing indicator (20002), presence update (20001), and observer
+        // frame (24200) — every ephemeral kind must be rejected with no match.
+        for ephemeral_kind in [20001u32, 20002, 24200] {
+            let event = make_event(ephemeral_kind, "typing...");
+            let result = match_event(&event, channel_id, &rules, "").await;
+            assert!(
+                result.is_none(),
+                "ephemeral kind {ephemeral_kind} must never match any rule"
+            );
+        }
+
+        // Control: a non-ephemeral kind (kind 9, stream message) matches the
+        // same wildcard rule — the guard only rejects ephemeral kinds.
+        let event = make_event(9, "hello");
+        let matched = match_event(&event, channel_id, &rules, "")
+            .await
+            .expect("non-ephemeral kind 9 must match the wildcard rule");
+        assert_eq!(matched.rule_index, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When an agent runs `subscribe=all` (or any wildcard subscription rule) with no curated `BUZZ_ACP_KINDS` allowlist, the resolved rule set admits **every** kind on the wire — including ephemeral kinds:

- **Kind 20001** — presence updates
- **Kind 20002** — typing indicators
- **Kind 24200** — agent observer frames

Every keystroke in a channel emits dozens of these ephemeral events. Each one woke the agent subprocess into a full model turn: **cost per keystroke** for the operator and a false **"agent is typing"** signal in Desktop for whoever is watching.

Closes #3649.

## Root Cause

`resolve_channel_filters` in `config.rs` resolves `SubscribeMode::All` with no `kinds_override` to `kinds: None` — a wildcard that matches every event kind. There is no design-level invariant that ephemeral events (kind 20000–29999, defined as "never stored" in `buzz-core/src/kind.rs`) should be excluded from agent delivery. The `match_event` function in `filter.rs` applied channel-scope, kind, mention, and expression filters — but had no concept of ephemeral exclusion.

## Fix

Add a design-level invariant to the shared delivery filter (`crates/buzz-acp/src/filter.rs`, `match_event`): **ephemeral events (kind 20000–29999) are never delivered to an agent subprocess**, regardless of any subscription rule that might otherwise admit them.

This guard runs before the rule loop, so it protects:
- `SubscribeMode::All` with no `kinds_override` (the reported case)
- Any wildcard `Config` rule with empty kinds
- Even an explicit `All` subscription that accidentally lists an ephemeral kind

Ephemeral events are transient by definition — they are not actionable work and must not wake an agent process. Failing closed here (never wake on any ephemeral kind) keeps wildcard subscriptions safe to use.

The guard uses the existing `buzz_core::kind::is_ephemeral` predicate (already a dependency of `buzz-acp`), so there is no new constant or duplicate logic.

## Testing

New test `test_match_event_ephemeral_never_wakes_agent_on_wildcard`:
- Builds a wildcard rule (empty kinds = match any kind) — the shape an `All` subscription with no curated list resolves to
- Asserts that kind 20001 (presence), 20002 (typing), and 24200 (observer frame) all return `None` (no match)
- Control: asserts that a non-ephemeral kind 9 (stream message) still matches the wildcard rule — the guard only rejects ephemeral kinds

Full buzz-acp lib test suite: **662 passed, 0 failed**.

## Backward Compatibility

Agents that explicitly subscribe to ephemeral kinds via `BUZZ_ACP_KINDS` will no longer receive them. This is the intended behavior — ephemeral events were never meant to be actionable, and any agent depending on them was paying a per-keystroke cost without realizing it. The fix is fail-closed: if an agent truly needs ambient channel activity, a future enhancement could add an opt-in `include_ephemeral` flag, but the default must be safe.
