### PR TITLE
test(relay): deflake trace_context_lookup test via rebuild_interest_cache

### DIFF
--- a/crates/buzz-relay/src/telemetry.rs
+++ b/crates/buzz-relay/src/telemetry.rs
@@ -473,6 +473,15 @@ mod tests {
 
     #[test]
     fn trace_context_lookup_does_not_enable_callsites() {
+        // tracing's callsite `interest` cache is global and per-process —
+        // `with_default` installs a *thread-local* dispatcher, but a static
+        // callsite's cached interest can be poisoned by another test going
+        // through the same callsite with a different subscriber active,
+        // letting our `LevelFilter::OFF` be bypassed (reproduced 1/6 on clean
+        // `main` under `cargo test -p buzz-relay --lib` before this fix).
+        // Forcing the cache to be rebuilt while our subscriber is installed
+        // makes the per-test filter authoritative again.
+        // See https://github.com/block/buzz/issues/3929.
         let context_lookup = TraceContextLookup::default();
         let subscriber = tracing_subscriber::registry().with(
             context_lookup
@@ -481,6 +490,7 @@ mod tests {
         );
 
         tracing::subscriber::with_default(subscriber, || {
+            tracing::callsite::rebuild_interest_cache();
             assert!(context_lookup
                 .dispatch
                 .get()
@@ -491,7 +501,11 @@ mod tests {
                 tracing::Level::ERROR
             ));
         });
+
+        // Restore interest cache so subsequent tests observe default values.
+        tracing::callsite::rebuild_interest_cache();
     }
+
 
     #[test]
     fn test_service_resource_default_when_env_unset() {


### PR DESCRIPTION
Fixes #3929.

## What

`telemetry::tests::trace_context_lookup_does_not_enable_callsites` was intermittently failing in the parallel `buzz-relay` lib suite — 1/6 of full-suite runs on clean `main`. Standalone the test passes 100% of the time, but under parallel scheduling the `tracing::enabled!` assertion could race with other tests that install a global default dispatcher.

## Root cause

`tracing` maintains a per-callsite `interest` cache that is **global and process-wide**, not per-subscriber. `with_default` only installs a *thread-local* dispatcher. If another test (or any prior thread) has primed a static callsite's `interest` to `always`, a later assertion on the same static callsite can consult stale cache and bypass our newly-installed `LevelFilter::OFF` layer.

## Change

Call `tracing::callsite::rebuild_interest_cache()`:

1. **Inside** `with_default` — forces all callsites to be re-evaluated against our subscriber, making the `LevelFilter::OFF` filter authoritative for this assertion.
2. **After** the block — restores the global default interest so downstream tests see fresh values.

This is the tracing-idiomatic escape hatch (tracing-rs/tracing#1527) and is more direct than the alternates:

- `ENV_LOCK` only serializes against *other* tests that take it — it can't catch a non-participating racer (the flake materialised precisely because the interferer isn't ENV_LOCK-adjacent).
- Per-run unique callsite targets would need dynamically-generated `&'static str`, which `tracing::event!`/`enabled!` cannot take.

## Why this is safe

- Test-only change; no production code touched.
- `rebuild_interest_cache()` is documented in `tracing-core` and is the standard escape hatch for stale-callsite flakes.
- The second `rebuild_interest_cache()` call restores the *default* interest — it doesn't lock in our `OFF` filter. Verified by running the full suite 6x post-fix.

## Verification

```
before (clean main, full suite): 6 runs -> 5 pass, 1 fail
after  (this branch, full suite): 6 runs -> 6 pass, 0 fail
```

`cargo clippy -p buzz-relay --all-targets -- -D warnings` — clean.
