### PR TITLE
fix(buzz-pairing-cli): install rustls crypto provider before wss:// use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ dependencies = [
  "futures-util",
  "hex",
  "nostr",
+ "rustls",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/buzz-pairing-cli/Cargo.toml
+++ b/crates/buzz-pairing-cli/Cargo.toml
@@ -16,6 +16,7 @@ buzz-core = { workspace = true }
 nostr = { workspace = true }
 tokio = { workspace = true }
 tokio-tungstenite = { workspace = true }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 futures-util = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }

--- a/crates/buzz-pairing-cli/src/main.rs
+++ b/crates/buzz-pairing-cli/src/main.rs
@@ -96,6 +96,9 @@ enum CliError {
 
 #[tokio::main]
 async fn main() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to install rustls crypto provider");
     let cli = Cli::parse();
     if let Err(e) = run(cli.command).await {
         eprintln!("error: {e}");


### PR DESCRIPTION
## Summary
- `buzz-pair` (the NIP-AB pairing interop CLI) panicked with `Could not automatically determine the process-level CryptoProvider` on any `wss://` relay — `tokio-tungstenite`'s `rustls-tls-webpki-roots` feature needs a provider installed explicitly. Every other binary in the workspace that touches TLS (`buzz-relay`, `buzz-desktop`) already does this; `buzz-pairing-cli` never did.
- Only surfaces when actually exercising `wss://`, since `ws://` never touches TLS — easy to miss since the tool defaults to a `wss://` public relay but most local dev/testing uses plain `ws://`.

## Test plan
- [x] `cargo build -p buzz-pairing-cli`
- [x] Ran `buzz-pair source --relay wss://<host>` and `buzz-pair target` against a real TLS-terminated relay — connects and proceeds past the crash point (reaches SAS exchange) instead of panicking immediately.
