### PR TITLE
fix(acp): exempt DM channels from mentions-mode mention requirement

### DIFF
--- a/crates/buzz-acp/src/filter.rs
+++ b/crates/buzz-acp/src/filter.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 /// Errors that can occur during filter expression evaluation.
 #[derive(Debug, thiserror::Error)]
@@ -351,8 +351,21 @@ const MAX_CONSECUTIVE_TIMEOUTS: u32 = 5;
 /// 2. **kinds** — if non-empty, the event kind must be in the list.
 /// 3. **require_mention** — if `true`, a `p` tag matching `agent_pubkey_hex` must
 ///    exist. Tag kind is checked via `tag.as_slice()` for stable, library-independent
-///    access.
+///    access. Bypassed entirely when `dm_mention_exempt` is `true` (see below).
 /// 4. **filter** — if `Some`, the evalexpr expression must evaluate to `true`.
+///
+/// # DM mention exemption
+///
+/// `dm_mention_exempt` is decided by the caller, not by the rule, so this
+/// function stays agnostic about subscribe modes. The harness sets it only for
+/// events arriving in a **DM channel while running in mentions mode**: a DM is
+/// already addressed to the agent, so requiring an explicit `p` tag there would
+/// silently drop plain DM text. It deliberately does **not** apply to
+/// config-mode rules — an operator who writes `require_mention: true` in their
+/// config gets exactly that, in every channel.
+///
+/// The exemption affects only the `require_mention` check. Channel scope, kind
+/// filters, and evalexpr filters are unchanged.
 ///
 /// # Fail-closed filter error handling
 ///
@@ -370,6 +383,7 @@ pub async fn match_event(
     channel_id: uuid::Uuid,
     rules: &[SubscriptionRule],
     agent_pubkey_hex: &str,
+    dm_mention_exempt: bool,
 ) -> Option<MatchedRule> {
     let filter_ctx = FilterContext::from_event(event, channel_id);
 
@@ -394,7 +408,15 @@ pub async fn match_event(
                     && s.get(1).map(|v| v.as_str()) == Some(agent_pubkey_hex)
             });
             if !mentioned {
-                continue;
+                if !dm_mention_exempt {
+                    continue;
+                }
+                debug!(
+                    rule = %rule.name,
+                    rule_index = index,
+                    channel_id = %channel_id,
+                    "dm mention exemption: dispatching unmentioned DM event"
+                );
             }
         }
 
@@ -601,7 +623,9 @@ mod tests {
             ),
         ];
 
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
+        let matched = match_event(&event, channel_id, &rules, "", false)
+            .await
+            .unwrap();
         assert_eq!(matched.rule_index, 0);
         assert_eq!(matched.prompt_tag, "tag-first");
     }
@@ -630,7 +654,9 @@ mod tests {
             ),
         ];
 
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
+        let matched = match_event(&event, channel_id, &rules, "", false)
+            .await
+            .unwrap();
         assert_eq!(matched.rule_index, 1);
         assert_eq!(matched.prompt_tag, "matched");
     }
@@ -653,11 +679,11 @@ mod tests {
         )];
 
         // Without mention — no match.
-        let result = match_event(&event_no_mention, channel_id, &rules, agent_pubkey).await;
+        let result = match_event(&event_no_mention, channel_id, &rules, agent_pubkey, false).await;
         assert!(result.is_none());
 
         // With mention — matches.
-        let matched = match_event(&event_with_mention, channel_id, &rules, agent_pubkey)
+        let matched = match_event(&event_with_mention, channel_id, &rules, agent_pubkey, false)
             .await
             .unwrap();
         assert_eq!(matched.prompt_tag, "mentioned");
@@ -677,7 +703,7 @@ mod tests {
             None,
         )];
 
-        let result = match_event(&event, channel_id, &rules, "").await;
+        let result = match_event(&event, channel_id, &rules, "", false).await;
         assert!(result.is_none());
     }
 
@@ -725,7 +751,9 @@ mod tests {
             None, // no explicit tag
         )];
 
-        let matched = match_event(&event, channel_id, &rules, "").await.unwrap();
+        let matched = match_event(&event, channel_id, &rules, "", false)
+            .await
+            .unwrap();
         assert_eq!(matched.prompt_tag, "my-rule");
     }
 
@@ -755,7 +783,7 @@ mod tests {
         ];
 
         // Must return None — not "catch-all".
