### PR TITLE
fix(media): allow direct inline playback

### DIFF
--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -586,6 +586,22 @@ fn validate_media_path(sha256_ext: &str) -> Result<(), MediaError> {
 /// additional range requests.
 const MAX_RANGE_CHUNK: u64 = 16 * 1024 * 1024;
 
+/// CSP for a blob response, kept least-privilege while allowing browser-native
+/// viewers to load the response as their generated `<img>` or `<video>` source.
+///
+/// Chromium applies the blob response's CSP when a user navigates directly to
+/// an image or video URL. A bare `default-src 'none'` therefore blocks the
+/// browser-generated media element from loading the very response being viewed.
+fn blob_content_security_policy(content_type: &str) -> &'static str {
+    if content_type.starts_with("image/") {
+        "default-src 'none'; img-src 'self'"
+    } else if content_type.starts_with("video/") {
+        "default-src 'none'; media-src 'self'"
+    } else {
+        "default-src 'none'"
+    }
+}
+
 /// GET /media/{sha256_ext} — Blossom BUD-01 serve blob, with HTTP 206 range support.
 ///
 /// `sha256_ext` is either:
@@ -657,14 +673,16 @@ pub(crate) async fn serve_blob_for_tenant(
     };
 
     // Images and video render inline; generic files force download. This is the
-    // primary defence for non-previewable types — combined with `nosniff` and
-    // `CSP: default-src 'none'`, an attachment disposition prevents an uploaded
-    // file from ever executing or rendering as active content in the client.
+    // primary defence for non-previewable types — combined with `nosniff` and a
+    // restrictive CSP, an attachment disposition prevents an uploaded file from
+    // ever executing or rendering as active content in the client. Inline media
+    // gets only its own CSP source directive so direct browser navigation works.
     let disposition = if buzz_media::serve_inline(&content_type) {
         "inline"
     } else {
         "attachment"
     };
+    let content_security_policy = blob_content_security_policy(&content_type);
 
     let key = resolve_s3_key(&state.media_storage, tenant, sha256_ext).await?;
 
@@ -694,7 +712,7 @@ pub(crate) async fn serve_blob_for_tenant(
                 .header(header::CONTENT_LENGTH, total.to_string())
                 .header(header::CONTENT_DISPOSITION, disposition)
                 .header(header::CACHE_CONTROL, cache_control)
-                .header(header::CONTENT_SECURITY_POLICY, "default-src 'none'")
+                .header(header::CONTENT_SECURITY_POLICY, content_security_policy)
                 .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
                 .header(header::ACCEPT_RANGES, "bytes")
                 .body(axum::body::Body::from_stream(stream))
@@ -736,7 +754,7 @@ pub(crate) async fn serve_blob_for_tenant(
                         .header(header::CONTENT_DISPOSITION, disposition)
                         .header(header::ACCEPT_RANGES, "bytes")
                         .header(header::CACHE_CONTROL, cache_control)
-                        .header(header::CONTENT_SECURITY_POLICY, "default-src 'none'")
+                        .header(header::CONTENT_SECURITY_POLICY, content_security_policy)
                         .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
                         .body(axum::body::Body::from(chunk))
                         .map_err(|_| MediaError::Internal)?)
@@ -943,6 +961,30 @@ mod tests {
         let bytes = b"\x00\x00\x00\x18ftypPRIV\x00\x00\x00\x00isommp42";
         assert!(infer::get(bytes).is_none());
         assert!(should_stream_as_video(bytes));
+    }
+
+    #[test]
+    fn inline_media_csp_allows_only_its_browser_native_viewer() {
+        assert_eq!(
+            blob_content_security_policy("video/mp4"),
+            "default-src 'none'; media-src 'self'"
+        );
+        assert_eq!(
+            blob_content_security_policy("image/png"),
+            "default-src 'none'; img-src 'self'"
+        );
+    }
+
+    #[test]
+    fn attachment_csp_keeps_all_resource_loading_disabled() {
+        assert_eq!(
+            blob_content_security_policy("application/pdf"),
+            "default-src 'none'"
+        );
+        assert_eq!(
+            blob_content_security_policy("application/octet-stream"),
+            "default-src 'none'"
+        );
     }
 
     async fn test_state() -> Arc<AppState> {


### PR DESCRIPTION
## What

- Select a least-privilege CSP by stored MIME type.
- Allow only same-origin media for video and same-origin images for image blobs.
- Apply the policy consistently to full 200 and ranged 206 responses.
- Preserve default-src none for downloadable attachments.

## Why

Direct navigation to a Buzz-hosted MP4 currently creates a browser-native video element, but the response header default-src none falls back to media-src none and blocks the element from loading its own URL. The files and range responses are valid; the response policy is the failure.

## Verification

- cargo fmt --check
- cargo check -p buzz-relay --lib
- cargo clippy -p buzz-relay --lib -- -D warnings
- Reproduced on the reported live MP4 in Chromium: currentSrc empty, readyState 0, networkState 3, and an explicit CSP console violation.
- Re-ran the same live asset while substituting the patched response header: currentSrc populated, readyState 4, duration 6.533333, and no media error.
- Both reported MP4s were SHA-256 matched, ffprobe validated as H.264 avc1/yuv420p, and decoded end-to-end with ffmpeg.

Focused cargo test -p buzz-relay csp was attempted locally but could not compile the Mesh dev dependency because this machine lacks pkg-config and OpenSSL development headers. The relay library and strict Clippy compilation both pass.

## Live path

This needs to reach the relay behind buzz.sovereignfirm.com. Merge alone does not make it live. The documented upstream path is main -> relay-v* release via just release-relay -> the docker.yml workflow publishes ghcr.io/block/buzz -> the Sovereign Firm relay service consumes the released image. This PR does not deploy.