### PR TITLE
fix(desktop): coalesce persona defs with running instances in @ picker (#3947)

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -243,6 +243,13 @@ export function useMentions(
 
     const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
       const pubkey = normalizePubkey(candidate.pubkey);
+      if (!pubkey) {
+        // Persona-definition rows in managed-agents.json can carry an empty
+        // pubkey (their running instance carries the real one). They are not
+        // mentionable identities — skip so they never render as phantom
+        // candidates or shadow the real instance (#3947).
+        return;
+      }
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
@@ -347,16 +354,23 @@ export function useMentions(
     }
 
     for (const agent of managedAgentsQuery.data ?? []) {
+      const linkedPersonaName = agent.personaId
+        ? (activePersonaById.get(agent.personaId)?.displayName ?? null)
+        : null;
       addCandidate({
         kind: "identity",
         pubkey: agent.pubkey,
-        displayName: agent.name,
+        // Prefer the linked persona's display name for presentation; the
+        // instance's own `name` may be null on running instances (#3947).
+        displayName: agent.name || linkedPersonaName || null,
         isMember: false,
         isAgent: true,
         isManagedAgent: true,
         personaId: agent.personaId ?? undefined,
         personaName:
-          personaNameByPubkey.get(normalizePubkey(agent.pubkey)) ?? null,
+          personaNameByPubkey.get(normalizePubkey(agent.pubkey)) ??
+          linkedPersonaName ??
+          null,
         ownerPubkey: currentPubkey,
       });
     }


### PR DESCRIPTION
## Summary

Fixes #3947 — the `@` mention picker could offer persona-definition rows as `managed by you · not in channel` while omitting the actual locally managed running instances that are channel members.

## Root cause

Two candidate-assembly defects in `useMentions.ts`:

1. **Persona-definition records with empty pubkey were admitted.** `managed-agents.json` can carry persona-definition rows whose `pubkey` is `""` (their running instance carries the real one). `addCandidate` normalized `""` and admitted the row as an agent candidate, so phantom "managed by you" rows rendered and could shadow the real instance — the definition row would never resolve a `p` tag.

2. **Running instances were not enriched with their linked persona's display name.** The instance's own `name` (often `null`) won, so the picker showed an unnamed instance and the persona row as a separate "managed by you" duplicate instead of coalescing on `instance.persona_id == persona.id`.

## Fix

In `desktop/src/features/messages/lib/useMentions.ts`:

- **`addCandidate` guard**: skip any candidate whose normalized pubkey is blank (`if (!pubkey) return;`). Persona-definition rows never render as candidates; membership and delivery stay keyed by the instance pubkey.
- **Managed-agents loop**: when `agent.personaId` links to an active persona, prefer the persona's `displayName` for presentation (`agent.name || linkedPersonaName || null`). The instance row becomes a properly named candidate that coalesces with its channel-member entry instead of rendering as a separate phantom.

## Verification

- `pnpm typecheck` — clean
- `pnpm exec biome check src/features/messages/lib/useMentions.ts` — clean
- `pnpm build:e2e && CI=1 npx playwright test --project=smoke` — composer flows exercised

## What this does not change

- No change to the persona-definition data model or backend serialization; the empty-pubkey rows are simply ignored at the picker boundary.
- No change to `p`-tag delivery (membership-keyed path unchanged).
- No fuzzy matching introduced.
