### PR TITLE
fix(buzz-acp): include no_mention_filter in the startup config summary

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -1123,7 +1123,7 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} no_mention_filter={} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1134,6 +1134,7 @@ impl Config {
             self.agents,
             self.heartbeat_interval_secs,
             self.subscribe_mode,
+            self.no_mention_filter,
             self.dedup_mode,
             self.multiple_event_handling,
             self.ignore_self,
@@ -1532,6 +1533,16 @@ mod tests {
 
         let f = result.get(&channels[0]).unwrap();
         assert!(!f.require_mention);
+    }
+
+    #[test]
+    fn test_summary_includes_no_mention_filter_state() {
+        let mut config = test_config(SubscribeMode::Mentions);
+        config.no_mention_filter = true;
+        assert!(config.summary().contains("no_mention_filter=true"));
+
+        config.no_mention_filter = false;
+        assert!(config.summary().contains("no_mention_filter=false"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The one-line startup summary buzz-acp logs did not include the `no_mention_filter` state: a unit running `--subscribe mentions --no-mention-filter` logged exactly `subscribe=Mentions` — byte-identical to a mention-gated deployment. Since the flag changes both the relay subscription (the `#p` filter is dropped) and the operator's cost model, the only way to confirm it took effect was an end-to-end probe (publish an untagged event from an allowlisted author and watch for a turn).

This adds `no_mention_filter={}` to `Config::summary()` right after the subscribe mode, so the journal line attests the effective filter state:

```
buzz-acp starting: relay=… subscribe=Mentions no_mention_filter=true dedup=Queue …
```

Implementation is deliberately minimal — one field added to the existing format string, matching the surrounding `key=value` style.

### Related issue

Fixes #4228. Searched open issues/PRs for duplicates — none found.

### Testing

- New regression test `test_summary_includes_no_mention_filter_state` asserts `summary()` reports both the `true` and `false` states.
- `cargo test -p buzz-acp --lib` passes locally.
- `cargo fmt -p buzz-acp -- --check` clean.

No UI change.
