### PR TITLE
fix(relay): widen per-peer audio channel capacity 8->16 frames

### DIFF
--- a/crates/buzz-relay/src/audio/room.rs
+++ b/crates/buzz-relay/src/audio/room.rs
@@ -36,8 +36,15 @@ pub enum PeerCtrl {
     Close,
 }
 
-/// Audio channel capacity per peer: 8 frames = 160ms at 20ms/frame.
-const AUDIO_CHANNEL_CAPACITY: usize = 8;
+/// Audio channel capacity per peer: 16 frames = 320ms at 20ms/frame.
+///
+/// Widened from 8 (160ms) after measuring jitter spikes of 150-152ms on an
+/// ordinary residential-ISP path to the relay — right at the old ceiling, so
+/// brief jitter was enough to make `try_send` drop frames outright (heard as
+/// audio grain, not lag). This raises the drop threshold; it does not change
+/// per-peer memory bounds materially (still a handful of Opus frames, each
+/// well under 1 KB).
+const AUDIO_CHANNEL_CAPACITY: usize = 16;
 /// Control channel capacity per peer: 32 slots — must never drop joined/left
 /// messages, which are state-bearing (they maintain the client's peer_index →
 /// pubkey map). Sized generously: even 30 simultaneous join/leave events fit.


### PR DESCRIPTION
## Summary
- `AUDIO_CHANNEL_CAPACITY` in `crates/buzz-relay/src/audio/room.rs` gates the per-peer `mpsc` channel the relay fans audio frames out through; at 8 frames (160ms) it sits right at the jitter ceiling for an ordinary residential-ISP path, so `try_send` was dropping frames outright under normal jitter — heard as audio grain, not lag.
- Widens it to 16 frames (320ms) to give headroom against that jitter. This reduces how often frames get dropped; it does not recover content once a frame is actually lost (that needs receive-side Opus FEC, which requires forking the upstream `neteq` crate — tracked separately in #4177).

## Context
Diagnosed live against the `web3services` GKE deployment (`buzz-cluster`) — pod CPU/mem were near-idle (ruling out a sizing/resourcing cause), but pings to the relay's LB IP showed jitter spikes of 150-152ms sitting right at the old 160ms channel-capacity ceiling.

## Test plan
- [x] `cargo test -p buzz-relay audio::room` — 9/9 pass
- [x] `cargo fmt -p buzz-relay -- --check` — clean
- [x] `cargo clippy -p buzz-relay --all-targets -- -D warnings` — clean
- [ ] Live verification against the `web3services` relay deployment (pending maintainer go-ahead to redeploy — this PR does not itself deploy anything)

Co-Authored-By: brunkstr <132263425+brunkstr@users.noreply.github.com>