### PR TITLE
fix(relay): accept NIP-59 backdated gift wraps without losing push wakes

### DIFF
--- a/crates/buzz-db/src/replica_fence.rs
+++ b/crates/buzz-db/src/replica_fence.rs
@@ -65,10 +65,18 @@ use uuid::Uuid;
 
 /// Seconds of `created_at` history the commit-time floor guard tolerates.
 ///
-/// Must exceed the relay's ingest envelope (±900 s) by enough slack that a
-/// legitimately accepted event still commits within the floor even under
-/// slow validation/lock waits. The writer pool arms the guard with this value
-/// and the fence subtracts it; the two uses must never diverge.
+/// Must exceed the relay's ingest envelope for **channel-bearing** kinds
+/// (±900 s) by enough slack that a legitimately accepted event still commits
+/// within the floor even under slow validation/lock waits. The writer pool
+/// arms the guard with this value and the fence subtracts it; the two uses
+/// must never diverge.
+///
+/// The floor deliberately does not cover NIP-59 gift wraps (kind 1059),
+/// which ingest accepts up to two days in the past: they are always stored
+/// `channel_id = NULL`, and the guard's trigger fires only for channel-
+/// bearing rows — the structural exemption [`verify_floor_guard_behavior`]
+/// pins in step 5. Channel-NULL rows are never keyset-paged by channel, so
+/// they sit outside the fence proof's read-window obligations.
 pub const CREATED_AT_FLOOR_SECS: i64 = 960;
 
 /// Safety margin subtracted from the fence on top of the floor.

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -1729,6 +1729,45 @@ async fn author_type_label(
     }
 }
 
+/// Maximum seconds an event's `created_at` may deviate from server time,
+/// in either direction, before ingest rejects it.
+pub(crate) const MAX_TIMESTAMP_DRIFT_SECS: i64 = 900; // ±15 minutes
+
+/// Extra past-side allowance for NIP-59 gift wraps (kind 1059), whose
+/// `created_at` clients randomize up to two days into the past ("SHOULD be
+/// tweaked to thwart time-analysis attacks") — `nostr-tools`' `wrapEvent`
+/// backdates by default, so a uniform freshness window rejects essentially
+/// every spec-compliant NIP-17 DM (#4192). The future-side bound is NOT
+/// widened: a wrap stamped into the future is still bogus.
+///
+/// Two couplings to keep in mind when touching this:
+/// - Push wakes: this allowance exceeds `push_runtime`'s usefulness window,
+///   so gift-wrap wake deadlines key on relay receipt time, not `created_at`
+///   (see `push_runtime::wake_deadline_basis` and the test pinning the
+///   relationship).
+/// - Replica fence: `buzz_db::replica_fence::CREATED_AT_FLOOR_SECS` covers
+///   channel-bearing kinds only; gift wraps are stored channel-NULL, which
+///   the floor guard structurally exempts (behaviorally verified by
+///   `verify_floor_guard_behavior`, step 5).
+pub(crate) const GIFT_WRAP_MAX_BACKDATE_SECS: i64 = 2 * 24 * 60 * 60;
+
+/// Whether `event_ts` (unix seconds) falls inside the ingest freshness
+/// window: ±[`MAX_TIMESTAMP_DRIFT_SECS`] for every kind, with the past side
+/// extended by [`GIFT_WRAP_MAX_BACKDATE_SECS`] for kind 1059 only.
+fn timestamp_within_ingest_window(kind: u32, event_ts: i64, now: i64) -> bool {
+    let max_past_drift = if kind == KIND_GIFT_WRAP {
+        MAX_TIMESTAMP_DRIFT_SECS + GIFT_WRAP_MAX_BACKDATE_SECS
+    } else {
+        MAX_TIMESTAMP_DRIFT_SECS
+    };
+    // Saturating: `created_at` arrives as a u64 and is cast to i64, so a
+    // hostile value can land anywhere in i64 — including where plain
+    // subtraction overflows (panic in debug builds). Saturation keeps the
+    // comparison exact for every representable drift.
+    now.saturating_sub(event_ts) <= max_past_drift
+        && event_ts.saturating_sub(now) <= MAX_TIMESTAMP_DRIFT_SECS
+}
+
 /// Ingest a signed Nostr event through the full validation pipeline.
 ///
 /// Shared by WebSocket and HTTP transports. The caller constructs [`IngestAuth`]
@@ -1856,10 +1895,9 @@ async fn ingest_event_inner(
     }
     let event = std::sync::Arc::try_unwrap(event).unwrap_or_else(|arc| (*arc).clone());
 
