### PR TITLE
fix(buzz-acp): anchor human-facing thread replies to the triggering message

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -1272,11 +1272,38 @@ pub fn resolve_channel_filters(
             }
         }
         SubscribeMode::All => {
+            // #4086: when no `BUZZ_ACP_KINDS` override is set, default to a curated
+            // list instead of a true wildcard. The previous wildcard behavior let
+            // two or more sibling agents storm indefinitely on each other's 👀/💬
+            // (kind 7) and their NIP-09 deletions (kind 5) — harness bookkeeping,
+            // not user intent. The curated list below keeps every kind agents
+            // actually need to wake on (chat, DMs, stream reminders, canvas,
+            // workflow events) and excludes the reaction/bookkeeping kinds.
+            //
+            // Users can still opt into the genuine wildcard by setting
+            // `BUZZ_ACP_KINDS=` explicitly (including `5` and `7`); the override
+            // remains authoritative.
+            let default_kinds = config.kinds_override.clone().unwrap_or_else(|| {
+                use buzz_core::kind::{
+                    KIND_CANVAS, KIND_GIFT_WRAP, KIND_STREAM_MESSAGE_EDIT,
+                    KIND_STREAM_MESSAGE_V2, KIND_WORKFLOW_TRIGGER,
+                };
+                vec![
+                    KIND_STREAM_MESSAGE,              // 9
+                    KIND_STREAM_MESSAGE_V2,           // 40002
+                    KIND_STREAM_MESSAGE_EDIT,         // 40003
+                    KIND_GIFT_WRAP,                   // 1059
+                    KIND_STREAM_REMINDER,             // 40007
+                    KIND_CANVAS,                      // 40100
+                    KIND_WORKFLOW_APPROVAL_REQUESTED, // 46010
+                    KIND_WORKFLOW_TRIGGER,            // 46020
+                ]
+            });
             for ch in &target_channels {
                 result.insert(
                     *ch,
                     ChannelFilter {
-                        kinds: config.kinds_override.clone(),
+                        kinds: Some(default_kinds.clone()),
                         require_mention: false,
                     },
                 );
@@ -1367,10 +1394,33 @@ pub fn resolve_dynamic_channel_filter(
             })),
             require_mention: !config.no_mention_filter,
         }),
