### PR TITLE
feat(buzz-acp): opt-in workflow-attribution author resolution for the respond-to gate

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -466,6 +466,25 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_ALLOWED_RESPOND_TO", value_delimiter = ',')]
     pub allowed_respond_to: Option<Vec<String>>,
 
+    /// Opt-in: honour workflow attribution in the inbound author gate.
+    ///
+    /// Value is the **relay's own signing pubkey** (64 hex chars) — the NIP-11
+    /// `self` field of the relay this harness connects to. Unset (the default)
+    /// disables the feature entirely.
+    ///
+    /// When set, an inbound event that is (a) signed by exactly this pubkey and
+    /// (b) tagged `["buzz:workflow","true"]` has its gate author resolved from
+    /// the first `p` attribution tag instead of `event.pubkey`. That resolved
+    /// author is then subjected to the *unchanged* `--respond-to` policy, so
+    /// `owner-only` still admits only the owner (or a verified sibling).
+    ///
+    /// Security: the pin is the trust anchor. Attribution tags are writable by
+    /// any member, so they are consulted **only** after the event's signature
+    /// verifies against this exact pubkey. Never set this to anything but the
+    /// relay's own key.
+    #[arg(long, env = "BUZZ_ACP_HONOR_WORKFLOW_ATTRIBUTION")]
+    pub honor_workflow_attribution: Option<String>,
+
     /// Team-owned instructions layered after `[System]` and before agent memory.
     #[arg(long, env = "BUZZ_ACP_TEAM_INSTRUCTIONS")]
     pub team_instructions: Option<String>,
