### PR TITLE
fix(agent): report load_skill truncation instead of silently dropping content

### DIFF
--- a/crates/buzz-agent/src/builtin.rs
+++ b/crates/buzz-agent/src/builtin.rs
@@ -99,11 +99,7 @@ pub async fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolRe
 
     // Apply the size cap to the full output (body + Supporting Files section)
     // so the total tool result stays within MAX_SKILL_BODY_BYTES.
-    let output = if output.len() > MAX_SKILL_BODY_BYTES {
-        truncate_at_boundary(&output, MAX_SKILL_BODY_BYTES).to_owned()
-    } else {
-        output
-    };
+    let output = truncate_with_marker(output, MAX_SKILL_BODY_BYTES, name);
 
     ToolResult {
         provider_id: String::new(),
@@ -203,11 +199,11 @@ async fn load_supporting_file(
                         "# Loaded: {}/{}\n\n{}\n\n---\nFile loaded into context.",
                         skill_name, rel_path_owned, content
                     );
-                    let output = if output.len() > MAX_SKILL_BODY_BYTES {
-                        truncate_at_boundary(&output, MAX_SKILL_BODY_BYTES).to_owned()
-                    } else {
-                        output
-                    };
+                    let output = truncate_with_marker(
+                        output,
+                        MAX_SKILL_BODY_BYTES,
+                        &format!("{skill_name}/{rel_path_owned}"),
+                    );
                     ToolResult {
                         provider_id: String::new(),
                         content: vec![ToolResultContent::Text(output)],
@@ -227,6 +223,43 @@ async fn load_supporting_file(
             "load_skill: could not resolve {skill_name:?}/{rel_path_owned}: {e}"
         )),
     }
