### PR TITLE
feat(mobile): removing deprecated axisAlignment and uses alignment property

### DIFF
--- a/mobile/lib/features/pairing/pairing_page/pairing_welcome_view.dart
+++ b/mobile/lib/features/pairing/pairing_page/pairing_welcome_view.dart
@@ -112,7 +112,7 @@ class _PairingWelcomeView extends StatelessWidget {
                           transitionBuilder: (child, animation) {
                             return SizeTransition(
                               sizeFactor: animation,
-                              axisAlignment: -1,
+                              alignment: Alignment(-1.0, -1.0),
                               child: FadeTransition(
                                 opacity: animation,
                                 child: child,


### PR DESCRIPTION
## Summary
Replaces the deprecated `axisAlignment` parameter with the newer `alignment` parameter introduced by Flutter. This removes the deprecation warning while preserving the existing animation behavior

from
```dart
return SizeTransition(
    sizeFactor: animation,
    axisAlignment: -1, // Deprecated
    child: FadeTransition(
      opacity: animation,
      child: child,
    ),
  );
```

to 

```dart
return SizeTransition(
    sizeFactor: animation,
    alignment: Alignment(-1.0, -1.0),
    child: FadeTransition(
      opacity: animation,
      child: child,
    ),
  );
  ```

### Related issue
none

### Testing
<!-- How was this verified? UI change? Include before/after screenshots (or a short recording). -->
Verified that the expand/collapse animation behaves identically on iOS after the change. No visual or behavioural differences were observed

Here's a gif on my ios Simluator iphone17

Before:

<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-08-02 at 03 19 19" src="https://github.com/user-attachments/assets/81b50a84-703c-47a4-9605-93e8c855e991" />


After:


<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-08-02 at 03 19 19" src="https://github.com/user-attachments/assets/81b50a84-703c-47a4-9605-93e8c855e991" />


