### PR TITLE
fix(desktop): keep live foreign agents in mention and add-member autocomplete

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -5,7 +5,7 @@ import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isKnownLiveAgentIdentity,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
@@ -136,27 +136,44 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
-test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
+test("isKnownLiveAgentIdentity: keeps people, managed agents, and directory-listed foreign agents", () => {
   const managedAgentPubkeys = new Set([PUB_A]);
+  const directoryAgentPubkeys = new Set([PUB_C]);
 
+  // People always pass.
   assert.equal(
-    isAgentIdentityInManagedList(
+    isKnownLiveAgentIdentity(
       { isAgent: false, pubkey: PUB_B },
       managedAgentPubkeys,
+      directoryAgentPubkeys,
     ),
     true,
   );
+  // Locally managed agent passes (pubkey normalization included).
   assert.equal(
-    isAgentIdentityInManagedList(
+    isKnownLiveAgentIdentity(
       { isAgent: true, pubkey: PUB_A.toUpperCase() },
       managedAgentPubkeys,
+      directoryAgentPubkeys,
     ),
     true,
   );
+  // Foreign agent with a live relay directory entry (kind:10100) passes —
+  // e.g. an agent managed by another desktop that is a channel member.
   assert.equal(
-    isAgentIdentityInManagedList(
+    isKnownLiveAgentIdentity(
+      { isAgent: true, pubkey: PUB_C },
+      managedAgentPubkeys,
+      directoryAgentPubkeys,
+    ),
+    true,
+  );
+  // Stale agent identity — neither managed nor in the directory — is dropped.
+  assert.equal(
+    isKnownLiveAgentIdentity(
       { isAgent: true, pubkey: PUB_B },
       managedAgentPubkeys,
+      directoryAgentPubkeys,
     ),
     false,
   );

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -54,13 +54,26 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
-export function isAgentIdentityInManagedList(
+/**
+ * A concrete agent identity is kept in autocomplete only when there is live
+ * evidence for it: the current user's managed Agents list, or a relay agent
+ * directory entry (kind:10100) published by its owning desktop. Stale
+ * identities — old p-tag/channel-member keys with no directory entry — are
+ * dropped. People are always kept. Whether a surviving foreign agent is
+ * ultimately shown is decided by `shouldHideAgentFromMentions`, which hides
+ * explicitly non-invocable ones.
+ */
+export function isKnownLiveAgentIdentity(
   candidate: { isAgent?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
+  directoryAgentPubkeys: ReadonlySet<string>,
 ) {
+  if (candidate.isAgent !== true) {
+    return true;
+  }
+  const normalized = normalizePubkey(candidate.pubkey);
   return (
-    candidate.isAgent !== true ||
-    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
+    managedAgentPubkeys.has(normalized) || directoryAgentPubkeys.has(normalized)
   );
 }
 

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -9,7 +9,7 @@ import {
 import { attachManagedAgentToChannel } from "@/features/agents/channelAgents";
 import {
   coalesceAgentAutocompleteCandidates,
-  isAgentIdentityInManagedList,
+  isKnownLiveAgentIdentity,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
@@ -272,6 +272,11 @@ export function MembersSidebar({
         .filter((label): label is string => Boolean(label)),
     );
     const managedAgentPubkeys = new Set(managedAgentsByPubkey.keys());
+    const directoryAgentPubkeys = new Set(
+      (relayAgentsQuery.data ?? []).map((agent) =>
+        normalizePubkey(agent.pubkey),
+      ),
+    );
 
     const addCandidate = (candidate: AddMemberSearchCandidate) => {
       const pubkey = normalizePubkey(candidate.pubkey);
@@ -282,7 +287,11 @@ export function MembersSidebar({
           )) ||
         memberPubkeys.has(pubkey) ||
         isArchivedDiscovery(pubkey) ||
-        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+        !isKnownLiveAgentIdentity(
+          candidate,
+          managedAgentPubkeys,
+          directoryAgentPubkeys,
+        )
       ) {
         return;
       }

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,7 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isKnownLiveAgentIdentity,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,7 +246,13 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (
+        !isKnownLiveAgentIdentity(
+          candidate,
+          managedAgentPubkeys,
+          directoryAgentPubkeys,
+        )
+      ) {
         return;
       }
       if (


### PR DESCRIPTION
## Problem

Since #2149, the composer's `@`-mention autocomplete and the members-sidebar add-member search drop **every concrete agent identity that is not in the current user's local managed Agents list** — including live, invocable agents owned by another desktop that are members of the current channel.

`useMentions.addCandidate` returns early via `isAgentIdentityInManagedList(...)` before `shouldHideAgentFromMentions(...)` (#1611) ever runs, so the whole "member / invocable / directory-exclusion" decision table from #1611 is unreachable for foreign agents. The same gate sits in `MembersSidebar.tsx`.

Concrete repro (two desktops, one relay):

1. Desktop B manages agent `GADS MacMini` and adds it to a shared channel.
2. On desktop A (different owner), open that channel and type `@gads`.
3. No suggestion appears — in the channel *or* in a 1:1 DM with the agent — even though the agent is a channel member, online, and listed in the relay agent directory (kind:10100). Send-time mention extraction (`extractMentionPubkeys`) scans the same candidate list, so typing the full name doesn't p-tag it either: the agent is effectively unmentionable from any other device.

Meanwhile #2149's goal is real: stale p-tag/member identities (superseded agent keys) should not resurface.

## Fix

Rename the gate to `isKnownLiveAgentIdentity` and let a **relay agent directory entry (kind:10100)** count as live evidence alongside the local managed list. Everything else is unchanged — surviving foreign agents still flow through `shouldHideAgentFromMentions`, so explicitly non-invocable ones stay hidden.

| candidate | before | after |
|---|---|---|
| person | show | show |
| locally managed agent | show | show |
| foreign agent, in directory, invocable (shared channel / allowlist) | **dropped** | show |
| foreign agent, in directory, not invocable ("Fizz", #1611) | dropped | hidden by `shouldHideAgentFromMentions` (as designed) |
| stale identity — no directory entry, not managed (#2149's Bumble) | dropped | dropped |

Applied to both call sites (`useMentions.ts`, `MembersSidebar.tsx`); `MembersSidebar` already had `relayAgentsQuery` in scope and in the memo deps.

## Tests

- `agentAutocompleteEligibility.test.mjs`: reworked the gate's test to cover person / managed / directory-listed-foreign / stale branches
- `pnpm test` → 3906/3906 pass
- `tsc --noEmit` → 0 errors
- `biome check` on the 4 changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
