### PR TITLE
fix(desktop): mobile pairing payload emits non-HTTPS relay URL when a workspace relay override is set

### DIFF
--- a/desktop/src-tauri/src/commands/pairing.rs
+++ b/desktop/src-tauri/src/commands/pairing.rs
@@ -16,7 +16,7 @@ use tokio_util::sync::CancellationToken;
 use zeroize::Zeroizing;
 
 use crate::app_state::AppState;
-use crate::relay::{relay_api_base_url_with_override, relay_ws_url_with_override};
+use crate::relay::{relay_api_base_url_for_mobile_pairing, relay_ws_url_with_override};
 
 #[derive(Serialize, Clone)]
 struct PairingSasPayload {
@@ -95,7 +95,10 @@ pub async fn start_pairing(
     let pubkey_hex = keys.public_key().to_hex();
 
     let ws_url = relay_ws_url_with_override(&state);
-    let http_url = relay_api_base_url_with_override(&state);
+    // The phone rejects non-HTTPS relay URLs in release builds, so the payload
+    // URL is resolved separately from the desktop's own connection URL (which
+    // stays on the workspace relay and keys the community row).
+    let http_url = relay_api_base_url_for_mobile_pairing(&state)?;
 
     // NIP-43 relays gate connections on membership, so an unpaired peer can't
     // reach the main relay yet — it must go through the /pair sidecar. Open

--- a/desktop/src-tauri/src/relay.rs
+++ b/desktop/src-tauri/src/relay.rs
@@ -70,6 +70,62 @@ pub fn effective_agent_relay_url(_record_relay: &str, workspace_relay: &str) -> 
     workspace_relay.to_string()
 }
 
+/// True when `url` carries an `https://` scheme (scheme match is
+/// case-insensitive per RFC 3986 §3.1).
+fn is_https_url(url: &str) -> bool {
+    url.trim_start()
+        .get(..8)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("https://"))
+}
+
+/// Core selection rule for the relay URL embedded in a mobile pairing
+/// credential payload. Split out as a pure function so it is testable without
+/// mutating process-wide env state.
+///
+/// Precedence: `BUZZ_RELAY_HTTP` (when HTTPS) > active relay base URL (when
+/// HTTPS) > error.
+pub(crate) fn select_mobile_pairing_relay_url(
+    env_http: Option<&str>,
+    base_url: &str,
+) -> Result<String, String> {
+    if let Some(env_url) = env_http {
+        let env_url = env_url.trim().trim_end_matches('/');
+        if is_https_url(env_url) {
+            return Ok(env_url.to_string());
+        }
+    }
+
+    let base = base_url.trim().trim_end_matches('/');
+    if is_https_url(base) {
+        return Ok(base.to_string());
+    }
+
+    Err(format!(
+        "mobile pairing requires an HTTPS relay URL — set BUZZ_RELAY_HTTP \
+         (current relay URL: {base})"
+    ))
+}
+
+/// Returns the relay HTTP base URL to embed in a mobile pairing credential
+/// payload.
+///
+/// This is deliberately NOT `relay_api_base_url_with_override`: the mobile
+/// client rejects any non-HTTPS relay URL in release builds
+/// (`_validateRelayUrl` in `mobile/lib/features/pairing/pairing_provider.dart`
+/// throws `FormatException: Relay URL must use HTTPS`). A workspace relay
+/// pinned to `ws://…` — which is legitimate for the desktop's own WebSocket
+/// connection and keys the community row — would otherwise be handed to the
+/// phone as `http://…` and fail there with a cryptic error.
+///
+/// Returning `Err` surfaces an actionable message in the desktop pairing UI
+/// instead of silently emitting a URL that cannot work.
+pub fn relay_api_base_url_for_mobile_pairing(state: &AppState) -> Result<String, String> {
+    select_mobile_pairing_relay_url(
+        configured_env_var("BUZZ_RELAY_HTTP").as_deref(),
+        &relay_api_base_url_with_override(state),
+    )
+}
+
 pub fn relay_http_base_url(relay_url: &str) -> String {
     let trimmed = relay_url.trim().trim_end_matches('/');
 
@@ -603,9 +659,104 @@ mod tests {
     use super::{
         build_profile_event, classify_intercepted_response, effective_agent_relay_url,
         extract_retry_in_hint, parse_command_response, relay_http_base_url,
-        MALFORMED_RESPONSE_MESSAGE,
+        select_mobile_pairing_relay_url, MALFORMED_RESPONSE_MESSAGE,
     };
     use serde::Deserialize;
+
+    // ── mobile pairing relay URL selection ───────────────────────────────────
+    //
+    // The mobile client throws `FormatException: Relay URL must use HTTPS` for
+    // any non-HTTPS relay URL in release builds, so the pairing payload must
+    // never emit one. These pin the precedence and the error path.
+
+    #[test]
+    fn mobile_pairing_prefers_https_env_over_http_base() {
+        assert_eq!(
+            select_mobile_pairing_relay_url(
+                Some("https://relay.example.ts.net:10443"),
+                "http://100.93.190.120:3000",
+            ),
+            Ok("https://relay.example.ts.net:10443".to_string())
+        );
+    }
+
+    #[test]
+    fn mobile_pairing_env_wins_over_https_base() {
+        assert_eq!(
+            select_mobile_pairing_relay_url(
+                Some("https://env.example.ts.net:10443"),
+                "https://base.example.com",
+            ),
+            Ok("https://env.example.ts.net:10443".to_string())
+        );
+    }
+
+    #[test]
+    fn mobile_pairing_falls_back_to_https_override_when_env_unset() {
+        assert_eq!(
+            select_mobile_pairing_relay_url(None, "https://base.example.com"),
+            Ok("https://base.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn mobile_pairing_errors_when_only_http_available() {
+        let err = select_mobile_pairing_relay_url(None, "http://100.93.190.120:3000")
+            .expect_err("http-only relay must not produce a pairing URL");
+        assert!(
+            err.contains("BUZZ_RELAY_HTTP"),
+            "error must name the env var to set: {err}"
+        );
+        assert!(
+            err.contains("http://100.93.190.120:3000"),
+            "error must echo the offending URL: {err}"
+        );
+    }
+
+    #[test]
+    fn mobile_pairing_ignores_non_https_env_and_errors() {
+        // A misconfigured http:// env value must not be emitted just because
+        // it was explicitly set — it fails on the phone the same way.
+        assert!(select_mobile_pairing_relay_url(
+            Some("http://env.example.com"),
+            "http://100.93.190.120:3000",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn mobile_pairing_ignores_non_https_env_but_uses_https_base() {
+        assert_eq!(
+            select_mobile_pairing_relay_url(
+                Some("ws://env.example.com"),
+                "https://base.example.com",
+            ),
+            Ok("https://base.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn mobile_pairing_trims_whitespace_and_trailing_slash() {
+        assert_eq!(
+            select_mobile_pairing_relay_url(Some("  https://relay.example.com:10443/  "), ""),
+            Ok("https://relay.example.com:10443".to_string())
+        );
+    }
+
+    #[test]
+    fn mobile_pairing_accepts_uppercase_scheme() {
+        // RFC 3986 §3.1: scheme comparison is case-insensitive.
+        assert_eq!(
+            select_mobile_pairing_relay_url(Some("HTTPS://relay.example.com"), ""),
+            Ok("HTTPS://relay.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn mobile_pairing_rejects_https_lookalike_host() {
+        // "https-relay.example.com" must not satisfy the HTTPS check.
+        assert!(select_mobile_pairing_relay_url(None, "http://https-relay.example.com").is_err());
+    }
 
     // ── extract_retry_in_hint ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

When the desktop's workspace relay is a plain-WS URL (e.g. `ws://<lan-ip>:3000`, common for self-hosted tailnet deployments), `start_pairing` builds the mobile credential payload with `relay_api_base_url_with_override`, which converts it to `http://<lan-ip>:3000`. The mobile app's `_validateRelayUrl` rejects any non-HTTPS relay URL in release builds, so pairing always fails with:

```
failed to import credentials: FormatException: Relay URL must use HTTPS
```

Setting `BUZZ_RELAY_HTTP` does not help: `relay_api_base_url_with_override` only consults it when no workspace override exists, so the env var is silently ignored in exactly the deployments that need it.

## Fix

Add `relay_api_base_url_for_mobile_pairing(state)`, used only by the pairing payload path:

1. `BUZZ_RELAY_HTTP` when set and HTTPS,
2. else the override/base URL when already HTTPS,
3. else a descriptive error surfaced in the pairing UI ("mobile pairing requires an HTTPS relay URL — set BUZZ_RELAY_HTTP") instead of emitting a payload the phone is guaranteed to reject with a cryptic FormatException.

The desktop's own WS connection path is untouched (`ws_url` remains byte-identical), so existing workspace/community wiring is unaffected.

## Testing

- 9 new unit tests on the pure selection helper (env precedence, non-HTTPS env skipped, http-only error, lookalike hosts, scheme case, trimming); `cargo test --lib`: 1858 passed.
- clippy + fmt clean.
- Verified end-to-end on a self-hosted deployment: workspace relay `ws://<lan-ip>:3000`, `BUZZ_RELAY_HTTP=https://<ts-hostname>:10443` (Tailscale Serve → Caddy → relay); the credential payload now carries the HTTPS URL and iOS accepts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)