### PR TITLE
fix(compose): honor external S3 settings

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -33,7 +33,11 @@ REDIS_PASSWORD=CHANGE_ME_RANDOM_PASSWORD
 BUZZ_S3_ACCESS_KEY=CHANGE_ME_RANDOM_ACCESS_KEY
 BUZZ_S3_SECRET_KEY=CHANGE_ME_RANDOM_SECRET_KEY
 BUZZ_S3_BUCKET=buzz-media
-# Bundled MinIO uses path-style URLs; deploy/compose/compose.yml pins this.
+# Object storage defaults target the bundled MinIO service. Set matching values
+# for an external S3-compatible provider when needed.
+BUZZ_S3_ENDPOINT=http://minio:9000
+BUZZ_S3_REGION=us-east-1
+# Bundled MinIO uses path-style URLs. Some external providers require virtual.
 BUZZ_S3_ADDRESSING_STYLE=path
 
 # Optional host ports. Base compose publishes the relay directly on BUZZ_HTTP_PORT.

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -38,11 +38,13 @@ keypair.
   migrations.
 - The stack uses Postgres, Redis, MinIO, and a git data volume because
   those are real Buzz dependencies today. Minimal mode can simplify this later.
-- The bundled Compose stack fixes the relay endpoint to `http://minio:9000` and
+- The bundled Compose stack defaults the relay to `http://minio:9000` and
   `BUZZ_S3_ADDRESSING_STYLE=path`: Docker DNS resolves `minio`, not
-  `<bucket>.minio`. It is not configurable for an external S3 provider through
-  `.env`; use the Helm chart or a custom Compose configuration for providers
-  such as new Railway Storage Buckets that require `virtual` addressing.
+  `<bucket>.minio`. To use external S3-compatible storage, set
+  `BUZZ_S3_ENDPOINT`, `BUZZ_S3_REGION`, and `BUZZ_S3_ADDRESSING_STYLE` in
+  `.env` for your provider (some providers require `virtual` addressing). The
+  base stack still starts MinIO and its bucket initializer; use a custom Compose
+  override to remove those services when external storage is the only target.
 
 Run `./run.sh backup-hint` for the backup checklist.
 

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -11,9 +11,10 @@ services:
       BUZZ_METRICS_PORT: "9102"
       DATABASE_URL: postgres://${POSTGRES_USER:-buzz}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-buzz}
       REDIS_URL: redis://:${REDIS_PASSWORD:?set REDIS_PASSWORD}@redis:6379
-      BUZZ_S3_ENDPOINT: http://minio:9000
+      BUZZ_S3_ENDPOINT: ${BUZZ_S3_ENDPOINT:-http://minio:9000}
+      BUZZ_S3_REGION: ${BUZZ_S3_REGION:-us-east-1}
       # Docker DNS resolves `minio`, not arbitrary `<bucket>.minio` hosts.
-      BUZZ_S3_ADDRESSING_STYLE: path
+      BUZZ_S3_ADDRESSING_STYLE: ${BUZZ_S3_ADDRESSING_STYLE:-path}
       BUZZ_S3_ACCESS_KEY: ${BUZZ_S3_ACCESS_KEY:?set BUZZ_S3_ACCESS_KEY}
       BUZZ_S3_SECRET_KEY: ${BUZZ_S3_SECRET_KEY:?set BUZZ_S3_SECRET_KEY}
       BUZZ_S3_BUCKET: ${BUZZ_S3_BUCKET:-buzz-media}


### PR DESCRIPTION
## Problem

The Compose relay environment hardcoded its S3 endpoint and addressing style, so values set in `.env` were silently ignored. That sent media to the bundled MinIO service instead of the configured S3-compatible provider.

Fixes #3794.

## Change

- Preserve the bundled MinIO defaults when S3 variables are unset.
- Pass `BUZZ_S3_ENDPOINT`, `BUZZ_S3_REGION`, and `BUZZ_S3_ADDRESSING_STYLE` from `.env` to the relay.
- Document the external-storage path and that the base stack still starts MinIO.

## Validation

- `git diff --check`
- Rendered Compose config with default values: MinIO endpoint, `us-east-1`, and path addressing.
- Rendered Compose config with external overrides: endpoint, region, and virtual addressing passed through unchanged.
