### PR TITLE
fix(mobile): complete policy-gated invite joins

### DIFF
--- a/mobile/lib/features/invites/invite_join_provider.dart
+++ b/mobile/lib/features/invites/invite_join_provider.dart
@@ -25,9 +25,29 @@ enum InviteJoinStatus {
   idle,
   confirming,
   claiming,
+  reviewingPolicy,
+  acceptingPolicy,
+  declined,
   success,
   switchedExisting,
   error,
+}
+
+class InviteJoinPolicy {
+  final String? termsMarkdown;
+  final String? privacyMarkdown;
+  final bool ageAttestationRequired;
+  final String version;
+
+  const InviteJoinPolicy({
+    this.termsMarkdown,
+    this.privacyMarkdown,
+    required this.ageAttestationRequired,
+    required this.version,
+  });
+
+  bool get agreementRequired =>
+      termsMarkdown != null || privacyMarkdown != null;
 }
 
 class InviteJoinState {
@@ -37,6 +57,9 @@ class InviteJoinState {
   final String? communityName;
   final String? errorMessage;
   final bool requiresFreshInvite;
+  final InviteJoinPolicy? policy;
+  final bool ageConfirmed;
+  final bool agreementConfirmed;
 
   const InviteJoinState({
     this.status = InviteJoinStatus.idle,
@@ -45,6 +68,9 @@ class InviteJoinState {
     this.communityName,
     this.errorMessage,
     this.requiresFreshInvite = false,
+    this.policy,
+    this.ageConfirmed = false,
+    this.agreementConfirmed = false,
   });
 
   InviteJoinState copyWith({
@@ -54,21 +80,32 @@ class InviteJoinState {
     String? communityName,
     String? errorMessage,
     bool? requiresFreshInvite,
+    InviteJoinPolicy? policy,
+    bool? ageConfirmed,
+    bool? agreementConfirmed,
+    bool clearErrorMessage = false,
+    bool clearPolicy = false,
   }) => InviteJoinState(
     status: status ?? this.status,
     invite: invite ?? this.invite,
     host: host ?? this.host,
     communityName: communityName ?? this.communityName,
-    errorMessage: errorMessage ?? this.errorMessage,
+    errorMessage: clearErrorMessage ? null : errorMessage ?? this.errorMessage,
     requiresFreshInvite: requiresFreshInvite ?? this.requiresFreshInvite,
+    policy: clearPolicy ? null : policy ?? this.policy,
+    ageConfirmed: ageConfirmed ?? this.ageConfirmed,
+    agreementConfirmed: agreementConfirmed ?? this.agreementConfirmed,
   );
 }
 
 class InviteJoinNotifier extends Notifier<InviteJoinState> {
+  nostr.Keys? _pendingKeys;
+
   @override
   InviteJoinState build() => const InviteJoinState();
 
   Future<void> prepare(InviteDeepLink invite) async {
+    _pendingKeys = null;
     validateInviteRelayUri(Uri.parse(invite.relayUrl));
     final communities = await ref.read(communityListProvider.future);
     final existing = _existingCommunity(communities, invite.relayUrl);
@@ -102,7 +139,6 @@ class InviteJoinNotifier extends Notifier<InviteJoinState> {
       return;
     }
 
-    state = state.copyWith(status: InviteJoinStatus.claiming);
     try {
       final communities = await ref.read(communityListProvider.future);
       final existing = _existingCommunity(communities, invite.relayUrl);
@@ -117,43 +153,84 @@ class InviteJoinNotifier extends Notifier<InviteJoinState> {
         return;
       }
 
-      final keys = ref.read(inviteKeyGeneratorProvider)();
-      final body = jsonEncode({
-        'code': invite.code,
-        if (invite.policyReceipt != null)
-          'policy_receipt': invite.policyReceipt,
-      });
-      final relayUri = Uri.parse(invite.relayUrl);
-      validateInviteRelayUri(relayUri);
-      final url = _claimUrlFromRelay(invite.relayUrl);
-      final request = http.Request('POST', Uri.parse(url))
-        ..followRedirects = false
-        ..headers.addAll({
-          'Authorization': buildNip98AuthHeader(
-            method: 'POST',
-            url: url,
-            bodyBytes: utf8.encode(body),
-            nsec: keys.nsec,
-          ),
-          'Content-Type': 'application/json',
-        })
-        ..body = body;
-      final streamedResponse = await ref
-          .read(inviteJoinHttpClientProvider)
-          .send(request);
-      final response = await http.Response.fromStream(streamedResponse);
-      final decoded = jsonDecode(response.body.isEmpty ? '{}' : response.body);
-      if (response.statusCode < 200 || response.statusCode >= 300) {
-        final message = decoded is Map && decoded['error'] is String
-            ? decoded['error'] as String
-            : 'HTTP ${response.statusCode}';
-        throw InviteClaimException(message);
-      }
-      if (decoded is! Map) {
-        throw const FormatException('Invite claim returned malformed JSON');
-      }
-      final claim = Map<String, dynamic>.from(decoded);
+      final keys = _pendingKeys ?? ref.read(inviteKeyGeneratorProvider)();
+      _pendingKeys = keys;
+      await _claimAndJoin(invite, keys, invite.policyReceipt);
+    } catch (error) {
+      _setClaimError(error);
+    }
+  }
 
+  void setAgeConfirmed(bool confirmed) {
+    if (state.status != InviteJoinStatus.reviewingPolicy) return;
+    state = state.copyWith(ageConfirmed: confirmed, clearErrorMessage: true);
+  }
+
+  void setAgreementConfirmed(bool confirmed) {
+    if (state.status != InviteJoinStatus.reviewingPolicy) return;
+    state = state.copyWith(
+      agreementConfirmed: confirmed,
+      clearErrorMessage: true,
+    );
+  }
+
+  Future<void> acceptPolicy() async {
+    final invite = state.invite;
+    final policy = state.policy;
+    if (invite == null ||
+        policy == null ||
+        state.status != InviteJoinStatus.reviewingPolicy) {
+      return;
+    }
+    if (policy.ageAttestationRequired && !state.ageConfirmed) {
+      state = state.copyWith(
+        errorMessage: 'Confirm that you are at least 18 years old.',
+      );
+      return;
+    }
+    if (policy.agreementRequired && !state.agreementConfirmed) {
+      state = state.copyWith(errorMessage: _policyAgreementError(policy));
+      return;
+    }
+
+    state = state.copyWith(
+      status: InviteJoinStatus.acceptingPolicy,
+      clearErrorMessage: true,
+    );
+    try {
+      final receipt = await _acceptJoinPolicy(invite, policy);
+      final keys = _pendingKeys ?? ref.read(inviteKeyGeneratorProvider)();
+      _pendingKeys = keys;
+      await _claimAndJoin(invite, keys, receipt);
+    } catch (error) {
+      state = state.copyWith(
+        status: InviteJoinStatus.reviewingPolicy,
+        errorMessage: _friendlyPolicyAcceptanceError(error),
+      );
+    }
+  }
+
+  void declinePolicy() {
+    if (state.status != InviteJoinStatus.reviewingPolicy) return;
+    _pendingKeys = null;
+    state = state.copyWith(
+      status: InviteJoinStatus.declined,
+      errorMessage:
+          'You declined this community\'s join policy. You were not joined.',
+    );
+  }
+
+  Future<void> _claimAndJoin(
+    InviteDeepLink invite,
+    nostr.Keys keys,
+    String? policyReceipt,
+  ) async {
+    state = state.copyWith(
+      status: InviteJoinStatus.claiming,
+      clearErrorMessage: true,
+    );
+    try {
+      final claim = await _claimInvite(invite, keys, policyReceipt);
       final community = Community.create(
         name: _communityNameFromClaim(claim, invite.relayUrl),
         relayUrl: invite.relayUrl,
@@ -163,21 +240,135 @@ class InviteJoinNotifier extends Notifier<InviteJoinState> {
       await ref
           .read(authProvider.notifier)
           .authenticateWithCommunity(community);
+      _pendingKeys = null;
       state = state.copyWith(
         status: InviteJoinStatus.success,
         communityName: community.name,
+        clearPolicy: true,
       );
     } catch (error) {
-      final requiresFreshInvite = _requiresFreshInvite(error);
+      if (_isJoinPolicyRequired(error)) {
+        await _loadJoinPolicy(invite);
+        return;
+      }
+      _setClaimError(error);
+    }
+  }
+
+  Future<Map<String, dynamic>> _claimInvite(
+    InviteDeepLink invite,
+    nostr.Keys keys,
+    String? policyReceipt,
+  ) async {
+    final body = jsonEncode({
+      'code': invite.code,
+      'policy_receipt': ?policyReceipt,
+    });
+    final url = _inviteApiUrl(invite.relayUrl, '/api/invites/claim');
+    final request = http.Request('POST', Uri.parse(url))
+      ..followRedirects = false
+      ..headers.addAll({
+        'Authorization': buildNip98AuthHeader(
+          method: 'POST',
+          url: url,
+          bodyBytes: utf8.encode(body),
+          nsec: keys.nsec,
+        ),
+        'Content-Type': 'application/json',
+      })
+      ..body = body;
+    final response = await _send(request);
+    return _decodeObjectResponse(response, 'Invite claim');
+  }
+
+  Future<void> _loadJoinPolicy(InviteDeepLink invite) async {
+    try {
+      final request = http.Request(
+        'GET',
+        Uri.parse(_inviteApiUrl(invite.relayUrl, '/api/join-policy')),
+      )..followRedirects = false;
+      final response = await _send(request);
+      final decoded = _decodeObjectResponse(response, 'Join policy');
+      final rawPolicy = decoded['policy'];
+      if (rawPolicy is! Map) {
+        throw const FormatException(
+          'Join policy response did not include a policy',
+        );
+      }
+      final policyJson = Map<String, dynamic>.from(rawPolicy);
+      final version = policyJson['version'];
+      final ageAttestationRequired = policyJson['age_attestation_required'];
+      if (version is! String ||
+          version.isEmpty ||
+          ageAttestationRequired is! bool) {
+        throw const FormatException('Join policy returned malformed JSON');
+      }
+      state = state.copyWith(
+        status: InviteJoinStatus.reviewingPolicy,
+        policy: InviteJoinPolicy(
+          termsMarkdown: _optionalNonEmptyString(policyJson['terms_markdown']),
+          privacyMarkdown: _optionalNonEmptyString(
+            policyJson['privacy_markdown'],
+          ),
+          ageAttestationRequired: ageAttestationRequired,
+          version: version,
+        ),
+        ageConfirmed: false,
+        agreementConfirmed: false,
+        requiresFreshInvite: false,
+        clearErrorMessage: true,
+      );
+    } catch (error) {
       state = state.copyWith(
         status: InviteJoinStatus.error,
-        errorMessage: _friendlyInviteError(error),
-        requiresFreshInvite: requiresFreshInvite,
+        errorMessage: 'Could not load this community\'s join policy: $error',
+        requiresFreshInvite: false,
+        clearPolicy: true,
       );
     }
   }
 
+  Future<String> _acceptJoinPolicy(
+    InviteDeepLink invite,
+    InviteJoinPolicy policy,
+  ) async {
+    final url = _inviteApiUrl(invite.relayUrl, '/api/invites/accept-policy');
+    final request = http.Request('POST', Uri.parse(url))
+      ..followRedirects = false
+      ..headers['Content-Type'] = 'application/json'
+      ..body = jsonEncode({
+        'code': invite.code,
+        'policy_version': policy.version,
+        'age_confirmed': state.ageConfirmed,
+      });
+    final response = await _send(request);
+    final decoded = _decodeObjectResponse(response, 'Policy acceptance');
+    final receipt = decoded['receipt'];
+    if (receipt is! String || receipt.isEmpty) {
+      throw const FormatException(
+        'Policy acceptance response did not include a receipt',
+      );
+    }
+    return receipt;
+  }
+
+  Future<http.Response> _send(http.Request request) async {
+    final streamedResponse = await ref
+        .read(inviteJoinHttpClientProvider)
+        .send(request);
+    return http.Response.fromStream(streamedResponse);
+  }
+
+  void _setClaimError(Object error) {
+    state = state.copyWith(
+      status: InviteJoinStatus.error,
+      errorMessage: _friendlyInviteError(error),
+      requiresFreshInvite: _requiresFreshInvite(error),
+    );
+  }
+
   void reset() {
+    _pendingKeys = null;
     state = const InviteJoinState();
   }
 }
@@ -239,7 +430,7 @@ String _hostFromRelay(String relayUrl) {
   return uri.host;
 }
 
-String _claimUrlFromRelay(String relayUrl) {
+String _inviteApiUrl(String relayUrl, String path) {
   final uri = Uri.parse(relayUrl);
   final scheme = switch (uri.scheme) {
     'wss' => 'https',
@@ -250,8 +441,30 @@ String _claimUrlFromRelay(String relayUrl) {
     scheme: scheme,
     host: uri.host,
     port: uri.hasPort ? uri.port : null,
-    path: '/api/invites/claim',
+    path: path,
   ).toString();
+}
+
+Map<String, dynamic> _decodeObjectResponse(
+  http.Response response,
+  String operation,
+) {
+  final decoded = jsonDecode(response.body.isEmpty ? '{}' : response.body);
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    final message = decoded is Map && decoded['error'] is String
+        ? decoded['error'] as String
+        : 'HTTP ${response.statusCode}';
+    throw InviteClaimException(message);
+  }
+  if (decoded is! Map) {
+    throw FormatException('$operation returned malformed JSON');
+  }
+  return Map<String, dynamic>.from(decoded);
+}
+
+String? _optionalNonEmptyString(Object? value) {
+  if (value is! String || value.trim().isEmpty) return null;
+  return value;
 }
 
 String _communityNameFromClaim(Map<String, dynamic> claim, String relayUrl) {
@@ -262,9 +475,11 @@ String _communityNameFromClaim(Map<String, dynamic> claim, String relayUrl) {
 
 bool _requiresFreshInvite(Object error) {
   final message = error.toString();
-  return message.contains('join_policy_required') ||
-      message.contains('invite_exhausted');
+  return message.contains('invite_exhausted');
 }
+
+bool _isJoinPolicyRequired(Object error) =>
+    error.toString().contains('join_policy_required');
 
 String _friendlyInviteError(Object error) {
   final message = error.toString();
@@ -274,7 +489,7 @@ String _friendlyInviteError(Object error) {
   }
   if (message.contains('invite_invalid')) return 'This invite is not valid.';
   if (message.contains('join_policy_required')) {
-    return 'This invite approval has expired. Re-open the invite link to try again.';
+    return 'This community requires you to review and accept its join policy.';
   }
   if (message.contains('SocketException') ||
       message.contains('Connection refused') ||
@@ -283,4 +498,22 @@ String _friendlyInviteError(Object error) {
     return 'Could not reach the relay. Check your connection and try again.';
   }
   return 'Could not join this community: $message';
+}
+
+String _friendlyPolicyAcceptanceError(Object error) {
+  final message = error.toString();
+  if (message.contains('join_policy_not_accepted')) {
+    return 'The policy changed or your confirmation was not accepted. Review it and try again.';
+  }
+  return 'Could not accept this community\'s join policy: $message';
+}
+
+String _policyAgreementError(InviteJoinPolicy policy) {
+  if (policy.termsMarkdown != null && policy.privacyMarkdown != null) {
+    return 'Agree to the Terms of Service and Privacy Policy.';
+  }
+  if (policy.termsMarkdown != null) {
+    return 'Agree to the Terms of Service.';
+  }
+  return 'Agree to the Privacy Policy.';
 }

--- a/mobile/lib/features/invites/invite_join_sheet.dart
+++ b/mobile/lib/features/invites/invite_join_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
@@ -28,6 +29,13 @@ class InviteJoinSheet extends ConsumerWidget {
 
     if (state.status == InviteJoinStatus.success) {
       return _InviteJoinSuccess(host: host, communityName: derivedName);
+    }
+    if (state.status == InviteJoinStatus.reviewingPolicy ||
+        state.status == InviteJoinStatus.acceptingPolicy) {
+      return _InviteJoinPolicyReview(state: state);
+    }
+    if (state.status == InviteJoinStatus.declined) {
+      return _InviteJoinDeclined(message: state.errorMessage);
     }
 
     return SafeArea(
@@ -127,6 +135,238 @@ class InviteJoinSheet extends ConsumerWidget {
                   ),
                 ),
               ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InviteJoinPolicyReview extends ConsumerWidget {
+  final InviteJoinState state;
+
+  const _InviteJoinPolicyReview({required this.state});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final policy = state.policy;
+    if (policy == null) return const SizedBox.shrink();
+
+    final isAccepting = state.status == InviteJoinStatus.acceptingPolicy;
+    final canAccept =
+        (!policy.ageAttestationRequired || state.ageConfirmed) &&
+        (!policy.agreementRequired || state.agreementConfirmed);
+    final agreementLabel = switch ((
+      policy.termsMarkdown != null,
+      policy.privacyMarkdown != null,
+    )) {
+      (true, true) =>
+        'I agree to the Terms of Service and Privacy Policy shown above.',
+      (true, false) => 'I agree to the Terms of Service shown above.',
+      (false, true) => 'I agree to the Privacy Policy shown above.',
+      (false, false) => '',
+    };
+    final notifier = ref.read(inviteJoinProvider.notifier);
+
+    return SafeArea(
+      child: SizedBox(
+        height: MediaQuery.sizeOf(context).height * 0.82,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(Grid.sm, 0, Grid.sm, Grid.sm),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Icon(
+                LucideIcons.fileCheck,
+                size: 40,
+                color: context.colors.primary,
+              ),
+              const SizedBox(height: Grid.sm),
+              Text(
+                'Review this community’s join policy',
+                style: context.textTheme.titleLarge,
+              ),
+              const SizedBox(height: Grid.xxs),
+              Text(
+                'Read the policy below, then confirm only the statements that are true for you.',
+                style: context.textTheme.bodyMedium?.copyWith(
+                  color: context.colors.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: Grid.sm),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      if (policy.termsMarkdown case final terms?) ...[
+                        Text(
+                          'Terms of Service',
+                          style: context.textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: Grid.xxs),
+                        GptMarkdown(terms, style: context.textTheme.bodyMedium),
+                        const SizedBox(height: Grid.sm),
+                      ],
+                      if (policy.privacyMarkdown case final privacy?) ...[
+                        Text(
+                          'Privacy Policy',
+                          style: context.textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: Grid.xxs),
+                        GptMarkdown(
+                          privacy,
+                          style: context.textTheme.bodyMedium,
+                        ),
+                        const SizedBox(height: Grid.sm),
+                      ],
+                      if (policy.ageAttestationRequired)
+                        _PolicyCheckbox(
+                          value: state.ageConfirmed,
+                          onChanged: isAccepting
+                              ? null
+                              : notifier.setAgeConfirmed,
+                          label: 'I am 18 years of age or older.',
+                        ),
+                      if (policy.agreementRequired) ...[
+                        if (policy.ageAttestationRequired)
+                          const SizedBox(height: Grid.xxs),
+                        _PolicyCheckbox(
+                          value: state.agreementConfirmed,
+                          onChanged: isAccepting
+                              ? null
+                              : notifier.setAgreementConfirmed,
+                          label: agreementLabel,
+                        ),
+                      ],
+                      if (state.errorMessage != null) ...[
+                        const SizedBox(height: Grid.sm),
+                        Text(
+                          state.errorMessage!,
+                          style: context.textTheme.bodySmall?.copyWith(
+                            color: context.colors.error,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: Grid.sm),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: isAccepting ? null : notifier.declinePolicy,
+                      child: const Text('Decline'),
+                    ),
+                  ),
+                  const SizedBox(width: Grid.sm),
+                  Expanded(
+                    child: FilledButton.icon(
+                      key: const Key('accept-join-policy'),
+                      onPressed: isAccepting || !canAccept
+                          ? null
+                          : notifier.acceptPolicy,
+                      icon: isAccepting
+                          ? SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: BuzzLoadingIndicator(
+                                size: 16,
+                                semanticLabel: 'Accepting join policy',
+                              ),
+                            )
+                          : const Icon(LucideIcons.check),
+                      label: Text(
+                        isAccepting ? 'Accepting…' : 'Accept and join',
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PolicyCheckbox extends StatelessWidget {
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+  final String label;
+
+  const _PolicyCheckbox({
+    required this.value,
+    required this.onChanged,
+    required this.label,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onChanged == null ? null : () => onChanged!(!value),
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: Grid.half),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Checkbox(
+              value: value,
+              onChanged: onChanged == null
+                  ? null
+                  : (checked) => onChanged!(checked ?? false),
+            ),
+            const SizedBox(width: Grid.xxs),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.only(top: Grid.twelve),
+                child: Text(label, style: context.textTheme.bodyMedium),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InviteJoinDeclined extends StatelessWidget {
+  final String? message;
+
+  const _InviteJoinDeclined({this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(Grid.sm, 0, Grid.sm, Grid.sm),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Icon(
+              LucideIcons.circleX,
+              size: 40,
+              color: context.colors.onSurfaceVariant,
+            ),
+            const SizedBox(height: Grid.sm),
+            Text('Community not joined', style: context.textTheme.titleLarge),
+            const SizedBox(height: Grid.xxs),
+            Text(
+              message ?? 'You did not accept this community’s join policy.',
+              style: context.textTheme.bodyMedium?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: Grid.lg),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Close'),
             ),
           ],
         ),

--- a/mobile/test/features/invites/invite_join_provider_test.dart
+++ b/mobile/test/features/invites/invite_join_provider_test.dart
@@ -174,17 +174,147 @@ void main() {
     expect(container.read(inviteJoinProvider).status, InviteJoinStatus.idle);
   });
 
-  test('join_policy_required requires a fresh link and cannot retry', () async {
+  test(
+    'policy-gated invite accepts policy and retries claim with receipt',
+    () async {
+      final keys = nostr.Keys.generate();
+      final requests = <http.Request>[];
+      var claimAttempts = 0;
+      var generatedKeys = 0;
+      final storage = CommunityStorage(secure: FakeSecureStorage());
+      final auth = _RecordingAuthNotifier();
+      final container = ProviderContainer(
+        overrides: [
+          communityStorageProvider.overrideWithValue(storage),
+          authProvider.overrideWith(() => auth),
+          inviteKeyGeneratorProvider.overrideWithValue(() {
+            generatedKeys++;
+            return keys;
+          }),
+          inviteJoinHttpClientProvider.overrideWithValue(
+            http_testing.MockClient((request) async {
+              requests.add(request);
+              if (request.url.path == '/api/join-policy') {
+                return http.Response(
+                  jsonEncode({
+                    'policy': {
+                      'terms_markdown': '# Be kind',
+                      'privacy_markdown': 'We retain your messages.',
+                      'age_attestation_required': true,
+                      'version': 'policy-v1',
+                    },
+                  }),
+                  200,
+                );
+              }
+              if (request.url.path == '/api/invites/accept-policy') {
+                return http.Response(
+                  jsonEncode({'receipt': 'new.receipt'}),
+                  200,
+                );
+              }
+              claimAttempts++;
+              if (claimAttempts == 1) {
+                return http.Response(
+                  jsonEncode({'error': 'join_policy_required'}),
+                  403,
+                );
+              }
+              return http.Response(
+                jsonEncode({
+                  'status': 'joined',
+                  'host': 'relay.example.com',
+                  'role': 'member',
+                }),
+                200,
+              );
+            }),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(inviteJoinProvider.notifier)
+          .prepare(
+            const InviteDeepLink(
+              relayUrl: 'wss://relay.example.com',
+              code: 'code',
+            ),
+          );
+      await container.read(inviteJoinProvider.notifier).confirmJoin();
+
+      var state = container.read(inviteJoinProvider);
+      expect(state.status, InviteJoinStatus.reviewingPolicy);
+      expect(state.policy?.termsMarkdown, '# Be kind');
+      expect(state.policy?.privacyMarkdown, 'We retain your messages.');
+      expect(state.ageConfirmed, isFalse);
+      expect(state.agreementConfirmed, isFalse);
+      expect(state.requiresFreshInvite, isFalse);
+
+      await container.read(inviteJoinProvider.notifier).acceptPolicy();
+      state = container.read(inviteJoinProvider);
+      expect(state.status, InviteJoinStatus.reviewingPolicy);
+      expect(state.errorMessage, 'Confirm that you are at least 18 years old.');
+      expect(requests, hasLength(2));
+
+      final notifier = container.read(inviteJoinProvider.notifier);
+      notifier.setAgeConfirmed(true);
+      notifier.setAgreementConfirmed(true);
+      await notifier.acceptPolicy();
+
+      state = container.read(inviteJoinProvider);
+      expect(state.status, InviteJoinStatus.success);
+      expect(claimAttempts, 2);
+      expect(generatedKeys, 1);
+      expect(requests.map((request) => request.url.path), [
+        '/api/invites/claim',
+        '/api/join-policy',
+        '/api/invites/accept-policy',
+        '/api/invites/claim',
+      ]);
+      expect(
+        requests[2].body,
+        jsonEncode({
+          'code': 'code',
+          'policy_version': 'policy-v1',
+          'age_confirmed': true,
+        }),
+      );
+      expect(
+        requests[3].body,
+        jsonEncode({'code': 'code', 'policy_receipt': 'new.receipt'}),
+      );
+      expect(auth.authenticatedCommunities.single.pubkey, keys.public);
+    },
+  );
+
+  test('declining join policy stops without accepting or joining', () async {
     final keys = nostr.Keys.generate();
-    var attempts = 0;
+    final requests = <http.Request>[];
     final storage = CommunityStorage(secure: FakeSecureStorage());
+    final auth = _RecordingAuthNotifier();
     final container = ProviderContainer(
       overrides: [
         communityStorageProvider.overrideWithValue(storage),
+        authProvider.overrideWith(() => auth),
         inviteKeyGeneratorProvider.overrideWithValue(() => keys),
         inviteJoinHttpClientProvider.overrideWithValue(
           http_testing.MockClient((request) async {
-            attempts++;
+            requests.add(request);
+            if (request.url.path == '/api/join-policy') {
+              return http.Response(
+                jsonEncode({
+                  'policy': {
+                    'terms_markdown': 'Community terms',
+                    'privacy_markdown': null,
+                    'age_attestation_required': true,
+                    'version': 'policy-v1',
+                  },
+                }),
+                200,
+              );
+            }
             return http.Response(
               jsonEncode({'error': 'join_policy_required'}),
               403,
@@ -201,22 +331,140 @@ void main() {
           const InviteDeepLink(
             relayUrl: 'wss://relay.example.com',
             code: 'code',
-            policyReceipt: 'expired.receipt',
           ),
         );
     await container.read(inviteJoinProvider.notifier).confirmJoin();
+    container.read(inviteJoinProvider.notifier).declinePolicy();
 
     final state = container.read(inviteJoinProvider);
-    expect(state.status, InviteJoinStatus.error);
-    expect(state.requiresFreshInvite, isTrue);
+    expect(state.status, InviteJoinStatus.declined);
     expect(
       state.errorMessage,
-      'This invite approval has expired. Re-open the invite link to try again.',
+      'You declined this community\'s join policy. You were not joined.',
     );
-
-    await container.read(inviteJoinProvider.notifier).confirmJoin();
-    expect(attempts, 1);
+    expect(requests, hasLength(2));
+    expect(auth.authenticatedCommunities, isEmpty);
   });
+
+  test('accept-policy failure stays on policy review with an error', () async {
+    final keys = nostr.Keys.generate();
+    final requests = <http.Request>[];
+    final storage = CommunityStorage(secure: FakeSecureStorage());
+    final auth = _RecordingAuthNotifier();
+    final container = ProviderContainer(
+      overrides: [
+        communityStorageProvider.overrideWithValue(storage),
+        authProvider.overrideWith(() => auth),
+        inviteKeyGeneratorProvider.overrideWithValue(() => keys),
+        inviteJoinHttpClientProvider.overrideWithValue(
+          http_testing.MockClient((request) async {
+            requests.add(request);
+            if (request.url.path == '/api/join-policy') {
+              return http.Response(
+                jsonEncode({
+                  'policy': {
+                    'terms_markdown': 'Community terms',
+                    'privacy_markdown': null,
+                    'age_attestation_required': true,
+                    'version': 'policy-v1',
+                  },
+                }),
+                200,
+              );
+            }
+            if (request.url.path == '/api/invites/accept-policy') {
+              return http.Response(
+                jsonEncode({'error': 'temporary_policy_failure'}),
+                503,
+              );
+            }
+            return http.Response(
+              jsonEncode({'error': 'join_policy_required'}),
+              403,
+            );
+          }),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(inviteJoinProvider.notifier)
+        .prepare(
+          const InviteDeepLink(
+            relayUrl: 'wss://relay.example.com',
+            code: 'code',
+          ),
+        );
+    await container.read(inviteJoinProvider.notifier).confirmJoin();
+    final notifier = container.read(inviteJoinProvider.notifier);
+    notifier.setAgeConfirmed(true);
+    notifier.setAgreementConfirmed(true);
+    await notifier.acceptPolicy();
+
+    final state = container.read(inviteJoinProvider);
+    expect(state.status, InviteJoinStatus.reviewingPolicy);
+    expect(
+      state.errorMessage,
+      'Could not accept this community\'s join policy: temporary_policy_failure',
+    );
+    expect(requests, hasLength(3));
+    expect(auth.authenticatedCommunities, isEmpty);
+  });
+
+  test(
+    'invite carrying a policy receipt claims without policy handshake',
+    () async {
+      final keys = nostr.Keys.generate();
+      final requests = <http.Request>[];
+      final storage = CommunityStorage(secure: FakeSecureStorage());
+      final auth = _RecordingAuthNotifier();
+      final container = ProviderContainer(
+        overrides: [
+          communityStorageProvider.overrideWithValue(storage),
+          authProvider.overrideWith(() => auth),
+          inviteKeyGeneratorProvider.overrideWithValue(() => keys),
+          inviteJoinHttpClientProvider.overrideWithValue(
+            http_testing.MockClient((request) async {
+              requests.add(request);
+              return http.Response(
+                jsonEncode({
+                  'status': 'joined',
+                  'host': 'relay.example.com',
+                  'role': 'member',
+                }),
+                200,
+              );
+            }),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container
+          .read(inviteJoinProvider.notifier)
+          .prepare(
+            const InviteDeepLink(
+              relayUrl: 'wss://relay.example.com',
+              code: 'code',
+              policyReceipt: 'existing.receipt',
+            ),
+          );
+      await container.read(inviteJoinProvider.notifier).confirmJoin();
+
+      expect(
+        container.read(inviteJoinProvider).status,
+        InviteJoinStatus.success,
+      );
+      expect(requests, hasLength(1));
+      expect(requests.single.url.path, '/api/invites/claim');
+      expect(
+        requests.single.body,
+        jsonEncode({'code': 'code', 'policy_receipt': 'existing.receipt'}),
+      );
+      expect(auth.authenticatedCommunities, hasLength(1));
+    },
+  );
 
   test('invite_exhausted requires a fresh invite and cannot retry', () async {
     final keys = nostr.Keys.generate();

--- a/mobile/test/features/invites/invite_join_sheet_test.dart
+++ b/mobile/test/features/invites/invite_join_sheet_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'package:buzz/features/invites/invite_join_provider.dart';
+import 'package:buzz/features/invites/invite_join_sheet.dart';
+import 'package:buzz/shared/deeplink/deep_link.dart';
+import 'package:buzz/shared/theme/theme.dart';
+
+void main() {
+  testWidgets('policy confirmations start unticked and gate acceptance', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [inviteJoinProvider.overrideWith(_PolicyReviewNotifier.new)],
+        child: MaterialApp(
+          theme: AppTheme.light(),
+          home: const Scaffold(body: InviteJoinSheet()),
+        ),
+      ),
+    );
+
+    expect(find.text('Terms of Service'), findsOneWidget);
+    expect(find.text('Be kind to other members.'), findsOneWidget);
+    expect(find.text('Privacy Policy'), findsOneWidget);
+    expect(find.text('We retain your messages.'), findsOneWidget);
+
+    var checkboxes = tester
+        .widgetList<Checkbox>(find.byType(Checkbox))
+        .toList();
+    expect(checkboxes, hasLength(2));
+    expect(checkboxes.every((checkbox) => checkbox.value == false), isTrue);
+    expect(
+      tester
+          .widget<FilledButton>(find.byKey(const Key('accept-join-policy')))
+          .onPressed,
+      isNull,
+    );
+
+    final ageConfirmation = find.text('I am 18 years of age or older.');
+    final agreementConfirmation = find.text(
+      'I agree to the Terms of Service and Privacy Policy shown above.',
+    );
+    await tester.ensureVisible(ageConfirmation);
+    await tester.tap(ageConfirmation);
+    await tester.pump();
+    await tester.ensureVisible(agreementConfirmation);
+    await tester.tap(agreementConfirmation);
+    await tester.pump();
+
+    checkboxes = tester.widgetList<Checkbox>(find.byType(Checkbox)).toList();
+    expect(checkboxes.every((checkbox) => checkbox.value == true), isTrue);
+    expect(
+      tester
+          .widget<FilledButton>(find.byKey(const Key('accept-join-policy')))
+          .onPressed,
+      isNotNull,
+    );
+  });
+}
+
+class _PolicyReviewNotifier extends InviteJoinNotifier {
+  @override
+  InviteJoinState build() => const InviteJoinState(
+    status: InviteJoinStatus.reviewingPolicy,
+    invite: InviteDeepLink(relayUrl: 'wss://relay.example.com', code: 'code'),
+    host: 'relay.example.com',
+    communityName: 'relay.example.com',
+    policy: InviteJoinPolicy(
+      termsMarkdown: 'Be kind to other members.',
+      privacyMarkdown: 'We retain your messages.',
+      ageAttestationRequired: true,
+      version: 'policy-v1',
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

A plain `buzz://join?relay=…&code=…` link that joins successfully on desktop stops on mobile when the relay requires a join policy.

The mobile claim path in `mobile/lib/features/invites/invite_join_provider.dart:133` sent an existing `policy_receipt` when the deep link already contained one, but its claim-error handling treated `join_policy_required` as a terminal fresh-link error. It therefore never fetched `/api/join-policy`, accepted the policy, or retried `/api/invites/claim` with the returned receipt.

Live verification against `creatormagic.communities.buzz.xyz` found that a policy receipt is scoped to the invite-code hash, policy version, and expiry; it contains no joining pubkey or joiner signature. Its measured lifetime was about ten minutes (589 seconds remaining immediately after mint). That makes receipt-bearing links a useful compatible path, but not a durable solution: a link can easily outlive its receipt. Mobile needs to mint its own receipt at the moment the user reviews and explicitly accepts the policy, then proceed directly to the claim. If a link-carried receipt has already expired and the relay returns `join_policy_required`, this change takes the same fresh-consent path instead of dead-ending.

This change completes that handshake on mobile. On `join_policy_required`, the provider fetches the policy, presents its terms and privacy text, requires explicit unticked age/agreement confirmations when applicable, posts the user's actual confirmation to `/api/invites/accept-policy`, and retries the claim with the receipt. Declining leaves the user unjoined with a clear result, and accept-policy failures remain retryable from the review screen. Links that already carry a receipt still take the existing direct-claim path.

The former provider test named `join_policy_required requires a fresh link and cannot retry` encoded the old behavior. That assertion was incorrect because `join_policy_required` is the relay's signal to begin the recoverable policy handshake, not evidence that the invite itself is unusable. It has been replaced with end-to-end handshake coverage rather than removed without replacement.

### Related issue

None found after searching open issues and pull requests for mobile policy-gated invite joins and `join_policy_required`.

### Testing

- `cd mobile && flutter analyze` — no issues
- `cd mobile && flutter test` — 1,026 passed, 1 existing skip
- `just ci` — passed (format, Clippy, frontend checks/tests/builds, Rust/Tauri tests, web build, and mobile checks/tests)
- Added provider coverage for gated success, decline, accept-policy failure, and pre-receipted links
- Added widget coverage that both consent controls start unticked and gate the accept action
- Widget-rendered screenshots are posted in a follow-up PR comment
