### PR TITLE
fix(acp): respawn on adapter-wrapped child-process exit errors (#4127)

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3028,6 +3028,28 @@ fn is_auth_error(error: &acp::AcpError) -> bool {
     message.contains("Re-authenticate") || message.contains("API Error: 401")
 }
 
+/// Returns true when an [`acp::AcpError::AgentError`] actually reports a dead
+/// agent *process* — i.e., the underlying adapter's child has exited but the
+/// adapter wrapped it as a JSON-RPC application error instead of the
+/// transport-class [`acp::AcpError::AgentExited`].
+///
+/// #4127: the Claude Code adapter (and others) surface their child-process
+/// death as `AgentError { code: -32603, message: "..exited unexpectedly" }`.
+/// Routing that through the application-error arm returns the corpse to the
+/// pool, poisoning every subsequent turn on the slot with the same error.
+///
+/// The exact substring is the wording adapters use for their "the child has
+/// exited" case (`buzz-acp`'s canonical form in [`acp::AcpError::AgentExited`]
+/// is the same phrase, keeping this in lockstep). False positives trigger an
+/// extra respawn — strictly better than the alternative (a slot that stays
+/// dead until process restart).
+fn is_agent_exit_error(error: &acp::AcpError) -> bool {
+    let acp::AcpError::AgentError { message, .. } = error else {
+        return false;
+    };
+    message.contains("exited unexpectedly")
+}
+
 /// Spawn a task that posts a user-visible failure notice to the relay.
 ///
 /// Shared by the hard-cap immediate dead-letter path and the retries-exhausted
@@ -3341,13 +3363,19 @@ fn handle_prompt_result(
         }
         // Errors fall into two categories:
         //
-        // 1. Transport-class (Io, WriteTimeout, Timeout, Protocol): the stdio
-        //    pipe may be corrupted or the agent desynchronized. These are fatal
-        //    to the agent regardless of whether they occurred during session
-        //    creation or an active prompt — respawn unconditionally.
+        // 1. Transport-class (Io, WriteTimeout, Timeout, Protocol, AgentExited,
+        //    and AgentError whose message reports the child process exited —
+        //    see #4127): the stdio pipe may be corrupted or the agent process
+        //    itself is dead. These are fatal to the slot regardless of whether
+        //    they occurred during session creation or an active prompt —
+        //    respawn unconditionally. Some adapters surface child-process death
+        //    as `AgentError` instead of the dedicated `AgentExited` variant; we
+        //    recognise that shape via `is_agent_exit_error` so the corpse does
+        //    not round-trip through the pool.
         //
-        // 2. Application-class (IdleTimeout, HardTimeout, Json): the pipe is
-        //    intact but the prompt failed. Return the agent to the pool so it
+        // 2. Application-class (IdleTimeout, HardTimeout, Json, remaining
+        //    AgentError shapes): the pipe is intact and the agent process is
+        //    alive, but the prompt failed. Return the agent to the pool so it
         //    can be reused for the next event.
 
         // Intentional cancel — agent is healthy, return it to the pool.
@@ -3371,7 +3399,8 @@ fn handle_prompt_result(
                     | acp::AcpError::WriteTimeout(_)
                     | acp::AcpError::Timeout(_)
                     | acp::AcpError::Protocol(_)
-            );
+                    | acp::AcpError::AgentExited
+            ) || is_agent_exit_error(e);
             let error_code = match &e {
                 acp::AcpError::AgentError { code, .. } => Some(*code),
                 _ => None,
@@ -6250,6 +6279,60 @@ mod error_outcome_emission_tests {
             !is_auth_error(&timeout),
             "WriteTimeout must not be classified as auth error"
         );
+    }
+
+    // ── is_agent_exit_error classification (#4127) ──────────────────────────
+
+    #[test]
+    fn is_agent_exit_error_matches_adapter_exited_unexpectedly_message() {
+        let e = acp::AcpError::AgentError {
+            code: -32603,
+            message: "Internal error: The Claude Agent process exited unexpectedly".to_string(),
+        };
+        assert!(
+            is_agent_exit_error(&e),
+            "adapter-wrapped child-process death must be classified as exit-class"
+        );
+    }
+
+    #[test]
+    fn is_agent_exit_error_rejects_other_agent_error_messages() {
+        // Auth errors, schema errors, and rate-limit errors must NOT be
+        // reclassified as exit-class — they don't imply a dead process and
+        // respawning on them wastes the slot's restart budget.
+        for (code, message) in [
+            (
+                -32000,
+                "API Error: 401 OAuth access token has expired. Re-authenticate to continue.",
+            ),
+            (-32601, "Method not found"),
+            (-32602, "Invalid params"),
+            (
+                -32000,
+                "API Error: 429 rate limited — please retry after 30 seconds",
+            ),
+        ] {
+            let e = acp::AcpError::AgentError {
+                code,
+                message: message.to_string(),
+            };
+            assert!(
+                !is_agent_exit_error(&e),
+                "{message} must NOT be classified as exit-class"
+            );
+        }
+    }
+
+    #[test]
+    fn is_agent_exit_error_rejects_transport_and_other_variants() {
+        // Non-AgentError variants must never be classified as exit-class —
+        // they're already handled by their own transport/timeout arms.
+        let io = acp::AcpError::Io(std::io::Error::other("pipe broke"));
+        assert!(!is_agent_exit_error(&io));
+        let idle = acp::AcpError::IdleTimeout(std::time::Duration::from_secs(1));
+        assert!(!is_agent_exit_error(&idle));
+        let protocol = acp::AcpError::Protocol("bad handshake".to_string());
+        assert!(!is_agent_exit_error(&protocol));
     }
 
     // ── auth error dead-letter behavior ────────────────────────────────────


