### PR TITLE
fix(relay/git): accept git-legal + and @ in ref names

### DIFF
--- a/crates/buzz-core/src/git_perms.rs
+++ b/crates/buzz-core/src/git_perms.rs
@@ -49,7 +49,9 @@ pub const MAX_WILDCARDS_PER_PATTERN: usize = 3;
 /// A validated ref pattern for matching git refs.
 ///
 /// Grammar: `segment ("/" segment)*` where segment is either a literal
-/// `[a-zA-Z0-9._-]+` or `*` (matches exactly one path segment).
+/// `[a-zA-Z0-9._+@-]+` or `*` (matches exactly one path segment). The literal
+/// alphabet matches `is_safe_refname` in the relay's git manifest layer, so
+/// every ref the relay accepts can also be named by a protection rule.
 ///
 /// Patterns MUST start with `refs/`. No `**`, `?`, `[...]`, or partial globs.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -147,10 +149,14 @@ impl RefPattern {
             {
                 // Partial globs (e.g., "v*") are not allowed.
                 return Err(PatternError::InvalidSegment(part.to_string()));
-            } else if !part
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
-            {
+            } else if !part.chars().all(|c| {
+                c.is_ascii_alphanumeric()
+                    || c == '.'
+                    || c == '_'
+                    || c == '-'
+                    || c == '+'
+                    || c == '@'
+            }) {
                 return Err(PatternError::InvalidSegment(part.to_string()));
             } else {
                 segments.push(PatternSegment::Literal(part.to_string()));
@@ -648,6 +654,18 @@ mod tests {
         let p = RefPattern::parse("refs/*/release/*").unwrap();
         assert!(p.matches("refs/heads/release/v1"));
         assert!(!p.matches("refs/heads/release/v1/hotfix"));
+    }
+
+    #[test]
+    fn pattern_literal_accepts_git_legal_plus_and_at() {
+        // Refs containing `+`/`@` are pushable (#4194), so literal protection
+        // rules must be able to name them.
+        let p = RefPattern::parse("refs/heads/test/842+841-devnet").unwrap();
+        assert!(p.matches("refs/heads/test/842+841-devnet"));
+        assert!(!p.matches("refs/heads/test/842-841-devnet"));
+
+        let p = RefPattern::parse("refs/heads/dependabot/npm_and_yarn/@types/node-1.2.3").unwrap();
+        assert!(p.matches("refs/heads/dependabot/npm_and_yarn/@types/node-1.2.3"));
     }
 
     #[test]

--- a/crates/buzz-relay/src/api/git/hydrate.rs
+++ b/crates/buzz-relay/src/api/git/hydrate.rs
@@ -488,6 +488,9 @@ mod tests {
         assert!(is_safe_refname("refs/heads/main"));
         assert!(is_safe_refname("refs/tags/v1.0.0"));
         assert!(is_safe_refname("refs/heads/feat/cas-publish"));
+        // Git-legal `+`/`@` refs hydrate as ordinary loose-ref paths (#4194).
+        assert!(is_safe_refname("refs/heads/test/842+841-devnet"));
+        assert!(is_safe_refname("refs/heads/user@host"));
         assert!(!is_safe_refname("refs/heads/../escape"));
         assert!(!is_safe_refname("HEAD"));
         assert!(!is_safe_refname("refs/heads/"));

--- a/crates/buzz-relay/src/api/git/manifest.rs
+++ b/crates/buzz-relay/src/api/git/manifest.rs
@@ -129,13 +129,24 @@ pub enum ManifestError {
     MalformedPackKey(String),
 }
 
-/// Conservative refname validation, used symmetrically on both the write side
-/// (in `Manifest::validate`, before `put_manifest`) and the read side (in
-/// `api::git::hydrate`, before writing the ref to disk).
+/// Conservative refname validation, used symmetrically on the write side
+/// (in `Manifest::validate`, before `put_manifest`), the read side (in
+/// `api::git::hydrate`, before writing the ref to disk), and the `info/refs`
+/// fast-path eligibility gate (`api::git::transport`, before emitting refnames
+/// into pkt-line bytes).
 ///
 /// Refuses traversal (`..`), null/newline/control chars, non-`refs/` prefixes,
 /// and leading/trailing/double slashes. Allowed alphabet:
-/// `[a-zA-Z0-9_./-]`.
+/// `[a-zA-Z0-9_./+@-]`.
+///
+/// `+` and `@` are git-legal (`git check-ref-format` accepts them anywhere in
+/// a component) and inert here: refnames are stored inside the manifest JSON
+/// body and written as loose-ref file paths — never used as object-store key
+/// components — and both characters are valid filename bytes on Unix and
+/// Windows. The two `@` forms git does forbid stay unreachable: a refname that
+/// is *entirely* the single character `@` cannot occur behind the mandatory
+/// `refs/` prefix, and the `@{` sequence requires `{`, which stays outside the
+/// alphabet.
 ///
 /// Sharing one predicate is load-bearing: any divergence creates the
 /// "valid CAS, un-clone-able output" hazard.
@@ -147,7 +158,7 @@ pub fn is_safe_refname(s: &str) -> bool {
         return false;
     }
     s.chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '.' | '-'))
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '.' | '-' | '+' | '@'))
 }
 
 /// Hex-OID predicate. Accepts both SHA-1 (40 chars) and SHA-256 (64 chars) —
