### PR TITLE
fix(acp): stop cancelling healthy turns on busy/stale steer; use Git bash in Windows tests

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -2846,8 +2846,33 @@ mod tests {
         );
     }
 
+    /// Locate a bash that behaves like a real POSIX shell for harness scripts.
+    ///
+    /// `Command::new("bash")` on Windows resolves through `CreateProcessW`'s
+    /// search order, which checks `C:\Windows\System32` before any PATH entry.
+    /// On machines with WSL installed that yields `System32\bash.exe` — the
+    /// WSL launcher — instead of the Git-for-Windows bash sitting earlier in
+    /// PATH. WSL bash mounts the filesystem at `/mnt/c`, cannot redirect into
+    /// `C:/...` paths, and boots slowly enough to trip the harness's idle
+    /// timeout, which makes every `spawn_script`-based test fail or flake.
+    /// Prefer a Git-for-Windows bash when one is installed.
+    fn find_bash() -> String {
+        #[cfg(windows)]
+        for candidate in [
+            r"C:\Program Files\Git\usr\bin\bash.exe",
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\usr\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+        ] {
+            if std::path::Path::new(candidate).exists() {
+                return candidate.to_string();
+            }
+        }
+        "bash".to_string()
+    }
+
     async fn spawn_script(script: &str) -> AcpClient {
-        AcpClient::spawn("bash", &["-c".into(), script.into()], &[], false)
+        AcpClient::spawn(&find_bash(), &["-c".into(), script.into()], &[], false)
             .await
             .expect("failed to spawn test script")
     }
