### PR TITLE
fix(dev-env): correct Keycloak healthcheck port and migrations auto-apply doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,9 @@ crates/
 desktop/              # Tauri 2 + React 19 desktop app
 web/                  # Browser web client (repo browser, served by the relay)
 mobile/               # Flutter mobile app
-migrations/           # SQL migrations (auto-applied on relay startup)
+migrations/           # SQL migrations — applied via `just migrate`; the relay
+                      # can also auto-apply them at startup with BUZZ_AUTO_MIGRATE=true
+                      # (default in the Helm chart, off elsewhere)
 scripts/              # Dev tooling
 .env.example          # Config template — copy to .env before running
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
     command: start-dev --http-port=8080
     environment:
       KC_DB: dev-mem
+      KC_HEALTH_ENABLED: "true"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
     ports:
@@ -86,7 +87,7 @@ services:
     networks:
       - buzz-net
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && cat <&3 | grep -q '200 OK'"]
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && cat <&3 | grep -q '200 OK'"]
       interval: 10s
       timeout: 5s
       retries: 15


### PR DESCRIPTION
## What
- Point Keycloak's docker-compose healthcheck at its management port (9000)
  instead of the main port (8080), where /health/ready 404s.
- Correct AGENTS.md's repo-structure comment: migrations are not
  "auto-applied on relay startup" by default — BUZZ_AUTO_MIGRATE defaults
  to false, and local dev applies them via `just migrate`/`just setup`.

## Why
Ran into both while onboarding a fresh clone. Keycloak reported "unhealthy"
in `docker compose ps` despite starting fine — Keycloak 26 moved health
endpoints to a separate management interface on port 9000 by default, so
the existing healthcheck (written for port 8080) always 404'd. Separately,
the relay's boot log said "Skipping database migrations because
BUZZ_AUTO_MIGRATE is not enabled," which contradicted the repo-structure
doc.

Note: I also found stale `TYPESENSE_*` vars in the root `.env.example`
during this pass, but that's already covered by #2555, so I left it out
here to avoid duplicating that effort.

## Testing
- `docker compose up -d keycloak` — container now reports `healthy` within
  ~15s (previously stayed `unhealthy` indefinitely)
- `docker compose config --quiet` — validates
- `just ci` — full local gate passes (fmt, clippy, unit tests, desktop
  build, Tauri check, mobile tests — 1022 mobile tests passed)

Searched open/closed PRs and issues for "keycloak", "typesense", and
"BUZZ_AUTO_MIGRATE" — no overlap besides #2555 noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
