### PR TITLE
docs: note that addressable channel events scope by d, not h

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,10 @@ first, then implement handling in the relay.
 
 **Channel scoping**: Channels use `h` tags (NIP-29 group tag), not `e` tags.
 Filters and queries must scope to `h` tags when operating within a channel.
+This applies to events *inside* a channel. Addressable events that describe a
+channel carry its id in their `d` tag instead: kind:39000 (metadata),
+kind:39001, kind:39002 (membership). `get_channels` resolves a user's channels
+from the `d` tag of their kind:39002 events, not from `h`.
 
 **Agent-facing operations go in `buzz-cli`**: New agent-facing features belong in `buzz-cli` — add a subcommand there first, then wire the REST/WebSocket call in `client.rs`. `buzz-dev-mcp` (shell + file tools for `buzz-agent`) is separate.
 


### PR DESCRIPTION
The channel scoping note in `AGENTS.md` reads as universal:

> **Channel scoping**: Channels use `h` tags (NIP-29 group tag), not `e` tags.
> Filters and queries must scope to `h` tags when operating within a channel.

It holds for events inside a channel, but not for the addressable events that
describe one. kind:39000, kind:39001 and kind:39002 carry the channel id in
their `d` tag, which is what `get_channels` already reads.

Taking the existing wording at face value while working on kind:39002 produces
an empty result rather than an error, since those events do carry `h` tags in
other flows, so the mistake is quiet and costs a debugging cycle. Came up while
working on #4023.

Four lines, no behaviour change.