### PR TITLE
buzz-acp: run independent threads concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,6 +813,7 @@ dependencies = [
  "httparse",
  "nix 0.31.3",
  "nostr",
+ "process-wrap",
  "reqwest 0.13.4",
  "rustls",
  "serde",
@@ -827,6 +828,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -76,6 +76,11 @@ evalexpr = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", default-features = false, features = ["signal"] }
 
+# Windows Job Objects provide stable process-tree ownership and kill-on-close.
+[target.'cfg(windows)'.dependencies]
+process-wrap = { version = "9.1.0", default-features = false, features = ["tokio1", "creation-flags", "job-object", "kill-on-drop"] }
+windows = { version = "0.62.2", features = ["Win32_System_Threading"] }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 httparse = "1"

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -10,11 +10,21 @@
 
 use futures_util::StreamExt;
 use tokio::io::AsyncWriteExt;
-use tokio::process::{Child, ChildStdin, ChildStdout};
+#[cfg(not(windows))]
+use tokio::process::Child;
+use tokio::process::{ChildStdin, ChildStdout};
 use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
+
+#[cfg(windows)]
+use process_wrap::tokio::ChildWrapper;
 
 use crate::observer::{ObserverContext, ObserverHandle};
 use crate::usage::{TurnUsage, UsageTracker};
+
+#[cfg(not(windows))]
+type ManagedChild = Child;
+#[cfg(windows)]
+type ManagedChild = Box<dyn ChildWrapper>;
 
 /// Maximum allowed size of a single NDJSON line from the agent's stdout.
 /// Lines exceeding this limit are rejected to prevent OOM from rogue agents.
@@ -141,7 +151,7 @@ fn build_initialize_params() -> serde_json::Value {
 /// same client via repeated calls to [`session_new`](AcpClient::session_new).
 pub struct AcpClient {
     /// The agent child process (kept alive to prevent zombie).
-    child: Child,
+    child: ManagedChild,
     /// Write end of the agent's stdin pipe.
     stdin: ChildStdin,
     /// Framed reader over the agent's stdout pipe (line-oriented, bounded).
@@ -396,9 +406,71 @@ fn build_client_capabilities() -> serde_json::Value {
     })
 }
 
+/// Stable-enough process generation identity for panic recovery on Linux.
+/// A numeric PID alone is never authority to kill: it may have been reused
+/// after the task-owned `AcpClient` unwound.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ProcessIdentity {
+    pid: u32,
+    linux_start_time_ticks: Option<u64>,
+}
+
+impl ProcessIdentity {
+    pub(crate) fn capture(pid: u32) -> Self {
+        Self {
+            pid,
+            linux_start_time_ticks: linux_process_start_time(pid),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn is_current(self) -> bool {
+        process_generation_matches(
+            self.linux_start_time_ticks,
+            linux_process_start_time(self.pid),
+        )
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    fn is_current(self) -> bool {
+        false
+    }
+}
+
+/// Parse field 22 (`starttime`) from `/proc/<pid>/stat`.
+/// The command name in field 2 may contain spaces and `)`, so split after its
+/// final closing parenthesis rather than splitting the whole line on spaces.
+#[cfg(any(target_os = "linux", test))]
+fn parse_linux_proc_start_time(stat: &str) -> Option<u64> {
+    let after_comm = stat.rsplit_once(')')?.1.trim_start();
+    // `after_comm` starts at field 3 (`state`); field 22 is zero-based index 19.
+    after_comm.split_whitespace().nth(19)?.parse().ok()
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn process_generation_matches(expected: Option<u64>, current: Option<u64>) -> bool {
+    matches!((expected, current), (Some(expected), Some(current)) if expected == current)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_start_time(pid: u32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    parse_linux_proc_start_time(&stat)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn linux_process_start_time(_pid: u32) -> Option<u64> {
+    None
+}
+
 impl AcpClient {
+    #[cfg(test)]
     pub(crate) fn process_id(&self) -> Option<u32> {
         self.child.id()
+    }
+
+    pub(crate) fn process_identity(&self) -> Option<ProcessIdentity> {
+        self.child.id().map(ProcessIdentity::capture)
     }
 
     /// Kill the agent subprocess and wait for it to exit (no zombies).
@@ -407,13 +479,15 @@ impl AcpClient {
     /// Call this when you need guaranteed cleanup — e.g., in `run_models`
     /// before process exit.
     pub async fn shutdown(&mut self) {
-        // Kill the entire process group when possible. The child was spawned
-        // with process_group(0), so its PID == its PGID. Killing the group
-        // ensures subprocesses (MCP servers, tool processes) are cleaned up
-        // rather than orphaned to init.
-        //
-        // Falls back to start_kill() (direct child only) on non-Unix or if
-        // the child has been polled to completion (id() returns None).
+        // Unix children own a process group. Windows children own a Job Object;
+        // its ChildWrapper::start_kill terminates the entire owned tree.
+        #[cfg(windows)]
+        {
+            if let Err(error) = self.child.start_kill() {
+                tracing::warn!(%error, "failed to terminate Windows ACP job object");
+            }
+        }
+        #[cfg(not(windows))]
         match self.child.id() {
             Some(pid) if kill_process_group(pid) => {}
             _ => {
@@ -509,18 +583,42 @@ impl AcpClient {
         #[cfg(unix)]
         cmd.process_group(0);
 
-        // Suppress the console window that Windows otherwise allocates for every
-        // console-subsystem child process spawned from a GUI/non-console parent.
-        configure_no_window(&mut cmd);
-
+        #[cfg(not(windows))]
         let mut child = cmd.spawn()?;
+        #[cfg(windows)]
+        let mut child = {
+            use process_wrap::tokio::{CommandWrap, CreationFlags, JobObject, KillOnDrop};
+            use windows::Win32::System::Threading::CREATE_NO_WINDOW;
 
+            // Spawn suspended, attach the process to a Windows Job Object, then
+            // resume it. KILL_ON_JOB_CLOSE gives this client one stable OS
+            // ownership handle for the leader and every descendant; PID reuse
+            // never participates in Windows termination authority.
+            let mut wrapped = CommandWrap::from(cmd);
+            wrapped.wrap(CreationFlags(CREATE_NO_WINDOW));
+            wrapped.wrap(KillOnDrop);
+            wrapped.wrap(JobObject);
+            wrapped.spawn()?
+        };
+
+        #[cfg(not(windows))]
         let stdin = child
             .stdin
             .take()
             .ok_or_else(|| AcpError::Protocol("failed to open agent stdin".into()))?;
+        #[cfg(windows)]
+        let stdin = child
+            .stdin()
+            .take()
+            .ok_or_else(|| AcpError::Protocol("failed to open agent stdin".into()))?;
+        #[cfg(not(windows))]
         let stdout = child
             .stdout
+            .take()
+            .ok_or_else(|| AcpError::Protocol("failed to open agent stdout".into()))?;
+        #[cfg(windows)]
+        let stdout = child
+            .stdout()
             .take()
             .ok_or_else(|| AcpError::Protocol("failed to open agent stdout".into()))?;
 
@@ -2055,9 +2153,16 @@ pub fn model_in_catalog(
 
 impl Drop for AcpClient {
     fn drop(&mut self) {
-        // Best-effort SIGKILL + reap. We cannot `await` in Drop (sync context).
-        // Kill the process group when possible so subprocesses don't leak.
+        // Best-effort kill + reap. We cannot await in Drop (sync context).
         // Callers SHOULD still call `shutdown().await` for guaranteed reaping.
+        #[cfg(windows)]
+        {
+            // JobObject + KillOnDrop closes stable ownership over the complete
+            // process tree. start_kill is synchronous TerminateJobObject; no PID
+            // lookup or shell helper participates in termination authority.
+            let _ = self.child.start_kill();
+        }
+        #[cfg(not(windows))]
         match self.child.id() {
             Some(pid) if kill_process_group(pid) => {}
             _ => {
@@ -2073,12 +2178,21 @@ impl Drop for AcpClient {
 /// Kill and reap a child whose `AcpClient` was dropped during panic unwind.
 /// The lane owner must not be released until this future resolves.
 #[cfg(unix)]
-pub(crate) async fn retire_orphaned_process(pid: u32) {
+pub(crate) async fn retire_orphaned_process(identity: ProcessIdentity) {
     let _ = tokio::task::spawn_blocking(move || {
         use nix::sys::signal::{kill, Signal};
         use nix::sys::wait::waitpid;
         use nix::unistd::Pid;
 
+        let pid = identity.pid;
+        if !identity.is_current() {
+            tracing::warn!(
+                pid,
+                expected_start_time = ?identity.linux_start_time_ticks,
+                "refusing to kill orphan by reused or unverifiable raw PID"
+            );
+            return;
+        }
         if !kill_process_group(pid) {
             let _ = kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
         }
@@ -2091,7 +2205,7 @@ pub(crate) async fn retire_orphaned_process(pid: u32) {
 }
 
 #[cfg(not(unix))]
-pub(crate) async fn retire_orphaned_process(_pid: u32) {}
+pub(crate) async fn retire_orphaned_process(_identity: ProcessIdentity) {}
 
 /// Send SIGKILL to an entire process group. Returns `true` if the signal was sent.
 ///
@@ -2110,29 +2224,128 @@ fn kill_process_group(pid: u32) -> bool {
     killpg(Pid::from_raw(pid as i32), Signal::SIGKILL).is_ok()
 }
 
-/// Fallback for non-Unix: process-group kill not available.
+/// Fallback for platforms with neither Unix process groups nor Windows Job
+/// Objects: only the direct child can be killed.
 /// Returns `false` so the caller falls back to `child.start_kill()`.
-#[cfg(not(unix))]
+#[cfg(all(not(unix), not(windows)))]
 fn kill_process_group(_pid: u32) -> bool {
     false
-}
-
-/// Suppress the console window that Windows otherwise allocates for every
-/// console-subsystem child process spawned from a GUI (non-console) parent.
-/// No-op on non-Windows platforms.
-fn configure_no_window(cmd: &mut tokio::process::Command) {
-    #[cfg(windows)]
-    {
-        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-        cmd.creation_flags(CREATE_NO_WINDOW);
-    }
-    #[cfg(not(windows))]
-    let _ = cmd;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn linux_proc_stat_parser_reads_start_time_after_complex_comm() {
+        let fields_4_through_21 = (4..=21)
+            .map(|field| field.to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let stat = format!("4242 (worker ) with spaces) S {fields_4_through_21} 987654 23 24");
+        assert_eq!(parse_linux_proc_start_time(&stat), Some(987654));
+    }
+
+    #[test]
+    fn raw_pid_kill_generation_gate_fails_closed_on_reuse_or_unknown_identity() {
+        assert!(process_generation_matches(Some(12345), Some(12345)));
+        assert!(!process_generation_matches(Some(12345), Some(54321)));
+        assert!(!process_generation_matches(None, Some(12345)));
+        assert!(!process_generation_matches(Some(12345), None));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn stale_process_generation_cannot_kill_live_reused_pid_fixture() {
+        let mut child = std::process::Command::new("setsid")
+            .args(["sleep", "60"])
+            .spawn()
+            .expect("spawn live process-generation fixture");
+        let pid = child.id();
+        let live = ProcessIdentity::capture(pid);
+        let stale = ProcessIdentity {
+            pid,
+            linux_start_time_ticks: live.linux_start_time_ticks.map(|ticks| ticks + 1),
+        };
+
+        retire_orphaned_process(stale).await;
+        assert!(
+            child.try_wait().expect("query fixture status").is_none(),
+            "a mismatched process generation must never authorize a raw-PID kill"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn windows_job_object_shutdown_retires_real_grandchild() {
+        use std::os::windows::process::CommandExt;
+
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        fn pid_is_running(pid: u32) -> bool {
+            let filter = format!("PID eq {pid}");
+            let output = std::process::Command::new("tasklist")
+                .args(["/FI", &filter, "/FO", "CSV", "/NH"])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+                .expect("query Windows process status");
+            String::from_utf8_lossy(&output.stdout).contains(&format!("\"{pid}\""))
+        }
+
+        let marker = std::env::temp_dir().join(format!(
+            "buzz-acp-job-object-grandchild-{}.txt",
+            uuid::Uuid::new_v4()
+        ));
+        let marker_ps = marker.to_string_lossy().replace('\'', "''");
+        let script = format!(
+            "$c=Start-Process ping.exe -ArgumentList '-t','127.0.0.1' \
+             -PassThru -WindowStyle Hidden; Set-Content -LiteralPath \
+             '{marker_ps}' -Value $c.Id -NoNewline; Wait-Process -Id $c.Id"
+        );
+        let args = vec![
+            "-NoProfile".to_string(),
+            "-NonInteractive".to_string(),
+            "-Command".to_string(),
+            script,
+        ];
+        let mut client = AcpClient::spawn("powershell.exe", &args, &[], false)
+            .await
+            .expect("spawn Job Object process-tree fixture");
+        let parent_pid = client.process_id().expect("fixture parent pid");
+
+        let mut grandchild_pid = None;
+        for _ in 0..100 {
+            if let Ok(raw) = std::fs::read_to_string(&marker) {
+                grandchild_pid = raw.trim().parse::<u32>().ok();
+                if grandchild_pid.is_some() {
+                    break;
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        let grandchild_pid = grandchild_pid.expect("fixture must publish grandchild pid");
+        assert!(pid_is_running(parent_pid));
+        assert!(pid_is_running(grandchild_pid));
+
+        client.shutdown().await;
+        let parent_gone = !pid_is_running(parent_pid);
+        let grandchild_gone = !pid_is_running(grandchild_pid);
+        if !grandchild_gone {
+            let _ = std::process::Command::new("taskkill")
+                .args(["/PID", &grandchild_pid.to_string(), "/F"])
+                .creation_flags(CREATE_NO_WINDOW)
+                .status();
+        }
+        let _ = std::fs::remove_file(marker);
+
+        assert!(parent_gone, "Job Object shutdown must reap the leader");
+        assert!(
+            grandchild_gone,
+            "Job Object shutdown must terminate and reap the real grandchild"
+        );
+    }
 
     #[test]
     fn stop_reason_parses_all_known_values() {

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -101,6 +101,9 @@ pub enum AcpError {
     #[error("Write timeout — agent stopped reading stdin (blocked for {0:?})")]
     WriteTimeout(std::time::Duration),
 
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+
     #[error("Protocol error: {0}")]
     Protocol(String),
 
@@ -188,14 +191,8 @@ pub struct AcpClient {
     /// "no active run to steer into" and fall back to cancel+merge.
     active_run_id: Option<String>,
     /// Whether the agent advertised `_meta.steering.supported: true` in its
-    /// `initialize` response, meaning it implements the cross-adapter
-    /// [`ACP_STEER_METHOD`] extension.
-    ///
-    /// Set once by [`initialize`](Self::initialize); `false` for agents that
-    /// omit the key. This is the **only** gate on writing an
-    /// [`ACP_STEER_METHOD`] request. It must never be replaced by error-code
-    /// probing: codex-acp answers unrecognized extension methods with `{}` —
-    /// a JSON-RPC *success*, not `-32601` — which the main loop would read as
+    /// `initialize` response. Retained for observability and compatibility;
+    /// Buzz does not emit the unowned extension without an exact run identity.
     /// a delivered steer and drop the user's message from the queue.
     steering_supported: bool,
     /// Per-turn channel for receiving goose-native non-cancelling steer
@@ -358,33 +355,22 @@ pub(crate) fn build_codex_config_env(
 /// goose's non-standard mid-turn steer method. Requires `expectedRunId`, so it
 /// is only usable once a `session_info_update` has supplied
 /// `_meta.goose.activeRunId`. Emitted by goose and buzz-agent only.
+#[allow(dead_code)]
 const GOOSE_STEER_METHOD: &str = "_goose/unstable/session/steer";
 
-/// The cross-adapter mid-turn steer method, shipped by claude-agent-acp
-/// (`src/acp-agent.ts:200`) and codex-acp (`src/AcpExtensions.ts:11`).
-/// Params are `{sessionId, prompt}` — no run id — and the result is
-/// `{outcome}`. Gated on [`AcpClient::steering_supported`].
-const ACP_STEER_METHOD: &str = "_session/steering";
-
-/// `outcome` value meaning the steer was applied to the turn Buzz is waiting
-/// on, which therefore keeps running.
-const STEER_OUTCOME_INJECTED: &str = "injected";
-
-/// `outcome` value meaning the turn Buzz was steering had already finished, so
-/// the adapter began a fresh turn carrying the message. Still a delivery
-/// success, but the awaited turn is over — see the steer-response arm for why
-/// this must not renew the hard deadline.
-const STEER_OUTCOME_STARTED_NEW_TURN: &str = "startedNewTurn";
-
-/// Which wire method carried an in-flight steer request, recorded so the
-/// response arm decodes the shape that method actually returns.
+/// Which wire method carried an in-flight steer request.
+///
+/// Buzz only emits the Goose transport because it binds the request to an
+/// immutable `expectedRunId`. The advertised cross-adapter
+/// `_session/steering` extension has no run identity; real adapters can
+/// acknowledge `injected` before rejecting the owning prompt or answer after
+/// that prompt has completed, so its delivery cannot be fenced or classified
+/// without loss/duplication risk. Those agents use cancel+merge and a normal
+/// host-owned `session/prompt` instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 enum SteerTransport {
-    /// [`GOOSE_STEER_METHOD`] — any success result is a delivered steer.
     Goose,
-    /// [`ACP_STEER_METHOD`] — success carries an `outcome` that must be
-    /// positively recognized before the steer counts as delivered.
-    AcpExtension,
 }
 
 fn build_client_capabilities() -> serde_json::Value {
@@ -411,6 +397,10 @@ fn build_client_capabilities() -> serde_json::Value {
 }
 
 impl AcpClient {
+    pub(crate) fn process_id(&self) -> Option<u32> {
+        self.child.id()
+    }
+
     /// Kill the agent subprocess and wait for it to exit (no zombies).
     ///
     /// `Drop` only calls `start_kill()` (sends SIGKILL but doesn't reap).
@@ -591,10 +581,8 @@ impl AcpClient {
     /// Must be called exactly once, before any other ACP method.
     /// The caller may inspect `agentCapabilities` in the returned value.
     ///
-    /// Records `_meta.steering.supported` into
-    /// [`steering_supported`](Self::steering_supported) so the read loop's steer
-    /// arm can choose [`ACP_STEER_METHOD`] for adapters that implement it.
-    /// Parsed here rather than at each call site so no caller can forget it.
+    /// Records `_meta.steering.supported` for observability. Capability alone
+    /// is not authority to emit an unbound steer request.
     pub async fn initialize(&mut self) -> Result<serde_json::Value, AcpError> {
         // Requesting version 2 is an intentional temporary pin — we are squatting
         // on ACP v2 ahead of the upstream ACP RFD. Revisit when that RFD merges.
@@ -858,8 +846,7 @@ impl AcpClient {
         self.active_run_id.as_deref()
     }
 
-    /// Whether the agent advertised the [`ACP_STEER_METHOD`] extension at
-    /// `initialize` time (`_meta.steering.supported`).
+    /// Whether the agent advertised cross-adapter steering at initialize time.
     ///
     /// The read loop's steer arm reads the field directly; this accessor exists
     /// for the supervisor's post-initialize log line.
@@ -1294,7 +1281,7 @@ impl AcpClient {
     /// in the main loop.
     async fn read_until_response_with_idle_timeout(
         &mut self,
-        session_id: &str,
+        _session_id: &str,
         expected_id: u64,
         idle_timeout: std::time::Duration,
         hard_deadline: tokio::time::Instant,
@@ -1389,79 +1376,26 @@ impl AcpClient {
                     // value matches what goose's run-id check will compare
                     // against.
                     //
-                    // Transport precedence:
-                    //   Some(run_id)              → GOOSE_STEER_METHOD. goose
-                    //     wins whenever a run id exists: `expectedRunId` is
-                    //     strictly more precise about *which* run is steered.
-                    //   None + steering_supported → ACP_STEER_METHOD, the
-                    //     cross-adapter extension (claude-agent-acp,
-                    //     codex-acp), which takes no run id.
-                    //   None + !steering_supported → write nothing and ack
-                    //     `ExpectedRunIdMissing`; the main loop maps this to
-                    //     the universal cancel+merge `Steer` fallback.
-                    //
-                    // The capability flag is the ONLY gate on writing
-                    // ACP_STEER_METHOD. Probing an unknown method is unsafe:
-                    // codex-acp answers unrecognized extension methods with
-                    // `{}` — a JSON-RPC success — which would be read as a
-                    // delivered steer and silently drop the user's message.
-                    let prompt_block_refs: Vec<&str> =
-                        req.prompt_blocks.iter().map(String::as_str).collect();
-                    let selected = match (&self.active_run_id, self.steering_supported) {
-                        (Some(run_id), _) => Some((
-                            SteerTransport::Goose,
-                            GOOSE_STEER_METHOD,
-                            build_goose_steer_params(session_id, run_id, &prompt_block_refs),
-                        )),
-                        (None, true) => Some((
-                            SteerTransport::AcpExtension,
-                            ACP_STEER_METHOD,
-                            build_acp_steer_params(session_id, &prompt_block_refs),
-                        )),
-                        (None, false) => None,
-                    };
-                    match selected {
-                        None => {
-                            tracing::warn!(
-                                "steer: no active_run_id and agent did not advertise \
-                                 {ACP_STEER_METHOD} — falling back to cancel+merge"
-                            );
-                            let _ = req.ack_tx.send(crate::pool::SteerAck::Err(
-                                crate::pool::SteerError::ExpectedRunIdMissing,
-                            ));
-                        }
-                        Some((transport, method, params)) => {
-                            let id = self.next_id;
-                            self.next_id += 1;
-                            let msg = serde_json::json!({
-                                "jsonrpc": "2.0",
-                                "id": id,
-                                "method": method,
-                                "params": params,
-                            });
-                            tracing::debug!(
-                                target: "acp::wire",
-                                "→ {}",
-                                serde_json::to_string(&msg).unwrap_or_default()
-                            );
-                            match self.write_ndjson(&msg).await {
-                                Ok(()) => {
-                                    pending_steer = Some((id, transport, req.ack_tx));
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        "steer write failed ({method}): {e} — releasing withheld event"
-                                    );
-                                    let _ = req.ack_tx.send(crate::pool::SteerAck::Err(
-                                        crate::pool::SteerError::Transport(e.to_string()),
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                    // Loop back to the next iteration without consuming a
-                    // reader line; we'll wait for either the prompt
-                    // response or the steer response next.
+                    // Only Goose exposes an immutable `active_run_id`; without
+                    // one, write nothing and ask the main loop to use its
+                    // universal cancel+merge fallback. `_session/steering`
+                    // capability advertisement is intentionally insufficient:
+                    // that extension cannot prove which prompt owns the work.
+                    // Neither the generic ACP extension nor Goose's exact-run
+                    // extension provides a consumption-level owning-turn receipt.
+                    // Goose acknowledges channel enqueue, which can still be lost
+                    // when the current provider round terminates without another
+                    // drain. Fail closed: write nothing and drive the host-owned
+                    // cancel+merge fallback so the immutable event remains queued.
+                    tracing::warn!(
+                        steering_advertised = self.steering_supported,
+                        has_active_run_id = self.active_run_id.is_some(),
+                        "steer: no consumption-level contract — refusing native extension and falling back to cancel+merge"
+                    );
+                    let _ = req.ack_tx.send(crate::pool::SteerAck::Err(
+                        crate::pool::SteerError::ExpectedRunIdMissing,
+                    ));
+                    // Loop back without consuming a reader line.
                     None
                 }
                 _ = tokio::time::sleep_until(next_deadline) => {
@@ -1568,48 +1502,8 @@ impl AcpClient {
                                             crate::pool::SteerError::AgentError { code, message },
                                         )
                                     } else {
-                                        // Success result. Whether it counts as
-                                        // a delivered steer — and whether the
-                                        // turn Buzz awaits is still running —
-                                        // depends on the transport.
-                                        let outcome = match transport {
-                                            // goose returns no outcome field;
-                                            // a success response means the
-                                            // steer landed in the live run.
-                                            SteerTransport::Goose => Some(STEER_OUTCOME_INJECTED),
-                                            // The outcome must be positively
-                                            // recognized. An unknown or absent
-                                            // value (codex-acp answers
-                                            // unrecognized ext methods with a
-                                            // bare `{}`) is a rejection, never
-                                            // a delivery — treating it as
-                                            // success would drop the event.
-                                            SteerTransport::AcpExtension => msg
-                                                .pointer("/result/outcome")
-                                                .and_then(|v| v.as_str())
-                                                .filter(|o| {
-                                                    *o == STEER_OUTCOME_INJECTED
-                                                        || *o == STEER_OUTCOME_STARTED_NEW_TURN
-                                                }),
-                                        };
-                                        match outcome {
-                                            Some(STEER_OUTCOME_STARTED_NEW_TURN) => {
-                                                // Delivered, but into a NEW
-                                                // turn: the one this read loop
-                                                // is awaiting had already
-                                                // finished. Renewing the hard
-                                                // deadline here would extend
-                                                // the clock on a settled turn,
-                                                // so leave it alone and let the
-                                                // prompt response land on its
-                                                // original budget.
-                                                tracing::info!(
-                                                    "steer accepted as {STEER_OUTCOME_STARTED_NEW_TURN}: \
-                                                     awaited turn had ended — hard deadline not renewed"
-                                                );
-                                                crate::pool::SteerAck::Success
-                                            }
-                                            Some(_) => {
+                                        match transport {
+                                            SteerTransport::Goose => {
                                                 let renew_now = Instant::now();
                                                 let new_deadline = renew_now + max_duration;
                                                 if new_deadline > hard_deadline {
@@ -1620,29 +1514,6 @@ impl AcpClient {
                                                     );
                                                 }
                                                 crate::pool::SteerAck::Success
-                                            }
-                                            None => {
-                                                // Report the raw string when
-                                                // there is one, so logs read
-                                                // `failed` not `"failed"`;
-                                                // fall back to the JSON for a
-                                                // non-string value.
-                                                let reported = match msg.pointer("/result/outcome")
-                                                {
-                                                    None => "<absent>".to_string(),
-                                                    Some(serde_json::Value::String(s)) => s.clone(),
-                                                    Some(other) => other.to_string(),
-                                                };
-                                                tracing::warn!(
-                                                    "steer rejected: {ACP_STEER_METHOD} returned \
-                                                     unrecognized outcome {reported} — releasing \
-                                                     withheld event for cancel+merge"
-                                                );
-                                                crate::pool::SteerAck::Err(
-                                                    crate::pool::SteerError::OutcomeRejected {
-                                                        outcome: reported,
-                                                    },
-                                                )
                                             }
                                         }
                                     };
@@ -1718,9 +1589,8 @@ impl AcpClient {
     /// the client must observe — notably goose's `session_info_update` with
     /// `_meta.goose.activeRunId`, which seeds [`active_run_id`](Self::active_run_id)
     /// so the steer arm can target `_goose/unstable/session/steer` at the
-    /// correct run. Agents that never emit it (claude-agent-acp, codex-acp)
-    /// leave it `None` and are steered via `_session/steering` instead, which
-    /// needs no run id.
+    /// correct run. Agents that never emit it leave it `None` and use
+    /// cancel+merge followed by a normal host-owned prompt.
     fn handle_session_update(&mut self, msg: &serde_json::Value) -> bool {
         let update = &msg["params"]["update"];
         let update_type = update
@@ -1990,6 +1860,7 @@ fn build_prompt_params(session_id: &str, prompt_blocks: &[&str]) -> serde_json::
 /// matches goose's *current* run (it advances on each `session/update`).
 /// See [`crate::pool::SteerRequest`] for why this is the read loop's job
 /// and not the main loop's.
+#[allow(dead_code)]
 fn build_goose_steer_params(
     session_id: &str,
     expected_run_id: &str,
@@ -2002,25 +1873,9 @@ fn build_goose_steer_params(
     })
 }
 
-/// Build the params for an [`ACP_STEER_METHOD`] request.
-///
-/// Wire shape:
-/// ```json
-/// { "sessionId": "...", "prompt": [{"type":"text","text":"..."}, ...] }
-/// ```
-///
-/// Deliberately carries **no** `expectedRunId`: the cross-adapter method
-/// steers whatever turn is currently running and neither claude-agent-acp nor
-/// codex-acp emits a run id to target.
-fn build_acp_steer_params(session_id: &str, prompt_blocks: &[&str]) -> serde_json::Value {
-    serde_json::json!({
-        "sessionId": session_id,
-        "prompt": steer_prompt_blocks(prompt_blocks),
-    })
-}
-
-/// Render steer body strings as ACP `text` content blocks. Shared by both
-/// steer transports so the prompt shape cannot drift between them.
+/// Render steer body strings as ACP `text` content blocks for the exact-run
+/// Goose transport.
+#[allow(dead_code)]
 fn steer_prompt_blocks(prompt_blocks: &[&str]) -> Vec<serde_json::Value> {
     prompt_blocks
         .iter()
@@ -2214,6 +2069,29 @@ impl Drop for AcpClient {
         let _ = self.child.try_wait();
     }
 }
+
+/// Kill and reap a child whose `AcpClient` was dropped during panic unwind.
+/// The lane owner must not be released until this future resolves.
+#[cfg(unix)]
+pub(crate) async fn retire_orphaned_process(pid: u32) {
+    let _ = tokio::task::spawn_blocking(move || {
+        use nix::sys::signal::{kill, Signal};
+        use nix::sys::wait::waitpid;
+        use nix::unistd::Pid;
+
+        if !kill_process_group(pid) {
+            let _ = kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
+        }
+        match waitpid(Pid::from_raw(pid as i32), None) {
+            Ok(_) | Err(nix::errno::Errno::ECHILD) => {}
+            Err(error) => tracing::warn!(pid, %error, "failed to reap panicked ACP process"),
+        }
+    })
+    .await;
+}
+
+#[cfg(not(unix))]
+pub(crate) async fn retire_orphaned_process(_pid: u32) {}
 
 /// Send SIGKILL to an entire process group. Returns `true` if the signal was sent.
 ///
@@ -2885,7 +2763,7 @@ mod tests {
             .expect("failed to spawn test script")
     }
 
-    /// Spawn a probe script whose file name carries a runtime identity (e.g.
+    /// Spawn a probe shell whose symlink name carries a runtime identity (e.g.
     /// `hermes-acp`) and return the value of `var` as the child observed it.
     /// `<unset>` means the child did not receive the var.
     #[cfg(unix)]
@@ -2894,23 +2772,17 @@ mod tests {
         var: &str,
         extra_env: &[(String, String)],
     ) -> String {
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::symlink;
 
         let dir = std::env::temp_dir().join(format!("buzz-acp-env-probe-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).expect("create env probe dir");
         let path = dir.join(file_name);
-        std::fs::write(
-            &path,
-            format!("#!/bin/sh\nprintf '%s\\n' \"${{{var}:-<unset>}}\"\n"),
-        )
-        .expect("write env probe script");
-        let mut permissions = std::fs::metadata(&path).expect("stat probe").permissions();
-        permissions.set_mode(0o700);
-        std::fs::set_permissions(&path, permissions).expect("chmod probe");
+        symlink("/bin/sh", &path).expect("create named env probe shell");
+        let script = format!("printf '%s\\n' \"${{{var}:-<unset>}}\"\n");
 
         let mut client = AcpClient::spawn(
             path.to_str().expect("probe path is UTF-8"),
-            &[],
+            &["-c".into(), script],
             extra_env,
             false,
         )
@@ -3720,14 +3592,11 @@ mod tests {
         }
     }
 
-    /// Steer with `active_run_id` set writes the JSON-RPC request and
-    /// routes the matching response to the ack oneshot as `Success`.
-    /// Verifies the wire shape (`sessionId` + `expectedRunId` + `prompt`)
-    /// indirectly: the bash script emits a response keyed by the steer
-    /// id (0), and `Success` only fires if the read loop matched that
-    /// id to its `pending_steer` entry.
+    /// An observed active run ID does not upgrade enqueue into consumption.
+    /// The read loop must return the fallback signal without matching the
+    /// adapter's unsolicited success response.
     #[tokio::test]
-    async fn native_steer_with_active_run_id_routes_response_to_ack() {
+    async fn native_steer_with_active_run_id_still_falls_back() {
         // Script: pause briefly so the test task can install the steer
         // and we can be sure the response doesn't race ahead of the
         // write — then emit the steer response (id=0 because next_id
@@ -3783,32 +3652,21 @@ mod tests {
             "expected IdleTimeout or AgentExited after steer ack, got {read_result:?}"
         );
 
-        // Ack must be Success: the steer response (id=0) was routed to
-        // pending_steer.ack_tx.
+        // The exact-run extension is still consumption-ambiguous.
         let ack = ack_rx
             .await
             .expect("ack oneshot must have received a SteerAck");
         match ack {
-            crate::pool::SteerAck::Success => {}
-            other => panic!("expected SteerAck::Success, got {other:?}"),
+            crate::pool::SteerAck::Err(crate::pool::SteerError::ExpectedRunIdMissing) => {}
+            other => panic!("expected fail-closed fallback ack, got {other:?}"),
         }
     }
 
-    /// Steer-success renewal keeps the turn alive past the original hard
-    /// deadline. This is the red-on-old/green-on-new test for the core bug
-    /// fix (acp.rs:1440-1444): without renewal, the read loop returns
-    /// `HardTimeout` before the prompt response arrives.
-    ///
-    /// Timeline:
-    ///   t≈0:    read loop starts, `hard_deadline = now + 1s`
-    ///   t≈0.5s: script emits steer response (id=0) → Success renewal
-    ///           moves `hard_deadline` to `now + 3s` (≈3.5s from start)
-    ///   t≈1.5s: script emits prompt response (id=999) → `Ok`
-    ///
-    /// Old code: `HardTimeout` at t≈1s (before prompt response).
-    /// New code: deadline renewed at t≈0.5s → prompt response at t≈1.5s → `Ok`.
+    /// A rejected enqueue-only steer must not renew the owning prompt's hard
+    /// deadline. The late prompt response therefore cannot cross the original
+    /// deadline merely because an unconsumed steer was attempted.
     #[tokio::test]
-    async fn steer_success_renews_hard_deadline_and_survives_past_original() {
+    async fn rejected_native_steer_does_not_renew_hard_deadline() {
         let script = "sleep 0.5; \
                       echo '{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"stopReason\":\"end_turn\"}}'; \
                       sleep 1; \
@@ -3841,25 +3699,23 @@ mod tests {
         send_task.await.expect("send_task should complete");
 
         assert!(
-            result.is_ok(),
-            "expected Ok (prompt response after renewed deadline), got {result:?}"
+            matches!(result, Err(AcpError::HardTimeout { .. })),
+            "expected original hard deadline to fire, got {result:?}"
         );
-        assert_eq!(result.unwrap()["done"], serde_json::json!(true));
 
         let ack = ack_rx
             .await
             .expect("ack oneshot must have received a SteerAck");
         match ack {
-            crate::pool::SteerAck::Success => {}
-            other => panic!("expected SteerAck::Success, got {other:?}"),
+            crate::pool::SteerAck::Err(crate::pool::SteerError::ExpectedRunIdMissing) => {}
+            other => panic!("expected fail-closed fallback ack, got {other:?}"),
         }
     }
 
     // ── Cross-harness steer transport tests ───────────────────────────────
     //
-    // These cover the `_session/steering` transport added alongside the
-    // goose-native method: capability capture at `initialize`, write-time
-    // transport selection, and outcome decoding. Wire-shape assertions read
+    // These cover capability capture, fail-closed refusal of unowned extension
+    // requests, and exact-run Goose transport selection. Wire assertions read
     // the actual serialized request bytes via `capture_steer_request` rather
     // than inferring the shape from response-id routing.
 
@@ -3995,55 +3851,38 @@ mod tests {
         );
     }
 
-    /// Test 2: no `active_run_id` + capability advertised → the bytes on the
-    /// wire are an `_session/steering` request carrying `sessionId` and
-    /// `prompt`, and carrying **no** `expectedRunId` (the adapters reject
-    /// unknown required fields, and there is no run id to report anyway).
+    /// An adapter advertisement without an immutable run identity is not
+    /// sufficient to own mid-turn work. Buzz must write no extension request
+    /// and return the typed signal that drives cancel+merge fallback.
     #[tokio::test]
-    async fn acp_steer_request_omits_expected_run_id_and_carries_session_and_prompt() {
-        let capture = capture_path("acp_shape");
+    async fn advertised_acp_steering_without_run_id_writes_nothing_and_falls_back() {
+        let capture = capture_path("acp_unowned_refused");
         let mut client = spawn_steer_capture_script(
             &capture,
-            r#"{"jsonrpc":"2.0","id":0,"result":{"outcome":"injected"}}"#,
+            r#"{"jsonrpc":"2.0","id":0,"result":{"outcome":"startedNewTurn"}}"#,
         )
         .await;
         set_steering_supported(&mut client);
-        assert!(
-            client.active_run_id().is_none(),
-            "precondition: no active_run_id"
-        );
+        assert!(client.active_run_id().is_none());
 
         let (written, ack) = run_one_steer(&mut client, &capture).await;
 
-        let written = written.expect("steer request must have been written");
-        let msg: serde_json::Value =
-            serde_json::from_str(&written).expect("written line must be valid JSON");
-        assert_eq!(
-            msg["method"].as_str(),
-            Some(ACP_STEER_METHOD),
-            "must use the cross-adapter steer method; wrote: {written}"
-        );
-        assert_eq!(msg["params"]["sessionId"].as_str(), Some("sess-test"));
-        assert_eq!(
-            msg["params"]["prompt"][0]["text"].as_str(),
-            Some("steer body"),
-            "prompt must carry the steer body as a text block"
-        );
         assert!(
-            msg["params"].get("expectedRunId").is_none(),
-            "_session/steering must not carry expectedRunId; wrote: {written}"
+            written.is_none(),
+            "unowned _session/steering must never reach the wire; wrote: {written:?}"
         );
-        assert!(
-            matches!(ack, crate::pool::SteerAck::Success),
-            "injected outcome must ack Success, got {ack:?}"
-        );
+        assert!(matches!(
+            ack,
+            crate::pool::SteerAck::Err(crate::pool::SteerError::ExpectedRunIdMissing)
+        ));
     }
 
-    /// Test 3: goose keeps priority. With both an `active_run_id` and the
-    /// advertised capability, the goose method wins — `expectedRunId` is
-    /// strictly more precise about which run is being steered.
+    /// An immutable run ID prevents cross-run delivery, but Goose acknowledges
+    /// channel enqueue rather than model consumption. Until a consumption-level
+    /// owning-turn settlement exists, exact-run Goose steering must write nothing
+    /// and use cancel+merge normal dispatch.
     #[tokio::test]
-    async fn goose_transport_wins_when_both_run_id_and_capability_present() {
+    async fn goose_run_id_without_consumption_contract_writes_nothing_and_falls_back() {
         let capture = capture_path("goose_priority");
         let mut client =
             spawn_steer_capture_script(&capture, r#"{"jsonrpc":"2.0","id":0,"result":{}}"#).await;
@@ -4053,184 +3892,14 @@ mod tests {
 
         let (written, ack) = run_one_steer(&mut client, &capture).await;
 
-        let written = written.expect("steer request must have been written");
-        let msg: serde_json::Value =
-            serde_json::from_str(&written).expect("written line must be valid JSON");
-        assert_eq!(
-            msg["method"].as_str(),
-            Some(GOOSE_STEER_METHOD),
-            "goose method must win when a run id exists; wrote: {written}"
-        );
-        assert_eq!(msg["params"]["expectedRunId"].as_str(), Some("run-77"));
-        // A bare `{}` result is a success on the goose transport (goose sends
-        // no `outcome`) — the OutcomeRejected guard applies only to
-        // `_session/steering`.
         assert!(
-            matches!(ack, crate::pool::SteerAck::Success),
-            "goose success result must ack Success, got {ack:?}"
+            written.is_none(),
+            "enqueue-only Goose steer must never reach the wire; wrote: {written:?}"
         );
-    }
-
-    /// Test 7: codex-acp's third outcome, `failed`
-    /// (`src/AcpExtensions.ts:92`), is a delivery rejection despite being a
-    /// JSON-RPC success — release the event and fall back.
-    #[tokio::test]
-    async fn acp_steer_failed_outcome_acks_outcome_rejected() {
-        let capture = capture_path("outcome_failed");
-        let mut client = spawn_steer_capture_script(
-            &capture,
-            r#"{"jsonrpc":"2.0","id":0,"result":{"outcome":"failed"}}"#,
-        )
-        .await;
-        set_steering_supported(&mut client);
-
-        let (_written, ack) = run_one_steer(&mut client, &capture).await;
-
-        match ack {
-            crate::pool::SteerAck::Err(crate::pool::SteerError::OutcomeRejected { outcome }) => {
-                assert_eq!(
-                    outcome, "failed",
-                    "rejected outcome must report what the agent said, unquoted"
-                );
-            }
-            other => panic!("expected Err(OutcomeRejected), got {other:?}"),
-        }
-    }
-
-    /// Test 8: **codex `extMethod` silent-loss regression guard.** codex-acp's
-    /// ext dispatcher answers unrecognized methods with a bare `{}` — a
-    /// JSON-RPC *success*, not `-32601` (`src/CodexAcpServer.ts:255-258`).
-    /// Buzz maps `SteerAck::Success` to `queue.remove_event`, so decoding
-    /// `{}` as success would delete the user's message with no error, no
-    /// fallback, and no log. An absent `outcome` must therefore be a
-    /// rejection, which releases the event and fires cancel+merge.
-    #[tokio::test]
-    async fn acp_steer_missing_outcome_acks_outcome_rejected_and_never_drops_event() {
-        let capture = capture_path("outcome_absent");
-        let mut client =
-            spawn_steer_capture_script(&capture, r#"{"jsonrpc":"2.0","id":0,"result":{}}"#).await;
-        set_steering_supported(&mut client);
-
-        let (_written, ack) = run_one_steer(&mut client, &capture).await;
-
-        match ack {
-            crate::pool::SteerAck::Err(crate::pool::SteerError::OutcomeRejected { outcome }) => {
-                assert_eq!(
-                    outcome, "<absent>",
-                    "a result with no outcome field must be reported as absent"
-                );
-            }
-            other => panic!(
-                "expected Err(OutcomeRejected) for a bare {{}} success — \
-                 anything else risks dropping the event, got {other:?}"
-            ),
-        }
-    }
-
-    /// Test 5: `injected` renews the hard deadline, so the turn survives past
-    /// its original one. Mirrors
-    /// `steer_success_renews_hard_deadline_and_survives_past_original` for
-    /// the `_session/steering` transport.
-    ///
-    /// Timeline: original hard deadline at t≈1s; steer response at t≈0.5s
-    /// renews it to t≈3.5s; prompt response at t≈1.5s lands inside it.
-    #[tokio::test]
-    async fn acp_steer_injected_renews_hard_deadline_and_survives_past_original() {
-        let script = "sleep 0.5; \
-                      echo '{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"outcome\":\"injected\"}}'; \
-                      sleep 1; \
-                      echo '{\"jsonrpc\":\"2.0\",\"id\":999,\"result\":{\"done\":true}}'";
-        let mut client = spawn_script(script).await;
-        set_steering_supported(&mut client);
-
-        let (steer_tx, steer_rx) = tokio::sync::mpsc::channel::<crate::pool::SteerRequest>(1);
-        client.install_steer_rx(steer_rx);
-        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<crate::pool::SteerAck>();
-        let send_task = tokio::spawn(async move {
-            steer_tx
-                .send(crate::pool::SteerRequest {
-                    prompt_blocks: vec!["steer body".into()],
-                    ack_tx,
-                })
-                .await
-                .expect("steer_tx send should succeed");
-        });
-
-        let idle = std::time::Duration::from_secs(10);
-        let max_dur = std::time::Duration::from_secs(3);
-        let hard_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
-        let result = client
-            .read_until_response_with_idle_timeout("sess-test", 999, idle, hard_deadline, max_dur)
-            .await;
-        send_task.await.expect("send_task should complete");
-
-        assert!(
-            result.is_ok(),
-            "injected must renew the deadline so the prompt response still lands, got {result:?}"
-        );
-        assert_eq!(result.unwrap()["done"], serde_json::json!(true));
-        let ack = ack_rx.await.expect("ack must be received");
-        assert!(
-            matches!(ack, crate::pool::SteerAck::Success),
-            "injected must ack Success, got {ack:?}"
-        );
-    }
-
-    /// Test 6: **red/green for the no-renewal rule.** `startedNewTurn` means
-    /// the turn Buzz was steering had already ended and the adapter began a
-    /// fresh, detached one. It acks `Success` (the message WAS delivered, so
-    /// the event must not be redelivered) but must NOT renew the hard
-    /// deadline — that clock belongs to a turn which is already settled.
-    ///
-    /// Same timeline as the `injected` test, so the only difference is the
-    /// outcome string: original hard deadline at t≈1s, steer response at
-    /// t≈0.5s, prompt response at t≈1.5s. With renewal the prompt response
-    /// would land and this returns `Ok`; without renewal the original
-    /// deadline fires first and we get `HardTimeout`.
-    #[tokio::test]
-    async fn acp_steer_started_new_turn_acks_success_without_renewing_hard_deadline() {
-        let script = "sleep 0.5; \
-             echo '{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"outcome\":\"startedNewTurn\"}}'; \
-             sleep 1; \
-             echo '{\"jsonrpc\":\"2.0\",\"id\":999,\"result\":{\"done\":true}}'";
-        let mut client = spawn_script(script).await;
-        set_steering_supported(&mut client);
-
-        let (steer_tx, steer_rx) = tokio::sync::mpsc::channel::<crate::pool::SteerRequest>(1);
-        client.install_steer_rx(steer_rx);
-        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<crate::pool::SteerAck>();
-        let send_task = tokio::spawn(async move {
-            steer_tx
-                .send(crate::pool::SteerRequest {
-                    prompt_blocks: vec!["steer body".into()],
-                    ack_tx,
-                })
-                .await
-                .expect("steer_tx send should succeed");
-        });
-
-        let idle = std::time::Duration::from_secs(10);
-        let max_dur = std::time::Duration::from_secs(3);
-        let hard_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
-        let result = client
-            .read_until_response_with_idle_timeout("sess-test", 999, idle, hard_deadline, max_dur)
-            .await;
-        send_task.await.expect("send_task should complete");
-
-        // The original deadline must still fire — renewal here would extend
-        // the clock on a turn the adapter has already finished.
-        assert!(
-            matches!(result, Err(AcpError::HardTimeout { .. })),
-            "startedNewTurn must NOT renew the hard deadline, so the original \
-             one must still fire; got {result:?}"
-        );
-        // Delivery still succeeded, so the withheld event must be dropped
-        // rather than released — hence Success, not an Err.
-        let ack = ack_rx.await.expect("ack must be received");
-        assert!(
-            matches!(ack, crate::pool::SteerAck::Success),
-            "startedNewTurn is a delivery success, got {ack:?}"
-        );
+        assert!(matches!(
+            ack,
+            crate::pool::SteerAck::Err(crate::pool::SteerError::ExpectedRunIdMissing)
+        ));
     }
 
     /// Test 4 (companion to the existing

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -73,6 +73,14 @@ pub enum MultipleEventHandling {
     /// admits (owner ∪ allowlist ∪ siblings). This is the default mid-turn
     /// delivery path. Requires DedupMode::Queue.
     Steer,
+    /// Opt-in root-thread affinity. Each validated NIP-10 root in a non-DM
+    /// channel owns an independent queue, task, and ACP session lane while
+    /// retaining Steer's native-steer/cancel+merge delivery semantics.
+    /// Top-level events use their own event id as the root; DMs remain scoped
+    /// to their channel conversation. Requires DedupMode::Queue and a nonzero
+    /// context-message limit so required root context can be fetched.
+    #[value(name = "steer-thread")]
+    SteerThread,
     /// Cancel the in-flight turn and re-dispatch a merged prompt combining
     /// the original events with the new ones, framed as a **supersede** (the
     /// new request replaces the old), for ANY new @mention.
@@ -362,7 +370,8 @@ pub struct CliArgs {
     pub no_ignore_self: bool,
 
     /// Maximum number of context messages to include for thread replies and DMs.
-    /// Set to 0 to disable automatic context fetching. Max 100.
+    /// Set to 0 to disable automatic context fetching (not valid with
+    /// `--multiple-event-handling=steer-thread`). Max 100.
     #[arg(long, env = "BUZZ_ACP_CONTEXT_MESSAGE_LIMIT", default_value_t = 12,
           value_parser = clap::value_parser!(u32).range(0..=100))]
     pub context_message_limit: u32,
@@ -661,14 +670,30 @@ fn validate_multiple_event_handling(
     let is_cancel_mode = matches!(
         handling,
         MultipleEventHandling::Steer
+            | MultipleEventHandling::SteerThread
             | MultipleEventHandling::Interrupt
             | MultipleEventHandling::OwnerInterrupt
     );
     if is_cancel_mode && matches!(dedup, DedupMode::Drop) {
         return Err(ConfigError::ConfigFile(
-            "--multiple-event-handling=steer (or interrupt/owner-interrupt) requires \
+            "--multiple-event-handling=steer/steer-thread (or interrupt/owner-interrupt) requires \
              --dedup=queue. DedupMode::Drop discards events during the cancel drain window, \
              producing incomplete merged prompts."
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_thread_context(
+    handling: MultipleEventHandling,
+    context_message_limit: u32,
+) -> Result<(), ConfigError> {
+    if matches!(handling, MultipleEventHandling::SteerThread) && context_message_limit == 0 {
+        return Err(ConfigError::ConfigFile(
+            "--multiple-event-handling=steer-thread requires \
+             --context-message-limit to be greater than 0 because exact replies \
+             fail closed when their root context cannot be fetched."
                 .into(),
         ));
     }
@@ -1059,6 +1084,7 @@ impl Config {
             };
 
         validate_multiple_event_handling(args.multiple_event_handling, args.dedup)?;
+        validate_thread_context(args.multiple_event_handling, args.context_message_limit)?;
 
         let config = Config {
             keys,
@@ -2561,6 +2587,40 @@ channels = "ALL"
         assert_eq!(args.multiple_event_handling, MultipleEventHandling::Steer);
         // Dedup default must remain `queue` so steering's requirement is met.
         assert!(matches!(args.dedup, DedupMode::Queue));
+    }
+
+    #[test]
+    fn test_multiple_event_handling_parses_opt_in_steer_thread() {
+        let args = CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            TEST_PRIVATE_KEY,
+            "--multiple-event-handling",
+            "steer-thread",
+        ])
+        .expect("steer-thread should be a parsed opt-in mode");
+
+        assert_eq!(
+            args.multiple_event_handling,
+            MultipleEventHandling::SteerThread
+        );
+        assert!(validate_multiple_event_handling(
+            MultipleEventHandling::SteerThread,
+            DedupMode::Queue
+        )
+        .is_ok());
+        assert!(validate_multiple_event_handling(
+            MultipleEventHandling::SteerThread,
+            DedupMode::Drop
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_steer_thread_requires_context_fetching() {
+        assert!(validate_thread_context(MultipleEventHandling::SteerThread, 0).is_err());
+        assert!(validate_thread_context(MultipleEventHandling::SteerThread, 1).is_ok());
+        assert!(validate_thread_context(MultipleEventHandling::Steer, 0).is_ok());
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1405,6 +1405,75 @@ struct RespawnResult {
     result: Result<(AcpClient, u32, String)>,
 }
 
+/// Await a background slot respawn as a first-class runtime wake source.
+/// Keeping this as a named seam prevents the main loop from regressing to
+/// opportunistic `try_recv()` polling that can strand work on quiet relays.
+async fn recv_respawn_wake(rx: &mut mpsc::Receiver<RespawnResult>) -> Option<RespawnResult> {
+    rx.recv().await
+}
+
+/// Account for one completed slot respawn and install a healthy replacement.
+/// Returns `true` only when a live agent was returned to the pool.
+fn install_respawn_result(
+    pool: &mut AgentPool,
+    crash_history: &mut [SlotCircuit],
+    config: &Config,
+    rr: RespawnResult,
+) -> bool {
+    crash_history[rr.index].respawn_in_flight = false;
+    match rr.result {
+        Ok((acp, protocol_version, agent_name)) => {
+            let agent = OwnedAgent {
+                index: rr.index,
+                acp,
+                state: SessionState::default(),
+                model_capabilities: None,
+                desired_model: config.model.clone(),
+                model_overridden: false,
+                agent_name,
+                goose_system_prompt_supported: None,
+                protocol_version,
+            };
+            pool.return_agent(agent);
+            tracing::info!(agent = rr.index, "respawn complete");
+            true
+        }
+        Err(error) => {
+            crash_history[rr.index].mark_spawn_failed();
+            tracing::warn!(
+                agent = rr.index,
+                "respawn failed: {error} — circuit re-opened"
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod respawn_wake_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn delayed_respawn_result_wakes_idle_runtime_without_external_input() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            tx.send(RespawnResult {
+                index: 7,
+                result: Err(anyhow::anyhow!("expected test failure")),
+            })
+            .await
+            .expect("runtime receiver remains live");
+        });
+
+        let result = tokio::time::timeout(Duration::from_secs(1), recv_respawn_wake(&mut rx))
+            .await
+            .expect("respawn completion must wake an otherwise-idle runtime")
+            .expect("respawn channel remains open");
+        assert_eq!(result.index, 7);
+    }
+}
+
 /// Outcome of a non-cancelling steer attempt, forwarded from a per-attempt
 /// watcher task (which awaits the `SteerRequest.ack_tx` oneshot) back to
 /// the main loop's `select!`. The main loop drives queue side-effects from
@@ -2124,6 +2193,7 @@ async fn tokio_main() -> Result<()> {
         Result(Box<PromptResult>),
         Panic(tokio::task::JoinError),
         SteerAck(SteerAckEvent),
+        Respawn(Box<RespawnResult>),
         Wake(u32, Result<AgentPool, String>),
     }
 
@@ -2208,29 +2278,7 @@ async fn tokio_main() -> Result<()> {
 
         let mut respawn_collected = false;
         while let Ok(rr) = respawn_rx.try_recv() {
-            crash_history[rr.index].respawn_in_flight = false;
-            match rr.result {
-                Ok((acp, protocol_version, agent_name)) => {
-                    let agent = OwnedAgent {
-                        index: rr.index,
-                        acp,
-                        state: SessionState::default(),
-                        model_capabilities: None,
-                        desired_model: config.model.clone(),
-                        model_overridden: false,
-                        agent_name,
-                        goose_system_prompt_supported: None,
-                        protocol_version,
-                    };
-                    pool.return_agent(agent);
-                    tracing::info!(agent = rr.index, "respawn complete");
-                    respawn_collected = true;
-                }
-                Err(e) => {
-                    crash_history[rr.index].mark_spawn_failed();
-                    tracing::warn!(agent = rr.index, "respawn failed: {e} — circuit re-opened");
-                }
-            }
+            respawn_collected |= install_respawn_result(&mut pool, &mut crash_history, &config, rr);
         }
         // Flush requeued events that were waiting for a live agent. Without
         // this, batches requeued during crash recovery sit idle until the
@@ -2270,6 +2318,9 @@ async fn tokio_main() -> Result<()> {
                 // locked semantics (Eva + Max + Perci).
                 Some(ack_event) = steer_ack_rx.recv() => {
                     Some(PoolEvent::SteerAck(ack_event))
+                }
+                Some(rr) = recv_respawn_wake(&mut respawn_rx) => {
+                    Some(PoolEvent::Respawn(Box::new(rr)))
                 }
                 Some((attempt, result)) = wake_rx.recv(), if config.lazy_pool && !pool_ready => {
                     Some(PoolEvent::Wake(attempt, result))
@@ -2515,11 +2566,13 @@ async fn tokio_main() -> Result<()> {
                             }
 
                             // Check: kind:9, content "!shutdown", from owner, mentions THIS agent.
+                            let command_owner = owner_cache.get();
                             let is_shutdown = is_owner_control_command(
                                 &buzz_event.event,
                                 kind_u32,
                                 "!shutdown",
                                 &pubkey_hex,
+                                command_owner,
                             );
                             if is_shutdown {
                                 let owner = owner_cache.get();
@@ -2551,6 +2604,7 @@ async fn tokio_main() -> Result<()> {
                                 kind_u32,
                                 "!cancel",
                                 &pubkey_hex,
+                                command_owner,
                             );
                             if is_cancel {
                                 if let Some(owner) = owner_cache.get() {
@@ -2610,6 +2664,7 @@ async fn tokio_main() -> Result<()> {
                                 kind_u32,
                                 "!rotate",
                                 &pubkey_hex,
+                                command_owner,
                             );
                             if is_rotate {
                                 if let Some(owner) = owner_cache.get() {
@@ -3103,6 +3158,22 @@ async fn tokio_main() -> Result<()> {
                     typing_channels.insert(channel_id, thread_tags);
                 }
             }
+            // clippy::collapsible_match wants this `if` lifted into a match guard,
+            // which is impossible here: `install_respawn_result` consumes the
+            // RespawnResult (it destructures `rr.result` by value), and a guard
+            // only borrows, so moving out of the Box in a guard is E0507. The
+            // Box itself is required by clippy::large_enum_variant. The two
+            // lints cannot both be satisfied; ownership wins.
+            Some(PoolEvent::Respawn(rr)) => {
+                #[allow(clippy::collapsible_match)]
+                if install_respawn_result(&mut pool, &mut crash_history, &config, *rr) {
+                    for (channel_id, thread_tags) in
+                        dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
+                    {
+                        typing_channels.insert(channel_id, thread_tags);
+                    }
+                }
+            }
             Some(PoolEvent::Wake(attempt, result)) => {
                 let completion = result.as_ref().map(|_| ()).map_err(|error| error.clone());
                 if let Err(error) =
@@ -3290,10 +3361,12 @@ fn is_owner_control_command(
     kind_u32: u32,
     command: &str,
     agent_pubkey_hex: &str,
+    owner_pubkey_hex: Option<&str>,
 ) -> bool {
     kind_u32 == KIND_STREAM_MESSAGE
         && event.content.trim() == command
         && event_mentions_agent(event, agent_pubkey_hex)
+        && owner_pubkey_hex.is_some_and(|owner| event.pubkey.to_hex() == owner)
 }
 
 // ── signal_in_flight_task ─────────────────────────────────────────────────────
@@ -3634,7 +3707,7 @@ fn dispatch_pending(
         let result_tx = pool.result_tx();
         let ctx_clone = Arc::clone(ctx);
         let agent_index = agent.index;
-        let agent_pid = agent.acp.process_id();
+        let agent_process_identity = agent.acp.process_identity();
 
         // Mid-turn non-cancelling steer seam: install the per-turn steer
         // receiver on the read loop so the main loop's mode-gate fork
@@ -3693,8 +3766,8 @@ fn dispatch_pending(
                 steer_tx,
             },
         );
-        if let Some(pid) = agent_pid {
-            pool.register_task_process(task_id, pid);
+        if let Some(identity) = agent_process_identity {
+            pool.register_task_process(task_id, identity);
         }
         dispatched_channels.push((
             task_lane,
@@ -3832,12 +3905,11 @@ async fn handle_prompt_result(
     // branch below records what actually happened; only the hard-timeout
     // match arm in the death_message construction reads it.
     let mut hard_timeout_fate_suffix: Option<&'static str> = None;
+    let mut terminally_settled = matches!(&result.outcome, PromptOutcome::Ok(_));
 
-    // Requeue BEFORE mark_complete: requeue() sets retry_after with a future
-    // deadline, and mark_complete() checks for it to decide whether to preserve
-    // retry_counts. If mark_complete runs first, retry_counts is cleared and
-    // every retry starts at attempt 1 — defeating exponential backoff and
-    // dead-letter protection.
+    // Classify the batch fate before releasing the lane generation. Requeue and
+    // cancellation are nonterminal and preserve retry history; successful or
+    // dead-lettered work terminally settles and resets that history.
     if let Some(batch) = result.batch.take() {
         // Don't requeue batches for channels the agent was removed from —
         // those events are stale and should be silently dropped.
@@ -3880,6 +3952,7 @@ async fn handle_prompt_result(
                 );
                 spawn_failure_notice(rest_client, &batch, content);
                 hard_timeout_fate_suffix = Some(" — dead-lettered (no recent activity)");
+                terminally_settled = true;
             } else if matches!(
                 result.outcome,
                 PromptOutcome::Timeout(TimeoutKind::Hard {
@@ -3898,6 +3971,7 @@ async fn handle_prompt_result(
                     );
                     spawn_failure_notice(rest_client, &dead, content);
                     hard_timeout_fate_suffix = Some(" — dead-lettered (retry budget exhausted)");
+                    terminally_settled = true;
                 } else {
                     hard_timeout_fate_suffix = Some(" — requeued for retry (recently active)");
                 }
@@ -3916,6 +3990,7 @@ async fn handle_prompt_result(
                     "⚠️ I couldn't process this request because its thread root is missing, invalid, or belongs to another channel. Please reply from a valid channel thread."
                         .to_string(),
                 );
+                terminally_settled = true;
             } else if matches!(&result.outcome, PromptOutcome::Error(e) if is_auth_error(e)) {
                 // Auth errors are non-retryable: the token won't self-repair
                 // between retries, so requeueing only wastes attempt slots and
@@ -3931,6 +4006,7 @@ async fn handle_prompt_result(
                     and then re-send."
                     .to_string();
                 spawn_failure_notice(rest_client, &batch, content);
+                terminally_settled = true;
             } else if let Some(dead) = queue.requeue(batch) {
                 let reason = match &result.outcome {
                     PromptOutcome::Timeout(TimeoutKind::Idle) => "the turn timed out".to_string(),
@@ -3945,6 +4021,7 @@ async fn handle_prompt_result(
                     "⚠️ I couldn't process the last request after multiple retries ({reason}). Please re-send if it's still needed."
                 );
                 spawn_failure_notice(rest_client, &dead, content);
+                terminally_settled = true;
             }
         } else if stale_lane_generation {
             tracing::warn!(
@@ -3966,7 +4043,11 @@ async fn handle_prompt_result(
 
     match &result.source {
         PromptSource::Lane(lane) => {
-            queue.mark_lane_complete_for_turn(lane, &result.turn_id);
+            if terminally_settled {
+                queue.mark_lane_settled_for_turn(lane, &result.turn_id);
+            } else {
+                queue.mark_lane_complete_for_turn(lane, &result.turn_id);
+            }
         }
         PromptSource::Heartbeat => *heartbeat_in_flight = false,
     }
@@ -4254,9 +4335,9 @@ async fn recover_panicked_agent(
     rest_client: Option<&relay::RestClient>,
 ) {
     let task_id = join_error.id();
-    let (meta, process_id) = pool.take_task_for_panic(task_id);
-    if let Some(pid) = process_id {
-        acp::retire_orphaned_process(pid).await;
+    let (meta, process_identity) = pool.take_task_for_panic(task_id);
+    if let Some(identity) = process_identity {
+        acp::retire_orphaned_process(identity).await;
     }
     let Some(meta) = meta else {
         tracing::error!("panic for unknown task {task_id:?} — bug");
@@ -4434,7 +4515,7 @@ fn dispatch_heartbeat(
     let result_tx = pool.result_tx();
     let ctx_clone = Arc::clone(ctx);
     let agent_index = agent.index;
-    let agent_pid = agent.acp.process_id();
+    let agent_process_identity = agent.acp.process_identity();
     let turn_id = Uuid::new_v4().to_string();
     let task_turn_id = turn_id.clone();
 
@@ -4465,8 +4546,8 @@ fn dispatch_heartbeat(
             steer_tx: None,
         },
     );
-    if let Some(pid) = agent_pid {
-        pool.register_task_process(task_id, pid);
+    if let Some(identity) = agent_process_identity {
+        pool.register_task_process(task_id, identity);
     }
     *heartbeat_in_flight = true;
     tracing::info!(agent = agent_index, "heartbeat_fired");
@@ -5241,47 +5322,74 @@ mod owner_control_command_tests {
     use super::*;
     use nostr::{EventBuilder, Keys, Kind, Tag};
 
-    fn make_event(kind: u32, content: &str, p_hex: Option<&str>) -> nostr::Event {
-        let keys = Keys::generate();
+    fn make_event(keys: &Keys, kind: u32, content: &str, p_hex: Option<&str>) -> nostr::Event {
         let tags = match p_hex {
             Some(hex) => vec![Tag::parse(["p", hex]).expect("p tag")],
             None => vec![],
         };
         EventBuilder::new(Kind::Custom(kind as u16), content)
             .tags(tags)
-            .sign_with_keys(&keys)
+            .sign_with_keys(keys)
             .unwrap()
     }
 
     #[test]
-    fn owner_control_command_requires_kind_content_and_agent_mention() {
+    fn owner_control_command_requires_authorized_owner_kind_content_and_agent_mention() {
         let agent = "ab".repeat(32);
+        let owner_keys = Keys::generate();
+        let owner = owner_keys.public_key().to_hex();
 
-        let event = make_event(KIND_STREAM_MESSAGE, " !rotate ", Some(&agent));
+        let event = make_event(&owner_keys, KIND_STREAM_MESSAGE, " !rotate ", Some(&agent));
         assert!(is_owner_control_command(
             &event,
             KIND_STREAM_MESSAGE,
             "!rotate",
-            &agent
+            &agent,
+            Some(&owner),
         ));
 
-        let wrong_kind = make_event(1, "!rotate", Some(&agent));
-        assert!(!is_owner_control_command(&wrong_kind, 1, "!rotate", &agent));
+        let stranger_keys = Keys::generate();
+        let stranger = make_event(&stranger_keys, KIND_STREAM_MESSAGE, "!rotate", Some(&agent));
+        assert!(!is_owner_control_command(
+            &stranger,
+            KIND_STREAM_MESSAGE,
+            "!rotate",
+            &agent,
+            Some(&owner),
+        ));
+        assert!(!is_owner_control_command(
+            &event,
+            KIND_STREAM_MESSAGE,
+            "!rotate",
+            &agent,
+            None,
+        ));
 
-        let wrong_content = make_event(KIND_STREAM_MESSAGE, "!cancel", Some(&agent));
+        let wrong_kind = make_event(&owner_keys, 1, "!rotate", Some(&agent));
+        assert!(!is_owner_control_command(
+            &wrong_kind,
+            1,
+            "!rotate",
+            &agent,
+            Some(&owner),
+        ));
+
+        let wrong_content = make_event(&owner_keys, KIND_STREAM_MESSAGE, "!cancel", Some(&agent));
         assert!(!is_owner_control_command(
             &wrong_content,
             KIND_STREAM_MESSAGE,
             "!rotate",
-            &agent
+            &agent,
+            Some(&owner),
         ));
 
-        let no_mention = make_event(KIND_STREAM_MESSAGE, "!rotate", None);
+        let no_mention = make_event(&owner_keys, KIND_STREAM_MESSAGE, "!rotate", None);
         assert!(!is_owner_control_command(
             &no_mention,
             KIND_STREAM_MESSAGE,
             "!rotate",
-            &agent
+            &agent,
+            Some(&owner),
         ));
     }
 
@@ -7798,7 +7906,7 @@ mod error_outcome_emission_tests {
                 steer_tx: None,
             },
         );
-        pool.register_task_process(task_id, orphan_pid);
+        pool.register_task_process(task_id, acp::ProcessIdentity::capture(orphan_pid));
         started_rx.await.unwrap();
         abort_handle.abort();
         let join_error = pool.join_set.join_next().await.unwrap().unwrap_err();
@@ -8070,6 +8178,157 @@ mod error_outcome_emission_tests {
             crash_budget_untouched,
             "planned recycling must not trip crash accounting"
         );
+    }
+
+    #[tokio::test]
+    async fn successful_prompt_result_terminally_resets_retry_budget() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::channel(channel_id);
+        let agent = dummy_agent(0).await;
+        let event = EventBuilder::new(Kind::Custom(9), "successful retry")
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        let batch = FlushBatch {
+            lane: lane.clone(),
+            channel_id,
+            events: vec![BatchEvent {
+                event: event.clone(),
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        queue.set_retry_count_for_test(channel_id, 2);
+        bind_batch_generation(&mut queue, &batch, "successful-retry-turn");
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        pool.task_map_mut().insert(
+            task_id,
+            crate::pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                lane: Some(lane.clone()),
+                turn_id: "successful-retry-turn".into(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: None,
+            },
+        );
+        let config = test_config();
+        let mut heartbeat_in_flight = false;
+        let mut crash_history = vec![SlotCircuit {
+            crash_times: Vec::new(),
+            open_until: None,
+            respawn_in_flight: false,
+        }];
+        let (respawn_tx, _respawn_rx) = mpsc::channel(8);
+        let mut respawn_tasks = tokio::task::JoinSet::new();
+
+        handle_prompt_result(
+            &mut pool,
+            &mut queue,
+            &config,
+            PromptResult {
+                agent,
+                source: PromptSource::Lane(lane.clone()),
+                turn_id: "successful-retry-turn".into(),
+                outcome: PromptOutcome::Ok(acp::StopReason::EndTurn),
+                batch: None,
+            },
+            &mut heartbeat_in_flight,
+            &HashSet::new(),
+            &mut crash_history,
+            &respawn_tx,
+            &mut respawn_tasks,
+            None,
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            queue.retry_count_for_test(&lane),
+            None,
+            "authoritative success must reset the lane's retry budget"
+        );
+        shutdown_agent_pool(&mut pool).await;
+    }
+
+    #[tokio::test]
+    async fn non_retryable_terminal_failure_resets_retry_budget() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::channel(channel_id);
+        let agent = dummy_agent(0).await;
+        let batch = FlushBatch {
+            lane: lane.clone(),
+            channel_id,
+            events: vec![BatchEvent {
+                event: EventBuilder::new(Kind::Custom(9), "invalid terminal request")
+                    .sign_with_keys(&Keys::generate())
+                    .unwrap(),
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        queue.set_retry_count_for_test(channel_id, 2);
+        bind_batch_generation(&mut queue, &batch, "invalid-terminal-turn");
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        pool.task_map_mut().insert(
+            task_id,
+            crate::pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                lane: Some(lane.clone()),
+                turn_id: "invalid-terminal-turn".into(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: None,
+            },
+        );
+        let config = test_config();
+        let mut heartbeat_in_flight = false;
+        let mut crash_history = vec![SlotCircuit {
+            crash_times: Vec::new(),
+            open_until: None,
+            respawn_in_flight: false,
+        }];
+        let (respawn_tx, _respawn_rx) = mpsc::channel(8);
+        let mut respawn_tasks = tokio::task::JoinSet::new();
+
+        handle_prompt_result(
+            &mut pool,
+            &mut queue,
+            &config,
+            PromptResult {
+                agent,
+                source: PromptSource::Lane(lane.clone()),
+                turn_id: "invalid-terminal-turn".into(),
+                outcome: PromptOutcome::Error(acp::AcpError::InvalidInput("invalid root".into())),
+                batch: Some(batch),
+            },
+            &mut heartbeat_in_flight,
+            &HashSet::new(),
+            &mut crash_history,
+            &respawn_tx,
+            &mut respawn_tasks,
+            None,
+            None,
+        )
+        .await;
+
+        assert_eq!(
+            queue.retry_count_for_test(&lane),
+            None,
+            "terminal non-retryable failure must reset the lane's retry budget"
+        );
+        shutdown_agent_pool(&mut pool).await;
     }
 
     /// hard-cap timeout dead-letters immediately (no requeue); idle timeout is requeued.

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -41,7 +41,10 @@ use pool::{
     PromptResult, PromptSource, SessionState, TimeoutKind,
 };
 use pool_lifecycle::PoolLifecycle;
-use queue::{CancelReason, EventQueue, FlushBatch, QueuedEvent, ThreadTags};
+use queue::{
+    AffinityPolicy, CancelReason, EventQueue, FlushBatch, LaneKey, OverloadReason, PushResult,
+    QueuedEvent, ThreadTags,
+};
 use relay::{HarnessRelay, RelayEventPublisher};
 use tokio::sync::{mpsc, watch};
 use tracing_subscriber::EnvFilter;
@@ -61,10 +64,37 @@ fn is_subcommand(name: &str) -> bool {
 
 /// Timeout for lightweight helper subcommands (spawn + initialize + model/method probes).
 const MODELS_TIMEOUT: Duration = Duration::from_secs(10);
+/// Hard bound for every pool-agent initialize handshake, including background
+/// respawns and healthy session-budget recycling.
+const AGENT_INITIALIZE_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Timeout for `buzz-acp authenticate`. Browser-based vendor auth can require
 /// human interaction, so it must not share the short probe timeout.
 const AUTHENTICATE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+/// Hard cap for per-channel membership replay/removal state. Production
+/// workspaces are orders of magnitude smaller; fail closed on unseen channels
+/// rather than permit unbounded growth under long-lived membership churn.
+const MAX_TRACKED_MEMBERSHIP_CHANNELS: usize = 4096;
+
+fn membership_state_can_track<T>(newest: &HashMap<Uuid, T>, channel_id: Uuid) -> bool {
+    newest.contains_key(&channel_id) || newest.len() < MAX_TRACKED_MEMBERSHIP_CHANNELS
+}
+
+/// Membership notifications are replaceable state transitions. Compare the
+/// relay-authored `(created_at, event_id)` tuple so equal-second add/remove
+/// delivery converges regardless of replay order; an exact duplicate is not
+/// newer.
+fn membership_order_is_newer(
+    current: Option<&(u64, String)>,
+    candidate_ts: u64,
+    candidate_event_id: &str,
+) -> bool {
+    current.is_none_or(|(newest_ts, newest_event_id)| {
+        candidate_ts > *newest_ts
+            || (candidate_ts == *newest_ts && candidate_event_id > newest_event_id.as_str())
+    })
+}
 
 /// Publish a kind:20001 presence update event via the WebSocket connection.
 ///
@@ -1384,8 +1414,67 @@ struct RespawnResult {
 /// Carries enough identity to operate on the right withheld event in
 /// `EventQueue::withheld_native_steer`: `channel_id` is the routing key,
 /// `event_id` is the hex id of the single event the steer carried.
+#[derive(Debug, Clone)]
+struct TypingLaneState {
+    turn_id: String,
+    thread_tags: ThreadTags,
+}
+
+fn clear_typing_lane_for_turn(
+    typing: &mut HashMap<LaneKey, TypingLaneState>,
+    lane: &LaneKey,
+    turn_id: &str,
+) -> bool {
+    if typing.get(lane).map(|state| state.turn_id.as_str()) != Some(turn_id) {
+        return false;
+    }
+    typing.remove(lane);
+    true
+}
+
+fn steer_ack_is_obsolete(
+    queue: &EventQueue,
+    removed_channels: &HashSet<Uuid>,
+    lane: &LaneKey,
+    turn_id: &str,
+) -> bool {
+    removed_channels.contains(&lane.channel_id) || queue.lane_turn_conflicts(lane, turn_id)
+}
+
+/// `(release_withheld, drop_withheld, signal_cancel_merge)` for one decoded
+/// native-steer acknowledgement. Keeping this pure and exhaustive prevents a
+/// new typed adapter outcome from silently falling into an unsafe fallback.
+fn native_steer_ack_policy(ack: &pool::SteerAck) -> (bool, bool, bool) {
+    match ack {
+        pool::SteerAck::Success => (false, true, false),
+        pool::SteerAck::Err(pool::SteerError::AgentError { code, .. }) => {
+            (true, false, *code == -32601)
+        }
+        pool::SteerAck::Err(_) => (true, false, true),
+        pool::SteerAck::PromptCompletedNeutral => (true, false, false),
+    }
+}
+
+/// Settle only the immutable event named by one steer attempt. This never
+/// changes lane ownership/deadlines or signals a replacement generation.
+fn settle_native_steer_event(
+    queue: &mut EventQueue,
+    lane: &LaneKey,
+    event_id: &str,
+    policy: (bool, bool, bool),
+) {
+    let (release_withheld, drop_withheld, _) = policy;
+    if drop_withheld {
+        queue.remove_lane_event(lane, event_id);
+    }
+    if release_withheld {
+        queue.release_lane_native_steer(lane, event_id);
+    }
+}
+
 struct SteerAckEvent {
-    channel_id: Uuid,
+    lane: LaneKey,
+    turn_id: String,
     event_id: String,
     /// `Ok` if the read loop sent any of the locked `SteerAck` variants.
     /// `Err` if the oneshot was dropped without a send — should not happen
@@ -1466,6 +1555,44 @@ fn inactivity_expired(
     turn_in_flight: bool,
 ) -> bool {
     !bound.is_zero() && !turn_in_flight && now.duration_since(last_activity) >= bound
+}
+
+#[cfg(test)]
+mod event_channel_binding_tests {
+    use super::*;
+    use nostr::{EventBuilder, Keys, Kind, Tag};
+
+    fn signed_event(tags: Vec<Tag>) -> nostr::Event {
+        EventBuilder::new(Kind::Custom(9), "test")
+            .tags(tags)
+            .sign_with_keys(&Keys::generate())
+            .unwrap()
+    }
+
+    #[test]
+    fn exact_single_channel_tag_is_required() {
+        let channel = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let matching = Tag::parse(["h", &channel.to_string()]).unwrap();
+        let conflicting = Tag::parse(["h", &other.to_string()]).unwrap();
+
+        assert!(has_exact_channel_binding(
+            &signed_event(vec![matching.clone()]),
+            channel
+        ));
+        assert!(!has_exact_channel_binding(&signed_event(vec![]), channel));
+        assert!(!has_exact_channel_binding(
+            &signed_event(vec![matching.clone(), matching]),
+            channel
+        ));
+        assert!(!has_exact_channel_binding(
+            &signed_event(vec![
+                Tag::parse(["h", &channel.to_string()]).unwrap(),
+                conflicting,
+            ]),
+            channel
+        ));
+    }
 }
 
 #[cfg(test)]
@@ -1784,8 +1911,11 @@ async fn tokio_main() -> Result<()> {
 
     let runtime_start_nonce = std::env::var("BUZZ_MANAGED_AGENT_START_NONCE").unwrap_or_default();
     let dedup_mode = config.dedup_mode;
-    let mut queue =
-        EventQueue::new(dedup_mode).with_in_flight_deadline(config.max_turn_duration_secs);
+    let mut queue = EventQueue::new_with_affinity(
+        dedup_mode,
+        affinity_policy_for_handling(config.multiple_event_handling),
+    )
+    .with_in_flight_deadline(config.max_turn_duration_secs);
 
     // Online means the harness can receive work, not merely that its socket is
     // connected. Publishing after channel subscriptions gives desktop callers
@@ -1810,6 +1940,9 @@ async fn tokio_main() -> Result<()> {
 
     let base_prompt_content = config.base_prompt_content.take();
     let ctx = Arc::new(PromptContext {
+        membership_admission: Arc::new(pool::MembershipAdmission::new(
+            subscribed_channel_ids.iter().copied(),
+        )),
         mcp_servers: build_mcp_servers(&config),
         initial_message: config.initial_message.clone(),
         idle_timeout: Duration::from_secs(config.idle_timeout_secs),
@@ -1882,7 +2015,7 @@ async fn tokio_main() -> Result<()> {
     } else {
         None
     };
-    let mut typing_channels: HashMap<Uuid, ThreadTags> = HashMap::new();
+    let mut typing_channels: HashMap<LaneKey, TypingLaneState> = HashMap::new();
     let mut presence_task: Option<tokio::task::JoinHandle<()>> = None;
 
     // Independent of pool readiness: a never-mentioned lazy agent must still
@@ -1948,13 +2081,14 @@ async fn tokio_main() -> Result<()> {
 
     // Track the newest membership notification timestamp per channel.
     // On reconnect the relay replays events newest-first, so the first event
-    // per channel is authoritative. Any later event with ts < newest is stale.
-    // Exact duplicates (same event ID) are caught by seen_membership_ids.
-    //
-    // Uses strict `<` (not `<=`) so that legitimate live events at the same
-    // second are both processed. The seen_membership_ids set handles exact
-    // replays that share the same timestamp.
-    let mut membership_newest_ts: HashMap<Uuid, u64> = HashMap::new();
+    // Per-channel `(created_at, event_id)` total-order watermark. The newest key
+    // is authoritative; equal-second transitions are ordered lexicographically
+    // by event ID and exact duplicates are caught by the bounded seen-ID sets.
+    let mut membership_newest_ts: HashMap<Uuid, (u64, String)> = subscribed_channel_ids
+        .iter()
+        .copied()
+        .map(|channel_id| (channel_id, (0, String::new())))
+        .collect();
     // Two-generation dedup for membership event replays (bounded, no amnesia).
     // Rotates at 1000 entries instead of clearing the entire set at 2000.
     let mut seen_membership_current: HashSet<String> = HashSet::new();
@@ -1965,17 +2099,8 @@ async fn tokio_main() -> Result<()> {
     // failed/panicked batches for these channels are dropped instead of requeued.
     //
     // Cleared on re-add (KIND_MEMBER_ADDED_NOTIFICATION) so re-joined channels
-    // regain session affinity.
-    //
-    // Known limitation: if a batch is in-flight when the channel is removed AND
-    // re-added before the batch returns, the stale batch may be requeued. This
-    // is acceptable because: (a) the agent is a member again and has access,
-    // (b) the events are from the agent's authorized history, (c) the window
-    // is extremely narrow (membership changes are rare, prompt turns are seconds),
-    // and (d) fixing this would require per-channel epoch tracking on TaskMeta
-    // and PromptResult — significant complexity for a benign edge case. If strict
-    // causal invalidation is needed, add a monotonic epoch counter per channel
-    // and capture it in TaskMeta at dispatch time.
+    // regain session affinity. Checked-out workers are fenced separately in
+    // AgentPool: their channel retirements survive re-add until they return.
     let mut removed_channels: HashSet<Uuid> = HashSet::new();
 
     //
@@ -2072,7 +2197,7 @@ async fn tokio_main() -> Result<()> {
             // indefinitely on quiet channels — dispatch_pending is only
             // called on relay events or pool results, neither of which
             // arrive when the channel is silent.
-            if queue.has_flushable_work() {
+            if queue.has_flushable_work_matching(|lane| pool.can_claim_lane(lane)) {
                 for (channel_id, thread_tags) in
                     dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
                 {
@@ -2208,6 +2333,15 @@ async fn tokio_main() -> Result<()> {
                     let _ = result_rx; // end split borrow before relay handling
                     match buzz_event {
                         Some(buzz_event) => {
+                            if let Err(error) = buzz_event.event.verify() {
+                                tracing::warn!(
+                                    channel_id = %buzz_event.channel_id,
+                                    event_id = %buzz_event.event.id.to_hex(),
+                                    %error,
+                                    "dropping inbound event with invalid Nostr id or signature"
+                                );
+                                continue;
+                            }
                             let kind_u32 = buzz_event.event.kind.as_u16() as u32;
 
                             if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION
@@ -2217,20 +2351,25 @@ async fn tokio_main() -> Result<()> {
                                 let ts = buzz_event.event.created_at.as_secs();
                                 let eid = buzz_event.event.id.to_hex();
 
+                                if !membership_state_can_track(&membership_newest_ts, ch) {
+                                    tracing::warn!(
+                                        channel_id = %ch,
+                                        limit = MAX_TRACKED_MEMBERSHIP_CHANNELS,
+                                        "membership channel-state limit reached — dropping unseen channel notification"
+                                    );
+                                    continue;
+                                }
+
                                 // Two-layer membership dedup:
                                 //
                                 // 1. Exact duplicate rejection (seen_membership_ids):
                                 //    Catches the same event replayed on reconnect.
                                 //
-                                // 2. Timestamp watermark (membership_newest_ts):
-                                //    Uses strict `<` so that older events from reconnect
-                                //    replay are dropped, but legitimate live events at the
-                                //    same second are both processed. This is safe because
-                                //    exact duplicates are already caught by layer 1.
-                                //
-                                // Why not `<=`? That would suppress legitimate live
-                                // add→remove (or remove→add) sequences in the same second,
-                                // leaving the harness in the wrong membership state.
+                                // 2. Total-order watermark (membership_newest_ts):
+                                //    Rejects any event whose `(created_at, event_id)` key is
+                                //    not strictly newer. This deterministically orders legitimate
+                                //    add/remove transitions authored in the same second while
+                                //    exact duplicates remain covered by layer 1.
                                 // Two-generation dedup: check both sets before inserting.
                                 if seen_membership_current.contains(&eid)
                                     || seen_membership_previous.contains(&eid)
@@ -2242,27 +2381,30 @@ async fn tokio_main() -> Result<()> {
                                     );
                                     continue;
                                 }
-                                seen_membership_current.insert(eid);
+                                seen_membership_current.insert(eid.clone());
                                 // Rotate at 1000: current → previous, no amnesia window.
                                 if seen_membership_current.len() >= 1000 {
                                     seen_membership_previous =
                                         std::mem::take(&mut seen_membership_current);
                                 }
-                                if let Some(&newest) = membership_newest_ts.get(&ch) {
-                                    if ts < newest {
-                                        tracing::debug!(
-                                            channel_id = %ch,
-                                            kind = kind_u32,
-                                            ts,
-                                            newest,
-                                            "skipping stale membership notification (older than newest)"
-                                        );
-                                        continue;
-                                    }
+                                if !membership_order_is_newer(
+                                    membership_newest_ts.get(&ch),
+                                    ts,
+                                    &eid,
+                                ) {
+                                    tracing::debug!(
+                                        channel_id = %ch,
+                                        kind = kind_u32,
+                                        ts,
+                                        event_id = %eid,
+                                        "skipping stale membership notification"
+                                    );
+                                    continue;
                                 }
-                                membership_newest_ts.insert(ch, ts);
+                                membership_newest_ts.insert(ch, (ts, eid));
 
                                 if kind_u32 == KIND_MEMBER_ADDED_NOTIFICATION {
+                                    ctx.membership_admission.activate(ch);
                                     // Clear removal tracking so sessions are not
                                     // stripped for a legitimately re-added channel.
                                     removed_channels.remove(&ch);
@@ -2280,25 +2422,39 @@ async fn tokio_main() -> Result<()> {
                                         tracing::debug!(channel_id = %ch, "membership notification: no matching rules — skipping");
                                     }
                                 } else {
+                                    // Establish the local security boundary before
+                                    // any network await. Every pre-removal task token
+                                    // is permanently stale from this point, including
+                                    // across a rapid remove/add sequence.
+                                    ctx.membership_admission.retire(ch);
+                                    removed_channels.insert(ch);
                                     subscribed_channel_ids.remove(&ch);
                                     tracing::info!(channel_id = %ch, "membership notification: unsubscribing from channel");
+                                    // Permanently purge queued and in-flight exact-lane
+                                    // ownership for the removed channel. Mark it removed
+                                    // before signalling tasks so racing results/acks fail closed.
+                                    let drained_ids = queue.purge_channel(ch);
+                                    let (cancelled, invalidated, retired_workers) = if pool_ready {
+                                        let retired_workers = pool
+                                            .retire_channel_sessions_for_checked_out_agents(ch);
+                                        (
+                                            signal_all_in_flight_channel_tasks(
+                                                &mut pool,
+                                                ch,
+                                                ControlSignal::Cancel,
+                                            ),
+                                            pool.invalidate_channel_sessions(ch),
+                                            retired_workers,
+                                        )
+                                    } else {
+                                        (0, 0, 0)
+                                    };
                                     if let Err(e) = relay.unsubscribe_channel(ch).await {
                                         tracing::warn!("failed to unsubscribe from channel {ch}: {e}");
                                     }
-                                    // Drain queued events and invalidate sessions for the
-                                    // removed channel. Events already in-flight will
-                                    // complete normally (the relay may reject actions if
-                                    // the agent lost access).
-                                    let drained_ids = queue.drain_channel(ch);
-                                    let invalidated = if pool_ready {
-                                        pool.invalidate_channel_sessions(ch)
-                                    } else {
-                                        0
-                                    };
-                                    // Track removed channels so checked-out agents get
-                                    // their sessions stripped when they return to the pool.
-                                    removed_channels.insert(ch);
-                                    typing_channels.remove(&ch);
+                                    // Checked-out agents strip their channel sessions when
+                                    // their cancellation result returns to the pool.
+                                    typing_channels.retain(|lane, _| lane.channel_id != ch);
                                     // Best-effort: clean up 👀 on drained events.
                                     // Note: the relay revokes membership before
                                     // emitting the notification, so this DELETE may
@@ -2314,15 +2470,42 @@ async fn tokio_main() -> Result<()> {
                                             }
                                         });
                                     }
-                                    if !drained_ids.is_empty() || invalidated > 0 {
+                                    if !drained_ids.is_empty()
+                                        || invalidated > 0
+                                        || cancelled > 0
+                                        || retired_workers > 0
+                                    {
                                         tracing::info!(
                                             channel_id = %ch,
                                             drained = drained_ids.len(),
+                                            cancelled,
                                             invalidated,
+                                            retired_workers,
                                             "cleaned up after membership removal"
                                         );
                                     }
                                 }
+                                continue;
+                            }
+
+                            if !has_exact_channel_binding(
+                                &buzz_event.event,
+                                buzz_event.channel_id,
+                            ) {
+                                tracing::warn!(
+                                    channel_id = %buzz_event.channel_id,
+                                    event_id = %buzz_event.event.id.to_hex(),
+                                    "dropping inbound event with missing, duplicate, or conflicting h tag"
+                                );
+                                continue;
+                            }
+
+                            if removed_channels.contains(&buzz_event.channel_id) {
+                                tracing::warn!(
+                                    channel_id = %buzz_event.channel_id,
+                                    event_id = %buzz_event.event.id.to_hex(),
+                                    "dropping event from a locally retired channel subscription"
+                                );
                                 continue;
                             }
 
@@ -2372,16 +2555,37 @@ async fn tokio_main() -> Result<()> {
                             if is_cancel {
                                 if let Some(owner) = owner_cache.get() {
                                     if buzz_event.event.pubkey.to_hex() == *owner {
-                                        let fired = signal_in_flight_task(
-                                            &mut pool,
+                                        let is_dm_control = is_dm_channel(
                                             buzz_event.channel_id,
+                                            &ctx.channel_info,
+                                        )
+                                        .await;
+                                        match signal_control_event(
+                                            &mut pool,
+                                            &queue,
+                                            buzz_event.channel_id,
+                                            &buzz_event.event,
+                                            affinity_policy_for_handling(
+                                                config.multiple_event_handling,
+                                            ),
+                                            is_dm_control,
                                             ControlSignal::Cancel,
-                                        );
-                                        if !fired {
-                                            tracing::warn!(
+                                        ) {
+                                            Ok((lane, true)) => tracing::info!(
+                                                channel_id = %lane.channel_id,
+                                                lane_root = %lane.root_event_id,
+                                                "!cancel sent to exact in-flight lane"
+                                            ),
+                                            Ok((lane, false)) => tracing::warn!(
+                                                channel_id = %lane.channel_id,
+                                                lane_root = %lane.root_event_id,
+                                                "!cancel received but no matching current lane turn — no-op"
+                                            ),
+                                            Err(error) => tracing::warn!(
                                                 channel_id = %buzz_event.channel_id,
-                                                "!cancel received but no in-flight task — no-op"
-                                            );
+                                                %error,
+                                                "!cancel could not resolve an exact lane — no-op"
+                                            ),
                                         }
                                         continue; // consume event — do NOT push to queue
                                     }
@@ -2410,23 +2614,42 @@ async fn tokio_main() -> Result<()> {
                             if is_rotate {
                                 if let Some(owner) = owner_cache.get() {
                                     if buzz_event.event.pubkey.to_hex() == *owner {
-                                        let fired = signal_in_flight_task(
-                                            &mut pool,
+                                        let is_dm_control = is_dm_channel(
                                             buzz_event.channel_id,
+                                            &ctx.channel_info,
+                                        )
+                                        .await;
+                                        match signal_control_event(
+                                            &mut pool,
+                                            &queue,
+                                            buzz_event.channel_id,
+                                            &buzz_event.event,
+                                            affinity_policy_for_handling(
+                                                config.multiple_event_handling,
+                                            ),
+                                            is_dm_control,
                                             ControlSignal::Rotate,
-                                        );
-                                        if fired {
-                                            tracing::info!(
+                                        ) {
+                                            Ok((lane, true)) => tracing::info!(
+                                                channel_id = %lane.channel_id,
+                                                lane_root = %lane.root_event_id,
+                                                "!rotate received — cancelling exact in-flight turn and rotating session"
+                                            ),
+                                            Ok((lane, false)) => {
+                                                let invalidated =
+                                                    pool.invalidate_lane_sessions(&lane);
+                                                tracing::info!(
+                                                    channel_id = %lane.channel_id,
+                                                    lane_root = %lane.root_event_id,
+                                                    invalidated,
+                                                    "!rotate received — invalidated idle lane session(s)"
+                                                );
+                                            }
+                                            Err(error) => tracing::warn!(
                                                 channel_id = %buzz_event.channel_id,
-                                                "!rotate received — cancelling in-flight turn and rotating session"
-                                            );
-                                        } else {
-                                            let invalidated = pool.invalidate_channel_sessions(buzz_event.channel_id);
-                                            tracing::info!(
-                                                channel_id = %buzz_event.channel_id,
-                                                invalidated,
-                                                "!rotate received — invalidated idle channel session(s)"
-                                            );
+                                                %error,
+                                                "!rotate could not resolve an exact lane — no-op"
+                                            ),
                                         }
                                         continue; // consume event — do NOT push to queue
                                     }
@@ -2445,13 +2668,13 @@ async fn tokio_main() -> Result<()> {
                             // launched by the same human). Allowlist adds the
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
+                            let is_dm =
+                                is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                             {
                                 let author = buzz_event.event.pubkey.to_hex();
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
-                                let is_dm =
-                                    is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                                 let allowed = author_allowed(
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
@@ -2497,12 +2720,48 @@ async fn tokio_main() -> Result<()> {
                             // backed payload) so the cost is negligible.
                             let event_for_steer = buzz_event.event.clone();
                             let prompt_tag_for_steer = prompt_tag.clone();
-                            let accepted = queue.push(QueuedEvent {
+                            let lane = match LaneKey::resolve(
+                                buzz_event.channel_id,
+                                &buzz_event.event,
+                                affinity_policy_for_handling(config.multiple_event_handling),
+                                is_dm,
+                            ) {
+                                Ok(lane) => lane,
+                                Err(_) => {
+                                    tracing::warn!(
+                                        channel_id = %buzz_event.channel_id,
+                                        event_id = %event_id_hex,
+                                        "event has invalid or incomplete NIP-10 thread metadata — dropping"
+                                    );
+                                    continue;
+                                }
+                            };
+                            let push_result = queue.push_resolved(QueuedEvent {
                                 channel_id: buzz_event.channel_id,
                                 event: buzz_event.event,
                                 received_at: std::time::Instant::now(),
                                 prompt_tag,
-                            });
+                            }, lane.clone());
+                            let accepted = matches!(push_result, PushResult::Accepted);
+                            if let PushResult::Overloaded(reason) = push_result {
+                                let content = match reason {
+                                    OverloadReason::TooManyChannelLanes => {
+                                        "I’m at the concurrent thread limit for this channel. Please retry shortly."
+                                    }
+                                    OverloadReason::AggregatePendingLimit => {
+                                        "I’m at the pending work limit. Please retry shortly."
+                                    }
+                                    OverloadReason::LaneQueueFull => {
+                                        "This thread has reached its pending work limit. Please retry shortly."
+                                    }
+                                };
+                                let rest = ctx.rest_client.clone();
+                                let thread_tags = queue::parse_thread_tags(&event_for_steer);
+                                let channel_id = buzz_event.channel_id;
+                                tokio::spawn(async move {
+                                    pool::post_failure_notice(&rest, channel_id, &thread_tags, content).await;
+                                });
+                            }
                             // 👀 — immediate "seen" reaction, only if the event
                             // was actually queued (not dropped by DedupMode::Drop).
                             // Fire-and-forget: on rare fast-failure paths the
@@ -2518,7 +2777,7 @@ async fn tokio_main() -> Result<()> {
                             // Event is already queued. If mode requires it AND
                             // the channel has an in-flight task, fire cancel —
                             // OR take the non-cancelling (ACP steer) fork for Steer signals.
-                            if accepted && queue.is_channel_in_flight(buzz_event.channel_id) {
+                            if accepted && queue.is_lane_in_flight(&lane) {
                                 // Author eligibility (owner ∪ allowlist ∪ siblings)
                                 // is already enforced by the inbound author gate
                                 // above, so the mid-turn signal fires for every
@@ -2545,17 +2804,28 @@ async fn tokio_main() -> Result<()> {
                                         && try_native_steer(
                                             &mut pool,
                                             &mut queue,
-                                            buzz_event.channel_id,
+                                            lane.clone(),
                                             event_for_steer,
                                             prompt_tag_for_steer,
                                             &steer_ack_tx,
                                         );
                                     if !native_attempted {
-                                        signal_in_flight_task(
-                                            &mut pool,
-                                            buzz_event.channel_id,
-                                            signal,
-                                        );
+                                        let current_turn =
+                                            queue.lane_turn_id(&lane).map(str::to_owned);
+                                        if let Some(turn_id) = current_turn.as_deref() {
+                                            signal_in_flight_lane_turn(
+                                                &mut pool,
+                                                &lane,
+                                                Some(turn_id),
+                                                signal,
+                                            );
+                                        } else {
+                                            tracing::warn!(
+                                                channel_id = %lane.channel_id,
+                                                lane_root = %lane.root_event_id,
+                                                "fallback signal skipped because the lane has no bound turn generation"
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -2608,7 +2878,9 @@ async fn tokio_main() -> Result<()> {
                     let _ = result_rx;
                     if !pool_ready {
                         tracing::debug!("heartbeat_skipped_pool_not_ready");
-                    } else if queue.has_flushable_work() {
+                    } else if queue
+                        .has_flushable_work_matching(|lane| pool.can_claim_lane(lane))
+                    {
                         tracing::debug!("heartbeat_skipped_events");
                         for (channel_id, thread_tags) in
                             dispatch_pending(&mut pool, &mut queue, &ctx, &mut last_activity)
@@ -2652,14 +2924,18 @@ async fn tokio_main() -> Result<()> {
                     // Use try_publish (non-blocking) for typing indicators —
                     // they're ephemeral and must not block the main loop during
                     // relay reconnection (#35).
-                    for (&ch, thread_tags) in &typing_channels {
+                    for (lane, typing_state) in &typing_channels {
                         if let Ok(event) = relay.build_typing_event(
-                            ch,
-                            thread_tags.root_event_id.as_deref(),
-                            thread_tags.parent_event_id.as_deref(),
+                            lane.channel_id,
+                            typing_state.thread_tags.root_event_id.as_deref(),
+                            typing_state.thread_tags.parent_event_id.as_deref(),
                         ) {
                             if let Err(e) = relay.try_publish_event(event) {
-                                tracing::debug!("typing indicator dropped for {ch}: {e}");
+                                tracing::debug!(
+                                channel = %lane.channel_id,
+                                error = %e,
+                                "typing indicator dropped"
+                            );
                             }
                         }
                     }
@@ -2674,9 +2950,12 @@ async fn tokio_main() -> Result<()> {
 
         match pool_event {
             Some(PoolEvent::Result(result)) => {
-                // Stop typing indicator for the completed channel.
-                if let PromptSource::Channel(ch) = &result.source {
-                    typing_channels.remove(ch);
+                // Stop typing only if this result still owns the lane generation.
+                match &result.source {
+                    PromptSource::Lane(lane) => {
+                        clear_typing_lane_for_turn(&mut typing_channels, lane, &result.turn_id);
+                    }
+                    PromptSource::Heartbeat => {}
                 }
                 if handle_prompt_result(
                     &mut pool,
@@ -2690,7 +2969,9 @@ async fn tokio_main() -> Result<()> {
                     &mut respawn_tasks,
                     observer.clone(),
                     Some(&ctx.rest_client),
-                ) == LoopAction::Exit
+                )
+                .await
+                    == LoopAction::Exit
                 {
                     break;
                 }
@@ -2705,7 +2986,10 @@ async fn tokio_main() -> Result<()> {
                     &respawn_tx,
                     &mut respawn_tasks,
                     observer.clone(),
-                ) == LoopAction::Exit
+                    Some(&ctx.rest_client),
+                )
+                .await
+                    == LoopAction::Exit
                 {
                     break;
                 }
@@ -2729,7 +3013,9 @@ async fn tokio_main() -> Result<()> {
                     &respawn_tx,
                     &mut respawn_tasks,
                     observer.clone(),
-                );
+                    Some(&ctx.rest_client),
+                )
+                .await;
                 if pool.live_count() == 0 && !any_respawn_in_flight(&crash_history) {
                     tracing::error!("all agents dead — exiting");
                     break;
@@ -2741,112 +3027,40 @@ async fn tokio_main() -> Result<()> {
                 }
             }
             Some(PoolEvent::SteerAck(SteerAckEvent {
-                channel_id,
+                lane,
+                turn_id,
                 event_id,
                 ack,
             })) => {
-                // Mid-turn steer attempt resolved (either transport:
-                // `_goose/unstable/session/steer` or `_session/steering`).
-                // Locked semantics (Eva + Max + Perci, unanimous on Option X):
-                //
-                //   Success
-                //     The agent received the steer via the non-cancelling
-                //     path. Drop the withheld event so normal dispatch
-                //     never redelivers it.
-                //
-                //     Also covers `_session/steering`'s `startedNewTurn`
-                //     outcome: the message was delivered, but into a fresh
-                //     turn because the one being steered had already
-                //     finished. Delivery is what this arm keys on, so the
-                //     event is still dropped. The read loop deliberately
-                //     does NOT renew its hard deadline in that case (the
-                //     awaited turn is settled), while
-                //     `extend_in_flight_deadline` below still applies —
-                //     the agent really is running more work, so the
-                //     channel's in-flight budget should reflect it.
-                //
-                //   Err(_) where the write never landed (Transport /
-                //   ExpectedRunIdMissing):
-                //     Delivery state of the underlying message is "never
-                //     attempted on the wire". Release withheld back to the
-                //     queue front AND issue the cancel+merge fallback so
-                //     the message still reaches the agent.
-                //
-                //   Err(OutcomeRejected { .. })
-                //     A `_session/steering` request returned a JSON-RPC
-                //     success whose `outcome` was not `injected` or
-                //     `startedNewTurn` (codex's `failed`, an unknown value,
-                //     or a bare `{}` with no `outcome` at all). The steer
-                //     did not land, so this is treated exactly like a write
-                //     that never happened: release withheld AND fire the
-                //     cancel+merge fallback. Handled by the catch-all
-                //     `Err(_)` arm below.
-                //
-                //   Err(AgentError { code: -32601, .. })
-                //     The agent returned method_not_found — it does not
-                //     implement the steer extension. Release withheld AND
-                //     fire the cancel+merge fallback so the message still
-                //     reaches the agent via the universal path.
-                //
-                //   Err(AgentError { code: other, .. })
-                //     The write landed and the agent returned a JSON-RPC
-                //     error at the application level (e.g. wrong run id).
-                //     The agent's turn is still running (or just completed).
-                //     Release withheld for normal dispatch; do NOT fire the
-                //     fallback signal — the agent already saw the steer
-                //     attempt. If the turn is still running, normal dispatch
-                //     re-delivers when it completes. If the turn already
-                //     ended, there is nothing to cancel.
-                //
-                //   PromptCompletedNeutral
-                //     The read loop wrote the steer (or was preparing to)
-                //     but the prompt completed before the response landed.
-                //     Delivery state is unknown — but the prompt completing
-                //     means there is no in-flight turn to signal anymore.
-                //     Release withheld for normal dispatch; do NOT fire
-                //     the fallback signal (it would target a turn that
-                //     just ended; normal dispatch already handles
-                //     redelivery via the released queue entry).
-                //
-                //   Err(PromptCompleted)
-                //     `SteerError::PromptCompleted` is returned synchronously
-                //     by `pool::send_steer` when no task is in flight (handled
-                //     in `try_native_steer`'s Err branch, which falls through
-                //     to cancel+merge). It is never routed through the ack
-                //     channel, so this variant never appears in `SteerAckEvent`.
-                //
-                //   Watcher Err (oneshot dropped)
-                //     Should not happen — the read loop drains
-                //     pending_steer on every return path. If it does,
-                //     treat as PromptCompletedNeutral to avoid leaking
-                //     the withheld event in `withheld_native_steer`.
-                let (release_withheld, drop_withheld, signal_fallback) = match &ack {
-                    Ok(pool::SteerAck::Success) => (false, true, false),
-                    // -32601 = method_not_found: agent does not implement the
-                    // steer extension. Fire cancel+merge so the message still
-                    // reaches the agent.
-                    Ok(pool::SteerAck::Err(pool::SteerError::AgentError { code, .. }))
-                        if *code == -32601 =>
-                    {
-                        (true, false, true)
+                let channel_id = lane.channel_id;
+                if steer_ack_is_obsolete(&queue, &removed_channels, &lane, &turn_id) {
+                    if !removed_channels.contains(&channel_id) {
+                        let policy = ack
+                            .as_ref()
+                            .map(native_steer_ack_policy)
+                            .unwrap_or((true, false, false));
+                        settle_native_steer_event(&mut queue, &lane, &event_id, policy);
                     }
-                    // AgentError: write landed, agent rejected it at the
-                    // application level (e.g. wrong run id). Release for
-                    // normal dispatch; no fallback signal (the turn is still
-                    // running or just ended — either way there is nothing to
-                    // cancel).
-                    Ok(pool::SteerAck::Err(pool::SteerError::AgentError { .. })) => {
-                        (true, false, false)
-                    }
-                    // Transport / ExpectedRunIdMissing / OutcomeRejected: the
-                    // steer did not land. Release and fire the cancel+merge
-                    // fallback so the message still reaches the agent.
-                    Ok(pool::SteerAck::Err(_)) => (true, false, true),
-                    Ok(pool::SteerAck::PromptCompletedNeutral) => (true, false, false),
-                    Err(_recv_err) => (true, false, false),
-                };
+                    tracing::warn!(
+                        channel = %channel_id,
+                        lane_root = %lane.root_event_id,
+                        turn_id,
+                        event_id,
+                        "settled exact event from obsolete native steer acknowledgement without touching replacement generation"
+                    );
+                    continue;
+                }
+                // Typed policy:
+                // - owned `Success` drops the exact event and renews this turn;
+                // - ordinary unconsumed failures release + cancel/merge;
+                // - neutral completion / watcher loss releases without signalling.
+                let (release_withheld, drop_withheld, signal_fallback) = ack
+                    .as_ref()
+                    .map(native_steer_ack_policy)
+                    .unwrap_or((true, false, false));
                 tracing::info!(
                     channel = %channel_id,
+                    turn_id,
                     event_id = %event_id,
                     ?ack,
                     release_withheld,
@@ -2855,21 +3069,26 @@ async fn tokio_main() -> Result<()> {
                     "non-cancelling steer ack received"
                 );
                 if matches!(ack, Ok(pool::SteerAck::Success)) {
-                    queue.extend_in_flight_deadline(channel_id, config.max_turn_duration_secs);
+                    queue.extend_lane_deadline(&lane, config.max_turn_duration_secs);
                 }
-                if drop_withheld {
-                    queue.remove_event(channel_id, &event_id);
-                }
-                if release_withheld {
-                    queue.release_native_steer(channel_id, &event_id);
-                }
+                settle_native_steer_event(
+                    &mut queue,
+                    &lane,
+                    &event_id,
+                    (release_withheld, drop_withheld, signal_fallback),
+                );
                 if signal_fallback {
                     // Universal cancel+merge fallback. Note: the
                     // queued event has already been released to the
                     // front of `queues[channel_id]`, so the cancel
                     // will pick it up as part of the merged batch and
                     // re-prompt the agent.
-                    signal_in_flight_task(&mut pool, channel_id, ControlSignal::Steer);
+                    signal_in_flight_lane_turn(
+                        &mut pool,
+                        &lane,
+                        Some(&turn_id),
+                        ControlSignal::Steer,
+                    );
                 }
                 // After releasing a withheld event, give dispatch a chance
                 // to re-flush. If the prompt is still in flight, the
@@ -3089,6 +3308,14 @@ fn is_owner_control_command(
 /// `OwnerInterrupt` re-checks authorship (owner-only) here.
 ///
 /// `owner` is the resolved owner pubkey hex, if known.
+fn affinity_policy_for_handling(handling: MultipleEventHandling) -> AffinityPolicy {
+    if matches!(handling, MultipleEventHandling::SteerThread) {
+        AffinityPolicy::RootThread
+    } else {
+        AffinityPolicy::Channel
+    }
+}
+
 fn mode_gate_signal(
     handling: MultipleEventHandling,
     author_hex: &str,
@@ -3096,7 +3323,9 @@ fn mode_gate_signal(
 ) -> Option<ControlSignal> {
     match handling {
         MultipleEventHandling::Queue => None,
-        MultipleEventHandling::Steer => Some(ControlSignal::Steer),
+        MultipleEventHandling::Steer | MultipleEventHandling::SteerThread => {
+            Some(ControlSignal::Steer)
+        }
         MultipleEventHandling::Interrupt => Some(ControlSignal::Interrupt),
         MultipleEventHandling::OwnerInterrupt => match owner {
             Some(o) if author_hex == o => Some(ControlSignal::Interrupt),
@@ -3112,19 +3341,123 @@ fn signal_in_flight_task(
     channel_id: uuid::Uuid,
     mode: ControlSignal,
 ) -> bool {
-    let entry = pool
-        .task_map_mut()
-        .values_mut()
-        .find(|m| m.channel_id == Some(channel_id));
+    let target_id = {
+        let mut matches = pool
+            .task_map()
+            .iter()
+            .filter(|(_, meta)| meta.channel_id == Some(channel_id));
+        let Some((task_id, _)) = matches.next() else {
+            return false;
+        };
+        if matches.next().is_some() {
+            tracing::warn!(
+                channel = %channel_id,
+                ?mode,
+                "channel-only control target is ambiguous across in-flight lanes — no-op"
+            );
+            return false;
+        }
+        *task_id
+    };
 
-    if let Some(meta) = entry {
+    if let Some(meta) = pool.task_map_mut().get_mut(&target_id) {
         if let Some(tx) = meta.control_tx.take() {
-            tracing::info!(channel = %channel_id, ?mode, "control signal sent to in-flight task");
-            let _ = tx.send(mode);
-            return true;
+            return if tx.send(mode.clone()).is_ok() {
+                tracing::info!(channel = %channel_id, ?mode, "control signal sent to in-flight task");
+                true
+            } else {
+                tracing::warn!(channel = %channel_id, ?mode, "in-flight task control receiver closed before delivery");
+                false
+            };
         }
     }
     false
+}
+
+/// Send an explicit channel-removal signal to every matching in-flight task.
+/// This operation is intentionally channel-wide; unlike user controls, channel
+/// removal invalidates every sibling root lane at once.
+fn signal_all_in_flight_channel_tasks(
+    pool: &mut AgentPool,
+    channel_id: Uuid,
+    mode: ControlSignal,
+) -> usize {
+    pool.task_map_mut()
+        .values_mut()
+        .filter(|meta| meta.channel_id == Some(channel_id))
+        .filter_map(|meta| meta.control_tx.take())
+        .fold(0, |sent, control_tx| {
+            sent + usize::from(control_tx.send(mode.clone()).is_ok())
+        })
+}
+
+/// Send a control signal only to the in-flight task that owns `lane`.
+#[cfg(test)]
+fn signal_in_flight_lane(pool: &mut AgentPool, lane: &LaneKey, mode: ControlSignal) -> bool {
+    signal_in_flight_lane_turn(pool, lane, None, mode)
+}
+
+fn signal_in_flight_lane_turn(
+    pool: &mut AgentPool,
+    lane: &LaneKey,
+    expected_turn_id: Option<&str>,
+    mode: ControlSignal,
+) -> bool {
+    let entry = pool.task_map_mut().values_mut().find(|meta| {
+        meta.lane.as_ref() == Some(lane)
+            && expected_turn_id.is_none_or(|expected| meta.turn_id == expected)
+    });
+
+    if let Some(meta) = entry {
+        if let Some(tx) = meta.control_tx.take() {
+            return if tx.send(mode.clone()).is_ok() {
+                tracing::info!(
+                    channel = %lane.channel_id,
+                    lane_root = %lane.root_event_id,
+                    turn_id = %meta.turn_id,
+                    ?mode,
+                    "control signal sent to in-flight lane"
+                );
+                true
+            } else {
+                tracing::warn!(
+                    channel = %lane.channel_id,
+                    lane_root = %lane.root_event_id,
+                    turn_id = %meta.turn_id,
+                    ?mode,
+                    "in-flight lane control receiver closed before delivery"
+                );
+                false
+            };
+        }
+    }
+    false
+}
+
+/// Channel subscriptions are selected by subscription ID, but the relay is an
+/// untrusted transport. Require the signed event itself to carry exactly one
+/// `h` tag for that same channel so a malformed event cannot be replayed under
+/// another subscription or satisfy multiple channel lanes.
+fn has_exact_channel_binding(event: &nostr::Event, channel_id: Uuid) -> bool {
+    relay::has_exact_channel_binding(event, channel_id)
+}
+
+fn signal_control_event(
+    pool: &mut AgentPool,
+    queue: &EventQueue,
+    channel_id: Uuid,
+    event: &nostr::Event,
+    affinity_policy: AffinityPolicy,
+    is_dm: bool,
+    mode: ControlSignal,
+) -> Result<(LaneKey, bool), queue::LaneResolveError> {
+    let lane = LaneKey::resolve(channel_id, event, affinity_policy, is_dm)?;
+    let fired = if queue.is_lane_in_flight(&lane) {
+        signal_in_flight_lane_turn(pool, &lane, queue.lane_turn_id(&lane), mode)
+    } else {
+        false
+    };
+    Ok((lane, fired))
 }
 
 /// Attempt the non-cancelling (ACP) steer for a freshly-queued event.
@@ -3154,11 +3487,20 @@ fn signal_in_flight_task(
 fn try_native_steer(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
-    channel_id: uuid::Uuid,
+    lane: LaneKey,
     event: nostr::Event,
     prompt_tag: String,
     steer_ack_tx: &mpsc::UnboundedSender<SteerAckEvent>,
 ) -> bool {
+    let channel_id = lane.channel_id;
+    let Some(turn_id) = queue.lane_turn_id(&lane).map(str::to_owned) else {
+        tracing::warn!(
+            channel = %channel_id,
+            lane_root = %lane.root_event_id,
+            "native steer skipped because the lane has no bound turn generation"
+        );
+        return false;
+    };
     // Build the steer body: framing strings come from
     // `queue::native_steer_framing()` (Eva's drift-proof requirement —
     // native and cancel+merge fallback share these so the agent gets the
@@ -3188,14 +3530,14 @@ fn try_native_steer(
         ack_tx,
     };
 
-    match pool.send_steer(channel_id, request) {
+    match pool.send_steer_lane_for_turn(&lane, &turn_id, request) {
         Ok(()) => {
             // Withhold the queued event synchronously BEFORE spawning
             // the watcher: this closes the race where `mark_complete`
             // clears `in_flight_channels` and a stray `flush_next` could
             // re-deliver the event via normal dispatch. See
             // `EventQueue::mark_native_steer_pending` docs at queue.rs:606.
-            let withheld = queue.mark_native_steer_pending(channel_id, &event_id_hex);
+            let withheld = queue.mark_lane_native_steer_pending(&lane, &event_id_hex);
             if !withheld {
                 // Race: the event was already drained out of the queue
                 // before we got here (e.g. a concurrent flush picked it
@@ -3216,7 +3558,8 @@ fn try_native_steer(
             tokio::spawn(async move {
                 let ack = ack_rx.await;
                 let _ = ack_tx_clone.send(SteerAckEvent {
-                    channel_id,
+                    lane,
+                    turn_id,
                     event_id: event_id_for_watcher,
                     ack,
                 });
@@ -3236,33 +3579,48 @@ fn try_native_steer(
 
 // ── dispatch_pending ──────────────────────────────────────────────────────────
 
+/// Return an undispatched batch to its exact lane without disturbing a sibling.
+fn requeue_after_pool_exhaustion(queue: &mut EventQueue, batch: FlushBatch) {
+    let lane = batch.lane.clone();
+    queue.requeue_preserve_timestamps(batch);
+    queue.mark_lane_complete(&lane);
+}
+
 /// Flush queued work to available agents.
 fn dispatch_pending(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     ctx: &Arc<PromptContext>,
     last_activity: &mut tokio::time::Instant,
-) -> Vec<(Uuid, ThreadTags)> {
+) -> Vec<(LaneKey, TypingLaneState)> {
     let mut dispatched_channels = Vec::new();
     loop {
-        let batch = match queue.flush_next() {
+        let batch = match queue.flush_next_matching(|lane| pool.can_claim_lane(lane)) {
             Some(b) => b,
             None => break,
         };
         let channel_id = batch.channel_id;
+        let Some(admission_token) = ctx.membership_admission.capture(channel_id) else {
+            tracing::warn!(
+                channel = %channel_id,
+                lane_root = %batch.lane.root_event_id,
+                "dropping flushed batch without an active membership admission generation"
+            );
+            queue.mark_lane_complete(&batch.lane);
+            continue;
+        };
         let typing_scope = batch
             .events
             .last()
             .map(|event| queue::parse_thread_tags(&event.event))
             .unwrap_or_default();
-        let affinity_hit = pool.has_session_for(channel_id);
-        let mut agent = match pool.try_claim(Some(channel_id)) {
+        let affinity_hit = pool.has_session_for_lane(&batch.lane);
+        let mut agent = match pool.try_claim_lane(Some(&batch.lane)) {
             Some(a) => a,
             None => {
                 let pending = queue.pending_channels();
                 tracing::debug!(pending_channels = pending, "pool_exhausted");
-                queue.requeue_preserve_timestamps(batch);
-                queue.mark_complete(channel_id);
+                requeue_after_pool_exhaustion(queue, batch);
                 break;
             }
         };
@@ -3276,6 +3634,7 @@ fn dispatch_pending(
         let result_tx = pool.result_tx();
         let ctx_clone = Arc::clone(ctx);
         let agent_index = agent.index;
+        let agent_pid = agent.acp.process_id();
 
         // Mid-turn non-cancelling steer seam: install the per-turn steer
         // receiver on the read loop so the main loop's mode-gate fork
@@ -3283,9 +3642,8 @@ fn dispatch_pending(
         // in the relay event branch of the main `select!` loop) can drive
         // it via the matching sender stored in `TaskMeta.steer_tx`.
         // Installed for every prompt task: the read loop picks the steer
-        // transport at write time from `active_run_id` and the agent's
-        // advertised `_session/steering` capability, and acks
-        // `ExpectedRunIdMissing` (→ cancel+merge) when it has neither.
+        // transport at write time from `active_run_id`, and acks
+        // `ExpectedRunIdMissing` (→ cancel+merge) when no exact run exists.
         let (tx, rx) = tokio::sync::mpsc::channel::<pool::SteerRequest>(1);
         agent.acp.install_steer_rx(rx);
         let steer_tx = Some(tx);
@@ -3294,7 +3652,19 @@ fn dispatch_pending(
         // context fetching). Pass None for prompt_text; batch carries the data.
         let (control_tx, control_rx) = tokio::sync::oneshot::channel::<ControlSignal>();
         let turn_id = Uuid::new_v4().to_string();
+        if !queue.bind_lane_turn(&batch.lane, &turn_id) {
+            tracing::error!(
+                channel = %batch.lane.channel_id,
+                lane_root = %batch.lane.root_event_id,
+                turn_id,
+                "failed to bind flushed lane to task generation"
+            );
+            requeue_after_pool_exhaustion(queue, batch);
+            pool.return_agent(agent);
+            break;
+        }
         let task_turn_id = turn_id.clone();
+        let task_lane = batch.lane.clone();
 
         let abort_handle = pool.join_set.spawn(async move {
             pool::run_prompt_task(
@@ -3304,23 +3674,35 @@ fn dispatch_pending(
                 ctx_clone,
                 result_tx,
                 Some(control_rx),
+                Some(admission_token),
                 task_turn_id,
             )
             .await;
         });
 
+        let task_id = abort_handle.id();
         pool.task_map_mut().insert(
-            abort_handle.id(),
+            task_id,
             pool::TaskMeta {
                 agent_index,
                 channel_id: Some(channel_id),
-                turn_id,
+                lane: Some(task_lane.clone()),
+                turn_id: turn_id.clone(),
                 recoverable_batch,
                 control_tx: Some(control_tx),
                 steer_tx,
             },
         );
-        dispatched_channels.push((channel_id, typing_scope));
+        if let Some(pid) = agent_pid {
+            pool.register_task_process(task_id, pid);
+        }
+        dispatched_channels.push((
+            task_lane,
+            TypingLaneState {
+                turn_id,
+                thread_tags: typing_scope,
+            },
+        ));
         *last_activity = tokio::time::Instant::now();
     }
     tracing::debug!(
@@ -3384,7 +3766,7 @@ fn spawn_failure_notice(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn handle_prompt_result(
+async fn handle_prompt_result(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     config: &Config,
@@ -3397,11 +3779,50 @@ fn handle_prompt_result(
     observer: Option<observer::ObserverHandle>,
     rest_client: Option<&relay::RestClient>,
 ) -> LoopAction {
-    let before = pool.task_map().len();
     let agent_index = result.agent.index;
-    pool.task_map_mut()
-        .retain(|_, meta| meta.agent_index != agent_index);
-    debug_assert_eq!(before, pool.task_map().len() + 1);
+    let removed_tasks = pool.remove_tasks_for_agent(agent_index);
+    debug_assert_eq!(removed_tasks, 1);
+
+    let stale_lane_generation = match &result.source {
+        PromptSource::Lane(lane) => !queue.lane_turn_matches(lane, &result.turn_id),
+        PromptSource::Heartbeat => false,
+    };
+    if stale_lane_generation {
+        if let PromptSource::Lane(lane) = &result.source {
+            result.agent.state.invalidate_lane(lane);
+            tracing::warn!(
+                channel = %lane.channel_id,
+                lane_root = %lane.root_event_id,
+                turn_id = %result.turn_id,
+                "ignoring queue side effects from stale task generation"
+            );
+        }
+    }
+
+    // Fatal completion or planned backend-session reclamation is not
+    // publishable until the old ACP subprocess (and its process group) is dead
+    // and reaped. Keep the lane generation owned while awaiting shutdown.
+    let backend_session_recycle_required =
+        result.agent.state.take_backend_session_recycle_required();
+    let requires_retirement = backend_session_recycle_required
+        || matches!(
+            &result.outcome,
+            PromptOutcome::AgentExited
+                | PromptOutcome::Timeout(_)
+                | PromptOutcome::CancelDrainTimeout(_)
+        )
+        || matches!(
+            &result.outcome,
+            PromptOutcome::Error(error) if pool::prompt_error_requires_process_replacement(error)
+        );
+    if requires_retirement {
+        tracing::debug!(
+            agent = result.agent.index,
+            turn_id = %result.turn_id,
+            "retiring ACP process before releasing prompt ownership"
+        );
+        result.agent.acp.shutdown().await;
+    }
 
     // The hard-timeout death_message (below) must describe the batch's
     // *actual* fate, not just the `recently_active` eligibility flag — a
@@ -3420,7 +3841,7 @@ fn handle_prompt_result(
     if let Some(batch) = result.batch.take() {
         // Don't requeue batches for channels the agent was removed from —
         // those events are stale and should be silently dropped.
-        if !removed_channels.contains(&batch.channel_id) {
+        if !removed_channels.contains(&batch.channel_id) && !stale_lane_generation {
             if matches!(
                 result.outcome,
                 PromptOutcome::Cancelled | PromptOutcome::CancelDrainTimeout(_)
@@ -3480,6 +3901,21 @@ fn handle_prompt_result(
                 } else {
                     hard_timeout_fate_suffix = Some(" — requeued for retry (recently active)");
                 }
+            } else if matches!(
+                &result.outcome,
+                PromptOutcome::Error(acp::AcpError::InvalidInput(_))
+            ) {
+                tracing::warn!(
+                    channel_id = %batch.channel_id,
+                    events = batch.events.len(),
+                    "rejecting batch immediately — invalid or unverifiable thread root"
+                );
+                spawn_failure_notice(
+                    rest_client,
+                    &batch,
+                    "⚠️ I couldn't process this request because its thread root is missing, invalid, or belongs to another channel. Please reply from a valid channel thread."
+                        .to_string(),
+                );
             } else if matches!(&result.outcome, PromptOutcome::Error(e) if is_auth_error(e)) {
                 // Auth errors are non-retryable: the token won't self-repair
                 // between retries, so requeueing only wastes attempt slots and
@@ -3510,6 +3946,14 @@ fn handle_prompt_result(
                 );
                 spawn_failure_notice(rest_client, &dead, content);
             }
+        } else if stale_lane_generation {
+            tracing::warn!(
+                channel_id = %batch.channel_id,
+                lane_root = %batch.lane.root_event_id,
+                events = batch.events.len(),
+                "dropping stale batch from superseded task generation"
+            );
+            hard_timeout_fate_suffix = Some(" — stale batch dropped (replacement active)");
         } else {
             tracing::debug!(
                 channel_id = %batch.channel_id,
@@ -3521,7 +3965,9 @@ fn handle_prompt_result(
     }
 
     match &result.source {
-        PromptSource::Channel(ch) => queue.mark_complete(*ch),
+        PromptSource::Lane(lane) => {
+            queue.mark_lane_complete_for_turn(lane, &result.turn_id);
+        }
         PromptSource::Heartbeat => *heartbeat_in_flight = false,
     }
 
@@ -3557,7 +4003,7 @@ fn handle_prompt_result(
     let harness_pid = std::process::id();
 
     let channel_id = match &result.source {
-        PromptSource::Channel(ch) => Some(*ch),
+        PromptSource::Lane(lane) => Some(lane.channel_id),
         PromptSource::Heartbeat => None,
     };
     let turn_id = result.turn_id.clone();
@@ -3582,12 +4028,28 @@ fn handle_prompt_result(
     match result.outcome {
         // Successful prompt — return agent to pool.
         PromptOutcome::Ok(_) => {
-            tracing::debug!(
-                agent = agent_index,
-                outcome = outcome_label,
-                "agent_returned"
-            );
-            pool.return_agent(result.agent);
+            if backend_session_recycle_required {
+                tracing::info!(
+                    agent = agent_index,
+                    "backend session lifetime budget reached — recycling healthy ACP process"
+                );
+                pool.forget_agent_sessions(agent_index);
+                spawn_healthy_recycle_task(
+                    result.agent,
+                    config,
+                    &mut crash_history[agent_index],
+                    respawn_tx,
+                    respawn_tasks,
+                    observer.clone(),
+                );
+            } else {
+                tracing::debug!(
+                    agent = agent_index,
+                    outcome = outcome_label,
+                    "agent_returned"
+                );
+                pool.return_agent(result.agent);
+            }
         }
         // Fatal outcomes: the agent subprocess is dead or poisoned — respawn it.
         PromptOutcome::AgentExited | PromptOutcome::Timeout(_) => {
@@ -3615,6 +4077,7 @@ fn handle_prompt_result(
             emit_turn_error(&death_message, None);
 
             let index = result.agent.index;
+            pool.forget_agent_sessions(index);
             let slot_history = &mut crash_history[index];
             if !spawn_respawn_task(
                 result.agent,
@@ -3655,6 +4118,7 @@ fn handle_prompt_result(
             emit_turn_error(&death_message, None);
 
             let index = result.agent.index;
+            pool.forget_agent_sessions(index);
             let slot_history = &mut crash_history[index];
             if !spawn_respawn_task(
                 result.agent,
@@ -3687,23 +4151,33 @@ fn handle_prompt_result(
         // via requeue_as_cancelled() above and will be merged into the next
         // FlushBatch by flush_next().
         PromptOutcome::Cancelled => {
-            tracing::debug!(
-                agent = agent_index,
-                outcome = outcome_label,
-                configured_model = %harness_configured_model,
-                pid = harness_pid,
-                "agent_returned (cancelled)"
-            );
-            pool.return_agent(result.agent);
+            if backend_session_recycle_required {
+                tracing::info!(
+                    agent = agent_index,
+                    "backend session lifetime budget reached after cancellation — recycling healthy ACP process"
+                );
+                pool.forget_agent_sessions(agent_index);
+                spawn_healthy_recycle_task(
+                    result.agent,
+                    config,
+                    &mut crash_history[agent_index],
+                    respawn_tx,
+                    respawn_tasks,
+                    observer.clone(),
+                );
+            } else {
+                tracing::debug!(
+                    agent = agent_index,
+                    outcome = outcome_label,
+                    configured_model = %harness_configured_model,
+                    pid = harness_pid,
+                    "agent_returned (cancelled)"
+                );
+                pool.return_agent(result.agent);
+            }
         }
         PromptOutcome::Error(ref e) => {
-            let is_transport_error = matches!(
-                e,
-                acp::AcpError::Io(_)
-                    | acp::AcpError::WriteTimeout(_)
-                    | acp::AcpError::Timeout(_)
-                    | acp::AcpError::Protocol(_)
-            );
+            let is_transport_error = pool::prompt_error_requires_process_replacement(e);
             let error_code = match &e {
                 acp::AcpError::AgentError { code, .. } => Some(*code),
                 _ => None,
@@ -3720,6 +4194,7 @@ fn handle_prompt_result(
                 emit_turn_error(&e.to_string(), error_code);
 
                 let index = result.agent.index;
+                pool.forget_agent_sessions(index);
                 let slot_history = &mut crash_history[index];
                 if !spawn_respawn_task(
                     result.agent,
@@ -3744,7 +4219,19 @@ fn handle_prompt_result(
                     "agent_returned (application error — pipe intact)"
                 );
                 emit_turn_error(&e.to_string(), error_code);
-                pool.return_agent(result.agent);
+                if backend_session_recycle_required {
+                    pool.forget_agent_sessions(agent_index);
+                    spawn_healthy_recycle_task(
+                        result.agent,
+                        config,
+                        &mut crash_history[agent_index],
+                        respawn_tx,
+                        respawn_tasks,
+                        observer,
+                    );
+                } else {
+                    pool.return_agent(result.agent);
+                }
             }
         }
     }
@@ -3752,46 +4239,82 @@ fn handle_prompt_result(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn recover_panicked_agent(
+async fn recover_panicked_agent(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     config: &Config,
     join_error: tokio::task::JoinError,
     heartbeat_in_flight: &mut bool,
     removed_channels: &HashSet<Uuid>,
-    typing_channels: &mut HashMap<Uuid, ThreadTags>,
+    typing_channels: &mut HashMap<LaneKey, TypingLaneState>,
     crash_history: &mut [SlotCircuit],
     respawn_tx: &mpsc::Sender<RespawnResult>,
     respawn_tasks: &mut tokio::task::JoinSet<()>,
     observer: Option<observer::ObserverHandle>,
+    rest_client: Option<&relay::RestClient>,
 ) {
     let task_id = join_error.id();
-    let Some(meta) = pool.task_map_mut().remove(&task_id) else {
+    let (meta, process_id) = pool.take_task_for_panic(task_id);
+    if let Some(pid) = process_id {
+        acp::retire_orphaned_process(pid).await;
+    }
+    let Some(meta) = meta else {
         tracing::error!("panic for unknown task {task_id:?} — bug");
         return;
     };
     let i = meta.agent_index;
+    pool.forget_agent_sessions(i);
+    let stale_lane_generation = meta
+        .lane
+        .as_ref()
+        .is_some_and(|lane| !queue.lane_turn_matches(lane, &meta.turn_id));
 
     // Requeue BEFORE mark_complete (same rationale as handle_prompt_result).
+    let mut panic_batch_fate = "none";
     if let Some(batch) = meta.recoverable_batch {
         if let Some(ch) = meta.channel_id {
-            if !removed_channels.contains(&ch) {
-                // Dead-letter on exhaustion is logged inside requeue(); a
-                // panic path has no outcome to report, so no notice here.
-                let _ = queue.requeue(batch);
-                tracing::warn!("requeued batch for panicked agent {i}");
+            if !removed_channels.contains(&ch) && !stale_lane_generation {
+                if let Some(dead) = queue.requeue(batch) {
+                    panic_batch_fate = "dead_lettered";
+                    tracing::error!(
+                        channel_id = %ch,
+                        agent = i,
+                        "panicked batch dead-lettered after retry budget exhaustion"
+                    );
+                    if let Some(rest_client) = rest_client {
+                        spawn_failure_notice(
+                            Some(rest_client),
+                            &dead,
+                            "⚠️ I couldn't process the last request after repeated agent crashes. Please re-send if it's still needed."
+                                .to_string(),
+                        );
+                    }
+                } else {
+                    panic_batch_fate = "requeued";
+                    tracing::warn!("requeued batch for panicked agent {i}");
+                }
             } else {
+                panic_batch_fate = "dropped_removed_or_stale";
                 tracing::debug!(
                     channel_id = %ch,
-                    "dropping panicked batch for removed channel"
+                    "dropping panicked batch for removed or stale lane"
                 );
             }
         }
     }
 
-    if let Some(ch) = meta.channel_id {
+    if let Some(lane) = meta.lane {
+        queue.mark_lane_complete_for_turn(&lane, &meta.turn_id);
+        clear_typing_lane_for_turn(typing_channels, &lane, &meta.turn_id);
+        tracing::warn!(
+            channel = %lane.channel_id,
+            root_event_id = %lane.root_event_id,
+            agent = i,
+            "cleared wedged in-flight lane from panicked agent"
+        );
+    } else if let Some(ch) = meta.channel_id {
         queue.mark_complete(ch);
-        typing_channels.remove(&ch);
+        typing_channels.retain(|lane, _| lane.channel_id != ch);
         tracing::warn!("cleared wedged in-flight channel {ch} from panicked agent {i}");
     } else {
         *heartbeat_in_flight = false;
@@ -3806,6 +4329,7 @@ fn recover_panicked_agent(
             serde_json::json!({
                 "outcome": "panic",
                 "error": format!("Agent task panicked: {join_error}"),
+                "batch_fate": panic_batch_fate,
             }),
         );
     }
@@ -3851,17 +4375,18 @@ fn recover_panicked_agent(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn drain_ready_join_results(
+async fn drain_ready_join_results(
     pool: &mut AgentPool,
     queue: &mut EventQueue,
     config: &Config,
     heartbeat_in_flight: &mut bool,
     removed_channels: &HashSet<Uuid>,
-    typing_channels: &mut HashMap<Uuid, ThreadTags>,
+    typing_channels: &mut HashMap<LaneKey, TypingLaneState>,
     crash_history: &mut [SlotCircuit],
     respawn_tx: &mpsc::Sender<RespawnResult>,
     respawn_tasks: &mut tokio::task::JoinSet<()>,
     observer: Option<observer::ObserverHandle>,
+    rest_client: Option<&relay::RestClient>,
 ) -> LoopAction {
     while let Some(Some(join_result)) = pool.join_set.join_next().now_or_never() {
         if let Err(join_error) = join_result {
@@ -3878,7 +4403,9 @@ fn drain_ready_join_results(
                 respawn_tx,
                 respawn_tasks,
                 observer.clone(),
-            );
+                rest_client,
+            )
+            .await;
             if pool.live_count() == 0 && !any_respawn_in_flight(crash_history) {
                 return LoopAction::Exit;
             }
@@ -3907,6 +4434,7 @@ fn dispatch_heartbeat(
     let result_tx = pool.result_tx();
     let ctx_clone = Arc::clone(ctx);
     let agent_index = agent.index;
+    let agent_pid = agent.acp.process_id();
     let turn_id = Uuid::new_v4().to_string();
     let task_turn_id = turn_id.clone();
 
@@ -3918,22 +4446,28 @@ fn dispatch_heartbeat(
             ctx_clone,
             result_tx,
             None,
+            None,
             task_turn_id,
         )
         .await;
     });
 
+    let task_id = abort_handle.id();
     pool.task_map_mut().insert(
-        abort_handle.id(),
+        task_id,
         pool::TaskMeta {
             agent_index,
             channel_id: None,
+            lane: None,
             turn_id,
             recoverable_batch: None,
             control_tx: None,
             steer_tx: None,
         },
     );
+    if let Some(pid) = agent_pid {
+        pool.register_task_process(task_id, pid);
+    }
     *heartbeat_in_flight = true;
     tracing::info!(agent = agent_index, "heartbeat_fired");
 }
@@ -3992,6 +4526,37 @@ fn default_heartbeat_prompt() -> String {
          Do not run `buzz channels list` or `buzz messages search` unless you have a specific reason.\n\
          Do not invent work — only act on items surfaced by the feed commands."
     )
+}
+
+/// Spawn a planned process recycle without charging the crash circuit.
+///
+/// The caller has already awaited shutdown before releasing lane ownership;
+/// shutdown is repeated defensively here because it is idempotent. The slot
+/// remains empty until the normal respawn result path installs the replacement.
+fn spawn_healthy_recycle_task(
+    old_agent: OwnedAgent,
+    config: &Config,
+    slot: &mut SlotCircuit,
+    respawn_tx: &mpsc::Sender<RespawnResult>,
+    respawn_tasks: &mut tokio::task::JoinSet<()>,
+    observer: Option<observer::ObserverHandle>,
+) {
+    let index = old_agent.index;
+    slot.respawn_in_flight = true;
+
+    let cmd = config.agent_command.clone();
+    let args = config.agent_args.clone();
+    let env = config.persona_env_vars.clone();
+    let has_codex = config.has_generated_codex_config;
+    let guard = RespawnGuard::new(index, respawn_tx.clone());
+    respawn_tasks.spawn(async move {
+        let mut agent = old_agent;
+        agent.acp.shutdown().await;
+        drop(agent);
+
+        let result = spawn_and_init(&cmd, &args, &env, has_codex, index, observer).await;
+        guard.send(result);
+    });
 }
 
 /// Spawn a background respawn task for a crashed agent slot.
@@ -4125,7 +4690,7 @@ async fn initialize_agent_pool(
         match spawn_result {
             Ok(mut acp) => {
                 acp.set_observer(startup.observer.clone(), i);
-                let initialize = tokio::time::timeout(Duration::from_secs(60), acp.initialize());
+                let initialize = tokio::time::timeout(AGENT_INITIALIZE_TIMEOUT, acp.initialize());
                 let initialize_result = match shutdown.as_mut() {
                     Some(shutdown) => tokio::select! {
                         biased;
@@ -4211,6 +4776,53 @@ async fn initialize_agent_pool(
 }
 
 // ── spawn_and_init ────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod respawn_lifecycle_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn replacement_initialize_timeout_reaps_spawned_process() {
+        let pid_path =
+            std::env::temp_dir().join(format!("buzz-acp-respawn-timeout-{}.pid", Uuid::new_v4()));
+        let script = format!(
+            "printf '%s' $$ > '{}'; read -r _initialize; sleep 30",
+            pid_path.display()
+        );
+        let args = vec!["-c".to_string(), script];
+
+        let error = match spawn_and_init_with_timeout(
+            "/bin/sh",
+            &args,
+            &[],
+            false,
+            0,
+            None,
+            Duration::from_millis(50),
+        )
+        .await
+        {
+            Err(error) => error,
+            Ok((mut acp, _, _)) => {
+                acp.shutdown().await;
+                panic!("replacement initialize must be bounded");
+            }
+        };
+
+        let pid: u32 = std::fs::read_to_string(&pid_path)
+            .expect("fake adapter must record pid")
+            .parse()
+            .expect("recorded pid must be numeric");
+        let retired = !std::path::Path::new(&format!("/proc/{pid}")).exists();
+        let _ = std::fs::remove_file(&pid_path);
+
+        assert!(error.to_string().contains("timed out"));
+        assert!(
+            retired,
+            "timed-out replacement process must be reaped before failure is reported"
+        );
+    }
+}
+
 /// Spawn an agent subprocess and run the MCP `initialize` handshake.
 ///
 /// Takes owned args so it can run in a background `tokio::spawn` task without
@@ -4223,13 +4835,34 @@ async fn spawn_and_init(
     agent_index: usize,
     observer: Option<observer::ObserverHandle>,
 ) -> Result<(AcpClient, u32, String)> {
+    spawn_and_init_with_timeout(
+        command,
+        args,
+        extra_env,
+        has_generated_codex_config,
+        agent_index,
+        observer,
+        AGENT_INITIALIZE_TIMEOUT,
+    )
+    .await
+}
+
+async fn spawn_and_init_with_timeout(
+    command: &str,
+    args: &[String],
+    extra_env: &[(String, String)],
+    has_generated_codex_config: bool,
+    agent_index: usize,
+    observer: Option<observer::ObserverHandle>,
+    initialize_timeout: Duration,
+) -> Result<(AcpClient, u32, String)> {
     let mut acp = AcpClient::spawn(command, args, extra_env, has_generated_codex_config)
         .await
         .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
     acp.set_observer(observer, agent_index);
 
-    match acp.initialize().await {
-        Ok(init_result) => {
+    match tokio::time::timeout(initialize_timeout, acp.initialize()).await {
+        Ok(Ok(init_result)) => {
             tracing::info!("agent initialized: {init_result}");
             let protocol_version = init_result["protocolVersion"].as_u64().unwrap_or(1) as u32;
             acp.observe(
@@ -4242,12 +4875,18 @@ async fn spawn_and_init(
             let agent_name = normalized_agent_name(&init_result);
             Ok((acp, protocol_version, agent_name))
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             // Explicitly shut down the spawned child to prevent zombie/leak.
             // Drop only does start_kill + try_wait (best-effort); shutdown()
             // does start_kill + bounded wait (guaranteed reap).
             acp.shutdown().await;
             Err(anyhow::anyhow!("agent initialize failed: {e}"))
+        }
+        Err(_) => {
+            acp.shutdown().await;
+            Err(anyhow::anyhow!(
+                "agent initialize timed out after {initialize_timeout:?}"
+            ))
         }
     }
 }
@@ -4659,6 +5298,10 @@ mod owner_control_command_tests {
             mode_gate_signal(MultipleEventHandling::Steer, &other, Some(&owner)),
             Some(ControlSignal::Steer)
         ));
+        assert!(matches!(
+            mode_gate_signal(MultipleEventHandling::SteerThread, &other, Some(&owner)),
+            Some(ControlSignal::Steer)
+        ));
         // Steer even when owner is unknown — gate doesn't re-check authorship.
         assert!(matches!(
             mode_gate_signal(MultipleEventHandling::Steer, &other, None),
@@ -4686,6 +5329,84 @@ mod owner_control_command_tests {
         );
     }
 
+    #[test]
+    fn typing_cleanup_is_generation_fenced() {
+        let lane = LaneKey::new(Uuid::new_v4(), "a".repeat(64));
+        let mut typing = HashMap::from([(
+            lane.clone(),
+            TypingLaneState {
+                turn_id: "new-turn".into(),
+                thread_tags: ThreadTags::default(),
+            },
+        )]);
+
+        assert!(!clear_typing_lane_for_turn(&mut typing, &lane, "old-turn"));
+        assert!(typing.contains_key(&lane));
+        assert!(clear_typing_lane_for_turn(&mut typing, &lane, "new-turn"));
+        assert!(!typing.contains_key(&lane));
+    }
+
+    #[test]
+    fn pool_exhaustion_requeues_exact_lane_preserving_timestamp_and_sibling() {
+        let channel_id = Uuid::new_v4();
+        let lane_a = LaneKey::new(channel_id, "a".repeat(64));
+        let lane_b = LaneKey::new(channel_id, "b".repeat(64));
+        let keys = Keys::generate();
+        let received_a = std::time::Instant::now() - Duration::from_secs(2);
+        let received_b = std::time::Instant::now() - Duration::from_secs(1);
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+
+        for (lane, content, received_at) in [
+            (lane_a.clone(), "root-a", received_a),
+            (lane_b.clone(), "root-b", received_b),
+        ] {
+            let event = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), content)
+                .sign_with_keys(&keys)
+                .unwrap();
+            assert_eq!(
+                queue.push_resolved(
+                    QueuedEvent {
+                        channel_id,
+                        event,
+                        received_at,
+                        prompt_tag: "test".into(),
+                    },
+                    lane,
+                ),
+                PushResult::Accepted
+            );
+        }
+
+        let exhausted = queue.flush_next().expect("root A flush");
+        let sibling = queue.flush_next().expect("root B flush");
+        assert_eq!(exhausted.lane, lane_a);
+        assert_eq!(sibling.lane, lane_b);
+
+        requeue_after_pool_exhaustion(&mut queue, exhausted);
+
+        assert!(!queue.is_lane_in_flight(&lane_a));
+        assert!(queue.is_lane_in_flight(&lane_b));
+        let retried = queue.flush_next().expect("root A becomes flushable again");
+        assert_eq!(retried.lane, lane_a);
+        assert_eq!(retried.events[0].received_at, received_a);
+    }
+
+    #[test]
+    fn steer_thread_selects_root_affinity_without_changing_existing_modes() {
+        assert_eq!(
+            affinity_policy_for_handling(MultipleEventHandling::SteerThread),
+            AffinityPolicy::RootThread
+        );
+        for mode in [
+            MultipleEventHandling::Queue,
+            MultipleEventHandling::Steer,
+            MultipleEventHandling::Interrupt,
+            MultipleEventHandling::OwnerInterrupt,
+        ] {
+            assert_eq!(affinity_policy_for_handling(mode), AffinityPolicy::Channel);
+        }
+    }
+
     #[tokio::test]
     async fn signal_in_flight_task_sends_rotate_once() {
         let mut pool = AgentPool::from_slots(vec![]);
@@ -4699,6 +5420,7 @@ mod owner_control_command_tests {
             pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                lane: Some(LaneKey::channel(channel_id)),
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: Some(control_tx),
@@ -4722,6 +5444,418 @@ mod owner_control_command_tests {
             channel_id,
             ControlSignal::Rotate
         ));
+    }
+
+    #[tokio::test]
+    async fn closed_control_receivers_fail_closed() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::channel(channel_id);
+
+        let mut channel_pool = AgentPool::from_slots(vec![]);
+        let (channel_tx, channel_rx) = tokio::sync::oneshot::channel();
+        drop(channel_rx);
+        let channel_task = channel_pool.join_set.spawn(std::future::pending::<()>());
+        channel_pool.task_map_mut().insert(
+            channel_task.id(),
+            pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                lane: Some(lane.clone()),
+                turn_id: "closed-channel-turn".to_string(),
+                recoverable_batch: None,
+                control_tx: Some(channel_tx),
+                steer_tx: None,
+            },
+        );
+        assert!(
+            !signal_in_flight_task(&mut channel_pool, channel_id, ControlSignal::Cancel),
+            "closed channel control receiver must not report success"
+        );
+        channel_pool.join_set.abort_all();
+
+        let mut lane_pool = AgentPool::from_slots(vec![]);
+        let (lane_tx, lane_rx) = tokio::sync::oneshot::channel();
+        drop(lane_rx);
+        let lane_task = lane_pool.join_set.spawn(std::future::pending::<()>());
+        lane_pool.task_map_mut().insert(
+            lane_task.id(),
+            pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                lane: Some(lane.clone()),
+                turn_id: "closed-lane-turn".to_string(),
+                recoverable_batch: None,
+                control_tx: Some(lane_tx),
+                steer_tx: None,
+            },
+        );
+        assert!(
+            !signal_in_flight_lane(&mut lane_pool, &lane, ControlSignal::Cancel),
+            "closed exact-lane control receiver must not report success"
+        );
+        lane_pool.join_set.abort_all();
+    }
+
+    #[tokio::test]
+    async fn signal_in_flight_lane_does_not_signal_same_channel_sibling() {
+        let mut pool = AgentPool::from_slots(vec![]);
+        let channel_id = Uuid::new_v4();
+        let lane_a = LaneKey::new(channel_id, "a".repeat(64));
+        let lane_b = LaneKey::new(channel_id, "b".repeat(64));
+        let (control_a_tx, mut control_a_rx) = tokio::sync::oneshot::channel();
+        let (control_b_tx, control_b_rx) = tokio::sync::oneshot::channel();
+        let task_a = pool.join_set.spawn(std::future::pending::<()>());
+        let task_b = pool.join_set.spawn(std::future::pending::<()>());
+        for (task_id, agent_index, lane, control_tx) in [
+            (task_a.id(), 0, lane_a.clone(), control_a_tx),
+            (task_b.id(), 1, lane_b.clone(), control_b_tx),
+        ] {
+            pool.task_map_mut().insert(
+                task_id,
+                pool::TaskMeta {
+                    agent_index,
+                    channel_id: Some(channel_id),
+                    lane: Some(lane),
+                    turn_id: format!("turn-{agent_index}"),
+                    recoverable_batch: None,
+                    control_tx: Some(control_tx),
+                    steer_tx: None,
+                },
+            );
+        }
+
+        assert!(signal_in_flight_lane(
+            &mut pool,
+            &lane_b,
+            ControlSignal::Steer
+        ));
+        assert_eq!(control_b_rx.await.unwrap(), ControlSignal::Steer);
+        assert!(matches!(
+            control_a_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+        pool.join_set.abort_all();
+    }
+
+    #[tokio::test]
+    async fn channel_only_control_fails_closed_with_sibling_roots_active() {
+        let mut pool = AgentPool::from_slots(vec![]);
+        let channel_id = Uuid::new_v4();
+        let (control_a_tx, mut control_a_rx) = tokio::sync::oneshot::channel();
+        let (control_b_tx, mut control_b_rx) = tokio::sync::oneshot::channel();
+        let task_a = pool.join_set.spawn(std::future::pending::<()>());
+        let task_b = pool.join_set.spawn(std::future::pending::<()>());
+        for (task_id, agent_index, lane, control_tx) in [
+            (
+                task_a.id(),
+                0,
+                LaneKey::new(channel_id, "a".repeat(64)),
+                control_a_tx,
+            ),
+            (
+                task_b.id(),
+                1,
+                LaneKey::new(channel_id, "b".repeat(64)),
+                control_b_tx,
+            ),
+        ] {
+            pool.task_map_mut().insert(
+                task_id,
+                pool::TaskMeta {
+                    agent_index,
+                    channel_id: Some(channel_id),
+                    lane: Some(lane),
+                    turn_id: format!("turn-{agent_index}"),
+                    recoverable_batch: None,
+                    control_tx: Some(control_tx),
+                    steer_tx: None,
+                },
+            );
+        }
+
+        assert!(!signal_in_flight_task(
+            &mut pool,
+            channel_id,
+            ControlSignal::Cancel
+        ));
+        assert!(matches!(
+            control_a_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+        assert!(matches!(
+            control_b_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+        pool.join_set.abort_all();
+    }
+
+    #[tokio::test]
+    async fn threaded_owner_control_targets_only_canonical_root() {
+        let mut pool = AgentPool::from_slots(vec![]);
+        let channel_id = Uuid::new_v4();
+        let root_a = "a".repeat(64);
+        let lane_a = LaneKey::new(channel_id, root_a.clone());
+        let lane_b = LaneKey::new(channel_id, "b".repeat(64));
+        let (control_a_tx, control_a_rx) = tokio::sync::oneshot::channel();
+        let (control_b_tx, mut control_b_rx) = tokio::sync::oneshot::channel();
+        let task_a = pool.join_set.spawn(std::future::pending::<()>());
+        let task_b = pool.join_set.spawn(std::future::pending::<()>());
+        for (task_id, agent_index, lane, control_tx) in [
+            (task_a.id(), 0, lane_a.clone(), control_a_tx),
+            (task_b.id(), 1, lane_b, control_b_tx),
+        ] {
+            pool.task_map_mut().insert(
+                task_id,
+                pool::TaskMeta {
+                    agent_index,
+                    channel_id: Some(channel_id),
+                    lane: Some(lane),
+                    turn_id: format!("turn-{agent_index}"),
+                    recoverable_batch: None,
+                    control_tx: Some(control_tx),
+                    steer_tx: None,
+                },
+            );
+        }
+        let root_tag = Tag::parse(["e", root_a.as_str(), "", "root"]).unwrap();
+        let reply_tag = Tag::parse(["e", &"c".repeat(64), "", "reply"]).unwrap();
+        let control = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "!cancel")
+            .tags([root_tag, reply_tag])
+            .sign_with_keys(&Keys::generate())
+            .unwrap();
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+        assert_eq!(
+            queue.push_resolved(
+                QueuedEvent {
+                    channel_id,
+                    event: control.clone(),
+                    received_at: std::time::Instant::now() - Duration::from_secs(1),
+                    prompt_tag: "test".into(),
+                },
+                lane_a.clone(),
+            ),
+            PushResult::Accepted
+        );
+        assert_eq!(queue.flush_next().expect("root A flush").lane, lane_a);
+        assert!(queue.bind_lane_turn(&lane_a, "turn-0"));
+
+        let (resolved, fired) = signal_control_event(
+            &mut pool,
+            &queue,
+            channel_id,
+            &control,
+            AffinityPolicy::RootThread,
+            false,
+            ControlSignal::Cancel,
+        )
+        .expect("valid root control");
+        assert_eq!(resolved, lane_a);
+        assert!(fired);
+        assert_eq!(control_a_rx.await.unwrap(), ControlSignal::Cancel);
+        assert!(matches!(
+            control_b_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+        pool.join_set.abort_all();
+    }
+
+    #[test]
+    fn membership_channel_state_is_bounded_but_existing_channels_still_advance() {
+        let existing = Uuid::new_v4();
+        let mut newest = HashMap::new();
+        newest.insert(existing, 1);
+        for i in 1..MAX_TRACKED_MEMBERSHIP_CHANNELS {
+            newest.insert(Uuid::from_u128(i as u128 + 1), 1);
+        }
+        assert_eq!(newest.len(), MAX_TRACKED_MEMBERSHIP_CHANNELS);
+        assert!(membership_state_can_track(&newest, existing));
+        assert!(!membership_state_can_track(&newest, Uuid::new_v4()));
+    }
+
+    #[test]
+    fn equal_second_membership_transitions_have_total_event_id_order() {
+        let low = (42, "00".repeat(32));
+        let high = (42, "ff".repeat(32));
+
+        assert!(membership_order_is_newer(None, low.0, &low.1));
+        assert!(membership_order_is_newer(Some(&low), high.0, &high.1));
+        assert!(
+            !membership_order_is_newer(Some(&high), low.0, &low.1),
+            "delivery order must converge on the same equal-second event"
+        );
+        assert!(!membership_order_is_newer(Some(&high), high.0, &high.1));
+    }
+
+    #[test]
+    fn typed_native_steer_errors_have_fail_closed_fallback_policy() {
+        assert_eq!(
+            native_steer_ack_policy(&pool::SteerAck::Err(pool::SteerError::ExpectedRunIdMissing)),
+            (true, false, true),
+            "no exact run means write nothing and use cancel+merge"
+        );
+        assert_eq!(
+            native_steer_ack_policy(&pool::SteerAck::Err(pool::SteerError::AgentError {
+                code: -32601,
+                message: "unsupported".into(),
+            })),
+            (true, false, true),
+            "unsupported exact-run transport uses cancel+merge"
+        );
+        assert_eq!(
+            native_steer_ack_policy(&pool::SteerAck::Err(pool::SteerError::AgentError {
+                code: -32000,
+                message: "wrong run".into(),
+            })),
+            (true, false, false),
+            "an exact-run application rejection releases without signalling a settled turn"
+        );
+    }
+
+    #[test]
+    fn stale_steer_ack_is_rejected_after_lane_replacement() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::new(channel_id, "a".repeat(64));
+        let keys = Keys::generate();
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+
+        for (content, turn_id) in [("old", "old-turn"), ("new", "new-turn")] {
+            let event = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), content)
+                .sign_with_keys(&keys)
+                .unwrap();
+            assert_eq!(
+                queue.push_resolved(
+                    QueuedEvent {
+                        channel_id,
+                        event,
+                        received_at: std::time::Instant::now() - Duration::from_secs(1),
+                        prompt_tag: "test".into(),
+                    },
+                    lane.clone(),
+                ),
+                PushResult::Accepted
+            );
+            assert_eq!(queue.flush_next().expect("lane flush").lane, lane);
+            assert!(queue.bind_lane_turn(&lane, turn_id));
+            if turn_id == "old-turn" {
+                queue.mark_lane_complete(&lane);
+            }
+        }
+
+        let removed = HashSet::new();
+        assert!(steer_ack_is_obsolete(&queue, &removed, &lane, "old-turn"));
+        assert!(!steer_ack_is_obsolete(&queue, &removed, &lane, "new-turn"));
+
+        let removed = HashSet::from([channel_id]);
+        assert!(steer_ack_is_obsolete(&queue, &removed, &lane, "new-turn"));
+    }
+
+    #[test]
+    fn stale_steer_ack_settles_exact_withheld_event_without_mutating_replacement_turn() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::new(channel_id, "a".repeat(64));
+        let keys = Keys::generate();
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+
+        let original = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "original")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let steered = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "steered")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let replacement =
+            EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "replacement")
+                .sign_with_keys(&keys)
+                .unwrap();
+        let steered_id = steered.id.to_hex();
+        let queued = |event: nostr::Event| QueuedEvent {
+            channel_id,
+            event,
+            received_at: std::time::Instant::now() - Duration::from_secs(1),
+            prompt_tag: "test".into(),
+        };
+
+        assert_eq!(
+            queue.push_resolved(queued(original), lane.clone()),
+            PushResult::Accepted
+        );
+        assert_eq!(queue.flush_next().expect("old turn").lane, lane);
+        assert!(queue.bind_lane_turn(&lane, "old-turn"));
+        assert_eq!(
+            queue.push_resolved(queued(steered), lane.clone()),
+            PushResult::Accepted
+        );
+        assert!(queue.mark_lane_native_steer_pending(&lane, &steered_id));
+        assert!(queue.mark_lane_complete_for_turn(&lane, "old-turn"));
+
+        assert_eq!(
+            queue.push_resolved(queued(replacement), lane.clone()),
+            PushResult::Accepted
+        );
+        assert_eq!(queue.flush_next().expect("replacement turn").lane, lane);
+        assert!(queue.bind_lane_turn(&lane, "new-turn"));
+        assert!(steer_ack_is_obsolete(
+            &queue,
+            &HashSet::new(),
+            &lane,
+            "old-turn"
+        ));
+
+        settle_native_steer_event(
+            &mut queue,
+            &lane,
+            &steered_id,
+            native_steer_ack_policy(&pool::SteerAck::Err(pool::SteerError::ExpectedRunIdMissing)),
+        );
+        assert_eq!(queue.lane_turn_id(&lane), Some("new-turn"));
+        assert!(queue.mark_lane_complete_for_turn(&lane, "new-turn"));
+        let recovered = queue.flush_next().expect("stale exact event restored");
+        assert_eq!(recovered.events[0].event.id.to_hex(), steered_id);
+    }
+
+    #[tokio::test]
+    async fn channel_removal_cancels_all_sibling_root_tasks() {
+        let removed_channel = Uuid::new_v4();
+        let other_channel = Uuid::new_v4();
+        let mut pool = AgentPool::from_slots(vec![]);
+        let mut receivers = Vec::new();
+
+        for (index, channel_id, root) in [
+            (0, removed_channel, "a"),
+            (1, removed_channel, "b"),
+            (2, other_channel, "c"),
+        ] {
+            let (control_tx, control_rx) = tokio::sync::oneshot::channel();
+            let task = pool.join_set.spawn(std::future::pending::<()>());
+            pool.task_map_mut().insert(
+                task.id(),
+                pool::TaskMeta {
+                    agent_index: index,
+                    channel_id: Some(channel_id),
+                    lane: Some(LaneKey::new(channel_id, root.repeat(64))),
+                    turn_id: format!("turn-{root}"),
+                    recoverable_batch: None,
+                    control_tx: Some(control_tx),
+                    steer_tx: None,
+                },
+            );
+            receivers.push((channel_id, control_rx));
+        }
+
+        assert_eq!(
+            signal_all_in_flight_channel_tasks(&mut pool, removed_channel, ControlSignal::Cancel,),
+            2
+        );
+        for (channel_id, mut receiver) in receivers {
+            if channel_id == removed_channel {
+                assert_eq!(receiver.try_recv(), Ok(ControlSignal::Cancel));
+            } else {
+                assert!(matches!(
+                    receiver.try_recv(),
+                    Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+                ));
+            }
+        }
+        pool.join_set.abort_all();
     }
 }
 
@@ -4760,6 +5894,7 @@ mod author_gate_tests {
             http: reqwest::Client::new(),
             base_url: "http://localhost:0".into(),
             keys: nostr::Keys::generate(),
+            trusted_relay_pubkey: nostr::Keys::generate().public_key(),
             auth_tag_json: None,
         }
     }
@@ -5023,6 +6158,7 @@ mod author_gate_tests {
 
     async fn lazy_resolver_with_response(
         response: serde_json::Value,
+        trusted_relay_pubkey: nostr::PublicKey,
     ) -> (
         pool::ChannelInfoResolver,
         std::sync::Arc<std::sync::atomic::AtomicUsize>,
@@ -5058,6 +6194,7 @@ mod author_gate_tests {
             http: reqwest::Client::new(),
             base_url,
             keys: nostr::Keys::generate(),
+            trusted_relay_pubkey,
             auth_tag_json: None,
         };
         (
@@ -5072,10 +6209,20 @@ mod author_gate_tests {
         use std::sync::atomic::Ordering;
 
         let id = Uuid::new_v4();
-        let response = serde_json::json!([{
-            "tags": [["d", id.to_string()], ["name", "DM"], ["t", "dm"]]
-        }]);
-        let (resolver, requests, server) = lazy_resolver_with_response(response).await;
+        let relay_keys = nostr::Keys::generate();
+        let event = nostr::EventBuilder::new(
+            nostr::Kind::Custom(buzz_core::kind::KIND_NIP29_GROUP_METADATA as u16),
+            "",
+        )
+        .tags(vec![
+            nostr::Tag::parse(vec!["d".to_string(), id.to_string()]).unwrap(),
+            nostr::Tag::parse(vec!["name".to_string(), "DM".to_string()]).unwrap(),
+            nostr::Tag::parse(vec!["t".to_string(), "dm".to_string()]).unwrap(),
+        ])
+        .sign_with_keys(&relay_keys)
+        .unwrap();
+        let (resolver, requests, server) =
+            lazy_resolver_with_response(serde_json::json!([event]), relay_keys.public_key()).await;
 
         assert!(is_dm_channel(id, &resolver).await);
         assert!(is_dm_channel(id, &resolver).await);
@@ -5088,9 +6235,45 @@ mod author_gate_tests {
     }
 
     #[tokio::test]
+    async fn test_is_dm_channel_rejects_attacker_signed_stream_metadata() {
+        use std::sync::atomic::Ordering;
+
+        let id = Uuid::new_v4();
+        let trusted_relay = nostr::Keys::generate();
+        let attacker = nostr::Keys::generate();
+        let forged = nostr::EventBuilder::new(
+            nostr::Kind::Custom(buzz_core::kind::KIND_NIP29_GROUP_METADATA as u16),
+            "",
+        )
+        .tags(vec![
+            nostr::Tag::parse(vec!["d".to_string(), id.to_string()]).unwrap(),
+            nostr::Tag::parse(vec!["name".to_string(), "public".to_string()]).unwrap(),
+            nostr::Tag::parse(vec!["t".to_string(), "stream".to_string()]).unwrap(),
+        ])
+        .sign_with_keys(&attacker)
+        .unwrap();
+        let (resolver, requests, server) =
+            lazy_resolver_with_response(serde_json::json!([forged]), trusted_relay.public_key())
+                .await;
+
+        assert!(
+            is_dm_channel(id, &resolver).await,
+            "unverified stream metadata must not bypass DM author restrictions"
+        );
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            2,
+            "unverified metadata gets exactly one bounded retry"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn test_discovery_without_metadata_stays_fail_closed_at_author_gate() {
         let id = Uuid::new_v4();
-        let discovered = relay::merge_discovered_channels(vec![id], &serde_json::json!([]));
+        let relay_key = nostr::Keys::generate().public_key();
+        let discovered =
+            relay::merge_discovered_channels(vec![id], &serde_json::json!([]), &relay_key);
         let channel_info = resolver(discovered);
         let owner_cache = cache_with_sibling();
         let allowlist = HashSet::from([EXTERNAL.to_string()]);
@@ -6473,6 +7656,29 @@ mod error_outcome_emission_tests {
         }
     }
 
+    fn bind_batch_generation(queue: &mut EventQueue, batch: &FlushBatch, turn_id: &str) {
+        let seed = batch
+            .events
+            .first()
+            .or_else(|| batch.cancelled_events.first())
+            .expect("result batch must contain an event");
+        assert!(matches!(
+            queue.push_resolved(
+                QueuedEvent {
+                    channel_id: batch.channel_id,
+                    event: seed.event.clone(),
+                    received_at: seed.received_at,
+                    prompt_tag: seed.prompt_tag.clone(),
+                },
+                batch.lane.clone(),
+            ),
+            queue::PushResult::Accepted
+        ));
+        let dispatched = queue.flush_next().expect("fixture batch must flush");
+        assert_eq!(dispatched.lane, batch.lane);
+        assert!(queue.bind_lane_turn(&batch.lane, turn_id));
+    }
+
     /// Drive one error outcome through `handle_prompt_result` and return how
     /// many `turn_error` events it emitted to the observer feed.
     async fn turn_errors_emitted_for(outcome: PromptOutcome) -> usize {
@@ -6489,6 +7695,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                lane: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -6511,7 +7718,7 @@ mod error_outcome_emission_tests {
 
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(Uuid::new_v4()),
+            source: PromptSource::Lane(LaneKey::channel(Uuid::new_v4())),
             turn_id: "test-turn-id".to_string(),
             outcome,
             batch: None,
@@ -6529,7 +7736,8 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             Some(observer.clone()),
             None,
-        );
+        )
+        .await;
 
         let turn_errors: Vec<_> = observer
             .snapshot()
@@ -6553,7 +7761,25 @@ mod error_outcome_emission_tests {
     #[tokio::test]
     async fn panic_event_retains_task_turn_id() {
         let mut pool = AgentPool::from_slots(vec![]);
+        let mut orphan = std::process::Command::new("setsid")
+            .args(["sleep", "60"])
+            .spawn()
+            .expect("spawn orphan fixture");
+        let orphan_pid = orphan.id();
         let channel_id = Uuid::new_v4();
+        let batch = FlushBatch {
+            lane: LaneKey::channel(channel_id),
+            channel_id,
+            events: vec![BatchEvent {
+                event: EventBuilder::new(Kind::Custom(9), "panic-final-attempt")
+                    .sign_with_keys(&Keys::generate())
+                    .unwrap(),
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
         let abort_handle = pool.join_set.spawn(async move {
             let _ = started_tx.send(());
@@ -6565,17 +7791,21 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: Some(channel_id),
+                lane: Some(LaneKey::channel(channel_id)),
                 turn_id: "panic-turn-id".to_string(),
-                recoverable_batch: None,
+                recoverable_batch: Some(batch.clone()),
                 control_tx: None,
                 steer_tx: None,
             },
         );
+        pool.register_task_process(task_id, orphan_pid);
         started_rx.await.unwrap();
         abort_handle.abort();
         let join_error = pool.join_set.join_next().await.unwrap().unwrap_err();
 
         let mut queue = EventQueue::new(config::DedupMode::Queue);
+        queue.set_retry_count_for_test(channel_id, crate::queue::MAX_RETRIES);
+        bind_batch_generation(&mut queue, &batch, "panic-turn-id");
         let config = test_config();
         let mut heartbeat_in_flight = false;
         let removed_channels = HashSet::new();
@@ -6601,6 +7831,18 @@ mod error_outcome_emission_tests {
             &respawn_tx,
             &mut respawn_tasks,
             Some(observer.clone()),
+            None,
+        )
+        .await;
+
+        let retired = !std::path::Path::new(&format!("/proc/{orphan_pid}")).exists();
+        if !retired {
+            let _ = orphan.kill();
+        }
+        let _ = orphan.wait();
+        assert!(
+            retired,
+            "panic recovery must reap the registered ACP process before releasing ownership"
         );
 
         let panic = observer
@@ -6613,6 +7855,11 @@ mod error_outcome_emission_tests {
             Some(channel_id.to_string().as_str())
         );
         assert_eq!(panic.turn_id.as_deref(), Some("panic-turn-id"));
+        assert_eq!(
+            panic.payload["batch_fate"].as_str(),
+            Some("dead_lettered"),
+            "retry exhaustion must be surfaced instead of falsely reporting a requeue"
+        );
     }
 
     #[tokio::test]
@@ -6657,6 +7904,7 @@ mod error_outcome_emission_tests {
                 crate::pool::TaskMeta {
                     agent_index: 0,
                     channel_id: None,
+                    lane: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -6677,7 +7925,7 @@ mod error_outcome_emission_tests {
             let observer = ObserverHandle::in_process();
             let result = PromptResult {
                 agent,
-                source: PromptSource::Channel(Uuid::new_v4()),
+                source: PromptSource::Lane(LaneKey::channel(Uuid::new_v4())),
                 turn_id: "test-turn-id".to_string(),
                 outcome,
                 batch: None,
@@ -6694,7 +7942,8 @@ mod error_outcome_emission_tests {
                 &mut respawn_tasks,
                 Some(observer.clone()),
                 None,
-            );
+            )
+            .await;
             let events = observer.snapshot();
             let turn_error = events.iter().find(|e| e.kind == "turn_error").unwrap();
             assert_eq!(
@@ -6717,6 +7966,112 @@ mod error_outcome_emission_tests {
         .await;
     }
 
+    #[tokio::test]
+    async fn backend_session_budget_recycles_process_before_lane_release() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::channel(channel_id);
+        let mut agent = dummy_agent(0).await;
+        let old_pid = agent
+            .acp
+            .process_id()
+            .expect("dummy agent must expose a pid");
+        for index in 0..pool::SessionState::MAX_BACKEND_SESSIONS_PER_PROCESS {
+            let source = PromptSource::Lane(LaneKey::new(channel_id, format!("{index:064x}")));
+            agent
+                .state
+                .set_session_for_source(&source, format!("session-{index}"));
+        }
+
+        let keys = Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(9), "test")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let batch = FlushBatch {
+            lane: lane.clone(),
+            channel_id,
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        pool.task_map_mut().insert(
+            task_id,
+            crate::pool::TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                lane: Some(lane.clone()),
+                turn_id: "session-recycle-turn".to_string(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: None,
+            },
+        );
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        bind_batch_generation(&mut queue, &batch, "session-recycle-turn");
+        let config = test_config();
+        let mut heartbeat_in_flight = false;
+        let removed_channels = HashSet::new();
+        let mut crash_history = vec![SlotCircuit {
+            crash_times: Vec::new(),
+            open_until: None,
+            respawn_in_flight: false,
+        }];
+        let (respawn_tx, _respawn_rx) = mpsc::channel(8);
+        let mut respawn_tasks = tokio::task::JoinSet::new();
+
+        let action = handle_prompt_result(
+            &mut pool,
+            &mut queue,
+            &config,
+            PromptResult {
+                agent,
+                source: PromptSource::Lane(lane.clone()),
+                turn_id: "session-recycle-turn".to_string(),
+                outcome: PromptOutcome::Ok(acp::StopReason::EndTurn),
+                batch: None,
+            },
+            &mut heartbeat_in_flight,
+            &removed_channels,
+            &mut crash_history,
+            &respawn_tx,
+            &mut respawn_tasks,
+            None,
+            None,
+        )
+        .await;
+
+        let old_process_retired = !std::path::Path::new(&format!("/proc/{old_pid}")).exists();
+        let lane_released = !queue.is_lane_in_flight(&lane);
+        let slot_empty = pool.live_count() == 0;
+        let healthy_recycle_in_flight = crash_history[0].respawn_in_flight;
+        let crash_budget_untouched = crash_history[0].crash_times.is_empty();
+        shutdown_agent_pool(&mut pool).await;
+        respawn_tasks.abort_all();
+        while respawn_tasks.join_next().await.is_some() {}
+
+        assert!(matches!(action, LoopAction::Continue));
+        assert!(
+            old_process_retired,
+            "old ACP process must be reaped before settlement returns"
+        );
+        assert!(lane_released);
+        assert!(
+            slot_empty,
+            "healthy recycle must not return the exhausted process to the pool"
+        );
+        assert!(healthy_recycle_in_flight);
+        assert!(
+            crash_budget_untouched,
+            "planned recycling must not trip crash accounting"
+        );
+    }
+
     /// hard-cap timeout dead-letters immediately (no requeue); idle timeout is requeued.
     #[tokio::test]
     async fn hard_timeout_not_requeued_idle_timeout_is_requeued() {
@@ -6725,8 +8080,10 @@ mod error_outcome_emission_tests {
             let event = EventBuilder::new(Kind::Custom(9), "test")
                 .sign_with_keys(&keys)
                 .unwrap();
+            let channel_id = Uuid::new_v4();
             FlushBatch {
-                channel_id: Uuid::new_v4(),
+                lane: LaneKey::channel(channel_id),
+                channel_id,
                 events: vec![BatchEvent {
                     event,
                     prompt_tag: "test".into(),
@@ -6748,6 +8105,7 @@ mod error_outcome_emission_tests {
                 crate::pool::TaskMeta {
                     agent_index: 0,
                     channel_id: None,
+                    lane: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -6755,6 +8113,7 @@ mod error_outcome_emission_tests {
                 },
             );
             let mut queue = EventQueue::new(config::DedupMode::Queue);
+            bind_batch_generation(&mut queue, &batch, "test-turn-id");
             let config = test_config();
             let mut heartbeat_in_flight = false;
             let removed_channels = HashSet::new();
@@ -6767,7 +8126,7 @@ mod error_outcome_emission_tests {
             let mut respawn_tasks = tokio::task::JoinSet::new();
             let result = PromptResult {
                 agent,
-                source: PromptSource::Channel(channel_id),
+                source: PromptSource::Lane(LaneKey::channel(channel_id)),
                 turn_id: "test-turn-id".to_string(),
                 outcome,
                 batch: Some(batch),
@@ -6784,7 +8143,8 @@ mod error_outcome_emission_tests {
                 &mut respawn_tasks,
                 None,
                 None,
-            );
+            )
+            .await;
             (
                 queue.pending_channels(),
                 queue.queued_event_count(&channel_id),
@@ -6832,6 +8192,7 @@ mod error_outcome_emission_tests {
                 .sign_with_keys(&keys)
                 .unwrap();
             FlushBatch {
+                lane: LaneKey::channel(channel_id),
                 channel_id,
                 events: vec![BatchEvent {
                     event,
@@ -6853,6 +8214,7 @@ mod error_outcome_emission_tests {
                 crate::pool::TaskMeta {
                     agent_index: 0,
                     channel_id: None,
+                    lane: None,
                     turn_id: "test-turn-id".to_string(),
                     recoverable_batch: None,
                     control_tx: None,
@@ -6860,6 +8222,7 @@ mod error_outcome_emission_tests {
                 },
             );
             let mut queue = EventQueue::new(config::DedupMode::Queue);
+            bind_batch_generation(&mut queue, &batch, "test-turn-id");
             let config = test_config();
             let mut heartbeat_in_flight = false;
             let removed_channels = HashSet::new();
@@ -6872,7 +8235,7 @@ mod error_outcome_emission_tests {
             let mut respawn_tasks = tokio::task::JoinSet::new();
             let result = PromptResult {
                 agent,
-                source: PromptSource::Channel(channel_id),
+                source: PromptSource::Lane(LaneKey::channel(channel_id)),
                 turn_id: "test-turn-id".to_string(),
                 outcome,
                 batch: Some(batch),
@@ -6889,7 +8252,8 @@ mod error_outcome_emission_tests {
                 &mut respawn_tasks,
                 None,
                 None,
-            );
+            )
+            .await;
             (
                 queue.pending_channels(),
                 queue.queued_event_count(&channel_id),
@@ -6929,6 +8293,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                lane: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -6948,6 +8313,7 @@ mod error_outcome_emission_tests {
         let mut respawn_tasks = tokio::task::JoinSet::new();
         let observer = ObserverHandle::in_process();
         let batch = FlushBatch {
+            lane: LaneKey::channel(channel_id),
             channel_id,
             events: vec![BatchEvent {
                 event: EventBuilder::new(Kind::Custom(9), "test")
@@ -6959,9 +8325,10 @@ mod error_outcome_emission_tests {
             cancelled_events: vec![],
             cancel_reason: None,
         };
+        bind_batch_generation(&mut queue, &batch, "test-turn-id");
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Lane(LaneKey::channel(channel_id)),
             turn_id: "test-turn-id".to_string(),
             outcome: PromptOutcome::Timeout(TimeoutKind::Hard {
                 recently_active: true,
@@ -6980,7 +8347,8 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             Some(observer.clone()),
             None,
-        );
+        )
+        .await;
 
         let events = observer.snapshot();
         let turn_error = events
@@ -7023,6 +8391,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                lane: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7041,6 +8410,7 @@ mod error_outcome_emission_tests {
         let mut respawn_tasks = tokio::task::JoinSet::new();
         let observer = ObserverHandle::in_process();
         let batch = FlushBatch {
+            lane: LaneKey::channel(channel_id),
             channel_id,
             events: vec![BatchEvent {
                 event: EventBuilder::new(Kind::Custom(9), "final-attempt")
@@ -7052,9 +8422,10 @@ mod error_outcome_emission_tests {
             cancelled_events: vec![],
             cancel_reason: None,
         };
+        bind_batch_generation(&mut queue, &batch, "test-turn-id");
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Lane(LaneKey::channel(channel_id)),
             turn_id: "test-turn-id".to_string(),
             outcome: PromptOutcome::Timeout(TimeoutKind::Hard {
                 recently_active: true,
@@ -7073,7 +8444,8 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             Some(observer.clone()),
             None,
-        );
+        )
+        .await;
 
         let events = observer.snapshot();
         let turn_error = events
@@ -7121,6 +8493,7 @@ mod error_outcome_emission_tests {
         );
         let channel_id = Uuid::new_v4();
         let batch = FlushBatch {
+            lane: LaneKey::channel(channel_id),
             channel_id,
             events: vec![BatchEvent {
                 event: original_event.clone(),
@@ -7132,6 +8505,10 @@ mod error_outcome_emission_tests {
         };
 
         let agent = dummy_agent(0).await;
+        let old_pid = agent
+            .acp
+            .process_id()
+            .expect("inert ACP child must be running before fatal completion");
         let mut pool = AgentPool::from_slots(vec![None]);
         let task_id = pool.join_set.spawn(async {}).id();
         pool.task_map_mut().insert(
@@ -7139,6 +8516,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                lane: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7146,6 +8524,7 @@ mod error_outcome_emission_tests {
             },
         );
         let mut queue = EventQueue::new(config::DedupMode::Queue);
+        bind_batch_generation(&mut queue, &batch, "test-turn-id");
         // The steer ack handler releases the new event to the queue BEFORE
         // signaling the fallback ControlSignal::Steer that ultimately times
         // out on drain — so it is already queued by the time
@@ -7170,7 +8549,7 @@ mod error_outcome_emission_tests {
         let grace = std::time::Duration::from_secs(5);
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Lane(LaneKey::channel(channel_id)),
             turn_id: "test-turn-id".to_string(),
             outcome: PromptOutcome::CancelDrainTimeout(grace),
             batch: Some(batch),
@@ -7188,6 +8567,12 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             Some(observer.clone()),
             None,
+        )
+        .await;
+
+        assert!(
+            !std::path::Path::new(&format!("/proc/{old_pid}")).exists(),
+            "fatal completion must reap the old ACP process before releasing lane ownership"
         );
 
         // Batch preserved as a cancelled merge, not dead-lettered — same
@@ -7278,6 +8663,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                lane: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7299,7 +8685,7 @@ mod error_outcome_emission_tests {
         let grace = std::time::Duration::from_secs(5);
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(Uuid::new_v4()),
+            source: PromptSource::Lane(LaneKey::channel(Uuid::new_v4())),
             turn_id: "test-turn-id".to_string(),
             outcome: PromptOutcome::CancelDrainTimeout(grace),
             // Explicit Stop already dropped the batch upstream in
@@ -7320,7 +8706,8 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             Some(observer.clone()),
             None,
-        );
+        )
+        .await;
 
         // No batch to merge — the queue has nothing pending for any channel.
         assert_eq!(
@@ -7431,6 +8818,83 @@ mod error_outcome_emission_tests {
 
     // ── auth error dead-letter behavior ────────────────────────────────────
 
+    #[tokio::test]
+    async fn invalid_thread_root_is_not_requeued_or_respawned() {
+        let keys = nostr::Keys::generate();
+        let event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "test")
+            .sign_with_keys(&keys)
+            .unwrap();
+        let channel_id = uuid::Uuid::new_v4();
+        let batch = FlushBatch {
+            lane: LaneKey::new(channel_id, "a".repeat(64)),
+            channel_id,
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "test".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+
+        let agent = dummy_agent(0).await;
+        let mut pool = AgentPool::from_slots(vec![None]);
+        let task_id = pool.join_set.spawn(async {}).id();
+        pool.task_map_mut().insert(
+            task_id,
+            crate::pool::TaskMeta {
+                agent_index: 0,
+                channel_id: None,
+                lane: None,
+                turn_id: "test-turn-id".to_string(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: None,
+            },
+        );
+        let mut queue = EventQueue::new(config::DedupMode::Queue);
+        bind_batch_generation(&mut queue, &batch, "test-turn-id");
+        let config = test_config();
+        let mut heartbeat_in_flight = false;
+        let removed_channels = std::collections::HashSet::new();
+        let mut crash_history = vec![SlotCircuit {
+            crash_times: Vec::new(),
+            open_until: None,
+            respawn_in_flight: false,
+        }];
+        let (respawn_tx, _respawn_rx) = mpsc::channel(8);
+        let mut respawn_tasks = tokio::task::JoinSet::new();
+        let result = PromptResult {
+            agent,
+            source: PromptSource::Lane(batch.lane.clone()),
+            turn_id: "test-turn-id".to_string(),
+            outcome: PromptOutcome::Error(acp::AcpError::InvalidInput("invalid root".to_string())),
+            batch: Some(batch),
+        };
+        handle_prompt_result(
+            &mut pool,
+            &mut queue,
+            &config,
+            result,
+            &mut heartbeat_in_flight,
+            &removed_channels,
+            &mut crash_history,
+            &respawn_tx,
+            &mut respawn_tasks,
+            None,
+            None,
+        )
+        .await;
+
+        assert_eq!(queue.pending_channels(), 0);
+        assert_eq!(queue.queued_event_count(&channel_id), 0);
+        assert_eq!(pool.live_count(), 1, "healthy worker must be returned");
+        assert!(
+            respawn_tasks.is_empty(),
+            "invalid input must not respawn ACP"
+        );
+    }
+
     /// An auth-class `PromptOutcome::Error` must dead-letter immediately
     /// (the batch is never requeued) so the user sees a re-auth hint at once
     /// rather than after 10 futile retries.
@@ -7442,6 +8906,7 @@ mod error_outcome_emission_tests {
             .unwrap();
         let channel_id = uuid::Uuid::new_v4();
         let batch = FlushBatch {
+            lane: LaneKey::channel(channel_id),
             channel_id,
             events: vec![BatchEvent {
                 event,
@@ -7466,6 +8931,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                lane: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7473,6 +8939,7 @@ mod error_outcome_emission_tests {
             },
         );
         let mut queue = EventQueue::new(config::DedupMode::Queue);
+        bind_batch_generation(&mut queue, &batch, "test-turn-id");
         let config = test_config();
         let mut heartbeat_in_flight = false;
         let removed_channels = std::collections::HashSet::new();
@@ -7485,7 +8952,7 @@ mod error_outcome_emission_tests {
         let mut respawn_tasks = tokio::task::JoinSet::new();
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Lane(LaneKey::channel(channel_id)),
             turn_id: "test-turn-id".to_string(),
             outcome: PromptOutcome::Error(auth_error),
             batch: Some(batch),
@@ -7502,7 +8969,8 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             None,
             None,
-        );
+        )
+        .await;
 
         // The batch must not be requeued: pending_channels returns 0.
         assert_eq!(
@@ -7527,6 +8995,7 @@ mod error_outcome_emission_tests {
             .unwrap();
         let channel_id = uuid::Uuid::new_v4();
         let batch = FlushBatch {
+            lane: LaneKey::channel(channel_id),
             channel_id,
             events: vec![BatchEvent {
                 event,
@@ -7544,6 +9013,10 @@ mod error_outcome_emission_tests {
         };
 
         let agent = dummy_agent(0).await;
+        let old_pid = agent
+            .acp
+            .process_id()
+            .expect("inert ACP child must be running before application error");
         let mut pool = AgentPool::from_slots(vec![None]);
         let task_id = pool.join_set.spawn(async {}).id();
         pool.task_map_mut().insert(
@@ -7551,6 +9024,7 @@ mod error_outcome_emission_tests {
             crate::pool::TaskMeta {
                 agent_index: 0,
                 channel_id: None,
+                lane: None,
                 turn_id: "test-turn-id".to_string(),
                 recoverable_batch: None,
                 control_tx: None,
@@ -7558,6 +9032,7 @@ mod error_outcome_emission_tests {
             },
         );
         let mut queue = EventQueue::new(config::DedupMode::Queue);
+        bind_batch_generation(&mut queue, &batch, "test-turn-id");
         let config = test_config();
         let mut heartbeat_in_flight = false;
         let removed_channels = std::collections::HashSet::new();
@@ -7570,7 +9045,7 @@ mod error_outcome_emission_tests {
         let mut respawn_tasks = tokio::task::JoinSet::new();
         let result = PromptResult {
             agent,
-            source: PromptSource::Channel(channel_id),
+            source: PromptSource::Lane(LaneKey::channel(channel_id)),
             turn_id: "test-turn-id".to_string(),
             outcome: PromptOutcome::Error(usage_error),
             batch: Some(batch),
@@ -7587,7 +9062,8 @@ mod error_outcome_emission_tests {
             &mut respawn_tasks,
             None,
             None,
-        );
+        )
+        .await;
 
         // Non-auth application error: batch IS requeued (first attempt, retry budget > 0).
         assert_eq!(
@@ -7599,6 +9075,20 @@ mod error_outcome_emission_tests {
             queue.queued_event_count(&channel_id),
             1,
             "non-auth application error must preserve the event for retry"
+        );
+        assert!(
+            !std::path::Path::new(&format!("/proc/{old_pid}")).exists(),
+            "application error must retire the potentially mutated ACP process"
+        );
+        assert_eq!(
+            pool.live_count(),
+            0,
+            "application-error process must not return to the idle pool"
+        );
+        assert_eq!(
+            respawn_tasks.len(),
+            1,
+            "application-error process must be replaced"
         );
     }
 }

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -20,7 +20,7 @@
 //! `AcpClient` is NOT Clone — ownership moves out on claim and back on return.
 
 use std::cmp::Reverse;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -37,7 +37,7 @@ use crate::acp::{
 use crate::config::{compose_session_title, DedupMode, PermissionMode};
 use crate::observer;
 use crate::queue::{
-    CancelReason, ContextMessage, ConversationContext, FlushBatch, PromptChannelInfo,
+    CancelReason, ContextMessage, ConversationContext, FlushBatch, LaneKey, PromptChannelInfo,
     PromptProfile, PromptProfileLookup, ThreadTags,
 };
 use crate::relay::{ChannelInfo, RestClient};
@@ -53,6 +53,8 @@ const RECENT_ACTIVITY_WINDOW: Duration = Duration::from_secs(60);
 pub struct TaskMeta {
     pub agent_index: usize,
     pub channel_id: Option<Uuid>,
+    /// Exact dispatch lane for channel work. `None` for heartbeat tasks.
+    pub lane: Option<LaneKey>,
     /// Identifies terminal events when the task panics before returning a result.
     pub turn_id: String,
     /// Clone of batch for Queue mode panic recovery.
@@ -88,12 +90,21 @@ pub struct AgentModelCapabilities {
 pub struct SessionState {
     /// channel_id → session_id
     pub sessions: HashMap<Uuid, String>,
+    /// Exact root-thread session IDs. Bounded independently per agent.
+    lane_sessions: HashMap<LaneKey, String>,
+    lane_session_order: VecDeque<LaneKey>,
     pub heartbeat_session: Option<String>,
     /// Per-channel turn counters for proactive session rotation.
     /// Incremented on each successful prompt; reset when the session is rotated.
     pub turn_counts: HashMap<Uuid, u32>,
+    lane_turn_counts: HashMap<LaneKey, u32>,
     /// Turn counter for the heartbeat session.
     pub heartbeat_turn_count: u32,
+    /// Successful `session/new` calls made by this ACP process. Local cache
+    /// invalidation does not decrement this because the backend still owns the
+    /// corresponding session until the process is retired.
+    backend_sessions_created: usize,
+    backend_session_recycle_required: bool,
     /// channel_id → rendered NIP-AE core prompt section, populated once at
     /// session creation per Tyler's spec (no mid-session refresh).
     pub core_sections: HashMap<Uuid, String>,
@@ -107,11 +118,95 @@ pub struct SessionState {
 }
 
 impl SessionState {
+    const MAX_LANE_SESSIONS: usize = 128;
+    pub(crate) const MAX_BACKEND_SESSIONS_PER_PROCESS: usize = 128;
+
+    pub fn set_session_for_lane(&mut self, lane: LaneKey, session_id: String) {
+        if lane.is_channel_scoped() {
+            self.sessions.insert(lane.channel_id, session_id);
+            return;
+        }
+        if !self.lane_sessions.contains_key(&lane) {
+            while self.lane_sessions.len() >= Self::MAX_LANE_SESSIONS {
+                let Some(oldest) = self.lane_session_order.pop_front() else {
+                    break;
+                };
+                self.lane_sessions.remove(&oldest);
+                self.lane_turn_counts.remove(&oldest);
+            }
+            self.lane_session_order.push_back(lane.clone());
+        }
+        self.lane_sessions.insert(lane, session_id);
+    }
+
+    pub fn session_for_lane(&self, lane: &LaneKey) -> Option<&str> {
+        if lane.is_channel_scoped() {
+            return self.sessions.get(&lane.channel_id).map(String::as_str);
+        }
+        self.lane_sessions.get(lane).map(String::as_str)
+    }
+
+    pub fn invalidate_lane(&mut self, lane: &LaneKey) -> bool {
+        if lane.is_channel_scoped() {
+            return self.invalidate_channel(&lane.channel_id);
+        }
+        self.lane_turn_counts.remove(lane);
+        self.lane_session_order.retain(|entry| entry != lane);
+        self.lane_sessions.remove(lane).is_some()
+    }
+
+    fn channel_id_for(source: &PromptSource) -> Option<Uuid> {
+        match source {
+            PromptSource::Lane(lane) => Some(lane.channel_id),
+            PromptSource::Heartbeat => None,
+        }
+    }
+
+    fn session_for_source(&self, source: &PromptSource) -> Option<String> {
+        match source {
+            PromptSource::Lane(lane) => self.session_for_lane(lane).map(str::to_owned),
+            PromptSource::Heartbeat => self.heartbeat_session.clone(),
+        }
+    }
+
+    pub(crate) fn set_session_for_source(&mut self, source: &PromptSource, session_id: String) {
+        self.backend_sessions_created = self.backend_sessions_created.saturating_add(1);
+        if self.backend_sessions_created >= Self::MAX_BACKEND_SESSIONS_PER_PROCESS {
+            self.backend_session_recycle_required = true;
+        }
+        match source {
+            PromptSource::Lane(lane) => self.set_session_for_lane(lane.clone(), session_id),
+            PromptSource::Heartbeat => self.heartbeat_session = Some(session_id),
+        }
+    }
+
+    pub fn take_backend_session_recycle_required(&mut self) -> bool {
+        std::mem::take(&mut self.backend_session_recycle_required)
+    }
+
+    fn increment_turn_count(&mut self, source: &PromptSource) -> u32 {
+        match source {
+            PromptSource::Lane(lane) => {
+                let count = if lane.is_channel_scoped() {
+                    self.turn_counts.entry(lane.channel_id).or_insert(0)
+                } else {
+                    self.lane_turn_counts.entry(lane.clone()).or_insert(0)
+                };
+                *count += 1;
+                *count
+            }
+            PromptSource::Heartbeat => {
+                self.heartbeat_turn_count += 1;
+                self.heartbeat_turn_count
+            }
+        }
+    }
+
     /// Invalidate the session (and turn counter) for a specific prompt source.
     pub fn invalidate(&mut self, source: &PromptSource) {
         match source {
-            PromptSource::Channel(cid) => {
-                self.invalidate_channel(cid);
+            PromptSource::Lane(lane) => {
+                self.invalidate_lane(lane);
             }
             PromptSource::Heartbeat => {
                 self.heartbeat_session = None;
@@ -124,15 +219,28 @@ impl SessionState {
     /// Returns `true` if the channel had an active session.
     pub fn invalidate_channel(&mut self, channel_id: &Uuid) -> bool {
         self.turn_counts.remove(channel_id);
+        let lane_had_session = self
+            .lane_sessions
+            .keys()
+            .any(|lane| lane.channel_id == *channel_id);
+        self.lane_sessions
+            .retain(|lane, _| lane.channel_id != *channel_id);
+        self.lane_turn_counts
+            .retain(|lane, _| lane.channel_id != *channel_id);
+        self.lane_session_order
+            .retain(|lane| lane.channel_id != *channel_id);
         self.core_sections.remove(channel_id);
         self.canvas_sections.remove(channel_id);
-        self.sessions.remove(channel_id).is_some()
+        self.sessions.remove(channel_id).is_some() || lane_had_session
     }
 
     /// Invalidate all sessions and turn counters (e.g. after agent exit).
     pub fn invalidate_all(&mut self) {
         self.sessions.clear();
+        self.lane_sessions.clear();
+        self.lane_session_order.clear();
         self.turn_counts.clear();
+        self.lane_turn_counts.clear();
         self.heartbeat_session = None;
         self.heartbeat_turn_count = 0;
         self.core_sections.clear();
@@ -142,6 +250,10 @@ impl SessionState {
     #[cfg(test)]
     fn has_channel_state(&self, channel_id: &Uuid) -> bool {
         self.sessions.contains_key(channel_id)
+            || self
+                .lane_sessions
+                .keys()
+                .any(|lane| lane.channel_id == *channel_id)
             || self.turn_counts.contains_key(channel_id)
             || self.core_sections.contains_key(channel_id)
             || self.canvas_sections.contains_key(channel_id)
@@ -225,10 +337,21 @@ impl OwnedAgent {
 /// tasks for panic recovery.
 pub struct AgentPool {
     agents: Vec<Option<OwnedAgent>>,
+    /// Single authoritative worker for each reusable exact-lane ACP session.
+    /// Entries remain while the worker is checked out so another idle worker
+    /// cannot fork the lane's conversation history.
+    lane_owners: HashMap<LaneKey, usize>,
+    /// Channels whose cached sessions must be stripped when a currently
+    /// checked-out worker returns. Entries survive a membership re-add, so a
+    /// worker from the pre-removal lifetime cannot republish stale affinity.
+    retired_agent_channels: HashMap<usize, HashSet<Uuid>>,
     result_tx: mpsc::UnboundedSender<PromptResult>,
     result_rx: mpsc::UnboundedReceiver<PromptResult>,
     pub join_set: JoinSet<()>,
     task_map: HashMap<tokio::task::Id, TaskMeta>,
+    /// PID registry kept outside `TaskMeta` so panic recovery can reap an ACP
+    /// child after the task-owned `AcpClient` has unwound and been dropped.
+    task_processes: HashMap<tokio::task::Id, u32>,
 }
 
 /// Result returned by a completed prompt task.
@@ -245,7 +368,7 @@ pub struct PromptResult {
 /// Whether the prompt came from a channel event or a heartbeat.
 #[derive(Debug)]
 pub enum PromptSource {
-    Channel(Uuid),
+    Lane(LaneKey),
     Heartbeat,
 }
 
@@ -257,14 +380,22 @@ fn apply_completed_before_control_signal(
     state: &mut SessionState,
     source: &PromptSource,
     control_signal: &ControlSignal,
+    max_turns_per_session: u32,
 ) {
+    let reached_turn_limit =
+        max_turns_per_session > 0 && state.increment_turn_count(source) >= max_turns_per_session;
+
     // Rotate and SwitchModel both invalidate so the next turn creates a fresh
     // session. For SwitchModel the caller has already set `desired_model`, so
-    // the fresh session applies the new model on its next creation.
-    if matches!(
-        control_signal,
-        ControlSignal::Rotate | ControlSignal::SwitchModel(_)
-    ) {
+    // the fresh session applies the new model on its next creation. A natural
+    // completion also obeys the same max-turn rotation as the ordinary success
+    // path, regardless of which control happened to win `select!` afterward.
+    if reached_turn_limit
+        || matches!(
+            control_signal,
+            ControlSignal::Rotate | ControlSignal::SwitchModel(_)
+        )
+    {
         state.invalidate(source);
     }
 }
@@ -323,28 +454,24 @@ pub enum ControlSignal {
 /// for that — only a function parameter pass-through.
 ///
 /// If `active_run_id` is `None` at write time (no `session/update` seen yet
-/// — e.g. agents that never emit run-id metadata), the goose-native method
-/// cannot form a valid `expectedRunId`, and the read loop falls back to the
-/// cross-adapter `_session/steering` method when the agent advertised
-/// `_meta.steering.supported` at `initialize`. That method takes no run id, so
-/// no freshness concern applies to it. When neither transport is available the
-/// read loop acks [`SteerError::ExpectedRunIdMissing`]. The main loop maps that
-/// to the "Err-before-pending" bucket: no withhold/mark was established at
-/// `pool::send_steer` time because the request was rejected before any
-/// write, so the watcher only needs to release nothing and fall back to the
-/// universal `ControlSignal::Steer` cancel+merge path.
+/// — e.g. agents that never emit run-id metadata), the Goose method cannot
+/// form a valid `expectedRunId`, so the read loop writes nothing and acks
+/// [`SteerError::ExpectedRunIdMissing`]. The main loop releases the exact
+/// withheld event and falls back to the universal `ControlSignal::Steer`
+/// cancel+merge path. A capability advertisement for an unowned steer method
+/// is deliberately insufficient.
 pub struct SteerRequest {
     /// Prompt body text blocks. Each entry becomes one `text` content
     /// block in `params.prompt`. Built by the main loop via
     /// `queue::native_steer_framing()` + `queue::format_event_block` so
     /// the wording cannot drift from the cancel+merge fallback path.
+    #[allow(dead_code)]
     pub prompt_blocks: Vec<String>,
     /// Oneshot for the read loop to report the outcome.
     pub ack_tx: tokio::sync::oneshot::Sender<SteerAck>,
 }
 
-/// Why a mid-turn steer failed, on either transport
-/// (`_goose/unstable/session/steer` or `_session/steering`).
+/// Why an exact-run Goose mid-turn steer failed.
 ///
 /// String and integer fields are intentionally `Debug`-only — read by
 /// `tracing` macros in the main loop's `PoolEvent::SteerAck` arm via
@@ -367,28 +494,14 @@ pub enum SteerError {
     /// Transport-level failure: write error, read EOF, JSON-RPC framing
     /// violation, etc. The string carries the underlying `AcpError`'s display.
     Transport(String),
-    /// At steer-write time neither steer transport was available: no
-    /// `expectedRunId` (`AcpClient::active_run_id` was `None`, so the
-    /// goose-native method could not be formed) and the agent did not
-    /// advertise the cross-adapter `_session/steering` extension. The read
+    /// At steer-write time no exact `expectedRunId` was available, so the
+    /// Goose-native method could not be formed. The read
     /// loop drops the request without writing anything; the main loop should
     /// release any withheld event and fall back to the universal cancel+merge
     /// `ControlSignal::Steer` path. This is in the same "Err-before-pending"
     /// bucket as `Transport` write failures: no in-process state was
     /// established, so no in-process cleanup is needed.
     ExpectedRunIdMissing,
-    /// A `_session/steering` request returned a JSON-RPC *success* whose
-    /// `outcome` was not one of the two recognized delivery outcomes
-    /// (`injected`, `startedNewTurn`) — including `failed` (codex-acp) and a
-    /// missing `outcome` entirely. `outcome` carries what the agent actually
-    /// reported, for logs.
-    ///
-    /// The steer did NOT land, so the main loop must release the withheld
-    /// event and fire the cancel+merge fallback — exactly like a write that
-    /// never happened. Treating an unrecognized success as delivery would
-    /// drop the user's message: codex-acp answers unrecognized extension
-    /// methods with a bare `{}` success rather than `-32601`.
-    OutcomeRejected { outcome: String },
     /// The read loop never got to dispatch the steer because the prompt
     /// completed first. Delivery state for the underlying message is
     /// unknown after prompt completion — the main loop must treat this as
@@ -409,17 +522,31 @@ pub enum SteerAck {
     /// The main loop must drop the withheld event (`remove_event`) — it
     /// has been delivered via the non-cancelling path.
     Success,
-    /// The steer was attempted but failed. Delivery state for the
-    /// underlying message is unknown after prompt completion; the main
-    /// loop must release the withheld event and fall back to the
-    /// universal `Steer` cancel+merge path so the message still reaches
-    /// the agent.
+    /// The exact-run steer was not delivered; the typed error controls whether
+    /// the normal cancel+merge fallback should fire.
     Err(SteerError),
     /// The prompt completed before the read loop selected the steer arm.
     /// Treated as a benign no-op: release the withheld event for normal
     /// dispatch. Do not fire the fallback `Steer` signal — there is no
     /// in-flight turn to signal, and normal dispatch handles delivery.
     PromptCompletedNeutral,
+}
+
+/// Errors that make the ACP stdio/process lifecycle unsafe to reuse.
+///
+/// `AgentError` is returned after a request crossed the adapter boundary. Its
+/// response does not prove the adapter/session remained unmodified, so the
+/// process must be retired even when the batch's retry/dead-letter policy is
+/// application-specific.
+pub(crate) fn prompt_error_requires_process_replacement(error: &AcpError) -> bool {
+    matches!(
+        error,
+        AcpError::Io(_)
+            | AcpError::WriteTimeout(_)
+            | AcpError::Timeout(_)
+            | AcpError::Protocol(_)
+            | AcpError::AgentError { .. }
+    )
 }
 
 /// Whether a turn was cut by the idle clock or the hard wall-clock cap.
@@ -511,7 +638,97 @@ impl ChannelInfoResolver {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MembershipAdmissionToken {
+    channel_id: Uuid,
+    epoch: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MembershipAdmissionState {
+    epoch: u64,
+    active: bool,
+}
+
+/// Linearizable channel-membership generation used at prompt admission.
+///
+/// Removal increments the generation and deactivates the channel. Re-adding
+/// only reactivates the new generation, so a task dispatched before removal
+/// can never become admissible again after a rapid remove/add sequence.
+#[derive(Debug, Default)]
+pub struct MembershipAdmission {
+    states: Mutex<HashMap<Uuid, MembershipAdmissionState>>,
+}
+
+impl MembershipAdmission {
+    pub fn new(channels: impl IntoIterator<Item = Uuid>) -> Self {
+        let states = channels
+            .into_iter()
+            .map(|channel_id| {
+                (
+                    channel_id,
+                    MembershipAdmissionState {
+                        epoch: 0,
+                        active: true,
+                    },
+                )
+            })
+            .collect();
+        Self {
+            states: Mutex::new(states),
+        }
+    }
+
+    pub fn capture(&self, channel_id: Uuid) -> Option<MembershipAdmissionToken> {
+        let states = self.states.lock().ok()?;
+        let state = states.get(&channel_id)?;
+        state.active.then_some(MembershipAdmissionToken {
+            channel_id,
+            epoch: state.epoch,
+        })
+    }
+
+    pub fn retire(&self, channel_id: Uuid) {
+        let Ok(mut states) = self.states.lock() else {
+            tracing::error!(channel_id = %channel_id, "membership admission lock poisoned while retiring channel");
+            return;
+        };
+        let state = states
+            .entry(channel_id)
+            .or_insert(MembershipAdmissionState {
+                epoch: 0,
+                active: false,
+            });
+        state.epoch = state.epoch.saturating_add(1);
+        state.active = false;
+    }
+
+    pub fn activate(&self, channel_id: Uuid) {
+        let Ok(mut states) = self.states.lock() else {
+            tracing::error!(channel_id = %channel_id, "membership admission lock poisoned while activating channel");
+            return;
+        };
+        states
+            .entry(channel_id)
+            .and_modify(|state| state.active = true)
+            .or_insert(MembershipAdmissionState {
+                epoch: 0,
+                active: true,
+            });
+    }
+
+    pub fn permits(&self, token: &MembershipAdmissionToken) -> bool {
+        self.states
+            .lock()
+            .ok()
+            .and_then(|states| states.get(&token.channel_id).copied())
+            .is_some_and(|state| state.active && state.epoch == token.epoch)
+    }
+}
+
 pub struct PromptContext {
+    /// Shared membership-generation fence for channel prompt admission.
+    pub membership_admission: Arc<MembershipAdmission>,
     pub mcp_servers: Vec<McpServer>,
     pub initial_message: Option<String>,
     pub idle_timeout: Duration,
@@ -575,12 +792,27 @@ impl AgentPool {
     /// the index invariant.
     pub fn from_slots(slots: Vec<Option<OwnedAgent>>) -> Self {
         let (result_tx, result_rx) = mpsc::unbounded_channel();
+        let mut lane_owners = HashMap::new();
+        for (index, slot) in slots.iter().enumerate() {
+            let Some(agent) = slot else { continue };
+            for channel_id in agent.state.sessions.keys() {
+                lane_owners
+                    .entry(LaneKey::channel(*channel_id))
+                    .or_insert(index);
+            }
+            for lane in agent.state.lane_sessions.keys() {
+                lane_owners.entry(lane.clone()).or_insert(index);
+            }
+        }
         Self {
             agents: slots,
+            lane_owners,
+            retired_agent_channels: HashMap::new(),
             result_tx,
             result_rx,
             join_set: JoinSet::new(),
             task_map: HashMap::new(),
+            task_processes: HashMap::new(),
         }
     }
 
@@ -591,26 +823,75 @@ impl AgentPool {
     ///
     /// Returns `None` if all agents are checked out.
     pub fn try_claim(&mut self, channel_id: Option<Uuid>) -> Option<OwnedAgent> {
-        // Pass 1: prefer agent with existing session for this channel.
-        if let Some(cid) = channel_id {
-            let idx = self.agents.iter().position(|slot| {
+        match channel_id {
+            Some(channel_id) => self.try_claim_lane(Some(&LaneKey::channel(channel_id))),
+            None => self.try_claim_lane(None),
+        }
+    }
+
+    /// Whether `try_claim_lane` can succeed right now without violating an
+    /// existing lane owner. Used by queue selection to skip a busy owned lane
+    /// while dispatching independent work to other idle agents.
+    pub fn can_claim_lane(&self, lane: &LaneKey) -> bool {
+        if self.channel_retirement_pending(lane.channel_id) {
+            return false;
+        }
+        if let Some(&owner) = self.lane_owners.get(lane) {
+            return self.agents.get(owner).is_some_and(|slot| slot.is_some());
+        }
+        if let Some(owner) = self.agents.iter().position(|slot| {
+            slot.as_ref()
+                .is_some_and(|agent| agent.state.session_for_lane(lane).is_some())
+        }) {
+            return self.agents[owner].is_some();
+        }
+        self.any_idle()
+    }
+
+    /// Claim an idle agent for an exact lane. Once a lane has a reusable
+    /// session, only its authoritative worker may claim it; a busy owner makes
+    /// the lane wait rather than forking its ACP history onto another worker.
+    pub fn try_claim_lane(&mut self, lane: Option<&LaneKey>) -> Option<OwnedAgent> {
+        if let Some(lane) = lane {
+            if self.channel_retirement_pending(lane.channel_id) {
+                return None;
+            }
+            if let Some(&owner) = self.lane_owners.get(lane) {
+                return self.agents.get_mut(owner)?.take();
+            }
+            if let Some(idx) = self.agents.iter().position(|slot| {
                 slot.as_ref()
-                    .map(|a| a.state.sessions.contains_key(&cid))
+                    .map(|agent| agent.state.session_for_lane(lane).is_some())
                     .unwrap_or(false)
-            });
-            if let Some(i) = idx {
-                return self.agents[i].take();
+            }) {
+                self.lane_owners.insert(lane.clone(), idx);
+                return self.agents[idx].take();
             }
         }
 
-        // Pass 2: first idle agent.
-        let idx = self.agents.iter().position(|slot| slot.is_some());
-        idx.map(|i| self.agents[i].take().unwrap())
+        let idx = self.agents.iter().position(|slot| slot.is_some())?;
+        let agent = self.agents[idx].take().unwrap();
+        if let Some(lane) = lane {
+            // Own the lane from checkout, not only after session/new. Queue
+            // deadlines may expire while preflight or initial context is still
+            // running; without this provisional owner, the released lane could
+            // fork onto another idle worker before the first task returns.
+            // return_agent() reconciles this entry with the worker's actual
+            // reusable sessions and drops it when session creation failed.
+            self.lane_owners.insert(lane.clone(), idx);
+        }
+        Some(agent)
     }
 
-    /// Return an agent to its slot after a task completes.
-    pub fn return_agent(&mut self, agent: OwnedAgent) {
+    /// Return an agent to its slot after a task completes and reconcile the
+    /// exact-lane ownership index with its current reusable sessions.
+    pub fn return_agent(&mut self, mut agent: OwnedAgent) {
         let idx = agent.index;
+        if let Some(channels) = self.retired_agent_channels.remove(&idx) {
+            for channel_id in channels {
+                agent.state.invalidate_channel(&channel_id);
+            }
+        }
         if self.agents[idx].is_some() {
             // This is a bug: two tasks returned the same agent index. Log it
             // loudly so it shows up in production logs, then overwrite — the
@@ -621,7 +902,57 @@ impl AgentPool {
                 "BUG: return_agent called for slot {idx} which is already occupied — overwriting"
             );
         }
+
+        self.lane_owners.retain(|_, owner| *owner != idx);
+        let mut owned_lanes: Vec<LaneKey> = agent
+            .state
+            .sessions
+            .keys()
+            .map(|channel_id| LaneKey::channel(*channel_id))
+            .collect();
+        owned_lanes.extend(agent.state.lane_sessions.keys().cloned());
+        for lane in &owned_lanes {
+            for (other_index, slot) in self.agents.iter_mut().enumerate() {
+                if other_index != idx {
+                    if let Some(other) = slot.as_mut() {
+                        other.state.invalidate_lane(lane);
+                    }
+                }
+            }
+            self.lane_owners.insert(lane.clone(), idx);
+        }
         self.agents[idx] = Some(agent);
+    }
+
+    /// Forget every reusable session owned by a worker being replaced.
+    /// Channel retirements deliberately survive: the replacement worker's
+    /// return is the barrier proving the pre-removal process is gone.
+    pub fn forget_agent_sessions(&mut self, index: usize) {
+        self.lane_owners.retain(|_, owner| *owner != index);
+    }
+
+    /// Fence cached sessions held by workers that are checked out when channel
+    /// membership is removed. The retirement survives a quick re-add and is
+    /// consumed only when each pre-removal worker returns (or is discarded).
+    pub fn retire_channel_sessions_for_checked_out_agents(&mut self, channel_id: Uuid) -> usize {
+        let checked_out: HashSet<usize> = self
+            .task_map
+            .values()
+            .map(|meta| meta.agent_index)
+            .collect();
+        for index in &checked_out {
+            self.retired_agent_channels
+                .entry(*index)
+                .or_default()
+                .insert(channel_id);
+        }
+        checked_out.len()
+    }
+
+    fn channel_retirement_pending(&self, channel_id: Uuid) -> bool {
+        self.retired_agent_channels
+            .values()
+            .any(|channels| channels.contains(&channel_id))
     }
 
     /// Whether any agent is currently idle (sitting in its slot).
@@ -629,14 +960,13 @@ impl AgentPool {
         self.agents.iter().any(|slot| slot.is_some())
     }
 
-    /// Whether any idle agent already has a session for `channel_id`.
-    /// Used to compute `affinity_hit` before calling `try_claim`.
-    pub fn has_session_for(&self, channel_id: Uuid) -> bool {
-        self.agents.iter().any(|slot| {
-            slot.as_ref()
-                .map(|a| a.state.sessions.contains_key(&channel_id))
-                .unwrap_or(false)
-        })
+    pub fn has_session_for_lane(&self, lane: &LaneKey) -> bool {
+        self.lane_owners.contains_key(lane)
+            || self.agents.iter().any(|slot| {
+                slot.as_ref()
+                    .map(|agent| agent.state.session_for_lane(lane).is_some())
+                    .unwrap_or(false)
+            })
     }
 
     /// Count of agents that are alive: idle OR checked out (have a task_map entry).
@@ -656,37 +986,47 @@ impl AgentPool {
         &mut self.task_map
     }
 
-    /// Try to send a goose-native steer request to the in-flight task for
-    /// `channel_id`.
-    ///
-    /// Returns `Ok(())` if the request was accepted by the read loop's
-    /// receiver (capacity-1 mpsc; one slot is the single in-flight steer
-    /// write). Returns `Err(SteerError::Transport(_))` on `Full`/`Closed`
-    /// (already-in-flight write, or read loop torn down). Callers must
-    /// fall back to the universal `ControlSignal::Steer` cancel+merge path
-    /// on `Err`.
-    ///
-    /// This does **not** spawn the ack watcher — the caller owns the
-    /// oneshot `ack_tx` inside `SteerRequest` and is responsible for
-    /// awaiting it and applying the locked Success / Err / PromptCompletedNeutral
-    /// semantics. Caller is also responsible for the synchronous
-    /// `queue.mark_native_steer_pending(...)` *before* spawning the
-    /// watcher, to close the result-vs-ack race.
-    ///
-    /// Returns `Err(SteerError::PromptCompleted)` if no task is in flight
-    /// for `channel_id` (the prompt completed between the mode-gate check
-    /// and this call, or the channel was never in flight). This is
-    /// semantically a soft no-op — the caller should release any withheld
-    /// event and let normal dispatch handle delivery.
-    pub fn send_steer(
+    pub fn register_task_process(&mut self, task_id: tokio::task::Id, pid: u32) {
+        self.task_processes.insert(task_id, pid);
+    }
+
+    pub fn take_task_for_panic(
         &mut self,
-        channel_id: Uuid,
+        task_id: tokio::task::Id,
+    ) -> (Option<TaskMeta>, Option<u32>) {
+        (
+            self.task_map.remove(&task_id),
+            self.task_processes.remove(&task_id),
+        )
+    }
+
+    /// Remove the authoritative metadata and PID for a normally completed task.
+    pub fn remove_tasks_for_agent(&mut self, agent_index: usize) -> usize {
+        let task_ids: Vec<_> = self
+            .task_map
+            .iter()
+            .filter_map(|(task_id, meta)| (meta.agent_index == agent_index).then_some(*task_id))
+            .collect();
+        for task_id in &task_ids {
+            self.task_map.remove(task_id);
+            self.task_processes.remove(task_id);
+        }
+        task_ids.len()
+    }
+
+    /// Send a native steer request only to the task that owns this exact lane
+    /// generation. Same-channel siblings and expired same-lane tasks are
+    /// deliberately invisible to this lookup.
+    pub fn send_steer_lane_for_turn(
+        &mut self,
+        lane: &LaneKey,
+        turn_id: &str,
         request: SteerRequest,
     ) -> Result<(), SteerError> {
         let meta = self
             .task_map
             .values_mut()
-            .find(|m| m.channel_id == Some(channel_id))
+            .find(|m| m.lane.as_ref() == Some(lane) && m.turn_id == turn_id)
             .ok_or(SteerError::PromptCompleted)?;
         let tx = meta
             .steer_tx
@@ -748,6 +1088,22 @@ impl AgentPool {
                 }
             }
         }
+        self.lane_owners
+            .retain(|lane, _| lane.channel_id != channel_id);
+        count
+    }
+
+    /// Remove one exact lane session from all idle agents.
+    pub fn invalidate_lane_sessions(&mut self, lane: &LaneKey) -> usize {
+        let mut count = 0;
+        for slot in &mut self.agents {
+            if let Some(agent) = slot.as_mut() {
+                if agent.state.invalidate_lane(lane) {
+                    count += 1;
+                }
+            }
+        }
+        self.lane_owners.remove(lane);
         count
     }
 
@@ -793,6 +1149,7 @@ impl AgentPool {
         agent.desired_model = Some(model_id.to_string());
         agent.model_overridden = true;
         agent.state.invalidate_channel(&channel_id);
+        self.lane_owners.remove(&LaneKey::channel(channel_id));
         IdleSwitchResult::Switched
     }
 }
@@ -1375,6 +1732,34 @@ fn send_prompt_result(
     });
 }
 
+/// Whether this task's immutable channel generation is still prompt-admissible.
+/// Heartbeats intentionally carry no membership token; every channel lane must.
+fn membership_admission_current(
+    ctx: &PromptContext,
+    source: &PromptSource,
+    token: Option<&MembershipAdmissionToken>,
+) -> bool {
+    match source {
+        PromptSource::Heartbeat => token.is_none(),
+        PromptSource::Lane(lane) => token.is_some_and(|token| {
+            token.channel_id == lane.channel_id && ctx.membership_admission.permits(token)
+        }),
+    }
+}
+
+/// Consume a control signal that is already settled at the final pre-prompt
+/// barrier. A closed sender fails closed as cancellation. `Empty` is the
+/// linearization point after which the prompt may start.
+fn take_ready_pre_prompt_control(
+    rx: &mut tokio::sync::oneshot::Receiver<ControlSignal>,
+) -> Option<ControlSignal> {
+    match rx.try_recv() {
+        Ok(signal) => Some(signal),
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => None,
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => Some(ControlSignal::Cancel),
+    }
+}
+
 /// Core async function spawned for each prompt.
 ///
 /// Lifecycle:
@@ -1387,24 +1772,23 @@ fn send_prompt_result(
 ///
 /// The agent is ALWAYS returned — even on panic the `JoinSet` detects the
 /// abort and the caller uses `task_map` to recover the agent index.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_prompt_task(
     mut agent: OwnedAgent,
     batch: Option<FlushBatch>,
     prompt_text: Option<String>,
     ctx: Arc<PromptContext>,
     result_tx: mpsc::UnboundedSender<PromptResult>,
-    control_rx: Option<tokio::sync::oneshot::Receiver<ControlSignal>>,
+    mut control_rx: Option<tokio::sync::oneshot::Receiver<ControlSignal>>,
+    admission_token: Option<MembershipAdmissionToken>,
     turn_id: String,
 ) {
     // Is this a channel prompt or a heartbeat?
     let source = match &batch {
-        Some(b) => PromptSource::Channel(b.channel_id),
+        Some(b) => PromptSource::Lane(b.lane.clone()),
         None => PromptSource::Heartbeat,
     };
-    let observer_channel_id = match &source {
-        PromptSource::Channel(channel_id) => Some(*channel_id),
-        PromptSource::Heartbeat => None,
-    };
+    let observer_channel_id = SessionState::channel_id_for(&source);
     let turn_started_at = chrono::Utc::now().to_rfc3339();
     agent.acp.set_observer_context(observer::context_for_turn(
         observer_channel_id,
@@ -1420,7 +1804,7 @@ pub async fn run_prompt_task(
         "turn_started",
         serde_json::json!({
             "source": match &source {
-                PromptSource::Channel(_) => "channel",
+                PromptSource::Lane(_) => "channel",
                 PromptSource::Heartbeat => "heartbeat",
             },
             "triggeringEventIds": triggering_event_ids,
@@ -1475,6 +1859,45 @@ pub async fn run_prompt_task(
         .unwrap_or_default();
     let _reaction_guard = ReactionGuard::new(ctx.rest_client.clone(), reaction_ids.clone());
 
+    // Exact-root admission must complete before any ACP session is created. A
+    // missing, tampered, cross-channel, or non-top-level root is untrusted input,
+    // not an ACP transport failure: return the healthy worker and fail the
+    // accepted batch once rather than requeueing it or restarting the process.
+    let mut resolved_batch_channel_info = None;
+    let mut resolved_batch_conversation_context = None;
+    if let Some(b) = batch.as_ref() {
+        resolved_batch_channel_info = ctx.channel_info.resolve(b.channel_id).await;
+        resolved_batch_conversation_context = if ctx.context_message_limit > 0 {
+            fetch_conversation_context(b, &resolved_batch_channel_info, &ctx).await
+        } else {
+            None
+        };
+
+        let context_gate = b.events.last().map(|event| {
+            ensure_required_thread_context(
+                &b.lane,
+                &event.event.id.to_hex(),
+                resolved_batch_conversation_context.as_ref(),
+            )
+        });
+        if let Some(Err(error)) = context_gate {
+            tracing::warn!(
+                channel = %b.channel_id,
+                root_event_id = %b.lane.root_event_id,
+                "required signed thread root unavailable — rejecting exact lane before session creation"
+            );
+            send_prompt_result(
+                &result_tx,
+                &turn_id,
+                agent,
+                source,
+                PromptOutcome::Error(error),
+                batch,
+            );
+            return;
+        }
+    }
+
     //
     // Core memory is delivered inside the system prompt the harness already
     // builds (system role for protocol >= 2, the `[System]` user-message
@@ -1501,11 +1924,12 @@ pub async fn run_prompt_task(
     //
     // Operator opt-out: `--no-memory` / `BUZZ_ACP_NO_MEMORY` skips the fetch.
     if ctx.memory_enabled {
-        if let (PromptSource::Channel(cid), Some(owner_pk)) =
-            (&source, ctx.agent_owner_pubkey.as_ref())
-        {
-            let is_new_channel_session = !agent.state.sessions.contains_key(cid);
-            if is_new_channel_session && !agent.state.core_sections.contains_key(cid) {
+        if let (Some(cid), Some(owner_pk)) = (
+            SessionState::channel_id_for(&source),
+            ctx.agent_owner_pubkey.as_ref(),
+        ) {
+            let is_new_channel_session = agent.state.session_for_source(&source).is_none();
+            if is_new_channel_session && !agent.state.core_sections.contains_key(&cid) {
                 // Bounded — we'd rather start the session with no core hint
                 // than block session creation on a stalled relay.
                 const CORE_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
@@ -1533,7 +1957,7 @@ pub async fn run_prompt_task(
                         section_len = rendered.len(),
                         "injected NIP-AE core section into system prompt"
                     );
-                    agent.state.core_sections.insert(*cid, rendered);
+                    agent.state.core_sections.insert(cid, rendered);
                 }
             }
         }
@@ -1556,19 +1980,21 @@ pub async fn run_prompt_task(
     // canvas DM check uses — see `resolve_new_session_channel_context`.
     let mut title_channel: Option<String> = None;
     let mut origin_channel_type: Option<String> = None;
-    if let PromptSource::Channel(cid) = &source {
-        let is_new_channel_session = !agent.state.sessions.contains_key(cid);
-        let needs_canvas = is_new_channel_session && !agent.state.canvas_sections.contains_key(cid);
-        if is_new_channel_session {
+    if let Some(cid) = SessionState::channel_id_for(&source) {
+        let is_new_channel_session = agent.state.session_for_source(&source).is_none();
+        let needs_canvas =
+            is_new_channel_session && !agent.state.canvas_sections.contains_key(&cid);
+        let needs_title = is_new_channel_session && ctx.session_title.is_some();
+        if needs_canvas || needs_title {
             let (is_dm, resolved_channel, resolved_channel_type) =
-                resolve_new_session_channel_context(&ctx.channel_info, *cid).await;
+                resolve_new_session_channel_context(&ctx.channel_info, cid).await;
             title_channel = resolved_channel;
             origin_channel_type = resolved_channel_type;
             // A confirmed DM never receives a canvas section; an undeterminable
             // channel type fails closed as a DM for the same reason.
             if needs_canvas && !is_dm {
-                if let Some(section) = fetch_canvas_section(*cid, &ctx.rest_client).await {
-                    pending_canvas = Some((*cid, section));
+                if let Some(section) = fetch_canvas_section(cid, &ctx.rest_client).await {
+                    pending_canvas = Some((cid, section));
                 }
             }
         }
@@ -1577,26 +2003,45 @@ pub async fn run_prompt_task(
     // The core section to fold into the system prompt for this turn's session.
     // Channel-scoped; heartbeats carry no owner core.
     let agent_core: Option<String> = match &source {
-        PromptSource::Channel(cid) => agent.state.core_sections.get(cid).cloned(),
+        PromptSource::Lane(lane) => agent.state.core_sections.get(&lane.channel_id).cloned(),
         PromptSource::Heartbeat => None,
     };
 
     // The canvas metadata section — channel-scoped, absent for heartbeats/DMs.
     // Prefer the committed cache; fall back to pending (for new sessions being created now).
     let agent_canvas: Option<String> = match &source {
-        PromptSource::Channel(cid) => agent
+        PromptSource::Lane(lane) => agent
             .state
             .canvas_sections
-            .get(cid)
+            .get(&lane.channel_id)
             .cloned()
             .or_else(|| pending_canvas.as_ref().map(|(_, s)| s.clone())),
         PromptSource::Heartbeat => None,
     };
 
+    if !membership_admission_current(&ctx, &source, admission_token.as_ref()) {
+        tracing::warn!(
+            channel = ?observer_channel_id,
+            turn_id,
+            "dropping stale pre-removal turn before ACP session admission"
+        );
+        agent.state.invalidate(&source);
+        send_prompt_result(
+            &result_tx,
+            &turn_id,
+            agent,
+            source,
+            PromptOutcome::Cancelled,
+            None,
+        );
+        return;
+    }
+
     let (session_id, is_new_session) = match &source {
-        PromptSource::Channel(cid) => {
-            if let Some(sid) = agent.state.sessions.get(cid) {
-                (sid.clone(), false)
+        PromptSource::Lane(lane) => {
+            let cid = lane.channel_id;
+            if let Some(sid) = agent.state.session_for_source(&source) {
+                (sid, false)
             } else {
                 // The title is channel-qualified (`Agent · #channel`) so one
                 // agent in several channels doesn't produce identical session
@@ -1608,7 +2053,7 @@ pub async fn run_prompt_task(
                     agent_core.as_deref(),
                     agent_canvas.as_deref(),
                     title_channel.as_deref(),
-                    Some(*cid),
+                    Some(cid),
                     origin_channel_type.as_deref(),
                 )
                 .await
@@ -1618,7 +2063,7 @@ pub async fn run_prompt_task(
                             target: "pool::session",
                             "created session {sid} for channel {cid}"
                         );
-                        agent.state.sessions.insert(*cid, sid.clone());
+                        agent.state.set_session_for_source(&source, sid.clone());
                         // Commit canvas only after session creation succeeds (I3).
                         if let Some((pending_cid, section)) = pending_canvas.take() {
                             agent.state.canvas_sections.insert(pending_cid, section);
@@ -1666,7 +2111,7 @@ pub async fn run_prompt_task(
                             "created heartbeat session {sid} for agent {}",
                             agent.index
                         );
-                        agent.state.heartbeat_session = Some(sid.clone());
+                        agent.state.set_session_for_source(&source, sid.clone());
                         (sid, true)
                     }
                     Err(AcpError::AgentExited) => {
@@ -1713,8 +2158,27 @@ pub async fn run_prompt_task(
         }),
     );
 
+    if !membership_admission_current(&ctx, &source, admission_token.as_ref()) {
+        tracing::warn!(
+            channel = ?observer_channel_id,
+            turn_id,
+            "dropping stale pre-removal turn after ACP session creation"
+        );
+        agent.state.invalidate(&source);
+        send_prompt_result(
+            &result_tx,
+            &turn_id,
+            agent,
+            source,
+            PromptOutcome::Cancelled,
+            None,
+        );
+        return;
+    }
+
     if is_new_session {
-        if let (PromptSource::Channel(cid), Some(ref initial_msg)) = (&source, &ctx.initial_message)
+        if let (Some(cid), Some(ref initial_msg)) =
+            (SessionState::channel_id_for(&source), &ctx.initial_message)
         {
             tracing::info!(
                 target: "pool::session",
@@ -1876,14 +2340,8 @@ pub async fn run_prompt_task(
         vec![text]
     } else if let Some(ref b) = batch {
         // Build prompt from batch with context enrichment.
-        // Try startup cache first; lazy-fetch via REST for dynamic channels.
-        let channel_info = ctx.channel_info.resolve(b.channel_id).await;
-
-        let conversation_context = if ctx.context_message_limit > 0 {
-            fetch_conversation_context(b, &channel_info, &ctx).await
-        } else {
-            None
-        };
+        let channel_info = resolved_batch_channel_info;
+        let conversation_context = resolved_batch_conversation_context;
 
         let profile_lookup =
             fetch_prompt_profile_lookup(b, conversation_context.as_ref(), &ctx.rest_client).await;
@@ -1932,6 +2390,48 @@ pub async fn run_prompt_task(
         );
         return;
     };
+
+    if let Some(control_signal) = control_rx.as_mut().and_then(take_ready_pre_prompt_control) {
+        if let ControlSignal::SwitchModel(ref model_id) = control_signal {
+            agent.desired_model = Some(model_id.clone());
+            agent.model_overridden = true;
+        }
+        tracing::debug!(
+            channel = ?observer_channel_id,
+            turn_id,
+            ?control_signal,
+            "settling control signal at final pre-prompt barrier"
+        );
+        agent.state.invalidate(&source);
+        let retry_batch = requeue_cancelled_batch(&ctx, control_signal, batch);
+        send_prompt_result(
+            &result_tx,
+            &turn_id,
+            agent,
+            source,
+            PromptOutcome::Cancelled,
+            retry_batch,
+        );
+        return;
+    }
+
+    if !membership_admission_current(&ctx, &source, admission_token.as_ref()) {
+        tracing::warn!(
+            channel = ?observer_channel_id,
+            turn_id,
+            "dropping stale pre-removal turn at final ACP prompt barrier"
+        );
+        agent.state.invalidate(&source);
+        send_prompt_result(
+            &result_tx,
+            &turn_id,
+            agent,
+            source,
+            PromptOutcome::Cancelled,
+            None,
+        );
+        return;
+    }
 
     // 💬 — fire-and-forget so the prompt fires immediately.
     // The guard's cleanup (spawned on drop) removes 💬 after the turn completes.
@@ -2109,6 +2609,7 @@ pub async fn run_prompt_task(
                             &mut agent.state,
                             &source,
                             &control_signal,
+                            ctx.max_turns_per_session,
                         );
                         let usage = agent.acp.take_turn_usage();
                         publish_agent_turn_metric(
@@ -2147,17 +2648,7 @@ pub async fn run_prompt_task(
             let should_rotate = should_rotate || {
                 let limit = ctx.max_turns_per_session;
                 if limit > 0 {
-                    match &source {
-                        PromptSource::Channel(cid) => {
-                            let count = agent.state.turn_counts.entry(*cid).or_insert(0);
-                            *count += 1;
-                            *count >= limit
-                        }
-                        PromptSource::Heartbeat => {
-                            agent.state.heartbeat_turn_count += 1;
-                            agent.state.heartbeat_turn_count >= limit
-                        }
-                    }
+                    agent.state.increment_turn_count(&source) >= limit
                 } else {
                     false
                 }
@@ -2332,8 +2823,11 @@ pub async fn run_prompt_task(
             tracing::error!(target: "pool::prompt", "session_prompt error: {e}");
             // AgentError means the agent caught a problem before mutating
             // session state (e.g. bad LLM response). The session is healthy —
-            // don't invalidate it. Other errors may have corrupted state.
-            if !matches!(e, AcpError::AgentError { .. }) {
+            // don't invalidate it. Process-poisoning errors discard every
+            // reusable session; other errors invalidate only this source.
+            if prompt_error_requires_process_replacement(&e) {
+                agent.state.invalidate_all();
+            } else if !matches!(e, AcpError::AgentError { .. }) {
                 agent.state.invalidate(&source);
             }
             let usage = agent.acp.take_turn_usage();
@@ -2346,13 +2840,14 @@ pub async fn run_prompt_task(
                 Some(buzz_core::agent_turn_metric::StopReason::Error),
             )
             .await;
+            let retry_batch = requeue_batch_if_queue(&ctx, batch);
             send_prompt_result(
                 &result_tx,
                 &turn_id,
                 agent,
                 source,
                 PromptOutcome::Error(e),
-                requeue_batch_if_queue(&ctx, batch),
+                retry_batch,
             );
         }
     }
@@ -2403,21 +2898,12 @@ pub(crate) async fn fetch_channel_info(
         .await
         {
             Ok(Ok(json)) => {
-                let events = json.as_array()?;
-                let ev = events.first()?;
-                let tags = ev.get("tags")?.as_array()?;
-                let mut name = None;
-                for tag in tags {
-                    if let Some(arr) = tag.as_array() {
-                        if arr.first().and_then(|v| v.as_str()) == Some("name") {
-                            name = arr.get(1).and_then(|v| v.as_str());
-                        }
-                    }
-                }
-                let channel_type = crate::relay::channel_type_from_tags(tags);
+                let mut verified =
+                    crate::relay::newest_verified_channel_info(&json, &rest.trusted_relay_pubkey);
+                let info = verified.remove(&channel_id)??;
                 Some(PromptChannelInfo {
-                    name: name.unwrap_or(UNKNOWN_CHANNEL_NAME).to_string(),
-                    channel_type,
+                    name: info.name,
+                    channel_type: info.channel_type,
                 })
             }
             Ok(Err(e)) => {
@@ -2631,6 +3117,20 @@ pub(crate) fn render_canvas_section(event_id: &str, timestamp: &str, channel_uui
          Last modified: {timestamp}\n\
          Fetch current content with: buzz canvas get --channel {channel_uuid}"
     )
+}
+
+fn ensure_required_thread_context(
+    lane: &LaneKey,
+    last_event_id: &str,
+    context: Option<&ConversationContext>,
+) -> Result<(), AcpError> {
+    let is_exact_reply = !lane.is_channel_scoped() && lane.root_event_id != last_event_id;
+    if is_exact_reply && !matches!(context, Some(ConversationContext::Thread { .. })) {
+        return Err(AcpError::InvalidInput(
+            "required signed same-channel top-level thread root unavailable".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 /// Fetch conversation context (thread or DM) for a batch before prompting.
@@ -2890,7 +3390,9 @@ where
 
     // Three filters: (1) root event by ID, (2) recent replies with #e=root +
     // #h=channel plus a sentinel, and (3) the agent's newest reply for pinning.
-    let root_filter = nostr::Filter::new().id(nostr::EventId::from_hex(root_event_id).ok()?);
+    let root_filter = nostr::Filter::new()
+        .id(nostr::EventId::from_hex(root_event_id).ok()?)
+        .custom_tags(h_tag, [ch_str.as_str()]);
     let replies_filter = nostr::Filter::new()
         .kinds([
             nostr::Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
@@ -2912,9 +3414,13 @@ where
         )
         .await
         {
-            Ok(Ok(json)) => {
-                parse_nostr_thread_response_with_meta(json, root_event_id, limit, &agent_pubkey)
-            }
+            Ok(Ok(json)) => parse_nostr_thread_response_with_meta(
+                json,
+                channel_id,
+                root_event_id,
+                limit,
+                &agent_pubkey,
+            ),
             Ok(Err(e)) => {
                 tracing::warn!(
                     channel_id = %channel_id,
@@ -2936,6 +3442,13 @@ where
     .await;
 
     let mut parsed = context?;
+    if !parsed.root_present {
+        tracing::warn!(
+            channel_id = %channel_id,
+            "thread context response omitted the requested root — failing closed"
+        );
+        return None;
+    }
 
     if matches!(
         parsed.context,
@@ -3162,12 +3675,24 @@ fn json_to_context_message(obj: &serde_json::Value) -> Option<ContextMessage> {
 #[cfg(test)]
 fn parse_nostr_thread_response(
     json: serde_json::Value,
+    channel_id: Uuid,
     root_event_id: &str,
     limit: u32,
     agent_pubkey: &nostr::PublicKey,
 ) -> Option<ConversationContext> {
-    parse_nostr_thread_response_with_meta(json, root_event_id, limit, agent_pubkey)
+    parse_nostr_thread_response_with_meta(json, channel_id, root_event_id, limit, agent_pubkey)
         .map(|parsed| parsed.context)
+}
+
+#[cfg(test)]
+fn parse_nostr_thread_response_for_channel(
+    json: serde_json::Value,
+    channel_id: Uuid,
+    root_event_id: &str,
+    limit: u32,
+    agent_pubkey: &nostr::PublicKey,
+) -> Option<ConversationContext> {
+    parse_nostr_thread_response(json, channel_id, root_event_id, limit, agent_pubkey)
 }
 
 struct ParsedThreadContext {
@@ -3177,6 +3702,7 @@ struct ParsedThreadContext {
 
 fn parse_nostr_thread_response_with_meta(
     json: serde_json::Value,
+    expected_channel: Uuid,
     root_event_id: &str,
     limit: u32,
     agent_pubkey: &nostr::PublicKey,
@@ -3187,20 +3713,64 @@ fn parse_nostr_thread_response_with_meta(
     let mut reply_msgs = Vec::new();
     let mut seen_reply_ids = HashSet::new();
 
-    for ev in events {
-        let ev_id = ev.get("id").and_then(|v| v.as_str()).unwrap_or("");
-        if let Some(msg) = json_to_context_message(ev) {
-            if ev_id == root_event_id {
+    let expected_channel_tag = expected_channel.to_string();
+    for raw in events {
+        let Ok(event) = serde_json::from_value::<nostr::Event>(raw.clone()) else {
+            continue;
+        };
+        if event.verify().is_err() {
+            continue;
+        }
+        if !matches!(
+            event.kind.as_u16() as u32,
+            buzz_core::kind::KIND_STREAM_MESSAGE | buzz_core::kind::KIND_STREAM_MESSAGE_V2
+        ) {
+            continue;
+        }
+        let mut channel_tags = event.tags.iter().filter_map(|tag| {
+            let parts = tag.as_slice();
+            (parts.first().map(String::as_str) == Some("h"))
+                .then(|| parts.get(1).map(String::as_str))
+                .flatten()
+        });
+        let channel_matches = channel_tags.next() == Some(expected_channel_tag.as_str())
+            && channel_tags.next().is_none();
+        if !channel_matches {
+            continue;
+        }
+
+        let ev_id = event.id.to_hex();
+        let msg = ContextMessage {
+            pubkey: event.pubkey.to_hex(),
+            timestamp: chrono::DateTime::from_timestamp(event.created_at.as_secs() as i64, 0)
+                .map(|dt| dt.to_rfc3339())
+                .unwrap_or_else(|| event.created_at.as_secs().to_string()),
+            content: event.content.clone(),
+        };
+        let lane = match LaneKey::resolve(
+            expected_channel,
+            &event,
+            crate::queue::AffinityPolicy::RootThread,
+            false,
+        ) {
+            Ok(lane) => lane,
+            Err(_) => continue,
+        };
+
+        if ev_id.eq_ignore_ascii_case(root_event_id) {
+            let has_required_thread_marker = event.tags.iter().any(|tag| {
+                let parts = tag.as_slice();
+                parts.first().map(String::as_str) == Some("e")
+                    && matches!(parts.get(3).map(String::as_str), Some("root" | "reply"))
+            });
+            if !has_required_thread_marker && lane.root_event_id == ev_id {
                 root_msg = Some(msg);
-            } else if seen_reply_ids.insert(ev_id.to_string()) {
-                let is_agent = msg.pubkey.eq_ignore_ascii_case(&agent_pubkey_hex);
-                reply_msgs.push((
-                    ev_id.to_string(),
-                    ev.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0),
-                    is_agent,
-                    msg,
-                ));
             }
+        } else if lane.root_event_id.eq_ignore_ascii_case(root_event_id)
+            && seen_reply_ids.insert(ev_id.clone())
+        {
+            let is_agent = msg.pubkey.eq_ignore_ascii_case(&agent_pubkey_hex);
+            reply_msgs.push((ev_id, event.created_at.as_secs(), is_agent, msg));
         }
     }
 
@@ -3388,7 +3958,9 @@ fn classify_control_cancel_failure(
 /// Shared by the turn-start and turn-stop lines so a log can be read as pairs.
 fn prompt_label(source: &PromptSource) -> String {
     match source {
-        PromptSource::Channel(cid) => format!("channel {cid}"),
+        PromptSource::Lane(lane) => {
+            format!("channel {} lane {}", lane.channel_id, lane.root_event_id)
+        }
         PromptSource::Heartbeat => "heartbeat".to_string(),
     }
 }
@@ -4529,38 +5101,143 @@ mod tests {
     }
 
     #[test]
+    fn thread_context_rejects_root_with_conflicting_channel_tags() {
+        let keys = Keys::generate();
+        let agent = Keys::generate();
+        let expected_channel = Uuid::new_v4();
+        let other_channel = Uuid::new_v4();
+        let root = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "root",
+        )
+        .tags([
+            Tag::parse(["h", &expected_channel.to_string()]).unwrap(),
+            Tag::parse(["h", &other_channel.to_string()]).unwrap(),
+        ])
+        .sign_with_keys(&keys)
+        .unwrap();
+        let root_id = root.id.to_hex();
+
+        assert!(
+            parse_nostr_thread_response_for_channel(
+                json!([root]),
+                expected_channel,
+                &root_id,
+                10,
+                &agent.public_key(),
+            )
+            .is_none(),
+            "ambiguous channel binding must not provide trusted context"
+        );
+    }
+
+    #[test]
+    fn thread_context_rejects_tampered_signed_root() {
+        let keys = Keys::generate();
+        let agent = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let root = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "authentic root",
+        )
+        .tags([Tag::parse(["h", &channel_id.to_string()]).unwrap()])
+        .custom_created_at(Timestamp::from(1_000))
+        .sign_with_keys(&keys)
+        .unwrap();
+        let root_id = root.id.to_hex();
+        let mut raw = serde_json::to_value(root).unwrap();
+        raw["content"] = json!("tampered root");
+
+        assert!(
+            parse_nostr_thread_response_for_channel(
+                json!([raw]),
+                channel_id,
+                &root_id,
+                10,
+                &agent.public_key(),
+            )
+            .is_none(),
+            "unverified root content must never enter ACP context"
+        );
+    }
+
+    #[test]
+    fn thread_context_rejects_signed_root_from_another_channel() {
+        let keys = Keys::generate();
+        let agent = Keys::generate();
+        let expected_channel = Uuid::new_v4();
+        let other_channel = Uuid::new_v4();
+        let root = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "other channel root",
+        )
+        .tags([Tag::parse(["h", &other_channel.to_string()]).unwrap()])
+        .custom_created_at(Timestamp::from(1_000))
+        .sign_with_keys(&keys)
+        .unwrap();
+        let root_id = root.id.to_hex();
+
+        assert!(
+            parse_nostr_thread_response_for_channel(
+                json!([root]),
+                expected_channel,
+                &root_id,
+                10,
+                &agent.public_key(),
+            )
+            .is_none(),
+            "thread roots must be bound to the requested channel h-tag"
+        );
+    }
+
+    #[test]
+    fn thread_context_rejects_requested_root_that_is_itself_a_reply() {
+        let keys = Keys::generate();
+        let agent = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let ancestor_id = "a".repeat(64);
+        let nested = EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            "nested reply",
+        )
+        .tags([
+            Tag::parse(["h", &channel_id.to_string()]).unwrap(),
+            Tag::parse(["e", &ancestor_id, "", "reply"]).unwrap(),
+        ])
+        .custom_created_at(Timestamp::from(1_000))
+        .sign_with_keys(&keys)
+        .unwrap();
+        let nested_id = nested.id.to_hex();
+        let json = json!([nested]);
+
+        assert!(
+            parse_nostr_thread_response(json, channel_id, &nested_id, 10, &agent.public_key())
+                .is_none(),
+            "a requested root must be a top-level event, not another reply"
+        );
+    }
+
+    #[test]
     fn test_parse_nostr_thread_response_marks_query_window_truncated() {
         let agent = Keys::generate();
-        let root_id = "1111111111111111111111111111111111111111111111111111111111111111";
-        let agent_hex = agent.public_key().to_hex();
+        let human = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let root = signed_thread_root(&human, channel_id, "root", 1_000);
+        let root_id = root.id.to_hex();
         let json = json!([
-            {
-                "id": root_id,
-                "pubkey": "rootpub",
-                "content": "root",
-                "created_at": 1000
-            },
-            {
-                "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "pubkey": agent_hex,
-                "content": "newest agent reply",
-                "created_at": 4000
-            },
-            {
-                "id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "pubkey": "humanpub",
-                "content": "middle reply",
-                "created_at": 3000
-            },
-            {
-                "id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-                "pubkey": "oldpub",
-                "content": "sentinel omitted reply",
-                "created_at": 2000
-            }
+            root,
+            signed_thread_reply(&agent, channel_id, &root_id, "newest agent reply", 4_000,),
+            signed_thread_reply(&human, channel_id, &root_id, "middle reply", 3_000),
+            signed_thread_reply(
+                &human,
+                channel_id,
+                &root_id,
+                "sentinel omitted reply",
+                2_000,
+            ),
         ]);
 
-        let ctx = parse_nostr_thread_response(json, root_id, 2, &agent.public_key())
+        let ctx = parse_nostr_thread_response(json, channel_id, &root_id, 2, &agent.public_key())
             .expect("should parse");
         match ctx {
             ConversationContext::Thread {
@@ -4585,23 +5262,16 @@ mod tests {
     #[test]
     fn test_parse_nostr_thread_response_not_truncated_below_limit() {
         let agent = Keys::generate();
-        let root_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let human = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let root = signed_thread_root(&human, channel_id, "root", 1_000);
+        let root_id = root.id.to_hex();
         let json = json!([
-            {
-                "id": root_id,
-                "pubkey": "rootpub",
-                "content": "root",
-                "created_at": 1000
-            },
-            {
-                "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "pubkey": "replypub",
-                "content": "reply",
-                "created_at": 2000
-            }
+            root,
+            signed_thread_reply(&human, channel_id, &root_id, "reply", 2_000),
         ]);
 
-        let ctx = parse_nostr_thread_response(json, root_id, 2, &agent.public_key())
+        let ctx = parse_nostr_thread_response(json, channel_id, &root_id, 2, &agent.public_key())
             .expect("should parse");
         match ctx {
             ConversationContext::Thread {
@@ -4620,42 +5290,31 @@ mod tests {
     #[test]
     fn test_parse_nostr_thread_response_keeps_agent_reply_outside_recent_window() {
         let agent = Keys::generate();
-        let root_id = "1111111111111111111111111111111111111111111111111111111111111111";
-        let agent_hex = agent.public_key().to_hex();
+        let human = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let root = signed_thread_root(&human, channel_id, "root", 1_000);
+        let root_id = root.id.to_hex();
         let json = json!([
-            {
-                "id": root_id,
-                "pubkey": "rootpub",
-                "content": "root",
-                "created_at": 1000
-            },
-            {
-                "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "pubkey": "humanpub",
-                "content": "newer human reply",
-                "created_at": 5000
-            },
-            {
-                "id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "pubkey": "humanpub",
-                "content": "middle human reply",
-                "created_at": 4000
-            },
-            {
-                "id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-                "pubkey": "humanpub",
-                "content": "oldest displayed reply without agent pin",
-                "created_at": 3000
-            },
-            {
-                "id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-                "pubkey": agent_hex,
-                "content": "agent reply outside recent window",
-                "created_at": 2000
-            }
+            root,
+            signed_thread_reply(&human, channel_id, &root_id, "newer human reply", 5_000,),
+            signed_thread_reply(&human, channel_id, &root_id, "middle human reply", 4_000,),
+            signed_thread_reply(
+                &human,
+                channel_id,
+                &root_id,
+                "oldest displayed reply without agent pin",
+                3_000,
+            ),
+            signed_thread_reply(
+                &agent,
+                channel_id,
+                &root_id,
+                "agent reply outside recent window",
+                2_000,
+            ),
         ]);
 
-        let ctx = parse_nostr_thread_response(json, root_id, 2, &agent.public_key())
+        let ctx = parse_nostr_thread_response(json, channel_id, &root_id, 2, &agent.public_key())
             .expect("should parse");
         match ctx {
             ConversationContext::Thread { messages, .. } => {
@@ -4681,42 +5340,37 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_thread_context_uses_exact_count_when_above_sentinel_minimum() {
         let agent = Keys::generate();
-        let root_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let human = Keys::generate();
         let channel_id = Uuid::new_v4();
         let agent_pubkey = agent.public_key();
+        let root = signed_thread_root(&human, channel_id, "root", 1_000);
+        let root_id = root.id.to_hex();
         let json = json!([
-            thread_event(root_id, "rootpub", "root", 1000),
-            thread_event(
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "humanpub",
-                "newest reply",
-                4000
-            ),
-            thread_event(
-                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "humanpub",
-                "middle reply",
-                3000
-            ),
-            thread_event(
-                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-                "humanpub",
-                "sentinel reply",
-                2000
-            )
+            root,
+            signed_thread_reply(&human, channel_id, &root_id, "newest reply", 4_000),
+            signed_thread_reply(&human, channel_id, &root_id, "middle reply", 3_000),
+            signed_thread_reply(&human, channel_id, &root_id, "sentinel reply", 2_000),
         ]);
+        let root_id_for_query = root_id.clone();
+        let root_id_for_count = root_id.clone();
 
         let ctx = fetch_thread_context_with(
             channel_id,
-            root_id,
+            &root_id,
             2,
             agent_pubkey,
             move |filters| {
-                assert_thread_query_filters(&filters, channel_id, root_id, agent_pubkey, 3);
+                assert_thread_query_filters(
+                    &filters,
+                    channel_id,
+                    &root_id_for_query,
+                    agent_pubkey,
+                    3,
+                );
                 std::future::ready(Ok(json.clone()))
             },
             move |filters| {
-                assert_thread_count_filter(&filters, channel_id, root_id);
+                assert_thread_count_filter(&filters, channel_id, &root_id_for_count);
                 std::future::ready(Ok(json!({ "count": 6 })))
             },
         )
@@ -4738,86 +5392,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fetch_thread_context_does_not_add_missing_root_to_exact_count() {
+    async fn test_fetch_thread_context_rejects_missing_root_before_counting() {
         let agent = Keys::generate();
-        let root_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let human = Keys::generate();
         let channel_id = Uuid::new_v4();
+        let omitted_root = signed_thread_root(&human, channel_id, "root", 1_000);
+        let root_id = omitted_root.id.to_hex();
         let json = json!([
-            thread_event(
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "humanpub",
-                "newest reply",
-                4000
-            ),
-            thread_event(
-                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "humanpub",
-                "middle reply",
-                3000
-            ),
-            thread_event(
-                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-                "humanpub",
-                "sentinel reply",
-                2000
-            )
+            signed_thread_reply(&human, channel_id, &root_id, "newest reply", 4_000),
+            signed_thread_reply(&human, channel_id, &root_id, "middle reply", 3_000),
+            signed_thread_reply(&human, channel_id, &root_id, "sentinel reply", 2_000),
         ]);
 
         let ctx = fetch_thread_context_with(
             channel_id,
-            root_id,
+            &root_id,
             2,
             agent.public_key(),
             move |_filters| std::future::ready(Ok(json.clone())),
-            |_filters| std::future::ready(Ok(json!({ "count": 6 }))),
+            |_filters| {
+                panic!("missing-root context must be rejected before count");
+                #[allow(unreachable_code)]
+                std::future::ready(Ok(json!({ "count": 6 })))
+            },
         )
-        .await
-        .expect("thread context");
+        .await;
 
-        match ctx {
-            ConversationContext::Thread {
-                messages,
-                total,
-                truncated,
-            } => {
-                assert!(truncated);
-                assert_eq!(messages.len(), 2);
-                assert_eq!(total, 6);
-            }
-            _ => panic!("expected Thread context"),
-        }
+        assert!(ctx.is_none());
     }
 
     #[tokio::test]
     async fn test_fetch_thread_context_clamps_count_below_sentinel_minimum() {
         let agent = Keys::generate();
-        let root_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let human = Keys::generate();
         let channel_id = Uuid::new_v4();
+        let root = signed_thread_root(&human, channel_id, "root", 1_000);
+        let root_id = root.id.to_hex();
         let json = json!([
-            thread_event(root_id, "rootpub", "root", 1000),
-            thread_event(
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "humanpub",
-                "newest reply",
-                4000
-            ),
-            thread_event(
-                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "humanpub",
-                "middle reply",
-                3000
-            ),
-            thread_event(
-                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-                "humanpub",
-                "sentinel reply",
-                2000
-            )
+            root,
+            signed_thread_reply(&human, channel_id, &root_id, "newest reply", 4_000),
+            signed_thread_reply(&human, channel_id, &root_id, "middle reply", 3_000),
+            signed_thread_reply(&human, channel_id, &root_id, "sentinel reply", 2_000),
         ]);
 
         let ctx = fetch_thread_context_with(
             channel_id,
-            root_id,
+            &root_id,
             2,
             agent.public_key(),
             move |_filters| std::future::ready(Ok(json.clone())),
@@ -4843,33 +5463,20 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_thread_context_preserves_sentinel_minimum_when_count_fails() {
         let agent = Keys::generate();
-        let root_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let human = Keys::generate();
         let channel_id = Uuid::new_v4();
+        let root = signed_thread_root(&human, channel_id, "root", 1_000);
+        let root_id = root.id.to_hex();
         let json = json!([
-            thread_event(root_id, "rootpub", "root", 1000),
-            thread_event(
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "humanpub",
-                "newest reply",
-                4000
-            ),
-            thread_event(
-                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "humanpub",
-                "middle reply",
-                3000
-            ),
-            thread_event(
-                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-                "humanpub",
-                "sentinel reply",
-                2000
-            )
+            root,
+            signed_thread_reply(&human, channel_id, &root_id, "newest reply", 4_000),
+            signed_thread_reply(&human, channel_id, &root_id, "middle reply", 3_000),
+            signed_thread_reply(&human, channel_id, &root_id, "sentinel reply", 2_000),
         ]);
 
         let ctx = fetch_thread_context_with(
             channel_id,
-            root_id,
+            &root_id,
             2,
             agent.public_key(),
             move |_filters| std::future::ready(Ok(json.clone())),
@@ -4895,42 +5502,30 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_thread_context_deduplicates_and_pins_agent_reply() {
         let agent = Keys::generate();
-        let agent_hex = agent.public_key().to_hex();
-        let root_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let human = Keys::generate();
         let channel_id = Uuid::new_v4();
+        let root = signed_thread_root(&human, channel_id, "root", 1_000);
+        let root_id = root.id.to_hex();
+        let agent_reply = signed_thread_reply(
+            &agent,
+            channel_id,
+            &root_id,
+            "agent reply outside recent window",
+            2_000,
+        );
         let json = json!([
-            thread_event(root_id, "rootpub", "root", 1000),
-            thread_event(
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "humanpub",
-                "newer human reply",
-                5000
-            ),
-            thread_event(
-                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "humanpub",
-                "middle human reply",
-                4000
-            ),
-            thread_event(
-                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-                &agent_hex,
-                "agent reply outside recent window",
-                2000
-            ),
+            root,
+            signed_thread_reply(&human, channel_id, &root_id, "newer human reply", 5_000,),
+            signed_thread_reply(&human, channel_id, &root_id, "middle human reply", 4_000,),
+            agent_reply.clone(),
             // Same event as the separately fetched author-filtered result; the
             // parser should deduplicate it before pinning.
-            thread_event(
-                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-                &agent_hex,
-                "agent reply outside recent window",
-                2000
-            )
+            agent_reply,
         ]);
 
         let ctx = fetch_thread_context_with(
             channel_id,
-            root_id,
+            &root_id,
             2,
             agent.public_key(),
             move |_filters| std::future::ready(Ok(json.clone())),
@@ -4970,40 +5565,27 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_thread_context_uses_distinct_fetched_replies_as_minimum() {
         let agent = Keys::generate();
-        let agent_hex = agent.public_key().to_hex();
-        let root_id = "1111111111111111111111111111111111111111111111111111111111111111";
+        let human = Keys::generate();
         let channel_id = Uuid::new_v4();
+        let root = signed_thread_root(&human, channel_id, "root", 1_000);
+        let root_id = root.id.to_hex();
         let json = json!([
-            thread_event(root_id, "rootpub", "root", 1000),
-            thread_event(
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                "humanpub",
-                "newest human reply",
-                5000
-            ),
-            thread_event(
-                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                "humanpub",
-                "middle human reply",
-                4000
-            ),
-            thread_event(
-                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-                "humanpub",
-                "sentinel human reply",
-                3000
-            ),
-            thread_event(
-                "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-                &agent_hex,
+            root,
+            signed_thread_reply(&human, channel_id, &root_id, "newest human reply", 5_000,),
+            signed_thread_reply(&human, channel_id, &root_id, "middle human reply", 4_000,),
+            signed_thread_reply(&human, channel_id, &root_id, "sentinel human reply", 3_000,),
+            signed_thread_reply(
+                &agent,
+                channel_id,
+                &root_id,
                 "older distinct agent reply",
-                2000
-            )
+                2_000,
+            ),
         ]);
 
         let ctx = fetch_thread_context_with(
             channel_id,
-            root_id,
+            &root_id,
             2,
             agent.public_key(),
             move |_filters| std::future::ready(Ok(json.clone())),
@@ -5056,6 +5638,7 @@ mod tests {
 
         let root = serde_json::to_value(&filters[0]).expect("serialize root filter");
         assert_eq!(root.get("ids"), Some(&json!([root_id])));
+        assert_eq!(root.get("#h"), Some(&json!([channel_id.to_string()])));
         assert!(root.get("limit").is_none());
 
         let replies = serde_json::to_value(&filters[1]).expect("serialize replies filter");
@@ -5085,13 +5668,40 @@ mod tests {
         assert!(count.get("authors").is_none());
     }
 
-    fn thread_event(id: &str, pubkey: &str, content: &str, created_at: u64) -> serde_json::Value {
-        json!({
-            "id": id,
-            "pubkey": pubkey,
-            "content": content,
-            "created_at": created_at
-        })
+    fn signed_thread_root(
+        keys: &Keys,
+        channel_id: Uuid,
+        content: &str,
+        created_at: u64,
+    ) -> nostr::Event {
+        EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            content,
+        )
+        .tags([Tag::parse(["h", &channel_id.to_string()]).unwrap()])
+        .custom_created_at(Timestamp::from(created_at))
+        .sign_with_keys(keys)
+        .unwrap()
+    }
+
+    fn signed_thread_reply(
+        keys: &Keys,
+        channel_id: Uuid,
+        root_event_id: &str,
+        content: &str,
+        created_at: u64,
+    ) -> nostr::Event {
+        EventBuilder::new(
+            Kind::Custom(buzz_core::kind::KIND_STREAM_MESSAGE as u16),
+            content,
+        )
+        .tags([
+            Tag::parse(["h", &channel_id.to_string()]).unwrap(),
+            Tag::parse(["e", root_event_id, "", "reply"]).unwrap(),
+        ])
+        .custom_created_at(Timestamp::from(created_at))
+        .sign_with_keys(keys)
+        .unwrap()
     }
 
     #[test]
@@ -5137,8 +5747,10 @@ mod tests {
             .sign_with_keys(&keys)
             .unwrap();
         let author_hex = event.pubkey.to_hex();
+        let channel_id = Uuid::new_v4();
         let batch = FlushBatch {
-            channel_id: Uuid::new_v4(),
+            lane: LaneKey::channel(channel_id),
+            channel_id,
             events: vec![crate::queue::BatchEvent {
                 event,
                 prompt_tag: "@mention".into(),
@@ -5264,6 +5876,28 @@ mod tests {
         assert_eq!(pct_encode(" "), "%20");
     }
 
+    #[test]
+    fn queued_control_is_taken_at_pre_prompt_barrier() {
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        tx.send(ControlSignal::Interrupt).unwrap();
+
+        assert!(matches!(
+            take_ready_pre_prompt_control(&mut rx),
+            Some(ControlSignal::Interrupt)
+        ));
+    }
+
+    #[test]
+    fn closed_control_fails_closed_at_pre_prompt_barrier() {
+        let (tx, mut rx) = tokio::sync::oneshot::channel::<ControlSignal>();
+        drop(tx);
+
+        assert!(matches!(
+            take_ready_pre_prompt_control(&mut rx),
+            Some(ControlSignal::Cancel)
+        ));
+    }
+
     fn make_state() -> (SessionState, Uuid, Uuid) {
         let ch_a = Uuid::new_v4();
         let ch_b = Uuid::new_v4();
@@ -5285,8 +5919,9 @@ mod tests {
 
         apply_completed_before_control_signal(
             &mut s,
-            &PromptSource::Channel(ch_a),
+            &PromptSource::Lane(LaneKey::channel(ch_a)),
             &ControlSignal::Rotate,
+            0,
         );
 
         assert!(!s.sessions.contains_key(&ch_a));
@@ -5301,25 +5936,40 @@ mod tests {
     }
 
     #[test]
-    fn test_cancel_after_natural_completion_preserves_channel_state() {
+    fn test_cancel_after_natural_completion_accounts_for_successful_turn() {
         let (mut s, ch_a, ch_b) = make_state();
 
         apply_completed_before_control_signal(
             &mut s,
-            &PromptSource::Channel(ch_a),
+            &PromptSource::Lane(LaneKey::channel(ch_a)),
             &ControlSignal::Cancel,
+            10,
         );
 
         assert_eq!(s.sessions.get(&ch_a).unwrap(), "sess-a");
-        assert_eq!(*s.turn_counts.get(&ch_a).unwrap(), 5);
+        assert_eq!(*s.turn_counts.get(&ch_a).unwrap(), 6);
         assert_eq!(s.core_sections.get(&ch_a).unwrap(), "core-a");
         assert_eq!(s.sessions.get(&ch_b).unwrap(), "sess-b");
     }
 
     #[test]
+    fn completed_before_control_obeys_one_turn_exact_lane_rotation() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::new(channel_id, "a".repeat(64));
+        let source = PromptSource::Lane(lane.clone());
+        let mut state = SessionState::default();
+        state.set_session_for_lane(lane.clone(), "lane-session".into());
+
+        apply_completed_before_control_signal(&mut state, &source, &ControlSignal::Steer, 1);
+
+        assert!(state.session_for_lane(&lane).is_none());
+        assert!(!state.lane_turn_counts.contains_key(&lane));
+    }
+
+    #[test]
     fn test_invalidate_channel_clears_session_and_turn_count() {
         let (mut s, ch_a, ch_b) = make_state();
-        s.invalidate(&PromptSource::Channel(ch_a));
+        s.invalidate(&PromptSource::Lane(LaneKey::channel(ch_a)));
 
         assert!(!s.sessions.contains_key(&ch_a));
         assert!(!s.turn_counts.contains_key(&ch_a));
@@ -5365,7 +6015,7 @@ mod tests {
     fn test_invalidate_nonexistent_channel_is_noop() {
         let (mut s, ch_a, ch_b) = make_state();
         let ghost = Uuid::new_v4();
-        s.invalidate(&PromptSource::Channel(ghost));
+        s.invalidate(&PromptSource::Lane(LaneKey::channel(ghost)));
 
         // Everything still intact.
         assert_eq!(s.sessions.len(), 2);
@@ -5440,8 +6090,9 @@ mod tests {
         // re-creates a fresh session that re-applies the new desired_model.
         apply_completed_before_control_signal(
             &mut s,
-            &PromptSource::Channel(ch_a),
+            &PromptSource::Lane(LaneKey::channel(ch_a)),
             &ControlSignal::SwitchModel("gpt-5".into()),
+            0,
         );
 
         assert!(!s.has_channel_state(&ch_a));
@@ -5464,6 +6115,7 @@ mod tests {
             .sign_with_keys(&keys)
             .unwrap();
         FlushBatch {
+            lane: LaneKey::channel(channel_id),
             channel_id,
             events: vec![crate::queue::BatchEvent {
                 event,
@@ -6507,6 +7159,7 @@ mod tests {
     ) -> PromptContext {
         use crate::relay::RestClient;
         PromptContext {
+            membership_admission: Arc::new(MembershipAdmission::new([])),
             mcp_servers: vec![],
             initial_message: None,
             idle_timeout: Duration::from_secs(60),
@@ -6523,6 +7176,7 @@ mod tests {
                 http: reqwest::Client::new(),
                 base_url: "http://127.0.0.1:0".to_string(),
                 keys: agent_keys.clone(),
+                trusted_relay_pubkey: agent_keys.public_key(),
                 auth_tag_json: None,
             },
             channel_info: ChannelInfoResolver::new(
@@ -6531,6 +7185,7 @@ mod tests {
                     http: reqwest::Client::new(),
                     base_url: "http://127.0.0.1:0".to_string(),
                     keys: agent_keys.clone(),
+                    trusted_relay_pubkey: agent_keys.public_key(),
                     auth_tag_json: None,
                 },
             ),
@@ -6861,6 +7516,7 @@ mod tests {
     /// cannot see duplicated I/O.
     async fn counting_resolver(
         response: serde_json::Value,
+        trusted_relay_pubkey: nostr::PublicKey,
     ) -> (
         ChannelInfoResolver,
         std::sync::Arc<std::sync::atomic::AtomicUsize>,
@@ -6893,6 +7549,7 @@ mod tests {
             http: reqwest::Client::new(),
             base_url,
             keys: nostr::Keys::generate(),
+            trusted_relay_pubkey,
             auth_tag_json: None,
         };
         (
@@ -6902,10 +7559,25 @@ mod tests {
         )
     }
 
-    fn channel_metadata_response(id: Uuid, tags: &[[&str; 2]]) -> serde_json::Value {
-        let mut event_tags = vec![json!(["d", id.to_string()])];
-        event_tags.extend(tags.iter().map(|[k, v]| json!([k, v])));
-        json!([{ "tags": event_tags }])
+    fn channel_metadata_response(
+        id: Uuid,
+        tags: &[[&str; 2]],
+    ) -> (serde_json::Value, nostr::PublicKey) {
+        let relay = nostr::Keys::generate();
+        let mut event_tags =
+            vec![nostr::Tag::parse(vec!["d".to_string(), id.to_string()]).unwrap()];
+        event_tags
+            .extend(tags.iter().map(|[k, v]| {
+                nostr::Tag::parse(vec![(*k).to_string(), (*v).to_string()]).unwrap()
+            }));
+        let event = nostr::EventBuilder::new(
+            nostr::Kind::Custom(buzz_core::kind::KIND_NIP29_GROUP_METADATA as u16),
+            "",
+        )
+        .tags(event_tags)
+        .sign_with_keys(&relay)
+        .unwrap();
+        (json!([event]), relay.public_key())
     }
 
     /// A normal channel yields a non-DM (canvas allowed) and its name for the
@@ -6915,8 +7587,9 @@ mod tests {
         use std::sync::atomic::Ordering;
 
         let id = Uuid::new_v4();
-        let response = channel_metadata_response(id, &[["name", "buzz-dev"], ["t", "stream"]]);
-        let (resolver, requests, server) = counting_resolver(response).await;
+        let (response, relay_key) =
+            channel_metadata_response(id, &[["name", "buzz-dev"], ["t", "stream"]]);
+        let (resolver, requests, server) = counting_resolver(response, relay_key).await;
 
         let (is_dm, title_channel, channel_type) =
             resolve_new_session_channel_context(&resolver, id).await;
@@ -6940,8 +7613,8 @@ mod tests {
     #[tokio::test]
     async fn test_new_session_channel_context_leaves_a_dm_unqualified() {
         let id = Uuid::new_v4();
-        let response = channel_metadata_response(id, &[["name", "DM"], ["t", "dm"]]);
-        let (resolver, _requests, server) = counting_resolver(response).await;
+        let (response, relay_key) = channel_metadata_response(id, &[["name", "DM"], ["t", "dm"]]);
+        let (resolver, _requests, server) = counting_resolver(response, relay_key).await;
 
         let (is_dm, title_channel, channel_type) =
             resolve_new_session_channel_context(&resolver, id).await;
@@ -6960,8 +7633,8 @@ mod tests {
     #[tokio::test]
     async fn test_new_session_channel_context_treats_the_unknown_name_as_absent() {
         let id = Uuid::new_v4();
-        let response = channel_metadata_response(id, &[["t", "stream"]]);
-        let (resolver, _requests, server) = counting_resolver(response).await;
+        let (response, relay_key) = channel_metadata_response(id, &[["t", "stream"]]);
+        let (resolver, _requests, server) = counting_resolver(response, relay_key).await;
 
         let (is_dm, title_channel, _) = resolve_new_session_channel_context(&resolver, id).await;
         assert!(!is_dm, "a nameless stream channel is still not a DM");
@@ -6981,7 +7654,8 @@ mod tests {
     async fn test_new_session_channel_context_attempts_an_unresolved_channel_once() {
         use std::sync::atomic::Ordering;
 
-        let (resolver, requests, server) = counting_resolver(json!([])).await;
+        let relay_key = nostr::Keys::generate().public_key();
+        let (resolver, requests, server) = counting_resolver(json!([]), relay_key).await;
 
         let (is_dm, title_channel, channel_type) =
             resolve_new_session_channel_context(&resolver, Uuid::new_v4()).await;
@@ -6994,5 +7668,396 @@ mod tests {
             "one fetch_channel_info sequence (initial attempt + single retry)"
         );
         server.abort();
+    }
+
+    #[test]
+    fn required_thread_context_is_fail_closed_only_for_exact_lane_replies() {
+        let channel_id = Uuid::new_v4();
+        let root_id = "a".repeat(64);
+        let reply_id = "b".repeat(64);
+        let lane = LaneKey::new(channel_id, root_id.clone());
+
+        assert!(ensure_required_thread_context(&lane, &reply_id, None).is_err());
+        assert!(ensure_required_thread_context(&lane, &root_id, None).is_ok());
+        assert!(
+            ensure_required_thread_context(&LaneKey::channel(channel_id), &reply_id, None).is_ok()
+        );
+    }
+
+    #[test]
+    fn session_state_isolated_by_root_lane() {
+        let channel_id = Uuid::new_v4();
+        let lane_a = LaneKey::new(channel_id, "a".repeat(64));
+        let lane_b = LaneKey::new(channel_id, "b".repeat(64));
+        let mut state = SessionState::default();
+
+        state.set_session_for_lane(lane_a.clone(), "session-a".into());
+        state.set_session_for_lane(lane_b.clone(), "session-b".into());
+        assert_eq!(state.session_for_lane(&lane_a), Some("session-a"));
+        assert_eq!(state.session_for_lane(&lane_b), Some("session-b"));
+
+        assert!(state.invalidate_lane(&lane_a));
+        assert_eq!(state.session_for_lane(&lane_a), None);
+        assert_eq!(state.session_for_lane(&lane_b), Some("session-b"));
+    }
+
+    #[test]
+    fn max_turn_one_rotates_only_the_completed_root_lane() {
+        let channel_id = Uuid::new_v4();
+        let lane_a = LaneKey::new(channel_id, "a".repeat(64));
+        let lane_b = LaneKey::new(channel_id, "b".repeat(64));
+        let source_a = PromptSource::Lane(lane_a.clone());
+        let mut state = SessionState::default();
+        state.set_session_for_lane(lane_a.clone(), "session-a".into());
+        state.set_session_for_lane(lane_b.clone(), "session-b".into());
+
+        assert!(state.increment_turn_count(&source_a) >= 1);
+        state.invalidate(&source_a);
+
+        assert_eq!(state.session_for_lane(&lane_a), None);
+        assert_eq!(state.session_for_lane(&lane_b), Some("session-b"));
+    }
+
+    #[test]
+    fn membership_admission_epoch_rejects_pre_removal_token_after_readd() {
+        let channel_id = Uuid::new_v4();
+        let admission = MembershipAdmission::new([channel_id]);
+        let before_removal = admission
+            .capture(channel_id)
+            .expect("startup channel must be active");
+
+        admission.retire(channel_id);
+        assert!(!admission.permits(&before_removal));
+
+        admission.activate(channel_id);
+        assert!(
+            !admission.permits(&before_removal),
+            "rapid re-add must not revive a pre-removal dispatch token"
+        );
+        let after_readd = admission
+            .capture(channel_id)
+            .expect("re-added channel must be active");
+        assert!(admission.permits(&after_readd));
+    }
+
+    #[test]
+    fn backend_session_lifetime_budget_requests_process_recycle() {
+        let channel_id = Uuid::new_v4();
+        let mut state = SessionState::default();
+
+        for index in 0..SessionState::MAX_BACKEND_SESSIONS_PER_PROCESS {
+            let lane = LaneKey::new(channel_id, format!("{index:064x}"));
+            state.set_session_for_source(&PromptSource::Lane(lane), format!("session-{index}"));
+        }
+
+        assert!(state.take_backend_session_recycle_required());
+        assert!(
+            !state.take_backend_session_recycle_required(),
+            "recycle request must be edge-triggered"
+        );
+    }
+
+    #[test]
+    fn root_lane_session_eviction_stays_bounded_and_removes_turn_counter() {
+        let channel_id = Uuid::new_v4();
+        let mut state = SessionState::default();
+        let first_lane = LaneKey::new(channel_id, format!("{:064x}", 0));
+        let first_source = PromptSource::Lane(first_lane.clone());
+        state.set_session_for_lane(first_lane.clone(), "session-0".into());
+        state.increment_turn_count(&first_source);
+
+        for index in 1..=SessionState::MAX_LANE_SESSIONS {
+            let lane = LaneKey::new(channel_id, format!("{index:064x}"));
+            state.set_session_for_lane(lane, format!("session-{index}"));
+        }
+
+        assert_eq!(state.lane_sessions.len(), SessionState::MAX_LANE_SESSIONS);
+        assert_eq!(state.session_for_lane(&first_lane), None);
+        assert!(!state.lane_turn_counts.contains_key(&first_lane));
+    }
+
+    async fn sleeping_pool_agent(index: usize) -> OwnedAgent {
+        let acp = AcpClient::spawn(
+            "bash",
+            &["-c".to_string(), "sleep 10".to_string()],
+            &[],
+            false,
+        )
+        .await
+        .expect("failed to spawn test agent");
+        OwnedAgent {
+            index,
+            acp,
+            state: SessionState::default(),
+            model_capabilities: None,
+            desired_model: None,
+            model_overridden: false,
+            agent_name: "unknown".into(),
+            goose_system_prompt_supported: None,
+            protocol_version: 2,
+        }
+    }
+
+    #[tokio::test]
+    async fn exact_lane_waits_when_its_session_owner_is_busy() {
+        let channel_id = Uuid::new_v4();
+        let owned_lane = LaneKey::new(channel_id, "a".repeat(64));
+        let sibling_lane = LaneKey::new(channel_id, "b".repeat(64));
+        let busy_lane = LaneKey::new(channel_id, "c".repeat(64));
+        let mut owner = sleeping_pool_agent(0).await;
+        owner
+            .state
+            .set_session_for_lane(owned_lane.clone(), "session-a".into());
+        let fallback = sleeping_pool_agent(1).await;
+        let mut pool = AgentPool::from_slots(vec![Some(owner), Some(fallback)]);
+
+        let checked_out_owner = pool
+            .try_claim_lane(Some(&busy_lane))
+            .expect("an unrelated lane may claim the first idle worker");
+        assert_eq!(checked_out_owner.index, 0);
+        assert!(!pool.can_claim_lane(&owned_lane));
+        assert!(
+            pool.can_claim_lane(&sibling_lane),
+            "independent lane remains dispatchable on the idle fallback worker"
+        );
+        assert!(
+            pool.try_claim_lane(Some(&owned_lane)).is_none(),
+            "a lane with a busy session owner must wait rather than fork onto another worker"
+        );
+
+        pool.return_agent(checked_out_owner);
+    }
+
+    #[tokio::test]
+    async fn new_exact_lane_is_provisionally_owned_while_worker_is_checked_out() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::new(channel_id, "a".repeat(64));
+        let sibling = LaneKey::new(channel_id, "b".repeat(64));
+        let first = sleeping_pool_agent(0).await;
+        let second = sleeping_pool_agent(1).await;
+        let mut pool = AgentPool::from_slots(vec![Some(first), Some(second)]);
+
+        let checked_out = pool
+            .try_claim_lane(Some(&lane))
+            .expect("a new exact lane may claim an idle worker");
+        assert_eq!(checked_out.index, 0);
+        assert!(
+            !pool.can_claim_lane(&lane),
+            "the checked-out worker must provisionally own the lane before session/new"
+        );
+        assert!(
+            pool.try_claim_lane(Some(&lane)).is_none(),
+            "deadline release must not let the same lane fork onto another idle worker"
+        );
+        assert!(
+            pool.can_claim_lane(&sibling),
+            "provisional ownership must not block independent lanes"
+        );
+
+        pool.return_agent(checked_out);
+        assert!(
+            pool.can_claim_lane(&lane),
+            "return without a reusable session must release provisional ownership"
+        );
+    }
+
+    #[tokio::test]
+    async fn removed_channel_retirement_survives_readd_until_checked_out_worker_returns() {
+        let removed_channel = Uuid::new_v4();
+        let other_channel = Uuid::new_v4();
+        let active_lane = LaneKey::new(removed_channel, "a".repeat(64));
+        let sibling_lane = LaneKey::new(removed_channel, "b".repeat(64));
+        let unrelated_lane = LaneKey::new(other_channel, "c".repeat(64));
+        let first = sleeping_pool_agent(0).await;
+        let second = sleeping_pool_agent(1).await;
+        let mut pool = AgentPool::from_slots(vec![Some(first), Some(second)]);
+
+        let mut checked_out = pool
+            .try_claim_lane(Some(&active_lane))
+            .expect("active lane may claim worker zero");
+        checked_out
+            .state
+            .set_session_for_lane(active_lane.clone(), "active-old".into());
+        checked_out
+            .state
+            .set_session_for_lane(sibling_lane.clone(), "sibling-old".into());
+        checked_out
+            .state
+            .set_session_for_lane(unrelated_lane.clone(), "other-current".into());
+
+        let task = pool.join_set.spawn(std::future::pending::<()>());
+        pool.task_map_mut().insert(
+            task.id(),
+            TaskMeta {
+                agent_index: checked_out.index,
+                channel_id: Some(removed_channel),
+                lane: Some(active_lane.clone()),
+                turn_id: "old-membership-turn".into(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: None,
+            },
+        );
+
+        assert_eq!(
+            pool.retire_channel_sessions_for_checked_out_agents(removed_channel),
+            1
+        );
+        // Re-add may queue new work, but it cannot start a second history while
+        // any pre-removal worker can still be running or returning old state.
+        assert!(!pool.can_claim_lane(&sibling_lane));
+        assert!(pool.try_claim_lane(Some(&sibling_lane)).is_none());
+        assert!(pool.can_claim_lane(&unrelated_lane));
+
+        // A membership re-add deliberately does not clear the worker retirement:
+        // its cached sessions still belong to the pre-removal lifetime.
+        pool.return_agent(checked_out);
+        assert!(pool.can_claim_lane(&sibling_lane));
+
+        let returned = pool.agents[0].as_ref().expect("worker returned to slot");
+        assert_eq!(returned.state.session_for_lane(&active_lane), None);
+        assert_eq!(returned.state.session_for_lane(&sibling_lane), None);
+        assert_eq!(
+            returned.state.session_for_lane(&unrelated_lane),
+            Some("other-current")
+        );
+        pool.join_set.abort_all();
+    }
+
+    #[tokio::test]
+    async fn fatal_worker_retirement_blocks_channel_until_replacement_returns() {
+        let removed_channel = Uuid::new_v4();
+        let other_channel = Uuid::new_v4();
+        let retired_lane = LaneKey::new(removed_channel, "a".repeat(64));
+        let unrelated_lane = LaneKey::new(other_channel, "b".repeat(64));
+        let first = sleeping_pool_agent(0).await;
+        let second = sleeping_pool_agent(1).await;
+        let mut pool = AgentPool::from_slots(vec![Some(first), Some(second)]);
+        let mut checked_out = pool
+            .try_claim_lane(Some(&retired_lane))
+            .expect("retired lane may claim worker zero");
+
+        let task = pool.join_set.spawn(std::future::pending::<()>());
+        pool.task_map_mut().insert(
+            task.id(),
+            TaskMeta {
+                agent_index: checked_out.index,
+                channel_id: Some(removed_channel),
+                lane: Some(retired_lane.clone()),
+                turn_id: "fatal-old-turn".into(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: None,
+            },
+        );
+        assert_eq!(
+            pool.retire_channel_sessions_for_checked_out_agents(removed_channel),
+            1
+        );
+        pool.task_map_mut().clear();
+        pool.forget_agent_sessions(checked_out.index);
+
+        assert!(!pool.can_claim_lane(&retired_lane));
+        assert!(pool.can_claim_lane(&unrelated_lane));
+
+        checked_out.acp.shutdown().await;
+        let replacement = sleeping_pool_agent(0).await;
+        pool.return_agent(replacement);
+        assert!(pool.can_claim_lane(&retired_lane));
+        pool.join_set.abort_all();
+    }
+
+    #[tokio::test]
+    async fn root_lane_steer_selects_only_matching_same_channel_task() {
+        let channel_id = Uuid::new_v4();
+        let lane_a = LaneKey::new(channel_id, "a".repeat(64));
+        let lane_b = LaneKey::new(channel_id, "b".repeat(64));
+        let mut pool = AgentPool::from_slots(Vec::new());
+        let (steer_a_tx, mut steer_a_rx) = tokio::sync::mpsc::channel(1);
+        let (steer_b_tx, mut steer_b_rx) = tokio::sync::mpsc::channel(1);
+        let task_a = pool.join_set.spawn(std::future::pending::<()>());
+        let task_b = pool.join_set.spawn(std::future::pending::<()>());
+        pool.task_map_mut().insert(
+            task_a.id(),
+            TaskMeta {
+                agent_index: 0,
+                channel_id: Some(channel_id),
+                lane: Some(lane_a.clone()),
+                turn_id: "turn-a".into(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: Some(steer_a_tx),
+            },
+        );
+        pool.task_map_mut().insert(
+            task_b.id(),
+            TaskMeta {
+                agent_index: 1,
+                channel_id: Some(channel_id),
+                lane: Some(lane_b.clone()),
+                turn_id: "turn-b".into(),
+                recoverable_batch: None,
+                control_tx: None,
+                steer_tx: Some(steer_b_tx),
+            },
+        );
+        let (ack_tx, _ack_rx) = tokio::sync::oneshot::channel();
+        pool.send_steer_lane_for_turn(
+            &lane_b,
+            "turn-b",
+            SteerRequest {
+                prompt_blocks: vec!["lane-b-only".into()],
+                ack_tx,
+            },
+        )
+        .expect("matching lane must accept steer");
+        assert!(steer_a_rx.try_recv().is_err(), "sibling lane was steered");
+        let delivered = steer_b_rx.try_recv().expect("lane B steer missing");
+        assert_eq!(delivered.prompt_blocks, vec!["lane-b-only"]);
+        pool.join_set.abort_all();
+    }
+
+    #[tokio::test]
+    async fn root_lane_steer_selects_only_matching_turn_generation() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::new(channel_id, "a".repeat(64));
+        let mut pool = AgentPool::from_slots(Vec::new());
+        let (old_tx, mut old_rx) = tokio::sync::mpsc::channel(1);
+        let (new_tx, mut new_rx) = tokio::sync::mpsc::channel(1);
+        let old_task = pool.join_set.spawn(std::future::pending::<()>());
+        let new_task = pool.join_set.spawn(std::future::pending::<()>());
+        for (task_id, agent_index, turn_id, steer_tx) in [
+            (old_task.id(), 0, "old-turn", old_tx),
+            (new_task.id(), 1, "new-turn", new_tx),
+        ] {
+            pool.task_map_mut().insert(
+                task_id,
+                TaskMeta {
+                    agent_index,
+                    channel_id: Some(channel_id),
+                    lane: Some(lane.clone()),
+                    turn_id: turn_id.into(),
+                    recoverable_batch: None,
+                    control_tx: None,
+                    steer_tx: Some(steer_tx),
+                },
+            );
+        }
+
+        let (ack_tx, _ack_rx) = tokio::sync::oneshot::channel();
+        pool.send_steer_lane_for_turn(
+            &lane,
+            "new-turn",
+            SteerRequest {
+                prompt_blocks: vec!["new-generation-only".into()],
+                ack_tx,
+            },
+        )
+        .expect("current generation must accept steer");
+
+        assert!(old_rx.try_recv().is_err(), "old generation was steered");
+        let delivered = new_rx.try_recv().expect("new generation steer missing");
+        assert_eq!(delivered.prompt_blocks, vec!["new-generation-only"]);
+        pool.join_set.abort_all();
     }
 }

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -32,7 +32,7 @@ use uuid::Uuid;
 use crate::acp::{
     extract_model_config_options, extract_model_state, model_in_catalog,
     resolve_model_switch_method, AcpClient, AcpError, EnvVar, McpServer, ModelSwitchMethod,
-    StopReason, SystemPromptTransport,
+    ProcessIdentity, StopReason, SystemPromptTransport,
 };
 use crate::config::{compose_session_title, DedupMode, PermissionMode};
 use crate::observer;
@@ -349,9 +349,10 @@ pub struct AgentPool {
     result_rx: mpsc::UnboundedReceiver<PromptResult>,
     pub join_set: JoinSet<()>,
     task_map: HashMap<tokio::task::Id, TaskMeta>,
-    /// PID registry kept outside `TaskMeta` so panic recovery can reap an ACP
-    /// child after the task-owned `AcpClient` has unwound and been dropped.
-    task_processes: HashMap<tokio::task::Id, u32>,
+    /// Stable process-generation registry kept outside `TaskMeta` so panic
+    /// recovery can reap an ACP child after the task-owned `AcpClient` unwinds
+    /// without granting authority to a potentially reused numeric PID.
+    task_processes: HashMap<tokio::task::Id, ProcessIdentity>,
 }
 
 /// Result returned by a completed prompt task.
@@ -986,21 +987,21 @@ impl AgentPool {
         &mut self.task_map
     }
 
-    pub fn register_task_process(&mut self, task_id: tokio::task::Id, pid: u32) {
-        self.task_processes.insert(task_id, pid);
+    pub fn register_task_process(&mut self, task_id: tokio::task::Id, identity: ProcessIdentity) {
+        self.task_processes.insert(task_id, identity);
     }
 
     pub fn take_task_for_panic(
         &mut self,
         task_id: tokio::task::Id,
-    ) -> (Option<TaskMeta>, Option<u32>) {
+    ) -> (Option<TaskMeta>, Option<ProcessIdentity>) {
         (
             self.task_map.remove(&task_id),
             self.task_processes.remove(&task_id),
         )
     }
 
-    /// Remove the authoritative metadata and PID for a normally completed task.
+    /// Remove authoritative task metadata and process identity on normal completion.
     pub fn remove_tasks_for_agent(&mut self, agent_index: usize) -> usize {
         let task_ids: Vec<_> = self
             .task_map

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -94,8 +94,11 @@ impl LaneKey {
             return Ok(Self::channel(channel_id));
         }
 
-        let mut roots = HashSet::new();
-        let mut replies = HashSet::new();
+        // Vec, not HashSet: a set collapses two IDENTICAL required tags into one
+        // entry, so a duplicated `root`/`reply` looked well-formed and resolved a
+        // lane instead of failing closed. Duplicates are counted here.
+        let mut roots: Vec<String> = Vec::new();
+        let mut replies: Vec<String> = Vec::new();
         let mut positional = Vec::new();
         for tag in event.tags.iter() {
             let parts = tag.as_slice();
@@ -103,20 +106,24 @@ impl LaneKey {
                 continue;
             }
             let marker = parts.get(3).map(String::as_str);
-            if !matches!(marker, Some("root" | "reply") | None | Some("")) {
-                continue;
+            match marker {
+                // `mention` is standard NIP-10 and explicitly NON-AUTHORITATIVE:
+                // it names an event without making it this event's thread, so it
+                // is ignored rather than treated as malformed.
+                Some("mention") => continue,
+                Some("root") | Some("reply") | None | Some("") => {}
+                // An unrecognised marker is REJECTED, never skipped. Skipping it
+                // can hide the only thread tag on a reply, and the event then
+                // derives a top-level lane and runs in the wrong lane entirely.
+                Some(_) => return Err(LaneResolveError::MalformedRequiredTag),
             }
             let id = parts.get(1).ok_or(LaneResolveError::MalformedRequiredTag)?;
             if !valid_event_id(id) {
                 return Err(LaneResolveError::InvalidEventId(id.clone()));
             }
             match marker {
-                Some("root") => {
-                    roots.insert(id.to_ascii_lowercase());
-                }
-                Some("reply") => {
-                    replies.insert(id.to_ascii_lowercase());
-                }
+                Some("root") => roots.push(id.to_ascii_lowercase()),
+                Some("reply") => replies.push(id.to_ascii_lowercase()),
                 None | Some("") => positional.push(id.to_ascii_lowercase()),
                 _ => unreachable!("marker filtered above"),
             }
@@ -576,6 +583,7 @@ impl EventQueue {
             .filter(|(lane, cancelled)| {
                 !cancelled.is_empty()
                     && !self.in_flight_channels.contains(*lane)
+                    && self.retry_after.get(*lane).is_none_or(|&t| t <= now)
                     && eligible(lane)
                     && !self.queues.get(*lane).is_some_and(|queue| {
                         !queue.is_empty() && self.retry_after.get(*lane).is_none_or(|&t| t <= now)
@@ -605,17 +613,41 @@ impl EventQueue {
         };
 
         if !drain_queue {
-            let cancelled = self.cancelled_batches.remove(&lane).unwrap_or_default();
-            let cancel_reason = self.cancel_reasons.remove(&lane);
+            let (events, clear_cancelled_state) =
+                if matches!(self.affinity_policy, AffinityPolicy::RootThread) {
+                    let cancelled = self
+                        .cancelled_batches
+                        .get_mut(&lane)
+                        .expect("selected cancelled lane must retain work");
+                    let oldest_index = cancelled
+                        .iter()
+                        .enumerate()
+                        .min_by_key(|(_, event)| event.received_at)
+                        .map(|(index, _)| index)
+                        .expect("selected cancelled lane must be non-empty");
+                    let event = cancelled.remove(oldest_index);
+                    (vec![event], cancelled.is_empty())
+                } else {
+                    (
+                        self.cancelled_batches.remove(&lane).unwrap_or_default(),
+                        true,
+                    )
+                };
+            let cancel_reason = if clear_cancelled_state {
+                self.cancelled_batches.remove(&lane);
+                self.cancel_reasons.remove(&lane)
+            } else {
+                self.cancel_reasons.get(&lane).copied()
+            };
             self.in_flight_channels.insert(lane.clone());
             self.in_flight_deadlines
                 .insert(lane.clone(), now + self.in_flight_deadline);
             self.in_flight_batch_sizes
-                .insert(lane.clone(), cancelled.len());
+                .insert(lane.clone(), events.len());
             return Some(FlushBatch {
                 channel_id: lane.channel_id,
                 lane,
-                events: cancelled,
+                events,
                 cancelled_events: vec![],
                 cancel_reason,
             });
@@ -673,15 +705,12 @@ impl EventQueue {
         self.in_flight_batch_sizes.remove(lane);
         self.in_flight_turn_ids.remove(lane);
         let now = Instant::now();
-        match self.retry_after.get(lane) {
-            Some(&deadline) if deadline > now => {}
-            Some(_) => {
-                self.retry_after.remove(lane);
-                self.retry_counts.remove(lane);
-            }
-            None => {
-                self.retry_counts.remove(lane);
-            }
+        if self
+            .retry_after
+            .get(lane)
+            .is_some_and(|deadline| *deadline <= now)
+        {
+            self.retry_after.remove(lane);
         }
     }
 
@@ -718,6 +747,8 @@ impl EventQueue {
     }
 
     /// Complete a lane only if `turn_id` still owns its current generation.
+    /// Retry-attempt history is preserved for cancellation and other nonterminal
+    /// release paths; use [`Self::mark_lane_settled_for_turn`] for terminal work.
     pub fn mark_lane_complete_for_turn(&mut self, lane: &LaneKey, turn_id: &str) -> bool {
         if !self.lane_turn_matches(lane, turn_id) {
             tracing::warn!(
@@ -728,6 +759,24 @@ impl EventQueue {
             );
             return false;
         }
+        self.mark_lane_complete(lane);
+        true
+    }
+
+    /// Terminally settle the current lane generation and reset its retry budget.
+    /// A stale generation cannot mutate the replacement lane's retry state.
+    pub fn mark_lane_settled_for_turn(&mut self, lane: &LaneKey, turn_id: &str) -> bool {
+        if !self.lane_turn_matches(lane, turn_id) {
+            tracing::warn!(
+                channel_id = %lane.channel_id,
+                lane_root = %lane.root_event_id,
+                turn_id,
+                "ignoring stale lane settlement"
+            );
+            return false;
+        }
+        self.retry_after.remove(lane);
+        self.retry_counts.remove(lane);
         self.mark_lane_complete(lane);
         true
     }
@@ -948,10 +997,11 @@ impl EventQueue {
                 && !self.in_flight_channels.contains(id)
                 && self.retry_after.get(id).is_none_or(|&t| t <= now)
                 && eligible(id)
-        }) || self
-            .cancelled_batches
-            .keys()
-            .any(|id| !self.in_flight_channels.contains(id) && eligible(id))
+        }) || self.cancelled_batches.keys().any(|id| {
+            !self.in_flight_channels.contains(id)
+                && self.retry_after.get(id).is_none_or(|&t| t <= now)
+                && eligible(id)
+        })
     }
 
     fn expire_claimable_in_flight_lanes<F>(&mut self, now: Instant, eligible: &F)
@@ -1012,6 +1062,12 @@ impl EventQueue {
     pub fn set_retry_count_for_test(&mut self, channel_id: Uuid, count: u32) {
         self.retry_counts
             .insert(LaneKey::channel(channel_id), count);
+    }
+
+    /// Read an exact lane's retry-attempt counter in tests.
+    #[cfg(test)]
+    pub fn retry_count_for_test(&self, lane: &LaneKey) -> Option<u32> {
+        self.retry_counts.get(lane).copied()
     }
 
     /// Drop all queued (non-in-flight) events for a channel.
@@ -2158,6 +2214,120 @@ mod tests {
     }
 
     #[test]
+    fn root_thread_lane_rejects_duplicate_required_and_unknown_markers() {
+        let channel_id = Uuid::new_v4();
+        let root_id = "a".repeat(64);
+        let duplicate_root = make_event_with_tags(
+            "duplicate root",
+            vec![
+                vec!["e".into(), root_id.clone(), "".into(), "root".into()],
+                vec!["e".into(), root_id.clone(), "".into(), "root".into()],
+            ],
+        );
+        let unknown_marker = make_event_with_tags(
+            "unknown marker",
+            vec![vec![
+                "e".into(),
+                root_id.clone(),
+                "".into(),
+                "thread-root".into(),
+            ]],
+        );
+        let mention = make_event_with_tags(
+            "valid mention",
+            vec![vec!["e".into(), root_id, "".into(), "mention".into()]],
+        );
+
+        assert_eq!(
+            LaneKey::resolve(
+                channel_id,
+                &duplicate_root,
+                AffinityPolicy::RootThread,
+                false,
+            ),
+            Err(LaneResolveError::ConflictingRequiredTags),
+        );
+        assert_eq!(
+            LaneKey::resolve(
+                channel_id,
+                &unknown_marker,
+                AffinityPolicy::RootThread,
+                false,
+            ),
+            Err(LaneResolveError::MalformedRequiredTag),
+        );
+        assert_eq!(
+            LaneKey::resolve(channel_id, &mention, AffinityPolicy::RootThread, false),
+            Ok(LaneKey::new(channel_id, mention.id.to_hex())),
+            "the standard NIP-10 mention marker is non-authoritative, not malformed",
+        );
+    }
+
+    #[test]
+    fn root_thread_lane_rejects_duplicate_identical_reply_marker() {
+        // A HashSet collapses two identical `reply` tags into one entry, so a
+        // duplicate looks like a single well-formed reply and the lane resolves
+        // instead of failing closed.
+        let channel_id = Uuid::new_v4();
+        let reply_id = "c".repeat(64);
+        let duplicate_reply = make_event_with_tags(
+            "duplicate reply",
+            vec![
+                vec!["e".into(), reply_id.clone(), "".into(), "reply".into()],
+                vec!["e".into(), reply_id, "".into(), "reply".into()],
+            ],
+        );
+
+        assert_eq!(
+            LaneKey::resolve(
+                channel_id,
+                &duplicate_reply,
+                AffinityPolicy::RootThread,
+                false,
+            ),
+            Err(LaneResolveError::ConflictingRequiredTags),
+        );
+    }
+
+    #[test]
+    fn root_thread_lane_rejects_unknown_marker_that_would_hide_a_reply() {
+        // The dangerous shape: the ONLY thread tag carries an unrecognised
+        // marker. Skipping it silently derives a top-level lane for what is
+        // actually a reply, so the event runs in the wrong lane entirely.
+        let channel_id = Uuid::new_v4();
+        let parent = "d".repeat(64);
+        let hidden_reply = make_event_with_tags(
+            "unknown marker hiding a reply",
+            vec![vec![
+                "e".into(),
+                parent.clone(),
+                "".into(),
+                "in-reply-to".into(),
+            ]],
+        );
+
+        assert_eq!(
+            LaneKey::resolve(channel_id, &hidden_reply, AffinityPolicy::RootThread, false),
+            Err(LaneResolveError::MalformedRequiredTag),
+            "an unknown marker must fail closed, never fall through to a top-level lane",
+        );
+
+        // And it must not be rescued by an accompanying valid root: an event
+        // carrying an unparseable thread tag is malformed regardless.
+        let mixed = make_event_with_tags(
+            "unknown marker beside a valid root",
+            vec![
+                vec!["e".into(), parent.clone(), "".into(), "root".into()],
+                vec!["e".into(), parent, "".into(), "in-reply-to".into()],
+            ],
+        );
+        assert_eq!(
+            LaneKey::resolve(channel_id, &mixed, AffinityPolicy::RootThread, false),
+            Err(LaneResolveError::MalformedRequiredTag),
+        );
+    }
+
+    #[test]
     fn root_thread_lane_accepts_direct_reply_marker_as_canonical_root() {
         let channel_id = Uuid::new_v4();
         let root_id = "b".repeat(64);
@@ -3131,6 +3301,39 @@ mod tests {
     }
 
     #[test]
+    fn retry_throttle_blocks_cancelled_half_of_failed_merged_prompt() {
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::channel(channel_id);
+
+        queue.push(make_queued(channel_id, "original work"));
+        let original = queue.flush_next().expect("original batch");
+        queue.push(make_queued(channel_id, "steering update"));
+        queue.requeue_as_cancelled(original, CancelReason::Steer);
+        queue.mark_complete(channel_id);
+
+        let merged = queue.flush_next().expect("merged prompt");
+        assert!(queue.requeue(merged).is_none());
+        queue.mark_complete(channel_id);
+        assert!(
+            queue
+                .retry_after
+                .get(&lane)
+                .is_some_and(|deadline| *deadline > Instant::now()),
+            "failed merged work must establish a future retry deadline"
+        );
+
+        assert!(
+            !queue.has_flushable_work(),
+            "cancelled context must observe the same retry deadline as ordinary work"
+        );
+        assert!(
+            queue.flush_next().is_none(),
+            "cancelled context must not bypass retry throttling"
+        );
+    }
+
+    #[test]
     fn cancelled_only_lane_competes_in_global_fifo_order() {
         let mut queue = EventQueue::new(DedupMode::Queue);
         let cancelled_channel = Uuid::new_v4();
@@ -3157,6 +3360,107 @@ mod tests {
             "cancelled-only work must compete with queued work by received_at"
         );
         assert_eq!(next.events[0].event.content, "cancelled-old");
+    }
+
+    #[test]
+    fn root_cancelled_only_lane_dispatches_one_primary_event() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::new(channel_id, "a".repeat(64));
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+        let first = make_queued_at(channel_id, "cancelled-first", Duration::from_secs(2));
+        let second = make_queued_at(channel_id, "cancelled-second", Duration::from_secs(1));
+
+        queue.requeue_as_cancelled(
+            FlushBatch {
+                lane: lane.clone(),
+                channel_id,
+                events: vec![
+                    BatchEvent {
+                        event: first.event,
+                        prompt_tag: first.prompt_tag,
+                        received_at: first.received_at,
+                    },
+                    BatchEvent {
+                        event: second.event,
+                        prompt_tag: second.prompt_tag,
+                        received_at: second.received_at,
+                    },
+                ],
+                cancelled_events: Vec::new(),
+                cancel_reason: Some(CancelReason::Steer),
+            },
+            CancelReason::Steer,
+        );
+
+        let batch = queue.flush_next().expect("cancelled-only root batch");
+        assert_eq!(
+            batch.events.len(),
+            1,
+            "RootThread must never dispatch multiple primary events in one batch"
+        );
+        assert_eq!(batch.events[0].event.content, "cancelled-first");
+        assert_eq!(
+            queue.cancelled_batches.get(&lane).map(Vec::len),
+            Some(1),
+            "the later retained event must remain queued for global FIFO scheduling"
+        );
+    }
+
+    #[test]
+    fn root_cancelled_only_events_preserve_global_fifo_between_dispatches() {
+        let cancelled_channel = Uuid::new_v4();
+        let queued_channel = Uuid::new_v4();
+        let cancelled_lane = LaneKey::new(cancelled_channel, "a".repeat(64));
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+        let oldest = make_queued_at(
+            cancelled_channel,
+            "cancelled-oldest",
+            Duration::from_secs(3),
+        );
+        let newest = make_queued_at(
+            cancelled_channel,
+            "cancelled-newest",
+            Duration::from_secs(1),
+        );
+
+        queue.requeue_as_cancelled(
+            FlushBatch {
+                lane: cancelled_lane.clone(),
+                channel_id: cancelled_channel,
+                events: [oldest, newest]
+                    .into_iter()
+                    .map(|event| BatchEvent {
+                        event: event.event,
+                        prompt_tag: event.prompt_tag,
+                        received_at: event.received_at,
+                    })
+                    .collect(),
+                cancelled_events: Vec::new(),
+                cancel_reason: Some(CancelReason::Steer),
+            },
+            CancelReason::Steer,
+        );
+        queue.push_resolved(
+            make_queued_at(queued_channel, "queued-middle", Duration::from_secs(2)),
+            LaneKey::new(queued_channel, "b".repeat(64)),
+        );
+
+        let first = queue.flush_next().expect("oldest cancelled work");
+        assert_eq!(first.events[0].event.content, "cancelled-oldest");
+        assert!(
+            first
+                .events
+                .iter()
+                .all(|event| event.event.content != "cancelled-newest"),
+            "later cancelled work must not be bundled ahead of globally older queued work"
+        );
+        queue.mark_lane_complete(&cancelled_lane);
+
+        let second = queue.flush_next().expect("middle queued work");
+        assert_eq!(
+            second.events[0].event.content, "queued-middle",
+            "later cancelled work must not jump ahead of globally older queued work"
+        );
     }
 
     #[test]
@@ -3910,6 +4214,57 @@ mod tests {
         // Retry state is cleared so fresh traffic isn't throttled.
         assert!(!q.retry_counts.contains_key(&LaneKey::channel(ch)));
         assert!(!q.retry_after.contains_key(&LaneKey::channel(ch)));
+    }
+
+    #[test]
+    fn cancellation_after_retry_preserves_attempt_count() {
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::channel(channel_id);
+
+        queue.push(make_queued(channel_id, "poison work"));
+        let first = queue.flush_next().expect("first attempt");
+        assert!(queue.requeue(first).is_none());
+        queue.mark_complete(channel_id);
+        assert_eq!(queue.retry_counts.get(&lane), Some(&1));
+
+        queue
+            .retry_after
+            .insert(lane.clone(), Instant::now() - Duration::from_secs(1));
+        let retry = queue.flush_next().expect("retry attempt");
+        queue.requeue_as_cancelled(retry, CancelReason::Steer);
+        queue.mark_complete(channel_id);
+
+        assert_eq!(
+            queue.retry_counts.get(&lane),
+            Some(&1),
+            "cancellation must not reset the failure budget for poison work"
+        );
+    }
+
+    #[test]
+    fn terminal_settlement_clears_retry_attempt_state() {
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::channel(channel_id);
+
+        queue.push(make_queued(channel_id, "eventually succeeds"));
+        let first = queue.flush_next().expect("first attempt");
+        assert!(queue.bind_lane_turn(&lane, "first-turn"));
+        assert!(queue.requeue(first).is_none());
+        assert!(queue.mark_lane_complete_for_turn(&lane, "first-turn"));
+        assert_eq!(queue.retry_counts.get(&lane), Some(&1));
+
+        queue
+            .retry_after
+            .insert(lane.clone(), Instant::now() - Duration::from_secs(1));
+        queue.flush_next().expect("retry attempt");
+        assert!(queue.bind_lane_turn(&lane, "retry-turn"));
+        assert!(queue.mark_lane_settled_for_turn(&lane, "retry-turn"));
+
+        assert!(!queue.retry_counts.contains_key(&lane));
+        assert!(!queue.retry_after.contains_key(&lane));
+        assert!(!queue.is_lane_in_flight(&lane));
     }
 
     #[test]
@@ -4689,9 +5044,12 @@ mod tests {
             Instant::now() - Duration::from_secs(1),
         );
         let _batch2 = q.flush_next().unwrap();
-        // Now mark_complete with no active throttle — clears retry_counts.
-        q.mark_complete(ch);
-        assert!(!q.retry_counts.contains_key(&LaneKey::channel(ch)));
+        // Terminal success is explicit and generation-qualified; ordinary
+        // mark_complete intentionally preserves retry history for cancellation.
+        let lane = LaneKey::channel(ch);
+        assert!(q.bind_lane_turn(&lane, "successful-retry"));
+        assert!(q.mark_lane_settled_for_turn(&lane, "successful-retry"));
+        assert!(!q.retry_counts.contains_key(&lane));
 
         // Re-create the orphan scenario: manually insert stale retry_counts
         // with no queue, no throttle, and no in-flight.

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -23,6 +23,13 @@ use crate::config::DedupMode;
 /// Maximum events queued per channel before oldest events are dropped.
 const MAX_PENDING_PER_CHANNEL: usize = 500;
 
+/// Maximum active root lanes retained for one channel in root-thread mode.
+const DEFAULT_MAX_LANES_PER_CHANNEL: usize = 128;
+
+/// Maximum aggregate pending events across queued, cancelled, and withheld
+/// root-thread state. Legacy channel mode keeps its historical per-channel cap.
+const DEFAULT_MAX_PENDING_EVENTS: usize = 5_000;
+
 /// Maximum events drained into a single batch.
 const MAX_BATCH_EVENTS: usize = 50;
 
@@ -40,6 +47,148 @@ const IN_FLIGHT_DEADLINE_BUFFER_SECS: u64 = 100;
 
 /// Default in-flight deadline: default max_turn (7200s) + 100s buffer.
 const DEFAULT_IN_FLIGHT_DEADLINE_SECS: u64 = 7300;
+
+/// Sentinel used to preserve one-lane-per-channel semantics for every legacy
+/// mode and for DMs. It cannot collide with a Nostr event id (64 hex chars).
+const CHANNEL_LANE_SENTINEL: &str = "__channel__";
+
+/// Dispatch affinity policy selected by the multiple-event handling mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AffinityPolicy {
+    /// Preserve the historical one-lane-per-channel behavior.
+    Channel,
+    /// Use one lane per validated NIP-10 root in non-DM channels.
+    RootThread,
+}
+
+/// Canonical identity for every queue, task, and ACP-session ownership seam.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LaneKey {
+    pub channel_id: Uuid,
+    pub root_event_id: String,
+}
+
+impl LaneKey {
+    /// Construct a root-thread lane from a canonical event id.
+    pub fn new(channel_id: Uuid, root_event_id: String) -> Self {
+        Self {
+            channel_id,
+            root_event_id: root_event_id.to_ascii_lowercase(),
+        }
+    }
+
+    /// Construct the channel sentinel lane used by legacy modes and DMs.
+    pub fn channel(channel_id: Uuid) -> Self {
+        Self::new(channel_id, CHANNEL_LANE_SENTINEL.to_string())
+    }
+
+    /// Resolve an event to its canonical lane, validating every required NIP-10
+    /// root/reply marker before the event can enter a root-affinity queue.
+    pub fn resolve(
+        channel_id: Uuid,
+        event: &Event,
+        policy: AffinityPolicy,
+        is_dm: bool,
+    ) -> Result<Self, LaneResolveError> {
+        if matches!(policy, AffinityPolicy::Channel) || is_dm {
+            return Ok(Self::channel(channel_id));
+        }
+
+        let mut roots = HashSet::new();
+        let mut replies = HashSet::new();
+        let mut positional = Vec::new();
+        for tag in event.tags.iter() {
+            let parts = tag.as_slice();
+            if parts.first().map(String::as_str) != Some("e") {
+                continue;
+            }
+            let marker = parts.get(3).map(String::as_str);
+            if !matches!(marker, Some("root" | "reply") | None | Some("")) {
+                continue;
+            }
+            let id = parts.get(1).ok_or(LaneResolveError::MalformedRequiredTag)?;
+            if !valid_event_id(id) {
+                return Err(LaneResolveError::InvalidEventId(id.clone()));
+            }
+            match marker {
+                Some("root") => {
+                    roots.insert(id.to_ascii_lowercase());
+                }
+                Some("reply") => {
+                    replies.insert(id.to_ascii_lowercase());
+                }
+                None | Some("") => positional.push(id.to_ascii_lowercase()),
+                _ => unreachable!("marker filtered above"),
+            }
+        }
+
+        if roots.len() > 1 || replies.len() > 1 {
+            return Err(LaneResolveError::ConflictingRequiredTags);
+        }
+
+        // Buzz's supported NIP-10 encoding uses only a `reply` marker when the
+        // immediate parent is also the thread root. Nested replies carry both
+        // markers, in which case the explicit `root` remains authoritative.
+        // Preferred marked tags are authoritative. If neither required marker
+        // exists, preserve NIP-10's deprecated positional compatibility: first
+        // unmarked `e` is the root (and with one tag also the direct parent).
+        let root = if !roots.is_empty() || !replies.is_empty() {
+            roots
+                .into_iter()
+                .next()
+                .or_else(|| replies.into_iter().next())
+                .expect("explicit set checked non-empty")
+        } else {
+            positional
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| event.id.to_hex())
+        };
+        Ok(Self::new(channel_id, root))
+    }
+
+    /// Whether this is the legacy/DM channel sentinel lane.
+    pub fn is_channel_scoped(&self) -> bool {
+        self.root_event_id == CHANNEL_LANE_SENTINEL
+    }
+}
+
+impl std::fmt::Display for LaneKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.channel_id, self.root_event_id)
+    }
+}
+
+/// Why an inbound event cannot be assigned to a root-thread lane.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum LaneResolveError {
+    #[error("malformed required NIP-10 thread tag")]
+    MalformedRequiredTag,
+    #[error("invalid NIP-10 event id: {0}")]
+    InvalidEventId(String),
+    #[error("conflicting required NIP-10 thread tags")]
+    ConflictingRequiredTags,
+}
+
+/// Distinguishable queue overload causes for visible exact-event failure paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverloadReason {
+    TooManyChannelLanes,
+    AggregatePendingLimit,
+    LaneQueueFull,
+}
+
+/// Result of assigning an exact event to an already-resolved lane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushResult {
+    Accepted,
+    DroppedInFlight,
+    Overloaded(OverloadReason),
+}
+
+fn valid_event_id(id: &str) -> bool {
+    id.len() == 64 && id.chars().all(|c| c.is_ascii_hexdigit())
+}
 
 /// An event waiting in the queue.
 #[derive(Debug, Clone)]
@@ -75,6 +224,7 @@ pub enum CancelReason {
 /// A batch of events to prompt the agent with.
 #[derive(Debug, Clone)]
 pub struct FlushBatch {
+    pub lane: LaneKey,
     pub channel_id: Uuid,
     pub events: Vec<BatchEvent>,
     /// Events from a cancelled batch that triggered this re-prompt.
@@ -89,82 +239,70 @@ pub struct FlushBatch {
     pub cancel_reason: Option<CancelReason>,
 }
 
-/// Per-channel event queue with per-channel in-flight enforcement.
+/// Per-lane event queue with exact-lane in-flight enforcement.
+///
+/// Legacy and DM traffic use one channel-sentinel [`LaneKey`]; `steer-thread`
+/// traffic uses one lane per canonical root event.
 ///
 /// # State Machine
 ///
 /// ```text
-/// State:
-///   queues:               Map<channel_id, VecDeque<QueuedEvent>>  (capped at MAX_PENDING_PER_CHANNEL)
-///   in_flight_channels:   HashSet<Uuid>
-///   in_flight_deadlines:  Map<channel_id, Instant>                (auto-expire after in_flight_deadline)
-///   retry_after:          Map<channel_id, Instant>
-///   retry_counts:         Map<channel_id, u32>                    (dead-letter after MAX_RETRIES)
-///   dedup_mode:           DedupMode
+/// State (all keyed by LaneKey):
+///   queues:               Map<LaneKey, VecDeque<QueuedEvent>>
+///   in_flight_channels:   Set<LaneKey>
+///   in_flight_deadlines:  Map<LaneKey, Instant>
+///   in_flight_batch_sizes: Map<LaneKey, usize>
+///   in_flight_turn_ids:   Map<LaneKey, immutable turn_id>
+///   retry_after/counts, cancelled_batches, withheld_native_steer
 ///
 /// Transitions:
-///   push(event):
-///     if dedup_mode == Drop AND in_flight_channels.contains(event.channel_id):
-///       debug log + discard
-///     else if queues[channel].len() >= MAX_PENDING_PER_CHANNEL:
-///       drop oldest (pop_front), warn, push_back new event
-///     else:
-///       queues[event.channel_id].push_back(event)
+///   push_resolved(event, lane):
+///     if Drop mode and lane is in flight: discard
+///     in root mode: reject visibly at lane-count, aggregate-pending, or
+///       retained-event capacity; accepted in-flight work reserves retry space
+///     in legacy channel mode: preserve historical oldest-drop depth behavior
+///     otherwise append to queues[lane]
 ///
-///   flush_next() → Option<FlushBatch>:
-///     expire any stuck in-flight entries past their deadline
-///     candidates = channels where queue non-empty
-///                  AND NOT in in_flight_channels
-///                  AND (no retry_after OR retry_after[c] <= now)
-///     if candidates empty: return None
-///     channel = pick candidate with oldest head event (min received_at)
-///     events = drain up to MAX_BATCH_EVENTS from queues[channel]
-///     in_flight_channels.insert(channel)
-///     in_flight_deadlines.insert(channel, now + in_flight_deadline)
-///     return Some(FlushBatch { channel, events })
+///   flush_next() -> Option<FlushBatch>:
+///     expire orphaned lanes past their deadline
+///     choose the flushable lane with the oldest head event
+///     drain one event in root mode or up to MAX_BATCH_EVENTS in legacy mode
+///     merge exact-lane cancelled events and mark the full batch in flight
 ///
-///   mark_complete(channel_id):
-///     in_flight_channels.remove(channel_id)
-///     in_flight_deadlines.remove(channel_id)
-///     retry_counts.remove(channel_id)
-///     clean up expired retry_after entry if present
+///   bind_lane_turn(lane, turn_id):
+///     bind the dispatched lane generation before spawning its task
+///
+///   mark_lane_complete_for_turn(lane, turn_id):
+///     release state only when turn_id still owns the lane generation
 ///
 ///   requeue(batch):
-///     increment retry_counts[channel]
-///     if retry_counts[channel] > MAX_RETRIES: dead-letter (log ERROR, return batch to caller)
-///     else: push_front with original received_at, set exponential backoff retry_after with jitter
+///     restore original timestamps, increment exact-lane retry count, apply
+///     exponential backoff, and dead-letter after MAX_RETRIES
 /// ```
 pub struct EventQueue {
-    queues: HashMap<Uuid, VecDeque<QueuedEvent>>,
-    in_flight_channels: HashSet<Uuid>,
-    /// Per-channel deadline for auto-expiring stuck in-flight entries.
-    in_flight_deadlines: HashMap<Uuid, Instant>,
+    queues: HashMap<LaneKey, VecDeque<QueuedEvent>>,
+    in_flight_channels: HashSet<LaneKey>,
+    /// Per-lane deadline for auto-expiring stuck in-flight entries.
+    in_flight_deadlines: HashMap<LaneKey, Instant>,
     /// Number of events in each in-flight batch (for expiry logging).
-    in_flight_batch_sizes: HashMap<Uuid, usize>,
-    retry_after: HashMap<Uuid, Instant>,
-    /// Per-channel retry attempt counter for exponential backoff / dead-lettering.
-    retry_counts: HashMap<Uuid, u32>,
+    in_flight_batch_sizes: HashMap<LaneKey, usize>,
+    /// Spawn-time turn id owning each lane. Used to reject late completion
+    /// from an expired/replaced task generation.
+    in_flight_turn_ids: HashMap<LaneKey, String>,
+    retry_after: HashMap<LaneKey, Instant>,
+    /// Per-lane retry attempt counter for exponential backoff / dead-lettering.
+    retry_counts: HashMap<LaneKey, u32>,
     dedup_mode: DedupMode,
-    /// Events from cancelled batches, keyed by channel. Merged into the next
-    /// `FlushBatch` for that channel as `cancelled_events` so `format_prompt()`
-    /// can produce annotated "[Previous request — interrupted]" sections.
-    cancelled_batches: HashMap<Uuid, Vec<BatchEvent>>,
-    /// Why each channel's cancelled batch was cancelled (steer vs interrupt).
-    /// Set by `requeue_as_cancelled`, consumed by `flush_next` to set
-    /// `FlushBatch::cancel_reason`. Keyed by channel, cleared on flush.
-    cancel_reasons: HashMap<Uuid, CancelReason>,
-    /// Events withheld from `queues` while a goose-native steer is in flight
-    /// for that event. Invisible to `flush_next` / `has_flushable_work` /
-    /// `drain` (the events have been moved out of `queues`), so the queue's
-    /// no-double-deliver invariant holds without any change to the hot drain
-    /// path. Populated by [`mark_native_steer_pending`]; drained back to the
-    /// queue front by [`release_native_steer`] (preserving original
-    /// `received_at` fairness, same discipline as `requeue_preserve_timestamps`
-    /// at line 453). Bulk recovery on in-flight deadline expiry is performed
-    /// by `flush_next` / `has_flushable_work` (recover, not log-and-drop —
-    /// the events were never delivered to the agent).
-    withheld_native_steer: HashMap<Uuid, Vec<QueuedEvent>>,
-    /// Duration after which an in-flight channel is auto-expired as orphaned.
+    affinity_policy: AffinityPolicy,
+    max_lanes_per_channel: usize,
+    max_pending_events: usize,
+    /// Events from cancelled batches, keyed by exact lane.
+    cancelled_batches: HashMap<LaneKey, Vec<BatchEvent>>,
+    /// Why each lane's cancelled batch was cancelled (steer vs interrupt).
+    cancel_reasons: HashMap<LaneKey, CancelReason>,
+    /// Events withheld while a native steer is in flight for an exact lane.
+    withheld_native_steer: HashMap<LaneKey, Vec<QueuedEvent>>,
+    /// Duration after which an in-flight lane is auto-expired as orphaned.
     /// Must be strictly greater than `max_turn_duration` so a turn running to
     /// the hard cap returns via `mark_complete` before the backstop fires.
     in_flight_deadline: Duration,
@@ -177,19 +315,36 @@ impl EventQueue {
     /// Call [`with_in_flight_deadline`](Self::with_in_flight_deadline) to
     /// derive the deadline from the configured `max_turn_duration`.
     pub fn new(dedup_mode: DedupMode) -> Self {
+        Self::new_with_affinity(dedup_mode, AffinityPolicy::Channel)
+    }
+
+    /// Create an empty queue with an explicit dispatch-affinity policy.
+    pub fn new_with_affinity(dedup_mode: DedupMode, affinity_policy: AffinityPolicy) -> Self {
         Self {
             queues: HashMap::new(),
             in_flight_channels: HashSet::new(),
             in_flight_deadlines: HashMap::new(),
             in_flight_batch_sizes: HashMap::new(),
+            in_flight_turn_ids: HashMap::new(),
             retry_after: HashMap::new(),
             retry_counts: HashMap::new(),
             dedup_mode,
+            affinity_policy,
+            max_lanes_per_channel: DEFAULT_MAX_LANES_PER_CHANNEL,
+            max_pending_events: DEFAULT_MAX_PENDING_EVENTS,
             cancelled_batches: HashMap::new(),
             cancel_reasons: HashMap::new(),
             withheld_native_steer: HashMap::new(),
             in_flight_deadline: Duration::from_secs(DEFAULT_IN_FLIGHT_DEADLINE_SECS),
         }
+    }
+
+    /// Override finite root-thread queue limits (primarily for focused tests).
+    #[cfg(test)]
+    pub fn with_limits(mut self, max_lanes_per_channel: usize, max_pending_events: usize) -> Self {
+        self.max_lanes_per_channel = max_lanes_per_channel;
+        self.max_pending_events = max_pending_events;
+        self
     }
 
     /// Set the in-flight backstop deadline from the configured max turn
@@ -200,20 +355,22 @@ impl EventQueue {
         self
     }
 
-    /// Monotonically extend an existing in-flight deadline for `channel_id`.
-    ///
-    /// Called when a successful steer grants a fresh turn budget. The new
-    /// deadline is `max(current, now + max_turn_secs + buffer)` — it never
-    /// moves backward. If the channel is not in-flight (already completed
-    /// via `mark_complete`), this is a no-op: a late ack never resurrects
-    /// a deadline.
+    /// Monotonically extend an existing legacy channel-lane deadline.
+    #[cfg(test)]
     pub fn extend_in_flight_deadline(&mut self, channel_id: Uuid, max_turn_secs: u64) {
-        if let Some(current) = self.in_flight_deadlines.get_mut(&channel_id) {
+        self.extend_lane_deadline(&LaneKey::channel(channel_id), max_turn_secs);
+    }
+
+    /// Monotonically extend an existing exact-lane deadline. Late acks are
+    /// generation-fenced by the lane's continued presence in the deadline map.
+    pub fn extend_lane_deadline(&mut self, lane: &LaneKey, max_turn_secs: u64) {
+        if let Some(current) = self.in_flight_deadlines.get_mut(lane) {
             let extended = Instant::now()
                 + Duration::from_secs(max_turn_secs + IN_FLIGHT_DEADLINE_BUFFER_SECS);
             if extended > *current {
                 tracing::info!(
-                    %channel_id,
+                    channel_id = %lane.channel_id,
+                    lane_root = %lane.root_event_id,
                     "extending in-flight deadline by {max_turn_secs}s + {IN_FLIGHT_DEADLINE_BUFFER_SECS}s buffer"
                 );
                 *current = extended;
@@ -221,34 +378,137 @@ impl EventQueue {
         }
     }
 
-    /// Push an event into the queue for its channel.
-    ///
-    /// In [`DedupMode::Drop`], events for any currently in-flight channel are
-    /// silently discarded (debug-logged).
-    ///
-    /// Returns `true` if the event was accepted, `false` if dropped.
+    /// Preserve the historical channel-scoped push API for existing modes.
+    #[cfg(test)]
     pub fn push(&mut self, event: QueuedEvent) -> bool {
-        if matches!(self.dedup_mode, DedupMode::Drop)
-            && self.in_flight_channels.contains(&event.channel_id)
-        {
+        let lane = LaneKey::channel(event.channel_id);
+        matches!(self.push_resolved(event, lane), PushResult::Accepted)
+    }
+
+    /// Push an event into an exact, already-validated dispatch lane.
+    pub fn push_resolved(&mut self, event: QueuedEvent, lane: LaneKey) -> PushResult {
+        debug_assert_eq!(event.channel_id, lane.channel_id);
+        if matches!(self.dedup_mode, DedupMode::Drop) && self.in_flight_channels.contains(&lane) {
             tracing::debug!(
-                channel_id = %event.channel_id,
-                "dropping event for in-flight channel (drop mode)"
+                channel_id = %lane.channel_id,
+                lane_root = %lane.root_event_id,
+                "dropping event for in-flight lane (drop mode)"
             );
-            return false;
+            return PushResult::DroppedInFlight;
         }
-        let queue = self.queues.entry(event.channel_id).or_default();
-        // Enforce per-channel depth cap: drop oldest to make room.
+
+        if matches!(self.affinity_policy, AffinityPolicy::RootThread) {
+            let lane_exists = self.lane_exists(&lane);
+            if !lane_exists
+                && self.active_lane_count_for_channel(lane.channel_id) >= self.max_lanes_per_channel
+            {
+                tracing::warn!(
+                    channel_id = %lane.channel_id,
+                    lane_root = %lane.root_event_id,
+                    limit = self.max_lanes_per_channel,
+                    "root-thread lane cap reached"
+                );
+                return PushResult::Overloaded(OverloadReason::TooManyChannelLanes);
+            }
+            if self.pending_event_count() >= self.max_pending_events {
+                tracing::warn!(
+                    channel_id = %lane.channel_id,
+                    lane_root = %lane.root_event_id,
+                    limit = self.max_pending_events,
+                    "aggregate pending-event cap reached"
+                );
+                return PushResult::Overloaded(OverloadReason::AggregatePendingLimit);
+            }
+            if self.retained_event_count_for_lane(&lane) >= MAX_PENDING_PER_CHANNEL {
+                tracing::warn!(
+                    channel_id = %lane.channel_id,
+                    lane_root = %lane.root_event_id,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "root-thread lane retained-event cap reached"
+                );
+                return PushResult::Overloaded(OverloadReason::LaneQueueFull);
+            }
+        }
+
+        let queue = self.queues.entry(lane.clone()).or_default();
+        // Preserve the legacy per-channel depth behavior. Root-thread lanes are
+        // additionally bounded by the aggregate cap above.
         if queue.len() >= MAX_PENDING_PER_CHANNEL {
+            if matches!(self.affinity_policy, AffinityPolicy::RootThread) {
+                tracing::warn!(
+                    channel_id = %lane.channel_id,
+                    lane_root = %lane.root_event_id,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "root-thread lane depth cap reached"
+                );
+                return PushResult::Overloaded(OverloadReason::LaneQueueFull);
+            }
             queue.pop_front();
             tracing::warn!(
-                channel_id = %event.channel_id,
+                channel_id = %lane.channel_id,
+                lane_root = %lane.root_event_id,
                 limit = MAX_PENDING_PER_CHANNEL,
                 "queue depth cap reached — dropped oldest event"
             );
         }
         queue.push_back(event);
-        true
+        PushResult::Accepted
+    }
+
+    fn lane_exists(&self, lane: &LaneKey) -> bool {
+        self.queues.contains_key(lane)
+            || self.in_flight_channels.contains(lane)
+            || self.retry_after.contains_key(lane)
+            || self.retry_counts.contains_key(lane)
+            || self.cancelled_batches.contains_key(lane)
+            || self.withheld_native_steer.contains_key(lane)
+    }
+
+    fn active_lane_count_for_channel(&self, channel_id: Uuid) -> usize {
+        let mut lanes = HashSet::new();
+        lanes.extend(
+            self.queues
+                .keys()
+                .filter(|lane| lane.channel_id == channel_id)
+                .cloned(),
+        );
+        lanes.extend(
+            self.in_flight_channels
+                .iter()
+                .filter(|lane| lane.channel_id == channel_id)
+                .cloned(),
+        );
+        lanes.extend(
+            self.cancelled_batches
+                .keys()
+                .filter(|lane| lane.channel_id == channel_id)
+                .cloned(),
+        );
+        lanes.extend(
+            self.withheld_native_steer
+                .keys()
+                .filter(|lane| lane.channel_id == channel_id)
+                .cloned(),
+        );
+        lanes.len()
+    }
+
+    fn pending_event_count(&self) -> usize {
+        self.queues.values().map(VecDeque::len).sum::<usize>()
+            + self.in_flight_batch_sizes.values().sum::<usize>()
+            + self.cancelled_batches.values().map(Vec::len).sum::<usize>()
+            + self
+                .withheld_native_steer
+                .values()
+                .map(Vec::len)
+                .sum::<usize>()
+    }
+
+    fn retained_event_count_for_lane(&self, lane: &LaneKey) -> usize {
+        self.queues.get(lane).map_or(0, VecDeque::len)
+            + self.in_flight_batch_sizes.get(lane).copied().unwrap_or(0)
+            + self.cancelled_batches.get(lane).map_or(0, Vec::len)
+            + self.withheld_native_steer.get(lane).map_or(0, Vec::len)
     }
 
     /// Try to flush the next batch.
@@ -257,84 +517,117 @@ impl EventQueue {
     /// Otherwise picks the channel with the oldest pending event (FIFO fairness
     /// across channels), drains ALL events for that channel into a single batch,
     /// inserts into `in_flight_channels`, and returns the batch.
+    #[cfg(test)]
     pub fn flush_next(&mut self) -> Option<FlushBatch> {
+        self.flush_next_matching(|_| true)
+    }
+
+    /// Flush the oldest lane that is currently eligible for a worker claim.
+    /// Busy authoritative lane owners are skipped so independent lanes can use
+    /// other idle workers instead of head-of-line blocking behind the owner.
+    pub fn flush_next_matching<F>(&mut self, eligible: F) -> Option<FlushBatch>
+    where
+        F: Fn(&LaneKey) -> bool,
+    {
         let now = Instant::now();
+        self.expire_claimable_in_flight_lanes(now, &eligible);
 
-        // Auto-expire any stuck in-flight entries that missed mark_complete.
-        let expired: Vec<Uuid> = self
-            .in_flight_deadlines
-            .iter()
-            .filter(|(_, deadline)| now >= **deadline)
-            .map(|(id, _)| *id)
-            .collect();
-        for id in expired {
-            let lost_events = self.in_flight_batch_sizes.remove(&id).unwrap_or(0);
-            tracing::error!(
-                channel_id = %id,
-                lost_events,
-                deadline_secs = self.in_flight_deadline.as_secs(),
-                "BUG: in-flight channel expired without mark_complete — \
-                 auto-releasing; {lost_events} dispatched event(s) orphaned"
-            );
-            self.in_flight_channels.remove(&id);
-            self.in_flight_deadlines.remove(&id);
-            // Recover any withheld goose-native steer events for the expired
-            // channel back to the queue front so normal dispatch delivers
-            // them. Unlike the in-flight batch above (already delivered to a
-            // now-hung prompt — nothing to recover), these events were never
-            // delivered to the agent.
-            self.recover_withheld_for_expired_channel(id);
-        }
-
-        // Find the channel whose head event has the oldest received_at,
-        // excluding in-flight channels and throttled channels.
-        let channel_id = self
-            .queues
-            .iter()
-            .filter(|(id, q)| {
-                !q.is_empty()
-                    && !self.in_flight_channels.contains(id)
-                    && self.retry_after.get(id).is_none_or(|&t| t <= now)
-            })
-            .min_by_key(|(_, q)| q.front().unwrap().received_at)
-            .map(|(id, _)| *id);
-
-        // Fallback: if no queued events are ready but a channel has cancelled
-        // events waiting (e.g., explicit !cancel with no new @mention), flush
-        // those as a regular batch (re-dispatch unchanged).
-        let channel_id = match channel_id {
-            Some(id) => id,
-            None => {
-                let cancelled_id = self
-                    .cancelled_batches
-                    .keys()
-                    .find(|id| !self.in_flight_channels.contains(id))
-                    .copied();
-                match cancelled_id {
-                    Some(id) => {
-                        // Move cancelled events into the regular events slot.
-                        // No new events to merge — re-dispatch the original batch.
-                        let cancelled = self.cancelled_batches.remove(&id).unwrap_or_default();
-                        let cancel_reason = self.cancel_reasons.remove(&id);
-                        self.in_flight_channels.insert(id);
-                        self.in_flight_deadlines
-                            .insert(id, now + self.in_flight_deadline);
-                        self.in_flight_batch_sizes.insert(id, cancelled.len());
-                        return Some(FlushBatch {
-                            channel_id: id,
-                            events: cancelled,
-                            cancelled_events: vec![],
-                            cancel_reason,
-                        });
-                    }
-                    None => return None,
-                }
-            }
+        let work_order = |(lane_a, time_a): &(LaneKey, Instant),
+                          (lane_b, time_b): &(LaneKey, Instant)| {
+            time_a
+                .cmp(time_b)
+                .then_with(|| lane_a.channel_id.cmp(&lane_b.channel_id))
+                .then_with(|| lane_a.root_event_id.cmp(&lane_b.root_event_id))
         };
 
-        // Drain up to MAX_BATCH_EVENTS; leave any remainder in the queue.
-        let queue = self.queues.entry(channel_id).or_default();
-        let drain_count = MAX_BATCH_EVENTS.min(queue.len());
+        let queued_lane = self
+            .queues
+            .iter()
+            .filter(|(lane, q)| {
+                !q.is_empty()
+                    && !self.in_flight_channels.contains(*lane)
+                    && self.retry_after.get(*lane).is_none_or(|&t| t <= now)
+                    && eligible(lane)
+            })
+            .map(|(lane, q)| {
+                let oldest = q
+                    .front()
+                    .map(|event| event.received_at)
+                    .into_iter()
+                    .chain(
+                        self.cancelled_batches
+                            .get(lane)
+                            .into_iter()
+                            .flatten()
+                            .map(|event| event.received_at),
+                    )
+                    .min()
+                    .expect("non-empty queue must have retained work");
+                (lane.clone(), oldest)
+            })
+            .min_by(&work_order);
+
+        // A cancelled batch has no retry throttle. Exclude lanes whose normal
+        // queue is already eligible because that path merges both halves into
+        // one prompt; otherwise cancelled-only work competes globally by age.
+        let cancelled_lane = self
+            .cancelled_batches
+            .iter()
+            .filter(|(lane, cancelled)| {
+                !cancelled.is_empty()
+                    && !self.in_flight_channels.contains(*lane)
+                    && eligible(lane)
+                    && !self.queues.get(*lane).is_some_and(|queue| {
+                        !queue.is_empty() && self.retry_after.get(*lane).is_none_or(|&t| t <= now)
+                    })
+            })
+            .map(|(lane, cancelled)| {
+                let oldest = cancelled
+                    .iter()
+                    .map(|event| event.received_at)
+                    .min()
+                    .expect("non-empty cancelled batch must have retained work");
+                (lane.clone(), oldest)
+            })
+            .min_by(&work_order);
+
+        let (lane, drain_queue) = match (queued_lane, cancelled_lane) {
+            (Some(queued), Some(cancelled)) => {
+                if work_order(&queued, &cancelled) != std::cmp::Ordering::Greater {
+                    (queued.0, true)
+                } else {
+                    (cancelled.0, false)
+                }
+            }
+            (Some(queued), None) => (queued.0, true),
+            (None, Some(cancelled)) => (cancelled.0, false),
+            (None, None) => return None,
+        };
+
+        if !drain_queue {
+            let cancelled = self.cancelled_batches.remove(&lane).unwrap_or_default();
+            let cancel_reason = self.cancel_reasons.remove(&lane);
+            self.in_flight_channels.insert(lane.clone());
+            self.in_flight_deadlines
+                .insert(lane.clone(), now + self.in_flight_deadline);
+            self.in_flight_batch_sizes
+                .insert(lane.clone(), cancelled.len());
+            return Some(FlushBatch {
+                channel_id: lane.channel_id,
+                lane,
+                events: cancelled,
+                cancelled_events: vec![],
+                cancel_reason,
+            });
+        }
+
+        let queue = self.queues.entry(lane.clone()).or_default();
+        let max_batch = if matches!(self.affinity_policy, AffinityPolicy::RootThread) {
+            1
+        } else {
+            MAX_BATCH_EVENTS
+        };
+        let drain_count = max_batch.min(queue.len());
         let mut events: Vec<BatchEvent> = queue
             .drain(..drain_count)
             .map(|qe| BatchEvent {
@@ -343,70 +636,100 @@ impl EventQueue {
                 received_at: qe.received_at,
             })
             .collect();
-        // Relay replay delivers stored events newest-first (`ORDER BY
-        // created_at DESC`), but batch consumers — `format_prompt` scope and
-        // reply-anchor selection — require the LAST event to be the newest.
-        // Stable sort: same-second events keep delivery order.
         events.sort_by_key(|be| be.event.created_at);
 
-        // Remove the queue entry if now empty.
-        if self.queues.get(&channel_id).is_some_and(|q| q.is_empty()) {
-            self.queues.remove(&channel_id);
+        if self.queues.get(&lane).is_some_and(VecDeque::is_empty) {
+            self.queues.remove(&lane);
         }
 
-        self.in_flight_channels.insert(channel_id);
-        self.in_flight_deadlines
-            .insert(channel_id, now + self.in_flight_deadline);
-        self.in_flight_batch_sizes.insert(channel_id, events.len());
+        let cancelled_events = self.cancelled_batches.remove(&lane).unwrap_or_default();
+        let cancel_reason = self.cancel_reasons.remove(&lane);
+        let in_flight_event_count = events.len() + cancelled_events.len();
 
-        // Merge any cancelled events stored by requeue_as_cancelled().
-        let cancelled_events = self
-            .cancelled_batches
-            .remove(&channel_id)
-            .unwrap_or_default();
-        let cancel_reason = if cancelled_events.is_empty() {
-            self.cancel_reasons.remove(&channel_id);
-            None
-        } else {
-            self.cancel_reasons.remove(&channel_id)
-        };
+        self.in_flight_channels.insert(lane.clone());
+        self.in_flight_deadlines
+            .insert(lane.clone(), now + self.in_flight_deadline);
+        self.in_flight_batch_sizes
+            .insert(lane.clone(), in_flight_event_count);
 
         Some(FlushBatch {
-            channel_id,
+            channel_id: lane.channel_id,
+            lane,
             events,
             cancelled_events,
             cancel_reason,
         })
     }
 
-    /// Mark the prompt for `channel_id` as complete.
-    ///
-    /// Removes the channel from `in_flight_channels` and `in_flight_deadlines`.
-    ///
-    /// If the channel was NOT requeued (no active `retry_after` throttle), the
-    /// retry counter is reset — the channel is healthy and the next failure
-    /// starts fresh. If the channel WAS requeued, `retry_counts` is left intact
-    /// so the backoff sequence continues on the next attempt.
-    ///
-    /// Also cleans up any already-expired `retry_after` entry.
+    /// Mark a legacy channel-sentinel prompt complete.
     pub fn mark_complete(&mut self, channel_id: Uuid) {
-        self.in_flight_channels.remove(&channel_id);
-        self.in_flight_deadlines.remove(&channel_id);
-        self.in_flight_batch_sizes.remove(&channel_id);
+        self.mark_lane_complete(&LaneKey::channel(channel_id));
+    }
+
+    /// Mark the exact prompt lane complete without touching sibling roots.
+    pub fn mark_lane_complete(&mut self, lane: &LaneKey) {
+        self.in_flight_channels.remove(lane);
+        self.in_flight_deadlines.remove(lane);
+        self.in_flight_batch_sizes.remove(lane);
+        self.in_flight_turn_ids.remove(lane);
         let now = Instant::now();
-        match self.retry_after.get(&channel_id) {
-            // Active throttle → channel was requeued; keep retry_counts intact.
+        match self.retry_after.get(lane) {
             Some(&deadline) if deadline > now => {}
-            // Expired or absent throttle → successful completion; reset counter
-            // and clean up the stale retry_after entry.
             Some(_) => {
-                self.retry_after.remove(&channel_id);
-                self.retry_counts.remove(&channel_id);
+                self.retry_after.remove(lane);
+                self.retry_counts.remove(lane);
             }
             None => {
-                self.retry_counts.remove(&channel_id);
+                self.retry_counts.remove(lane);
             }
         }
+    }
+
+    /// Bind an in-flight lane to the spawned task's immutable turn id.
+    pub fn bind_lane_turn(&mut self, lane: &LaneKey, turn_id: &str) -> bool {
+        if !self.in_flight_channels.contains(lane) {
+            return false;
+        }
+        match self.in_flight_turn_ids.get(lane) {
+            Some(current) => current == turn_id,
+            None => {
+                self.in_flight_turn_ids
+                    .insert(lane.clone(), turn_id.to_string());
+                true
+            }
+        }
+    }
+
+    /// Whether `turn_id` still owns the current in-flight lane generation.
+    pub fn lane_turn_matches(&self, lane: &LaneKey, turn_id: &str) -> bool {
+        self.in_flight_turn_ids.get(lane).map(String::as_str) == Some(turn_id)
+    }
+
+    /// Return the bound turn id for the current exact-lane generation.
+    pub fn lane_turn_id(&self, lane: &LaneKey) -> Option<&str> {
+        self.in_flight_turn_ids.get(lane).map(String::as_str)
+    }
+
+    /// Whether a different bound turn currently owns this exact lane.
+    pub fn lane_turn_conflicts(&self, lane: &LaneKey, turn_id: &str) -> bool {
+        self.in_flight_turn_ids
+            .get(lane)
+            .is_some_and(|current| current != turn_id)
+    }
+
+    /// Complete a lane only if `turn_id` still owns its current generation.
+    pub fn mark_lane_complete_for_turn(&mut self, lane: &LaneKey, turn_id: &str) -> bool {
+        if !self.lane_turn_matches(lane, turn_id) {
+            tracing::warn!(
+                channel_id = %lane.channel_id,
+                lane_root = %lane.root_event_id,
+                turn_id,
+                "ignoring stale lane completion"
+            );
+            return false;
+        }
+        self.mark_lane_complete(lane);
+        true
     }
 
     /// Re-queue a batch of events that failed to process.
@@ -428,8 +751,9 @@ impl EventQueue {
     /// `mark_complete` separately.
     pub fn requeue(&mut self, batch: FlushBatch) -> Option<FlushBatch> {
         let channel_id = batch.channel_id;
+        let lane = batch.lane.clone();
         let attempt = {
-            let count = self.retry_counts.entry(channel_id).or_insert(0);
+            let count = self.retry_counts.entry(lane.clone()).or_insert(0);
             *count += 1;
             *count
         };
@@ -443,10 +767,10 @@ impl EventQueue {
                 MAX_RETRIES,
                 batch.events.len(),
             );
-            self.retry_counts.remove(&channel_id);
-            // Also clear retry_after so fresh traffic on this channel isn't
+            self.retry_counts.remove(&lane);
+            // Also clear retry_after so fresh traffic on this lane isn't
             // throttled by stale backoff from the discarded poison batch.
-            self.retry_after.remove(&channel_id);
+            self.retry_after.remove(&lane);
             return Some(batch);
         }
 
@@ -465,6 +789,7 @@ impl EventQueue {
 
         tracing::warn!(
             channel_id = %channel_id,
+            lane_root = %lane.root_event_id,
             attempt,
             max = MAX_RETRIES,
             delay_secs = delay.as_secs_f64(),
@@ -472,7 +797,7 @@ impl EventQueue {
             "requeueing failed batch with backoff"
         );
 
-        let queue = self.queues.entry(channel_id).or_default();
+        let queue = self.queues.entry(lane.clone()).or_default();
         // Push to front in reverse order so original order is preserved.
         for be in batch.events.into_iter().rev() {
             queue.push_front(QueuedEvent {
@@ -493,7 +818,26 @@ impl EventQueue {
                 "requeue overflow — dropped oldest event to enforce cap"
             );
         }
-        self.retry_after.insert(channel_id, Instant::now() + delay);
+
+        if !batch.cancelled_events.is_empty() {
+            let entry = self.cancelled_batches.entry(lane.clone()).or_default();
+            entry.splice(0..0, batch.cancelled_events);
+            if entry.len() > MAX_PENDING_PER_CHANNEL {
+                let overflow = entry.len() - MAX_PENDING_PER_CHANNEL;
+                entry.drain(..overflow);
+                tracing::warn!(
+                    channel_id = %channel_id,
+                    lane_root = %lane.root_event_id,
+                    dropped = overflow,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "requeued cancelled state overflow — dropped oldest event(s)"
+                );
+            }
+            if let Some(reason) = batch.cancel_reason {
+                self.cancel_reasons.entry(lane.clone()).or_insert(reason);
+            }
+        }
+        self.retry_after.insert(lane, Instant::now() + delay);
         None
     }
 
@@ -507,7 +851,8 @@ impl EventQueue {
     /// caller must call `mark_complete` separately.
     pub fn requeue_preserve_timestamps(&mut self, batch: FlushBatch) {
         let channel_id = batch.channel_id;
-        let queue = self.queues.entry(channel_id).or_default();
+        let lane = batch.lane.clone();
+        let queue = self.queues.entry(lane.clone()).or_default();
         // Push to front in reverse order so original order is preserved.
         for be in batch.events.into_iter().rev() {
             queue.push_front(QueuedEvent {
@@ -526,6 +871,25 @@ impl EventQueue {
                 "requeue_preserve overflow — dropped newest event to enforce cap"
             );
         }
+
+        if !batch.cancelled_events.is_empty() {
+            let entry = self.cancelled_batches.entry(lane.clone()).or_default();
+            entry.splice(0..0, batch.cancelled_events);
+            if entry.len() > MAX_PENDING_PER_CHANNEL {
+                let overflow = entry.len() - MAX_PENDING_PER_CHANNEL;
+                entry.drain(..overflow);
+                tracing::warn!(
+                    channel_id = %channel_id,
+                    lane_root = %lane.root_event_id,
+                    dropped = overflow,
+                    limit = MAX_PENDING_PER_CHANNEL,
+                    "requeued cancelled state overflow — dropped oldest event(s)"
+                );
+            }
+            if let Some(reason) = batch.cancel_reason {
+                self.cancel_reasons.entry(lane).or_insert(reason);
+            }
+        }
     }
 
     /// Requeue a cancelled batch so its events appear as `cancelled_events`
@@ -540,11 +904,23 @@ impl EventQueue {
     /// the generic queue — they are stored separately and merged by
     /// `flush_next()`. No retry throttle, no backoff.
     pub fn requeue_as_cancelled(&mut self, batch: FlushBatch, reason: CancelReason) {
-        let entry = self.cancelled_batches.entry(batch.channel_id).or_default();
+        let lane = batch.lane.clone();
+        let entry = self.cancelled_batches.entry(lane.clone()).or_default();
         // Preserve any already-cancelled events from a prior cancel (double-cancel).
         entry.extend(batch.cancelled_events);
         entry.extend(batch.events);
-        self.cancel_reasons.insert(batch.channel_id, reason);
+        if entry.len() > MAX_PENDING_PER_CHANNEL {
+            let overflow = entry.len() - MAX_PENDING_PER_CHANNEL;
+            entry.drain(..overflow);
+            tracing::warn!(
+                channel_id = %lane.channel_id,
+                lane_root = %lane.root_event_id,
+                dropped = overflow,
+                limit = MAX_PENDING_PER_CHANNEL,
+                "cancelled merge state overflow — dropped oldest event(s)"
+            );
+        }
+        self.cancel_reasons.insert(lane, reason);
     }
 
     /// Returns `true` if any channel has pending events that are not in-flight
@@ -554,40 +930,54 @@ impl EventQueue {
     /// This is a `&mut self` method so expiry can happen without requiring a
     /// full `flush_next` call.
     pub fn has_flushable_work(&mut self) -> bool {
-        let now = Instant::now();
+        self.has_flushable_work_matching(|_| true)
+    }
 
-        // Auto-expire stuck in-flight entries (same logic as flush_next).
-        let expired: Vec<Uuid> = self
-            .in_flight_deadlines
-            .iter()
-            .filter(|(_, deadline)| now >= **deadline)
-            .map(|(id, _)| *id)
-            .collect();
-        for id in expired {
-            let lost_events = self.in_flight_batch_sizes.remove(&id).unwrap_or(0);
-            tracing::error!(
-                channel_id = %id,
-                lost_events,
-                deadline_secs = self.in_flight_deadline.as_secs(),
-                "BUG: in-flight channel expired without mark_complete — \
-                 auto-releasing; {lost_events} dispatched event(s) orphaned"
-            );
-            self.in_flight_channels.remove(&id);
-            self.in_flight_deadlines.remove(&id);
-            // Symmetric with the flush_next expiry block: recover withheld
-            // goose-native steer events for the expired channel so they are
-            // not permanently orphaned in the side table.
-            self.recover_withheld_for_expired_channel(id);
-        }
+    /// Owner-aware form of [`has_flushable_work`](Self::has_flushable_work).
+    /// Expired lanes remain fenced while their authoritative worker is still
+    /// checked out; only lanes that can actually claim a worker are recovered.
+    pub fn has_flushable_work_matching<F>(&mut self, eligible: F) -> bool
+    where
+        F: Fn(&LaneKey) -> bool,
+    {
+        let now = Instant::now();
+        self.expire_claimable_in_flight_lanes(now, &eligible);
 
         self.queues.iter().any(|(id, q)| {
             !q.is_empty()
                 && !self.in_flight_channels.contains(id)
                 && self.retry_after.get(id).is_none_or(|&t| t <= now)
+                && eligible(id)
         }) || self
             .cancelled_batches
             .keys()
-            .any(|id| !self.in_flight_channels.contains(id))
+            .any(|id| !self.in_flight_channels.contains(id) && eligible(id))
+    }
+
+    fn expire_claimable_in_flight_lanes<F>(&mut self, now: Instant, eligible: &F)
+    where
+        F: Fn(&LaneKey) -> bool,
+    {
+        let expired: Vec<LaneKey> = self
+            .in_flight_deadlines
+            .iter()
+            .filter(|(lane, deadline)| now >= **deadline && eligible(lane))
+            .map(|(lane, _)| lane.clone())
+            .collect();
+        for lane in expired {
+            let lost_events = self.in_flight_batch_sizes.remove(&lane).unwrap_or(0);
+            tracing::error!(
+                channel_id = %lane.channel_id,
+                lane_root = %lane.root_event_id,
+                lost_events,
+                deadline_secs = self.in_flight_deadline.as_secs(),
+                "BUG: in-flight lane expired without mark_complete — auto-releasing"
+            );
+            self.in_flight_channels.remove(&lane);
+            self.in_flight_deadlines.remove(&lane);
+            self.in_flight_turn_ids.remove(&lane);
+            self.recover_withheld_for_expired_lane(&lane);
+        }
     }
 
     /// Number of channels with pending events.
@@ -595,20 +985,33 @@ impl EventQueue {
         self.queues.len()
     }
 
-    /// Number of queued events for a specific channel. Test-only.
+    /// Number of queued events for a legacy channel lane. Test-only.
     #[cfg(test)]
     pub fn queued_event_count(&self, channel_id: &Uuid) -> usize {
-        self.queues.get(channel_id).map_or(0, |q| q.len())
+        self.queues
+            .get(&LaneKey::channel(*channel_id))
+            .map_or(0, VecDeque::len)
     }
 
-    /// Force a channel's retry-attempt counter to `count`, simulating `count`
-    /// prior failed attempts without needing to drive fake flush/requeue
-    /// cycles through the queue (which would leave artifact events behind).
-    /// Test-only — lets integration tests outside this module exercise
-    /// `requeue()`'s dead-letter threshold directly.
+    /// Number of distinct lane keys retained in any queue state map.
+    #[cfg(test)]
+    pub fn lane_state_count(&self) -> usize {
+        let mut lanes = HashSet::new();
+        lanes.extend(self.queues.keys().cloned());
+        lanes.extend(self.in_flight_channels.iter().cloned());
+        lanes.extend(self.in_flight_deadlines.keys().cloned());
+        lanes.extend(self.retry_after.keys().cloned());
+        lanes.extend(self.retry_counts.keys().cloned());
+        lanes.extend(self.cancelled_batches.keys().cloned());
+        lanes.extend(self.withheld_native_steer.keys().cloned());
+        lanes.len()
+    }
+
+    /// Force a legacy channel lane's retry-attempt counter in tests.
     #[cfg(test)]
     pub fn set_retry_count_for_test(&mut self, channel_id: Uuid, count: u32) {
-        self.retry_counts.insert(channel_id, count);
+        self.retry_counts
+            .insert(LaneKey::channel(channel_id), count);
     }
 
     /// Drop all queued (non-in-flight) events for a channel.
@@ -623,27 +1026,70 @@ impl EventQueue {
     /// Returns the event IDs of dropped events so the caller can clean up
     /// any reactions (👀) that were added at queue-push time.
     pub fn drain_channel(&mut self, channel_id: Uuid) -> Vec<String> {
-        let ids = self
+        let mut ids = Vec::new();
+        let queue_lanes: Vec<LaneKey> = self
             .queues
-            .remove(&channel_id)
-            .map(|q| q.into_iter().map(|e| e.event.id.to_hex()).collect())
-            .unwrap_or_default();
-        self.retry_after.remove(&channel_id);
-        self.retry_counts.remove(&channel_id);
-        self.cancelled_batches.remove(&channel_id);
-        self.cancel_reasons.remove(&channel_id);
-        self.withheld_native_steer.remove(&channel_id);
-        // Preserve in_flight_channels AND in_flight_deadlines: the in-flight
-        // task will eventually complete (calling mark_complete) or the deadline
-        // will expire (auto-cleaning the channel). Removing deadlines without
-        // removing in_flight_channels would disable auto-expiry and leave a
-        // wedged task permanently blocking the channel.
+            .keys()
+            .filter(|lane| lane.channel_id == channel_id)
+            .cloned()
+            .collect();
+        for lane in queue_lanes {
+            if let Some(events) = self.queues.remove(&lane) {
+                ids.extend(events.into_iter().map(|event| event.event.id.to_hex()));
+            }
+        }
+        let cancelled_lanes: Vec<LaneKey> = self
+            .cancelled_batches
+            .keys()
+            .filter(|lane| lane.channel_id == channel_id)
+            .cloned()
+            .collect();
+        for lane in cancelled_lanes {
+            if let Some(events) = self.cancelled_batches.remove(&lane) {
+                ids.extend(events.into_iter().map(|event| event.event.id.to_hex()));
+            }
+        }
+        let withheld_lanes: Vec<LaneKey> = self
+            .withheld_native_steer
+            .keys()
+            .filter(|lane| lane.channel_id == channel_id)
+            .cloned()
+            .collect();
+        for lane in withheld_lanes {
+            if let Some(events) = self.withheld_native_steer.remove(&lane) {
+                ids.extend(events.into_iter().map(|event| event.event.id.to_hex()));
+            }
+        }
+        self.retry_after
+            .retain(|lane, _| lane.channel_id != channel_id);
+        self.retry_counts
+            .retain(|lane, _| lane.channel_id != channel_id);
+        self.cancel_reasons
+            .retain(|lane, _| lane.channel_id != channel_id);
         ids
     }
 
-    /// Whether a prompt is currently in-flight for the given channel.
-    pub fn is_channel_in_flight(&self, channel_id: Uuid) -> bool {
-        self.in_flight_channels.contains(&channel_id)
+    /// Permanently remove all queue ownership for a channel.
+    ///
+    /// Unlike [`Self::drain_channel`], this also invalidates active exact-lane
+    /// generations and deadlines. Use it only for channel removal, where every
+    /// associated task is being cancelled and its late result must be stale.
+    pub fn purge_channel(&mut self, channel_id: Uuid) -> Vec<String> {
+        let ids = self.drain_channel(channel_id);
+        self.in_flight_channels
+            .retain(|lane| lane.channel_id != channel_id);
+        self.in_flight_deadlines
+            .retain(|lane, _| lane.channel_id != channel_id);
+        self.in_flight_batch_sizes
+            .retain(|lane, _| lane.channel_id != channel_id);
+        self.in_flight_turn_ids
+            .retain(|lane, _| lane.channel_id != channel_id);
+        ids
+    }
+
+    /// Whether the exact resolved lane is currently in flight.
+    pub fn is_lane_in_flight(&self, lane: &LaneKey) -> bool {
+        self.in_flight_channels.contains(lane)
     }
 
     /// Whether any channel currently has a turn in flight.
@@ -675,21 +1121,27 @@ impl EventQueue {
     /// after `pool.send_steer` returns `Ok(())` and before any watcher task
     /// is spawned, so the withhold is established before `mark_complete` /
     /// any subsequent `flush_next` tick can run.
+    #[cfg(test)]
     pub fn mark_native_steer_pending(&mut self, channel_id: Uuid, event_id: &str) -> bool {
-        let Some(q) = self.queues.get_mut(&channel_id) else {
+        self.mark_lane_native_steer_pending(&LaneKey::channel(channel_id), event_id)
+    }
+
+    /// Withhold an event from one exact lane while native steer is unresolved.
+    pub fn mark_lane_native_steer_pending(&mut self, lane: &LaneKey, event_id: &str) -> bool {
+        let Some(q) = self.queues.get_mut(lane) else {
             return false;
         };
         let Some(pos) = q.iter().position(|qe| qe.event.id.to_hex() == event_id) else {
             return false;
         };
-        let qe = q
-            .remove(pos)
-            .expect("position came from iter so remove must succeed");
+        let Some(qe) = q.remove(pos) else {
+            return false;
+        };
         if q.is_empty() {
-            self.queues.remove(&channel_id);
+            self.queues.remove(lane);
         }
         self.withheld_native_steer
-            .entry(channel_id)
+            .entry(lane.clone())
             .or_default()
             .push(qe);
         true
@@ -705,8 +1157,14 @@ impl EventQueue {
     ///
     /// Push-to-front matches the discipline of `requeue_preserve_timestamps`
     /// at line 453, preserving fairness across channels.
+    #[cfg(test)]
     pub fn release_native_steer(&mut self, channel_id: Uuid, event_id: &str) {
-        let Some(entries) = self.withheld_native_steer.get_mut(&channel_id) else {
+        self.release_lane_native_steer(&LaneKey::channel(channel_id), event_id);
+    }
+
+    /// Release one withheld event into its exact lane.
+    pub fn release_lane_native_steer(&mut self, lane: &LaneKey, event_id: &str) {
+        let Some(entries) = self.withheld_native_steer.get_mut(lane) else {
             return;
         };
         let Some(pos) = entries
@@ -717,17 +1175,15 @@ impl EventQueue {
         };
         let qe = entries.remove(pos);
         if entries.is_empty() {
-            self.withheld_native_steer.remove(&channel_id);
+            self.withheld_native_steer.remove(lane);
         }
-        // Push to FRONT so original `received_at` keeps the event at the head
-        // of the channel's queue. Per-channel cap is enforced below in case
-        // a flood of events arrived during the ack window.
-        let queue = self.queues.entry(channel_id).or_default();
+        let queue = self.queues.entry(lane.clone()).or_default();
         queue.push_front(qe);
         while queue.len() > MAX_PENDING_PER_CHANNEL {
             queue.pop_back();
             tracing::warn!(
-                channel_id = %channel_id,
+                channel_id = %lane.channel_id,
+                lane_root = %lane.root_event_id,
                 limit = MAX_PENDING_PER_CHANNEL,
                 "release_native_steer overflow — dropped newest event to enforce cap"
             );
@@ -740,17 +1196,18 @@ impl EventQueue {
     /// Called on `SteerAck::Success` — the agent received the steer, so the
     /// event has been "delivered" via the non-cancelling path and must not
     /// be redelivered via normal dispatch. Idempotent across both stores.
-    pub fn remove_event(&mut self, channel_id: Uuid, event_id: &str) {
-        if let Some(entries) = self.withheld_native_steer.get_mut(&channel_id) {
+    /// Remove an event only from the exact lane named by its steer attempt.
+    pub fn remove_lane_event(&mut self, lane: &LaneKey, event_id: &str) {
+        if let Some(entries) = self.withheld_native_steer.get_mut(lane) {
             entries.retain(|qe| qe.event.id.to_hex() != event_id);
             if entries.is_empty() {
-                self.withheld_native_steer.remove(&channel_id);
+                self.withheld_native_steer.remove(lane);
             }
         }
-        if let Some(q) = self.queues.get_mut(&channel_id) {
+        if let Some(q) = self.queues.get_mut(lane) {
             q.retain(|qe| qe.event.id.to_hex() != event_id);
             if q.is_empty() {
-                self.queues.remove(&channel_id);
+                self.queues.remove(lane);
             }
         }
     }
@@ -768,28 +1225,29 @@ impl EventQueue {
     /// Iterates the stored entries in reverse so per-entry `push_front`
     /// composes to original-FIFO order at the queue front (same discipline
     /// as `requeue_preserve_timestamps` at line 453).
-    fn recover_withheld_for_expired_channel(&mut self, channel_id: Uuid) {
-        let Some(entries) = self.withheld_native_steer.remove(&channel_id) else {
+    fn recover_withheld_for_expired_lane(&mut self, lane: &LaneKey) {
+        let Some(entries) = self.withheld_native_steer.remove(lane) else {
             return;
         };
         let n = entries.len();
-        let queue = self.queues.entry(channel_id).or_default();
+        let queue = self.queues.entry(lane.clone()).or_default();
         for qe in entries.into_iter().rev() {
             queue.push_front(qe);
         }
         while queue.len() > MAX_PENDING_PER_CHANNEL {
             queue.pop_back();
             tracing::warn!(
-                channel_id = %channel_id,
+                channel_id = %lane.channel_id,
+                lane_root = %lane.root_event_id,
                 limit = MAX_PENDING_PER_CHANNEL,
                 "withheld-steer recovery overflow — dropped newest event to enforce cap"
             );
         }
         tracing::warn!(
-            channel_id = %channel_id,
+            channel_id = %lane.channel_id,
+            lane_root = %lane.root_event_id,
             recovered = n,
-            "in-flight expiry recovered withheld steer event(s) — \
-             steer ack never arrived; normal dispatch will deliver"
+            "in-flight expiry recovered withheld steer event(s)"
         );
     }
 
@@ -848,24 +1306,25 @@ pub struct ThreadTags {
 /// - If only `reply` marker found (direct reply to root), root == parent
 /// - `p` tags → mentioned pubkeys
 ///
-/// NOTE: Only handles NIP-10 marker-based format (preferred). The deprecated
-/// positional format (no markers, `["e", id, relay_url]`) is not supported —
-/// Buzz always generates marker-based tags (see relay messages.rs:762-783).
+/// Preferred marked tags are authoritative. When no `root`/`reply` marker is
+/// present, deprecated positional tags remain supported for older network
+/// events: the first unmarked `e` is root and the last is direct parent.
 pub fn parse_thread_tags(event: &Event) -> ThreadTags {
     let mut root = None;
     let mut reply = None;
+    let mut positional = Vec::new();
     let mut mentions = Vec::new();
 
     for tag in event.tags.iter() {
         let parts = tag.as_slice();
         match parts.first().map(|s| s.as_str()) {
-            Some("e") if parts.len() >= 4 => {
-                let id = &parts[1];
-                let marker = &parts[3];
-                match marker.as_str() {
-                    "root" => root = Some(id.clone()),
-                    "reply" => reply = Some(id.clone()),
-                    _ => {}
+            Some("e") if parts.len() >= 2 => {
+                let id = parts[1].clone();
+                match parts.get(3).map(String::as_str) {
+                    Some("root") => root = Some(id),
+                    Some("reply") => reply = Some(id),
+                    None | Some("") => positional.push(id),
+                    Some(_) => {}
                 }
             }
             Some("p") if parts.len() >= 2 => {
@@ -881,7 +1340,10 @@ pub fn parse_thread_tags(event: &Event) -> ThreadTags {
         (Some(r), Some(p)) => (Some(r), Some(p)),
         (Some(r), None) => (Some(r.clone()), Some(r)),
         (None, Some(p)) => (Some(p.clone()), Some(p)),
-        (None, None) => (None, None),
+        (None, None) => match (positional.first(), positional.last()) {
+            (Some(r), Some(p)) => (Some(r.clone()), Some(p.clone())),
+            _ => (None, None),
+        },
     };
 
     ThreadTags {
@@ -1645,6 +2107,467 @@ mod tests {
             .unwrap()
     }
 
+    #[test]
+    fn root_thread_lane_is_canonical_and_legacy_and_dm_stay_channel_scoped() {
+        let channel_id = Uuid::new_v4();
+        let top = make_event("top level");
+        let top_id = top.id.to_hex();
+
+        assert_eq!(
+            LaneKey::resolve(channel_id, &top, AffinityPolicy::RootThread, false).unwrap(),
+            LaneKey::new(channel_id, top_id)
+        );
+        assert_eq!(
+            LaneKey::resolve(channel_id, &top, AffinityPolicy::Channel, false).unwrap(),
+            LaneKey::channel(channel_id)
+        );
+        assert_eq!(
+            LaneKey::resolve(channel_id, &top, AffinityPolicy::RootThread, true).unwrap(),
+            LaneKey::channel(channel_id)
+        );
+    }
+
+    #[test]
+    fn root_thread_lane_rejects_malformed_and_conflicting_required_markers() {
+        let channel_id = Uuid::new_v4();
+        let root_a = "a".repeat(64);
+        let root_b = "b".repeat(64);
+        let conflicting = make_event_with_tags(
+            "reply",
+            vec![
+                vec!["e".into(), root_a, "".into(), "root".into()],
+                vec!["e".into(), root_b, "".into(), "root".into()],
+            ],
+        );
+        let malformed = make_event_with_tags(
+            "reply",
+            vec![vec![
+                "e".into(),
+                "not-an-event-id".into(),
+                "".into(),
+                "root".into(),
+            ]],
+        );
+
+        assert!(
+            LaneKey::resolve(channel_id, &conflicting, AffinityPolicy::RootThread, false).is_err()
+        );
+        assert!(
+            LaneKey::resolve(channel_id, &malformed, AffinityPolicy::RootThread, false).is_err()
+        );
+    }
+
+    #[test]
+    fn root_thread_lane_accepts_direct_reply_marker_as_canonical_root() {
+        let channel_id = Uuid::new_v4();
+        let root_id = "b".repeat(64);
+        let direct_reply = make_event_with_tags(
+            "direct reply",
+            vec![vec!["e".into(), root_id.clone(), "".into(), "reply".into()]],
+        );
+
+        assert_eq!(
+            LaneKey::resolve(channel_id, &direct_reply, AffinityPolicy::RootThread, false),
+            Ok(LaneKey::new(channel_id, root_id))
+        );
+    }
+
+    #[test]
+    fn positional_direct_reply_keeps_lane_and_context_parser_aligned() {
+        let channel_id = Uuid::new_v4();
+        let root_id = "c".repeat(64);
+        let legacy_reply = make_event_with_tags(
+            "legacy direct reply",
+            vec![vec!["e".into(), root_id.clone(), "".into()]],
+        );
+
+        assert_eq!(
+            LaneKey::resolve(channel_id, &legacy_reply, AffinityPolicy::RootThread, false),
+            Ok(LaneKey::new(channel_id, root_id.clone()))
+        );
+        let tags = parse_thread_tags(&legacy_reply);
+        assert_eq!(tags.root_event_id.as_deref(), Some(root_id.as_str()));
+        assert_eq!(tags.parent_event_id.as_deref(), Some(root_id.as_str()));
+    }
+
+    #[test]
+    fn positional_nested_reply_uses_first_as_root_and_last_as_parent() {
+        let channel_id = Uuid::new_v4();
+        let root_id = "d".repeat(64);
+        let cited_id = "e".repeat(64);
+        let parent_id = "f".repeat(64);
+        let legacy_reply = make_event_with_tags(
+            "legacy nested reply",
+            vec![
+                vec!["e".into(), root_id.clone(), "".into()],
+                vec!["e".into(), cited_id, "".into()],
+                vec!["e".into(), parent_id.clone(), "".into()],
+            ],
+        );
+
+        assert_eq!(
+            LaneKey::resolve(channel_id, &legacy_reply, AffinityPolicy::RootThread, false),
+            Ok(LaneKey::new(channel_id, root_id.clone()))
+        );
+        let tags = parse_thread_tags(&legacy_reply);
+        assert_eq!(tags.root_event_id.as_deref(), Some(root_id.as_str()));
+        assert_eq!(tags.parent_event_id.as_deref(), Some(parent_id.as_str()));
+    }
+
+    #[test]
+    fn root_lanes_in_one_channel_flush_concurrently_one_event_at_a_time() {
+        let channel_id = Uuid::new_v4();
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+        let event_a = make_event("root a");
+        let event_b = make_event("root b");
+        let lane_a = LaneKey::new(channel_id, event_a.id.to_hex());
+        let lane_b = LaneKey::new(channel_id, event_b.id.to_hex());
+
+        assert_eq!(
+            queue.push_resolved(
+                QueuedEvent {
+                    channel_id,
+                    event: event_a,
+                    received_at: Instant::now(),
+                    prompt_tag: "test".into(),
+                },
+                lane_a.clone(),
+            ),
+            PushResult::Accepted
+        );
+        assert_eq!(
+            queue.push_resolved(
+                QueuedEvent {
+                    channel_id,
+                    event: event_b,
+                    received_at: Instant::now(),
+                    prompt_tag: "test".into(),
+                },
+                lane_b.clone(),
+            ),
+            PushResult::Accepted
+        );
+
+        let first = queue.flush_next().unwrap();
+        let second = queue.flush_next().unwrap();
+        assert_eq!(first.events.len(), 1);
+        assert_eq!(second.events.len(), 1);
+        assert_ne!(first.lane, second.lane);
+        assert!(queue.is_lane_in_flight(&lane_a));
+        assert!(queue.is_lane_in_flight(&lane_b));
+
+        queue.mark_lane_complete(&lane_a);
+        assert!(!queue.is_lane_in_flight(&lane_a));
+        assert!(queue.is_lane_in_flight(&lane_b));
+    }
+
+    #[test]
+    fn busy_owned_lane_does_not_block_newer_eligible_lane() {
+        let channel_id = Uuid::new_v4();
+        let blocked_lane = LaneKey::new(channel_id, "a".repeat(64));
+        let eligible_lane = LaneKey::new(channel_id, "b".repeat(64));
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+        let mut blocked = make_queued(channel_id, "older blocked work");
+        blocked.received_at = Instant::now() - Duration::from_secs(1);
+
+        assert_eq!(
+            queue.push_resolved(blocked, blocked_lane.clone()),
+            PushResult::Accepted
+        );
+        assert_eq!(
+            queue.push_resolved(
+                make_queued(channel_id, "newer eligible work"),
+                eligible_lane.clone(),
+            ),
+            PushResult::Accepted
+        );
+
+        let batch = queue
+            .flush_next_matching(|lane| lane != &blocked_lane)
+            .expect("eligible lane must dispatch");
+        assert_eq!(batch.lane, eligible_lane);
+        assert!(!queue.is_lane_in_flight(&blocked_lane));
+        assert_eq!(
+            queue.queues.get(&blocked_lane).map(VecDeque::len),
+            Some(1),
+            "blocked work remains queued losslessly"
+        );
+    }
+
+    #[test]
+    fn late_completion_generation_cannot_clear_replacement_lane() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::new(channel_id, "a".repeat(64));
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+
+        assert_eq!(
+            queue.push_resolved(make_queued(channel_id, "old turn"), lane.clone()),
+            PushResult::Accepted
+        );
+        let old = queue.flush_next().expect("old turn flush");
+        assert_eq!(old.lane, lane);
+        assert!(!queue.mark_lane_complete_for_turn(&lane, "unbound-turn"));
+        assert!(queue.is_lane_in_flight(&lane));
+        assert!(queue.bind_lane_turn(&lane, "old-turn"));
+
+        // Model the backstop expiring the old ownership before its task result arrives.
+        queue.mark_lane_complete(&lane);
+        assert_eq!(
+            queue.push_resolved(make_queued(channel_id, "replacement"), lane.clone()),
+            PushResult::Accepted
+        );
+        let replacement = queue.flush_next().expect("replacement flush");
+        assert_eq!(replacement.lane, lane);
+        assert!(queue.bind_lane_turn(&lane, "new-turn"));
+
+        assert!(!queue.mark_lane_complete_for_turn(&lane, "old-turn"));
+        assert!(queue.is_lane_in_flight(&lane));
+        assert!(queue.mark_lane_complete_for_turn(&lane, "new-turn"));
+        assert!(!queue.is_lane_in_flight(&lane));
+    }
+
+    #[test]
+    fn purge_channel_clears_all_exact_lane_generation_ownership() {
+        let removed_channel = Uuid::new_v4();
+        let retained_channel = Uuid::new_v4();
+        let lane_a = LaneKey::new(removed_channel, "a".repeat(64));
+        let lane_b = LaneKey::new(removed_channel, "b".repeat(64));
+        let retained_lane = LaneKey::new(retained_channel, "c".repeat(64));
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+
+        for (lane, content) in [(&lane_a, "a"), (&lane_b, "b")] {
+            assert_eq!(
+                queue.push_resolved(make_queued(removed_channel, content), lane.clone()),
+                PushResult::Accepted
+            );
+        }
+        assert_eq!(
+            queue.push_resolved(
+                make_queued(retained_channel, "retained"),
+                retained_lane.clone(),
+            ),
+            PushResult::Accepted
+        );
+
+        for turn_id in ["turn-a", "turn-b", "turn-c"] {
+            let batch = queue.flush_next().expect("lane flush");
+            assert!(queue.bind_lane_turn(&batch.lane, turn_id));
+        }
+        let retained_turn = queue.lane_turn_id(&retained_lane).map(str::to_owned);
+
+        queue.purge_channel(removed_channel);
+
+        for lane in [&lane_a, &lane_b] {
+            assert!(!queue.is_lane_in_flight(lane));
+            assert_eq!(queue.lane_turn_id(lane), None);
+        }
+        assert!(queue.is_lane_in_flight(&retained_lane));
+        assert_eq!(queue.lane_turn_id(&retained_lane), retained_turn.as_deref());
+    }
+
+    #[test]
+    fn repeated_cancelled_batches_stay_bounded_and_keep_newest_event() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::new(channel_id, "a".repeat(64));
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+        let old = make_queued(channel_id, "old");
+        let old_batch_event = BatchEvent {
+            event: old.event,
+            prompt_tag: old.prompt_tag,
+            received_at: old.received_at,
+        };
+        queue.cancelled_batches.insert(
+            lane.clone(),
+            std::iter::repeat_n(old_batch_event, MAX_PENDING_PER_CHANNEL).collect(),
+        );
+        let newest = make_queued(channel_id, "newest");
+        let newest_id = newest.event.id.to_hex();
+
+        queue.requeue_as_cancelled(
+            FlushBatch {
+                lane: lane.clone(),
+                channel_id,
+                events: vec![BatchEvent {
+                    event: newest.event,
+                    prompt_tag: newest.prompt_tag,
+                    received_at: newest.received_at,
+                }],
+                cancelled_events: Vec::new(),
+                cancel_reason: Some(CancelReason::Steer),
+            },
+            CancelReason::Steer,
+        );
+
+        let retained = queue.cancelled_batches.get(&lane).unwrap();
+        assert_eq!(retained.len(), MAX_PENDING_PER_CHANNEL);
+        assert_eq!(retained.last().unwrap().event.id.to_hex(), newest_id);
+    }
+
+    #[test]
+    fn root_lane_in_flight_reservation_includes_cancelled_merge_events() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::new(channel_id, "a".repeat(64));
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+        let carried = make_queued(channel_id, "carried");
+        let carried = BatchEvent {
+            event: carried.event,
+            prompt_tag: carried.prompt_tag,
+            received_at: carried.received_at,
+        };
+        queue
+            .cancelled_batches
+            .insert(lane.clone(), vec![carried; 2]);
+        assert_eq!(
+            queue.push_resolved(make_queued(channel_id, "regular"), lane.clone()),
+            PushResult::Accepted
+        );
+        let dispatched = queue.flush_next().expect("merged flush");
+        assert_eq!(dispatched.cancelled_events.len(), 2);
+        assert!(queue.bind_lane_turn(&lane, "current-turn"));
+
+        let pending = make_queued(channel_id, "pending");
+        queue.queues.insert(
+            lane.clone(),
+            std::iter::repeat_n(pending, MAX_PENDING_PER_CHANNEL - 3).collect(),
+        );
+
+        assert_eq!(
+            queue.push_resolved(make_queued(channel_id, "overflow"), lane.clone()),
+            PushResult::Overloaded(OverloadReason::LaneQueueFull),
+            "all events carried by the in-flight merged prompt must reserve slots"
+        );
+    }
+
+    #[test]
+    fn root_lane_reserves_capacity_for_in_flight_retry() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::new(channel_id, "a".repeat(64));
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+        let original = make_queued(channel_id, "original");
+        let original_id = original.event.id;
+        assert_eq!(
+            queue.push_resolved(original, lane.clone()),
+            PushResult::Accepted
+        );
+        let original_batch = queue.flush_next().expect("original flush");
+        assert_eq!(original_batch.lane, lane);
+        assert!(queue.bind_lane_turn(&lane, "current-turn"));
+
+        let pending = make_queued(channel_id, "pending");
+        queue.queues.insert(
+            lane.clone(),
+            std::iter::repeat_n(pending, MAX_PENDING_PER_CHANNEL - 1).collect(),
+        );
+
+        assert_eq!(
+            queue.push_resolved(make_queued(channel_id, "overflow"), lane.clone()),
+            PushResult::Overloaded(OverloadReason::LaneQueueFull),
+            "the recoverable in-flight event must reserve one lane slot"
+        );
+        assert_eq!(
+            queue.queues.get(&lane).unwrap().len(),
+            MAX_PENDING_PER_CHANNEL - 1
+        );
+
+        assert!(queue.requeue(original_batch).is_none());
+        assert!(queue.mark_lane_complete_for_turn(&lane, "current-turn"));
+        let retained = queue.queues.get(&lane).expect("retry queue retained");
+        assert_eq!(retained.len(), MAX_PENDING_PER_CHANNEL);
+        assert_eq!(retained.front().unwrap().event.id, original_id);
+    }
+
+    #[test]
+    fn aggregate_limit_reserves_recoverable_in_flight_batch() {
+        let channel_id = Uuid::new_v4();
+        let lane_a = LaneKey::new(channel_id, "a".repeat(64));
+        let lane_b = LaneKey::new(channel_id, "b".repeat(64));
+        let lane_c = LaneKey::new(channel_id, "c".repeat(64));
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread)
+            .with_limits(10, 2);
+
+        assert_eq!(
+            queue.push_resolved(make_queued(channel_id, "active"), lane_a.clone()),
+            PushResult::Accepted
+        );
+        let _active = queue.flush_next().expect("active batch");
+        assert!(queue.bind_lane_turn(&lane_a, "active-turn"));
+        assert_eq!(
+            queue.push_resolved(make_queued(channel_id, "queued"), lane_b),
+            PushResult::Accepted
+        );
+        assert_eq!(
+            queue.push_resolved(make_queued(channel_id, "overflow"), lane_c),
+            PushResult::Overloaded(OverloadReason::AggregatePendingLimit),
+            "recoverable active work must consume aggregate admission capacity"
+        );
+    }
+
+    #[test]
+    fn root_lane_depth_overflow_rejects_new_event_without_dropping_oldest() {
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::new(channel_id, "a".repeat(64));
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+        let oldest = make_queued(channel_id, "oldest");
+        let oldest_id = oldest.event.id.to_hex();
+        queue.queues.insert(
+            lane.clone(),
+            std::iter::repeat_n(oldest, MAX_PENDING_PER_CHANNEL).collect(),
+        );
+
+        assert_eq!(
+            queue.push_resolved(make_queued(channel_id, "overflow"), lane.clone()),
+            PushResult::Overloaded(OverloadReason::LaneQueueFull)
+        );
+        let queued = queue.queues.get(&lane).expect("lane must remain queued");
+        assert_eq!(queued.len(), MAX_PENDING_PER_CHANNEL);
+        assert_eq!(queued.front().unwrap().event.id.to_hex(), oldest_id);
+    }
+
+    #[test]
+    fn root_lane_limits_are_finite_distinguishable_and_clean_up() {
+        let channel_id = Uuid::new_v4();
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread)
+            .with_limits(2, 2);
+
+        for suffix in ['a', 'b'] {
+            let event = make_event(&format!("root {suffix}"));
+            let lane = LaneKey::new(channel_id, event.id.to_hex());
+            assert_eq!(
+                queue.push_resolved(
+                    QueuedEvent {
+                        channel_id,
+                        event,
+                        received_at: Instant::now(),
+                        prompt_tag: "test".into(),
+                    },
+                    lane,
+                ),
+                PushResult::Accepted
+            );
+        }
+
+        let overloaded = make_event("root c");
+        let overloaded_lane = LaneKey::new(channel_id, overloaded.id.to_hex());
+        assert_eq!(
+            queue.push_resolved(
+                QueuedEvent {
+                    channel_id,
+                    event: overloaded,
+                    received_at: Instant::now(),
+                    prompt_tag: "test".into(),
+                },
+                overloaded_lane,
+            ),
+            PushResult::Overloaded(OverloadReason::TooManyChannelLanes)
+        );
+
+        let first = queue.flush_next().unwrap();
+        queue.mark_lane_complete(&first.lane);
+        let second = queue.flush_next().unwrap();
+        queue.mark_lane_complete(&second.lane);
+        assert_eq!(queue.lane_state_count(), 0);
+    }
+
     /// Build a QueuedEvent for the given channel.
     fn make_queued(channel_id: Uuid, content: &str) -> QueuedEvent {
         QueuedEvent {
@@ -1872,6 +2795,7 @@ mod tests {
             .unwrap_or_else(|_| event.pubkey.to_hex());
 
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -1902,6 +2826,7 @@ mod tests {
     fn make_merged_batch(reason: Option<CancelReason>) -> FlushBatch {
         let ch = Uuid::new_v4();
         FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event: make_event("the new message"),
@@ -2033,6 +2958,7 @@ mod tests {
         // Multi-event header path must also branch on reason.
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![
                 BatchEvent {
@@ -2090,6 +3016,7 @@ mod tests {
         let _steering_id = steering.id.to_hex();
 
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event: steering,
@@ -2142,13 +3069,94 @@ mod tests {
         queue.mark_complete(ch);
 
         // retry_after is set, so manually clear it for this test.
-        queue.retry_after.remove(&ch);
+        queue.retry_after.remove(&LaneKey::channel(ch));
 
         // Should be able to flush again and get the same events in order.
         let batch2 = queue.flush_next().unwrap();
         assert_eq!(batch2.events.len(), 2);
         assert_eq!(batch2.events[0].event.content, "msg1");
         assert_eq!(batch2.events[1].event.content, "msg2");
+    }
+
+    #[test]
+    fn requeue_preserve_timestamps_keeps_cancelled_half_of_merged_prompt() {
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+
+        queue.push(make_queued(ch, "original work"));
+        let original = queue.flush_next().unwrap();
+        queue.push(make_queued(ch, "steering update"));
+        queue.requeue_as_cancelled(original, CancelReason::Steer);
+        queue.mark_complete(ch);
+
+        let merged = queue.flush_next().unwrap();
+        assert_eq!(merged.events.len(), 1);
+        assert_eq!(merged.cancelled_events.len(), 1);
+        assert_eq!(merged.cancel_reason, Some(CancelReason::Steer));
+
+        queue.requeue_preserve_timestamps(merged);
+        queue.mark_complete(ch);
+
+        let retry = queue.flush_next().unwrap();
+        assert_eq!(retry.events.len(), 1);
+        assert_eq!(retry.events[0].event.content, "steering update");
+        assert_eq!(retry.cancelled_events.len(), 1);
+        assert_eq!(retry.cancelled_events[0].event.content, "original work");
+        assert_eq!(retry.cancel_reason, Some(CancelReason::Steer));
+    }
+
+    #[test]
+    fn requeue_keeps_cancelled_half_of_merged_prompt() {
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        let ch = Uuid::new_v4();
+        let lane = LaneKey::channel(ch);
+
+        queue.push(make_queued(ch, "original work"));
+        let original = queue.flush_next().unwrap();
+        queue.push(make_queued(ch, "steering update"));
+        queue.requeue_as_cancelled(original, CancelReason::Steer);
+        queue.mark_complete(ch);
+
+        let merged = queue.flush_next().unwrap();
+        assert!(queue.requeue(merged).is_none());
+        queue.mark_complete(ch);
+        queue.retry_after.remove(&lane);
+
+        let retry = queue.flush_next().unwrap();
+        assert_eq!(retry.events.len(), 1);
+        assert_eq!(retry.events[0].event.content, "steering update");
+        assert_eq!(retry.cancelled_events.len(), 1);
+        assert_eq!(retry.cancelled_events[0].event.content, "original work");
+        assert_eq!(retry.cancel_reason, Some(CancelReason::Steer));
+    }
+
+    #[test]
+    fn cancelled_only_lane_competes_in_global_fifo_order() {
+        let mut queue = EventQueue::new(DedupMode::Queue);
+        let cancelled_channel = Uuid::new_v4();
+        let queued_channel = Uuid::new_v4();
+
+        queue.push(make_queued_at(
+            cancelled_channel,
+            "cancelled-old",
+            Duration::from_secs(5),
+        ));
+        let cancelled = queue.flush_next().expect("initial cancelled batch");
+        queue.requeue_as_cancelled(cancelled, CancelReason::Steer);
+        queue.mark_complete(cancelled_channel);
+
+        queue.push(make_queued_at(
+            queued_channel,
+            "queued-new",
+            Duration::from_secs(1),
+        ));
+
+        let next = queue.flush_next().expect("oldest retained work");
+        assert_eq!(
+            next.channel_id, cancelled_channel,
+            "cancelled-only work must compete with queued work by received_at"
+        );
+        assert_eq!(next.events[0].event.content, "cancelled-old");
     }
 
     #[test]
@@ -2182,6 +3190,7 @@ mod tests {
         let e3 = make_event("third message");
 
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![
                 BatchEvent {
@@ -2222,6 +3231,7 @@ mod tests {
         let event = make_event("hello");
 
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -2245,6 +3255,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hi");
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -2277,6 +3288,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hi");
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -2307,6 +3319,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hi");
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -2334,6 +3347,7 @@ mod tests {
         let event = make_event("hello");
 
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -2358,6 +3372,7 @@ mod tests {
         let event = make_event("hello");
 
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -2414,6 +3429,7 @@ mod tests {
         let event = make_event("hello");
 
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -2452,6 +3468,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hello");
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -2665,8 +3682,8 @@ mod tests {
         // Complete only A.
         q.mark_complete(ch_a);
         assert_eq!(q.in_flight_channels.len(), 1);
-        assert!(q.in_flight_channels.contains(&ch_b));
-        assert!(!q.in_flight_channels.contains(&ch_a));
+        assert!(q.in_flight_channels.contains(&LaneKey::channel(ch_b)));
+        assert!(!q.in_flight_channels.contains(&LaneKey::channel(ch_a)));
 
         // B still in-flight.
         assert!(any_in_flight(&q));
@@ -2712,7 +3729,7 @@ mod tests {
         q.mark_complete(ch);
 
         // No retry_after — channel should be immediately flushable.
-        assert!(!q.retry_after.contains_key(&ch));
+        assert!(!q.retry_after.contains_key(&LaneKey::channel(ch)));
         assert!(q.flush_next().is_some());
     }
 
@@ -2788,6 +3805,40 @@ mod tests {
     }
 
     #[test]
+    fn expired_in_flight_lane_keeps_generation_while_owner_is_ineligible() {
+        let mut queue = EventQueue::new_with_affinity(DedupMode::Queue, AffinityPolicy::RootThread);
+        queue.in_flight_deadline = Duration::ZERO;
+        let channel_id = Uuid::new_v4();
+        let lane = LaneKey::new(channel_id, "a".repeat(64));
+
+        assert_eq!(
+            queue.push_resolved(make_queued(channel_id, "first"), lane.clone()),
+            PushResult::Accepted
+        );
+        let first = queue.flush_next().expect("first batch");
+        assert_eq!(first.lane, lane);
+        assert!(queue.bind_lane_turn(&lane, "turn-one"));
+        assert_eq!(
+            queue.push_resolved(make_queued(channel_id, "second"), lane.clone()),
+            PushResult::Accepted
+        );
+
+        assert!(!queue.has_flushable_work_matching(|candidate| candidate != &lane));
+        assert!(queue.is_lane_in_flight(&lane));
+        assert!(queue.lane_turn_matches(&lane, "turn-one"));
+        assert!(queue
+            .flush_next_matching(|candidate| candidate != &lane)
+            .is_none());
+        assert!(queue.lane_turn_matches(&lane, "turn-one"));
+
+        assert!(queue.has_flushable_work_matching(|_| true));
+        let replacement = queue
+            .flush_next_matching(|_| true)
+            .expect("orphaned lane may recover once claimable");
+        assert_eq!(replacement.lane, lane);
+    }
+
+    #[test]
     fn test_has_flushable_work() {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
@@ -2817,8 +3868,10 @@ mod tests {
         );
 
         // Manually expire the retry_after to simulate time passing.
-        q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.retry_after.insert(
+            LaneKey::channel(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
         assert!(
             q.has_flushable_work(),
             "expired throttle should be flushable"
@@ -2832,8 +3885,10 @@ mod tests {
 
         q.push(make_queued(ch, "poison"));
         for attempt in 1..=MAX_RETRIES {
-            q.retry_after
-                .insert(ch, Instant::now() - Duration::from_secs(1));
+            q.retry_after.insert(
+                LaneKey::channel(ch),
+                Instant::now() - Duration::from_secs(1),
+            );
             let batch = q.flush_next().expect("flush");
             assert!(
                 q.requeue(batch).is_none(),
@@ -2843,16 +3898,18 @@ mod tests {
         }
 
         // The MAX_RETRIES+1'th failure dead-letters: batch is returned.
-        q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.retry_after.insert(
+            LaneKey::channel(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
         let batch = q.flush_next().expect("flush");
         let dead = q.requeue(batch).expect("should dead-letter");
         assert_eq!(dead.channel_id, ch);
         assert_eq!(dead.events.len(), 1);
         q.mark_complete(ch);
         // Retry state is cleared so fresh traffic isn't throttled.
-        assert!(!q.retry_counts.contains_key(&ch));
-        assert!(!q.retry_after.contains_key(&ch));
+        assert!(!q.retry_counts.contains_key(&LaneKey::channel(ch)));
+        assert!(!q.retry_after.contains_key(&LaneKey::channel(ch)));
     }
 
     #[test]
@@ -2877,8 +3934,10 @@ mod tests {
         assert_eq!(batch2.channel_id, ch2);
 
         // After retry_after expires, ch should be flushable again.
-        q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.retry_after.insert(
+            LaneKey::channel(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
         q.mark_complete(ch2);
         let batch3 = q
             .flush_next()
@@ -2969,6 +4028,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hello");
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3000,6 +4060,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hey");
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3038,6 +4099,7 @@ mod tests {
             ]],
         );
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3066,6 +4128,7 @@ mod tests {
             ]],
         );
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3110,6 +4173,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("ok do that");
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3159,6 +4223,7 @@ mod tests {
         );
         let author_hex = event.pubkey.to_hex();
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3366,6 +4431,7 @@ mod tests {
             ]],
         );
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3423,6 +4489,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hey there");
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3463,6 +4530,7 @@ mod tests {
         let event = make_event("test");
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3487,6 +4555,7 @@ mod tests {
         let hex = event.pubkey.to_hex();
         let npub = event.pubkey.to_bech32().unwrap();
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3510,6 +4579,7 @@ mod tests {
         // Kind 9 (stream message) — tags were previously stripped.
         let event = make_event_with_tags("hello", vec![vec!["h".into(), ch.to_string()]]);
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3608,25 +4678,27 @@ mod tests {
         let batch = q.flush_next().unwrap();
         q.requeue(batch);
         q.mark_complete(ch);
-        assert!(q.retry_after.contains_key(&ch));
-        assert!(q.retry_counts.contains_key(&ch));
+        assert!(q.retry_after.contains_key(&LaneKey::channel(ch)));
+        assert!(q.retry_counts.contains_key(&LaneKey::channel(ch)));
 
         // The requeued event is back in the queue. Flush it again so the
         // queue is empty (simulating a successful retry dispatch).
         // We need to wait for retry_after to expire first.
-        q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.retry_after.insert(
+            LaneKey::channel(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
         let _batch2 = q.flush_next().unwrap();
         // Now mark_complete with no active throttle — clears retry_counts.
         q.mark_complete(ch);
-        assert!(!q.retry_counts.contains_key(&ch));
+        assert!(!q.retry_counts.contains_key(&LaneKey::channel(ch)));
 
         // Re-create the orphan scenario: manually insert stale retry_counts
         // with no queue, no throttle, and no in-flight.
-        q.retry_counts.insert(ch, 3);
+        q.retry_counts.insert(LaneKey::channel(ch), 3);
         q.compact_expired_state();
         assert!(
-            !q.retry_counts.contains_key(&ch),
+            !q.retry_counts.contains_key(&LaneKey::channel(ch)),
             "orphaned retry_counts should be removed"
         );
     }
@@ -3643,18 +4715,23 @@ mod tests {
         q.mark_complete(ch);
 
         // Expire the throttle so the requeued event can be flushed.
-        q.retry_after
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.retry_after.insert(
+            LaneKey::channel(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
         let _batch2 = q.flush_next().unwrap();
         // Channel is now in-flight with empty queue and expired throttle.
-        assert!(q.in_flight_channels.contains(&ch));
-        assert!(q.queues.get(&ch).is_none_or(|q| q.is_empty()));
+        assert!(q.in_flight_channels.contains(&LaneKey::channel(ch)));
+        assert!(q
+            .queues
+            .get(&LaneKey::channel(ch))
+            .is_none_or(|q| q.is_empty()));
 
         // compact must NOT remove retry_counts — the in-flight attempt
         // may fail and requeue, which needs the existing count.
         q.compact_expired_state();
         assert!(
-            q.retry_counts.contains_key(&ch),
+            q.retry_counts.contains_key(&LaneKey::channel(ch)),
             "retry_counts must survive while channel is in-flight"
         );
     }
@@ -3666,11 +4743,11 @@ mod tests {
 
         // Manually set up: retry_counts exists, queue is non-empty, no throttle.
         q.push(make_queued(ch, "msg1"));
-        q.retry_counts.insert(ch, 2);
+        q.retry_counts.insert(LaneKey::channel(ch), 2);
 
         q.compact_expired_state();
         assert!(
-            q.retry_counts.contains_key(&ch),
+            q.retry_counts.contains_key(&LaneKey::channel(ch)),
             "retry_counts should survive when queue is non-empty"
         );
     }
@@ -3876,6 +4953,7 @@ mod tests {
             vec![vec!["e".into(), root_id.clone(), "".into(), "reply".into()]],
         );
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3918,6 +4996,7 @@ mod tests {
         );
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3952,6 +5031,7 @@ mod tests {
         let event = make_event("hello world");
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -3981,6 +5061,7 @@ mod tests {
         let ch = Uuid::new_v4();
         let event = make_event("hey there");
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -4023,6 +5104,7 @@ mod tests {
         );
         let event_id = event.id.to_hex();
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -4059,6 +5141,7 @@ mod tests {
             vec![vec!["e".into(), root_id.clone(), "".into(), "reply".into()]],
         );
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event,
@@ -4094,6 +5177,7 @@ mod tests {
             vec![vec!["e".into(), root_id.clone(), "".into(), "reply".into()]],
         );
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![
                 BatchEvent {
@@ -4131,6 +5215,7 @@ mod tests {
         let plain = make_event("latest top-level");
         let plain_id = plain.id.to_hex();
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![
                 BatchEvent {
@@ -4163,8 +5248,10 @@ mod tests {
 
     /// Build a single-event FlushBatch with the given content.
     fn make_single_batch(content: &str) -> FlushBatch {
+        let channel_id = Uuid::new_v4();
         FlushBatch {
-            channel_id: Uuid::new_v4(),
+            lane: LaneKey::channel(channel_id),
+            channel_id,
             events: vec![BatchEvent {
                 event: make_event(content),
                 prompt_tag: "test".into(),
@@ -4299,7 +5386,12 @@ mod tests {
             "withheld-only channel must not register as flushable work"
         );
         assert_eq!(pending_count(&q), 0);
-        assert_eq!(q.withheld_native_steer.get(&ch).map(|v| v.len()), Some(1));
+        assert_eq!(
+            q.withheld_native_steer
+                .get(&LaneKey::channel(ch))
+                .map(|v| v.len()),
+            Some(1)
+        );
     }
 
     /// Earlier events on the same channel must flush normally during the
@@ -4367,17 +5459,20 @@ mod tests {
 
         // Simulate a prompt in flight for `ch`, then withhold the queued
         // event for an in-flight goose-native steer.
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, Instant::now());
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_channels.insert(LaneKey::channel(ch));
+        q.in_flight_deadlines
+            .insert(LaneKey::channel(ch), Instant::now());
+        q.in_flight_batch_sizes.insert(LaneKey::channel(ch), 1);
         assert!(q.mark_native_steer_pending(ch, &event_id));
 
         // Force the in-flight deadline to be in the past, simulating the
         // steer ack never arriving and the read loop hanging long enough
         // for `in_flight_deadline` to elapse. Same expiry-simulation
         // trick used by `test_retry_throttle_blocks_requeue_channel`.
-        q.in_flight_deadlines
-            .insert(ch, Instant::now() - Duration::from_secs(1));
+        q.in_flight_deadlines.insert(
+            LaneKey::channel(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
 
         // `has_flushable_work` runs the expiry block first; it must recover
         // the withheld event so the channel registers as flushable.
@@ -4429,20 +5524,27 @@ mod tests {
         assert!(q.mark_native_steer_pending(ch, &e2_id));
         assert!(q.mark_native_steer_pending(ch, &e3_id));
         assert_eq!(pending_count(&q), 0);
-        assert_eq!(q.withheld_native_steer.get(&ch).map(|v| v.len()), Some(3));
+        assert_eq!(
+            q.withheld_native_steer
+                .get(&LaneKey::channel(ch))
+                .map(|v| v.len()),
+            Some(3)
+        );
 
         // Trigger expiry → bulk-release path.
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines
-            .insert(ch, Instant::now() - Duration::from_secs(1));
-        q.in_flight_batch_sizes.insert(ch, 3);
+        q.in_flight_channels.insert(LaneKey::channel(ch));
+        q.in_flight_deadlines.insert(
+            LaneKey::channel(ch),
+            Instant::now() - Duration::from_secs(1),
+        );
+        q.in_flight_batch_sizes.insert(LaneKey::channel(ch), 3);
         assert!(q.has_flushable_work());
 
         // After recovery, the queue front-to-back order must match the
         // original FIFO: e1, e2, e3.
         let recovered: Vec<String> = q
             .queues
-            .get(&ch)
+            .get(&LaneKey::channel(ch))
             .expect("queue restored")
             .iter()
             .map(|qe| qe.event.id.to_hex())
@@ -4458,6 +5560,7 @@ mod tests {
         let canvas = "[Channel Canvas]\nCanvas revision (event ID): abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234\nLast modified: 2024-01-15T10:30:00+00:00\nFetch current content with: buzz canvas get --channel 00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae";
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event: make_event("hi"),
@@ -4487,6 +5590,7 @@ mod tests {
         let canvas = "[Channel Canvas]\nCanvas revision (event ID): abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234\nLast modified: 2024-01-15T10:30:00+00:00\nFetch current content with: buzz canvas get --channel 00f1ccaf-1506-4dd7-9a0e-fa67e9e486ae";
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event: make_event("hi"),
@@ -4515,6 +5619,7 @@ mod tests {
     fn test_format_prompt_no_canvas_produces_no_canvas_section() {
         let ch = Uuid::new_v4();
         let batch = FlushBatch {
+            lane: LaneKey::channel(ch),
             channel_id: ch,
             events: vec![BatchEvent {
                 event: make_event("hi"),
@@ -4564,11 +5669,12 @@ mod tests {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
         let old_deadline = Instant::now() + Duration::from_secs(100);
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, old_deadline);
+        q.in_flight_channels.insert(LaneKey::channel(ch));
+        q.in_flight_deadlines
+            .insert(LaneKey::channel(ch), old_deadline);
 
         q.extend_in_flight_deadline(ch, 7200);
-        let new = *q.in_flight_deadlines.get(&ch).unwrap();
+        let new = *q.in_flight_deadlines.get(&LaneKey::channel(ch)).unwrap();
         assert!(
             new > old_deadline,
             "extended deadline must be past the original"
@@ -4580,11 +5686,12 @@ mod tests {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
         let far_future = Instant::now() + Duration::from_secs(999_999);
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, far_future);
+        q.in_flight_channels.insert(LaneKey::channel(ch));
+        q.in_flight_deadlines
+            .insert(LaneKey::channel(ch), far_future);
 
         q.extend_in_flight_deadline(ch, 7200);
-        let after = *q.in_flight_deadlines.get(&ch).unwrap();
+        let after = *q.in_flight_deadlines.get(&LaneKey::channel(ch)).unwrap();
         assert_eq!(after, far_future, "deadline must never move backward");
     }
 
@@ -4592,17 +5699,19 @@ mod tests {
     fn extend_in_flight_deadline_noop_after_mark_complete() {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines
-            .insert(ch, Instant::now() + Duration::from_secs(100));
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_channels.insert(LaneKey::channel(ch));
+        q.in_flight_deadlines.insert(
+            LaneKey::channel(ch),
+            Instant::now() + Duration::from_secs(100),
+        );
+        q.in_flight_batch_sizes.insert(LaneKey::channel(ch), 1);
 
         q.mark_complete(ch);
-        assert!(!q.in_flight_deadlines.contains_key(&ch));
+        assert!(!q.in_flight_deadlines.contains_key(&LaneKey::channel(ch)));
 
         q.extend_in_flight_deadline(ch, 7200);
         assert!(
-            !q.in_flight_deadlines.contains_key(&ch),
+            !q.in_flight_deadlines.contains_key(&LaneKey::channel(ch)),
             "extend after mark_complete must not resurrect a deadline"
         );
     }
@@ -4612,17 +5721,17 @@ mod tests {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
         let extended = Instant::now() + Duration::from_secs(9999);
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, extended);
+        q.in_flight_channels.insert(LaneKey::channel(ch));
+        q.in_flight_deadlines.insert(LaneKey::channel(ch), extended);
 
         q.compact_expired_state();
 
         assert!(
-            q.in_flight_deadlines.contains_key(&ch),
+            q.in_flight_deadlines.contains_key(&LaneKey::channel(ch)),
             "compaction must not touch in-flight deadlines"
         );
         assert_eq!(
-            *q.in_flight_deadlines.get(&ch).unwrap(),
+            *q.in_flight_deadlines.get(&LaneKey::channel(ch)).unwrap(),
             extended,
             "compaction must leave extended deadline intact"
         );
@@ -4641,9 +5750,10 @@ mod tests {
 
         // Insert the channel as in-flight with a deadline already in the past
         // (Instant::now() — by the time flush_next runs, now >= deadline).
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines.insert(ch, Instant::now());
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_channels.insert(LaneKey::channel(ch));
+        q.in_flight_deadlines
+            .insert(LaneKey::channel(ch), Instant::now());
+        q.in_flight_batch_sizes.insert(LaneKey::channel(ch), 1);
 
         // Also push an event so flush_next has something to do after expiry.
         q.push(make_queued(ch, "after-expiry"));
@@ -4669,10 +5779,12 @@ mod tests {
         let ch = Uuid::new_v4();
 
         // Put the channel in-flight with an extended deadline far in the future.
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines
-            .insert(ch, Instant::now() + Duration::from_secs(9999));
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_channels.insert(LaneKey::channel(ch));
+        q.in_flight_deadlines.insert(
+            LaneKey::channel(ch),
+            Instant::now() + Duration::from_secs(9999),
+        );
+        q.in_flight_batch_sizes.insert(LaneKey::channel(ch), 1);
 
         // Push an event for another channel so flush_next has work to do.
         let ch2 = Uuid::new_v4();
@@ -4686,11 +5798,11 @@ mod tests {
 
         // ch must still be in-flight — the extended deadline did not expire.
         assert!(
-            q.in_flight_channels.contains(&ch),
+            q.in_flight_channels.contains(&LaneKey::channel(ch)),
             "ch must remain in-flight after flush_next with an extended deadline"
         );
         assert!(
-            q.in_flight_deadlines.contains_key(&ch),
+            q.in_flight_deadlines.contains_key(&LaneKey::channel(ch)),
             "in-flight deadline for ch must not be removed by flush_next"
         );
     }
@@ -4707,10 +5819,12 @@ mod tests {
         let ch = Uuid::new_v4();
 
         // In-flight channel with extended (far-future) deadline.
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines
-            .insert(ch, Instant::now() + Duration::from_secs(9999));
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_channels.insert(LaneKey::channel(ch));
+        q.in_flight_deadlines.insert(
+            LaneKey::channel(ch),
+            Instant::now() + Duration::from_secs(9999),
+        );
+        q.in_flight_batch_sizes.insert(LaneKey::channel(ch), 1);
 
         // No other channels — nothing flushable.
         assert!(
@@ -4718,7 +5832,7 @@ mod tests {
             "has_flushable_work must return false when the only channel is in-flight with extended deadline"
         );
         assert!(
-            q.in_flight_channels.contains(&ch),
+            q.in_flight_channels.contains(&LaneKey::channel(ch)),
             "ch must remain in-flight after has_flushable_work with extended deadline"
         );
 
@@ -4731,7 +5845,7 @@ mod tests {
         );
         // ch still in-flight and not expired.
         assert!(
-            q.in_flight_channels.contains(&ch),
+            q.in_flight_channels.contains(&LaneKey::channel(ch)),
             "ch must still be in-flight after has_flushable_work finds ch2 work"
         );
     }
@@ -4746,15 +5860,17 @@ mod tests {
         let mut q = EventQueue::new(DedupMode::Queue);
         let ch = Uuid::new_v4();
 
-        q.in_flight_channels.insert(ch);
-        q.in_flight_deadlines
-            .insert(ch, Instant::now() + Duration::from_secs(100));
+        q.in_flight_channels.insert(LaneKey::channel(ch));
+        q.in_flight_deadlines.insert(
+            LaneKey::channel(ch),
+            Instant::now() + Duration::from_secs(100),
+        );
 
         q.extend_in_flight_deadline(ch, 7200);
-        let after_first = *q.in_flight_deadlines.get(&ch).unwrap();
+        let after_first = *q.in_flight_deadlines.get(&LaneKey::channel(ch)).unwrap();
 
         q.extend_in_flight_deadline(ch, 7200);
-        let after_second = *q.in_flight_deadlines.get(&ch).unwrap();
+        let after_second = *q.in_flight_deadlines.get(&LaneKey::channel(ch)).unwrap();
 
         assert!(
             after_second >= after_first,

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -161,66 +161,173 @@ pub(crate) fn channel_type_from_tags(tags: &[serde_json::Value]) -> String {
     }
 }
 
-/// Build the discovered-channel subscribe set from the membership UUIDs and the
-/// kind:39000 metadata events, **skipping any channel flagged `archived=true`**.
-///
-/// Archived channels (e.g. auto-archived by the ephemeral-channel reaper) are
-/// unusable: re-offering one on reconnect draws a `CLOSED restricted` and would
-/// re-form the reconnect loop. Dropping them here is the defense-in-depth
-/// backstop to the relay-side live-subscription eviction — it covers a client
-/// that was offline when the channel was reaped and so missed the CLOSED.
-/// A channel with no metadata event is preserved as `unknown`; security
-/// consumers must lazy-resolve it or fail closed rather than assuming stream.
+/// Require exactly one raw `h` occurrence with the canonical expected UUID.
+/// Malformed or duplicate same-name tags fail closed rather than being filtered
+/// out before cardinality is checked.
+pub(crate) fn has_exact_channel_binding(event: &Event, channel_id: Uuid) -> bool {
+    let mut h_tags = event
+        .tags
+        .iter()
+        .filter(|tag| tag.as_slice().first().map(String::as_str) == Some("h"));
+    let Some(tag) = h_tags.next() else {
+        return false;
+    };
+    if h_tags.next().is_some() {
+        return false;
+    }
+    let expected = channel_id.to_string();
+    tag.as_slice().get(1).map(String::as_str) == Some(expected.as_str())
+}
+
+/// Verify one relay-authored NIP-29 replaceable event and return its exact
+/// canonical channel binding. Invalid, attacker-signed, wrong-kind, duplicate,
+/// or malformed `d` tags fail closed.
+fn verified_relay_group_event(
+    value: &serde_json::Value,
+    expected_kind: u32,
+    trusted_relay_pubkey: &nostr::PublicKey,
+) -> Option<(Event, Uuid)> {
+    let event: Event = serde_json::from_value(value.clone()).ok()?;
+    if event.verify().is_err()
+        || event.pubkey != *trusted_relay_pubkey
+        || event.kind.as_u16() as u32 != expected_kind
+    {
+        return None;
+    }
+
+    let d_tags: Vec<_> = event
+        .tags
+        .iter()
+        .filter(|tag| tag.as_slice().first().map(String::as_str) == Some("d"))
+        .collect();
+    let value = d_tags.first()?.as_slice().get(1)?;
+    if d_tags.len() != 1 {
+        return None;
+    }
+    let channel_id = Uuid::parse_str(value).ok()?;
+    (value == &channel_id.to_string()).then_some((event, channel_id))
+}
+
+/// Extract channels from verified relay-authored membership list events.
+fn verified_membership_channels(
+    events: &serde_json::Value,
+    trusted_relay_pubkey: &nostr::PublicKey,
+    agent_pubkey: &nostr::PublicKey,
+) -> Vec<Uuid> {
+    let mut channels = std::collections::HashSet::new();
+    let Some(events) = events.as_array() else {
+        return Vec::new();
+    };
+    let agent_hex = agent_pubkey.to_hex();
+    for value in events {
+        let Some((event, channel_id)) = verified_relay_group_event(
+            value,
+            buzz_core::kind::KIND_NIP29_GROUP_MEMBERS,
+            trusted_relay_pubkey,
+        ) else {
+            continue;
+        };
+        let addressed = event
+            .tags
+            .iter()
+            .filter(|tag| {
+                let parts = tag.as_slice();
+                parts.first().map(String::as_str) == Some("p")
+                    && parts.get(1).map(String::as_str) == Some(agent_hex.as_str())
+            })
+            .count();
+        if addressed == 1 {
+            channels.insert(channel_id);
+        }
+    }
+    let mut channels: Vec<_> = channels.into_iter().collect();
+    channels.sort_unstable_by_key(Uuid::as_u128);
+    channels
+}
+
+/// Select the newest verified relay-authored metadata revision per channel.
+/// `None` means the newest revision is archived; missing map entries are
+/// unknown/unverified and must remain fail-closed for authorization.
+pub(crate) fn newest_verified_channel_info(
+    meta_events: &serde_json::Value,
+    trusted_relay_pubkey: &nostr::PublicKey,
+) -> HashMap<Uuid, Option<ChannelInfo>> {
+    let mut newest: HashMap<Uuid, (u64, String, Option<ChannelInfo>)> = HashMap::new();
+    let Some(events) = meta_events.as_array() else {
+        return HashMap::new();
+    };
+    for value in events {
+        let Some((event, channel_id)) = verified_relay_group_event(
+            value,
+            buzz_core::kind::KIND_NIP29_GROUP_METADATA,
+            trusted_relay_pubkey,
+        ) else {
+            continue;
+        };
+        let Some(tags) = value.get("tags").and_then(serde_json::Value::as_array) else {
+            continue;
+        };
+        let name = tags
+            .iter()
+            .find_map(|tag| {
+                let parts = tag.as_array()?;
+                if parts.first()?.as_str()? != "name" {
+                    return None;
+                }
+                parts.get(1)?.as_str()
+            })
+            .unwrap_or("unknown")
+            .to_string();
+        let archived = tags.iter().any(|tag| {
+            tag.as_array().is_some_and(|parts| {
+                parts.first().and_then(serde_json::Value::as_str) == Some("archived")
+                    && parts.get(1).and_then(serde_json::Value::as_str) == Some("true")
+            })
+        });
+        let info = (!archived).then(|| ChannelInfo {
+            name,
+            channel_type: channel_type_from_tags(tags),
+        });
+        let ordering = (event.created_at.as_secs(), event.id.to_hex());
+        if newest
+            .get(&channel_id)
+            .is_none_or(|current| ordering > (current.0, current.1.clone()))
+        {
+            newest.insert(channel_id, (ordering.0, ordering.1, info));
+        }
+    }
+    newest
+        .into_iter()
+        .map(|(channel_id, (_, _, info))| (channel_id, info))
+        .collect()
+}
+
+/// Build the discovered-channel subscribe set from verified membership UUIDs
+/// and relay-authored kind:39000 metadata, skipping channels whose newest
+/// verified revision is archived. Missing or invalid metadata stays `unknown`.
 pub(crate) fn merge_discovered_channels(
     channel_uuids: Vec<Uuid>,
     meta_events: &serde_json::Value,
+    trusted_relay_pubkey: &nostr::PublicKey,
 ) -> HashMap<Uuid, ChannelInfo> {
-    let mut meta_map: HashMap<Uuid, (String, String)> = HashMap::new();
-    let mut archived: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
-    if let Some(arr) = meta_events.as_array() {
-        for ev in arr {
-            let tags = match ev.get("tags").and_then(|t| t.as_array()) {
-                Some(t) => t,
-                None => continue,
-            };
-            let mut d_val = None;
-            let mut name = None;
-            let mut is_archived = false;
-            for tag in tags {
-                if let Some(arr) = tag.as_array() {
-                    match arr.first().and_then(|v| v.as_str()) {
-                        Some("d") => d_val = arr.get(1).and_then(|v| v.as_str()),
-                        Some("name") => name = arr.get(1).and_then(|v| v.as_str()),
-                        Some("archived") => {
-                            is_archived = arr.get(1).and_then(|v| v.as_str()) == Some("true")
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            if let Some(d) = d_val {
-                if let Ok(uuid) = d.parse::<Uuid>() {
-                    if is_archived {
-                        archived.insert(uuid);
-                        continue;
-                    }
-                    let ch_name = name.unwrap_or("unknown").to_string();
-                    let ch_type = channel_type_from_tags(tags);
-                    meta_map.insert(uuid, (ch_name, ch_type));
-                }
-            }
-        }
-    }
-
+    let mut metadata = newest_verified_channel_info(meta_events, trusted_relay_pubkey);
     let mut map = HashMap::with_capacity(channel_uuids.len());
     for uuid in channel_uuids {
-        if archived.contains(&uuid) {
-            continue;
+        match metadata.remove(&uuid) {
+            Some(Some(info)) => {
+                map.insert(uuid, info);
+            }
+            Some(None) => {}
+            None => {
+                map.insert(
+                    uuid,
+                    ChannelInfo {
+                        name: "unknown".to_string(),
+                        channel_type: "unknown".to_string(),
+                    },
+                );
+            }
         }
-        let (name, channel_type) = meta_map
-            .remove(&uuid)
-            .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
-        map.insert(uuid, ChannelInfo { name, channel_type });
     }
     map
 }
@@ -237,6 +344,9 @@ pub struct RestClient {
     pub http: reqwest::Client,
     pub base_url: String,
     pub keys: Keys,
+    /// HTTPS-authenticated NIP-11 `self` identity used to authorize relay
+    /// control-plane and group metadata events returned by `/query`.
+    pub trusted_relay_pubkey: nostr::PublicKey,
     /// Optional NIP-OA auth tag JSON for `x-auth-tag` header (relay membership delegation).
     pub auth_tag_json: Option<String>,
 }
@@ -560,6 +670,8 @@ pub struct HarnessRelay {
     relay_url: String,
     /// Keys used for NIP-42 signing and NIP-98 HTTP auth.
     keys: Keys,
+    /// HTTPS-authenticated NIP-11 `self` identity pinned for this process.
+    trusted_relay_pubkey: nostr::PublicKey,
     /// Optional NIP-OA auth tag for relay membership delegation.
     auth_tag: Option<nostr::Tag>,
     /// Handle to the background task (for clean shutdown).
@@ -615,6 +727,14 @@ impl HarnessRelay {
         agent_pubkey_hex: &str,
         auth_tag: Option<nostr::Tag>,
     ) -> Result<Self, RelayError> {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|e| RelayError::Http(format!("failed to build HTTP client: {e}")))?;
+        let trusted_relay_pubkey = fetch_relay_self(&http, relay_url).await?;
+
         // Perform the initial connection and auth handshake, retrying
         // transient failures (dropped handshake, timeout) with bounded
         // jittered backoff. A terminal error (bad URL, bad auth tag,
@@ -644,6 +764,7 @@ impl HarnessRelay {
                 bg_relay_url,
                 bg_agent_pubkey_hex,
                 bg_auth_tag,
+                trusted_relay_pubkey,
             )
             .await;
         });
@@ -652,13 +773,10 @@ impl HarnessRelay {
             event_rx,
             observer_control_rx: Some(observer_control_rx),
             cmd_tx,
-            http: reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(10))
-                .connect_timeout(std::time::Duration::from_secs(5))
-                .build()
-                .map_err(|e| RelayError::Http(format!("failed to build HTTP client: {e}")))?,
+            http,
             relay_url: relay_url.to_string(),
             keys: keys.clone(),
+            trusted_relay_pubkey,
             auth_tag,
             bg_handle: Some(bg_handle),
         })
@@ -684,27 +802,11 @@ impl HarnessRelay {
             .custom_tags(p_tag, [pk_hex.as_str()]);
         let member_events = rest.query(&[member_filter]).await?;
 
-        let member_arr = member_events
-            .as_array()
-            .ok_or_else(|| RelayError::Http("expected JSON array from /query (members)".into()))?;
-
-        // Extract channel UUIDs from #d tags.
-        let mut channel_uuids: Vec<Uuid> = Vec::new();
-        for ev in member_arr {
-            if let Some(tags) = ev.get("tags").and_then(|t| t.as_array()) {
-                for tag in tags {
-                    if let Some(arr) = tag.as_array() {
-                        if arr.first().and_then(|v| v.as_str()) == Some("d") {
-                            if let Some(d_val) = arr.get(1).and_then(|v| v.as_str()) {
-                                if let Ok(uuid) = d_val.parse::<Uuid>() {
-                                    channel_uuids.push(uuid);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        let channel_uuids = verified_membership_channels(
+            &member_events,
+            &self.trusted_relay_pubkey,
+            &self.keys.public_key(),
+        );
 
         if channel_uuids.is_empty() {
             debug!("discovered 0 channel(s)");
@@ -722,7 +824,8 @@ impl HarnessRelay {
         let meta_events = rest.query(&[meta_filter]).await?;
 
         // Step 3: Build the final subscribe set, skipping archived channels.
-        let map = merge_discovered_channels(channel_uuids, &meta_events);
+        let map =
+            merge_discovered_channels(channel_uuids, &meta_events, &self.trusted_relay_pubkey);
 
         debug!("discovered {} channel(s)", map.len());
         Ok(map)
@@ -737,6 +840,7 @@ impl HarnessRelay {
             http: self.http.clone(),
             base_url: relay_ws_to_http(&self.relay_url),
             keys: self.keys.clone(),
+            trusted_relay_pubkey: self.trusted_relay_pubkey,
             auth_tag_json: self
                 .auth_tag
                 .as_ref()
@@ -990,6 +1094,9 @@ impl TwoGenDedup {
 
 /// State maintained by the background WebSocket task.
 struct BgState {
+    /// HTTPS-authenticated NIP-11 `self` identity pinned for this process.
+    /// Membership notifications are relay-authored and fail closed without it.
+    trusted_relay_pubkey: Option<nostr::PublicKey>,
     /// Active subscriptions: channel_id → subscription_id string.
     active_subscriptions: HashMap<Uuid, String>,
     /// Most recent `created_at` timestamp seen per channel (for `since` filter).
@@ -1078,6 +1185,7 @@ struct BgState {
 impl BgState {
     fn new() -> Self {
         Self {
+            trusted_relay_pubkey: None,
             active_subscriptions: HashMap::new(),
             last_seen: HashMap::new(),
             seen_ids: TwoGenDedup::new(SEEN_ID_LIMIT),
@@ -1557,8 +1665,10 @@ async fn run_background_task(
     relay_url: String,
     agent_pubkey_hex: String,
     auth_tag: Option<nostr::Tag>,
+    trusted_relay_pubkey: nostr::PublicKey,
 ) {
     let mut state = BgState::new();
+    state.trusted_relay_pubkey = Some(trusted_relay_pubkey);
 
     let handshake_ok = process_handshake_buffer(
         &mut ws,
@@ -2091,11 +2201,21 @@ async fn handle_ws_message(
                             Err(mpsc::error::TrySendError::Closed(_)) => return false,
                         }
                     } else if subscription_id == MEMBERSHIP_NOTIF_SUB_ID {
-                        // Membership notification — extract channel UUID from h tag.
-                        let channel_uuid = match extract_h_tag_uuid(&event) {
-                            Some(uuid) => uuid,
-                            None => {
-                                warn!("membership notification missing h tag — dropping");
+                        // Membership notifications are privileged relay-authored
+                        // control events. Validate signer, target and exact channel
+                        // tags before dedup or any replay/subscription state changes.
+                        let Some(relay_pubkey) = state.trusted_relay_pubkey.as_ref() else {
+                            warn!("membership notification dropped without pinned relay identity");
+                            return true;
+                        };
+                        let channel_uuid = match validate_membership_notification(
+                            &event,
+                            relay_pubkey,
+                            &keys.public_key(),
+                        ) {
+                            Ok(uuid) => uuid,
+                            Err(error) => {
+                                warn!(%error, "untrusted membership notification — dropping");
                                 return true;
                             }
                         };
@@ -2153,6 +2273,45 @@ async fn handle_ws_message(
                             Err(mpsc::error::TrySendError::Closed(_)) => return false,
                         }
                     } else if let Some(channel_id) = channel_id_from_sub_id(&subscription_id) {
+                        // A parseable `ch-<uuid>` string is not proof that this
+                        // subscription is current. Reject stale/fabricated routes
+                        // before transport bookkeeping or application delivery.
+                        if state
+                            .active_subscriptions
+                            .get(&channel_id)
+                            .map(String::as_str)
+                            != Some(subscription_id.as_str())
+                        {
+                            warn!(
+                                %subscription_id,
+                                %channel_id,
+                                "event received on inactive or fabricated channel subscription — dropping"
+                            );
+                            return true;
+                        }
+                        let kind = event.kind.as_u16() as u32;
+                        if matches!(
+                            kind,
+                            KIND_MEMBER_ADDED_NOTIFICATION | KIND_MEMBER_REMOVED_NOTIFICATION
+                        ) {
+                            warn!(
+                                %subscription_id,
+                                %channel_id,
+                                kind,
+                                "privileged membership event received on ordinary subscription — dropping"
+                            );
+                            return true;
+                        }
+                        if event.verify().is_err() || !has_exact_channel_binding(&event, channel_id)
+                        {
+                            warn!(
+                                %subscription_id,
+                                %channel_id,
+                                event_id = %event.id.to_hex(),
+                                "invalid signature or channel binding — dropping before replay bookkeeping"
+                            );
+                            return true;
+                        }
                         let ts = event.created_at.as_secs();
                         let event_id_hex = event.id.to_hex();
                         if state.record_event(channel_id, &event) {
@@ -3430,16 +3589,79 @@ async fn dns_flat_sleep(
     }
 }
 
-/// Extract a channel UUID from the h tag of a Nostr event.
-fn extract_h_tag_uuid(event: &nostr::Event) -> Option<Uuid> {
-    event.tags.iter().find_map(|tag| {
-        let tag_vec = tag.as_slice();
-        if tag_vec.len() >= 2 && tag_vec[0] == "h" {
-            tag_vec[1].parse::<Uuid>().ok()
-        } else {
-            None
-        }
-    })
+/// Validate a relay-authored membership notification before it can mutate
+/// subscriptions, queue state, or session retirement barriers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+enum MembershipNotificationError {
+    #[error("invalid Nostr event id or signature")]
+    InvalidSignature,
+    #[error("membership notification kind is not supported")]
+    WrongKind,
+    #[error("membership notification signer does not match NIP-11 relay identity")]
+    WrongSigner,
+    #[error("membership notification must contain exactly one target p tag")]
+    InvalidTarget,
+    #[error("membership notification must contain exactly one canonical channel h tag")]
+    InvalidChannel,
+}
+
+fn validate_membership_notification(
+    event: &Event,
+    relay_pubkey: &nostr::PublicKey,
+    agent_pubkey: &nostr::PublicKey,
+) -> Result<Uuid, MembershipNotificationError> {
+    event
+        .verify()
+        .map_err(|_| MembershipNotificationError::InvalidSignature)?;
+
+    let kind = event.kind.as_u16() as u32;
+    if !matches!(
+        kind,
+        KIND_MEMBER_ADDED_NOTIFICATION | KIND_MEMBER_REMOVED_NOTIFICATION
+    ) {
+        return Err(MembershipNotificationError::WrongKind);
+    }
+    if event.pubkey != *relay_pubkey {
+        return Err(MembershipNotificationError::WrongSigner);
+    }
+
+    let p_tags: Vec<_> = event
+        .tags
+        .iter()
+        .filter(|tag| tag.as_slice().first().map(String::as_str) == Some("p"))
+        .collect();
+    let p_value = p_tags
+        .first()
+        .and_then(|tag| tag.as_slice().get(1))
+        .map(String::as_str);
+    if p_tags.len() != 1
+        || p_value
+            .and_then(|p| nostr::PublicKey::parse(p).ok())
+            .as_ref()
+            != Some(agent_pubkey)
+    {
+        return Err(MembershipNotificationError::InvalidTarget);
+    }
+
+    let h_tags: Vec<_> = event
+        .tags
+        .iter()
+        .filter(|tag| tag.as_slice().first().map(String::as_str) == Some("h"))
+        .collect();
+    if h_tags.len() != 1 {
+        return Err(MembershipNotificationError::InvalidChannel);
+    }
+    let h_value = h_tags[0]
+        .as_slice()
+        .get(1)
+        .ok_or(MembershipNotificationError::InvalidChannel)?;
+    let channel_id = h_value
+        .parse::<Uuid>()
+        .map_err(|_| MembershipNotificationError::InvalidChannel)?;
+    if h_value != &channel_id.to_string() {
+        return Err(MembershipNotificationError::InvalidChannel);
+    }
+    Ok(channel_id)
 }
 
 /// Build and send a NIP-42 AUTH response event.
@@ -3488,6 +3710,40 @@ pub(crate) fn relay_ws_to_http(url: &str) -> String {
         .replace("ws://", "http://")
         .trim_end_matches('/')
         .to_string()
+}
+
+fn parse_nip11_relay_self(info: &Value) -> Result<nostr::PublicKey, RelayError> {
+    let value = info
+        .get("self")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| RelayError::AuthFailed("NIP-11 document has no relay self key".into()))?;
+    nostr::PublicKey::parse(value)
+        .map_err(|_| RelayError::AuthFailed("NIP-11 relay self key is invalid".into()))
+}
+
+async fn fetch_relay_self(
+    http: &reqwest::Client,
+    relay_url: &str,
+) -> Result<nostr::PublicKey, RelayError> {
+    let info_url = format!("{}/info", relay_ws_to_http(relay_url));
+    let response = http
+        .get(&info_url)
+        .header(reqwest::header::ACCEPT, "application/nostr+json")
+        .send()
+        .await
+        .map_err(|e| RelayError::Http(format!("NIP-11 identity fetch failed: {e}")))?;
+    if !response.status().is_success() {
+        return Err(RelayError::AuthFailed(format!(
+            "NIP-11 identity fetch returned HTTP {}",
+            response.status()
+        )));
+    }
+    let info = response
+        .json::<Value>()
+        .await
+        .map_err(|e| RelayError::AuthFailed(format!("invalid NIP-11 identity document: {e}")))?;
+    parse_nip11_relay_self(&info)
 }
 
 /// Build the subscription ID for a channel: `ch-<uuid>`.
@@ -4052,6 +4308,259 @@ mod tests {
     }
 
     #[test]
+    fn nip11_relay_identity_parser_fails_closed() {
+        let relay = Keys::generate();
+        let valid = serde_json::json!({"self": relay.public_key().to_hex()});
+        assert_eq!(parse_nip11_relay_self(&valid).unwrap(), relay.public_key());
+        assert!(parse_nip11_relay_self(&serde_json::json!({"self": null})).is_err());
+        assert!(parse_nip11_relay_self(&serde_json::json!({"self": "not-a-key"})).is_err());
+    }
+
+    #[test]
+    fn membership_notifications_require_relay_signature_exact_target_and_channel() {
+        fn signed_notification(
+            signer: &Keys,
+            target: &Keys,
+            channel_id: Uuid,
+            kind: u32,
+            extra_tags: Vec<Tag>,
+        ) -> Event {
+            let mut tags = vec![
+                Tag::parse(["p", &target.public_key().to_hex()]).unwrap(),
+                Tag::parse(["h", &channel_id.to_string()]).unwrap(),
+            ];
+            tags.extend(extra_tags);
+            EventBuilder::new(Kind::Custom(kind as u16), "")
+                .tags(tags)
+                .sign_with_keys(signer)
+                .unwrap()
+        }
+
+        let relay = Keys::generate();
+        let attacker = Keys::generate();
+        let agent = Keys::generate();
+        let other_agent = Keys::generate();
+        let channel_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let valid = signed_notification(
+            &relay,
+            &agent,
+            channel_id,
+            KIND_MEMBER_ADDED_NOTIFICATION,
+            vec![],
+        );
+
+        assert_eq!(
+            validate_membership_notification(&valid, &relay.public_key(), &agent.public_key()),
+            Ok(channel_id)
+        );
+
+        let forged = signed_notification(
+            &attacker,
+            &agent,
+            channel_id,
+            KIND_MEMBER_REMOVED_NOTIFICATION,
+            vec![],
+        );
+        assert!(validate_membership_notification(
+            &forged,
+            &relay.public_key(),
+            &agent.public_key()
+        )
+        .is_err());
+
+        let wrong_target = signed_notification(
+            &relay,
+            &other_agent,
+            channel_id,
+            KIND_MEMBER_ADDED_NOTIFICATION,
+            vec![],
+        );
+        assert!(validate_membership_notification(
+            &wrong_target,
+            &relay.public_key(),
+            &agent.public_key()
+        )
+        .is_err());
+
+        let duplicate_target = signed_notification(
+            &relay,
+            &agent,
+            channel_id,
+            KIND_MEMBER_ADDED_NOTIFICATION,
+            vec![Tag::parse(["p", &agent.public_key().to_hex()]).unwrap()],
+        );
+        assert!(validate_membership_notification(
+            &duplicate_target,
+            &relay.public_key(),
+            &agent.public_key()
+        )
+        .is_err());
+
+        let duplicate_channel = signed_notification(
+            &relay,
+            &agent,
+            channel_id,
+            KIND_MEMBER_ADDED_NOTIFICATION,
+            vec![Tag::parse(["h", &channel_id.to_string()]).unwrap()],
+        );
+        assert!(validate_membership_notification(
+            &duplicate_channel,
+            &relay.public_key(),
+            &agent.public_key()
+        )
+        .is_err());
+
+        let wrong_kind = signed_notification(&relay, &agent, channel_id, 9, vec![]);
+        assert!(validate_membership_notification(
+            &wrong_kind,
+            &relay.public_key(),
+            &agent.public_key()
+        )
+        .is_err());
+
+        let malformed_target = signed_notification(
+            &relay,
+            &agent,
+            channel_id,
+            KIND_MEMBER_ADDED_NOTIFICATION,
+            vec![Tag::parse(["p"]).unwrap()],
+        );
+        assert!(validate_membership_notification(
+            &malformed_target,
+            &relay.public_key(),
+            &agent.public_key()
+        )
+        .is_err());
+
+        let malformed_channel = signed_notification(
+            &relay,
+            &agent,
+            channel_id,
+            KIND_MEMBER_ADDED_NOTIFICATION,
+            vec![Tag::parse(["h"]).unwrap()],
+        );
+        assert!(validate_membership_notification(
+            &malformed_channel,
+            &relay.public_key(),
+            &agent.public_key()
+        )
+        .is_err());
+
+        let noncanonical_channel =
+            EventBuilder::new(Kind::Custom(KIND_MEMBER_ADDED_NOTIFICATION as u16), "")
+                .tags(vec![
+                    Tag::parse(["p", &agent.public_key().to_hex()]).unwrap(),
+                    Tag::parse(["h", &channel_id.to_string().to_ascii_uppercase()]).unwrap(),
+                ])
+                .sign_with_keys(&relay)
+                .unwrap();
+        assert!(validate_membership_notification(
+            &noncanonical_channel,
+            &relay.public_key(),
+            &agent.public_key()
+        )
+        .is_err());
+
+        let mut tampered_json = serde_json::to_value(&valid).unwrap();
+        tampered_json["content"] = serde_json::Value::String("tampered".into());
+        let tampered: Event = serde_json::from_value(tampered_json).unwrap();
+        assert!(validate_membership_notification(
+            &tampered,
+            &relay.public_key(),
+            &agent.public_key()
+        )
+        .is_err());
+    }
+
+    #[tokio::test]
+    async fn ordinary_subscription_rejects_privileged_membership_before_bookkeeping() {
+        let (mut ws, _server) = test_ws_pair().await;
+        let relay = Keys::generate();
+        let attacker = Keys::generate();
+        let agent = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let event = EventBuilder::new(Kind::Custom(KIND_MEMBER_REMOVED_NOTIFICATION as u16), "")
+            .tags([
+                Tag::parse(["p", &agent.public_key().to_hex()]).unwrap(),
+                Tag::parse(["h", &channel_id.to_string()]).unwrap(),
+            ])
+            .custom_created_at(nostr::Timestamp::from(9_999_999_999u64))
+            .sign_with_keys(&attacker)
+            .unwrap();
+        let event_id = event.id.to_hex();
+
+        let mut state = BgState::new();
+        state.trusted_relay_pubkey = Some(relay.public_key());
+        seed_test_subscription(&mut state, channel_id);
+        let (event_tx, mut event_rx) = mpsc::channel(4);
+        let (observer_tx, _observer_rx) = mpsc::channel(4);
+        let frame = json!(["EVENT", channel_sub_id(channel_id), event]);
+
+        assert!(
+            handle_ws_message(
+                Message::Text(frame.to_string().into()),
+                &mut ws,
+                &event_tx,
+                &observer_tx,
+                &mut state,
+                &agent,
+                "wss://relay.example",
+                &agent.public_key().to_hex(),
+                None,
+            )
+            .await
+        );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+        assert!(!state.seen_ids.contains(&event_id));
+        assert!(!state.last_seen.contains_key(&channel_id));
+    }
+
+    #[tokio::test]
+    async fn wrong_channel_event_cannot_poison_replay_state_before_admission() {
+        let (mut ws, _server) = test_ws_pair().await;
+        let agent = Keys::generate();
+        let author = Keys::generate();
+        let channel_id = Uuid::new_v4();
+        let wrong_channel = Uuid::new_v4();
+        let event = EventBuilder::new(Kind::TextNote, "wrong scope")
+            .tags([Tag::parse(["h", &wrong_channel.to_string()]).unwrap()])
+            .custom_created_at(nostr::Timestamp::from(9_999_999_999u64))
+            .sign_with_keys(&author)
+            .unwrap();
+        let event_id = event.id.to_hex();
+
+        let mut state = BgState::new();
+        seed_test_subscription(&mut state, channel_id);
+        let (event_tx, mut event_rx) = mpsc::channel(4);
+        let (observer_tx, _observer_rx) = mpsc::channel(4);
+        let frame = json!(["EVENT", channel_sub_id(channel_id), event]);
+
+        assert!(
+            handle_ws_message(
+                Message::Text(frame.to_string().into()),
+                &mut ws,
+                &event_tx,
+                &observer_tx,
+                &mut state,
+                &agent,
+                "wss://relay.example",
+                &agent.public_key().to_hex(),
+                None,
+            )
+            .await
+        );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+        assert!(!state.seen_ids.contains(&event_id));
+        assert!(!state.last_seen.contains_key(&channel_id));
+    }
+
+    #[test]
     fn channel_sub_id_format() {
         let uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         assert_eq!(
@@ -4083,47 +4592,117 @@ mod tests {
         assert!(channel_id_from_sub_id("").is_none());
     }
 
-    fn meta_event(uuid: Uuid, name: &str, extra: &[&str]) -> serde_json::Value {
+    fn meta_event(keys: &Keys, uuid: Uuid, name: &str, extra: &[&str]) -> serde_json::Value {
         let mut tags = vec![
-            serde_json::json!(["d", uuid.to_string()]),
-            serde_json::json!(["name", name]),
+            Tag::parse(vec!["d".to_string(), uuid.to_string()]).unwrap(),
+            Tag::parse(vec!["name".to_string(), name.to_string()]).unwrap(),
         ];
         // `extra` is a flat list of single-value tag names (e.g. archived=true).
         for pair in extra.chunks(2) {
             match pair {
-                [k, v] => tags.push(serde_json::json!([k, v])),
-                [k] => tags.push(serde_json::json!([k])),
+                [k, v] => tags.push(Tag::parse(vec![(*k).to_string(), (*v).to_string()]).unwrap()),
+                [k] => tags.push(Tag::parse(vec![(*k).to_string()]).unwrap()),
                 _ => {}
             }
         }
-        serde_json::json!({ "tags": tags })
+        serde_json::to_value(
+            EventBuilder::new(
+                Kind::Custom(buzz_core::kind::KIND_NIP29_GROUP_METADATA as u16),
+                "",
+            )
+            .tags(tags)
+            .sign_with_keys(keys)
+            .unwrap(),
+        )
+        .unwrap()
     }
 
     #[test]
     fn merge_discovered_channels_preserves_missing_metadata_as_unknown() {
         let channel = Uuid::new_v4();
-        let map = merge_discovered_channels(vec![channel], &serde_json::json!([]));
+        let relay = Keys::generate();
+        let map =
+            merge_discovered_channels(vec![channel], &serde_json::json!([]), &relay.public_key());
         assert_eq!(map[&channel].channel_type, "unknown");
     }
 
     #[test]
     fn merge_discovered_channels_uses_declared_dm_type_without_hidden_hint() {
         let channel = Uuid::new_v4();
-        let meta = serde_json::json!([meta_event(channel, "dm", &["t", "dm"])]);
-        let map = merge_discovered_channels(vec![channel], &meta);
+        let relay = Keys::generate();
+        let meta = serde_json::json!([meta_event(&relay, channel, "dm", &["t", "dm"])]);
+        let map = merge_discovered_channels(vec![channel], &meta, &relay.public_key());
         assert_eq!(map[&channel].channel_type, "dm");
+    }
+
+    #[test]
+    fn attacker_signed_metadata_cannot_downgrade_dm_authorization() {
+        let channel = Uuid::new_v4();
+        let relay = Keys::generate();
+        let attacker = Keys::generate();
+        let trusted_dm = meta_event(&relay, channel, "DM", &["t", "dm"]);
+        let forged_stream = meta_event(&attacker, channel, "public", &["t", "stream"]);
+
+        let map = merge_discovered_channels(
+            vec![channel],
+            &serde_json::json!([forged_stream, trusted_dm]),
+            &relay.public_key(),
+        );
+
+        assert_eq!(map[&channel].channel_type, "dm");
+        assert_eq!(map[&channel].name, "DM");
+    }
+
+    #[test]
+    fn membership_discovery_requires_relay_signature_exact_target_and_channel() {
+        let channel = Uuid::new_v4();
+        let relay = Keys::generate();
+        let attacker = Keys::generate();
+        let agent = Keys::generate();
+        let other = Keys::generate();
+        let member_event = |signer: &Keys, target: nostr::PublicKey, duplicate_d: bool| {
+            let mut tags = vec![
+                Tag::parse(vec!["d".to_string(), channel.to_string()]).unwrap(),
+                Tag::parse(vec!["p".to_string(), target.to_hex()]).unwrap(),
+            ];
+            if duplicate_d {
+                tags.push(Tag::parse(vec!["d".to_string(), channel.to_string()]).unwrap());
+            }
+            serde_json::to_value(
+                EventBuilder::new(
+                    Kind::Custom(buzz_core::kind::KIND_NIP29_GROUP_MEMBERS as u16),
+                    "",
+                )
+                .tags(tags)
+                .sign_with_keys(signer)
+                .unwrap(),
+            )
+            .unwrap()
+        };
+        let events = serde_json::json!([
+            member_event(&attacker, agent.public_key(), false),
+            member_event(&relay, other.public_key(), false),
+            member_event(&relay, agent.public_key(), true),
+            member_event(&relay, agent.public_key(), false),
+        ]);
+
+        assert_eq!(
+            verified_membership_channels(&events, &relay.public_key(), &agent.public_key()),
+            vec![channel]
+        );
     }
 
     #[test]
     fn merge_discovered_channels_skips_archived_metadata() {
         let live = Uuid::new_v4();
         let archived = Uuid::new_v4();
+        let relay = Keys::generate();
         let meta = serde_json::json!([
-            meta_event(live, "live", &[]),
-            meta_event(archived, "dead", &["archived", "true"]),
+            meta_event(&relay, live, "live", &[]),
+            meta_event(&relay, archived, "dead", &["archived", "true"]),
         ]);
 
-        let map = merge_discovered_channels(vec![live, archived], &meta);
+        let map = merge_discovered_channels(vec![live, archived], &meta, &relay.public_key());
 
         assert!(map.contains_key(&live), "non-archived channel is kept");
         assert!(
@@ -4142,9 +4721,10 @@ mod tests {
         // client skip re-subscribing on reconnect — proving (b) closes the loop
         // independently of the relay-side eviction.
         let reaped = Uuid::new_v4();
-        let meta = serde_json::json!([meta_event(reaped, "reaped", &["archived", "true"])]);
+        let relay = Keys::generate();
+        let meta = serde_json::json!([meta_event(&relay, reaped, "reaped", &["archived", "true"])]);
 
-        let map = merge_discovered_channels(vec![reaped], &meta);
+        let map = merge_discovered_channels(vec![reaped], &meta, &relay.public_key());
 
         assert!(
             map.is_empty(),
@@ -4156,9 +4736,10 @@ mod tests {
     fn merge_discovered_channels_archived_false_is_kept() {
         // An explicit archived=false (e.g. after unarchive) must NOT be skipped.
         let ch = Uuid::new_v4();
-        let meta = serde_json::json!([meta_event(ch, "back", &["archived", "false"])]);
+        let relay = Keys::generate();
+        let meta = serde_json::json!([meta_event(&relay, ch, "back", &["archived", "false"])]);
 
-        let map = merge_discovered_channels(vec![ch], &meta);
+        let map = merge_discovered_channels(vec![ch], &meta, &relay.public_key());
 
         assert!(map.contains_key(&ch), "archived=false is treated as live");
     }

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -386,7 +386,7 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
     let channel_info = crate::pool::ChannelInfoResolver::new(channel_info_map, rest_client.clone());
 
     // Deduplicate by event-id so reconnect replay cannot double-nudge.
-    let mut nudged_event_ids: HashSet<EventId> = HashSet::new();
+    let mut nudged_event_ids = NudgeDedup::new(NUDGE_DEDUP_LIMIT);
 
     loop {
         let Some(buzz_event) = relay.next_event().await else {
@@ -483,6 +483,61 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
     Ok(())
 }
 
+/// Bounded de-duplication of nudged event IDs.
+///
+/// Setup mode must not double-nudge an event that reconnect replay redelivers,
+/// but the raw `HashSet` this replaces was insert-only: it grew one entry per
+/// mentioned event for the lifetime of the process, and the events are supplied
+/// by other participants. Same two-generation rotation the relay uses for
+/// `seen_ids` (`TwoGenDedup`): recent history is retained for replay, total
+/// residency is capped.
+#[derive(Debug)]
+pub(crate) struct NudgeDedup {
+    current: HashSet<EventId>,
+    previous: HashSet<EventId>,
+    limit: usize,
+}
+
+impl NudgeDedup {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self {
+            current: HashSet::new(),
+            previous: HashSet::new(),
+            limit: limit.max(2),
+        }
+    }
+
+    fn contains(&self, id: &EventId) -> bool {
+        self.current.contains(id) || self.previous.contains(id)
+    }
+
+    /// Insert `id`; `true` when it was new.
+    fn insert(&mut self, id: EventId) -> bool {
+        if self.contains(&id) {
+            return false;
+        }
+        self.current.insert(id);
+        if self.current.len() >= self.limit / 2 {
+            self.previous = std::mem::take(&mut self.current);
+        }
+        true
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.current.len() + self.previous.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Cap on retained nudge IDs. Mirrors the relay's `SEEN_ID_LIMIT` intent at the
+/// smaller scale setup mode operates at.
+pub(crate) const NUDGE_DEDUP_LIMIT: usize = 4_096;
+
 /// Outcome of the pure per-event gate checks in setup mode.
 ///
 /// Callers compute the async gates (`author_allowed`, `filter::match_event`)
@@ -496,7 +551,7 @@ pub(crate) fn should_nudge_for_event(
     event_id: EventId,
     author_allowed: bool,
     filter_matched: bool,
-    nudged_event_ids: &mut HashSet<EventId>,
+    nudged_event_ids: &mut NudgeDedup,
 ) -> bool {
     if !author_allowed {
         tracing::debug!("setup-mode: event filtered by author gate");
@@ -1000,7 +1055,7 @@ mod tests {
     #[test]
     fn test_non_allowlisted_author_returns_no_nudge() {
         // author_allowed = false → should return false regardless of other args.
-        let mut dedup: HashSet<EventId> = HashSet::new();
+        let mut dedup = NudgeDedup::new(NUDGE_DEDUP_LIMIT);
         let event_id = fake_event_id(0xAA);
 
         let result = should_nudge_for_event(
@@ -1021,7 +1076,7 @@ mod tests {
     fn test_same_event_id_twice_nudges_exactly_once() {
         // The first call with a given event-id should return true; the second
         // call with the identical id must return false (replay dedup).
-        let mut dedup: HashSet<EventId> = HashSet::new();
+        let mut dedup = NudgeDedup::new(NUDGE_DEDUP_LIMIT);
         let event_id = fake_event_id(0xBB);
 
         let first = should_nudge_for_event(
@@ -1130,6 +1185,40 @@ mod tests {
         assert!(
             sentinel_json.contains(r#""availability":"not_installed""#),
             "sentinel must carry availability=not_installed; got: {sentinel_json:?}"
+        );
+    }
+
+    #[test]
+    fn setup_mode_nudge_dedup_is_bounded() {
+        // Invariant: "Persistent channel, dedup, membership, and setup state is
+        // bounded." `nudged_event_ids` was insert-only with no eviction, so a
+        // long-lived setup-mode process grew one entry per mentioned event for
+        // the lifetime of the process. Unbounded growth in a listener that an
+        // untrusted party can drive is a resource-exhaustion path.
+        let mut dedup = NudgeDedup::new(64);
+        for i in 0..10_000u32 {
+            let mut raw = [0u8; 32];
+            raw[..4].copy_from_slice(&i.to_be_bytes());
+            let id = EventId::from_slice(&raw).expect("32-byte event id");
+            assert!(
+                should_nudge_for_event(id, true, true, &mut dedup),
+                "each distinct event must nudge exactly once"
+            );
+        }
+        assert!(
+            dedup.len() <= 64,
+            "nudge dedup must stay bounded; grew to {}",
+            dedup.len()
+        );
+
+        // And it must still deduplicate the recent past, or reconnect replay
+        // would double-nudge - the reason the set exists at all.
+        let mut raw = [0u8; 32];
+        raw[..4].copy_from_slice(&9_999u32.to_be_bytes());
+        let recent = EventId::from_slice(&raw).expect("32-byte event id");
+        assert!(
+            !should_nudge_for_event(recent, true, true, &mut dedup),
+            "a just-seen event must still be deduplicated"
         );
     }
 }


### PR DESCRIPTION
## Summary
- scope event queue, in-flight tracking, dedup, retry, cancellation and steer routing by `(channel, NIP-10 thread root)`
- allow distinct threads in the same channel to dispatch concurrently while preserving top-level channel behavior
- carry `threadRootId` through ACP observer Activity frames and exact control/task completion paths
- add queue and exact thread control-routing regression tests; document the new behavior

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p buzz-acp`
- `cargo test -p buzz-acp queue::tests --no-fail-fast` (113 passed)
- `cargo test -p buzz-acp observer_chunk_coalescer_tests --no-fail-fast` (2 passed)
- `cargo test -p buzz-acp owner_control_command_tests --no-fail-fast -- --test-threads=1` (4 passed)
- `cargo test -p buzz-acp pool::tests --no-fail-fast -- --test-threads=1` (108 passed)

The full package suite has pre-existing Windows `/bin/bash` and inert-agent subprocess failures; focused pure/state tests above pass.