+}
+
+/// Byte allowance reserved for the truncation marker inside
+/// [`truncate_with_marker`]. The marker is fixed text plus two decimal byte
+/// counts — under 100 bytes for any `usize` — so the slack keeps the
+/// arithmetic safely one-sided, as `truncate_middle` does for its own marker.
+const TRUNCATION_MARKER_ALLOWANCE: usize = 128;
+
+/// Cap `output` at `limit` bytes, appending an in-band marker and logging once
+/// when content is dropped.
+///
+/// `load_skill` returns authored instructions, not tool output. A skill that
+/// loses its tail still loads with `is_error: false`, so without a marker the
+/// model follows instructions it cannot tell are incomplete — the rules,
+/// output formats, and checklists that live at the end of a SKILL.md are
+/// simply absent. The marker is charged against `limit` rather than appended
+/// past it, so the cap stays a budget the caller can rely on.
+///
+/// If `limit` is smaller than the marker itself the marker still wins: a
+/// pathologically small budget is worth overrunning to keep the loss visible.
+/// `MAX_SKILL_BODY_BYTES` is 32 KiB, so this cannot happen on the live path.
+fn truncate_with_marker(output: String, limit: usize, requested: &str) -> String {
+    if output.len() <= limit {
+        return output;
+    }
+    tracing::warn!(
+        skill = %requested,
+        bytes = output.len(),
+        limit,
+        "load_skill content truncated"
+    );
+    let kept = truncate_at_boundary(&output, limit.saturating_sub(TRUNCATION_MARKER_ALLOWANCE));
+    format!(
+        "{kept}\n\n[truncated: {} of {} bytes shown; the remainder was dropped by load_skill]",
+        kept.len(),
+        output.len()
+    )
 }
 
 fn error_result(msg: &str) -> ToolResult {
@@ -571,5 +604,152 @@ mod tests {
             text.starts_with("# Loaded: big/references/huge.md"),
             "missing supporting-file header: {text}"
         );
+    }
+
+    const MARKER_PREFIX: &str = "\n\n[truncated: ";
+
+    /// Split a truncated result into the content that survived and the two byte
+    /// counts the marker reports. Panics if the marker is absent.
+    fn split_marker(text: &str) -> (&str, usize, usize) {
+        let at = text
+            .find(MARKER_PREFIX)
+            .unwrap_or_else(|| panic!("missing truncation marker in: {text:?}"));
+        let (kept, marker) = text.split_at(at);
+        let rest = marker.strip_prefix(MARKER_PREFIX).unwrap();
+        let (shown, rest) = rest.split_once(" of ").unwrap();
+        let (total, _) = rest.split_once(" bytes shown").unwrap();
+        (kept, shown.parse().unwrap(), total.parse().unwrap())
+    }
+
+    #[test]
+    fn truncate_with_marker_leaves_content_under_the_limit_byte_identical() {
+        let content = "Skill body.\n\n## Rules\n\nAlways answer in JSON.\n".to_owned();
+        let out = truncate_with_marker(content.clone(), MAX_SKILL_BODY_BYTES, "small");
+        assert_eq!(out, content, "content under the limit must pass through");
+        assert!(!out.contains("[truncated:"), "unexpected marker: {out}");
+    }
+
+    #[test]
+    fn truncate_with_marker_reports_accurate_byte_counts() {
+        let content = "x".repeat(40 * 1024);
+        let out = truncate_with_marker(content.clone(), MAX_SKILL_BODY_BYTES, "big");
+        assert!(
+            out.len() <= MAX_SKILL_BODY_BYTES,
+            "marker must fit inside the cap, got {}",
+            out.len()
+        );
+        let (kept, shown, total) = split_marker(&out);
+        assert_eq!(shown, kept.len(), "shown count must match the kept content");
+        assert_eq!(total, content.len(), "total must be the pre-cut length");
+        assert!(shown < total, "shown {shown} should be below total {total}");
+        assert!(content.starts_with(kept), "kept content must be a prefix");
+    }
+
+    #[test]
+    fn truncate_with_marker_keeps_valid_utf8_on_a_multibyte_cut() {
+        // 2-byte chars plus odd limits push the cut into the middle of a char.
+        let content = "é".repeat(60_000);
+        for limit in [1025usize, 4097, MAX_SKILL_BODY_BYTES - 1] {
+            let out = truncate_with_marker(content.clone(), limit, "accented");
+            assert!(out.len() <= limit, "limit={limit} got {}", out.len());
+            assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+            let (kept, shown, total) = split_marker(&out);
+            assert_eq!(shown, kept.len(), "limit={limit}");
+            assert_eq!(total, content.len(), "limit={limit}");
+            assert!(content.starts_with(kept), "limit={limit}");
+        }
+    }
+
+    #[test]
+    fn truncate_with_marker_keeps_the_marker_when_the_limit_cannot_hold_it() {
+        // Unreachable at MAX_SKILL_BODY_BYTES, but the helper is total: a budget
+        // too small to report the loss is worth overrunning to report it anyway.
+        let out = truncate_with_marker("x".repeat(1024), 16, "tiny");
+        let (kept, shown, total) = split_marker(&out);
+        assert!(kept.is_empty(), "no content fits, got: {kept:?}");
+        assert_eq!(shown, 0);
+        assert_eq!(total, 1024);
+    }
+
+    #[tokio::test]
+    async fn call_load_skill_marks_truncated_body() {
+        let tmp = TempDir::new().unwrap();
+        let skill_md = tmp.path().join("SKILL.md");
+        // The tail of a SKILL.md is where output rules tend to live — drop it
+        // and the skill still "loads", which is the bug the marker reports.
+        let body = format!(
+            "{}\n## SENTINEL\n\nAlways refuse X.\n",
+            "filler\n".repeat(6 * 1024)
+        );
+        std::fs::write(
+            &skill_md,
+            format!("---\nname: big\ndescription: desc\n---\n{body}"),
+        )
+        .unwrap();
+
+        let skills = vec![make_skill("big", "desc", skill_md)];
+        let result = call_load_skill(&serde_json::json!({"name": "big"}), &skills).await;
+        assert!(!result.is_error);
+        let text = text_content(&result);
+        assert!(
+            !text.contains("SENTINEL"),
+            "test setup: the tail should have been cut"
+        );
+        let (kept, shown, total) = split_marker(&text);
+        assert_eq!(shown, kept.len());
+        assert!(
+            total > MAX_SKILL_BODY_BYTES,
+            "total {total} should be the untruncated length"
+        );
+    }
+
+    #[tokio::test]
+    async fn call_load_skill_marks_truncated_supporting_file() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp.path();
+        let skill_md = skill_dir.join("SKILL.md");
+        std::fs::write(&skill_md, "---\nname: big\ndescription: desc\n---\nBody.\n").unwrap();
+
+        let refs_dir = skill_dir.join("references");
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        let ref_file = refs_dir.join("huge.md");
+        std::fs::write(&ref_file, "x".repeat(MAX_SKILL_BODY_BYTES * 2)).unwrap();
+
+        let skills = vec![make_skill_with_files(
+            "big",
+            "desc",
+            skill_md,
+            vec![ref_file],
+        )];
+        let result = call_load_skill(
+            &serde_json::json!({"name": "big/references/huge.md"}),
+            &skills,
+        )
+        .await;
+        assert!(!result.is_error);
+        let text = text_content(&result);
+        let (kept, shown, total) = split_marker(&text);
+        assert_eq!(shown, kept.len());
+        assert!(
+            total > MAX_SKILL_BODY_BYTES * 2,
+            "total {total} should cover the wrapped file content"
+        );
+    }
+
+    #[tokio::test]
+    async fn call_load_skill_does_not_mark_body_under_the_limit() {
+        let tmp = TempDir::new().unwrap();
+        let skill_md = tmp.path().join("SKILL.md");
+        std::fs::write(
+            &skill_md,
+            "---\nname: small\ndescription: desc\n---\nBody.\n\n## Rules\n\nRefuse X.\n",
+        )
+        .unwrap();
+        let skills = vec![make_skill("small", "desc", skill_md)];
+        let result = call_load_skill(&serde_json::json!({"name": "small"}), &skills).await;
+        assert!(!result.is_error);
+        let text = text_content(&result);
+        assert!(!text.contains("[truncated:"), "unexpected marker: {text}");
+        assert!(text.contains("Refuse X."), "tail must survive: {text}");
     }
 }