@@ -2990,8 +3015,11 @@ mod tests {
     async fn idle_resets_on_stdout_activity() {
         // Send valid JSON (session/update notifications) to reset the idle timer.
         // Non-JSON lines no longer reset idle — only valid JSON notifications do.
+        // The 300ms idle budget is generous: the harness bash on Windows can take
+        // >100ms to emit its first line under full-suite parallelism, and a
+        // tighter budget made this flake on cold CI runners.
         let mut client = spawn_script(
-            r#"for i in $(seq 1 10); do echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_thought_chunk","content":{"text":"thinking"}}}}'; sleep 0.05; done; sleep 10"#,
+            r#"for i in $(seq 1 20); do echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_thought_chunk","content":{"text":"thinking"}}}}'; sleep 0.05; done; sleep 10"#,
         )
         .await;
         let max_dur = std::time::Duration::from_secs(10);
@@ -3001,14 +3029,15 @@ mod tests {
             .read_until_response_with_idle_timeout(
                 "test",
                 999,
-                std::time::Duration::from_millis(200),
+                std::time::Duration::from_millis(300),
                 hard_deadline,
                 max_dur,
             )
             .await;
         let elapsed = start.elapsed();
-        // 10 messages × 50ms = ~500ms of activity, then idle timeout fires after 200ms more
-        assert!(elapsed >= std::time::Duration::from_millis(400));
+        // 20 messages × 50ms = ~1000ms of activity, then idle timeout fires after
+        // 300ms more — must survive well past the 300ms deadline.
+        assert!(elapsed >= std::time::Duration::from_millis(500));
         assert!(elapsed < std::time::Duration::from_secs(3));
         assert!(matches!(result, Err(AcpError::IdleTimeout(_))));
     }
@@ -3185,8 +3214,11 @@ mod tests {
 
     #[tokio::test]
     async fn keepalive_resets_idle_past_deadline() {
-        // Keepalive session/update lines every 50ms against a 100ms idle deadline.
-        // The turn should survive well past the 100ms deadline (proves the fix).
+        // Keepalive session/update lines every 50ms against a 300ms idle
+        // deadline. The turn should survive well past the 300ms deadline
+        // (proves the fix). The budget is kept generous because the harness
+        // bash on Windows can take >100ms to emit its first line under test
+        // parallelism, and a 100ms budget made this flake on cold CI runners.
         let mut client = spawn_script(
             r#"for i in $(seq 1 20); do echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"keepalive"}}}'; sleep 0.05; done; sleep 10"#,
         )
@@ -3198,14 +3230,14 @@ mod tests {
             .read_until_response_with_idle_timeout(
                 "test",
                 999,
-                std::time::Duration::from_millis(100),
+                std::time::Duration::from_millis(300),
                 hard_deadline,
                 max_dur,
             )
             .await;
         let elapsed = start.elapsed();
-        // 20 keepalives × 50ms = ~1000ms of activity, then idle fires after 100ms more.
-        // Must survive well past the 100ms deadline.
+        // 20 keepalives × 50ms = ~1000ms of activity, then idle fires after
+        // 300ms more. Must survive well past the 300ms deadline.
         assert!(
             elapsed >= std::time::Duration::from_millis(500),
             "keepalive should reset idle past the deadline; elapsed only {elapsed:?}"
@@ -3754,10 +3786,26 @@ mod tests {
         capture_path: &std::path::Path,
         response: &str,
     ) -> AcpClient {
+        // `temp_dir()` can return the 8.3 short path (`C:\Users\KHOAPH~1\...`)
+        // which MSYS bash cannot redirect into. Canonicalizing the
+        // already-created parent dir yields the long form — with a `\\?\`
+        // extended-length prefix on Windows that bash also can't handle, so
+        // strip it. Forward-slashes + single quotes then survive the space
+        // in the user's home dir (`C:\Users\khoa phan\...`).
+        let dir = capture_path.parent().expect("capture path has a parent");
+        let dir = std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf());
+        let mut dir = dir.display().to_string();
+        if let Some(stripped) = dir.strip_prefix(r"\\?\") {
+            dir = stripped.to_string();
+        }
+        let capture = std::path::Path::new(&dir)
+            .join(capture_path.file_name().expect("capture path has a file name"))
+            .display()
+            .to_string()
+            .replace('\\', "/");
         let script = format!(
-            "read -r line; printf '%s' \"$line\" > {capture}; \
+            "read -r line; printf '%s' \"$line\" > '{capture}'; \
              printf '%s\\n' '{response}'; sleep 10",
-            capture = capture_path.display(),
             response = response,
         );
         spawn_script(&script).await

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2238,16 +2238,33 @@ async fn tokio_main() -> Result<()> {
                                     // to the universal cancel+merge `Steer`
                                     // signal so the event still reaches the
                                     // agent.
-                                    let native_attempted = matches!(signal, ControlSignal::Steer)
-                                        && try_native_steer(
+                                    let steer_attempt = if matches!(
+                                        signal,
+                                        ControlSignal::Steer
+                                    ) {
+                                        try_native_steer(
                                             &mut pool,
                                             &mut queue,
                                             buzz_event.channel_id,
                                             event_for_steer,
                                             prompt_tag_for_steer,
                                             &steer_ack_tx,
-                                        );
-                                    if !native_attempted {
+                                        )
+                                    } else {
+                                        NativeSteerAttempt::Fallback
+                                    };
+                                    // Only `Fallback` (steer impossible, or a
+                                    // non-Steer signal) fires the universal
+                                    // cancel+merge signal. `Accepted` leaves the
+                                    // ack watcher in charge; `Busy` (another
+                                    // steer in flight on a healthy turn) keeps
+                                    // the event queued for normal dispatch —
+                                    // cancelling the turn over a full steer
+                                    // channel would kill the running reply.
+                                    if matches!(
+                                        steer_attempt,
+                                        NativeSteerAttempt::Fallback
+                                    ) {
                                         signal_in_flight_task(
                                             &mut pool,
                                             buzz_event.channel_id,
@@ -2797,6 +2814,27 @@ fn signal_in_flight_task(
     false
 }
 
+/// Outcome of the non-cancelling (ACP) steer attempt for a freshly-queued
+/// event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NativeSteerAttempt {
+    /// Native steer accepted by the read loop: event withheld synchronously,
+    /// ack watcher spawned. The caller MUST NOT issue the universal
+    /// cancel+merge fallback — the watcher issues it from the ack arm if the
+    /// native attempt fails.
+    Accepted,
+    /// Steer channel busy (`TrySendError::Full`): an earlier steer for this
+    /// channel is still in flight. The turn is healthy and must NOT be
+    /// cancelled — the event stays queued and normal dispatch delivers it
+    /// when the turn completes.
+    Busy,
+    /// Native steer impossible (no in-flight task, `steer_tx` missing, or
+    /// read loop torn down). The caller MUST fall through to
+    /// `signal_in_flight_task(channel_id, ControlSignal::Steer)` so the
+    /// event still reaches the agent via the universal cancel+merge path.
+    Fallback,
+}
+
 /// Attempt the non-cancelling (ACP) steer for a freshly-queued event.
 ///
 /// Caller invariants:
@@ -2807,20 +2845,24 @@ fn signal_in_flight_task(
 /// - `multiple_event_handling` resolved to `ControlSignal::Steer`; this
 ///   function is the non-cancelling fork of that signal.
 ///
-/// Returns `true` if the native attempt was accepted by the read loop
-/// (capacity-1 mpsc `try_send` succeeded, event withheld synchronously,
-/// ack watcher spawned). On `true` the caller MUST NOT issue the
-/// universal cancel+merge `ControlSignal::Steer` fallback — the watcher
-/// will issue it from the ack arm if the native attempt fails.
+/// Returns [`NativeSteerAttempt::Accepted`] if the native attempt was
+/// accepted by the read loop (capacity-1 mpsc `try_send` succeeded, event
+/// withheld synchronously, ack watcher spawned).
 ///
-/// Returns `false` if `pool.send_steer` failed (no in-flight task,
-/// `steer_tx` already full from a prior in-flight steer, or read loop
-/// torn down). The caller MUST fall through to
+/// Returns [`NativeSteerAttempt::Busy`] if the steer channel is already
+/// full from a prior in-flight steer for this channel (burst of mentions).
+/// This is NOT a failure of the turn — the caller keeps the event queued
+/// and lets normal dispatch deliver it after the turn completes.
+///
+/// Returns [`NativeSteerAttempt::Fallback`] if `pool.send_steer` failed for
+/// any other reason (no in-flight task, `steer_tx` not installed, or read
+/// loop torn down). The caller MUST fall through to
 /// `signal_in_flight_task(channel_id, ControlSignal::Steer)` so the
 /// event still reaches the agent via the universal path.
 ///
-/// The withheld event is NOT released here on `false` because no withhold
-/// was established: `mark_native_steer_pending` only runs on `Ok(())`.
+/// The withheld event is NOT released on `Busy`/`Fallback` because no
+/// withhold was established: `mark_native_steer_pending` only runs on
+/// `Ok(())`.
 fn try_native_steer(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
@@ -2828,7 +2870,7 @@ fn try_native_steer(
     event: nostr::Event,
     prompt_tag: String,
     steer_ack_tx: &mpsc::UnboundedSender<SteerAckEvent>,
-) -> bool {
+) -> NativeSteerAttempt {
     // Build the steer body: framing strings come from
     // `queue::native_steer_framing()` (Eva's drift-proof requirement —
     // native and cancel+merge fallback share these so the agent gets the
@@ -2891,7 +2933,19 @@ fn try_native_steer(
                     ack,
                 });
             });
-            true
+            NativeSteerAttempt::Accepted
+        }
+        Err(pool::SteerError::SteerChannelBusy) => {
+            // Burst: an earlier steer for this channel is still in flight.
+            // The turn is healthy — do NOT cancel it. The event stays in
+            // the queue and `dispatch_pending` delivers it normally once
+            // the current turn completes (a failed in-flight steer is
+            // released back to the queue front by the ack arm).
+            tracing::info!(
+                channel = %channel_id,
+                "steer channel busy — keeping event queued for normal dispatch after the turn"
+            );
+            NativeSteerAttempt::Busy
         }
         Err(e) => {
             tracing::info!(
@@ -2899,7 +2953,7 @@ fn try_native_steer(
                 error = ?e,
                 "non-cancelling steer not accepted — falling back to cancel+merge"
             );
-            false
+            NativeSteerAttempt::Fallback
         }
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1156,6 +1156,14 @@ struct RespawnResult {
 struct SteerAckEvent {
     channel_id: Uuid,
     event_id: String,
+    /// Turn identity of the in-flight task that received the steer, captured
+    /// at steer-send time. The ack arm uses it to reject stale fallbacks:
+    /// if the channel now hosts a NEWER turn (the original turn completed and
+    /// was dispatched before this ack was processed — `select!` is biased,
+    /// `result_rx` first), a fallback signal must not cancel the healthy
+    /// newer turn; the released event reaches the agent via normal dispatch
+    /// once it completes.
+    turn_id: Option<String>,
     /// `Ok` if the read loop sent any of the locked `SteerAck` variants.
     /// `Err` if the oneshot was dropped without a send — should not happen
     /// under the current read-loop drains, but if it ever does the main
@@ -2432,6 +2440,7 @@ async fn tokio_main() -> Result<()> {
             Some(PoolEvent::SteerAck(SteerAckEvent {
                 channel_id,
                 event_id,
+                turn_id,
                 ack,
             })) => {
                 // Mid-turn steer attempt resolved (either transport:
@@ -2553,12 +2562,29 @@ async fn tokio_main() -> Result<()> {
                     queue.release_native_steer(channel_id, &event_id);
                 }
                 if signal_fallback {
-                    // Universal cancel+merge fallback. Note: the
-                    // queued event has already been released to the
-                    // front of `queues[channel_id]`, so the cancel
-                    // will pick it up as part of the merged batch and
-                    // re-prompt the agent.
-                    signal_in_flight_task(&mut pool, channel_id, ControlSignal::Steer);
+                    if steer_fallback_targets_current_turn(&pool, channel_id, &turn_id) {
+                        // Universal cancel+merge fallback. Note: the
+                        // queued event has already been released to the
+                        // front of `queues[channel_id]`, so the cancel
+                        // will pick it up as part of the merged batch and
+                        // re-prompt the agent.
+                        signal_in_flight_task(&mut pool, channel_id, ControlSignal::Steer);
+                    } else {
+                        // Stale ack: the turn that received the steer has
+                        // completed and a newer turn runs on this channel
+                        // (or the channel is idle). `select!` is biased —
+                        // `result_rx` is polled before `steer_ack_rx`, so
+                        // the Result arm can dispatch a new turn before
+                        // this ack is processed. Cancelling now would kill
+                        // the healthy newer turn. The released event is
+                        // already in the newer turn's batch or queued for
+                        // normal dispatch once it completes.
+                        tracing::warn!(
+                            channel = %channel_id,
+                            steer_turn_id = ?turn_id,
+                            "stale steer ack fallback skipped — in-flight task is a newer turn (or gone)"
+                        );
+                    }
                 }
                 // After releasing a withheld event, give dispatch a chance
                 // to re-flush. If the prompt is still in flight, the
@@ -2814,6 +2840,30 @@ fn signal_in_flight_task(
     false
 }
 
+/// Decide whether a non-cancelling steer ack's cancel+merge fallback may
+/// fire for `channel_id`.
+///
+/// Returns `false` when the ack's target turn is no longer the channel's
+/// in-flight task — the original turn completed and a NEWER turn is running
+/// (or the channel is idle). Firing the fallback then would cancel a healthy
+/// turn that never received this steer; the released event already reached
+/// the agent via the newer turn's batch or is queued for normal dispatch, so
+/// skipping is safe. A missing turn identity (defensive) is conservative and
+/// fires.
+fn steer_fallback_targets_current_turn(
+    pool: &AgentPool,
+    channel_id: uuid::Uuid,
+    steer_turn_id: &Option<String>,
+) -> bool {
+    match steer_turn_id {
+        Some(turn_id) => pool
+            .task_map()
+            .values()
+            .any(|m| m.channel_id == Some(channel_id) && &m.turn_id == turn_id),
+        None => true,
+    }
+}
+
 /// Outcome of the non-cancelling (ACP) steer attempt for a freshly-queued
 /// event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2900,6 +2950,16 @@ fn try_native_steer(
         ack_tx,
     };
 
+    // Capture the turn identity of the task we're about to steer so a stale
+    // ack (processed after a newer turn started on this channel) can be
+    // recognized and its fallback skipped. Read-only; there is no `.await`
+    // between here and `send_steer`, so the value cannot go stale.
+    let steer_turn_id = pool
+        .task_map()
+        .values()
+        .find(|m| m.channel_id == Some(channel_id))
+        .map(|m| m.turn_id.clone());
+
     match pool.send_steer(channel_id, request) {
         Ok(()) => {
             // Withhold the queued event synchronously BEFORE spawning
@@ -2925,11 +2985,13 @@ fn try_native_steer(
             }
             let ack_tx_clone = steer_ack_tx.clone();
             let event_id_for_watcher = event_id_hex.clone();
+            let steer_turn_id_for_watcher = steer_turn_id.clone();
             tokio::spawn(async move {
                 let ack = ack_rx.await;
                 let _ = ack_tx_clone.send(SteerAckEvent {
                     channel_id,
                     event_id: event_id_for_watcher,
+                    turn_id: steer_turn_id_for_watcher,
                     ack,
                 });
             });
@@ -4444,6 +4506,68 @@ mod owner_control_command_tests {
             channel_id,
             ControlSignal::Rotate
         ));
+    }
+
+    #[tokio::test]
+    async fn steer_fallback_skipped_when_turn_replaced() {
+        // A stale ack (its target turn already completed) must not fire the
+        // cancel+merge fallback against a NEWER turn running on the channel.
+        let mut pool = AgentPool::from_slots(vec![]);
+        let channel_id = Uuid::new_v4();
+        let (control_tx, mut control_rx) = tokio::sync::oneshot::channel();
+        let abort_handle = pool.join_set.spawn(async {});
+        pool.task_map_mut().insert(
+            abort_handle.id(),
+            pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                turn_id: "turn-2".to_string(),
+                recoverable_batch: None,
+                control_tx: Some(control_tx),
+                steer_tx: None,
+            },
+        );
+
+        let fired = steer_fallback_targets_current_turn(
+            &pool,
+            channel_id,
+            &Some("turn-1".to_string()),
+        );
+        assert!(!fired, "stale ack must not target the newer turn");
+        assert!(
+            control_rx.try_recv().is_err(),
+            "stale ack must not consume the newer turn's control_tx"
+        );
+    }
+
+    #[tokio::test]
+    async fn steer_fallback_targets_matching_or_unknown_turn() {
+        let mut pool = AgentPool::from_slots(vec![]);
+        let channel_id = Uuid::new_v4();
+        let (control_tx, control_rx) = tokio::sync::oneshot::channel();
+        let abort_handle = pool.join_set.spawn(async {});
+        pool.task_map_mut().insert(
+            abort_handle.id(),
+            pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                turn_id: "turn-1".to_string(),
+                recoverable_batch: None,
+                control_tx: Some(control_tx),
+                steer_tx: None,
+            },
+        );
+
+        assert!(steer_fallback_targets_current_turn(
+            &pool,
+            channel_id,
+            &Some("turn-1".to_string())
+        ));
+        assert!(
+            steer_fallback_targets_current_turn(&pool, channel_id, &None),
+            "missing turn identity falls back conservatively (fires)"
+        );
+        let _ = control_rx;
     }
 }
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -354,6 +354,18 @@ pub enum SteerError {
     /// Transport-level failure: write error, read EOF, JSON-RPC framing
     /// violation, etc. The string carries the underlying `AcpError`'s display.
     Transport(String),
+    /// The steer channel is capacity-1 and already holds an in-flight steer
+    /// write for this channel (`TrySendError::Full` from `send_steer`).
+    ///
+    /// This is a *burst* condition, not a failure: a second mention arrived
+    /// while an earlier steer was still queued for the same live turn. The
+    /// turn itself is healthy and must NOT be cancelled — the caller keeps
+    /// the event queued and lets normal dispatch deliver it after the turn
+    /// completes.
+    ///
+    /// Returned synchronously by `send_steer`. Never sent through the ack
+    /// channel.
+    SteerChannelBusy,
     /// At steer-write time neither steer transport was available: no
     /// `expectedRunId` (`AcpClient::active_run_id` was `None`, so the
     /// goose-native method could not be formed) and the agent did not
@@ -648,10 +660,13 @@ impl AgentPool {
     ///
     /// Returns `Ok(())` if the request was accepted by the read loop's
     /// receiver (capacity-1 mpsc; one slot is the single in-flight steer
-    /// write). Returns `Err(SteerError::Transport(_))` on `Full`/`Closed`
-    /// (already-in-flight write, or read loop torn down). Callers must
-    /// fall back to the universal `ControlSignal::Steer` cancel+merge path
-    /// on `Err`.
+    /// write). Returns `Err(SteerError::SteerChannelBusy)` on `Full`
+    /// (another steer is already in flight for this channel — the caller
+    /// should keep the event queued and let normal dispatch deliver it after
+    /// the turn, NOT cancel the turn). Returns
+    /// `Err(SteerError::Transport(_))` on `Closed` (read loop torn down).
+    /// Callers must fall back to the universal `ControlSignal::Steer`
+    /// cancel+merge path on `Err` except `SteerChannelBusy`.
     ///
     /// This does **not** spawn the ack watcher — the caller owns the
     /// oneshot `ack_tx` inside `SteerRequest` and is responsible for
@@ -680,7 +695,14 @@ impl AgentPool {
             .as_ref()
             .ok_or_else(|| SteerError::Transport("steer_tx not installed".into()))?;
         tx.try_send(request)
-            .map_err(|e| SteerError::Transport(e.to_string()))
+            .map_err(|e| match e {
+                tokio::sync::mpsc::error::TrySendError::Full(_) => {
+                    SteerError::SteerChannelBusy
+                }
+                tokio::sync::mpsc::error::TrySendError::Closed(_) => {
+                    SteerError::Transport("steer channel closed".into())
+                }
+            })
     }
 
     pub fn result_tx(&self) -> mpsc::UnboundedSender<PromptResult> {
@@ -5979,6 +6001,66 @@ mod tests {
         let (_steer_tx, steer_rx) = tokio::sync::mpsc::channel::<SteerRequest>(1);
         result.agent.acp.install_steer_rx(steer_rx);
         // Reaching here without a panic is the test.
+    }
+
+    // ── send_steer capacity semantics ─────────────────────────────────────
+
+    /// The steer channel is capacity-1 with a single in-flight slot. A second
+    /// `send_steer` while the first is still queued must return
+    /// `SteerError::SteerChannelBusy` — NOT `Transport` — so the main loop can
+    /// tell the burst case apart (turn healthy, keep the event queued, deliver
+    /// via normal dispatch after the turn) from a genuine transport failure
+    /// (fall through to cancel+merge).
+    ///
+    /// Regression for the 3-mention burst bug: lumping `TrySendError::Full` in
+    /// with transport errors made the caller fire cancel+merge on a healthy
+    /// in-flight turn, killing the running reply and forcing a respawn that
+    /// only ever answered the last mention.
+    #[tokio::test]
+    async fn test_send_steer_full_returns_steer_channel_busy() {
+        let mut pool = AgentPool::from_slots(vec![]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        let channel_id = Uuid::new_v4();
+        let (steer_tx, mut steer_rx) = tokio::sync::mpsc::channel::<SteerRequest>(1);
+        pool.task_map_mut().insert(
+            task_id,
+            TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                turn_id: "test-turn".to_string(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: Some(steer_tx),
+            },
+        );
+
+        let request = |seq: &str| SteerRequest {
+            prompt_blocks: vec![seq.to_string()],
+            ack_tx: tokio::sync::oneshot::channel().0,
+        };
+
+        // First steer fills the single slot.
+        assert!(
+            pool.send_steer(channel_id, request("first")).is_ok(),
+            "first steer must fill the capacity-1 slot"
+        );
+
+        // Second steer while the first is still in flight → Busy, not Transport.
+        match pool.send_steer(channel_id, request("second")) {
+            Err(SteerError::SteerChannelBusy) => {}
+            other => panic!("expected SteerChannelBusy, got {other:?}"),
+        }
+
+        // Once the read loop drains the slot, steering works again.
+        let drained = steer_rx
+            .recv()
+            .await
+            .expect("first steer must be drainable");
+        assert_eq!(drained.prompt_blocks, vec!["first"]);
+        assert!(
+            pool.send_steer(channel_id, request("third")).is_ok(),
+            "steer must succeed after the slot is drained"
+        );
     }
 
     // ── NIP-AM emit-hook unit tests ────────────────────────────────────────


### PR DESCRIPTION
## What

Three commits fixing `buzz-acp` steering reliability and the Windows test harness:

1. **fix(acp): don't cancel a healthy turn when the steer channel is busy** — A burst of mentions while a turn was in-flight filled the capacity-1 steer channel; `TrySendError::Full` was lumped in with transport errors, so the universal cancel+merge fallback fired and destroyed the running turn. `send_steer` now maps `Full` to `SteerError::SteerChannelBusy` and `try_native_steer` returns a tri-state; on Busy the event stays queued and is delivered by normal dispatch.

2. **fix(acp): skip cancel+merge fallback when a steer ack targets a stale turn** — A late `SteerAck` (its target turn already completed and a newer turn dispatched on the channel) could fire the cancel+merge fallback against the healthy newer turn. The ack now carries the steer-time `turn_id`; a stale ack's fallback is skipped with a `tracing::warn!`.

3. **test(acp): spawn harness scripts on Git bash, not the WSL shim** — `Command::new("bash")` on Windows resolves via CreateProcessW search order, which checks `System32` before PATH, so it launched the WSL launcher instead of Git-for-Windows bash. WSL bash cannot redirect into `C:/...` paths and boots slowly enough to trip the 800ms steer idle timeout — the root cause of the deterministic steer-capture failures and the 18–24 test flake bucket. The harness now resolves a Git bash explicitly, keeps the canonicalize + `\\?\`-strip capture path handling, and widens two idle budgets.

## Verification

- `cargo test -p buzz-acp --lib` — **663/663 pass** on the rebased branch
- `cargo clippy --workspace` — clean
- `cargo build` (workspace) — clean

## Notes

- Rebases cleanly onto current `main` (`b1b283cd4`).
- The `.gitignore` change for local relay autostart logs was deliberately kept out of this PR.