@@ -539,6 +558,10 @@ pub struct Config {
     pub respond_to_allowlist: HashSet<String>,
     /// Allowed `respond_to` modes. Empty = all modes allowed.
     pub allowed_respond_to: Vec<String>,
+    /// Pinned relay signing pubkey (lowercase hex) enabling workflow-attribution
+    /// author resolution in the inbound gate. `None` = feature off (default).
+    /// See [`Args::honor_workflow_attribution`] for the security contract.
+    pub honor_workflow_attribution: Option<String>,
     /// Per-persona env vars to inject at agent spawn time (e.g., GOOSE_PROVIDER, GOOSE_MODEL, BUZZ_AGENT_MODEL).
     /// Populated from persona pack resolution. Empty when no pack is configured.
     pub persona_env_vars: Vec<(String, String)>,
@@ -986,6 +1009,27 @@ impl Config {
             HashSet::new()
         };
 
+        // Workflow-attribution pin: must be a well-formed 64-char hex pubkey.
+        // A malformed value is a startup error rather than a silent no-op —
+        // silently disabling a security-relevant gate extension because of a
+        // typo is exactly the failure mode operators would not notice.
+        let honor_workflow_attribution = match args.honor_workflow_attribution {
+            Some(raw) => {
+                let trimmed = raw.trim().to_ascii_lowercase();
+                if trimmed.is_empty() {
+                    None
+                } else if trimmed.len() != 64 || !trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+                    return Err(ConfigError::ConfigFile(format!(
+                        "invalid BUZZ_ACP_HONOR_WORKFLOW_ATTRIBUTION: '{raw}' \
+                         (must be the relay's own pubkey — exactly 64 hex characters)"
+                    )));
+                } else {
+                    Some(trimmed)
+                }
+            }
+            None => None,
+        };
+
         // Validate respond_to against the allowed set.
         let allowed_respond_to = if let Some(raw) = args.allowed_respond_to {
             // Validate each entry is a known RespondTo mode.
@@ -1071,6 +1115,7 @@ impl Config {
             respond_to: args.respond_to,
             respond_to_allowlist,
             allowed_respond_to,
+            honor_workflow_attribution,
             persona_env_vars,
             has_generated_codex_config,
             relay_observer: args.relay_observer,
@@ -1098,8 +1143,14 @@ impl Config {
             modes.sort();
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
+        // Surfaced at startup so an operator can tell at a glance whether the
+        // gate extension is armed and against which relay key.
+        let workflow_attribution_detail = match &self.honor_workflow_attribution {
+            Some(pk) => format!(" honor_workflow_attribution={}…", &pk[..8.min(pk.len())]),
+            None => String::new(),
+        };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1122,6 +1173,7 @@ impl Config {
             self.permission_mode,
             respond_to_detail,
             allowed_respond_to_detail,
+            workflow_attribution_detail,
         )
     }
 }
@@ -1441,6 +1493,7 @@ mod tests {
             respond_to: RespondTo::Anyone,
             respond_to_allowlist: HashSet::new(),
             allowed_respond_to: Vec::new(),
+            honor_workflow_attribution: None,
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -215,6 +215,95 @@ async fn is_owner_or_sibling(
     is_sibling
 }
 
+/// Tag name marking an event as produced by the relay's workflow engine.
+/// Written by `buzz-relay`'s `RelayActionSink::send_message`
+/// (`crates/buzz-relay/src/workflow_sink.rs`) as `["buzz:workflow","true"]`.
+const WORKFLOW_MARKER_TAG: &str = "buzz:workflow";
+
+/// Resolve the author the inbound gate should judge, honouring workflow
+/// attribution when — and only when — the opt-in pin is configured and the
+/// event proves it came from that relay's own signing key.
+///
+/// Returns `Some(attributed_author_hex)` when all of the following hold:
+///
+/// 1. `relay_pubkey_pin` is set (the `--honor-workflow-attribution` /
+///    `BUZZ_ACP_HONOR_WORKFLOW_ATTRIBUTION` opt-in; unset ⇒ always `None`).
+/// 2. `event.pubkey` equals the pin exactly.
+/// 3. The event's id hash and Schnorr signature verify
+///    ([`buzz_core::verify_event`]) — so the pubkey field is *proven*, not
+///    merely claimed. This is the trust anchor.
+/// 4. The event carries the `buzz:workflow` marker tag.
+/// 5. A first `p` tag exists carrying a well-formed 64-hex pubkey.
+///
+/// Otherwise `None`, and the caller falls back to `event.pubkey` — today's
+/// behaviour, byte for byte.
+///
+/// # Why the signature check is non-negotiable
+///
+/// Attribution tags are ordinary event tags: **any** channel member can write
+/// `["buzz:workflow","true"]` and `["p", <owner>]` into an event they sign
+/// themselves. If the gate trusted tags alone, any member could impersonate the
+/// owner and drive an `owner-only` agent. The relay's signature over the whole
+/// event (tags included) is the only thing that makes the attribution
+/// trustworthy, because only the relay's workflow engine can produce it.
+///
+/// Note the resolved author is *not* thereby trusted — it is fed back into the
+/// unchanged `--respond-to` policy, so `owner-only` still admits only the owner
+/// or a verified sibling. This widens *who can be spoken for*, never *who is
+/// allowed*.
+fn resolve_workflow_attributed_author(
+    event: &nostr::Event,
+    relay_pubkey_pin: Option<&str>,
+) -> Option<String> {
+    // (1) Opt-in gate — unset means the whole feature does not exist.
+    let pin = relay_pubkey_pin?;
+
+    // (2) The event must claim to be from the pinned relay key.
+    let author = event.pubkey.to_hex();
+    if author != pin {
+        return None;
+    }
+
+    // (4) Marker check before signature verification: `verify_event` is
+    // CPU-bound Schnorr work, and the marker is a cheap tag scan. Ordering is
+    // security-neutral (both must pass) but keeps the common case cheap.
+    let has_marker = event.tags.iter().any(|t| {
+        let parts = t.as_slice();
+        parts.len() >= 2 && parts[0] == WORKFLOW_MARKER_TAG && parts[1] == "true"
+    });
+    if !has_marker {
+        return None;
+    }
+
+    // (3) THE trust anchor: prove the relay actually signed these exact tags.
+    // Without this, a forged event carrying the relay's pubkey in its `pubkey`
+    // field would be accepted on the strength of a field anyone can type.
+    if let Err(err) = buzz_core::verify_event(event) {
+        tracing::warn!(
+            event_id = %event.id.to_hex(),
+            %err,
+            "event claims the pinned relay pubkey but fails signature verification — \
+             refusing workflow attribution"
+        );
+        return None;
+    }
+
+    // (5) First `p` tag is the attribution tag — `workflow_sink.rs` writes the
+    // workflow owner first, then appends one `p` per resolved @mention.
+    let attributed = event.tags.iter().find_map(|t| {
+        let parts = t.as_slice();
+        if parts.len() >= 2 && parts[0] == "p" {
+            let candidate = parts[1].trim().to_ascii_lowercase();
+            if candidate.len() == 64 && candidate.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Some(candidate);
+            }
+        }
+        None
+    })?;
+
+    Some(attributed)
+}
+
 /// Inbound author gate decision: does this author's event fire a turn?
 ///
 /// Coarse security policy applied before subscription rules. Both `OwnerOnly`
@@ -2143,7 +2232,22 @@ async fn tokio_main() -> Result<()> {
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
                             {
-                                let author = buzz_event.event.pubkey.to_hex();
+                                // Workflow attribution (opt-in, off by default):
+                                // when the event is *cryptographically proven* to
+                                // come from the pinned relay key AND carries the
+                                // `buzz:workflow` marker, judge the `p` attribution
+                                // tag instead of the relay's own pubkey. The
+                                // resolved author still faces the unchanged
+                                // respond_to policy below. Feature unset ⇒
+                                // `attributed` is None and this is a no-op.
+                                let attributed = resolve_workflow_attributed_author(
+                                    &buzz_event.event,
+                                    config.honor_workflow_attribution.as_deref(),
+                                );
+                                let author = match &attributed {
+                                    Some(a) => a.clone(),
+                                    None => buzz_event.event.pubkey.to_hex(),
+                                };
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
@@ -2161,12 +2265,21 @@ async fn tokio_main() -> Result<()> {
                                 if !allowed {
                                     tracing::debug!(
                                         channel_id = %buzz_event.channel_id,
-                                        author = %buzz_event.event.pubkey.to_hex(),
+                                        author = %author,
+                                        signer = %buzz_event.event.pubkey.to_hex(),
+                                        workflow_attributed = attributed.is_some(),
                                         mode = %config.respond_to,
                                         is_dm,
                                         "inbound author gate — dropping event"
                                     );
                                     continue;
+                                }
+                                if attributed.is_some() {
+                                    tracing::info!(
+                                        channel_id = %buzz_event.channel_id,
+                                        attributed_author = %&author[..8.min(author.len())],
+                                        "workflow-attributed event admitted"
+                                    );
                                 }
                             }
 
@@ -4772,6 +4885,249 @@ mod author_gate_tests {
     }
 }
 
+/// Opt-in workflow-attribution extension to the inbound author gate.
+///
+/// These tests exercise the gate exactly as the event loop composes it:
+/// resolve the effective author with [`resolve_workflow_attributed_author`],
+/// then feed that author to [`author_allowed`] under `owner-only`. The
+/// load-bearing case is `spoofed_*`: a non-relay signer writing the same
+/// marker and attribution tags must be rejected, because tags are writable by
+/// any channel member and only the relay's signature is trustworthy.
+#[cfg(test)]
+mod workflow_attribution_gate_tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    fn dummy_rest_client() -> relay::RestClient {
+        relay::RestClient {
+            http: reqwest::Client::new(),
+            base_url: "http://localhost:0".into(),
+            keys: nostr::Keys::generate(),
+            auth_tag_json: None,
+        }
+    }
+
+    /// Build a kind:9 event shaped like `workflow_sink.rs` emits: `p`
+    /// attribution tag, `h` channel tag, `buzz:workflow` marker, plus one `p`
+    /// per mentioned member. `signer` decides whose signature covers it.
+    fn workflow_style_event(
+        signer: &Keys,
+        attributed_to: &str,
+        marker: bool,
+        mention: Option<&str>,
+    ) -> nostr::Event {
+        let mut tags = vec![
+            Tag::parse(["p", attributed_to]).expect("p tag"),
+            Tag::parse(["h", &uuid::Uuid::new_v4().to_string()]).expect("h tag"),
+        ];
+        if marker {
+            tags.push(Tag::parse(["buzz:workflow", "true"]).expect("workflow tag"));
+        }
+        if let Some(m) = mention {
+            tags.push(Tag::parse(["p", m]).expect("mention p tag"));
+        }
+        EventBuilder::new(
+            Kind::Custom(KIND_STREAM_MESSAGE as u16),
+            "@builderbot pulse",
+        )
+        .tags(tags)
+        .sign_with_keys(signer)
+        .expect("sign")
+    }
+
+    /// The composed gate decision, mirroring the event-loop call site.
+    async fn gate_admits(event: &nostr::Event, pin: Option<&str>, owner: &str) -> bool {
+        let attributed = resolve_workflow_attributed_author(event, pin);
+        let author = attributed.clone().unwrap_or_else(|| event.pubkey.to_hex());
+        let cache = OwnerCache::new(Some(owner.to_string()));
+        // Non-owner authors would otherwise trigger a sibling profile lookup
+        // over HTTP; pin them as known non-siblings so the decision is local.
+        if author != owner {
+            cache.cache_sibling(author.clone(), false);
+        }
+        author_allowed(
+            &RespondTo::OwnerOnly,
+            &HashSet::new(),
+            &author,
+            false,
+            &cache,
+            &dummy_rest_client(),
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn relay_signed_marked_owner_attributed_is_admitted() {
+        let relay_keys = Keys::generate();
+        let pin = relay_keys.public_key().to_hex();
+        let owner = "cd".repeat(32);
+        let agent = "ef".repeat(32);
+        let event = workflow_style_event(&relay_keys, &owner, true, Some(&agent));
+
+        assert_eq!(
+            resolve_workflow_attributed_author(&event, Some(&pin)),
+            Some(owner.clone()),
+            "the first p tag is the attribution tag and must resolve to the owner"
+        );
+        assert!(
+            gate_admits(&event, Some(&pin), &owner).await,
+            "a relay-signed, workflow-marked event attributed to the owner must be admitted"
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_signed_marked_non_owner_attributed_is_dropped() {
+        let relay_keys = Keys::generate();
+        let pin = relay_keys.public_key().to_hex();
+        let owner = "cd".repeat(32);
+        let other = "ab".repeat(32);
+        let event = workflow_style_event(&relay_keys, &other, true, None);
+
+        assert_eq!(
+            resolve_workflow_attributed_author(&event, Some(&pin)),
+            Some(other),
+            "attribution resolves, but resolution is not authorisation"
+        );
+        assert!(
+            !gate_admits(&event, Some(&pin), &owner).await,
+            "owner-only must still reject a workflow attributed to a non-owner"
+        );
+    }
+
+    /// THE load-bearing test. Any channel member can write
+    /// `["buzz:workflow","true"]` and `["p", <owner>]` into an event they sign
+    /// themselves. Without the signature check that is full impersonation of
+    /// the owner against an `owner-only` agent.
+    #[tokio::test]
+    async fn spoofed_marked_and_attributed_event_from_non_relay_signer_is_dropped() {
+        let relay_keys = Keys::generate();
+        let pin = relay_keys.public_key().to_hex();
+        let attacker = Keys::generate();
+        let owner = "cd".repeat(32);
+        let event = workflow_style_event(&attacker, &owner, true, None);
+
+        assert_eq!(
+            resolve_workflow_attributed_author(&event, Some(&pin)),
+            None,
+            "attribution tags from a non-relay signer must never be honoured"
+        );
+        assert!(
+            !gate_admits(&event, Some(&pin), &owner).await,
+            "a spoofed workflow event must be dropped by the owner-only gate"
+        );
+    }
+
+    /// Second half of the spoof surface: an event whose `pubkey` field *claims*
+    /// the pinned relay key but whose signature does not verify against it.
+    /// The pubkey field alone is not proof — only `verify_event` is.
+    #[tokio::test]
+    async fn forged_pubkey_field_without_valid_signature_is_dropped() {
+        let relay_keys = Keys::generate();
+        let pin = relay_keys.public_key().to_hex();
+        let attacker = Keys::generate();
+        let owner = "cd".repeat(32);
+
+        let honest = workflow_style_event(&attacker, &owner, true, None);
+        // Swap in the relay's pubkey, leaving the attacker's signature intact.
+        let mut forged = honest.clone();
+        forged.pubkey = relay_keys.public_key();
+
+        assert_eq!(forged.pubkey.to_hex(), pin, "forgery targets the pin");
+        assert!(
+            buzz_core::verify_event(&forged).is_err(),
+            "the tampered event must fail verification"
+        );
+        assert_eq!(
+            resolve_workflow_attributed_author(&forged, Some(&pin)),
+            None,
+            "a claimed-but-unproven relay pubkey must not unlock attribution"
+        );
+        assert!(
+            !gate_admits(&forged, Some(&pin), &owner).await,
+            "a forged relay-pubkey event must be dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_signed_but_unmarked_event_is_dropped() {
+        let relay_keys = Keys::generate();
+        let pin = relay_keys.public_key().to_hex();
+        let owner = "cd".repeat(32);
+        // Same shape, no `buzz:workflow` marker — an ordinary relay-signed post.
+        let event = workflow_style_event(&relay_keys, &owner, false, None);
+
+        assert_eq!(
+            resolve_workflow_attributed_author(&event, Some(&pin)),
+            None,
+            "without the workflow marker the p tag is just a mention, not attribution"
+        );
+        assert!(
+            !gate_admits(&event, Some(&pin), &owner).await,
+            "an unmarked relay-signed event must be gated on the relay pubkey as before"
+        );
+    }
+
+    /// Flag unset ⇒ today's behaviour exactly: every one of the above events is
+    /// judged on `event.pubkey`, and none of those signers is the owner.
+    #[tokio::test]
+    async fn flag_unset_drops_every_case() {
+        let relay_keys = Keys::generate();
+        let attacker = Keys::generate();
+        let owner = "cd".repeat(32);
+
+        let cases = [
+            ("relay-signed marked owner-attributed", &relay_keys, true),
+            ("relay-signed unmarked", &relay_keys, false),
+            ("spoofed marked", &attacker, true),
+        ];
+        for (label, signer, marker) in cases {
+            let event = workflow_style_event(signer, &owner, marker, None);
+            assert_eq!(
+                resolve_workflow_attributed_author(&event, None),
+                None,
+                "with the flag unset, {label} must not resolve attribution"
+            );
+            assert!(
+                !gate_admits(&event, None, &owner).await,
+                "with the flag unset, {label} must be dropped as it is today"
+            );
+        }
+    }
+
+    /// A different relay's key (or any other pinned-mismatch) does not unlock
+    /// attribution, even with a perfectly valid signature and marker.
+    #[tokio::test]
+    async fn valid_signature_from_a_different_key_than_the_pin_is_dropped() {
+        let pinned_relay = Keys::generate();
+        let other_relay = Keys::generate();
+        let pin = pinned_relay.public_key().to_hex();
+        let owner = "cd".repeat(32);
+        let event = workflow_style_event(&other_relay, &owner, true, None);
+
+        assert_eq!(
+            resolve_workflow_attributed_author(&event, Some(&pin)),
+            None,
+            "only the pinned key may speak for others"
+        );
+        assert!(!gate_admits(&event, Some(&pin), &owner).await);
+    }
+
+    /// A malformed attribution tag must not resolve to a truncated/garbage
+    /// author that could accidentally collide with a policy decision.
+    #[tokio::test]
+    async fn malformed_attribution_tag_does_not_resolve() {
+        let relay_keys = Keys::generate();
+        let pin = relay_keys.public_key().to_hex();
+        let event = workflow_style_event(&relay_keys, "not-a-pubkey", true, None);
+
+        assert_eq!(
+            resolve_workflow_attributed_author(&event, Some(&pin)),
+            None,
+            "a non-64-hex p tag must be ignored rather than partially trusted"
+        );
+    }
+}
+
 #[cfg(test)]
 mod observer_snapshot_race_tests {
     use super::*;
@@ -5012,6 +5368,7 @@ mod build_mcp_servers_tests {
             respond_to: config::RespondTo::Anyone,
             respond_to_allowlist: std::collections::HashSet::new(),
             allowed_respond_to: vec![],
+            honor_workflow_attribution: None,
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
@@ -5233,6 +5590,7 @@ mod error_outcome_emission_tests {
             respond_to: config::RespondTo::Anyone,
             respond_to_allowlist: HashSet::new(),
             allowed_respond_to: vec![],
+            honor_workflow_attribution: None,
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,


### PR DESCRIPTION
## Problem

Relay workflows can post @mentions of an ACP agent (kind 9, signed by the relay keypair, carrying a `p` attribution tag for the workflow owner and a `["buzz:workflow","true"]` marker). But `buzz-acp`'s `--respond-to owner-only` gate resolves the author from `event.pubkey` — the relay key, which is neither the owner nor a sibling — so every workflow-originated mention is dropped and a workflow can never start an agent turn. This makes the scheduler→agent pattern (workflow as trigger, agent as executor) impossible under the default, safest respond-to posture.

Verified empirically on a self-hosted deployment: an owner-signed mention gets a reply in ~2s; a workflow post with an identical `p` tag is silently dropped.

## Fix

New opt-in flag `--honor-workflow-attribution <relay-pubkey-hex>` / `BUZZ_ACP_HONOR_WORKFLOW_ATTRIBUTION`. When set, an event is resolved through the attribution path only if ALL of:

1. `event.pubkey` equals the configured relay pubkey (the flag value IS the trust anchor — operator-declared, not discovered, so nothing the relay asserts at runtime can move it),
2. the event passes full Schnorr signature verification (`buzz_core::verify_event`),
3. the `buzz:workflow` marker is present.

Only then is the first `p` tag treated as the author — and that attributed author still goes through the unchanged `respond-to` check. Attribution tags alone are never trusted (any member can write tags; the relay signature is what makes them meaningful). This widens who can be *spoken for*, not who is *allowed*. Unset flag = byte-identical behavior to today; malformed pin = hard startup error.

## Testing

8 new unit tests including the load-bearing spoof cases: non-relay-signed event with forged attribution → dropped; relay-signed but unmarked → dropped; relay-signed + marked + non-owner-attributed → dropped under owner-only; flag unset → all dropped (today's behavior). `cargo test -p buzz-acp`: 636 + 9 integration, 0 failures. fmt + clippy clean.

End-to-end verified on a live deployment: scheduled workflow → attributed mention admitted → agent turn ran → reply posted.

## Design notes

- The pin-over-discovery choice is deliberate: NIP-11 `self` is used to *source* the value, but a discovery-based runtime anchor could be moved by whatever the relay endpoint asserts; a pin cannot move without an operator edit. Happy to switch to NIP-11 discovery with pin-on-first-use if maintainers prefer.
- Admission is logged at info with the attributed author prefix for auditability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)