### PR TITLE
test(buzz-acp): pin exact-match boundary for unadvertised model variants (#4004)

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -2822,6 +2822,50 @@ mod tests {
         assert!(!super::model_in_catalog(&[], None, "anything"));
     }
 
+    // ── Issue #4004: bracket-modifier miss pins the exact-match boundary ─────
+    //
+    // The cursor-agent ACP catalog advertises `composer-2.5[fast=true]` as its
+    // only Composer 2.5 model id. When the desktop persisted
+    // `composer-2.5[fast=false]` (a variant the harness never reported), the
+    // exact-match below must miss so the pool's fallback arm
+    // (`pool.rs:955-977`) fires and the desktop learns the pick is
+    // unsupported, instead of silently applying the agent default and billing
+    // the user against `fast=true`.
+
+    #[test]
+    fn resolve_model_switch_method_misses_unadvertised_bracket_variant() {
+        // Cursor-agent-shaped session/new: exactly one model, `fast=true` only.
+        let session_new = serde_json::json!({
+            "stable": { "configOptions": [] },
+            "models": {
+                "currentModelId": "composer-2.5[fast=true]",
+                "availableModels": [
+                    { "modelId": "composer-2.5[fast=true]", "name": "Composer 2.5 Fast" }
+                ]
+            }
+        });
+        assert_eq!(
+            super::resolve_model_switch_method(&session_new, "composer-2.5[fast=false]"),
+            None,
+            "exact-match must miss a variant the harness never advertised"
+        );
+    }
+
+    #[test]
+    fn model_in_catalog_misses_unadvertised_bracket_variant() {
+        let available = serde_json::json!({
+            "currentModelId": "composer-2.5[fast=true]",
+            "availableModels": [
+                { "modelId": "composer-2.5[fast=true]", "name": "Composer 2.5 Fast" }
+            ]
+        });
+        assert!(!super::model_in_catalog(
+            &[],
+            Some(&available),
+            "composer-2.5[fast=false]"
+        ));
+    }
+
     // ── Error variant display ─────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

Refs #4004.

The issue reports Buzz Desktop letting a user set `composer-2.5[fast=false]` while the cursor-agent ACP catalog only advertises `composer-2.5[fast=true]` — so the session silently runs (and bills) the wrong variant.

The runtime boundary that decides this lives in `resolve_model_switch_method` / `model_in_catalog` (`crates/buzz-acp/src/acp.rs`): both match the desired model id against the fresh `session/new` catalog by **exact string equality**. The miss is intentional and load-bearing — the pool's fallback arm (`crates/buzz-acp/src/pool.rs:955-977`) consumes it to emit a `control_result { status: "unsupported_model" }` frame so the desktop rejects the pick instead of silently no-op'ing.

## Changes

Two regression tests under `acp.rs::tests` pin that boundary against a cursor-agent-shaped catalog (one model, `[fast=true]` only):

- `resolve_model_switch_method_misses_unadvertised_bracket_variant`
- `model_in_catalog_misses_unadvertised_bracket_variant`

Both assert the bracket-suffixed variant `composer-2.5[fast=false]` does **not** match when the harness never advertised it — the exact behavior the silent-billing report depends on for detection.

## Why test-only

The detection + surfacing chain already exists in current `main` (exact-match miss → `unsupported_model` frame → desktop live-pick rejection via `liveSwitchOutcome`). The reporter's observed silent fallback is consistent with running a harness/desktop build older than that chain. This PR pins the contract so the boundary can't regress silently; it deliberately does **not** add fuzzy/bracket-insensitive matching, which would trade a loud, fixable UX miss for silent execution of a model the user did not select — the failure mode #4004 is itself reporting.

## Test plan

```
cargo test --lib -p buzz-acp           # 663 passed (661 existing + 2 new), 0 failed
cargo clippy -p buzz-acp --all-targets # clean
```
