### PR TITLE
docs(contributing): fix pinned Rust version and drop stale e2e_mcp.rs reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ We review as capacity allows — focused PRs that follow this guide move fastest
 
 | Tool | Version | Notes |
 |------|---------|-------|
-| Rust | 1.88+ | Install via [rustup](https://rustup.rs/) |
+| Rust | 1.95.0 (pinned) | Pinned via `rust-toolchain.toml` — [rustup](https://rustup.rs/) installs it automatically |
 | Node.js | 24+ | Required for desktop app commands and `just ci` |
 | pnpm | 10+ | Required for desktop app commands and `just ci` |
 | Flutter | 3.41+ | Required for mobile app — install via [flutter.dev](https://docs.flutter.dev/get-started/install) |
@@ -216,7 +216,6 @@ already running.
 End-to-end tests live in `crates/buzz-test-client/tests/`:
 
 - `e2e_relay.rs` — WebSocket relay tests
-- `e2e_mcp.rs` — MCP tool tests
 - `e2e_nostr_interop.rs` — Nostr protocol interoperability tests
 - `e2e_media.rs` — media upload/download tests
 - `e2e_media_extended.rs` — extended media tests (GIF, image processing)


### PR DESCRIPTION
## Summary
Fixes two spots where `CONTRIBUTING.md` has drifted from the tree:

- **Rust version**: the prerequisites table said `1.88+`, but the toolchain is pinned to **1.95.0** in `rust-toolchain.toml`, which rustup picks up automatically. The row now states the pinned version and points at the pin file (matching the `lefthook` row's "(Hermit-pinned)" idiom), so the table can't silently disagree with the pin again.
- **Stale test reference**: the End-to-End Tests section listed `e2e_mcp.rs — MCP tool tests`, but that file no longer exists in `crates/buzz-test-client/tests/`. The other four listed files all still exist, so this is a one-line removal. (`AGENTS.md`'s equivalent e2e list already omits it.)

### Related issue
None found — searched open and closed issues/PRs for the Rust-version row, `e2e_mcp`, and CONTRIBUTING drift; nothing covers these.

### Testing
Docs-only change; no code paths touched. Verified against `main` @ `ac4fa13`:
- `cat rust-toolchain.toml` → `channel = "1.95.0"`
- `ls crates/buzz-test-client/tests/` → no `e2e_mcp.rs`; `e2e_relay.rs`, `e2e_nostr_interop.rs`, `e2e_media.rs`, `e2e_media_extended.rs` all present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