-    const MAX_TIMESTAMP_DRIFT_SECS: i64 = 900; // ±15 minutes
     let now = chrono::Utc::now().timestamp();
     let event_ts = event.created_at.as_secs() as i64;
-    if (event_ts - now).abs() > MAX_TIMESTAMP_DRIFT_SECS {
+    if !timestamp_within_ingest_window(kind_u32, event_ts, now) {
         return Err(IngestError::Rejected(
             "invalid: event timestamp too far from server time".into(),
         ));
@@ -2044,6 +2082,11 @@ async fn ingest_event_inner(
             }
         }
     } else if is_gift_wrap {
+        // Load-bearing beyond DM semantics: channel-NULL is what exempts
+        // gift wraps from the replica fence's commit-time `created_at` floor
+        // (see `buzz_db::replica_fence`), which their NIP-59-backdated
+        // timestamps would otherwise violate. Verified behaviorally by
+        // `verify_floor_guard_behavior` step 5.
         None
     } else if kind_u32 == KIND_DELETION {
         // Standard deletion (kind:5): derive channel from the target event.
@@ -2915,6 +2958,88 @@ mod tests {
         KIND_STREAM_MESSAGE_DIFF, KIND_TEAM, KIND_USER_STATUS,
     };
     use nostr::{EventBuilder, Kind};
+
+    /// The uniform ±15-minute envelope is pre-existing behavior for every
+    /// ordinary kind — pinned at the exact boundary so the gift-wrap
+    /// carve-out (#4192) cannot silently widen it.
+    #[test]
+    fn ingest_window_keeps_uniform_bounds_for_ordinary_kinds() {
+        let now = 1_700_000_000;
+        assert!(timestamp_within_ingest_window(
+            KIND_STREAM_MESSAGE,
+            now - 900,
+            now
+        ));
+        assert!(timestamp_within_ingest_window(
+            KIND_STREAM_MESSAGE,
+            now + 900,
+            now
+        ));
+        assert!(!timestamp_within_ingest_window(
+            KIND_STREAM_MESSAGE,
+            now - 901,
+            now
+        ));
+        assert!(!timestamp_within_ingest_window(
+            KIND_STREAM_MESSAGE,
+            now + 901,
+            now
+        ));
+    }
+
+    /// NIP-59 wraps randomize `created_at` up to two days into the past
+    /// (nostr-tools `wrapEvent` default); the relay must accept the whole
+    /// randomization range plus ordinary skew, and nothing older (#4192).
+    #[test]
+    fn gift_wraps_accept_nip59_backdated_timestamps() {
+        let now = 1_700_000_000;
+        let two_days = 2 * 24 * 60 * 60;
+        assert!(timestamp_within_ingest_window(
+            KIND_GIFT_WRAP,
+            now - two_days,
+            now
+        ));
+        assert!(timestamp_within_ingest_window(
+            KIND_GIFT_WRAP,
+            now - two_days - 900,
+            now
+        ));
+        assert!(!timestamp_within_ingest_window(
+            KIND_GIFT_WRAP,
+            now - two_days - 901,
+            now
+        ));
+    }
+
+    /// The carve-out is past-side only: a future-stamped wrap is as bogus as
+    /// any other future-stamped event.
+    #[test]
+    fn gift_wraps_get_no_future_allowance() {
+        let now = 1_700_000_000;
+        assert!(timestamp_within_ingest_window(
+            KIND_GIFT_WRAP,
+            now + 900,
+            now
+        ));
+        assert!(!timestamp_within_ingest_window(
+            KIND_GIFT_WRAP,
+            now + 901,
+            now
+        ));
+    }
+
+    /// Hostile timestamps: a u64 `created_at` at or above 2^63 wraps negative
+    /// through `as i64`, landing where plain subtraction would overflow. The
+    /// saturating window must reject every such extreme for every kind.
+    #[test]
+    fn ingest_window_rejects_extreme_timestamps() {
+        let now = 1_700_000_000;
+        for kind in [KIND_STREAM_MESSAGE, KIND_GIFT_WRAP] {
+            assert!(!timestamp_within_ingest_window(kind, i64::MIN, now));
+            assert!(!timestamp_within_ingest_window(kind, i64::MAX, now));
+            assert!(!timestamp_within_ingest_window(kind, 0, now));
+        }
+    }
 
     /// A banned relay admin must be refused with the same wire prefix and
     /// transport status as every other durable-restriction refusal:

--- a/crates/buzz-relay/src/push_runtime.rs
+++ b/crates/buzz-relay/src/push_runtime.rs
@@ -269,7 +269,7 @@ fn match_job(
             }
         }
         let Some(class) = class else { continue };
