### PR TITLE
test(relay): serialize flaky trace_context_lookup callsite test under ENV_LOCK (#3929)

### DIFF
--- a/crates/buzz-relay/src/telemetry.rs
+++ b/crates/buzz-relay/src/telemetry.rs
@@ -473,6 +473,16 @@ mod tests {
 
     #[test]
     fn trace_context_lookup_does_not_enable_callsites() {
+        // #3929: this test intermittently failed under the parallel suite
+        // because `tracing`'s callsite *interest* cache is global per
+        // callsite, not per-subscriber. A neighbor test that registers a
+        // global default dispatcher can poison this callsite's cached
+        // interest before our thread-local `with_default` runs, so the probe
+        // consults a stale entry. Serialize against the other global-state
+        // tests via the shared ENV_LOCK (the same mutex they already take),
+        // so no global-dispatcher registration can overlap this test.
+        let _guard = ENV_LOCK.lock().unwrap();
+
         let context_lookup = TraceContextLookup::default();
         let subscriber = tracing_subscriber::registry().with(
             context_lookup


### PR DESCRIPTION
## Summary

Refs #3929 — makes `telemetry::tests::trace_context_lookup_does_not_enable_callsites` deterministic under the parallel `buzz-relay --lib` suite. Pre-existing on clean `main`; not introduced by any open PR.

## The flake

The test installs a `TraceContextLookup` layer with `LevelFilter::OFF` via a *thread-local* `with_default` and asserts `!tracing::enabled!(target: "trace_context_lookup_filter_test", ERROR)`. Under parallel load it could fail with the callsite unexpectedly enabled (1/6 on clean main; 2/6 observed on the #3844 branch head, which was the negative-control prompt).

`tracing`'s callsite *interest* cache is **global per callsite, not per-subscriber**. A neighbor test that registers a global default dispatcher can poison this callsite's cached interest before the thread-local `with_default` runs, so the `enabled!` probe consults a stale entry rather than the OFF filter.

## Fix

Serialize this test against the other global-state tests by taking the same `ENV_LOCK` mutex they already hold (`telemetry.rs:498+`), so no global-dispatcher registration can overlap it. This matches the existing repo convention for exactly this class of shared-state flake.

**Why not the unique-callsite fix:** the reporter's preferred option (2) — a unique per-run callsite target — was evaluated and rejected: `tracing::enabled!`'s `target:` position requires a *constant* and rejects a runtime `&str` (`E0435: attempt to use a non-constant value in a constant`). Option (1) is the sound mechanical fix here.

## Verification

Under the real repro (`cargo test -p buzz-relay --lib`, the full parallel suite), this test **no longer appears among failures across 3 consecutive runs**.

The **9 remaining suite failures are all pre-existing** `api::media` / `api::admin` sidecar/env-gated cases on clean main (`media_get_auth_flag_*`, `upload_concurrency_limit_is_scoped_by_community`, `feedback_attachment_rejects_unknown_feedback`, `report_detail_rejects_unknown_report`, …), consistent across runs and unrelated to this test.

- `cargo check -p buzz-relay` — clean
- Filtered telemetry suite — 8/8 pass
- Clippy — clean
