### PR TITLE
fix(desktop): restore workflows overview results

### DIFF
--- a/desktop/src/features/workflows/ui/WorkflowsView.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowsView.tsx
@@ -10,7 +10,7 @@ import { WorkflowDialog } from "@/features/workflows/ui/WorkflowDialog";
 import type { Channel, Workflow } from "@/shared/api/types";
 import {
   deleteWorkflow,
-  getChannelsWorkflows,
+  getChannelWorkflows,
   triggerWorkflow,
 } from "@/shared/api/tauriWorkflows";
 import { Button } from "@/shared/ui/button";
@@ -83,20 +83,17 @@ export function WorkflowsView({
   const allWorkflowsQuery = useQuery({
     queryKey: allWorkflowsQueryKey(channelIdKey),
     queryFn: async () => {
-      // Single batched relay query for all member channels, then group by the
-      // channel_id each workflow carries — replaces the per-channel fanout.
-      const channelNameById = new Map(
-        memberChannels.map((channel) => [channel.id, channel.name]),
+      const channelWorkflows = await Promise.all(
+        memberChannels.map(async (channel) => ({
+          channel,
+          workflows: await getChannelWorkflows(channel.id),
+        })),
       );
-      const workflows = await getChannelsWorkflows(channelIds);
       const results: WorkflowWithChannel[] = [];
-      for (const workflow of workflows) {
-        results.push({
-          workflow,
-          channelName: workflow.channelId
-            ? (channelNameById.get(workflow.channelId) ?? "")
-            : "",
-        });
+      for (const { channel, workflows } of channelWorkflows) {
+        for (const workflow of workflows) {
+          results.push({ workflow, channelName: channel.name });
+        }
       }
       return results;
     },


### PR DESCRIPTION
## Summary
- restore per-channel workflow reads in the Workflows overview
- preserve channel labels while combining results
- avoid the batched multi-channel query that returns an empty result against the live relay

## Verification
- `pnpm --dir desktop check`
- `pnpm --dir desktop test` (3,906 passed)
- `pnpm --dir desktop build`
- verified live relay state: 9 workflows across the two Test huddle channels while the overview rendered `No workflows yet`

Originating Buzz channel: `a078a1cd-49db-4241-bda9-5c15d5413a96`