-        let event_deadline = job.event.event.created_at.as_secs() as i64 + EVENT_USEFUL_SECS;
+        let event_deadline = wake_deadline_basis(&job.event) + EVENT_USEFUL_SECS;
         let expires_at = lease.expires_at.min(event_deadline);
         if expires_at <= Utc::now().timestamp() {
             continue;
@@ -285,6 +285,32 @@ fn match_job(
     }
     Ok(wakes)
 }
+
+/// The instant a wake's usefulness window (`EVENT_USEFUL_SECS`) counts from.
+///
+/// Author-controlled `created_at` for ordinary kinds. For NIP-59 gift wraps
+/// (kind 1059) it is relay receipt time: their `created_at` is deliberately
+/// randomized up to two days into the past, and ingest accepts that window
+/// (#4192) — strictly wider than `EVENT_USEFUL_SECS`, so keying on
+/// `created_at` would silently drop the wake for almost every spec-compliant
+/// DM (and hand senders a deliberate no-notification delivery primitive).
+fn wake_deadline_basis(event: &buzz_core::StoredEvent) -> i64 {
+    if buzz_core::kind::event_kind_u32(&event.event) == buzz_core::kind::KIND_GIFT_WRAP {
+        event.received_at.timestamp()
+    } else {
+        event.event.created_at.as_secs() as i64
+    }
+}
+
+// Compile-time pin of the relationship that makes the special case above
+// necessary: ingest's full past-side window admits gift wraps older than the
+// usefulness window. If this ever inverts, `wake_deadline_basis` can
+// collapse to `created_at`.
+const _: () = assert!(
+    crate::handlers::ingest::MAX_TIMESTAMP_DRIFT_SECS
+        + crate::handlers::ingest::GIFT_WRAP_MAX_BACKDATE_SECS
+        > EVENT_USEFUL_SECS
+);
 
 /// Match-time counterpart of REQ's filter-level `#p` authorization gate.
 /// Kind 1059 is globally stored and leaks recipient activity through wake
@@ -613,6 +639,40 @@ mod tests {
             &event,
             &recipient_hex
         ));
+    }
+
+    /// Gift wraps carry NIP-59-randomized timestamps up to two days old —
+    /// accepted by ingest (#4192) but far beyond `EVENT_USEFUL_SECS` — so
+    /// their wake deadline must count from relay receipt, or every backdated
+    /// DM is stored yet never wakes a device.
+    #[test]
+    fn gift_wrap_wake_deadline_counts_from_receipt_not_created_at() {
+        let sender = nostr::Keys::generate();
+        let recipient = nostr::Keys::generate();
+        let now = chrono::Utc::now();
+        let backdated = (now.timestamp() - 2 * 24 * 60 * 60) as u64;
+        let wrap = EventBuilder::new(Kind::GiftWrap, "ciphertext")
+            .tag(Tag::public_key(recipient.public_key()))
+            .custom_created_at(nostr::Timestamp::from(backdated))
+            .sign_with_keys(&sender)
+            .unwrap();
+        let stored = buzz_core::StoredEvent::with_received_at(wrap, now, None, true);
+        assert_eq!(wake_deadline_basis(&stored), now.timestamp());
+        // created_at-based math would have expired this wake long ago.
+        assert!(backdated as i64 + EVENT_USEFUL_SECS <= now.timestamp());
+    }
+
+    #[test]
+    fn ordinary_kind_wake_deadline_counts_from_created_at() {
+        let author = nostr::Keys::generate();
+        let now = chrono::Utc::now();
+        let stamped = (now.timestamp() - 120) as u64;
+        let note = EventBuilder::new(Kind::TextNote, "hi")
+            .custom_created_at(nostr::Timestamp::from(stamped))
+            .sign_with_keys(&author)
+            .unwrap();
+        let stored = buzz_core::StoredEvent::with_received_at(note, now, None, true);
+        assert_eq!(wake_deadline_basis(&stored), stamped as i64);
     }
 
     async fn capture(


### PR DESCRIPTION
## Summary

NIP-59 tells clients to randomize a gift wrap's `created_at` into the past ("tweaked to thwart time-analysis attacks"); `nostr-tools`' `wrapEvent` backdates uniformly up to two days by default. The relay's uniform ±15-minute ingest freshness window therefore rejects ~99% of spec-compliant NIP-17 DMs with `invalid: event timestamp too far from server time`, and the only workaround (re-stamping the wrap to `now`) defeats exactly the timing privacy the spec mandates.

Two coordinated changes:

**1. Ingest: past-side allowance for kind 1059 only.** The freshness check moves into a pure helper; ordinary kinds keep the exact ±900 s behavior, gift wraps get `900 s + 2 days` on the past side. The future-side bound is not widened for any kind — a wrap stamped into the future is still bogus.

**2. Push runtime: gift-wrap wake deadlines key on receipt time.** This is the half of the fix that's easy to miss: the wake matcher computes `event_deadline = created_at + EVENT_USEFUL_SECS (3600 s)` and silently skips expired wakes. That coupling is invisible today only because 900 < 3600. With the widened window alone, a wrap backdated >1 h (≈98% of NIP-59's uniform randomization) would be accepted, stored, fanned out to live sockets — and never wake a backgrounded device; it would also hand senders a deliberate no-notification delivery primitive. Gift-wrap deadlines now use relay-assigned `StoredEvent::received_at` (author-controlled `created_at` stays authoritative for every other kind; verified that the push matcher re-loads events from the DB, so `received_at` is the original ingest stamp, never refreshed). A compile-time `const` assertion pins the full relationship (`MAX_TIMESTAMP_DRIFT_SECS + GIFT_WRAP_MAX_BACKDATE_SECS > EVENT_USEFUL_SECS`) so the coupling is explicit.

