### PR TITLE
fix(relay,desktop,acp): bound publish waits and reject rate-limited EVENTs with NIP-20 OK false

### DIFF
--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -2374,6 +2374,23 @@ async fn handle_ws_message(
                         warn!("mid-session AUTH rejected (event {event_id}): {message} — triggering reconnect");
                         return false;
                     }
+                    if !accepted && message.starts_with("rate-limited:") {
+                        // The relay rejects rate-limited EVENTs with a per-event
+                        // OK false. Same treatment as the NOTICE path: arm the
+                        // gate and requeue in-flight frames — acknowledging here
+                        // would silently drop the frame.
+                        let secs = parse_rate_limit_retry_secs(&message).unwrap_or(0);
+                        let deadline = state.set_rate_limit_gate(secs);
+                        state.requeue_observer_in_flight();
+                        warn!(
+                            "event {event_id} rate-limited — gate armed until ~{:.1}s from now",
+                            deadline
+                                .checked_duration_since(tokio::time::Instant::now())
+                                .unwrap_or_default()
+                                .as_secs_f64()
+                        );
+                        return true;
+                    }
                     state.acknowledge_observer_frame(&event_id);
                     debug!("OK for event {event_id}: accepted={accepted} message={message}");
                 }

--- a/crates/buzz-relay/src/connection.rs
+++ b/crates/buzz-relay/src/connection.rs
@@ -625,7 +625,14 @@ async fn enforce_ws_admission(
         ClientMessage::Req { sub_id, .. } => Some(sub_id.as_str()),
         _ => None,
     };
