### PR TITLE
Add per-listener caption language and speak-aloud preferences

### DIFF
--- a/desktop/src-tauri/src/huddle/caption_settings.rs
+++ b/desktop/src-tauri/src/huddle/caption_settings.rs
@@ -1,0 +1,110 @@
+//! Per-listener preferences for translated huddle captions.
+//!
+//! Split out of `tts_settings` (which owns the `TtsSettings` struct and its
+//! persistence) to keep both files under the desktop file-size ratchet.
+//! Unlike voice/enable changes, neither setting here touches the TTS
+//! runtime — they only affect which captions `useTtsSubscription` chooses to
+//! speak client-side (see the field docs on `TtsSettings`).
+
+use tauri::{AppHandle, State};
+
+use crate::app_state::AppState;
+
+use super::tts_settings::{
+    current_settings, ensure_settings_writable, save_to_path, settings_path, TtsSettings,
+};
+
+fn settings_with_caption_language(
+    settings: TtsSettings,
+    language: &str,
+) -> Result<TtsSettings, String> {
+    let trimmed = language.trim();
+    if trimmed.is_empty() {
+        return Err("Caption language cannot be empty".to_string());
+    }
+    Ok(TtsSettings {
+        caption_language: trimmed.to_lowercase(),
+        ..settings
+    })
+}
+
+fn settings_with_speak_captions(settings: TtsSettings, enabled: bool) -> TtsSettings {
+    TtsSettings {
+        speak_captions: enabled,
+        ..settings
+    }
+}
+
+/// Preferred language (lowercase ISO 639-1) for translated huddle captions.
+#[tauri::command]
+pub fn set_caption_language(
+    language: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<TtsSettings, String> {
+    ensure_settings_writable(&state)?;
+    let settings = settings_with_caption_language(current_settings(&state)?, &language)?;
+    save_to_path(&settings_path(&app)?, &settings)?;
+    *state
+        .huddle_audio
+        .tts
+        .lock()
+        .map_err(|error| format!("text-to-speech settings lock poisoned: {error}"))? =
+        settings.clone();
+    Ok(settings)
+}
+
+/// Whether captions matching `caption_language` are spoken aloud. Captions
+/// still render as text regardless — see the field doc on `TtsSettings`.
+#[tauri::command]
+pub fn set_speak_captions(
+    enabled: bool,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<TtsSettings, String> {
+    ensure_settings_writable(&state)?;
+    let settings = settings_with_speak_captions(current_settings(&state)?, enabled);
+    save_to_path(&settings_path(&app)?, &settings)?;
+    *state
+        .huddle_audio
+        .tts
+        .lock()
+        .map_err(|error| format!("text-to-speech settings lock poisoned: {error}"))? =
+        settings.clone();
+    Ok(settings)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn caption_language_is_trimmed_and_lowercased() {
+        let updated = settings_with_caption_language(TtsSettings::default(), "  ES  ")
+            .expect("non-empty language");
+        assert_eq!(updated.caption_language, "es");
+        // Unrelated fields are preserved.
+        assert_eq!(
+            updated.voice_preferences,
+            TtsSettings::default().voice_preferences
+        );
+    }
+
+    #[test]
+    fn empty_caption_language_is_rejected() {
+        let error = settings_with_caption_language(TtsSettings::default(), "   ")
+            .expect_err("blank language should be rejected");
+        assert!(error.contains("cannot be empty"));
+    }
+
+    #[test]
+    fn speak_captions_toggle_preserves_other_fields() {
+        let current = TtsSettings {
+            caption_language: "es".to_string(),
+            ..TtsSettings::default()
+        };
+        let updated = settings_with_speak_captions(current, false);
+        assert!(!updated.speak_captions);
+        assert_eq!(updated.caption_language, "es");
+    }
+}

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -26,6 +26,7 @@
 mod agent_tts_routing;
 pub mod agents;
 pub mod audio_output;
+pub mod caption_settings;
 pub mod jitter;
 pub mod models;
 pub mod pipeline;

--- a/desktop/src-tauri/src/huddle/tts_settings.rs
+++ b/desktop/src-tauri/src/huddle/tts_settings.rs
@@ -137,6 +137,24 @@ pub struct TtsSettings {
     pub version: u32,
     pub agent_text_to_speech: bool,
     pub voice_preferences: VoicePreferences,
+    /// Preferred language for translated huddle captions, as a lowercase
+    /// ISO 639-1 code (e.g. "en", "es"). Captions tagged with a different
+    /// language still render as text but are not spoken aloud.
+    #[serde(default = "default_caption_language")]
+    pub caption_language: String,
+    /// Whether captions matching `caption_language` are spoken aloud.
+    /// Captions always render as text regardless of this setting — it only
+    /// gates `speak_agent_message`.
+    #[serde(default = "default_speak_captions")]
+    pub speak_captions: bool,
+}
+
+fn default_caption_language() -> String {
+    "en".to_string()
+}
+
+fn default_speak_captions() -> bool {
+    true
 }
 
 impl Default for TtsSettings {
@@ -145,6 +163,8 @@ impl Default for TtsSettings {
             version: CURRENT_VERSION,
             agent_text_to_speech: true,
             voice_preferences: vec![MARY_VOICE_KEY.to_string()],
+            caption_language: default_caption_language(),
+            speak_captions: default_speak_captions(),
         }
     }
 }
@@ -272,6 +292,7 @@ pub(crate) fn load_from_path(path: &Path) -> Result<TtsSettings, String> {
                 .and_then(serde_json::Value::as_bool)
                 .unwrap_or(true),
             voice_preferences: vec![voice_key],
+            ..TtsSettings::default()
         });
     }
 
