### PR TITLE
fix(mentions): coalesce persona definitions with running instances

### DIFF
--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -233,6 +233,41 @@ export function useMentions(
     () => new Set(activePersonas.map((persona) => persona.id)),
     [activePersonas],
   );
+  // Issue #3947: Also track persona IDs that have running instances (channel
+  // members or relay agents). Persona candidates should be filtered out when
+  // an instance exists for the same persona, so we only offer the actual
+  // running instance with a valid pubkey.
+  const instancePersonaIds = React.useMemo(() => {
+    const personaIds = new Set<string>();
+    for (const member of members ?? []) {
+      const pubkey = normalizePubkey(member.pubkey);
+      const personaId =
+        managedAgentPersonaIdsByPubkey.get(pubkey) ??
+        (activePersonaById.has(pubkey) ? pubkey : undefined);
+      if (personaId) {
+        personaIds.add(personaId);
+      }
+    }
+    for (const agent of relayAgentsQuery.data ?? []) {
+      const pubkey = normalizePubkey(agent.pubkey);
+      const personaId = managedAgentPersonaIdsByPubkey.get(pubkey);
+      if (personaId) {
+        personaIds.add(personaId);
+      }
+    }
+    for (const agent of managedAgentsQuery.data ?? []) {
+      if (agent.personaId && agent.pubkey) {
+        personaIds.add(agent.personaId);
+      }
+    }
+    return personaIds;
+  }, [
+    members,
+    relayAgentsQuery.data,
+    managedAgentsQuery.data,
+    managedAgentPersonaIdsByPubkey,
+    activePersonaById,
+  ]);
   const memberPubkeys = React.useMemo(
     () =>
       new Set((members ?? []).map((member) => normalizePubkey(member.pubkey))),
@@ -386,8 +421,15 @@ export function useMentions(
       }
     }
 
+    // Issue #3947: Filter out personas that have running instances. Only show
+    // persona definitions when there's no actual instance available (i.e., the
+    // persona hasn't been deployed yet).
     const personaCandidates: MentionCandidate[] = activePersonas
-      .filter((persona) => !managedAgentPersonaIds.has(persona.id))
+      .filter(
+        (persona) =>
+          !managedAgentPersonaIds.has(persona.id) &&
+          !instancePersonaIds.has(persona.id),
+      )
       .map((persona) => ({
         kind: "persona" as const,
         personaId: persona.id,
@@ -416,6 +458,7 @@ export function useMentions(
     canSearchGlobalUsers,
     currentPubkey,
     directoryAgentPubkeys,
+    instancePersonaIds,
     isArchivedDiscovery,
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,


### PR DESCRIPTION
## Summary

Fixes #3947: Mention picker was showing persona-definition rows as "managed by you · not in channel" while omitting the actual running channel-member instances of those personas.

## Root Cause

The mention candidate assembly had two issues:

1. Persona candidates were only filtered by `managedAgentPersonaIds` (personas linked to managed agent *definitions*), but running instances with `personaId` set (from channel members or relay agents) were not tracked separately.
2. This caused orphaned persona definitions (no pubkey, no running instance) to appear while actual running instances (with valid pubkeys) were omitted from the picker.

## Fix

Added `instancePersonaIds` to track personas that have running instances (from channel members, relay agents, or managed agents with pubkeys). Persona candidates are now filtered to exclude any persona that has a running instance, ensuring:

- Running channel-member instances are offered and prioritized
- Persona definitions linked to existing instances are not shown as separate candidates
- Only "orphan" personas (no instances at all) appear as mintable candidates

## Changes

- `useMentions.ts`: Added `instancePersonaIds` tracking set + updated persona candidate filter to check both `managedAgentPersonaIds` and `instancePersonaIds`

## Testing

- TypeScript compiles clean (`tsc --noEmit`)
- E2E build succeeds (`pnpm build:e2e`)
- Manual verification: with a persona definition and running instance, the picker now shows the instance (not the definition)
