### PR TITLE
fix(desktop): throttle devicechange-driven media enumeration

### DIFF
--- a/desktop/src/features/huddle/lib/useAudioDevices.ts
+++ b/desktop/src/features/huddle/lib/useAudioDevices.ts
@@ -16,14 +16,38 @@ export function useAudioDevices(
 
   // Enumerate audio input devices on mount and when devices change.
   React.useEffect(() => {
+    // WebKitGTK's libcamera backend can retry a failing camera manager in a
+    // tight loop, firing `devicechange` on every cycle. Each cycle spawns a new
+    // libcamera manager and leaks file descriptors in the web process; on
+    // machines where the camera fails to enumerate ("No such device") this
+    // escalates until EMFILE aborts the app ("Too many open files", GLib
+    // "Creating pipes for GWakeup"). Throttle refreshes so the frontend can't
+    // amplify the loop, and back off after repeated failures.
+    const MIN_REFRESH_MS = 2000;
+    const BACKOFF_MS = 30_000;
+    const MAX_FAILURES = 3;
+    let lastRefresh = 0;
+    let failures = 0;
+    let backoffUntil = 0;
+
     function refreshDevices() {
+      const now = Date.now();
+      if (now < backoffUntil || now - lastRefresh < MIN_REFRESH_MS) {
+        return;
+      }
+      lastRefresh = now;
       navigator.mediaDevices
         .enumerateDevices()
-        .then((devices) =>
-          setAudioDevices(devices.filter((d) => d.kind === "audioinput")),
-        )
+        .then((devices) => {
+          failures = 0;
+          setAudioDevices(devices.filter((d) => d.kind === "audioinput"));
+        })
         .catch(() => {
-          /* best-effort */
+          failures += 1;
+          if (failures >= MAX_FAILURES) {
+            backoffUntil = Date.now() + BACKOFF_MS;
+            failures = 0;
+          }
         });
     }
     refreshDevices();


### PR DESCRIPTION
## Summary

On Linux, Buzz Desktop **crashes on its own** a few seconds after launch on machines where the webcam fails to enumerate: `GLib-ERROR **: Creating pipes for GWakeup: Too many open files` aborts the `WebKitWebProcess`.

This PR breaks the frontend half of the feedback loop that drives the crash: `useAudioDevices` listened to `devicechange` with no throttle, so each failed media probe re-triggered `enumerateDevices()`.

## Root cause

1. `HuddleProvider` is mounted at the app root (`desktop/src/app/AppShell.tsx`), so `useAudioDevices` calls `navigator.mediaDevices.enumerateDevices()` on mount and registers a `devicechange` listener (`desktop/src/features/huddle/lib/useAudioDevices.ts`).
2. WebKitGTK (media stream enabled at boot by #2771) probes devices through libcamera.
3. On affected hardware, libcamera **cannot start the camera manager** — `Failed to start camera manager: No such device` (reproduced with an integrated UVC camera, 2 interfaces, 4 `/dev/video*` nodes).
4. WebKit retries the probe in a tight loop; every cycle spawns a new `camera_manager` process and **leaks file descriptors in the web process**.
5. Each cycle emits `devicechange`, and the frontend listener called `enumerateDevices()` again **without any throttle** — amplifying the loop.
6. FD exhaustion → `EMFILE` → GLib abort in `WebKitWebProcess` → the whole app dies.

Measured on the affected machine (idle app, no user interaction, 40 s):

| t+ | FDs in WebKitWebProcess |
|----|-------------------------|
| 5 s | 144 |
| 10 s | 176 |
| 15 s | 229 |
| 20 s | 257 |
| 25 s | 295 |
| 30 s | 335 |
| 35 s | 375 |
| 40 s | 403 |

~6.5 leaked FDs/s (linear, never released), plus ~16 `camera_manager` spawns per second (new PID on every log line). `ulimit -n` was 524288, so this is a genuine leak, not a low system limit.

## Fix

Throttle `devicechange`-driven refreshes to at most one per 2 s, and back off for 30 s after 3 consecutive failures. This breaks the feedback loop while keeping hotplug responsiveness (a healthy device still gets picked up on the next refresh).

## Scope / honesty

The frontend throttle stops the **amplification**, but the internal WebKitGTK/libcamera probe loop and FD leak remain — on a broken-camera machine the app would still crash, just later. The real fix belongs upstream in WebKitGTK (stop retrying / close FDs when the camera manager fails to start) and should be reported to bugs.webkit.org. This PR is the Buzz-side mitigation.

## Duplicate search

- `repo:block/buzz type:pr "open files"` → 15 PRs, none about this FD leak / camera retry loop.
- `repo:block/buzz type:pr devicechange` / `enumerateDevices` → one open PR: **#3817** `fix(huddle): guard mediaDevices access when the API is unavailable`.
- **#3817 is not a duplicate** — it guards `navigator.mediaDevices` being `undefined` (non-secure context → TypeError crash on mount). This PR handles the case where the API exists but the camera fails to enumerate (EMFILE crash). Complementary.
- ⚠️ Both touch `useAudioDevices.ts` (same `refreshDevices`); if #3817 merges first this branch will need a rebase.

## Test plan

- Affected machine: app no longer crashes at boot; camera spam in stderr drops to ≤1 probe per 2 s and stops after repeated failures (30 s backoff).
- Healthy machine: device list still populates; hotplug still works (devicechange triggers a refresh, throttled).
- `pnpm lint` / `tsc --noEmit` pass.
