### PR TITLE
test(db): pin the fence verdict guard; fix the two #3829-broken owner-limit tests

### DIFF
--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -6110,8 +6110,11 @@ mod tests {
         let db = setup_db().await;
         let owner = format!("{:064x}", Uuid::new_v4().as_u128());
 
-        // Create 3 communities for this owner (the max).
-        for i in 0..3 {
+        // Create the maximum number of communities for this owner. Seed from
+        // the same limit the code enforces so this test tracks the configured
+        // value instead of a literal (#3829 raised the default and broke the
+        // hardcoded 3).
+        for i in 0..relay_members::max_communities_per_owner() {
             let host = format!("limit-test-{}-{}.example", i, Uuid::new_v4().simple());
             assert!(matches!(
                 db.create_community_with_owner(&host, &owner)
@@ -6121,7 +6124,7 @@ mod tests {
             ));
         }
 
-        let host = format!("limit-test-3-{}.example", Uuid::new_v4().simple());
+        let host = format!("limit-test-over-{}.example", Uuid::new_v4().simple());
         assert_eq!(
             db.create_community_with_owner(&host, &owner)
                 .await
@@ -7505,6 +7508,87 @@ mod tests {
                 .await
                 .expect("entry too old"),
             "an over-budget entry must fail closed to the writer"
+        );
+
+        // A reader session proving an OLDER entry than the ring's newest —
+        // the real replication-lag case, and the only shape that pins the
+        // verdict stage. A single injected entry cannot express it: it is
+        // simultaneously the newest AND the one proved, so the cheap
+        // precheck alone fails the read closed and the verdict guard can be
+        // deleted with byte-identical metrics (asserting `reason == "stale"`
+        // on the leg above therefore proves neither guard).
+        //
+        // Two entries separate them. The reader observes token 100, so
+        // `resolve` returns the greatest entry with `token <= 100` — the
+        // stale token-50 one — while `newest` (token 999, just committed)
+        // passes the precheck. Only the per-session re-evaluation can catch
+        // that, so deleting it serves a stale replica answer, which the
+        // divergent fixture sees as the replica's row.
+        let epoch: Uuid = sqlx::query_scalar("SELECT epoch FROM replica_heartbeat WHERE id = 1")
+            .fetch_one(&replica)
+            .await
+            .expect("read the replica's heartbeat epoch");
+        sqlx::query("UPDATE replica_heartbeat SET token = 100 WHERE id = 1")
+            .execute(&replica)
+            .await
+            .expect("pin the observable reader token");
+        db.fence().close();
+        // Proved-but-stale: observable (token <= 100), committed long ago.
+        db.fence().record(
+            50,
+            epoch,
+            std::time::Instant::now() - std::time::Duration::from_secs(10),
+            chrono::Utc::now(),
+        );
+        // Newest-and-fresh, but unobservable (token > 100): passes the
+        // precheck, cannot be proved by this reader.
+        db.fence()
+            .record(999, epoch, std::time::Instant::now(), chrono::Utc::now());
+
+        let recorder = metrics_util::debugging::DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        // Thread-local recorder must stay installed across the await, hence
+        // the guard form; `current_thread` keeps the emit on this thread.
+        let served = {
+            let _guard = metrics::set_default_local_recorder(&recorder);
+            db.is_relay_member(cid, &writer_only).await
+        }
+        .expect("a stale proof must still answer, on the writer");
+        assert!(
+            served,
+            "proving an entry older than the budget must fail closed to the \
+             writer even when the ring's newest entry is fresh"
+        );
+        let routes: std::collections::HashMap<(String, String), u64> = snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .filter(|(key, ..)| key.key().name() == "buzz_db_route_decision")
+            .map(|(key, _, _, value)| {
+                let metrics_util::debugging::DebugValue::Counter(n) = value else {
+                    panic!("buzz_db_route_decision must be a counter");
+                };
+                let labels: Vec<_> = key.key().labels().collect();
+                let label = |name: &str| {
+                    labels
+                        .iter()
+                        .find(|l| l.key() == name)
+                        .map(|l| l.value().to_owned())
+                        .unwrap_or_default()
+                };
+                ((label("decision"), label("reason")), n)
+            })
+            .collect();
+        assert_eq!(
+            routes.get(&("writer".to_owned(), "stale".to_owned())),
+            Some(&1),
+            "the proved entry is over budget, so this must record \
+             writer/stale; got {routes:?}"
+        );
+        assert!(
+            !routes.keys().any(|(decision, _)| decision == "replica"),
+            "no replica answer may be recorded when the proved entry is \
+             over budget; got {routes:?}"
         );
 
         drop_scratch_db(&admin, replica, &rname).await;

--- a/crates/buzz-db/src/relay_members.rs
+++ b/crates/buzz-db/src/relay_members.rs
@@ -998,8 +998,10 @@ mod tests {
         let owner = test_pubkey();
         let transferee = test_pubkey();
 
-        // Give the transferee 3 communities (the max).
-        for _ in 0..3 {
+        // Give the transferee the maximum number of communities, seeded from
+        // the enforced limit rather than a literal (#3829 raised the default
+        // and broke the hardcoded 3).
+        for _ in 0..max_communities_per_owner() {
             let c = make_test_community(&pool).await;
             bootstrap_owner(&pool, c, &transferee)
                 .await

--- a/crates/buzz-relay/src/api/operator.rs
+++ b/crates/buzz-relay/src/api/operator.rs
@@ -1083,7 +1083,7 @@ mod tests {
             return;
         };
 
-        for _ in 0..buzz_db::relay_members::MAX_COMMUNITIES_PER_OWNER {
+        for _ in 0..buzz_db::relay_members::max_communities_per_owner() {
             let host = format!("community-{}.example", Uuid::new_v4().simple());
             assert_eq!(
                 provision_community(state.clone(), &operator, &host, &owner)


### PR DESCRIPTION
Test-only follow-up from the #4124 review round. No production code changes.

## 1. Two-entry fence fixture — pins the verdict guard

Dawn's mutation testing on #4124 found that the over-budget leg of `is_relay_member_is_bounded_routed_and_fails_closed` could not independently pin either staleness guard: with a single injected fence entry, the entry is simultaneously the ring's newest AND the one the reader proves, so the cheap precheck alone fails the read closed — the authoritative per-session verdict guard could be deleted with byte-identical test results. Sami then proved the proposed one-line `reason == "stale"` assert kills neither mutant (both guards emit the identical label; the precheck short-circuits) and designed this fixture instead; Dawn independently rebuilt it and confirmed.

The new leg expresses the real replication-lag case — a reader session proving an *older* entry than the shared ring's newest:

- pin the replica's observable token to 100, then record a proved-but-stale entry (token 50, committed 10s ago) and a fresh unobservable one (token 999, just committed), both under the replica's **real heartbeat epoch** (a fresh UUID would route to the writer via `EpochMismatch` — the wrong reason, and the test would pass while proving nothing)
- the precheck passes on the fresh newest; `resolve()` proves the stale token-50 entry; only the verdict stage can catch that
- asserts the **outcome** (the writer's divergent row is served), the `writer/stale` route metric, and the **absence of any replica decision** — label as corroboration, outcome as proof

Mutation results (verified locally at this head):

| Mutant | Result |
|---|---|
| Verdict stage: `Bounded => Some("fresh")` | **FAILS — killed** (was surviving) |
| Precheck: never `Err("stale")` | passes — **correct**: it is availability hygiene, not soundness (`replica_fence.rs`); the verdict stage re-decides authoritatively |

Credit: diagnosis Dawn, fixture design + patch Sami (verified on merged main `ac4fa13b8`), independent reproduction Dawn.

## 3. Seed the operator owner-limit test from the function, not the constant

Same defect class as item 2, found by Sami after this PR opened: `fresh_host_at_owner_limit_returns_limit_reached_conflict` (`buzz-relay/api/operator.rs`) looped over the `MAX_COMMUNITIES_PER_OWNER` **constant** while `provision_community` enforces `max_communities_per_owner()`, which reads `BUZZ_MAX_COMMUNITIES_PER_OWNER` with the constant only as fallback. Latent today (nothing wires that env var), but the moment an operator sets it the loop count and the enforced limit diverge and the CONFLICT assertion inverts. Verified RED/GREEN with `BUZZ_MAX_COMMUNITIES_PER_OWNER=3`: before, 409 at iteration 4 of 5; after, passes at env=3, env=7, and default.

## 2. Un-break the two owner-limit tests (#3829)

#3829 raised the default per-owner community limit 3 → 5 without updating `create_community_with_owner_enforces_per_owner_limit` and `transfer_ownership_returns_limit_reached_for_maxed_transferee`; both have failed on main since (they seed exactly 3, then expect `LimitReached`). Both now seed from `max_communities_per_owner()` — the same value the code enforces — so they track the configured limit instead of a literal.

## Validation

At `7db75a607` (branched from merged main `ac4fa13b8`):

- Full PG-gated `buzz-relay` suite serial: 37/0; non-PG `buzz-relay`: 835 passed, 1 failed — `mesh_demo::demo_join_forwarded_arm_round_trips_echo`, a known pre-existing flake unrelated to this diff (fails identically on the clean previous head in the same environment)
- Operator limit test RED/GREEN as above

At `8fd5ab04d` (previous head, buzz-db portion unchanged since):

- Full PG-gated `buzz-db` suite serial: **153 passed / 0 failed** (main is 151/2 — the two failures are the #3829 tests fixed here)
- Non-PG `buzz-db` suite: 94/0
- Verdict mutant applied → routed test **fails**; reverted → passes (RED/GREEN, same shell)
- `cargo fmt --check` + `cargo clippy -p buzz-db --all-targets` clean

