### PR TITLE
fix(desktop): canonicalize stray --acp flag to the acp subcommand for kimi harnesses (#4106)

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -468,6 +468,7 @@ fn default_agent_args(command: &str) -> Option<Vec<String>> {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        "kimi" => Some(vec!["acp".to_string()]),
         _ => None,
     }
 }
@@ -477,6 +478,20 @@ pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<Strin
         .into_iter()
         .map(|arg| arg.trim().to_string())
         .filter(|arg| !arg.is_empty())
+        .map(|arg| {
+            // Canonicalize a stray `--acp`/`-acp` flag form to the bare `acp`
+            // subcommand. Subcommand-style harnesses (kimi, omp, opencode,
+            // devin, cursor-agent, goose…) reject the flag form outright
+            // ("unknown option '--acp'"), and earlier releases persisted
+            // `--acp` into harness definitions and instance args. The flag
+            // form is never meaningful input for a flag-style CLI, so this is
+            // a pure repair with no behaviour change for flag-style agents.
+            if arg.eq_ignore_ascii_case("--acp") || arg.eq_ignore_ascii_case("-acp") {
+                "acp".to_string()
+            } else {
+                arg
+            }
+        })
         .collect::<Vec<_>>();
 
     let Some(default_args) = default_agent_args(command) else {

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -95,6 +95,70 @@ fn normalizes_buzz_agent_args_to_empty() {
 }
 
 #[test]
+fn canonicalizes_stray_acp_flag_to_subcommand() {
+    // Regression for #4106: subcommand-style harnesses (kimi, omp, opencode,
+    // devin, cursor-agent…) reject the `--acp` flag form with
+    // "unknown option '--acp'". Earlier releases persisted `--acp` into
+    // harness definitions and instance args; normalize it to the subcommand.
+    assert_eq!(
+        normalize_agent_args("kimi", vec!["--acp".into()]),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("kimi", vec!["-acp".into()]),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("/Users/dev/.kimi-code/bin/kimi", vec!["--acp".into()]),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("opencode", vec!["--acp".into()]),
+        vec!["acp".to_string()]
+    );
+    // Case-insensitive, and extra args are preserved.
+    assert_eq!(
+        normalize_agent_args("kimi", vec!["--ACP".into(), "--verbose".into()]),
+        vec!["acp".to_string(), "--verbose".to_string()]
+    );
+    // The correct subcommand form passes through unchanged.
+    assert_eq!(
+        normalize_agent_args("kimi", vec!["acp".into()]),
+        vec!["acp".to_string()]
+    );
+    // Flag-style agents (codex/claude/buzz-agent) still strip the ACP arg.
+    assert_eq!(
+        normalize_agent_args("codex-acp", vec!["--acp".into()]),
+        Vec::<String>::new()
+    );
+    // Unrelated flags are left alone for subcommand-style CLIs.
+    assert_eq!(
+        normalize_agent_args("kimi", vec!["--model".into(), "kimi-k3".into()]),
+        vec!["--model".to_string(), "kimi-k3".to_string()]
+    );
+}
+
+#[test]
+fn kimi_default_args_fallback_covers_empty_args() {
+    // When no args are persisted at all (empty instance args + empty harness
+    // definition args), kimi still launches as `kimi acp` via the same
+    // known-harness fallback that covers goose.
+    assert_eq!(
+        normalize_agent_args("kimi", Vec::new()),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("kimi", vec!["  ".into(), "".into()]),
+        vec!["acp".to_string()]
+    );
+    // Explicit instance args still win over the fallback.
+    assert_eq!(
+        normalize_agent_args("kimi", vec!["--verbose".into()]),
+        vec!["--verbose".to_string()]
+    );
+}
+
+#[test]
 fn login_shell_lookup_treats_command_as_data() {
     let marker =
         std::env::temp_dir().join(format!("buzz-discovery-marker-{}", uuid::Uuid::new_v4()));


### PR DESCRIPTION
## Summary
- `normalize_agent_args` now canonicalizes the `--acp` / `-acp` flag form (case-insensitive) to the bare `acp` subcommand before args reach the spawn/readiness/config-hash/model-probe paths. Subcommand-style ACP CLIs — Kimi Code, Oh My Pi, OpenCode, Devin, cursor-agent — exit immediately on the flag form with `error: unknown option '--acp'`, so every affected agent failed to start.
- The reporter's environment shows a harness definition whose Arguments field contains `--acp` (persisted state / manual entry): the Kimi preset itself already ships `args: &["acp"]` and hint text `(kimi acp)` on main, so this fixes the flag form at the single shared normalization seam instead of chasing each persisted definition.
- Flag-style harnesses are unchanged: `codex-acp` / `claude-*` / `buzz-agent` still strip the ACP arg to empty via the existing rule, and no flag-style ACP CLI accepts a literal `--acp`, so this is a pure repair. Non-`acp` args pass through untouched.

## Root cause
`normalize_agentargs` trimmed and filtered args but passed a literal `--acp` straight through to the spawned command (`BUZZ_ACP_AGENT_ARGS` → `buzz-acp` clap `value_delimiter=','`). Modern Kimi CLI parses it as an unknown option and exits, so `buzz-acp` reports "agent process exited unexpectedly / all N agents failed to start".

## Changes
- `desktop/src-tauri/src/managed_agents/discovery.rs`: `--acp`/`-acp` → `acp` canonicalization inside `normalize_agent_args` (case-insensitive), with a comment explaining the repair.
- `desktop/src-tauri/src/managed_agents/discovery/tests.rs:98-139`: new `canonicalizes_stray_acp_flag_to_subcommand` regression test covering bare `kimi`, path-form `.../bin/kimi`, `opencode`, case-insensitivity, multi-arg preservation, correct-form passthrough, `codex-acp` strip-to-empty, and non-acp flag passthrough.

## Verification
- `cargo test --lib canonicalizes_stray_acp_flag_to_subcommand` — pass.
- `cargo test --lib normalize` — 26 passed, 0 failed (includes existing agent-args tests).
- `cargo test --lib discovery` — 245 passed, 0 failed.
- `cargo test --lib readiness` — 56 passed, 0 failed.
- `pnpm typecheck` — clean.

Fixes #4106