-        let result = match_event(&event, channel_id, &rules, "").await;
+        let result = match_event(&event, channel_id, &rules, "", false).await;
         assert!(
             result.is_none(),
             "filter error must fail closed, not fall through to next rule"
@@ -781,7 +809,187 @@ mod tests {
             .store(MAX_CONSECUTIVE_TIMEOUTS, Ordering::Relaxed);
 
         let rules = vec![rule];
-        let result = match_event(&event, channel_id, &rules, "").await;
+        let result = match_event(&event, channel_id, &rules, "", false).await;
         assert!(result.is_none(), "disabled rule must return None");
+    }
+
+    // --- DM mention exemption -------------------------------------------
+    //
+    // `dm_mention_exempt` is decided by the caller (mentions mode + DM
+    // channel) and relaxes ONLY the `require_mention` check. These tests pin
+    // both halves of that contract: the exemption fires, and it does not leak
+    // into any other gate.
+
+    const AGENT_PUBKEY: &str = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+    /// A `require_mention: true` rule scoped to every channel, all kinds.
+    fn mention_rule() -> SubscriptionRule {
+        make_rule(
+            "mention-only",
+            ChannelScope::All("all".into()),
+            vec![],
+            true,
+            None,
+            Some("mentioned"),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_match_event_dm_exempt_dispatches_unmentioned_event() {
+        // Plain DM text carries no `p` tag. With the exemption on, the
+        // require_mention rule must still match.
+        let event = make_event(9, "hey, status?");
+        let channel_id = any_channel();
+        let rules = vec![mention_rule()];
+
+        let matched = match_event(&event, channel_id, &rules, AGENT_PUBKEY, true)
+            .await
+            .expect("dm exemption must dispatch an unmentioned event");
+        assert_eq!(matched.rule_index, 0);
+        assert_eq!(matched.prompt_tag, "mentioned");
+    }
+
+    #[tokio::test]
+    async fn test_match_event_dm_exempt_off_filters_unmentioned_event() {
+        // Same event, exemption off — the pre-existing behavior: filtered.
+        let event = make_event(9, "hey, status?");
+        let channel_id = any_channel();
+        let rules = vec![mention_rule()];
+
+        let result = match_event(&event, channel_id, &rules, AGENT_PUBKEY, false).await;
+        assert!(
+            result.is_none(),
+            "without the exemption an unmentioned event must stay filtered"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_match_event_dm_exempt_still_matches_mentioned_event() {
+        // No regression for the mentioned case: exemption on must not change
+        // the outcome for an event that does carry the agent's `p` tag.
+        let event = make_event_with_p_tag(9, "hey @agent", AGENT_PUBKEY);
+        let channel_id = any_channel();
+        let rules = vec![mention_rule()];
+
+        let matched = match_event(&event, channel_id, &rules, AGENT_PUBKEY, true)
+            .await
+            .expect("mentioned event must match with the exemption on");
+        assert_eq!(matched.prompt_tag, "mentioned");
+    }
+
+    #[tokio::test]
+    async fn test_match_event_dm_exempt_does_not_bypass_kind_filter() {
+        // The exemption relaxes require_mention only — a kind mismatch must
+        // still filter the event out.
+        let event = make_event(1, "hey, status?");
+        let channel_id = any_channel();
+
+        let rules = vec![make_rule(
+            "kind-9-mention-only",
+            ChannelScope::All("all".into()),
+            vec![9],
+            true,
+            None,
+            Some("should-not-match"),
+        )];
+
+        let result = match_event(&event, channel_id, &rules, AGENT_PUBKEY, true).await;
+        assert!(
+            result.is_none(),
+            "dm exemption must not bypass the kind filter"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_match_event_dm_exempt_does_not_bypass_evalexpr_filter() {
+        // An evalexpr filter evaluating to false must still filter, even for
+        // an unmentioned event with the exemption on.
+        let event = make_event(9, "just chatter");
+        let channel_id = any_channel();
+
+        let rules = vec![make_rule(
+            "p1-mention-only",
+            ChannelScope::All("all".into()),
+            vec![],
+            true,
+            Some(r#"str_contains(content, "P1")"#),
+            Some("should-not-match"),
+        )];
+
+        let result = match_event(&event, channel_id, &rules, AGENT_PUBKEY, true).await;
+        assert!(
+            result.is_none(),
+            "dm exemption must not bypass the evalexpr filter"
+        );
+
+        // Control: same rule + exemption, content that satisfies the filter.
+        let hit = make_event(9, "P1 incident");
+        let matched = match_event(&hit, channel_id, &rules, AGENT_PUBKEY, true)
+            .await
+            .expect("filter-true unmentioned event must match under the exemption");
+        assert_eq!(matched.prompt_tag, "should-not-match");
+    }
+
+    #[tokio::test]
+    async fn test_match_event_dm_exempt_does_not_bypass_channel_scope() {
+        // Channel scope is checked before require_mention and is untouched by
+        // the exemption.
+        let event = make_event(9, "hey, status?");
+        let in_scope = any_channel();
+        let out_of_scope = any_channel();
+
+        let rules = vec![make_rule(
+            "scoped-mention-only",
+            ChannelScope::List(vec![in_scope.to_string()]),
+            vec![],
+            true,
+            None,
+            Some("scoped"),
+        )];
+
+        let result = match_event(&event, out_of_scope, &rules, AGENT_PUBKEY, true).await;
+        assert!(
+            result.is_none(),
+            "dm exemption must not bypass channel scope"
+        );
+
+        let matched = match_event(&event, in_scope, &rules, AGENT_PUBKEY, true)
+            .await
+            .expect("in-scope unmentioned event must match under the exemption");
+        assert_eq!(matched.prompt_tag, "scoped");
+    }
+
+    #[tokio::test]
+    async fn test_match_event_dm_exempt_skips_to_later_matching_rule() {
+        // The exemption must not short-circuit rule ordering: a rule rejected
+        // on kind still falls through to the next rule, which then benefits
+        // from the exemption.
+        let event = make_event(9, "hey, status?");
+        let channel_id = any_channel();
+
+        let rules = vec![
+            make_rule(
+                "wrong-kind",
+                ChannelScope::All("all".into()),
+                vec![1],
+                true,
+                None,
+                Some("wrong"),
+            ),
+            make_rule(
+                "right-kind",
+                ChannelScope::All("all".into()),
+                vec![9],
+                true,
+                None,
+                Some("right"),
+            ),
+        ];
+
+        let matched = match_event(&event, channel_id, &rules, AGENT_PUBKEY, true)
+            .await
+            .expect("second rule must match under the exemption");
+        assert_eq!(matched.rule_index, 1);
+        assert_eq!(matched.prompt_tag, "right");
     }
 }

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -286,6 +286,70 @@ pub(crate) async fn is_dm_channel(
     }
 }
 
+/// Strip the `#p` subscription filter from DM channels in mentions mode.
+///
+/// Mentions mode subscribes with `require_mention: true`, which the relay
+/// renders as a `#p` tag filter (see `relay::build_channel_filter`). A plain DM
+/// carries no `p` tag, so without this the event never comes off the wire and
+/// the local `require_mention` exemption in [`filter::match_event`] could never
+/// see it. Both gates must be exempted for the feature to work end to end.
+///
+/// Applies to [`SubscribeMode::Mentions`] only. `All` mode already has
+/// `require_mention: false`, and `Config` mode rules keep their operator-declared
+/// `require_mention` semantics in every channel, DM or not.
+///
+/// # Unknown channel types are treated as NOT-DM (deliberate divergence)
+///
+/// This helper only exempts channels whose type `channel_info` definitively
+/// reports as `"dm"`. A channel missing from the map keeps its narrower `#p`
+/// subscription. That is the **opposite** of [`is_dm_channel`], which fails
+/// *closed to DM* (treats unresolved channels as DMs).
+///
+/// The divergence is intentional and the two directions mean different things:
+/// - [`is_dm_channel`] guards the **author gate**, where "unknown ⇒ DM" is the
+///   restrictive answer (only owner/siblings get through).
+/// - Here, "unknown ⇒ DM" would be the **permissive** answer — it would widen a
+///   subscription to every message in a channel that may well be a public
+///   stream. Startup discovery metadata is definitive for the channels it
+///   covers, so an absent entry means "not a channel we discovered as a DM" and
+///   the narrow subscription stands.
+///
+/// The dynamic (post-startup membership) subscribe path does the reverse and
+/// accepts `is_dm_channel`'s fail-closed-to-DM answer, because agent-initiated
+/// DMs have no startup metadata at all and would otherwise never be exempted.
+/// Widening there is safe: the author gate still runs on every event.
+///
+/// Returns the number of channels whose filter was changed.
+pub(crate) fn apply_dm_mention_exemption(
+    filters: &mut HashMap<Uuid, config::ChannelFilter>,
+    channel_info: &HashMap<Uuid, relay::ChannelInfo>,
+    mode: &SubscribeMode,
+) -> usize {
+    if *mode != SubscribeMode::Mentions {
+        return 0;
+    }
+
+    let mut exempted = 0;
+    for (channel_id, filter) in filters.iter_mut() {
+        if !filter.require_mention {
+            continue;
+        }
+        let is_dm = channel_info
+            .get(channel_id)
+            .is_some_and(|info| info.channel_type == "dm");
+        if !is_dm {
+            continue;
+        }
+        filter.require_mention = false;
+        exempted += 1;
+        tracing::debug!(
+            channel_id = %channel_id,
+            "dm mention exemption: subscribing to DM channel without #p filter"
+        );
+    }
+    exempted
+}
+
 /// Query an author's kind:0 profile and check if their NIP-OA auth tag
 /// proves the same owner as us.
 async fn check_sibling_via_profile(
@@ -1471,7 +1535,21 @@ async fn tokio_main() -> Result<()> {
         }
     };
 
-    let channel_filters = config::resolve_channel_filters(&config, &channel_ids, &rules);
+    let mut channel_filters = config::resolve_channel_filters(&config, &channel_ids, &rules);
+    // Mentions mode only: DM channels must not carry a `#p` subscription filter
+    // or plain DM text never reaches the local exemption. See the helper's doc
+    // comment for why unknown channel types stay narrow here.
+    let dm_exempted = apply_dm_mention_exemption(
+        &mut channel_filters,
+        &channel_info_map,
+        &config.subscribe_mode,
+    );
+    if dm_exempted > 0 {
+        tracing::info!(
+            channels = dm_exempted,
+            "dm mention exemption applied to DM channel subscription(s)"
+        );
+    }
     if channel_filters.is_empty() {
         tracing::warn!("no channel subscriptions resolved — agent will sit idle");
     }
@@ -1966,7 +2044,26 @@ async fn tokio_main() -> Result<()> {
 
                                     if subscribed_channel_ids.contains(&ch) {
                                         tracing::debug!(channel_id = %ch, "membership notification: channel already subscribed");
-                                    } else if let Some(filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules) {
+                                    } else if let Some(mut filter) = config::resolve_dynamic_channel_filter(&config, ch, &rules) {
+                                        // Same intent as apply_dm_mention_exemption()
+                                        // on the startup path, but deliberately
+                                        // NOT shared with it: this path has one
+                                        // filter and no startup metadata, so it
+                                        // must await the async is_dm_channel()
+                                        // resolver and accepts its fail-closed-
+                                        // to-DM answer. Agent-initiated DMs
+                                        // arrive on exactly this path and would
+                                        // never be exempted otherwise.
+                                        if config.subscribe_mode == SubscribeMode::Mentions
+                                            && filter.require_mention
+                                            && is_dm_channel(ch, &ctx.channel_info).await
+                                        {
+                                            filter.require_mention = false;
+                                            tracing::debug!(
+                                                channel_id = %ch,
+                                                "dm mention exemption: subscribing to DM channel without #p filter"
+                                            );
+                                        }
                                         tracing::info!(channel_id = %ch, "membership notification: subscribing to new channel");
                                         if let Err(e) = relay.subscribe_channel_from(ch, filter, Some(ts)).await {
                                             tracing::warn!("failed to subscribe to new channel {ch}: {e}");
@@ -2142,13 +2239,15 @@ async fn tokio_main() -> Result<()> {
                             // launched by the same human). Allowlist adds the
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
+                            // DM hardening: resolve channel type (fail-closed to
+                            // DM) so allowlist/anyone modes cannot be exercised
+                            // by non-owner authors inside DMs. Hoisted out of the
+                            // author-gate block because the mentions-mode DM
+                            // exemption below needs the same answer.
+                            let is_dm =
+                                is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                             {
                                 let author = buzz_event.event.pubkey.to_hex();
-                                // DM hardening: resolve channel type (fail-closed
-                                // to DM) so allowlist/anyone modes cannot be
-                                // exercised by non-owner authors inside DMs.
-                                let is_dm =
-                                    is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
                                 let allowed = author_allowed(
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
@@ -2170,7 +2269,13 @@ async fn tokio_main() -> Result<()> {
                                 }
                             }
 
-                            let matched = filter::match_event(&buzz_event.event, buzz_event.channel_id, &rules, &pubkey_hex).await;
+                            // Mentions mode only: a DM is already addressed to the
+                            // agent, so the require_mention gate must not apply
+                            // there. Config-mode rules keep their declared
+                            // require_mention semantics in every channel.
+                            let dm_mention_exempt =
+                                config.subscribe_mode == SubscribeMode::Mentions && is_dm;
+                            let matched = filter::match_event(&buzz_event.event, buzz_event.channel_id, &rules, &pubkey_hex, dm_mention_exempt).await;
                             let prompt_tag = match matched {
                                 Some(m) => m.prompt_tag,
                                 None => {
@@ -4785,6 +4890,199 @@ mod author_gate_tests {
             is_dm_channel(Uuid::new_v4(), &resolver(HashMap::new())).await,
             "an unresolvable channel type must be treated as a DM"
         );
+    }
+}
+
+#[cfg(test)]
+mod dm_mention_exemption_tests {
+    //! Startup wire-filter side of the DM mention exemption.
+    //!
+    //! `apply_dm_mention_exemption` decides which channels get subscribed
+    //! WITHOUT a `#p` filter. The local `require_mention` exemption in
+    //! `filter::match_event` is useless if the event never comes off the wire,
+    //! so these tests pin the subscription half.
+
+    use super::*;
+
+    fn dm_info() -> relay::ChannelInfo {
+        relay::ChannelInfo {
+            name: "dm-with-owner".into(),
+            channel_type: "dm".into(),
+        }
+    }
+
+    fn stream_info() -> relay::ChannelInfo {
+        relay::ChannelInfo {
+            name: "engineering".into(),
+            channel_type: "stream".into(),
+        }
+    }
+
+    /// A channel filter as mentions mode resolves it: narrow, `#p`-gated.
+    fn mentions_filter() -> config::ChannelFilter {
+        config::ChannelFilter {
+            kinds: None,
+            require_mention: true,
+        }
+    }
+
+    #[test]
+    fn test_dm_channel_in_mentions_mode_drops_mention_filter() {
+        let dm = Uuid::new_v4();
+        let mut filters = HashMap::from([(dm, mentions_filter())]);
+        let info = HashMap::from([(dm, dm_info())]);
+
+        let exempted =
+            apply_dm_mention_exemption(&mut filters, &info, &config::SubscribeMode::Mentions);
+
+        assert_eq!(exempted, 1, "the one DM channel must be counted as changed");
+        assert!(
+            !filters[&dm].require_mention,
+            "a DM channel must subscribe without the #p filter"
+        );
+    }
+
+    #[test]
+    fn test_stream_channel_keeps_mention_filter() {
+        let stream = Uuid::new_v4();
+        let mut filters = HashMap::from([(stream, mentions_filter())]);
+        let info = HashMap::from([(stream, stream_info())]);
+
+        let exempted =
+            apply_dm_mention_exemption(&mut filters, &info, &config::SubscribeMode::Mentions);
+
+        assert_eq!(exempted, 0, "a stream channel must not be exempted");
+        assert!(
+            filters[&stream].require_mention,
+            "a stream channel keeps its #p subscription in mentions mode"
+        );
+    }
+
+    #[test]
+    fn test_unknown_channel_type_keeps_mention_filter() {
+        // Deliberate divergence from is_dm_channel(), which fails CLOSED to DM.
+        // Here "unknown ⇒ DM" would be the permissive answer — it would widen a
+        // subscription to every message in a possibly-public channel — so an
+        // absent entry keeps the narrow filter.
+        let absent = Uuid::new_v4();
+        let declared_unknown = Uuid::new_v4();
+        let mut filters = HashMap::from([
+            (absent, mentions_filter()),
+            (declared_unknown, mentions_filter()),
+        ]);
+        let info = HashMap::from([(
+            declared_unknown,
+            relay::ChannelInfo {
+                name: "mystery".into(),
+                channel_type: "unknown".into(),
+            },
+        )]);
+
+        let exempted =
+            apply_dm_mention_exemption(&mut filters, &info, &config::SubscribeMode::Mentions);
+
+        assert_eq!(
+            exempted, 0,
+            "unresolved channel types must not be exempted here"
+        );
+        assert!(
+            filters[&absent].require_mention,
+            "a channel missing from discovery metadata keeps the narrow #p filter"
+        );
+        assert!(
+            filters[&declared_unknown].require_mention,
+            "an explicitly 'unknown' channel type keeps the narrow #p filter"
+        );
+    }
+
+    #[test]
+    fn test_non_mentions_modes_leave_filters_untouched() {
+        // Config mode: an operator who declared require_mention gets exactly
+        // that, in every channel, DM included. All mode never sets it true.
+        let dm = Uuid::new_v4();
+        let info = HashMap::from([(dm, dm_info())]);
+
+        for mode in [config::SubscribeMode::Config, config::SubscribeMode::All] {
+            let mut filters = HashMap::from([(dm, mentions_filter())]);
+            let exempted = apply_dm_mention_exemption(&mut filters, &info, &mode);
+
+            assert_eq!(exempted, 0, "{mode:?} mode must exempt nothing");
+            assert!(
+                filters[&dm].require_mention,
+                "{mode:?} mode must leave a DM channel's filter untouched"
+            );
+        }
+    }
+
+    #[test]
+    fn test_already_open_dm_filter_is_not_counted() {
+        // require_mention already false — nothing changed, so nothing counted.
+        let dm = Uuid::new_v4();
+        let mut filters = HashMap::from([(
+            dm,
+            config::ChannelFilter {
+                kinds: None,
+                require_mention: false,
+            },
+        )]);
+        let info = HashMap::from([(dm, dm_info())]);
+
+        let exempted =
+            apply_dm_mention_exemption(&mut filters, &info, &config::SubscribeMode::Mentions);
+
+        assert_eq!(exempted, 0, "an already-open filter is not a change");
+        assert!(!filters[&dm].require_mention);
+    }
+
+    #[test]
+    fn test_mixed_channel_set_exempts_only_dms() {
+        // The realistic startup shape: DMs, streams, and an undiscovered
+        // channel resolved in one pass.
+        let dm_a = Uuid::new_v4();
+        let dm_b = Uuid::new_v4();
+        let stream = Uuid::new_v4();
+        let absent = Uuid::new_v4();
+
+        let mut filters = HashMap::from([
+            (dm_a, mentions_filter()),
+            (dm_b, mentions_filter()),
+            (stream, mentions_filter()),
+            (absent, mentions_filter()),
+        ]);
+        let info = HashMap::from([
+            (dm_a, dm_info()),
+            (dm_b, dm_info()),
+            (stream, stream_info()),
+        ]);
+
+        let exempted =
+            apply_dm_mention_exemption(&mut filters, &info, &config::SubscribeMode::Mentions);
+
+        assert_eq!(exempted, 2, "both DM channels must be counted");
+        assert!(!filters[&dm_a].require_mention);
+        assert!(!filters[&dm_b].require_mention);
+        assert!(filters[&stream].require_mention);
+        assert!(filters[&absent].require_mention);
+    }
+
+    #[test]
+    fn test_exemption_preserves_kinds() {
+        // The exemption touches require_mention only — the kinds filter is
+        // resolved elsewhere and must survive untouched.
+        let dm = Uuid::new_v4();
+        let mut filters = HashMap::from([(
+            dm,
+            config::ChannelFilter {
+                kinds: Some(vec![9, 45001]),
+                require_mention: true,
+            },
+        )]);
+        let info = HashMap::from([(dm, dm_info())]);
+
+        apply_dm_mention_exemption(&mut filters, &info, &config::SubscribeMode::Mentions);
+
+        assert_eq!(filters[&dm].kinds, Some(vec![9, 45001]));
+        assert!(!filters[&dm].require_mention);
     }
 }
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3354,10 +3354,13 @@ fn handle_prompt_result(
 
     match result.outcome {
         // Successful prompt — return agent to pool.
-        PromptOutcome::Ok(_) => {
+        PromptOutcome::Ok(ref stop_reason) => {
+            // Surface the StopReason — `outcome_label` collapses every Ok to
+            // "ok", hiding refusals and turn-limit stops.
             tracing::debug!(
                 agent = agent_index,
                 outcome = outcome_label,
+                stop_reason = ?stop_reason,
                 "agent_returned"
             );
             pool.return_agent(result.agent);

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1171,6 +1171,25 @@ fn append_new_thread_reply_instruction(s: &mut String, event_id: &str) {
     ));
 }
 
+/// Append an explicit send instruction for an unthreaded DM turn.
+///
+/// The harness only *prompts* the agent — the agent publishes its own reply by
+/// running `buzz messages send`. Threaded turns get that instruction from
+/// [`append_reply_instruction`] / [`append_new_thread_reply_instruction`], but
+/// an unthreaded DM has no reply anchor and previously carried no send
+/// instruction at all, so weakly-instructed agents read the context and ended
+/// the turn silently. No `--reply-to` here: the turn is not threaded.
+fn append_dm_send_instruction(s: &mut String, channel_id: Uuid) {
+    s.push_str(&format!(
+        "\nIMPORTANT: This is a direct message from a human, and it is not \
+         threaded. You MUST publish your reply yourself — it is not sent for \
+         you. Send it with `buzz messages send --channel {channel_id} \
+         --content \"<your reply>\"`. Do NOT pass `--reply-to` for this turn. \
+         Do NOT use @mentions in a DM — the recipient is the only other party, \
+         and an `@` triggers a mention preflight that can abort the send."
+    ));
+}
+
 /// Decide whether a turn is human-facing for reply-anchor purposes.
 ///
 /// A turn is human-facing when the triggering sender is a human, OR a human
@@ -1275,6 +1294,10 @@ fn format_context_hints(
             if let Some(event_id) = reply_anchor {
                 append_reply_instruction(&mut s, event_id);
             }
+        } else {
+            // Unthreaded DM: no reply anchor exists, so nothing above tells the
+            // agent to publish anything. Say it explicitly.
+            append_dm_send_instruction(&mut s, channel_id);
         }
         s
     } else if let Some(ref root) = thread_tags.root_event_id {
@@ -3020,6 +3043,146 @@ mod tests {
         assert!(prompt.contains("Scope: dm"));
     }
 
+    /// An unthreaded DM must carry an explicit send directive — the harness
+    /// only prompts; the agent publishes its own reply.
+    #[test]
+    fn test_format_prompt_unthreaded_dm_has_send_directive() {
+        let ch = Uuid::new_v4();
+        let event = make_event("hey");
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "dm".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let ci = PromptChannelInfo {
+            name: "DM".into(),
+            channel_type: "dm".into(),
+        };
+
+        let prompt = format_prompt(
+            &batch,
+            &FormatPromptArgs {
+                channel_info: Some(&ci),
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+
+        assert!(prompt.contains("Scope: dm"), "got:\n{prompt}");
+        assert!(
+            prompt.contains(&format!("buzz messages send --channel {ch}")),
+            "unthreaded DM must name the send command with the channel uuid, got:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("Do NOT pass `--reply-to` for this turn."),
+            "unthreaded DM must not ask for --reply-to, got:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("Do NOT use @mentions in a DM"),
+            "unthreaded DM must carry the no-mention guidance, got:\n{prompt}"
+        );
+    }
+
+    /// Threaded DMs keep the pre-existing `--reply-to` instruction and must NOT
+    /// pick up the unthreaded send directive.
+    #[test]
+    fn test_format_prompt_threaded_dm_keeps_reply_to_instruction() {
+        let ch = Uuid::new_v4();
+        let event = make_event_with_tags(
+            "sounds good",
+            vec![vec![
+                "e".into(),
+                "dmroot123".into(),
+                "".into(),
+                "reply".into(),
+            ]],
+        );
+        let event_id = event.id.to_hex();
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "dm".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let ci = PromptChannelInfo {
+            name: "DM".into(),
+            channel_type: "dm".into(),
+        };
+
+        let prompt = format_prompt(
+            &batch,
+            &FormatPromptArgs {
+                channel_info: Some(&ci),
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+
+        assert!(prompt.contains("Scope: dm"), "got:\n{prompt}");
+        assert!(prompt.contains("Thread root: dmroot123"), "got:\n{prompt}");
+        assert!(
+            prompt.contains(&format!("use `--reply-to {event_id}`")),
+            "threaded DM must keep its reply anchor, got:\n{prompt}"
+        );
+        assert!(
+            !prompt.contains("Do NOT use @mentions in a DM"),
+            "threaded DM must not gain the unthreaded send directive, got:\n{prompt}"
+        );
+        assert!(
+            !prompt.contains("Do NOT pass `--reply-to` for this turn."),
+            "threaded DM must not gain the unthreaded send directive, got:\n{prompt}"
+        );
+    }
+
+    /// Channel-scope prompts are unaffected by the DM send directive.
+    #[test]
+    fn test_format_prompt_channel_scope_has_no_dm_send_directive() {
+        let ch = Uuid::new_v4();
+        let event = make_event("hello everyone");
+        let batch = FlushBatch {
+            channel_id: ch,
+            events: vec![BatchEvent {
+                event,
+                prompt_tag: "@mention".into(),
+                received_at: Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let ci = PromptChannelInfo {
+            name: "engineering".into(),
+            channel_type: "stream".into(),
+        };
+
+        let prompt = format_prompt(
+            &batch,
+            &FormatPromptArgs {
+                channel_info: Some(&ci),
+                ..Default::default()
+            },
+        )
+        .join("\n\n");
+
+        assert!(prompt.contains("Scope: channel"), "got:\n{prompt}");
+        assert!(
+            !prompt.contains("This is a direct message from a human"),
+            "channel prompt must not gain the DM directive, got:\n{prompt}"
+        );
+        assert!(
+            !prompt.contains("Do NOT use @mentions in a DM"),
+            "channel prompt must not gain the DM directive, got:\n{prompt}"
+        );
+    }
+
     #[test]
     fn test_format_prompt_thread_scope() {
         let ch = Uuid::new_v4();
@@ -3971,8 +4134,12 @@ mod tests {
         );
     }
 
+    /// An unthreaded DM must not be given a `--reply-to` anchor. It still gets
+    /// the explicit send directive (see
+    /// `test_format_prompt_unthreaded_dm_has_send_directive`), which names
+    /// `--reply-to` only to tell the agent NOT to pass it.
     #[test]
-    fn test_reply_instruction_absent_for_dm_non_reply() {
+    fn test_reply_anchor_absent_for_dm_non_reply() {
         let ch = Uuid::new_v4();
         let event = make_event("hey there");
         let batch = FlushBatch {
@@ -3999,8 +4166,12 @@ mod tests {
         )
         .join("\n\n");
         assert!(
-            !prompt.contains("--reply-to"),
-            "DM non-reply should NOT include reply instruction"
+            !prompt.contains("use `--reply-to"),
+            "DM non-reply should NOT be given a reply anchor, got:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("Do NOT pass `--reply-to` for this turn."),
+            "DM non-reply should be told explicitly not to thread, got:\n{prompt}"
         );
     }
 

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -446,6 +446,10 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
             buzz_event.channel_id,
             &rules,
             &pubkey_hex,
+            // No DM mention exemption in setup mode: the explicit
+            // `event_mentions_agent` gate above already required a mention, so
+            // exempting here would change nothing but blur the contract.
+            false,
         )
         .await
         .is_some();


### PR DESCRIPTION
## Problem

In `subscribe=mentions` mode (the default), plain DM text sent to an agent is silently dropped — the agent never responds and nothing is logged at INFO. Two layers filter it:

1. **Wire layer**: the relay subscription for every channel carries a `#p` filter (`ChannelFilter.require_mention`), so an unmentioned kind-9 DM never comes off the wire.
2. **Local layer**: the built-in mentions-mode rule sets `require_mention`, so even a delivered event without a `p` tag is filtered in `match_event`.

A DM is already addressed to the agent — requiring an explicit @mention inside it makes agent DMs effectively unusable (users type plain text, see the agent stay silent, and have no feedback why).

## Change

Exempt DM channels from both gates, **mentions mode only**:

- **Startup wire filters**: new helper `apply_dm_mention_exemption()` drops the `#p` requirement for channels discovered as `channel_type == "dm"`. Unknown/absent types keep the narrow filter — deliberately the opposite of `is_dm_channel()`'s fail-closed-to-DM, because here "treat as DM" would *widen* a subscription; the divergence is documented on the helper.
- **Dynamic membership path**: uses async `is_dm_channel()` (agent-initiated DMs have no startup metadata). Widening on unresolved type is safe here because the inbound author gate still runs per-event.
- **`match_event`**: new `dm_mention_exempt: bool` param, set only for `subscribe=mentions` + DM channel. Config-mode rules keep their `require_mention` contract everywhere — an operator who writes `require_mention: true` gets exactly that, in every channel.

Author gate, channel scope, kind filters, and evalexpr filters are unchanged.

## Tests

14 new tests across both layers, sabotage-verified (reverting the feature turns them red):
- 7 in `filter.rs`: exemption dispatches unmentioned DM events; exempt=false preserves old behavior; exemption does not leak into kind/evalexpr/channel-scope gates or rule ordering.
- 7 in `lib.rs` (`dm_mention_exemption_tests`): dm flips `require_mention` off (count=1), stream/unknown/absent stay narrow, non-mentions modes untouched, kinds preserved.

`cargo fmt` / `clippy --all-targets -D warnings` clean. Verified live against a hosted relay: pre-patch an unmentioned DM produced zero harness activity; post-patch it reaches the author gate (`is_dm=true`) and owner DMs dispatch normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)