### PR TITLE
feat(desktop): add font-size preference to Appearance settings (#3938)

### DIFF
--- a/desktop/src/features/settings/ui/FontSizeSetting.tsx
+++ b/desktop/src/features/settings/ui/FontSizeSetting.tsx
@@ -1,0 +1,114 @@
+import { useMemo } from "react";
+import { Minus, Plus } from "lucide-react";
+
+import {
+  FONT_SCALE_PRESETS,
+  setFontScale,
+  useFontScale,
+} from "@/shared/lib/fontScalePreference";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { SettingsOptionGroup, SettingsOptionRow } from "./SettingsOptionGroup";
+
+/**
+ * Font-size preference control. Lets the user pick a base font scale (85%–130%)
+ * to improve readability on high-DPI or unusually-scaled displays.
+ *
+ * The value is persisted in localStorage and applied to the document root
+ * as a CSS `font-size` multiplier via the {@link FontScaleApplier} component.
+ */
+export function FontSizeSetting() {
+  const fontScale = useFontScale();
+
+  const { sliderPercent, label } = useMemo(() => {
+    const min = FONT_SCALE_PRESETS[0];
+    const max = FONT_SCALE_PRESETS[FONT_SCALE_PRESETS.length - 1];
+    const percent = ((fontScale - min) / (max - min)) * 100;
+    return {
+      sliderPercent: percent,
+      label: `${Math.round(fontScale * 100)}%`,
+    };
+  }, [fontScale]);
+
+  const currentIndex = FONT_SCALE_PRESETS.indexOf(
+    fontScale as (typeof FONT_SCALE_PRESETS)[number],
+  );
+  const canDecrease = currentIndex > 0;
+  const canIncrease =
+    currentIndex >= 0 && currentIndex < FONT_SCALE_PRESETS.length - 1;
+
+  const handleDecrease = () => {
+    if (canDecrease) {
+      setFontScale(FONT_SCALE_PRESETS[currentIndex - 1]);
+    }
+  };
+
+  const handleIncrease = () => {
+    if (canIncrease) {
+      setFontScale(FONT_SCALE_PRESETS[currentIndex + 1]);
+    }
+  };
+
+  return (
+    <SettingsOptionGroup className="mt-4">
+      <SettingsOptionRow>
+        <div className="min-w-0">
+          <p className="text-sm font-medium">Font size</p>
+          <p className="text-sm font-normal text-muted-foreground">
+            Scale the base text size for readability on high-DPI displays.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            aria-label="Decrease font size"
+            className="h-7 w-7 shrink-0 rounded-full border border-border/50 bg-muted/45 p-0 text-foreground shadow-none hover:bg-muted/70"
+            data-testid="font-size-decrease"
+            disabled={!canDecrease}
+            onClick={handleDecrease}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            <Minus className="h-4 w-4" />
+          </Button>
+          <span
+            className="min-w-12 text-center text-xs font-medium tabular-nums"
+            data-testid="font-size-label"
+          >
+            {label}
+          </span>
+          <Button
+            aria-label="Increase font size"
+            className="h-7 w-7 shrink-0 rounded-full border border-border/50 bg-muted/45 p-0 text-foreground shadow-none hover:bg-muted/70"
+            data-testid="font-size-increase"
+            disabled={!canIncrease}
+            onClick={handleIncrease}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
+      </SettingsOptionRow>
+      {/* Native range slider for direct/drag interaction */}
+      <input
+        aria-label="Font size slider"
+        className={cn(
+          "mt-2 w-full cursor-pointer accent-primary",
+          "h-1.5 appearance-none rounded-full bg-muted",
+        )}
+        data-testid="font-size-slider"
+        max={FONT_SCALE_PRESETS[FONT_SCALE_PRESETS.length - 1]}
+        min={FONT_SCALE_PRESETS[0]}
+        onChange={(e) => setFontScale(Number.parseFloat(e.target.value))}
+        step={0.01}
+        style={{
+          background: `linear-gradient(to right, hsl(var(--primary)) ${sliderPercent}%, hsl(var(--muted)) ${sliderPercent}%)`,
+        }}
+        type="range"
+        value={fontScale}
+      />
+    </SettingsOptionGroup>
+  );
+}

--- a/desktop/src/features/settings/ui/SettingsPanels.tsx
+++ b/desktop/src/features/settings/ui/SettingsPanels.tsx
@@ -81,6 +81,7 @@ import { appearanceCommunityLabel } from "../lib/appearanceScopeCopy";
 import { ChannelTemplatesSettingsCard } from "./ChannelTemplatesSettingsCard";
 import { HarnessesSettingsPanel } from "./HarnessesSettingsPanel";
 import { ExperimentalFeaturesCard } from "./ExperimentalFeaturesCard";
+import { FontSizeSetting } from "./FontSizeSetting";
 import { KeyboardShortcutsCard } from "./KeyboardShortcutsCard";
 import { MeshComputeSettingsCard } from "@/features/mesh-compute/ui/MeshComputeSettingsCard";
 import { MobilePairingCard } from "./MobilePairingCard";
@@ -701,6 +702,7 @@ function ThemeSettingsCard() {
 
       <LinkPreviewStyleSetting />
       <ThreadLayoutSetting />
+      <FontSizeSetting />
     </section>
   );
 }

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -14,6 +14,7 @@ import { huddleWindowChannelId } from "@/features/huddle/lib/huddleWindow";
 import { CommunityOnboardingProvider } from "@/features/onboarding/communityOnboarding";
 import { ThemeProvider } from "@/shared/theme/ThemeProvider";
 import { EmojiBurstProvider } from "@/shared/ui/EmojiBurstProvider";
