### PR TITLE
fix(desktop): let anyone mention an agent that is already in the channel

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -5,7 +5,7 @@ import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isAgentIdentityDiscoverable,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
@@ -136,29 +136,39 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
-test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
+test("isAgentIdentityDiscoverable: keeps people and locally managed agent identities", () => {
   const managedAgentPubkeys = new Set([PUB_A]);
 
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentIdentityDiscoverable(
       { isAgent: false, pubkey: PUB_B },
       managedAgentPubkeys,
     ),
     true,
   );
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentIdentityDiscoverable(
       { isAgent: true, pubkey: PUB_A.toUpperCase() },
       managedAgentPubkeys,
     ),
     true,
   );
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentIdentityDiscoverable(
       { isAgent: true, pubkey: PUB_B },
       managedAgentPubkeys,
     ),
     false,
+  );
+});
+
+test("isAgentIdentityDiscoverable: keeps channel-member agents managed on another device", () => {
+  assert.equal(
+    isAgentIdentityDiscoverable(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      new Set(),
+    ),
+    true,
   );
 });
 
@@ -169,7 +179,6 @@ test("shouldHideAgentFromMentions: never hides non-agents", () => {
       isMember: false,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set([PUB_A]),
     }),
     false,
   );
@@ -182,7 +191,6 @@ test("shouldHideAgentFromMentions: shows invocable agents even when non-member",
       isMember: false,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set([PUB_A]),
-      directoryAgentPubkeys: new Set([PUB_A]),
     }),
     false,
   );
@@ -195,22 +203,20 @@ test("shouldHideAgentFromMentions: hides non-member non-invocable agents", () =>
       isMember: false,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set(),
     }),
     true,
   );
 });
 
-test("shouldHideAgentFromMentions: hides member agents with an explicit not-invocable directory entry (Fizz)", () => {
+test("shouldHideAgentFromMentions: shows member agents even when the local owner is unavailable", () => {
   assert.equal(
     shouldHideAgentFromMentions({
       isAgent: true,
       isMember: true,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set([PUB_A]),
     }),
-    true,
+    false,
   );
 });
 
@@ -221,7 +227,6 @@ test("shouldHideAgentFromMentions: shows member agents with unknown invocability
       isMember: true,
       pubkey: PUB_A,
       mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set(),
     }),
     false,
   );
