### PR TITLE
fix(desktop): harden Windows managed-agent lifecycle recovery

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1081,6 +1081,7 @@ dependencies = [
  "opus",
  "plist",
  "png 0.18.1",
+ "processkit",
  "regex",
  "reqwest 0.13.4",
  "rodio",
@@ -5751,6 +5752,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "mutants"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ac067452ff1aca8c5002111bd6b1c895baee6e45fcbc44e0193aea17be56"
+
+[[package]]
 name = "n0-error"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7618,6 +7625,23 @@ dependencies = [
  "tokio",
  "tracing",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "processkit"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1728d92a6cfe686aacdaef7a81c3f2364dbf005fa86cf4c3b5b005039cf6e157"
+dependencies = [
+ "async-trait",
+ "encoding_rs",
+ "libc",
+ "mutants",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -56,7 +56,8 @@ user-idle = { version = "0.6", default-features = false }
 plist = "1"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Security", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_Registry", "Win32_System_Threading", "Win32_Foundation"] }
+windows-sys = { version = "0.61", features = ["Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Registry", "Win32_System_Threading", "Win32_Foundation"] }
+processkit = "3.1.0"
 keyring = { version = "3.6.3", default-features = false, features = ["windows-native", "vendored"], optional = true }
 user-idle = { version = "0.6", default-features = false }
 

--- a/desktop/src-tauri/src/commands/agent_config.rs
+++ b/desktop/src-tauri/src/commands/agent_config.rs
@@ -1,6 +1,3 @@
-use serde::Serialize;
-use tauri::{AppHandle, State};
-
 use crate::{
     app_state::AppState,
     managed_agents::{
@@ -12,12 +9,14 @@ use crate::{
                 NormalizedField, RuntimeConfigSurface, SessionConfigCache,
             },
         },
-        current_instance_id, known_acp_runtime, load_managed_agents, load_personas,
+        known_acp_runtime, load_managed_agents, load_personas,
         resolve_effective_prompt_model_provider, save_managed_agents, sync_managed_agent_processes,
         AgentDefinition, GlobalAgentConfig, KnownAcpRuntime, ManagedAgentRecord,
         ManagedAgentRuntimeKey,
     },
 };
+use serde::Serialize;
+use tauri::{AppHandle, State};
 
 /// Subset of the goose file config exposed to the frontend for gate evaluation.
 ///
@@ -349,6 +348,7 @@ pub async fn get_agent_config_surface(
     state: State<'_, AppState>,
 ) -> Result<RuntimeConfigSurface, String> {
     let record = {
+        let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(&state)?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -359,12 +359,12 @@ pub async fn get_agent_config_surface(
             .lock()
             .map_err(|e| e.to_string())?;
         let (sync_changed, exited_pubkeys) =
-            sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
+            sync_managed_agent_processes(&app, &mut records, &mut runtimes);
         if sync_changed {
             save_managed_agents(&app, &records)?;
         }
-        for pubkey in &exited_pubkeys {
-            state.clear_agent_session_caches(pubkey);
+        for key in &exited_pubkeys {
+            state.clear_agent_session_caches(&key.pubkey);
         }
         records
             .into_iter()

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -465,6 +465,7 @@ async fn restart_setup_mode_agents_after_install(
             .iter()
             .filter(|record| {
                 let is_local = record.backend == BackendKind::Local;
+                let auto_restart = record.auto_restart_on_config_change;
                 let effective_cmd = record_agent_command(record, &personas);
                 let runtime_matches =
                     known_acp_runtime(&effective_cmd).is_some_and(|r| r.id == runtime_id_owned);
@@ -485,7 +486,7 @@ async fn restart_setup_mode_agents_after_install(
                         && crate::managed_agents::process_is_running(runtime.child.id())
                 });
                 should_restart_after_install(
-                    is_local,
+                    is_local && auto_restart,
                     pid_alive,
                     runtime_matches,
                     setup_mode,
@@ -517,11 +518,6 @@ async fn restart_setup_mode_agents_after_install(
     (restarted_count, failed_restart_count)
 }
 
-/// Stop-then-start a single setup-mode agent after a successful adapter install.
-///
-/// Mirrors `restart_local_agent_on_config_change` from `global_agent_config.rs`:
-/// eligibility is re-verified under the store lock before the stop, then the
-/// agent is restarted via `start_local_agent_with_preflight`.
 async fn restart_single_agent_after_install(
     app: &tauri::AppHandle,
     pubkey: &str,
@@ -530,50 +526,54 @@ async fn restart_single_agent_after_install(
     use crate::{
         app_state::AppState,
         managed_agents::{
-            agent_readiness, current_instance_id, find_managed_agent_mut, known_acp_runtime,
-            load_global_agent_config, load_managed_agents, load_personas, record_agent_command,
+            agent_readiness, find_managed_agent_mut, known_acp_runtime, load_global_agent_config,
+            load_managed_agents, load_personas, persist_stop, record_agent_command,
             resolve_effective_agent_env, save_managed_agents, stop_managed_agent_process,
             sync_managed_agent_processes, AgentReadiness, BackendKind,
         },
     };
     use tauri::Manager;
-
+    let state = app.state::<AppState>();
+    let mesh_model_id = match super::agents::preflight_local_agent_pairs(app, &state, pubkey).await
+    {
+        Ok(model_id) => model_id,
+        Err(error) => {
+            eprintln!("buzz-desktop: install_acp_runtime: preflight failed for {pubkey}: {error}");
+            return InstallRestartOutcome::Skipped;
+        }
+    };
     let app_for_stop = app.clone();
     let pubkey_owned = pubkey.to_string();
     let runtime_id_owned = runtime_id.to_string();
-
     let stop_result = tokio::task::spawn_blocking(move || {
         let state = app_for_stop.state::<AppState>();
-
+        let _transition = state
+            .managed_agent_runtime_transition
+            .lock()
+            .map_err(|e| e.to_string())?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
             .map_err(|e| format!("failed to acquire store lock: {e}"))?;
-
         let mut records = load_managed_agents(&app_for_stop)?;
         let mut runtimes = state
             .managed_agent_processes
             .lock()
             .map_err(|e| format!("failed to acquire runtimes lock: {e}"))?;
 
-        // Sync process state so PID liveness reflects current reality.
-        let (sync_changed, _) = sync_managed_agent_processes(
-            &mut records,
-            &mut runtimes,
-            &current_instance_id(&app_for_stop),
-        );
+        let (sync_changed, _) =
+            sync_managed_agent_processes(&app_for_stop, &mut records, &mut runtimes);
         if sync_changed {
             save_managed_agents(&app_for_stop, &records)?;
         }
-
-        // Re-verify eligibility under lock.
         let record = records
             .iter()
             .find(|r| r.pubkey == pubkey_owned)
             .ok_or_else(|| format!("agent {pubkey_owned} not found"))?;
-
-        if record.backend != BackendKind::Local {
-            return Err(format!("agent {pubkey_owned} is no longer a local agent"));
+        if record.backend != BackendKind::Local || !record.auto_restart_on_config_change {
+            return Err(format!(
+                "agent {pubkey_owned} is no longer eligible for automatic restart"
+            ));
         }
         let runtime_keys =
             crate::managed_agents::managed_agent_runtime_keys(&runtimes, &pubkey_owned);
@@ -614,56 +614,56 @@ async fn restart_single_agent_after_install(
             ));
         }
 
-        // Stop the process.
         let record_mut = find_managed_agent_mut(&mut records, &pubkey_owned)?;
-        stop_managed_agent_process(&app_for_stop, record_mut, &mut runtimes)?;
+        let stopped = stop_managed_agent_process(&app_for_stop, record_mut, &mut runtimes);
+        persist_stop(stopped, || save_managed_agents(&app_for_stop, &records))?;
         save_managed_agents(&app_for_stop, &records)?;
-
-        Ok(runtime_keys)
+        let relay_urls: Vec<_> = runtime_keys.into_iter().map(|key| key.relay_url).collect();
+        drop(runtimes);
+        drop(_store_guard);
+        super::agents::start_local_agent_pairs_under_transition(
+            &app_for_stop,
+            &state,
+            &pubkey_owned,
+            &relay_urls,
+            &mesh_model_id,
+            &_transition,
+        )
+        .map(|_| ())
+        .map_err(|error| format!("start failed after serialized stop: {error}"))
     })
     .await;
 
-    let runtime_keys = match stop_result {
-        Ok(Ok(runtime_keys)) => runtime_keys,
-        Ok(Err(e)) => {
-            eprintln!("buzz-desktop: install_acp_runtime: skipping restart of {pubkey}: {e}");
-            return InstallRestartOutcome::Skipped;
-        }
-        Err(e) => {
-            eprintln!(
-                "buzz-desktop: install_acp_runtime: spawn_blocking failed for stop of {pubkey}: {e}"
-            );
-            return InstallRestartOutcome::Skipped;
-        }
-    };
-
-    let relay_urls: Vec<_> = runtime_keys.into_iter().map(|key| key.relay_url).collect();
-    let state = app.state::<AppState>();
-    match super::agents::start_local_agent_pairs_with_preflight(app, &state, pubkey, &relay_urls)
-        .await
-    {
-        Ok(_) => {
+    match stop_result {
+        Ok(Ok(())) => {
             eprintln!(
                 "buzz-desktop: install_acp_runtime: restarted setup-mode agent {pubkey} after install"
             );
             InstallRestartOutcome::Restarted
         }
-        Err(e) => {
-            eprintln!(
-                "buzz-desktop: install_acp_runtime: failed to start {pubkey} after install: {e}"
-            );
-            if let Err(save_err) = persist_last_error_on_install(app, pubkey, &e) {
+        Ok(Err(error)) if error.starts_with("start failed after serialized stop:") => {
+            eprintln!("buzz-desktop: install_acp_runtime: {error}");
+            if let Err(save_error) = persist_last_error_on_install(app, pubkey, &error) {
                 eprintln!(
-                    "buzz-desktop: install_acp_runtime: failed to persist last_error for {pubkey}: {save_err}"
+                    "buzz-desktop: install_acp_runtime: failed to persist last_error for {pubkey}: {save_error}"
                 );
             }
             InstallRestartOutcome::FailedAfterStop
         }
+        Ok(Err(error)) => {
+            eprintln!("buzz-desktop: install_acp_runtime: skipping restart of {pubkey}: {error}");
+            InstallRestartOutcome::Skipped
+        }
+        Err(error) => {
+            eprintln!(
+                "buzz-desktop: install_acp_runtime: spawn_blocking failed for restart of {pubkey}: {error}"
+            );
+            InstallRestartOutcome::Skipped
+        }
     }
 }
 
-/// Persist a `last_error` on the agent record under the store lock.
-/// Best-effort: called only after a failed restart.
+/// Best-effort persistence of install-restart failures under the store lock.
 fn persist_last_error_on_install(
     app: &tauri::AppHandle,
     pubkey: &str,

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -1,7 +1,6 @@
-use std::collections::{BTreeMap, HashSet};
-
 use nostr::Keys;
 use serde::Deserialize;
+use std::collections::{BTreeMap, HashSet};
 use tauri::{AppHandle, State};
 
 use super::agent_model_process::run_agent_models_command;
@@ -17,11 +16,11 @@ use super::agent_update_rollback::{rollback_failed_agent_update, AgentUpdateRoll
 use crate::{
     app_state::AppState,
     managed_agents::{
-        build_managed_agent_summary, current_instance_id, discovery_env_with_baked_floor,
-        find_managed_agent_mut, known_acp_runtime, load_global_agent_config, load_managed_agents,
-        load_personas, managed_agent_avatar_url, missing_command_message, normalize_agent_args,
-        resolve_command, save_managed_agents, sync_managed_agent_processes, try_regenerate_nest,
-        AgentModelInfo, AgentModelsResponse, UpdateManagedAgentRequest, UpdateManagedAgentResponse,
+        build_managed_agent_summary, discovery_env_with_baked_floor, find_managed_agent_mut,
+        known_acp_runtime, load_global_agent_config, load_managed_agents, load_personas,
+        managed_agent_avatar_url, missing_command_message, normalize_agent_args, resolve_command,
+        save_managed_agents, sync_managed_agent_processes, try_regenerate_nest, AgentModelInfo,
+        AgentModelsResponse, UpdateManagedAgentRequest, UpdateManagedAgentResponse,
         DEFAULT_ACP_COMMAND,
     },
     relay::{relay_ws_url_with_override, sync_managed_agent_profile},
@@ -39,6 +38,7 @@ pub async fn get_agent_models(
     state: State<'_, AppState>,
 ) -> Result<AgentModelsResponse, String> {
     let (resolved_acp, agent_command, discovery) = {
+        let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(&state)?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -49,12 +49,12 @@ pub async fn get_agent_models(
             .lock()
             .map_err(|e| e.to_string())?;
         let (sync_changed, exited_pubkeys) =
-            sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
+            sync_managed_agent_processes(&app, &mut records, &mut runtimes);
         if sync_changed {
             save_managed_agents(&app, &records)?;
         }
-        for pubkey in &exited_pubkeys {
-            state.clear_agent_session_caches(pubkey);
+        for key in &exited_pubkeys {
+            state.clear_agent_session_caches(&key.pubkey);
         }
 
         let record = records
@@ -815,6 +815,7 @@ pub async fn update_managed_agent(
 ) -> Result<UpdateManagedAgentResponse, String> {
     // Phase 1: local save (synchronous, under lock)
     let (summary, sync_params, rollback) = {
+        let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(&state)?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -824,10 +825,9 @@ pub async fn update_managed_agent(
             .managed_agent_processes
             .lock()
             .map_err(|e| e.to_string())?;
-        let (_, exited_pubkeys) =
-            sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
-        for pubkey in &exited_pubkeys {
-            state.clear_agent_session_caches(pubkey);
+        let (_, exited_pubkeys) = sync_managed_agent_processes(&app, &mut records, &mut runtimes);
+        for key in &exited_pubkeys {
+            state.clear_agent_session_caches(&key.pubkey);
         }
 
         let record = find_managed_agent_mut(&mut records, &input.pubkey)?;

--- a/desktop/src-tauri/src/commands/agent_settings.rs
+++ b/desktop/src-tauri/src/commands/agent_settings.rs
@@ -4,9 +4,8 @@ use tauri::{AppHandle, Manager, State};
 use crate::{
     app_state::AppState,
     managed_agents::{
-        build_managed_agent_summary, current_instance_id, find_managed_agent_mut,
-        load_managed_agents, load_personas, save_managed_agents, sync_managed_agent_processes,
-        ManagedAgentSummary,
+        build_managed_agent_summary, find_managed_agent_mut, load_managed_agents, load_personas,
+        save_managed_agents, sync_managed_agent_processes, ManagedAgentSummary,
     },
     util::now_iso,
 };
@@ -26,6 +25,7 @@ pub async fn set_managed_agent_start_on_app_launch(
 ) -> Result<ManagedAgentSummary, String> {
     tokio::task::spawn_blocking(move || {
         let state = app.state::<AppState>();
+        let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(&state)?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -37,12 +37,12 @@ pub async fn set_managed_agent_start_on_app_launch(
             .map_err(|error| error.to_string())?;
 
         let (sync_changed, exited_pubkeys) =
-            sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
+            sync_managed_agent_processes(&app, &mut records, &mut runtimes);
         if sync_changed {
             save_managed_agents(&app, &records)?;
         }
-        for pubkey in &exited_pubkeys {
-            state.clear_agent_session_caches(pubkey);
+        for key in &exited_pubkeys {
+            state.clear_agent_session_caches(&key.pubkey);
         }
 
         {
@@ -77,6 +77,7 @@ pub async fn set_managed_agent_auto_restart(
 ) -> Result<ManagedAgentSummary, String> {
     tokio::task::spawn_blocking(move || {
         let state = app.state::<AppState>();
+        let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(&state)?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -88,12 +89,12 @@ pub async fn set_managed_agent_auto_restart(
             .map_err(|error| error.to_string())?;
 
         let (sync_changed, exited_pubkeys) =
-            sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
+            sync_managed_agent_processes(&app, &mut records, &mut runtimes);
         if sync_changed {
             save_managed_agents(&app, &records)?;
         }
-        for pubkey in &exited_pubkeys {
-            state.clear_agent_session_caches(pubkey);
+        for key in &exited_pubkeys {
+            state.clear_agent_session_caches(&key.pubkey);
         }
 
         {

--- a/desktop/src-tauri/src/commands/agent_update_rollback.rs
+++ b/desktop/src-tauri/src/commands/agent_update_rollback.rs
@@ -79,6 +79,7 @@ pub(super) fn rollback_failed_agent_update(
     rollback: AgentUpdateRollback,
 ) -> Result<(), String> {
     {
+        let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(state)?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()

--- a/desktop/src-tauri/src/commands/agents.rs
+++ b/desktop/src-tauri/src/commands/agents.rs
@@ -1,14 +1,14 @@
 use nostr::{Keys, ToBech32};
 use tauri::{AppHandle, State};
 
+use crate::managed_agents::mesh_preflight::verify_relay_mesh_preflight;
 use crate::{
     app_state::AppState,
     managed_agents::{
-        build_managed_agent_summary, current_instance_id, discover_provider_candidates,
-        ensure_persona_is_active, find_managed_agent_mut, load_managed_agents, load_personas,
-        load_teams, managed_agent_avatar_url, normalize_agent_args, provider_deploy,
-        resolve_provider_binary, save_managed_agents, start_managed_agent_process,
-        stop_managed_agent_process, stop_managed_agent_workspace_pair,
+        build_managed_agent_summary, discover_provider_candidates, ensure_persona_is_active,
+        find_managed_agent_mut, load_managed_agents, load_personas, load_teams,
+        normalize_agent_args, provider_deploy, resolve_provider_binary, save_managed_agents,
+        start_managed_agent_process, stop_managed_agent_process, stop_managed_agent_workspace_pair,
         sync_managed_agent_processes, try_regenerate_nest, validate_provider_config, BackendKind,
         CreateManagedAgentRequest, CreateManagedAgentResponse, ManagedAgentRecord,
         ManagedAgentSummary, RelayMeshConfig, DEFAULT_ACP_COMMAND, DEFAULT_AGENT_PARALLELISM,
@@ -201,51 +201,6 @@ pub(super) fn archive_managed_agent_pending(app: &AppHandle, state: &AppState, a
     }
 }
 
-fn normalize_relay_mesh(
-    config: Option<&RelayMeshConfig>,
-    backend: &BackendKind,
-) -> Result<Option<RelayMeshConfig>, String> {
-    let Some(config) = config else {
-        return Ok(None);
-    };
-
-    let model_ref = config.model_ref.trim();
-    if model_ref.is_empty() {
-        return Err("Buzz shared compute model is required".to_string());
-    }
-    if backend != &BackendKind::Local {
-        return Err("Buzz shared compute agents must use the local backend".to_string());
-    }
-
-    Ok(Some(RelayMeshConfig {
-        model_ref: model_ref.to_string(),
-    }))
-}
-
-fn trim_to_optional_string(value: &str) -> Option<String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-}
-
-fn resolve_created_avatar_url(
-    requested_avatar_url: Option<&str>,
-    persona_avatar_url: Option<String>,
-    agent_command: &str,
-) -> Option<String> {
-    requested_avatar_url
-        .and_then(trim_to_optional_string)
-        .or_else(|| {
-            persona_avatar_url
-                .as_deref()
-                .and_then(trim_to_optional_string)
-        })
-        .or_else(|| managed_agent_avatar_url(agent_command))
-}
-
 #[cfg(feature = "mesh-llm")]
 async fn ensure_relay_mesh_for_record(
     app: &AppHandle,
@@ -264,13 +219,12 @@ async fn ensure_relay_mesh_for_record(
     Ok(())
 }
 
-pub(super) async fn start_local_agent_pairs_with_preflight(
+pub(super) async fn preflight_local_agent_pairs(
     app: &AppHandle,
     state: &AppState,
     pubkey: &str,
-    relay_urls: &[String],
-) -> Result<ManagedAgentSummary, String> {
-    let record_snapshot = {
+) -> Result<Option<String>, String> {
+    let record = {
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -280,20 +234,27 @@ pub(super) async fn start_local_agent_pairs_with_preflight(
             .find(|record| record.pubkey == pubkey)
             .ok_or_else(|| format!("agent {pubkey} not found"))?
     };
-    if record_snapshot.backend != BackendKind::Local {
+    if record.backend != BackendKind::Local {
         return Err(format!("agent {pubkey} is not a local agent"));
     }
-    let personas_for_preflight = load_personas(app).unwrap_or_default();
-    let global_for_preflight =
-        crate::managed_agents::load_global_agent_config(app).unwrap_or_default();
+    let personas = load_personas(app).unwrap_or_default();
+    let global = crate::managed_agents::load_global_agent_config(app).unwrap_or_default();
     let mesh_model_id =
         crate::managed_agents::effective_config::resolve_effective_relay_mesh_model_id(
-            &record_snapshot,
-            &personas_for_preflight,
-            &global_for_preflight,
+            &record, &personas, &global,
         );
     ensure_relay_mesh_for_record(app, mesh_model_id.as_deref(), false).await?;
+    Ok(mesh_model_id)
+}
 
+pub(super) fn start_local_agent_pairs_under_transition(
+    app: &AppHandle,
+    state: &AppState,
+    pubkey: &str,
+    relay_urls: &[String],
+    mesh_model_id: &Option<String>,
+    transition: &std::sync::MutexGuard<'_, ()>,
+) -> Result<ManagedAgentSummary, String> {
     {
         let _store_guard = state
             .managed_agents_store_lock
@@ -308,6 +269,7 @@ pub(super) async fn start_local_agent_pairs_with_preflight(
                 record.updated_at = crate::util::now_iso();
             }
         }
+        verify_relay_mesh_preflight(app, record, &personas, mesh_model_id, "restart")?;
         save_managed_agents(app, &records)?;
         if let Some(saved_record) = records.iter().find(|record| record.pubkey == pubkey) {
             retain_managed_agent_pending(app, state, saved_record);
@@ -316,11 +278,14 @@ pub(super) async fn start_local_agent_pairs_with_preflight(
 
     let mut errors = Vec::new();
     for relay_url in relay_urls {
-        if let Err(error) = crate::managed_agents::start_managed_agent_runtime_pair_lazy(
-            pubkey.to_string(),
-            relay_url.clone(),
-            app.clone(),
-        ) {
+        if let Err(error) =
+            crate::managed_agents::start_managed_agent_runtime_pair_lazy_under_transition(
+                pubkey.to_string(),
+                relay_url.clone(),
+                transition,
+                app.clone(),
+            )
+        {
             errors.push(format!("{relay_url}: {error}"));
         }
     }
@@ -353,7 +318,6 @@ pub(super) async fn start_local_agent_pairs_with_preflight(
         &crate::managed_agents::load_global_agent_config(app).unwrap_or_default(),
     )
 }
-
 pub(super) async fn start_local_agent_with_preflight(
     app: &AppHandle,
     state: &AppState,
@@ -395,6 +359,14 @@ pub(super) async fn start_local_agent_with_preflight(
         );
     ensure_relay_mesh_for_record(app, mesh_model_id.as_deref(), allow_fresh_create_start).await?;
 
+    let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(state)?;
+    if state
+        .shutdown_started
+        .load(std::sync::atomic::Ordering::Acquire)
+    {
+        return Err("desktop shutdown has started".into());
+    }
+
     let _store_guard = state
         .managed_agents_store_lock
         .lock()
@@ -429,7 +401,14 @@ pub(super) async fn start_local_agent_with_preflight(
             }
         }
     }
-    start_managed_agent_process(app, record, &mut runtimes, Some(owner_hex))?;
+    verify_relay_mesh_preflight(app, record, &personas, &mesh_model_id, "start")?;
+    if let Err(start_error) =
+        start_managed_agent_process(app, record, &mut runtimes, Some(owner_hex))
+    {
+        return persist_failed_local_start(&records, start_error, |records| {
+            save_managed_agents(app, records)
+        });
+    }
     save_managed_agents(app, &records)?;
     if let Some(saved_record) = records.iter().find(|r| r.pubkey == pubkey) {
         retain_managed_agent_pending(app, state, saved_record);
@@ -525,6 +504,7 @@ pub async fn list_managed_agents(app: AppHandle) -> Result<Vec<ManagedAgentSumma
     use tauri::Manager;
     tokio::task::spawn_blocking(move || {
         let state = app.state::<AppState>();
+        let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(&state)?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -536,12 +516,12 @@ pub async fn list_managed_agents(app: AppHandle) -> Result<Vec<ManagedAgentSumma
             .map_err(|error| error.to_string())?;
 
         let (sync_changed, exited_pubkeys) =
-            sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
+            sync_managed_agent_processes(&app, &mut records, &mut runtimes);
         if sync_changed {
             save_managed_agents(&app, &records)?;
         }
-        for pubkey in &exited_pubkeys {
-            state.clear_agent_session_caches(pubkey);
+        for key in &exited_pubkeys {
+            state.clear_agent_session_caches(&key.pubkey);
         }
 
         let personas = load_personas(&app).unwrap_or_default();
@@ -607,6 +587,7 @@ pub async fn create_managed_agent(
 
     // ── Phase 1: generate keys (sync lock) ────────────────────────────────────
     let (agent_keys, private_key_nsec, pubkey, resolved_relay_url, input) = {
+        let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(&state)?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -618,12 +599,12 @@ pub async fn create_managed_agent(
             .map_err(|error| error.to_string())?;
 
         let (sync_changed, exited_pubkeys) =
-            sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
+            sync_managed_agent_processes(&app, &mut records, &mut runtimes);
         if sync_changed {
             save_managed_agents(&app, &records)?;
         }
-        for pubkey in &exited_pubkeys {
-            state.clear_agent_session_caches(pubkey);
+        for key in &exited_pubkeys {
+            state.clear_agent_session_caches(&key.pubkey);
         }
         if let Some(persona_id) = requested_persona_id.as_deref() {
             let personas = load_personas(&app)?;
@@ -678,6 +659,7 @@ pub async fn create_managed_agent(
 
     // ── Phase 3: save record (sync lock) ───────────────────────────────────────
     let (agent, resolved_avatar_url) = {
+        let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(&state)?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -689,12 +671,12 @@ pub async fn create_managed_agent(
             .map_err(|error| error.to_string())?;
 
         let (sync_changed, exited_pubkeys) =
-            sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
+            sync_managed_agent_processes(&app, &mut records, &mut runtimes);
         if sync_changed {
             save_managed_agents(&app, &records)?;
         }
-        for pubkey in &exited_pubkeys {
-            state.clear_agent_session_caches(pubkey);
+        for key in &exited_pubkeys {
+            state.clear_agent_session_caches(&key.pubkey);
         }
 
         // Guard against a duplicate pubkey appearing between phase 1 and phase 3
@@ -946,6 +928,8 @@ pub async fn create_managed_agent(
         match start_local_agent_with_preflight(&app, &state, &pubkey, &owner_hex, true).await {
             Ok(agent) => agent,
             Err(error) => {
+                let _transition =
+                    crate::managed_agents::lock_managed_agent_runtime_transition(&state)?;
                 let _store_guard = state
                     .managed_agents_store_lock
                     .lock()
@@ -1083,6 +1067,7 @@ pub async fn start_managed_agent(
     // Collect backend info under lock; async preflight/spawn happens below.
     // Also snapshot profile reconciliation data for the background task.
     let (target, reconcile_data) = {
+        let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(&state)?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -1094,12 +1079,12 @@ pub async fn start_managed_agent(
             .map_err(|error| error.to_string())?;
 
         let (sync_changed, exited_pubkeys) =
-            sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
+            sync_managed_agent_processes(&app, &mut records, &mut runtimes);
         if sync_changed {
             save_managed_agents(&app, &records)?;
         }
-        for pubkey in &exited_pubkeys {
-            state.clear_agent_session_caches(pubkey);
+        for key in &exited_pubkeys {
+            state.clear_agent_session_caches(&key.pubkey);
         }
 
         let record = find_managed_agent_mut(&mut records, &pubkey)?;
@@ -1220,6 +1205,7 @@ pub async fn stop_managed_agent(
     use tauri::Manager;
     tokio::task::spawn_blocking(move || {
         let state = app.state::<AppState>();
+        let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(&state)?;
         let _store_guard = state
             .managed_agents_store_lock
             .lock()
@@ -1231,12 +1217,12 @@ pub async fn stop_managed_agent(
             .map_err(|error| error.to_string())?;
 
         let (sync_changed, exited_pubkeys) =
-            sync_managed_agent_processes(&mut records, &mut runtimes, &current_instance_id(&app));
+            sync_managed_agent_processes(&app, &mut records, &mut runtimes);
         if sync_changed {
             save_managed_agents(&app, &records)?;
         }
-        for pubkey in &exited_pubkeys {
-            state.clear_agent_session_caches(pubkey);
+        for key in &exited_pubkeys {
+            state.clear_agent_session_caches(&key.pubkey);
         }
 
         {
@@ -1250,7 +1236,12 @@ pub async fn stop_managed_agent(
             }
             // Pair-scoped: stops only the active workspace's pair; delete and
             // the config-restart flows still drain every pair.
-            stop_managed_agent_workspace_pair(&app, record, &mut runtimes)?;
+            if let Err(stop_error) = stop_managed_agent_workspace_pair(&app, record, &mut runtimes)
+            {
+                return crate::managed_agents::persist_failed_stop(stop_error, || {
+                    save_managed_agents(&app, &records)
+                });
+            }
         }
         save_managed_agents(&app, &records)?;
         let record = records
@@ -1281,6 +1272,7 @@ pub async fn delete_managed_agent(
     use tauri::Manager;
     tokio::task::spawn_blocking(move || {
         let state = app.state::<AppState>();
+        let _transition = crate::managed_agents::lock_managed_agent_runtime_transition(&state)?;
         {
             let _store_guard = state
                 .managed_agents_store_lock
@@ -1292,16 +1284,13 @@ pub async fn delete_managed_agent(
                 .lock()
                 .map_err(|error| error.to_string())?;
 
-            let (sync_changed, exited_pubkeys) = sync_managed_agent_processes(
-                &mut records,
-                &mut runtimes,
-                &current_instance_id(&app),
-            );
+            let (sync_changed, exited_pubkeys) =
+                sync_managed_agent_processes(&app, &mut records, &mut runtimes);
             if sync_changed {
                 save_managed_agents(&app, &records)?;
             }
-            for pubkey in &exited_pubkeys {
-                state.clear_agent_session_caches(pubkey);
+            for key in &exited_pubkeys {
+                state.clear_agent_session_caches(&key.pubkey);
             }
 
             // Guard: reject deletion of deployed remote agents unless explicitly forced.
@@ -1322,7 +1311,11 @@ pub async fn delete_managed_agent(
             }
 
             if let Some(record) = records.iter_mut().find(|record| record.pubkey == pubkey) {
-                stop_managed_agent_process(&app, record, &mut runtimes)?;
+                if let Err(stop_error) = stop_managed_agent_process(&app, record, &mut runtimes) {
+                    return crate::managed_agents::persist_failed_stop(stop_error, || {
+                        save_managed_agents(&app, &records)
+                    });
+                }
             }
             state.clear_agent_session_caches(&pubkey);
             let initial_len = records.len();
@@ -1355,6 +1348,13 @@ pub async fn delete_managed_agent(
 // 2. Harness sees it, exits gracefully, sets presence to "offline"
 // 3. Desktop's existing presence polling sees "offline" — UI updates automatically
 // No backend Tauri command needed. Presence IS the status.
+
+#[path = "agents_helpers.rs"]
+mod helpers;
+use helpers::{
+    normalize_relay_mesh, persist_failed_local_start, resolve_created_avatar_url,
+    trim_to_optional_string,
+};
 
 #[path = "agents_deploy.rs"]
 mod deploy;

--- a/desktop/src-tauri/src/commands/agents_helpers.rs
+++ b/desktop/src-tauri/src/commands/agents_helpers.rs
@@ -1,0 +1,54 @@
+use crate::managed_agents::{
+    managed_agent_avatar_url, BackendKind, ManagedAgentRecord, RelayMeshConfig,
+};
+
+pub(super) fn normalize_relay_mesh(
+    config: Option<&RelayMeshConfig>,
+    backend: &BackendKind,
+) -> Result<Option<RelayMeshConfig>, String> {
+    let Some(config) = config else {
+        return Ok(None);
+    };
+    let model_ref = config.model_ref.trim();
+    if model_ref.is_empty() {
+        return Err("Buzz shared compute model is required".to_string());
+    }
+    if backend != &BackendKind::Local {
+        return Err("Buzz shared compute agents must use the local backend".to_string());
+    }
+    Ok(Some(RelayMeshConfig {
+        model_ref: model_ref.to_string(),
+    }))
+}
+
+pub(super) fn trim_to_optional_string(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+pub(super) fn resolve_created_avatar_url(
+    requested_avatar_url: Option<&str>,
+    persona_avatar_url: Option<String>,
+    agent_command: &str,
+) -> Option<String> {
+    requested_avatar_url
+        .and_then(trim_to_optional_string)
+        .or_else(|| {
+            persona_avatar_url
+                .as_deref()
+                .and_then(trim_to_optional_string)
+        })
+        .or_else(|| managed_agent_avatar_url(agent_command))
+}
+
+pub(super) fn persist_failed_local_start<T>(
+    records: &[ManagedAgentRecord],
+    start_error: String,
+    persist: impl FnOnce(&[ManagedAgentRecord]) -> Result<(), String>,
+) -> Result<T, String> {
+    let persistence = persist(records)
+        .err()
+        .map(|save_error| format!("; failed to persist start recovery state: {save_error}"))
+        .unwrap_or_default();
+    Err(format!("{start_error}{persistence}"))
+}

--- a/desktop/src-tauri/src/commands/agents_tests.rs
+++ b/desktop/src-tauri/src/commands/agents_tests.rs
@@ -445,3 +445,62 @@ fn deploy_payload_carries_the_full_behavioral_quad() {
     assert_eq!(payload["provider"], "openai");
     assert_eq!(payload["relay_url"], "wss://relay.example");
 }
+
+#[test]
+fn failed_local_start_persists_mutated_records_before_returning_error() {
+    let dir = tempfile::tempdir().expect("temporary recovery directory");
+    let path = dir.path().join("managed-agents.json");
+    let mut record: ManagedAgentRecord = serde_json::from_str(
+        r#"{
+            "pubkey":"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            "name":"test","private_key_nsec":"nsec1fake","relay_url":"",
+            "acp_command":"buzz-acp","agent_command":"buzz-agent","agent_args":[],
+            "mcp_command":"","turn_timeout_seconds":320,"system_prompt":null,
+            "model":null,"provider":null,"env_vars":{},
+            "created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z",
+            "last_started_at":null,"last_stopped_at":null,"last_exit_code":null,
+            "last_error":null
+        }"#,
+    )
+    .expect("managed-agent recovery record");
+    record.runtime_pid = Some(4242);
+    record.last_error = Some("receipt write failed; cleanup remains tracked".to_string());
+    let records = vec![record];
+
+    let result: Result<(), String> = persist_failed_local_start(
+        &records,
+        "receipt write failed; cleanup remains tracked".to_string(),
+        |records| {
+            let bytes = serde_json::to_vec_pretty(records).map_err(|error| error.to_string())?;
+            std::fs::write(&path, bytes).map_err(|error| error.to_string())
+        },
+    );
+
+    assert_eq!(
+        result.unwrap_err(),
+        "receipt write failed; cleanup remains tracked"
+    );
+    let saved: Vec<ManagedAgentRecord> = serde_json::from_slice(
+        &std::fs::read(path).expect("durable managed-agent recovery readback"),
+    )
+    .expect("parse durable managed-agent recovery state");
+    assert_eq!(saved[0].runtime_pid, Some(4242));
+    assert_eq!(
+        saved[0].last_error.as_deref(),
+        Some("receipt write failed; cleanup remains tracked")
+    );
+}
+
+#[test]
+fn failed_local_start_reports_recovery_persistence_failure() {
+    let records = Vec::<ManagedAgentRecord>::new();
+    let result: Result<(), String> =
+        persist_failed_local_start(&records, "receipt write failed".to_string(), |_| {
+            Err("disk unavailable".to_string())
+        });
+
+    assert_eq!(
+        result.unwrap_err(),
+        "receipt write failed; failed to persist start recovery state: disk unavailable"
+    );
+}

--- a/desktop/src-tauri/src/commands/global_agent_config.rs
+++ b/desktop/src-tauri/src/commands/global_agent_config.rs
@@ -16,11 +16,11 @@ use tauri::AppHandle;
 use crate::{
     app_state::AppState,
     managed_agents::{
-        agent_readiness, current_instance_id, find_managed_agent_mut, known_acp_runtime,
-        load_global_agent_config, load_managed_agents, load_personas, record_agent_command,
-        resolve_effective_agent_env, save_global_agent_config, save_managed_agents,
-        stop_managed_agent_process, sync_managed_agent_processes, validate_global_config,
-        AgentReadiness, BackendKind, GlobalAgentConfig,
+        agent_readiness, find_managed_agent_mut, known_acp_runtime, load_global_agent_config,
+        load_managed_agents, load_personas, record_agent_command, resolve_effective_agent_env,
+        save_global_agent_config, save_managed_agents, stop_managed_agent_process,
+        sync_managed_agent_processes, validate_global_config, AgentReadiness, BackendKind,
+        GlobalAgentConfig,
     },
 };
 
@@ -188,7 +188,7 @@ fn collect_restart_candidates(
     let candidates = records
         .iter()
         .filter(|record| {
-            if record.backend != BackendKind::Local {
+            if record.backend != BackendKind::Local || !record.auto_restart_on_config_change {
                 return false;
             }
             let has_live_runtime = runtimes.iter_mut().any(|(key, runtime)| {
@@ -227,11 +227,9 @@ fn collect_restart_candidates(
 /// This is the per-agent restart step in Phase 2 of `set_global_agent_config`.
 /// It mirrors the semantics of a manual agent restart:
 ///
-/// 1. **Stop under lock** — acquires the store lock, calls
-///    `sync_managed_agent_processes`, re-verifies eligibility (local backend,
-///    live process, effective env changed or readiness transition), then stops
-///    the process and saves the record.  The lock is released before the start
-///    so `start_local_agent_with_preflight` can re-acquire it cleanly.
+/// 1. **Serialized restart** — acquires the transition and store locks, syncs
+///    process state, re-verifies eligibility, stops, and starts all prior pairs
+///    without releasing the transition lease.
 ///    `personas_snapshot` is reused here instead of loading from disk again.
 ///
 /// 2. **Start via the normal preflight path** — calls
@@ -251,7 +249,20 @@ async fn restart_local_agent_on_config_change(
     new_global: &GlobalAgentConfig,
     personas_snapshot: &[crate::managed_agents::AgentDefinition],
 ) -> RestartOutcome {
-    // ── Step 1: stop under lock, re-verifying eligibility ─────────────────
+    use tauri::Manager;
+    let state = app.state::<AppState>();
+    let mesh_model_id = match super::agents::preflight_local_agent_pairs(app, &state, pubkey).await
+    {
+        Ok(model_id) => model_id,
+        Err(error) => {
+            eprintln!(
+                "buzz-desktop: set_global_agent_config: preflight failed for {pubkey}: {error}"
+            );
+            return RestartOutcome::Skipped;
+        }
+    };
+    // Stop and start retain one transition lease; asynchronous preflight is
+    // complete before the synchronous serialized section begins.
     let app_for_stop = app.clone();
     let pubkey_owned = pubkey.to_string();
     let old_global_clone = old_global.clone();
@@ -261,6 +272,10 @@ async fn restart_local_agent_on_config_change(
     let stop_result = tokio::task::spawn_blocking(move || {
         use tauri::Manager;
         let state = app_for_stop.state::<AppState>();
+        let _transition = state
+            .managed_agent_runtime_transition
+            .lock()
+            .map_err(|e| format!("failed to acquire runtime transition lock: {e}"))?;
 
         let _store_guard = state
             .managed_agents_store_lock
@@ -274,11 +289,8 @@ async fn restart_local_agent_on_config_change(
             .map_err(|e| format!("failed to acquire runtimes lock: {e}"))?;
 
         // Sync process state so PID liveness reflects current reality.
-        let (sync_changed, _) = sync_managed_agent_processes(
-            &mut records,
-            &mut runtimes,
-            &current_instance_id(&app_for_stop),
-        );
+        let (sync_changed, _) =
+            sync_managed_agent_processes(&app_for_stop, &mut records, &mut runtimes);
         if sync_changed {
             save_managed_agents(&app_for_stop, &records)?;
         }
@@ -289,8 +301,10 @@ async fn restart_local_agent_on_config_change(
             .find(|r| r.pubkey == pubkey_owned)
             .ok_or_else(|| format!("agent {pubkey_owned} not found"))?;
 
-        if record.backend != BackendKind::Local {
-            return Err(format!("agent {pubkey_owned} is no longer a local agent"));
+        if record.backend != BackendKind::Local || !record.auto_restart_on_config_change {
+            return Err(format!(
+                "agent {pubkey_owned} is no longer eligible for automatic restart"
+            ));
         }
         let runtime_keys =
             crate::managed_agents::managed_agent_runtime_keys(&runtimes, &pubkey_owned);
@@ -324,49 +338,57 @@ async fn restart_local_agent_on_config_change(
 
         // Stop the process.
         let record_mut = find_managed_agent_mut(&mut records, &pubkey_owned)?;
-        stop_managed_agent_process(&app_for_stop, record_mut, &mut runtimes)?;
+        if let Err(stop_error) =
+            stop_managed_agent_process(&app_for_stop, record_mut, &mut runtimes)
+        {
+            return crate::managed_agents::persist_failed_stop(stop_error, || {
+                save_managed_agents(&app_for_stop, &records)
+            });
+        }
         save_managed_agents(&app_for_stop, &records)?;
-
-        Ok(runtime_keys)
+        let relay_urls: Vec<_> = runtime_keys.into_iter().map(|key| key.relay_url).collect();
+        drop(runtimes);
+        drop(_store_guard);
+        super::agents::start_local_agent_pairs_under_transition(
+            &app_for_stop,
+            &state,
+            &pubkey_owned,
+            &relay_urls,
+            &mesh_model_id,
+            &_transition,
+        )
+        .map(|_| ())
+        .map_err(|error| format!("start failed after serialized stop: {error}"))
     })
     .await;
 
-    let runtime_keys = match stop_result {
-        Ok(Ok(runtime_keys)) => runtime_keys,
-        Ok(Err(e)) => {
-            eprintln!("buzz-desktop: set_global_agent_config: skipping restart of {pubkey}: {e}");
-            return RestartOutcome::Skipped;
-        }
-        Err(e) => {
-            eprintln!(
-                "buzz-desktop: set_global_agent_config: spawn_blocking failed for stop of {pubkey}: {e}"
-            );
-            return RestartOutcome::Skipped;
-        }
-    };
-
-    let relay_urls: Vec<_> = runtime_keys.into_iter().map(|key| key.relay_url).collect();
-    use tauri::Manager;
-    let state = app.state::<AppState>();
-    match super::agents::start_local_agent_pairs_with_preflight(app, &state, pubkey, &relay_urls)
-        .await
-    {
-        Ok(_) => {
+    match stop_result {
+        Ok(Ok(())) => {
             eprintln!(
                 "buzz-desktop: set_global_agent_config: restarted agent {pubkey} with updated config"
             );
             RestartOutcome::Restarted
         }
-        Err(e) => {
-            eprintln!(
-                "buzz-desktop: set_global_agent_config: failed to start {pubkey} after restart: {e}"
-            );
-            if let Err(save_err) = persist_last_error(app, pubkey, &e) {
+        Ok(Err(error)) if error.starts_with("start failed after serialized stop:") => {
+            eprintln!("buzz-desktop: set_global_agent_config: {error}");
+            if let Err(save_error) = persist_last_error(app, pubkey, &error) {
                 eprintln!(
-                    "buzz-desktop: set_global_agent_config: failed to persist last_error for {pubkey}: {save_err}"
+                    "buzz-desktop: set_global_agent_config: failed to persist last_error for {pubkey}: {save_error}"
                 );
             }
             RestartOutcome::FailedAfterStop
+        }
+        Ok(Err(error)) => {
+            eprintln!(
+                "buzz-desktop: set_global_agent_config: skipping restart of {pubkey}: {error}"
+            );
+            RestartOutcome::Skipped
+        }
+        Err(error) => {
+            eprintln!(
+                "buzz-desktop: set_global_agent_config: spawn_blocking failed for restart of {pubkey}: {error}"
+            );
+            RestartOutcome::Skipped
         }
     }
 }

--- a/desktop/src-tauri/src/commands/identity.rs
+++ b/desktop/src-tauri/src/commands/identity.rs
@@ -541,10 +541,12 @@ pub async fn sign_out(app: tauri::AppHandle) -> Result<(), String> {
         );
     }
 
-    // Stop all managed agents before restart so they don't race the wipe.
-    if let Err(e) = crate::shutdown::shutdown_managed_agents(&app) {
-        eprintln!("buzz-desktop sign-out: agent shutdown: {e}");
-    }
+    // Stop all managed agents before restart so they don't race the wipe. A
+    // failed bounded cleanup must block sentinel creation/restart; otherwise a
+    // second boot can destroy the remaining recovery identity.
+    crate::shutdown::shutdown_managed_agents(&app).map_err(|error| {
+        format!("sign out blocked because managed agents did not stop: {error}")
+    })?;
 
     // Write the reset sentinel — destruction happens on next boot.
     let data_dir = app

--- a/desktop/src-tauri/src/commands/personas/delete_cascade_tests.rs
+++ b/desktop/src-tauri/src/commands/personas/delete_cascade_tests.rs
@@ -6,7 +6,10 @@
 //! helper that identifies the agents to cascade-delete, using plain
 //! in-memory data structures (no `AppHandle` required).
 
-use super::{collect_cascade_pubkeys, collect_remote_deployed, commit_cascade_agents};
+use super::{
+    collect_cascade_pubkeys, collect_remote_deployed, commit_cascade_agents,
+    require_cascade_stop_success,
+};
 use crate::managed_agents::{BackendKind, ManagedAgentRecord, RespondTo};
 use std::collections::BTreeMap;
 use std::collections::HashSet;
@@ -161,6 +164,17 @@ fn failing_save_is_retry_safe() {
     // By construction: commit_cascade_agents returns Err before reaching the
     // keyring deletions and tombstones at the delete_persona call site.
     // Retrying delete_persona re-runs the full cascade cleanly from scratch.
+}
+
+#[test]
+fn failed_runtime_stop_blocks_cascade_commit() {
+    let errors = vec!["pk-a: bounded Stop failed".to_string()];
+    let result = require_cascade_stop_success(&errors);
+    assert!(
+        result.is_err(),
+        "any Stop failure must block record/key deletion"
+    );
+    assert!(result.unwrap_err().contains("pk-a"));
 }
 
 /// A provider-deployed cascade target (non-local backend with a live

--- a/desktop/src-tauri/src/commands/personas/mod.rs
+++ b/desktop/src-tauri/src/commands/personas/mod.rs
@@ -3,10 +3,10 @@ use tauri::AppHandle;
 use crate::{
     app_state::AppState,
     managed_agents::{
-        current_instance_id, delete_agent_key, load_managed_agents, load_personas, load_teams,
-        save_managed_agents, save_personas, stop_managed_agent_process,
-        sync_managed_agent_processes, try_regenerate_nest, validate_persona_activation_change,
-        validate_persona_deletion, AgentDefinition, ManagedAgentRecord,
+        delete_agent_key, load_managed_agents, load_personas, load_teams, save_managed_agents,
+        save_personas, stop_managed_agent_process, sync_managed_agent_processes,
+        try_regenerate_nest, validate_persona_activation_change, validate_persona_deletion,
+        AgentDefinition, ManagedAgentRecord,
     },
     util::now_iso,
 };
@@ -93,6 +93,19 @@ fn collect_remote_deployed(
         .collect()
 }
 
+/// Fail closed before cascade commit when any linked runtime did not stop.
+/// This pure seam keeps record/key deletion mechanically after the safety gate.
+fn require_cascade_stop_success(errors: &[String]) -> Result<(), String> {
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "persona deletion blocked because one or more managed agents did not stop: {}",
+            errors.join("; ")
+        ))
+    }
+}
+
 /// Remove cascade agents from `agents` and persist via the injectable `save`.
 ///
 /// Extracted from `delete_persona` so unit tests can inject a failing save and
@@ -114,6 +127,10 @@ pub async fn delete_persona(id: String, app: AppHandle) -> Result<(), String> {
     use tauri::Manager;
     tokio::task::spawn_blocking(move || {
         let state = app.state::<AppState>();
+        let _transition = state
+            .managed_agent_runtime_transition
+            .lock()
+            .map_err(|error| error.to_string())?;
 
         {
             // Store lock held across all three phases.
@@ -152,16 +169,13 @@ pub async fn delete_persona(id: String, app: AppHandle) -> Result<(), String> {
                     .managed_agent_processes
                     .lock()
                     .map_err(|error| error.to_string())?;
-                let (sync_changed, exited_pubkeys) = sync_managed_agent_processes(
-                    &mut agents,
-                    &mut runtimes,
-                    &current_instance_id(&app),
-                );
+                let (sync_changed, exited_pubkeys) =
+                    sync_managed_agent_processes(&app, &mut agents, &mut runtimes);
                 if sync_changed {
                     save_managed_agents(&app, &agents)?;
                 }
-                for pk in &exited_pubkeys {
-                    state.clear_agent_session_caches(pk);
+                for key in &exited_pubkeys {
+                    state.clear_agent_session_caches(&key.pubkey);
                 }
                 // runtimes drops here (process lock released before Phase 2).
             }
@@ -184,26 +198,26 @@ pub async fn delete_persona(id: String, app: AppHandle) -> Result<(), String> {
 
             // ── Phase 2: Stop ───────────────────────────────────────────────
             //
-            // Best-effort stop each running cascade instance. Lock ordering:
-            // store lock (held) → process lock acquired per-agent and released
-            // between stops so the process lock is not held across the full poll
-            // cycle (stop_managed_agent_process polls 100ms×10 before SIGKILL).
-            //
-            // Per-agent stop errors are swallowed — these records are deleted in
-            // Phase 3 regardless. Intentional difference from delete_managed_agent
-            // (single-agent, fatal on stop failure); here the cascade is multi-agent
-            // and deletion must proceed even if one instance cannot be stopped.
+            // Stop every running cascade instance before any record/key
+            // deletion. If any stop fails, preserve the complete cascade so
+            // the remaining Job/Child authority stays visible and retryable.
+            let mut stop_errors = Vec::new();
             for pk in &cascade {
                 if let Some(rec) = agents.iter_mut().find(|a| a.pubkey == *pk) {
                     let mut runtimes = state
                         .managed_agent_processes
                         .lock()
                         .map_err(|error| error.to_string())?;
-                    if let Err(e) = stop_managed_agent_process(&app, rec, &mut runtimes) {
-                        eprintln!("buzz-desktop: delete_persona: failed to stop agent {pk}: {e}");
+                    if let Err(error) = stop_managed_agent_process(&app, rec, &mut runtimes) {
+                        stop_errors.push(format!("{pk}: {error}"));
                     }
                     // runtimes drops here (per-agent, process lock not held across stops).
                 }
+            }
+            if let Err(stop_error) = require_cascade_stop_success(&stop_errors) {
+                return crate::managed_agents::persist_failed_stop(stop_error, || {
+                    save_managed_agents(&app, &agents)
+                });
             }
 
             // ── Phase 3: Commit ─────────────────────────────────────────────

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -12,6 +12,8 @@ mod identity_storage;
 mod key_backup;
 mod linux_media;
 mod managed_agents;
+#[cfg(target_os = "windows")]
+pub mod managed_launcher;
 mod media_proxy;
 #[cfg(feature = "mesh-llm")]
 mod mesh_llm;
@@ -113,12 +115,7 @@ async fn wait_for_stable_initial_window_geometry<R: tauri::Runtime>(window: &tau
     let mut stable_polls = 0;
 
     for _ in 0..MAX_POLLS {
-        // Accept whatever geometry the window-state plugin restores — maximized
-        // or a normal saved size. macOS applies the restore asynchronously, so
-        // we only need consecutive identical outer bounds to know it settled.
-        // Gating on `is_maximized()` here would leave `bounds` permanently
-        // `None` for restored non-maximized windows and stall the reveal until
-        // the poll timeout.
+        // Consecutive identical outer bounds prove async macOS restore has settled.
         let bounds = match (window.outer_position(), window.outer_size()) {
             (Ok(position), Ok(size)) => Some((position.x, position.y, size.width, size.height)),
             _ => None,
@@ -971,14 +968,17 @@ pub fn run() {
                 }
             }
         }
-        RunEvent::ExitRequested { code, .. } => {
+        RunEvent::ExitRequested { code, api, .. } => {
             if is_restart_request(code) {
                 restart_requested.store(true, Ordering::SeqCst);
             }
-            shut_down_app(app_handle, &run_shutdown_done);
+            let shutdown = shut_down_app(app_handle, &run_shutdown_done);
+            if shutdown::exit_blocked(shutdown, &restart_requested) {
+                api.prevent_exit();
+            }
         }
         RunEvent::Exit => {
-            shut_down_app(app_handle, &run_shutdown_done);
+            shutdown::report_final_shutdown(shut_down_app(app_handle, &run_shutdown_done));
             app_handle.state::<ClipboardState>().release();
 
             #[cfg(all(feature = "mesh-llm", target_os = "macos"))]

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,7 +1,12 @@
-// Prevents additional console window on Windows in release, DO NOT REMOVE!!
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+// Prevents any additional console window on Windows, DO NOT REMOVE!!
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 
 fn main() {
+    #[cfg(target_os = "windows")]
+    if buzz_lib::managed_launcher::run_if_requested() {
+        return;
+    }
+
     // Before anything else: WebKitGTK reads its rendering environment once at
     // process start, and this is the only point where the process is still
     // single threaded and no GTK object exists yet, which is what makes

--- a/desktop/src-tauri/src/managed_agents/env_vars.rs
+++ b/desktop/src-tauri/src/managed_agents/env_vars.rs
@@ -87,6 +87,9 @@ pub(crate) const RESERVED_ENV_KEYS: &[&str] = &[
     // for same-session sweep decisions.
     "BUZZ_MANAGED_AGENT",
     "BUZZ_MANAGED_AGENT_START_NONCE",
+    // Internal launcher envelope. Only the desktop may construct these.
+    "BUZZ_MANAGED_LAUNCH_PROGRAM_WIDE",
+    "BUZZ_MANAGED_LAUNCH_ARGS_WIDE",
 ];
 
 pub(crate) fn is_reserved_env_key(key: &str) -> bool {

--- a/desktop/src-tauri/src/managed_agents/mesh_preflight.rs
+++ b/desktop/src-tauri/src/managed_agents/mesh_preflight.rs
@@ -1,0 +1,21 @@
+use tauri::AppHandle;
+
+use super::{load_global_agent_config, AgentDefinition, ManagedAgentRecord};
+
+pub(crate) fn verify_relay_mesh_preflight(
+    app: &AppHandle,
+    record: &ManagedAgentRecord,
+    personas: &[AgentDefinition],
+    expected_model_id: &Option<String>,
+    action: &str,
+) -> Result<(), String> {
+    let global = load_global_agent_config(app).unwrap_or_default();
+    let current_model_id =
+        super::effective_config::resolve_effective_relay_mesh_model_id(record, personas, &global);
+    if &current_model_id == expected_model_id {
+        return Ok(());
+    }
+    Err(format!(
+        "managed-agent mesh configuration changed while {action} preflight was in flight; retry {action}"
+    ))
+}

--- a/desktop/src-tauri/src/managed_agents/mod.rs
+++ b/desktop/src-tauri/src/managed_agents/mod.rs
@@ -15,13 +15,36 @@ mod env_vars;
 pub(crate) mod git_bash;
 pub(crate) mod global_config;
 mod managed_node_paths;
+pub(crate) mod mesh_preflight;
 mod nest;
 mod persona_avatars;
 pub(crate) mod persona_events;
 mod personas;
 #[cfg(windows)]
+mod process_child;
+#[cfg(windows)]
 mod process_lifecycle;
+
+pub(crate) const UNVERIFIED_JOB_REAP_PREFIX: &str = "windows_job_reap_unverified:";
+
+pub(crate) fn lock_managed_agent_runtime_transition(
+    state: &crate::app_state::AppState,
+) -> Result<std::sync::MutexGuard<'_, ()>, String> {
+    state
+        .managed_agent_runtime_transition
+        .lock()
+        .map_err(|error| error.to_string())
+}
+
+pub(crate) fn has_unverified_job_reap(record: &ManagedAgentRecord) -> bool {
+    record.last_error.as_deref().is_some_and(|error| {
+        error
+            .lines()
+            .any(|line| line.starts_with(UNVERIFIED_JOB_REAP_PREFIX))
+    })
+}
 pub(crate) mod readiness;
+mod receipt_storage;
 pub(crate) mod reconcile;
 mod relay_mesh;
 mod repos;
@@ -61,11 +84,14 @@ pub(crate) use managed_node_paths::*;
 pub use nest::*;
 pub use personas::*;
 #[cfg(windows)]
-pub use process_lifecycle::*;
+pub(crate) use process_child::*;
+#[cfg(windows)]
+pub(crate) use process_lifecycle::*;
 pub(crate) use readiness::{
     agent_readiness, resolve_effective_agent_env, resolve_effective_harness_descriptor,
     AgentReadiness, Requirement,
 };
+pub use receipt_storage::*;
 pub use relay_mesh::*;
 pub use repos::{
     effective_repos_dir, ensure_repos_symlink, resolve_repos_at_boot, validate_repos_dir,

--- a/desktop/src-tauri/src/managed_agents/process_child.rs
+++ b/desktop/src-tauri/src/managed_agents/process_child.rs
@@ -1,0 +1,45 @@
+#[derive(Debug)]
+enum ManagedAgentChildInner {
+    Tokio(Box<tokio::process::Child>),
+    #[cfg(test)]
+    Std(std::process::Child),
+}
+
+#[derive(Debug)]
+pub(crate) struct ManagedAgentChild {
+    inner: ManagedAgentChildInner,
+    pid: u32,
+}
+
+impl ManagedAgentChild {
+    pub(crate) fn new(inner: tokio::process::Child) -> Result<Self, String> {
+        let pid = inner
+            .id()
+            .ok_or_else(|| "managed child has no process id after spawn".to_string())?;
+        Ok(Self {
+            inner: ManagedAgentChildInner::Tokio(Box::new(inner)),
+            pid,
+        })
+    }
+
+    pub(crate) fn id(&self) -> u32 {
+        self.pid
+    }
+
+    pub(crate) fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
+        match &mut self.inner {
+            ManagedAgentChildInner::Tokio(child) => child.try_wait(),
+            #[cfg(test)]
+            ManagedAgentChildInner::Std(child) => child.try_wait(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_std_for_test(inner: std::process::Child) -> Self {
+        let pid = inner.id();
+        Self {
+            inner: ManagedAgentChildInner::Std(inner),
+            pid,
+        }
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/process_lifecycle.rs
+++ b/desktop/src-tauri/src/managed_agents/process_lifecycle.rs
@@ -1,158 +1,583 @@
-//! Windows process-tree lifecycle primitives for managed agents.
+//! Safe Windows managed-process containment.
 //!
-//! The Unix teardown uses `process_group(0)` + group signals (in `runtime.rs`).
-//! Windows has no process groups, so the harness's 24 agent workers + MCP
-//! servers are reaped two ways here:
-//!   - [`JobHandle`] / [`create_job_for_child`] — the in-process stop path. A
-//!     Job Object owns the tree and `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` kills
-//!     it when the handle drops.
-//!   - [`taskkill_tree`] — the after-restart path, where only the PID survives
-//!     in the record and no job handle is available.
-//!
-//! This module is `#[cfg(windows)]`-only; nothing here compiles on other
-//! platforms.
+//! The desktop executable is a no-console launcher. `processkit::ProcessGroup`
+//! creates that launcher suspended, assigns it to a kill-on-close Job Object,
+//! and only then resumes it. The launcher reconstructs and starts the real
+//! harness with `CREATE_NO_WINDOW`, so no descendant can execute outside the
+//! owned Job and no console window is shown.
 
-use windows_sys::Win32::Foundation::HANDLE;
+use super::{AcpAvailabilityStatus, ManagedAgentChild, ManagedAgentProcess};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-/// Win32 Job Object that owns the harness process and (via Windows' default
-/// child-inheritance) every process it spawns. Dropping the handle with
-/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` set kills the whole tree — the Windows
-/// mirror of the Unix `process_group(0)` + group-signal teardown. This is what
-/// guarantees the 24 agent workers + MCP servers die when we stop or when the
-/// app exits, instead of being orphaned by a bare `Child::kill()`.
-pub struct JobHandle(HANDLE);
+const MANAGED_LAUNCHER_ARG: &str = "--buzz-managed-agent-launcher";
+const MANAGED_LAUNCH_PROGRAM_ENV: &str = "BUZZ_MANAGED_LAUNCH_PROGRAM_WIDE";
+const MANAGED_LAUNCH_ARGS_ENV: &str = "BUZZ_MANAGED_LAUNCH_ARGS_WIDE";
 
-// The handle is owned exclusively by this wrapper; moving it across threads is
-// sound (the spawn path in restore.rs runs in a thread scope).
-unsafe impl Send for JobHandle {}
+#[cfg_attr(test, allow(dead_code))]
+fn wrap_managed_agent_command_with_launcher(
+    command: std::process::Command,
+    launcher_exe: &std::path::Path,
+    environment_cleared: bool,
+) -> Result<std::process::Command, String> {
+    use std::os::windows::ffi::OsStrExt;
 
-impl std::fmt::Debug for JobHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("JobHandle(..)")
+    let program: Vec<u16> = command.get_program().encode_wide().collect();
+    let args: Vec<Vec<u16>> = command
+        .get_args()
+        .map(|argument| argument.encode_wide().collect())
+        .collect();
+    let current_dir = command.get_current_dir().map(std::path::Path::to_path_buf);
+    let env_changes: Vec<(std::ffi::OsString, Option<std::ffi::OsString>)> = command
+        .get_envs()
+        .map(|(key, value)| (key.to_os_string(), value.map(std::ffi::OsStr::to_os_string)))
+        .collect();
+
+    let mut wrapped = std::process::Command::new(launcher_exe);
+    if environment_cleared {
+        wrapped.env_clear();
     }
-}
-
-impl Drop for JobHandle {
-    fn drop(&mut self) {
-        // KILL_ON_JOB_CLOSE means the tree dies when the LAST handle closes.
-        // We hold the only handle (not inheritable), so this reaps the tree.
-        unsafe { windows_sys::Win32::Foundation::CloseHandle(self.0) };
+    wrapped.arg(MANAGED_LAUNCHER_ARG);
+    if let Some(current_dir) = current_dir {
+        wrapped.current_dir(current_dir);
     }
-}
-
-/// Create a Job Object, assign `pid` to it, and configure it to kill the whole
-/// tree when the returned handle is dropped. Returns `None` on any failure so
-/// the caller can fall back to `Child::kill()` — a degraded teardown beats a
-/// failed spawn.
-///
-/// Assignment happens immediately after spawn, on the same parent thread. The
-/// child (buzz-acp) does spawn its 24 workers before it connects to the relay,
-/// so the window between our spawn and our assignment is NOT structurally empty.
-/// What closes it is assign-latency: `OpenProcess` + `AssignProcessToJobObject`
-/// are a few synchronous Win32 calls (microseconds), while buzz-acp must init
-/// tokio, parse its config, and spawn 24 children (tens-to-hundreds of ms), so
-/// the assign reliably wins before any worker exists. Once assigned, Windows
-/// places every subsequently-spawned descendant in the job automatically.
-///
-/// `CREATE_SUSPENDED` -> assign -> `ResumeThread` would make the window airtight
-/// regardless of child timing, but it requires raw `CreateProcessW`/`ResumeThread`
-/// (materially more unsafe Win32) to close a microsecond race, so it is
-/// deliberately not used here.
-fn create_job_for_child(pid: u32) -> Option<JobHandle> {
-    use std::ptr::null;
-    use windows_sys::Win32::Foundation::{CloseHandle, FALSE};
-    use windows_sys::Win32::System::JobObjects::{
-        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
-        SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
-        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-    };
-    use windows_sys::Win32::System::Threading::{
-        OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
-    };
-
-    unsafe {
-        let job = CreateJobObjectW(null(), null());
-        if job.is_null() {
-            return None;
+    for (key, value) in env_changes {
+        match value {
+            Some(value) => {
+                wrapped.env(key, value);
+            }
+            None => {
+                wrapped.env_remove(key);
+            }
         }
-
-        let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
-        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-        let ok = SetInformationJobObject(
-            job,
-            JobObjectExtendedLimitInformation,
-            &info as *const _ as *const _,
-            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+    }
+    // The internal envelope is applied last so inherited/user command edits
+    // cannot remove or replace desktop launcher authority.
+    wrapped
+        .env(
+            MANAGED_LAUNCH_PROGRAM_ENV,
+            serde_json::to_string(&program)
+                .map_err(|error| format!("failed to encode managed-agent program: {error}"))?,
+        )
+        .env(
+            MANAGED_LAUNCH_ARGS_ENV,
+            serde_json::to_string(&args)
+                .map_err(|error| format!("failed to encode managed-agent arguments: {error}"))?,
         );
-        if ok == FALSE {
-            CloseHandle(job);
-            return None;
-        }
-
-        let process = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, FALSE, pid);
-        if process.is_null() {
-            CloseHandle(job);
-            return None;
-        }
-        let assigned = AssignProcessToJobObject(job, process);
-        CloseHandle(process);
-        if assigned == FALSE {
-            CloseHandle(job);
-            return None;
-        }
-
-        Some(JobHandle(job))
-    }
+    Ok(wrapped)
 }
 
-/// Kill the entire process tree rooted at `pid` via `taskkill /T`, the closest
-/// equivalent to the Unix process-group kill. Used on the after-restart path
-/// where no job handle survived. `CREATE_NO_WINDOW` keeps taskkill's own
-/// console from flashing.
-pub fn taskkill_tree(pid: u32) -> Result<(), String> {
+#[cfg_attr(test, allow(dead_code))]
+fn wrap_managed_agent_command(
+    command: std::process::Command,
+) -> Result<std::process::Command, String> {
+    let launcher_exe = std::env::current_exe()
+        .map_err(|error| format!("failed to locate managed-agent launcher: {error}"))?;
+    wrap_managed_agent_command_with_launcher(command, &launcher_exe, false)
+}
+
+pub(crate) fn run_managed_agent_launcher_if_requested() -> bool {
+    if std::env::args_os().nth(1).as_deref() != Some(std::ffi::OsStr::new(MANAGED_LAUNCHER_ARG)) {
+        return false;
+    }
+    let exit_code = match run_managed_agent_launcher() {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("buzz-desktop managed-agent launcher: {error}");
+            1
+        }
+    };
+    std::process::exit(exit_code);
+}
+
+fn run_managed_agent_launcher() -> Result<i32, String> {
+    use std::os::windows::ffi::OsStringExt;
     use std::os::windows::process::CommandExt;
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-    let status = std::process::Command::new("taskkill")
-        .args(["/T", "/F", "/PID", &pid.to_string()])
-        .creation_flags(CREATE_NO_WINDOW)
-        .status()
-        .map_err(|error| format!("failed to run taskkill for pid {pid}: {error}"))?;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(format!(
-            "taskkill exited with status {status} for pid {pid}"
-        ))
+
+    let encoded_program = std::env::var(MANAGED_LAUNCH_PROGRAM_ENV).map_err(|error| {
+        format!("missing launcher environment {MANAGED_LAUNCH_PROGRAM_ENV}: {error}")
+    })?;
+    let encoded_args = std::env::var(MANAGED_LAUNCH_ARGS_ENV).map_err(|error| {
+        format!("missing launcher environment {MANAGED_LAUNCH_ARGS_ENV}: {error}")
+    })?;
+    let program: Vec<u16> = serde_json::from_str(&encoded_program).map_err(|error| {
+        format!("invalid launcher environment {MANAGED_LAUNCH_PROGRAM_ENV}: {error}")
+    })?;
+    if program.is_empty() {
+        return Err("managed-agent launcher program is empty".to_string());
     }
+    let args: Vec<Vec<u16>> = serde_json::from_str(&encoded_args).map_err(|error| {
+        format!("invalid launcher environment {MANAGED_LAUNCH_ARGS_ENV}: {error}")
+    })?;
+
+    let mut command = std::process::Command::new(std::ffi::OsString::from_wide(&program));
+    command.args(
+        args.iter()
+            .map(|argument| std::ffi::OsString::from_wide(argument)),
+    );
+    command
+        .env_remove(MANAGED_LAUNCH_PROGRAM_ENV)
+        .env_remove(MANAGED_LAUNCH_ARGS_ENV)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit());
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    command.creation_flags(CREATE_NO_WINDOW);
+    let status = command
+        .status()
+        .map_err(|error| format!("failed to start managed-agent harness: {error}"))?;
+    status
+        .code()
+        .ok_or_else(|| "managed-agent harness exited without a numeric status".to_string())
 }
 
-/// Assign a freshly-spawned harness `child` to a Job Object and package it into
-/// a [`ManagedAgentProcess`]. On job-assignment failure the process is still
-/// returned with `job: None` — teardown then falls back to `Child::kill()`,
-/// which kills only the harness (a degraded teardown beats a failed spawn).
-pub fn finish_spawn(
-    child: std::process::Child,
-    log_path: std::path::PathBuf,
+/// Spawn the managed command through the no-console desktop launcher directly
+/// inside a race-free Windows Job Object.
+pub(crate) fn spawn_managed_agent_process(
+    command: std::process::Command,
+    log_path: PathBuf,
     spawn_config_hash: u64,
     setup_mode: bool,
-    adapter_availability: Option<super::AcpAvailabilityStatus>,
+    adapter_availability: Option<AcpAvailabilityStatus>,
     start_nonce: String,
-    agent_name: &str,
-) -> super::ManagedAgentProcess {
-    let job = create_job_for_child(child.id());
-    if job.is_none() {
-        eprintln!(
-            "buzz-desktop: failed to assign agent {agent_name} to a Job Object; \
-             teardown will fall back to killing only the harness process"
-        );
+) -> Result<ManagedAgentProcess, String> {
+    #[cfg(not(test))]
+    let command = wrap_managed_agent_command(command)?;
+    #[cfg(test)]
+    let command = command;
+    spawn_prepared_managed_agent_process(
+        command,
+        log_path,
+        spawn_config_hash,
+        setup_mode,
+        adapter_availability,
+        start_nonce,
+    )
+}
+
+pub(crate) fn spawn_managed_agent_process_with_launcher(
+    command: std::process::Command,
+    launcher_exe: &std::path::Path,
+    log_path: PathBuf,
+    environment_cleared: bool,
+) -> Result<ManagedAgentProcess, String> {
+    let command =
+        wrap_managed_agent_command_with_launcher(command, launcher_exe, environment_cleared)?;
+    spawn_prepared_managed_agent_process(
+        command,
+        log_path,
+        0,
+        false,
+        None,
+        "native-production-boundary-proof".to_string(),
+    )
+}
+
+fn spawn_prepared_managed_agent_process(
+    mut command: std::process::Command,
+    log_path: PathBuf,
+    spawn_config_hash: u64,
+    setup_mode: bool,
+    adapter_availability: Option<AcpAvailabilityStatus>,
+    start_nonce: String,
+) -> Result<ManagedAgentProcess, String> {
+    command.stdin(std::process::Stdio::null());
+    if log_path.as_os_str().is_empty() {
+        command
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+    } else {
+        let stdout = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .map_err(|error| format!("failed to open managed-agent log: {error}"))?;
+        let stderr = stdout
+            .try_clone()
+            .map_err(|error| format!("failed to clone managed-agent log handle: {error}"))?;
+        command
+            .stdout(std::process::Stdio::from(stdout))
+            .stderr(std::process::Stdio::from(stderr));
     }
-    super::ManagedAgentProcess {
+
+    let group = Arc::new(
+        processkit::ProcessGroup::new()
+            .map_err(|error| format!("failed to create managed-agent Job Object: {error}"))?,
+    );
+    let child = group
+        .spawn(tokio::process::Command::from(command))
+        .map_err(|error| format!("failed to spawn managed agent inside Job Object: {error}"))?;
+    let child = ManagedAgentChild::new(child)?;
+    Ok(ManagedAgentProcess {
         child,
         log_path,
         spawn_config_hash,
         setup_mode,
         adapter_availability,
         start_nonce,
-        job,
+        job: Some(group),
+    })
+}
+
+/// Terminate the complete Job tree, prove membership is empty, and reap the
+/// exact owned launcher. Every failure leaves both authorities attached.
+pub(crate) fn terminate_managed_agent_process(
+    process: &mut ManagedAgentProcess,
+) -> Result<std::process::ExitStatus, String> {
+    let group = process
+        .job
+        .as_ref()
+        .ok_or_else(|| "managed Windows runtime is missing its required Job Object".to_string())?;
+    group
+        .kill_all()
+        .map_err(|error| format!("failed to terminate managed-agent Job Object: {error}"))?;
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let members = group
+            .members()
+            .map_err(|error| format!("failed to query managed-agent Job membership: {error}"))?;
+        let launcher_status = process
+            .child
+            .try_wait()
+            .map_err(|error| format!("failed to inspect managed launcher exit: {error}"))?;
+        if members.is_empty() {
+            if let Some(status) = launcher_status {
+                return Ok(status);
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "managed-agent Job cleanup remained incomplete after the bounded wait (members: {}, launcher exited: {})",
+                members.len(),
+                launcher_status.is_some()
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+/// Release the empty Job authority only after durable receipt deletion commits.
+/// Callers retain the complete process value on every error.
+pub(crate) fn release_finalized_managed_agent_process(
+    process: &mut ManagedAgentProcess,
+) -> Result<(), String> {
+    let group = process
+        .job
+        .as_ref()
+        .ok_or_else(|| "managed Windows runtime is missing its required Job Object".to_string())?;
+    let members = group
+        .members()
+        .map_err(|error| format!("failed to recheck managed-agent Job membership: {error}"))?;
+    if !members.is_empty() {
+        return Err(format!(
+            "cannot release managed-agent Job authority while {} member(s) remain",
+            members.len()
+        ));
+    }
+    if process
+        .child
+        .try_wait()
+        .map_err(|error| format!("failed to recheck managed launcher exit: {error}"))?
+        .is_none()
+    {
+        return Err("cannot release managed-agent Job authority before launcher exit".to_string());
+    }
+    process.job.take();
+    Ok(())
+}
+
+pub(crate) fn finalize_tracked_runtime_with(
+    runtime: &mut ManagedAgentProcess,
+    remove_receipt: impl FnOnce() -> Result<(), String>,
+) -> Result<std::process::ExitStatus, String> {
+    if runtime.job.is_none() {
+        let status = runtime
+            .child
+            .try_wait()
+            .map_err(|error| format!("failed to recheck finalized managed launcher: {error}"))?
+            .ok_or_else(|| {
+                "finalized managed runtime lost Job authority before launcher exit".to_string()
+            })?;
+        remove_receipt()?;
+        return Ok(status);
+    }
+    let status = terminate_managed_agent_process(runtime)?;
+    remove_receipt()?;
+    // Receipt retirement is the commit point for releasing the empty Job.
+    // The reaped Child handle remains an idempotent terminal-proof token if a
+    // later recovery-authority persistence step requires an in-memory retry.
+    runtime.job.take();
+    Ok(status)
+}
+
+/// Complete checked process teardown, commit receipt deletion, then retain the
+/// reaped Child handle as an idempotent terminal-proof token for the caller.
+pub(crate) fn finalize_tracked_runtime(
+    app: &tauri::AppHandle,
+    key: &super::ManagedAgentRuntimeKey,
+    runtime: &mut super::ManagedAgentPairRuntime,
+) -> Result<std::process::ExitStatus, String> {
+    finalize_tracked_runtime_with(runtime, || super::remove_agent_runtime_receipt(app, key))
+}
+
+/// Numeric-PID tree termination is retained only for unrelated cleanup paths;
+/// managed runtimes always use their owned child and Job authority instead.
+pub(crate) fn taskkill_tree(pid: u32) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let mut child = std::process::Command::new("taskkill")
+        .args(["/T", "/F", "/PID", &pid.to_string()])
+        .creation_flags(CREATE_NO_WINDOW)
+        .spawn()
+        .map_err(|error| format!("failed to run taskkill for pid {pid}: {error}"))?;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => return Ok(()),
+            Ok(Some(status)) => {
+                return Err(format!(
+                    "taskkill exited with status {status} for pid {pid}"
+                ));
+            }
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                return Err(format!("taskkill timed out for pid {pid}"));
+            }
+            Err(error) => {
+                return Err(format!("failed waiting for taskkill pid {pid}: {error}"));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+
+    #[test]
+    fn launcher_envelope_preserves_unpaired_wide_argument() {
+        use std::os::windows::ffi::OsStringExt;
+
+        let raw = vec![0xd800, 0x0061];
+        let mut command = Command::new("target.exe");
+        command.arg(std::ffi::OsString::from_wide(&raw));
+        let wrapped = wrap_managed_agent_command_with_launcher(
+            command,
+            std::path::Path::new("launcher.exe"),
+            false,
+        )
+        .unwrap();
+        let encoded = wrapped
+            .get_envs()
+            .find(|(key, _)| key.eq_ignore_ascii_case(MANAGED_LAUNCH_ARGS_ENV))
+            .and_then(|(_, value)| value)
+            .and_then(|value| value.to_str())
+            .unwrap();
+        let arguments: Vec<Vec<u16>> = serde_json::from_str(encoded).unwrap();
+        assert_eq!(arguments, vec![raw]);
+    }
+
+    #[test]
+    fn launcher_wrapper_encodes_wide_empty_and_spaced_arguments_last() {
+        use std::os::windows::ffi::OsStringExt;
+
+        let dir = tempfile::tempdir().expect("wrapper directory");
+        let program = std::ffi::OsString::from_wide(&[
+            b'C' as u16,
+            b':' as u16,
+            b'\\' as u16,
+            0x96ea,
+            b'.' as u16,
+            b'e' as u16,
+            b'x' as u16,
+            b'e' as u16,
+        ]);
+        let mut original = Command::new(&program);
+        original
+            .arg("two words")
+            .arg("")
+            .arg("wide-雪")
+            .current_dir(dir.path())
+            .env_remove(MANAGED_LAUNCH_PROGRAM_ENV)
+            .env_remove(MANAGED_LAUNCH_ARGS_ENV);
+        let wrapped = wrap_managed_agent_command(original).expect("wrap managed command");
+        assert_eq!(
+            wrapped.get_program(),
+            std::env::current_exe().expect("current exe")
+        );
+        assert_eq!(
+            wrapped.get_args().collect::<Vec<_>>(),
+            vec![std::ffi::OsStr::new(MANAGED_LAUNCHER_ARG)]
+        );
+        assert_eq!(wrapped.get_current_dir(), Some(dir.path()));
+        let envs = wrapped
+            .get_envs()
+            .collect::<std::collections::BTreeMap<_, _>>();
+        let encoded_program = envs[std::ffi::OsStr::new(MANAGED_LAUNCH_PROGRAM_ENV)]
+            .expect("program envelope")
+            .to_string_lossy();
+        let encoded_args = envs[std::ffi::OsStr::new(MANAGED_LAUNCH_ARGS_ENV)]
+            .expect("argument envelope")
+            .to_string_lossy();
+        let decoded_program: Vec<u16> =
+            serde_json::from_str(&encoded_program).expect("decode program envelope");
+        let decoded_args: Vec<Vec<u16>> =
+            serde_json::from_str(&encoded_args).expect("decode argument envelope");
+        assert_eq!(std::ffi::OsString::from_wide(&decoded_program), program);
+        let decoded_args: Vec<std::ffi::OsString> = decoded_args
+            .iter()
+            .map(|argument| std::ffi::OsString::from_wide(argument))
+            .collect();
+        assert_eq!(
+            decoded_args,
+            vec![
+                std::ffi::OsString::from("two words"),
+                std::ffi::OsString::from(""),
+                std::ffi::OsString::from("wide-雪"),
+            ]
+        );
+    }
+
+    #[test]
+    fn safe_job_spawn_preserves_wide_args_cwd_and_environment() {
+        let dir = tempfile::tempdir().expect("safe Job spawn directory");
+        let output = dir.path().join("spawn.json");
+        let script = dir.path().join("probe.ps1");
+        std::fs::write(
+            &script,
+            r#"$payload=[ordered]@{cwd=(Get-Location).Path;value=$env:BUZZ_JOB_TEST;args=@($args)}
+$payload|ConvertTo-Json -Compress|Set-Content -Encoding utf8 -LiteralPath $env:BUZZ_JOB_OUTPUT"#,
+        )
+        .expect("write safe Job spawn probe");
+        let mut command = Command::new("powershell.exe");
+        command
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+            ])
+            .arg(&script)
+            .arg("two words")
+            .arg("")
+            .current_dir(dir.path())
+            .env("BUZZ_JOB_TEST", "kept")
+            .env("BUZZ_JOB_OUTPUT", &output)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut process = spawn_managed_agent_process(
+            command,
+            PathBuf::new(),
+            0,
+            false,
+            None,
+            "safe-job-test".into(),
+        )
+        .expect("spawn safe Job probe");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while process
+            .child
+            .try_wait()
+            .expect("inspect safe Job probe")
+            .is_none()
+        {
+            assert!(Instant::now() < deadline, "safe Job probe timed out");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(process
+            .job
+            .as_ref()
+            .expect("owned Job")
+            .members()
+            .expect("query Job")
+            .is_empty());
+        let bytes = std::fs::read(&output).expect("safe Job probe output");
+        let bytes = bytes.strip_prefix(&[0xef, 0xbb, 0xbf]).unwrap_or(&bytes);
+        let payload: serde_json::Value = serde_json::from_slice(bytes).expect("probe JSON");
+        assert_eq!(payload["cwd"], dir.path().display().to_string());
+        assert_eq!(payload["value"], "kept");
+        assert_eq!(payload["args"][0], "two words");
+        assert_eq!(payload["args"][1], "");
+        process.job.take();
+    }
+
+    #[test]
+    fn receipt_deletion_failure_retains_empty_job_and_reaped_child_authority() {
+        let mut command = Command::new("powershell.exe");
+        command
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "while ($true) { Start-Sleep -Seconds 1 }",
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut process = spawn_managed_agent_process(
+            command,
+            PathBuf::new(),
+            0,
+            false,
+            None,
+            "receipt-delete-failure".into(),
+        )
+        .expect("spawn receipt deletion fixture");
+
+        let error = finalize_tracked_runtime_with(&mut process, || {
+            Err("synthetic receipt deletion failure".to_string())
+        })
+        .expect_err("receipt deletion must fail finalization");
+
+        assert!(error.contains("receipt deletion failure"));
+        let job = process.job.as_ref().expect("Job authority retained");
+        assert!(job.members().expect("query retained Job").is_empty());
+        assert!(process
+            .child
+            .try_wait()
+            .expect("inspect retained launcher")
+            .is_some());
+        release_finalized_managed_agent_process(&mut process)
+            .expect("release retained empty Job authority");
+    }
+
+    #[test]
+    fn terminal_proof_retains_reaped_child_for_idempotent_recovery_clear_retry() {
+        let mut command = Command::new("powershell.exe");
+        command
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "while ($true) { Start-Sleep -Seconds 1 }",
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let mut process = spawn_managed_agent_process(
+            command,
+            PathBuf::new(),
+            0,
+            false,
+            None,
+            "terminal-proof-retry".into(),
+        )
+        .expect("spawn terminal-proof retry fixture");
+
+        finalize_tracked_runtime_with(&mut process, || Ok(())).expect("first terminal proof");
+        assert!(process.job.is_none());
+        finalize_tracked_runtime_with(&mut process, || Ok(())).expect("idempotent terminal proof");
     }
 }

--- a/desktop/src-tauri/src/managed_agents/receipt_storage.rs
+++ b/desktop/src-tauri/src/managed_agents/receipt_storage.rs
@@ -1,0 +1,102 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tauri::AppHandle;
+
+use super::{managed_agents_base_dir, ManagedAgentRuntimeKey};
+
+pub fn remove_agent_runtime_receipt(
+    app: &AppHandle,
+    key: &ManagedAgentRuntimeKey,
+) -> Result<(), String> {
+    let path = managed_agents_base_dir(app)?
+        .join("agent-pids")
+        .join(format!("{}.json", key.runtime_id()));
+    remove_agent_runtime_receipt_path(&path)
+}
+
+pub fn receipt_deletion_tombstone(path: &Path) -> PathBuf {
+    path.with_extension("json.delete-pending")
+}
+
+pub fn finish_pending_agent_runtime_receipt_deletion(path: &Path) -> Result<(), String> {
+    let tombstone = receipt_deletion_tombstone(path);
+    if !tombstone.exists() {
+        return Ok(());
+    }
+    fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&tombstone)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| {
+            format!(
+                "failed to flush managed-agent receipt tombstone {}: {error}",
+                tombstone.display()
+            )
+        })?;
+    fs::remove_file(&tombstone).map_err(|error| {
+        format!(
+            "failed to remove managed-agent receipt tombstone {}: {error}",
+            tombstone.display()
+        )
+    })?;
+    verify_absent(&tombstone)
+}
+
+pub fn remove_agent_runtime_receipt_path(path: &Path) -> Result<(), String> {
+    let tombstone = receipt_deletion_tombstone(path);
+    if !path.exists() {
+        return finish_pending_agent_runtime_receipt_deletion(path);
+    }
+    if tombstone.exists() {
+        return Err(format!(
+            "both runtime receipt and deletion tombstone exist for {}",
+            path.display()
+        ));
+    }
+    fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| {
+            format!(
+                "failed to flush managed-agent runtime receipt {}: {error}",
+                path.display()
+            )
+        })?;
+    fs::rename(path, &tombstone).map_err(|error| {
+        format!(
+            "failed to retire managed-agent runtime receipt {}: {error}",
+            path.display()
+        )
+    })?;
+    fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&tombstone)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| {
+            format!(
+                "failed to durably commit runtime receipt retirement {}: {error}",
+                tombstone.display()
+            )
+        })?;
+    finish_pending_agent_runtime_receipt_deletion(path)?;
+    verify_absent(path)
+}
+
+fn verify_absent(path: &Path) -> Result<(), String> {
+    match fs::symlink_metadata(path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Ok(_) => Err(format!(
+            "managed-agent runtime receipt artifact still exists: {}",
+            path.display()
+        )),
+        Err(error) => Err(format!(
+            "failed to verify managed-agent runtime receipt artifact {}: {error}",
+            path.display()
+        )),
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/restore.rs
+++ b/desktop/src-tauri/src/managed_agents/restore.rs
@@ -8,21 +8,81 @@ use crate::util;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::Manager;
 
+fn tracked_receipt_pids_for_restore(
+    receipts: Result<Vec<(std::path::PathBuf, super::ManagedAgentRuntimeReceipt)>, String>,
+    instance_id: &str,
+) -> Result<Vec<u32>, String> {
+    Ok(receipts?
+        .into_iter()
+        .filter_map(|(path, receipt)| {
+            super::valid_agent_runtime_receipt(&path, &receipt, instance_id).then_some(receipt.pid)
+        })
+        .collect())
+}
+
 /// Outcome of a Phase B spawn attempt for one restore candidate.
 ///
-/// `Skipped` covers the case where a concurrently-running startup reconcile
-/// already spawned and tracked this exact pair during the Phase A window (the
-/// transition lock is only held from Phase B onward). Restore must then leave
-/// that live child alone rather than terminate-and-respawn it — mirroring the
-/// live-child guard in `start_pair` (`runtime_commands.rs`). Without this,
-/// restore would kill reconcile's lazy child by its receipt and replace it with
-/// an eager one, flipping the pair's laziness on a startup race.
+/// `Skipped` means this exact pair already has a live tracked child. Restore
+/// holds the global transition lock from candidate selection through runtime
+/// registration, so Stop/delete/restart cannot race this outcome.
 enum SpawnOutcome {
     Spawned(super::ManagedAgentRuntimeKey, ManagedAgentProcess),
     Skipped,
     Failed(String),
 }
 type AgentSpawnResult = (String, SpawnOutcome);
+
+/// Return `true` when an exact live runtime already owns this pair. An exited
+/// launcher is fully finalized before replacement; every inspection/finalizer
+/// failure reinserts the exact runtime authority.
+fn prepare_restore_pair(
+    app: &tauri::AppHandle,
+    key: &super::ManagedAgentRuntimeKey,
+) -> Result<bool, String> {
+    let state = app.state::<AppState>();
+    let mut runtimes = state
+        .managed_agent_processes
+        .lock()
+        .map_err(|error| error.to_string())?;
+    let Some(mut runtime) = runtimes.remove(key) else {
+        return Ok(false);
+    };
+    match runtime.child.try_wait() {
+        Ok(None) => {
+            runtimes.insert(key.clone(), runtime);
+            Ok(true)
+        }
+        Ok(Some(_)) => {
+            #[cfg(windows)]
+            let finalized =
+                super::process_lifecycle::finalize_tracked_runtime(app, key, &mut runtime);
+            #[cfg(not(windows))]
+            let finalized = runtime
+                .child
+                .wait()
+                .map_err(|error| error.to_string())
+                .and_then(|status| {
+                    super::remove_agent_runtime_receipt(app, key)?;
+                    Ok(status)
+                });
+            match finalized {
+                Ok(_) => Ok(false),
+                Err(error) => {
+                    runtimes.insert(key.clone(), runtime);
+                    Err(format!(
+                        "exited restore runtime could not be finalized: {error}"
+                    ))
+                }
+            }
+        }
+        Err(error) => {
+            runtimes.insert(key.clone(), runtime);
+            Err(format!(
+                "restore runtime exit could not be inspected: {error}"
+            ))
+        }
+    }
+}
 
 /// Backfill the pinned persona snapshot for pre-existing agents created before
 /// the record became the spawn source of truth. Runs once at launch, before
@@ -99,6 +159,47 @@ pub async fn restore_managed_agents_on_launch(
 
     let state = app.state::<AppState>();
 
+    #[cfg(feature = "mesh-llm")]
+    let mesh_preflights = {
+        let records = {
+            let _store_guard = state
+                .managed_agents_store_lock
+                .lock()
+                .map_err(|error| error.to_string())?;
+            load_managed_agents(app)?
+        };
+        let personas = load_personas(app).unwrap_or_default();
+        let global = super::load_global_agent_config(app).unwrap_or_default();
+        let mut outcomes = std::collections::HashMap::new();
+        for record in records
+            .into_iter()
+            .filter(|record| record.start_on_app_launch && record.backend == BackendKind::Local)
+        {
+            let mesh_model_id = super::effective_config::resolve_effective_relay_mesh_model_id(
+                &record, &personas, &global,
+            );
+            let result = if mesh_model_id.is_some() {
+                crate::commands::ensure_relay_mesh_for_record(app, mesh_model_id.as_deref(), false)
+                    .await
+            } else {
+                Ok(())
+            };
+            outcomes.insert(record.pubkey, (mesh_model_id, result));
+        }
+        outcomes
+    };
+
+    // Hold one transition lease from candidate selection through registration.
+    // Stop/delete/restart therefore cannot complete against a stale Phase-A
+    // snapshot and then be undone by this restore.
+    let _restore_transition = state
+        .managed_agent_runtime_transition
+        .lock()
+        .map_err(|error| error.to_string())?;
+    if shutdown_started.load(Ordering::SeqCst) {
+        return Ok(());
+    }
+
     // ── Phase A (under lock): housekeeping + collect agents to restore ──
     let mut agents_to_start: Vec<super::ManagedAgentRecord>;
     {
@@ -116,29 +217,19 @@ pub async fn restore_managed_agents_on_launch(
             .managed_agent_processes
             .lock()
             .map_err(|error| error.to_string())?;
-        let (mut changed, _exited) = sync_managed_agent_processes(
-            &mut records,
-            &mut runtimes,
-            &super::current_instance_id(app),
-        );
+        let (mut changed, _exited) = sync_managed_agent_processes(app, &mut records, &mut runtimes);
         changed |=
             kill_stale_tracked_processes(&mut records, &runtimes, &super::current_instance_id(app));
 
+        let instance_id = super::current_instance_id(app);
+        let receipt_pids = tracked_receipt_pids_for_restore(
+            super::read_all_agent_runtime_receipts(app),
+            &instance_id,
+        )?;
         let tracked_pids: Vec<u32> = runtimes
             .values()
             .map(|runtime| runtime.child.id())
-            .chain(
-                super::read_all_agent_runtime_receipts(app)
-                    .into_iter()
-                    .filter_map(|(path, receipt)| {
-                        super::valid_agent_runtime_receipt(
-                            &path,
-                            &receipt,
-                            &super::current_instance_id(app),
-                        )
-                        .then_some(receipt.pid)
-                    }),
-            )
+            .chain(receipt_pids)
             .collect();
         super::sweep_orphaned_agent_processes(app, &tracked_pids);
 
@@ -169,6 +260,46 @@ pub async fn restore_managed_agents_on_launch(
             .map(|record| record.pubkey.clone())
             .collect();
 
+        #[cfg(feature = "mesh-llm")]
+        let candidates = {
+            let personas = load_personas(app).unwrap_or_default();
+            let global = super::load_global_agent_config(app).unwrap_or_default();
+            let mut approved = Vec::new();
+            for pubkey in candidates {
+                let Some(record) = records.iter_mut().find(|record| record.pubkey == pubkey) else {
+                    continue;
+                };
+                let current_model = super::effective_config::resolve_effective_relay_mesh_model_id(
+                    record, &personas, &global,
+                );
+                let outcome = mesh_preflights.get(&pubkey);
+                let error = match outcome {
+                    Some((preflight_model, Ok(()))) if *preflight_model == current_model => None,
+                    Some((preflight_model, Ok(()))) => Some(format!(
+                        "managed agent changed from mesh model {preflight_model:?} to {current_model:?} while restore preflight was in flight; retry restore"
+                    )),
+                    Some((preflight_model, Err(error))) if *preflight_model == current_model => {
+                        Some(error.clone())
+                    }
+                    Some((preflight_model, Err(_))) => Some(format!(
+                        "managed agent changed from mesh model {preflight_model:?} to {current_model:?} while restore preflight was in flight; retry restore"
+                    )),
+                    None => Some(
+                        "managed agent became eligible after restore preflight; retry restore".to_string(),
+                    ),
+                };
+                if let Some(error) = error {
+                    record.updated_at = util::now_iso();
+                    record.last_error = Some(error);
+                    record.last_error_code = None;
+                    changed = true;
+                } else {
+                    approved.push(pubkey);
+                }
+            }
+            approved
+        };
+
         let mut to_start = Vec::new();
         for pubkey in &candidates {
             if let Some(runtime) = runtimes
@@ -180,9 +311,16 @@ pub async fn restore_managed_agents_on_launch(
                     continue;
                 }
             }
-            if let Some(record) = records.iter().find(|r| r.pubkey == *pubkey) {
-                if let Some(pid) = record.runtime_pid {
-                    if super::process_is_running(pid) {
+            if let Some(record) = records.iter_mut().find(|r| r.pubkey == *pubkey) {
+                let workspace_relay =
+                    crate::relay::relay_ws_url_with_override(&app.state::<AppState>());
+                let relay_url =
+                    crate::relay::effective_agent_relay_url(&record.relay_url, &workspace_relay);
+                if let Ok(key) =
+                    super::ManagedAgentRuntimeKey::new(record.pubkey.clone(), &relay_url)
+                {
+                    if super::recovery_admission_error(app, record, &key)?.is_some() {
+                        changed |= super::record_blocked_recovery_admission(record);
                         continue;
                     }
                 }
@@ -238,54 +376,6 @@ pub async fn restore_managed_agents_on_launch(
         .ok()
         .map(|k| k.public_key().to_hex());
 
-    #[cfg(feature = "mesh-llm")]
-    let agents_to_start = {
-        // Preflight against the same resolution spawn uses — `resolve_effective_config`
-        // (definition → global fallback). A linked instance's own `provider`/`model`/
-        // `relay_mesh` bytes never contribute. See `start_local_agent_with_preflight`
-        // in `commands/agents.rs` for the identical rationale on the interactive path.
-        let personas = load_personas(app).unwrap_or_default();
-        let global = super::load_global_agent_config(app).unwrap_or_default();
-        let mut mesh_preflight_failures = std::collections::HashSet::new();
-        for record in &agents_to_start {
-            let mesh_model_id = super::effective_config::resolve_effective_relay_mesh_model_id(
-                record, &personas, &global,
-            );
-            if mesh_model_id.is_none() {
-                continue;
-            }
-            // Auto-start after relaunch: re-resolve a live bootstrap target and
-            // dial it. Skip (with an actionable error) only when no live target
-            // serves this model right now.
-            if let Err(error) =
-                crate::commands::ensure_relay_mesh_for_record(app, mesh_model_id.as_deref(), false)
-                    .await
-            {
-                persist_restore_error(app, &state, &record.pubkey, error)?;
-                mesh_preflight_failures.insert(record.pubkey.clone());
-            }
-        }
-        agents_to_start
-            .into_iter()
-            .filter(|record| !mesh_preflight_failures.contains(&record.pubkey))
-            .collect::<Vec<_>>()
-    };
-    if agents_to_start.is_empty() {
-        return Ok(());
-    }
-
-    // Serialize spawning and runtime registration with shutdown cleanup. The
-    // shutdown flag is rechecked after taking the lock so shutdown either
-    // prevents this transition or waits until every child is tracked and can
-    // be terminated.
-    let restore_transition = state
-        .managed_agent_runtime_transition
-        .lock()
-        .map_err(|error| error.to_string())?;
-    if shutdown_started.load(Ordering::SeqCst) {
-        return Ok(());
-    }
-
     // ── Phase B (transition lock held): resolve commands and spawn in parallel ──
     let spawn_results: Vec<AgentSpawnResult> = std::thread::scope(|scope| {
         let owner_hex_ref = owner_hex.as_deref();
@@ -303,33 +393,24 @@ pub async fn restore_managed_agents_on_launch(
                     let outcome =
                         match super::ManagedAgentRuntimeKey::new(record.pubkey.clone(), &relay_url)
                         {
-                            Ok(key) => {
-                                // F2: if a concurrent startup reconcile already
-                                // tracked a live child for this exact pair during
-                                // the Phase A window, leave it alone. Mirrors the
-                                // live-child guard in `start_pair`.
-                                let already_live = app
-                                    .state::<AppState>()
-                                    .managed_agent_processes
-                                    .lock()
-                                    .ok()
-                                    .and_then(|mut runtimes| {
-                                        runtimes.get_mut(&key).map(|runtime| {
-                                            runtime.child.try_wait().ok().flatten().is_none()
-                                        })
-                                    })
-                                    .unwrap_or(false);
-                                if already_live {
-                                    SpawnOutcome::Skipped
-                                } else {
+                            Ok(key) => match prepare_restore_pair(app, &key) {
+                                Ok(true) => SpawnOutcome::Skipped,
+                                Err(error) => SpawnOutcome::Failed(error),
+                                Ok(false) => {
+                                    if let Some(error) =
+                                        super::recovery_admission_error(app, record, &key)
+                                            .unwrap_or_else(Some)
+                                    {
+                                        return (
+                                            record.pubkey.clone(),
+                                            SpawnOutcome::Failed(error),
+                                        );
+                                    }
                                     match super::terminate_untracked_pair_runtime(app, &key)
                                         .and_then(|()| {
-                                            // F1: restore spawns lazy, matching
-                                            // reconcile and manual start. Eager on
-                                            // restore buys nothing — a crashed
-                                            // mid-turn session is not resumed by an
-                                            // eager child — and silently reintroduces
-                                            // N idle brains on every launch.
+                                            // Restore spawns lazy, matching reconcile
+                                            // and manual start. A crashed mid-turn
+                                            // session is not resumed by an eager child.
                                             spawn_agent_child(
                                                 app,
                                                 record,
@@ -342,7 +423,7 @@ pub async fn restore_managed_agents_on_launch(
                                         Err(error) => SpawnOutcome::Failed(error),
                                     }
                                 }
-                            }
+                            },
                             Err(error) => SpawnOutcome::Failed(error),
                         };
                     (record.pubkey.clone(), outcome)
@@ -378,6 +459,20 @@ pub async fn restore_managed_agents_on_launch(
             SpawnOutcome::Skipped => continue,
             SpawnOutcome::Spawned(key, mut process) => {
                 let Ok(record) = find_managed_agent_mut(&mut records, &pubkey) else {
+                    #[cfg(windows)]
+                    if let Err(cleanup_error) =
+                        super::process_lifecycle::terminate_managed_agent_process(&mut process)
+                    {
+                        runtimes.insert(key, super::ManagedAgentPairRuntime::starting(process));
+                        return Err(format!(
+                            "restored runtime lost its record and cleanup remains tracked for retry: {cleanup_error}"
+                        ));
+                    }
+                    #[cfg(not(windows))]
+                    {
+                        let _ = super::terminate_process(process.child.id());
+                        let _ = process.child.wait();
+                    }
                     continue;
                 };
                 let now = util::now_iso();
@@ -386,20 +481,36 @@ pub async fn restore_managed_agents_on_launch(
                     pid: process.child.id(),
                     desktop_instance_id: super::current_instance_id(app),
                     started_at: now.clone(),
+                    windows_job_contained: super::process_has_windows_job(&process),
                 };
                 if let Err(error) = super::write_agent_runtime_receipt(app, &receipt) {
-                    let _ = super::terminate_process(process.child.id());
-                    let _ = process.child.wait();
-                    record.updated_at = now;
-                    record.last_error = Some(error);
+                    let cleanup_error = match super::runtime::receipt_failure::cleanup(
+                        app,
+                        process,
+                        record,
+                        &mut runtimes,
+                        key,
+                        now.clone(),
+                        error,
+                    ) {
+                        Err(error) => error,
+                        Ok(()) => {
+                            "receipt cleanup returned without reporting its failure".to_string()
+                        }
+                    };
+                    if record.last_error.is_none() {
+                        record.updated_at = now;
+                        record.last_error = Some(cleanup_error);
+                    }
                     continue;
                 }
                 record.updated_at = now.clone();
-                record.runtime_pid = None;
                 record.last_started_at = Some(now);
                 record.last_stopped_at = None;
                 record.last_exit_code = None;
-                record.last_error = None;
+                if !super::has_unverified_job_reap(record) {
+                    record.last_error = None;
+                }
                 runtimes.insert(key, super::ManagedAgentPairRuntime::starting(process));
                 successfully_spawned.push(pubkey);
             }
@@ -447,7 +558,7 @@ pub async fn restore_managed_agents_on_launch(
     save_managed_agents(app, &records)?;
     drop(runtimes);
     drop(_store_guard);
-    drop(restore_transition);
+    drop(_restore_transition);
 
     // ── Profile reconciliation (fire-and-forget) ────────────────────────────
     // Spawn background tasks to ensure each restored agent's kind:0 profile is
@@ -468,20 +579,19 @@ pub async fn restore_managed_agents_on_launch(
     Ok(())
 }
 
-#[cfg(feature = "mesh-llm")]
-fn persist_restore_error(
-    app: &tauri::AppHandle,
-    state: &AppState,
-    pubkey: &str,
-    error: String,
-) -> Result<(), String> {
-    let _store_guard = state
-        .managed_agents_store_lock
-        .lock()
-        .map_err(|error| error.to_string())?;
-    let mut records = load_managed_agents(app)?;
-    let record = find_managed_agent_mut(&mut records, pubkey)?;
-    record.updated_at = util::now_iso();
-    record.last_error = Some(error);
-    save_managed_agents(app, &records)
+#[cfg(test)]
+mod receipt_discovery_tests {
+    #[test]
+    fn receipt_store_uncertainty_blocks_restore_admission() {
+        let discovery: Result<
+            Vec<(
+                std::path::PathBuf,
+                crate::managed_agents::ManagedAgentRuntimeReceipt,
+            )>,
+            String,
+        > = Err("receipt store indeterminate".to_string());
+
+        let error = super::tracked_receipt_pids_for_restore(discovery, "instance").unwrap_err();
+        assert!(error.contains("receipt store indeterminate"));
+    }
 }

--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -26,9 +26,13 @@ pub(crate) use metadata::{
     SESSION_TITLE_ENV_VAR,
 };
 
+pub(crate) mod receipt_failure;
 mod stop;
 pub(crate) use stop::managed_agent_runtime_keys;
-pub use stop::{stop_managed_agent_process, stop_managed_agent_workspace_pair};
+pub use stop::{
+    persist_failed_stop, persist_stop, stop_managed_agent_process,
+    stop_managed_agent_workspace_pair,
+};
 
 mod sweep;
 pub(crate) use sweep::sweep_untracked_bundle_harnesses;
@@ -44,6 +48,11 @@ use process::{
 pub(crate) use process::{
     current_instance_id, process_belongs_to_us, process_has_buzz_marker, process_is_running,
     terminate_process, terminate_untracked_pair_runtime, valid_agent_runtime_receipt,
+};
+#[cfg(all(test, windows))]
+use process::{
+    persisted_windows_receipt_can_retire, persisted_windows_receipt_for_pair,
+    persisted_windows_receipt_matches,
 };
 
 mod orphan_sweep;
@@ -66,9 +75,9 @@ use instance_reaper::{buffer_contains_identifier, is_desktop_binary};
 // Exact-path harness sweep lives in runtime/sweep.rs (re-exported above).
 
 mod lifecycle;
-#[cfg(test)]
-use lifecycle::kill_stale_tracked_processes_with;
 pub use lifecycle::{kill_stale_tracked_processes, sync_managed_agent_processes};
+#[cfg(test)]
+pub(crate) use lifecycle::{kill_stale_tracked_processes_with, sync_managed_agent_processes_with};
 
 /// Classify an agent's persona against the live catalog for the Agents-menu
 /// drift indicator. Returns `(out_of_date, orphaned)`.
@@ -889,24 +898,6 @@ pub fn spawn_agent_child(
         use std::os::unix::process::CommandExt;
         command.process_group(0);
     }
-    // Windows: suppress the harness console window. Without this a bare
-    // terminal pops for buzz-acp.exe and lingers (the app itself sets
-    // windows_subsystem="windows", but the spawned child does not inherit it).
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-        command.creation_flags(CREATE_NO_WINDOW);
-    }
-
-    let child = command.spawn().map_err(|error| {
-        format!(
-            "failed to spawn `{}` for agent {}: {error}",
-            resolved_acp_command.display(),
-            record.name
-        )
-    })?;
-
     // Stamp the effective spawn config so the summary builder can flag
     // needs_restart when disk state drifts from what this process runs.
     // `effective_relay_url` is already resolved, and resolution is idempotent,
@@ -934,19 +925,23 @@ pub fn spawn_agent_child(
     };
 
     // Receipt persistence belongs to the caller's atomic register transition.
-
-    // Windows: assign the harness to a Job Object so its whole tree dies with
-    // the handle. The Unix process-group equivalent is set above.
     #[cfg(windows)]
-    return Ok(super::process_lifecycle::finish_spawn(
-        child,
+    return super::process_lifecycle::spawn_managed_agent_process(
+        command,
         log_path,
         spawn_config_hash,
         spawned_setup_mode,
         spawned_adapter_availability,
         start_nonce,
-        &record.name,
-    ));
+    );
+    #[cfg(not(windows))]
+    let child = command.spawn().map_err(|error| {
+        format!(
+            "failed to spawn `{}` for agent {}: {error}",
+            resolved_acp_command.display(),
+            record.name
+        )
+    })?;
     #[cfg(not(windows))]
     Ok(crate::managed_agents::ManagedAgentProcess {
         child,
@@ -981,43 +976,43 @@ pub fn start_managed_agent_process(
         )
     };
     let key = ManagedAgentRuntimeKey::new(record.pubkey.clone(), &relay_url)?;
+    super::ensure_recovery_admission(app, record, &key)?;
     if let Some(runtime) = runtimes.get_mut(&key) {
-        if runtime
+        match runtime
             .child
             .try_wait()
             .map_err(|error| format!("failed to inspect running process: {error}"))?
-            .is_none()
         {
-            return Ok(());
+            None => return Ok(()),
+            Some(_) => {
+                #[cfg(windows)]
+                super::process_lifecycle::finalize_tracked_runtime(app, &key, runtime)?;
+                #[cfg(not(windows))]
+                super::remove_agent_runtime_receipt(app, &key)?;
+            }
         }
-
         runtimes.remove(&key);
-        super::remove_agent_runtime_receipt(app, &key);
     }
+    super::terminate_untracked_pair_runtime(app, &key)?;
 
-    // Scalar PIDs are migration-only and never establish pair liveness.
-    record.runtime_pid = None;
-
-    let mut process = spawn_agent_child(app, record, &key.relay_url, false, owner_hex)?;
+    let process = spawn_agent_child(app, record, &key.relay_url, false, owner_hex)?;
     let now = now_iso();
     let receipt = super::ManagedAgentRuntimeReceipt {
         key: key.clone(),
         pid: process.child.id(),
         desktop_instance_id: current_instance_id(app),
         started_at: now.clone(),
+        windows_job_contained: super::process_has_windows_job(&process),
     };
     if let Err(error) = super::write_agent_runtime_receipt(app, &receipt) {
-        let _ = terminate_process(process.child.id());
-        let _ = process.child.wait();
-        return Err(error);
+        return receipt_failure::cleanup(app, process, record, runtimes, key, now, error);
     }
 
     record.updated_at = now.clone();
     record.last_started_at = Some(now);
     record.last_stopped_at = None;
     record.last_exit_code = None;
-    record.last_error = None;
-    record.last_error_code = None;
+    receipt_failure::clear_error_after_verified_start(record);
 
     runtimes.insert(key, ManagedAgentPairRuntime::starting(process));
     Ok(())

--- a/desktop/src-tauri/src/managed_agents/runtime/lifecycle.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/lifecycle.rs
@@ -3,6 +3,39 @@ use super::*;
 /// Kill stale agent processes from a previous session whose PID is still alive
 /// but not tracked in the current `runtimes` map. Updates the record fields and
 /// returns `true` if any records were modified.
+#[cfg(windows)]
+pub fn kill_stale_tracked_processes(
+    records: &mut [ManagedAgentRecord],
+    runtimes: &HashMap<ManagedAgentRuntimeKey, ManagedAgentPairRuntime>,
+    _instance_id: &str,
+) -> bool {
+    use crate::managed_agents::BackendKind;
+
+    let mut changed = false;
+    for record in records.iter_mut() {
+        let Some(pid) = record.runtime_pid else {
+            continue;
+        };
+        if record.backend != BackendKind::Local
+            || runtimes.keys().any(|key| key.pubkey == record.pubkey)
+            || super::super::has_unverified_job_reap(record)
+        {
+            continue;
+        }
+        let message = format!(
+            "cannot safely reconcile persisted Windows PID {pid} without owned Child/Job authority; preserving recovery identity"
+        );
+        if record.last_error.as_deref() != Some(message.as_str()) {
+            record.updated_at = crate::util::now_iso();
+            record.last_error = Some(message);
+            record.last_error_code = None;
+            changed = true;
+        }
+    }
+    changed
+}
+
+#[cfg(not(windows))]
 pub fn kill_stale_tracked_processes(
     records: &mut [ManagedAgentRecord],
     runtimes: &HashMap<ManagedAgentRuntimeKey, ManagedAgentPairRuntime>,
@@ -35,15 +68,33 @@ pub(crate) fn kill_stale_tracked_processes_with(
         let Some(pid) = record.runtime_pid else {
             continue;
         };
+        if super::super::has_unverified_job_reap(record) {
+            // Post-Job launcher reap remains unverified. Preserve durable
+            // PID/receipt recovery identity; Windows marker probes cannot
+            // prove this process absent.
+            continue;
+        }
         if !runtimes.keys().any(|key| key.pubkey == record.pubkey) {
             // Name-gate is omitted intentionally: custom harnesses use arbitrary
             // binary names not in KNOWN_AGENT_BINARIES. BUZZ_MANAGED_AGENT is the
             // authoritative ownership proof; terminate only if it matches.
             if has_marker(pid) {
-                let _ = kill(pid);
+                if let Err(error) = kill(pid) {
+                    // A failed termination must retain the persisted PID so a
+                    // later reconciliation can retry with the same ownership
+                    // marker instead of publishing a false stopped state.
+                    record.updated_at = crate::util::now_iso();
+                    record.last_error = Some(format!(
+                        "failed to terminate stale managed-agent process {pid}: {error}"
+                    ));
+                    record.last_error_code = None;
+                    changed = true;
+                    continue;
+                }
+                record.last_stopped_at = Some(crate::util::now_iso());
+                record.last_error = None;
             }
             record.runtime_pid = None;
-            record.last_stopped_at = Some(crate::util::now_iso());
             record.updated_at = crate::util::now_iso();
             changed = true;
         }
@@ -52,27 +103,126 @@ pub(crate) fn kill_stale_tracked_processes_with(
 }
 
 pub fn sync_managed_agent_processes(
+    app: &tauri::AppHandle,
     records: &mut [ManagedAgentRecord],
     runtimes: &mut HashMap<ManagedAgentRuntimeKey, ManagedAgentPairRuntime>,
-    _instance_id: &str,
-) -> (bool, Vec<String>) {
+) -> (bool, Vec<ManagedAgentRuntimeKey>) {
+    sync_managed_agent_processes_with(Some(app), records, runtimes, |key, runtime| {
+        let status = runtime.child.try_wait()?;
+        #[cfg(windows)]
+        if status.is_some() {
+            return super::super::process_lifecycle::finalize_tracked_runtime(app, key, runtime)
+                .map(Some)
+                .map_err(std::io::Error::other);
+        }
+        #[cfg(not(windows))]
+        if status.is_some() {
+            super::super::remove_agent_runtime_receipt(app, key).map_err(std::io::Error::other)?;
+        }
+        Ok(status)
+    })
+}
+
+pub(crate) fn sync_managed_agent_processes_with(
+    app: Option<&tauri::AppHandle>,
+    records: &mut [ManagedAgentRecord],
+    runtimes: &mut HashMap<ManagedAgentRuntimeKey, ManagedAgentPairRuntime>,
+    inspect: impl FnMut(
+        &ManagedAgentRuntimeKey,
+        &mut ManagedAgentPairRuntime,
+    ) -> std::io::Result<Option<std::process::ExitStatus>>,
+) -> (bool, Vec<ManagedAgentRuntimeKey>) {
+    sync_managed_agent_processes_with_recovery(app, records, runtimes, inspect, |record, key| {
+        if let Some(app) = app {
+            super::super::clear_pair_recovery_with_terminal_proof(app, record, key)
+        } else {
+            Ok(false)
+        }
+    })
+}
+
+pub(crate) fn sync_managed_agent_processes_with_recovery(
+    app: Option<&tauri::AppHandle>,
+    records: &mut [ManagedAgentRecord],
+    runtimes: &mut HashMap<ManagedAgentRuntimeKey, ManagedAgentPairRuntime>,
+    inspect: impl FnMut(
+        &ManagedAgentRuntimeKey,
+        &mut ManagedAgentPairRuntime,
+    ) -> std::io::Result<Option<std::process::ExitStatus>>,
+    clear_recovery: impl FnMut(&mut ManagedAgentRecord, &ManagedAgentRuntimeKey) -> Result<bool, String>,
+) -> (bool, Vec<ManagedAgentRuntimeKey>) {
+    sync_managed_agent_processes_with_recovery_and_persist(
+        app,
+        records,
+        runtimes,
+        inspect,
+        clear_recovery,
+        |records| match app {
+            Some(app) => super::super::save_managed_agents(app, records),
+            None => Ok(()),
+        },
+    )
+}
+
+pub(crate) fn sync_managed_agent_processes_with_recovery_and_persist(
+    app: Option<&tauri::AppHandle>,
+    records: &mut [ManagedAgentRecord],
+    runtimes: &mut HashMap<ManagedAgentRuntimeKey, ManagedAgentPairRuntime>,
+    mut inspect: impl FnMut(
+        &ManagedAgentRuntimeKey,
+        &mut ManagedAgentPairRuntime,
+    ) -> std::io::Result<Option<std::process::ExitStatus>>,
+    mut clear_recovery: impl FnMut(
+        &mut ManagedAgentRecord,
+        &ManagedAgentRuntimeKey,
+    ) -> Result<bool, String>,
+    persist: impl FnOnce(&[ManagedAgentRecord]) -> Result<(), String>,
+) -> (bool, Vec<ManagedAgentRuntimeKey>) {
     let mut changed = false;
     let mut exited = Vec::new();
+    let mut terminal_summaries = std::collections::HashMap::<
+        String,
+        Vec<(
+            String,
+            Option<i32>,
+            Option<super::super::storage::AgentLogError>,
+        )>,
+    >::new();
+    let mut runtime_keys = runtimes.keys().cloned().collect::<Vec<_>>();
+    runtime_keys.sort_by_key(ManagedAgentRuntimeKey::runtime_id);
 
-    for (key, runtime) in runtimes.iter_mut() {
-        let status = match runtime.child.try_wait() {
+    for key in runtime_keys {
+        let Some(runtime) = runtimes.get_mut(&key) else {
+            continue;
+        };
+        let status = match inspect(&key, runtime) {
             Ok(status) => status,
             Err(error) => {
                 if let Some(record) = records
                     .iter_mut()
                     .find(|record| record.pubkey == key.pubkey)
                 {
-                    record.updated_at = now_iso();
-                    record.last_error = Some(format!("failed to inspect process state: {error}"));
-                    record.last_error_code = None;
+                    #[cfg(windows)]
+                    super::receipt_failure::mark_unverified_runtime(
+                        app,
+                        record,
+                        &key,
+                        runtime.child.id(),
+                        now_iso(),
+                        format!("failed to inspect or finalize process state: {error}"),
+                    );
+                    #[cfg(not(windows))]
+                    {
+                        record.updated_at = now_iso();
+                        record.last_error =
+                            Some(format!("failed to inspect process state: {error}"));
+                        record.last_error_code = None;
+                    }
                 }
                 changed = true;
-                exited.push(key.clone());
+                // Inspection failure is not proof of exit. Preserve the exact
+                // Child/Job authority so callers can retry Stop instead of
+                // converting an uncertain live tree into an invisible orphan.
                 continue;
             }
         };
@@ -81,45 +231,134 @@ pub fn sync_managed_agent_processes(
             continue;
         };
 
+        let log_err = if status.success() {
+            None
+        } else {
+            Some(
+                super::super::meaningful_agent_error_from_log(&runtime.log_path).unwrap_or_else(
+                    || super::super::storage::AgentLogError {
+                        message: format!("harness exited with status {status}"),
+                        code: None,
+                    },
+                ),
+            )
+        };
+
         if let Some(record) = records
             .iter_mut()
             .find(|record| record.pubkey == key.pubkey)
         {
             record.updated_at = now_iso();
-            record.last_stopped_at = Some(now_iso());
-            record.last_exit_code = status.code();
-            let log_err = if status.success() {
-                None
-            } else {
-                Some(
-                    super::super::meaningful_agent_error_from_log(&runtime.log_path)
-                        .unwrap_or_else(|| super::super::storage::AgentLogError {
-                            message: format!("harness exited with status {status}"),
-                            code: None,
-                        }),
-                )
-            };
-            record.last_error = log_err.as_ref().map(|e| e.message.clone());
-            record.last_error_code = log_err.as_ref().and_then(|e| e.code);
+            if !status.success() || super::super::pending_pair_failures(record).is_empty() {
+                record.last_exit_code = status.code();
+            }
+            if let Err(error) = clear_recovery(record, &key) {
+                super::super::record_terminal_proof_pending_recovery_clear(
+                    record,
+                    &key,
+                    runtime.child.id(),
+                    &error,
+                );
+                if let Some(log_error) = &log_err {
+                    super::super::record_pending_pair_failure(
+                        record,
+                        &key,
+                        status.code(),
+                        log_error,
+                    );
+                }
+                changed = true;
+                // Keep the finalized Child/Job token in memory until either
+                // the canonical clear or its exact-pair retry marker commits.
+                continue;
+            }
+            if let Some(error) = &log_err {
+                super::super::record_pending_pair_failure(record, &key, status.code(), error);
+            }
+            terminal_summaries
+                .entry(key.pubkey.clone())
+                .or_default()
+                .push((key.runtime_id(), status.code(), log_err));
         }
 
         changed = true;
         exited.push(key.clone());
     }
 
-    let exited_pubkeys: Vec<String> = exited.iter().map(|key| key.pubkey.clone()).collect();
-    for key in exited {
-        runtimes.remove(&key);
+    for record in records.iter_mut() {
+        let Some(mut summaries) = terminal_summaries.remove(&record.pubkey) else {
+            continue;
+        };
+        if runtimes
+            .keys()
+            .any(|key| key.pubkey == record.pubkey && !exited.iter().any(|exited| exited == key))
+            || super::super::has_unverified_job_reap(record)
+        {
+            continue;
+        }
+        summaries.sort_by(|left, right| left.0.cmp(&right.0));
+        let mut failures = super::super::pending_pair_failures(record);
+        for (runtime_id, _, error) in &summaries {
+            if let Some(error) = error {
+                failures.insert(runtime_id.clone(), error.message.clone());
+            }
+        }
+        let current_failure_code = summaries
+            .iter()
+            .find_map(|(_, _, error)| error.as_ref().and_then(|error| error.code));
+        record.last_stopped_at = Some(now_iso());
+        if failures.is_empty() {
+            record.last_exit_code = summaries.first().and_then(|summary| summary.1);
+            record.last_error = None;
+            record.last_error_code = None;
+        } else {
+            record.last_exit_code = summaries
+                .iter()
+                .find(|summary| summary.2.is_some())
+                .and_then(|summary| summary.1)
+                .or(record.last_exit_code);
+            record.last_error = Some(
+                failures
+                    .iter()
+                    .map(|(runtime_id, message)| format!("{runtime_id}: {message}"))
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            );
+            record.last_error_code = current_failure_code.or(record.last_error_code);
+        }
     }
 
     // `runtime_pid` is legacy bookkeeping. Pair runtimes and receipts are the
     // authoritative lifecycle source; migration cleanup is handled separately.
     for record in records.iter_mut() {
+        #[cfg(windows)]
+        if record.runtime_pid.is_some() {
+            // A persisted Windows PID without its owned Child/Job handle is
+            // unresolved recovery evidence. Generic polling cannot prove it
+            // absent because the Windows liveness probe is intentionally not
+            // PID-authoritative; admission/migration must classify it first.
+            continue;
+        }
+        if super::super::has_unverified_job_reap(record) {
+            continue;
+        }
         if record.runtime_pid.take().is_some() {
             record.updated_at = now_iso();
             changed = true;
         }
     }
 
-    (changed, exited_pubkeys)
+    if !exited.is_empty() {
+        if persist(records).is_ok() {
+            for key in &exited {
+                runtimes.remove(key);
+            }
+        } else {
+            // The Child/Job token remains authoritative until the terminal
+            // record update has crossed its durable commit barrier.
+            exited.clear();
+        }
+    }
+
+    (changed, exited)
 }

--- a/desktop/src-tauri/src/managed_agents/runtime/orphan_sweep.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/orphan_sweep.rs
@@ -10,13 +10,26 @@ use super::*;
 pub(crate) fn sweep_orphaned_agent_processes(app: &AppHandle, skip_pids: &[u32]) {
     let legacy_entries = super::super::read_all_agent_pid_files(app);
     let instance_id = current_instance_id(app);
-    let receipt_entries: Vec<_> = super::super::read_all_agent_runtime_receipts(app)
+    let receipt_entries = match super::super::read_all_agent_runtime_receipts(app) {
+        Ok(entries) => entries,
+        Err(error) => {
+            eprintln!(
+                "buzz-desktop: orphan sweep skipped because runtime receipt discovery is indeterminate: {error}"
+            );
+            return;
+        }
+    };
+    let receipt_entries: Vec<_> = receipt_entries
         .into_iter()
         .filter_map(|(path, receipt)| {
             if valid_agent_runtime_receipt(&path, &receipt, &instance_id) {
                 Some((path, receipt))
             } else {
-                super::super::remove_agent_runtime_receipt_path(&path);
+                if let Err(error) = super::super::remove_agent_runtime_receipt_path(&path) {
+                    eprintln!(
+                        "buzz-desktop: orphan sweep could not remove invalid receipt: {error}"
+                    );
+                }
                 None
             }
         })
@@ -60,7 +73,9 @@ pub(crate) fn sweep_orphaned_agent_processes(app: &AppHandle, skip_pids: &[u32])
             continue;
         }
         if !process_is_running(receipt.pid) || !process_has_buzz_marker(receipt.pid, &instance_id) {
-            super::super::remove_agent_runtime_receipt(app, &receipt.key);
+            if let Err(error) = super::super::remove_agent_runtime_receipt(app, &receipt.key) {
+                eprintln!("buzz-desktop: orphan sweep could not remove finalized receipt: {error}");
+            }
         }
     }
 }

--- a/desktop/src-tauri/src/managed_agents/runtime/process.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/process.rs
@@ -425,12 +425,12 @@ pub(super) fn terminate_runtime_receipt_with(
     receipt: &super::super::ManagedAgentRuntimeReceipt,
     terminate: impl FnOnce(u32) -> Result<(), String>,
     mut is_running: impl FnMut(u32) -> bool,
-    remove: impl FnOnce(&std::path::Path),
+    remove: impl FnOnce(&std::path::Path) -> Result<(), String>,
 ) -> Result<(), String> {
     terminate(receipt.pid)?;
     for _ in 0..20 {
         if !is_running(receipt.pid) {
-            remove(path);
+            remove(path)?;
             return Ok(());
         }
         std::thread::sleep(std::time::Duration::from_millis(100));
@@ -445,20 +445,85 @@ pub(super) fn terminate_runtime_receipt_with(
 /// the same pair. The caller must hold the runtime transition lock so receipt
 /// inspection, termination, spawn, and registration cannot race shutdown or
 /// another start.
+#[cfg(windows)]
+pub(super) fn persisted_windows_receipt_matches(
+    path: &std::path::Path,
+    receipt: &super::super::ManagedAgentRuntimeReceipt,
+    key: &ManagedAgentRuntimeKey,
+) -> bool {
+    receipt.key == *key
+        && ManagedAgentRuntimeKey::new(receipt.key.pubkey.clone(), &receipt.key.relay_url)
+            .is_ok_and(|canonical| canonical == receipt.key)
+        && path.file_name().and_then(|name| name.to_str())
+            == Some(&format!("{}.json", key.runtime_id()))
+}
+
+#[cfg(windows)]
+pub(super) fn persisted_windows_receipt_can_retire(
+    receipt: &super::super::ManagedAgentRuntimeReceipt,
+) -> Result<bool, String> {
+    if receipt.windows_job_contained {
+        return Ok(true);
+    }
+    processkit::process_is_alive(receipt.pid, None)
+        .map(|alive| !alive)
+        .map_err(|error| {
+            format!(
+                "cannot inspect legacy runtime PID {} for pair {} on {}: {error}",
+                receipt.pid, receipt.key.pubkey, receipt.key.relay_url
+            )
+        })
+}
+
+#[cfg(windows)]
+pub(super) fn persisted_windows_receipt_for_pair(
+    receipts: Result<Vec<(std::path::PathBuf, super::super::ManagedAgentRuntimeReceipt)>, String>,
+    key: &ManagedAgentRuntimeKey,
+) -> Result<Option<(std::path::PathBuf, super::super::ManagedAgentRuntimeReceipt)>, String> {
+    Ok(receipts?
+        .into_iter()
+        .find(|(path, receipt)| persisted_windows_receipt_matches(path, receipt, key)))
+}
+
 pub(crate) fn terminate_untracked_pair_runtime(
     app: &AppHandle,
     key: &ManagedAgentRuntimeKey,
 ) -> Result<(), String> {
+    #[cfg(not(windows))]
     let instance_id = current_instance_id(app);
-    let Some((path, receipt)) = super::super::read_all_agent_runtime_receipts(app)
+    #[cfg(windows)]
+    let receipt = persisted_windows_receipt_for_pair(
+        super::super::read_all_agent_runtime_receipts(app),
+        key,
+    )?;
+    #[cfg(not(windows))]
+    let receipt = super::super::read_all_agent_runtime_receipts(app)?
         .into_iter()
         .find(|(path, receipt)| {
             receipt.key == *key && valid_agent_runtime_receipt(path, receipt, &instance_id)
-        })
-    else {
+        });
+    let Some((path, receipt)) = receipt else {
         return Ok(());
     };
 
+    #[cfg(windows)]
+    {
+        // Receipts from this generation prove mandatory kill-on-close Job
+        // containment, so loss of the owning process also proves closure of that
+        // Job handle. Legacy receipts carry no such proof: retire them only after
+        // read-only liveness inspection proves their recorded PID is absent. A
+        // live or uninspectable legacy PID blocks replacement; it is never kill
+        // authority.
+        if !persisted_windows_receipt_can_retire(&receipt)? {
+            return Err(format!(
+                "legacy runtime PID {} for pair {} on {} is still live; refusing numeric-PID termination",
+                receipt.pid, receipt.key.pubkey, receipt.key.relay_url
+            ));
+        }
+        super::super::remove_agent_runtime_receipt_path(&path)
+    }
+
+    #[cfg(not(windows))]
     terminate_runtime_receipt_with(
         &path,
         &receipt,

--- a/desktop/src-tauri/src/managed_agents/runtime/receipt_failure.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/receipt_failure.rs
@@ -1,0 +1,226 @@
+use std::collections::HashMap;
+
+use super::ManagedAgentPairRuntime;
+use crate::managed_agents::{
+    ManagedAgentProcess, ManagedAgentRecord, ManagedAgentRuntimeKey, UNVERIFIED_JOB_REAP_PREFIX,
+};
+
+pub(crate) fn mark_unverified_runtime(
+    app: Option<&tauri::AppHandle>,
+    record: &mut ManagedAgentRecord,
+    key: &ManagedAgentRuntimeKey,
+    recovery_pid: u32,
+    now: String,
+    detail: String,
+) -> String {
+    let message = app
+        .map(|app| {
+            crate::managed_agents::mark_pair_recovery_uncertain(
+                app,
+                record,
+                key,
+                recovery_pid,
+                detail.clone(),
+            )
+        })
+        .transpose();
+    if let Err(error) = message {
+        let pair = serde_json::to_string(key).unwrap_or_else(|_| key.runtime_id());
+        let projected_pair_is_preserved = record.last_error.as_deref().is_some_and(|current| {
+            current.starts_with(UNVERIFIED_JOB_REAP_PREFIX)
+                && current.contains(&format!("pair={pair} pid={recovery_pid}"))
+        });
+        if !projected_pair_is_preserved {
+            record.runtime_pid = Some(recovery_pid);
+            record.last_stopped_at = None;
+            record.last_error = Some(format!(
+                "{UNVERIFIED_JOB_REAP_PREFIX} pair={pair} pid={recovery_pid}; recovery sidecar persistence failed closed: {error}; {detail}"
+            ));
+            record.last_error_code = None;
+        }
+    } else if app.is_none() {
+        record.runtime_pid = Some(recovery_pid);
+        record.last_stopped_at = None;
+        record.last_error = Some(format!(
+            "{UNVERIFIED_JOB_REAP_PREFIX} pair={} pid={recovery_pid}; {detail}",
+            serde_json::to_string(key).unwrap_or_else(|_| key.runtime_id())
+        ));
+        record.last_error_code = None;
+    }
+    record.updated_at = now;
+    record.last_error.clone().unwrap_or_else(|| {
+        format!(
+            "{UNVERIFIED_JOB_REAP_PREFIX} exact pair recovery remains uncertain for pid {recovery_pid}"
+        )
+    })
+}
+
+pub(crate) fn clear_error_after_verified_start(record: &mut ManagedAgentRecord) {
+    if !crate::managed_agents::has_unverified_job_reap(record) {
+        record.last_error = None;
+        record.last_error_code = None;
+    }
+}
+
+#[cfg(windows)]
+struct ReceiptFailureContext {
+    key: ManagedAgentRuntimeKey,
+    now: String,
+    error: String,
+}
+
+#[cfg(windows)]
+fn cleanup_failed_receipt_with(
+    app: Option<&tauri::AppHandle>,
+    mut process: ManagedAgentProcess,
+    record: &mut ManagedAgentRecord,
+    runtimes: &mut HashMap<ManagedAgentRuntimeKey, ManagedAgentPairRuntime>,
+    context: ReceiptFailureContext,
+    terminate: impl FnOnce(&mut ManagedAgentProcess) -> Result<std::process::ExitStatus, String>,
+) -> Result<(), String> {
+    let ReceiptFailureContext { key, now, error } = context;
+    match terminate(&mut process) {
+        Ok(_) => Err(error),
+        Err(cleanup_error) => {
+            let recovery_pid = process.child.id();
+            let message = mark_unverified_runtime(
+                app,
+                record,
+                &key,
+                recovery_pid,
+                now,
+                format!(
+                    "{error}; cleanup is incomplete and exact pair authority remains tracked for retry: {cleanup_error}"
+                ),
+            );
+            runtimes.insert(key, ManagedAgentPairRuntime::starting(process));
+            Err(message)
+        }
+    }
+}
+
+pub(crate) fn cleanup(
+    app: &tauri::AppHandle,
+    process: ManagedAgentProcess,
+    record: &mut ManagedAgentRecord,
+    runtimes: &mut HashMap<ManagedAgentRuntimeKey, ManagedAgentPairRuntime>,
+    key: ManagedAgentRuntimeKey,
+    now: String,
+    error: String,
+) -> Result<(), String> {
+    #[cfg(windows)]
+    {
+        cleanup_failed_receipt_with(
+            Some(app),
+            process,
+            record,
+            runtimes,
+            ReceiptFailureContext { key, now, error },
+            crate::managed_agents::process_lifecycle::terminate_managed_agent_process,
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = app;
+        let _ = super::terminate_process(process.child.id());
+        let _ = process.child.wait();
+        Err(error)
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn receipt_and_cleanup_failure_retains_exact_runtime_key_and_record_error() {
+        let mut record: ManagedAgentRecord = serde_json::from_str(
+            r#"{
+                "pubkey": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                "name": "receipt-test",
+                "private_key_nsec": "nsec1fake",
+                "relay_url": "",
+                "acp_command": "buzz-acp",
+                "agent_command": "buzz-agent",
+                "agent_args": [],
+                "mcp_command": "",
+                "turn_timeout_seconds": 320,
+                "system_prompt": null,
+                "model": null,
+                "provider": null,
+                "env_vars": {},
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z"
+            }"#,
+        )
+        .expect("receipt failure fixture");
+        let key = ManagedAgentRuntimeKey::new(record.pubkey.clone(), "wss://relay.example")
+            .expect("receipt failure runtime key");
+        let mut command = Command::new("ping.exe");
+        command
+            .args(["-t", "127.0.0.1"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let process = crate::managed_agents::process_lifecycle::spawn_managed_agent_process(
+            command,
+            std::path::PathBuf::new(),
+            0,
+            false,
+            None,
+            "receipt-generation".into(),
+        )
+        .expect("spawn receipt failure child in Job Object");
+        let child_id = process.child.id();
+        let mut runtimes = HashMap::new();
+
+        let error = cleanup_failed_receipt_with(
+            None,
+            process,
+            &mut record,
+            &mut runtimes,
+            ReceiptFailureContext {
+                key: key.clone(),
+                now: "2026-01-02T00:00:00Z".into(),
+                error: "receipt write failed".into(),
+            },
+            |_| Err("cleanup denied".into()),
+        )
+        .expect_err("receipt plus cleanup failure must propagate");
+
+        assert!(error.contains("receipt write failed"));
+        assert!(error.contains("cleanup denied"));
+        assert!(runtimes.contains_key(&key));
+        assert!(record
+            .last_error
+            .as_deref()
+            .is_some_and(|message| message.contains("cleanup denied")));
+        let persisted = serde_json::to_string(&record).expect("serialize mutated recovery record");
+        let reloaded: ManagedAgentRecord =
+            serde_json::from_str(&persisted).expect("reload mutated recovery record");
+        assert!(reloaded
+            .last_error
+            .as_deref()
+            .is_some_and(|message| message.starts_with(UNVERIFIED_JOB_REAP_PREFIX)));
+        assert_eq!(reloaded.runtime_pid, Some(child_id));
+        let durable_error = reloaded
+            .last_error
+            .as_deref()
+            .expect("durable recovery error");
+        assert!(durable_error.contains(&key.pubkey));
+        assert!(durable_error.contains(&key.relay_url));
+        let mut runtime = runtimes.remove(&key).expect("retained exact runtime");
+        crate::managed_agents::process_lifecycle::terminate_managed_agent_process(
+            &mut runtime.process,
+        )
+        .expect("cleanup retained Job authority");
+        assert!(runtime.process.job.is_some());
+        crate::managed_agents::process_lifecycle::release_finalized_managed_agent_process(
+            &mut runtime.process,
+        )
+        .expect("release retained Job after no receipt was committed");
+        assert!(runtime.process.job.is_none());
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/runtime/stop.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/stop.rs
@@ -3,20 +3,25 @@ use std::collections::HashMap;
 use tauri::AppHandle;
 
 use super::{
-    append_log_marker, current_instance_id, now_iso, process_belongs_to_us,
-    process_has_buzz_marker, process_is_running, terminate_process, ManagedAgentPairRuntime,
-    ManagedAgentRecord, ManagedAgentRuntimeKey,
+    append_log_marker, now_iso, ManagedAgentPairRuntime, ManagedAgentRecord, ManagedAgentRuntimeKey,
+};
+#[cfg(not(windows))]
+use super::{
+    current_instance_id, process_belongs_to_us, process_has_buzz_marker, process_is_running,
+    terminate_process,
 };
 
 pub(crate) fn managed_agent_runtime_keys<T>(
     runtimes: &HashMap<ManagedAgentRuntimeKey, T>,
     pubkey: &str,
 ) -> Vec<ManagedAgentRuntimeKey> {
-    runtimes
+    let mut keys = runtimes
         .keys()
         .filter(|key| key.pubkey.eq_ignore_ascii_case(pubkey))
         .cloned()
-        .collect()
+        .collect::<Vec<_>>();
+    keys.sort_by_key(ManagedAgentRuntimeKey::runtime_id);
+    keys
 }
 
 #[cfg(test)]
@@ -30,13 +35,32 @@ pub(crate) fn managed_agent_runtime_relay_urls<T>(
         .collect()
 }
 
+pub fn persist_stop<T>(
+    result: Result<T, String>,
+    persist: impl FnOnce() -> Result<(), String>,
+) -> Result<T, String> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(error) => persist_failed_stop(error, persist),
+    }
+}
+
+pub fn persist_failed_stop<T>(
+    stop_error: String,
+    persist: impl FnOnce() -> Result<(), String>,
+) -> Result<T, String> {
+    let persistence = persist()
+        .err()
+        .map(|save_error| format!("; failed to persist Stop recovery state: {save_error}"))
+        .unwrap_or_default();
+    Err(format!("{stop_error}{persistence}"))
+}
+
 /// Stop the single tracked runtime pair at `key`, if present.
 ///
 /// Terminates the child, records the exit code, removes the pair receipt,
-/// and appends a stop marker to the pair log. On teardown failure the
-/// runtime is reinserted so the pair stays visible and stoppable instead of
-/// becoming an invisible orphan. Touches no other pair for the agent and
-/// does no record-level stop bookkeeping — callers own that.
+/// and appends a stop marker to the pair log. Any failure retains the exact
+/// Child/Job authority under the same pair key for retry.
 fn stop_managed_agent_pair(
     app: &AppHandle,
     record: &mut ManagedAgentRecord,
@@ -48,26 +72,30 @@ fn stop_managed_agent_pair(
     };
     let result = (|| -> Result<(), String> {
         #[cfg(unix)]
-        terminate_process(runtime.child.id())?;
+        let status = {
+            terminate_process(runtime.child.id())?;
+            runtime
+                .child
+                .wait()
+                .map_err(|error| format!("failed to wait for agent shutdown: {error}"))?
+        };
         #[cfg(windows)]
-        match runtime.job.take() {
-            Some(job) => drop(job),
-            None => runtime
+        let status =
+            super::super::process_lifecycle::finalize_tracked_runtime(app, key, &mut runtime)?;
+        #[cfg(not(any(unix, windows)))]
+        let status = {
+            runtime
                 .child
                 .kill()
-                .map_err(|error| format!("failed to kill agent process: {error}"))?,
-        }
-        #[cfg(not(any(unix, windows)))]
-        runtime
-            .child
-            .kill()
-            .map_err(|error| format!("failed to kill agent process: {error}"))?;
-        let status = runtime
-            .child
-            .wait()
-            .map_err(|error| format!("failed to wait for agent shutdown: {error}"))?;
+                .map_err(|error| format!("failed to kill agent process: {error}"))?;
+            runtime
+                .child
+                .wait()
+                .map_err(|error| format!("failed to wait for agent shutdown: {error}"))?
+        };
         record.last_exit_code = status.code();
-        super::super::remove_agent_runtime_receipt(app, key);
+        #[cfg(not(windows))]
+        super::super::remove_agent_runtime_receipt(app, key)?;
         if let Err(error) = append_log_marker(
             &runtime.log_path,
             &format!(
@@ -85,9 +113,32 @@ fn stop_managed_agent_pair(
         Ok(())
     })();
     if let Err(error) = result {
-        // Keep failed teardown visible/manageable instead of orphaning it.
+        // Keep failed teardown and its exact authority visible/manageable.
+        #[cfg(windows)]
+        let error = super::receipt_failure::mark_unverified_runtime(
+            Some(app),
+            record,
+            key,
+            runtime.child.id(),
+            now_iso(),
+            format!(
+                "Stop cleanup is incomplete and exact pair authority remains tracked for retry: {error}"
+            ),
+        );
         runtimes.insert(key.clone(), runtime);
         return Err(error);
+    }
+    if let Err(error) = super::super::clear_pair_recovery_with_terminal_proof(app, record, key) {
+        super::super::record_terminal_proof_pending_recovery_clear(
+            record,
+            key,
+            runtime.child.id(),
+            &error,
+        );
+        runtimes.insert(key.clone(), runtime);
+        return Err(format!(
+            "failed to retire exact-pair recovery authority after terminal proof: {error}"
+        ));
     }
     Ok(())
 }
@@ -95,17 +146,57 @@ fn stop_managed_agent_pair(
 /// Terminate a legacy scalar-PID child (pre-pair records) and remove the
 /// agent-scoped pid file. Pair receipts are restored separately.
 fn stop_legacy_scalar_pid(app: &AppHandle, record: &mut ManagedAgentRecord) -> Result<(), String> {
-    if let Some(pid) = record.runtime_pid.take() {
-        if process_is_running(pid)
-            && process_belongs_to_us(pid)
-            && process_has_buzz_marker(pid, &current_instance_id(app))
+    if super::super::has_unverified_job_reap(record) {
+        return Err(
+            "prior Windows Job closure remains unverified; preserving PID recovery authority"
+                .into(),
+        );
+    }
+    if let Some(pid) = record.runtime_pid {
+        #[cfg(windows)]
         {
-            terminate_process(pid)?;
+            let message = format!(
+                "cannot safely terminate persisted Windows PID {pid} without its owned Child/Job authority; preserving recovery identity"
+            );
+            record.updated_at = now_iso();
+            record.last_error = Some(message.clone());
+            record.last_error_code = None;
+            return Err(message);
         }
-        record.updated_at = now_iso();
+        #[cfg(not(windows))]
+        {
+            if process_is_running(pid)
+                && process_belongs_to_us(pid)
+                && process_has_buzz_marker(pid, &current_instance_id(app))
+            {
+                terminate_process(pid)?;
+            }
+            record.runtime_pid = None;
+            record.updated_at = now_iso();
+        }
     }
     super::super::remove_agent_pid_file(app, &record.pubkey);
     Ok(())
+}
+
+fn untracked_runtime_keys_for_agent_from(
+    receipts: Result<Vec<(std::path::PathBuf, super::super::ManagedAgentRuntimeReceipt)>, String>,
+    pubkey: &str,
+) -> Result<Vec<ManagedAgentRuntimeKey>, String> {
+    Ok(receipts?
+        .into_iter()
+        .filter_map(|(_, receipt)| (receipt.key.pubkey == pubkey).then_some(receipt.key))
+        .collect())
+}
+
+fn untracked_runtime_keys_for_agent(
+    app: &AppHandle,
+    pubkey: &str,
+) -> Result<Vec<ManagedAgentRuntimeKey>, String> {
+    untracked_runtime_keys_for_agent_from(
+        super::super::read_all_agent_runtime_receipts(app),
+        pubkey,
+    )
 }
 
 /// Stop the runtime pair this record resolves to for the active workspace
@@ -130,15 +221,22 @@ pub fn stop_managed_agent_workspace_pair(
             state.clear_agent_session_cache(&pair_key);
             super::super::remove_agent_pid_file(app, &record.pubkey);
             let now = now_iso();
-            record.runtime_pid = None;
             record.updated_at = now.clone();
-            record.last_stopped_at = Some(now);
-            record.last_error = None;
-            record.last_error_code = None;
+            let sibling_active = runtimes.keys().any(|key| key.pubkey == record.pubkey);
+            if !sibling_active && !super::super::has_unverified_job_reap(record) {
+                record.runtime_pid = None;
+                record.last_stopped_at = Some(now);
+                if !super::super::finalize_pending_pair_failures(record) {
+                    record.last_error = None;
+                    record.last_error_code = None;
+                }
+            }
         }
         Some(pair_key) => {
-            // No tracked pair here — a pubkey-wide cache clear would disturb
-            // live pairs in other communities, so stay pair-scoped.
+            // No tracked pair here — discover and resolve exact persisted
+            // authority before falling back to the legacy scalar PID evidence.
+            super::terminate_untracked_pair_runtime(app, &pair_key)?;
+            super::super::clear_pair_recovery_with_terminal_proof(app, record, &pair_key)?;
             stop_legacy_scalar_pid(app, record)?;
             state.clear_agent_session_cache(&pair_key);
         }
@@ -150,44 +248,163 @@ pub fn stop_managed_agent_workspace_pair(
     Ok(())
 }
 
+fn apply_agent_stop_outcome(
+    record: &mut ManagedAgentRecord,
+    errors: &[String],
+    now: String,
+) -> Result<(), String> {
+    record.updated_at = now.clone();
+
+    if errors.is_empty() && !super::super::has_unverified_job_reap(record) {
+        record.runtime_pid = None;
+        record.last_stopped_at = Some(now);
+        if !super::super::finalize_pending_pair_failures(record) {
+            record.last_error = None;
+            record.last_error_code = None;
+        }
+        Ok(())
+    } else if errors.is_empty() {
+        Err("managed-agent recovery authority remains uncertain after Stop".to_string())
+    } else {
+        let error = format!(
+            "failed to stop one or more managed-agent runtimes: {}",
+            errors.join("; ")
+        );
+        if !super::super::has_unverified_job_reap(record) {
+            record.last_error = Some(error.clone());
+        }
+        Err(error)
+    }
+}
+
 pub fn stop_managed_agent_process(
     app: &AppHandle,
     record: &mut ManagedAgentRecord,
     runtimes: &mut HashMap<ManagedAgentRuntimeKey, ManagedAgentPairRuntime>,
 ) -> Result<(), String> {
     let keys = managed_agent_runtime_keys(runtimes, &record.pubkey);
-    if keys.is_empty() {
+    let persisted_keys = untracked_runtime_keys_for_agent(app, &record.pubkey)?;
+    if keys.is_empty() && persisted_keys.is_empty() {
         return stop_legacy_scalar_pid(app, record);
     }
 
     let mut errors = Vec::new();
-    for key in keys {
-        if let Err(error) = stop_managed_agent_pair(app, record, runtimes, &key) {
+    for key in &keys {
+        if let Err(error) = stop_managed_agent_pair(app, record, runtimes, key) {
             errors.push(format!("{}: {error}", key.relay_url));
         }
     }
-
-    let now = now_iso();
-    record.runtime_pid = None;
-    record.updated_at = now.clone();
-    record.last_stopped_at = Some(now);
-    record.last_error = None;
-    record.last_error_code = None;
-    super::super::remove_agent_pid_file(app, &record.pubkey);
-
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(format!(
-            "failed to stop one or more managed-agent runtimes: {}",
-            errors.join("; ")
-        ))
+    for key in persisted_keys {
+        if keys.contains(&key) {
+            continue;
+        }
+        if let Err(error) = super::terminate_untracked_pair_runtime(app, &key) {
+            errors.push(format!("{}: {error}", key.relay_url));
+        } else {
+            super::super::clear_pair_recovery_with_terminal_proof(app, record, &key)?;
+        }
     }
+
+    let result = apply_agent_stop_outcome(record, &errors, now_iso());
+    if result.is_ok() {
+        super::super::remove_agent_pid_file(app, &record.pubkey);
+    }
+    result
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn minimal_record() -> ManagedAgentRecord {
+        serde_json::from_str(
+            r#"{
+                "pubkey": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                "name": "test",
+                "private_key_nsec": "nsec1fake",
+                "relay_url": "",
+                "acp_command": "buzz-acp",
+                "agent_command": "buzz-agent",
+                "agent_args": [],
+                "mcp_command": "",
+                "turn_timeout_seconds": 320,
+                "system_prompt": null,
+                "model": null,
+                "provider": null,
+                "env_vars": {},
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "last_started_at": null,
+                "last_stopped_at": "2026-01-02T00:00:00Z",
+                "last_exit_code": null,
+                "last_error": null
+            }"#,
+        )
+        .expect("stop record fixture")
+    }
+
+    #[test]
+    fn failed_agent_wide_stop_preserves_error_and_does_not_claim_stopped() {
+        let mut record = minimal_record();
+        record.runtime_pid = Some(4242);
+        let original_stopped_at = record.last_stopped_at.clone();
+        let errors = vec!["relay: bounded Stop failed".to_string()];
+
+        let result =
+            apply_agent_stop_outcome(&mut record, &errors, "2026-01-03T00:00:00Z".to_string());
+
+        assert!(result.is_err());
+        assert_eq!(record.last_stopped_at, original_stopped_at);
+        assert_eq!(record.runtime_pid, Some(4242));
+        assert!(record
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("bounded Stop failed")));
+    }
+
+    #[test]
+    fn agent_wide_stop_does_not_launder_unverified_reap_marker() {
+        let mut record = minimal_record();
+        record.runtime_pid = Some(5252);
+        record.last_error = Some(format!(
+            "{} first pair reap unverified",
+            crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX
+        ));
+
+        let result = apply_agent_stop_outcome(
+            &mut record,
+            &["second pair also failed".to_string()],
+            "2026-01-03T00:00:00Z".to_string(),
+        );
+
+        assert!(result.is_err());
+        assert!(crate::managed_agents::has_unverified_job_reap(&record));
+    }
+
+    #[test]
+    fn successful_retry_stop_preserves_observed_terminal_failure() {
+        let mut record = minimal_record();
+        let key =
+            ManagedAgentRuntimeKey::new(record.pubkey.clone(), "wss://terminal-failure.example")
+                .unwrap();
+        super::super::super::record_pending_pair_failure(
+            &mut record,
+            &key,
+            Some(13),
+            &super::super::super::storage::AgentLogError {
+                message: "harness exited with status 13".into(),
+                code: None,
+            },
+        );
+
+        apply_agent_stop_outcome(&mut record, &[], "2026-01-03T00:00:00Z".into()).unwrap();
+
+        assert_eq!(record.last_exit_code, Some(13));
+        assert!(record
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("status 13")));
+    }
 
     #[test]
     fn pair_preserving_restart_targets_exact_original_relays() {
@@ -246,5 +463,74 @@ mod tests {
         let mut selected = managed_agent_runtime_keys(&runtimes, &agent);
         selected.sort_by(|left, right| left.relay_url.cmp(&right.relay_url));
         assert_eq!(selected, vec![first, second]);
+    }
+
+    #[test]
+    fn failed_stop_persists_recovery_state_before_propagation() {
+        let dir = tempfile::tempdir().expect("temporary recovery directory");
+        let path = dir.path().join("managed-agents.json");
+        let recovery = r#"{"runtime_pid":8181,"last_error":"stop remains uncertain"}"#;
+        let result: Result<(), String> =
+            persist_failed_stop("bounded Stop failed".to_string(), || {
+                std::fs::write(&path, recovery).map_err(|error| error.to_string())
+            });
+
+        assert_eq!(result.unwrap_err(), "bounded Stop failed");
+        assert_eq!(
+            std::fs::read_to_string(path).expect("durable Stop recovery readback"),
+            recovery
+        );
+    }
+
+    #[test]
+    fn untracked_agent_wide_stop_propagates_receipt_store_uncertainty() {
+        let result = untracked_runtime_keys_for_agent_from(
+            Err("receipt store indeterminate".to_string()),
+            &"aa".repeat(32),
+        );
+        assert!(result.unwrap_err().contains("receipt store indeterminate"));
+    }
+
+    #[test]
+    fn untracked_agent_wide_stop_selects_every_persisted_pair_for_agent() {
+        let agent = "aa".repeat(32);
+        let other = "bb".repeat(32);
+        let first = ManagedAgentRuntimeKey::new(&agent, "wss://one.example").unwrap();
+        let second = ManagedAgentRuntimeKey::new(&agent, "wss://two.example").unwrap();
+        let unrelated = ManagedAgentRuntimeKey::new(&other, "wss://one.example").unwrap();
+        let receipt =
+            |key: ManagedAgentRuntimeKey| super::super::super::ManagedAgentRuntimeReceipt {
+                key,
+                pid: 1,
+                desktop_instance_id: "instance".to_string(),
+                started_at: "now".to_string(),
+                windows_job_contained: true,
+            };
+        let receipts = vec![
+            (
+                std::path::PathBuf::from("first.json"),
+                receipt(first.clone()),
+            ),
+            (
+                std::path::PathBuf::from("second.json"),
+                receipt(second.clone()),
+            ),
+            (std::path::PathBuf::from("other.json"), receipt(unrelated)),
+        ];
+
+        let mut selected = untracked_runtime_keys_for_agent_from(Ok(receipts), &agent).unwrap();
+        selected.sort_by(|left, right| left.relay_url.cmp(&right.relay_url));
+        assert_eq!(selected, vec![first, second]);
+    }
+
+    #[test]
+    fn failed_stop_reports_persistence_failure() {
+        let result: Result<(), String> =
+            persist_failed_stop("bounded Stop failed".to_string(), || {
+                Err("disk unavailable".to_string())
+            });
+        let error = result.unwrap_err();
+        assert!(error.contains("bounded Stop failed"));
+        assert!(error.contains("failed to persist Stop recovery state: disk unavailable"));
     }
 }

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -1,6 +1,5 @@
 use crate::managed_agents::known_acp_runtime;
-
-// ── desktop binary name tests ───────────────────────────────────────────
+mod windows_receipt_recovery;
 
 #[test]
 fn appimage_binary_matches_truncated_linux_comm_name() {
@@ -897,7 +896,6 @@ fn own_group_grandchild_detected_by_ancestor_walk() {
 }
 
 // ── pair receipt validation tests ───────────────────────────────────────
-
 fn receipt_fixture(
     key: crate::managed_agents::ManagedAgentRuntimeKey,
 ) -> crate::managed_agents::ManagedAgentRuntimeReceipt {
@@ -906,6 +904,7 @@ fn receipt_fixture(
         pid: std::process::id(),
         desktop_instance_id: "test-instance".into(),
         started_at: "now".into(),
+        windows_job_contained: true,
     }
 }
 
@@ -962,7 +961,10 @@ fn replacement_removes_receipt_only_after_confirmed_exit() {
             polls.set(poll);
             poll < 2
         },
-        |path| *removed.borrow_mut() = Some(path.to_path_buf()),
+        |path| {
+            *removed.borrow_mut() = Some(path.to_path_buf());
+            Ok(())
+        },
     )
     .unwrap();
 
@@ -985,21 +987,18 @@ fn replacement_failure_keeps_receipt() {
         &receipt,
         |_| Err("signal failed".into()),
         |_| false,
-        |_| removed.set(true),
+        |_| {
+            removed.set(true);
+            Ok(())
+        },
     )
     .unwrap_err();
 
     assert_eq!(error, "signal failed");
     assert!(!removed.get());
 }
-
-// ── workspace pair-key resolution (summary/stop scoping) ────────────────
-
 #[test]
 fn unpinned_record_resolves_pair_key_per_workspace() {
-    // Community-scoped truth: an unpinned agent running only on relay A must
-    // read as running in workspace A and stopped in workspace B — the pair
-    // key the summary looks up differs per workspace.
     let pubkey = "aa".repeat(32);
     let key_a = super::resolve_workspace_pair_key(&pubkey, "", "wss://one.example").unwrap();
     let key_b = super::resolve_workspace_pair_key(&pubkey, "", "wss://two.example").unwrap();
@@ -1254,10 +1253,7 @@ fn make_pair_runtime_placeholder() -> crate::managed_agents::ManagedAgentPairRun
     // Spawn a real child so ManagedAgentProcess's Child field is satisfied.
     // `true` exits immediately with 0 — just a handle we need for type purposes.
     //
-    // Absolute `/usr/bin/true` on unix (present on both macOS and Linux):
-    // parallel tests holding `lock_path_mutex` swap PATH to a tempdir, and a
-    // bare `true` lookup during that window fails with NotFound (observed
-    // flake). Windows keeps the PATH lookup — no test there swaps PATH.
+    // Use an absolute path on unix because parallel PATH tests can hide `true`.
     #[cfg(unix)]
     let program = "/usr/bin/true";
     #[cfg(windows)]
@@ -1268,6 +1264,8 @@ fn make_pair_runtime_placeholder() -> crate::managed_agents::ManagedAgentPairRun
         .stderr(Stdio::null())
         .spawn()
         .expect("spawn true for placeholder");
+    #[cfg(windows)]
+    let child = crate::managed_agents::ManagedAgentChild::from_std_for_test(child);
     let process = crate::managed_agents::ManagedAgentProcess {
         child,
         log_path: std::path::PathBuf::new(),
@@ -1314,3 +1312,5 @@ fn restart_eligible_false_when_orphan_has_no_drift() {
 fn restart_eligible_false_when_non_orphan_has_no_drift() {
     assert!(!super::restart_eligible(false, false, false));
 }
+
+mod lifecycle_regressions;

--- a/desktop/src-tauri/src/managed_agents/runtime/tests/lifecycle_regressions.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests/lifecycle_regressions.rs
@@ -1,0 +1,375 @@
+use super::*;
+
+#[test]
+fn kill_stale_failure_retains_pid_and_records_error() {
+    let mut record = minimal_record("pubkey-retry");
+    record.runtime_pid = Some(9004);
+    let original_stopped_at = record.last_stopped_at.clone();
+    let mut records = vec![record];
+    let runtimes = std::collections::HashMap::new();
+
+    let changed = super::super::kill_stale_tracked_processes_with(
+        &mut records,
+        &runtimes,
+        |_pid| true,
+        |_pid| Err("taskkill denied".to_string()),
+    );
+
+    assert!(changed);
+    assert_eq!(records[0].runtime_pid, Some(9004));
+    assert_eq!(records[0].last_stopped_at, original_stopped_at);
+    assert!(records[0]
+        .last_error
+        .as_deref()
+        .is_some_and(|error| error.contains("taskkill denied")));
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_stale_pid_refusal_never_terminates_the_numeric_pid() {
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new("ping.exe")
+        .args(["-t", "127.0.0.1"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("stale PID sentinel");
+    let pid = child.id();
+    let mut record = minimal_record(&"da".repeat(32));
+    record.runtime_pid = Some(pid);
+    let mut records = vec![record];
+    let runtimes = std::collections::HashMap::new();
+
+    let changed = super::super::kill_stale_tracked_processes(
+        &mut records,
+        &runtimes,
+        "different-desktop-instance",
+    );
+
+    assert!(changed);
+    assert_eq!(records[0].runtime_pid, Some(pid));
+    assert!(records[0].last_error.as_deref().is_some_and(|error| {
+        error.contains("reconcile persisted Windows PID")
+            && error.contains("without owned Child/Job authority")
+            && error.contains("preserving recovery identity")
+    }));
+    assert!(
+        child
+            .try_wait()
+            .expect("inspect stale PID sentinel")
+            .is_none(),
+        "Windows stale reconciliation must not kill by persisted numeric PID"
+    );
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn unverified_job_reap_is_not_laundered_by_stale_cleanup() {
+    let mut record = minimal_record(&"ce".repeat(32));
+    record.runtime_pid = Some(4141);
+    record.last_error = Some(format!(
+        "{} synthetic reap uncertainty",
+        crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX
+    ));
+    let mut records = vec![record];
+    let runtimes = std::collections::HashMap::new();
+
+    let changed = super::super::kill_stale_tracked_processes_with(
+        &mut records,
+        &runtimes,
+        |_| true,
+        |_| panic!("unverified Job reap must not fall through to PID kill"),
+    );
+
+    assert!(!changed);
+    assert_eq!(records[0].runtime_pid, Some(4141));
+    assert!(records[0]
+        .last_error
+        .as_deref()
+        .is_some_and(|error| error.starts_with(crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX)));
+}
+
+#[test]
+fn unverified_job_reap_pid_survives_runtime_sync() {
+    let mut record = minimal_record(&"cf".repeat(32));
+    record.runtime_pid = Some(5151);
+    record.last_error = Some(format!(
+        "{} synthetic reap uncertainty",
+        crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX
+    ));
+    let mut records = vec![record];
+    let mut runtimes = std::collections::HashMap::new();
+
+    let (changed, exited) = super::super::lifecycle::sync_managed_agent_processes_with(
+        None,
+        &mut records,
+        &mut runtimes,
+        |_key, _runtime| Ok(None),
+    );
+
+    assert!(!changed);
+    assert!(exited.is_empty());
+    assert_eq!(records[0].runtime_pid, Some(5151));
+    assert!(crate::managed_agents::has_unverified_job_reap(&records[0]));
+}
+
+#[cfg(windows)]
+#[test]
+fn legacy_windows_pid_without_marker_survives_runtime_sync() {
+    let mut record = minimal_record(&"cd".repeat(32));
+    record.runtime_pid = Some(5252);
+    record.last_error = None;
+    let original_stopped_at = record.last_stopped_at.clone();
+    let mut records = vec![record];
+    let mut runtimes = std::collections::HashMap::new();
+
+    let (changed, exited) = super::super::lifecycle::sync_managed_agent_processes_with(
+        None,
+        &mut records,
+        &mut runtimes,
+        |_key, _runtime| Ok(None),
+    );
+
+    assert!(!changed);
+    assert!(exited.is_empty());
+    assert_eq!(records[0].runtime_pid, Some(5252));
+    assert_eq!(records[0].last_stopped_at, original_stopped_at);
+    assert_eq!(records[0].last_error, None);
+}
+
+#[test]
+fn sync_inspection_error_preserves_runtime_authority() {
+    use std::collections::HashMap;
+
+    let pubkey = "ee".repeat(32);
+    let key =
+        crate::managed_agents::ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://relay.example")
+            .expect("runtime key fixture");
+    let mut records = vec![minimal_record(&pubkey)];
+    let mut runtimes = HashMap::from([(key.clone(), make_pair_runtime_placeholder())]);
+
+    let (changed, exited) = super::super::lifecycle::sync_managed_agent_processes_with(
+        None,
+        &mut records,
+        &mut runtimes,
+        |_key, _runtime| Err(std::io::Error::other("synthetic inspection failure")),
+    );
+
+    assert!(changed);
+    assert!(exited.is_empty(), "inspection error is not proof of exit");
+    assert!(
+        runtimes.contains_key(&key),
+        "Child/Job authority must remain tracked for retry"
+    );
+    assert!(records[0]
+        .last_error
+        .as_deref()
+        .is_some_and(|error| error.contains("synthetic inspection failure")));
+}
+
+#[cfg(windows)]
+#[test]
+fn sync_two_terminal_siblings_records_a_final_stopped_state() {
+    use std::collections::HashMap;
+    use std::os::windows::process::ExitStatusExt;
+
+    let pubkey = "ef".repeat(32);
+    let pair_a =
+        crate::managed_agents::ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://one.example")
+            .expect("pair A key");
+    let pair_b =
+        crate::managed_agents::ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://two.example")
+            .expect("pair B key");
+    let mut record = minimal_record(&pubkey);
+    record.last_stopped_at = None;
+    let mut records = vec![record];
+    let mut runtimes = HashMap::from([
+        (pair_a, make_pair_runtime_placeholder()),
+        (pair_b, make_pair_runtime_placeholder()),
+    ]);
+
+    let (_, exited) = super::super::lifecycle::sync_managed_agent_processes_with(
+        None,
+        &mut records,
+        &mut runtimes,
+        |_, _| Ok(Some(std::process::ExitStatus::from_raw(0))),
+    );
+
+    assert_eq!(exited.len(), 2);
+    assert!(runtimes.is_empty());
+    assert!(records[0].last_stopped_at.is_some());
+    assert_eq!(records[0].last_exit_code, Some(0));
+}
+
+#[cfg(windows)]
+#[test]
+fn staggered_terminal_sibling_success_preserves_earlier_failure() {
+    use std::collections::HashMap;
+    use std::os::windows::process::ExitStatusExt;
+
+    let pubkey = "f0".repeat(32);
+    let pair_a =
+        crate::managed_agents::ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://fail.example")
+            .unwrap();
+    let pair_b =
+        crate::managed_agents::ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://ok.example")
+            .unwrap();
+    let pair_a_id = pair_a.runtime_id();
+    let mut records = vec![minimal_record(&pubkey)];
+    records[0].last_stopped_at = None;
+    let mut runtimes = HashMap::from([
+        (pair_a.clone(), make_pair_runtime_placeholder()),
+        (pair_b.clone(), make_pair_runtime_placeholder()),
+    ]);
+
+    let (_, first_exited) = super::super::lifecycle::sync_managed_agent_processes_with(
+        None,
+        &mut records,
+        &mut runtimes,
+        |key, _| Ok((key == &pair_a).then(|| std::process::ExitStatus::from_raw(1))),
+    );
+    assert_eq!(first_exited, vec![pair_a]);
+    assert!(runtimes.contains_key(&pair_b));
+    assert_eq!(records[0].last_exit_code, Some(1));
+    assert!(records[0]
+        .last_error
+        .as_deref()
+        .is_some_and(|error| error.contains(&pair_a_id)));
+
+    let (_, second_exited) = super::super::lifecycle::sync_managed_agent_processes_with(
+        None,
+        &mut records,
+        &mut runtimes,
+        |_, _| Ok(Some(std::process::ExitStatus::from_raw(0))),
+    );
+    assert_eq!(second_exited, vec![pair_b]);
+    assert!(records[0].last_stopped_at.is_some());
+    assert_eq!(records[0].last_exit_code, Some(1));
+    assert!(records[0]
+        .last_error
+        .as_deref()
+        .is_some_and(|error| error.contains(&pair_a_id)));
+}
+
+#[cfg(windows)]
+#[test]
+fn terminal_clear_failure_retains_runtime_and_parseable_retry_marker() {
+    use std::collections::HashMap;
+    use std::os::windows::process::ExitStatusExt;
+
+    let pubkey = "f1".repeat(32);
+    let key =
+        crate::managed_agents::ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://retry.example")
+            .unwrap();
+    let mut records = vec![minimal_record(&pubkey)];
+    let mut runtimes = HashMap::from([(key.clone(), make_pair_runtime_placeholder())]);
+    let (_, exited) = super::super::lifecycle::sync_managed_agent_processes_with_recovery(
+        None,
+        &mut records,
+        &mut runtimes,
+        |_, _| Ok(Some(std::process::ExitStatus::from_raw(1))),
+        |_, _| Err("synthetic recovery sidecar save failure".into()),
+    );
+
+    assert!(exited.is_empty());
+    assert!(runtimes.contains_key(&key));
+    assert_eq!(
+        crate::managed_agents::terminal_proof_pending_recovery_clears(&records[0]),
+        vec![key]
+    );
+    assert_eq!(records[0].last_stopped_at, None);
+    assert_eq!(records[0].last_exit_code, Some(1));
+    assert!(records[0]
+        .last_error
+        .as_deref()
+        .is_some_and(|error| error.contains("status") && error.contains("recovery sidecar")));
+}
+
+#[cfg(windows)]
+#[test]
+fn terminal_clear_success_without_main_record_commit_retains_runtime_authority() {
+    use std::collections::HashMap;
+    use std::os::windows::process::ExitStatusExt;
+
+    let pubkey = "f3".repeat(32);
+    let key = crate::managed_agents::ManagedAgentRuntimeKey::new(
+        pubkey.clone(),
+        "wss://commit-barrier.example",
+    )
+    .unwrap();
+    let mut records = vec![minimal_record(&pubkey)];
+    let mut runtimes = HashMap::from([(key.clone(), make_pair_runtime_placeholder())]);
+
+    let (_, exited) =
+        super::super::lifecycle::sync_managed_agent_processes_with_recovery_and_persist(
+            None,
+            &mut records,
+            &mut runtimes,
+            |_, _| Ok(Some(std::process::ExitStatus::from_raw(0))),
+            |_, _| Ok(true),
+            |_| Err("synthetic main record persistence failure".into()),
+        );
+
+    assert!(exited.is_empty());
+    assert!(runtimes.contains_key(&key));
+
+    let (_, exited) =
+        super::super::lifecycle::sync_managed_agent_processes_with_recovery_and_persist(
+            None,
+            &mut records,
+            &mut runtimes,
+            |_, _| Ok(Some(std::process::ExitStatus::from_raw(0))),
+            |_, _| Ok(false),
+            |_| Ok(()),
+        );
+    assert_eq!(exited, vec![key.clone()]);
+    assert!(!runtimes.contains_key(&key));
+}
+
+#[cfg(windows)]
+#[test]
+fn sibling_exit_failure_cannot_overwrite_remaining_recovery_pair() {
+    use std::collections::HashMap;
+    use std::os::windows::process::ExitStatusExt;
+
+    let pubkey = "f2".repeat(32);
+    let pair_a = crate::managed_agents::ManagedAgentRuntimeKey::new(
+        pubkey.clone(),
+        "wss://uncertain.example",
+    )
+    .unwrap();
+    let pair_b =
+        crate::managed_agents::ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://exited.example")
+            .unwrap();
+    let pair_b_id = pair_b.runtime_id();
+    let mut authority = crate::managed_agents::ManagedAgentRecoveryAuthority::default();
+    authority.mark_pair(&pair_a, 9601, "pair A uncertainty".into());
+    authority.mark_pair(&pair_b, 9602, "pair B uncertainty".into());
+    let mut records = vec![minimal_record(&pubkey)];
+    authority.project_compatibility(&mut records[0]);
+    let mut runtimes = HashMap::from([(pair_b.clone(), make_pair_runtime_placeholder())]);
+
+    let (_, exited) = super::super::lifecycle::sync_managed_agent_processes_with_recovery(
+        None,
+        &mut records,
+        &mut runtimes,
+        |_, _| Ok(Some(std::process::ExitStatus::from_raw(9))),
+        |record, key| {
+            authority.clear_pair_with_terminal_proof(key);
+            authority.project_compatibility(record);
+            Ok(true)
+        },
+    );
+
+    assert_eq!(exited, vec![pair_b]);
+    assert!(crate::managed_agents::has_unverified_job_reap(&records[0]));
+    assert_eq!(records[0].last_stopped_at, None);
+    assert_eq!(records[0].last_exit_code, Some(9));
+    assert!(records[0]
+        .last_error
+        .as_deref()
+        .is_some_and(|error| error.contains("uncertain.example") && error.contains(&pair_b_id)));
+}

--- a/desktop/src-tauri/src/managed_agents/runtime/tests/windows_receipt_recovery.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests/windows_receipt_recovery.rs
@@ -1,0 +1,80 @@
+#![cfg(windows)]
+
+#[test]
+fn stale_exact_pair_receipt_is_durably_retired_without_pid_authority() {
+    let key =
+        crate::managed_agents::ManagedAgentRuntimeKey::new("aa".repeat(32), "wss://relay.example")
+            .unwrap();
+    let mut receipt = super::receipt_fixture(key.clone());
+    receipt.pid = u32::MAX;
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join(format!("{}.json", key.runtime_id()));
+    std::fs::write(&path, serde_json::to_vec(&receipt).unwrap()).unwrap();
+
+    assert!(super::super::persisted_windows_receipt_matches(
+        &path, &receipt, &key
+    ));
+    assert!(super::super::persisted_windows_receipt_can_retire(&receipt).unwrap());
+    crate::managed_agents::remove_agent_runtime_receipt_path(&path).unwrap();
+    assert!(!path.exists());
+    let tombstone = crate::managed_agents::receipt_deletion_tombstone(&path);
+    assert!(!tombstone.exists());
+    std::fs::write(&tombstone, b"retired-receipt").unwrap();
+    crate::managed_agents::remove_agent_runtime_receipt_path(&path).unwrap();
+    assert!(!tombstone.exists());
+}
+
+#[test]
+fn live_legacy_receipt_fails_closed_without_pid_kill_authority() {
+    let key =
+        crate::managed_agents::ManagedAgentRuntimeKey::new("bb".repeat(32), "wss://relay.example")
+            .unwrap();
+    let mut receipt = super::receipt_fixture(key);
+    receipt.pid = std::process::id();
+    receipt.windows_job_contained = false;
+
+    assert!(!super::super::persisted_windows_receipt_can_retire(&receipt).unwrap());
+}
+
+#[test]
+fn exited_legacy_receipt_can_converge_without_pid_termination() {
+    let key =
+        crate::managed_agents::ManagedAgentRuntimeKey::new("cc".repeat(32), "wss://relay.example")
+            .unwrap();
+    let mut receipt = super::receipt_fixture(key);
+    receipt.pid = u32::MAX;
+    receipt.windows_job_contained = false;
+
+    assert!(super::super::persisted_windows_receipt_can_retire(&receipt).unwrap());
+}
+
+#[test]
+fn receipt_store_uncertainty_blocks_pair_admission_before_pid_authority() {
+    let key =
+        crate::managed_agents::ManagedAgentRuntimeKey::new("ee".repeat(32), "wss://relay.example")
+            .unwrap();
+    let discovery: Result<
+        Vec<(
+            std::path::PathBuf,
+            crate::managed_agents::ManagedAgentRuntimeReceipt,
+        )>,
+        String,
+    > = Err("receipt store indeterminate".to_string());
+
+    let error = super::super::persisted_windows_receipt_for_pair(discovery, &key).unwrap_err();
+    assert!(error.contains("receipt store indeterminate"));
+}
+
+#[test]
+fn missing_containment_marker_deserializes_as_legacy() {
+    let key =
+        crate::managed_agents::ManagedAgentRuntimeKey::new("dd".repeat(32), "wss://relay.example")
+            .unwrap();
+    let receipt = super::receipt_fixture(key);
+    let mut value = serde_json::to_value(receipt).unwrap();
+    value.as_object_mut().unwrap().remove("windowsJobContained");
+
+    let decoded: crate::managed_agents::ManagedAgentRuntimeReceipt =
+        serde_json::from_value(value).unwrap();
+    assert!(!decoded.windows_job_contained);
+}

--- a/desktop/src-tauri/src/managed_agents/runtime_commands.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands.rs
@@ -5,12 +5,13 @@ use tauri::{AppHandle, Emitter, Manager};
 use super::{
     agent_readiness, append_log_marker, current_instance_id, find_managed_agent_mut,
     load_global_agent_config, load_managed_agents, load_personas, managed_agent_runtime_log_path,
-    process_is_running, record_agent_command, resolve_effective_agent_env, save_managed_agents,
-    spawn_agent_child, terminate_process, terminate_untracked_pair_runtime,
-    write_agent_runtime_receipt, AgentReadiness, BackendKind, ManagedAgentPairRuntime,
-    ManagedAgentRuntimeKey, ManagedAgentRuntimeLifecycle, ManagedAgentRuntimeReceipt,
-    ManagedAgentRuntimeStatus,
+    record_agent_command, resolve_effective_agent_env, save_managed_agents, spawn_agent_child,
+    terminate_untracked_pair_runtime, write_agent_runtime_receipt, AgentReadiness, BackendKind,
+    ManagedAgentPairRuntime, ManagedAgentRuntimeKey, ManagedAgentRuntimeLifecycle,
+    ManagedAgentRuntimeReceipt, ManagedAgentRuntimeStatus,
 };
+#[cfg(not(windows))]
+use super::{process_is_running, terminate_process};
 use crate::app_state::AppState;
 
 const STATUS_EVENT: &str = "managed-agent-runtime-status";
@@ -137,6 +138,44 @@ pub fn put_managed_agent_runtime_lifecycle(
     Ok(status)
 }
 
+fn commit_polled_terminal_recovery<T>(
+    record: &mut super::ManagedAgentRecord,
+    key: &ManagedAgentRuntimeKey,
+    recovery_pid: u32,
+    retained_runtimes: &std::collections::HashMap<ManagedAgentRuntimeKey, T>,
+    clear: impl FnOnce(&mut super::ManagedAgentRecord, &ManagedAgentRuntimeKey) -> Result<bool, String>,
+) -> Result<(), String> {
+    if !retained_runtimes.contains_key(key) {
+        return Err(
+            "finalized managed-agent runtime token is unavailable for durable retirement".into(),
+        );
+    }
+    if let Err(error) = clear(record, key) {
+        super::record_terminal_proof_pending_recovery_clear(record, key, recovery_pid, &error);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn record_polled_terminal_outcome(
+    record: &mut super::ManagedAgentRecord,
+    key: &ManagedAgentRuntimeKey,
+    status: std::process::ExitStatus,
+    log_error: Option<super::storage::AgentLogError>,
+) {
+    if status.success() {
+        if record.last_error.is_none() {
+            record.last_exit_code = status.code();
+        }
+    } else {
+        let error = log_error.unwrap_or_else(|| super::storage::AgentLogError {
+            message: format!("harness exited with status {status}"),
+            code: None,
+        });
+        super::record_pending_pair_failure(record, key, status.code(), &error);
+    }
+}
+
 #[tauri::command]
 pub fn list_managed_agent_runtimes(
     app: AppHandle,
@@ -160,25 +199,74 @@ pub fn list_managed_agent_runtimes(
         .managed_agent_processes
         .lock()
         .map_err(|e| e.to_string())?;
+    let mut inspection_errors = Vec::new();
     let exited_keys: Vec<_> = runtimes
         .iter_mut()
         .filter_map(|(key, runtime)| match runtime.child.try_wait() {
-            Ok(Some(_)) | Err(_) => Some(key.clone()),
+            Ok(Some(status)) => {
+                #[cfg(windows)]
+                if let Err(error) =
+                    super::process_lifecycle::finalize_tracked_runtime(&app, key, runtime)
+                {
+                    inspection_errors.push((key.clone(), error));
+                    return None;
+                }
+                #[cfg(not(windows))]
+                if let Err(error) = super::remove_agent_runtime_receipt(&app, key) {
+                    inspection_errors.push((key.clone(), error));
+                    return None;
+                }
+                Some((key.clone(), status))
+            }
             Ok(None) => None,
+            Err(error) => {
+                inspection_errors.push((key.clone(), error.to_string()));
+                None
+            }
         })
         .collect();
-    let records_changed = !exited_keys.is_empty();
+    let records_changed = !exited_keys.is_empty() || !inspection_errors.is_empty();
+    let mut terminal_clear_failures = Vec::new();
+    let mut terminal_clear_successes = Vec::new();
     let mut statuses = Vec::new();
-    for key in exited_keys {
-        runtimes.remove(&key);
-        super::remove_agent_runtime_receipt(&app, &key);
-        state.clear_agent_session_cache(&key);
+    for (key, exit_status) in exited_keys {
+        let Some(recovery_pid) = runtimes.get(&key).map(|runtime| runtime.child.id()) else {
+            continue;
+        };
+        let log_error = if exit_status.success() {
+            None
+        } else {
+            runtimes
+                .get(&key)
+                .and_then(|runtime| super::meaningful_agent_error_from_log(&runtime.log_path))
+        };
         if let Some(record) = records
             .iter_mut()
             .find(|record| record.pubkey.eq_ignore_ascii_case(&key.pubkey))
         {
             record.updated_at = crate::util::now_iso();
-            record.last_stopped_at = Some(record.updated_at.clone());
+            if !exit_status.success() || record.last_error.is_none() {
+                record.last_exit_code = exit_status.code();
+            }
+            if let Err(error) = commit_polled_terminal_recovery(
+                record,
+                &key,
+                recovery_pid,
+                &runtimes,
+                |record, key| super::clear_pair_recovery_with_terminal_proof(&app, record, key),
+            ) {
+                terminal_clear_failures.push((key, error));
+                continue;
+            }
+            record_polled_terminal_outcome(record, &key, exit_status, log_error);
+            terminal_clear_successes.push(key.clone());
+            let sibling_active = runtimes.keys().any(|runtime_key| {
+                runtime_key.pubkey == record.pubkey
+                    && !terminal_clear_successes.contains(runtime_key)
+            });
+            if !sibling_active && !super::has_recovery_uncertainty(&app, record)? {
+                record.last_stopped_at = Some(record.updated_at.clone());
+            }
             let status = status_for_with(
                 &app,
                 record,
@@ -190,33 +278,95 @@ pub fn list_managed_agent_runtimes(
                     global: &global,
                 },
             );
-            emit_status(&app, &status);
             statuses.push(status);
         }
     }
-    statuses.extend(runtimes.iter().filter_map(|(key, runtime)| {
-        let record = records
+    for (key, error) in inspection_errors {
+        if let Some(record) = records
+            .iter_mut()
+            .find(|record| record.pubkey.eq_ignore_ascii_case(&key.pubkey))
+        {
+            #[cfg(windows)]
+            if let Some(runtime) = runtimes.get(&key) {
+                super::runtime::receipt_failure::mark_unverified_runtime(
+                    Some(&app),
+                    record,
+                    &key,
+                    runtime.child.id(),
+                    crate::util::now_iso(),
+                    format!("failed to inspect or finalize process state: {error}"),
+                );
+            }
+            #[cfg(not(windows))]
+            {
+                record.updated_at = crate::util::now_iso();
+                record.last_error = Some(format!("failed to inspect process state: {error}"));
+                record.last_error_code = None;
+            }
+        }
+    }
+    statuses.extend(
+        runtimes
             .iter()
-            .find(|record| record.pubkey.eq_ignore_ascii_case(&key.pubkey))?;
-        Some(status_for_with(
-            &app,
-            record,
-            key,
-            Some(runtime),
-            None,
-            StatusInputs {
-                personas: &personas,
-                global: &global,
-            },
-        ))
-    }));
-    drop(runtimes);
-    // Records are only mutated above when a runtime exited — skip the store
-    // rewrite on the common nothing-changed poll.
+            .filter(|(key, _)| !terminal_clear_successes.contains(key))
+            .filter_map(|(key, runtime)| {
+                let record = records
+                    .iter()
+                    .find(|record| record.pubkey.eq_ignore_ascii_case(&key.pubkey))?;
+                Some(status_for_with(
+                    &app,
+                    record,
+                    key,
+                    Some(runtime),
+                    None,
+                    StatusInputs {
+                        personas: &personas,
+                        global: &global,
+                    },
+                ))
+            }),
+    );
+    // Skip the store rewrite on the common nothing-changed poll.
     if records_changed {
-        save_managed_agents(&app, &records)?;
+        if let Err(error) = save_managed_agents(&app, &records) {
+            drop(runtimes);
+            let clear_errors = terminal_clear_failures
+                .iter()
+                .map(|(key, error)| format!("{}: {error}", key.runtime_id()))
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(if clear_errors.is_empty() {
+                error
+            } else {
+                format!("{clear_errors}; failed to persist terminal-proof retry markers: {error}")
+            });
+        }
+    }
+    for key in &terminal_clear_successes {
+        runtimes.remove(key);
+        state.clear_agent_session_cache(key);
+    }
+    drop(runtimes);
+    if !terminal_clear_failures.is_empty() {
+        return Err(terminal_clear_failures
+            .into_iter()
+            .map(|(key, error)| format!("{}: {error}", key.runtime_id()))
+            .collect::<Vec<_>>()
+            .join("; "));
+    }
+    for status in &statuses {
+        emit_status(&app, status);
     }
     Ok(statuses)
+}
+
+pub(crate) fn start_managed_agent_runtime_pair_lazy_under_transition(
+    pubkey: String,
+    relay_url: String,
+    transition: &std::sync::MutexGuard<'_, ()>,
+    app: AppHandle,
+) -> Result<ManagedAgentRuntimeStatus, String> {
+    start_pair(pubkey, relay_url, true, None, Some(transition), app)
 }
 
 pub(crate) fn start_managed_agent_runtime_pair_lazy(
@@ -224,7 +374,7 @@ pub(crate) fn start_managed_agent_runtime_pair_lazy(
     relay_url: String,
     app: AppHandle,
 ) -> Result<ManagedAgentRuntimeStatus, String> {
-    start_pair(pubkey, relay_url, true, None, app)
+    start_pair(pubkey, relay_url, true, None, None, app)
 }
 
 #[tauri::command]
@@ -241,13 +391,20 @@ fn start_pair(
     relay_url: String,
     lazy: bool,
     expected_updated_at: Option<&str>,
+    transition_held: Option<&std::sync::MutexGuard<'_, ()>>,
     app: AppHandle,
 ) -> Result<ManagedAgentRuntimeStatus, String> {
     let state = app.state::<AppState>();
-    let _transition = state
-        .managed_agent_runtime_transition
-        .lock()
-        .map_err(|e| e.to_string())?;
+    let _transition = if transition_held.is_some() {
+        None
+    } else {
+        Some(
+            state
+                .managed_agent_runtime_transition
+                .lock()
+                .map_err(|e| e.to_string())?,
+        )
+    };
     if state.shutdown_started.load(Ordering::Acquire) {
         return Err("desktop shutdown has started".into());
     }
@@ -264,16 +421,28 @@ fn start_pair(
         return Err("managed agent changed while runtime reconciliation was in flight".into());
     }
     let key = ManagedAgentRuntimeKey::new(pubkey, &relay_url)?;
+    if let Some(error) = super::recovery_admission_error(&app, record, &key)? {
+        return Err(error);
+    }
     let mut runtimes = state
         .managed_agent_processes
         .lock()
         .map_err(|e| e.to_string())?;
-    if runtimes
-        .get_mut(&key)
-        .is_some_and(|runtime| runtime.child.try_wait().ok().flatten().is_none())
-    {
-        let status = status_for(&app, record, &key, runtimes.get(&key), None);
-        return Ok(status);
+    if let Some(runtime) = runtimes.get_mut(&key) {
+        match runtime
+            .child
+            .try_wait()
+            .map_err(|error| error.to_string())?
+        {
+            None => {
+                let status = status_for(&app, record, &key, Some(runtime), None);
+                return Ok(status);
+            }
+            Some(_) => {
+                #[cfg(windows)]
+                super::process_lifecycle::finalize_tracked_runtime(&app, &key, runtime)?;
+            }
+        }
     }
     runtimes.remove(&key);
     terminate_untracked_pair_runtime(&app, &key)?;
@@ -283,24 +452,41 @@ fn start_pair(
         .lock()
         .ok()
         .map(|keys| keys.public_key().to_hex());
-    let mut process = spawn_agent_child(&app, record, &key.relay_url, lazy, owner.as_deref())?;
+    let process = spawn_agent_child(&app, record, &key.relay_url, lazy, owner.as_deref())?;
     let now = crate::util::now_iso();
     let receipt = ManagedAgentRuntimeReceipt {
         key: key.clone(),
         pid: process.child.id(),
         desktop_instance_id: current_instance_id(&app),
         started_at: now.clone(),
+        windows_job_contained: super::process_has_windows_job(&process),
     };
     if let Err(error) = write_agent_runtime_receipt(&app, &receipt) {
-        let _ = terminate_process(process.child.id());
-        let _ = process.child.wait();
-        return Err(error);
+        let cleanup_error = match super::runtime::receipt_failure::cleanup(
+            &app,
+            process,
+            record,
+            &mut runtimes,
+            key,
+            now,
+            error,
+        ) {
+            Err(error) => error,
+            Ok(()) => return Err("receipt-write failure was not propagated".to_string()),
+        };
+        drop(runtimes);
+        let persistence = save_managed_agents(&app, &records)
+            .err()
+            .map(|save_error| format!("; failed to persist cleanup state: {save_error}"))
+            .unwrap_or_default();
+        return Err(format!("{cleanup_error}{persistence}"));
     }
-    record.runtime_pid = None;
     record.updated_at = now.clone();
     record.last_started_at = Some(now);
     record.last_stopped_at = None;
-    record.last_error = None;
+    if !super::has_unverified_job_reap(record) {
+        record.last_error = None;
+    }
     runtimes.insert(key.clone(), ManagedAgentPairRuntime::starting(process));
     let status = status_for(&app, record, &key, runtimes.get(&key), None);
     drop(runtimes);
@@ -315,11 +501,26 @@ pub fn stop_managed_agent_runtime(
     relay_url: String,
     app: AppHandle,
 ) -> Result<ManagedAgentRuntimeStatus, String> {
+    stop_pair(pubkey, relay_url, None, app)
+}
+
+fn stop_pair(
+    pubkey: String,
+    relay_url: String,
+    transition_held: Option<&std::sync::MutexGuard<'_, ()>>,
+    app: AppHandle,
+) -> Result<ManagedAgentRuntimeStatus, String> {
     let state = app.state::<AppState>();
-    let _transition = state
-        .managed_agent_runtime_transition
-        .lock()
-        .map_err(|e| e.to_string())?;
+    let _transition = if transition_held.is_some() {
+        None
+    } else {
+        Some(
+            state
+                .managed_agent_runtime_transition
+                .lock()
+                .map_err(|e| e.to_string())?,
+        )
+    };
     let _store = state
         .managed_agents_store_lock
         .lock()
@@ -332,6 +533,10 @@ pub fn stop_managed_agent_runtime(
         .lock()
         .map_err(|e| e.to_string())?;
     if let Some(mut runtime) = runtimes.remove(&key) {
+        #[cfg(windows)]
+        let stop_result =
+            super::process_lifecycle::finalize_tracked_runtime(&app, &key, &mut runtime);
+        #[cfg(not(windows))]
         let stop_result = if process_is_running(runtime.child.id()) {
             terminate_process(runtime.child.id())
         } else {
@@ -341,17 +546,56 @@ pub fn stop_managed_agent_runtime(
         match stop_result {
             Ok(status) => {
                 record.last_exit_code = status.code();
+                if let Err(error) =
+                    super::clear_pair_recovery_with_terminal_proof(&app, record, &key)
+                {
+                    super::record_terminal_proof_pending_recovery_clear(
+                        record,
+                        &key,
+                        runtime.child.id(),
+                        &error,
+                    );
+                    runtimes.insert(key.clone(), runtime);
+                    drop(runtimes);
+                    save_managed_agents(&app, &records)?;
+                    return Err(format!(
+                        "failed to retire exact-pair recovery authority after terminal proof: {error}"
+                    ));
+                }
                 let _ = append_log_marker(&runtime.log_path, "=== stopped pair runtime ===");
             }
             Err(error) => {
-                // Keep failed teardown visible/manageable instead of
-                // orphaning it: the child stays tracked and the receipt
-                // stays on disk until a stop actually succeeds.
-                runtimes.insert(key, runtime);
-                return Err(error);
+                // Keep the exact child/Job authority and receipt under this
+                // pair key until a stop actually succeeds, and persist the
+                // failure mutation before returning.
+                let recovery_pid = runtime.child.id();
+                runtimes.insert(key.clone(), runtime);
+                let error = super::runtime::receipt_failure::mark_unverified_runtime(
+                    Some(&app),
+                    record,
+                    &key,
+                    recovery_pid,
+                    crate::util::now_iso(),
+                    format!(
+                        "Stop cleanup is incomplete and exact pair authority remains tracked for retry: {error}"
+                    ),
+                );
+                drop(runtimes);
+                return match save_managed_agents(&app, &records) {
+                    Ok(()) => Err(error),
+                    Err(persist_error) => Err(format!(
+                        "{error}; additionally failed to persist managed-agent stop failure: {persist_error}"
+                    )),
+                };
             }
         }
     } else {
+        #[cfg(windows)]
+        if super::terminal_proof_pending_recovery_clears(record).contains(&key) {
+            super::clear_pair_recovery_with_terminal_proof(&app, record, &key)?;
+        } else if let Some(error) = super::recovery_admission_error(&app, record, &key)? {
+            return Err(error);
+        }
         // No runtime is tracked at this key, but a valid prior-session
         // receipt may still point at a live child (e.g. the crash-recovery
         // window for a non-auto-start agent). Terminate that orphan before
@@ -363,12 +607,21 @@ pub fn stop_managed_agent_runtime(
         // only removes it after the child exits), mirroring the tracked
         // path's keep-until-success invariant.
         terminate_untracked_pair_runtime(&app, &key)?;
+        super::clear_pair_recovery_with_terminal_proof(&app, record, &key)?;
     }
-    super::remove_agent_runtime_receipt(&app, &key);
+    #[cfg(not(windows))]
+    super::remove_agent_runtime_receipt(&app, &key)?;
     state.clear_agent_session_cache(&key);
-    record.runtime_pid = None;
     record.updated_at = crate::util::now_iso();
-    record.last_stopped_at = Some(record.updated_at.clone());
+    let sibling_active = runtimes
+        .keys()
+        .any(|runtime_key| runtime_key.pubkey == record.pubkey);
+    if !sibling_active && !super::has_unverified_job_reap(record) {
+        record.runtime_pid = None;
+        record.last_stopped_at = Some(record.updated_at.clone());
+        record.last_error = None;
+        record.last_error_code = None;
+    }
     let status = status_for(&app, record, &key, None, None);
     drop(runtimes);
     save_managed_agents(&app, &records)?;
@@ -382,8 +635,25 @@ pub fn restart_managed_agent_runtime(
     relay_url: String,
     app: AppHandle,
 ) -> Result<ManagedAgentRuntimeStatus, String> {
-    stop_managed_agent_runtime(pubkey.clone(), relay_url.clone(), app.clone())?;
-    start_pair(pubkey, relay_url, true, None, app)
+    let state = app.state::<AppState>();
+    let _transition = state
+        .managed_agent_runtime_transition
+        .lock()
+        .map_err(|e| e.to_string())?;
+    stop_pair(
+        pubkey.clone(),
+        relay_url.clone(),
+        Some(&_transition),
+        app.clone(),
+    )?;
+    start_pair(
+        pubkey,
+        relay_url,
+        true,
+        None,
+        Some(&_transition),
+        app.clone(),
+    )
 }
 
 /// Probe whether this agent can operate on `requested_relay_url`.
@@ -507,6 +777,7 @@ pub async fn reconcile_managed_agent_runtimes(
                         key.relay_url.clone(),
                         true,
                         Some(&record.updated_at),
+                        None,
                         app.clone(),
                     ) {
                         Ok(mut status) => {
@@ -569,148 +840,5 @@ pub async fn reconcile_managed_agent_runtimes(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn payload(
-        relay_url: &str,
-        lifecycle: ManagedAgentRuntimeLifecycle,
-        error: Option<&str>,
-    ) -> super::super::ManagedAgentRuntimeLifecycleObserverPayload {
-        super::super::ManagedAgentRuntimeLifecycleObserverPayload {
-            pubkey: "aa".repeat(32),
-            relay_url: relay_url.into(),
-            start_nonce: "test-generation".into(),
-            lifecycle,
-            error: error.map(str::to_owned),
-        }
-    }
-
-    fn record_with_relay(relay_url: &str) -> super::super::ManagedAgentRecord {
-        serde_json::from_str(&format!(
-            r#"{{
-                "pubkey": "{}",
-                "name": "pin-test",
-                "relay_url": "{relay_url}",
-                "acp_command": "buzz-acp",
-                "agent_command": "goose",
-                "agent_args": [],
-                "mcp_command": "",
-                "turn_timeout_seconds": 320,
-                "system_prompt": "",
-                "created_at": "2026-01-01T00:00:00Z",
-                "updated_at": "2026-01-01T00:00:00Z"
-            }}"#,
-            "aa".repeat(32)
-        ))
-        .unwrap()
-    }
-
-    #[test]
-    fn legacy_relay_pin_is_ignored_for_fan_out() {
-        // Zero-touch cutover (#2122): a record carrying a creation-era
-        // `relay_url` pin must fan out exactly like an unpinned one — the
-        // stored field is parsed but never consulted. See
-        // `effective_agent_relay_url`.
-        let unpinned = record_with_relay("");
-        let pinned = record_with_relay("wss://one.example");
-        for record in [&unpinned, &pinned] {
-            assert_eq!(
-                crate::relay::effective_agent_relay_url(&record.relay_url, "wss://two.example"),
-                "wss://two.example"
-            );
-        }
-    }
-
-    #[test]
-    fn unkeyable_relay_degrades_to_failed_row() {
-        // A requested URL that cannot form a pair key must still yield a
-        // Failed row keyed by the raw requested string, so one bad community
-        // never aborts the rest of the reconcile batch.
-        let record = record_with_relay("");
-        let status = unkeyable_failed_status(
-            &record,
-            "not a url".to_string(),
-            "relay access probe timed out".to_string(),
-            &[],
-            &super::super::GlobalAgentConfig::default(),
-        );
-        assert!(matches!(
-            status.lifecycle,
-            ManagedAgentRuntimeLifecycle::Failed
-        ));
-        assert_eq!(status.relay_url, "not a url");
-        assert_eq!(status.requested_relay_url.as_deref(), Some("not a url"));
-        assert_eq!(status.pubkey, record.pubkey);
-        assert_eq!(
-            status.error.as_deref(),
-            Some("relay access probe timed out")
-        );
-        assert!(status.pid.is_none());
-    }
-
-    #[test]
-    fn runtime_key_rejects_non_hex_pubkeys() {
-        assert!(ManagedAgentRuntimeKey::new("../not-a-key", "wss://relay.example").is_err());
-        assert!(ManagedAgentRuntimeKey::new("gg".repeat(32), "wss://relay.example").is_err());
-    }
-
-    #[test]
-    fn runtime_key_canonicalizes_hex_pubkeys() {
-        let key = ManagedAgentRuntimeKey::new("AA".repeat(32), "wss://relay.example").unwrap();
-        assert_eq!(key.pubkey, "aa".repeat(32));
-    }
-
-    #[test]
-    fn observer_lifecycle_key_preserves_exact_canonical_pair() {
-        let first = payload(
-            "WSS://Relay.Example:443/",
-            ManagedAgentRuntimeLifecycle::Ready,
-            None,
-        );
-        let key = observer_lifecycle_key(&first.pubkey, &first).unwrap();
-        assert_eq!(key.pubkey, first.pubkey);
-        assert_eq!(key.relay_url, "wss://relay.example");
-
-        let other = payload(
-            "wss://other.example",
-            ManagedAgentRuntimeLifecycle::Ready,
-            None,
-        );
-        assert_ne!(key, observer_lifecycle_key(&other.pubkey, &other).unwrap());
-    }
-
-    #[test]
-    fn observer_lifecycle_rejects_cross_agent_and_desktop_states() {
-        let ready = payload(
-            "wss://relay.example",
-            ManagedAgentRuntimeLifecycle::Ready,
-            None,
-        );
-        assert!(observer_lifecycle_key(&"bb".repeat(32), &ready).is_err());
-
-        let stopped = payload(
-            "wss://relay.example",
-            ManagedAgentRuntimeLifecycle::Stopped,
-            None,
-        );
-        assert!(observer_lifecycle_key(&stopped.pubkey, &stopped).is_err());
-    }
-
-    #[test]
-    fn observer_lifecycle_enforces_failed_error_contract() {
-        let failed = payload(
-            "wss://relay.example",
-            ManagedAgentRuntimeLifecycle::Failed,
-            None,
-        );
-        assert!(observer_lifecycle_key(&failed.pubkey, &failed).is_err());
-
-        let ready_with_error = payload(
-            "wss://relay.example",
-            ManagedAgentRuntimeLifecycle::Ready,
-            Some("unexpected"),
-        );
-        assert!(observer_lifecycle_key(&ready_with_error.pubkey, &ready_with_error).is_err());
-    }
-}
+#[path = "runtime_commands/tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/managed_agents/runtime_commands/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_commands/tests.rs
@@ -1,0 +1,535 @@
+#[cfg(windows)]
+use super::super::process_lifecycle::finalize_tracked_runtime_with;
+use super::*;
+
+#[cfg(windows)]
+#[tokio::test]
+async fn tracked_windows_runtime_stop_uses_the_owned_job_and_is_bounded() {
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    let mut command = Command::new("powershell.exe");
+    command
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "ping -t 127.0.0.1 | Out-Null",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let process = crate::managed_agents::process_lifecycle::spawn_managed_agent_process(
+        command,
+        std::path::PathBuf::new(),
+        0,
+        false,
+        None,
+        "test-generation".into(),
+    )
+    .expect("spawn tracked Windows stop fixture inside a Job Object");
+    let mut runtime = ManagedAgentPairRuntime::starting(process);
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+
+    let started = Instant::now();
+    std::thread::spawn(move || {
+        let result = finalize_tracked_runtime_with(&mut runtime, || Ok(()));
+        let _ = sender.send((result, runtime.job.is_some()));
+    });
+    let (result, job_retained) = receiver
+        .recv_timeout(Duration::from_secs(7))
+        .expect("tracked Windows stop exceeded its external bound");
+    result.expect("owned tracked runtime must terminate and reap");
+
+    assert!(started.elapsed() < Duration::from_secs(7));
+    assert!(
+        !job_retained,
+        "successful Stop must consume the kill-on-close Job handle"
+    );
+    println!(
+        "NATIVE_STOP_PROOF elapsed_ms={} job_members=0 child_reaped=true",
+        started.elapsed().as_millis()
+    );
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn tracked_windows_runtime_stop_reaps_a_descendant_process() {
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock after Unix epoch")
+        .as_nanos();
+    let fixture_dir =
+        std::env::temp_dir().join(format!("buzz-stop-tree-{}-{nonce}", std::process::id()));
+    std::fs::create_dir_all(&fixture_dir).expect("create process-tree fixture directory");
+    let pid_path = fixture_dir.join("child.pid");
+    let quote = |path: &std::path::Path| path.display().to_string().replace('\'', "''");
+    let script = format!(
+        "$ErrorActionPreference='Stop'; \
+         $child=Start-Process -FilePath 'ping.exe' \
+           -ArgumentList '-t','127.0.0.1' -WindowStyle Hidden -PassThru; \
+         Set-Content -LiteralPath '{}' -Value $child.Id; \
+         Wait-Process -Id $child.Id",
+        quote(&pid_path),
+    );
+    let mut command = Command::new("powershell.exe");
+    command
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            &script,
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let process = crate::managed_agents::process_lifecycle::spawn_managed_agent_process(
+        command,
+        std::path::PathBuf::new(),
+        0,
+        false,
+        None,
+        "tree-test-generation".into(),
+    )
+    .expect("spawn process-tree fixture inside a Job Object");
+
+    let pid_deadline = Instant::now() + Duration::from_secs(5);
+    let descendant_pid = loop {
+        if let Ok(raw) = std::fs::read_to_string(&pid_path) {
+            break raw
+                .trim()
+                .parse::<u32>()
+                .expect("parse descendant process id");
+        }
+        assert!(
+            Instant::now() < pid_deadline,
+            "descendant process did not start within five seconds"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    };
+
+    let mut runtime = ManagedAgentPairRuntime::starting(process);
+    let started = Instant::now();
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let result = finalize_tracked_runtime_with(&mut runtime, || Ok(()));
+        let _ = sender.send((result, runtime.job.is_some()));
+    });
+    let (result, job_retained) = receiver
+        .recv_timeout(Duration::from_secs(7))
+        .expect("process-tree stop exceeded its external bound");
+    result.expect("process-tree stop must succeed");
+    assert!(
+        !job_retained,
+        "tree Stop must consume the kill-on-close Job handle"
+    );
+
+    let output = Command::new("tasklist.exe")
+        .args([
+            "/FI",
+            &format!("PID eq {descendant_pid}"),
+            "/FO",
+            "CSV",
+            "/NH",
+        ])
+        .output()
+        .expect("query descendant process after stop");
+    let listing = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !listing.contains(&format!(",\"{descendant_pid}\",")),
+        "descendant process {descendant_pid} survived tracked Stop: {listing}"
+    );
+    println!(
+        "NATIVE_TREE_STOP_PROOF elapsed_ms={} job_members=0 child_reaped=true descendant_pid={} descendant_alive=false",
+        started.elapsed().as_millis(),
+        descendant_pid
+    );
+    let _ = std::fs::remove_dir_all(&fixture_dir);
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn syncing_an_exited_launcher_finalizes_its_live_job_descendant() {
+    use std::collections::HashMap;
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    let fixture_dir = std::env::temp_dir().join(format!(
+        "buzz-sync-exited-tree-{}-{nonce}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&fixture_dir).expect("create exited-tree fixture directory");
+    let pid_path = fixture_dir.join("child.pid");
+    let script = format!(
+        "$child=Start-Process -FilePath 'ping.exe' \
+           -ArgumentList '-t','127.0.0.1' -WindowStyle Hidden -PassThru; \
+         Set-Content -LiteralPath '{}' -Value $child.Id",
+        pid_path.display().to_string().replace('\'', "''"),
+    );
+    let mut command = Command::new("powershell.exe");
+    command
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let process = crate::managed_agents::process_lifecycle::spawn_managed_agent_process(
+        command,
+        std::path::PathBuf::new(),
+        0,
+        false,
+        None,
+        "sync-exited-generation".into(),
+    )
+    .expect("spawn exited-tree fixture inside a Job Object");
+    let key = ManagedAgentRuntimeKey::new("aa".repeat(32), "wss://relay.example")
+        .expect("exited-tree runtime key");
+    let mut runtimes = HashMap::from([(key.clone(), ManagedAgentPairRuntime::starting(process))]);
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let descendant_pid = loop {
+        if let Ok(raw) = std::fs::read_to_string(&pid_path) {
+            break raw.trim().parse::<u32>().expect("parse descendant pid");
+        }
+        assert!(Instant::now() < deadline, "descendant pid was not written");
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    while runtimes
+        .get_mut(&key)
+        .expect("tracked exited-tree runtime")
+        .process
+        .child
+        .try_wait()
+        .expect("inspect launcher")
+        .is_none()
+    {
+        assert!(Instant::now() < deadline, "launcher did not exit");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        !runtimes[&key]
+            .process
+            .job
+            .as_ref()
+            .expect("owned Job")
+            .members()
+            .expect("query Job members")
+            .is_empty(),
+        "fixture must have a live descendant after launcher exit"
+    );
+
+    let mut records = vec![record_with_relay("wss://relay.example")];
+    let started = Instant::now();
+    let (_, exited) = super::super::runtime::sync_managed_agent_processes_with(
+        None,
+        &mut records,
+        &mut runtimes,
+        |_key, runtime| {
+            let status = runtime.child.try_wait()?;
+            if status.is_some() {
+                return super::super::process_lifecycle::finalize_tracked_runtime_with(
+                    runtime,
+                    || Ok(()),
+                )
+                .map(Some)
+                .map_err(std::io::Error::other);
+            }
+            Ok(status)
+        },
+    );
+    assert_eq!(exited, vec![key.clone()]);
+    assert!(runtimes.is_empty());
+    let output = Command::new("tasklist.exe")
+        .args([
+            "/FI",
+            &format!("PID eq {descendant_pid}"),
+            "/FO",
+            "CSV",
+            "/NH",
+        ])
+        .output()
+        .expect("query reconciled descendant process");
+    let listing = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !listing.contains(&format!(",\"{descendant_pid}\",")),
+        "descendant {descendant_pid} survived exited-launcher reconciliation: {listing}"
+    );
+    println!(
+        "NATIVE_EXITED_LAUNCHER_PROOF elapsed_ms={} job_members=0 child_reaped=true descendant_pid={} descendant_alive=false",
+        started.elapsed().as_millis(),
+        descendant_pid
+    );
+    let _ = std::fs::remove_dir_all(fixture_dir);
+}
+
+fn payload(
+    relay_url: &str,
+    lifecycle: ManagedAgentRuntimeLifecycle,
+    error: Option<&str>,
+) -> super::super::ManagedAgentRuntimeLifecycleObserverPayload {
+    super::super::ManagedAgentRuntimeLifecycleObserverPayload {
+        pubkey: "aa".repeat(32),
+        relay_url: relay_url.into(),
+        start_nonce: "test-generation".into(),
+        lifecycle,
+        error: error.map(str::to_owned),
+    }
+}
+
+fn record_with_relay(relay_url: &str) -> super::super::ManagedAgentRecord {
+    serde_json::from_str(&format!(
+        r#"{{
+            "pubkey": "{}",
+            "name": "pin-test",
+            "relay_url": "{relay_url}",
+            "acp_command": "buzz-acp",
+            "agent_command": "goose",
+            "agent_args": [],
+            "mcp_command": "",
+            "turn_timeout_seconds": 320,
+            "system_prompt": "",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z"
+        }}"#,
+        "aa".repeat(32)
+    ))
+    .unwrap()
+}
+
+#[test]
+fn legacy_relay_pin_is_ignored_for_fan_out() {
+    // Zero-touch cutover (#2122): a record carrying a creation-era
+    // `relay_url` pin must fan out exactly like an unpinned one — the
+    // stored field is parsed but never consulted. See
+    // `effective_agent_relay_url`.
+    let unpinned = record_with_relay("");
+    let pinned = record_with_relay("wss://one.example");
+    for record in [&unpinned, &pinned] {
+        assert_eq!(
+            crate::relay::effective_agent_relay_url(&record.relay_url, "wss://two.example"),
+            "wss://two.example"
+        );
+    }
+}
+
+#[test]
+fn unkeyable_relay_degrades_to_failed_row() {
+    // A requested URL that cannot form a pair key must still yield a
+    // Failed row keyed by the raw requested string, so one bad community
+    // never aborts the rest of the reconcile batch.
+    let record = record_with_relay("");
+    let status = unkeyable_failed_status(
+        &record,
+        "not a url".to_string(),
+        "relay access probe timed out".to_string(),
+        &[],
+        &super::super::GlobalAgentConfig::default(),
+    );
+    assert!(matches!(
+        status.lifecycle,
+        ManagedAgentRuntimeLifecycle::Failed
+    ));
+    assert_eq!(status.relay_url, "not a url");
+    assert_eq!(status.requested_relay_url.as_deref(), Some("not a url"));
+    assert_eq!(status.pubkey, record.pubkey);
+    assert_eq!(
+        status.error.as_deref(),
+        Some("relay access probe timed out")
+    );
+    assert!(status.pid.is_none());
+}
+
+#[test]
+fn runtime_key_rejects_non_hex_pubkeys() {
+    assert!(ManagedAgentRuntimeKey::new("../not-a-key", "wss://relay.example").is_err());
+    assert!(ManagedAgentRuntimeKey::new("gg".repeat(32), "wss://relay.example").is_err());
+}
+
+#[test]
+fn runtime_key_canonicalizes_hex_pubkeys() {
+    let key = ManagedAgentRuntimeKey::new("AA".repeat(32), "wss://relay.example").unwrap();
+    assert_eq!(key.pubkey, "aa".repeat(32));
+}
+
+#[test]
+fn observer_lifecycle_key_preserves_exact_canonical_pair() {
+    let first = payload(
+        "WSS://Relay.Example:443/",
+        ManagedAgentRuntimeLifecycle::Ready,
+        None,
+    );
+    let key = observer_lifecycle_key(&first.pubkey, &first).unwrap();
+    assert_eq!(key.pubkey, first.pubkey);
+    assert_eq!(key.relay_url, "wss://relay.example");
+
+    let other = payload(
+        "wss://other.example",
+        ManagedAgentRuntimeLifecycle::Ready,
+        None,
+    );
+    assert_ne!(key, observer_lifecycle_key(&other.pubkey, &other).unwrap());
+}
+
+#[test]
+fn observer_lifecycle_rejects_cross_agent_and_desktop_states() {
+    let ready = payload(
+        "wss://relay.example",
+        ManagedAgentRuntimeLifecycle::Ready,
+        None,
+    );
+    assert!(observer_lifecycle_key(&"bb".repeat(32), &ready).is_err());
+
+    let stopped = payload(
+        "wss://relay.example",
+        ManagedAgentRuntimeLifecycle::Stopped,
+        None,
+    );
+    assert!(observer_lifecycle_key(&stopped.pubkey, &stopped).is_err());
+}
+
+#[test]
+fn observer_lifecycle_enforces_failed_error_contract() {
+    let failed = payload(
+        "wss://relay.example",
+        ManagedAgentRuntimeLifecycle::Failed,
+        None,
+    );
+    assert!(observer_lifecycle_key(&failed.pubkey, &failed).is_err());
+
+    let ready_with_error = payload(
+        "wss://relay.example",
+        ManagedAgentRuntimeLifecycle::Ready,
+        Some("unexpected"),
+    );
+    assert!(observer_lifecycle_key(&ready_with_error.pubkey, &ready_with_error).is_err());
+}
+
+#[test]
+fn polled_terminal_clear_failure_keeps_runtime_and_exact_retry_marker() {
+    let pubkey = "bc".repeat(32);
+    let key = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://poll-retry.example").unwrap();
+    let mut record: super::super::ManagedAgentRecord = serde_json::from_str(&format!(
+        r#"{{"pubkey":"{pubkey}","name":"test","private_key_nsec":"nsec1fake","relay_url":"","acp_command":"buzz-acp","agent_command":"buzz-agent","agent_args":[],"mcp_command":"","turn_timeout_seconds":320,"system_prompt":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","last_started_at":null,"last_stopped_at":null,"last_exit_code":null,"last_error":null}}"#
+    ))
+    .unwrap();
+    let mut runtimes = std::collections::HashMap::from([(key.clone(), ())]);
+
+    assert!(
+        commit_polled_terminal_recovery(&mut record, &key, 9001, &runtimes, |_, _| {
+            Err("synthetic sidecar clear failure".into())
+        })
+        .is_err()
+    );
+    assert!(runtimes.contains_key(&key));
+    assert_eq!(
+        super::super::terminal_proof_pending_recovery_clears(&record),
+        vec![key]
+    );
+
+    let success_key = ManagedAgentRuntimeKey::new(pubkey, "wss://poll-commit.example").unwrap();
+    runtimes.insert(success_key.clone(), ());
+    commit_polled_terminal_recovery(&mut record, &success_key, 9002, &runtimes, |_, _| Ok(true))
+        .unwrap();
+    assert!(
+        runtimes.contains_key(&success_key),
+        "terminal token retires only after the main record commit"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn polled_nonzero_terminal_status_is_persisted() {
+    use std::os::windows::process::ExitStatusExt;
+
+    let pubkey = "bd".repeat(32);
+    let mut record: super::super::ManagedAgentRecord = serde_json::from_str(&format!(
+        r#"{{"pubkey":"{pubkey}","name":"test","private_key_nsec":"nsec1fake","relay_url":"","acp_command":"buzz-acp","agent_command":"buzz-agent","agent_args":[],"mcp_command":"","turn_timeout_seconds":320,"system_prompt":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","last_started_at":null,"last_stopped_at":null,"last_exit_code":null,"last_error":null}}"#
+    ))
+    .unwrap();
+    let status = std::process::ExitStatus::from_raw(7);
+
+    let key = ManagedAgentRuntimeKey::new(pubkey, "wss://poll-exit.example").unwrap();
+    record_polled_terminal_outcome(&mut record, &key, status, None);
+    assert_eq!(record.last_exit_code, Some(7));
+    assert!(record
+        .last_error
+        .as_deref()
+        .is_some_and(|error| error.contains('7')));
+
+    record_polled_terminal_outcome(
+        &mut record,
+        &key,
+        std::process::ExitStatus::from_raw(0),
+        None,
+    );
+    assert_eq!(record.last_exit_code, Some(7));
+}
+
+#[cfg(windows)]
+#[test]
+fn polled_exit_diagnostic_preserves_sibling_recovery_projection() {
+    use std::os::windows::process::ExitStatusExt;
+
+    let pubkey = "be".repeat(32);
+    let sibling = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://sibling.example").unwrap();
+    let exited = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://failed.example").unwrap();
+    let mut record: super::super::ManagedAgentRecord = serde_json::from_str(&format!(
+        r#"{{"pubkey":"{pubkey}","name":"test","private_key_nsec":"nsec1fake","relay_url":"","acp_command":"buzz-acp","agent_command":"buzz-agent","agent_args":[],"mcp_command":"","turn_timeout_seconds":320,"system_prompt":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","last_started_at":null,"last_stopped_at":null,"last_exit_code":null,"last_error":null}}"#
+    ))
+    .unwrap();
+    let mut authority = super::super::ManagedAgentRecoveryAuthority::default();
+    authority.mark_pair(&sibling, 9701, "sibling uncertainty".into());
+    authority.project_compatibility(&mut record);
+
+    record_polled_terminal_outcome(
+        &mut record,
+        &exited,
+        std::process::ExitStatus::from_raw(11),
+        None,
+    );
+
+    assert!(super::super::has_unverified_job_reap(&record));
+    assert!(record.last_error.as_deref().is_some_and(|error| {
+        error.contains("sibling.example") && error.contains(&exited.runtime_id())
+    }));
+    let failures = super::super::pending_pair_failures(&record);
+    assert_eq!(failures.len(), 1);
+    assert!(failures
+        .get(&exited.runtime_id())
+        .is_some_and(|message| message.contains("11")));
+}
+
+#[test]
+fn pending_pair_failure_encoding_does_not_invent_siblings() {
+    let pubkey = "bf".repeat(32);
+    let key = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://encoded.example").unwrap();
+    let mut record: super::super::ManagedAgentRecord = serde_json::from_str(&format!(
+        r#"{{"pubkey":"{pubkey}","name":"test","private_key_nsec":"nsec1fake","relay_url":"","acp_command":"buzz-acp","agent_command":"buzz-agent","agent_args":[],"mcp_command":"","turn_timeout_seconds":320,"system_prompt":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","last_started_at":null,"last_stopped_at":null,"last_exit_code":null,"last_error":null}}"#
+    ))
+    .unwrap();
+
+    super::super::record_pending_pair_failure(
+        &mut record,
+        &key,
+        Some(19),
+        &super::super::storage::AgentLogError {
+            message: "primary failure; fake-runtime: not a sibling".into(),
+            code: None,
+        },
+    );
+
+    assert_eq!(
+        super::super::pending_pair_failures(&record),
+        std::collections::BTreeMap::from([(
+            key.runtime_id(),
+            "primary failure; fake-runtime: not a sibling".to_string()
+        )])
+    );
+}

--- a/desktop/src-tauri/src/managed_agents/runtime_types.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime_types.rs
@@ -1,21 +1,113 @@
-use serde::{Deserialize, Serialize};
+use serde::{de::MapAccess, de::Visitor, Deserialize, Deserializer, Serialize};
 use sha2::{Digest as _, Sha256};
+use std::collections::BTreeMap;
 
 use super::ManagedAgentProcess;
 
+const MAX_RECOVERY_RELAY_URL_BYTES: usize = 4096;
+const TERMINAL_PROOF_PENDING_CLEAR_DETAIL: &str =
+    "terminal proof established; recovery clear pending";
+const PENDING_PAIR_FAILURE_PREFIX: &str = "pending managed-agent pair failures: ";
+
+fn recovery_projection_present(error: &str) -> bool {
+    error
+        .lines()
+        .any(|line| line.starts_with(super::UNVERIFIED_JOB_REAP_PREFIX))
+}
+
+fn pending_pair_failure_line(error: Option<&str>) -> Option<String> {
+    error?
+        .lines()
+        .find(|line| line.starts_with(PENDING_PAIR_FAILURE_PREFIX))
+        .map(str::to_string)
+}
+
+pub(crate) fn pending_pair_failures(
+    record: &super::ManagedAgentRecord,
+) -> BTreeMap<String, String> {
+    pending_pair_failure_line(record.last_error.as_deref())
+        .and_then(|line| {
+            line.strip_prefix(PENDING_PAIR_FAILURE_PREFIX)
+                .map(str::to_string)
+        })
+        .map(|failures| {
+            let mut deserializer = serde_json::Deserializer::from_str(&failures);
+            BTreeMap::deserialize(&mut deserializer).unwrap_or_else(|_| {
+                // Read the short-lived predecessor representation emitted by
+                // blocked local generations before this map became JSON.
+                failures
+                    .split("; ")
+                    .filter_map(|failure| failure.split_once(": "))
+                    .map(|(runtime_id, message)| (runtime_id.to_string(), message.to_string()))
+                    .collect()
+            })
+        })
+        .unwrap_or_default()
+}
+
+pub(crate) fn record_pending_pair_failure(
+    record: &mut super::ManagedAgentRecord,
+    key: &ManagedAgentRuntimeKey,
+    exit_code: Option<i32>,
+    error: &super::storage::AgentLogError,
+) {
+    let mut failures = pending_pair_failures(record);
+    failures.insert(key.runtime_id(), error.message.replace(['\r', '\n'], " "));
+    let encoded = serde_json::to_string(&failures).unwrap_or_else(|_| {
+        failures
+            .iter()
+            .map(|(runtime_id, message)| format!("{runtime_id}: {message}"))
+            .collect::<Vec<_>>()
+            .join("; ")
+    });
+    let failure_line = format!("{PENDING_PAIR_FAILURE_PREFIX}{encoded}");
+    let recovery_lines = record
+        .last_error
+        .as_deref()
+        .into_iter()
+        .flat_map(str::lines)
+        .filter(|line| line.starts_with(super::UNVERIFIED_JOB_REAP_PREFIX))
+        .collect::<Vec<_>>();
+    record.last_error = Some(if recovery_lines.is_empty() {
+        failure_line
+    } else {
+        format!("{}\n{failure_line}", recovery_lines.join("\n"))
+    });
+    record.last_exit_code = exit_code.or(record.last_exit_code);
+    record.last_error_code = error.code.or(record.last_error_code);
+}
+
+pub(crate) fn finalize_pending_pair_failures(record: &mut super::ManagedAgentRecord) -> bool {
+    let failures = pending_pair_failures(record);
+    if failures.is_empty() {
+        return false;
+    }
+    record.last_error = Some(
+        failures
+            .iter()
+            .map(|(runtime_id, message)| format!("{runtime_id}: {message}"))
+            .collect::<Vec<_>>()
+            .join("; "),
+    );
+    true
+}
+
 /// Canonical identity of one managed-agent harness on one relay.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(rename_all = "camelCase")]
-pub struct ManagedAgentRuntimeKey {
-    pub pubkey: String,
-    pub relay_url: String,
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ManagedAgentRuntimeKey {
+    pub(crate) pubkey: String,
+    pub(crate) relay_url: String,
 }
 
 impl ManagedAgentRuntimeKey {
-    pub fn new(pubkey: impl Into<String>, relay_url: &str) -> Result<Self, String> {
+    pub(crate) fn new(pubkey: impl Into<String>, relay_url: &str) -> Result<Self, String> {
         let pubkey = pubkey.into();
         if pubkey.len() != 64 || !pubkey.bytes().all(|byte| byte.is_ascii_hexdigit()) {
             return Err("managed-agent pubkey must be 64 hexadecimal characters".into());
+        }
+        if relay_url.len() > MAX_RECOVERY_RELAY_URL_BYTES {
+            return Err("managed-agent recovery relay URL exceeds 4096 bytes".into());
         }
         Ok(Self {
             pubkey: pubkey.to_ascii_lowercase(),
@@ -28,6 +120,635 @@ impl ManagedAgentRuntimeKey {
     pub fn runtime_id(&self) -> String {
         let relay_hash = hex::encode(Sha256::digest(self.relay_url.as_bytes()));
         format!("{}__{relay_hash}", self.pubkey)
+    }
+}
+
+pub(crate) const MANAGED_AGENT_RECOVERY_STORE_VERSION: u32 = 2;
+
+/// Typed, durable recovery authority for one managed agent.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ManagedAgentRecoveryAuthority {
+    generation: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) agent_quarantine: Option<ManagedAgentRecoveryEvidence>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) uncertain_pairs: Vec<ManagedAgentPairRecoveryEvidence>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    compatibility_snapshot: Option<ManagedAgentRecoveryCompatibilitySnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ManagedAgentRecoveryEvidence {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) pid: Option<u32>,
+    pub(crate) detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ManagedAgentPairRecoveryEvidence {
+    pub(crate) key: ManagedAgentRuntimeKey,
+    pub(crate) pid: u32,
+    pub(crate) detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ManagedAgentRecoveryStore {
+    pub(crate) version: u32,
+    #[serde(default, deserialize_with = "deserialize_authorities")]
+    pub(crate) authorities: BTreeMap<String, ManagedAgentRecoveryAuthority>,
+    #[serde(default)]
+    pub(crate) migration_complete: bool,
+}
+
+impl Default for ManagedAgentRecoveryStore {
+    fn default() -> Self {
+        Self {
+            version: MANAGED_AGENT_RECOVERY_STORE_VERSION,
+            authorities: BTreeMap::new(),
+            migration_complete: false,
+        }
+    }
+}
+
+fn deserialize_authorities<'de, D>(
+    deserializer: D,
+) -> Result<BTreeMap<String, ManagedAgentRecoveryAuthority>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct AuthorityMapVisitor;
+
+    impl<'de> Visitor<'de> for AuthorityMapVisitor {
+        type Value = BTreeMap<String, ManagedAgentRecoveryAuthority>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("a managed-agent recovery authority map with unique keys")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            let mut authorities = BTreeMap::new();
+            while let Some((pubkey, authority)) = map.next_entry()? {
+                if authorities.insert(pubkey, authority).is_some() {
+                    return Err(serde::de::Error::custom(
+                        "duplicate managed-agent recovery authority key",
+                    ));
+                }
+            }
+            Ok(authorities)
+        }
+    }
+
+    deserializer.deserialize_map(AuthorityMapVisitor)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ManagedAgentRecoveryCompatibilitySnapshot {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    runtime_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_error: Option<String>,
+}
+
+impl ManagedAgentRecoveryAuthority {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.agent_quarantine.is_none() && self.uncertain_pairs.is_empty()
+    }
+
+    pub(crate) fn from_legacy(runtime_pid: Option<u32>, last_error: Option<&str>) -> Self {
+        let legacy_error = last_error.unwrap_or_default();
+        let Some(pid) = runtime_pid else {
+            if recovery_projection_present(legacy_error) {
+                return Self {
+                    generation: uuid::Uuid::new_v4().to_string(),
+                    agent_quarantine: Some(ManagedAgentRecoveryEvidence {
+                        pid: None,
+                        detail: format!(
+                            "malformed recovery evidence is missing its compatibility PID: {legacy_error}"
+                        ),
+                    }),
+                    uncertain_pairs: Vec::new(),
+                    compatibility_snapshot: None,
+                };
+            }
+            return Self::default();
+        };
+        if recovery_projection_present(legacy_error) {
+            let only_known_lines = legacy_error.lines().all(|line| {
+                line.starts_with(super::UNVERIFIED_JOB_REAP_PREFIX)
+                    || line.starts_with(PENDING_PAIR_FAILURE_PREFIX)
+            });
+            let parsed: Option<Vec<_>> = legacy_error
+                .lines()
+                .filter(|line| !line.starts_with(PENDING_PAIR_FAILURE_PREFIX))
+                .map(parse_legacy_pair_recovery)
+                .collect();
+            if let Some(entries) = parsed.filter(|entries| {
+                if !only_known_lines {
+                    return false;
+                }
+                if entries.is_empty() {
+                    return false;
+                }
+                let unique = entries
+                    .iter()
+                    .map(|entry| entry.key.runtime_id())
+                    .collect::<std::collections::BTreeSet<_>>();
+                unique.len() == entries.len()
+            }) {
+                let generations = legacy_error
+                    .lines()
+                    .filter_map(parse_legacy_generation)
+                    .collect::<std::collections::BTreeSet<_>>();
+                let generation = if generations.len() == 1 {
+                    generations.into_iter().next().unwrap_or_default()
+                } else {
+                    uuid::Uuid::new_v4().to_string()
+                };
+                return Self {
+                    generation,
+                    agent_quarantine: None,
+                    uncertain_pairs: entries,
+                    compatibility_snapshot: None,
+                };
+            }
+        }
+        Self {
+            generation: uuid::Uuid::new_v4().to_string(),
+            agent_quarantine: Some(ManagedAgentRecoveryEvidence {
+                pid: Some(pid),
+                detail: if legacy_error.is_empty() {
+                    "unscoped legacy Windows runtime PID has no owned Child/Job terminal proof"
+                        .into()
+                } else {
+                    format!("unscoped or malformed legacy recovery evidence: {legacy_error}")
+                },
+            }),
+            uncertain_pairs: Vec::new(),
+            compatibility_snapshot: None,
+        }
+    }
+
+    pub(crate) fn admission_error(&self, key: &ManagedAgentRuntimeKey) -> Option<String> {
+        if let Some(evidence) = &self.agent_quarantine {
+            return Some(format!(
+                "managed-agent recovery is quarantined for every relay pair: {}",
+                evidence.detail
+            ));
+        }
+        self.uncertain_pairs
+            .iter()
+            .find(|evidence| evidence.key == *key)
+            .map(|evidence| {
+                format!(
+                    "managed-agent recovery remains uncertain for this exact relay pair (pid {}): {}",
+                    evidence.pid, evidence.detail
+                )
+            })
+    }
+
+    pub(crate) fn mark_pair(&mut self, key: &ManagedAgentRuntimeKey, pid: u32, detail: String) {
+        self.generation = uuid::Uuid::new_v4().to_string();
+        if let Some(existing) = self
+            .uncertain_pairs
+            .iter_mut()
+            .find(|evidence| evidence.key == *key)
+        {
+            existing.pid = pid;
+            existing.detail = detail;
+        } else {
+            self.uncertain_pairs.push(ManagedAgentPairRecoveryEvidence {
+                key: key.clone(),
+                pid,
+                detail,
+            });
+        }
+        self.uncertain_pairs.sort_by(|left, right| {
+            left.key
+                .runtime_id()
+                .cmp(&right.key.runtime_id())
+                .then_with(|| left.pid.cmp(&right.pid))
+        });
+    }
+
+    pub(crate) fn clear_pair_with_terminal_proof(&mut self, key: &ManagedAgentRuntimeKey) -> bool {
+        let old_len = self.uncertain_pairs.len();
+        self.uncertain_pairs.retain(|evidence| evidence.key != *key);
+        self.uncertain_pairs.len() != old_len
+    }
+
+    pub(crate) fn capture_compatibility_snapshot(&mut self, record: &super::ManagedAgentRecord) {
+        self.compatibility_snapshot = Some(ManagedAgentRecoveryCompatibilitySnapshot {
+            runtime_pid: record.runtime_pid,
+            last_error: record.last_error.clone(),
+        });
+    }
+
+    pub(crate) fn accepts_compatibility_record(&self, record: &super::ManagedAgentRecord) -> bool {
+        let has_recovery_projection = record.runtime_pid.is_some()
+            || record
+                .last_error
+                .as_deref()
+                .is_some_and(recovery_projection_present);
+        if !has_recovery_projection {
+            return true;
+        }
+        self.compatibility_snapshot
+            .as_ref()
+            .is_some_and(|snapshot| {
+                snapshot.runtime_pid == record.runtime_pid
+                    && snapshot.last_error == record.last_error
+            })
+    }
+
+    pub(crate) fn merge_compatibility_record(
+        &mut self,
+        record: &super::ManagedAgentRecord,
+    ) -> Result<(), String> {
+        let fallback = Self::from_legacy(record.runtime_pid, record.last_error.as_deref());
+        if fallback.is_empty() {
+            return Ok(());
+        }
+        let fallback_generation = fallback.generation.clone();
+        if self.agent_quarantine.is_some() || fallback.agent_quarantine.is_some() {
+            let details = self
+                .agent_quarantine
+                .iter()
+                .map(|evidence| evidence.detail.as_str())
+                .chain(
+                    fallback
+                        .agent_quarantine
+                        .iter()
+                        .map(|evidence| evidence.detail.as_str()),
+                )
+                .chain(
+                    self.uncertain_pairs
+                        .iter()
+                        .map(|evidence| evidence.detail.as_str()),
+                )
+                .chain(
+                    fallback
+                        .uncertain_pairs
+                        .iter()
+                        .map(|evidence| evidence.detail.as_str()),
+                )
+                .collect::<Vec<_>>()
+                .join("; ");
+            let pid = self
+                .agent_quarantine
+                .as_ref()
+                .and_then(|evidence| evidence.pid)
+                .or_else(|| {
+                    fallback
+                        .agent_quarantine
+                        .as_ref()
+                        .and_then(|evidence| evidence.pid)
+                })
+                .or_else(|| self.uncertain_pairs.first().map(|evidence| evidence.pid))
+                .or_else(|| {
+                    fallback
+                        .uncertain_pairs
+                        .first()
+                        .map(|evidence| evidence.pid)
+                });
+            self.agent_quarantine = Some(ManagedAgentRecoveryEvidence {
+                pid,
+                detail: format!(
+                    "conflicting sidecar and compatibility recovery evidence: {details}"
+                ),
+            });
+            self.uncertain_pairs.clear();
+        } else {
+            for evidence in fallback.uncertain_pairs {
+                if let Some(existing) = self
+                    .uncertain_pairs
+                    .iter_mut()
+                    .find(|existing| existing.key == evidence.key)
+                {
+                    if existing.pid == evidence.pid
+                        && fallback_generation == self.generation
+                        && evidence
+                            .detail
+                            .starts_with(TERMINAL_PROOF_PENDING_CLEAR_DETAIL)
+                    {
+                        existing.detail = evidence.detail;
+                    } else if existing.pid != evidence.pid || existing.detail != evidence.detail {
+                        self.agent_quarantine = Some(ManagedAgentRecoveryEvidence {
+                            pid: Some(existing.pid),
+                            detail: format!(
+                                "conflicting recovery evidence for exact pair {}",
+                                evidence.key.runtime_id()
+                            ),
+                        });
+                        self.uncertain_pairs.clear();
+                        break;
+                    }
+                } else {
+                    self.uncertain_pairs.push(evidence);
+                }
+            }
+            self.uncertain_pairs
+                .sort_by_key(|evidence| evidence.key.runtime_id());
+        }
+        self.generation = uuid::Uuid::new_v4().to_string();
+        Ok(())
+    }
+
+    pub(crate) fn project_compatibility(&self, record: &mut super::ManagedAgentRecord) {
+        let pending_failure = pending_pair_failure_line(record.last_error.as_deref());
+        let has_pending_failure = pending_failure.is_some();
+        if self.is_empty() {
+            if self.compatibility_snapshot.is_some() {
+                record.runtime_pid = None;
+                if record
+                    .last_error
+                    .as_deref()
+                    .is_some_and(recovery_projection_present)
+                {
+                    record.last_error = pending_failure;
+                    if !has_pending_failure {
+                        record.last_error_code = None;
+                    }
+                }
+            }
+            return;
+        }
+
+        record.last_stopped_at = None;
+        if let Some(quarantine) = &self.agent_quarantine {
+            record.runtime_pid = quarantine.pid.or(record.runtime_pid);
+            let recovery = format!(
+                "{} generation={} quarantine; {}",
+                super::UNVERIFIED_JOB_REAP_PREFIX,
+                self.generation,
+                quarantine.detail
+            );
+            record.last_error = Some(match pending_failure {
+                Some(failure) => format!("{recovery}\n{failure}"),
+                None => recovery,
+            });
+            if !has_pending_failure {
+                record.last_error_code = None;
+            }
+            return;
+        }
+        record.runtime_pid = self.uncertain_pairs.first().map(|evidence| evidence.pid);
+        let recovery = self
+            .uncertain_pairs
+            .iter()
+            .map(|evidence| {
+                let pair = serde_json::to_string(&evidence.key)
+                    .unwrap_or_else(|_| evidence.key.runtime_id());
+                format!(
+                    "{} generation={} pair={} pid={}; {}",
+                    super::UNVERIFIED_JOB_REAP_PREFIX,
+                    self.generation,
+                    pair,
+                    evidence.pid,
+                    evidence.detail
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        record.last_error = Some(match pending_failure {
+            Some(failure) => format!("{recovery}\n{failure}"),
+            None => recovery,
+        });
+        if !has_pending_failure {
+            record.last_error_code = None;
+        }
+    }
+}
+
+fn parse_legacy_pair_recovery(line: &str) -> Option<ManagedAgentPairRecoveryEvidence> {
+    let body = line.strip_prefix(super::UNVERIFIED_JOB_REAP_PREFIX)?;
+    let pair_start = if let Some(generated) = body.strip_prefix(" generation=") {
+        let (_, pair) = generated.split_once(" pair=")?;
+        pair
+    } else {
+        body.strip_prefix(" pair=")?
+    };
+    let pair_end = pair_start.find("} pid=")? + 1;
+    let parsed_key: ManagedAgentRuntimeKey = serde_json::from_str(&pair_start[..pair_end]).ok()?;
+    let key = ManagedAgentRuntimeKey::new(parsed_key.pubkey.clone(), &parsed_key.relay_url).ok()?;
+    if key != parsed_key {
+        return None;
+    }
+    let remainder = pair_start[pair_end..].strip_prefix(" pid=")?;
+    let (pid, detail) = remainder.split_once(';')?;
+    Some(ManagedAgentPairRecoveryEvidence {
+        key,
+        pid: pid.parse().ok()?,
+        detail: detail.trim().to_string(),
+    })
+}
+
+fn parse_legacy_generation(line: &str) -> Option<String> {
+    let generated = line
+        .strip_prefix(super::UNVERIFIED_JOB_REAP_PREFIX)?
+        .strip_prefix(" generation=")?;
+    let (generation, _) = generated.split_once(' ')?;
+    uuid::Uuid::parse_str(generation).ok()?;
+    Some(generation.to_string())
+}
+
+pub(crate) fn record_terminal_proof_pending_recovery_clear(
+    record: &mut super::ManagedAgentRecord,
+    key: &ManagedAgentRuntimeKey,
+    pid: u32,
+    detail: &str,
+) {
+    let pending_failure = pending_pair_failure_line(record.last_error.as_deref());
+    let has_pending_failure = pending_failure.is_some();
+    let generation = record
+        .last_error
+        .as_deref()
+        .and_then(|error| error.lines().find_map(parse_legacy_generation))
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    let pair = serde_json::to_string(key).unwrap_or_else(|_| key.runtime_id());
+    record.runtime_pid = Some(pid);
+    record.last_stopped_at = None;
+    let recovery = format!(
+        "{} generation={generation} pair={pair} pid={pid}; {TERMINAL_PROOF_PENDING_CLEAR_DETAIL}: {detail}",
+        super::UNVERIFIED_JOB_REAP_PREFIX
+    );
+    record.last_error = Some(match pending_failure {
+        Some(failure) => format!("{recovery}\n{failure}"),
+        None => recovery,
+    });
+    if !has_pending_failure {
+        record.last_error_code = None;
+    }
+}
+
+pub(crate) fn record_blocked_recovery_admission(_record: &super::ManagedAgentRecord) -> bool {
+    // Rejected recovery admission is observational only. Every compatibility
+    // field remains byte-for-byte available for an authoritative retry.
+    false
+}
+
+pub(crate) fn append_shutdown_diagnostic(
+    record: &mut super::ManagedAgentRecord,
+    detail: &str,
+    force_recovery_projection: bool,
+) {
+    let pending = pending_pair_failure_line(record.last_error.as_deref());
+    let mut lines = record
+        .last_error
+        .as_deref()
+        .into_iter()
+        .flat_map(str::lines)
+        .filter(|line| !line.starts_with(PENDING_PAIR_FAILURE_PREFIX))
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if let Some(recovery) = lines
+        .iter_mut()
+        .find(|line| line.starts_with(super::UNVERIFIED_JOB_REAP_PREFIX))
+    {
+        recovery.push_str("; ");
+        recovery.push_str(detail);
+    } else if force_recovery_projection {
+        lines.push(format!("{} {detail}", super::UNVERIFIED_JOB_REAP_PREFIX));
+    } else {
+        // Canonical sidecar authority may be the only recovery evidence. Do
+        // not broaden that exact-pair authority into an agent quarantine.
+        lines.push(detail.to_string());
+    }
+    if let Some(pending) = pending {
+        lines.push(pending);
+    } else {
+        record.last_error_code = None;
+    }
+    record.last_error = Some(lines.join("\n"));
+}
+
+pub(crate) fn terminal_proof_pending_recovery_clears(
+    record: &super::ManagedAgentRecord,
+) -> Vec<ManagedAgentRuntimeKey> {
+    ManagedAgentRecoveryAuthority::from_legacy(record.runtime_pid, record.last_error.as_deref())
+        .uncertain_pairs
+        .into_iter()
+        .filter(|evidence| {
+            evidence
+                .detail
+                .starts_with(TERMINAL_PROOF_PENDING_CLEAR_DETAIL)
+        })
+        .map(|evidence| evidence.key)
+        .collect()
+}
+
+impl ManagedAgentRecoveryStore {
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        if self.version != MANAGED_AGENT_RECOVERY_STORE_VERSION {
+            return Err(format!(
+                "unsupported managed-agent recovery store version {}",
+                self.version
+            ));
+        }
+        if self.authorities.len() > 1024 {
+            return Err("managed-agent recovery store exceeds 1024 agents".into());
+        }
+        if self.authorities.is_empty() && !self.migration_complete {
+            return Err(
+                "managed-agent recovery store cannot persist unmigrated semantic absence".into(),
+            );
+        }
+        for (pubkey, authority) in &self.authorities {
+            if pubkey.len() != 64
+                || !pubkey.bytes().all(|byte| byte.is_ascii_hexdigit())
+                || *pubkey != pubkey.to_ascii_lowercase()
+            {
+                return Err(format!(
+                    "managed-agent recovery store contains a noncanonical agent key: {pubkey}"
+                ));
+            }
+            if authority.agent_quarantine.is_some() && !authority.uncertain_pairs.is_empty() {
+                return Err(format!(
+                    "managed-agent recovery store contains contradictory authority for {pubkey}"
+                ));
+            }
+            if uuid::Uuid::parse_str(&authority.generation).is_err() {
+                return Err(format!(
+                    "managed-agent recovery store contains an invalid generation for {pubkey}"
+                ));
+            }
+            if authority.is_empty() && authority.compatibility_snapshot.is_none() {
+                return Err(format!(
+                    "managed-agent recovery store contains an empty authority for {pubkey}"
+                ));
+            }
+            if authority.uncertain_pairs.len() > 128 {
+                return Err(format!(
+                    "managed-agent recovery store exceeds 128 pairs for {pubkey}"
+                ));
+            }
+            if let Some(quarantine) = &authority.agent_quarantine {
+                if quarantine.pid == Some(0)
+                    || quarantine.detail.trim().is_empty()
+                    || quarantine.detail.len() > 4096
+                {
+                    return Err(format!(
+                        "managed-agent recovery store contains invalid quarantine evidence for {pubkey}"
+                    ));
+                }
+            }
+            if let Some(snapshot) = &authority.compatibility_snapshot {
+                if snapshot.runtime_pid == Some(0)
+                    || snapshot
+                        .last_error
+                        .as_ref()
+                        .is_some_and(|error| error.len() > 16_384)
+                {
+                    return Err(format!(
+                        "managed-agent recovery store contains an invalid compatibility snapshot for {pubkey}"
+                    ));
+                }
+                if authority.is_empty()
+                    && !snapshot.last_error.as_deref().is_some_and(|error| {
+                        error.contains(&format!(" generation={} ", authority.generation))
+                    })
+                {
+                    return Err(format!(
+                        "managed-agent recovery tombstone lacks record-backed generation for {pubkey}"
+                    ));
+                }
+            }
+            let mut runtime_ids = std::collections::BTreeSet::new();
+            for evidence in &authority.uncertain_pairs {
+                let canonical = ManagedAgentRuntimeKey::new(
+                    evidence.key.pubkey.clone(),
+                    &evidence.key.relay_url,
+                )?;
+                if canonical != evidence.key || evidence.key.pubkey != *pubkey {
+                    return Err(format!(
+                        "managed-agent recovery store contains a noncanonical or mismatched pair key for {pubkey}"
+                    ));
+                }
+                if evidence.pid == 0
+                    || evidence.detail.trim().is_empty()
+                    || evidence.detail.len() > 4096
+                {
+                    return Err(format!(
+                        "managed-agent recovery store contains invalid pair evidence for {}",
+                        evidence.key.runtime_id()
+                    ));
+                }
+                if !runtime_ids.insert(evidence.key.runtime_id()) {
+                    return Err(format!(
+                        "managed-agent recovery store contains duplicate authority for pair {}",
+                        evidence.key.runtime_id()
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -117,4 +838,21 @@ pub struct ManagedAgentRuntimeReceipt {
     pub pid: u32,
     pub desktop_instance_id: String,
     pub started_at: String,
+    /// True only when this process was assigned to Buzz's mandatory Windows
+    /// kill-on-close Job before its receipt was committed. Missing markers are
+    /// legacy and require a separate read-only liveness proof before retirement.
+    #[serde(default)]
+    pub windows_job_contained: bool,
+}
+
+pub(crate) fn process_has_windows_job(process: &ManagedAgentProcess) -> bool {
+    #[cfg(windows)]
+    {
+        process.job.is_some()
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = process;
+        false
+    }
 }

--- a/desktop/src-tauri/src/managed_agents/storage.rs
+++ b/desktop/src-tauri/src/managed_agents/storage.rs
@@ -52,6 +52,15 @@ fn managed_agents_logs_dir(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(dir)
 }
 
+mod recovery;
+
+pub(crate) use recovery::{
+    admission_error as recovery_admission_error, authority_for as recovery_authority_for,
+    clear_pair_with_terminal_proof as clear_pair_recovery_with_terminal_proof,
+    ensure_admission as ensure_recovery_admission, has_uncertainty as has_recovery_uncertainty,
+    mark_pair_uncertain as mark_pair_recovery_uncertain,
+};
+
 /// Install-log path for `runtime_id`, alongside the agent logs.
 pub fn install_log_path(app: &AppHandle, runtime_id: &str) -> Result<PathBuf, String> {
     Ok(managed_agents_logs_dir(app)?.join(install_log_filename(runtime_id)?))
@@ -263,6 +272,9 @@ pub fn load_managed_agents(app: &AppHandle) -> Result<Vec<ManagedAgentRecord>, S
     let mut records = load_agent_store(app)?;
     records.retain(|record| !record.pubkey.is_empty());
     hydrate_keys(&mut records);
+    for record in &mut records {
+        recovery_authority_for(app, record)?.project_compatibility(record);
+    }
     Ok(records)
 }
 
@@ -378,7 +390,8 @@ pub fn save_managed_agents(app: &AppHandle, records: &[ManagedAgentRecord]) -> R
     // keyring is unreachable, the key stays inline.
     persist_agent_keys(&mut sorted);
 
-    write_agent_store(app, definitions, sorted)
+    write_agent_store(app, definitions, sorted.clone())?;
+    recovery::compact_tombstones(app, &sorted)
 }
 
 /// Save the key-less agent *definitions*, preserving the keyed instances —
@@ -736,41 +749,105 @@ pub fn write_agent_runtime_receipt(
     receipt: &ManagedAgentRuntimeReceipt,
 ) -> Result<(), String> {
     let path = agent_pids_dir(app)?.join(format!("{}.json", receipt.key.runtime_id()));
+    super::finish_pending_agent_runtime_receipt_deletion(&path)?;
     let payload = serde_json::to_vec(receipt)
         .map_err(|error| format!("failed to serialize runtime receipt: {error}"))?;
     atomic_write_json_restricted(&path, &payload)
 }
 
-pub fn remove_agent_runtime_receipt(app: &AppHandle, key: &ManagedAgentRuntimeKey) {
-    if let Ok(dir) = agent_pids_dir(app) {
-        let _ = fs::remove_file(dir.join(format!("{}.json", key.runtime_id())));
+fn read_agent_runtime_receipts_with<List, ResolveTombstone, Read>(
+    dir: &Path,
+    list: List,
+    mut resolve_tombstone: ResolveTombstone,
+    read: Read,
+) -> Result<Vec<(PathBuf, ManagedAgentRuntimeReceipt)>, String>
+where
+    List: FnOnce(&Path) -> Result<Vec<PathBuf>, String>,
+    ResolveTombstone: FnMut(&Path) -> Result<(), String>,
+    Read: Fn(&Path) -> Result<Vec<u8>, String>,
+{
+    let mut receipts = Vec::new();
+    for path in list(dir)? {
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".json.delete-pending"))
+        {
+            resolve_tombstone(&path)?;
+            continue;
+        }
+        if path.extension().is_none_or(|ext| ext != "json") {
+            continue;
+        }
+        let bytes = read(&path)?;
+        let receipt: ManagedAgentRuntimeReceipt =
+            serde_json::from_slice(&bytes).map_err(|error| {
+                format!(
+                    "failed to parse runtime receipt {}: {error}",
+                    path.display()
+                )
+            })?;
+        let expected_path = dir.join(format!("{}.json", receipt.key.runtime_id()));
+        if path != expected_path {
+            return Err(format!(
+                "runtime receipt path {} does not match embedded runtime key (expected {})",
+                path.display(),
+                expected_path.display()
+            ));
+        }
+        receipts.push((path, receipt));
     }
+    Ok(receipts)
 }
 
-pub fn remove_agent_runtime_receipt_path(path: &Path) {
-    let _ = fs::remove_file(path);
+fn resolve_runtime_receipt_tombstone(tombstone: &Path) -> Result<(), String> {
+    let receipt_path = tombstone.with_extension("");
+    match fs::symlink_metadata(&receipt_path) {
+        Ok(_) => Err(format!(
+            "both runtime receipt and deletion tombstone exist for {}",
+            receipt_path.display()
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            super::finish_pending_agent_runtime_receipt_deletion(&receipt_path)
+        }
+        Err(error) => Err(format!(
+            "failed to inspect runtime receipt paired with tombstone {}: {error}",
+            tombstone.display()
+        )),
+    }
 }
 
 pub fn read_all_agent_runtime_receipts(
     app: &AppHandle,
-) -> Vec<(PathBuf, ManagedAgentRuntimeReceipt)> {
-    let Ok(dir) = agent_pids_dir(app) else {
-        return Vec::new();
-    };
-    let Ok(entries) = fs::read_dir(dir) else {
-        return Vec::new();
-    };
-    entries
-        .flatten()
-        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "json"))
-        .filter_map(|entry| {
-            let path = entry.path();
-            let bytes = fs::read(&path).ok()?;
-            serde_json::from_slice(&bytes)
-                .ok()
-                .map(|receipt| (path, receipt))
-        })
-        .collect()
+) -> Result<Vec<(PathBuf, ManagedAgentRuntimeReceipt)>, String> {
+    let dir = agent_pids_dir(app)?;
+    read_agent_runtime_receipts_with(
+        &dir,
+        |dir| {
+            fs::read_dir(dir)
+                .map_err(|error| {
+                    format!(
+                        "failed to read runtime receipt directory {}: {error}",
+                        dir.display()
+                    )
+                })?
+                .map(|entry| {
+                    entry.map(|entry| entry.path()).map_err(|error| {
+                        format!(
+                            "failed to inspect runtime receipt directory entry in {}: {error}",
+                            dir.display()
+                        )
+                    })
+                })
+                .collect()
+        },
+        resolve_runtime_receipt_tombstone,
+        |path| {
+            fs::read(path).map_err(|error| {
+                format!("failed to read runtime receipt {}: {error}", path.display())
+            })
+        },
+    )
 }
 
 /// Remove the PID file for an agent (e.g. on normal stop).

--- a/desktop/src-tauri/src/managed_agents/storage/recovery.rs
+++ b/desktop/src-tauri/src/managed_agents/storage/recovery.rs
@@ -1,0 +1,585 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::{Mutex, MutexGuard, OnceLock},
+};
+
+use tauri::AppHandle;
+
+use super::{atomic_write_json_restricted, managed_agents_base_dir};
+use crate::managed_agents::{
+    ManagedAgentRecord, ManagedAgentRecoveryAuthority, ManagedAgentRecoveryStore,
+    ManagedAgentRuntimeKey,
+};
+
+const MAX_RECOVERY_STORE_BYTES: u64 = 1024 * 1024;
+static RECOVERY_STORE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn recovery_store_guard() -> Result<MutexGuard<'static, ()>, String> {
+    RECOVERY_STORE_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| "managed-agent recovery store lock is poisoned".to_string())
+}
+
+fn recovery_store_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(managed_agents_base_dir(app)?.join("managed-agent-recovery.json"))
+}
+
+fn load_from_path(path: &Path) -> Result<ManagedAgentRecoveryStore, String> {
+    if !path.exists() {
+        return Ok(ManagedAgentRecoveryStore::default());
+    }
+    let size = fs::metadata(path)
+        .map_err(|error| format!("failed to inspect managed-agent recovery store: {error}"))?
+        .len();
+    if size > MAX_RECOVERY_STORE_BYTES {
+        return Err(format!(
+            "managed-agent recovery store exceeds {MAX_RECOVERY_STORE_BYTES} bytes"
+        ));
+    }
+    let content = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read managed-agent recovery store: {error}"))?;
+    let migration_field_missing = match serde_json::from_str::<serde_json::Value>(&content) {
+        Ok(serde_json::Value::Object(object)) => !object.contains_key("migrationComplete"),
+        _ => false,
+    };
+    let mut store: ManagedAgentRecoveryStore = serde_json::from_str(&content)
+        .map_err(|error| format!("failed to parse managed-agent recovery store: {error}"))?;
+    if store.version == 2 && store.authorities.is_empty() && migration_field_missing {
+        store.migration_complete = true;
+    }
+    store.validate()?;
+    Ok(store)
+}
+
+fn save_to_path(path: &Path, store: &ManagedAgentRecoveryStore) -> Result<(), String> {
+    store.validate()?;
+    let payload = serde_json::to_vec_pretty(store)
+        .map_err(|error| format!("failed to serialize managed-agent recovery store: {error}"))?;
+    if payload.len() as u64 > MAX_RECOVERY_STORE_BYTES {
+        return Err(format!(
+            "managed-agent recovery store exceeds {MAX_RECOVERY_STORE_BYTES} bytes"
+        ));
+    }
+    atomic_write_json_restricted(path, &payload)
+}
+
+fn update_path<T>(
+    path: &Path,
+    update: impl FnOnce(&mut ManagedAgentRecoveryStore) -> Result<T, String>,
+) -> Result<T, String> {
+    let _guard = recovery_store_guard()?;
+    let mut store = load_from_path(path)?;
+    let original = store.clone();
+    let result = update(&mut store)?;
+    if store != original {
+        save_to_path(path, &store)?;
+    }
+    Ok(result)
+}
+
+fn compact_tombstones_at_path(path: &Path, records: &[ManagedAgentRecord]) -> Result<(), String> {
+    let _guard = recovery_store_guard()?;
+    let mut store = load_from_path(path)?;
+    let mut changed = false;
+    let tombstones = store
+        .authorities
+        .iter()
+        .filter_map(|(pubkey, authority)| authority.is_empty().then_some(pubkey.clone()))
+        .collect::<Vec<_>>();
+    for pubkey in tombstones {
+        let compatibility_is_clear = records
+            .iter()
+            .find(|record| record.pubkey == pubkey)
+            .map(authority_from_record)
+            .is_none_or(|authority| authority.is_empty());
+        if compatibility_is_clear {
+            store.authorities.remove(&pubkey);
+            store.migration_complete = true;
+            changed = true;
+        }
+    }
+    if changed {
+        save_to_path(path, &store)?;
+    }
+    Ok(())
+}
+
+pub(super) fn compact_tombstones(
+    app: &AppHandle,
+    records: &[ManagedAgentRecord],
+) -> Result<(), String> {
+    #[cfg(not(windows))]
+    {
+        let _ = (app, records);
+        Ok(())
+    }
+    #[cfg(windows)]
+    {
+        compact_tombstones_at_path(&recovery_store_path(app)?, records)
+    }
+}
+
+fn authority_from_record(record: &ManagedAgentRecord) -> ManagedAgentRecoveryAuthority {
+    #[cfg(windows)]
+    {
+        ManagedAgentRecoveryAuthority::from_legacy(record.runtime_pid, record.last_error.as_deref())
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = record;
+        ManagedAgentRecoveryAuthority::default()
+    }
+}
+
+fn reconcile_authority(
+    mut authority: ManagedAgentRecoveryAuthority,
+    record: &mut ManagedAgentRecord,
+) -> Result<ManagedAgentRecoveryAuthority, String> {
+    if !authority.accepts_compatibility_record(record) {
+        authority.merge_compatibility_record(record)?;
+        authority.project_compatibility(record);
+        authority.capture_compatibility_snapshot(record);
+    }
+    Ok(authority)
+}
+
+fn authority_for_path(
+    path: &Path,
+    record: &ManagedAgentRecord,
+) -> Result<ManagedAgentRecoveryAuthority, String> {
+    let mut store = load_from_path(path)?;
+    if record.runtime_pid.is_none() && crate::managed_agents::has_unverified_job_reap(record) {
+        // Malformed fallback evidence is an admission blocker, not migration
+        // authority. Preserve both persisted bytes and the caller's evidence.
+        let mut authority = store
+            .authorities
+            .get(&record.pubkey)
+            .cloned()
+            .unwrap_or_default();
+        authority.merge_compatibility_record(record)?;
+        return Ok(authority);
+    }
+    if let Some(existing) = store.authorities.remove(&record.pubkey) {
+        let mut projected_record = record.clone();
+        let authority = reconcile_authority(existing, &mut projected_record)?;
+        if projected_record != *record {
+            store
+                .authorities
+                .insert(record.pubkey.clone(), authority.clone());
+            save_to_path(path, &store)?;
+        }
+        return Ok(authority);
+    }
+    let mut authority = authority_from_record(record);
+    if !authority.is_empty() {
+        let mut projected_record = record.clone();
+        authority.project_compatibility(&mut projected_record);
+        authority.capture_compatibility_snapshot(&projected_record);
+        store
+            .authorities
+            .insert(record.pubkey.clone(), authority.clone());
+        save_to_path(path, &store)?;
+    }
+    Ok(authority)
+}
+
+pub(crate) fn authority_for(
+    app: &AppHandle,
+    record: &ManagedAgentRecord,
+) -> Result<ManagedAgentRecoveryAuthority, String> {
+    #[cfg(not(windows))]
+    {
+        let _ = (app, record);
+        return Ok(ManagedAgentRecoveryAuthority::default());
+    }
+    #[cfg(windows)]
+    {
+        let _guard = recovery_store_guard()?;
+        let path = recovery_store_path(app)?;
+        authority_for_path(&path, record)
+    }
+}
+
+pub(crate) fn admission_error(
+    app: &AppHandle,
+    record: &ManagedAgentRecord,
+    key: &ManagedAgentRuntimeKey,
+) -> Result<Option<String>, String> {
+    Ok(authority_for(app, record)?.admission_error(key))
+}
+
+pub(crate) fn ensure_admission(
+    app: &AppHandle,
+    record: &ManagedAgentRecord,
+    key: &ManagedAgentRuntimeKey,
+) -> Result<(), String> {
+    match admission_error(app, record, key)? {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+pub(crate) fn has_uncertainty(
+    app: &AppHandle,
+    record: &ManagedAgentRecord,
+) -> Result<bool, String> {
+    Ok(!authority_for(app, record)?.is_empty())
+}
+
+pub(crate) fn mark_pair_uncertain(
+    app: &AppHandle,
+    record: &mut ManagedAgentRecord,
+    key: &ManagedAgentRuntimeKey,
+    pid: u32,
+    detail: String,
+) -> Result<String, String> {
+    #[cfg(not(windows))]
+    {
+        let _ = (app, record, key, detail);
+        return Ok(format!(
+            "managed-agent recovery remains uncertain for pid {pid}"
+        ));
+    }
+    #[cfg(windows)]
+    {
+        mark_pair_at_path(&recovery_store_path(app)?, record, key, pid, detail)
+    }
+}
+
+fn mark_pair_at_path(
+    path: &Path,
+    record: &mut ManagedAgentRecord,
+    key: &ManagedAgentRuntimeKey,
+    pid: u32,
+    detail: String,
+) -> Result<String, String> {
+    let mut projected = record.clone();
+    let result = update_path(path, |store| {
+        let authority = store
+            .authorities
+            .remove(&projected.pubkey)
+            .unwrap_or_else(|| authority_from_record(&projected));
+        let mut authority = reconcile_authority(authority, &mut projected)?;
+        authority.mark_pair(key, pid, detail);
+        authority.project_compatibility(&mut projected);
+        authority.capture_compatibility_snapshot(&projected);
+        store
+            .authorities
+            .insert(projected.pubkey.clone(), authority);
+        Ok(projected
+            .last_error
+            .clone()
+            .unwrap_or_else(|| format!("managed-agent recovery remains uncertain for pid {pid}")))
+    })?;
+    *record = projected;
+    Ok(result)
+}
+
+pub(crate) fn clear_pair_with_terminal_proof(
+    app: &AppHandle,
+    record: &mut ManagedAgentRecord,
+    key: &ManagedAgentRuntimeKey,
+) -> Result<bool, String> {
+    #[cfg(not(windows))]
+    {
+        let _ = (app, record, key);
+        return Ok(false);
+    }
+    #[cfg(windows)]
+    {
+        clear_pair_at_path(&recovery_store_path(app)?, record, key)
+    }
+}
+
+fn clear_pair_at_path(
+    path: &Path,
+    record: &mut ManagedAgentRecord,
+    key: &ManagedAgentRuntimeKey,
+) -> Result<bool, String> {
+    let mut projected = record.clone();
+    let cleared = update_path(path, |store| {
+        let existing = store.authorities.remove(&projected.pubkey);
+        let had_entry = existing.is_some();
+        let authority = existing.unwrap_or_else(|| authority_from_record(&projected));
+        let mut authority = reconcile_authority(authority, &mut projected)?;
+        let requires_tombstone = had_entry || !authority.is_empty();
+        if requires_tombstone {
+            authority.project_compatibility(&mut projected);
+            authority.capture_compatibility_snapshot(&projected);
+        }
+        let cleared = authority.clear_pair_with_terminal_proof(key);
+        if cleared {
+            authority.project_compatibility(&mut projected);
+        }
+        if requires_tombstone {
+            store
+                .authorities
+                .insert(projected.pubkey.clone(), authority);
+        }
+        Ok(cleared)
+    })?;
+    *record = projected;
+    Ok(cleared)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+
+    fn key(pubkey_byte: &str, relay: &str) -> ManagedAgentRuntimeKey {
+        ManagedAgentRuntimeKey::new(pubkey_byte.repeat(32), relay).unwrap()
+    }
+
+    #[test]
+    fn concurrent_real_read_modify_write_transactions_preserve_both_agents() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = Arc::new(dir.path().join("recovery.json"));
+        let barrier = Arc::new(Barrier::new(3));
+        let mut joins = Vec::new();
+        for (owner, relay, pid) in [
+            ("a1", "wss://a.example", 8101),
+            ("b2", "wss://b.example", 8102),
+        ] {
+            let path = path.clone();
+            let barrier = barrier.clone();
+            joins.push(std::thread::spawn(move || {
+                let runtime_key = key(owner, relay);
+                barrier.wait();
+                update_path(&path, |store| {
+                    let mut authority = ManagedAgentRecoveryAuthority::default();
+                    authority.mark_pair(&runtime_key, pid, "concurrent uncertainty".into());
+                    store
+                        .authorities
+                        .insert(runtime_key.pubkey.clone(), authority);
+                    Ok(())
+                })
+                .unwrap();
+            }));
+        }
+        barrier.wait();
+        for join in joins {
+            join.join().unwrap();
+        }
+        let store = load_from_path(&path).unwrap();
+        assert_eq!(store.authorities.len(), 2);
+    }
+
+    #[test]
+    fn no_op_update_does_not_materialize_unmigrated_absence() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recovery.json");
+        update_path(&path, |_| Ok(())).unwrap();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn persisted_unmigrated_semantic_absence_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recovery.json");
+        fs::write(
+            &path,
+            r#"{"version":2,"authorities":{},"migrationComplete":false}"#,
+        )
+        .unwrap();
+        assert!(load_from_path(&path)
+            .unwrap_err()
+            .contains("cannot persist unmigrated semantic absence"));
+    }
+
+    #[test]
+    fn legacy_v2_empty_store_migrates_to_completed_without_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recovery.json");
+        fs::write(&path, r#"{"version":2,"authorities":{}}"#).unwrap();
+        let store = load_from_path(&path).unwrap();
+        assert!(store.authorities.is_empty());
+        assert!(store.migration_complete);
+    }
+
+    #[test]
+    fn missing_pid_recovery_evidence_blocks_without_creating_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recovery.json");
+        let pubkey = "d5".repeat(32);
+        let key = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://malformed.example").unwrap();
+        let mut record: ManagedAgentRecord = serde_json::from_str(&format!(
+            r#"{{"pubkey":"{pubkey}","name":"test","private_key_nsec":"nsec1fake","relay_url":"","acp_command":"buzz-acp","agent_command":"buzz-agent","agent_args":[],"mcp_command":"","turn_timeout_seconds":320,"system_prompt":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","last_started_at":null,"last_stopped_at":null,"last_exit_code":null,"last_error":null}}"#
+        ))
+        .unwrap();
+        record.last_error = Some(format!(
+            "{} generation={} pair={} pid=9401; missing persisted PID",
+            crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX,
+            uuid::Uuid::new_v4(),
+            serde_json::to_string(&key).unwrap()
+        ));
+        record.last_error_code = Some(73);
+        let before = record.clone();
+
+        let authority = authority_for_path(&path, &record).unwrap();
+
+        assert!(authority.admission_error(&key).is_some());
+        assert_eq!(record, before);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn missing_pid_recovery_evidence_does_not_rewrite_empty_tombstone() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recovery.json");
+        let pubkey = "d6".repeat(32);
+        let key = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://malformed.example").unwrap();
+        let mut authority = ManagedAgentRecoveryAuthority::default();
+        let mut projected: ManagedAgentRecord = serde_json::from_str(&format!(
+            r#"{{"pubkey":"{pubkey}","name":"test","private_key_nsec":"nsec1fake","relay_url":"","acp_command":"buzz-acp","agent_command":"buzz-agent","agent_args":[],"mcp_command":"","turn_timeout_seconds":320,"system_prompt":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","last_started_at":null,"last_stopped_at":null,"last_exit_code":null,"last_error":null}}"#
+        ))
+        .unwrap();
+        authority.mark_pair(&key, 9402, "prior evidence".into());
+        authority.project_compatibility(&mut projected);
+        authority.capture_compatibility_snapshot(&projected);
+        assert!(authority.clear_pair_with_terminal_proof(&key));
+        let mut store = ManagedAgentRecoveryStore::default();
+        store.authorities.insert(pubkey, authority);
+        save_to_path(&path, &store).unwrap();
+
+        projected.runtime_pid = None;
+        projected.last_error = Some(format!(
+            "{} generation={} pair={} pid=9402; missing persisted PID",
+            crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX,
+            uuid::Uuid::new_v4(),
+            serde_json::to_string(&key).unwrap()
+        ));
+        projected.last_error_code = Some(74);
+        let record_before = projected.clone();
+        let sidecar_before = fs::read(&path).unwrap();
+
+        let merged = authority_for_path(&path, &projected).unwrap();
+
+        assert!(merged.admission_error(&key).is_some());
+        assert_eq!(projected, record_before);
+        assert_eq!(fs::read(path).unwrap(), sidecar_before);
+    }
+
+    #[test]
+    fn failed_clear_sidecar_write_does_not_mutate_fallback_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let blocked_parent = dir.path().join("not-a-directory");
+        fs::write(&blocked_parent, "block child creation").unwrap();
+        let path = blocked_parent.join("recovery.json");
+        let runtime_key = key("d4", "wss://atomic-clear.example");
+        let mut record: ManagedAgentRecord = serde_json::from_str(&format!(
+            r#"{{"pubkey":"{}","name":"test","private_key_nsec":"nsec1fake","relay_url":"","acp_command":"buzz-acp","agent_command":"buzz-agent","agent_args":[],"mcp_command":"","turn_timeout_seconds":320,"system_prompt":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","last_started_at":null,"last_stopped_at":null,"last_exit_code":null,"last_error":null}}"#,
+            runtime_key.pubkey
+        ))
+        .unwrap();
+        let mut authority = ManagedAgentRecoveryAuthority::default();
+        authority.mark_pair(&runtime_key, 8301, "uncertain".into());
+        authority.project_compatibility(&mut record);
+        let before = record.clone();
+
+        assert!(clear_pair_at_path(&path, &mut record, &runtime_key).is_err());
+        assert_eq!(record, before);
+
+        crate::managed_agents::record_terminal_proof_pending_recovery_clear(
+            &mut record,
+            &runtime_key,
+            8301,
+            "synthetic save failure",
+        );
+        authority.merge_compatibility_record(&record).unwrap();
+        assert!(authority.agent_quarantine.is_none());
+        assert!(authority.admission_error(&runtime_key).is_some());
+    }
+
+    #[test]
+    fn oversized_valid_store_is_rejected_before_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recovery.json");
+        let mut store = ManagedAgentRecoveryStore::default();
+        for agent in 0..300_u32 {
+            let pubkey = format!("{agent:064x}");
+            let runtime_key =
+                ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://large.example").unwrap();
+            let mut authority = ManagedAgentRecoveryAuthority::default();
+            authority.mark_pair(&runtime_key, agent + 1, "x".repeat(4096));
+            store.authorities.insert(pubkey, authority);
+        }
+        let error = save_to_path(&path, &store).unwrap_err();
+        assert!(error.contains("exceeds 1048576 bytes"));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn persisted_nonempty_sidecar_merges_divergent_record_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recovery.json");
+        let pubkey = "c3".repeat(32);
+        let pair_a = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://a.example").unwrap();
+        let pair_b = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://b.example").unwrap();
+        update_path(&path, |store| {
+            let mut authority = ManagedAgentRecoveryAuthority::default();
+            authority.mark_pair(&pair_a, 8201, "A uncertain".into());
+            store.authorities.insert(pubkey.clone(), authority);
+            Ok(())
+        })
+        .unwrap();
+
+        let mut fallback = ManagedAgentRecoveryAuthority::default();
+        fallback.mark_pair(&pair_b, 8202, "B fallback".into());
+        let mut record: ManagedAgentRecord = serde_json::from_str(&format!(
+            r#"{{"pubkey":"{pubkey}","name":"test","private_key_nsec":"nsec1fake","relay_url":"","acp_command":"buzz-acp","agent_command":"buzz-agent","agent_args":[],"mcp_command":"","turn_timeout_seconds":320,"system_prompt":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","last_started_at":null,"last_stopped_at":null,"last_exit_code":null,"last_error":null}}"#
+        ))
+        .unwrap();
+        fallback.project_compatibility(&mut record);
+        update_path(&path, |store| {
+            let existing = store.authorities.remove(&pubkey).unwrap();
+            let authority = reconcile_authority(existing, &mut record)?;
+            assert!(authority.admission_error(&pair_a).is_some());
+            assert!(authority.admission_error(&pair_b).is_some());
+            store.authorities.insert(pubkey.clone(), authority);
+            Ok(())
+        })
+        .unwrap();
+        let reloaded = load_from_path(&path).unwrap();
+        let authority = reloaded.authorities.get(&pubkey).unwrap();
+        assert!(authority.admission_error(&pair_a).is_some());
+        assert!(authority.admission_error(&pair_b).is_some());
+    }
+
+    #[test]
+    fn resolved_tombstones_compact_to_bounded_global_migration_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recovery.json");
+        let mut records = Vec::new();
+        update_path(&path, |store| {
+            for agent in 0..200_u32 {
+                let pubkey = format!("{agent:064x}");
+                let runtime_key =
+                    ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://compact.example").unwrap();
+                let mut authority = ManagedAgentRecoveryAuthority::default();
+                authority.mark_pair(&runtime_key, agent + 1, "x".repeat(4096));
+                let mut record: ManagedAgentRecord = serde_json::from_str(&format!(
+                    r#"{{"pubkey":"{pubkey}","name":"test","private_key_nsec":"nsec1fake","relay_url":"","acp_command":"buzz-acp","agent_command":"buzz-agent","agent_args":[],"mcp_command":"","turn_timeout_seconds":320,"system_prompt":null,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z","last_started_at":null,"last_stopped_at":null,"last_exit_code":null,"last_error":null}}"#
+                ))
+                .unwrap();
+                authority.project_compatibility(&mut record);
+                authority.capture_compatibility_snapshot(&record);
+                assert!(authority.clear_pair_with_terminal_proof(&runtime_key));
+                authority.project_compatibility(&mut record);
+                records.push(record);
+                store.authorities.insert(pubkey, authority);
+            }
+            Ok(())
+        })
+        .unwrap();
+        records.pop();
+
+        compact_tombstones_at_path(&path, &records).unwrap();
+        let store = load_from_path(&path).unwrap();
+        assert!(store.authorities.is_empty());
+        assert!(store.migration_complete);
+        assert!(fs::metadata(path).unwrap().len() < 100_000);
+    }
+}

--- a/desktop/src-tauri/src/managed_agents/storage_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/storage_tests.rs
@@ -699,6 +699,137 @@ fn try_delete_agent_key_returns_result() {
     let _: fn(&str) -> Result<(), String> = super::try_delete_agent_key;
 }
 
+// ── runtime receipt discovery ────────────────────────────────────────────────
+
+fn runtime_receipt_fixture(
+    pubkey_byte: &str,
+) -> (std::path::PathBuf, super::ManagedAgentRuntimeReceipt) {
+    let key = super::ManagedAgentRuntimeKey::new(pubkey_byte.repeat(64), "wss://relay.example")
+        .expect("runtime key");
+    let path = std::path::PathBuf::from(format!("receipt-store/{}.json", key.runtime_id()));
+    (
+        path,
+        super::ManagedAgentRuntimeReceipt {
+            key,
+            pid: 1,
+            desktop_instance_id: "instance".to_string(),
+            started_at: "2026-08-01T00:00:00Z".to_string(),
+            windows_job_contained: true,
+        },
+    )
+}
+
+#[test]
+fn runtime_receipt_discovery_distinguishes_absence_from_directory_failure() {
+    let dir = Path::new("receipt-store");
+    let absent = super::read_agent_runtime_receipts_with(
+        dir,
+        |_| Ok(Vec::new()),
+        |_| Ok(()),
+        |_| unreachable!("an absent store has no receipt files"),
+    );
+    assert!(absent.unwrap().is_empty());
+
+    let unavailable = super::read_agent_runtime_receipts_with(
+        dir,
+        |_| Err("receipt directory unavailable".to_string()),
+        |_| Ok(()),
+        |_| unreachable!("directory failure must stop before file reads"),
+    );
+    assert!(unavailable
+        .unwrap_err()
+        .contains("receipt directory unavailable"));
+}
+
+#[test]
+fn runtime_receipt_discovery_fails_closed_on_directory_entry_failure() {
+    let result = super::read_agent_runtime_receipts_with(
+        Path::new("receipt-store"),
+        |_| Err("failed to inspect receipt directory entry".to_string()),
+        |_| Ok(()),
+        |_| unreachable!("entry failure must stop before file reads"),
+    );
+    assert!(result
+        .unwrap_err()
+        .contains("failed to inspect receipt directory entry"));
+}
+
+#[test]
+fn runtime_receipt_discovery_fails_closed_on_receipt_file_read_failure() {
+    let path = std::path::PathBuf::from("receipt-store/runtime.json");
+    let result = super::read_agent_runtime_receipts_with(
+        Path::new("receipt-store"),
+        |_| Ok(vec![path.clone()]),
+        |_| Ok(()),
+        |_| Err("receipt file unreadable".to_string()),
+    );
+    assert!(result.unwrap_err().contains("receipt file unreadable"));
+}
+
+#[test]
+fn runtime_receipt_discovery_fails_closed_on_malformed_or_partial_json() {
+    let path = std::path::PathBuf::from("receipt-store/runtime.json");
+    for bytes in [b"{".to_vec(), b"not-json".to_vec()] {
+        let result = super::read_agent_runtime_receipts_with(
+            Path::new("receipt-store"),
+            |_| Ok(vec![path.clone()]),
+            |_| Ok(()),
+            |_| Ok(bytes.clone()),
+        );
+        assert!(result.unwrap_err().contains("parse runtime receipt"));
+    }
+}
+
+#[test]
+fn runtime_receipt_discovery_never_returns_a_partial_authoritative_list() {
+    let (first, receipt) = runtime_receipt_fixture("a");
+    let second = std::path::PathBuf::from("receipt-store/second.json");
+    let first_bytes = serde_json::to_vec(&receipt).expect("serialize receipt");
+    let result = super::read_agent_runtime_receipts_with(
+        Path::new("receipt-store"),
+        |_| Ok(vec![first.clone(), second.clone()]),
+        |_| Ok(()),
+        |path| {
+            if path == first {
+                Ok(first_bytes.clone())
+            } else {
+                Err("second receipt unreadable".to_string())
+            }
+        },
+    );
+    assert!(result.unwrap_err().contains("second receipt unreadable"));
+}
+
+#[test]
+fn runtime_receipt_discovery_rejects_path_key_provenance_mismatch() {
+    let (_, receipt) = runtime_receipt_fixture("b");
+    let wrong_path = std::path::PathBuf::from("receipt-store/wrong.json");
+    let bytes = serde_json::to_vec(&receipt).expect("serialize receipt");
+    let result = super::read_agent_runtime_receipts_with(
+        Path::new("receipt-store"),
+        |_| Ok(vec![wrong_path.clone()]),
+        |_| Ok(()),
+        |_| Ok(bytes.clone()),
+    );
+    assert!(result
+        .unwrap_err()
+        .contains("does not match embedded runtime key"));
+}
+
+#[test]
+fn runtime_receipt_discovery_blocks_when_pending_tombstone_cannot_converge() {
+    let tombstone = std::path::PathBuf::from("receipt-store/runtime.json.delete-pending");
+    let result = super::read_agent_runtime_receipts_with(
+        Path::new("receipt-store"),
+        |_| Ok(vec![tombstone.clone()]),
+        |_| Err("tombstone cleanup unavailable".to_string()),
+        |_| unreachable!("a tombstone is not parsed as a receipt"),
+    );
+    assert!(result
+        .unwrap_err()
+        .contains("tombstone cleanup unavailable"));
+}
+
 // ── install logs ─────────────────────────────────────────────────────────────
 
 /// Install output can carry registry tokens and proxy credentials a failing

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -1,5 +1,9 @@
+#[cfg(windows)]
+use super::process_child::ManagedAgentChild;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, path::PathBuf, process::Child};
+#[cfg(not(windows))]
+use std::process::Child;
+use std::{collections::BTreeMap, path::PathBuf};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -221,7 +225,6 @@ pub struct ManagedAgentRecord {
     /// by `pubkey`) rather than serialized to `managed-agents.json`. The
     /// storage layer blanks this before writing JSON once the key is safely in
     /// the keyring, and re-hydrates it from the keyring on load.
-    ///
     /// It is only serialized inline (the `0o600` JSON fallback) when the
     /// keyring is unreachable — `skip_serializing_if` keeps it out of JSON in
     /// the normal keyring-backed case. `default` also lets an old build parse a
@@ -338,9 +341,13 @@ pub struct ManagedAgentRecord {
     pub persona_name_in_team: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+    #[serde(default)]
     pub last_started_at: Option<String>,
+    #[serde(default)]
     pub last_stopped_at: Option<String>,
+    #[serde(default)]
     pub last_exit_code: Option<i32>,
+    #[serde(default)]
     pub last_error: Option<String>,
     #[serde(default)]
     pub last_error_code: Option<i64>,
@@ -458,16 +465,14 @@ pub struct RelayMeshConfig {
     pub model_ref: String,
 }
 
+#[cfg(not(windows))]
+pub type ManagedAgentChild = Child;
+
 #[derive(Debug)]
 pub struct ManagedAgentProcess {
-    pub child: Child,
+    pub child: ManagedAgentChild,
     pub log_path: PathBuf,
-    /// Digest of the effective spawn config at launch (see
-    /// `spawn_hash::spawn_config_hash`). Runtime-only — never persisted. The
-    /// summary builder recomputes the hash from current disk state and flags
-    /// `needs_restart` on mismatch. Agents adopted via a persisted
-    /// `runtime_pid` have no `ManagedAgentProcess` entry, so their spawn
-    /// config is unknown and the badge stays off.
+    /// Hash used to detect when effective spawn configuration has drifted.
     pub spawn_config_hash: u64,
     /// Whether this process was spawned in setup-listener mode (i.e.
     /// `BUZZ_ACP_SETUP_PAYLOAD` was set at launch because the agent was
@@ -483,12 +488,10 @@ pub struct ManagedAgentProcess {
     pub adapter_availability: Option<AcpAvailabilityStatus>,
     /// Unpredictable identity shared only with this harness generation.
     pub start_nonce: String,
-    /// Win32 Job Object owning the harness + its entire process tree. Closing
-    /// the handle (via `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) kills the whole
-    /// tree — the Windows mirror of the Unix process-group teardown. `None`
-    /// if job creation/assignment failed (we fall back to `Child::kill()`).
+    /// Safe Job Object container owning the harness + its entire process tree.
+    /// Its kernel kill-on-close guarantee also covers abrupt Buzz exits.
     #[cfg(windows)]
-    pub job: Option<crate::managed_agents::JobHandle>,
+    pub job: Option<std::sync::Arc<processkit::ProcessGroup>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -982,18 +985,15 @@ pub fn resolve_mint_behavioral_defaults(
             None => None,
         },
     };
-
     Ok(MintBehavioralDefaults {
         respond_to,
         respond_to_allowlist,
         parallelism,
     })
 }
-
 mod catalog_source;
 pub use catalog_source::CatalogSource;
 mod requests;
 pub use requests::*;
-
 #[cfg(test)]
 mod tests;

--- a/desktop/src-tauri/src/managed_agents/types/recovery_review_tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/recovery_review_tests.rs
@@ -1,0 +1,175 @@
+use crate::managed_agents::{
+    ManagedAgentRecord, ManagedAgentRecoveryAuthority, ManagedAgentRuntimeKey,
+};
+
+fn record(pubkey: &str) -> ManagedAgentRecord {
+    serde_json::from_str(&format!(
+        r#"{{
+            "pubkey": "{pubkey}",
+            "name": "recovery-review-test",
+            "private_key_nsec": "nsec1fake",
+            "relay_url": "",
+            "acp_command": "buzz-acp",
+            "agent_command": "buzz-agent",
+            "agent_args": [],
+            "mcp_command": "",
+            "turn_timeout_seconds": 320,
+            "system_prompt": null,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "last_started_at": null,
+            "last_stopped_at": null,
+            "last_exit_code": null,
+            "last_error": null
+        }}"#
+    ))
+    .unwrap()
+}
+
+#[test]
+fn nonempty_authority_merges_divergent_legacy_pair_without_laundering_either_pair() {
+    let pubkey = "7d".repeat(32);
+    let pair_a = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://a.example").unwrap();
+    let pair_b = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://b.example").unwrap();
+    let mut authority = ManagedAgentRecoveryAuthority::default();
+    authority.mark_pair(&pair_a, 7101, "pair A uncertain".into());
+    let mut sidecar_projection = record(&pubkey);
+    authority.project_compatibility(&mut sidecar_projection);
+    authority.capture_compatibility_snapshot(&sidecar_projection);
+
+    let mut fallback = ManagedAgentRecoveryAuthority::default();
+    fallback.mark_pair(&pair_b, 7102, "pair B fallback".into());
+    let mut divergent_record = record(&pubkey);
+    fallback.project_compatibility(&mut divergent_record);
+
+    assert!(!authority.accepts_compatibility_record(&divergent_record));
+    authority
+        .merge_compatibility_record(&divergent_record)
+        .expect("divergent exact-pair fallback must merge fail-closed");
+    assert!(authority.admission_error(&pair_a).is_some());
+    assert!(authority.admission_error(&pair_b).is_some());
+}
+
+#[test]
+fn tombstone_generation_does_not_accept_replayed_identical_pid_and_detail() {
+    let pubkey = "7e".repeat(32);
+    let pair = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://replay.example").unwrap();
+    let mut first = ManagedAgentRecoveryAuthority::default();
+    first.mark_pair(&pair, 7201, "same detail".into());
+    let mut first_record = record(&pubkey);
+    first.project_compatibility(&mut first_record);
+    first.capture_compatibility_snapshot(&first_record);
+    assert!(first.clear_pair_with_terminal_proof(&pair));
+
+    let mut later = ManagedAgentRecoveryAuthority::default();
+    later.mark_pair(&pair, 7201, "same detail".into());
+    let mut later_record = record(&pubkey);
+    later.project_compatibility(&mut later_record);
+
+    assert_ne!(first_record.last_error, later_record.last_error);
+    assert!(!first.accepts_compatibility_record(&later_record));
+}
+
+#[test]
+fn recovery_runtime_key_rejects_oversized_relay_url() {
+    let relay = format!("wss://relay.example/{}", "a".repeat(5000));
+    assert!(ManagedAgentRuntimeKey::new("7f".repeat(32), &relay).is_err());
+}
+
+#[test]
+fn terminal_proof_pending_clear_marker_is_exact_pair_scoped() {
+    let mut record = record(&"aa".repeat(32));
+    let exact =
+        ManagedAgentRuntimeKey::new(record.pubkey.clone(), "wss://terminal.example").unwrap();
+    let sibling =
+        ManagedAgentRuntimeKey::new(record.pubkey.clone(), "wss://sibling.example").unwrap();
+    crate::managed_agents::record_terminal_proof_pending_recovery_clear(
+        &mut record,
+        &exact,
+        7301,
+        "synthetic clear failure",
+    );
+
+    let pending = crate::managed_agents::terminal_proof_pending_recovery_clears(&record);
+    assert_eq!(pending, vec![exact]);
+    assert!(!pending.contains(&sibling));
+}
+
+#[test]
+fn duplicate_top_level_authority_keys_are_rejected_before_map_collapse() {
+    let pubkey = "ab".repeat(32);
+    let key = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://duplicate.example").unwrap();
+    let mut authority = ManagedAgentRecoveryAuthority::default();
+    authority.mark_pair(&key, 7401, "duplicate authority fixture".into());
+    let authority = serde_json::to_string(&authority).unwrap();
+    let payload = format!(
+        r#"{{"version":2,"authorities":{{"{pubkey}":{authority},"{pubkey}":{authority}}}}}"#
+    );
+
+    assert!(
+        serde_json::from_str::<crate::managed_agents::ManagedAgentRecoveryStore>(&payload).is_err()
+    );
+}
+
+#[test]
+fn restore_admission_does_not_replace_exact_recovery_projection() {
+    let mut record = record(&"ac".repeat(32));
+    let key = ManagedAgentRuntimeKey::new(record.pubkey.clone(), "wss://restore.example").unwrap();
+    let mut authority = ManagedAgentRecoveryAuthority::default();
+    authority.mark_pair(&key, 9301, "restore uncertainty".into());
+    authority.project_compatibility(&mut record);
+    authority.capture_compatibility_snapshot(&record);
+    record.last_error_code = Some(73);
+    let before = record.clone();
+
+    crate::managed_agents::record_blocked_recovery_admission(&record);
+    assert_eq!(record, before);
+    assert!(authority.accepts_compatibility_record(&record));
+}
+
+#[test]
+fn recovery_prefixed_evidence_without_pid_quarantines() {
+    let pubkey = "fa".repeat(32);
+    let key = ManagedAgentRuntimeKey::new(pubkey, "wss://missing-pid.example").unwrap();
+    let pair = serde_json::to_string(&key).unwrap();
+    let error = format!(
+        "{} generation={} pair={} pid=9401; unresolved",
+        crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX,
+        uuid::Uuid::new_v4(),
+        pair
+    );
+
+    let authority = ManagedAgentRecoveryAuthority::from_legacy(None, Some(&error));
+    assert!(authority.agent_quarantine.is_some());
+    assert!(authority.admission_error(&key).is_some());
+}
+
+#[test]
+fn empty_tombstone_cannot_launder_missing_pid_recovery_evidence() {
+    let pubkey = "fb".repeat(32);
+    let key = ManagedAgentRuntimeKey::new(pubkey.clone(), "wss://tombstone.example").unwrap();
+    let pair = serde_json::to_string(&key).unwrap();
+    let mut current_record = record(&pubkey);
+    current_record.runtime_pid = None;
+    current_record.last_error = Some(format!(
+        "{} generation={} pair={} pid=9501; unresolved",
+        crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX,
+        uuid::Uuid::new_v4(),
+        pair
+    ));
+    let clean_record = record(&pubkey);
+    let mut tombstone = ManagedAgentRecoveryAuthority::default();
+    tombstone.capture_compatibility_snapshot(&clean_record);
+
+    tombstone
+        .merge_compatibility_record(&current_record)
+        .unwrap();
+    tombstone.project_compatibility(&mut current_record);
+
+    assert!(tombstone.agent_quarantine.is_some());
+    assert!(tombstone.admission_error(&key).is_some());
+    assert!(current_record
+        .last_error
+        .as_deref()
+        .is_some_and(|error| error.contains("unresolved")));
+}

--- a/desktop/src-tauri/src/managed_agents/types/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/tests.rs
@@ -1,5 +1,271 @@
 use super::{AgentDefinition, CatalogSource, ManagedAgentRecord};
+use crate::managed_agents::{
+    ManagedAgentPairRecoveryEvidence, ManagedAgentRecoveryAuthority, ManagedAgentRecoveryEvidence,
+    ManagedAgentRecoveryStore, ManagedAgentRuntimeKey, MANAGED_AGENT_RECOVERY_STORE_VERSION,
+};
 use std::path::PathBuf;
+
+fn recovery_record() -> ManagedAgentRecord {
+    serde_json::from_str(
+        r#"{
+            "pubkey": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "name": "recovery-test",
+            "private_key_nsec": "nsec1fake",
+            "relay_url": "",
+            "acp_command": "buzz-acp",
+            "agent_command": "buzz-agent",
+            "agent_args": [],
+            "mcp_command": "",
+            "turn_timeout_seconds": 320,
+            "system_prompt": null,
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "last_started_at": null,
+            "last_stopped_at": "2026-01-02T00:00:00Z",
+            "last_exit_code": null,
+            "last_error": null
+        }"#,
+    )
+    .expect("recovery record fixture")
+}
+
+fn recovery_key(relay: &str) -> ManagedAgentRuntimeKey {
+    ManagedAgentRuntimeKey::new("aa".repeat(32), relay).expect("recovery runtime key")
+}
+
+#[test]
+fn recovery_authority_legacy_pid_quarantines_every_pair() {
+    let authority = ManagedAgentRecoveryAuthority::from_legacy(Some(4242), None);
+
+    assert!(authority
+        .admission_error(&recovery_key("wss://one.example"))
+        .is_some());
+    assert!(authority
+        .admission_error(&recovery_key("wss://two.example"))
+        .is_some());
+    assert!(authority.agent_quarantine.is_some());
+}
+
+#[test]
+fn recovery_authority_malformed_legacy_evidence_remains_quarantined() {
+    let error = format!(
+        "{} pair=not-json pid=5151; uncertain",
+        crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX
+    );
+    let authority = ManagedAgentRecoveryAuthority::from_legacy(Some(5151), Some(&error));
+
+    assert!(authority.agent_quarantine.is_some());
+    assert!(!authority.is_empty());
+}
+
+#[test]
+fn recovery_authority_duplicate_legacy_pairs_remain_quarantined() {
+    let key = recovery_key("wss://one.example");
+    let encoded = serde_json::to_string(&key).expect("encode pair key");
+    let line = format!(
+        "{} pair={encoded} pid=5151; uncertain",
+        crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX
+    );
+    let error = format!("{line}\n{line}");
+
+    let authority = ManagedAgentRecoveryAuthority::from_legacy(Some(5151), Some(&error));
+
+    assert!(authority.agent_quarantine.is_some());
+    assert!(authority.uncertain_pairs.is_empty());
+}
+
+#[test]
+fn recovery_store_rejects_pair_key_owned_by_another_agent() {
+    let owner = "aa".repeat(32);
+    let other_key = ManagedAgentRuntimeKey::new("bb".repeat(32), "wss://one.example")
+        .expect("other-agent recovery key");
+    let mut authority = ManagedAgentRecoveryAuthority::default();
+    authority.mark_pair(&other_key, 5151, "uncertain".into());
+    let mut store = ManagedAgentRecoveryStore::default();
+    store.authorities.insert(owner, authority);
+
+    assert!(store.validate().is_err());
+}
+
+#[test]
+fn empty_recovery_authority_entry_is_semantically_invalid() {
+    let mut store = ManagedAgentRecoveryStore::default();
+    store
+        .authorities
+        .insert("aa".repeat(32), ManagedAgentRecoveryAuthority::default());
+
+    assert!(store.validate().is_err());
+}
+
+#[test]
+fn unknown_recovery_store_version_is_rejected() {
+    let mut store = ManagedAgentRecoveryStore::default();
+    store.version += 1;
+    assert!(store.validate().is_err());
+}
+
+#[test]
+fn recovery_store_rejects_unknown_fields() {
+    let parsed = serde_json::from_value::<ManagedAgentRecoveryStore>(serde_json::json!({
+        "version": MANAGED_AGENT_RECOVERY_STORE_VERSION,
+        "authorities": {},
+        "futureAuthority": true
+    }));
+    assert!(parsed.is_err());
+}
+
+#[test]
+fn recovery_store_rejects_zero_pid_and_contradictory_authority() {
+    let owner = "7a".repeat(32);
+    let key = ManagedAgentRuntimeKey::new(owner.clone(), "wss://one.example").expect("key");
+    let mut authority = ManagedAgentRecoveryAuthority::default();
+    authority.agent_quarantine = Some(ManagedAgentRecoveryEvidence {
+        pid: Some(7),
+        detail: "legacy pid".to_string(),
+    });
+    authority
+        .uncertain_pairs
+        .push(ManagedAgentPairRecoveryEvidence {
+            key,
+            pid: 0,
+            detail: "pair".to_string(),
+        });
+    let mut store = ManagedAgentRecoveryStore::default();
+    store.authorities.insert(owner, authority);
+    assert!(store.validate().is_err());
+}
+
+#[test]
+fn recovery_store_rejects_zero_pair_pid() {
+    let owner = "7b".repeat(32);
+    let key = ManagedAgentRuntimeKey::new(owner.clone(), "wss://one.example").expect("key");
+    let mut authority = ManagedAgentRecoveryAuthority::default();
+    authority
+        .uncertain_pairs
+        .push(ManagedAgentPairRecoveryEvidence {
+            key,
+            pid: 0,
+            detail: "pair".to_string(),
+        });
+    authority.capture_compatibility_snapshot(&recovery_record());
+    let mut store = ManagedAgentRecoveryStore::default();
+    store.authorities.insert(owner, authority);
+    assert!(store.validate().is_err());
+}
+
+#[test]
+fn empty_default_authority_preserves_ordinary_lifecycle_history() {
+    let authority = ManagedAgentRecoveryAuthority::default();
+    let mut record = recovery_record();
+    record.last_exit_code = Some(0);
+    record.last_error = Some("ordinary prior error".into());
+
+    authority.project_compatibility(&mut record);
+
+    assert_eq!(
+        record.last_stopped_at.as_deref(),
+        Some("2026-01-02T00:00:00Z")
+    );
+    assert_eq!(record.last_exit_code, Some(0));
+    assert_eq!(record.last_error.as_deref(), Some("ordinary prior error"));
+}
+
+#[test]
+fn explicit_compatibility_tombstone_clears_only_stale_recovery_projection() {
+    let mut record = recovery_record();
+    record.runtime_pid = Some(5151);
+    record.last_error = Some(format!(
+        "{} quarantine; legacy",
+        crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX
+    ));
+    let mut authority = ManagedAgentRecoveryAuthority::default();
+    authority.capture_compatibility_snapshot(&record);
+    let stopped_at = record.last_stopped_at.clone();
+
+    authority.project_compatibility(&mut record);
+
+    assert_eq!(record.runtime_pid, None);
+    assert_eq!(record.last_error, None);
+    assert_eq!(record.last_stopped_at, stopped_at);
+}
+
+#[test]
+fn compatibility_tombstone_rejects_different_new_legacy_evidence() {
+    let mut record = recovery_record();
+    record.runtime_pid = Some(444);
+    record.last_error = Some(format!(
+        "{} old",
+        crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX
+    ));
+    let mut authority = ManagedAgentRecoveryAuthority::default();
+    authority.capture_compatibility_snapshot(&record);
+
+    record.runtime_pid = Some(445);
+    record.last_error = Some(format!(
+        "{} new",
+        crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX
+    ));
+    assert!(!authority.accepts_compatibility_record(&record));
+}
+
+#[path = "recovery_review_tests.rs"]
+mod recovery_review_tests;
+
+#[test]
+fn recovery_authority_exact_pairs_round_trip_and_clear_only_exact_key() {
+    let mut authority = ManagedAgentRecoveryAuthority::default();
+    let pair_a = recovery_key("wss://one.example");
+    let pair_b = recovery_key("wss://two.example");
+    authority.mark_pair(&pair_a, 6001, "pair A uncertain".into());
+    authority.mark_pair(&pair_b, 6002, "pair B uncertain".into());
+
+    let persisted = serde_json::to_string(&authority).expect("serialize recovery authority");
+    let mut reloaded: ManagedAgentRecoveryAuthority =
+        serde_json::from_str(&persisted).expect("reload recovery authority");
+
+    assert_eq!(reloaded.uncertain_pairs.len(), 2);
+    assert!(reloaded.clear_pair_with_terminal_proof(&pair_b));
+    assert!(reloaded.admission_error(&pair_a).is_some());
+    assert!(reloaded.admission_error(&pair_b).is_none());
+    assert!(!reloaded.is_empty());
+}
+
+#[test]
+fn recovery_authority_sibling_terminal_proof_does_not_launder_uncertainty() {
+    let mut authority = ManagedAgentRecoveryAuthority::default();
+    let pair_a = recovery_key("wss://one.example");
+    let sibling = recovery_key("wss://two.example");
+    authority.mark_pair(&pair_a, 7001, "pair A uncertain".into());
+
+    assert!(!authority.clear_pair_with_terminal_proof(&sibling));
+    assert!(!authority.is_empty());
+    assert!(authority.clear_pair_with_terminal_proof(&pair_a));
+    assert!(authority.is_empty());
+
+    let mut record = recovery_record();
+    authority.project_compatibility(&mut record);
+    assert_eq!(record.runtime_pid, None);
+    assert_eq!(record.last_error, None);
+}
+
+#[test]
+fn managed_agent_legacy_lifecycle_fields_default_independently() {
+    for field in ["runtime_pid", "last_stopped_at", "last_error"] {
+        let mut value = serde_json::to_value(recovery_record()).expect("serialize legacy fixture");
+        value
+            .as_object_mut()
+            .expect("managed-agent record object")
+            .remove(field);
+        let record: ManagedAgentRecord =
+            serde_json::from_value(value).expect("legacy lifecycle field should default");
+        match field {
+            "runtime_pid" => assert_eq!(record.runtime_pid, None),
+            "last_stopped_at" => assert_eq!(record.last_stopped_at, None),
+            "last_error" => assert_eq!(record.last_error, None),
+            _ => unreachable!("fixed lifecycle field fixture"),
+        }
+    }
+}
 
 #[test]
 fn persona_record_defaults_active_when_field_is_missing() {

--- a/desktop/src-tauri/src/managed_launcher.rs
+++ b/desktop/src-tauri/src/managed_launcher.rs
@@ -1,0 +1,75 @@
+//! Windows managed-agent launcher entry point and contained-process boundary.
+
+use std::process::{Command, ExitStatus};
+
+/// Run launcher mode before Tauri starts.
+///
+/// Returns `false` for normal desktop invocations; launcher mode exits after
+/// forwarding the contained target's real exit code.
+pub fn run_if_requested() -> bool {
+    crate::managed_agents::run_managed_agent_launcher_if_requested()
+}
+
+/// Opaque handle used by the native boundary proof.
+///
+/// Construction and finalization deliberately delegate to the same private
+/// production functions used by managed-agent lifecycle commands. Keeping the
+/// owned Child and Job inaccessible prevents callers from bypassing checked
+/// teardown.
+#[doc(hidden)]
+pub struct ContainedManagedProcess(crate::managed_agents::ManagedAgentProcess);
+
+impl ContainedManagedProcess {
+    /// PID of the exact desktop launcher child retained for observation/reaping.
+    pub fn launcher_pid(&self) -> u32 {
+        self.0.child.id()
+    }
+
+    /// Current members of the owned Windows Job.
+    pub fn active_process_count(&self) -> Result<usize, String> {
+        let job = self
+            .0
+            .job
+            .as_ref()
+            .ok_or_else(|| "managed process no longer owns a Windows Job".to_string())?;
+        job.members()
+            .map(|members| members.len())
+            .map_err(|error| format!("failed to query managed Windows Job: {error}"))
+    }
+
+    /// Terminate the Job, prove zero membership, reap the exact launcher, and
+    /// only then release the Job authority.
+    pub fn terminate_checked(&mut self) -> Result<(ExitStatus, usize), String> {
+        let status = crate::managed_agents::terminate_managed_agent_process(&mut self.0)?;
+        let remaining = self.active_process_count()?;
+        if remaining != 0 {
+            return Err(format!(
+                "managed Windows Job still has {remaining} members after checked termination"
+            ));
+        }
+        crate::managed_agents::release_finalized_managed_agent_process(&mut self.0)?;
+        Ok((status, remaining))
+    }
+}
+
+/// Spawn an original target command through the production launcher envelope
+/// and safe `processkit` Job boundary.
+///
+/// This narrow diagnostic API exists so the native integration test can prove
+/// the complete original-command → wrapper → Job → target chain rather than
+/// reconstructing private launcher variables itself.
+#[doc(hidden)]
+pub fn spawn_contained(
+    command: Command,
+    launcher_exe: &std::path::Path,
+    log_path: &std::path::Path,
+    environment_cleared: bool,
+) -> Result<ContainedManagedProcess, String> {
+    crate::managed_agents::spawn_managed_agent_process_with_launcher(
+        command,
+        launcher_exe,
+        log_path.to_path_buf(),
+        environment_cleared,
+    )
+    .map(ContainedManagedProcess)
+}

--- a/desktop/src-tauri/src/shutdown.rs
+++ b/desktop/src-tauri/src/shutdown.rs
@@ -7,24 +7,135 @@ use crate::managed_agents::{
 };
 use crate::{prevent_sleep, util};
 
+#[cfg(windows)]
+#[derive(Default)]
+struct RecordShutdownOutcome {
+    stopped_pair: bool,
+    last_exit_code: Option<i32>,
+    errors: Vec<String>,
+}
+
+#[cfg(windows)]
+fn apply_record_shutdown_outcomes(
+    app: Option<&tauri::AppHandle>,
+    records: &mut [managed_agents::ManagedAgentRecord],
+    outcomes: Vec<RecordShutdownOutcome>,
+) {
+    for (idx, outcome) in outcomes.into_iter().enumerate() {
+        let recovery_uncertain = match app {
+            Some(app) => {
+                managed_agents::has_recovery_uncertainty(app, &records[idx]).unwrap_or(true)
+            }
+            None => managed_agents::has_unverified_job_reap(&records[idx]),
+        };
+        if !outcome.errors.is_empty() {
+            let outcome_has_uncertainty = outcome
+                .errors
+                .iter()
+                .any(|error| error.starts_with(managed_agents::UNVERIFIED_JOB_REAP_PREFIX));
+            let record = &mut records[idx];
+            record.updated_at = util::now_iso();
+            let joined = outcome.errors.join("; ");
+            if recovery_uncertain || outcome_has_uncertainty {
+                managed_agents::append_shutdown_diagnostic(
+                    record,
+                    &joined,
+                    outcome_has_uncertainty,
+                );
+            } else {
+                record.last_error = Some(joined);
+                record.last_error_code = None;
+            }
+            // At least one pair remains tracked, so do not claim the agent as
+            // fully stopped even if a sibling pair exited successfully.
+        } else if outcome.stopped_pair && !recovery_uncertain {
+            let record = &mut records[idx];
+            record.runtime_pid = None;
+            record.last_stopped_at = Some(util::now_iso());
+            record.updated_at = util::now_iso();
+            if managed_agents::pending_pair_failures(record).is_empty() {
+                record.last_exit_code = outcome.last_exit_code;
+            }
+            if !managed_agents::finalize_pending_pair_failures(record) {
+                record.last_error = None;
+                record.last_error_code = None;
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+fn retry_terminal_proof_pending_clears_with(
+    records: &mut [managed_agents::ManagedAgentRecord],
+    mut clear: impl FnMut(
+        &mut managed_agents::ManagedAgentRecord,
+        &managed_agents::ManagedAgentRuntimeKey,
+    ) -> Result<(), String>,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+    for record in records {
+        let keys = managed_agents::terminal_proof_pending_recovery_clears(record);
+        for key in keys {
+            if let Err(error) = clear(record, &key) {
+                errors.push(format!("{} ({}): {error}", record.name, key.runtime_id()));
+            }
+        }
+    }
+    errors
+}
+
 pub(crate) fn is_restart_request(code: Option<i32>) -> bool {
     code == Some(tauri::RESTART_EXIT_CODE)
 }
 
-pub(crate) fn shut_down_app(app: &tauri::AppHandle, shutdown_done: &std::sync::atomic::AtomicBool) {
+fn run_retryable_shutdown_attempt(
+    shutdown_done: &std::sync::atomic::AtomicBool,
+    attempt: impl FnOnce() -> Result<(), String>,
+) -> Result<(), String> {
     use std::sync::atomic::Ordering;
 
-    app.state::<AppState>()
-        .shutdown_started
-        .store(true, Ordering::SeqCst);
-    if !shutdown_done.swap(true, Ordering::SeqCst) {
-        prevent_sleep::release(&app.state::<AppState>().prevent_sleep);
-        if let Err(error) = shutdown_managed_agents(app) {
-            eprintln!("buzz-desktop: failed to stop managed agents: {error}");
+    if shutdown_done
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Ok(());
+    }
+    match attempt() {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            shutdown_done.store(false, Ordering::SeqCst);
+            Err(error)
         }
+    }
+}
+
+pub(crate) fn shut_down_app(
+    app: &tauri::AppHandle,
+    shutdown_done: &std::sync::atomic::AtomicBool,
+) -> Result<(), String> {
+    use std::sync::atomic::Ordering;
+
+    run_retryable_shutdown_attempt(shutdown_done, || {
+        app.state::<AppState>()
+            .shutdown_started
+            .store(true, Ordering::SeqCst);
+        prevent_sleep::release(&app.state::<AppState>().prevent_sleep);
+
+        if let Err(error) = shutdown_managed_agents(app) {
+            // ExitRequested prevents this exit. Reset the admission flag before
+            // returning so the same retained authority can be retried.
+            app.state::<AppState>()
+                .shutdown_started
+                .store(false, Ordering::SeqCst);
+            let _ = prevent_sleep::acquire(&app.state::<AppState>().prevent_sleep, app);
+            return Err(format!("failed to stop managed agents: {error}"));
+        }
+
         #[cfg(feature = "mesh-llm")]
         shutdown_mesh_runtime(app);
-    }
+
+        Ok(())
+    })
 }
 
 /// Install SIGINT/SIGTERM/SIGHUP cleanup on ctrlc's dedicated handler thread.
@@ -133,11 +244,7 @@ pub(crate) fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), Stri
         .managed_agent_processes
         .lock()
         .map_err(|error| error.to_string())?;
-    let (mut changed, _exited) = sync_managed_agent_processes(
-        &mut records,
-        &mut runtimes,
-        &managed_agents::current_instance_id(app),
-    );
+    let (mut changed, _exited) = sync_managed_agent_processes(app, &mut records, &mut runtimes);
     changed |= kill_stale_tracked_processes(
         &mut records,
         &runtimes,
@@ -147,7 +254,10 @@ pub(crate) fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), Stri
     // Stop all tracked agents. Send SIGTERM to all process
     // groups first, then wait for exits in parallel to avoid serial 1s waits.
     struct AgentToStop {
-        idx: usize,
+        idx: Option<usize>,
+        #[cfg(windows)]
+        key: managed_agents::ManagedAgentRuntimeKey,
+        #[cfg(unix)]
         pid: u32,
         runtime: Option<managed_agents::ManagedAgentPairRuntime>,
     }
@@ -164,6 +274,7 @@ pub(crate) fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), Stri
         // grace below.
         for key in managed_agents::managed_agent_runtime_keys(&runtimes, &record.pubkey) {
             let runtime = runtimes.remove(&key);
+            #[cfg(unix)]
             let Some(pid) = runtime
                 .as_ref()
                 .map(|rt| rt.child.id())
@@ -171,10 +282,186 @@ pub(crate) fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), Stri
             else {
                 continue;
             };
-            to_stop.push(AgentToStop { idx, pid, runtime });
+            #[cfg(windows)]
+            if runtime.is_none() {
+                continue;
+            }
+            to_stop.push(AgentToStop {
+                idx: Some(idx),
+                #[cfg(windows)]
+                key,
+                #[cfg(unix)]
+                pid,
+                runtime,
+            });
         }
     }
 
+    // A failed pre-registration cleanup can retain exact Job/Child authority
+    // even if its record vanished. Shutdown must still drain those runtimes.
+    #[cfg(windows)]
+    let mut remaining_keys = runtimes.keys().cloned().collect::<Vec<_>>();
+    #[cfg(windows)]
+    remaining_keys.sort_by_key(managed_agents::ManagedAgentRuntimeKey::runtime_id);
+    #[cfg(windows)]
+    for key in remaining_keys {
+        if let Some(runtime) = runtimes.remove(&key) {
+            to_stop.push(AgentToStop {
+                idx: records
+                    .iter()
+                    .position(|record| record.pubkey.eq_ignore_ascii_case(&key.pubkey)),
+                key,
+                runtime: Some(runtime),
+            });
+        }
+    }
+
+    #[cfg(windows)]
+    if !to_stop.is_empty() {
+        to_stop.sort_by_key(|agent| agent.key.runtime_id());
+        changed = true;
+        let mut errors = Vec::new();
+        let mut outcomes: Vec<RecordShutdownOutcome> = (0..records.len())
+            .map(|_| RecordShutdownOutcome::default())
+            .collect();
+
+        for mut agent in to_stop {
+            let Some(mut runtime) = agent.runtime.take() else {
+                let error = format!(
+                    "tracked runtime {} was removed without an owned process",
+                    agent.key.pubkey
+                );
+                if let Some(idx) = agent.idx {
+                    outcomes[idx].errors.push(error.clone());
+                }
+                errors.push(error);
+                continue;
+            };
+
+            match managed_agents::finalize_tracked_runtime(app, &agent.key, &mut runtime) {
+                Ok(status) => {
+                    if let Some(idx) = agent.idx {
+                        if let Err(error) = managed_agents::clear_pair_recovery_with_terminal_proof(
+                            app,
+                            &mut records[idx],
+                            &agent.key,
+                        ) {
+                            let error = format!(
+                                "failed to retire exact-pair recovery authority after terminal proof: {error}"
+                            );
+                            managed_agents::record_terminal_proof_pending_recovery_clear(
+                                &mut records[idx],
+                                &agent.key,
+                                runtime.child.id(),
+                                &error,
+                            );
+                            outcomes[idx].errors.push(error.clone());
+                            errors.push(format!("{}: {error}", records[idx].name));
+                            runtimes.insert(agent.key.clone(), runtime);
+                            continue;
+                        }
+                        let record = &records[idx];
+                        let _ = managed_agents::append_log_marker(
+                            &runtime.log_path,
+                            &format!(
+                                "=== stopped {} ({}) at {} ===",
+                                record.name,
+                                record.pubkey,
+                                util::now_iso()
+                            ),
+                        );
+                        if outcomes[idx].errors.is_empty() {
+                            outcomes[idx].stopped_pair = true;
+                            outcomes[idx].last_exit_code = status.code();
+                        }
+                    } else {
+                        let _ = managed_agents::append_log_marker(
+                            &runtime.log_path,
+                            &format!(
+                                "=== stopped unregistered pair {} at {} ===",
+                                agent.key.pubkey,
+                                util::now_iso()
+                            ),
+                        );
+                    }
+                    // `runtime` drops here only after bounded termination,
+                    // receipt deletion, launcher reaping, and recovery clear succeeded.
+                }
+                Err(error) => {
+                    let error = if let Some(idx) = agent.idx {
+                        managed_agents::receipt_failure::mark_unverified_runtime(
+                            Some(app),
+                            &mut records[idx],
+                            &agent.key,
+                            runtime.child.id(),
+                            util::now_iso(),
+                            format!(
+                                "shutdown cleanup is incomplete and exact pair authority remains tracked for retry: {error}"
+                            ),
+                        )
+                    } else {
+                        error
+                    };
+                    let label = agent
+                        .idx
+                        .map(|idx| records[idx].name.clone())
+                        .unwrap_or_else(|| agent.key.pubkey.clone());
+                    if let Some(idx) = agent.idx {
+                        outcomes[idx].errors.push(error.clone());
+                    }
+                    errors.push(format!("{label}: {error}"));
+                    // Preserve the exact Job/Child authority under its pair key.
+                    runtimes.insert(agent.key, runtime);
+                }
+            }
+        }
+
+        apply_record_shutdown_outcomes(Some(app), &mut records, outcomes);
+
+        if !errors.is_empty() {
+            save_managed_agents(app, &records)?;
+            return Err(format!(
+                "managed-agent shutdown incomplete: {}",
+                errors.join("; ")
+            ));
+        }
+    }
+
+    #[cfg(windows)]
+    let retry_errors = retry_terminal_proof_pending_clears_with(&mut records, |record, key| {
+        match managed_agents::clear_pair_recovery_with_terminal_proof(app, record, key)? {
+            true => Ok(()),
+            false => Err("terminal-proof marker had no exact-pair recovery authority".into()),
+        }
+    });
+    #[cfg(windows)]
+    if !retry_errors.is_empty() {
+        save_managed_agents(app, &records)?;
+        return Err(format!(
+            "managed-agent shutdown incomplete: {}",
+            retry_errors.join("; ")
+        ));
+    }
+
+    #[cfg(windows)]
+    let unresolved_record = records.iter().find_map(|record| {
+        match managed_agents::has_recovery_uncertainty(app, record) {
+            Ok(true) => Some(Ok(record)),
+            Ok(false) => None,
+            Err(error) => Some(Err(error)),
+        }
+    });
+    if let Some(record) = unresolved_record.transpose()? {
+        if changed {
+            save_managed_agents(app, &records)?;
+        }
+        return Err(format!(
+            "managed-agent shutdown incomplete: recovery authority for {} remains uncertain",
+            record.name
+        ));
+    }
+
+    #[cfg(unix)]
     if !to_stop.is_empty() {
         changed = true;
 
@@ -215,13 +502,16 @@ pub(crate) fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), Stri
 
         // Reap children and update records.
         for mut agent in to_stop {
+            let Some(idx) = agent.idx else {
+                continue;
+            };
             if let Some(ref mut rt) = agent.runtime {
                 // Best-effort reap — don’t block shutdown if the child is stuck
                 // in uninterruptible sleep. The zombie will be cleaned up when
                 // our process exits and launchd reaps it.
                 let _ = rt.child.try_wait();
                 // Write log marker (best-effort).
-                let record = &records[agent.idx];
+                let record = &records[idx];
                 let _ = managed_agents::append_log_marker(
                     &rt.log_path,
                     &format!(
@@ -232,7 +522,7 @@ pub(crate) fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), Stri
                     ),
                 );
             }
-            let record = &mut records[agent.idx];
+            let record = &mut records[idx];
             record.runtime_pid = None;
             record.last_stopped_at = Some(util::now_iso());
             record.updated_at = util::now_iso();
@@ -263,14 +553,257 @@ pub(crate) fn shutdown_managed_agents(app: &tauri::AppHandle) -> Result<(), Stri
     Ok(())
 }
 
+pub(crate) fn exit_blocked(
+    result: Result<(), String>,
+    restart_requested: &std::sync::atomic::AtomicBool,
+) -> bool {
+    if let Err(error) = result {
+        eprintln!("buzz-desktop: {error}");
+        restart_requested.store(false, std::sync::atomic::Ordering::SeqCst);
+        true
+    } else {
+        false
+    }
+}
+
+pub(crate) fn report_final_shutdown(result: Result<(), String>) {
+    if let Err(error) = result {
+        eprintln!("buzz-desktop: final shutdown attempt failed: {error}");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::is_restart_request;
+
+    #[cfg(windows)]
+    fn minimal_record() -> crate::managed_agents::ManagedAgentRecord {
+        serde_json::from_str(
+            r#"{
+                "pubkey": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                "name": "test",
+                "private_key_nsec": "nsec1fake",
+                "relay_url": "",
+                "acp_command": "buzz-acp",
+                "agent_command": "buzz-agent",
+                "agent_args": [],
+                "mcp_command": "",
+                "turn_timeout_seconds": 320,
+                "system_prompt": null,
+                "model": null,
+                "provider": null,
+                "env_vars": {},
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "last_started_at": null,
+                "last_stopped_at": null,
+                "last_exit_code": null,
+                "last_error": null
+            }"#,
+        )
+        .expect("shutdown record fixture")
+    }
 
     #[test]
     fn only_tauri_restart_exit_code_requests_a_relaunch() {
         assert!(is_restart_request(Some(tauri::RESTART_EXIT_CODE)));
         assert!(!is_restart_request(None));
         assert!(!is_restart_request(Some(0)));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn mixed_pair_shutdown_preserves_failure_and_does_not_claim_full_stop() {
+        let mut record = minimal_record();
+        let original_stopped_at = record.last_stopped_at.clone();
+        let outcomes = vec![super::RecordShutdownOutcome {
+            stopped_pair: true,
+            last_exit_code: Some(1),
+            errors: vec!["pair still owned for retry".to_string()],
+        }];
+
+        super::apply_record_shutdown_outcomes(None, std::slice::from_mut(&mut record), outcomes);
+
+        assert_eq!(
+            record.last_error.as_deref(),
+            Some("pair still owned for retry")
+        );
+        assert_eq!(record.last_stopped_at, original_stopped_at);
+        assert_eq!(record.last_exit_code, None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn mixed_pair_shutdown_does_not_launder_unverified_reap_marker() {
+        let mut record = minimal_record();
+        record.runtime_pid = Some(6262);
+        let outcomes = vec![super::RecordShutdownOutcome {
+            stopped_pair: true,
+            last_exit_code: None,
+            errors: vec![
+                "ordinary sibling failure".to_string(),
+                format!(
+                    "{} reap status unknown",
+                    crate::managed_agents::UNVERIFIED_JOB_REAP_PREFIX
+                ),
+            ],
+        }];
+
+        super::apply_record_shutdown_outcomes(None, std::slice::from_mut(&mut record), outcomes);
+
+        assert!(crate::managed_agents::has_unverified_job_reap(&record));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn successful_retry_shutdown_preserves_observed_terminal_failure() {
+        let mut record = minimal_record();
+        let key = crate::managed_agents::ManagedAgentRuntimeKey::new(
+            record.pubkey.clone(),
+            "wss://terminal-failure.example",
+        )
+        .unwrap();
+        crate::managed_agents::record_pending_pair_failure(
+            &mut record,
+            &key,
+            Some(17),
+            &crate::managed_agents::storage::AgentLogError {
+                message: "harness exited with status 17".into(),
+                code: None,
+            },
+        );
+        let outcomes = vec![super::RecordShutdownOutcome {
+            stopped_pair: true,
+            last_exit_code: Some(0),
+            errors: Vec::new(),
+        }];
+
+        super::apply_record_shutdown_outcomes(None, std::slice::from_mut(&mut record), outcomes);
+
+        assert_eq!(record.last_exit_code, Some(17));
+        assert!(record
+            .last_error
+            .as_deref()
+            .is_some_and(|error| error.contains("status 17")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn shutdown_error_preserves_combined_recovery_and_pending_failure() {
+        let mut record = minimal_record();
+        let recovery_key = crate::managed_agents::ManagedAgentRuntimeKey::new(
+            record.pubkey.clone(),
+            "wss://recovery.example",
+        )
+        .unwrap();
+        let failed_key = crate::managed_agents::ManagedAgentRuntimeKey::new(
+            record.pubkey.clone(),
+            "wss://failed.example",
+        )
+        .unwrap();
+        let mut authority = crate::managed_agents::ManagedAgentRecoveryAuthority::default();
+        authority.mark_pair(&recovery_key, 7171, "recovery remains uncertain".into());
+        authority.project_compatibility(&mut record);
+        crate::managed_agents::record_pending_pair_failure(
+            &mut record,
+            &failed_key,
+            Some(17),
+            &crate::managed_agents::storage::AgentLogError {
+                message: "harness exited with status 17".into(),
+                code: Some(801),
+            },
+        );
+        record
+            .last_error
+            .as_mut()
+            .unwrap()
+            .push_str("; legacy appended shutdown diagnostic");
+
+        super::apply_record_shutdown_outcomes(
+            None,
+            std::slice::from_mut(&mut record),
+            vec![super::RecordShutdownOutcome {
+                stopped_pair: false,
+                last_exit_code: None,
+                errors: vec!["another shutdown attempt failed".into()],
+            }],
+        );
+
+        let failures = crate::managed_agents::pending_pair_failures(&record);
+        assert_eq!(
+            failures.get(&failed_key.runtime_id()).map(String::as_str),
+            Some("harness exited with status 17")
+        );
+        assert_eq!(record.last_error_code, Some(801));
+        assert!(crate::managed_agents::has_unverified_job_reap(&record));
+    }
+
+    #[test]
+    fn exit_request_failure_blocks_exit_and_cancels_restart() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let restart = AtomicBool::new(true);
+        assert!(super::exit_blocked(Err("cleanup failed".into()), &restart));
+        assert!(!restart.load(Ordering::SeqCst));
+        assert!(!super::exit_blocked(Ok(()), &restart));
+    }
+
+    #[test]
+    fn failed_shutdown_attempt_resets_latch_and_allows_retry() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+        let done = AtomicBool::new(false);
+        let attempts = AtomicUsize::new(0);
+        let first = super::run_retryable_shutdown_attempt(&done, || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            Err("managed cleanup remains uncertain".to_string())
+        });
+        assert!(first.is_err());
+        assert!(!done.load(Ordering::SeqCst));
+
+        let second = super::run_retryable_shutdown_attempt(&done, || {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        });
+        assert!(second.is_ok());
+        assert!(done.load(Ordering::SeqCst));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn transient_terminal_proof_clear_failure_is_retried_by_next_shutdown() {
+        let mut record = minimal_record();
+        let key = crate::managed_agents::ManagedAgentRuntimeKey::new(
+            record.pubkey.clone(),
+            "wss://retry-clear.example",
+        )
+        .unwrap();
+        crate::managed_agents::record_terminal_proof_pending_recovery_clear(
+            &mut record,
+            &key,
+            7401,
+            "first clear failed",
+        );
+        let mut records = vec![record];
+
+        let first =
+            super::retry_terminal_proof_pending_clears_with(&mut records, |_record, attempted| {
+                assert_eq!(attempted, &key);
+                Err("transient sidecar failure".to_string())
+            });
+        assert_eq!(first.len(), 1);
+
+        let second =
+            super::retry_terminal_proof_pending_clears_with(&mut records, |record, attempted| {
+                assert_eq!(attempted, &key);
+                record.runtime_pid = None;
+                record.last_error = None;
+                Ok(())
+            });
+        assert!(second.is_empty());
+        assert!(
+            crate::managed_agents::terminal_proof_pending_recovery_clears(&records[0]).is_empty()
+        );
     }
 }

--- a/desktop/src-tauri/tests/managed_launcher_boundary.rs
+++ b/desktop/src-tauri/tests/managed_launcher_boundary.rs
@@ -1,0 +1,160 @@
+#![cfg(target_os = "windows")]
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn process_is_gone(pid: u32) -> bool {
+    Command::new("powershell.exe")
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            &format!(
+                "if (Get-Process -Id {pid} -ErrorAction SilentlyContinue) {{ exit 1 }} else {{ exit 0 }}"
+            ),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[test]
+fn production_wrapper_preserves_boundary_and_contains_descendants() {
+    let dir = tempfile::tempdir().expect("launcher boundary directory");
+    let output = dir.path().join("launcher.json");
+    let script = dir.path().join("launcher-probe.ps1");
+    std::fs::write(
+        &script,
+        r#"$stdinEof=([Console]::In.ReadToEnd()).Length -eq 0
+Write-Output 'launcher-stdout-marker'
+[Console]::Error.WriteLine('launcher-stderr-marker')
+$descendant=Start-Process -FilePath (Join-Path $PSHOME 'powershell.exe') -ArgumentList @('-NoLogo','-NoProfile','-NonInteractive','-Command','while ($true) { Start-Sleep -Seconds 1 }') -WindowStyle Hidden -PassThru
+$payload=[ordered]@{
+  cwd=(Get-Location).Path
+  value=$env:BUZZ_LAUNCHER_TEST
+  removed=$env:BUZZ_LAUNCHER_REMOVE
+  inherited=$env:USERPROFILE
+  stdinEof=$stdinEof
+  programEnvelope=$env:BUZZ_MANAGED_LAUNCH_PROGRAM_WIDE
+  argsEnvelope=$env:BUZZ_MANAGED_LAUNCH_ARGS_WIDE
+  args=@($args)
+  descendantPid=$descendant.Id
+}
+$payload|ConvertTo-Json -Compress|Set-Content -Encoding utf8 -LiteralPath $env:BUZZ_LAUNCHER_OUTPUT
+while ($true) { Start-Sleep -Seconds 1 }"#,
+    )
+    .expect("write launcher boundary probe");
+
+    let log = dir.path().join("launcher.log");
+    let mut command = Command::new(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe");
+    command
+        .env_clear()
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+        ])
+        .arg(&script)
+        .arg("two words")
+        .arg("")
+        .arg("wide-雪")
+        .current_dir(dir.path())
+        .env("SystemRoot", r"C:\Windows")
+        .env("BUZZ_LAUNCHER_TEST", "kept")
+        .env("BUZZ_LAUNCHER_OUTPUT", &output)
+        .env("BUZZ_LAUNCHER_REMOVE", "must-not-survive")
+        .env_remove("BUZZ_LAUNCHER_REMOVE")
+        // Case-varied user collisions must not replace the private envelope.
+        .env("buzz_managed_launch_program_wide", "malicious")
+        .env("BuZz_MaNaGeD_LaUnCh_ArGs_WiDe", "malicious")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let mut process = buzz_lib::managed_launcher::spawn_contained(
+        command,
+        std::path::Path::new(env!("CARGO_BIN_EXE_buzz-desktop")),
+        &log,
+        true,
+    )
+    .expect("spawn through production managed wrapper");
+    let launcher_pid = process.launcher_pid();
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !output.exists() {
+        assert!(Instant::now() < deadline, "production launcher timed out");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    let bytes = {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match std::fs::read(&output) {
+                Ok(bytes) => break bytes,
+                Err(_) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(25))
+                }
+                Err(error) => panic!("launcher output: {error}"),
+            }
+        }
+    };
+    let bytes = bytes.strip_prefix(&[0xef, 0xbb, 0xbf]).unwrap_or(&bytes);
+    let payload: serde_json::Value = serde_json::from_slice(bytes).expect("launcher JSON");
+    let descendant_pid = payload["descendantPid"]
+        .as_u64()
+        .and_then(|pid| u32::try_from(pid).ok())
+        .expect("descendant PID");
+
+    assert_eq!(payload["cwd"], dir.path().display().to_string());
+    assert_eq!(payload["value"], "kept");
+    assert_eq!(payload["removed"], serde_json::Value::Null);
+    assert_eq!(payload["inherited"], serde_json::Value::Null);
+    assert_eq!(payload["stdinEof"], true);
+    assert_eq!(payload["programEnvelope"], serde_json::Value::Null);
+    assert_eq!(payload["argsEnvelope"], serde_json::Value::Null);
+    assert_eq!(payload["args"][0], "two words");
+    assert_eq!(payload["args"][1], "");
+    assert_eq!(payload["args"][2], "wide-雪");
+    let log_text = std::fs::read_to_string(&log).expect("managed launcher log");
+    assert_eq!(log_text.matches("launcher-stdout-marker").count(), 1);
+    assert_eq!(log_text.matches("launcher-stderr-marker").count(), 1);
+    assert!(
+        process.active_process_count().expect("query owned Job") >= 2,
+        "owned Job did not contain the launcher/target tree"
+    );
+
+    let started = Instant::now();
+    let (status, remaining_members) = process
+        .terminate_checked()
+        .expect("checked production-boundary termination");
+    let elapsed = started.elapsed();
+    assert!(elapsed < Duration::from_secs(5), "Stop took {elapsed:?}");
+    assert!(
+        !status.success(),
+        "terminated launcher unexpectedly succeeded"
+    );
+    assert_eq!(remaining_members, 0, "Job membership was not zero");
+
+    let gone_deadline = Instant::now() + Duration::from_secs(5);
+    while !(process_is_gone(launcher_pid) && process_is_gone(descendant_pid)) {
+        assert!(
+            Instant::now() < gone_deadline,
+            "launcher or descendant survived checked termination"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    println!(
+        "NATIVE_PRODUCTION_BOUNDARY_PROOF elapsed_ms={} job_members={} launcher_pid={} descendant_pid={} survivors=0",
+        elapsed.as_millis(),
+        remaining_members,
+        launcher_pid,
+        descendant_pid
+    );
+}


### PR DESCRIPTION
## Status

**Draft / help wanted — not merge-ready.**

This contribution hardens Windows managed-agent Stop, shutdown, restore, and crash-recovery behavior. It is intentionally being posted for upstream collaboration rather than held locally for another open-ended repair cycle.

A final independent review pass found two unresolved safety concerns, documented below. Passing tests do not overrule those counterexamples.

## What this changes

- Adds typed, versioned recovery authority scoped to an exact `(agent, relay/workspace)` pair.
- Fails closed when Windows PID/process-ownership evidence is missing, malformed, or contradictory.
- Preserves process, exit-status, Windows Job, receipt, pending-failure, retry, and recovery evidence across persistence failures.
- Keeps rejected restore admission observationally read-only.
- Adds durable recovery-sidecar validation, migration, reconciliation, transaction locking, and tombstone compaction.
- Extends Stop, poll/list, shutdown, startup restore, and managed-launcher lifecycle coverage.

## Known review concerns

### 1. Shutdown diagnostics may broaden exact-pair uncertainty

`shutdown.rs` can append a shutdown diagnostic to canonical recovery detail through `runtime_types.rs`. A later reconciliation may treat the same exact key/PID with changed detail as conflicting evidence, escalate it into agent-wide quarantine, and block a clean sibling pair.

Help requested: separate ordinary diagnostic history from canonical recovery identity/provenance, or otherwise ensure diagnostic enrichment cannot manufacture conflicting ownership evidence.

### 2. Some Stop/shutdown paths may retire Child/Job authority before the primary record commits

The shared synchronization path preserves the finalized runtime token through primary-record persistence, but explicit Stop, pair-runtime Stop, and shutdown paths still appear able to clear/retire finalized Child/Job authority before the caller's managed-agent record save succeeds.

Help requested: decide where the durable commit barrier belongs in the Stop API so a failed primary-record save retains equivalent retry authority and cannot publish a terminal state prematurely.

## Validation

Exact current-main port commit: `0262a73ac2f419aa8cdf04a6a284594437ca888b`

Windows MSVC (`rustc 1.95.0`):

- Full desktop Rust suite: **2,071 passed, 0 failed, 10 ignored**
- `cargo check --workspace --all-targets --all-features`: passed
- `cargo fmt --check`: passed
- `git diff --check`: passed
- Repository file-size gate: passed
- Current upstream merge/port: no conflicts

Linux-target validation was not run because this test host has only the Windows MSVC standard library installed.

## Coordination check

I searched open and recent Buzz PRs before publication. The closest items were:

- #3179 — managed-agent liveness/SLA status; overlaps runtime status files but not durable Stop/recovery authority.
- #3446 — ACP session retirement and terminal receipts; a different session lifecycle.
- #2321 — Unix TTY/process-group detachment; not Windows managed-agent recovery.

No existing PR appeared to implement or clearly supersede this exact Windows recovery-authority work.

## Review request

Windows, Rust lifecycle, and persistence reviewers: please help resolve or challenge the two commit-barrier/reconciliation concerns above. Architectural guidance or focused follow-up commits are welcome. This draft should remain non-merge-ready until those concerns are resolved or maintainers explicitly determine that the current behavior is acceptable.
