### PR TITLE
mobile: onion-authenticated ws + ws/wss port-0 fix (self-hosted onion relay)

### DIFF
--- a/mobile/lib/features/pairing/pairing_provider.dart
+++ b/mobile/lib/features/pairing/pairing_provider.dart
@@ -874,7 +874,10 @@ class PairingNotifier extends Notifier<PairingState> {
       throw const FormatException('Pairing payload missing nsec');
     }
     final uri = Uri.parse(relayUrl);
-    final scheme = uri.scheme == 'https' ? 'wss' : 'ws';
+    // Preserve transport security: https/wss -> wss, http/ws -> ws. (Avoids
+    // silently downgrading a `wss://<onion>` payload to plain ws.)
+    final secure = uri.scheme == 'https' || uri.scheme == 'wss';
+    final scheme = secure ? 'wss' : 'ws';
     final wsUrl = uri.replace(scheme: scheme).toString();
 
     final socket = RelaySocket(
@@ -923,15 +926,20 @@ class PairingNotifier extends Notifier<PairingState> {
 
   void _validateRelayUrl(String url) {
     final uri = Uri.parse(url);
+    final host = uri.host.toLowerCase();
+    final isOnion = isOnionHost(host);
 
-    if (!kDebugMode && uri.scheme != 'https') {
-      throw const FormatException('Relay URL must use HTTPS');
-    }
-    if (uri.scheme != 'http' && uri.scheme != 'https') {
+    // Onion hosts are authenticated by Tor's rendezvous handshake (the .onion
+    // address IS the relay's ed25519 pubkey), so they need no CA-issued cert
+    // and may pair over ws/wss directly. Clearnet relays still require HTTPS.
+    const allowedSchemes = {'http', 'https', 'ws', 'wss'};
+    if (!allowedSchemes.contains(uri.scheme)) {
       throw FormatException('Invalid URL scheme: ${uri.scheme}');
     }
+    if (!kDebugMode && !isOnion && uri.scheme != 'https') {
+      throw const FormatException('Relay URL must use HTTPS');
+    }
 
-    final host = uri.host.toLowerCase();
     if (host == 'localhost' || host == '127.0.0.1' || host == '::1') {
       if (!kDebugMode) {
         throw const FormatException('Relay URL cannot target localhost');

--- a/mobile/lib/features/pairing/pairing_socket.dart
+++ b/mobile/lib/features/pairing/pairing_socket.dart
@@ -5,6 +5,7 @@ import 'package:nostr/nostr.dart' as nostr;
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../../shared/relay/nostr_models.dart';
+import '../../shared/relay/onion_ws.dart';
 
 const _desktopPairingAuthChallengeGrace = Duration(seconds: 3);
 const _pairingAuthOkTimeout = Duration(seconds: 8);
@@ -46,8 +47,7 @@ class PairingSocket {
     required void Function(Object? error) onDisconnected,
     Duration authChallengeTimeout = _desktopPairingAuthChallengeGrace,
     Duration authResponseTimeout = _pairingAuthOkTimeout,
-    WebSocketChannel Function(Uri uri) channelFactory =
-        WebSocketChannel.connect,
+    WebSocketChannel Function(Uri uri) channelFactory = onionAwareChannel,
   }) : _wsUrl = wsUrl,
        _ephemeralPrivkey = ephemeralPrivkey,
        _onMessage = onMessage,

--- a/mobile/lib/shared/relay/onion_ws.dart
+++ b/mobile/lib/shared/relay/onion_ws.dart
@@ -1,0 +1,94 @@
+/// Onion-authenticated WebSocket transport (no CA required).
+///
+/// A v3 `.onion` address *is* the hidden service's ed25519 public key, and
+/// Tor's rendezvous handshake cryptographically proves the server holds the
+/// matching private key **before** any app traffic flows. That means the
+/// server is already authenticated at the transport layer — exactly the job a
+/// TLS certificate normally does. Over `.onion`, TLS therefore only provides
+/// (redundant) encryption, so the certificate does not need to chain to a CA.
+///
+/// This helper builds an [HttpClient] that accepts an otherwise-untrusted TLS
+/// certificate **iff** the host is an onion address, and wraps it into a
+/// [WebSocketChannel]. For every non-onion (clearnet) host the default
+/// web-PKI verification is left completely untouched.
+library;
+
+import 'dart:io';
+
+import 'package:web_socket_channel/io.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Returns true iff [host] is a Tor onion address.
+///
+/// Strict exact-suffix match on a parsed host (never a substring test):
+/// the host must end with the `.onion` label and have a non-empty label in
+/// front of it. `evil.onion.example.com` does NOT match (it does not end in
+/// `.onion`); `notonion` does not match (no dot). Comparison is
+/// case-insensitive.
+bool isOnionHost(String host) {
+  final h = host.toLowerCase();
+  const suffix = '.onion';
+  if (!h.endsWith(suffix)) return false;
+  // Require a non-empty label before ".onion" (reject a bare ".onion").
+  return h.length > suffix.length;
+}
+
+/// An [HttpClient] that trusts an otherwise-invalid TLS certificate **only**
+/// when the connection target is an onion host.
+///
+/// The [HttpClient.badCertificateCallback] is invoked by dart:io only when the
+/// default trust evaluation has already failed. Returning `true` overrides that
+/// failure; returning `false` preserves the default (web-PKI) rejection. We
+/// override **iff** [isOnionHost] — safe because `.onion` resolution only
+/// happens over Tor, which has already authenticated the server by its key.
+///
+/// Defense-in-depth (verifier option B) could additionally require the cert's
+/// SAN to include [host]; option A (onion-transport trust) is intentionally
+/// minimal and is what ships here.
+HttpClient onionAwareHttpClient() {
+  final client = HttpClient();
+  client.badCertificateCallback =
+      (X509Certificate cert, String host, int port) {
+        return isOnionHost(host);
+      };
+  return client;
+}
+
+/// Connects a [WebSocketChannel] using the onion-aware TLS trust policy.
+///
+/// Synchronous, matching `WebSocketChannel.connect`'s signature so it can be
+/// dropped in as a channel factory. The returned channel connects lazily and
+/// exposes readiness via [WebSocketChannel.ready]. Only `wss://<onion>` traffic
+/// is affected by the relaxed trust; `wss://` to any clearnet host still goes
+/// through full web-PKI verification, and `ws://` (plain) is unchanged.
+WebSocketChannel onionAwareChannel(Uri uri, {Duration? pingInterval}) {
+  return IOWebSocketChannel.connect(
+    _withExplicitPort(uri),
+    pingInterval: pingInterval,
+    customClient: onionAwareHttpClient(),
+  );
+}
+
+/// Make the port explicit so it is never resolved to 0.
+///
+/// dart:io's `WebSocket.connect` builds the HTTP upgrade request straight from
+/// [Uri.port], but Dart's [Uri] only defines default ports for the `http`
+/// (80) and `https` (443) schemes — for `ws`/`wss` with no explicit port,
+/// [Uri.port] returns **0**. That leaks a `:0` into the connect target (e.g.
+/// `http://<host>:0`), which the transport (Tor/Orbot here) immediately resets.
+/// A `ws://<onion>` payload with no port therefore fails until the default is
+/// filled in here. Only touches URIs that omit the port; explicit ports (and
+/// non-ws schemes) pass through untouched.
+Uri _withExplicitPort(Uri uri) {
+  if (uri.hasPort) return uri;
+  switch (uri.scheme) {
+    case 'wss':
+    case 'https':
+      return uri.replace(port: 443);
+    case 'ws':
+    case 'http':
+      return uri.replace(port: 80);
+    default:
+      return uri;
+  }
+}

--- a/mobile/lib/shared/relay/relay.dart
+++ b/mobile/lib/shared/relay/relay.dart
@@ -5,6 +5,7 @@ export 'media_image.dart';
 export 'media_upload.dart';
 export 'nostr_filters.dart';
 export 'nostr_models.dart';
+export 'onion_ws.dart';
 export 'relay_closed_policy.dart';
 export 'relay_client.dart';
 export 'relay_provider.dart';

--- a/mobile/lib/shared/relay/relay_socket.dart
+++ b/mobile/lib/shared/relay/relay_socket.dart
@@ -3,10 +3,10 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:nostr/nostr.dart' as nostr;
-import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'nostr_models.dart';
+import 'onion_ws.dart';
 
 /// Low-level websocket connection with NIP-42 authentication.
 ///
@@ -70,7 +70,11 @@ class RelaySocket {
     _state = SocketState.connecting;
 
     try {
-      _channel = IOWebSocketChannel.connect(
+      // Onion-aware transport: a `wss://<onion>` connection is authenticated
+      // by Tor (the .onion address is the relay's ed25519 key), so its TLS
+      // cert need not chain to a CA. Clearnet hosts keep full web-PKI trust.
+      // Also normalizes a missing ws/wss port so it never resolves to :0.
+      _channel = onionAwareChannel(
         Uri.parse(_wsUrl),
         pingInterval: debugPingInterval,
       );


### PR DESCRIPTION
## Summary
Lets the Buzz mobile app pair with / connect to a self-hosted relay reachable only as a Tor v3 .onion, over plain ws (or wss with the relay's self-signed cert) with NO CA — the .onion address is the relay's ed25519 pubkey and Tor authenticates the server, so web-PKI is redundant.

- lib/shared/relay/onion_ws.dart (new): onionAwareChannel() with a badCertificateCallback that trusts certs ONLY for .onion hosts, plus _withExplicitPort() — Dart's Uri returns port 0 for the ws/wss schemes when no port is explicit, so ws://<onion> was dialing <onion>:0 (Connection reset by peer). Fills in 80/443 before IOWebSocketChannel.connect.
- Wire onionAwareChannel into relay_socket.dart and pairing_socket.dart.
- Relax pairing_provider _validateRelayUrl to accept ws/wss/http/https for .onion hosts (skip the HTTPS-only gate for onion).

### Related issue
none found

### Testing
Deployed a debug APK build and successfully paired and interacted over Tor (Orbot).

Note: the Tor link can take a while to become active, so pairing can be flaky.