### PR TITLE
fix(buzz-acp): curated default kind list for SubscribeMode::All

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -1272,11 +1272,38 @@ pub fn resolve_channel_filters(
             }
         }
         SubscribeMode::All => {
+            // #4086: when no `BUZZ_ACP_KINDS` override is set, default to a curated
+            // list instead of a true wildcard. The previous wildcard behavior let
+            // two or more sibling agents storm indefinitely on each other's 👀/💬
+            // (kind 7) and their NIP-09 deletions (kind 5) — harness bookkeeping,
+            // not user intent. The curated list below keeps every kind agents
+            // actually need to wake on (chat, DMs, stream reminders, canvas,
+            // workflow events) and excludes the reaction/bookkeeping kinds.
+            //
+            // Users can still opt into the genuine wildcard by setting
+            // `BUZZ_ACP_KINDS=` explicitly (including `5` and `7`); the override
+            // remains authoritative.
+            let default_kinds = config.kinds_override.clone().unwrap_or_else(|| {
+                use buzz_core::kind::{
+                    KIND_CANVAS, KIND_GIFT_WRAP, KIND_STREAM_MESSAGE_EDIT,
+                    KIND_STREAM_MESSAGE_V2, KIND_WORKFLOW_TRIGGER,
+                };
+                vec![
+                    KIND_STREAM_MESSAGE,              // 9
+                    KIND_STREAM_MESSAGE_V2,           // 40002
+                    KIND_STREAM_MESSAGE_EDIT,         // 40003
+                    KIND_GIFT_WRAP,                   // 1059
+                    KIND_STREAM_REMINDER,             // 40007
+                    KIND_CANVAS,                      // 40100
+                    KIND_WORKFLOW_APPROVAL_REQUESTED, // 46010
+                    KIND_WORKFLOW_TRIGGER,            // 46020
+                ]
+            });
             for ch in &target_channels {
                 result.insert(
                     *ch,
                     ChannelFilter {
-                        kinds: config.kinds_override.clone(),
+                        kinds: Some(default_kinds.clone()),
                         require_mention: false,
                     },
                 );
@@ -1367,10 +1394,33 @@ pub fn resolve_dynamic_channel_filter(
             })),
             require_mention: !config.no_mention_filter,
         }),