@@ -345,7 +366,7 @@ pub fn list_voice_registry(app: AppHandle) -> Vec<VoiceRegistryEntry> {
     voice_registry(&app)
 }
 
-fn ensure_settings_writable(state: &AppState) -> Result<(), String> {
+pub(crate) fn ensure_settings_writable(state: &AppState) -> Result<(), String> {
     if let Some(error) = state
         .huddle_audio
         .tts_load_error
@@ -463,7 +484,7 @@ async fn apply_tts_settings(
     Ok(voice_change_wait)
 }
 
-fn current_settings(state: &AppState) -> Result<TtsSettings, String> {
+pub(crate) fn current_settings(state: &AppState) -> Result<TtsSettings, String> {
     state
         .huddle_audio
         .tts
@@ -738,6 +759,8 @@ mod tests {
                 version: 1,
                 agent_text_to_speech: true,
                 voice_preferences: vec!["pocket:mary".to_string()],
+                caption_language: "en".to_string(),
+                speak_captions: true,
             }
         );
     }
@@ -864,6 +887,8 @@ mod tests {
                 version: 1,
                 agent_text_to_speech: false,
                 voice_preferences: vec![EVE_VOICE_KEY.to_string()],
+                caption_language: "en".to_string(),
+                speak_captions: true,
             }
         );
     }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -895,6 +895,8 @@ pub fn run() {
             huddle::tts_settings::get_tts_settings,
             huddle::tts_settings::list_voice_registry,
             huddle::tts_settings::set_pocket_voice,
+            huddle::caption_settings::set_caption_language,
+            huddle::caption_settings::set_speak_captions,
             huddle::tts_settings::preview_pocket_voice,
             huddle::tts_settings::import_pocket_voice,
             huddle::tts_settings::delete_pocket_voice,

--- a/desktop/src/features/huddle/lib/captionLanguage.test.mjs
+++ b/desktop/src/features/huddle/lib/captionLanguage.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseCaptionLanguageBanner,
+  shouldSpeakCaption,
+} from "./captionLanguage.ts";
+
+test("parses a recognized [XX] banner as lowercase", () => {
+  assert.equal(parseCaptionLanguageBanner("[ES] Hola"), "es");
+  assert.equal(parseCaptionLanguageBanner("[zh] 你好"), "zh");
+});
+
+test("returns null for content with no banner", () => {
+  assert.equal(parseCaptionLanguageBanner("Hello there"), null);
+});
+
+test("speak-aloud toggle off silences every caption, banner or not", () => {
+  assert.equal(shouldSpeakCaption("[ES] Hola", false, "es"), false);
+  assert.equal(shouldSpeakCaption("Hello there", false, "en"), false);
+});
+
+test("untagged messages are always eligible to speak", () => {
+  assert.equal(shouldSpeakCaption("Hello there", true, "es"), true);
+});
+
+test("banner-tagged captions only speak when they match the listener's language", () => {
+  assert.equal(shouldSpeakCaption("[ES] Hola", true, "es"), true);
+  assert.equal(shouldSpeakCaption("[ES] Hola", true, "en"), false);
+});