### PR DESCRIPTION
## S18 — Public Guest Studio + Linear-Motion Homepage

Two-part delivery on `s18-public-studio-linear-motion` (base `s15-interface-craft-polish`):

1. **Public guest studio** — invisible per-browser guest identity, no login ceremony, authorization/isolation/rate-limits preserved
2. **Linear-system homepage** — payment-method-agnostic, three-fold layout, GSAP ScrollTrigger motion, proper footer, honest vision messaging

---

### What changed

**P3 — public guest sessions (auth)**
- `middleware.ts`: provisions an invisible per-browser guest identity via `admin.createUser` + `signInWithPassword` on the first non-public request. `PUBLIC_ROUTES = ["/api/health"]`; `/login` → `/flows`; unauthenticated `/api/*` → 401 JSON.
- Guest provisioning is rate-limited to **500/day** through `api_rate_limits` scope `juno:guest-provision`, and is **fail-closed** (a quota/infra error stops provisioning rather than opening access).
- Juspay-only gate removed from `lib/auth/studio-context.ts` (dev-bypass preserved for local). `signOut`, `/login`, and `/auth/callback` deleted. Studio pages render for any authenticated `user`.

**F17 — Linear-system homepage (`app/page.tsx`)**
- Acid `#e4f222` single CTA accent on void `#08090a`; hairline `0.5px`-weight borders; stacked "How it works" step rows with mono `01/02/03`; a Proof fold with mono artifact metadata chips (`render_8f2a · 30fps · 00:14 · 1080×1920 · H.264`) + a 4-stat grid; hairline footer.
- Copy is **payment-method-agnostic** — no UPI / Intent / Collect / Autopay / GPay language.

**F18 — GSAP motion (`components/marketing/MarketingMotion.tsx`)**
- Client island registering one **paused** GSAP timeline per `[data-mo]` container, driven by `ScrollTrigger` (`once: true`, `start: "top 88%"`). `y 24→0` + `opacity 0→1`, `duration 0.55s`, `ease power2.out`, `stagger 80ms`.
- `prefers-reduced-motion` early-returns (no animation code runs); `display: contents` wrapper so the server-rendered sections stay direct children of `<main>`.

**Migration `supabase/migrations/0005_guest_sessions.sql` — guest RLS**
- **Drops all 13 legacy policies** created by `0001_init.sql` — the broad `juspay users can read …` readers **and** the old per-owner insert/update/delete policies — then installs 5 strict per-browser policies keyed on `auth.uid()` (templates read-all; brands owner + seeded-read; flows owner; renders via owning flow).
- PostgreSQL OR-combines permissive RLS policies, so the legacy drops are required for strict per-browser isolation to actually bind.
- ⚠️ **Not yet applied to the remote.** Delivered as paste-ready SQL for the dashboard SQL editor because local (`0001`–`0005`, applied manually) and remote (55+ ad-hoc timestamped migrations) migration history diverged and `supabase db push` refuses to run rather than risk replaying them. The authenticated CLI `link` was made read-only and the migration lock acquired + released.

---

### Gate receipts

| Check | Result |
|---|---|
| `pnpm typecheck` | ✅ clean |
| `pnpm lint` | ✅ 0 errors (2 pre-existing `redirect` unused-import warnings) |
| `pnpm build` | ✅ compiled + static params + all routes |
| A11y (`morning/a11y-receipt.txt`) | ✅ PASS — 0 critical/serious on landing/flows/flow-detail |
| F20 renders | ✅ intent 456KB · collect 511KB · autopay 590KB, all exit 0 |
| F19 Higgsfield acid hero | ⚠️ `not_enough_credits` — honest receipt `morning/higgsfield-receipts/hero-create-s18-acid.json`; prior asset retained |
| Fidelity | Honest bootstrap-pass (Figma MCP unavailable this session) |

### Two fix-forward commits folded in
- `MarketingMotion` now **wraps** the animated sections as `children` (was an empty sibling → TS2741 + animation never observed).
- A11y fix: muted metadata text `#62666d → #8a8f98` (3.45 → 6.13:1) — caught by the a11y gate on the new homepage.
- `tests/e2e/demo-loop.spec.ts`: dropped the deprecated `NEXT_PUBLIC_AUTH_BYPASS` gate — guest sessions are the always-available path under S18.

### Blocking follow-up (needs Sarthak, ~2 min)
Apply `supabase/migrations/0005_guest_sessions.sql` in the Supabase SQL editor on `djmnndnyzmesyiigvvzs`. The two-browser guest-isolation E2E against the **live** DB will 403 on writes until this lands.

Decision log: `decisions/CLAUDE-DECISIONS.md` (D18-1 → D18-5).
