### PR TITLE
fix(desktop): stop the instance form offering AI-config edits it discards

### DIFF
--- a/desktop/src/features/agents/ui/AgentAiDefaults.tsx
+++ b/desktop/src/features/agents/ui/AgentAiDefaults.tsx
@@ -28,6 +28,7 @@ export function formatAiDefaultsSummary({
 export function AgentAiDefaultsNotice({
   isConfigured = true,
   onEditDefaults,
+  onEditDefinition,
   triggerRef,
   explicitModel,
   explicitProvider,
@@ -37,6 +38,12 @@ export function AgentAiDefaultsNotice({
 }: {
   isConfigured?: boolean;
   onEditDefaults: () => void;
+  /**
+   * Set only when a linked definition owns these values, which is also when
+   * the surface's own model/provider controls are read-only. Without it the
+   * summary would name the values and offer no way to reach them.
+   */
+  onEditDefinition?: () => void;
   triggerRef?: React.Ref<HTMLButtonElement>;
   explicitModel: string;
   explicitProvider: string;
@@ -91,17 +98,36 @@ export function AgentAiDefaultsNotice({
           {model || "Not configured"}
         </dd>
       </dl>
-      <Button
-        className="h-auto px-0 py-1"
-        data-testid="edit-ai-defaults"
-        onClick={onEditDefaults}
-        ref={triggerRef}
-        size="xs"
-        type="button"
-        variant="link"
-      >
-        Edit global defaults
-      </Button>
+      {onEditDefinition ? (
+        <p className="text-xs text-muted-foreground">
+          Set on the agent definition and shared by every agent created from it.
+        </p>
+      ) : null}
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          className="h-auto px-0 py-1"
+          data-testid="edit-ai-defaults"
+          onClick={onEditDefaults}
+          ref={triggerRef}
+          size="xs"
+          type="button"
+          variant="link"
+        >
+          Edit global defaults
+        </Button>
+        {onEditDefinition ? (
+          <Button
+            className="h-auto px-0 py-1"
+            data-testid="edit-agent-definition"
+            onClick={onEditDefinition}
+            size="xs"
+            type="button"
+            variant="link"
+          >
+            Edit agent definition
+          </Button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -25,6 +25,7 @@ import { Dialog } from "@/shared/ui/dialog";
 import { Input } from "@/shared/ui/input";
 import { setManagedAgentAutoRestart } from "@/shared/api/tauriManagedAgents";
 import { EditAgentAdvancedFields } from "./EditAgentAdvancedFields";
+import { EditAgentModelField } from "./EditAgentModelField";
 import {
   AUTO_PROVIDER_DROPDOWN_VALUE,
   BLOCK_BUILD_HIDDEN_PROVIDER_IDS,
@@ -49,6 +50,7 @@ import {
 } from "./relayMeshModelPicker";
 import {
   computeEditAgentFormValidity,
+  definitionOwnsAiConfig,
   envVarsEqual,
   isEditAgentProviderSaveValid,
   resolveAgentCommandUpdate,
@@ -152,6 +154,12 @@ export function AgentInstanceEditDialog({
         : null,
     [agent.personaId, personasQuery.data],
   );
+  const aiConfigIsDefinitionOwned = definitionOwnsAiConfig(linkedPersona);
+  // Model and LLM provider stay visible when the definition owns them — the
+  // value is the answer to "what does this agent run on" — but read-only, and
+  // the summary below routes the edit to the definition dialog.
+  const aiFieldsDisabled =
+    updateMutation.isPending || aiConfigIsDefinitionOwned;
   const inheritedEnvVars = linkedPersona?.envVars ?? {};
   const [respondTo, setRespondTo] = React.useState<RespondToMode>(
     agent.respondTo,
@@ -589,13 +597,27 @@ export function AgentInstanceEditDialog({
     onOpenChange(next);
   }
 
-  const providerValid = isEditAgentProviderSaveValid({
-    llmProviderFieldVisible,
-    currentProvider: provider,
-    originalProvider: agent.provider,
-    globalProvider: inheritedProviderDefault.value,
-    originalRuntimeSupportsProvider,
-  });
+  // Definition-owned fields are edited in the definition dialog, which the
+  // caller opens; this form closes first so the two are never both mounted.
+  const handleEditLinkedPersona = onEditLinkedPersona
+    ? () => {
+        handleOpenChange(false);
+        onEditLinkedPersona();
+      }
+    : undefined;
+
+  // A field this form never sends cannot make it invalid. Switching harness
+  // can blank the provider draft, which would otherwise block Save on a
+  // read-only field the user has no way to repair.
+  const providerValid =
+    aiConfigIsDefinitionOwned ||
+    isEditAgentProviderSaveValid({
+      llmProviderFieldVisible,
+      currentProvider: provider,
+      originalProvider: agent.provider,
+      globalProvider: inheritedProviderDefault.value,
+      originalRuntimeSupportsProvider,
+    });
 
   const canSubmit =
     computeEditAgentFormValidity({
@@ -679,35 +701,34 @@ export function AgentInstanceEditDialog({
             ? parsedParallelism
             : undefined,
         // Linked instances defer model/provider/systemPrompt to the definition.
-        systemPrompt:
-          linkedPersona != null
-            ? undefined
-            : (systemPrompt.trim() || null) !== agent.systemPrompt
-              ? systemPrompt.trim() || null
-              : undefined,
-        model:
-          linkedPersona != null
-            ? undefined
-            : normalizedModel !== (agent.model ?? null)
-              ? normalizedModel
-              : undefined,
+        // Same predicate the controls above read, so a field can never be
+        // editable here and dropped on the wire.
+        systemPrompt: aiConfigIsDefinitionOwned
+          ? undefined
+          : (systemPrompt.trim() || null) !== agent.systemPrompt
+            ? systemPrompt.trim() || null
+            : undefined,
+        model: aiConfigIsDefinitionOwned
+          ? undefined
+          : normalizedModel !== (agent.model ?? null)
+            ? normalizedModel
+            : undefined,
         // Tri-state provider persistence keyed on providerRuntimeCapability:
         //   "capable"  → persist: value if changed, omit if unchanged.
         //   "locked"   → clear: send null if provider was set, else omit.
         //   "unknown"  → omit always (never send null for a transient state).
         // llmProviderFieldVisible is for UX visibility only; not used here.
-        provider:
-          linkedPersona != null
-            ? undefined
-            : providerRuntimeCapability === "capable"
-              ? normalizedSubmitProvider !== (agent.provider ?? null)
-                ? normalizedSubmitProvider
+        provider: aiConfigIsDefinitionOwned
+          ? undefined
+          : providerRuntimeCapability === "capable"
+            ? normalizedSubmitProvider !== (agent.provider ?? null)
+              ? normalizedSubmitProvider
+              : undefined
+            : providerRuntimeCapability === "locked"
+              ? (agent.provider ?? null) !== null
+                ? null
                 : undefined
-              : providerRuntimeCapability === "locked"
-                ? (agent.provider ?? null) !== null
-                  ? null
-                  : undefined
-                : undefined, // "unknown" → omit always
+              : undefined, // "unknown" → omit always
         envVars: envVarsEqual(submitEnvVars, agent.envVars)
           ? undefined
           : submitEnvVars,
@@ -887,13 +908,10 @@ export function AgentInstanceEditDialog({
               onUploadPendingChange={setIsAvatarUploadPending}
               onSelectAvatar={setAvatarUrl}
             />
-            {onEditLinkedPersona ? (
+            {handleEditLinkedPersona ? (
               <Button
                 className="w-full"
-                onClick={() => {
-                  handleOpenChange(false);
-                  onEditLinkedPersona();
-                }}
+                onClick={handleEditLinkedPersona}
                 size="sm"
                 type="button"
                 variant="outline"
@@ -1026,7 +1044,7 @@ export function AgentInstanceEditDialog({
                   )}
                 </label>
                 <PersonaDropdownField
-                  disabled={updateMutation.isPending}
+                  disabled={aiFieldsDisabled}
                   id="edit-agent-llm-provider"
                   onValueChange={handleProviderDropdownChange}
                   options={providerDropdownOptions}
@@ -1047,7 +1065,7 @@ export function AgentInstanceEditDialog({
                         "h-8 px-0 py-0 leading-6",
                         PERSONA_FIELD_CONTROL_CLASS,
                       )}
-                      disabled={updateMutation.isPending}
+                      disabled={aiFieldsDisabled}
                       id="edit-agent-custom-provider"
                       onChange={(event) => setProvider(event.target.value)}
                       placeholder="Custom provider ID"
@@ -1080,59 +1098,24 @@ export function AgentInstanceEditDialog({
             ) : null}
 
             {/* Model */}
-            <div className="space-y-1.5">
-              <label
-                className="text-sm font-medium text-foreground"
-                htmlFor="edit-agent-model"
-              >
-                Model
-                {modelRequired ? (
-                  <span className="ml-1 text-destructive" aria-hidden="true">
-                    *
-                  </span>
-                ) : (
-                  <span className={PERSONA_LABEL_OPTIONAL_CLASS}>Optional</span>
-                )}
-              </label>
-              <PersonaDropdownField
-                disabled={updateMutation.isPending || modelDiscoveryLoading}
-                id="edit-agent-model"
-                onValueChange={handleModelDropdownChange}
-                options={modelDropdownOptions}
-                placeholder="Default model"
-                value={modelSelectValue}
-              />
-              {showCustomModelInput ? (
-                <div
-                  className={cn(
-                    "mt-2 flex min-h-11 items-center px-3",
-                    PERSONA_FIELD_SHELL_CLASS,
-                  )}
-                >
-                  <Input
-                    aria-label="Custom model ID"
-                    autoCorrect="off"
-                    className={cn(
-                      "h-8 px-0 py-0 leading-6",
-                      PERSONA_FIELD_CONTROL_CLASS,
-                    )}
-                    disabled={updateMutation.isPending}
-                    id="edit-agent-custom-model"
-                    onChange={(event) => setModel(event.target.value)}
-                    placeholder="Custom model ID"
-                    value={model}
-                  />
-                </div>
-              ) : null}
-              {modelStatusMessage ? (
-                <p className="text-xs text-muted-foreground">
-                  {modelStatusMessage}
-                </p>
-              ) : null}
-            </div>
+            <EditAgentModelField
+              disabled={aiFieldsDisabled}
+              discoveryLoading={modelDiscoveryLoading}
+              isRequired={modelRequired}
+              model={model}
+              onCustomModelChange={setModel}
+              onModelValueChange={handleModelDropdownChange}
+              options={modelDropdownOptions}
+              selectValue={modelSelectValue}
+              showCustomModelInput={showCustomModelInput}
+              statusMessage={modelStatusMessage}
+            />
 
             <AgentAiDefaultsNotice
               onEditDefaults={() => setAiDefaultsOpen(true)}
+              onEditDefinition={
+                aiConfigIsDefinitionOwned ? handleEditLinkedPersona : undefined
+              }
               triggerRef={aiDefaultsTriggerRef}
               explicitModel={inheritedSubmission.model ?? ""}
               explicitProvider={inheritedSubmission.provider ?? ""}

--- a/desktop/src/features/agents/ui/EditAgentModelField.tsx
+++ b/desktop/src/features/agents/ui/EditAgentModelField.tsx
@@ -1,0 +1,94 @@
+import { cn } from "@/shared/lib/cn";
+import { Input } from "@/shared/ui/input";
+import { PersonaDropdownField } from "./PersonaDropdownField";
+import {
+  type PersonaDropdownOption,
+  PERSONA_FIELD_CONTROL_CLASS,
+  PERSONA_FIELD_SHELL_CLASS,
+  PERSONA_LABEL_OPTIONAL_CLASS,
+} from "./agentConfigOptions";
+
+/**
+ * Model field for the instance edit form — the counterpart to
+ * `PersonaModelField` on the definition form, split out of
+ * `AgentInstanceEditDialog` for the same reason that one is separate.
+ *
+ * `disabled` covers the custom-model escape hatch as well as the dropdown, so
+ * a caller that owns the value elsewhere (a linked definition) closes both
+ * ways in. `discoveryLoading` disables only the dropdown, whose options are
+ * what's still loading.
+ */
+export function EditAgentModelField({
+  disabled,
+  discoveryLoading,
+  isRequired,
+  model,
+  onCustomModelChange,
+  onModelValueChange,
+  options,
+  selectValue,
+  showCustomModelInput,
+  statusMessage,
+}: {
+  disabled: boolean;
+  discoveryLoading: boolean;
+  isRequired: boolean;
+  model: string;
+  onCustomModelChange: (value: string) => void;
+  onModelValueChange: (value: string) => void;
+  options: readonly PersonaDropdownOption[];
+  selectValue: string;
+  showCustomModelInput: boolean;
+  statusMessage: string | null;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label
+        className="text-sm font-medium text-foreground"
+        htmlFor="edit-agent-model"
+      >
+        Model
+        {isRequired ? (
+          <span className="ml-1 text-destructive" aria-hidden="true">
+            *
+          </span>
+        ) : (
+          <span className={PERSONA_LABEL_OPTIONAL_CLASS}>Optional</span>
+        )}
+      </label>
+      <PersonaDropdownField
+        disabled={disabled || discoveryLoading}
+        id="edit-agent-model"
+        onValueChange={onModelValueChange}
+        options={options}
+        placeholder="Default model"
+        value={selectValue}
+      />
+      {showCustomModelInput ? (
+        <div
+          className={cn(
+            "mt-2 flex min-h-11 items-center px-3",
+            PERSONA_FIELD_SHELL_CLASS,
+          )}
+        >
+          <Input
+            aria-label="Custom model ID"
+            autoCorrect="off"
+            className={cn(
+              "h-8 px-0 py-0 leading-6",
+              PERSONA_FIELD_CONTROL_CLASS,
+            )}
+            disabled={disabled}
+            id="edit-agent-custom-model"
+            onChange={(event) => onCustomModelChange(event.target.value)}
+            placeholder="Custom model ID"
+            value={model}
+          />
+        </div>
+      ) : null}
+      {statusMessage ? (
+        <p className="text-xs text-muted-foreground">{statusMessage}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/src/features/agents/ui/definitionOwnedAiConfig.test.mjs
+++ b/desktop/src/features/agents/ui/definitionOwnedAiConfig.test.mjs
@@ -1,0 +1,116 @@
+/**
+ * Contract tests for definition-owned AI config on the instance edit form.
+ *
+ * #1968 made the linked definition authoritative for model, LLM provider, and
+ * system prompt: `resolve_effective_config` reads them from the definition and
+ * never consults the instance record. That commit changed the write path and
+ * left the instance form's Model and LLM provider dropdowns live, so editing
+ * them reported a successful save and changed nothing — the user had to find
+ * the definition dialog and set the same field a second time.
+ *
+ * The fix is one predicate feeding both seams. These tests pin that: if a
+ * future change re-derives either the omission or the control state from its
+ * own `linkedPersona != null` check, the two can drift apart again and this
+ * file fails.
+ */
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { definitionOwnsAiConfig } from "./personaRuntimeModel.ts";
+
+const dialogSource = await readFile(
+  new URL("./AgentInstanceEditDialog.tsx", import.meta.url),
+  "utf8",
+);
+const modelFieldSource = await readFile(
+  new URL("./EditAgentModelField.tsx", import.meta.url),
+  "utf8",
+);
+
+/** JSX wraps wherever the formatter decides; match on collapsed whitespace. */
+const collapsedDialog = dialogSource.replace(/\s+/g, " ");
+
+test("a linked definition owns the AI config", () => {
+  assert.equal(definitionOwnsAiConfig({ id: "persona-1" }), true);
+});
+
+test("a definition-less instance owns its own AI config", () => {
+  // Both absent forms: no personaId at all, and a personaId whose definition
+  // has not resolved (or no longer exists — an orphan still edits locally).
+  assert.equal(definitionOwnsAiConfig(null), false);
+  assert.equal(definitionOwnsAiConfig(undefined), false);
+});
+
+test("the submit path omits all three definition-owned fields", () => {
+  for (const field of ["systemPrompt", "model", "provider"]) {
+    assert.match(
+      collapsedDialog,
+      new RegExp(`${field}: aiConfigIsDefinitionOwned \\? undefined`),
+      `${field} must be omitted from UpdateManagedAgentInput when the definition owns it`,
+    );
+  }
+});
+
+test("no seam re-derives definition ownership on its own", () => {
+  // One call, at the top of the component. Everything else reads the result.
+  const derivations = dialogSource.match(/definitionOwnsAiConfig\(/g) ?? [];
+  assert.equal(derivations.length, 1);
+  assert.doesNotMatch(dialogSource, /linkedPersona != null/);
+});
+
+test("the shared disabled flag is the one the submit path reads", () => {
+  assert.match(
+    collapsedDialog,
+    /const aiFieldsDisabled = updateMutation\.isPending \|\| aiConfigIsDefinitionOwned;/,
+  );
+});
+
+test("every control for a definition-owned field is disabled with it", () => {
+  // The dropdown and its custom-value escape hatch, for both fields. Missing
+  // one of the four leaves a live control over a value the save discards.
+  // The model pair lives in EditAgentModelField, which the dialog hands the
+  // same flag; the assertion below pins that hand-off.
+  for (const [source, id, flag] of [
+    [collapsedDialog, "edit-agent-llm-provider", "aiFieldsDisabled"],
+    [collapsedDialog, "edit-agent-custom-provider", "aiFieldsDisabled"],
+    [modelFieldSource, "edit-agent-model", "disabled"],
+    [modelFieldSource, "edit-agent-custom-model", "disabled"],
+  ]) {
+    const controlAt = source.indexOf(`id="${id}"`);
+    assert.ok(controlAt > 0, `${id} not found`);
+    // `disabled` precedes `id` in every control in these files (props are
+    // alphabetized), so scan back to the start of the element.
+    const elementAt = source.lastIndexOf("<", controlAt);
+    assert.match(
+      source.slice(elementAt, controlAt),
+      new RegExp(`disabled=\\{[^}]*${flag}`),
+      `${id} must be disabled when the definition owns the value`,
+    );
+  }
+
+  assert.match(
+    collapsedDialog,
+    /<EditAgentModelField disabled=\{aiFieldsDisabled\}/,
+  );
+});
+
+test("a definition-owned provider never blocks Save", () => {
+  // Changing harness re-derives the provider draft and can blank it. With the
+  // provider control read-only that would be an unrepairable disabled Save on
+  // a value this form does not send at all.
+  assert.match(
+    collapsedDialog,
+    /const providerValid = aiConfigIsDefinitionOwned \|\| isEditAgentProviderSaveValid\(\{/,
+  );
+});
+
+test("the read-only summary offers a route to the definition", () => {
+  // A disabled control with no way to reach the real one is the same dead end
+  // in a different costume.
+  assert.match(
+    collapsedDialog,
+    /onEditDefinition=\{ aiConfigIsDefinitionOwned \? handleEditLinkedPersona : undefined \}/,
+  );
+});

--- a/desktop/src/features/agents/ui/personaRuntimeModel.ts
+++ b/desktop/src/features/agents/ui/personaRuntimeModel.ts
@@ -291,6 +291,26 @@ export function isEditAgentProviderSaveValid({
   );
 }
 
+/**
+ * Whether the linked definition — not this instance — owns model, LLM
+ * provider, and system prompt.
+ *
+ * `resolve_effective_config` reads those three from the definition for a
+ * linked instance and never consults the record's own bytes (#1968), so the
+ * instance submit path omits them and `update_managed_agent` drops them again
+ * server-side. An editable control for them on the instance form is therefore
+ * a control that reports a successful save and changes nothing.
+ *
+ * Presentation and omission must derive from THIS predicate, not from two
+ * independent `linkedPersona != null` checks — the dead-control bug it fixes
+ * was exactly the write path moving while the control stayed live.
+ */
+export function definitionOwnsAiConfig(
+  linkedPersona: unknown | null | undefined,
+): boolean {
+  return linkedPersona != null;
+}
+
 export function envVarsEqual(
   a: Record<string, string>,
   b: Record<string, string>,


### PR DESCRIPTION
## Summary

#1968 (`8c0e8cb16`) made the linked definition authoritative for model, LLM provider, and system prompt: `resolve_effective_config` reads all three from the definition and never consults the instance record. The write path moved; the controls did not.

`AgentInstanceEditDialog` still renders Model and LLM provider as live dropdowns, prefilled from the definition, while `handleSubmit` omits them for a linked instance and `update_managed_agent` drops them again server-side (`apply_model_provider_prompt_update` returns early on `record.persona_id.is_some()`). Editing either one reports a successful save and changes nothing, so the value has to be set a second time in the definition dialog.

Reported as "there are two places to edit an agent and you have to edit both."

- `personaRuntimeModel.ts`: add `definitionOwnsAiConfig`, one predicate for "the definition, not this instance, owns these fields". The submit omissions and the control state now both derive from it instead of two independent `linkedPersona != null` checks — which is exactly how they drifted apart.
- `AgentInstanceEditDialog.tsx`: Model and LLM provider, and the custom-value inputs behind both, go read-only when a definition owns them. They stay visible — the value answers "what does this agent run on" — but cannot be edited where the edit would be discarded.
- `AgentAiDefaults.tsx`: `AgentAiDefaultsNotice` takes an optional `onEditDefinition`. When set it names the definition as the source and adds an **Edit agent definition** link — the same hand-off "Edit avatar" already makes. A disabled control with no route to the real one is the same dead end in a different costume.
- A definition-owned provider no longer gates Save. Switching harness re-derives the provider draft and can blank it, which would otherwise leave Save disabled on a read-only field the user cannot repair, over a value this form never sends.
- The Model field moves to `EditAgentModelField`, mirroring `PersonaModelField` on the definition form. `AgentInstanceEditDialog` is already 228 lines over the 1000-line cap and the file-size ratchet forbids growth; 1228 → 1211.

Definition-level respond-to and parallelism are a separate gap — they reach an instance at mint time only — and are not touched here.

## Validation

Hermit toolchain, at `a0a9982a`:

- `just desktop-check` — clean. The 2 `useTemplate` infos are pre-existing in `personaCatalogRelay.test.mjs`, untouched here and present at base `ac4fa13b8`.
- `just desktop-typecheck` — clean
- `just desktop-test` — **3914 passed, 0 failed** (8 new)
- `just desktop-build` — succeeds; the new copy and the `edit-agent-definition` testid are present in `desktop/dist`
- `desktop/scripts/check-file-sizes.mjs` passes

New contract tests (`definitionOwnedAiConfig.test.mjs`) pin the predicate and both seams, so a future change that re-derives either one independently fails rather than silently reopening the same hole.

**Not verified: the rendered dialog.** No screenshot — the desktop E2E mock bridge cannot seed a linked managed agent for this surface, so verification stops at the built bundle.

## Test plan

1. Agents → Edit on an agent created from a definition.
2. Model and LLM provider show the definition's values and are not editable; the summary below reads "Set on the agent definition and shared by every agent created from it."
3. **Edit agent definition** closes the dialog and opens the definition form, where the change takes.
4. On an agent with no linked definition, both fields remain editable and save as before.