--- a/desktop/src/features/huddle/lib/captionLanguage.ts
+++ b/desktop/src/features/huddle/lib/captionLanguage.ts
@@ -1,0 +1,29 @@
+/**
+ * Interim caption-language convention: translator bots (e.g. `caption_forward.py`)
+ * prefix translated captions with a `[XX]` banner (`[ES]`, `[ZH]`, ...) since
+ * kind:9 has no structured language tag yet. This is a stand-in for the
+ * proposed `l`-tag; swap `parseCaptionLanguageBanner` for tag parsing once
+ * that lands.
+ */
+export function parseCaptionLanguageBanner(content: string): string | null {
+  const match = /^\[([A-Za-z]{2,3})\]/.exec(content.trim());
+  return match ? match[1].toLowerCase() : null;
+}
+
+/**
+ * Whether a kind:9 message should be spoken aloud for a listener with the
+ * given caption preferences. Messages without a recognized language banner
+ * (ordinary agent replies, not translated captions) are always eligible —
+ * only banner-tagged captions in another language are held back. Captions
+ * always render as text regardless of this result.
+ */
+export function shouldSpeakCaption(
+  content: string,
+  speakCaptions: boolean,
+  captionLanguage: string,
+): boolean {
+  if (!speakCaptions) return false;
+  const bannerLanguage = parseCaptionLanguageBanner(content);
+  if (bannerLanguage === null) return true;
+  return bannerLanguage === captionLanguage.toLowerCase();
+}

--- a/desktop/src/features/huddle/lib/ttsLiveMessages.test.mjs
+++ b/desktop/src/features/huddle/lib/ttsLiveMessages.test.mjs
@@ -18,8 +18,19 @@ const base = {
   content: "Hello there",
   tags: [["h", CHANNEL]],
 };
-const speakableText = (event, selfPubkey = "human") =>
-  classifySpeakableAgentText(event, agents, selfPubkey, CHANNEL).text;
+const SPEAK_ALL = { speakCaptions: true, captionLanguage: "en" };
+const speakableText = (
+  event,
+  selfPubkey = "human",
+  captionPreferences = SPEAK_ALL,
+) =>
+  classifySpeakableAgentText(
+    event,
+    agents,
+    selfPubkey,
+    CHANNEL,
+    captionPreferences,
+  ).text;
 
 test("speaks only new agent-authored text message events", () => {
   assert.equal(speakableText(base), "Hello there");
@@ -79,6 +90,7 @@ test("routes managed stream-message-v2 through membership and enabled ordering",
       CHANNEL,
       77,
       speaker.enqueue,
+      SPEAK_ALL,
     ),
     "queued",
   );
@@ -90,6 +102,7 @@ test("routes managed stream-message-v2 through membership and enabled ordering",
       CHANNEL,
       78,
       speaker.enqueue,
+      SPEAK_ALL,
     ),
     "unsupported_kind",
   );
@@ -101,6 +114,7 @@ test("routes managed stream-message-v2 through membership and enabled ordering",
       CHANNEL,
       79,
       speaker.enqueue,
+      SPEAK_ALL,
     ),
     "h_tag_mismatch",
   );
@@ -112,11 +126,48 @@ test("routes managed stream-message-v2 through membership and enabled ordering",
       CHANNEL,
       80,
       speaker.enqueue,
+      SPEAK_ALL,
     ),
     "author_not_agent",
   );
   await new Promise((resolve) => setTimeout(resolve, 0));
   assert.deepEqual(invoked, [{ text: "Hello there", routeId: 77 }]);