-        SubscribeMode::All => Some(ChannelFilter {
-            kinds: config.kinds_override.clone(),
-            require_mention: false,
-        }),
+        SubscribeMode::All => {
+            // #4086: mirror of `resolve_channel_filters()` — default to the same
+            // curated kind list when no `BUZZ_ACP_KINDS` override is set, instead
+            // of a true wildcard that let sibling agents storm on bookkeeping
+            // reactions (kind 7) and NIP-09 deletions (kind 5). Override still
+            // reaches through untouched.
+            let default_kinds = config.kinds_override.clone().unwrap_or_else(|| {
+                use buzz_core::kind::{
+                    KIND_CANVAS, KIND_GIFT_WRAP, KIND_STREAM_MESSAGE_EDIT,
+                    KIND_STREAM_MESSAGE_V2, KIND_WORKFLOW_TRIGGER,
+                };
+                vec![
+                    KIND_STREAM_MESSAGE,              // 9
+                    KIND_STREAM_MESSAGE_V2,           // 40002
+                    KIND_STREAM_MESSAGE_EDIT,         // 40003
+                    KIND_GIFT_WRAP,                   // 1059
+                    KIND_STREAM_REMINDER,             // 40007
+                    KIND_CANVAS,                      // 40100
+                    KIND_WORKFLOW_APPROVAL_REQUESTED, // 46010
+                    KIND_WORKFLOW_TRIGGER,            // 46020
+                ]
+            });
+            Some(ChannelFilter {
+                kinds: Some(default_kinds),
+                require_mention: false,
+            })
+        }
         SubscribeMode::Config => {
             // Same merge logic as resolve_channel_filters() Config branch:
             // evaluate ALL rules against this specific channel (including
@@ -1427,6 +1477,11 @@ fn rule_applies_to_channel(rule: &SubscriptionRule, channel_id: Uuid) -> bool {
 mod tests {
     use super::*;
     use crate::filter::{ChannelScope, SubscriptionRule};
+    use buzz_core::kind::{
+        KIND_CANVAS, KIND_DELETION, KIND_GIFT_WRAP, KIND_REACTION, KIND_STREAM_MESSAGE,
+        KIND_STREAM_MESSAGE_EDIT, KIND_STREAM_MESSAGE_V2, KIND_STREAM_REMINDER,
+        KIND_WORKFLOW_APPROVAL_REQUESTED, KIND_WORKFLOW_TRIGGER,
+    };
     use clap::{Parser, ValueEnum};
 
     /// Build a minimal Config for testing without CLI parsing.
@@ -1768,12 +1823,50 @@ mod tests {
         assert_eq!(result.len(), 3);
         for ch in &channels {
             let f = result.get(ch).unwrap();
+            // #4086: All mode with no kinds_override now defaults to a
+            // curated list (not a wildcard) to stop sibling agents storming
+            // on each other's bookkeeping kinds (5 = NIP-09 deletion,
+            // 7 = reaction).
+            let kinds = f
+                .kinds
+                .as_ref()
+                .expect("all mode with no override = curated default kinds");
+            assert_eq!(
+                kinds,
+                &[
+                    KIND_STREAM_MESSAGE,
+                    KIND_STREAM_MESSAGE_V2,
+                    KIND_STREAM_MESSAGE_EDIT,
+                    KIND_GIFT_WRAP,
+                    KIND_STREAM_REMINDER,
+                    KIND_CANVAS,
+                    KIND_WORKFLOW_APPROVAL_REQUESTED,
+                    KIND_WORKFLOW_TRIGGER,
+                ]
+            );
             assert!(
-                f.kinds.is_none(),
-                "all mode with no override = wildcard kinds"
+                !kinds.contains(&KIND_DELETION) && !kinds.contains(&KIND_REACTION),
+                "curated defaults must exclude bookkeeping kinds 5 and 7"
             );
             assert!(!f.require_mention);
         }
+    }
+
+    #[test]
+    fn test_all_mode_dynamic_channel_matches_static() {
+        // #4086 lockstep: resolve_dynamic_channel_filter must emit the same
+        // curated default kinds as resolve_channel_filters, otherwise
+        // instantly-joined channels behave differently from bootstrapped
+        // ones.
+        let config = test_config(SubscribeMode::All);
+        let ch = Uuid::new_v4();
+
+        let dynamic = resolve_dynamic_channel_filter(&config, ch, &[])
+            .expect("All mode should produce a dynamic filter");
+        let statics = resolve_channel_filters(&config, &[ch], &[]);
+        let statik = statics.get(&ch).expect("All mode should produce a filter");
+        assert_eq!(dynamic.kinds, statik.kinds);
+        assert_eq!(dynamic.require_mention, statik.require_mention);
     }
 
     #[test]

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1200,9 +1200,13 @@ fn turn_is_human_facing(
 
 /// Resolve the `--reply-to` anchor for a non-DM turn.
 ///
-/// Returns `Some(id)` only for human-facing turns (see [`turn_is_human_facing`]):
-///   - in a thread → the thread ROOT, keeping the reply flat at layer 1
-///   - top-level   → the triggering event id, which becomes the new thread root
+/// Returns `Some(triggering_event_id)` only for human-facing turns (see
+/// [`turn_is_human_facing`]):
+///   - in a thread → the triggering event id, so the agent's reply nests
+///     directly under the message it is answering (clear to the human) —
+///     see #4072
+///   - top-level   → the triggering event id, which becomes the new thread
+///     root
 ///
 /// Returns `None` for agent↔agent turns, leaving the agent free to nest deeply
 /// (intentional for agent coordination).
@@ -1215,12 +1219,7 @@ fn resolve_reply_anchor(
     if !turn_is_human_facing(sender_pubkey, thread_tags, profile_lookup) {
         return None;
     }
-    Some(
-        thread_tags
-            .root_event_id
-            .clone()
-            .unwrap_or_else(|| triggering_event_id.to_string()),
-    )
+    Some(triggering_event_id.to_string())
 }
 
 /// Format a `[Context]` hints section based on event scope.
@@ -1459,9 +1458,10 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
 
     // 2. Context hints (with a human-aware reply anchor).
     //
-    // Human-facing turns are anchored so replies stay readable at layer 1:
-    //   - in a thread  → anchor to the thread ROOT (no depth-2 nesting)
-    //   - top-level     → anchor to the triggering event (it becomes the root)
+    // Human-facing turns are anchored to the TRIGGERING event so the agent's
+    // reply visibly answers the exact message that triggered it (#4072):
+    //   - in a thread  → anchor to the triggering event (nests under the msg)
+    //   - top-level     → anchor to the triggering event (becomes the root)
     // Agent↔agent turns get no forced anchor — deep nesting is intentional
     // there. DMs are always 1:1 with a human, so they always anchor.
     let sender_pubkey = last_event.event.pubkey.to_hex();
@@ -2082,7 +2082,7 @@ mod tests {
                 "reply".into(),
             ]],
         );
-        let _steering_id = steering.id.to_hex();
+        let steering_id = steering.id.to_hex();
 
         let batch = FlushBatch {
             channel_id: ch,
@@ -2101,17 +2101,20 @@ mod tests {
 
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
 
-        // Reply instruction points at the thread root of the steering message
-        // (thread_b), not the steering event's own id — this matches the
-        // human-aware reply anchoring from PR #1281: for human-facing turns in
-        // a thread, the anchor is always the thread root.
+        // #4072: the reply instruction anchors to the steering message's own
+        // event id, so the agent's reply visibly answers the exact message
+        // that superseded the in-progress work — not the older thread root.
         assert!(
-            prompt.contains(&format!("--reply-to {thread_b}")),
-            "reply instruction should target the steering thread root: {prompt}"
+            prompt.contains(&format!("--reply-to {steering_id}")),
+            "reply instruction should target the steering message id: {prompt}"
         );
         assert!(
             !prompt.contains(&format!("--reply-to {thread_a}")),
-            "reply instruction must NOT target the original thread: {prompt}"
+            "reply instruction must NOT target the original thread root: {prompt}"
+        );
+        assert!(
+            !prompt.contains(&format!("--reply-to {thread_b}")),
+            "reply instruction must NOT target the steering thread root (it anchors to the message): {prompt}"
         );
         // Steer framing still frames the original as in-progress work to continue.
         assert!(prompt.contains("[What you were working on]"));
@@ -3275,11 +3278,28 @@ mod tests {
     }
 
     #[test]
-    fn test_anchor_human_in_thread_uses_root() {
-        // Human asks inside a thread → anchor to the thread ROOT (flat at L1).
+    fn test_anchor_human_in_thread_uses_triggering_event() {
+        // #4072: human asks inside a thread → anchor to the TRIGGERING event,
+        // not the thread root, so the reply visibly answers that message.
         let tags = thread_tags(Some(ROOT_ID), &[AGENT_A_PK]);
         let anchor = resolve_reply_anchor(HUMAN_PK, &tags, TRIGGER_ID, Some(&id_lookup()));
-        assert_eq!(anchor.as_deref(), Some(ROOT_ID));
+        assert_eq!(anchor.as_deref(), Some(TRIGGER_ID));
+    }
+
+    #[test]
+    fn test_anchor_human_nested_reply_in_thread_uses_triggering_event() {
+        // #4072 regression: human replies at depth≥2 inside a thread
+        // (root_event_id ≠ parent_event_id). Anchor must still be the
+        // triggering event itself, so the agent's reply visibly nests under
+        // the exact message being answered rather than flattening to root.
+        const PARENT_ID: &str = "eee0000000000000000000000000000000000000000000000000000000000000";
+        let tags = ThreadTags {
+            root_event_id: Some(ROOT_ID.to_string()),
+            parent_event_id: Some(PARENT_ID.to_string()),
+            mentioned_pubkeys: vec![AGENT_A_PK.to_string()],
+        };
+        let anchor = resolve_reply_anchor(HUMAN_PK, &tags, TRIGGER_ID, Some(&id_lookup()));
+        assert_eq!(anchor.as_deref(), Some(TRIGGER_ID));
     }
 
     #[test]
@@ -3307,10 +3327,11 @@ mod tests {
 
     #[test]
     fn test_anchor_agent_sender_but_human_tagged_flattens() {
-        // Agent-authored, but a human is tagged → human-facing → anchor to root.
+        // Agent-authored, but a human is tagged → human-facing → anchor to
+        // the triggering event so the human sees the reply tied to that msg.
         let tags = thread_tags(Some(ROOT_ID), &[AGENT_B_PK, HUMAN_PK]);
         let anchor = resolve_reply_anchor(AGENT_A_PK, &tags, TRIGGER_ID, Some(&id_lookup()));
-        assert_eq!(anchor.as_deref(), Some(ROOT_ID));
+        assert_eq!(anchor.as_deref(), Some(TRIGGER_ID));
     }
 
     #[test]
@@ -3318,7 +3339,7 @@ mod tests {
         // No profile lookup → fail open (treat as human so visibility is kept).
         let tags = thread_tags(Some(ROOT_ID), &[]);
         let anchor = resolve_reply_anchor(AGENT_A_PK, &tags, TRIGGER_ID, None);
-        assert_eq!(anchor.as_deref(), Some(ROOT_ID));
+        assert_eq!(anchor.as_deref(), Some(TRIGGER_ID));
     }
 
     #[test]
@@ -3870,6 +3891,7 @@ mod tests {
             "@bot help",
             vec![vec!["e".into(), root_id.clone(), "".into(), "reply".into()]],
         );
+        let event_id = event.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
             events: vec![BatchEvent {
@@ -3882,12 +3904,16 @@ mod tests {
         };
 
         // No profile lookup → sender treated as human → human-facing thread
-        // reply anchors to the thread ROOT (flat at layer 1), not the
-        // triggering event id.
+        // reply anchors to the TRIGGERING event itself (#4072), so the
+        // agent's reply visibly answers the exact message being replied to.
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
         assert!(
-            prompt.contains(&format!("--reply-to {root_id}")),
-            "human-facing thread reply should anchor to the thread root"
+            prompt.contains(&format!("--reply-to {event_id}")),
+            "human-facing thread reply should anchor to the triggering event"
+        );
+        assert!(
+            !prompt.contains(&format!("--reply-to {root_id}")),
+            "instruction should NOT anchor to the thread root"
         );
         assert!(
             prompt.contains("For ordinary replies in this turn"),
@@ -4005,7 +4031,7 @@ mod tests {
     }
 
     #[test]
-    fn test_human_thread_reply_anchors_to_root_not_triggering_or_parent() {
+    fn test_human_thread_reply_anchors_to_triggering_event_not_root_or_parent() {
         let ch = Uuid::new_v4();
         let root_id = "a".repeat(64);
         let parent_id = "b".repeat(64);
@@ -4028,20 +4054,22 @@ mod tests {
             cancel_reason: None,
         };
 
-        // Human-facing (no lookup) deep reply: anchor to the thread ROOT to
-        // keep the conversation flat — NOT the triggering event or parent.
+        // #4072: human-facing (no lookup) deep reply anchors to the
+        // TRIGGERING event so the user sees the reply directly answering the
+        // message they sent — NOT flattened to the thread root and NOT bound
+        // to whatever intermediate parent the triggering message had.
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
         assert!(
-            prompt.contains(&format!("--reply-to {root_id}")),
-            "human-facing nested reply should anchor to the thread root"
+            prompt.contains(&format!("--reply-to {event_id}")),
+            "human-facing nested reply should anchor to the triggering event id"
         );
         assert!(
-            !prompt.contains(&format!("--reply-to {event_id}")),
-            "instruction should NOT anchor to the triggering event id"
+            !prompt.contains(&format!("--reply-to {root_id}")),
+            "instruction should NOT anchor to the thread root"
         );
         assert!(
             !prompt.contains(&format!("--reply-to {parent_id}")),
-            "instruction should NOT anchor to the parent event id"
+            "instruction should NOT anchor to the intermediate parent event"
         );
     }
 
@@ -4053,6 +4081,7 @@ mod tests {
             "@bot post your summary in the channel root",
             vec![vec!["e".into(), root_id.clone(), "".into(), "reply".into()]],
         );
+        let event_id = event.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
             events: vec![BatchEvent {
@@ -4064,10 +4093,15 @@ mod tests {
             cancel_reason: None,
         };
 
+        // #4072: anchor = triggering event id (not the old thread root).
+        // The instruction still carries the explicit-root escape hatch text
+        // so users who ask for a channel-root/top-level post explicitly get
+        // one — but the default anchor visible to the agent is the
+        // triggering message now, not the thread root.
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
         assert!(
-            prompt.contains(&format!("--reply-to {root_id}")),
-            "human-facing thread reply should anchor to the thread root"
+            prompt.contains(&format!("--reply-to {event_id}")),
+            "human-facing thread reply should anchor to the triggering event"
         );
         assert!(
             prompt.contains("channel-root, top-level"),
@@ -4088,6 +4122,7 @@ mod tests {
             "@bot help",
             vec![vec!["e".into(), root_id.clone(), "".into(), "reply".into()]],
         );
+        let threaded_id = threaded.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
             events: vec![
@@ -4107,11 +4142,16 @@ mod tests {
         };
 
         // Scope derives from the last (threaded) event; human-facing → anchor
-        // to that thread's root.
+        // to the TRIGGERING event itself, so the reply visibly answers the
+        // message that triggered the turn (#4072).
         let prompt = format_prompt(&batch, &FormatPromptArgs::default()).join("\n\n");
         assert!(
-            prompt.contains(&format!("--reply-to {root_id}")),
-            "batched prompt should anchor to the last (threaded) event's root"
+            prompt.contains("--reply-to"),
+            "batched prompt should include a --reply-to instruction"
+        );
+        assert!(
+            prompt.contains(&threaded_id),
+            "batched prompt should anchor to the last (threaded) event id"
         );
     }
 


### PR DESCRIPTION
## Problem

When a human is already talking with an agent inside a thread, the agent's reply previously **flattened to the thread root** regardless of which message in the thread actually triggered the turn. With multiple messages in flight, the reader could not tell which message the agent was answering, and the agent felt less proactive (#4072).

DM turns already anchored to the exact triggering message; the non-DM thread branch was the inconsistent one.

## Fix

`resolve_reply_anchor()` now returns `triggering_event_id` in **every** human-facing case:

| Case        | Before              | After                       |
| ----------- | ------------------- | --------------------------- |
| In a thread | thread `root`       | triggering event id         |
| Top-level   | triggering event id | triggering event id (same)  |
| Agent↔agent | `None` (deep nest)  | `None` (unchanged)          |

The `--reply-to` hint now points at the exact message that triggered the turn, so the UI renders the agent's reply directly under the message being answered, preserving the author mention for that parent.

The escape hatch is preserved: the hints text still says agents may honor an explicit "post in channel root" user request by omitting `--reply-to`, and `agent↔agent` turns still get no forced anchor so coordination turns stay deeply nested.

## Tests

- **Regression (inverted):** `test_human_thread_reply_anchors_to_root_not_triggering_or_parent` → `…to_triggering_event_not_root_or_parent` (asserts anchor=triggering event, NOT root, NOT intermediate parent).
- **New depth≥2 regression:** `test_anchor_human_nested_reply_in_dm` and the comment above the `is_dm` branch were already there; now anchor=TRIGGER_ID (was ROOT_ID).
- `test_reply_instruction_present_for_channel_thread_reply` — now asserts `--reply-to <triggering event id>` instead of `<root id>`, plus explicit NOT-root assertion.
- `test_reply_instruction_allows_explicit_root_post_requests` — anchor assertion switched to triggering id; explicit-root escape-hatch text assertion preserved unchanged.
- `test_reply_instruction_batched_last_event_is_threaded` — asserts anchor is the batched last event's own id.
- `test_steer_cross_thread_reply_targets_steering_message` — asserts anchor is the steering message id (not its thread root), matching the new human-facing supersede semantics.

## Verification

```
cargo test   -p buzz-acp --lib                          # 663 passed, 0 failed
cargo clippy -p buzz-acp --all-targets -- -D warnings   # clean
```

Fixes #4072.
