### PR TITLE
docs(nip-ap): behavioral fields are active, not reserved; clarify which respond_to is live

### DIFF
--- a/docs/nips/NIP-AP.md
+++ b/docs/nips/NIP-AP.md
@@ -100,13 +100,24 @@ at creation and may be reconfigured independently afterwards. They were
 previously carried only on the kind:30177 projection (see
 "Slimming: kind:30177" below).
 
-**Status: reserved.** In the current implementation these behavioral fields are
-*parsed but not yet applied*: readers tolerate and preserve them at the wire
-layer, but the local definition store does not yet carry them and writers do
-not emit them. The instance-copy-at-creation behavior activates in a
-subsequent release (the create-path unification). Until then a definition
-carrying these fields round-trips through the wire type but the values do not
-survive a local edit-and-republish cycle.
+**Status: active.** Writers emit these fields whenever they are set on the
+local definition, and the local definition store carries them (in the
+unified agent store they appear on key-less definition records as
+`definition_respond_to`, `definition_respond_to_allowlist`, and
+`definition_parallelism`, keeping them distinct from the sibling
+instance-level fields). At instance creation the effective respond-to
+policy resolves in order: explicit creation input, then the definition's
+default, then the client default (`owner-only`). After creation the
+instance's policy is independent instance state: it lives on the instance
+record, is published via the instance's kind:30177 event, and editing the
+definition does NOT retroactively change existing instances.
+
+**Which value is live?** For a running instance the instance-level
+`respond_to` (kind:30177 head / the keyed instance record) is what the
+spawner enforces; the definition-level field only seeds new instances.
+Clients that surface both should label the definition value as a default,
+not as the running policy — displaying the definition field for an
+existing agent shows a value the spawner may not be using.
 
 Unknown fields MUST be ignored by readers (forward compatibility).
 


### PR DESCRIPTION
The "Status: reserved" paragraph under Optional fields predates the current implementation. As of the current desktop, writers emit `respond_to` / `respond_to_allowlist` / `parallelism` on kind:30175 events whenever they are set locally (verified against a live retention store), the local definition store carries them (`definition_respond_to` etc. on key-less records in the unified agent store), and instance creation resolves explicit input > definition default > client default.

This PR updates the status paragraph and adds a short "Which value is live?" note. The note exists because the two same-named fields invite a real operator error we hit while building fleet tooling: editing the definition-level value and expecting a running agent's gate to change. The instance-level value (kind:30177 head) is what the spawner enforces; the definition value only seeds new instances.

Docs-only change; no code touched. Rebased on current `main` (no overlap with the kind:30178 additions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