Interactions checked and intentionally out of scope:

- **Replica fence (migration 0021):** the commit-time `created_at` floor guard fires only for `channel_id IS NOT NULL` rows; gift wraps are structurally stored channel-NULL, so the fence is unaffected. The `CREATED_AT_FLOOR_SECS` doc comment now states its invariant precisely (floor covers channel-bearing kinds) instead of implying a single global envelope.
- **Replay/dedup:** unchanged — events dedupe on `(community_id, id)` `ON CONFLICT DO NOTHING`.
- **Retention/partitioning:** no `created_at`-keyed retention applies to kind 1059 (channel-TTL keys on `clock_timestamp()`; NIP-RS retention is kind-30078); the monthly range partitioning has a `MINVALUE` catch-all. Push backfill windows already key on `received_at`.
- **The HTTP bridge's** `kind 1059 is only accepted via WebSocket` restriction (the issue's side observation) is untouched — and it sits before the timestamp check, so bridge-submitted wraps never reach the new window logic.
- **REQ `since`/`until` and keyset paging still key on `created_at`** — inherent to Nostr semantics, and inherent to NIP-59: a client that pages gift wraps with a narrow `since` will miss backdated wraps *on any relay*, which is exactly why spec-following NIP-17 clients query kind 1059 with a ~2-day-wide window. Worth naming the resulting UX asymmetry honestly: a recipient can get a push wake for a wrap their `since`-based sync then doesn't fetch. No in-repo client subscribes to 1059 with `since` today (verified across desktop/web/mobile), and push-lease filters structurally cannot carry `since`/`until` (rejected, not ignored — `ALLOWED` list in `push_lease.rs`), so nothing trips it now; if it ever matters, the natural follow-up is serving `#p`-scoped wrap reads on a `received_at` basis, the same choice the push backfill already made.
- **Partitioning:** `events` is month-range-partitioned on `created_at` with a `MINVALUE` catch-all; a wrap backdated across a month boundary lands in the prior month's partition, which is valid (no partition-drop code exists).
- `api/git/policy.rs`'s "timestamp too far in future" is git hook-callback freshness — unrelated path.
- #4067 fixes the same error string for kind-30617 announcements by re-stamping client-side; that remedy is correct there but is exactly what NIP-59 forbids for gift wraps, hence the relay-side carve-out here.

### Related issue

Fixes #4192. Closest adjacent work: #4067 (same error string, client-side fix for a kind where re-stamping is harmless). At filing (2026-08-02 00:59 UTC) no PR addressed 1059 freshness. **Update:** #4253 and #4324 (its successor) have since been filed for this issue. Both widen the ingest window only, and symmetrically (`.abs()` — wraps stamped up to two days in the *future* also become acceptable, though NIP-59 randomizes into the past only), and both leave the push-wake deadline keyed on `created_at`, so accepted backdated DMs would be stored but never wake a backgrounded device (analysis above). This PR widens the past side only and rekeys the kind-1059 wake deadline on `received_at`.

### Testing

- `cargo test -p buzz-relay --lib` — passed (new: ±900 boundary pins for ordinary kinds; 1059 accepts `now − 2d` and the `now − (2d + 900 s)` boundary, rejects older; future +901 s rejected for 1059 too; hostile extreme timestamps (`i64::MIN`/`MAX`, wrapped-negative u64 casts) rejected via saturating arithmetic; wake-deadline basis tests: backdated wrap wakes from `received_at`, ordinary kinds from `created_at`; plus a compile-time constant-relationship pin).
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` — clean.
- Toolchain note: Windows `x86_64-pc-windows-gnu` (as in #2638); Postgres-gated suites (`#[ignore]`) not run.