-        SubscribeMode::All => Some(ChannelFilter {
-            kinds: config.kinds_override.clone(),
-            require_mention: false,
-        }),
+        SubscribeMode::All => {
+            // #4086: mirror of `resolve_channel_filters()` — default to the same
+            // curated kind list when no `BUZZ_ACP_KINDS` override is set, instead
+            // of a true wildcard that let sibling agents storm on bookkeeping
+            // reactions (kind 7) and NIP-09 deletions (kind 5). Override still
+            // reaches through untouched.
+            let default_kinds = config.kinds_override.clone().unwrap_or_else(|| {
+                use buzz_core::kind::{
+                    KIND_CANVAS, KIND_GIFT_WRAP, KIND_STREAM_MESSAGE_EDIT,
+                    KIND_STREAM_MESSAGE_V2, KIND_WORKFLOW_TRIGGER,
+                };
+                vec![
+                    KIND_STREAM_MESSAGE,              // 9
+                    KIND_STREAM_MESSAGE_V2,           // 40002
+                    KIND_STREAM_MESSAGE_EDIT,         // 40003
+                    KIND_GIFT_WRAP,                   // 1059
+                    KIND_STREAM_REMINDER,             // 40007
+                    KIND_CANVAS,                      // 40100
+                    KIND_WORKFLOW_APPROVAL_REQUESTED, // 46010
+                    KIND_WORKFLOW_TRIGGER,            // 46020
+                ]
+            });
+            Some(ChannelFilter {
+                kinds: Some(default_kinds),
+                require_mention: false,
+            })
+        }
         SubscribeMode::Config => {
             // Same merge logic as resolve_channel_filters() Config branch:
             // evaluate ALL rules against this specific channel (including
@@ -1427,6 +1477,11 @@ fn rule_applies_to_channel(rule: &SubscriptionRule, channel_id: Uuid) -> bool {
 mod tests {
     use super::*;
     use crate::filter::{ChannelScope, SubscriptionRule};
+    use buzz_core::kind::{
+        KIND_CANVAS, KIND_DELETION, KIND_GIFT_WRAP, KIND_REACTION, KIND_STREAM_MESSAGE,
+        KIND_STREAM_MESSAGE_EDIT, KIND_STREAM_MESSAGE_V2, KIND_STREAM_REMINDER,
+        KIND_WORKFLOW_APPROVAL_REQUESTED, KIND_WORKFLOW_TRIGGER,
+    };
     use clap::{Parser, ValueEnum};
 
     /// Build a minimal Config for testing without CLI parsing.
@@ -1768,12 +1823,50 @@ mod tests {
         assert_eq!(result.len(), 3);
         for ch in &channels {
             let f = result.get(ch).unwrap();
+            // #4086: All mode with no kinds_override now defaults to a
+            // curated list (not a wildcard) to stop sibling agents storming
+            // on each other's bookkeeping kinds (5 = NIP-09 deletion,
+            // 7 = reaction).
+            let kinds = f
+                .kinds
+                .as_ref()
+                .expect("all mode with no override = curated default kinds");
+            assert_eq!(
+                kinds,
+                &[
+                    KIND_STREAM_MESSAGE,
+                    KIND_STREAM_MESSAGE_V2,
+                    KIND_STREAM_MESSAGE_EDIT,
+                    KIND_GIFT_WRAP,
+                    KIND_STREAM_REMINDER,
+                    KIND_CANVAS,
+                    KIND_WORKFLOW_APPROVAL_REQUESTED,
+                    KIND_WORKFLOW_TRIGGER,
+                ]
+            );
             assert!(
-                f.kinds.is_none(),
-                "all mode with no override = wildcard kinds"
+                !kinds.contains(&KIND_DELETION) && !kinds.contains(&KIND_REACTION),
+                "curated defaults must exclude bookkeeping kinds 5 and 7"
             );
             assert!(!f.require_mention);
         }
+    }
+
+    #[test]
+    fn test_all_mode_dynamic_channel_matches_static() {
+        // #4086 lockstep: resolve_dynamic_channel_filter must emit the same
+        // curated default kinds as resolve_channel_filters, otherwise
+        // instantly-joined channels behave differently from bootstrapped
+        // ones.
+        let config = test_config(SubscribeMode::All);
+        let ch = Uuid::new_v4();
+
+        let dynamic = resolve_dynamic_channel_filter(&config, ch, &[])
+            .expect("All mode should produce a dynamic filter");
+        let statics = resolve_channel_filters(&config, &[ch], &[]);
+        let statik = statics.get(&ch).expect("All mode should produce a filter");
+        assert_eq!(dynamic.kinds, statik.kinds);
+        assert_eq!(dynamic.require_mention, statik.require_mention);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In `SubscribeMode::All`, when the operator does **not** set a `BUZZ_ACP_KINDS` override, the ACP harness opens each channel subscription with a true wildcard (`kinds: None`) — see `resolve_channel_filters()` and `resolve_dynamic_channel_filter()`.

A wildcard subscription means every sibling agent sharing a channel wakes on **every** event in it — including pure harness bookkeeping:

- **kind 7 (reactions)** — the harness's own `👀` (`REACTION_SEEN`) / `💬` (`REACTION_WORKING`) lifecycle markers, and
- **kind 5 (NIP-09 deletions)** from other agents.

Two or more agents in the same channel then mutually wake on each other's bookkeeping, storm indefinitely, burn tokens, and flood the channel with turns no user asked for. Reported in #4086 with a repro.

## Fix (issue's option 3 — curated default with escape hatch)

When `kinds_override` is `None`, both resolvers now install the same **curated default kind list** instead of a wildcard:

```
[9, 40002, 40003, 1059, 40007, 40100, 46010, 46020]
```

| Kind    | Name                              | Why include                |
| ------- | --------------------------------- | -------------------------- |
| 9       | `KIND_STREAM_MESSAGE`             | stream chat v1             |
| 40002   | `KIND_STREAM_MESSAGE_V2`          | stream chat v2             |
| 40003   | `KIND_STREAM_MESSAGE_EDIT`        | chat edits                 |
| 1059    | `KIND_GIFT_WRAP`                  | gift-wrapped DMs (NIP-17)  |
| 40007   | `KIND_STREAM_REMINDER`            | stream reminders           |
| 40100   | `KIND_CANVAS`                     | channel canvas             |
| 46010   | `KIND_WORKFLOW_APPROVAL_REQUESTED`| workflow approval requests |
| 46020   | `KIND_WORKFLOW_TRIGGER`           | workflow triggers          |

Kinds **5 (NIP-09 deletion)** and **7 (reaction)** are deliberately **excluded** — they are harness bookkeeping, not user intent.

This exactly matches the reporter's verified workaround list from the issue discussion and is applied identically in both `resolve_channel_filters()` (bootstrap path) and `resolve_dynamic_channel_filter()` (instant-join path) so instantly-joined channels behave identically to bootstrapped ones.

**Escape hatch preserved**: setting `BUZZ_ACP_KINDS` explicitly (including `5` and `7`) still takes effect unchanged; the override remains authoritative.

## Tests

- `test_all_mode_wildcard` — updated: now asserts the curated `Some(kinds)` and asserts it **excludes** `KIND_DELETION` and `KIND_REACTION`.
- `test_all_mode_dynamic_channel_matches_static` — **new** lockstep test: dynamic join resolver must emit identical kinds/require_mention as the bootstrap resolver.
- `test_all_mode_with_kinds_override` — unchanged, still passes (override `Some([9, 7])` flows through untouched).

## Verification

```
cargo check  -p buzz-acp                            # OK
cargo test   -p buzz-acp --lib                      # 662 passed, 0 failed
cargo clippy -p buzz-acp --all-targets -- -D warnings  # OK
```

Fixes #4086.
