### PR TITLE
ci(sprig): create the rolling release before editing it

### DIFF
--- a/.github/workflows/sprig.yml
+++ b/.github/workflows/sprig.yml
@@ -139,6 +139,17 @@ jobs:
           TITLE="Sprig (rolling)"
           NOTES="Rolling Linux build of Sprig (all-in-one buzz-acp + buzz-agent + buzz-dev-mcp), tracking \`main\` (\`${SHA}\`)."
 
+          # `edit` fails with "release not found" until the rolling release
+          # exists, so the first run on any repo — this one included, and every
+          # fork — needs to create it. `create` is skipped once it is there so
+          # the tag keeps pointing at the release GitHub already knows.
+          gh release view "$TAG" >/dev/null 2>&1 \
+            || gh release create "$TAG" \
+              --target "$SHA" \
+              --prerelease \
+              --title "$TITLE" \
+              --notes "$NOTES"
+
           gh release edit "$TAG" \
             --prerelease \
             --title "$TITLE" \


### PR DESCRIPTION
The `Publish rolling release` job calls `gh release edit "sprig-latest"` with no create path:

https://github.com/block/buzz/blob/ac4fa13b8e4d947071d57deb6918dcf12bf74961/.github/workflows/sprig.yml#L142-L146

`gh release edit` exits 1 with `release not found` when the release does not exist yet, and nothing in the repo creates it — `publish-tag` only runs on `refs/tags/sprig-v*` and creates a versioned release instead.

So the job fails on the first push to `main` in any repo that has no `sprig-latest` yet. Forks hit it permanently: forks inherit no releases, so `gh release list` is empty and every push to a fork's `main` fails the same way ~12s in. Sprig can never bootstrap its own rolling release there.

## The change

Create the release when `gh release view` says it is absent, then fall through to the same `edit` as before. A repo that already has `sprig-latest` takes the `view` short-circuit and behaves exactly as it does today — the diff is inert once the release exists. `--target "$SHA"` puts the new tag on the commit that produced the artifacts.

## Test plan

- `bash -n` on the extracted `run:` block, and the workflow still parses as YAML.
- Reproduced on a fork of this repo: `Publish rolling release` failed on every push to `main` with `release not found`; with this change the first run creates the `sprig-latest` prerelease and uploads both musl tarballs, and subsequent runs take the `edit` path.
- No behaviour change is exercisable on `block/buzz` itself, where `sprig-latest` already exists — that is the point of gating the `create` on `view`.