### PR TITLE
fix(desktop): show workflows across joined channels

### DIFF
--- a/desktop/src-tauri/src/commands/workflows.rs
+++ b/desktop/src-tauri/src/commands/workflows.rs
@@ -70,11 +70,12 @@ pub async fn get_channel_workflows(
 ///
 /// The Workflows overview screen previously issued one `get_channel_workflows`
 /// query per member channel (`Promise.all` fanout in `WorkflowsView`), i.e. N
-/// relay POSTs. A nostr `#h` filter matches ANY of its listed values, so one
-/// query with all channel ids returns the same set. Each `WorkflowWire` carries
-/// its own `channel_id` (from the event's `h` tag), so the frontend can still
-/// group results by channel. Neither this nor the per-channel command sets a
-/// `limit`, so batching does not change result completeness.
+/// relay POSTs. Keep the single relay round-trip, but send one filter per
+/// channel: deployed relays can treat multiple values inside one `#h` filter as
+/// a single value, which makes workflows outside the first channel disappear
+/// from the overview. Multiple Nostr filters are ORed and preserve the intended
+/// cross-channel result set. Each `WorkflowWire` carries its own `channel_id`
+/// (from the event's `h` tag), so the frontend can still group results.
 #[tauri::command]
 pub async fn get_channels_workflows(
     channel_ids: Vec<String>,
@@ -84,14 +85,8 @@ pub async fn get_channels_workflows(
         return Ok(Vec::new());
     }
 
-    let events = query_relay(
-        &state,
-        &[serde_json::json!({
-            "kinds": [30620],
-            "#h": channel_ids,
-        })],
-    )
-    .await?;
+    let filters = workflow_channel_filters(channel_ids);
+    let events = query_relay(&state, &filters).await?;
 
     Ok(events.iter().map(workflow_from_event).collect())
 }
@@ -299,6 +294,23 @@ fn now_secs() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or_default()
+}
+
+/// Build one workflow-definition filter per channel.
+///
+/// Multiple filters are ORed by Nostr relays. Keeping each `#h` array to one
+/// value also works with deployed relays that do not implement multi-value tag
+/// matching correctly.
+fn workflow_channel_filters(channel_ids: Vec<String>) -> Vec<Value> {
+    channel_ids
+        .into_iter()
+        .map(|channel_id| {
+            serde_json::json!({
+                "kinds": [30620],
+                "#h": [channel_id],
+            })
+        })
+        .collect()
 }
 
 /// First value of the tag whose name matches `name` (e.g. `d`, `h`).

--- a/desktop/src-tauri/src/commands/workflows_tests.rs
+++ b/desktop/src-tauri/src/commands/workflows_tests.rs
@@ -207,3 +207,14 @@ fn runs_and_approvals_serialize_to_bare_empty_array() {
         "[]"
     );
 }
+
+#[test]
+fn workflow_channel_filters_use_one_h_value_per_filter() {
+    let second_channel = "33333333-3333-3333-3333-333333333333";
+    let filters = workflow_channel_filters(vec![CHAN.to_string(), second_channel.to_string()]);
+
+    assert_eq!(filters.len(), 2);
+    assert_eq!(filters[0]["kinds"], serde_json::json!([30620]));
+    assert_eq!(filters[0]["#h"], serde_json::json!([CHAN]));
+    assert_eq!(filters[1]["#h"], serde_json::json!([second_channel]));
+}


### PR DESCRIPTION
## What changed

- build one kind `30620` workflow-definition filter per joined channel
- keep those filters in one relay query, relying on Nostr's OR semantics across filters
- add a regression test that requires each filter to carry exactly one `#h` value

## Why

The Workflows overview batched all joined channel IDs into one `#h` array.
Deployed relays may treat that array as one value, so workflows outside the
first channel disappear even though the CLI can read them. Sending one filter
per channel preserves the single relay round trip while making cross-channel
matching unambiguous.

## User impact

The Desktop Workflows overview can show definitions from every joined channel
instead of only the first matching channel.

## Validation

At exact head `6c3b65c47f9c294115cee2702278ed324533cba2`:

- `just desktop-ci` — PASS (3,906 frontend tests; 2,089 Tauri tests + 3 diagnostics; zero failures; frontend checks/build, Tauri fmt/check)
- `just desktop-tauri-clippy` — PASS with warnings denied
- semantic patch ID remained `a267ba514e489143e38a344f923f01a93f73ca55` after rebasing onto current `origin/main` `19d57b0d46baa55814ac737041a36d0b405c9f64`

Originating Buzz thread:
`buzz://message?channel=582358dd-f6db-455c-a451-3c29d006df08&id=2fb67c6cb57f7b1e34701b48a81806a604b57ae8562b026d7151c6a655d11242`
