### PR TITLE
buzz-acp: add structured MCP server configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -159,7 +159,8 @@ RUST_LOG=buzz_relay=debug,buzz_datastore=info,buzz_db=debug,buzz_auth=debug,buzz
 # Binary for an optional MCP server sidecar (e.g. buzz-dev-mcp for buzz-agent).
 # BUZZ_ACP_MCP_COMMAND=
 
-# Path to an optional version 1 JSON file defining additional stdio MCP servers.
+# Path to an optional version 1 JSON file defining additional stdio and
+# Streamable HTTP MCP servers.
 # This file may contain credentials. Keep it out of Git and restrict it to
 # its owner.
 # BUZZ_ACP_MCP_CONFIG=/absolute/path/to/mcp-servers.json

--- a/.env.example
+++ b/.env.example
@@ -159,6 +159,11 @@ RUST_LOG=buzz_relay=debug,buzz_datastore=info,buzz_db=debug,buzz_auth=debug,buzz
 # Binary for an optional MCP server sidecar (e.g. buzz-dev-mcp for buzz-agent).
 # BUZZ_ACP_MCP_COMMAND=
 
+# Path to an optional version 1 JSON file defining additional stdio MCP servers.
+# This file may contain credentials. Keep it out of Git and restrict it to
+# its owner.
+# BUZZ_ACP_MCP_CONFIG=/absolute/path/to/mcp-servers.json
+
 # Number of parallel agent subprocesses (1–32).
 # BUZZ_ACP_AGENTS=1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 name = "buzz-acp"
 version = "0.1.0"
 dependencies = [
+ "aho-corasick",
  "anyhow",
  "base64 0.22.1",
  "buzz-core",
@@ -827,6 +828,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,6 +988,7 @@ dependencies = [
  "chrono",
  "hex",
  "hmac 0.13.0",
+ "http",
  "nostr",
  "percent-encoding",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tokio-util  = { version = "0.7", features = ["rt", "codec"] }
 
 # HTTP + WebSocket
 axum        = { version = "0.8", features = ["ws", "macros"] }
+http        = "1"
 tower       = { version = "0.5", features = ["timeout", "util", "limit"] }
 tower-http  = { version = "0.6", features = ["trace", "cors", "compression-gzip", "limit", "timeout", "fs"] }
 

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -74,7 +74,7 @@ evalexpr = { workspace = true }
 # Process-group kill (safe wrapper around killpg) — Unix-only; kill_process_group
 # has a #[cfg(not(unix))] fallback in acp.rs.
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["signal"] }
+nix = { version = "0.31", default-features = false, features = ["signal", "user"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/buzz-acp/Cargo.toml
+++ b/crates/buzz-acp/Cargo.toml
@@ -34,6 +34,7 @@ tokio-tungstenite = { workspace = true }
 tokio-util = { workspace = true }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 futures-util = { workspace = true }
+aho-corasick = "1.1"
 
 # HTTP (channel discovery REST API)
 reqwest = { workspace = true }
@@ -61,6 +62,7 @@ tracing-subscriber = { workspace = true }
 # Error handling
 thiserror = { workspace = true }
 anyhow = { workspace = true }
+zeroize = { workspace = true }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -145,9 +145,7 @@ and remote MCP servers:
       "headers": [
         {
           "name": "Authorization",
-          "env_file": "/run/secrets/hosted-context.env",
-          "env_name": "MCP_TOKEN",
-          "value_prefix": "Bearer "
+          "value": "Bearer replace-me"
         }
       ]
     }
@@ -163,9 +161,10 @@ before writing this document.
 The JSON is strict. The only top-level fields are `version` and `servers`.
 Each server has a `name` and tagged `transport`. A `stdio` entry contains
 `command`, `args`, and `env`; an `http` entry contains a URL and optional
-headers. URLs and header values can be literal, loaded from protected files,
-or selected by name from protected environment files. Public endpoints require
-HTTPS; plain HTTP is limited to literal private IP addresses. Server names must
+headers. URLs and header values are final resolved values; Project or deployment
+code must resolve any secret selectors before writing the protected handoff.
+HTTP is allowed only on a literal loopback address and must be credential-free;
+all other endpoints require HTTPS. Server names must
 be unique, contain 1 to 128 ASCII bytes using only letters, digits, `_`, or `-`,
 and cannot contain `__`.
 Names are checked across both structured entries and the legacy server.
@@ -189,6 +188,22 @@ the `buzz` CLI. Some adapters may propagate inherited variables to MCP child
 processes. Per-server `env` entries are explicit configuration, not a process
 isolation boundary. Use a separate account, container, or credential-brokered
 service when the MCP process must not inherit adapter credentials.
+
+MCP transport capability and tool authorization are separate gates. Before an
+unattended launch, the Project or deployment resolver must pre-authorize the
+resolved servers and tools in the selected adapter's protected, agent-specific
+configuration. Do not restore a global permission bypass. An adapter that
+advertises HTTP support can still deny every tool call under a non-interactive
+`dontAsk` policy; ACP currently exposes no portable initialize-time proof of
+those adapter-local approvals, so the launcher must fail closed when it cannot
+establish them.
+
+Release acceptance for a mixed configuration must exercise the real adapter,
+not only configuration parsing: create a session containing the legacy Buzz
+stdio companion and at least one structured HTTP server, call one harmless tool
+from each transport, then publish the result through the companion's constrained
+`send` tool. Tool listing, model completion, or a fake-adapter payload capture
+alone does not prove end-to-end composition or outbound publishing.
 
 If the JSON contains secrets, keep it outside Git and restrict the file to its
 owner. On Unix:

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -111,7 +111,7 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_AGENT_COMMAND` | no | `goose` | Agent binary to spawn. |
 | `BUZZ_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
-| `BUZZ_ACP_MCP_CONFIG` | no | `""` (empty) | Path to a version 1 JSON file defining additional stdio MCP servers. |
+| `BUZZ_ACP_MCP_CONFIG` | no | `""` (empty) | Path to a version 1 JSON file defining additional stdio and Streamable HTTP MCP servers. |
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
@@ -122,8 +122,8 @@ All configuration is via environment variables (or CLI flags — every env var h
 
 ### Multiple MCP servers
 
-Use `--mcp-config <absolute-path>` or `BUZZ_ACP_MCP_CONFIG` to add named stdio
-MCP servers:
+Use `--mcp-config <absolute-path>` or `BUZZ_ACP_MCP_CONFIG` to add named local
+and remote MCP servers:
 
 ```json
 {
@@ -137,6 +137,19 @@ MCP servers:
       "env": {
         "ANALYTICS_TOKEN": "replace-me"
       }
+    },
+    {
+      "name": "hosted-context",
+      "transport": "http",
+      "url": "https://mcp.example.test/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "env_file": "/run/secrets/hosted-context.env",
+          "env_name": "MCP_TOKEN",
+          "value_prefix": "Bearer "
+        }
+      ]
     }
   ]
 }
@@ -148,9 +161,13 @@ loaded by `buzz-acp` automatically; a launcher must resolve and approve them
 before writing this document.
 
 The JSON is strict. The only top-level fields are `version` and `servers`.
-Each server has `name`, `transport`, `command`, `args`, and `env`. Version 1
-supports the `stdio` transport. Server names must be unique, contain 1 to 128
-ASCII bytes using only letters, digits, `_`, or `-`, and cannot contain `__`.
+Each server has a `name` and tagged `transport`. A `stdio` entry contains
+`command`, `args`, and `env`; an `http` entry contains a URL and optional
+headers. URLs and header values can be literal, loaded from protected files,
+or selected by name from protected environment files. Public endpoints require
+HTTPS; plain HTTP is limited to literal private IP addresses. Server names must
+be unique, contain 1 to 128 ASCII bytes using only letters, digits, `_`, or `-`,
+and cannot contain `__`.
 Names are checked across both structured entries and the legacy server.
 
 The config file is limited to 64 KiB. A harness can have at most 16 MCP

--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -111,6 +111,7 @@ All configuration is via environment variables (or CLI flags — every env var h
 | `BUZZ_ACP_AGENT_COMMAND` | no | `goose` | Agent binary to spawn. |
 | `BUZZ_ACP_AGENT_ARGS` | no | `acp` | Agent arguments (comma-separated). |
 | `BUZZ_ACP_MCP_COMMAND` | no | `""` (empty) | Path to an optional MCP server binary to provide to the agent subprocess. |
+| `BUZZ_ACP_MCP_CONFIG` | no | `""` (empty) | Path to a version 1 JSON file defining additional stdio MCP servers. |
 | `BUZZ_ACP_IDLE_TIMEOUT` | no | `620` | Idle timeout: max seconds of silence before cancelling a turn. Resets on any agent stdout activity. |
 | `BUZZ_ACP_MAX_TURN_DURATION` | no | `7200` | Absolute wall-clock cap per turn (safety valve). |
 | `BUZZ_API_TOKEN` | no | — | API token (required if relay enforces token auth). |
@@ -118,6 +119,67 @@ All configuration is via environment variables (or CLI flags — every env var h
 **Note:** `BUZZ_ACP_AGENT_ARGS` splits on commas. For args with values, use: `-c,key="value"`.
 
 **Legacy env vars:** `BUZZ_ACP_PRIVATE_KEY`, `BUZZ_ACP_API_TOKEN`, and `BUZZ_ACP_TURN_TIMEOUT` (replaced by `BUZZ_ACP_IDLE_TIMEOUT`) are still accepted as fallbacks.
+
+### Multiple MCP servers
+
+Use `--mcp-config <absolute-path>` or `BUZZ_ACP_MCP_CONFIG` to add named stdio
+MCP servers:
+
+```json
+{
+  "version": 1,
+  "servers": [
+    {
+      "name": "analytics",
+      "transport": "stdio",
+      "command": "/opt/mcp/analytics-server",
+      "args": ["--stdio"],
+      "env": {
+        "ANALYTICS_TOKEN": "replace-me"
+      }
+    }
+  ]
+}
+```
+
+This file is a resolved, device-local launch handoff. It is not a persona or
+template authoring format. MCP declarations parsed by `buzz-persona` are not
+loaded by `buzz-acp` automatically; a launcher must resolve and approve them
+before writing this document.
+
+The JSON is strict. The only top-level fields are `version` and `servers`.
+Each server has `name`, `transport`, `command`, `args`, and `env`. Version 1
+supports the `stdio` transport. Server names must be unique, contain 1 to 128
+ASCII bytes using only letters, digits, `_`, or `-`, and cannot contain `__`.
+Names are checked across both structured entries and the legacy server.
+
+The config file is limited to 64 KiB. A harness can have at most 16 MCP
+servers in total, including the server from `BUZZ_ACP_MCP_COMMAND`. An
+unreadable file, malformed JSON, an unsupported version, an unknown field, or
+an invalid server entry stops startup. Buzz does not silently drop a server.
+
+`BUZZ_ACP_MCP_COMMAND` keeps its current behavior. It defines one privileged
+Buzz companion and receives the relay URL and Buzz identity credentials.
+For a structured server, Buzz puts only the values listed in its `env` object
+into the ACP `env` list. Protected Buzz identity and authentication keys are
+rejected. Buzz sends the list to the ACP adapter in `session/new`, and the
+adapter controls the MCP processes. Treat the adapter as a credential broker
+and use one you trust. Buzz sends arguments and environment values unchanged
+to that adapter, but redacts both from its own wire logs and observer feed.
+
+The adapter still inherits the harness environment so its shell tools can use
+the `buzz` CLI. Some adapters may propagate inherited variables to MCP child
+processes. Per-server `env` entries are explicit configuration, not a process
+isolation boundary. Use a separate account, container, or credential-brokered
+service when the MCP process must not inherit adapter credentials.
+
+If the JSON contains secrets, keep it outside Git and restrict the file to its
+owner. On Unix:
+
+```bash
+chmod 600 /absolute/path/to/mcp-servers.json
+buzz-acp --mcp-config /absolute/path/to/mcp-servers.json
+```
 
 ### Parallel Agents & Heartbeat
 

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -24,6 +24,32 @@ use crate::usage::{TurnUsage, UsageTracker};
 const MAX_LINE_SIZE: usize = 10_000_000; // 10 MB
 
 const REDACTED_MCP_VALUE: &str = "[REDACTED]";
+/// Substring redaction is a fallback for adapter echoes outside the structured
+/// `mcpServers` object. Very short values create destructive false positives
+/// in ordinary diagnostics, so they are protected structurally only.
+const MIN_SENSITIVE_PATTERN_BYTES: usize = 12;
+const COMMON_MCP_VALUES: [&str; 13] = [
+    "true",
+    "false",
+    "null",
+    "none",
+    "default",
+    "prod",
+    "production",
+    "dev",
+    "development",
+    "test",
+    "staging",
+    "local",
+    "localhost",
+];
+
+fn safe_sensitive_pattern(value: &str) -> bool {
+    value.len() >= MIN_SENSITIVE_PATTERN_BYTES
+        && !COMMON_MCP_VALUES
+            .iter()
+            .any(|common| value.eq_ignore_ascii_case(common))
+}
 
 /// An MCP server configuration passed to `session/new`.
 ///
@@ -303,6 +329,15 @@ fn redact_wire_value(
                                             REDACTED_MCP_VALUE.to_string(),
                                         );
                                     }
+                                }
+                                if server.get("type").and_then(serde_json::Value::as_str)
+                                    == Some("http")
+                                    && server.contains_key("url")
+                                {
+                                    server.insert(
+                                        "url".to_string(),
+                                        serde_json::Value::String(REDACTED_MCP_VALUE.to_string()),
+                                    );
                                 }
                             }
                         }
@@ -805,7 +840,7 @@ impl AcpClient {
         for value in servers
             .iter()
             .flat_map(McpServer::sensitive_values)
-            .filter(|value| !value.is_empty())
+            .filter(|value| safe_sensitive_pattern(value))
         {
             if !self
                 .sensitive_mcp_env_values
@@ -2550,7 +2585,7 @@ mod tests {
         let mut patterns = values
             .iter()
             .map(String::as_str)
-            .filter(|value| !value.is_empty())
+            .filter(|value| safe_sensitive_pattern(value))
             .collect::<Vec<_>>();
         patterns.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
         patterns.dedup();
@@ -2973,13 +3008,26 @@ mod tests {
             .as_str()
             .expect("redacted error message");
         assert!(!message.contains(longer));
-        assert!(!message.contains(shorter));
         assert_eq!(message, REDACTED_MCP_VALUE);
         assert_eq!(redacted["ordinary"], source["ordinary"]);
         assert_eq!(
             source, original_source,
             "the protocol value must stay unchanged"
         );
+    }
+
+    #[test]
+    fn short_or_common_mcp_values_do_not_redact_unrelated_diagnostics() {
+        let values = ["1", "/", "true", "prod", "production", "localhost", "token"]
+            .map(str::to_string)
+            .to_vec();
+        let matcher = sensitive_matcher(&values);
+        assert!(matcher.is_none());
+
+        let diagnostic = serde_json::json!({
+            "message": "production retry 1/true on localhost used token accounting"
+        });
+        assert_eq!(redact_wire_value(&diagnostic, matcher.as_ref()), diagnostic);
     }
 
     #[test]
@@ -4350,6 +4398,77 @@ mod tests {
             }
             client.shutdown().await;
         }
+    }
+
+    #[tokio::test]
+    async fn session_new_sends_exact_mixed_legacy_stdio_and_http_payload() {
+        let script = r#"
+            read -t 2 _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":2,"agentCapabilities":{"mcpCapabilities":{"http":true}}}}'
+            read -t 2 REQ
+            echo '{"jsonrpc":"2.0","id":1,"result":{"sessionId":"ses_mixed","_receivedRequest":'"$REQ"'}}'
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        let initialize = client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+        assert_eq!(
+            initialize.pointer("/agentCapabilities/mcpCapabilities/http"),
+            Some(&serde_json::Value::Bool(true))
+        );
+
+        let servers = vec![
+            McpServer::Stdio(McpServerStdio {
+                name: "buzz-tools-mcp".into(),
+                command: "/opt/buzz-tools-mcp/server.py".into(),
+                args: vec![],
+                env: vec![EnvVar {
+                    name: "BUZZ_RELAY_URL".into(),
+                    value: "wss://relay.example.test".into(),
+                }],
+            }),
+            McpServer::Http(McpServerHttp {
+                transport: HttpTransport::Http,
+                name: "analytics-read".into(),
+                url: "https://mcp.example.test/mcp".into(),
+                headers: vec![EnvVar {
+                    name: "Authorization".into(),
+                    value: "Bearer opaque-token".into(),
+                }],
+            }),
+        ];
+        let response = client
+            .session_new_full("/tmp", servers, None, None)
+            .await
+            .expect("mixed session/new should succeed");
+
+        let received = &response.raw["_receivedRequest"]["params"]["mcpServers"];
+        assert_eq!(
+            received,
+            &serde_json::json!([
+                {
+                    "name": "buzz-tools-mcp",
+                    "command": "/opt/buzz-tools-mcp/server.py",
+                    "args": [],
+                    "env": [{
+                        "name": "BUZZ_RELAY_URL",
+                        "value": "wss://relay.example.test"
+                    }]
+                },
+                {
+                    "type": "http",
+                    "name": "analytics-read",
+                    "url": "https://mcp.example.test/mcp",
+                    "headers": [{
+                        "name": "Authorization",
+                        "value": "Bearer opaque-token"
+                    }]
+                }
+            ])
+        );
+        client.shutdown().await;
     }
 
     #[tokio::test]

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -11,6 +11,7 @@
 use aho_corasick::AhoCorasick;
 use futures_util::StreamExt;
 use std::borrow::Cow;
+use std::collections::HashSet;
 use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, ChildStdin, ChildStdout};
 use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
@@ -24,11 +25,11 @@ use crate::usage::{TurnUsage, UsageTracker};
 const MAX_LINE_SIZE: usize = 10_000_000; // 10 MB
 
 const REDACTED_MCP_VALUE: &str = "[REDACTED]";
-/// Substring redaction is a fallback for adapter echoes outside the structured
-/// `mcpServers` object. Very short values create destructive false positives
-/// in ordinary diagnostics, so short values use exact or token-boundary matching.
-const MIN_SENSITIVE_PATTERN_BYTES: usize = 12;
-const MIN_BOUNDED_SENSITIVE_PATTERN_BYTES: usize = 8;
+/// Bound retained values across repeated sessions. Crossing either limit
+/// switches diagnostics to fail-closed redaction instead of dropping an old
+/// credential from protection or allowing unbounded matcher growth.
+const MAX_RETAINED_MCP_VALUES: usize = 8_192;
+const MAX_RETAINED_MCP_VALUE_BYTES: usize = 256 * 1024;
 const COMMON_MCP_VALUES: [&str; 13] = [
     "true",
     "false",
@@ -51,52 +52,23 @@ fn common_mcp_value(value: &str) -> bool {
         .any(|common| value.eq_ignore_ascii_case(common))
 }
 
-fn safe_sensitive_pattern(value: &str) -> bool {
-    value.len() >= MIN_SENSITIVE_PATTERN_BYTES && !common_mcp_value(value)
-}
-
-fn bounded_sensitive_pattern(value: &str) -> bool {
-    (MIN_BOUNDED_SENSITIVE_PATTERN_BYTES..MIN_SENSITIVE_PATTERN_BYTES).contains(&value.len())
-        && !common_mcp_value(value)
-}
-
-fn contains_bounded_value(text: &str, value: &str) -> bool {
-    let bytes = text.as_bytes();
-    text.match_indices(value).any(|(start, _)| {
-        let end = start + value.len();
-        let before_is_boundary =
-            start == 0 || !bytes[start - 1].is_ascii_alphanumeric() && bytes[start - 1] != b'_';
-        let after_is_boundary =
-            end == bytes.len() || !bytes[end].is_ascii_alphanumeric() && bytes[end] != b'_';
-        before_is_boundary && after_is_boundary
-    })
-}
-
 #[derive(Default)]
 struct SensitiveMcpValueMatcher {
     substring: Option<AhoCorasick>,
-    exact: Vec<String>,
-    bounded: Vec<String>,
+    exact: HashSet<String>,
+    redact_all: bool,
 }
 
 impl SensitiveMcpValueMatcher {
     fn new(values: &[String]) -> Result<Self, aho_corasick::BuildError> {
-        let mut exact = values
+        let exact = values
             .iter()
             .filter(|value| !value.is_empty())
             .cloned()
-            .collect::<Vec<_>>();
-        exact.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
-        exact.dedup();
-
-        let bounded = exact
-            .iter()
-            .filter(|value| bounded_sensitive_pattern(value))
-            .cloned()
-            .collect();
+            .collect::<HashSet<_>>();
         let substring_patterns = exact
             .iter()
-            .filter(|value| safe_sensitive_pattern(value))
+            .filter(|value| !common_mcp_value(value))
             .collect::<Vec<_>>();
         let substring = if substring_patterns.is_empty() {
             None
@@ -107,20 +79,24 @@ impl SensitiveMcpValueMatcher {
         Ok(Self {
             substring,
             exact,
-            bounded,
+            redact_all: false,
         })
     }
 
+    fn fail_closed() -> Self {
+        Self {
+            redact_all: true,
+            ..Self::default()
+        }
+    }
+
     fn is_match(&self, text: &str) -> bool {
-        self.exact.iter().any(|value| text == value)
+        self.redact_all
+            || self.exact.contains(text)
             || self
                 .substring
                 .as_ref()
                 .is_some_and(|matcher| matcher.find(text).is_some())
-            || self
-                .bounded
-                .iter()
-                .any(|value| contains_bounded_value(text, value))
     }
 }
 
@@ -507,6 +483,8 @@ pub struct AcpClient {
     observer_context: ObserverContext,
     /// Credential values retained across sessions for log and observer redaction.
     sensitive_mcp_values: Vec<String>,
+    /// Encoded bytes retained in `sensitive_mcp_values`.
+    sensitive_mcp_value_bytes: usize,
     /// Multi-pattern matcher rebuilt when a session introduces new credentials.
     sensitive_mcp_matcher: SensitiveMcpValueMatcher,
     /// Most recently observed `_meta.goose.activeRunId` from a
@@ -884,6 +862,7 @@ impl AcpClient {
             observer_agent_index: None,
             observer_context: ObserverContext::default(),
             sensitive_mcp_values: Vec::new(),
+            sensitive_mcp_value_bytes: 0,
             sensitive_mcp_matcher: SensitiveMcpValueMatcher::default(),
             active_run_id: None,
             steering_supported: false,
@@ -914,6 +893,10 @@ impl AcpClient {
     }
 
     fn register_sensitive_mcp_values(&mut self, servers: &[McpServer]) -> Result<(), AcpError> {
+        if self.sensitive_mcp_matcher.redact_all {
+            return Ok(());
+        }
+
         let mut changed = false;
         for value in servers
             .iter()
@@ -925,7 +908,17 @@ impl AcpClient {
                 .iter()
                 .any(|registered| registered == value)
             {
+                let next_bytes = self.sensitive_mcp_value_bytes.saturating_add(value.len());
+                if self.sensitive_mcp_values.len() >= MAX_RETAINED_MCP_VALUES
+                    || next_bytes > MAX_RETAINED_MCP_VALUE_BYTES
+                {
+                    self.sensitive_mcp_values.clear();
+                    self.sensitive_mcp_value_bytes = 0;
+                    self.sensitive_mcp_matcher = SensitiveMcpValueMatcher::fail_closed();
+                    return Ok(());
+                }
                 self.sensitive_mcp_values.push(value.clone());
+                self.sensitive_mcp_value_bytes = next_bytes;
                 changed = true;
             }
         }
@@ -3087,14 +3080,52 @@ mod tests {
     }
 
     #[test]
-    fn short_or_common_mcp_values_do_not_redact_unrelated_diagnostics() {
-        let values = ["1", "/", "true", "prod", "production", "localhost", "token"]
+    fn wire_redaction_suppresses_embedded_short_sensitive_echoes() {
+        let values = ["s3cr3t", "!@#", "🔑"].map(str::to_string);
+        let source = serde_json::json!({
+            "word": "authentication failed for s3cr3t",
+            "punctuation": "credential!@#rejected",
+            "unicode": "credential🔑rejected"
+        });
+        let matcher = sensitive_matcher(&values);
+
+        let redacted = redact_wire_value(&source, &matcher);
+
+        assert_eq!(redacted["word"], REDACTED_MCP_VALUE);
+        assert_eq!(redacted["punctuation"], REDACTED_MCP_VALUE);
+        assert_eq!(redacted["unicode"], REDACTED_MCP_VALUE);
+        assert_eq!(
+            source["word"], "authentication failed for s3cr3t",
+            "redaction must not mutate the wire payload"
+        );
+    }
+
+    #[test]
+    fn configured_short_non_common_values_fail_closed_in_diagnostics() {
+        let matcher = sensitive_matcher(&["1".into(), "/".into(), "token".into()]);
+
+        for diagnostic in [
+            "retry 1 failed",
+            "invalid / path",
+            "token accounting failed",
+        ] {
+            assert_eq!(
+                redact_wire_value(&serde_json::json!(diagnostic), &matcher),
+                REDACTED_MCP_VALUE,
+                "configured values take precedence over diagnostic detail"
+            );
+        }
+    }
+
+    #[test]
+    fn common_mcp_values_do_not_redact_unrelated_diagnostics() {
+        let values = ["true", "prod", "production", "localhost"]
             .map(str::to_string)
             .to_vec();
         let matcher = sensitive_matcher(&values);
 
         let diagnostic = serde_json::json!({
-            "message": "production retry 1/true on localhost used token accounting"
+            "message": "production retry used true on localhost"
         });
         assert_eq!(redact_wire_value(&diagnostic, &matcher), diagnostic);
         for value in values {
@@ -4209,7 +4240,7 @@ mod tests {
 
     #[tokio::test]
     async fn plain_mcp_argument_echo_is_redacted() {
-        let argument_secret = "s3cr3t8!";
+        let argument_secret = "s3cr3t";
         let error_response = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -4342,6 +4373,35 @@ mod tests {
         assert!(!serialized_events.contains(first_secret));
         assert!(!serialized_events.contains(second_secret));
         assert!(serialized_events.contains(REDACTED_MCP_VALUE));
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn sensitive_value_retention_limit_fails_closed() {
+        let mut client = spawn_inert_client().await;
+        let payload = "x".repeat(40 * 1024);
+
+        for index in 0..8 {
+            let value = format!("{index}:{payload}");
+            client
+                .register_sensitive_mcp_values(&[McpServer::Stdio(McpServerStdio {
+                    name: "bounded-redaction".into(),
+                    command: "test-mcp".into(),
+                    args: vec![],
+                    env: vec![EnvVar {
+                        name: "TOKEN".into(),
+                        value,
+                    }],
+                })])
+                .expect("credential redactor should remain available");
+        }
+
+        assert!(client.sensitive_mcp_matcher.redact_all);
+        assert!(client.sensitive_mcp_values.is_empty());
+        assert_eq!(
+            client.redact_wire_value(&serde_json::json!("ordinary diagnostic")),
+            REDACTED_MCP_VALUE
+        );
         client.shutdown().await;
     }
 

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -20,11 +20,13 @@ use crate::usage::{TurnUsage, UsageTracker};
 /// Lines exceeding this limit are rejected to prevent OOM from rogue agents.
 const MAX_LINE_SIZE: usize = 10_000_000; // 10 MB
 
+const REDACTED_MCP_VALUE: &str = "[REDACTED]";
+
 /// An MCP server configuration passed to `session/new`.
 ///
 /// Corresponds to the `McpServerStdio` variant in the ACP schema.
 /// All four fields are **required** by the schema (`args` and `env` may be empty arrays).
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Clone, serde::Serialize)]
 pub struct McpServer {
     pub name: String,
     pub command: String,
@@ -32,11 +34,33 @@ pub struct McpServer {
     pub env: Vec<EnvVar>,
 }
 
+impl std::fmt::Debug for McpServer {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("McpServer")
+            .field("name", &self.name)
+            .field("command", &self.command)
+            .field("arg_count", &self.args.len())
+            .field("env", &self.env)
+            .finish()
+    }
+}
+
 /// A single environment variable for an MCP server.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Clone, serde::Serialize)]
 pub struct EnvVar {
     pub name: String,
     pub value: String,
+}
+
+impl std::fmt::Debug for EnvVar {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("EnvVar")
+            .field("name", &self.name)
+            .field("value", &REDACTED_MCP_VALUE)
+            .finish()
+    }
 }
 
 /// Stop reason returned by `session/prompt` when the agent finishes a turn.
@@ -114,11 +138,114 @@ pub enum AcpError {
 /// detail (e.g. a `data` field) is not lost.
 fn agent_error_from_json(error: &serde_json::Value) -> AcpError {
     let code = error.get("code").and_then(|c| c.as_i64()).unwrap_or(-32000);
-    let message = match error.get("message").and_then(|m| m.as_str()) {
+    let redacted_error = redact_wire_value(error);
+    let message = match redacted_error.get("message").and_then(|m| m.as_str()) {
         Some(m) => m.to_string(),
-        None => error.to_string(),
+        None => redacted_error.to_string(),
     };
     AcpError::AgentError { code, message }
+}
+
+fn contains_serialized_json_key(text: &str, key: &str) -> bool {
+    text.match_indices(key).any(|(start, _)| {
+        let bytes = text.as_bytes();
+        if start == 0 || bytes[start - 1] != b'"' {
+            return false;
+        }
+
+        let mut cursor = start + key.len();
+        while bytes.get(cursor) == Some(&b'\\') {
+            cursor += 1;
+        }
+        if bytes.get(cursor) != Some(&b'"') {
+            return false;
+        }
+        cursor += 1;
+        while bytes
+            .get(cursor)
+            .is_some_and(|byte| byte.is_ascii_whitespace())
+        {
+            cursor += 1;
+        }
+        bytes.get(cursor) == Some(&b':')
+    })
+}
+
+fn redact_wire_text(text: &str) -> &str {
+    let looks_like_serialized_mcp_config = contains_serialized_json_key(text, "mcpServers")
+        && (contains_serialized_json_key(text, "args")
+            || (contains_serialized_json_key(text, "env")
+                && contains_serialized_json_key(text, "value")));
+    if looks_like_serialized_mcp_config {
+        REDACTED_MCP_VALUE
+    } else {
+        text
+    }
+}
+
+/// Return a logging-safe copy of an ACP wire value.
+///
+/// MCP arguments and environment values are needed by the adapter on the real
+/// wire, but must not reach tracing or observer frames.
+fn redact_wire_value(value: &serde_json::Value) -> serde_json::Value {
+    fn redact_in_place(value: &mut serde_json::Value) {
+        match value {
+            serde_json::Value::Array(values) => {
+                for value in values {
+                    redact_in_place(value);
+                }
+            }
+            serde_json::Value::Object(fields) => {
+                for (key, value) in fields {
+                    if key == "mcpServers" {
+                        if let serde_json::Value::Array(servers) = value {
+                            for server in servers {
+                                let serde_json::Value::Object(server) = server else {
+                                    continue;
+                                };
+                                if let Some(serde_json::Value::Array(args)) = server.get_mut("args")
+                                {
+                                    for argument in args {
+                                        *argument = serde_json::Value::String(
+                                            REDACTED_MCP_VALUE.to_string(),
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if key == "env" {
+                        if let serde_json::Value::Array(entries) = value {
+                            for entry in entries {
+                                if let serde_json::Value::Object(env_var) = entry {
+                                    if env_var.contains_key("value") {
+                                        env_var.insert(
+                                            "value".to_string(),
+                                            serde_json::Value::String(
+                                                REDACTED_MCP_VALUE.to_string(),
+                                            ),
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    redact_in_place(value);
+                }
+            }
+            serde_json::Value::String(text) => {
+                let observed = redact_wire_text(text);
+                if observed != text.as_str() {
+                    *text = observed.to_string();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut redacted = value.clone();
+    redact_in_place(&mut redacted);
+    redacted
 }
 
 fn build_initialize_params() -> serde_json::Value {
@@ -576,6 +703,14 @@ impl AcpClient {
 
     /// Emit a semantic event to the local observer feed, if enabled.
     pub fn observe(&self, kind: impl Into<String>, payload: serde_json::Value) {
+        if self.observer.is_none() {
+            return;
+        }
+        self.emit_observer(kind, redact_wire_value(&payload));
+    }
+
+    /// Emit an event whose payload is already a logging-safe copy.
+    fn emit_observer(&self, kind: impl Into<String>, payload: serde_json::Value) {
         if let Some(observer) = &self.observer {
             observer.emit(
                 kind,
@@ -788,7 +923,6 @@ impl AcpClient {
             "params": params,
         });
 
-        tracing::debug!(target: "acp::wire", "→ {}", &serde_json::to_string(&msg).unwrap_or_default());
         if let Err(e) = self.write_ndjson(&msg).await {
             self.last_prompt_id = None;
             self.current_hard_deadline = None;
@@ -1047,6 +1181,8 @@ impl AcpClient {
     /// (e.g., it's stuck or dead), the write would otherwise block forever.
     async fn write_ndjson(&mut self, value: &serde_json::Value) -> Result<(), AcpError> {
         const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+        let observed_value = redact_wire_value(value);
+        tracing::debug!(target: "acp::wire", "→ {observed_value}");
         let line = serde_json::to_string(value)?;
         tokio::time::timeout(WRITE_TIMEOUT, async {
             self.stdin.write_all(line.as_bytes()).await?;
@@ -1057,8 +1193,41 @@ impl AcpClient {
         .await
         .map_err(|_| AcpError::WriteTimeout(WRITE_TIMEOUT))?
         .map_err(AcpError::Io)?;
-        self.observe("acp_write", value.clone());
+        self.emit_observer("acp_write", observed_value);
         Ok(())
+    }
+
+    /// Parse one non-empty agent stdout line and emit only a safe copy.
+    ///
+    /// Parse failures expose the line length and parser error, never the raw
+    /// line. Successful messages retain their raw value for protocol handling.
+    fn parse_inbound_line(&self, line: &str) -> Option<serde_json::Value> {
+        match serde_json::from_str(line) {
+            Ok(msg) => {
+                let observed_value = redact_wire_value(&msg);
+                tracing::debug!(target: "acp::wire", "← {observed_value}");
+                self.emit_observer("acp_read", observed_value);
+                Some(msg)
+            }
+            Err(error) => {
+                let line_length = line.len();
+                let error = error.to_string();
+                self.observe(
+                    "acp_parse_error",
+                    serde_json::json!({
+                        "lineLength": line_length,
+                        "error": error,
+                    }),
+                );
+                tracing::warn!(
+                    target: "acp::wire",
+                    line_length,
+                    error = %error,
+                    "failed to parse agent stdout as JSON; skipping"
+                );
+                None
+            }
+        }
     }
 
     /// Default timeout for non-prompt RPCs (initialize, session/new, etc.).
@@ -1087,8 +1256,6 @@ impl AcpClient {
             "method": method,
             "params": params,
         });
-
-        tracing::debug!(target: "acp::wire", "→ {}", &serde_json::to_string(&msg).unwrap_or_default());
 
         // Wrap write + read in a single timeout so a hung agent can't block forever.
         // We cannot use an async block that borrows `self` mutably across two awaits
@@ -1153,7 +1320,6 @@ impl AcpClient {
             "params": params,
         });
 
-        tracing::debug!(target: "acp::wire", "→ (notification) {}", &serde_json::to_string(&msg).unwrap_or_default());
         self.write_ndjson(&msg).await?;
         Ok(())
     }
@@ -1195,27 +1361,10 @@ impl AcpClient {
                 continue;
             }
 
-            // Only log and reset idle after we have a valid non-empty line.
-            tracing::debug!(target: "acp::wire", "← {trimmed}");
-
-            let msg: serde_json::Value = match serde_json::from_str(trimmed) {
-                Ok(v) => v,
-                Err(e) => {
-                    self.observe(
-                        "acp_parse_error",
-                        serde_json::json!({
-                            "line": trimmed,
-                            "error": e.to_string(),
-                        }),
-                    );
-                    tracing::warn!(
-                        target: "acp::wire",
-                        "failed to parse line as JSON: {e} — skipping"
-                    );
-                    continue;
-                }
+            let msg = match self.parse_inbound_line(trimmed) {
+                Some(msg) => msg,
+                None => continue,
             };
-            self.observe("acp_read", msg.clone());
 
             // Check if this is a response to our expected request (has matching id
             // AND no `method` field — a `method` field means it's an agent-initiated
@@ -1440,11 +1589,6 @@ impl AcpClient {
                                 "method": method,
                                 "params": params,
                             });
-                            tracing::debug!(
-                                target: "acp::wire",
-                                "→ {}",
-                                serde_json::to_string(&msg).unwrap_or_default()
-                            );
                             match self.write_ndjson(&msg).await {
                                 Ok(()) => {
                                     pending_steer = Some((id, transport, req.ack_tx));
@@ -1519,26 +1663,10 @@ impl AcpClient {
                         continue;
                     }
 
-                    tracing::debug!(target: "acp::wire", "← {trimmed}");
-
-                    let msg: serde_json::Value = match serde_json::from_str(trimmed) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            self.observe(
-                                "acp_parse_error",
-                                serde_json::json!({
-                                    "line": trimmed,
-                                    "error": e.to_string(),
-                                }),
-                            );
-                            tracing::warn!(
-                                target: "acp::wire",
-                                "failed to parse line as JSON: {e} — skipping"
-                            );
-                            continue;
-                        }
+                    let msg = match self.parse_inbound_line(trimmed) {
+                        Some(msg) => msg,
+                        None => continue,
                     };
-                    self.observe("acp_read", msg.clone());
 
                     let activity_now = Instant::now();
                     idle_deadline = activity_now + idle_timeout;
@@ -1564,7 +1692,7 @@ impl AcpClient {
                                             .get("code")
                                             .and_then(|c| c.as_i64())
                                             .unwrap_or(-1);
-                                        let message = error.to_string();
+                                        let message = redact_wire_value(error).to_string();
                                         crate::pool::SteerAck::Err(
                                             crate::pool::SteerError::AgentError { code, message },
                                         )
@@ -1732,6 +1860,7 @@ impl AcpClient {
         match update_type {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
+                    let text = redact_wire_text(text);
                     tracing::info!(target: "acp::stream", "{text}");
                 }
                 false
@@ -1745,6 +1874,8 @@ impl AcpClient {
                     .get("kind")
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
+                let title = redact_wire_text(title);
+                let kind = redact_wire_text(kind);
                 tracing::info!(target: "acp::tool", "tool_call: {title} ({kind})");
                 true
             }
@@ -1754,6 +1885,8 @@ impl AcpClient {
                     .and_then(|v| v.as_str())
                     .unwrap_or("?");
                 let status = update.get("status").and_then(|v| v.as_str()).unwrap_or("?");
+                let tool_id = redact_wire_text(tool_id);
+                let status = redact_wire_text(status);
                 tracing::info!(target: "acp::tool", "tool_call_update: {tool_id} → {status}");
                 false
             }
@@ -1763,6 +1896,7 @@ impl AcpClient {
             }
             "agent_thought_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
+                    let text = redact_wire_text(text);
                     tracing::debug!(target: "acp::thought", "{text}");
                 }
                 false
@@ -1772,7 +1906,12 @@ impl AcpClient {
                 // Logged for observability; UI surfacing is a follow-up.
                 let names: Vec<&str> = update["availableCommands"]
                     .as_array()
-                    .map(|cmds| cmds.iter().filter_map(|c| c["name"].as_str()).collect())
+                    .map(|cmds| {
+                        cmds.iter()
+                            .filter_map(|c| c["name"].as_str())
+                            .map(redact_wire_text)
+                            .collect()
+                    })
                     .unwrap_or_default();
                 tracing::info!(
                     target: "acp::update",
@@ -1799,9 +1938,10 @@ impl AcpClient {
                 if let Some(goose_meta) = meta {
                     match goose_meta.get("activeRunId") {
                         Some(serde_json::Value::String(run_id)) => {
+                            let observed_run_id = redact_wire_text(run_id);
                             tracing::debug!(
                                 target: "acp::update",
-                                "session_info_update: activeRunId={run_id}"
+                                "session_info_update: activeRunId={observed_run_id}"
                             );
                             self.active_run_id = Some(run_id.clone());
                         }
@@ -1820,6 +1960,7 @@ impl AcpClient {
             }
             "keepalive" => false,
             other => {
+                let other = redact_wire_text(other);
                 tracing::debug!(target: "acp::update", "session/update: {other}");
                 false
             }
@@ -1847,9 +1988,10 @@ impl AcpClient {
         match serde_json::from_value::<GooseSessionUpdateNotification>(params.clone()) {
             Ok(notif) => {
                 if let GooseSessionUpdateVariant::UsageUpdate(payload) = &notif.update {
+                    let observed_session_id = redact_wire_text(&notif.session_id);
                     tracing::debug!(
                         target: "acp::usage",
-                        session_id = %notif.session_id,
+                        session_id = %observed_session_id,
                         input = payload.accumulated_input_tokens,
                         output = payload.accumulated_output_tokens,
                         // A subset of `input`, logged so downstream accounting can
@@ -1863,9 +2005,11 @@ impl AcpClient {
                 }
             }
             Err(e) => {
+                let error = e.to_string();
+                let observed_error = redact_wire_text(&error);
                 tracing::debug!(
                     target: "acp::usage",
-                    "_goose/unstable/session/update: deserialization error: {e}"
+                    "_goose/unstable/session/update: deserialization error: {observed_error}"
                 );
             }
         }
@@ -2497,6 +2641,136 @@ mod tests {
     }
 
     #[test]
+    fn mcp_debug_redacts_environment_and_argument_values() {
+        let env_secret = "debug-env-secret-must-not-render";
+        let arg_secret = "debug-arg-secret-must-not-render";
+        let rendered = format!(
+            "{:?}",
+            McpServer {
+                name: "analytics".into(),
+                command: "analytics-mcp".into(),
+                args: vec!["--token".into(), arg_secret.into()],
+                env: vec![EnvVar {
+                    name: "ANALYTICS_TOKEN".into(),
+                    value: env_secret.into(),
+                }],
+            }
+        );
+
+        assert!(rendered.contains("ANALYTICS_TOKEN"));
+        assert!(rendered.contains("arg_count: 2"));
+        assert!(rendered.contains(REDACTED_MCP_VALUE));
+        assert!(!rendered.contains(env_secret));
+        assert!(!rendered.contains(arg_secret));
+    }
+
+    #[test]
+    fn wire_redaction_covers_nested_env_values_without_changing_source() {
+        let source = serde_json::json!({
+            "method": "session/new",
+            "params": {
+                "mcpServers": [{
+                    "name": "analytics",
+                    "args": ["--token", "argument-secret"],
+                    "env": [
+                        {"name": "ANALYTICS_TOKEN", "value": "secret-one"},
+                        {"name": "EMPTY_VALUE", "value": ""}
+                    ]
+                }],
+                "nested": {
+                    "env": [{"name": "OTHER_TOKEN", "value": "secret-two"}]
+                },
+                "ordinary": {"value": "keep-me"}
+            }
+        });
+
+        let redacted = redact_wire_value(&source);
+
+        assert_eq!(
+            source["params"]["mcpServers"][0]["env"][0]["value"], "secret-one",
+            "the source value sent on the wire must stay unchanged"
+        );
+        assert_eq!(
+            source["params"]["mcpServers"][0]["args"][1], "argument-secret",
+            "the source argument sent on the wire must stay unchanged"
+        );
+        assert_eq!(
+            redacted["params"]["mcpServers"][0]["args"],
+            serde_json::json!([REDACTED_MCP_VALUE, REDACTED_MCP_VALUE])
+        );
+        assert_eq!(
+            redacted["params"]["mcpServers"][0]["env"][0]["value"],
+            REDACTED_MCP_VALUE
+        );
+        assert_eq!(
+            redacted["params"]["mcpServers"][0]["env"][1]["value"],
+            REDACTED_MCP_VALUE
+        );
+        assert_eq!(
+            redacted["params"]["nested"]["env"][0]["value"],
+            REDACTED_MCP_VALUE
+        );
+        assert_eq!(
+            redacted["params"]["ordinary"]["value"], "keep-me",
+            "value fields outside env arrays must remain visible"
+        );
+    }
+
+    #[test]
+    fn wire_redaction_suppresses_serialized_mcp_configs_without_broad_string_matching() {
+        let secret = "quote\" slash\\ newline\n snowman \u{2603}";
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {
+                "mcpServers": [{
+                    "name": "analytics",
+                    "command": "analytics-mcp",
+                    "args": [],
+                    "env": [{"name": "ANALYTICS_TOKEN", "value": secret}]
+                }]
+            }
+        })
+        .to_string();
+        let mut serialized_levels = vec![request];
+        for _ in 0..3 {
+            let next = serde_json::to_string(
+                serialized_levels
+                    .last()
+                    .expect("at least one serialized request"),
+            )
+            .expect("serialize request again");
+            serialized_levels.push(next);
+        }
+        let source = serde_json::json!({
+            "echoes": serialized_levels
+                .iter()
+                .map(|request| format!("adapter rejected {request}; check configuration"))
+                .collect::<Vec<_>>(),
+            "ordinary": r#"invalid {"environment":"prod","value":"x"}"#,
+            "nearMiss": r#"invalid {"mcpServers":[],"envValue":"prod","value":"x"}"#,
+            "unrelated": "ordinary adapter error",
+            "shortPublicValues": ["/", "1", "A", "--stdio"]
+        });
+        let original_source = source.clone();
+
+        let redacted = redact_wire_value(&source);
+
+        for echo in redacted["echoes"].as_array().expect("redacted echoes") {
+            assert_eq!(echo, REDACTED_MCP_VALUE);
+        }
+        assert_eq!(redacted["ordinary"], source["ordinary"]);
+        assert_eq!(redacted["nearMiss"], source["nearMiss"]);
+        assert_eq!(redacted["unrelated"], source["unrelated"]);
+        assert_eq!(redacted["shortPublicValues"], source["shortPublicValues"]);
+        assert_eq!(
+            source, original_source,
+            "the protocol value must stay unchanged"
+        );
+    }
+
+    #[test]
     fn session_prompt_request_format() {
         let prompt_text = "[Buzz @mention]\nChannel: test\nFrom: npub1...\nMessage: hello";
         let msg = serde_json::json!({
@@ -2920,6 +3194,74 @@ mod tests {
         AcpClient::spawn("bash", &["-c".into(), script.into()], &[], false)
             .await
             .expect("failed to spawn test script")
+    }
+
+    fn assert_safe_parse_error_event(observer: &ObserverHandle, raw_line: &str) {
+        let event = observer
+            .snapshot()
+            .into_iter()
+            .find(|event| event.kind == "acp_parse_error")
+            .expect("parse error observer event");
+        assert_eq!(
+            event.payload["lineLength"].as_u64(),
+            Some(raw_line.len() as u64)
+        );
+        assert!(event.payload["error"].is_string());
+        assert!(
+            event.payload.get("line").is_none(),
+            "the raw line field must not exist"
+        );
+        assert!(
+            !event.payload.to_string().contains(raw_line),
+            "the raw malformed line must not reach the observer"
+        );
+    }
+
+    #[tokio::test]
+    async fn regular_read_loop_reports_malformed_json_without_raw_line() {
+        let raw_line = "regular-loop-sensitive-malformed-json";
+        let script = format!(
+            "read -t 2 _REQ\nprintf '%s\\n' '{raw_line}'\nprintf '%s\\n' \
+             '{{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{{\"ok\":true}}}}'\nsleep 1"
+        );
+        let mut client = spawn_script(&script).await;
+        let observer = ObserverHandle::in_process();
+        client.set_observer(Some(observer.clone()), 0);
+
+        let result = client
+            .send_request("test/request", serde_json::json!({}))
+            .await
+            .expect("valid response after malformed line");
+        assert_eq!(result["ok"], true);
+        assert_safe_parse_error_event(&observer, raw_line);
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn idle_read_loop_reports_malformed_json_without_raw_line() {
+        let raw_line = "idle-loop-sensitive-malformed-json";
+        let script = format!(
+            "printf '%s\\n' '{raw_line}'\nprintf '%s\\n' \
+             '{{\"jsonrpc\":\"2.0\",\"id\":999,\"result\":{{\"ok\":true}}}}'\nsleep 1"
+        );
+        let mut client = spawn_script(&script).await;
+        let observer = ObserverHandle::in_process();
+        client.set_observer(Some(observer.clone()), 0);
+        let max_duration = std::time::Duration::from_secs(5);
+
+        let result = client
+            .read_until_response_with_idle_timeout(
+                "test",
+                999,
+                std::time::Duration::from_secs(1),
+                tokio::time::Instant::now() + max_duration,
+                max_duration,
+            )
+            .await
+            .expect("valid idle-loop response after malformed line");
+        assert_eq!(result["ok"], true);
+        assert_safe_parse_error_event(&observer, raw_line);
+        client.shutdown().await;
     }
 
     /// Spawn a probe script whose file name carries a runtime identity (e.g.
@@ -3357,6 +3699,354 @@ mod tests {
             Some("Custom system prompt"),
             "systemPrompt should be included in params when Some"
         );
+    }
+
+    #[tokio::test]
+    async fn session_new_sends_real_mcp_values_but_observer_only_sees_redacted_values() {
+        let script = r#"
+            read -t 2 _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":2,"agentCapabilities":{}}}'
+            read -t 2 REQ
+            echo '{"jsonrpc":"2.0","id":1,"result":{"sessionId":"ses_secret_test","_receivedRequest":'"$REQ"'}}'
+            sleep 1
+        "#;
+        let mut client = spawn_script(script).await;
+        let observer = ObserverHandle::in_process();
+        client.set_observer(Some(observer.clone()), 0);
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+
+        let env_secret = "mcp-env-secret-must-not-reach-observer";
+        let arg_secret = "mcp-arg-secret-must-not-reach-observer";
+        let response = client
+            .session_new_full(
+                "/tmp",
+                vec![McpServer {
+                    name: "analytics".into(),
+                    command: "analytics-mcp".into(),
+                    args: vec!["--token".into(), arg_secret.into()],
+                    env: vec![EnvVar {
+                        name: "ANALYTICS_TOKEN".into(),
+                        value: env_secret.into(),
+                    }],
+                }],
+                None,
+                None,
+            )
+            .await
+            .expect("session/new should succeed");
+
+        assert_eq!(
+            response.raw["_receivedRequest"]["params"]["mcpServers"][0]["env"][0]["value"],
+            env_secret,
+            "the adapter must receive the real MCP environment value"
+        );
+        assert_eq!(
+            response.raw["_receivedRequest"]["params"]["mcpServers"][0]["args"][1], arg_secret,
+            "the adapter must receive the real MCP argument"
+        );
+
+        let events = observer.snapshot();
+        let session_write = events
+            .iter()
+            .find(|event| event.kind == "acp_write" && event.payload["method"] == "session/new")
+            .expect("session/new write observer event");
+        assert_eq!(
+            session_write.payload["params"]["mcpServers"][0]["env"][0]["value"],
+            REDACTED_MCP_VALUE
+        );
+        assert_eq!(
+            session_write.payload["params"]["mcpServers"][0]["args"],
+            serde_json::json!([REDACTED_MCP_VALUE, REDACTED_MCP_VALUE])
+        );
+
+        let echoed_read = events
+            .iter()
+            .find(|event| {
+                event.kind == "acp_read"
+                    && event.payload["result"]["sessionId"] == "ses_secret_test"
+            })
+            .expect("session/new response observer event");
+        assert_eq!(
+            echoed_read.payload["result"]["_receivedRequest"]["params"]["mcpServers"][0]["env"][0]
+                ["value"],
+            REDACTED_MCP_VALUE
+        );
+        assert_eq!(
+            echoed_read.payload["result"]["_receivedRequest"]["params"]["mcpServers"][0]["args"],
+            serde_json::json!([REDACTED_MCP_VALUE, REDACTED_MCP_VALUE])
+        );
+
+        let serialized_events =
+            serde_json::to_string(&events).expect("serialize observer snapshot");
+        assert!(
+            !serialized_events.contains(env_secret),
+            "no observer frame may contain the real MCP environment value"
+        );
+        assert!(
+            !serialized_events.contains(arg_secret),
+            "no observer frame may contain the real MCP argument"
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn session_new_error_cannot_echo_serialized_mcp_config() {
+        let secret = "adapter-echo-secret";
+        let embedded_request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/new",
+            "params": {
+                "mcpServers": [{
+                    "name": "analytics",
+                    "command": "analytics-mcp",
+                    "args": [],
+                    "env": [{"name": "ANALYTICS_TOKEN", "value": secret}]
+                }]
+            }
+        })
+        .to_string();
+        let error_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {
+                "code": -32055,
+                "message": format!("adapter rejected {embedded_request}")
+            }
+        })
+        .to_string();
+        let script = format!(
+            "read -t 2 _init\n\
+             printf '%s\\n' '{{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{{\"protocolVersion\":2,\"agentCapabilities\":{{}}}}}}'\n\
+             read -t 2 _session\n\
+             printf '%s\\n' '{error_response}'\n\
+             sleep 1"
+        );
+        let mut client = spawn_script(&script).await;
+        let observer = ObserverHandle::in_process();
+        client.set_observer(Some(observer.clone()), 0);
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+
+        let result = client
+            .session_new_full(
+                "/tmp",
+                vec![McpServer {
+                    name: "analytics".into(),
+                    command: "analytics-mcp".into(),
+                    args: vec![],
+                    env: vec![EnvVar {
+                        name: "ANALYTICS_TOKEN".into(),
+                        value: secret.into(),
+                    }],
+                }],
+                None,
+                None,
+            )
+            .await;
+
+        match result {
+            Err(AcpError::AgentError { code, message }) => {
+                assert_eq!(code, -32055);
+                assert_eq!(message, REDACTED_MCP_VALUE);
+                assert!(!message.contains(secret));
+            }
+            Err(other) => panic!("expected redacted AgentError, got {other:?}"),
+            Ok(_) => panic!("expected session/new to return an error"),
+        }
+
+        client.observe(
+            "adapter_diagnostic",
+            serde_json::json!({"message": embedded_request}),
+        );
+        let serialized_events =
+            serde_json::to_string(&observer.snapshot()).expect("serialize observer snapshot");
+        assert!(!serialized_events.contains(secret));
+        assert!(serialized_events.contains(REDACTED_MCP_VALUE));
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn semantic_traces_cannot_echo_serialized_mcp_config() {
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone, Default)]
+        struct TraceCapture(Arc<Mutex<Vec<u8>>>);
+
+        struct TraceWriter(Arc<Mutex<Vec<u8>>>);
+
+        impl Write for TraceWriter {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                self.0
+                    .lock()
+                    .expect("trace buffer lock")
+                    .extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for TraceCapture {
+            type Writer = TraceWriter;
+
+            fn make_writer(&'a self) -> Self::Writer {
+                TraceWriter(self.0.clone())
+            }
+        }
+
+        let secret = "semantic-trace-secret";
+        let embedded_request = serde_json::json!({
+            "method": "session/new",
+            "params": {
+                "mcpServers": [{
+                    "env": [{"name": "ANALYTICS_TOKEN", "value": secret}]
+                }]
+            }
+        })
+        .to_string();
+        let update = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": embedded_request}
+                }
+            }
+        });
+        let mut client = spawn_inert_client().await;
+        let trace = TraceCapture::default();
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(trace.clone())
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            let _ = client.handle_session_update(&update);
+            client.handle_goose_usage_update(&serde_json::json!({
+                "params": {
+                    "sessionId": embedded_request,
+                    "update": {
+                        "sessionUpdate": "usage_update",
+                        "accumulatedInputTokens": 10,
+                        "accumulatedOutputTokens": 5,
+                        "accumulatedCachedInputTokens": null,
+                        "accumulatedCost": null
+                    }
+                }
+            }));
+            client.handle_goose_usage_update(&serde_json::json!({
+                "params": {
+                    "sessionId": "ordinary-session",
+                    "update": {
+                        "sessionUpdate": "usage_update",
+                        "accumulatedInputTokens": embedded_request,
+                        "accumulatedOutputTokens": 5,
+                        "accumulatedCachedInputTokens": null,
+                        "accumulatedCost": null
+                    }
+                }
+            }));
+        });
+
+        let output = String::from_utf8(trace.0.lock().expect("trace buffer lock").clone())
+            .expect("trace output should be UTF-8");
+        assert!(!output.contains(secret));
+        assert!(output.contains(REDACTED_MCP_VALUE));
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn structured_mcp_servers_survive_repeated_sessions_and_adapter_restart() {
+        let script = r#"
+            read -t 2 _init
+            echo '{"jsonrpc":"2.0","id":0,"result":{"protocolVersion":2,"agentCapabilities":{}}}'
+            read -t 2 FIRST
+            echo '{"jsonrpc":"2.0","id":1,"result":{"sessionId":"ses_first","_receivedRequest":'"$FIRST"'}}'
+            read -t 2 SECOND
+            echo '{"jsonrpc":"2.0","id":2,"result":{"sessionId":"ses_second","_receivedRequest":'"$SECOND"'}}'
+            sleep 1
+        "#;
+        let servers = vec![
+            McpServer {
+                name: "analytics".into(),
+                command: "/opt/MCP Servers/analytics,prod".into(),
+                args: vec!["--stdio".into(), "literal value".into()],
+                env: vec![EnvVar {
+                    name: "ANALYTICS_ENDPOINT".into(),
+                    value: "https://example.test/a=b".into(),
+                }],
+            },
+            McpServer {
+                name: "search".into(),
+                command: "/opt/search-mcp".into(),
+                args: vec![],
+                env: vec![],
+            },
+        ];
+
+        for _restart in 0..2 {
+            let mut client = spawn_script(script).await;
+            let observer = ObserverHandle::in_process();
+            client.set_observer(Some(observer.clone()), 0);
+            client
+                .initialize()
+                .await
+                .expect("initialize should succeed");
+
+            for expected_session_id in ["ses_first", "ses_second"] {
+                let response = client
+                    .session_new_full("/tmp", servers.clone(), None, None)
+                    .await
+                    .expect("session/new should succeed");
+                assert_eq!(response.session_id, expected_session_id);
+                let received = &response.raw["_receivedRequest"]["params"]["mcpServers"];
+                assert_eq!(received[0]["name"], "analytics");
+                assert_eq!(received[0]["command"], "/opt/MCP Servers/analytics,prod");
+                assert_eq!(
+                    received[0]["args"],
+                    serde_json::json!(["--stdio", "literal value"])
+                );
+                assert_eq!(received[0]["env"][0]["name"], "ANALYTICS_ENDPOINT");
+                assert_eq!(received[0]["env"][0]["value"], "https://example.test/a=b");
+                assert_eq!(received[1]["name"], "search");
+                assert_eq!(received[1]["command"], "/opt/search-mcp");
+            }
+
+            let writes = observer
+                .snapshot()
+                .into_iter()
+                .filter(|event| {
+                    event.kind == "acp_write" && event.payload["method"] == "session/new"
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(writes.len(), 2);
+            for write in writes {
+                let sent = &write.payload["params"]["mcpServers"];
+                assert_eq!(sent[0]["name"], "analytics");
+                assert_eq!(sent[0]["command"], "/opt/MCP Servers/analytics,prod");
+                assert_eq!(
+                    sent[0]["args"],
+                    serde_json::json!([REDACTED_MCP_VALUE, REDACTED_MCP_VALUE])
+                );
+                assert_eq!(sent[0]["env"][0]["name"], "ANALYTICS_ENDPOINT");
+                assert_eq!(sent[0]["env"][0]["value"], REDACTED_MCP_VALUE);
+                assert_eq!(sent[1]["name"], "search");
+                assert_eq!(sent[1]["command"], "/opt/search-mcp");
+            }
+            client.shutdown().await;
+        }
     }
 
     #[tokio::test]
@@ -4403,6 +5093,26 @@ mod tests {
             }
             other => panic!("expected AgentError, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn agent_error_from_json_redacts_mcp_env_before_display_or_turn_error() {
+        let secret = "agent-error-secret";
+        let error = serde_json::json!({
+            "code": -32002,
+            "data": {
+                "env": [{
+                    "name": "ANALYTICS_TOKEN",
+                    "value": secret
+                }]
+            }
+        });
+
+        let rendered = super::agent_error_from_json(&error).to_string();
+
+        assert!(!rendered.contains(secret));
+        assert!(rendered.contains(REDACTED_MCP_VALUE));
+        assert_eq!(error["data"]["env"][0]["value"], secret);
     }
 
     #[test]

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -26,8 +26,9 @@ const MAX_LINE_SIZE: usize = 10_000_000; // 10 MB
 const REDACTED_MCP_VALUE: &str = "[REDACTED]";
 /// Substring redaction is a fallback for adapter echoes outside the structured
 /// `mcpServers` object. Very short values create destructive false positives
-/// in ordinary diagnostics, so they are protected structurally only.
+/// in ordinary diagnostics, so short values use exact or token-boundary matching.
 const MIN_SENSITIVE_PATTERN_BYTES: usize = 12;
+const MIN_BOUNDED_SENSITIVE_PATTERN_BYTES: usize = 8;
 const COMMON_MCP_VALUES: [&str; 13] = [
     "true",
     "false",
@@ -44,11 +45,83 @@ const COMMON_MCP_VALUES: [&str; 13] = [
     "localhost",
 ];
 
+fn common_mcp_value(value: &str) -> bool {
+    COMMON_MCP_VALUES
+        .iter()
+        .any(|common| value.eq_ignore_ascii_case(common))
+}
+
 fn safe_sensitive_pattern(value: &str) -> bool {
-    value.len() >= MIN_SENSITIVE_PATTERN_BYTES
-        && !COMMON_MCP_VALUES
+    value.len() >= MIN_SENSITIVE_PATTERN_BYTES && !common_mcp_value(value)
+}
+
+fn bounded_sensitive_pattern(value: &str) -> bool {
+    (MIN_BOUNDED_SENSITIVE_PATTERN_BYTES..MIN_SENSITIVE_PATTERN_BYTES).contains(&value.len())
+        && !common_mcp_value(value)
+}
+
+fn contains_bounded_value(text: &str, value: &str) -> bool {
+    let bytes = text.as_bytes();
+    text.match_indices(value).any(|(start, _)| {
+        let end = start + value.len();
+        let before_is_boundary =
+            start == 0 || !bytes[start - 1].is_ascii_alphanumeric() && bytes[start - 1] != b'_';
+        let after_is_boundary =
+            end == bytes.len() || !bytes[end].is_ascii_alphanumeric() && bytes[end] != b'_';
+        before_is_boundary && after_is_boundary
+    })
+}
+
+#[derive(Default)]
+struct SensitiveMcpValueMatcher {
+    substring: Option<AhoCorasick>,
+    exact: Vec<String>,
+    bounded: Vec<String>,
+}
+
+impl SensitiveMcpValueMatcher {
+    fn new(values: &[String]) -> Result<Self, aho_corasick::BuildError> {
+        let mut exact = values
             .iter()
-            .any(|common| value.eq_ignore_ascii_case(common))
+            .filter(|value| !value.is_empty())
+            .cloned()
+            .collect::<Vec<_>>();
+        exact.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
+        exact.dedup();
+
+        let bounded = exact
+            .iter()
+            .filter(|value| bounded_sensitive_pattern(value))
+            .cloned()
+            .collect();
+        let substring_patterns = exact
+            .iter()
+            .filter(|value| safe_sensitive_pattern(value))
+            .collect::<Vec<_>>();
+        let substring = if substring_patterns.is_empty() {
+            None
+        } else {
+            Some(AhoCorasick::new(substring_patterns)?)
+        };
+
+        Ok(Self {
+            substring,
+            exact,
+            bounded,
+        })
+    }
+
+    fn is_match(&self, text: &str) -> bool {
+        self.exact.iter().any(|value| text == value)
+            || self
+                .substring
+                .as_ref()
+                .is_some_and(|matcher| matcher.find(text).is_some())
+            || self
+                .bounded
+                .iter()
+                .any(|value| contains_bounded_value(text, value))
+    }
 }
 
 /// An MCP server configuration passed to `session/new`.
@@ -247,7 +320,7 @@ pub enum AcpError {
 /// detail (e.g. a `data` field) is not lost.
 fn agent_error_from_json(
     error: &serde_json::Value,
-    sensitive_value_matcher: Option<&AhoCorasick>,
+    sensitive_value_matcher: &SensitiveMcpValueMatcher,
 ) -> AcpError {
     let code = error.get("code").and_then(|c| c.as_i64()).unwrap_or(-32000);
     let redacted_error = redact_wire_value(error, sensitive_value_matcher);
@@ -285,7 +358,7 @@ fn contains_serialized_json_key(text: &str, key: &str) -> bool {
 
 fn redact_wire_text<'a>(
     text: &'a str,
-    sensitive_value_matcher: Option<&AhoCorasick>,
+    sensitive_value_matcher: &SensitiveMcpValueMatcher,
 ) -> Cow<'a, str> {
     let looks_like_serialized_mcp_config = contains_serialized_json_key(text, "mcpServers")
         && (contains_serialized_json_key(text, "args")
@@ -295,7 +368,7 @@ fn redact_wire_text<'a>(
     if looks_like_serialized_mcp_config {
         return Cow::Borrowed(REDACTED_MCP_VALUE);
     }
-    if sensitive_value_matcher.is_some_and(|matcher| matcher.find(text).is_some()) {
+    if sensitive_value_matcher.is_match(text) {
         return Cow::Borrowed(REDACTED_MCP_VALUE);
     }
     Cow::Borrowed(text)
@@ -307,11 +380,11 @@ fn redact_wire_text<'a>(
 /// wire, but must not reach tracing or observer frames.
 fn redact_wire_value(
     value: &serde_json::Value,
-    sensitive_value_matcher: Option<&AhoCorasick>,
+    sensitive_value_matcher: &SensitiveMcpValueMatcher,
 ) -> serde_json::Value {
     fn redact_in_place(
         value: &mut serde_json::Value,
-        sensitive_value_matcher: Option<&AhoCorasick>,
+        sensitive_value_matcher: &SensitiveMcpValueMatcher,
     ) {
         match value {
             serde_json::Value::Array(values) => {
@@ -435,7 +508,7 @@ pub struct AcpClient {
     /// Credential values retained across sessions for log and observer redaction.
     sensitive_mcp_values: Vec<String>,
     /// Multi-pattern matcher rebuilt when a session introduces new credentials.
-    sensitive_mcp_matcher: Option<AhoCorasick>,
+    sensitive_mcp_matcher: SensitiveMcpValueMatcher,
     /// Most recently observed `_meta.goose.activeRunId` from a
     /// `session/update` notification of kind `session_info_update`.
     ///
@@ -811,7 +884,7 @@ impl AcpClient {
             observer_agent_index: None,
             observer_context: ObserverContext::default(),
             sensitive_mcp_values: Vec::new(),
-            sensitive_mcp_matcher: None,
+            sensitive_mcp_matcher: SensitiveMcpValueMatcher::default(),
             active_run_id: None,
             steering_supported: false,
             steer_rx: None,
@@ -845,7 +918,7 @@ impl AcpClient {
         for value in servers
             .iter()
             .flat_map(McpServer::sensitive_values)
-            .filter(|value| safe_sensitive_pattern(value))
+            .filter(|value| !value.is_empty())
         {
             if !self
                 .sensitive_mcp_values
@@ -862,23 +935,23 @@ impl AcpClient {
 
         self.sensitive_mcp_values
             .sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
-        self.sensitive_mcp_matcher =
-            Some(AhoCorasick::new(&self.sensitive_mcp_values).map_err(|_| {
+        self.sensitive_mcp_matcher = SensitiveMcpValueMatcher::new(&self.sensitive_mcp_values)
+            .map_err(|_| {
                 AcpError::Protocol("failed to initialize MCP credential redaction".to_string())
-            })?);
+            })?;
         Ok(())
     }
 
     fn redact_wire_text<'a>(&self, text: &'a str) -> Cow<'a, str> {
-        redact_wire_text(text, self.sensitive_mcp_matcher.as_ref())
+        redact_wire_text(text, &self.sensitive_mcp_matcher)
     }
 
     fn redact_wire_value(&self, value: &serde_json::Value) -> serde_json::Value {
-        redact_wire_value(value, self.sensitive_mcp_matcher.as_ref())
+        redact_wire_value(value, &self.sensitive_mcp_matcher)
     }
 
     fn agent_error_from_json(&self, error: &serde_json::Value) -> AcpError {
-        agent_error_from_json(error, self.sensitive_mcp_matcher.as_ref())
+        agent_error_from_json(error, &self.sensitive_mcp_matcher)
     }
 
     /// Emit a semantic event to the local observer feed, if enabled.
@@ -2585,15 +2658,8 @@ fn configure_no_window(cmd: &mut tokio::process::Command) {
 mod tests {
     use super::*;
 
-    fn sensitive_matcher(values: &[String]) -> Option<AhoCorasick> {
-        let mut patterns = values
-            .iter()
-            .map(String::as_str)
-            .filter(|value| safe_sensitive_pattern(value))
-            .collect::<Vec<_>>();
-        patterns.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
-        patterns.dedup();
-        (!patterns.is_empty()).then(|| AhoCorasick::new(patterns).expect("valid patterns"))
+    fn sensitive_matcher(values: &[String]) -> SensitiveMcpValueMatcher {
+        SensitiveMcpValueMatcher::new(values).expect("valid patterns")
     }
 
     #[test]
@@ -2876,7 +2942,7 @@ mod tests {
             }
         });
 
-        let redacted = redact_wire_value(&source, None);
+        let redacted = redact_wire_value(&source, &SensitiveMcpValueMatcher::default());
 
         assert_eq!(
             source["params"]["mcpServers"][0]["env"][0]["value"], "secret-one",
@@ -2947,7 +3013,7 @@ mod tests {
         });
         let original_source = source.clone();
 
-        let redacted = redact_wire_value(&source, None);
+        let redacted = redact_wire_value(&source, &SensitiveMcpValueMatcher::default());
 
         for echo in redacted["echoes"].as_array().expect("redacted echoes") {
             assert_eq!(echo, REDACTED_MCP_VALUE);
@@ -2975,7 +3041,7 @@ mod tests {
             }
         });
 
-        let redacted = redact_wire_value(&source, None);
+        let redacted = redact_wire_value(&source, &SensitiveMcpValueMatcher::default());
         assert_eq!(
             redacted["params"]["mcpServers"][0]["headers"][0]["value"],
             REDACTED_MCP_VALUE
@@ -3006,7 +3072,7 @@ mod tests {
         ];
 
         let matcher = sensitive_matcher(&sensitive_values);
-        let redacted = redact_wire_value(&source, matcher.as_ref());
+        let redacted = redact_wire_value(&source, &matcher);
 
         let message = redacted["error"]["message"]
             .as_str()
@@ -3026,12 +3092,18 @@ mod tests {
             .map(str::to_string)
             .to_vec();
         let matcher = sensitive_matcher(&values);
-        assert!(matcher.is_none());
 
         let diagnostic = serde_json::json!({
             "message": "production retry 1/true on localhost used token accounting"
         });
-        assert_eq!(redact_wire_value(&diagnostic, matcher.as_ref()), diagnostic);
+        assert_eq!(redact_wire_value(&diagnostic, &matcher), diagnostic);
+        for value in values {
+            assert_eq!(
+                redact_wire_value(&serde_json::json!({"message": value}), &matcher)["message"],
+                REDACTED_MCP_VALUE,
+                "an exact short-value echo must still be protected"
+            );
+        }
     }
 
     #[test]
@@ -4137,7 +4209,7 @@ mod tests {
 
     #[tokio::test]
     async fn plain_mcp_argument_echo_is_redacted() {
-        let argument_secret = "argument-secret-returned-by-adapter";
+        let argument_secret = "s3cr3t8!";
         let error_response = serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -5567,7 +5639,7 @@ mod tests {
         // Errors without a string `message` field (e.g. only a `data` field) must
         // not be silently truncated to "unknown error" — the full JSON is preserved.
         let error = serde_json::json!({"code": -32000, "data": "quota exceeded"});
-        match super::agent_error_from_json(&error, None) {
+        match super::agent_error_from_json(&error, &SensitiveMcpValueMatcher::default()) {
             AcpError::AgentError { code, message } => {
                 assert_eq!(code, -32000);
                 assert!(
@@ -5592,7 +5664,8 @@ mod tests {
             }
         });
 
-        let rendered = super::agent_error_from_json(&error, None).to_string();
+        let rendered =
+            super::agent_error_from_json(&error, &SensitiveMcpValueMatcher::default()).to_string();
 
         assert!(!rendered.contains(secret));
         assert!(rendered.contains(REDACTED_MCP_VALUE));
@@ -5602,7 +5675,7 @@ mod tests {
     #[test]
     fn agent_error_from_json_uses_message_field_when_present() {
         let error = serde_json::json!({"code": -32001, "message": "auth denied"});
-        match super::agent_error_from_json(&error, None) {
+        match super::agent_error_from_json(&error, &SensitiveMcpValueMatcher::default()) {
             AcpError::AgentError { code, message } => {
                 assert_eq!(code, -32001);
                 assert_eq!(message, "auth denied");

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -76,7 +76,12 @@ impl McpServer {
 
     fn sensitive_values(&self) -> Box<dyn Iterator<Item = &String> + '_> {
         match self {
-            Self::Stdio(server) => Box::new(server.env.iter().map(|entry| &entry.value)),
+            Self::Stdio(server) => Box::new(
+                server
+                    .args
+                    .iter()
+                    .chain(server.env.iter().map(|entry| &entry.value)),
+            ),
             Self::Http(server) => Box::new(
                 std::iter::once(&server.url).chain(server.headers.iter().map(|entry| &entry.value)),
             ),
@@ -428,9 +433,9 @@ pub struct AcpClient {
     /// Best-effort context attached to raw ACP wire events.
     observer_context: ObserverContext,
     /// Credential values retained across sessions for log and observer redaction.
-    sensitive_mcp_env_values: Vec<String>,
+    sensitive_mcp_values: Vec<String>,
     /// Multi-pattern matcher rebuilt when a session introduces new credentials.
-    sensitive_mcp_env_matcher: Option<AhoCorasick>,
+    sensitive_mcp_matcher: Option<AhoCorasick>,
     /// Most recently observed `_meta.goose.activeRunId` from a
     /// `session/update` notification of kind `session_info_update`.
     ///
@@ -805,8 +810,8 @@ impl AcpClient {
             observer: None,
             observer_agent_index: None,
             observer_context: ObserverContext::default(),
-            sensitive_mcp_env_values: Vec::new(),
-            sensitive_mcp_env_matcher: None,
+            sensitive_mcp_values: Vec::new(),
+            sensitive_mcp_matcher: None,
             active_run_id: None,
             steering_supported: false,
             steer_rx: None,
@@ -835,7 +840,7 @@ impl AcpClient {
         self.observer_agent_index
     }
 
-    fn register_sensitive_mcp_env_values(&mut self, servers: &[McpServer]) -> Result<(), AcpError> {
+    fn register_sensitive_mcp_values(&mut self, servers: &[McpServer]) -> Result<(), AcpError> {
         let mut changed = false;
         for value in servers
             .iter()
@@ -843,11 +848,11 @@ impl AcpClient {
             .filter(|value| safe_sensitive_pattern(value))
         {
             if !self
-                .sensitive_mcp_env_values
+                .sensitive_mcp_values
                 .iter()
                 .any(|registered| registered == value)
             {
-                self.sensitive_mcp_env_values.push(value.clone());
+                self.sensitive_mcp_values.push(value.clone());
                 changed = true;
             }
         }
@@ -855,26 +860,25 @@ impl AcpClient {
             return Ok(());
         }
 
-        self.sensitive_mcp_env_values
+        self.sensitive_mcp_values
             .sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
-        self.sensitive_mcp_env_matcher = Some(
-            AhoCorasick::new(&self.sensitive_mcp_env_values).map_err(|_| {
+        self.sensitive_mcp_matcher =
+            Some(AhoCorasick::new(&self.sensitive_mcp_values).map_err(|_| {
                 AcpError::Protocol("failed to initialize MCP credential redaction".to_string())
-            })?,
-        );
+            })?);
         Ok(())
     }
 
     fn redact_wire_text<'a>(&self, text: &'a str) -> Cow<'a, str> {
-        redact_wire_text(text, self.sensitive_mcp_env_matcher.as_ref())
+        redact_wire_text(text, self.sensitive_mcp_matcher.as_ref())
     }
 
     fn redact_wire_value(&self, value: &serde_json::Value) -> serde_json::Value {
-        redact_wire_value(value, self.sensitive_mcp_env_matcher.as_ref())
+        redact_wire_value(value, self.sensitive_mcp_matcher.as_ref())
     }
 
     fn agent_error_from_json(&self, error: &serde_json::Value) -> AcpError {
-        agent_error_from_json(error, self.sensitive_mcp_env_matcher.as_ref())
+        agent_error_from_json(error, self.sensitive_mcp_matcher.as_ref())
     }
 
     /// Emit a semantic event to the local observer feed, if enabled.
@@ -953,7 +957,7 @@ impl AcpClient {
         system_prompt: Option<SystemPromptTransport<'_>>,
         session_title: Option<&str>,
     ) -> Result<SessionNewResponse, AcpError> {
-        self.register_sensitive_mcp_env_values(&mcp_servers)?;
+        self.register_sensitive_mcp_values(&mcp_servers)?;
         let mut params = serde_json::json!({
             "cwd": cwd,
             "mcpServers": mcp_servers,
@@ -4132,6 +4136,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn plain_mcp_argument_echo_is_redacted() {
+        let argument_secret = "argument-secret-returned-by-adapter";
+        let error_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {
+                "code": -32057,
+                "message": format!("adapter rejected argument {argument_secret}")
+            }
+        })
+        .to_string();
+        let script = format!(
+            "read -t 2 _init\n\
+             printf '%s\\n' '{{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{{\"protocolVersion\":2,\"agentCapabilities\":{{}}}}}}'\n\
+             read -t 2 _session\n\
+             printf '%s\\n' '{error_response}'\n\
+             sleep 1"
+        );
+        let mut client = spawn_script(&script).await;
+        let observer = ObserverHandle::in_process();
+        client.set_observer(Some(observer.clone()), 0);
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+
+        let result = client
+            .session_new_full(
+                "/tmp",
+                vec![McpServer::Stdio(McpServerStdio {
+                    name: "analytics".into(),
+                    command: "analytics-mcp".into(),
+                    args: vec!["--token".into(), argument_secret.into()],
+                    env: vec![],
+                })],
+                None,
+                None,
+            )
+            .await;
+
+        match result {
+            Err(AcpError::AgentError { code, message }) => {
+                assert_eq!(code, -32057);
+                assert_eq!(message, REDACTED_MCP_VALUE);
+                assert!(!message.contains(argument_secret));
+            }
+            Err(other) => panic!("expected redacted AgentError, got {other:?}"),
+            Ok(_) => panic!("expected session/new to return an error"),
+        }
+
+        let serialized_events =
+            serde_json::to_string(&observer.snapshot()).expect("serialize observer snapshot");
+        assert!(!serialized_events.contains(argument_secret));
+        assert!(serialized_events.contains(REDACTED_MCP_VALUE));
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn plain_mcp_secret_echo_is_redacted_and_old_session_values_are_retained() {
         let first_secret = "first-session-adapter-secret";
         let second_secret = "second-session-adapter-secret";
@@ -4191,16 +4253,16 @@ mod tests {
             Ok(_) => panic!("expected second session/new to return an error"),
         }
 
-        assert_eq!(client.sensitive_mcp_env_values.len(), 2);
+        assert_eq!(client.sensitive_mcp_values.len(), 2);
         assert!(
             client
-                .sensitive_mcp_env_values
+                .sensitive_mcp_values
                 .iter()
                 .any(|value| value == first_secret),
             "credentials from earlier sessions must remain registered"
         );
         assert!(client
-            .sensitive_mcp_env_values
+            .sensitive_mcp_values
             .iter()
             .any(|value| value == second_secret));
         let serialized_events =
@@ -4265,7 +4327,7 @@ mod tests {
         });
         let mut client = spawn_inert_client().await;
         client
-            .register_sensitive_mcp_env_values(&[McpServer::Stdio(McpServerStdio {
+            .register_sensitive_mcp_values(&[McpServer::Stdio(McpServerStdio {
                 name: "analytics".into(),
                 command: "analytics-mcp".into(),
                 args: vec![],

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -8,10 +8,13 @@
 //! 4. [`AcpClient::session_prompt_with_idle_timeout`] — send prompt with idle/hard deadline, return stop reason
 //! 5. [`AcpClient::session_cancel`] / [`AcpClient::cancel_with_cleanup`] — cancel in-flight turn
 
+use aho_corasick::AhoCorasick;
 use futures_util::StreamExt;
+use std::borrow::Cow;
 use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, ChildStdin, ChildStdout};
 use tokio_util::codec::{FramedRead, LinesCodec, LinesCodecError};
+use zeroize::Zeroizing;
 
 use crate::observer::{ObserverContext, ObserverHandle};
 use crate::usage::{TurnUsage, UsageTracker};
@@ -24,26 +27,101 @@ const REDACTED_MCP_VALUE: &str = "[REDACTED]";
 
 /// An MCP server configuration passed to `session/new`.
 ///
-/// Corresponds to the `McpServerStdio` variant in the ACP schema.
-/// All four fields are **required** by the schema (`args` and `env` may be empty arrays).
+/// ACP models stdio servers as an untagged object and HTTP servers as an
+/// object tagged with `type: "http"`, so the outer enum is untagged.
 #[derive(Clone, serde::Serialize)]
-pub struct McpServer {
+#[serde(untagged)]
+pub enum McpServer {
+    Stdio(McpServerStdio),
+    Http(McpServerHttp),
+}
+
+impl McpServer {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Stdio(server) => &server.name,
+            Self::Http(server) => &server.name,
+        }
+    }
+
+    pub fn is_http(&self) -> bool {
+        matches!(self, Self::Http(_))
+    }
+
+    fn sensitive_values(&self) -> Box<dyn Iterator<Item = &String> + '_> {
+        match self {
+            Self::Stdio(server) => Box::new(server.env.iter().map(|entry| &entry.value)),
+            Self::Http(server) => Box::new(
+                std::iter::once(&server.url).chain(server.headers.iter().map(|entry| &entry.value)),
+            ),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn as_stdio(&self) -> Option<&McpServerStdio> {
+        match self {
+            Self::Stdio(server) => Some(server),
+            Self::Http(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Debug for McpServer {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Stdio(server) => server.fmt(formatter),
+            Self::Http(server) => server.fmt(formatter),
+        }
+    }
+}
+
+/// A child-process MCP server.
+#[derive(Clone, serde::Serialize)]
+pub struct McpServerStdio {
     pub name: String,
     pub command: String,
     pub args: Vec<String>,
     pub env: Vec<EnvVar>,
 }
 
-impl std::fmt::Debug for McpServer {
+impl std::fmt::Debug for McpServerStdio {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
-            .debug_struct("McpServer")
+            .debug_struct("McpServerStdio")
             .field("name", &self.name)
             .field("command", &self.command)
             .field("arg_count", &self.args.len())
             .field("env", &self.env)
             .finish()
     }
+}
+
+/// A remote Streamable HTTP MCP server.
+#[derive(Clone, serde::Serialize)]
+pub struct McpServerHttp {
+    #[serde(rename = "type")]
+    pub transport: HttpTransport,
+    pub name: String,
+    pub url: String,
+    pub headers: Vec<EnvVar>,
+}
+
+impl std::fmt::Debug for McpServerHttp {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("McpServerHttp")
+            .field("transport", &self.transport)
+            .field("name", &self.name)
+            .field("url", &REDACTED_MCP_VALUE)
+            .field("headers", &self.headers)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HttpTransport {
+    Http,
 }
 
 /// A single environment variable for an MCP server.
@@ -136,9 +214,12 @@ pub enum AcpError {
 /// preserving the numeric code. When the `message` field is missing or
 /// non-string, fall back to the full JSON object so provider-specific
 /// detail (e.g. a `data` field) is not lost.
-fn agent_error_from_json(error: &serde_json::Value) -> AcpError {
+fn agent_error_from_json(
+    error: &serde_json::Value,
+    sensitive_value_matcher: Option<&AhoCorasick>,
+) -> AcpError {
     let code = error.get("code").and_then(|c| c.as_i64()).unwrap_or(-32000);
-    let redacted_error = redact_wire_value(error);
+    let redacted_error = redact_wire_value(error, sensitive_value_matcher);
     let message = match redacted_error.get("message").and_then(|m| m.as_str()) {
         Some(m) => m.to_string(),
         None => redacted_error.to_string(),
@@ -171,28 +252,40 @@ fn contains_serialized_json_key(text: &str, key: &str) -> bool {
     })
 }
 
-fn redact_wire_text(text: &str) -> &str {
+fn redact_wire_text<'a>(
+    text: &'a str,
+    sensitive_value_matcher: Option<&AhoCorasick>,
+) -> Cow<'a, str> {
     let looks_like_serialized_mcp_config = contains_serialized_json_key(text, "mcpServers")
         && (contains_serialized_json_key(text, "args")
-            || (contains_serialized_json_key(text, "env")
+            || ((contains_serialized_json_key(text, "env")
+                || contains_serialized_json_key(text, "headers"))
                 && contains_serialized_json_key(text, "value")));
     if looks_like_serialized_mcp_config {
-        REDACTED_MCP_VALUE
-    } else {
-        text
+        return Cow::Borrowed(REDACTED_MCP_VALUE);
     }
+    if sensitive_value_matcher.is_some_and(|matcher| matcher.find(text).is_some()) {
+        return Cow::Borrowed(REDACTED_MCP_VALUE);
+    }
+    Cow::Borrowed(text)
 }
 
 /// Return a logging-safe copy of an ACP wire value.
 ///
 /// MCP arguments and environment values are needed by the adapter on the real
 /// wire, but must not reach tracing or observer frames.
-fn redact_wire_value(value: &serde_json::Value) -> serde_json::Value {
-    fn redact_in_place(value: &mut serde_json::Value) {
+fn redact_wire_value(
+    value: &serde_json::Value,
+    sensitive_value_matcher: Option<&AhoCorasick>,
+) -> serde_json::Value {
+    fn redact_in_place(
+        value: &mut serde_json::Value,
+        sensitive_value_matcher: Option<&AhoCorasick>,
+    ) {
         match value {
             serde_json::Value::Array(values) => {
                 for value in values {
-                    redact_in_place(value);
+                    redact_in_place(value, sensitive_value_matcher);
                 }
             }
             serde_json::Value::Object(fields) => {
@@ -214,7 +307,7 @@ fn redact_wire_value(value: &serde_json::Value) -> serde_json::Value {
                             }
                         }
                     }
-                    if key == "env" {
+                    if key == "env" || key == "headers" {
                         if let serde_json::Value::Array(entries) = value {
                             for entry in entries {
                                 if let serde_json::Value::Object(env_var) = entry {
@@ -230,13 +323,13 @@ fn redact_wire_value(value: &serde_json::Value) -> serde_json::Value {
                             }
                         }
                     }
-                    redact_in_place(value);
+                    redact_in_place(value, sensitive_value_matcher);
                 }
             }
             serde_json::Value::String(text) => {
-                let observed = redact_wire_text(text);
+                let observed = redact_wire_text(text, sensitive_value_matcher);
                 if observed != text.as_str() {
-                    *text = observed.to_string();
+                    *text = observed.into_owned();
                 }
             }
             _ => {}
@@ -244,7 +337,7 @@ fn redact_wire_value(value: &serde_json::Value) -> serde_json::Value {
     }
 
     let mut redacted = value.clone();
-    redact_in_place(&mut redacted);
+    redact_in_place(&mut redacted, sensitive_value_matcher);
     redacted
 }
 
@@ -299,6 +392,10 @@ pub struct AcpClient {
     observer_agent_index: Option<usize>,
     /// Best-effort context attached to raw ACP wire events.
     observer_context: ObserverContext,
+    /// Credential values retained across sessions for log and observer redaction.
+    sensitive_mcp_env_values: Vec<String>,
+    /// Multi-pattern matcher rebuilt when a session introduces new credentials.
+    sensitive_mcp_env_matcher: Option<AhoCorasick>,
     /// Most recently observed `_meta.goose.activeRunId` from a
     /// `session/update` notification of kind `session_info_update`.
     ///
@@ -673,6 +770,8 @@ impl AcpClient {
             observer: None,
             observer_agent_index: None,
             observer_context: ObserverContext::default(),
+            sensitive_mcp_env_values: Vec::new(),
+            sensitive_mcp_env_matcher: None,
             active_run_id: None,
             steering_supported: false,
             steer_rx: None,
@@ -701,12 +800,54 @@ impl AcpClient {
         self.observer_agent_index
     }
 
+    fn register_sensitive_mcp_env_values(&mut self, servers: &[McpServer]) -> Result<(), AcpError> {
+        let mut changed = false;
+        for value in servers
+            .iter()
+            .flat_map(McpServer::sensitive_values)
+            .filter(|value| !value.is_empty())
+        {
+            if !self
+                .sensitive_mcp_env_values
+                .iter()
+                .any(|registered| registered == value)
+            {
+                self.sensitive_mcp_env_values.push(value.clone());
+                changed = true;
+            }
+        }
+        if !changed {
+            return Ok(());
+        }
+
+        self.sensitive_mcp_env_values
+            .sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
+        self.sensitive_mcp_env_matcher = Some(
+            AhoCorasick::new(&self.sensitive_mcp_env_values).map_err(|_| {
+                AcpError::Protocol("failed to initialize MCP credential redaction".to_string())
+            })?,
+        );
+        Ok(())
+    }
+
+    fn redact_wire_text<'a>(&self, text: &'a str) -> Cow<'a, str> {
+        redact_wire_text(text, self.sensitive_mcp_env_matcher.as_ref())
+    }
+
+    fn redact_wire_value(&self, value: &serde_json::Value) -> serde_json::Value {
+        redact_wire_value(value, self.sensitive_mcp_env_matcher.as_ref())
+    }
+
+    fn agent_error_from_json(&self, error: &serde_json::Value) -> AcpError {
+        agent_error_from_json(error, self.sensitive_mcp_env_matcher.as_ref())
+    }
+
     /// Emit a semantic event to the local observer feed, if enabled.
     pub fn observe(&self, kind: impl Into<String>, payload: serde_json::Value) {
         if self.observer.is_none() {
             return;
         }
-        self.emit_observer(kind, redact_wire_value(&payload));
+        self.emit_observer(kind, self.redact_wire_value(&payload));
     }
 
     /// Emit an event whose payload is already a logging-safe copy.
@@ -777,6 +918,7 @@ impl AcpClient {
         system_prompt: Option<SystemPromptTransport<'_>>,
         session_title: Option<&str>,
     ) -> Result<SessionNewResponse, AcpError> {
+        self.register_sensitive_mcp_env_values(&mcp_servers)?;
         let mut params = serde_json::json!({
             "cwd": cwd,
             "mcpServers": mcp_servers,
@@ -1181,11 +1323,11 @@ impl AcpClient {
     /// (e.g., it's stuck or dead), the write would otherwise block forever.
     async fn write_ndjson(&mut self, value: &serde_json::Value) -> Result<(), AcpError> {
         const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-        let observed_value = redact_wire_value(value);
+        let observed_value = self.redact_wire_value(value);
         tracing::debug!(target: "acp::wire", "→ {observed_value}");
-        let line = serde_json::to_string(value)?;
+        let line = Zeroizing::new(serde_json::to_vec(value)?);
         tokio::time::timeout(WRITE_TIMEOUT, async {
-            self.stdin.write_all(line.as_bytes()).await?;
+            self.stdin.write_all(&line).await?;
             self.stdin.write_all(b"\n").await?;
             self.stdin.flush().await?;
             Ok::<(), std::io::Error>(())
@@ -1204,7 +1346,7 @@ impl AcpClient {
     fn parse_inbound_line(&self, line: &str) -> Option<serde_json::Value> {
         match serde_json::from_str(line) {
             Ok(msg) => {
-                let observed_value = redact_wire_value(&msg);
+                let observed_value = self.redact_wire_value(&msg);
                 tracing::debug!(target: "acp::wire", "← {observed_value}");
                 self.emit_observer("acp_read", observed_value);
                 Some(msg)
@@ -1372,7 +1514,7 @@ impl AcpClient {
             if let Some(id) = msg.get("id") {
                 if *id == serde_json::json!(expected_id) && msg.get("method").is_none() {
                     if let Some(error) = msg.get("error") {
-                        return Err(agent_error_from_json(error));
+                        return Err(self.agent_error_from_json(error));
                     }
                     return Ok(msg["result"].clone());
                 }
@@ -1692,7 +1834,7 @@ impl AcpClient {
                                             .get("code")
                                             .and_then(|c| c.as_i64())
                                             .unwrap_or(-1);
-                                        let message = redact_wire_value(error).to_string();
+                                        let message = self.redact_wire_value(error).to_string();
                                         crate::pool::SteerAck::Err(
                                             crate::pool::SteerError::AgentError { code, message },
                                         )
@@ -1785,7 +1927,7 @@ impl AcpClient {
                                         let _ = ack_tx
                                             .send(crate::pool::SteerAck::PromptCompletedNeutral);
                                     }
-                                    return Err(agent_error_from_json(error));
+                                    return Err(self.agent_error_from_json(error));
                                 }
                                 if let Some((_, _, ack_tx)) = pending_steer.take() {
                                     let _ =
@@ -1860,7 +2002,7 @@ impl AcpClient {
         match update_type {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
-                    let text = redact_wire_text(text);
+                    let text = self.redact_wire_text(text);
                     tracing::info!(target: "acp::stream", "{text}");
                 }
                 false
@@ -1874,8 +2016,8 @@ impl AcpClient {
                     .get("kind")
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
-                let title = redact_wire_text(title);
-                let kind = redact_wire_text(kind);
+                let title = self.redact_wire_text(title);
+                let kind = self.redact_wire_text(kind);
                 tracing::info!(target: "acp::tool", "tool_call: {title} ({kind})");
                 true
             }
@@ -1885,8 +2027,8 @@ impl AcpClient {
                     .and_then(|v| v.as_str())
                     .unwrap_or("?");
                 let status = update.get("status").and_then(|v| v.as_str()).unwrap_or("?");
-                let tool_id = redact_wire_text(tool_id);
-                let status = redact_wire_text(status);
+                let tool_id = self.redact_wire_text(tool_id);
+                let status = self.redact_wire_text(status);
                 tracing::info!(target: "acp::tool", "tool_call_update: {tool_id} → {status}");
                 false
             }
@@ -1896,7 +2038,7 @@ impl AcpClient {
             }
             "agent_thought_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
-                    let text = redact_wire_text(text);
+                    let text = self.redact_wire_text(text);
                     tracing::debug!(target: "acp::thought", "{text}");
                 }
                 false
@@ -1904,12 +2046,12 @@ impl AcpClient {
             "available_commands_update" => {
                 // Advertised slash commands (ACP slash-commands extension).
                 // Logged for observability; UI surfacing is a follow-up.
-                let names: Vec<&str> = update["availableCommands"]
+                let names: Vec<String> = update["availableCommands"]
                     .as_array()
                     .map(|cmds| {
                         cmds.iter()
                             .filter_map(|c| c["name"].as_str())
-                            .map(redact_wire_text)
+                            .map(|name| self.redact_wire_text(name).into_owned())
                             .collect()
                     })
                     .unwrap_or_default();
@@ -1938,7 +2080,7 @@ impl AcpClient {
                 if let Some(goose_meta) = meta {
                     match goose_meta.get("activeRunId") {
                         Some(serde_json::Value::String(run_id)) => {
-                            let observed_run_id = redact_wire_text(run_id);
+                            let observed_run_id = self.redact_wire_text(run_id);
                             tracing::debug!(
                                 target: "acp::update",
                                 "session_info_update: activeRunId={observed_run_id}"
@@ -1960,7 +2102,7 @@ impl AcpClient {
             }
             "keepalive" => false,
             other => {
-                let other = redact_wire_text(other);
+                let other = self.redact_wire_text(other);
                 tracing::debug!(target: "acp::update", "session/update: {other}");
                 false
             }
@@ -1988,7 +2130,7 @@ impl AcpClient {
         match serde_json::from_value::<GooseSessionUpdateNotification>(params.clone()) {
             Ok(notif) => {
                 if let GooseSessionUpdateVariant::UsageUpdate(payload) = &notif.update {
-                    let observed_session_id = redact_wire_text(&notif.session_id);
+                    let observed_session_id = self.redact_wire_text(&notif.session_id);
                     tracing::debug!(
                         target: "acp::usage",
                         session_id = %observed_session_id,
@@ -2006,7 +2148,7 @@ impl AcpClient {
             }
             Err(e) => {
                 let error = e.to_string();
-                let observed_error = redact_wire_text(&error);
+                let observed_error = self.redact_wire_text(&error);
                 tracing::debug!(
                     target: "acp::usage",
                     "_goose/unstable/session/update: deserialization error: {observed_error}"
@@ -2404,6 +2546,17 @@ fn configure_no_window(cmd: &mut tokio::process::Command) {
 mod tests {
     use super::*;
 
+    fn sensitive_matcher(values: &[String]) -> Option<AhoCorasick> {
+        let mut patterns = values
+            .iter()
+            .map(String::as_str)
+            .filter(|value| !value.is_empty())
+            .collect::<Vec<_>>();
+        patterns.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
+        patterns.dedup();
+        (!patterns.is_empty()).then(|| AhoCorasick::new(patterns).expect("valid patterns"))
+    }
+
     #[test]
     fn stop_reason_parses_all_known_values() {
         assert_eq!(StopReason::from_str("end_turn"), Some(StopReason::EndTurn));
@@ -2609,7 +2762,7 @@ mod tests {
     #[test]
     fn session_new_mcp_server_has_required_fields() {
         // Schema requires name, command, args, env — all present, args/env may be empty.
-        let server = McpServer {
+        let server = McpServer::Stdio(McpServerStdio {
             name: "test-mcp".into(),
             command: "/usr/local/bin/test-mcp-server".into(),
             args: vec![],
@@ -2623,7 +2776,7 @@ mod tests {
                     value: "nsec1abc".into(),
                 },
             ],
-        };
+        });
         let serialized = serde_json::to_value(&server).unwrap();
         assert_eq!(serialized["name"].as_str(), Some("test-mcp"));
         assert_eq!(
@@ -2646,7 +2799,7 @@ mod tests {
         let arg_secret = "debug-arg-secret-must-not-render";
         let rendered = format!(
             "{:?}",
-            McpServer {
+            McpServer::Stdio(McpServerStdio {
                 name: "analytics".into(),
                 command: "analytics-mcp".into(),
                 args: vec!["--token".into(), arg_secret.into()],
@@ -2654,7 +2807,7 @@ mod tests {
                     name: "ANALYTICS_TOKEN".into(),
                     value: env_secret.into(),
                 }],
-            }
+            })
         );
 
         assert!(rendered.contains("ANALYTICS_TOKEN"));
@@ -2684,7 +2837,7 @@ mod tests {
             }
         });
 
-        let redacted = redact_wire_value(&source);
+        let redacted = redact_wire_value(&source, None);
 
         assert_eq!(
             source["params"]["mcpServers"][0]["env"][0]["value"], "secret-one",
@@ -2755,7 +2908,7 @@ mod tests {
         });
         let original_source = source.clone();
 
-        let redacted = redact_wire_value(&source);
+        let redacted = redact_wire_value(&source, None);
 
         for echo in redacted["echoes"].as_array().expect("redacted echoes") {
             assert_eq!(echo, REDACTED_MCP_VALUE);
@@ -2764,6 +2917,65 @@ mod tests {
         assert_eq!(redacted["nearMiss"], source["nearMiss"]);
         assert_eq!(redacted["unrelated"], source["unrelated"]);
         assert_eq!(redacted["shortPublicValues"], source["shortPublicValues"]);
+        assert_eq!(
+            source, original_source,
+            "the protocol value must stay unchanged"
+        );
+    }
+
+    #[test]
+    fn wire_redaction_covers_http_header_values() {
+        let source = serde_json::json!({
+            "params": {
+                "mcpServers": [{
+                    "type": "http",
+                    "name": "hosted-context",
+                    "url": "https://mcp.example.test/mcp",
+                    "headers": [{"name": "Authorization", "value": "Bearer secret"}]
+                }]
+            }
+        });
+
+        let redacted = redact_wire_value(&source, None);
+        assert_eq!(
+            redacted["params"]["mcpServers"][0]["headers"][0]["value"],
+            REDACTED_MCP_VALUE
+        );
+        assert_eq!(
+            source["params"]["mcpServers"][0]["headers"][0]["value"], "Bearer secret",
+            "redaction must not mutate the wire payload"
+        );
+    }
+
+    #[test]
+    fn wire_redaction_suppresses_plain_sensitive_echoes_without_changing_source() {
+        let shorter = "token";
+        let longer = "token-with-suffix";
+        let source = serde_json::json!({
+            "error": {
+                "message": format!("[adapter] rejected {longer}; retry with {shorter}")
+            },
+            "ordinary": "safe diagnostic"
+        });
+        let original_source = source.clone();
+        let sensitive_values = vec![
+            longer.to_string(),
+            shorter.to_string(),
+            "[".to_string(),
+            String::new(),
+            longer.to_string(),
+        ];
+
+        let matcher = sensitive_matcher(&sensitive_values);
+        let redacted = redact_wire_value(&source, matcher.as_ref());
+
+        let message = redacted["error"]["message"]
+            .as_str()
+            .expect("redacted error message");
+        assert!(!message.contains(longer));
+        assert!(!message.contains(shorter));
+        assert_eq!(message, REDACTED_MCP_VALUE);
+        assert_eq!(redacted["ordinary"], source["ordinary"]);
         assert_eq!(
             source, original_source,
             "the protocol value must stay unchanged"
@@ -3723,7 +3935,7 @@ mod tests {
         let response = client
             .session_new_full(
                 "/tmp",
-                vec![McpServer {
+                vec![McpServer::Stdio(McpServerStdio {
                     name: "analytics".into(),
                     command: "analytics-mcp".into(),
                     args: vec!["--token".into(), arg_secret.into()],
@@ -3731,7 +3943,7 @@ mod tests {
                         name: "ANALYTICS_TOKEN".into(),
                         value: env_secret.into(),
                     }],
-                }],
+                })],
                 None,
                 None,
             )
@@ -3836,7 +4048,7 @@ mod tests {
         let result = client
             .session_new_full(
                 "/tmp",
-                vec![McpServer {
+                vec![McpServer::Stdio(McpServerStdio {
                     name: "analytics".into(),
                     command: "analytics-mcp".into(),
                     args: vec![],
@@ -3844,7 +4056,7 @@ mod tests {
                         name: "ANALYTICS_TOKEN".into(),
                         value: secret.into(),
                     }],
-                }],
+                })],
                 None,
                 None,
             )
@@ -3867,6 +4079,86 @@ mod tests {
         let serialized_events =
             serde_json::to_string(&observer.snapshot()).expect("serialize observer snapshot");
         assert!(!serialized_events.contains(secret));
+        assert!(serialized_events.contains(REDACTED_MCP_VALUE));
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn plain_mcp_secret_echo_is_redacted_and_old_session_values_are_retained() {
+        let first_secret = "first-session-adapter-secret";
+        let second_secret = "second-session-adapter-secret";
+        let error_response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "error": {
+                "code": -32056,
+                "message": format!("adapter failed while using {first_secret}")
+            }
+        })
+        .to_string();
+        let script = format!(
+            "read -t 2 _init\n\
+             printf '%s\\n' '{{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{{\"protocolVersion\":2,\"agentCapabilities\":{{}}}}}}'\n\
+             read -t 2 _first_session\n\
+             printf '%s\\n' '{{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{{\"sessionId\":\"ses_first\"}}}}'\n\
+             read -t 2 _second_session\n\
+             printf '%s\\n' '{error_response}'\n\
+             sleep 1"
+        );
+        let mut client = spawn_script(&script).await;
+        let observer = ObserverHandle::in_process();
+        client.set_observer(Some(observer.clone()), 0);
+        client
+            .initialize()
+            .await
+            .expect("initialize should succeed");
+
+        let server_with_secret = |value: &str| {
+            McpServer::Stdio(McpServerStdio {
+                name: "analytics".into(),
+                command: "analytics-mcp".into(),
+                args: vec![],
+                env: vec![EnvVar {
+                    name: "ANALYTICS_TOKEN".into(),
+                    value: value.into(),
+                }],
+            })
+        };
+
+        client
+            .session_new_full("/tmp", vec![server_with_secret(first_secret)], None, None)
+            .await
+            .expect("first session should succeed");
+        let result = client
+            .session_new_full("/tmp", vec![server_with_secret(second_secret)], None, None)
+            .await;
+
+        match result {
+            Err(AcpError::AgentError { code, message }) => {
+                assert_eq!(code, -32056);
+                assert_eq!(message, REDACTED_MCP_VALUE);
+                assert!(!message.contains(first_secret));
+            }
+            Err(other) => panic!("expected redacted AgentError, got {other:?}"),
+            Ok(_) => panic!("expected second session/new to return an error"),
+        }
+
+        assert_eq!(client.sensitive_mcp_env_values.len(), 2);
+        assert!(
+            client
+                .sensitive_mcp_env_values
+                .iter()
+                .any(|value| value == first_secret),
+            "credentials from earlier sessions must remain registered"
+        );
+        assert!(client
+            .sensitive_mcp_env_values
+            .iter()
+            .any(|value| value == second_secret));
+        let serialized_events =
+            serde_json::to_string(&observer.snapshot()).expect("serialize observer snapshot");
+        assert!(!serialized_events.contains(first_secret));
+        assert!(!serialized_events.contains(second_secret));
         assert!(serialized_events.contains(REDACTED_MCP_VALUE));
         client.shutdown().await;
     }
@@ -3924,6 +4216,17 @@ mod tests {
             }
         });
         let mut client = spawn_inert_client().await;
+        client
+            .register_sensitive_mcp_env_values(&[McpServer::Stdio(McpServerStdio {
+                name: "analytics".into(),
+                command: "analytics-mcp".into(),
+                args: vec![],
+                env: vec![EnvVar {
+                    name: "ANALYTICS_TOKEN".into(),
+                    value: secret.into(),
+                }],
+            })])
+            .expect("credential redactor should initialize");
         let trace = TraceCapture::default();
         let subscriber = tracing_subscriber::fmt()
             .without_time()
@@ -3979,7 +4282,7 @@ mod tests {
             sleep 1
         "#;
         let servers = vec![
-            McpServer {
+            McpServer::Stdio(McpServerStdio {
                 name: "analytics".into(),
                 command: "/opt/MCP Servers/analytics,prod".into(),
                 args: vec!["--stdio".into(), "literal value".into()],
@@ -3987,13 +4290,13 @@ mod tests {
                     name: "ANALYTICS_ENDPOINT".into(),
                     value: "https://example.test/a=b".into(),
                 }],
-            },
-            McpServer {
+            }),
+            McpServer::Stdio(McpServerStdio {
                 name: "search".into(),
                 command: "/opt/search-mcp".into(),
                 args: vec![],
                 env: vec![],
-            },
+            }),
         ];
 
         for _restart in 0..2 {
@@ -5083,7 +5386,7 @@ mod tests {
         // Errors without a string `message` field (e.g. only a `data` field) must
         // not be silently truncated to "unknown error" — the full JSON is preserved.
         let error = serde_json::json!({"code": -32000, "data": "quota exceeded"});
-        match super::agent_error_from_json(&error) {
+        match super::agent_error_from_json(&error, None) {
             AcpError::AgentError { code, message } => {
                 assert_eq!(code, -32000);
                 assert!(
@@ -5108,7 +5411,7 @@ mod tests {
             }
         });
 
-        let rendered = super::agent_error_from_json(&error).to_string();
+        let rendered = super::agent_error_from_json(&error, None).to_string();
 
         assert!(!rendered.contains(secret));
         assert!(rendered.contains(REDACTED_MCP_VALUE));
@@ -5118,7 +5421,7 @@ mod tests {
     #[test]
     fn agent_error_from_json_uses_message_field_when_present() {
         let error = serde_json::json!({"code": -32001, "message": "auth denied"});
-        match super::agent_error_from_json(&error) {
+        match super::agent_error_from_json(&error, None) {
             AcpError::AgentError { code, message } => {
                 assert_eq!(code, -32001);
                 assert_eq!(message, "auth denied");

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -4,8 +4,12 @@
 //! Config file (TOML) for complex subscription rules.
 
 use std::collections::{HashMap, HashSet};
+use std::io::Read;
 use std::path::PathBuf;
 
+use buzz_core::mcp_config::{
+    parse_mcp_config_document, MCP_CONFIG_MAX_BYTES, MCP_SERVER_MAX_COUNT,
+};
 use clap::Parser;
 use clap::ValueEnum;
 use nostr::Keys;
@@ -14,6 +18,14 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::filter::SubscriptionRule;
+pub(crate) use buzz_core::mcp_config::ConfiguredMcpServer;
+#[cfg(test)]
+use buzz_core::mcp_config::{
+    MCP_CONFIG_VERSION, MCP_SERVER_MAX_ARGS, MCP_SERVER_MAX_ENV, MCP_SERVER_NAME_MAX_BYTES,
+    PROTECTED_MCP_ENV_NAMES,
+};
+#[cfg(test)]
+use std::collections::BTreeMap;
 
 /// Default idle timeout (seconds) when neither `--idle-timeout` nor the
 /// deprecated `--turn-timeout` is set.
@@ -45,6 +57,121 @@ pub enum ConfigError {
 
     #[error("config file error: {0}")]
     ConfigFile(String),
+}
+
+fn read_mcp_config(path: &std::path::Path) -> Result<Vec<u8>, ConfigError> {
+    if !path.is_absolute() {
+        return Err(ConfigError::ConfigFile(
+            "MCP config path must be absolute".to_string(),
+        ));
+    }
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(nix::libc::O_NONBLOCK | nix::libc::O_NOFOLLOW);
+    }
+    let file = options.open(path).map_err(|error| {
+        ConfigError::ConfigFile(format!(
+            "failed to open MCP config {}: {error}",
+            path.display()
+        ))
+    })?;
+    let metadata = file.metadata().map_err(|error| {
+        ConfigError::ConfigFile(format!(
+            "failed to inspect MCP config {}: {error}",
+            path.display()
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(ConfigError::ConfigFile(format!(
+            "MCP config {} must be a regular file",
+            path.display()
+        )));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        if metadata.uid() != nix::unistd::Uid::effective().as_raw() {
+            return Err(ConfigError::ConfigFile(format!(
+                "MCP config {} must be owned by the current user",
+                path.display()
+            )));
+        }
+        if metadata.mode() & 0o077 != 0 {
+            return Err(ConfigError::ConfigFile(format!(
+                "MCP config {} must be accessible only by its owner",
+                path.display()
+            )));
+        }
+    }
+    let mut content = Vec::new();
+    file.take(MCP_CONFIG_MAX_BYTES + 1)
+        .read_to_end(&mut content)
+        .map_err(|error| {
+            ConfigError::ConfigFile(format!(
+                "failed to read MCP config {}: {error}",
+                path.display()
+            ))
+        })?;
+    if content.len() as u64 > MCP_CONFIG_MAX_BYTES {
+        return Err(ConfigError::ConfigFile(format!(
+            "MCP config {} exceeds the {} byte limit",
+            path.display(),
+            MCP_CONFIG_MAX_BYTES
+        )));
+    }
+    Ok(content)
+}
+
+fn load_mcp_config(
+    path: &std::path::Path,
+    legacy_mcp_command: &str,
+) -> Result<Vec<ConfiguredMcpServer>, ConfigError> {
+    let content = read_mcp_config(path)?;
+    let servers = parse_mcp_config_document(&content).map_err(|error| {
+        ConfigError::ConfigFile(format!("invalid MCP config {}: {error}", path.display()))
+    })?;
+    validate_legacy_mcp_composition(&servers, legacy_mcp_command)?;
+    Ok(servers)
+}
+
+/// Derive the ACP name used by the legacy single-command MCP configuration.
+pub(crate) fn legacy_mcp_server_name(command: &str) -> String {
+    std::path::Path::new(command)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("mcp")
+        .to_string()
+}
+
+fn validate_legacy_mcp_composition(
+    servers: &[ConfiguredMcpServer],
+    legacy_mcp_command: &str,
+) -> Result<(), ConfigError> {
+    if legacy_mcp_command.is_empty() {
+        return Ok(());
+    }
+    if servers.len() + 1 > MCP_SERVER_MAX_COUNT {
+        return Err(ConfigError::ConfigFile(format!(
+            "too many MCP servers ({} configured + 1 legacy, max {MCP_SERVER_MAX_COUNT})",
+            servers.len()
+        )));
+    }
+    let legacy_name = legacy_mcp_server_name(legacy_mcp_command);
+    if servers.iter().any(|server| {
+        matches!(
+            server,
+            ConfiguredMcpServer::Stdio { name, .. } if name == &legacy_name
+        )
+    }) {
+        return Err(ConfigError::ConfigFile(format!(
+            "MCP server name '{legacy_name}' collides with the legacy --mcp-command server"
+        )));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, clap::ValueEnum)]
@@ -255,6 +382,10 @@ pub struct CliArgs {
 
     #[arg(long, env = "BUZZ_ACP_MCP_COMMAND", default_value = "")]
     pub mcp_command: String,
+
+    /// Path to a versioned JSON document defining additional local MCP servers.
+    #[arg(long, env = "BUZZ_ACP_MCP_CONFIG")]
+    pub mcp_config: Option<PathBuf>,
 
     /// Idle timeout: max seconds of silence before killing a turn.
     /// Resets on any agent stdout activity.
@@ -494,6 +625,8 @@ pub struct Config {
     pub agent_command: String,
     pub agent_args: Vec<String>,
     pub mcp_command: String,
+    /// Additional local MCP servers loaded once from `--mcp-config`.
+    pub configured_mcp_servers: Vec<ConfiguredMcpServer>,
     pub idle_timeout_secs: u64,
     pub max_turn_duration_secs: u64,
     pub agents: u32,
@@ -821,10 +954,23 @@ pub fn propagate_legacy_env_vars() {
     }
 }
 
+/// Prepare environment fallbacks before Clap and Tokio read process state.
+///
+/// Deployment templates commonly render optional values as empty strings.
+/// Clap treats an empty value for `Option<PathBuf>` as an invalid supplied
+/// value, so normalize this one optional path to the same state as an unset
+/// variable before argument parsing starts.
+pub fn prepare_process_env() {
+    propagate_legacy_env_vars();
+    if std::env::var_os("BUZZ_ACP_MCP_CONFIG").is_some_and(|value| value.is_empty()) {
+        std::env::remove_var("BUZZ_ACP_MCP_CONFIG");
+    }
+}
+
 impl Config {
     pub fn from_cli() -> Result<Self, ConfigError> {
         // Legacy env-var propagation is intentionally NOT done here.
-        // Call `propagate_legacy_env_vars()` before the tokio runtime starts
+        // Call `prepare_process_env()` before the tokio runtime starts
         // (in the sync `fn main()` wrapper) — see Rust 2024 edition safety.
         let args = CliArgs::parse();
         Self::from_args(args)
@@ -907,6 +1053,10 @@ impl Config {
         }
 
         let agent_args = normalize_agent_args(&agent_command, args.agent_args);
+        let configured_mcp_servers = match args.mcp_config.as_deref() {
+            Some(path) => load_mcp_config(path, &args.mcp_command)?,
+            None => Vec::new(),
+        };
 
         if let Some(ref channels) = args.channels {
             for ch in channels {
@@ -1060,6 +1210,7 @@ impl Config {
             agent_command,
             agent_args,
             mcp_command: args.mcp_command,
+            configured_mcp_servers,
             idle_timeout_secs,
             max_turn_duration_secs,
             agents: args.agents,
@@ -1125,12 +1276,13 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} legacy_mcp_server={} structured_mcp_servers={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
             self.agent_args.join(" "),
-            self.mcp_command,
+            !self.mcp_command.is_empty(),
+            self.configured_mcp_servers.len(),
             self.idle_timeout_secs,
             self.max_turn_duration_secs,
             self.agents,
@@ -1439,6 +1591,7 @@ mod tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "".into(),
+            configured_mcp_servers: Vec::new(),
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,
@@ -2917,6 +3070,517 @@ channels = "ALL"
     fn compose_session_title_drops_the_channel_when_the_agent_name_fills_the_cap() {
         let agent = "a".repeat(SESSION_TITLE_MAX_CHARS);
         assert_eq!(compose_session_title(&agent, Some("buzz-dev")), agent);
+    }
+
+    struct TempMcpConfig {
+        path: PathBuf,
+    }
+
+    impl TempMcpConfig {
+        fn write(content: &[u8]) -> Self {
+            let path =
+                std::env::temp_dir().join(format!("buzz-acp-mcp-config-{}.json", Uuid::new_v4()));
+            std::fs::write(&path, content).expect("write temporary MCP config");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                    .expect("restrict temporary MCP config permissions");
+            }
+            Self { path }
+        }
+    }
+
+    impl Drop for TempMcpConfig {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    fn config_from_mcp_file(
+        file: &TempMcpConfig,
+        legacy_command: Option<&str>,
+    ) -> Result<Config, ConfigError> {
+        let mut argv = vec![
+            "buzz-acp".to_string(),
+            "--private-key".to_string(),
+            TEST_PRIVATE_KEY.to_string(),
+            "--mcp-config".to_string(),
+            file.path.display().to_string(),
+        ];
+        if let Some(command) = legacy_command {
+            argv.push("--mcp-command".to_string());
+            argv.push(command.to_string());
+        }
+        let args = CliArgs::try_parse_from(argv).expect("clap should parse MCP config arguments");
+        Config::from_args(args)
+    }
+
+    fn server_json(name: &str) -> serde_json::Value {
+        serde_json::json!({
+            "name": name,
+            "transport": "stdio",
+            "command": "mcp",
+            "args": [],
+            "env": {}
+        })
+    }
+
+    fn document_json(servers: Vec<serde_json::Value>) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "version": MCP_CONFIG_VERSION,
+            "servers": servers
+        }))
+        .expect("serialize MCP test document")
+    }
+
+    #[test]
+    fn structured_mcp_config_preserves_order_and_exact_values() {
+        let posix_command = "/Applications/Tool Suite/工具 mcp";
+        let windows_command = r"C:\Program Files\Agent Tools\server.exe";
+        let literal_metacharacters = r#"$HOME;$(echo nope)|&<>*?`literal`"#;
+        let file = TempMcpConfig::write(&document_json(vec![
+            serde_json::json!({
+                "name": "analytics-primary",
+                "transport": "stdio",
+                "command": posix_command,
+                "args": [
+                    "",
+                    "with spaces",
+                    "comma,value",
+                    "quote\"value",
+                    r"C:\data\reports",
+                    literal_metacharacters,
+                    "雪"
+                ],
+                "env": {
+                    "Z_LAST": "backslash\\quote\"雪",
+                    "A_FIRST": ""
+                }
+            }),
+            serde_json::json!({
+                "name": "windows_server",
+                "transport": "stdio",
+                "command": windows_command,
+                "args": ["--stdio"],
+                "env": {}
+            }),
+        ]));
+
+        let config = config_from_mcp_file(&file, None).expect("structured config should load");
+        assert_eq!(config.configured_mcp_servers.len(), 2);
+        let ConfiguredMcpServer::Stdio {
+            name,
+            command,
+            args,
+            env,
+        } = &config.configured_mcp_servers[0];
+        assert_eq!(name, "analytics-primary");
+        assert_eq!(command, posix_command);
+        assert_eq!(
+            args,
+            &vec![
+                "",
+                "with spaces",
+                "comma,value",
+                "quote\"value",
+                r"C:\data\reports",
+                literal_metacharacters,
+                "雪"
+            ]
+        );
+        assert_eq!(
+            env.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["A_FIRST", "Z_LAST"]
+        );
+        assert_eq!(env["Z_LAST"], "backslash\\quote\"雪");
+        let ConfiguredMcpServer::Stdio { command, .. } = &config.configured_mcp_servers[1];
+        assert_eq!(command, windows_command);
+    }
+
+    #[test]
+    fn summary_reports_only_structured_mcp_count() {
+        let secret_value = "value-that-must-not-be-logged";
+        let command = "/private/path/tool";
+        let file = TempMcpConfig::write(&document_json(vec![serde_json::json!({
+            "name": "safe",
+            "transport": "stdio",
+            "command": command,
+            "args": [],
+            "env": {"DOMAIN_TOKEN": secret_value}
+        })]));
+        let config =
+            config_from_mcp_file(&file, Some("/legacy/private/tool")).expect("config should load");
+
+        let summary = config.summary();
+        assert!(summary.contains("legacy_mcp_server=true"));
+        assert!(summary.contains("structured_mcp_servers=1"));
+        assert!(!summary.contains(secret_value));
+        assert!(!summary.contains(command));
+        assert!(!summary.contains("/legacy/private/tool"));
+        assert!(!summary.contains("DOMAIN_TOKEN"));
+    }
+
+    #[test]
+    fn legacy_mcp_name_matches_existing_file_stem_behavior() {
+        assert_eq!(
+            legacy_mcp_server_name("/opt/bin/my-mcp-server"),
+            "my-mcp-server"
+        );
+        assert_eq!(legacy_mcp_server_name("."), "mcp");
+        assert_eq!(legacy_mcp_server_name(""), "mcp");
+    }
+
+    #[test]
+    fn mcp_config_rejects_unreadable_file() {
+        let path = std::env::temp_dir().join(format!(
+            "buzz-acp-missing-mcp-config-{}.json",
+            Uuid::new_v4()
+        ));
+        let argv = vec![
+            "buzz-acp".to_string(),
+            "--private-key".to_string(),
+            TEST_PRIVATE_KEY.to_string(),
+            "--mcp-config".to_string(),
+            path.display().to_string(),
+        ];
+        let args = CliArgs::try_parse_from(argv).expect("clap should parse arguments");
+        let error = Config::from_args(args).expect_err("missing MCP config must fail");
+        assert!(error.to_string().contains("failed to open MCP config"));
+    }
+
+    #[test]
+    fn mcp_config_rejects_non_regular_files() {
+        let path = std::env::temp_dir().join(format!("buzz-acp-mcp-config-dir-{}", Uuid::new_v4()));
+        std::fs::create_dir(&path).expect("create temporary MCP config directory");
+
+        let error = read_mcp_config(&path).expect_err("directories must not be read as MCP config");
+        let _ = std::fs::remove_dir(&path);
+        assert!(error.to_string().contains("must be a regular file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mcp_config_rejects_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let target = TempMcpConfig::write(&document_json(Vec::new()));
+        let link_path =
+            std::env::temp_dir().join(format!("buzz-acp-mcp-config-link-{}.json", Uuid::new_v4()));
+        symlink(&target.path, &link_path).expect("create MCP config symlink");
+
+        let error = read_mcp_config(&link_path).expect_err("MCP config symlinks must be rejected");
+        let _ = std::fs::remove_file(&link_path);
+        assert!(error.to_string().contains("failed to open MCP config"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mcp_config_requires_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        for mode in [0o644, 0o640] {
+            let file = TempMcpConfig::write(&document_json(Vec::new()));
+            std::fs::set_permissions(&file.path, std::fs::Permissions::from_mode(mode))
+                .expect("set shared MCP config permissions");
+
+            let error = read_mcp_config(&file.path)
+                .expect_err("group- or world-accessible MCP config must be rejected");
+            assert!(error
+                .to_string()
+                .contains("must be accessible only by its owner"));
+        }
+
+        for mode in [0o600, 0o400] {
+            let file = TempMcpConfig::write(&document_json(Vec::new()));
+            std::fs::set_permissions(&file.path, std::fs::Permissions::from_mode(mode))
+                .expect("set owner-only MCP config permissions");
+            read_mcp_config(&file.path).expect("owner-only MCP config should be accepted");
+        }
+    }
+
+    #[test]
+    fn mcp_config_requires_an_absolute_path() {
+        let error = read_mcp_config(std::path::Path::new("mcp-servers.json"))
+            .expect_err("relative MCP config path must be rejected");
+        assert!(error.to_string().contains("path must be absolute"));
+    }
+
+    #[test]
+    fn mcp_config_enforces_file_size_boundary() {
+        let base = document_json(Vec::new());
+        let mut at_limit = base.clone();
+        at_limit.resize(MCP_CONFIG_MAX_BYTES as usize, b' ');
+        let file = TempMcpConfig::write(&at_limit);
+        config_from_mcp_file(&file, None).expect("64 KiB MCP config should be accepted");
+
+        let mut over_limit = base;
+        over_limit.resize(MCP_CONFIG_MAX_BYTES as usize + 1, b' ');
+        let file = TempMcpConfig::write(&over_limit);
+        let error =
+            config_from_mcp_file(&file, None).expect_err("MCP config over 64 KiB must fail");
+        assert!(error.to_string().contains("65536 byte limit"));
+    }
+
+    #[test]
+    fn mcp_config_rejects_malformed_wrong_version_and_unknown_fields() {
+        let cases: Vec<(&str, Vec<u8>)> = vec![
+            ("malformed", br#"{"version":1,"servers":["#.to_vec()),
+            (
+                "wrong version",
+                br#"{"version":2,"servers":[]}"#.to_vec(),
+            ),
+            (
+                "unknown document field",
+                br#"{"version":1,"servers":[],"extra":true}"#.to_vec(),
+            ),
+            (
+                "unknown server field",
+                br#"{"version":1,"servers":[{"name":"one","transport":"stdio","command":"mcp","args":[],"env":{},"extra":true}]}"#.to_vec(),
+            ),
+            (
+                "missing required field",
+                br#"{"version":1,"servers":[{"name":"one","transport":"stdio","command":"mcp","env":{}}]}"#.to_vec(),
+            ),
+            (
+                "missing transport",
+                br#"{"version":1,"servers":[{"name":"one","command":"mcp","args":[],"env":{}}]}"#.to_vec(),
+            ),
+            (
+                "unsupported transport",
+                br#"{"version":1,"servers":[{"name":"one","transport":"http","url":"https://example.test/mcp","headers":{}}]}"#.to_vec(),
+            ),
+        ];
+
+        for (label, content) in cases {
+            let file = TempMcpConfig::write(&content);
+            assert!(
+                config_from_mcp_file(&file, None).is_err(),
+                "{label} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_config_validates_server_names_and_collisions() {
+        let invalid_names = vec![
+            String::new(),
+            "contains space".to_string(),
+            "contains.dot".to_string(),
+            "double__underscore".to_string(),
+            "unicodé".to_string(),
+            "a".repeat(MCP_SERVER_NAME_MAX_BYTES + 1),
+        ];
+        for invalid_name in invalid_names {
+            let file = TempMcpConfig::write(&document_json(vec![server_json(&invalid_name)]));
+            assert!(
+                config_from_mcp_file(&file, None).is_err(),
+                "invalid name {invalid_name:?} should fail"
+            );
+        }
+
+        let file = TempMcpConfig::write(&document_json(vec![
+            server_json("same"),
+            server_json("same"),
+        ]));
+        let error =
+            config_from_mcp_file(&file, None).expect_err("duplicate server name should fail");
+        assert!(error.to_string().contains("duplicate MCP server name"));
+
+        let file = TempMcpConfig::write(&document_json(vec![server_json("my-mcp-server")]));
+        let error = config_from_mcp_file(&file, Some("/opt/bin/my-mcp-server"))
+            .expect_err("legacy name collision should fail");
+        assert!(error.to_string().contains("collides"));
+    }
+
+    #[test]
+    fn startup_error_does_not_echo_invalid_environment_key_or_pasted_secret() {
+        let pasted_secret = "startup-pasted-secret-that-must-not-appear";
+        let invalid_key = format!("INVALID-KEY-{pasted_secret}");
+        let file = TempMcpConfig::write(&document_json(vec![serde_json::json!({
+            "name": "safe",
+            "transport": "stdio",
+            "command": "mcp",
+            "args": [],
+            "env": { (invalid_key.clone()): "value" }
+        })]));
+
+        let error = config_from_mcp_file(&file, None)
+            .expect_err("invalid MCP environment key must fail startup")
+            .to_string();
+
+        assert!(!error.contains(&invalid_key));
+        assert!(!error.contains(pasted_secret));
+        assert!(error.contains("environment entry"));
+    }
+
+    #[test]
+    fn mcp_config_limits_total_servers_including_legacy() {
+        let sixteen = (0..MCP_SERVER_MAX_COUNT)
+            .map(|index| server_json(&format!("server-{index}")))
+            .collect::<Vec<_>>();
+        let file = TempMcpConfig::write(&document_json(sixteen));
+        config_from_mcp_file(&file, None).expect("16 structured servers should be accepted");
+        assert!(
+            config_from_mcp_file(&file, Some("legacy-mcp")).is_err(),
+            "16 structured plus one legacy server should fail"
+        );
+
+        let seventeen = (0..=MCP_SERVER_MAX_COUNT)
+            .map(|index| server_json(&format!("server-{index}")))
+            .collect::<Vec<_>>();
+        let file = TempMcpConfig::write(&document_json(seventeen));
+        assert!(
+            config_from_mcp_file(&file, None).is_err(),
+            "17 structured servers should fail"
+        );
+    }
+
+    #[test]
+    fn mcp_config_enforces_argument_limit() {
+        let args = (0..MCP_SERVER_MAX_ARGS)
+            .map(|index| format!("arg-{index}"))
+            .collect::<Vec<_>>();
+        let file = TempMcpConfig::write(&document_json(vec![serde_json::json!({
+            "name": "limit",
+            "transport": "stdio",
+            "command": "mcp",
+            "args": args,
+            "env": {}
+        })]));
+        config_from_mcp_file(&file, None).expect("128 arguments should be accepted");
+
+        let args = (0..=MCP_SERVER_MAX_ARGS)
+            .map(|index| format!("arg-{index}"))
+            .collect::<Vec<_>>();
+        let file = TempMcpConfig::write(&document_json(vec![serde_json::json!({
+            "name": "over-limit",
+            "transport": "stdio",
+            "command": "mcp",
+            "args": args,
+            "env": {}
+        })]));
+        let error =
+            config_from_mcp_file(&file, None).expect_err("129 arguments should be rejected");
+        assert!(error.to_string().contains("too many arguments"));
+    }
+
+    #[test]
+    fn mcp_config_enforces_environment_limit() {
+        let env = (0..MCP_SERVER_MAX_ENV)
+            .map(|index| (format!("KEY_{index}"), format!("value-{index}")))
+            .collect::<BTreeMap<_, _>>();
+        let file = TempMcpConfig::write(&document_json(vec![serde_json::json!({
+            "name": "limit",
+            "transport": "stdio",
+            "command": "mcp",
+            "args": [],
+            "env": env
+        })]));
+        config_from_mcp_file(&file, None).expect("128 environment entries should be accepted");
+
+        let env = (0..=MCP_SERVER_MAX_ENV)
+            .map(|index| (format!("KEY_{index}"), format!("value-{index}")))
+            .collect::<BTreeMap<_, _>>();
+        let file = TempMcpConfig::write(&document_json(vec![serde_json::json!({
+            "name": "over-limit",
+            "transport": "stdio",
+            "command": "mcp",
+            "args": [],
+            "env": env
+        })]));
+        let error = config_from_mcp_file(&file, None)
+            .expect_err("129 environment entries should be rejected");
+        assert!(error.to_string().contains("too many environment entries"));
+    }
+
+    #[test]
+    fn mcp_config_rejects_invalid_duplicate_and_protected_env_names() {
+        for invalid_key in ["", "1STARTS_WITH_DIGIT", "BAD-NAME", "UNICODÉ"] {
+            let content = format!(
+                r#"{{"version":1,"servers":[{{"name":"one","transport":"stdio","command":"mcp","args":[],"env":{{"{invalid_key}":"value"}}}}]}}"#
+            );
+            let file = TempMcpConfig::write(content.as_bytes());
+            assert!(
+                config_from_mcp_file(&file, None).is_err(),
+                "invalid environment key {invalid_key:?} should fail"
+            );
+        }
+
+        for protected in PROTECTED_MCP_ENV_NAMES {
+            let lowercase = protected.to_ascii_lowercase();
+            let content = format!(
+                r#"{{"version":1,"servers":[{{"name":"one","transport":"stdio","command":"mcp","args":[],"env":{{"{lowercase}":"value"}}}}]}}"#
+            );
+            let file = TempMcpConfig::write(content.as_bytes());
+            let error = config_from_mcp_file(&file, None)
+                .expect_err("protected environment key should fail case-insensitively");
+            assert!(error.to_string().contains("protected environment key"));
+        }
+
+        for duplicate_env in [
+            r#"{"KEY":"one","KEY":"two"}"#,
+            r#"{"KEY":"one","key":"two"}"#,
+        ] {
+            let content = format!(
+                r#"{{"version":1,"servers":[{{"name":"one","transport":"stdio","command":"mcp","args":[],"env":{duplicate_env}}}]}}"#
+            );
+            let file = TempMcpConfig::write(content.as_bytes());
+            let error =
+                config_from_mcp_file(&file, None).expect_err("duplicate env key should fail");
+            assert!(error
+                .to_string()
+                .contains("environment keys must be unique ignoring ASCII case"));
+        }
+    }
+
+    #[test]
+    fn mcp_config_rejects_empty_or_nul_process_values() {
+        let cases = vec![
+            serde_json::json!({
+                "name": "empty-command",
+                "transport": "stdio",
+                "command": "",
+                "args": [],
+                "env": {}
+            }),
+            serde_json::json!({
+                "name": "blank-command",
+                "transport": "stdio",
+                "command": " \t\n ",
+                "args": [],
+                "env": {}
+            }),
+            serde_json::json!({
+                "name": "nul-command",
+                "transport": "stdio",
+                "command": "mc\u{0}p",
+                "args": [],
+                "env": {}
+            }),
+            serde_json::json!({
+                "name": "nul-arg",
+                "transport": "stdio",
+                "command": "mcp",
+                "args": ["ok", "bad\u{0}arg"],
+                "env": {}
+            }),
+            serde_json::json!({
+                "name": "nul-value",
+                "transport": "stdio",
+                "command": "mcp",
+                "args": [],
+                "env": {"DOMAIN_KEY": "bad\u{0}value"}
+            }),
+        ];
+
+        for server in cases {
+            let file = TempMcpConfig::write(&document_json(vec![server]));
+            assert!(
+                config_from_mcp_file(&file, None).is_err(),
+                "invalid process value should fail"
+            );
+        }
     }
 
     /// Every arg whose env var name contains KEY/SECRET/TOKEN/PASSWORD/CRED/AUTH

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -20,6 +20,8 @@ use uuid::Uuid;
 use crate::filter::SubscriptionRule;
 pub(crate) use buzz_core::mcp_config::ConfiguredMcpServer;
 #[cfg(test)]
+pub(crate) use buzz_core::mcp_config::McpHttpHeaderConfig;
+#[cfg(test)]
 use buzz_core::mcp_config::{
     MCP_CONFIG_VERSION, MCP_SERVER_MAX_ARGS, MCP_SERVER_MAX_ENV, MCP_SERVER_NAME_MAX_BYTES,
     PROTECTED_MCP_ENV_NAMES,
@@ -131,9 +133,10 @@ fn load_mcp_config(
     legacy_mcp_command: &str,
 ) -> Result<Vec<ConfiguredMcpServer>, ConfigError> {
     let content = read_mcp_config(path)?;
-    let servers = parse_mcp_config_document(&content).map_err(|error| {
+    let mut servers = parse_mcp_config_document(&content).map_err(|error| {
         ConfigError::ConfigFile(format!("invalid MCP config {}: {error}", path.display()))
     })?;
+    resolve_http_mcp_secrets(&mut servers)?;
     validate_legacy_mcp_composition(&servers, legacy_mcp_command)?;
     Ok(servers)
 }
@@ -169,6 +172,102 @@ fn validate_legacy_mcp_composition(
     }) {
         return Err(ConfigError::ConfigFile(format!(
             "MCP server name '{legacy_name}' collides with the legacy --mcp-command server"
+        )));
+    }
+    Ok(())
+}
+
+fn resolve_http_mcp_secrets(servers: &mut [ConfiguredMcpServer]) -> Result<(), ConfigError> {
+    for server in servers {
+        let ConfiguredMcpServer::Http {
+            name,
+            url,
+            url_env_file,
+            url_env_name,
+            headers,
+        } = server
+        else {
+            continue;
+        };
+        if let (Some(path), Some(env_name)) = (url_env_file.take(), url_env_name.take()) {
+            *url = read_named_env_value(&path, &env_name, "remote MCP URL")?;
+        }
+        validate_remote_mcp_url(name, url)?;
+        for header in headers {
+            if let Some(path) = header.value_file.take() {
+                header.value = std::fs::read_to_string(&path)
+                    .map_err(|error| {
+                        ConfigError::ConfigFile(format!(
+                            "failed to read remote MCP header value file {}: {error}",
+                            path.display()
+                        ))
+                    })?
+                    .trim()
+                    .to_string();
+            }
+            if let (Some(path), Some(env_name)) = (header.env_file.take(), header.env_name.take()) {
+                header.value = read_named_env_value(
+                    &path,
+                    &env_name,
+                    "remote MCP header environment variable",
+                )?;
+            }
+            if header.value.is_empty() || header.value.contains(['\r', '\n', '\0']) {
+                return Err(ConfigError::ConfigFile(format!(
+                    "remote MCP server '{name}' header credential resolved empty or contains a control delimiter"
+                )));
+            }
+            if !header.value_prefix.is_empty() {
+                header.value = format!("{}{}", header.value_prefix, header.value);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn read_named_env_value(
+    path: &std::path::Path,
+    name: &str,
+    description: &str,
+) -> Result<String, ConfigError> {
+    let contents = std::fs::read_to_string(path).map_err(|error| {
+        ConfigError::ConfigFile(format!(
+            "failed to read {description} file {}: {error}",
+            path.display()
+        ))
+    })?;
+    let prefix = format!("{name}=");
+    contents
+        .lines()
+        .map(str::trim)
+        .find_map(|line| line.strip_prefix(&prefix))
+        .map(str::trim)
+        .map(|value| value.trim_matches(['\"', '\'']).to_string())
+        .ok_or_else(|| {
+            ConfigError::ConfigFile(format!(
+                "{description} '{name}' not found in {}",
+                path.display()
+            ))
+        })
+}
+
+fn validate_remote_mcp_url(name: &str, value: &str) -> Result<(), ConfigError> {
+    let parsed = Url::parse(value).map_err(|error| {
+        ConfigError::ConfigFile(format!(
+            "remote MCP server '{name}' has invalid URL: {error}"
+        ))
+    })?;
+    let private_http = parsed.scheme() == "http"
+        && parsed
+            .host_str()
+            .and_then(|host| host.parse::<std::net::IpAddr>().ok())
+            .is_some_and(|address| match address {
+                std::net::IpAddr::V4(address) => address.is_private(),
+                std::net::IpAddr::V6(address) => address.is_unique_local(),
+            });
+    if parsed.scheme() != "https" && !private_http {
+        return Err(ConfigError::ConfigFile(format!(
+            "remote MCP server '{name}' requires HTTPS, or HTTP on a literal private IP address"
         )));
     }
     Ok(())
@@ -3174,7 +3273,10 @@ channels = "ALL"
             command,
             args,
             env,
-        } = &config.configured_mcp_servers[0];
+        } = &config.configured_mcp_servers[0]
+        else {
+            panic!("analytics must be stdio");
+        };
         assert_eq!(name, "analytics-primary");
         assert_eq!(command, posix_command);
         assert_eq!(
@@ -3194,8 +3296,58 @@ channels = "ALL"
             vec!["A_FIRST", "Z_LAST"]
         );
         assert_eq!(env["Z_LAST"], "backslash\\quote\"雪");
-        let ConfiguredMcpServer::Stdio { command, .. } = &config.configured_mcp_servers[1];
+        let ConfiguredMcpServer::Stdio { command, .. } = &config.configured_mcp_servers[1] else {
+            panic!("windows server must be stdio");
+        };
         assert_eq!(command, windows_command);
+    }
+
+    #[test]
+    fn structured_mcp_config_loads_http_transport_and_protected_credentials() {
+        let secrets = TempMcpConfig::write(
+            b"REMOTE_URL=https://mcp.example.test/mcp\nREMOTE_TOKEN=opaque-token\n",
+        );
+        let file = TempMcpConfig::write(&document_json(vec![serde_json::json!({
+            "name": "hosted-context",
+            "transport": "http",
+            "url_env_file": secrets.path,
+            "url_env_name": "REMOTE_URL",
+            "headers": [{
+                "name": "Authorization",
+                "env_file": secrets.path,
+                "env_name": "REMOTE_TOKEN",
+                "value_prefix": "Bearer "
+            }]
+        })]));
+
+        let config = config_from_mcp_file(&file, None).expect("HTTP MCP config should load");
+        let ConfiguredMcpServer::Http {
+            name, url, headers, ..
+        } = &config.configured_mcp_servers[0]
+        else {
+            panic!("configured server must be HTTP");
+        };
+        assert_eq!(name, "hosted-context");
+        assert_eq!(url, "https://mcp.example.test/mcp");
+        assert_eq!(headers[0].name, "Authorization");
+        assert_eq!(headers[0].value, "Bearer opaque-token");
+        let debug = format!("{:?}", config.configured_mcp_servers[0]);
+        assert!(!debug.contains("opaque-token"));
+    }
+
+    #[test]
+    fn structured_mcp_config_rejects_public_plain_http() {
+        let file = TempMcpConfig::write(&document_json(vec![serde_json::json!({
+            "name": "unsafe-remote",
+            "transport": "http",
+            "url": "http://example.test/mcp",
+            "headers": []
+        })]));
+
+        let error = config_from_mcp_file(&file, None)
+            .expect_err("public plain HTTP must be rejected")
+            .to_string();
+        assert!(error.contains("requires HTTPS"));
     }
 
     #[test]

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -133,10 +133,10 @@ fn load_mcp_config(
     legacy_mcp_command: &str,
 ) -> Result<Vec<ConfiguredMcpServer>, ConfigError> {
     let content = read_mcp_config(path)?;
-    let mut servers = parse_mcp_config_document(&content).map_err(|error| {
+    let servers = parse_mcp_config_document(&content).map_err(|error| {
         ConfigError::ConfigFile(format!("invalid MCP config {}: {error}", path.display()))
     })?;
-    resolve_http_mcp_secrets(&mut servers)?;
+    validate_http_mcp_servers(&servers)?;
     validate_legacy_mcp_composition(&servers, legacy_mcp_command)?;
     Ok(servers)
 }
@@ -164,12 +164,7 @@ fn validate_legacy_mcp_composition(
         )));
     }
     let legacy_name = legacy_mcp_server_name(legacy_mcp_command);
-    if servers.iter().any(|server| {
-        matches!(
-            server,
-            ConfiguredMcpServer::Stdio { name, .. } if name == &legacy_name
-        )
-    }) {
+    if servers.iter().any(|server| server.name() == legacy_name) {
         return Err(ConfigError::ConfigFile(format!(
             "MCP server name '{legacy_name}' collides with the legacy --mcp-command server"
         )));
@@ -177,97 +172,37 @@ fn validate_legacy_mcp_composition(
     Ok(())
 }
 
-fn resolve_http_mcp_secrets(servers: &mut [ConfiguredMcpServer]) -> Result<(), ConfigError> {
+fn validate_http_mcp_servers(servers: &[ConfiguredMcpServer]) -> Result<(), ConfigError> {
     for server in servers {
-        let ConfiguredMcpServer::Http {
-            name,
-            url,
-            url_env_file,
-            url_env_name,
-            headers,
-        } = server
-        else {
+        let ConfiguredMcpServer::Http { name, url, headers } = server else {
             continue;
         };
-        if let (Some(path), Some(env_name)) = (url_env_file.take(), url_env_name.take()) {
-            *url = read_named_env_value(&path, &env_name, "remote MCP URL")?;
-        }
-        validate_remote_mcp_url(name, url)?;
-        for header in headers {
-            if let Some(path) = header.value_file.take() {
-                header.value = std::fs::read_to_string(&path)
-                    .map_err(|error| {
-                        ConfigError::ConfigFile(format!(
-                            "failed to read remote MCP header value file {}: {error}",
-                            path.display()
-                        ))
-                    })?
-                    .trim()
-                    .to_string();
-            }
-            if let (Some(path), Some(env_name)) = (header.env_file.take(), header.env_name.take()) {
-                header.value = read_named_env_value(
-                    &path,
-                    &env_name,
-                    "remote MCP header environment variable",
-                )?;
-            }
-            if header.value.is_empty() || header.value.contains(['\r', '\n', '\0']) {
-                return Err(ConfigError::ConfigFile(format!(
-                    "remote MCP server '{name}' header credential resolved empty or contains a control delimiter"
-                )));
-            }
-            if !header.value_prefix.is_empty() {
-                header.value = format!("{}{}", header.value_prefix, header.value);
-            }
-        }
+        validate_remote_mcp_url(name, url, !headers.is_empty())?;
     }
     Ok(())
 }
 
-fn read_named_env_value(
-    path: &std::path::Path,
-    name: &str,
-    description: &str,
-) -> Result<String, ConfigError> {
-    let contents = std::fs::read_to_string(path).map_err(|error| {
-        ConfigError::ConfigFile(format!(
-            "failed to read {description} file {}: {error}",
-            path.display()
-        ))
-    })?;
-    let prefix = format!("{name}=");
-    contents
-        .lines()
-        .map(str::trim)
-        .find_map(|line| line.strip_prefix(&prefix))
-        .map(str::trim)
-        .map(|value| value.trim_matches(['\"', '\'']).to_string())
-        .ok_or_else(|| {
-            ConfigError::ConfigFile(format!(
-                "{description} '{name}' not found in {}",
-                path.display()
-            ))
-        })
-}
-
-fn validate_remote_mcp_url(name: &str, value: &str) -> Result<(), ConfigError> {
+fn validate_remote_mcp_url(name: &str, value: &str, has_headers: bool) -> Result<(), ConfigError> {
     let parsed = Url::parse(value).map_err(|error| {
         ConfigError::ConfigFile(format!(
             "remote MCP server '{name}' has invalid URL: {error}"
         ))
     })?;
-    let private_http = parsed.scheme() == "http"
-        && parsed
-            .host_str()
-            .and_then(|host| host.parse::<std::net::IpAddr>().ok())
-            .is_some_and(|address| match address {
-                std::net::IpAddr::V4(address) => address.is_private(),
-                std::net::IpAddr::V6(address) => address.is_unique_local(),
-            });
-    if parsed.scheme() != "https" && !private_http {
+    let cleartext_loopback = parsed.scheme() == "http"
+        && parsed.host().is_some_and(|host| match host {
+            url::Host::Ipv4(address) => address.is_loopback(),
+            url::Host::Ipv6(address) => address.is_loopback(),
+            url::Host::Domain(_) => false,
+        });
+    let embedded_credentials = !parsed.username().is_empty() || parsed.password().is_some();
+    if parsed.scheme() != "https" && !cleartext_loopback {
         return Err(ConfigError::ConfigFile(format!(
-            "remote MCP server '{name}' requires HTTPS, or HTTP on a literal private IP address"
+            "remote MCP server '{name}' requires HTTPS, or credential-free HTTP on a literal loopback address"
+        )));
+    }
+    if cleartext_loopback && (has_headers || embedded_credentials) {
+        return Err(ConfigError::ConfigFile(format!(
+            "remote MCP server '{name}' may not send credentials over cleartext loopback HTTP"
         )));
     }
     Ok(())
@@ -3303,20 +3238,14 @@ channels = "ALL"
     }
 
     #[test]
-    fn structured_mcp_config_loads_http_transport_and_protected_credentials() {
-        let secrets = TempMcpConfig::write(
-            b"REMOTE_URL=https://mcp.example.test/mcp\nREMOTE_TOKEN=opaque-token\n",
-        );
+    fn structured_mcp_config_loads_resolved_http_transport() {
         let file = TempMcpConfig::write(&document_json(vec![serde_json::json!({
             "name": "hosted-context",
             "transport": "http",
-            "url_env_file": secrets.path,
-            "url_env_name": "REMOTE_URL",
+            "url": "https://mcp.example.test/mcp",
             "headers": [{
                 "name": "Authorization",
-                "env_file": secrets.path,
-                "env_name": "REMOTE_TOKEN",
-                "value_prefix": "Bearer "
+                "value": "Bearer opaque-token"
             }]
         })]));
 
@@ -3348,6 +3277,60 @@ channels = "ALL"
             .expect_err("public plain HTTP must be rejected")
             .to_string();
         assert!(error.contains("requires HTTPS"));
+    }
+
+    #[test]
+    fn structured_mcp_config_allows_credential_free_loopback_http() {
+        for url in ["http://127.0.0.1:8200/mcp", "http://[::1]:8200/mcp"] {
+            let file = TempMcpConfig::write(&document_json(vec![serde_json::json!({
+                "name": "local",
+                "transport": "http",
+                "url": url,
+                "headers": []
+            })]));
+            config_from_mcp_file(&file, None).expect("credential-free loopback is allowed");
+        }
+    }
+
+    #[test]
+    fn structured_mcp_config_rejects_cleartext_private_networks_and_loopback_credentials() {
+        for server in [
+            serde_json::json!({
+                "name": "lan",
+                "transport": "http",
+                "url": "http://10.0.20.86:8200/mcp",
+                "headers": []
+            }),
+            serde_json::json!({
+                "name": "local-header",
+                "transport": "http",
+                "url": "http://127.0.0.1:8200/mcp",
+                "headers": [{"name": "Authorization", "value": "Bearer secret"}]
+            }),
+            serde_json::json!({
+                "name": "local-userinfo",
+                "transport": "http",
+                "url": "http://user:secret@127.0.0.1:8200/mcp",
+                "headers": []
+            }),
+        ] {
+            let file = TempMcpConfig::write(&document_json(vec![server]));
+            config_from_mcp_file(&file, None).expect_err("cleartext credentials must fail");
+        }
+    }
+
+    #[test]
+    fn legacy_mcp_name_collision_includes_http_servers() {
+        let file = TempMcpConfig::write(&document_json(vec![serde_json::json!({
+            "name": "buzz-tools-mcp",
+            "transport": "http",
+            "url": "https://mcp.example.test/mcp",
+            "headers": []
+        })]));
+        let error = config_from_mcp_file(&file, Some("/opt/buzz-tools-mcp"))
+            .expect_err("HTTP names must collide with the legacy server")
+            .to_string();
+        assert!(error.contains("collides"));
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1513,7 +1513,7 @@ mod inactivity_tests {
 }
 
 pub fn run() -> Result<()> {
-    config::propagate_legacy_env_vars();
+    config::prepare_process_env();
     tokio_main()
 }
 
@@ -1811,6 +1811,7 @@ async fn tokio_main() -> Result<()> {
     let base_prompt_content = config.base_prompt_content.take();
     let ctx = Arc::new(PromptContext {
         mcp_servers: build_mcp_servers(&config),
+        git_origin_mcp_server_index: (!config.mcp_command.is_empty()).then_some(0),
         initial_message: config.initial_message.clone(),
         idle_timeout: Duration::from_secs(config.idle_timeout_secs),
         max_turn_duration: Duration::from_secs(config.max_turn_duration_secs),
@@ -4509,60 +4510,83 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
 }
 
 fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
-    if config.mcp_command.is_empty() {
-        return vec![];
+    let mut servers = Vec::with_capacity(
+        usize::from(!config.mcp_command.is_empty()) + config.configured_mcp_servers.len(),
+    );
+
+    if !config.mcp_command.is_empty() {
+        servers.push(McpServer {
+            name: config::legacy_mcp_server_name(&config.mcp_command),
+            command: config.mcp_command.clone(),
+            args: vec![],
+            env: {
+                let mut env = vec![
+                    EnvVar {
+                        name: "BUZZ_RELAY_URL".into(),
+                        value: config.relay_url.clone(),
+                    },
+                    EnvVar {
+                        name: "BUZZ_PRIVATE_KEY".into(),
+                        // bech32 encoding of a valid secret key is infallible.
+                        // Panic here is correct: injecting a bogus secret would cause
+                        // delayed, hard-to-diagnose agent failures downstream.
+                        value: config
+                            .keys
+                            .secret_key()
+                            .to_bech32()
+                            .expect("secret key bech32 encoding should never fail"),
+                    },
+                ];
+                // Forward BUZZ_AUTH_TAG (NIP-OA owner attestation credential)
+                // so the MCP server can attach it to every signed event.
+                if let Ok(auth_tag) = std::env::var("BUZZ_AUTH_TAG") {
+                    if !auth_tag.is_empty() {
+                        env.push(EnvVar {
+                            name: "BUZZ_AUTH_TAG".into(),
+                            value: auth_tag,
+                        });
+                    }
+                }
+                // Forward the agent's display name so dev-mcp can use it as the git
+                // author name instead of the raw npub. Read from the process env
+                // rather than Config: this is a pass-through of a contract owned
+                // upstream, and absent simply means dev-mcp falls back to the npub.
+                if let Ok(display_name) = std::env::var("BUZZ_ACP_DISPLAY_NAME") {
+                    if !display_name.is_empty() {
+                        env.push(EnvVar {
+                            name: "BUZZ_ACP_DISPLAY_NAME".into(),
+                            value: display_name,
+                        });
+                    }
+                }
+                env
+            },
+        });
     }
-    vec![McpServer {
-        name: std::path::Path::new(&config.mcp_command)
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("mcp")
-            .to_string(),
-        command: config.mcp_command.clone(),
-        args: vec![],
-        env: {
-            let mut env = vec![
-                EnvVar {
-                    name: "BUZZ_RELAY_URL".into(),
-                    value: config.relay_url.clone(),
-                },
-                EnvVar {
-                    name: "BUZZ_PRIVATE_KEY".into(),
-                    // bech32 encoding of a valid secret key is infallible.
-                    // Panic here is correct: injecting a bogus secret would cause
-                    // delayed, hard-to-diagnose agent failures downstream.
-                    value: config
-                        .keys
-                        .secret_key()
-                        .to_bech32()
-                        .expect("secret key bech32 encoding should never fail"),
-                },
-            ];
-            // Forward BUZZ_AUTH_TAG (NIP-OA owner attestation credential)
-            // so the MCP server can attach it to every signed event.
-            if let Ok(auth_tag) = std::env::var("BUZZ_AUTH_TAG") {
-                if !auth_tag.is_empty() {
-                    env.push(EnvVar {
-                        name: "BUZZ_AUTH_TAG".into(),
-                        value: auth_tag,
-                    });
-                }
-            }
-            // Forward the agent's display name so dev-mcp can use it as the git
-            // author name instead of the raw npub. Read from the process env
-            // rather than Config: this is a pass-through of a contract owned
-            // upstream, and absent simply means dev-mcp falls back to the npub.
-            if let Ok(display_name) = std::env::var("BUZZ_ACP_DISPLAY_NAME") {
-                if !display_name.is_empty() {
-                    env.push(EnvVar {
-                        name: "BUZZ_ACP_DISPLAY_NAME".into(),
-                        value: display_name,
-                    });
-                }
-            }
-            env
-        },
-    }]
+
+    servers.extend(config.configured_mcp_servers.iter().map(|configured| {
+        match configured {
+            config::ConfiguredMcpServer::Stdio {
+                name,
+                command,
+                args,
+                env,
+            } => McpServer {
+                name: name.clone(),
+                command: command.clone(),
+                args: args.clone(),
+                env: env
+                    .iter()
+                    .map(|(name, value)| EnvVar {
+                        name: name.clone(),
+                        value: value.clone(),
+                    })
+                    .collect(),
+            },
+        }
+    }));
+
+    servers
 }
 
 #[cfg(test)]
@@ -6163,6 +6187,8 @@ mod observer_chunk_coalescer_tests {
 #[cfg(test)]
 mod build_mcp_servers_tests {
     use super::*;
+    use clap::Parser;
+    use std::collections::BTreeMap;
     use std::sync::Mutex;
 
     /// Env-var-touching tests must run serially — env vars are process-global.
@@ -6175,6 +6201,7 @@ mod build_mcp_servers_tests {
             agent_command: "goose".into(),
             agent_args: vec!["acp".into()],
             mcp_command: "test-mcp-server".into(),
+            configured_mcp_servers: Vec::new(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,
@@ -6211,6 +6238,50 @@ mod build_mcp_servers_tests {
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
+        }
+    }
+
+    fn configured_server(
+        name: &str,
+        command: &str,
+        args: &[&str],
+        env: &[(&str, &str)],
+    ) -> config::ConfiguredMcpServer {
+        config::ConfiguredMcpServer::Stdio {
+            name: name.into(),
+            command: command.into(),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            env: env
+                .iter()
+                .map(|(name, value)| ((*name).to_string(), (*value).to_string()))
+                .collect::<BTreeMap<_, _>>(),
+        }
+    }
+
+    struct TempMcpConfig {
+        path: std::path::PathBuf,
+    }
+
+    impl TempMcpConfig {
+        fn write(content: &[u8]) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "buzz-acp-mcp-build-test-{}.json",
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::write(&path, content).expect("write temporary MCP config");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                    .expect("restrict temporary MCP config permissions");
+            }
+            Self { path }
+        }
+    }
+
+    impl Drop for TempMcpConfig {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
         }
     }
 
@@ -6329,6 +6400,226 @@ mod build_mcp_servers_tests {
     }
 
     #[test]
+    fn structured_servers_preserve_order_and_literal_values_without_legacy_credentials() {
+        let mut config = test_config();
+        config.mcp_command.clear();
+        config.configured_mcp_servers = vec![
+            configured_server(
+                "analytics",
+                "/opt/MCP Servers/analytics,prod",
+                &[
+                    "--stdio",
+                    "two words",
+                    "comma,value",
+                    "\"quoted\"",
+                    r"C:\Program Files\MCP\server.exe",
+                    "雪",
+                    "$(literal)",
+                    "`literal`",
+                    "a|b;c",
+                ],
+                &[
+                    ("ANALYTICS_ENDPOINT", "https://example.test/a=b"),
+                    ("LITERAL_VALUE", "$HOME;`id`|雪"),
+                ],
+            ),
+            configured_server("search", "/opt/search-mcp", &[], &[]),
+        ];
+
+        let servers = build_mcp_servers(&config);
+
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers[0].name, "analytics");
+        assert_eq!(servers[1].name, "search");
+        assert_eq!(servers[0].command, "/opt/MCP Servers/analytics,prod");
+        assert_eq!(
+            servers[0].args,
+            vec![
+                "--stdio",
+                "two words",
+                "comma,value",
+                "\"quoted\"",
+                r"C:\Program Files\MCP\server.exe",
+                "雪",
+                "$(literal)",
+                "`literal`",
+                "a|b;c",
+            ]
+        );
+        assert_eq!(
+            servers[0]
+                .env
+                .iter()
+                .map(|entry| (entry.name.as_str(), entry.value.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("ANALYTICS_ENDPOINT", "https://example.test/a=b"),
+                ("LITERAL_VALUE", "$HOME;`id`|雪"),
+            ]
+        );
+        assert!(
+            servers[0].env.iter().all(|entry| !matches!(
+                entry.name.as_str(),
+                "BUZZ_PRIVATE_KEY" | "BUZZ_AUTH_TAG" | "BUZZ_RELAY_URL"
+            )),
+            "structured servers must receive only their declared environment"
+        );
+    }
+
+    #[test]
+    fn legacy_server_remains_first_when_structured_servers_are_present() {
+        let mut config = test_config();
+        config.configured_mcp_servers = vec![configured_server(
+            "analytics",
+            "/opt/analytics-mcp",
+            &["--stdio"],
+            &[("ANALYTICS_TOKEN", "opaque-test-token")],
+        )];
+
+        let servers = build_mcp_servers(&config);
+
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers[0].name, "test-mcp-server");
+        assert_eq!(servers[1].name, "analytics");
+        assert!(servers[0]
+            .env
+            .iter()
+            .any(|entry| entry.name == "BUZZ_PRIVATE_KEY"));
+        assert_eq!(
+            servers[1]
+                .env
+                .iter()
+                .map(|entry| (entry.name.as_str(), entry.value.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("ANALYTICS_TOKEN", "opaque-test-token")]
+        );
+    }
+
+    #[test]
+    fn git_origin_is_added_only_to_the_privileged_legacy_companion() {
+        let mut config = test_config();
+        config.configured_mcp_servers = vec![configured_server(
+            "analytics",
+            "/opt/analytics-mcp",
+            &["--stdio"],
+            &[("ANALYTICS_TOKEN", "opaque-test-token")],
+        )];
+        let channel_id = uuid::Uuid::new_v4();
+
+        let servers = pool::mcp_servers_with_git_origin(
+            &build_mcp_servers(&config),
+            (!config.mcp_command.is_empty()).then_some(0),
+            Some(channel_id),
+            Some("stream"),
+            None,
+        );
+
+        assert!(servers[0].env.iter().any(|entry| {
+            entry.name == "BUZZ_GIT_ORIGIN_CHANNEL_ID" && entry.value == channel_id.to_string()
+        }));
+        assert_eq!(
+            servers[1]
+                .env
+                .iter()
+                .map(|entry| (entry.name.as_str(), entry.value.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("ANALYTICS_TOKEN", "opaque-test-token")],
+            "session enrichment must not widen a structured server's declared environment"
+        );
+    }
+
+    #[test]
+    fn structured_only_sessions_do_not_receive_git_origin_metadata() {
+        let mut config = test_config();
+        config.mcp_command.clear();
+        config.configured_mcp_servers = vec![configured_server(
+            "analytics",
+            "/opt/analytics-mcp",
+            &[],
+            &[("ANALYTICS_TOKEN", "opaque-test-token")],
+        )];
+
+        let servers = pool::mcp_servers_with_git_origin(
+            &build_mcp_servers(&config),
+            (!config.mcp_command.is_empty()).then_some(0),
+            Some(uuid::Uuid::new_v4()),
+            Some("stream"),
+            None,
+        );
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].env.len(), 1);
+        assert_eq!(servers[0].env[0].name, "ANALYTICS_TOKEN");
+    }
+
+    #[test]
+    fn structured_json_reaches_initial_repeated_and_respawn_session_lists() {
+        let document = serde_json::json!({
+            "version": 1,
+            "servers": [
+                {
+                    "name": "analytics",
+                    "transport": "stdio",
+                    "command": "/opt/MCP Servers/analytics,prod",
+                    "args": ["--stdio", "literal value"],
+                    "env": {
+                        "ANALYTICS_ENDPOINT": "https://example.test/a=b"
+                    }
+                },
+                {
+                    "name": "search",
+                    "transport": "stdio",
+                    "command": "/opt/search-mcp",
+                    "args": [],
+                    "env": {}
+                }
+            ]
+        });
+        let file = TempMcpConfig::write(
+            &serde_json::to_vec(&document).expect("serialize MCP config fixture"),
+        );
+        let private_key = nostr::Keys::generate()
+            .secret_key()
+            .to_bech32()
+            .expect("encode temporary private key");
+        let args = config::CliArgs::try_parse_from([
+            "buzz-acp",
+            "--private-key",
+            private_key.as_str(),
+            "--mcp-command",
+            "/opt/buzz-dev-mcp",
+            "--mcp-config",
+            file.path.to_str().expect("temporary path is UTF-8"),
+        ])
+        .expect("parse MCP arguments");
+        let config = Config::from_args(args).expect("load structured MCP config");
+
+        let initial_session = build_mcp_servers(&config);
+        let repeated_session = initial_session.clone();
+        let respawned_session = repeated_session.clone();
+        let initial_json =
+            serde_json::to_value(&initial_session).expect("serialize initial MCP list");
+        let repeated_json =
+            serde_json::to_value(&repeated_session).expect("serialize repeated MCP list");
+        let respawned_json =
+            serde_json::to_value(&respawned_session).expect("serialize respawned MCP list");
+
+        assert_eq!(initial_json, repeated_json);
+        assert_eq!(initial_json, respawned_json);
+        assert_eq!(initial_json.as_array().map(Vec::len), Some(3));
+        assert_eq!(initial_json[0]["name"], "buzz-dev-mcp");
+        assert_eq!(initial_json[1]["name"], "analytics");
+        assert_eq!(initial_json[2]["name"], "search");
+        assert_eq!(
+            initial_json[1]["env"],
+            serde_json::json!([{
+                "name": "ANALYTICS_ENDPOINT",
+                "value": "https://example.test/a=b"
+            }])
+        );
+    }
+
+    #[test]
     fn absolute_path_mcp_command_uses_file_stem_as_name() {
         let mut config = test_config();
         config.mcp_command = "/opt/bin/my-mcp-server".into();
@@ -6397,6 +6688,7 @@ mod error_outcome_emission_tests {
             agent_command: "true".into(),
             agent_args: vec![],
             mcp_command: "test-mcp-server".into(),
+            configured_mcp_servers: Vec::new(),
             idle_timeout_secs: config::DEFAULT_IDLE_TIMEOUT_SECS,
             max_turn_duration_secs: config::DEFAULT_MAX_TURN_DURATION_SECS,
             agents: 1,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -18,7 +18,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
-use acp::{AcpClient, EnvVar, McpServer};
+use acp::{AcpClient, EnvVar, HttpTransport, McpServer, McpServerHttp, McpServerStdio};
 use anyhow::Result;
 use buzz_core::kind::{
     KIND_MEMBER_ADDED_NOTIFICATION, KIND_MEMBER_REMOVED_NOTIFICATION, KIND_STREAM_MESSAGE,
@@ -1371,8 +1371,8 @@ fn any_respawn_in_flight(crash_history: &[SlotCircuit]) -> bool {
 /// Result of a background respawn task.
 struct RespawnResult {
     index: usize,
-    /// Tuple: (initialized client, protocol version, agent name).
-    result: Result<(AcpClient, u32, String)>,
+    /// Tuple: (initialized client, protocol version, agent name, HTTP MCP support).
+    result: Result<(AcpClient, u32, String, bool)>,
 }
 
 /// Outcome of a non-cancelling steer attempt, forwarded from a per-attempt
@@ -1416,7 +1416,7 @@ impl RespawnGuard {
     /// Send the result and disarm the guard. Uses `try_send` (sync) so there
     /// is no await boundary between marking `sent` and actually enqueueing —
     /// cancellation cannot slip between the two.
-    fn send(mut self, result: Result<(AcpClient, u32, String)>) {
+    fn send(mut self, result: Result<(AcpClient, u32, String, bool)>) {
         // Invariant: try_send succeeds because the channel capacity equals the
         // slot count, and respawn_in_flight guarantees at most one outstanding
         // result per slot. If this ever fails, the channel sizing or the
@@ -2086,7 +2086,7 @@ async fn tokio_main() -> Result<()> {
         while let Ok(rr) = respawn_rx.try_recv() {
             crash_history[rr.index].respawn_in_flight = false;
             match rr.result {
-                Ok((acp, protocol_version, agent_name)) => {
+                Ok((acp, protocol_version, agent_name, http_mcp_supported)) => {
                     let agent = OwnedAgent {
                         index: rr.index,
                         acp,
@@ -2097,6 +2097,7 @@ async fn tokio_main() -> Result<()> {
                         agent_name,
                         goose_system_prompt_supported: None,
                         protocol_version,
+                        http_mcp_supported,
                     };
                     pool.return_agent(agent);
                     tracing::info!(agent = rr.index, "respawn complete");
@@ -3017,7 +3018,7 @@ async fn tokio_main() -> Result<()> {
     // Drain any respawn results that completed before the abort. Explicitly
     // shut down returned agents instead of relying on AcpClient::Drop.
     while let Ok(rr) = respawn_rx.try_recv() {
-        if let Ok((mut acp, _, _)) = rr.result {
+        if let Ok((mut acp, _, _, _)) = rr.result {
             acp.shutdown().await;
             tracing::debug!(agent = rr.index, "reaped respawned agent on shutdown");
         }
@@ -4163,6 +4164,7 @@ async fn initialize_agent_pool(
                             }),
                         );
                         let agent_name = normalized_agent_name(&init_result);
+                        let http_mcp_supported = pool::supports_http_mcp(&init_result);
                         agent_slots.push(Some(OwnedAgent {
                             index: i,
                             acp,
@@ -4173,6 +4175,7 @@ async fn initialize_agent_pool(
                             agent_name,
                             goose_system_prompt_supported: None,
                             protocol_version,
+                            http_mcp_supported,
                         }));
                     }
                     Ok(Err(e)) => {
@@ -4223,7 +4226,7 @@ async fn spawn_and_init(
     has_generated_codex_config: bool,
     agent_index: usize,
     observer: Option<observer::ObserverHandle>,
-) -> Result<(AcpClient, u32, String)> {
+) -> Result<(AcpClient, u32, String, bool)> {
     let mut acp = AcpClient::spawn(command, args, extra_env, has_generated_codex_config)
         .await
         .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
@@ -4241,7 +4244,8 @@ async fn spawn_and_init(
                 }),
             );
             let agent_name = normalized_agent_name(&init_result);
-            Ok((acp, protocol_version, agent_name))
+            let http_mcp_supported = pool::supports_http_mcp(&init_result);
+            Ok((acp, protocol_version, agent_name, http_mcp_supported))
         }
         Err(e) => {
             // Explicitly shut down the spawned child to prevent zombie/leak.
@@ -4515,7 +4519,7 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
     );
 
     if !config.mcp_command.is_empty() {
-        servers.push(McpServer {
+        servers.push(McpServer::Stdio(McpServerStdio {
             name: config::legacy_mcp_server_name(&config.mcp_command),
             command: config.mcp_command.clone(),
             args: vec![],
@@ -4561,7 +4565,7 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
                 }
                 env
             },
-        });
+        }));
     }
 
     servers.extend(config.configured_mcp_servers.iter().map(|configured| {
@@ -4571,7 +4575,7 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
                 command,
                 args,
                 env,
-            } => McpServer {
+            } => McpServer::Stdio(McpServerStdio {
                 name: name.clone(),
                 command: command.clone(),
                 args: args.clone(),
@@ -4582,7 +4586,21 @@ fn build_mcp_servers(config: &Config) -> Vec<McpServer> {
                         value: value.clone(),
                     })
                     .collect(),
-            },
+            }),
+            config::ConfiguredMcpServer::Http {
+                name, url, headers, ..
+            } => McpServer::Http(McpServerHttp {
+                transport: HttpTransport::Http,
+                name: name.clone(),
+                url: url.clone(),
+                headers: headers
+                    .iter()
+                    .map(|header| EnvVar {
+                        name: header.name.clone(),
+                        value: header.value.clone(),
+                    })
+                    .collect(),
+            }),
         }
     }));
 
@@ -6290,7 +6308,7 @@ mod build_mcp_servers_tests {
         let config = test_config();
         let servers = build_mcp_servers(&config);
         assert_eq!(servers.len(), 1);
-        let server = &servers[0];
+        let server = servers[0].as_stdio().expect("legacy MCP is stdio");
         assert_eq!(server.name, "test-mcp-server");
 
         let names: Vec<&str> = server.env.iter().map(|e| e.name.as_str()).collect();
@@ -6312,7 +6330,7 @@ mod build_mcp_servers_tests {
         let servers = build_mcp_servers(&config);
         std::env::remove_var("BUZZ_AUTH_TAG");
 
-        let server = &servers[0];
+        let server = servers[0].as_stdio().expect("legacy MCP is stdio");
         let auth_tag_env = server.env.iter().find(|e| e.name == "BUZZ_AUTH_TAG");
         assert!(
             auth_tag_env.is_some(),
@@ -6329,7 +6347,7 @@ mod build_mcp_servers_tests {
         let servers = build_mcp_servers(&config);
         std::env::remove_var("BUZZ_AUTH_TAG");
 
-        let server = &servers[0];
+        let server = servers[0].as_stdio().expect("legacy MCP is stdio");
         let has_auth_tag = server.env.iter().any(|e| e.name == "BUZZ_AUTH_TAG");
         assert!(!has_auth_tag, "empty BUZZ_AUTH_TAG should not be forwarded");
     }
@@ -6343,6 +6361,8 @@ mod build_mcp_servers_tests {
         std::env::remove_var("BUZZ_ACP_DISPLAY_NAME");
 
         let entry = servers[0]
+            .as_stdio()
+            .expect("legacy MCP is stdio")
             .env
             .iter()
             .find(|e| e.name == "BUZZ_ACP_DISPLAY_NAME");
@@ -6364,6 +6384,8 @@ mod build_mcp_servers_tests {
         // falls back to the npub when the key is missing or blank.
         assert!(
             !servers[0]
+                .as_stdio()
+                .expect("legacy MCP is stdio")
                 .env
                 .iter()
                 .any(|e| e.name == "BUZZ_ACP_DISPLAY_NAME"),
@@ -6381,6 +6403,8 @@ mod build_mcp_servers_tests {
 
         assert!(
             !servers[0]
+                .as_stdio()
+                .expect("legacy MCP is stdio")
                 .env
                 .iter()
                 .any(|e| e.name == "BUZZ_ACP_DISPLAY_NAME"),
@@ -6429,11 +6453,12 @@ mod build_mcp_servers_tests {
         let servers = build_mcp_servers(&config);
 
         assert_eq!(servers.len(), 2);
-        assert_eq!(servers[0].name, "analytics");
-        assert_eq!(servers[1].name, "search");
-        assert_eq!(servers[0].command, "/opt/MCP Servers/analytics,prod");
+        let analytics = servers[0].as_stdio().expect("analytics is stdio");
+        assert_eq!(servers[0].name(), "analytics");
+        assert_eq!(servers[1].name(), "search");
+        assert_eq!(analytics.command, "/opt/MCP Servers/analytics,prod");
         assert_eq!(
-            servers[0].args,
+            analytics.args,
             vec![
                 "--stdio",
                 "two words",
@@ -6447,7 +6472,7 @@ mod build_mcp_servers_tests {
             ]
         );
         assert_eq!(
-            servers[0]
+            analytics
                 .env
                 .iter()
                 .map(|entry| (entry.name.as_str(), entry.value.as_str()))
@@ -6458,7 +6483,7 @@ mod build_mcp_servers_tests {
             ]
         );
         assert!(
-            servers[0].env.iter().all(|entry| !matches!(
+            analytics.env.iter().all(|entry| !matches!(
                 entry.name.as_str(),
                 "BUZZ_PRIVATE_KEY" | "BUZZ_AUTH_TAG" | "BUZZ_RELAY_URL"
             )),
@@ -6479,14 +6504,18 @@ mod build_mcp_servers_tests {
         let servers = build_mcp_servers(&config);
 
         assert_eq!(servers.len(), 2);
-        assert_eq!(servers[0].name, "test-mcp-server");
-        assert_eq!(servers[1].name, "analytics");
+        assert_eq!(servers[0].name(), "test-mcp-server");
+        assert_eq!(servers[1].name(), "analytics");
         assert!(servers[0]
+            .as_stdio()
+            .expect("legacy MCP is stdio")
             .env
             .iter()
             .any(|entry| entry.name == "BUZZ_PRIVATE_KEY"));
         assert_eq!(
             servers[1]
+                .as_stdio()
+                .expect("analytics is stdio")
                 .env
                 .iter()
                 .map(|entry| (entry.name.as_str(), entry.value.as_str()))
@@ -6514,11 +6543,14 @@ mod build_mcp_servers_tests {
             None,
         );
 
-        assert!(servers[0].env.iter().any(|entry| {
+        let legacy = servers[0].as_stdio().expect("legacy MCP is stdio");
+        assert!(legacy.env.iter().any(|entry| {
             entry.name == "BUZZ_GIT_ORIGIN_CHANNEL_ID" && entry.value == channel_id.to_string()
         }));
         assert_eq!(
             servers[1]
+                .as_stdio()
+                .expect("analytics is stdio")
                 .env
                 .iter()
                 .map(|entry| (entry.name.as_str(), entry.value.as_str()))
@@ -6548,8 +6580,9 @@ mod build_mcp_servers_tests {
         );
 
         assert_eq!(servers.len(), 1);
-        assert_eq!(servers[0].env.len(), 1);
-        assert_eq!(servers[0].env[0].name, "ANALYTICS_TOKEN");
+        let server = servers[0].as_stdio().expect("analytics is stdio");
+        assert_eq!(server.env.len(), 1);
+        assert_eq!(server.env[0].name, "ANALYTICS_TOKEN");
     }
 
     #[test]
@@ -6620,12 +6653,41 @@ mod build_mcp_servers_tests {
     }
 
     #[test]
+    fn structured_http_server_serializes_as_acp_http_transport() {
+        let mut config = test_config();
+        config.mcp_command.clear();
+        config.configured_mcp_servers = vec![config::ConfiguredMcpServer::Http {
+            name: "hosted-context".into(),
+            url: "https://mcp.example.test/mcp".into(),
+            url_env_file: None,
+            url_env_name: None,
+            headers: vec![config::McpHttpHeaderConfig {
+                name: "Authorization".into(),
+                value: "Bearer opaque-token".into(),
+                value_file: None,
+                env_file: None,
+                env_name: None,
+                value_prefix: String::new(),
+            }],
+        }];
+
+        let servers = build_mcp_servers(&config);
+        let serialized = serde_json::to_value(&servers[0]).expect("serialize HTTP MCP server");
+        assert_eq!(serialized["type"], "http");
+        assert_eq!(serialized["name"], "hosted-context");
+        assert_eq!(serialized["url"], "https://mcp.example.test/mcp");
+        assert_eq!(serialized["headers"][0]["name"], "Authorization");
+        assert_eq!(serialized["headers"][0]["value"], "Bearer opaque-token");
+        assert!(serialized.get("command").is_none());
+    }
+
+    #[test]
     fn absolute_path_mcp_command_uses_file_stem_as_name() {
         let mut config = test_config();
         config.mcp_command = "/opt/bin/my-mcp-server".into();
         let servers = build_mcp_servers(&config);
         assert_eq!(servers.len(), 1);
-        assert_eq!(servers[0].name, "my-mcp-server");
+        assert_eq!(servers[0].name(), "my-mcp-server");
     }
 
     #[test]
@@ -6647,7 +6709,8 @@ mod build_mcp_servers_tests {
         let servers = build_mcp_servers(&config);
         assert_eq!(servers.len(), 1);
         assert_eq!(
-            servers[0].name, "mcp",
+            servers[0].name(),
+            "mcp",
             "Path::new(\".\").file_stem() is None — should fall back to \"mcp\""
         );
     }
@@ -6762,6 +6825,7 @@ mod error_outcome_emission_tests {
             // Error branches under test never read this; 1 is the legacy
             // non-systemPrompt path, the simplest valid value.
             protocol_version: 1,
+            http_mcp_supported: false,
         }
     }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -2061,9 +2061,12 @@ async fn tokio_main() -> Result<()> {
                 let env = config.persona_env_vars.clone();
                 let has_codex = config.has_generated_codex_config;
                 let observer = observer.clone();
+                let mcp_servers = ctx.mcp_servers.clone();
                 let guard = RespawnGuard::new(idx, respawn_tx.clone());
                 respawn_tasks.spawn(async move {
-                    let result = spawn_and_init(&cmd, &args, &env, has_codex, idx, observer).await;
+                    let result =
+                        spawn_and_init(&cmd, &args, &env, has_codex, idx, observer, &mcp_servers)
+                            .await;
                     guard.send(result);
                 });
             }
@@ -3842,12 +3845,13 @@ fn recover_panicked_agent(
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
     let has_codex = config.has_generated_codex_config;
+    let mcp_servers = build_mcp_servers(config);
     let guard = RespawnGuard::new(i, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, i, observer).await;
+        let result = spawn_and_init(&cmd, &args, &env, has_codex, i, observer, &mcp_servers).await;
         guard.send(result);
     });
 }
@@ -4036,6 +4040,7 @@ fn spawn_respawn_task(
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
     let has_codex = config.has_generated_codex_config;
+    let mcp_servers = build_mcp_servers(config);
     let guard = RespawnGuard::new(index, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         // Shutdown old agent (reap child, prevent zombie).
@@ -4047,7 +4052,8 @@ fn spawn_respawn_task(
             tokio::time::sleep(delay).await;
         }
 
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, index, observer).await;
+        let result =
+            spawn_and_init(&cmd, &args, &env, has_codex, index, observer, &mcp_servers).await;
         guard.send(result);
     });
 
@@ -4093,6 +4099,7 @@ struct PoolStartup {
     has_generated_codex_config: bool,
     model: Option<String>,
     observer: Option<observer::ObserverHandle>,
+    mcp_servers: Vec<McpServer>,
 }
 
 impl PoolStartup {
@@ -4105,6 +4112,7 @@ impl PoolStartup {
             has_generated_codex_config: config.has_generated_codex_config,
             model: config.model.clone(),
             observer,
+            mcp_servers: build_mcp_servers(config),
         }
     }
 }
@@ -4142,17 +4150,27 @@ async fn initialize_agent_pool(
                 };
                 match initialize_result {
                     Ok(Ok(init_result)) => {
-                        tracing::info!(agent = i, "agent initialized: {init_result}");
                         let protocol_version =
                             init_result["protocolVersion"].as_u64().unwrap_or(1) as u32;
+                        let agent_name = normalized_agent_name(&init_result);
+                        let http_mcp_supported = pool::supports_http_mcp(&init_result);
+                        if let Err(error) = pool::validate_mcp_transport_capabilities(
+                            http_mcp_supported,
+                            &agent_name,
+                            &startup.mcp_servers,
+                        ) {
+                            tracing::error!(
+                                agent = i,
+                                "agent capability validation failed: {error}"
+                            );
+                            acp.shutdown().await;
+                            agent_slots.push(None);
+                            continue;
+                        }
+                        tracing::info!(agent = i, "agent initialized: {init_result}");
                         tracing::info!(
                             agent = i,
-                            name = init_result
-                                .get("agentInfo")
-                                .or_else(|| init_result.get("serverInfo"))
-                                .and_then(|info| info.get("name"))
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("unknown"),
+                            name = agent_name,
                             steering_supported = acp.steering_supported(),
                             "agent initialized"
                         );
@@ -4163,8 +4181,6 @@ async fn initialize_agent_pool(
                                 "initializeResult": init_result,
                             }),
                         );
-                        let agent_name = normalized_agent_name(&init_result);
-                        let http_mcp_supported = pool::supports_http_mcp(&init_result);
                         agent_slots.push(Some(OwnedAgent {
                             index: i,
                             acp,
@@ -4226,6 +4242,7 @@ async fn spawn_and_init(
     has_generated_codex_config: bool,
     agent_index: usize,
     observer: Option<observer::ObserverHandle>,
+    mcp_servers: &[McpServer],
 ) -> Result<(AcpClient, u32, String, bool)> {
     let mut acp = AcpClient::spawn(command, args, extra_env, has_generated_codex_config)
         .await
@@ -4234,8 +4251,20 @@ async fn spawn_and_init(
 
     match acp.initialize().await {
         Ok(init_result) => {
-            tracing::info!("agent initialized: {init_result}");
             let protocol_version = init_result["protocolVersion"].as_u64().unwrap_or(1) as u32;
+            let agent_name = normalized_agent_name(&init_result);
+            let http_mcp_supported = pool::supports_http_mcp(&init_result);
+            if let Err(error) = pool::validate_mcp_transport_capabilities(
+                http_mcp_supported,
+                &agent_name,
+                mcp_servers,
+            ) {
+                acp.shutdown().await;
+                return Err(anyhow::anyhow!(
+                    "agent capability validation failed: {error}"
+                ));
+            }
+            tracing::info!("agent initialized: {init_result}");
             acp.observe(
                 "agent_initialized",
                 serde_json::json!({
@@ -4243,8 +4272,6 @@ async fn spawn_and_init(
                     "initializeResult": init_result,
                 }),
             );
-            let agent_name = normalized_agent_name(&init_result);
-            let http_mcp_supported = pool::supports_http_mcp(&init_result);
             Ok((acp, protocol_version, agent_name, http_mcp_supported))
         }
         Err(e) => {
@@ -4254,6 +4281,100 @@ async fn spawn_and_init(
             acp.shutdown().await;
             Err(anyhow::anyhow!("agent initialize failed: {e}"))
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod mcp_capability_startup_tests {
+    use super::*;
+
+    fn http_server() -> McpServer {
+        McpServer::Http(McpServerHttp {
+            transport: HttpTransport::Http,
+            name: "analytics-read".into(),
+            url: "https://mcp.example.test/mcp".into(),
+            headers: Vec::new(),
+        })
+    }
+
+    fn adapter_script(http_supported: bool) -> Vec<String> {
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "result": {
+                "protocolVersion": 2,
+                "agentInfo": {"name": "fake-adapter"},
+                "agentCapabilities": {
+                    "mcpCapabilities": {"http": http_supported}
+                }
+            }
+        })
+        .to_string();
+        vec![
+            "-c".into(),
+            format!("read _request; printf '%s\\n' '{response}'; sleep 1"),
+        ]
+    }
+
+    #[tokio::test]
+    async fn respawn_rejects_http_incapable_adapter_during_initialize() {
+        let error = match spawn_and_init(
+            "/bin/sh",
+            &adapter_script(false),
+            &[],
+            false,
+            0,
+            None,
+            &[http_server()],
+        )
+        .await
+        {
+            Ok((mut acp, ..)) => {
+                acp.shutdown().await;
+                panic!("HTTP-incapable adapter returned a live respawn slot");
+            }
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("capability validation failed"));
+    }
+
+    #[tokio::test]
+    async fn initial_and_wakeup_pool_reject_http_incapable_adapter_before_ready() {
+        let startup = PoolStartup {
+            agents: 1,
+            command: "/bin/sh".into(),
+            args: adapter_script(false),
+            extra_env: Vec::new(),
+            has_generated_codex_config: false,
+            model: None,
+            observer: None,
+            mcp_servers: vec![http_server()],
+        };
+        let error = match initialize_agent_pool(&startup, None).await {
+            Ok(mut pool) => {
+                shutdown_agent_pool(&mut pool).await;
+                panic!("an incompatible pool became ready");
+            }
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("all 1 agents failed to start"));
+    }
+
+    #[tokio::test]
+    async fn respawn_accepts_http_capable_adapter() {
+        let (mut acp, _, _, supported) = spawn_and_init(
+            "/bin/sh",
+            &adapter_script(true),
+            &[],
+            false,
+            0,
+            None,
+            &[http_server()],
+        )
+        .await
+        .expect("HTTP-capable adapter should return a live slot");
+        assert!(supported);
+        acp.shutdown().await;
     }
 }
 
@@ -6659,15 +6780,9 @@ mod build_mcp_servers_tests {
         config.configured_mcp_servers = vec![config::ConfiguredMcpServer::Http {
             name: "hosted-context".into(),
             url: "https://mcp.example.test/mcp".into(),
-            url_env_file: None,
-            url_env_name: None,
             headers: vec![config::McpHttpHeaderConfig {
                 name: "Authorization".into(),
                 value: "Bearer opaque-token".into(),
-                value_file: None,
-                env_file: None,
-                env_name: None,
-                value_prefix: String::new(),
             }],
         }];
 

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -170,6 +170,34 @@ pub struct OwnedAgent {
     pub goose_system_prompt_supported: Option<bool>,
     /// Protocol version reported by the agent in its initialize response.
     pub protocol_version: u32,
+    /// Whether the adapter advertises Streamable HTTP MCP support.
+    pub http_mcp_supported: bool,
+}
+
+pub(crate) fn supports_http_mcp(initialize_result: &serde_json::Value) -> bool {
+    initialize_result
+        .get("agentCapabilities")
+        .and_then(|capabilities| capabilities.get("mcpCapabilities"))
+        .and_then(|capabilities| capabilities.get("http"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn validate_mcp_transport_capabilities(
+    http_mcp_supported: bool,
+    runtime_name: &str,
+    servers: &[McpServer],
+) -> Result<(), AcpError> {
+    if http_mcp_supported {
+        return Ok(());
+    }
+    if let Some(server) = servers.iter().find(|server| server.is_http()) {
+        return Err(AcpError::Protocol(format!(
+            "MCP server '{}' requires HTTP MCP support, but runtime '{}' did not advertise agentCapabilities.mcpCapabilities.http",
+            server.name(), runtime_name
+        )));
+    }
+    Ok(())
 }
 
 /// Package name reported by `claude-agent-acp` in its `initialize` response.
@@ -894,6 +922,11 @@ async fn create_session_and_apply_model(
     channel_id: Option<Uuid>,
     channel_type: Option<&str>,
 ) -> Result<String, AcpError> {
+    validate_mcp_transport_capabilities(
+        agent.http_mcp_supported,
+        &agent.agent_name,
+        &ctx.mcp_servers,
+    )?;
     // Build base_prompt + system_prompt + agent core + canvas metadata into a
     // single prompt. Standard protocol-v2 agents receive it in `session/new`;
     // Goose receives it through the custom request below. Legacy agents receive
@@ -1053,7 +1086,9 @@ pub(crate) fn mcp_servers_with_git_origin(
         (None, _) => None,
     };
     if let Some(origin) = origin {
-        if let Some(server) = git_origin_mcp_server_index.and_then(|index| servers.get_mut(index)) {
+        if let Some(McpServer::Stdio(server)) =
+            git_origin_mcp_server_index.and_then(|index| servers.get_mut(index))
+        {
             server.env.push(origin);
         }
     }
@@ -4036,12 +4071,12 @@ mod tests {
     use serde_json::json;
 
     fn test_mcp_server() -> McpServer {
-        McpServer {
+        McpServer::Stdio(crate::acp::McpServerStdio {
             name: "dev".into(),
             command: "buzz-dev-mcp".into(),
             args: vec![],
             env: vec![],
-        }
+        })
     }
 
     #[test]
@@ -4054,10 +4089,13 @@ mod tests {
             Some("stream"),
             None,
         );
-        assert!(servers[0].env.iter().any(|entry| {
+        let McpServer::Stdio(server) = &servers[0] else {
+            panic!("expected stdio")
+        };
+        assert!(server.env.iter().any(|entry| {
             entry.name == "BUZZ_GIT_ORIGIN_CHANNEL_ID" && entry.value == channel_id.to_string()
         }));
-        assert!(!servers[0]
+        assert!(!server
             .env
             .iter()
             .any(|entry| entry.name == "BUZZ_GIT_ORIGIN_AGENT_NAME"));
@@ -4072,13 +4110,51 @@ mod tests {
             Some("dm"),
             Some("Builder"),
         );
-        assert!(servers[0].env.iter().any(|entry| {
+        let McpServer::Stdio(server) = &servers[0] else {
+            panic!("expected stdio")
+        };
+        assert!(server.env.iter().any(|entry| {
             entry.name == "BUZZ_GIT_ORIGIN_AGENT_NAME" && entry.value == "Builder"
         }));
-        assert!(!servers[0]
+        assert!(!server
             .env
             .iter()
             .any(|entry| entry.name == "BUZZ_GIT_ORIGIN_CHANNEL_ID"));
+    }
+
+    #[test]
+    fn initialize_capability_allows_http_mcp() {
+        let init = json!({
+            "agentCapabilities": {"mcpCapabilities": {"http": true}}
+        });
+        let servers = vec![McpServer::Http(crate::acp::McpServerHttp {
+            transport: crate::acp::HttpTransport::Http,
+            name: "context".into(),
+            url: "https://mcp.example.test/mcp".into(),
+            headers: vec![],
+        })];
+
+        assert!(
+            validate_mcp_transport_capabilities(supports_http_mcp(&init), "codex", &servers)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn initialize_without_http_capability_rejects_remote_server() {
+        let init = json!({"agentCapabilities": {"mcpCapabilities": {}}});
+        let servers = vec![McpServer::Http(crate::acp::McpServerHttp {
+            transport: crate::acp::HttpTransport::Http,
+            name: "context".into(),
+            url: "https://mcp.example.test/mcp".into(),
+            headers: vec![],
+        })];
+
+        let error =
+            validate_mcp_transport_capabilities(supports_http_mcp(&init), "buzz-agent", &servers)
+                .expect_err("HTTP-incapable runtimes must fail before session/new");
+        assert!(error.to_string().contains("context"));
+        assert!(error.to_string().contains("HTTP MCP"));
     }
 
     // These pin the initial_message dispatch path (run_prompt_task, ~line 855):
@@ -6025,6 +6101,7 @@ mod tests {
             agent_name: "unknown".into(),
             goose_system_prompt_supported: None,
             protocol_version: 2,
+            http_mcp_supported: false,
         };
 
         // Simulate dispatch: install a steer receiver (normally done by
@@ -6083,6 +6160,7 @@ mod tests {
             agent_name: "unknown".into(),
             goose_system_prompt_supported: None,
             protocol_version: 2,
+            http_mcp_supported: false,
         };
 
         // Simulate a completed turn: `steer_rx` was consumed by the read loop

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -183,7 +183,7 @@ pub(crate) fn supports_http_mcp(initialize_result: &serde_json::Value) -> bool {
         .unwrap_or(false)
 }
 
-fn validate_mcp_transport_capabilities(
+pub(crate) fn validate_mcp_transport_capabilities(
     http_mcp_supported: bool,
     runtime_name: &str,
     servers: &[McpServer],

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -513,6 +513,9 @@ impl ChannelInfoResolver {
 
 pub struct PromptContext {
     pub mcp_servers: Vec<McpServer>,
+    /// Index of the privileged Buzz companion MCP, when configured. Only this
+    /// server receives Buzz git-origin metadata.
+    pub git_origin_mcp_server_index: Option<usize>,
     pub initial_message: Option<String>,
     pub idle_timeout: Duration,
     pub max_turn_duration: Duration,
@@ -915,6 +918,7 @@ async fn create_session_and_apply_model(
         .map(|agent_name| compose_session_title(agent_name, channel_name));
     let mcp_servers = mcp_servers_with_git_origin(
         &ctx.mcp_servers,
+        ctx.git_origin_mcp_server_index,
         channel_id,
         channel_type,
         ctx.session_title.as_deref(),
@@ -1027,8 +1031,9 @@ async fn create_session_and_apply_model(
     Ok(resp.session_id)
 }
 
-fn mcp_servers_with_git_origin(
+pub(crate) fn mcp_servers_with_git_origin(
     servers: &[McpServer],
+    git_origin_mcp_server_index: Option<usize>,
     channel_id: Option<Uuid>,
     channel_type: Option<&str>,
     agent_name: Option<&str>,
@@ -1048,8 +1053,8 @@ fn mcp_servers_with_git_origin(
         (None, _) => None,
     };
     if let Some(origin) = origin {
-        for server in &mut servers {
-            server.env.push(origin.clone());
+        if let Some(server) = git_origin_mcp_server_index.and_then(|index| servers.get_mut(index)) {
+            server.env.push(origin);
         }
     }
     servers
@@ -4044,6 +4049,7 @@ mod tests {
         let channel_id = Uuid::new_v4();
         let servers = mcp_servers_with_git_origin(
             &[test_mcp_server()],
+            Some(0),
             Some(channel_id),
             Some("stream"),
             None,
@@ -4061,6 +4067,7 @@ mod tests {
     fn private_session_forwards_agent_name_without_channel_id() {
         let servers = mcp_servers_with_git_origin(
             &[test_mcp_server()],
+            Some(0),
             Some(Uuid::new_v4()),
             Some("dm"),
             Some("Builder"),
@@ -6508,6 +6515,7 @@ mod tests {
         use crate::relay::RestClient;
         PromptContext {
             mcp_servers: vec![],
+            git_origin_mcp_server_index: None,
             initial_message: None,
             idle_timeout: Duration::from_secs(60),
             max_turn_duration: Duration::from_secs(120),

--- a/crates/buzz-acp/tests/config_env.rs
+++ b/crates/buzz-acp/tests/config_env.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+#[test]
+fn empty_mcp_config_environment_value_is_treated_as_unset() {
+    let output = Command::new(env!("CARGO_BIN_EXE_buzz-acp"))
+        .env("BUZZ_ACP_MCP_CONFIG", "")
+        .args(["--private-key", "not-a-valid-nostr-key"])
+        .output()
+        .expect("run buzz-acp");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success());
+    assert!(
+        stderr.contains("configuration error: failed to parse nostr keys"),
+        "empty optional MCP config should reach normal configuration validation: {stderr}"
+    );
+    assert!(
+        !stderr.contains("a value is required for '--mcp-config"),
+        "empty optional MCP config must not fail Clap parsing: {stderr}"
+    );
+}

--- a/crates/buzz-agent/tests/regressions.rs
+++ b/crates/buzz-agent/tests/regressions.rs
@@ -333,6 +333,125 @@ async fn assistant_text_preserved_across_prompts() {
     h.shutdown().await;
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn two_mcp_servers_initialize_list_and_execute_tools() {
+    let llm = spawn_capturing_llm(vec![
+        openai_tool_call("call-alpha", "alpha__tool_0", json!({})),
+        openai_tool_call("call-beta", "beta__tool_0", json!({})),
+        openai_text("done"),
+        openai_tool_call("call-alpha-again", "alpha__tool_0", json!({})),
+        openai_tool_call("call-beta-again", "beta__tool_0", json!({})),
+        openai_text("done again"),
+    ])
+    .await;
+    let mut h = Harness::spawn(&llm.url).await;
+    let fake_mcp = env!("CARGO_BIN_EXE_fake-mcp");
+    let temp = tempfile::tempdir().unwrap();
+    let alpha_pid = temp.path().join("alpha.pid");
+    let beta_pid = temp.path().join("beta.pid");
+    let alpha_call = temp.path().join("alpha.call");
+    let beta_call = temp.path().join("beta.call");
+
+    let mcp_servers = json!([
+        {
+            "name": "alpha",
+            "command": fake_mcp,
+            "args": [],
+            "env": [
+                { "name": "FAKE_MCP_PID_FILE", "value": alpha_pid },
+                { "name": "FAKE_MCP_CALL_RECEIVED", "value": alpha_call },
+            ],
+        },
+        {
+            "name": "beta",
+            "command": fake_mcp,
+            "args": [],
+            "env": [
+                { "name": "FAKE_MCP_PID_FILE", "value": beta_pid },
+                { "name": "FAKE_MCP_CALL_RECEIVED", "value": beta_call },
+            ],
+        },
+    ]);
+    let sid = init_session(&mut h, mcp_servers.clone()).await;
+    assert!(alpha_pid.exists(), "alpha MCP server did not initialize");
+    assert!(beta_pid.exists(), "beta MCP server did not initialize");
+    let first_alpha_pid = std::fs::read_to_string(&alpha_pid).unwrap();
+    let first_beta_pid = std::fs::read_to_string(&beta_pid).unwrap();
+
+    let prompt = h
+        .send(
+            "session/prompt",
+            json!({"sessionId": sid, "prompt": [{"type":"text","text":"use both tools"}]}),
+        )
+        .await;
+    let response = h.recv_until(|value| value["id"] == json!(prompt)).await;
+    assert!(
+        response.get("result").is_some(),
+        "prompt failed: {response}"
+    );
+    assert!(alpha_call.exists(), "alpha MCP tool was not called");
+    assert!(beta_call.exists(), "beta MCP tool was not called");
+
+    std::fs::remove_file(&alpha_call).unwrap();
+    std::fs::remove_file(&beta_call).unwrap();
+    let second_session = h
+        .send(
+            "session/new",
+            json!({"cwd":"/tmp","mcpServers": mcp_servers}),
+        )
+        .await;
+    let second_response = h
+        .recv_until(|value| value["id"] == json!(second_session))
+        .await;
+    let second_sid = second_response["result"]["sessionId"]
+        .as_str()
+        .unwrap_or_else(|| panic!("second session failed: {second_response}"));
+    assert_ne!(
+        std::fs::read_to_string(&alpha_pid).unwrap(),
+        first_alpha_pid,
+        "second session reused alpha MCP process"
+    );
+    assert_ne!(
+        std::fs::read_to_string(&beta_pid).unwrap(),
+        first_beta_pid,
+        "second session reused beta MCP process"
+    );
+
+    let second_prompt = h
+        .send(
+            "session/prompt",
+            json!({"sessionId": second_sid, "prompt": [{"type":"text","text":"use both tools again"}]}),
+        )
+        .await;
+    let second_prompt_response = h
+        .recv_until(|value| value["id"] == json!(second_prompt))
+        .await;
+    assert!(
+        second_prompt_response.get("result").is_some(),
+        "second prompt failed: {second_prompt_response}"
+    );
+    assert!(alpha_call.exists(), "second alpha MCP tool was not called");
+    assert!(beta_call.exists(), "second beta MCP tool was not called");
+
+    let captured = llm.captured.lock().await;
+    let first_tools = captured[0]["tools"].as_array().expect("LLM tools");
+    assert!(first_tools
+        .iter()
+        .any(|tool| tool["function"]["name"] == "alpha__tool_0"));
+    assert!(first_tools
+        .iter()
+        .any(|tool| tool["function"]["name"] == "beta__tool_0"));
+    let second_tools = captured[3]["tools"].as_array().expect("second LLM tools");
+    assert!(second_tools
+        .iter()
+        .any(|tool| tool["function"]["name"] == "alpha__tool_0"));
+    assert!(second_tools
+        .iter()
+        .any(|tool| tool["function"]["name"] == "beta__tool_0"));
+    drop(captured);
+    h.shutdown().await;
+}
+
 /// MCP init that hangs forever must time out within ~2s, surface an error,
 /// and the child process must be killed (not lingering).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/buzz-core/Cargo.toml
+++ b/crates/buzz-core/Cargo.toml
@@ -20,6 +20,7 @@ uuid       = { workspace = true }
 chrono     = { workspace = true }
 hex        = { workspace = true }
 hmac       = { workspace = true }
+http       = { workspace = true }
 sha2       = { workspace = true }
 rand              = { workspace = true }
 subtle            = { workspace = true }

--- a/crates/buzz-core/src/lib.rs
+++ b/crates/buzz-core/src/lib.rs
@@ -24,6 +24,8 @@ pub mod git_perms;
 pub mod invite;
 /// Buzz kind number registry — custom event type constants.
 pub mod kind;
+/// Versioned MCP configuration shared by launchers and the ACP harness.
+pub mod mcp_config;
 /// Network utilities — SSRF-safe IP classification.
 pub mod network;
 /// Agent observer frame helpers.

--- a/crates/buzz-core/src/mcp_config.rs
+++ b/crates/buzz-core/src/mcp_config.rs
@@ -5,7 +5,6 @@
 //! a successful launch producing a document that the harness cannot parse.
 
 use std::collections::{BTreeMap, HashSet};
-use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -97,21 +96,12 @@ impl McpLaunchConfigDocument {
                 command, args, env, ..
             } = server
             else {
-                let ConfiguredMcpServer::Http {
-                    url,
-                    url_env_file,
-                    url_env_name,
-                    headers,
-                    ..
-                } = server
-                else {
+                let ConfiguredMcpServer::Http { url, headers, .. } = server else {
                     continue;
                 };
-                if url_env_file.is_some() != url_env_name.is_some()
-                    || usize::from(!url.is_empty()) + usize::from(url_env_file.is_some()) != 1
-                {
+                if url.is_empty() {
                     return Err(McpConfigError::Invalid(format!(
-                        "remote MCP server '{name}' requires exactly one complete URL source"
+                        "remote MCP server '{name}' requires a resolved URL"
                     )));
                 }
                 if headers.len() > MCP_SERVER_MAX_ENV {
@@ -123,11 +113,8 @@ impl McpLaunchConfigDocument {
                 for header in headers {
                     if header.name.trim().is_empty()
                         || header.name.contains(['\r', '\n', '\0'])
-                        || header.env_file.is_some() != header.env_name.is_some()
-                        || usize::from(!header.value.is_empty())
-                            + usize::from(header.value_file.is_some())
-                            + usize::from(header.env_file.is_some())
-                            != 1
+                        || header.value.is_empty()
+                        || header.value.contains(['\r', '\n', '\0'])
                     {
                         return Err(McpConfigError::Invalid(format!(
                             "remote MCP server '{name}' has an invalid header configuration"
@@ -206,9 +193,9 @@ impl McpLaunchConfigDocument {
 
 /// One MCP server loaded from the structured MCP configuration.
 ///
-/// The transport tag is part of version 1 even though the first version
-/// supports only stdio. Additional transports extend this ordered list instead
-/// of introducing another configuration surface.
+/// Version 1 includes both stdio and Streamable HTTP so its meaning is fixed
+/// before either transport ships. Additional transports require a new schema
+/// version rather than changing an already-published version in place.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "transport", rename_all = "snake_case", deny_unknown_fields)]
 pub enum ConfiguredMcpServer {
@@ -228,16 +215,9 @@ pub enum ConfiguredMcpServer {
     Http {
         /// Stable ACP identifier for this server.
         name: String,
-        /// Literal URL. Exactly one of this and the `url_env_*` pair is required.
-        #[serde(default)]
+        /// Resolved URL supplied by the trusted launch resolver.
         url: String,
-        /// Protected environment file containing the URL.
-        #[serde(default)]
-        url_env_file: Option<PathBuf>,
-        /// Variable name to read from `url_env_file`.
-        #[serde(default)]
-        url_env_name: Option<String>,
-        /// Headers sent to the remote server.
+        /// Resolved headers supplied by the trusted launch resolver.
         #[serde(default)]
         headers: Vec<McpHttpHeaderConfig>,
     },
@@ -258,21 +238,8 @@ impl ConfiguredMcpServer {
 pub struct McpHttpHeaderConfig {
     /// HTTP header name.
     pub name: String,
-    /// Literal header value.
-    #[serde(default)]
+    /// Final resolved header value.
     pub value: String,
-    /// File containing the entire header value.
-    #[serde(default)]
-    pub value_file: Option<PathBuf>,
-    /// Protected environment file containing a named value.
-    #[serde(default)]
-    pub env_file: Option<PathBuf>,
-    /// Variable selected from `env_file`.
-    #[serde(default)]
-    pub env_name: Option<String>,
-    /// Public prefix prepended after resolving the configured value.
-    #[serde(default)]
-    pub value_prefix: String,
 }
 
 impl std::fmt::Debug for McpHttpHeaderConfig {
@@ -281,10 +248,6 @@ impl std::fmt::Debug for McpHttpHeaderConfig {
             .debug_struct("McpHttpHeaderConfig")
             .field("name", &self.name)
             .field("value", &"[REDACTED]")
-            .field("value_file", &self.value_file)
-            .field("env_file", &self.env_file)
-            .field("env_name", &self.env_name)
-            .field("value_prefix", &self.value_prefix)
             .finish()
     }
 }
@@ -316,18 +279,10 @@ impl std::fmt::Debug for ConfiguredMcpServer {
                 .field("arg_count", &args.len())
                 .field("env", &RedactedMcpEnv(env))
                 .finish(),
-            Self::Http {
-                name,
-                url: _,
-                url_env_file,
-                url_env_name,
-                headers,
-            } => formatter
+            Self::Http { name, headers, .. } => formatter
                 .debug_struct("Http")
                 .field("name", name)
                 .field("url", &"[REDACTED]")
-                .field("url_env_file", url_env_file)
-                .field("url_env_name", url_env_name)
                 .field("headers", headers)
                 .finish(),
         }
@@ -481,15 +436,9 @@ mod tests {
         let document = McpLaunchConfigDocument::new(vec![ConfiguredMcpServer::Http {
             name: "hosted-context".to_string(),
             url: "https://mcp.example.test/mcp".to_string(),
-            url_env_file: None,
-            url_env_name: None,
             headers: vec![McpHttpHeaderConfig {
                 name: "Authorization".to_string(),
                 value: "Bearer secret".to_string(),
-                value_file: None,
-                env_file: None,
-                env_name: None,
-                value_prefix: String::new(),
             }],
         }]);
 
@@ -499,6 +448,37 @@ mod tests {
             document.servers
         );
         assert!(!format!("{document:?}").contains("Bearer secret"));
+    }
+
+    #[test]
+    fn http_transport_requires_resolved_control_free_values() {
+        for server in [
+            ConfiguredMcpServer::Http {
+                name: "missing-url".to_string(),
+                url: String::new(),
+                headers: Vec::new(),
+            },
+            ConfiguredMcpServer::Http {
+                name: "empty-header".to_string(),
+                url: "https://mcp.example.test/mcp".to_string(),
+                headers: vec![McpHttpHeaderConfig {
+                    name: "Authorization".to_string(),
+                    value: String::new(),
+                }],
+            },
+            ConfiguredMcpServer::Http {
+                name: "injected-header".to_string(),
+                url: "https://mcp.example.test/mcp".to_string(),
+                headers: vec![McpHttpHeaderConfig {
+                    name: "Authorization".to_string(),
+                    value: "Bearer safe\r\nInjected: true".to_string(),
+                }],
+            },
+        ] {
+            assert!(McpLaunchConfigDocument::new(vec![server])
+                .validate()
+                .is_err());
+        }
     }
 
     #[test]

--- a/crates/buzz-core/src/mcp_config.rs
+++ b/crates/buzz-core/src/mcp_config.rs
@@ -1,0 +1,416 @@
+//! Versioned MCP configuration shared by launchers and the ACP harness.
+//!
+//! The launcher that writes an ephemeral configuration and the harness that
+//! consumes it must use the same wire contract. Keeping the schema here avoids
+//! a successful launch producing a document that the harness cannot parse.
+
+use std::collections::{BTreeMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Current structured MCP configuration version.
+pub const MCP_CONFIG_VERSION: u32 = 1;
+/// Maximum encoded size accepted for one structured MCP configuration.
+pub const MCP_CONFIG_MAX_BYTES: u64 = 64 * 1024;
+/// Maximum number of MCP servers in one launch document.
+pub const MCP_SERVER_MAX_COUNT: usize = 16;
+/// Maximum number of arguments for one stdio MCP server.
+pub const MCP_SERVER_MAX_ARGS: usize = 128;
+/// Maximum number of environment entries for one stdio MCP server.
+pub const MCP_SERVER_MAX_ENV: usize = 128;
+/// Maximum encoded length of an MCP server name.
+pub const MCP_SERVER_NAME_MAX_BYTES: usize = 128;
+
+/// Harness identity and authorization variables that an MCP server may not override.
+pub const PROTECTED_MCP_ENV_NAMES: [&str; 6] = [
+    "BUZZ_PRIVATE_KEY",
+    "NOSTR_PRIVATE_KEY",
+    "BUZZ_AUTH_TAG",
+    "BUZZ_API_TOKEN",
+    "BUZZ_ACP_PRIVATE_KEY",
+    "BUZZ_ACP_API_TOKEN",
+];
+
+/// A versioned collection of MCP servers supplied to an agent launch.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpLaunchConfigDocument {
+    /// Wire-schema version.
+    pub version: u32,
+    /// Ordered MCP servers supplied to the ACP session.
+    pub servers: Vec<ConfiguredMcpServer>,
+}
+
+impl std::fmt::Debug for McpLaunchConfigDocument {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("McpLaunchConfigDocument")
+            .field("version", &self.version)
+            .field("servers", &self.servers)
+            .finish()
+    }
+}
+
+impl McpLaunchConfigDocument {
+    /// Construct a document using the current wire-schema version.
+    pub fn new(servers: Vec<ConfiguredMcpServer>) -> Self {
+        Self {
+            version: MCP_CONFIG_VERSION,
+            servers,
+        }
+    }
+
+    /// Validate this launch document independently of any compatibility input.
+    pub fn validate(&self) -> Result<(), McpConfigError> {
+        if self.version != MCP_CONFIG_VERSION {
+            return Err(McpConfigError::Invalid(format!(
+                "unsupported MCP config version {} (expected {MCP_CONFIG_VERSION})",
+                self.version
+            )));
+        }
+
+        if self.servers.len() > MCP_SERVER_MAX_COUNT {
+            return Err(McpConfigError::Invalid(format!(
+                "too many MCP servers ({} configured, max {MCP_SERVER_MAX_COUNT})",
+                self.servers.len()
+            )));
+        }
+
+        let mut names = HashSet::with_capacity(self.servers.len());
+        for (index, server) in self.servers.iter().enumerate() {
+            let ConfiguredMcpServer::Stdio {
+                name,
+                command,
+                args,
+                env,
+            } = server;
+            if !valid_mcp_server_name(name) {
+                return Err(McpConfigError::Invalid(format!(
+                    "MCP server {} has invalid name '{}': use 1 to {MCP_SERVER_NAME_MAX_BYTES} ASCII letters, digits, underscores, or hyphens, without '__'",
+                    index + 1,
+                    name
+                )));
+            }
+            if !names.insert(name.as_str()) {
+                return Err(McpConfigError::Invalid(format!(
+                    "duplicate MCP server name '{name}'"
+                )));
+            }
+            if command.trim().is_empty() || command.contains('\0') {
+                return Err(McpConfigError::Invalid(format!(
+                    "MCP server '{name}' command must not be blank and must contain no NUL bytes"
+                )));
+            }
+            if args.len() > MCP_SERVER_MAX_ARGS {
+                return Err(McpConfigError::Invalid(format!(
+                    "MCP server '{name}' has too many arguments ({}, max {MCP_SERVER_MAX_ARGS})",
+                    args.len()
+                )));
+            }
+            if args.iter().any(|argument| argument.contains('\0')) {
+                return Err(McpConfigError::Invalid(format!(
+                    "MCP server '{name}' arguments must contain no NUL bytes"
+                )));
+            }
+            if env.len() > MCP_SERVER_MAX_ENV {
+                return Err(McpConfigError::Invalid(format!(
+                    "MCP server '{name}' has too many environment entries ({}, max {MCP_SERVER_MAX_ENV})",
+                    env.len()
+                )));
+            }
+            let mut normalized_env_names = HashSet::with_capacity(env.len());
+            for (env_index, (key, value)) in env.iter().enumerate() {
+                if !valid_mcp_env_name(key) {
+                    return Err(McpConfigError::Invalid(format!(
+                        "MCP server '{name}' environment entry {} has an invalid key",
+                        env_index + 1
+                    )));
+                }
+                if !normalized_env_names.insert(key.to_ascii_uppercase()) {
+                    return Err(McpConfigError::Invalid(format!(
+                        "MCP server '{name}' has environment keys that differ only by ASCII case"
+                    )));
+                }
+                if PROTECTED_MCP_ENV_NAMES
+                    .iter()
+                    .any(|protected| key.eq_ignore_ascii_case(protected))
+                {
+                    return Err(McpConfigError::Invalid(format!(
+                        "MCP server '{name}' may not configure a protected environment key"
+                    )));
+                }
+                if value.contains('\0') {
+                    return Err(McpConfigError::Invalid(format!(
+                        "MCP server '{name}' environment entry {} contains a NUL byte",
+                        env_index + 1
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate and encode this document within the wire-size limit.
+    pub fn to_json(&self) -> Result<Vec<u8>, McpConfigError> {
+        self.validate()?;
+        let encoded =
+            serde_json::to_vec(self).map_err(|error| McpConfigError::Invalid(error.to_string()))?;
+        if encoded.len() as u64 > MCP_CONFIG_MAX_BYTES {
+            return Err(McpConfigError::Invalid(format!(
+                "MCP config exceeds the {MCP_CONFIG_MAX_BYTES} byte limit"
+            )));
+        }
+        Ok(encoded)
+    }
+}
+
+/// One MCP server loaded from the structured MCP configuration.
+///
+/// The transport tag is part of version 1 even though the first version
+/// supports only stdio. Additional transports extend this ordered list instead
+/// of introducing another configuration surface.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "transport", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ConfiguredMcpServer {
+    /// A local MCP child process connected over stdio.
+    Stdio {
+        /// Stable ACP identifier for this server.
+        name: String,
+        /// Executable invoked directly without shell parsing.
+        command: String,
+        /// Arguments passed to the executable in their configured order.
+        args: Vec<String>,
+        /// Server-specific environment in deterministic key order.
+        #[serde(deserialize_with = "deserialize_mcp_env")]
+        env: BTreeMap<String, String>,
+    },
+}
+
+struct RedactedMcpEnv<'a>(&'a BTreeMap<String, String>);
+
+impl std::fmt::Debug for RedactedMcpEnv<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut map = formatter.debug_map();
+        for key in self.0.keys() {
+            map.entry(key, &"[REDACTED]");
+        }
+        map.finish()
+    }
+}
+
+impl std::fmt::Debug for ConfiguredMcpServer {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Stdio {
+                name,
+                command,
+                args,
+                env,
+            } => formatter
+                .debug_struct("Stdio")
+                .field("name", name)
+                .field("command", command)
+                .field("arg_count", &args.len())
+                .field("env", &RedactedMcpEnv(env))
+                .finish(),
+        }
+    }
+}
+
+/// Structured MCP configuration validation failure.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum McpConfigError {
+    /// The document or one of its server entries is invalid.
+    #[error("{0}")]
+    Invalid(String),
+}
+
+/// Parse and validate one structured MCP configuration document.
+pub fn parse_mcp_config_document(
+    content: &[u8],
+) -> Result<Vec<ConfiguredMcpServer>, McpConfigError> {
+    if content.len() as u64 > MCP_CONFIG_MAX_BYTES {
+        return Err(McpConfigError::Invalid(format!(
+            "MCP config exceeds the {MCP_CONFIG_MAX_BYTES} byte limit"
+        )));
+    }
+    let document: McpLaunchConfigDocument = serde_json::from_slice(content)
+        .map_err(|error| McpConfigError::Invalid(error.to_string()))?;
+    document.validate()?;
+    Ok(document.servers)
+}
+
+fn valid_mcp_server_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MCP_SERVER_NAME_MAX_BYTES
+        && !name.contains("__")
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
+
+fn valid_mcp_env_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    matches!(bytes.next(), Some(byte) if byte.is_ascii_alphabetic() || byte == b'_')
+        && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+fn deserialize_mcp_env<'de, D>(deserializer: D) -> Result<BTreeMap<String, String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct EnvVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for EnvVisitor {
+        type Value = BTreeMap<String, String>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("an object containing unique environment variable names")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            let mut env = BTreeMap::new();
+            let mut normalized_names = HashSet::new();
+            while let Some((key, value)) = map.next_entry::<String, String>()? {
+                if !normalized_names.insert(key.to_ascii_uppercase()) {
+                    return Err(serde::de::Error::custom(
+                        "environment keys must be unique ignoring ASCII case",
+                    ));
+                }
+                env.insert(key, value);
+            }
+            Ok(env)
+        }
+    }
+
+    deserializer.deserialize_map(EnvVisitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stdio_server(name: &str) -> ConfiguredMcpServer {
+        ConfiguredMcpServer::Stdio {
+            name: name.to_string(),
+            command: "mcp-server".to_string(),
+            args: vec!["--stdio".to_string()],
+            env: BTreeMap::from([("TOKEN".to_string(), "secret-value".to_string())]),
+        }
+    }
+
+    #[test]
+    fn serialized_document_carries_the_transport_tag() {
+        let document = McpLaunchConfigDocument::new(vec![stdio_server("analytics")]);
+        let encoded = document.to_json().unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
+
+        assert_eq!(json["version"], MCP_CONFIG_VERSION);
+        assert_eq!(json["servers"][0]["transport"], "stdio");
+        assert_eq!(
+            parse_mcp_config_document(&encoded).unwrap(),
+            vec![stdio_server("analytics")]
+        );
+    }
+
+    #[test]
+    fn writer_rejects_case_insensitive_environment_collisions() {
+        let document = McpLaunchConfigDocument::new(vec![ConfiguredMcpServer::Stdio {
+            name: "one".to_string(),
+            command: "mcp".to_string(),
+            args: Vec::new(),
+            env: BTreeMap::from([
+                ("Token".to_string(), "first".to_string()),
+                ("TOKEN".to_string(), "second".to_string()),
+            ]),
+        }]);
+
+        assert!(document.to_json().is_err());
+    }
+
+    #[test]
+    fn environment_validation_errors_do_not_echo_untrusted_keys() {
+        let pasted_secret = "pasted-secret-that-must-not-appear";
+        let invalid_key = format!("BAD-KEY-{pasted_secret}");
+        let document = McpLaunchConfigDocument::new(vec![ConfiguredMcpServer::Stdio {
+            name: "one".to_string(),
+            command: "mcp".to_string(),
+            args: Vec::new(),
+            env: BTreeMap::from([(invalid_key.clone(), "value".to_string())]),
+        }]);
+
+        let error = document.validate().unwrap_err().to_string();
+        assert!(!error.contains(&invalid_key));
+        assert!(!error.contains(pasted_secret));
+    }
+
+    #[test]
+    fn missing_or_unknown_transport_is_rejected() {
+        for content in [
+            br#"{"version":1,"servers":[{"name":"one","command":"mcp","args":[],"env":{}}]}"#
+                .as_slice(),
+            br#"{"version":1,"servers":[{"name":"one","transport":"http","url":"https://example.test"}]}"#
+                .as_slice(),
+        ] {
+            assert!(parse_mcp_config_document(content).is_err());
+        }
+    }
+
+    #[test]
+    fn validation_rejects_duplicate_names_and_protected_environment() {
+        let duplicate =
+            McpLaunchConfigDocument::new(vec![stdio_server("one"), stdio_server("one")]);
+        assert!(duplicate.validate().is_err());
+
+        let protected = McpLaunchConfigDocument::new(vec![ConfiguredMcpServer::Stdio {
+            name: "one".to_string(),
+            command: "mcp".to_string(),
+            args: Vec::new(),
+            env: BTreeMap::from([("BUZZ_PRIVATE_KEY".to_string(), "secret".to_string())]),
+        }]);
+        assert!(protected.validate().is_err());
+    }
+
+    #[test]
+    fn validation_rejects_blank_commands() {
+        let document = McpLaunchConfigDocument::new(vec![ConfiguredMcpServer::Stdio {
+            name: "one".to_string(),
+            command: " \t\n ".to_string(),
+            args: Vec::new(),
+            env: BTreeMap::new(),
+        }]);
+
+        assert!(document.validate().is_err());
+    }
+
+    #[test]
+    fn debug_output_redacts_environment_values() {
+        let output = format!(
+            "{:?}",
+            McpLaunchConfigDocument::new(vec![stdio_server("one")])
+        );
+        assert!(output.contains("TOKEN"));
+        assert!(output.contains("[REDACTED]"));
+        assert!(!output.contains("secret-value"));
+    }
+
+    #[test]
+    fn encoding_and_parsing_enforce_the_same_size_limit() {
+        let oversized = McpLaunchConfigDocument::new(vec![ConfiguredMcpServer::Stdio {
+            name: "one".to_string(),
+            command: "mcp".to_string(),
+            args: Vec::new(),
+            env: BTreeMap::from([(
+                "TOKEN".to_string(),
+                "x".repeat(MCP_CONFIG_MAX_BYTES as usize),
+            )]),
+        }]);
+
+        assert!(oversized.to_json().is_err());
+        assert!(parse_mcp_config_document(&vec![b' '; MCP_CONFIG_MAX_BYTES as usize + 1]).is_err());
+    }
+}

--- a/crates/buzz-core/src/mcp_config.rs
+++ b/crates/buzz-core/src/mcp_config.rs
@@ -111,10 +111,9 @@ impl McpLaunchConfigDocument {
                     )));
                 }
                 for header in headers {
-                    if header.name.trim().is_empty()
-                        || header.name.contains(['\r', '\n', '\0'])
+                    if http::HeaderName::from_bytes(header.name.as_bytes()).is_err()
                         || header.value.is_empty()
-                        || header.value.contains(['\r', '\n', '\0'])
+                        || http::HeaderValue::from_bytes(header.value.as_bytes()).is_err()
                     {
                         return Err(McpConfigError::Invalid(format!(
                             "remote MCP server '{name}' has an invalid header configuration"
@@ -472,6 +471,30 @@ mod tests {
                 headers: vec![McpHttpHeaderConfig {
                     name: "Authorization".to_string(),
                     value: "Bearer safe\r\nInjected: true".to_string(),
+                }],
+            },
+            ConfiguredMcpServer::Http {
+                name: "whitespace-header-name".to_string(),
+                url: "https://mcp.example.test/mcp".to_string(),
+                headers: vec![McpHttpHeaderConfig {
+                    name: "Bad Header".to_string(),
+                    value: "value".to_string(),
+                }],
+            },
+            ConfiguredMcpServer::Http {
+                name: "colon-header-name".to_string(),
+                url: "https://mcp.example.test/mcp".to_string(),
+                headers: vec![McpHttpHeaderConfig {
+                    name: "Bad:Header".to_string(),
+                    value: "value".to_string(),
+                }],
+            },
+            ConfiguredMcpServer::Http {
+                name: "control-header-value".to_string(),
+                url: "https://mcp.example.test/mcp".to_string(),
+                headers: vec![McpHttpHeaderConfig {
+                    name: "Authorization".to_string(),
+                    value: "Bearer \u{0001}secret".to_string(),
                 }],
             },
         ] {

--- a/crates/buzz-core/src/mcp_config.rs
+++ b/crates/buzz-core/src/mcp_config.rs
@@ -5,6 +5,7 @@
 //! a successful launch producing a document that the harness cannot parse.
 
 use std::collections::{BTreeMap, HashSet};
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -79,12 +80,7 @@ impl McpLaunchConfigDocument {
 
         let mut names = HashSet::with_capacity(self.servers.len());
         for (index, server) in self.servers.iter().enumerate() {
-            let ConfiguredMcpServer::Stdio {
-                name,
-                command,
-                args,
-                env,
-            } = server;
+            let name = server.name();
             if !valid_mcp_server_name(name) {
                 return Err(McpConfigError::Invalid(format!(
                     "MCP server {} has invalid name '{}': use 1 to {MCP_SERVER_NAME_MAX_BYTES} ASCII letters, digits, underscores, or hyphens, without '__'",
@@ -92,11 +88,54 @@ impl McpLaunchConfigDocument {
                     name
                 )));
             }
-            if !names.insert(name.as_str()) {
+            if !names.insert(name) {
                 return Err(McpConfigError::Invalid(format!(
                     "duplicate MCP server name '{name}'"
                 )));
             }
+            let ConfiguredMcpServer::Stdio {
+                command, args, env, ..
+            } = server
+            else {
+                let ConfiguredMcpServer::Http {
+                    url,
+                    url_env_file,
+                    url_env_name,
+                    headers,
+                    ..
+                } = server
+                else {
+                    continue;
+                };
+                if url_env_file.is_some() != url_env_name.is_some()
+                    || usize::from(!url.is_empty()) + usize::from(url_env_file.is_some()) != 1
+                {
+                    return Err(McpConfigError::Invalid(format!(
+                        "remote MCP server '{name}' requires exactly one complete URL source"
+                    )));
+                }
+                if headers.len() > MCP_SERVER_MAX_ENV {
+                    return Err(McpConfigError::Invalid(format!(
+                        "remote MCP server '{name}' has too many headers ({}, max {MCP_SERVER_MAX_ENV})",
+                        headers.len()
+                    )));
+                }
+                for header in headers {
+                    if header.name.trim().is_empty()
+                        || header.name.contains(['\r', '\n', '\0'])
+                        || header.env_file.is_some() != header.env_name.is_some()
+                        || usize::from(!header.value.is_empty())
+                            + usize::from(header.value_file.is_some())
+                            + usize::from(header.env_file.is_some())
+                            != 1
+                    {
+                        return Err(McpConfigError::Invalid(format!(
+                            "remote MCP server '{name}' has an invalid header configuration"
+                        )));
+                    }
+                }
+                continue;
+            };
             if command.trim().is_empty() || command.contains('\0') {
                 return Err(McpConfigError::Invalid(format!(
                     "MCP server '{name}' command must not be blank and must contain no NUL bytes"
@@ -185,6 +224,69 @@ pub enum ConfiguredMcpServer {
         #[serde(deserialize_with = "deserialize_mcp_env")]
         env: BTreeMap<String, String>,
     },
+    /// A remote Streamable HTTP MCP server.
+    Http {
+        /// Stable ACP identifier for this server.
+        name: String,
+        /// Literal URL. Exactly one of this and the `url_env_*` pair is required.
+        #[serde(default)]
+        url: String,
+        /// Protected environment file containing the URL.
+        #[serde(default)]
+        url_env_file: Option<PathBuf>,
+        /// Variable name to read from `url_env_file`.
+        #[serde(default)]
+        url_env_name: Option<String>,
+        /// Headers sent to the remote server.
+        #[serde(default)]
+        headers: Vec<McpHttpHeaderConfig>,
+    },
+}
+
+impl ConfiguredMcpServer {
+    /// Stable name supplied to ACP for this server.
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Stdio { name, .. } | Self::Http { name, .. } => name,
+        }
+    }
+}
+
+/// Header attached to requests for a remote HTTP MCP server.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpHttpHeaderConfig {
+    /// HTTP header name.
+    pub name: String,
+    /// Literal header value.
+    #[serde(default)]
+    pub value: String,
+    /// File containing the entire header value.
+    #[serde(default)]
+    pub value_file: Option<PathBuf>,
+    /// Protected environment file containing a named value.
+    #[serde(default)]
+    pub env_file: Option<PathBuf>,
+    /// Variable selected from `env_file`.
+    #[serde(default)]
+    pub env_name: Option<String>,
+    /// Public prefix prepended after resolving the configured value.
+    #[serde(default)]
+    pub value_prefix: String,
+}
+
+impl std::fmt::Debug for McpHttpHeaderConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("McpHttpHeaderConfig")
+            .field("name", &self.name)
+            .field("value", &"[REDACTED]")
+            .field("value_file", &self.value_file)
+            .field("env_file", &self.env_file)
+            .field("env_name", &self.env_name)
+            .field("value_prefix", &self.value_prefix)
+            .finish()
+    }
 }
 
 struct RedactedMcpEnv<'a>(&'a BTreeMap<String, String>);
@@ -213,6 +315,20 @@ impl std::fmt::Debug for ConfiguredMcpServer {
                 .field("command", command)
                 .field("arg_count", &args.len())
                 .field("env", &RedactedMcpEnv(env))
+                .finish(),
+            Self::Http {
+                name,
+                url: _,
+                url_env_file,
+                url_env_name,
+                headers,
+            } => formatter
+                .debug_struct("Http")
+                .field("name", name)
+                .field("url", &"[REDACTED]")
+                .field("url_env_file", url_env_file)
+                .field("url_env_name", url_env_name)
+                .field("headers", headers)
                 .finish(),
         }
     }
@@ -353,11 +469,36 @@ mod tests {
         for content in [
             br#"{"version":1,"servers":[{"name":"one","command":"mcp","args":[],"env":{}}]}"#
                 .as_slice(),
-            br#"{"version":1,"servers":[{"name":"one","transport":"http","url":"https://example.test"}]}"#
+            br#"{"version":1,"servers":[{"name":"one","transport":"tcp","url":"https://example.test"}]}"#
                 .as_slice(),
         ] {
             assert!(parse_mcp_config_document(content).is_err());
         }
+    }
+
+    #[test]
+    fn http_transport_round_trips_in_the_shared_document() {
+        let document = McpLaunchConfigDocument::new(vec![ConfiguredMcpServer::Http {
+            name: "hosted-context".to_string(),
+            url: "https://mcp.example.test/mcp".to_string(),
+            url_env_file: None,
+            url_env_name: None,
+            headers: vec![McpHttpHeaderConfig {
+                name: "Authorization".to_string(),
+                value: "Bearer secret".to_string(),
+                value_file: None,
+                env_file: None,
+                env_name: None,
+                value_prefix: String::new(),
+            }],
+        }]);
+
+        let encoded = document.to_json().unwrap();
+        assert_eq!(
+            parse_mcp_config_document(&encoded).unwrap(),
+            document.servers
+        );
+        assert!(!format!("{document:?}").contains("Bearer secret"));
     }
 
     #[test]

--- a/crates/buzz-persona/PERSONA_PACK_SPEC.md
+++ b/crates/buzz-persona/PERSONA_PACK_SPEC.md
@@ -433,7 +433,8 @@ therefore do not reach a running session in the current implementation.
 
 The runtime launch boundary is a separate, versioned MCP launch document. A future
 resolver must convert approved persona or template requirements and Project Connections
-into that document. Version 1 of the launch document supports stdio only.
+into that document. Version 1 of the launch document supports local stdio and remote
+Streamable HTTP servers.
 
 ### Pack-Level: `.mcp.json`
 

--- a/crates/buzz-persona/PERSONA_PACK_SPEC.md
+++ b/crates/buzz-persona/PERSONA_PACK_SPEC.md
@@ -426,13 +426,14 @@ enforce required metadata fields (see PF-5).
 ## 7. MCP Server Configuration
 
 MCP servers provide external tool access (GitHub, Semgrep, databases, etc.). Configuration is
-defined at two levels: pack-level (shared across all agents) and per-persona (agent-specific).
-buzz-acp merges them and passes the result via the ACP protocol — no filesystem placement required.
+defined at two authoring levels: pack-level (shared across all agents) and per-persona
+(agent-specific). `buzz-persona` currently parses and merges these declarations, but
+`buzz-acp` does not yet consume the resolved persona MCP list. Persona MCP declarations
+therefore do not reach a running session in the current implementation.
 
-> **Transport Warning**: Only `stdio` and `streamable_http` transports are supported. SSE transport
-> is rejected by the ACP runtime with the error `"SSE is unsupported, migrate to streamable_http"` and
-> will cause session startup to fail. Migrate any SSE-based MCP servers to streamable_http before
-> packaging.
+The runtime launch boundary is a separate, versioned MCP launch document. A future
+resolver must convert approved persona or template requirements and Project Connections
+into that document. Version 1 of the launch document supports stdio only.
 
 ### Pack-Level: `.mcp.json`
 
@@ -469,13 +470,14 @@ mcp_servers:
 
 1. Pack-level servers are the base set; per-persona servers merged on top.
 2. **Name collision**: per-persona entry wins entirely (no partial merge).
-3. The merged set is passed to the agent runtime via `NewSessionRequest.mcp_servers`.
+3. The merged set remains authoring output until an explicit launch resolver converts it
+   into the runtime MCP launch document.
 
 ### Environment Variable Interpolation
 
 > **Implementation note**: MCP env var interpolation (`${VAR_NAME}` resolution) is planned but not
-> yet implemented. In the current release, `${VAR_NAME}` strings are passed through as literals
-> to the agent runtime, which may resolve them via its own MCP server configuration handling.
+> yet implemented. In the current release, persona MCP declarations remain authoring data and
+> do not reach the agent runtime.
 
 When implemented, all `env` values will be scanned for `${VAR_NAME}`. buzz-acp will resolve
 from the process environment **before** passing to the agent runtime. Unresolved variables will
@@ -483,7 +485,10 @@ cause a startup error.
 
 ### Delivery
 
-buzz-acp passes the merged config via `NewSessionRequest.mcp_servers`. **No `.mcp.json` is written to the agent's working directory.**
+Persona MCP delivery is not wired yet. The launch resolver must validate and bind the
+authoring declarations before `buzz-acp` passes the resulting servers through
+`NewSessionRequest.mcp_servers`. No `.mcp.json` should be written into the agent's
+working directory.
 
 ---
 
@@ -935,7 +940,7 @@ How each pack component reaches the running agent:
 | Component | Delivery Method | Mechanism | Filesystem Write? |
 |-----------|----------------|-----------|-------------------|
 | Skills | Copy at deploy time (planned) | buzz-acp will copy `skills/` → `$AGENT_CWD/.agents/skills/` | ✅ Yes (only one) |
-| MCP servers | ACP protocol | `NewSessionRequest.mcp_servers` | ❌ No |
+| MCP servers | Not wired | Parsed by `buzz-persona`; requires an explicit resolver into the MCP launch document | ❌ No |
 | Persona prompt | User message prefix | `[System]` block prepended to user message text by buzz-acp | ❌ No |
 | Pack instructions | User message prefix | Appended to `[System]` block in user message text | ❌ No |
 | Lifecycle hooks | Harness internal | buzz-acp fires shell commands directly | ❌ No |
@@ -987,7 +992,7 @@ The `[System]` prefix re-sends the full persona prompt on every turn. True syste
 | `rules/*.mdc` files | Agent runtimes typically don't read `.mdc` files |
 | `skills/` at pack root (without copying) | Agent runtimes scan `.agents/skills/`, not `skills/` |
 | Hooks in goose config | Agent runtimes have no hook system; hooks are a harness feature |
-| SSE transport in `.mcp.json` | ACP runtime rejects SSE; use stdio or streamable_http |
+| Assuming `.mcp.json` is live runtime configuration | Persona MCP declarations are parsed but are not yet connected to the ACP launch path |
 | SKILL.md without `name:` or `description:` | Skill silently skipped; no fallback |
 | Setting `GOOSE_MODEL` on parent process (multi-persona) | Affects all agents; use per-subprocess injection via `extra_env` |
 | Expecting `defaults` sub-key inheritance | No deep merge; object/array fields replaced entirely |
@@ -999,10 +1004,10 @@ The `[System]` prefix re-sends the full persona prompt on every turn. True syste
 ### Secret Management
 
 Never embed secrets in pack files. Use `${VAR_NAME}` references in all `env` blocks. Currently,
-`${VAR_NAME}` strings are passed through as literals to the agent runtime (see Section 7). When
-harness-side interpolation is implemented, buzz-acp will resolve them from the process
-environment at startup and refuse to start if any are unresolved. Inject secrets via your
-deployment mechanism (systemd env files, Vault, Kubernetes secrets, etc.).
+persona MCP declarations are not delivered to the agent runtime (see Section 7). When an
+approved launch resolver and harness-side interpolation are implemented, unresolved references
+must fail startup rather than becoming literal credentials. Inject secrets through the
+target-local deployment mechanism rather than embedding them in the pack.
 
 ### Pack Integrity
 

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1046,6 +1046,7 @@ dependencies = [
  "chrono",
  "hex",
  "hmac 0.13.0",
+ "http",
  "nostr",
  "percent-encoding",
  "rand 0.10.2",

--- a/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars/tests.rs
@@ -179,6 +179,7 @@ fn reserved_keys_include_code_execution_surface() {
         "BUZZ_ACP_AGENT_COMMAND",
         "BUZZ_ACP_AGENT_ARGS",
         "BUZZ_ACP_MCP_COMMAND",
+        "BUZZ_ACP_MCP_CONFIG",
     ] {
         assert!(is_reserved_env_key(key), "{key} should be reserved");
     }

--- a/desktop/src-tauri/src/managed_agents/reserved_env_keys.rs
+++ b/desktop/src-tauri/src/managed_agents/reserved_env_keys.rs
@@ -41,6 +41,7 @@ pub(crate) const RESERVED_ENV_KEYS: &[&str] = &[
     "BUZZ_ACP_AGENT_COMMAND",
     "BUZZ_ACP_AGENT_ARGS",
     "BUZZ_ACP_MCP_COMMAND",
+    "BUZZ_ACP_MCP_CONFIG",
     // Control-plane parallelism: the Desktop resolves the effective
     // worker-pool size (applying any per-harness cap) and writes it into
     // launch.policy_env. A user-supplied BUZZ_ACP_AGENTS would bypass the


### PR DESCRIPTION
## Summary

This gives Buzz one versioned MCP launch document instead of separate formats for each adapter and transport. `buzz-acp` accepts multiple named stdio and Streamable HTTP servers, preserves their resolved configuration, checks the runtime's transport capability, and sends the same ordered list through every ACP session. The existing `BUZZ_ACP_MCP_COMMAND` path remains the first compatibility input.

Desktop and Project Connections can resolve approved tools into this boundary without teaching the runtime about personas, templates, or project state. Launchers can evolve while the ACP handoff stays stable.

## Boundary

This document is resolved launch input. Personas, templates, and Projects remain authoring state and are not passed directly to a runtime.

The JSON contract is strict and bounded. Remote servers require HTTPS; literal loopback HTTP is allowed only without credentials. Server names are checked across structured and legacy inputs, protected Buzz credentials cannot be overridden, and MCP arguments, environment values, URLs, and headers are redacted from logs and observer output.

The adapter still inherits the harness environment, so this is explicit configuration rather than process isolation. Before unattended launch, the launcher must also establish the adapter's tool authorization policy. Transport support and permission to call a tool are separate gates.

## Validation

- `just ci`
- `cargo test -p buzz-core -p buzz-acp -p buzz-agent --no-fail-fast`
- `cargo clippy -p buzz-core -p buzz-acp -p buzz-agent --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Real-process regression: two stdio MCP children initialize, list, and execute tools across two fresh ACP sessions
- Mixed-transport regression: the legacy Buzz companion and HTTP server reach `session/new` together with capability, URL, header, collision, and redaction coverage

Fixes #4154.