### PR TITLE
feat(deploy): support extra compose override files via BUZZ_COMPOSE_EXTRA_FILES

### DIFF
--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -23,6 +23,34 @@ The bootstrap script should eventually replace manual `.env` editing for normal
 users. It is responsible for generating stable secrets and, optionally, an owner
 keypair.
 
+## Site-local overrides
+
+`run.sh` passes explicit `-f` flags to `docker compose`, which disables
+Compose's automatic `compose.override.yml` loading. To layer your own override
+files (resource limits, extra labels, host-specific tweaks), set
+`BUZZ_COMPOSE_EXTRA_FILES` to a colon- or space-separated list of paths. They
+are appended after the built-in files, so your values win the Compose merge.
+Relative paths are resolved from `deploy/compose/`.
+
+For example, to cap relay memory on a shared host — instead of re-running
+`docker update` after every upgrade:
+
+```yaml
+# deploy/compose/compose.limits.yml
+services:
+  relay:
+    mem_limit: 2g
+```
+
+```bash
+BUZZ_COMPOSE_EXTRA_FILES=compose.limits.yml ./run.sh start
+```
+
+The extra files apply to every `run.sh` command, so set the variable
+persistently (e.g. in the shell profile of the deploy user) to keep `upgrade`
+and `restart` consistent with `start`. Use `./run.sh config` to verify the
+merged result.
+
 ## Production notes
 
 - Requires Docker Compose v2.24.4 or newer; the TLS override uses Compose's

--- a/deploy/compose/run.sh
+++ b/deploy/compose/run.sh
@@ -11,6 +11,20 @@ fi
 if [[ "${BUZZ_COMPOSE_DEV:-false}" == "true" ]]; then
   COMPOSE_FILES+=(-f compose.dev.yml)
 fi
+if [[ -n "${BUZZ_COMPOSE_EXTRA_FILES:-}" ]]; then
+  IFS=': ' read -r -a EXTRA_FILES <<<"${BUZZ_COMPOSE_EXTRA_FILES}"
+  for extra_file in "${EXTRA_FILES[@]}"; do
+    if [[ -z "${extra_file}" ]]; then
+      continue
+    fi
+    if [[ ! -f "${extra_file}" ]]; then
+      echo "BUZZ_COMPOSE_EXTRA_FILES entry not found: ${extra_file}" >&2
+      echo "Paths are resolved relative to deploy/compose/." >&2
+      exit 1
+    fi
+    COMPOSE_FILES+=(-f "${extra_file}")
+  done
+fi
 
 compose() {
   docker compose --env-file .env "${COMPOSE_FILES[@]}" "$@"
@@ -123,6 +137,10 @@ Commands:
 Environment switches:
   BUZZ_COMPOSE_TLS=true   Include compose.caddy.yml for automatic HTTPS
   BUZZ_COMPOSE_DEV=true   Include compose.dev.yml for local admin ports/tools
+  BUZZ_COMPOSE_EXTRA_FILES=<paths>
+                          Colon- or space-separated compose files appended
+                          after the built-in ones (site-local overrides such
+                          as resource limits win the Compose merge)
 MSG
     ;;
   *)


### PR DESCRIPTION
## Summary

`deploy/compose/run.sh` assembles its `docker compose` invocation from explicit `-f` flags (`compose.yml` plus the conditional caddy/dev overlays). Passing any explicit `-f` disables Compose's automatic `compose.override.yml` loading, so operators currently have **no way to layer site-local overrides** — a `compose.override.yml` sitting in the directory is silently ignored.

This adds a `BUZZ_COMPOSE_EXTRA_FILES` environment switch: a colon- or space-separated list of compose files appended as additional `-f` flags **after** the built-in ones, so operator values win the Compose merge. Missing entries fail fast with a clear error instead of a mid-command `docker compose` failure.

Real-world motivation: staging the relay on a shared ML box needed memory caps on the relay container, which today requires re-running `docker update` after every `./run.sh upgrade`. With this change the cap lives in a small override file and survives upgrades:

```yaml
# deploy/compose/compose.limits.yml
services:
  relay:
    mem_limit: 2g
```

```bash
BUZZ_COMPOSE_EXTRA_FILES=compose.limits.yml ./run.sh start
```

## Changes

- `deploy/compose/run.sh` — parse `BUZZ_COMPOSE_EXTRA_FILES` (colon- or space-separated), validate each path exists, append as `-f` flags after the built-in files; document the switch in `./run.sh help`
- `deploy/compose/README.md` — new "Site-local overrides" section with the resource-limit example and a note that explicit `-f` flags are why `compose.override.yml` is not auto-loaded

## Testing

- `bash -n run.sh` syntax check
- Functional test with a stubbed `docker` on `PATH` asserting exact flags:
  - baseline (no var): `-f compose.yml` unchanged
  - colon-separated: `-f compose.yml -f /tmp/x-limits.yml -f /tmp/x-labels.yml`
  - space-separated: same result
  - missing file: exits 1 with `BUZZ_COMPOSE_EXTRA_FILES entry not found: ...`
  - combined with `BUZZ_COMPOSE_TLS=true`: extra file appended after `compose.caddy.yml`
- `just ci` — all recipes pass except `mobile-test`, which fails on one **pre-existing** widget test (`ChannelDetailPage keeps follow mode off while a tall newest message stays visible`, `mobile/test/features/channels/channel_detail_page_test.dart:1042`). It fails identically on clean `main` (7e9b77f7) and this PR touches only `deploy/compose/`, so it is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
