### PR TITLE
fix(acp): recover idle thread mentions

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -362,8 +362,10 @@ const GOOSE_STEER_METHOD: &str = "_goose/unstable/session/steer";
 
 /// The cross-adapter mid-turn steer method, shipped by claude-agent-acp
 /// (`src/acp-agent.ts:200`) and codex-acp (`src/AcpExtensions.ts:11`).
-/// Params are `{sessionId, prompt}` — no run id — and the result is
-/// `{outcome}`. Gated on [`AcpClient::steering_supported`].
+/// Params are `{sessionId, prompt, _meta}` — no run id — and the result is
+/// `{outcome}`. The request opts into host-owned idle fallback so an adapter
+/// can return `promptRequired` without detaching a new turn. Gated on
+/// [`AcpClient::steering_supported`].
 const ACP_STEER_METHOD: &str = "_session/steering";
 
 /// `outcome` value meaning the steer was applied to the turn Buzz is waiting
@@ -375,6 +377,15 @@ const STEER_OUTCOME_INJECTED: &str = "injected";
 /// success, but the awaited turn is over — see the steer-response arm for why
 /// this must not renew the hard deadline.
 const STEER_OUTCOME_STARTED_NEW_TURN: &str = "startedNewTurn";
+
+/// `outcome` value meaning the adapter found no running turn and deliberately
+/// left the steer content untouched for Buzz to resubmit through
+/// `session/prompt`.
+const STEER_OUTCOME_PROMPT_REQUIRED: &str = "promptRequired";
+
+/// Required companion reason for [`STEER_OUTCOME_PROMPT_REQUIRED`]. Unknown
+/// reasons are rejected rather than treated as safe-to-retry delivery states.
+const STEER_REASON_NO_RUNNING_TURN: &str = "noRunningTurn";
 
 /// Which wire method carried an in-flight steer request, recorded so the
 /// response arm decodes the shape that method actually returns.