@@ -336,6 +347,19 @@ mod tests {
         assert!(is_safe_refname("refs/heads/main"));
         assert!(is_safe_refname("refs/tags/v1.0.0"));
         assert!(is_safe_refname("refs/heads/feat/cas-publish"));
+        // Git-legal `+` and `@` (#4194): real-world refs that must round-trip.
+        assert!(is_safe_refname("refs/heads/test/842+841-devnet"));
+        assert!(is_safe_refname(
+            "refs/heads/dependabot/npm_and_yarn/@types/node-1.2.3"
+        ));
+        assert!(is_safe_refname("refs/tags/v1.0.0+build.5"));
+        assert!(is_safe_refname("refs/heads/user@host"));
+        // A component that is only `@` is git-legal too (git forbids only the
+        // whole-refname `@`, unreachable behind the `refs/` prefix).
+        assert!(is_safe_refname("refs/heads/@"));
+        assert!(is_safe_refname("refs/@/x"));
+        // `@{` stays impossible: `{` is outside the alphabet.
+        assert!(!is_safe_refname("refs/heads/a@{0}"));
         assert!(!is_safe_refname("refs/heads/../escape"));
         assert!(!is_safe_refname("HEAD"));
         assert!(!is_safe_refname(""));

--- a/crates/buzz-relay/src/api/git/manifest_event.rs
+++ b/crates/buzz-relay/src/api/git/manifest_event.rs
@@ -64,7 +64,9 @@ pub enum BuildError {
 ///   state announcements" semantics).
 /// - OIDs validated as 40-hex (SHA-1) or 64-hex (SHA-256). Invalid OIDs are
 ///   skipped, not failed — same conservative behavior as the legacy code.
-/// - Ref names validated (no `//`, no leading `/`, alphanumeric + `/_.-`).
+/// - Ref names validated by the shared `is_safe_refname` predicate (the same
+///   one the write path accepted the manifest with), so a pushable ref can
+///   never be silently dropped from the ref-state event by alphabet drift.
 /// - Output tag ordering is deterministic for testability: `d`, refs (sorted
 ///   by `BTreeMap` iteration), HEAD, p.
 pub fn build_ref_state_event(
@@ -114,15 +116,16 @@ pub fn build_ref_state_event(
 }
 
 /// NIP-34 kind:30618 only emits refs under heads/ and tags/.
+///
+/// Character/structure rules delegate to [`super::manifest::is_safe_refname`]
+/// — the predicate every ref in a committed manifest has already passed — so
+/// this filter can only narrow by *namespace*, never by alphabet. A private
+/// re-spelling of the alphabet here is exactly how a pushable ref becomes
+/// invisible to every kind:30618 subscriber (#4194: `+`/`@` refs CASed fine
+/// and then vanished from branch listings).
 fn is_emittable_ref(name: &str) -> bool {
-    if !(name.starts_with("refs/heads/") || name.starts_with("refs/tags/")) {
-        return false;
-    }
-    if name.starts_with('/') || name.contains("//") {
-        return false;
-    }
-    name.chars()
-        .all(|c| c.is_ascii_alphanumeric() || "/_.-".contains(c))
+    (name.starts_with("refs/heads/") || name.starts_with("refs/tags/"))
+        && super::manifest::is_safe_refname(name)
 }
 
 /// Accept SHA-1 (40 hex) and SHA-256 (64 hex) OIDs.
@@ -363,6 +366,32 @@ mod tests {
         assert!(first_tag(&ev, "refs/heads/legit").is_some());
         // Malformed refs should not appear.
         assert_eq!(tags_with_kind(&ev, "refs/heads//double").len(), 0);
+    }
+
+    /// A ref that passed manifest validation must reach the kind:30618 event:
+    /// every branch lister reads this event, so an alphabet re-spelling here
+    /// turns a pushable `+`/`@` ref into a branch that CASes, hydrates, and
+    /// clones — and is invisible in every client (#4194).
+    #[test]
+    fn emits_git_legal_plus_and_at_refs() {
+        let oid = "1111111111111111111111111111111111111111";
+        let refs = refs_with(&[
+            ("refs/heads/test/842+841-devnet", oid),
+            ("refs/heads/dependabot/npm_and_yarn/@types/node-1.2.3", oid),
+            ("refs/tags/v1.0.0+build.5", oid),
+        ]);
+        let inputs = RefStateInputs {
+            repo_id: "r",
+            head: "refs/heads/test/842+841-devnet",
+            refs: &refs,
+            actor_pubkey_hex: &owner_hex(),
+        };
+        let ev = build_ref_state_event(&inputs, &relay_keys()).unwrap();
+        assert!(first_tag(&ev, "refs/heads/test/842+841-devnet").is_some());
+        assert!(first_tag(&ev, "refs/heads/dependabot/npm_and_yarn/@types/node-1.2.3").is_some());
+        assert!(first_tag(&ev, "refs/tags/v1.0.0+build.5").is_some());
+        // HEAD pointing at a `+` branch emits too.
+        assert!(first_tag(&ev, "HEAD").is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`is_safe_refname` allows only `[a-zA-Z0-9_./-]`, so git-legal ref names containing `+` or `@` cannot be pushed at all — the push 400s at pre-CAS manifest validation. The reported real-world case is `refs/heads/test/842+841-devnet` in `OriginTrail/dkg` (1 ref out of 1,339 blocks the mirror); `@` covers the equally common dependabot pattern `refs/heads/dependabot/npm_and_yarn/@types/node-1.2.3`.

This PR widens the shared predicate's alphabet to `[a-zA-Z0-9_./+@-]`, and closes the two places that would otherwise re-reject or silently drop the newly accepted refs:

- `RefPattern::parse`'s literal-segment alphabet in `buzz-core` widens to match, so every ref the relay now accepts can also be named by a branch-protection rule (literal matching is segment-equality, not glob, so neither character carries metacharacter meaning).
- `is_emittable_ref` in `manifest_event.rs` had a private re-spelling of the old alphabet and would have **silently omitted** `+`/`@` refs from the kind:30618 ref-state event — a branch that pushes, hydrates, and clones fine but is invisible in every branch lister (desktop and web both read kind:30618). It now delegates character/structure rules to the shared `is_safe_refname` (keeping only the NIP-34 heads/tags namespace filter local), so this filter can never again drift from what the write path accepts. A test pins the round-trip.

Why this is safe (verified against every consumer of the predicate):

- Refnames never become object-store key components — packs/manifests are digest-keyed and the pointer key is `repos/<community>/<owner>/<repo>/pointer`; refnames live inside the manifest JSON body. (The issue suggested percent-encoding at the storage boundary; it turns out none is needed.) No encoding, no collision surface.
- On hydrate, refnames become loose-ref file paths; `+` and `@` are valid filename bytes on Unix and NTFS, and the structural checks (`..`, `//`, control chars, prefix) are untouched.
- The `info/refs` fast path re-runs the same predicate before emitting refnames into pkt-line bytes; both characters are inert there.
- Refnames reach no subprocess argv and no shell; `for-each-ref` output parsing splits on whitespace, which git forbids in refnames.
- The two `@` forms git forbids stay unreachable: a refname that is *entirely* `@` cannot occur behind the mandatory `refs/` prefix, and `@{` requires `{`, which remains outside the alphabet. (`git check-ref-format` confirms `refs/heads/@` and `refs/@/x` are legal git, so no per-component `@` restriction is added.)

Adjacent and deliberately untouched:

- The predicate today accepts a few names git itself refuses (`.lock` suffix, leading-dot components). Not reachable in practice — refs enter manifests via `receive-pack`/`for-each-ref`, which enforce git's rules — and tightening is a separate concern from this widening.
- The desktop app still has three client-side validators with the old alphabet (`clean_branch` in `src-tauri/commands/project_git_exec.rs`, a second `clean_target_ref` in `project_git_diff.rs`, and `BRANCH_CHARACTERS` in `src/features/projects/lib/projectBranches.ts`). Those are visible client-side rejections (a user can't select/create such a branch from the desktop UI), not silent server-side drops, and fixing them means touching the desktop TS test suite — happy to do that here if preferred, but it seemed better as a follow-up so the relay fix isn't blocked on desktop tooling. Two hazards for whoever picks it up: `clean_branch`'s output is passed as a bare refspec positional to `git fetch` (a leading `+` means force there — prefix `refs/heads/` or guard it), and its `trim_start_matches("refs/heads/")` strips repeatedly, so `refs/heads/@` would reduce to `@`, git's HEAD alias. Server-side, this PR is complete: push → CAS → hydrate → advertisement → kind:30618 all accept the same set.
- The push-policy endpoint's own ref gate is byte-range-based and wider than `is_safe_refname`, so git-legal refs *outside* ASCII (e.g. non-ASCII branch names) still authorize, run receive-pack, and then 400 at manifest validation — the same failure shape #4194 reports, for a much bigger character class. Unifying those two gates is a larger conversation than two characters; flagging rather than fixing here.

### Related issue

Fixes #4194. Duplicate search at filing (2026-08-02 00:59 UTC): none found. **Update:** #4244 and #4257 have since been filed for the same issue. Both widen the shared predicate only; neither covers the kind:30618 emission filter (`is_emittable_ref`) or the `RefPattern` literal alphabet, so `+`/`@` refs would push but stay invisible to branch listers and unnameable by literal protection rules. This PR covers all three surfaces.

### Testing

- `cargo test -p buzz-core git_perms` — 35 passed (new: literal patterns with `+`/`@` parse and match).
- `cargo test -p buzz-relay --lib api::git` — passed (new predicate cases in both `manifest.rs` and `hydrate.rs` test suites: the reported `+` ref, the dependabot `@` ref, `refs/tags/v1.0.0+build.5`, `refs/heads/user@host`, `refs/heads/@`, `refs/@/x` accepted; `@{`, traversal, control chars, prefix violations still rejected).
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` — clean.
- Toolchain note: built on Windows with `x86_64-pc-windows-gnu` (same setup as #2638); Postgres-gated suites (`#[ignore]`) not run.