-    if !send_admission_result(conn, ws_result, sub_id) {
+    // Rejected EVENTs must get a per-event OK false (NIP-01/NIP-20), not just a
+    // NOTICE: clients correlate publish outcomes by event id, and a NOTICE-only
+    // rejection leaves the message pending until the client-side timeout.
+    let event_id_hex = match msg {
+        ClientMessage::Event(event) => Some(event.id.to_hex()),
+        _ => None,
+    };
+    if !send_admission_result(conn, ws_result, sub_id, event_id_hex.as_deref()) {
         return false;
     }
 
@@ -644,7 +651,7 @@ async fn enforce_ws_admission(
             message_limit,
         )
         .await;
-        if !send_admission_result(conn, message_result, None) {
+        if !send_admission_result(conn, message_result, None, event_id_hex.as_deref()) {
             return false;
         }
     }
@@ -656,23 +663,26 @@ fn send_admission_result(
     conn: &ConnectionState,
     result: Result<(), crate::admission::AdmissionError>,
     sub_id: Option<&str>,
+    event_id_hex: Option<&str>,
 ) -> bool {
+    let send_rejection = |reason: &str| {
+        conn.send(match event_id_hex {
+            Some(event_id) => RelayMessage::ok(event_id, false, reason),
+            None => request_rejection_message(sub_id, reason),
+        });
+    };
     match result {
         Ok(()) => true,
         Err(crate::admission::AdmissionError::Exceeded { reset_in_secs }) => {
             metrics::counter!("buzz_admission_rejections_total", "transport" => "websocket", "reason" => "quota").increment(1);
-            conn.send(request_rejection_message(
-                sub_id,
-                &format!("rate-limited: quota exceeded; retry in {reset_in_secs}s"),
+            send_rejection(&format!(
+                "rate-limited: quota exceeded; retry in {reset_in_secs}s"
             ));
             false
         }
         Err(crate::admission::AdmissionError::Unavailable) => {
             metrics::counter!("buzz_admission_rejections_total", "transport" => "websocket", "reason" => "unavailable").increment(1);
-            conn.send(request_rejection_message(
-                sub_id,
-                "rate-limited: shared admission unavailable",
-            ));
+            send_rejection("rate-limited: shared admission unavailable");
             false
         }
     }

--- a/desktop/src/shared/api/relayClientSession.ts
+++ b/desktop/src/shared/api/relayClientSession.ts
@@ -67,6 +67,40 @@ import {
 import { closeWebSocket } from "@/shared/api/relayWebSocketClose";
 import { buildThreadReferenceTags } from "@/features/messages/lib/threading";
 
+/**
+ * Await `promise` but reject with `timeoutMessage` once `deadlineAt` passes.
+ * The underlying promise is not cancelled; a late rejection is swallowed so an
+ * abandoned connect/gate wait cannot surface as an unhandled rejection.
+ */
+async function raceWithDeadline<T>(
+  promise: Promise<T>,
+  deadlineAt: number,
+  timeoutMessage: string,
+): Promise<T> {
+  const remainingMs = deadlineAt - Date.now();
+  if (remainingMs <= 0) {
+    promise.catch(() => {});
+    throw new Error(timeoutMessage);
+  }
+  let timer: number | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = window.setTimeout(
+          () => reject(new Error(timeoutMessage)),
+          remainingMs,
+        );
+      }),
+    ]);
+  } catch (error) {
+    promise.catch(() => {});
+    throw error;
+  } finally {
+    window.clearTimeout(timer);
+  }
+}
+
 export class RelayClient {
   private wsId: number | null = null;
   private relayUrl: string | null = null;
@@ -251,8 +285,7 @@ export class RelayClient {
     mentionPubkeys: string[] = [],
     extraTags: string[][] = [],
   ) {
-    await this.ensureConnected();
-
+    // Connection is established inside publishEvent, bounded by its deadline.
     const tags: string[][] = [["h", channelId]];
     for (const pubkey of mentionPubkeys) {
       tags.push(["p", pubkey]);
@@ -275,8 +308,6 @@ export class RelayClient {
   }
 
   async sendPresence(status: PresenceStatus) {
-    await this.ensureConnected();
-
     const event = await signRelayEvent({
       kind: 20001,
       content: status,
@@ -379,7 +410,6 @@ export class RelayClient {
   }
 
   async publishUserStatus(text: string, emoji: string): Promise<void> {
-    await this.ensureConnected();
     const tags: string[][] = [["d", "general"]];
     if (emoji) tags.push(["emoji", emoji]);
     const event = await signRelayEvent({
@@ -696,14 +726,26 @@ export class RelayClient {
     timeoutMessage: string,
     sendErrorMessage: string,
   ) {
-    // Await the gate before sending EVENT; op timeout starts after the wait.
-    await waitForRateLimit();
+    // One deadline covers the whole publish: the rate-limit gate, any in-flight
+    // reconnect (which resolves only after subscription replay), and the OK
+    // round trip. Arming the timer only after those waits left sends pending
+    // unbounded — visible as messages stuck in "Sending…" for minutes.
+    const deadlineAt = Date.now() + PUBLISH_TIMEOUT_MS;
+    await raceWithDeadline(waitForRateLimit(), deadlineAt, timeoutMessage);
+    await raceWithDeadline(
+      this.ensureConnected(),
+      deadlineAt,
+      timeoutMessage,
+    );
 
     return new Promise<RelayEvent>((resolve, reject) => {
-      const timeout = window.setTimeout(() => {
-        this.pendingEvents.delete(event.id);
-        reject(new Error(timeoutMessage));
-      }, PUBLISH_TIMEOUT_MS);
+      const timeout = window.setTimeout(
+        () => {
+          this.pendingEvents.delete(event.id);
+          reject(new Error(timeoutMessage));
+        },
+        Math.max(0, deadlineAt - Date.now()),
+      );
 
       this.pendingEvents.set(event.id, {
         event,
@@ -914,6 +956,11 @@ export class RelayClient {
     if (success) {
       pendingEvent.resolve(pendingEvent.event);
     } else {
+      // The relay signals admission rejections as OK false with a
+      // `rate-limited:` reason — activate the gate just like a NOTICE.
+      if (message.startsWith("rate-limited:")) {
+        activateRateLimit(parseRateLimitHint(message));
+      }
       pendingEvent.reject(new Error(message || "Relay rejected the event."));
     }
   }


### PR DESCRIPTION
Messages could sit in 'Sending...' for minutes. Three causes:

- relay: per-pubkey admission rejections of EVENTs only sent a generic
  NOTICE, so clients could not correlate the rejection with the pending
  event. Send ["OK", <event_id>, false, "rate-limited: ..."] instead
  (REQ/COUNT keep CLOSED/NOTICE).
- desktop: publishEvent armed its 25s timeout only after two unbounded
  awaits (rate-limit gate, ensureConnected with full subscription
  replay). One deadline now covers gate wait + connect + OK round trip,
  and handleOk arms the rate-limit gate on OK false rate-limited
  reasons.
- buzz-acp: an OK false with a rate-limited reason now arms the gate
  and requeues the in-flight observer frame instead of acknowledging
  (which silently dropped it), matching the NOTICE path.

Verified: cargo check/test (relay admission suite), desktop typecheck +
3906 unit tests, and manual T1-T4 (baseline send + mention reply, relay
down fails/rolls back in ~25s, send during reconnect bounded, rate
limit rejections tick reason=quota and client recovers).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J5gQmQ6ZtahVXAYCM4e79R