@@ -1573,9 +1584,51 @@ impl AcpClient {
                                                 .filter(|o| {
                                                     *o == STEER_OUTCOME_INJECTED
                                                         || *o == STEER_OUTCOME_STARTED_NEW_TURN
+                                                        || *o == STEER_OUTCOME_PROMPT_REQUIRED
                                                 }),
                                         };
                                         match outcome {
+                                            Some(STEER_OUTCOME_PROMPT_REQUIRED)
+                                                if msg
+                                                    .pointer("/result/reason")
+                                                    .and_then(|v| v.as_str())
+                                                    == Some(STEER_REASON_NO_RUNNING_TURN) =>
+                                            {
+                                                // The adapter did not consume
+                                                // the content. Release the
+                                                // withheld event so normal
+                                                // dispatch submits it through
+                                                // session/prompt after the
+                                                // just-settled prompt response
+                                                // reaches this read loop.
+                                                tracing::info!(
+                                                    "steer requires host prompt: no running turn — \
+                                                     releasing withheld event for session/prompt"
+                                                );
+                                                crate::pool::SteerAck::PromptRequired
+                                            }
+                                            Some(STEER_OUTCOME_PROMPT_REQUIRED) => {
+                                                let reported_reason =
+                                                    msg.pointer("/result/reason").map_or_else(
+                                                        || "<absent>".to_string(),
+                                                        |reason| match reason {
+                                                            serde_json::Value::String(s) => {
+                                                                s.clone()
+                                                            }
+                                                            other => other.to_string(),
+                                                        },
+                                                    );
+                                                tracing::warn!(
+                                                    "steer rejected: {STEER_OUTCOME_PROMPT_REQUIRED} \
+                                                     returned unrecognized reason {reported_reason}"
+                                                );
+                                                crate::pool::SteerAck::Err(
+                                                    crate::pool::SteerError::OutcomeRejected {
+                                                        outcome: STEER_OUTCOME_PROMPT_REQUIRED
+                                                            .to_string(),
+                                                    },
+                                                )
+                                            }
                                             Some(STEER_OUTCOME_STARTED_NEW_TURN) => {
                                                 // Delivered, but into a NEW
                                                 // turn: the one this read loop
@@ -1989,7 +2042,11 @@ fn build_goose_steer_params(
 ///
 /// Wire shape:
 /// ```json
-/// { "sessionId": "...", "prompt": [{"type":"text","text":"..."}, ...] }
+/// {
+///   "sessionId": "...",
+///   "prompt": [{"type":"text","text":"..."}, ...],
+///   "_meta": {"steering":{"idleBehavior":"promptRequired"}}
+/// }
 /// ```
 ///
 /// Deliberately carries **no** `expectedRunId`: the cross-adapter method
@@ -1999,6 +2056,11 @@ fn build_acp_steer_params(session_id: &str, prompt_blocks: &[&str]) -> serde_jso
     serde_json::json!({
         "sessionId": session_id,
         "prompt": steer_prompt_blocks(prompt_blocks),
+        "_meta": {
+            "steering": {
+                "idleBehavior": STEER_OUTCOME_PROMPT_REQUIRED,
+            }
+        },
     })
 }
 
@@ -3877,9 +3939,10 @@ mod tests {
     }
 
     /// Test 2: no `active_run_id` + capability advertised → the bytes on the
-    /// wire are an `_session/steering` request carrying `sessionId` and
-    /// `prompt`, and carrying **no** `expectedRunId` (the adapters reject
-    /// unknown required fields, and there is no run id to report anyway).
+    /// wire are an `_session/steering` request carrying `sessionId`, `prompt`,
+    /// and the host-owned idle fallback opt-in, while carrying **no**
+    /// `expectedRunId` (the adapters reject unknown required fields, and there
+    /// is no run id to report anyway).
     #[tokio::test]
     async fn acp_steer_request_omits_expected_run_id_and_carries_session_and_prompt() {
         let capture = capture_path("acp_shape");
@@ -3910,6 +3973,11 @@ mod tests {
             Some("steer body"),
             "prompt must carry the steer body as a text block"
         );
+        assert_eq!(
+            msg["params"]["_meta"]["steering"]["idleBehavior"].as_str(),
+            Some(STEER_OUTCOME_PROMPT_REQUIRED),
+            "Buzz must retain ownership when the adapter finds no running turn"
+        );
         assert!(
             msg["params"].get("expectedRunId").is_none(),
             "_session/steering must not carry expectedRunId; wrote: {written}"
@@ -3918,6 +3986,51 @@ mod tests {
             matches!(ack, crate::pool::SteerAck::Success),
             "injected outcome must ack Success, got {ack:?}"
         );
+    }
+
+    /// Claude ACP 0.64+ can report that the turn settled before the steer
+    /// landed. The adapter leaves the content untouched, so Buzz must release
+    /// the withheld event for a normal `session/prompt` instead of treating it
+    /// as delivered or firing cancel+merge against a turn that no longer runs.
+    #[tokio::test]
+    async fn acp_steer_prompt_required_releases_for_host_prompt() {
+        let capture = capture_path("prompt_required");
+        let mut client = spawn_steer_capture_script(
+            &capture,
+            r#"{"jsonrpc":"2.0","id":0,"result":{"outcome":"promptRequired","reason":"noRunningTurn"}}"#,
+        )
+        .await;
+        set_steering_supported(&mut client);
+
+        let (_written, ack) = run_one_steer(&mut client, &capture).await;
+
+        assert!(
+            matches!(ack, crate::pool::SteerAck::PromptRequired),
+            "promptRequired/noRunningTurn must return content to host dispatch, got {ack:?}"
+        );
+    }
+
+    /// A future or malformed `promptRequired` response must not enter the
+    /// no-cancel retry path unless it carries the one reason whose ownership
+    /// contract Buzz understands.
+    #[tokio::test]
+    async fn acp_steer_prompt_required_with_unknown_reason_is_rejected() {
+        let capture = capture_path("prompt_required_unknown_reason");
+        let mut client = spawn_steer_capture_script(
+            &capture,
+            r#"{"jsonrpc":"2.0","id":0,"result":{"outcome":"promptRequired","reason":"unknown"}}"#,
+        )
+        .await;
+        set_steering_supported(&mut client);
+
+        let (_written, ack) = run_one_steer(&mut client, &capture).await;
+
+        match ack {
+            crate::pool::SteerAck::Err(crate::pool::SteerError::OutcomeRejected { outcome }) => {
+                assert_eq!(outcome, STEER_OUTCOME_PROMPT_REQUIRED);
+            }
+            other => panic!("expected Err(OutcomeRejected), got {other:?}"),
+        }
     }
 
     /// Test 3: goose keeps priority. With both an `active_run_id` and the

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2437,6 +2437,13 @@ async fn tokio_main() -> Result<()> {
                 //     the agent really is running more work, so the
                 //     channel's in-flight budget should reflect it.
                 //
+                //   PromptRequired
+                //     The adapter found no running turn and left the content
+                //     untouched under Buzz's host-owned idle fallback opt-in.
+                //     Release the withheld event for normal `session/prompt`
+                //     dispatch. Do NOT signal cancel+merge: the prior turn is
+                //     already settled.
+                //
                 //   Err(_) where the write never landed (Transport /
                 //   ExpectedRunIdMissing):
                 //     Delivery state of the underlying message is "never
@@ -2494,6 +2501,7 @@ async fn tokio_main() -> Result<()> {
                 //     the withheld event in `withheld_native_steer`.
                 let (release_withheld, drop_withheld, signal_fallback) = match &ack {
                     Ok(pool::SteerAck::Success) => (false, true, false),
+                    Ok(pool::SteerAck::PromptRequired) => (true, false, false),
                     // -32601 = method_not_found: agent does not implement the
                     // steer extension. Fire cancel+merge so the message still
                     // reaches the agent.

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -396,6 +396,11 @@ pub enum SteerAck {
     /// The main loop must drop the withheld event (`remove_event`) — it
     /// has been delivered via the non-cancelling path.
     Success,
+    /// The adapter found no running turn and, because Buzz opted into the
+    /// host-owned idle fallback, did not consume the steer content. The main
+    /// loop must release the withheld event for normal `session/prompt`
+    /// dispatch without signalling cancel+merge against the settled turn.
+    PromptRequired,
     /// The steer was attempted but failed. Delivery state for the
     /// underlying message is unknown after prompt completion; the main
     /// loop must release the withheld event and fall back to the

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -693,10 +693,10 @@ impl EventQueue {
     /// Release a single withheld event back to the front of
     /// `queues[channel_id]`, preserving its original `received_at`.
     ///
-    /// Called on `SteerAck::Err(_)` and `SteerAck::PromptCompletedNeutral`
-    /// (delivery unknown after prompt completion; restoring queued event
-    /// for normal dispatch). Idempotent: a no-op if the event was already
-    /// removed or never withheld.
+    /// Called on `SteerAck::Err(_)`, `SteerAck::PromptRequired`, and
+    /// `SteerAck::PromptCompletedNeutral` (content not delivered through the
+    /// native steer path; restoring the queued event for normal dispatch).
+    /// Idempotent: a no-op if the event was already removed or never withheld.
     ///
     /// Push-to-front matches the discipline of `requeue_preserve_timestamps`
     /// at line 453, preserving fairness across channels.


### PR DESCRIPTION
## Problem

An idle managed agent can receive a thread-reply mention through Buzz's non-cancelling steer path after the prior turn has already settled. Claude ACP 0.64 reports this state as `promptRequired` / `noRunningTurn` when the host opts into owning the fallback. Buzz did not send that opt-in or recognize that response, so it could not safely return the untouched event to normal `session/prompt` dispatch.

Closes #3282.

## Fix

- opt into `_meta.steering.idleBehavior = "promptRequired"` on `_session/steering`
- recognize only the paired `promptRequired` / `noRunningTurn` response as an untouched event
- release that event for normal `session/prompt` dispatch without signalling cancel-and-merge against a settled turn
- reject unknown `promptRequired` reasons so future protocol changes cannot silently drop or duplicate content
- cover the request shape, successful host fallback, and malformed-reason path with regression tests

## Impact

Idle thread mentions are no longer consumed as control-only input when Claude reports that no turn is running. Existing `injected`, `startedNewTurn`, Goose run-id steering, method-not-found, and cancel-and-merge behavior remains unchanged.

## Validation

At commit `2de0f4d3f396d069d032000b10d0d5da8ce75058`:

- `cargo test -p buzz-acp --quiet` — 663 unit tests and 9 lifecycle tests passed
- `cargo clippy -p buzz-acp --all-targets --quiet -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- broader `just ci` attempt passed workspace clippy, Desktop checks, Desktop Tauri clippy, web checks, mobile formatting/analysis, and the core/auth/voice unit packages; the host then exhausted disk space while compiling unrelated remaining packages

## Origin

Buzz channel: `3667f55e-b52e-584f-8f71-dafdf62169be`

Buzz thread: `buzz://message?channel=3667f55e-b52e-584f-8f71-dafdf62169be&id=de56f8ac4a9c41cc417d81537db3fe007bcd5850b456c393fb681cae7331490f`
