### PR TITLE
docs(git): document macOS osxkeychain conflict and URL-scoped helper setup

### DIFF
--- a/crates/git-credential-nostr/README.md
+++ b/crates/git-credential-nostr/README.md
@@ -28,6 +28,39 @@ git config --global nostr.keyfile ~/.nostr/key
 
 That's it. Use git normally — `git clone`, `git push`, `git fetch`.
 
+### macOS: scope the helper to your relay
+
+On macOS, Xcode's bundled gitconfig registers `osxkeychain` as a credential
+helper for every repository:
+
+```
+$ git config --show-origin --get-all credential.helper
+file:/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig   osxkeychain
+```
+
+`git config --global credential.helper nostr` **appends** to that chain rather
+than replacing it. Both helpers run, and after each successful operation git
+asks every helper in the chain to store the credential — osxkeychain cannot
+store the Nostr credential shape and prints:
+
+```
+failed to store: -1
+```
+
+Operations still succeed; the error is pure noise. To silence it — and to keep
+the helper from ever running for github.com or other hosts — register the
+helper scoped to your relay URL instead of globally (the same idiom GitHub's
+`gh` CLI uses):
+
+```bash
+git config --global --add credential.https://relay.example.com.helper ""     # reset the chain for this URL
+git config --global --add credential.https://relay.example.com.helper nostr
+git config --global credential.useHttpPath true
+```
+
+The empty first entry resets the helper chain for that URL, so only `nostr`
+runs against your relay and osxkeychain keeps handling everything else.
+
 ## CI / CD
 
 Set `$NOSTR_PRIVATE_KEY` instead of a key file. The env var takes precedence
@@ -66,4 +99,5 @@ git ──stdin──▶ git-credential-nostr ──stdout──▶ git
 | `method hint` | Server's `WWW-Authenticate` header is missing `method="..."` | Upgrade the Buzz server |
 | `useHttpPath` | `credential.useHttpPath` is not set | `git config --global credential.useHttpPath true` |
 | Empty output / no auth | git version is older than 2.46 | Upgrade git |
+| `failed to store: -1` after successful operations (macOS) | Xcode's global `osxkeychain` helper runs alongside `nostr` and can't store the Nostr credential | Scope the helper to your relay URL — see [macOS](#macos-scope-the-helper-to-your-relay) |
 | `clock skew` / auth rejected | System clock is off by more than 60 s | Sync your system clock (`ntpdate`, `timedatectl`) |


### PR DESCRIPTION
## Summary

Following the README's Setup section on macOS produces `failed to store: -1` after every successful push, fetch, and ls-remote. Operations succeed — the error is pure noise — but it looks like a failure and nothing in the docs explains it.

Cause: Xcode's bundled gitconfig registers `osxkeychain` as a credential helper for every repo, and `git config --global credential.helper nostr` **appends** to that chain rather than replacing it. `GIT_TRACE=1` shows `git credential-osxkeychain get` running before `git credential-nostr get`; after auth succeeds, git asks every helper in the chain to store the credential, and osxkeychain fails on the Nostr credential shape. (This is not a defect in `git-credential-nostr` itself — it correctly no-ops on `store`.)

This PR adds a macOS subsection to Setup documenting the URL-scoped helper idiom (chain reset + `nostr`, the same pattern GitHub's `gh` CLI uses), which both silences the error and scopes the helper so it never runs for github.com or other hosts. Also adds the symptom to the Troubleshooting table.

### Related issue

None filed for this specifically — searched open/closed issues and PRs; closest are #2316 (credential-helper debugging pain on Linux) and PRs #3435 / #3299 (helper *path* quoting), none of which cover the osxkeychain chain conflict.

### Testing

Docs-only change. The documented commands are verified on a live macOS setup (macOS, Apple Silicon, git 2.50.1 / Apple Git-155) against a self-hosted relay with git hosting enabled: with the URL-scoped config, `failed to store: -1` disappears and push/fetch/ls-remote continue to authenticate correctly; github.com operations no longer invoke the nostr helper at all.
