### PR TITLE
fix(acp): surface silent turn-end when agent replies but never publishes (#3980)

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -211,6 +211,14 @@ pub struct AcpClient {
     /// deltas. Both goose and buzz-agent emit this notification; goose gates
     /// on client capability advertisement, buzz-agent emits unconditionally.
     goose_usage: UsageTracker,
+    /// Text the agent streamed as `agent_message_chunk` during the current
+    /// turn that was NOT followed by a successful publish tool call. Used to
+    /// surface a "turn ended without publishing" signal (#3980).
+    unpublished_turn_text: String,
+    /// Whether the agent completed at least one tool call this turn. An agent
+    /// that produced text but completed zero tool calls never shelled out to
+    /// `buzz messages send`, so its reply is invisible on the relay.
+    completed_tool_call_this_turn: bool,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -550,6 +558,8 @@ impl AcpClient {
             steering_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
+            unpublished_turn_text: String::new(),
+            completed_tool_call_this_turn: false,
         })
     }
 
@@ -560,6 +570,19 @@ impl AcpClient {
     }
 
     /// Update metadata that will be attached to subsequent raw wire events.
+    /// Drain per-turn unpublished-text state. Returns `Some(text)` when the
+    /// agent streamed non-empty reply text but completed no tool call — i.e.
+    /// its reply never reached the relay (#3980). Resets both fields so the
+    /// next turn starts clean; safe to call on every turn boundary.
+    pub fn take_unpublished_turn_notice(&mut self) -> Option<String> {
+        let text = std::mem::take(&mut self.unpublished_turn_text);
+        let had_tool = std::mem::take(&mut self.completed_tool_call_this_turn);
+        if had_tool || text.trim().is_empty() {
+            return None;
+        }
+        Some(text)
+    }
+
     pub fn set_observer_context(&mut self, context: ObserverContext) {
         self.observer_context = context;
     }
@@ -1715,6 +1738,9 @@ impl AcpClient {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::info!(target: "acp::stream", "{text}");
+                    // Accumulate silent (unpublished) reply text so a turn that
+                    // ends without a publish surfaces a notice (#3980).
+                    self.unpublished_turn_text.push_str(text);
                 }
                 false
             }
@@ -1737,6 +1763,12 @@ impl AcpClient {
                     .unwrap_or("?");
                 let status = update.get("status").and_then(|v| v.as_str()).unwrap_or("?");
                 tracing::info!(target: "acp::tool", "tool_call_update: {tool_id} → {status}");
+                // A successfully completed tool call means the agent shelled
+                // out (potentially to publish) — don't flag the turn as
+                // silent-unpublished (#3980).
+                if status == "completed" {
+                    self.completed_tool_call_this_turn = true;
+                }
                 false
             }
             "plan" => {

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -1316,6 +1316,20 @@ fn send_prompt_result(
     batch: Option<FlushBatch>,
 ) {
     agent.acp.clear_steer_rx();
+    // #3980: a turn that produced non-empty reply text but completed no tool
+    // call ends silently — the reply never reached the relay. Log it so the
+    // silent-failure mode is at least visible in operator logs (observable
+    // via Desktop's observer view); publishing via `post_failure_notice`
+    // requires channel + thread context unavailable at this chokepoint.
+    if let Some(silent) = agent.acp.take_unpublished_turn_notice() {
+        tracing::warn!(
+            target: "pool::prompt",
+            turn = %turn_id,
+            bytes = silent.len(),
+            "turn produced reply text but no publish — silent on relay (#3980): {:.200}",
+            silent.trim()
+        );
+    }
     let _ = result_tx.send(PromptResult {
         agent,
         source,


### PR DESCRIPTION
## Summary

Refs #3980 — surfaces the silent-failure mode when a `buzz-acp` agent ends a turn with non-empty `agent_message_chunk` text but never makes a successful `buzz messages send` call.

Today that turn ends with **zero signal**: no relay message, no warning, no failure notice. Desktop's activity/observer view shows a coherent reply while the relay has nothing, so an operator can't tell the agent failed to publish.

## What this does

- **Accumulates** streamed `agent_message_chunk` text per turn in `AcpClient` (`unpublished_turn_text`), alongside a `completed_tool_call_this_turn` flag set by any `tool_call_update` with `status == "completed"`.
- **`take_unpublished_turn_notice()`** (public, per-turn) returns `Some(text)` only when the turn produced non-empty text *and* completed zero tool calls — the case where the agent never shelled out to `buzz messages send`, so its reply is invisible on the relay. Resets both fields so each turn starts clean.
- **At turn end**, in the shared `send_prompt_result` chokepoint (so every outcome inherits it), the harness emits a `pool::prompt` warning with the turn id, byte count, and a content preview. That makes the silent-failure mode visible in operator logs and Desktop's observer view.

## Scope (deliberately bounded)

This adds turn-level accumulation + detection + a warning. A **relay-visible failure notice** (via `post_failure_notice`) is the natural follow-on but is **not** in this PR: that path needs `channel_id` + thread tags at the publish site, which the shared result chokepoint doesn't carry, and wiring it without that context risks leaking or wrong-channel posts. The accumulation state introduced here is exactly what that follow-on consumes.

Publishing itself is unchanged; agents that complete any tool call (the publish path) never trigger the warning. No fuzzy matching introduced.

## Verification

- `cargo check -p buzz-acp` — clean
- `cargo test -p buzz-acp` — 661 + 9 passing (matches `main` baseline, no regression)
- `cargo clippy -p buzz-acp` — clean