@@ -234,12 +239,11 @@ test("shouldHideAgentFromMentions: normalizes the pubkey before lookup", () => {
   assert.equal(
     shouldHideAgentFromMentions({
       isAgent: true,
-      isMember: true,
+      isMember: false,
       pubkey: mixedCase,
-      mentionableAgentPubkeys: new Set(),
-      directoryAgentPubkeys: new Set([normalized]),
+      mentionableAgentPubkeys: new Set([normalized]),
     }),
-    true,
+    false,
   );
 });
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -54,12 +54,13 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
-export function isAgentIdentityInManagedList(
-  candidate: { isAgent?: boolean; pubkey: string },
+export function isAgentIdentityDiscoverable(
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
   managedAgentPubkeys: ReadonlySet<string>,
 ) {
   return (
     candidate.isAgent !== true ||
+    candidate.isMember === true ||
     managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
   );
 }
@@ -69,32 +70,16 @@ export function shouldHideAgentFromMentions({
   isMember,
   pubkey,
   mentionableAgentPubkeys,
-  directoryAgentPubkeys,
 }: {
   isAgent: boolean;
   isMember: boolean;
   pubkey: string;
   mentionableAgentPubkeys: ReadonlySet<string>;
-  directoryAgentPubkeys: ReadonlySet<string>;
 }) {
-  if (!isAgent) return false;
-  const normalized = normalizePubkey(pubkey);
-  // Invocable => always show.
-  if (mentionableAgentPubkeys.has(normalized)) return false;
-  // Non-member, non-invocable => hide (preserves prior behavior).
-  if (!isMember) return true;
-  // Member (Option B): hide only when we have an explicit not-invocable
-  // signal — a relay directory (kind:10100) entry that excludes us.
-  // Unknown invocability (not in directory) => show.
-  //
-  // NOTE: this assumes `directoryAgentPubkeys` and `mentionableAgentPubkeys`
-  // share the same source query (`relayAgentsQuery.data`), so directory
-  // presence without membership in `mentionableAgentPubkeys` is a real
-  // explicit-exclusion signal. If a future change sources the directory set
-  // from a different query, an agent that's directory-present but whose
-  // mentionability is still loading could be hidden prematurely — keep the
-  // two sets derived from the same query.
-  return directoryAgentPubkeys.has(normalized);
+  // Channel membership is sufficient for people and agents alike. Whether an
+  // agent is managed on this device only governs local lifecycle controls.
+  if (!isAgent || isMember) return false;
+  return !mentionableAgentPubkeys.has(normalizePubkey(pubkey));
 }
 
 type AgentAutocompleteCandidate = {

--- a/desktop/src/features/agents/lib/agentMentionComposedPath.test.mjs
+++ b/desktop/src/features/agents/lib/agentMentionComposedPath.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldHideAgentFromMentions } from "./agentAutocompleteEligibility.ts";
+import { snapshotDraftMentionRefs } from "../../messages/lib/draftMentionRefs.ts";
+import { mentionCandidateLabel } from "../../messages/lib/mentionCandidates.ts";
+import { mapMentionCandidateToSuggestion } from "../../messages/lib/mentionSuggestionMapping.ts";
+import { messageMentionPubkeys } from "../../messages/lib/messageMentionPubkeys.ts";
+
+/**
+ * The eligibility predicate is well covered on its own, which is exactly why it
+ * was possible to relax it and still not know whether an agent someone else
+ * manages actually becomes mentionable. Answering that means walking the whole
+ * path a picked mention travels — filter, label, suggestion, draft ref, `p` tag
+ * — because every stage can drop it, and only the last one is observable to the
+ * agent.
+ */
+const SENDER = "a".repeat(64);
+const PEER = "b".repeat(64);
+const ERP_AGENT = "e".repeat(64);
+
+const channel = (over = {}) => ({
+  channelType: "stream",
+  memberPubkeys: [SENDER, PEER],
+  participantPubkeys: [],
+  ...over,
+});
+
+const agent = (over = {}) => ({
+  kind: "identity",
+  pubkey: ERP_AGENT,
+  displayName: "erp",
+  isAgent: true,
+  isMember: true,
+  ...over,
+});
+
+/**
+ * One composer round trip: would the autocomplete offer this candidate, and if
+ * the author picks it and sends, which pubkeys does the event address?
+ */
+function compose(
+  candidate,
+  { chan = channel(), mentionableAgentPubkeys = new Set(), typedAs } = {},
+) {
+  const hidden = shouldHideAgentFromMentions({
+    isAgent: candidate.isAgent,
+    isMember: candidate.isMember,
+    pubkey: candidate.pubkey,
+    mentionableAgentPubkeys,
+  });
+  if (hidden) return { suggested: false, pubkeys: [] };
+
+  const label = mentionCandidateLabel(candidate);
+  const suggestion = mapMentionCandidateToSuggestion({
+    candidate,
+    label,
+    channelType: chan.channelType,
+    currentPubkey: SENDER,
+  });
+  const content = `@${typedAs ?? suggestion.displayName} what is the ARR?`;
+  const refs = snapshotDraftMentionRefs(
+    content,
+    new Map([[suggestion.displayName, suggestion.pubkey]]),
+    [suggestion.displayName],
+  );
+  return {
+    suggested: true,
+    suggestion,
+    pubkeys: messageMentionPubkeys(
+      chan,
+      SENDER,
+      refs.map((ref) => ref.pubkey),
+    ),
+  };
+}
+
+test("a channel-member agent managed on another device reaches the p tag", () => {
+  // The ERP and Codex agents' state on everyone's device but the operator's:
+  // in the channel, in the relay directory, absent from the local managed list.
+  const result = compose(agent(), { mentionableAgentPubkeys: new Set() });
+
+  assert.equal(result.suggested, true);
+  assert.equal(result.suggestion.isAgent, true);
+  // Not flagged as an outsider being pulled in — it is already in the channel.
+  assert.equal(result.suggestion.notInChannel, false);
+  assert.deepEqual(result.pubkeys, [ERP_AGENT]);
+});
+
+test("an agent in nobody's channel and nobody's managed list never reaches a p tag", () => {
+  const result = compose(agent({ isMember: false }), {
+    mentionableAgentPubkeys: new Set(),
+  });
+
+  assert.equal(result.suggested, false);
+  assert.deepEqual(result.pubkeys, []);
+});
+
+test("a locally managed agent still reaches the p tag from outside the channel", () => {
+  // Unchanged behaviour: your own agent is invocable wherever you are, and the
+  // suggestion says plainly that it is not in this channel yet.
+  const result = compose(agent({ isMember: false }), {
+    mentionableAgentPubkeys: new Set([ERP_AGENT]),
+  });
+
+  assert.equal(result.suggested, true);
+  assert.equal(result.suggestion.notInChannel, true);
+  assert.deepEqual(result.pubkeys, [ERP_AGENT]);
+});
+
+test("a DM addresses its own participants, not an agent that is not in it", () => {
+  // Membership is what widened, and in a DM the member list is the two people
+  // in it — so the DM's recipients are unchanged and an uninvolved agent, which
+  // can never carry `isMember`, is filtered before it becomes a suggestion.
+  const dm = channel({ channelType: "dm" });
+
+  assert.deepEqual(compose(agent({ isMember: false }), { chan: dm }), {
+    suggested: false,
+    pubkeys: [],
+  });
+  assert.deepEqual(messageMentionPubkeys(dm, SENDER), [PEER]);
+});
+
+test("the mention survives being typed in a different case to the label", () => {
+  // The label round-trips through free text before it becomes a `p` tag, so a
+  // member agent someone types from memory rather than picking still routes.
+  const result = compose(agent({ displayName: "ERP" }), { typedAs: "erp" });
+  assert.deepEqual(result.pubkeys, [ERP_AGENT]);
+});

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -9,7 +9,7 @@ import {
 import { attachManagedAgentToChannel } from "@/features/agents/channelAgents";
 import {
   coalesceAgentAutocompleteCandidates,
-  isAgentIdentityInManagedList,
+  isAgentIdentityDiscoverable,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
@@ -282,7 +282,7 @@ export function MembersSidebar({
           )) ||
         memberPubkeys.has(pubkey) ||
         isArchivedDiscovery(pubkey) ||
-        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+        !isAgentIdentityDiscoverable(candidate, managedAgentPubkeys)
       ) {
         return;
       }

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,7 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isAgentIdentityDiscoverable,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -179,15 +179,6 @@ export function useMentions(
       ),
     [relayAgentsQuery.data],
   );
-  const directoryAgentPubkeys = React.useMemo(
-    () =>
-      new Set(
-        (relayAgentsQuery.data ?? []).map((agent) =>
-          normalizePubkey(agent.pubkey),
-        ),
-      ),
-    [relayAgentsQuery.data],
-  );
   const sharedChannelIds = React.useMemo(
     () => getSharedChannelIds(channelsQuery.data),
     [channelsQuery.data],
@@ -246,7 +237,7 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (!isAgentIdentityDiscoverable(candidate, managedAgentPubkeys)) {
         return;
       }
       if (
@@ -255,7 +246,6 @@ export function useMentions(
           isMember: candidate.isMember === true,
           pubkey,
           mentionableAgentPubkeys,
-          directoryAgentPubkeys,
         })
       ) {
         return;
@@ -415,7 +405,6 @@ export function useMentions(
     userSearchResults,
     canSearchGlobalUsers,
     currentPubkey,
-    directoryAgentPubkeys,
     isArchivedDiscovery,
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -209,7 +209,10 @@ test("@ trigger prioritizes channel members before runnable personas and other m
 
   const dropdown = autocomplete(page);
   await expect(dropdown).toBeVisible();
-  await expect(dropdown.getByText("alice")).toHaveCount(0);
+  // alice is relay-classified as an agent and is an owner-member of #general —
+  // i.e. an agent someone else runs. Being in the channel is what makes her
+  // mentionable here; nobody on this device manages her.
+  await expect(dropdown.getByText("alice")).toBeVisible();
   await expect(dropdown.getByText("bob")).toBeVisible();
   await expect(dropdown.getByText("Fizz")).toBeVisible();
   await expect(dropdown.getByText("charlie")).toBeVisible();
@@ -217,11 +220,13 @@ test("@ trigger prioritizes channel members before runnable personas and other m
   const charlieRow = dropdown.locator("button", { hasText: "charlie" });
   await expect(charlieRow.getByTestId("mention-agent-icon")).toBeVisible();
   await expect(charlieRow.getByText("not in channel")).toBeVisible();
+  // ...and because she is in it, she carries no "not in channel" caveat, which
+  // is the whole difference between her row and charlie's.
   await expect(
     dropdown
       .locator("button", { hasText: "alice" })
       .getByText("not in channel"),
-  ).not.toBeVisible();
+  ).toHaveCount(0);
 
   const suggestions = dropdown.locator("button");
   const suggestionText = await suggestions.allInnerTexts();


### PR DESCRIPTION
An agent that is a member of a channel is invisible in `@` autocomplete to everyone except the person whose device manages it.

`shouldHideAgentFromMentions` currently treats "listed in the relay directory (kind:10100) but absent from the local `mentionableAgentPubkeys`" as an explicit *not invocable* signal and hides the candidate — even when the agent is a member of the channel you are typing in. That combination is not an edge case: it is the state of every relay-hosted agent on every device other than its operator's, because `mentionableAgentPubkeys` is derived from what this device can run.

The result is a participant nobody in the room can address. It posts messages, it appears in the member sidebar, its profile popover opens — and typing `@` does not offer it. We run two such agents on our relay; teammates could see them talking and had no way to reply.

This behaviour arrived with #2149, which was solving a different problem (preferring live agents). The member branch it added reads directory presence as exclusion, and locally-unmanaged is not exclusion.

## The change

Channel membership is sufficient, for agents as it already is for people:

```ts
if (!isAgent || isMember) return false;
return !mentionableAgentPubkeys.has(normalizePubkey(pubkey));
```

Whether an agent is managed on *this* device decides local lifecycle controls — start, stop, attach — not whether a peer may speak to it. `directoryAgentPubkeys` becomes unused and is removed along with the memo that built it.

`isAgentIdentityInManagedList` is renamed `isAgentIdentityDiscoverable`, because with the membership clause its answer is no longer "is this managed here" but "may this be surfaced at all".

### DMs are unaffected

`isMember: true` is set in exactly one place: the `members` loop in `useMentions` (~line 305), from the channel's own member list. Every other candidate source hard-codes `isMember: false`, and `coalesceAutocompleteCandidatesByKey` only ORs the flag. An agent that is not a party to the conversation still falls through to the managed-list branch and stays gated.

Nor is anything newly disclosed — channel members are already listed in the sidebar.

## Tests

The existing tests stopped at the predicate, which is how it stayed possible to relax it and still not know whether a mention actually *reaches* the agent. New `agentMentionComposedPath.test.mjs` walks the whole path a picked mention travels — eligibility → `mentionCandidateLabel` → `mapMentionCandidateToSuggestion` → `snapshotDraftMentionRefs` → `messageMentionPubkeys` — and asserts on the emitted `p` tag, which is the only stage the agent can observe:

- a channel-member agent managed on another device reaches the `p` tag
- an agent in nobody's channel and nobody's managed list never reaches one
- a locally managed agent still reaches it from outside the channel
- a DM addresses its own participants, not an agent that is not in it
- the mention survives being typed in a different case to the label

`mentions.spec.ts:190` is the one spec that pinned the old policy: #2149 flipped its `alice` assertion to `toHaveCount(0)`. `alice` is relay-classified as an agent (`mockAgentPubkeys` in `e2eBridge.ts`) and an owner-member of `#general` — the fixture's stand-in for an agent someone else runs — so restoring her is the point of the change. The sibling assertion becomes load-bearing in the process: `.not.toBeVisible()` on her "not in channel" badge passed while the row did not exist at all; `toHaveCount(0)` on a row that now exists actually proves a member agent carries no caveat.

## Test plan

Run against this branch, rebased on `main` (`ac4fa13b8`):

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec biome check` on the touched files — clean
- desktop unit suite — **3912 passed, 0 failed**
- `pnpm exec playwright test --project=smoke tests/e2e/mentions.spec.ts` — **49 passed**