+import { FontScaleApplier } from "@/shared/ui/FontScaleApplier";
 import { PoofBurstProvider } from "@/shared/ui/PoofBurstProvider";
 import { Toaster } from "@/shared/ui/sonner";
 import { TooltipProvider } from "@/shared/ui/tooltip";
@@ -85,6 +86,7 @@ function renderApp() {
             enabled={huddleWindowChannelId() === null}
           >
             <ThemeProvider defaultTheme="buzz">
+              <FontScaleApplier />
               <TooltipProvider delayDuration={300}>
                 <EmojiBurstProvider>
                   <PoofBurstProvider>

--- a/desktop/src/shared/lib/fontScalePreference.test.mjs
+++ b/desktop/src/shared/lib/fontScalePreference.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  FONT_SCALE_PRESETS,
+  getFontScale,
+  setFontScale,
+} from "./fontScalePreference.ts";
+
+function installLocalStorage() {
+  const store = new Map();
+  const ls = {
+    getItem: (key) => store.get(key) ?? null,
+    removeItem: (key) => store.delete(key),
+    setItem(key, value) {
+      store.set(key, value);
+    },
+  };
+  if (typeof globalThis.window === "undefined") {
+    globalThis.window = {};
+  }
+  globalThis.window.localStorage = ls;
+  globalThis.localStorage = ls;
+  return store;
+}
+
+describe("fontScalePreference", () => {
+  it("clamps the stored value into the supported 85%-130% range", () => {
+    installLocalStorage();
+    setFontScale(0.5);
+    assert.equal(getFontScale(), FONT_SCALE_PRESETS[0]);
+
+    setFontScale(1.4);
+    assert.equal(getFontScale(), FONT_SCALE_PRESETS[FONT_SCALE_PRESETS.length - 1]);
+  });
+
+  it("persists the exact finite value across reads", () => {
+    installLocalStorage();
+    setFontScale(1.15);
+    assert.equal(getFontScale(), 1.15);
+  });
+
+  it("round-trips through localStorage when available", () => {
+    const store = installLocalStorage();
+    setFontScale(1.2);
+    assert.equal(store.get("buzz.ui.fontScale"), "1.2");
+  });
+
+  it("resets to 100% for NaN input", () => {
+    installLocalStorage();
+    setFontScale(Number.NaN);
+    assert.equal(getFontScale(), 1);
+  });
+});