### PR DESCRIPTION
## Summary

`load_skill` capped its output at `MAX_SKILL_BODY_BYTES` (32 KiB) and returned the head as if it were the whole thing — no log, no marker, `is_error: false`. Since the tail of a SKILL.md is usually where the output format, refusal rules, and verification checklist live, an oversized skill loads "successfully" and then behaves subtly wrong, and nothing anywhere says why.

Both truncating call sites in `crates/buzz-agent/src/builtin.rs` now go through one helper that appends `[truncated: N of M bytes shown; the remainder was dropped by load_skill]` and emits a `tracing::warn!` naming the requested skill. Behaviour is otherwise unchanged: content under the cap is returned byte-identical.

### Related issue

Fixes #4163.

Duplicate search: **none found.** No open or closed PR mentions `load_skill`, `MAX_SKILL_BODY_BYTES`, or skill truncation. The nearest neighbours are all unrelated: #3532 (`fix/pack-validate-skill-metadata`, validation of skill *metadata* at pack time), #4027 (Windows skill symlinks), #2525 (skill directory rename). #3262 (draft, swapping the agent loop onto goose) touches `builtin.rs` but not this path.

### Decisions

Three calls worth flagging, since the issue left them open:

1. **The marker is charged against the cap, not appended past it.** The patch sketched in the issue appends after truncating, so the result exceeds 32 KiB. Two things argue against that here: `truncate_middle` in `mcp.rs` already reserves `ELISION_MARKER_ALLOWANCE` inside its own budget, so reserving is the house pattern; and the existing tests `call_load_skill_truncates_large_body` / `call_load_skill_truncates_large_supporting_file` both assert `text.len() <= MAX_SKILL_BODY_BYTES`, which the issue's version would break. The cap is a context budget, so it should stay one. Edge case: if the limit is ever smaller than the reserved allowance, the marker still wins and the result overruns — reporting the loss beats honouring a budget too small to report it in. That is unreachable at 32 KiB but the helper is total, and there's a test pinning it.

2. **Kept tail-truncation rather than switching to `truncate_middle`.** Middle-elision would preserve the tail, which for a skill body is often the part that matters most — a real argument, and it's a one-line change if you'd rather have it. I left it because it's a behaviour change beyond what the issue reports, and because the failure modes differ: a head cut produces a document that visibly stops, whereas a middle elision produces one that reads as intact at both ends while the procedure the tail's rules refer to is gone. `truncate_middle`'s own doc comment justifies itself for *tool output* ("test summaries, error trailers"), which is a different shape of text from an authored document. The bug filed is "silent", not "wrong half" — fixing the reporting first leaves the choice of which half survives as a clean, separate decision.

3. **Both call sites, one helper.** The supporting-file path had the identical defect and is easy to miss, so the marker construction lives in `truncate_with_marker` and both sites call it. The `tracing::warn!` logs the name as requested (`my-skill` or `my-skill/references/foo.md`), which is the string the caller actually passed.

### Testing

`cargo test -p buzz-agent` — 389 unit + 85 integration tests pass, including the two pre-existing cap assertions. `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean on the crate. I scoped to `buzz-agent` rather than running `just ci`; the change is confined to one file in that crate.

New tests, matching the style of `truncate_middle_respects_max_and_boundaries`:

- `truncate_with_marker_reports_accurate_byte_counts` — marker fits inside the cap, and its two counts match the kept length and the pre-cut length.
- `truncate_with_marker_leaves_content_under_the_limit_byte_identical` — no marker, byte-identical passthrough.
- `truncate_with_marker_keeps_valid_utf8_on_a_multibyte_cut` — `"é".repeat(60_000)` at odd limits, so the cut lands mid-character.
- `truncate_with_marker_keeps_the_marker_when_the_limit_cannot_hold_it` — pins the edge case in decision 1.
- `call_load_skill_marks_truncated_body` — end-to-end on the SKILL.md path; a `## SENTINEL` tail is dropped and the marker reports it. Fails on `main`.
- `call_load_skill_marks_truncated_supporting_file` — same for the supporting-file path. Fails on `main`.
- `call_load_skill_does_not_mark_body_under_the_limit` — no marker on a normal skill.

**What I could not test:** I have no model credential wired to this checkout, so I have not observed an agent reading the marker in a live session — same caveat as the issue. The change is covered by the unit tests above and by reading the call path; I have not run a real `load_skill` round-trip against a provider.

### Scope

`load_skill` only. `MAX_HINTS_BYTES` and the `AGENTS.md` chain in `hints.rs` have the same shape and are deliberately left alone — the issue names that as a separate, milder follow-up (the chain is additive rather than a single authored document), and a focused diff reviews faster. Happy to do it in a second PR if you want it. No UI change, so no screenshots.
