### PR TITLE
fix(desktop): allow in-channel relay agents in mention autocomplete

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -55,11 +55,12 @@ export function getMentionableAgentPubkeys({
 }
 
 export function isAgentIdentityInManagedList(
-  candidate: { isAgent?: boolean; pubkey: string },
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
 ) {
   return (
     candidate.isAgent !== true ||
+    candidate.isMember === true ||
     managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
   );
 }

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { isAgentIdentityInManagedList } from "../../src/features/agents/lib/agentAutocompleteEligibility";
+
 import {
   installMockBridge,
   openChannelBrowser,
@@ -35,6 +37,19 @@ const DM_THREAD_AGENT_MENTION_ERROR_TEXT =
   "Agents must already be in a DM to be mentioned in its threads. Start a new conversation that includes the agent.";
 const DM_THREAD_MEMBERS_LOADING_ERROR_TEXT =
   "Checking conversation members. Try again in a moment.";
+
+test("in-channel relay agents pass autocomplete eligibility without a local management record", () => {
+  expect(
+    isAgentIdentityInManagedList(
+      {
+        pubkey: ALLOWLIST_RELAY_AGENT_PUBKEY,
+        isAgent: true,
+        isMember: true,
+      },
+      new Set(),
+    ),
+  ).toBe(true);
+});
 
 /** Locator scoped to the mention autocomplete dropdown inside the composer. */
 function autocomplete(page: import("@playwright/test").Page) {


### PR DESCRIPTION
## Problem

The desktop mention picker rejects every identity classified as an agent unless that identity also exists in the local managed-agent store. A relay-hosted agent can therefore be an authoritative member of the open channel and still be impossible to tag from another desktop installation.

This makes remote agents look offline or absent even though the relay membership and agent profile are valid.

## Fix

Treat authoritative channel membership as sufficient autocomplete eligibility. Relay-only agents outside the current channel remain subject to the existing discovery and policy filters.

## Regression coverage

Adds a focused test proving that an in-channel relay agent is eligible without a local management record.

## Verification

- `pnpm build`
- `pnpm exec biome check src/features/agents/lib/agentAutocompleteEligibility.ts tests/e2e/mentions.spec.ts`
- focused Playwright regression test passes
- `git diff --check`

Signed-off-by: EliteServer <eliteserver@EliteServers-Mac-mini.local>