### PR TITLE
Add Novita AI as a provider option

### DIFF
--- a/crates/buzz-agent/README.md
+++ b/crates/buzz-agent/README.md
@@ -24,7 +24,7 @@
                                   Anthropic Messages API,
                                    OpenRouter, or any OpenAI-compat
                                   (vLLM, llama.cpp, Databricks,
-                                   Block Gateway, Ollama, …)
+                                   Block Gateway, Novita AI, Ollama, …)
 ```
 
 A client sends `session/prompt`. The agent loops: call the LLM → get tool calls → run them via MCP → feed results back → repeat. The loop terminates when the LLM stops asking for tools, the round cap is hit, or the client cancels.
@@ -142,7 +142,7 @@ Everything is environment variables. No flags, no config files. (We are a subpro
 | `ANTHROPIC_API_VERSION` | `2023-06-01` | |
 | `OPENAI_COMPAT_API_KEY` | — | Required when provider=openai. |
 | `OPENAI_COMPAT_MODEL` | — | Required when provider=openai. |
-| `OPENAI_COMPAT_BASE_URL` | `https://api.openai.com/v1` | Point at vLLM, llama.cpp, Ollama, etc. |
+| `OPENAI_COMPAT_BASE_URL` | `https://api.openai.com/v1` | Point at vLLM, llama.cpp, Novita AI, Ollama, etc. |
 | `OPENAI_COMPAT_API` | `auto` | `auto` \| `chat` \| `responses`. `auto` picks Responses for `*.openai.com`, Chat Completions everywhere else. |
 | `OPENROUTER_API_KEY` | — | Required when provider=openrouter. |
 | `OPENROUTER_MODEL` | — | Required when provider=openrouter. Use OpenRouter's `vendor/model` id, e.g. `anthropic/claude-sonnet-4.5`. |
@@ -177,6 +177,7 @@ Everything is environment variables. No flags, no config files. (We are a subpro
 | llama.cpp | `openai` | `POST {base}/chat/completions` | any tool-calling GGUF |
 | Ollama | `openai` | `POST {base}/chat/completions` | llama3.1, qwen2.5-coder |
 | Block Gateway | `openai` | `POST {base}/chat/completions` | gpt-5, claude |
+| Novita AI | `openai` | `POST {base}/chat/completions` | deepseek/deepseek-v3.2, moonshotai/kimi-k2.6 |
 | OpenRouter | `openrouter` | `POST {base}/chat/completions` | anything they route (extended-thinking replay, provider-agnostic tool calling) |
 | Databricks | `databricks` | `POST {host}/serving-endpoints/{model}/invocations` | goose-claude-4-6-sonnet |
 | Databricks AI Gateway v2 | `databricks_v2` | `POST {host}/ai-gateway/{provider}/v1/...` | databricks-gpt-5-5, databricks-claude-opus-4-7 |

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -1060,7 +1060,7 @@ fn parse_openai_api(raw: Option<&str>) -> Result<OpenAiApi, String> {
 
 /// `true` when `base_url` is an official OpenAI host. Hosts on
 /// `*.openai.com` get Responses under `Auto`; everything else (vLLM,
-/// Ollama, OpenRouter, Block Gateway, …) gets Chat Completions.
+/// Ollama, OpenRouter, Novita AI, Block Gateway, …) gets Chat Completions.
 /// Lookalike-safe: `api.openai.com.evil.example` returns `false`.
 pub fn is_openai_host(base_url: &str) -> bool {
     let rest = match base_url
@@ -1309,6 +1309,7 @@ mod tests {
             ("http://eu.api.openai.com/v1", true),
             ("http://localhost:11434/v1", false),
             ("https://openrouter.ai/api/v1", false),
+            ("https://api.novita.ai/v3/openai", false),
             ("https://gateway.block.example/v1", false),
             ("https://api.openai.com.evil.example/v1", false),
             ("not a url", false),

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -1309,7 +1309,7 @@ mod tests {
             ("http://eu.api.openai.com/v1", true),
             ("http://localhost:11434/v1", false),
             ("https://openrouter.ai/api/v1", false),
-            ("https://api.novita.ai/v3/openai", false),
+            ("https://api.novita.ai/openai", false),
             ("https://gateway.block.example/v1", false),
             ("https://api.openai.com.evil.example/v1", false),
             ("not a url", false),


### PR DESCRIPTION
## Summary

- Adds Novita AI as a provider option.

## Validation

Compared against the baseline on `f3e5e812677f`: compared_to_baseline. Pre-existing failures are left as-is.

## Reviewer Notes

- This is a docs/config-only change (README provider table + one host-matrix unit test assertion); no new runtime code path was added, so `cargo test -p buzz-agent --lib config::` passing (121/121, from the original submission) demonstrates no regression, not that a live request against Novita's endpoint was exercised. This revision was made in an environment without a Rust toolchain, so it was not re-tested; the change is a single string literal swap in a test's input data, and the assertion's expected boolean is unaffected either way (neither URL is an `*.openai.com` host), but that is an inference, not a verified result.
- Only the `config::` unit test module was run (on the original submission), not the full crate, workspace, or desktop (`pnpm test`/`tsc`/`biome`) test suites — the sandbox's Rust toolchain build directory ran out of disk space until `CARGO_TARGET_DIR` was redirected to a separate volume, so wider verification (integration tests, desktop typecheck) was not attempted, then or in this revision.
- This PR deliberately does not add a Rust `Provider` enum variant or touch the desktop `PERSONA_LLM_PROVIDER_OPTIONS` dropdown — Novita AI is exposed only via the existing `provider=openai` + `OPENAI_COMPAT_BASE_URL` path, matching the most similar recent precedent (#3096, OrcaRouter). A reviewer may prefer first-class UI treatment instead, or none at all.
- CONTRIBUTING.md requests linking the closest existing PR (#3096, which adds a different third-party OpenAI-compatible provider in an identical two-file shape) and recommends opening an issue first for anything beyond a small fix; this branch does not include a PR description or issue, since that step is left to the maintainer of this submission.
- Six other third-party-provider PRs (#1975, #2053, #3055, #3152, #3096, #2464) have been open with zero review comments for days to weeks, including #3096 which is structurally identical to this change — there's no evidence this category of PR gets prompt attention.
- **The base URL literal in the host-matrix test was corrected in this revision.** The original commit used `https://api.novita.ai/v3/openai`, an older path that Novita's current documentation (novita.ai/docs/guides/llm-api) no longer shows; the currently documented endpoint is `https://api.novita.ai/openai`. Both paths return identical, working results today (verified against `/models` and `/chat/completions`), and the test's expected boolean is unchanged either way — so this was a stale citation rather than a functional break, but if your own testing shows Novita's API surface has moved again since 2026-08-01, please treat your own verification as authoritative over this PR's claim.
