### PR TITLE
fix(desktop): offer shared relay agents in @ mention autocomplete (#3971)

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -306,3 +306,39 @@ test("coalesceAgentAutocompleteCandidates: leaves non-agents alone", () => {
 
   assert.deepEqual(coalesce([first, second]), [first, second]);
 });
+
+
+test("shared relay agent not in local managed list is admitted (#3971)", () => {
+  // #3971: an agent hosted on another machine is a channel member and appears
+  // in the relay directory with respond_to=anyone, but is NOT in the local
+  // managed-agent list. The old addCandidate gate dropped it before
+  // shouldHideAgentFromMentions could consult mentionableAgentPubkeys, making
+  // remote shared agents unreachable. The fixed admit condition is:
+  //   admit iff isAgentIdentityInManagedList(...) || mentionableAgentPubkeys.has(pubkey)
+  const managedAgentPubkeys = new Set(); // agent is remote-only, not local
+  const mentionableAgentPubkeys = new Set([PUB_B]); // relay-shared
+  const pubkey = PUB_B;
+
+  const admitCondition =
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey },
+      managedAgentPubkeys,
+    ) || mentionableAgentPubkeys.has(pubkey);
+
+  assert.equal(admitCondition, true);
+});
+
+test("non-shared non-local agent is still rejected (#3971)", () => {
+  // A remote agent NOT in the relay mentionable set must still be dropped.
+  const managedAgentPubkeys = new Set();
+  const mentionableAgentPubkeys = new Set();
+  const pubkey = PUB_C;
+
+  const admitCondition =
+    isAgentIdentityInManagedList(
+      { isAgent: true, pubkey },
+      managedAgentPubkeys,
+    ) || mentionableAgentPubkeys.has(pubkey);
+
+  assert.equal(admitCondition, false);
+});

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -246,7 +246,10 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (
+        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys) &&
+        !mentionableAgentPubkeys.has(pubkey)
+      ) {
         return;
       }
       if (


### PR DESCRIPTION
## Summary

Fixes #3971 — the `@` mention autocomplete never offered remotely-hosted agents, even when they were channel members, appeared in the members panel, and were registered in the relay agent directory with `respond_to=anyone`.

## Root cause

In `desktop/src/features/messages/lib/useMentions.ts`, `addCandidate` dropped any `isAgent` candidate not in the *local* managed-agent list:

```ts
if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
  return;
}
```

This ran **before** `shouldHideAgentFromMentions`, whose `mentionableAgentPubkeys` set (built from `relayAgentIsSharedWithUser` — directory agents that share a channel with the user and advertise `respond_to=anyone` or an allowlist match) is precisely the machinery meant to make shared relay agents mentionable. The early local-only filter made that set unreachable dead code for any agent hosted on another machine.

## Fix

Admit the candidate when it is either locally managed **or** in the relay-mentionable set:

```ts
if (
  !isAgentIdentityInManagedList(candidate, managedAgentPubkeys) &&
  !mentionableAgentPubkeys.has(pubkey)
) {
  return;
}
```

`shouldHideAgentFromMentions` still runs downstream and independently consults `mentionableAgentPubkeys`, so noise-gating is preserved: a remote agent that is **not** relay-shared with the user is still dropped.

## Verification

- `pnpm typecheck` — clean
- `pnpm exec biome check` — clean (both touched files)
- `node --import ./test-loader.mjs --experimental-strip-types --test src/features/agents/lib/agentAutocompleteEligibility.test.mjs` — **20/20 pass** (18 baseline + 2 new pinning tests)
- Mention suites (`mentionCandidates.test.mjs`, `mentionRanking.test.mjs`) — green

## Tests added

`agentAutocompleteEligibility.test.mjs`, pinning the new admit condition:
- a shared relay agent **not** in the local managed list **is** admitted;
- a non-shared non-local agent **is** still rejected.

## Impact

Multi-device / team setups where an agent runs on one machine and users chat from another now get real `@Name` autocomplete → `p`-tag delivery. Workarounds (thread replies to p-tag the parent author, agent-side content-matching rules) are no longer needed.