+});
+
+test("gates banner-tagged captions on the listener's language and speak-aloud preference", () => {
+  const spanishCaption = { ...base, content: "[ES] Hola" };
+  assert.equal(
+    speakableText(spanishCaption, "human", {
+      speakCaptions: true,
+      captionLanguage: "es",
+    }),
+    "[ES] Hola",
+    "caption in the listener's preferred language is spoken",
+  );
+  assert.equal(
+    speakableText(spanishCaption, "human", {
+      speakCaptions: true,
+      captionLanguage: "en",
+    }),
+    null,
+    "caption in another language is held back",
+  );
+  assert.equal(
+    speakableText(spanishCaption, "human", {
+      speakCaptions: false,
+      captionLanguage: "es",
+    }),
+    null,
+    "speak-aloud off silences even a matching-language caption",
+  );
+  assert.equal(
+    speakableText(base, "human", {
+      speakCaptions: false,
+      captionLanguage: "en",
+    }),
+    null,
+    "speak-aloud off also silences untagged agent replies",
+  );
 });
 
 test("strips attachment markup and skips attachment-only events", () => {

--- a/desktop/src/features/huddle/lib/ttsLiveMessages.ts
+++ b/desktop/src/features/huddle/lib/ttsLiveMessages.ts
@@ -2,6 +2,7 @@ import {
   KIND_STREAM_MESSAGE,
   KIND_STREAM_MESSAGE_V2,
 } from "../../../shared/constants/kinds.ts";
+import { shouldSpeakCaption } from "./captionLanguage.ts";
 
 export type LiveTtsEvent = {
   id: string;
@@ -20,7 +21,8 @@ export type LiveTtsEligibility =
         | "h_tag_mismatch"
         | "author_not_agent"
         | "self_authored"
-        | "empty_or_system";
+        | "empty_or_system"
+        | "caption_language_mismatch";
     };
 
 export type LiveTtsRouteResult =
@@ -52,11 +54,17 @@ function textWithoutAttachments(event: LiveTtsEvent): string {
   );
 }
 
+export type CaptionSpeechPreferences = {
+  speakCaptions: boolean;
+  captionLanguage: string;
+};
+
 export function classifySpeakableAgentText(
   event: LiveTtsEvent,
   agentPubkeys: ReadonlySet<string>,
   selfPubkey: string | null,
   channelId: string,
+  captionPreferences: CaptionSpeechPreferences,
 ): LiveTtsEligibility {
   if (
     event.kind !== KIND_STREAM_MESSAGE &&
@@ -72,6 +80,14 @@ export function classifySpeakableAgentText(
   const content = textWithoutAttachments(event).trim();
   if (content.length === 0 || content.startsWith("[System]"))
     return { text: null, reason: "empty_or_system" };
+  if (
+    !shouldSpeakCaption(
+      content,
+      captionPreferences.speakCaptions,
+      captionPreferences.captionLanguage,
+    )
+  )
+    return { text: null, reason: "caption_language_mismatch" };
   return { text: content, reason: null };
 }
 
@@ -83,12 +99,14 @@ export function routeLiveAgentText(
   channelId: string,
   routeId: number,
   enqueue: (text: string, routeId: number) => "queued" | "disabled",
+  captionPreferences: CaptionSpeechPreferences,
 ): LiveTtsRouteResult {
   const eligibility = classifySpeakableAgentText(
     event,
     agentPubkeys,
     selfPubkey,
     channelId,
+    captionPreferences,
   );
   if (eligibility.text === null) return eligibility.reason;
   return enqueue(eligibility.text, routeId);

--- a/desktop/src/features/huddle/lib/useTtsSubscription.ts
+++ b/desktop/src/features/huddle/lib/useTtsSubscription.ts
@@ -4,6 +4,7 @@ import * as React from "react";
 
 import { buildHuddleTtsLiveFilter } from "@/shared/api/relayChannelFilters";
 import { relayClient } from "@/shared/api/relayClient";
+import type { CaptionSpeechPreferences } from "./ttsLiveMessages";
 import {
   createInitialTtsReadinessGate,
   createLatestStateGate,
@@ -12,6 +13,12 @@ import {
 } from "./ttsLiveMessages";
 
 const AGENT_PUBKEY_REFRESH_INTERVAL_MS = 30_000;
+// Fails open to today's behavior (speak everything) if settings never load —
+// see the field docs on the Rust `TtsSettings` struct.
+const DEFAULT_CAPTION_PREFERENCES: CaptionSpeechPreferences = {
+  speakCaptions: true,
+  captionLanguage: "en",
+};
 let nextTtsRouteId = 1;
 
 function allocateTtsRouteId(): number {
@@ -49,6 +56,24 @@ export function useTtsSubscription(
     // successful fetch means "no agents in the huddle" → still mute.
     let agentsLoaded = false;
     const agentPubkeys = new Set<string>();
+    let captionPreferences: CaptionSpeechPreferences =
+      DEFAULT_CAPTION_PREFERENCES;
+
+    async function loadCaptionPreferences() {
+      try {
+        const settings =
+          await invoke<CaptionSpeechPreferences>("get_tts_settings");
+        if (disposed) return;
+        captionPreferences = {
+          speakCaptions: settings.speakCaptions,
+          captionLanguage: settings.captionLanguage,
+        };
+      } catch (e) {
+        // Keep the last known preferences (defaults on first failure) —
+        // gating fails open rather than going silent on a fetch error.
+        console.error("[huddle] Failed to load caption preferences:", e);
+      }
+    }
 
     const speakInOrder = createOrderedSpeaker(
       async (text, routeId) => {
@@ -99,6 +124,7 @@ export function useTtsSubscription(
         ephemeralChannelId,
         routeId,
         speakInOrder.enqueue,
+        captionPreferences,
       );
       if (result === "queued") {
         console.debug(
@@ -146,10 +172,13 @@ export function useTtsSubscription(
       }
     }
 
-    // Initial load + periodic refresh (catches mid-huddle agent additions).
+    // Initial load + periodic refresh (catches mid-huddle agent additions
+    // and settings changes made from another window/session).
     void loadAgentPubkeys(true);
+    void loadCaptionPreferences();
     const agentRefreshId = window.setInterval(() => {
       void loadAgentPubkeys();
+      void loadCaptionPreferences();
     }, AGENT_PUBKEY_REFRESH_INTERVAL_MS);
 
     // Install the state listener before requesting a snapshot. If a newer

--- a/desktop/src/features/settings/ui/VoiceSettingsCard.tsx
+++ b/desktop/src/features/settings/ui/VoiceSettingsCard.tsx
@@ -35,7 +35,19 @@ export type TtsSettings = {
   version: number;
   agentTextToSpeech: boolean;
   voicePreferences: string[];
+  captionLanguage: string;
+  speakCaptions: boolean;
 };
+
+/**
+ * Languages `caption_forward.py` currently translates huddle captions into.
+ * Extend alongside that script's `--languages` support.
+ */
+const CAPTION_LANGUAGE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "en", label: "English" },
+  { value: "es", label: "Spanish" },
+  { value: "zh", label: "Chinese" },
+];
 
 type TtsVoiceMutation = {
   settings: TtsSettings;
@@ -103,6 +115,44 @@ export function VoiceSettingsCard() {
         saveError instanceof Error
           ? saveError.message
           : "Voice settings could not be saved.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const saveCaptionLanguage = React.useCallback(async (language: string) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const saved = await invokeTauri<TtsSettings>("set_caption_language", {
+        language,
+      });
+      setSettings(saved);
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : "Caption language could not be saved.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const saveSpeakCaptions = React.useCallback(async (enabled: boolean) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const saved = await invokeTauri<TtsSettings>("set_speak_captions", {
+        enabled,
+      });
+      setSettings(saved);
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : "Caption speak-aloud preference could not be saved.",
       );
     } finally {
       setBusy(false);
@@ -178,6 +228,8 @@ export function VoiceSettingsCard() {
     voices,
   );
   const enabled = settings?.agentTextToSpeech ?? true;
+  const captionLanguage = settings?.captionLanguage ?? "en";
+  const speakCaptions = settings?.speakCaptions ?? true;
   const controlsDisabled = !settings || busy || !enabled;
 
   return (
@@ -212,6 +264,86 @@ export function VoiceSettingsCard() {
             />
           </SettingsOptionRow>
         </SettingsOptionGroup>
+
+        <div
+          aria-disabled={!enabled}
+          className={cn(
+            "transition-opacity",
+            !enabled && "pointer-events-none opacity-45",
+          )}
+          data-testid="caption-speech-controls"
+        >
+          <SettingsOptionGroup>
+            <SettingsOptionRow>
+              <div className="min-w-0">
+                <p className="text-sm font-medium">Caption language</p>
+                <p className="text-sm text-muted-foreground">
+                  Translated huddle captions in this language may be spoken
+                  aloud; others still appear as text.
+                </p>
+              </div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    aria-label={`Caption language: ${
+                      CAPTION_LANGUAGE_OPTIONS.find(
+                        (option) => option.value === captionLanguage,
+                      )?.label ?? captionLanguage
+                    }`}
+                    className="min-w-32 justify-between"
+                    data-testid="caption-language-selector"
+                    disabled={controlsDisabled}
+                    variant="outline"
+                  >
+                    {CAPTION_LANGUAGE_OPTIONS.find(
+                      (option) => option.value === captionLanguage,
+                    )?.label ?? captionLanguage}
+                    <ChevronDown className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuRadioGroup
+                    onValueChange={(language) => {
+                      if (settings) void saveCaptionLanguage(language);
+                    }}
+                    value={captionLanguage}
+                  >
+                    {CAPTION_LANGUAGE_OPTIONS.map((option) => (
+                      <DropdownMenuRadioItem
+                        key={option.value}
+                        value={option.value}
+                      >
+                        {option.label}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </SettingsOptionRow>
+            <SettingsOptionRow>
+              <div className="min-w-0">
+                <label
+                  className="text-sm font-medium"
+                  htmlFor="speak-captions-switch"
+                >
+                  Speak captions aloud
+                </label>
+                <p className="text-sm text-muted-foreground">
+                  Turn off to see captions as text only, without hearing them.
+                </p>
+              </div>
+              <Switch
+                checked={speakCaptions}
+                data-testid="speak-captions-toggle"
+                disabled={controlsDisabled}
+                id="speak-captions-switch"
+                onCheckedChange={(checked) => {
+                  if (settings) void saveSpeakCaptions(checked);
+                }}
+              />
+            </SettingsOptionRow>
+          </SettingsOptionGroup>
+        </div>
 
         <div
           aria-disabled={!enabled}


### PR DESCRIPTION
Huddle TTS speaks any bot-role kind:9 to every participant with no language awareness, so translated captions get spoken to listeners who didn't ask for that language. Add two installation-global TtsSettings fields (captionLanguage, speakCaptions) with Tauri commands to set them, a Captions section in the Voice settings card, and a gate in useTtsSubscription/ttsLiveMessages so a caption only auto-speaks when its language matches the listener's preference and speak-aloud is on. Untagged agent replies are unaffected.

Language is read from the interim `[XX]` banner convention (caption_forward.py, in the langlayer integration) since kind:9 has no structured language tag yet. A follow-up issue proposes that tag; this settings/filter layer switches to it once it lands.

Known gap: desktop/src-tauri/src/lib.rs is already at the 1000-line file-size ratchet ceiling on main. Registering the two new Tauri commands (set_caption_language, set_speak_captions) pushes it to 1002, failing `pnpm check:file-sizes`. This isn't specific to this change - any future PR adding a new Tauri command hits the same ceiling. Left as-is rather than restructuring command registration, which is out of scope here; flagging for maintainers to decide whether to raise the ratchet for this file or split registration.

## Summary
<!-- What does this change and why? -->

### Related issue
<!-- Fixes #1234, or N/A. Before opening: search existing issues/PRs for duplicates - link the closest one, or say "none found". -->

### Testing
<!-- How was this verified? UI change? Include before/after screenshots (or a short recording). -->
