### PR TITLE
Support streamed 2 GB mobile video uploads

### DIFF
--- a/crates/buzz-media/src/config.rs
+++ b/crates/buzz-media/src/config.rs
@@ -34,7 +34,7 @@ impl FromStr for S3AddressingStyle {
 }
 
 fn default_max_video_bytes() -> u64 {
-    524_288_000 // 500 MB
+    2_147_483_648 // 2 GiB
 }
 
 fn default_max_file_bytes() -> u64 {
@@ -71,7 +71,7 @@ pub struct MediaConfig {
     pub max_image_bytes: u64,
     /// Maximum upload size for animated GIFs (bytes). Default: 10 MB.
     pub max_gif_bytes: u64,
-    /// Maximum upload size for video files (bytes). Default: 500 MB.
+    /// Maximum upload size for video files (bytes). Default: 2 GiB.
     #[serde(default = "default_max_video_bytes")]
     pub max_video_bytes: u64,
     /// Maximum upload size for generic (non-image, non-video) files (bytes). Default: 100 MB.

--- a/crates/buzz-media/src/storage.rs
+++ b/crates/buzz-media/src/storage.rs
@@ -84,7 +84,7 @@ impl MediaStorage {
     ///
     /// Uses rust-s3's `put_object_stream_with_content_type` which reads from
     /// the file incrementally via an 8 MiB `BufReader`. The full file is never
-    /// held in memory simultaneously. Intended for video blobs (up to 500 MB).
+    /// held in memory simultaneously. Intended for large video blobs (up to 2 GiB).
     pub async fn put_file(
         &self,
         key: &str,

--- a/crates/buzz-relay/src/config.rs
+++ b/crates/buzz-relay/src/config.rs
@@ -698,7 +698,7 @@ impl Config {
             max_video_bytes: std::env::var("BUZZ_MAX_VIDEO_BYTES")
                 .ok()
                 .and_then(|v| v.parse().ok())
-                .unwrap_or(500 * 1024 * 1024),
+                .unwrap_or(2 * 1024 * 1024 * 1024),
             max_file_bytes: std::env::var("BUZZ_MAX_FILE_BYTES")
                 .ok()
                 .and_then(|v| v.parse().ok())

--- a/mobile/lib/shared/relay/media_upload.dart
+++ b/mobile/lib/shared/relay/media_upload.dart
@@ -59,7 +59,8 @@ const _allowedImageMimeTypes = {
   'image/webp',
 };
 const _allowedVideoMimeTypes = {'video/mp4'};
-const _maxVideoSizeBytes = 100 * 1024 * 1024; // 100MB
+const _maxVideoSizeBytes =
+    2 * 1024 * 1024 * 1024; // 2 GiB; keep in sync with relay default.
 const _maxFileSizeBytes = 100 * 1024 * 1024; // 100MB
 const _mediaPolicyUploadMessage = "We couldn't prepare this image for upload.";
 
@@ -265,7 +266,7 @@ class MediaUploadService {
     final length = await pickedVideo.length();
     if (length > _maxVideoSizeBytes) {
       throw Exception(
-        'Video is too large (${(length / 1024 / 1024).toStringAsFixed(0)}MB). Maximum is 100MB.',
+        'Video is too large (${(length / 1024 / 1024).toStringAsFixed(0)}MB). Maximum is 2GB.',
       );
     }
 
@@ -278,11 +279,10 @@ class MediaUploadService {
       final transcodedLength = await transcodedFile.length();
       if (transcodedLength > _maxVideoSizeBytes) {
         throw Exception(
-          'Transcoded video is too large (${(transcodedLength / 1024 / 1024).toStringAsFixed(0)}MB). Maximum is 100MB.',
+          'Transcoded video is too large (${(transcodedLength / 1024 / 1024).toStringAsFixed(0)}MB). Maximum is 2GB.',
         );
       }
-      final bytes = await transcodedFile.readAsBytes();
-      return uploadBytes(bytes, mimeType: 'video/mp4');
+      return await _uploadPreparedFile(transcodedFile, mimeType: 'video/mp4');
     } finally {
       if (transcodedPath != null) {
         try {
@@ -397,6 +397,57 @@ class MediaUploadService {
     return BlobDescriptor.fromJson(
       jsonDecode(response.body) as Map<String, dynamic>,
     );
+  }
+
+  Future<BlobDescriptor> _uploadPreparedFile(
+    File file, {
+    required String mimeType,
+  }) async {
+    final sha256 = await _sha256File(file);
+    var response = await _sendUploadFileRequest(
+      file: file,
+      mimeType: mimeType,
+      sha256: sha256,
+      path: _mediaUploadPath,
+    );
+    if (response.statusCode == HttpStatus.notFound ||
+        response.statusCode == HttpStatus.methodNotAllowed) {
+      response = await _sendUploadFileRequest(
+        file: file,
+        mimeType: mimeType,
+        sha256: sha256,
+        path: _legacyMediaUploadPath,
+      );
+    }
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception(
+        'upload failed (${response.statusCode}): ${response.body}',
+      );
+    }
+    return BlobDescriptor.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
+  }
+
+  Future<http.Response> _sendUploadFileRequest({
+    required File file,
+    required String mimeType,
+    required String sha256,
+    required String path,
+  }) async {
+    final request = http.StreamedRequest(
+      'PUT',
+      Uri.parse(_baseUrl).resolve(path),
+    );
+    request.contentLength = await file.length();
+    request.headers.addAll(
+      _buildUploadHeaders(mimeType: mimeType, sha256: sha256),
+    );
+
+    final responseFuture = _http.send(request);
+    await request.sink.addStream(file.openRead());
+    await request.sink.close();
+    return http.Response.fromStream(await responseFuture);
   }
 
   http.Request _buildUploadRequest({
@@ -550,6 +601,17 @@ String _safeAttachmentFilename(String filename) {
 String _sha256Hex(Uint8List bytes) {
   final digest = SHA256Digest().process(bytes);
   return digest.map((byte) => byte.toRadixString(16).padLeft(2, '0')).join();
+}
+
+Future<String> _sha256File(File file) async {
+  final digest = SHA256Digest();
+  await for (final chunk in file.openRead()) {
+    final bytes = chunk is Uint8List ? chunk : Uint8List.fromList(chunk);
+    digest.update(bytes, 0, bytes.length);
+  }
+  final output = Uint8List(digest.digestSize);
+  digest.doFinal(output, 0);
+  return output.map((byte) => byte.toRadixString(16).padLeft(2, '0')).join();
 }
 
 String? _tryDetectImageMimeType(Uint8List bytes) {

--- a/mobile/test/shared/relay/media_upload_test.dart
+++ b/mobile/test/shared/relay/media_upload_test.dart
@@ -1352,12 +1352,55 @@ void main() {
       expect(result, isNull);
     });
 
-    test('rejects videos over 100MB', () async {
-      // Create a temp file with 101MB of zeros.
+    test(
+      'accepts a source video larger than 1GB and streams the result',
+      () async {
+        final dir = await Directory.systemTemp.createTemp('video_size_test_');
+        final sourceFile = File('${dir.path}/source.mov');
+        final sourceRaf = await sourceFile.open(mode: FileMode.write);
+        await sourceRaf.truncate(1100 * 1024 * 1024);
+        await sourceRaf.close();
+        final transcodedFile = File('${dir.path}/transcoded.mp4');
+        final transcodedBytes = buildFtypHeader('isom');
+        await transcodedFile.writeAsBytes(transcodedBytes);
+
+        try {
+          final service = MediaUploadService(
+            baseUrl: 'https://relay.example',
+            nsec: nostr.Keys.generate().nsec,
+            httpClient: http_testing.MockClient((request) async {
+              expect(request.bodyBytes, transcodedBytes);
+              return http.Response(
+                jsonEncode({
+                  'url': 'https://relay.example/media/test.mp4',
+                  'sha256':
+                      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+                  'size': transcodedBytes.length,
+                  'type': 'video/mp4',
+                  'uploaded': 1,
+                }),
+                HttpStatus.ok,
+              );
+            }),
+            pickGalleryVideo: () async => XFile(sourceFile.path),
+            pickGalleryImage: () async => null,
+            transcodeVideoToMp4: (_) async => transcodedFile.path,
+          );
+
+          final descriptor = await service.pickAndUploadVideo();
+          expect(descriptor!.size, transcodedBytes.length);
+        } finally {
+          await dir.delete(recursive: true);
+        }
+      },
+    );
+
+    test('rejects videos over 2GB', () async {
+      // Use a sparse file so the test does not allocate more than 2GB.
       final dir = await Directory.systemTemp.createTemp('video_size_test_');
       final file = File('${dir.path}/huge.mp4');
       final raf = await file.open(mode: FileMode.write);
-      await raf.truncate(101 * 1024 * 1024);
+      await raf.truncate((2 * 1024 * 1024 * 1024) + 1);
       await raf.close();
 
       try {


### PR DESCRIPTION
## Summary

- raise the mobile and relay video limit from 100/500 MB to 2 GiB
- stream mobile video uploads from disk instead of loading the full video into memory
- calculate SHA-256 incrementally while streaming
- keep the temporary upload file alive until the HTTP request completes
- retain the existing 100 MB cap for generic files
- add sparse-file tests proving a 1,100 MB video is accepted without allocating 1.1 GB, and a video over 2 GiB is rejected

The mobile picker currently rejects videos over 100 MB before the relay can receive them. Even if that cap is raised alone, reading a long phone video fully into memory is unsafe. This change aligns the mobile and relay limits and makes the mobile transfer constant-memory.

Desktop and CLI upload paths remain unchanged in this PR.

### Product target

- no five-minute or ten-minute duration cutoff is introduced
- support a real phone-originated video at least ten minutes long when its file size is at or below 2 GiB
- provide a 2 GiB per-video ceiling, twice Slack's currently published 1 GB per-file upload limit
- release acceptance requires the same ten-minute-or-longer attachment to upload, open, play, and download on phone and desktop

### Related issue

None found after searching open Buzz issues and PRs for mobile video upload-size reports.

### Testing

- `flutter analyze mobile/lib/shared/relay/media_upload.dart mobile/test/shared/relay/media_upload_test.dart`
- targeted Flutter media upload tests: 33 passed, including 1,100 MB sparse-video streaming and over-2-GiB rejection
- `cargo test -p buzz-media config`: 8 passed
- `cargo test -p buzz-relay config`: 41 passed, 1 ignored because it requires PostgreSQL
- full relay compilation passed
- gitleaks scanned the introduced commit range: no leaks found

### Release verification still required

This is implementation proof, not a claim that existing installed mobile clients can already upload 2 GB. A signed mobile build and a relay deployment using the new cap still need an end-to-end upload of a real phone video at least ten minutes long, followed by phone playback, desktop playback, and recipient download, before the capability is considered live.
