### PR TITLE
fix(mobile): show live thread replies immediately

### DIFF
--- a/mobile/lib/features/channels/channel_messages_provider.dart
+++ b/mobile/lib/features/channels/channel_messages_provider.dart
@@ -254,7 +254,6 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
           ),
         );
       }
-      if (!_isBroadcastReply(event)) return false;
     }
     // Thread summaries are neither a timeline row nor an aux event, but they are
     // how the root's "N replies" row learns a reply landed — a reply itself
@@ -493,12 +492,6 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
     });
     return true;
   }
-}
-
-bool _isBroadcastReply(NostrEvent event) {
-  return event.tags.any(
-    (tag) => tag.length >= 2 && tag[0] == 'broadcast' && tag[1] == '1',
-  );
 }
 
 int _currentUnixSeconds() => DateTime.now().millisecondsSinceEpoch ~/ 1000;

--- a/mobile/lib/features/channels/channel_window.dart
+++ b/mobile/lib/features/channels/channel_window.dart
@@ -295,7 +295,16 @@ ChannelWindowStore mergeLiveChannelWindowEvent(
     }
     return ChannelWindowStore(
       pages: current.pages,
-      liveOverlay: current.liveOverlay,
+      // Non-broadcast replies are retained only as a short-lived fallback so
+      // the root count updates before the relay recount arrives. Once the
+      // authoritative summary covers that reply, keeping the raw event would
+      // grow this overlay forever because channel pages contain top-level rows.
+      liveOverlay: current.liveOverlay.where((candidate) {
+        final thread = candidate.threadReference;
+        if (thread.parentId == null || thread.rootId != rootId) return true;
+        if (_isBroadcastReply(candidate)) return true;
+        return candidate.createdAt > event.createdAt;
+      }).toList(),
       liveAux: current.liveAux,
       liveThreadSummaries: {
         ...current.liveThreadSummaries,
@@ -322,6 +331,19 @@ ChannelWindowStore mergeLiveChannelWindowEvent(
     );
   }
 
+  final thread = event.threadReference;
+  final liveSummary = thread.rootId == null
+      ? null
+      : current.liveThreadSummaries[thread.rootId];
+  if (thread.parentId != null &&
+      !_isBroadcastReply(event) &&
+      liveSummary != null &&
+      liveSummary.createdAt >= event.createdAt) {
+    // The summary and reply can arrive through different relay paths. If the
+    // authoritative recount won that race, do not re-add its covered reply.
+    return current;
+  }
+
   final inPages = current.pages.any(
     (page) => page.rows.any((row) => row.event.id == event.id),
   );
@@ -342,6 +364,12 @@ ChannelWindowStore mergeLiveChannelWindowEvent(
     liveOverlay: overlay,
     liveAux: current.liveAux,
     liveThreadSummaries: current.liveThreadSummaries,
+  );
+}
+
+bool _isBroadcastReply(NostrEvent event) {
+  return event.tags.any(
+    (tag) => tag.length >= 2 && tag[0] == 'broadcast' && tag[1] == '1',
   );
 }
 

--- a/mobile/test/features/channels/channel_messages_provider_test.dart
+++ b/mobile/test/features/channels/channel_messages_provider_test.dart
@@ -7,6 +7,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:buzz/features/channels/channel_messages_provider.dart';
 import 'package:buzz/features/channels/pending_local_messages_provider.dart';
 import 'package:buzz/features/channels/thread_replies_provider.dart';
+import 'package:buzz/features/channels/timeline_message.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
 void main() {
@@ -314,6 +315,79 @@ void main() {
             .read(channelMessagesProvider(_channelId))
             .value
             ?.map((event) => event.id),
+        ['root'],
+      );
+    },
+  );
+
+  test('live non-broadcast reply updates its parent thread summary', () async {
+    final relaySession = _RecordingRelaySessionNotifier(
+      queryResults: [
+        [_event(id: 'root', createdAt: 10), _bounds()],
+      ],
+    );
+    final container = _buildContainer(relaySession);
+    addTearDown(container.dispose);
+
+    container.read(channelMessagesProvider(_channelId));
+    await relaySession.subscribed;
+    await _pumpEventQueue();
+
+    relaySession.emit(
+      _event(
+        id: 'reply',
+        createdAt: 20,
+        extraTags: const [
+          ['e', 'root', '', 'reply'],
+        ],
+      ),
+    );
+    await _pumpEventQueue();
+
+    final notifier = container.read(
+      channelMessagesProvider(_channelId).notifier,
+    );
+    final events = container.read(channelMessagesProvider(_channelId)).value!;
+    final entries = buildMainTimelineEntries(
+      formatTimeline(events),
+      relaySummaries: notifier.threadSummaries,
+    );
+
+    expect(entries.single.summary?.replyCount, 1);
+  });
+
+  test(
+    'live non-broadcast reply stays out of the top-level timeline',
+    () async {
+      final relaySession = _RecordingRelaySessionNotifier(
+        queryResults: [
+          [_event(id: 'root', createdAt: 10), _bounds()],
+        ],
+      );
+      final container = _buildContainer(relaySession);
+      addTearDown(container.dispose);
+
+      container.read(channelMessagesProvider(_channelId));
+      await relaySession.subscribed;
+      await _pumpEventQueue();
+
+      relaySession.emit(
+        _event(
+          id: 'reply',
+          createdAt: 20,
+          extraTags: const [
+            ['e', 'root', '', 'reply'],
+          ],
+        ),
+      );
+      await _pumpEventQueue();
+
+      final events = container.read(channelMessagesProvider(_channelId)).value!;
+      expect(events.map((event) => event.id), ['root', 'reply']);
+      expect(
+        buildMainTimelineEntries(
+          formatTimeline(events),
+        ).map((entry) => entry.message.id),
         ['root'],
       );
     },

--- a/mobile/test/features/channels/channel_window_test.dart
+++ b/mobile/test/features/channels/channel_window_test.dart
@@ -181,6 +181,73 @@ void main() {
       expect(channelWindowThreadSummaries(merged)['mine']?.replyCount, 2);
     });
 