--- a/desktop/src/shared/lib/fontScalePreference.ts
+++ b/desktop/src/shared/lib/fontScalePreference.ts
@@ -1,0 +1,82 @@
+import * as React from "react";
+
+/**
+ * User preference for the base font scale of the Buzz Desktop chat UI.
+ *
+ * Stored as a number in the range [0.85, 1.30] (i.e. 85%–130% of the default
+ * size). The value is applied as a CSS `font-size` multiplier on the
+ * document root, cascading into all rem-based typography.
+ *
+ * Persisted in localStorage. This is a device-level accessibility preference,
+ * not community-scoped data, so it is intentionally not reset on community
+ * switch.
+ */
+
+const STORAGE_KEY = "buzz.ui.fontScale";
+
+const DEFAULT_FONT_SCALE = 1;
+
+const MIN_FONT_SCALE = 0.85;
+const MAX_FONT_SCALE = 1.3;
+
+/** Snap points for the slider — makes the control feel deterministic. */
+export const FONT_SCALE_PRESETS = [0.85, 0.9, 0.95, 1, 1.1, 1.2, 1.3] as const;
+
+const listeners = new Set<() => void>();
+
+let fontScale = readStoredFontScale();
+
+function clampFontScale(value: number): number {
+  if (Number.isNaN(value)) return DEFAULT_FONT_SCALE;
+  return Math.min(MAX_FONT_SCALE, Math.max(MIN_FONT_SCALE, value));
+}
+
+function readStoredFontScale(): number {
+  try {
+    const raw = globalThis.localStorage?.getItem(STORAGE_KEY);
+    if (raw === null) return DEFAULT_FONT_SCALE;
+    return clampFontScale(Number.parseFloat(raw));
+  } catch {
+    return DEFAULT_FONT_SCALE;
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): number {
+  return fontScale;
+}
+
+function getServerSnapshot(): number {
+  return DEFAULT_FONT_SCALE;
+}
+
+/** Read the persisted font scale preference outside of React. */
+export function getFontScale(): number {
+  return fontScale;
+}
+
+/** Update the font scale preference and notify all subscribed components. */
+export function setFontScale(scale: number): void {
+  fontScale = clampFontScale(scale);
+
+  try {
+    globalThis.localStorage?.setItem(STORAGE_KEY, String(fontScale));
+  } catch {
+    // Persistence is best-effort; the in-memory value still applies.
+  }
+
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/** The base font-size multiplier for the Buzz Desktop UI. */
+export function useFontScale(): number {
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/desktop/src/shared/ui/FontScaleApplier.tsx
+++ b/desktop/src/shared/ui/FontScaleApplier.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+import { useFontScale } from "@/shared/lib/fontScalePreference";
+
+/**
+ * Applies the persisted font-scale preference to the document root as a CSS
+ * `font-size` multiplier. Mounted once near the app root; every rem-based
+ * style cascades from this value.
+ *
+ * The base font-size is 16px (the browser default), so a scale of 1.2 sets
+ * `font-size: 19.2px` on `<html>`, and every `rem` unit grows proportionally.
+ */
+export function FontScaleApplier() {
+  const fontScale = useFontScale();
+
+  useEffect(() => {
+    document.documentElement.style.fontSize = `${fontScale * 16}px`;
+  }, [fontScale]);
+
+  return null;
+}


### PR DESCRIPTION
## Problem

Buzz Desktop (Linux, Tauri) has no way to adjust the base font/text size in the chat view. High-DPI or unusually-scaled displays render the default size poorly, with no user-side workaround (#3938).

## Fix

Adds an adjustable font-size preference to **Settings → Appearance**, persisted locally and applied globally as a document-root font-size multiplier:

- **`shared/lib/fontScalePreference.ts`** — `useSyncExternalStore`-backed preference store persisted to `localStorage` under `buzz.ui.fontScale`. Clamps to 85%–130% with named presets; modeled directly on `threadViewModePreference`.
- **`shared/ui/FontScaleApplier.tsx`** — mounted once in `main.tsx` inside `ThemeProvider`; applies the scale as `font-size: ${scale * 16}px` on `<html>`, cascading into every rem-based token.
- **`features/settings/ui/FontSizeSetting.tsx`** — settings card with stepper buttons (+/-) plus a range slider, visually mirroring `ThreadLayoutSetting` (same `SettingsOptionGroup`/`SettingsOptionRow` vocabulary).
- **Tests** — pin clamp boundaries, NaN → 100% fallback, and the `localStorage` round-trip.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm exec biome check` clean across all touched files
- [x] New `fontScalePreference.test.mjs` (4 tests) pins clamp, NaN, persistence behavior
- [x] Full `pnpm test` — 3910 passing, no regressions

Closes #3938.
