### PR TITLE
fix(desktop): keep Create controls on empty Projects (#4009)

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -108,6 +108,7 @@ export default defineConfig({
         "**/project-inbox.spec.ts",
         "**/project-issue-comments.spec.ts",
         "**/project-pr-review.spec.ts",
+        "**/projects-empty-create.spec.ts",
         "**/persona-model-combobox-screenshots.spec.ts",
         "**/drafts-screenshots.spec.ts",
         "**/drafts-all-fix-screenshots.spec.ts",

--- a/desktop/src/features/projects/ui/ProjectCards.tsx
+++ b/desktop/src/features/projects/ui/ProjectCards.tsx
@@ -327,9 +327,16 @@ function RepositoryUnavailableIndicator({
   );
 }
 
-export function EmptyState() {
+export function EmptyState({
+  onCreateRepository,
+}: {
+  onCreateRepository?: () => void;
+} = {}) {
   return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-3 px-4 py-16 text-center">
+    <div
+      className="flex flex-1 flex-col items-center justify-center gap-3 px-4 py-16 text-center"
+      data-testid="projects-empty-state"
+    >
       <Folders className="h-10 w-10 text-muted-foreground/40" />
       <div className="space-y-1">
         <p className="text-sm font-medium text-foreground">No projects yet</p>
@@ -337,6 +344,17 @@ export function EmptyState() {
           Projects published to this relay will appear here.
         </p>
       </div>
+      {onCreateRepository ? (
+        <Button
+          className="mt-2"
+          data-testid="projects-empty-create-repository"
+          onClick={onCreateRepository}
+          size="sm"
+          type="button"
+        >
+          Create repository
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -592,10 +592,6 @@ export function ProjectsView() {
     );
   }
 
-  if (projects.length === 0) {
-    return <EmptyState />;
-  }
-
   const projectItems =
     visibleProjects.length === 0 ? (
       <EmptyFilteredState />
@@ -850,7 +846,11 @@ export function ProjectsView() {
           </div>
           <div className="mx-auto w-full max-w-6xl">
             <div className="w-full min-w-0 pb-4 pt-4">
-              {filter === "all" ? (
+              {projects.length === 0 ? (
+                <EmptyState
+                  onCreateRepository={() => setCreateProjectOpen(true)}
+                />
+              ) : filter === "all" ? (
                 <ProjectsOverviewPanel
                   metadata={
                     <ProjectsOverviewRail

--- a/desktop/tests/e2e/projects-empty-create.spec.ts
+++ b/desktop/tests/e2e/projects-empty-create.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const DEFAULT_MOCK_PUBKEY = "deadbeef".repeat(8);
+
+// The projects surface is a preview feature — opt in before the app mounts.
+async function enableProjectsFeature(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "buzz-feature-overrides-v1",
+      JSON.stringify({ projects: true }),
+    );
+  });
+}
+
+/** Hide every seeded mock project so Projects renders the true empty state. */
+async function hideAllMockProjects(page: import("@playwright/test").Page) {
+  const hiddenCards = [
+    `30617:${DEFAULT_MOCK_PUBKEY}:buzz`,
+    `30617:${TEST_IDENTITIES.alice.pubkey}:relay-tools`,
+    `30617:${TEST_IDENTITIES.bob.pubkey}:design-system`,
+  ];
+  await page.addInitScript((cards) => {
+    window.localStorage.setItem(
+      "buzz.projects.hidden-cards.v1",
+      JSON.stringify(cards),
+    );
+  }, hiddenCards);
+}
+
+test("empty Projects keeps Create repository controls", async ({ page }) => {
+  await enableProjectsFeature(page);
+  await hideAllMockProjects(page);
+  await installMockBridge(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("open-projects-view").click();
+
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Projects" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("projects-empty-state")).toBeVisible();
+  await expect(page.getByTestId("projects-create-menu")).toBeVisible();
+
+  await page.getByTestId("projects-create-menu").hover();
+  await page.getByRole("menuitem", { name: "Repository" }).click();
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  await page.getByTestId("projects-empty-create-repository").click();
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+  await expect(page.getByTestId("create-project-name")).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Fixes #4009.

When the Projects view had no visible projects it returned `<EmptyState />` before the `PageHeader`, toolbar, and `ProjectsCreateMenu` mounted — so the Create menu was missing and there was no way to create the first project from the empty view.

## Approach

Reimplements the approach from the closed PR #3620 (which the issue body points to), adapted to current `main`:

- Remove the `projects.length === 0` early return in `ProjectsView.tsx`; the main content section now renders the empty state *inside* the page chrome, so the header, toolbar, and `+` Create menu stay mounted.
- `EmptyState` gains an optional `onCreateRepository` callback that renders a `Create repository` CTA button opening the create-project dialog.
- Both entry points (toolbar Create menu → Repository, empty-state button) open the same `CreateProjectDialog`.

## Test coverage

- `typecheck` (tsc --noEmit) — clean
- `biome check` on all touched files — clean
- New Playwright smoke spec `tests/e2e/projects-empty-create.spec.ts` covering the empty Projects view and both Create entry points — **passes** (`1 passed`)

## Notes

This is intentionally scoped to the empty-list Create-controls fix. The related "deleted + re-announced projects remain missing" behavior noted in the issue is a separate relay/query concern and is not changed here.