+    test(
+      'a live summary removes covered fallback replies from the overlay',
+      () {
+        var store = replaceNewestChannelWindow(
+          const ChannelWindowStore.empty(),
+          _page(rows: [_row('root', createdAt: 10)]),
+        );
+        store = mergeLiveChannelWindowEvent(
+          store,
+          _reply('reply', rootId: 'root', createdAt: 20),
+          isTimelineRow: true,
+        );
+        expect(store.liveOverlay.map((event) => event.id), ['reply']);
+
+        store = mergeLiveChannelWindowEvent(
+          store,
+          _summary('root', replyCount: 1, participants: ['p1'], createdAt: 20),
+          isTimelineRow: false,
+        );
+
+        expect(store.liveOverlay, isEmpty);
+        expect(channelWindowThreadSummaries(store)['root']?.replyCount, 1);
+      },
+    );
+
+    test('a live summary keeps broadcast replies in the overlay', () {
+      var store = replaceNewestChannelWindow(
+        const ChannelWindowStore.empty(),
+        _page(rows: [_row('root', createdAt: 10)]),
+      );
+      store = mergeLiveChannelWindowEvent(
+        store,
+        _reply('broadcast', rootId: 'root', createdAt: 20, broadcast: true),
+        isTimelineRow: true,
+      );
+
+      store = mergeLiveChannelWindowEvent(
+        store,
+        _summary('root', replyCount: 1, participants: ['p1'], createdAt: 20),
+        isTimelineRow: false,
+      );
+
+      expect(store.liveOverlay.map((event) => event.id), ['broadcast']);
+    });
+
+    test('a covered reply is not retained when its summary arrives first', () {
+      var store = replaceNewestChannelWindow(
+        const ChannelWindowStore.empty(),
+        _page(rows: [_row('root', createdAt: 10)]),
+      );
+      store = mergeLiveChannelWindowEvent(
+        store,
+        _summary('root', replyCount: 1, participants: ['p1'], createdAt: 20),
+        isTimelineRow: false,
+      );
+
+      final merged = mergeLiveChannelWindowEvent(
+        store,
+        _reply('reply', rootId: 'root', createdAt: 20),
+        isTimelineRow: true,
+      );
+
+      expect(identical(merged, store), isTrue);
+      expect(merged.liveOverlay, isEmpty);
+      expect(channelWindowThreadSummaries(merged)['root']?.replyCount, 1);
+    });
+
     test('a later live summary replaces an earlier one', () {
       var store = replaceNewestChannelWindow(
         const ChannelWindowStore.empty(),
@@ -460,6 +527,22 @@ NostrEvent _row(String id, {int createdAt = 10}) => _event(
   kind: EventKind.streamMessageV2,
   tags: const [
     ['h', _channelId],
+  ],
+);
+
+NostrEvent _reply(
+  String id, {
+  required String rootId,
+  required int createdAt,
+  bool broadcast = false,
+}) => _event(
+  id: id,
+  createdAt: createdAt,
+  kind: EventKind.streamMessageV2,
+  tags: [
+    ['h', _channelId],
+    ['e', rootId, '', 'reply'],
+    if (broadcast) ['broadcast', '1'],
   ],
 );
 


### PR DESCRIPTION
## Summary

Fixes #3293.

Mobile channel subscriptions were discarding non-broadcast thread replies before they could update the root message's reply summary. This keeps each live reply as a temporary fallback until the relay's authoritative thread summary arrives.

The temporary reply is then removed in either delivery order, reply before summary or summary before reply, so the live overlay stays bounded. Broadcast replies remain visible in the main timeline.

This builds on the root-cause analysis in #3344 and adds retention cleanup plus event-order race coverage.

## Changes

- Allow live non-broadcast replies into the channel window fallback.
- Remove covered replies when their authoritative thread summary arrives.
- Skip covered replies when the summary arrives first.
- Preserve broadcast replies as top-level timeline entries.
- Add provider and channel-window regression tests.

## Verification

- `just ci`
- 1,027 mobile tests passed, with one expected skip.
- 2,088 desktop Rust tests passed, with 14 expected ignores.
- Independent adversarial review verdict: `NO BLOCKERS`.
