### PR TITLE
test(relay): skip 2 PG-dependent admin report/feedback 404 tests when BUZZ_TEST_DATABASE_URL unset

### DIFF
--- a/crates/buzz-relay/src/api/admin/mod.rs
+++ b/crates/buzz-relay/src/api/admin/mod.rs
@@ -390,6 +390,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires a live Postgres: set BUZZ_TEST_DATABASE_URL"]
     async fn report_detail_rejects_unknown_report() {
         let response = router(test_state().await)
             .oneshot(
@@ -420,6 +421,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires a live Postgres: set BUZZ_TEST_DATABASE_URL"]
     async fn feedback_attachment_rejects_unknown_feedback() {
         let response = router(test_state().await)
             .oneshot(


### PR DESCRIPTION
test(relay): skip 2 PG-dependent admin report/feedback 404 tests when BUZZ_TEST_DATABASE_URL unset

## Summary

`crates/buzz-relay/src/api/admin/mod.rs` has two PG-dependent integration tests that fail hard without a live Postgres, mirroring the exact problem tracked in #4080 for `api::media::tests`:

- `admin::tests::report_detail_rejects_unknown_report`
- `admin::tests::feedback_attachment_rejects_unknown_feedback`

Both call `test_state()` which eagerly seeds a community via `ensure_configured_community` — panicking when `BUZZ_DATABASE_URL` is unset (and hitting `PoolTimedOut` / connect errors when it points at a dead database), surfacing as a 500 rather than the expected 404.

Sibling 403 (admin-host gate) tests continue to pass without Postgres — these two are the only ones that hit the post-`authorize` DB call.

## Fix

Apply the same `#[ignore = "requires a live Postgres: set BUZZ_TEST_DATABASE_URL"]` attribute pattern used in:

- `crates/buzz-search/tests/fts_integration.rs`
- `crates/buzz-relay/src/api/media.rs` (landed for #4080)

## Testing

In a PG-less environment with `BUZZ_TEST_DATABASE_URL` / `BUZZ_DATABASE_URL` unset:

```
cargo test -p buzz-relay --lib admin::tests::
test result: ok. 28 passed; 0 failed; 2 ignored; 0 measured; 838 filtered out; finished in 0.12s
```

Both target tests are ignored (as expected); all sibling admin tests pass. Opt back into the live-Postgres surface with:

```sh
BUZZ_TEST_DATABASE_URL=postgres://buzz:buzz_dev@localhost:5432/buzz \
  cargo test -p buzz-relay -- --include-ignored
```

## Follow-up (out of scope)

Refactoring `test_state()` to stop eagerly seeding a community (the same DX problem called out in #4080) would let even more admin tests run without PG.

Fixes #4083
