### PR TITLE
feat(kanban): in-app board creation (P3 inline create)

### DIFF
--- a/crates/buzz-cli/src/commands/boards.rs
+++ b/crates/buzz-cli/src/commands/boards.rs
@@ -1,0 +1,386 @@
+use crate::client::BuzzClient;
+use crate::error::CliError;
+use crate::validate::sdk_err;
+use buzz_core::kind::KIND_KANBAN_BOARD;
+use buzz_sdk::{build_kanban_board, KanbanBoardMeta, KanbanColumnDef};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+fn self_hex(client: &BuzzClient) -> String {
+    client.keys().public_key().to_hex()
+}
+
+async fn query_events(client: &BuzzClient, filter: &Value) -> Result<Vec<Value>, CliError> {
+    let raw = client.query(filter).await?;
+    Ok(serde_json::from_str(&raw).unwrap_or_default())
+}
+
+/// First value of a named tag on an event.
+pub(crate) fn tag(ev: &Value, name: &str) -> Option<String> {
+    let tags = ev.get("tags").and_then(|t| t.as_array())?;
+    for t in tags {
+        let a = t.as_array()?;
+        if a.first().and_then(|s| s.as_str()) == Some(name) {
+            return a.get(1).and_then(|s| s.as_str()).map(String::from);
+        }
+    }
+    None
+}
+
+/// All values of a named tag on an event.
+fn multi_tag(ev: &Value, name: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(tags) = ev.get("tags").and_then(|t| t.as_array()) {
+        for t in tags {
+            if let Some(a) = t.as_array() {
+                if a.first().and_then(|s| s.as_str()) == Some(name) {
+                    if let Some(v) = a.get(1).and_then(|s| s.as_str()) {
+                        out.push(v.to_string());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+pub(crate) fn columns(ev: &Value) -> Vec<KanbanColumnDef> {
+    let mut cols = Vec::new();
+    if let Some(tags) = ev.get("tags").and_then(|t| t.as_array()) {
+        for t in tags {
+            if let Some(a) = t.as_array() {
+                if a.first().and_then(|s| s.as_str()) == Some("column") {
+                    let id = a.get(1).and_then(|s| s.as_str()).unwrap_or_default().to_string();
+                    // Columns are emitted as key/value pairs after the colid:
+                    //   ["column", id, "name", <name>, "wip", <n>, "order", <n>]
+                    // or (no WIP limit) the shorter:
+                    //   ["column", id, "name", <name>, "order", <n>]
+                    // Parse by key, never by fixed index — the 6-element no-wip
+                    // form would otherwise misread the trailing order value as wip.
+                    let mut name = String::new();
+                    let mut wip = None;
+                    let mut order = 0u32;
+                    let mut i = 2;
+                    while i + 1 < a.len() {
+                        match a[i].as_str() {
+                            Some("name") => name = a[i + 1].as_str().unwrap_or_default().to_string(),
+                            Some("wip") => {
+                                wip = a[i + 1].as_str().and_then(|s| s.parse().ok())
+                            }
+                            Some("order") => {
+                                order = a[i + 1]
+                                    .as_str()
+                                    .and_then(|s| s.parse().ok())
+                                    .unwrap_or(0)
+                            }
+                            _ => {}
+                        }
+                        i += 2;
+                    }
+                    cols.push(KanbanColumnDef { id, name, wip, order });
+                }
+            }
+        }
+    }
+    cols.sort_by_key(|c| c.order);
+    cols
+}
+
+/// Fetch the signed-in user's board event + resolved column meta.
+async fn fetch_board(client: &BuzzClient, board_id: &str) -> Result<(Value, KanbanBoardMeta), CliError> {
+    let me = self_hex(client);
+    let filter = json!({ "kinds": [KIND_KANBAN_BOARD], "authors": [me], "limit": 1000 });
+    let events = query_events(client, &filter).await?;
+    let ev = events
+        .into_iter()
+        .find(|e| tag(e, "d").as_deref() == Some(board_id))
+        .ok_or_else(|| CliError::Usage(format!("board {board_id} not found for this key")))?;
+    let meta = KanbanBoardMeta {
+        columns: columns(&ev),
+        channels: multi_tag(&ev, "h"),
+        invites: multi_tag(&ev, "invite"),
+    };
+    Ok((ev, meta))
+}
+
+fn new_colid() -> String {
+    format!("col-{}", &Uuid::new_v4().simple().to_string()[..8])
+}
+
+fn parse_columns(s: &str) -> Result<Vec<(String, Option<u32>)>, CliError> {
+    let mut out = Vec::new();
+    for part in s.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        match part.split_once(':') {
+            Some((name, wip)) => {
+                let wip: u32 = wip
+                    .trim()
+                    .parse()
+                    .map_err(|_| CliError::Usage(format!("invalid WIP limit in {part:?}")))?;
+                out.push((name.trim().to_string(), Some(wip)));
+            }
+            None => out.push((part.to_string(), None)),
+        }
+    }
+    if out.is_empty() {
+        return Err(CliError::Usage("no columns specified".into()));
+    }
+    Ok(out)
+}
+
+fn template_columns(name: &str) -> Vec<(&'static str, Option<u32>)> {
+    match name {
+        "kanban" => vec![("Backlog", Some(5)), ("In Progress", Some(3)), ("Review", None), ("Done", None)],
+        "sprint" => vec![("To Do", Some(5)), ("In Progress", Some(3)), ("Blocked", None), ("Done", None)],
+        "sales" => vec![("Lead", None), ("Qualified", None), ("Proposal", None), ("Won", None), ("Lost", None)],
+        _ => vec![("Backlog", None)], // blank
+    }
+}
+
+/// Submit a signed Kanban event and confirm the relay treated it as
+/// authoritative. Like `buzz mem`, the relay returns `{accepted, message}`
+/// where `message` starts with `"duplicate:"` when a NIP-33 write was rejected
+/// as already-superseded by a newer head (LWW). We surface that as a
+/// `Conflict` — CLI exit code 5 — instead of lying about success.
+pub(crate) async fn submit_lww_event(
+    client: &BuzzClient,
+    event: nostr::Event,
+) -> Result<serde_json::Value, CliError> {
+    let raw = client.submit_event(event).await?;
+    let parsed: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| CliError::Other(format!("relay response is not JSON: {e} ({raw})")))?;
+    let accepted = parsed
+        .get("accepted")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let message = parsed.get("message").and_then(|v| v.as_str()).unwrap_or("");
+    if !accepted {
+        return Err(CliError::Other(format!("relay rejected event: {message}")));
+    }
+    if message.starts_with("duplicate:") || message == "duplicate" {
+        return Err(CliError::Conflict(
+            "relay reported event as duplicate / dominated by a newer head".into(),
+        ));
+    }
+    Ok(parsed)
+}
+
+async fn submit_board(
+    client: &BuzzClient,
+    board_id: &str,
+    owner: &str,
+    name: &str,
+    content: &str,
+    meta: &KanbanBoardMeta,
+) -> Result<(), CliError> {
+    let builder = build_kanban_board(board_id, owner, name, content, meta).map_err(sdk_err)?;
+    let event = client.sign_event(builder)?;
+    submit_lww_event(client, event).await?;
+    Ok(())
+}
+
+fn board_content(name: &str, description: Option<&str>) -> String {
+    match description {
+        Some(d) if !d.trim().is_empty() => format!("## {name}\n\n{}", d.trim()),
+        _ => format!("## {name}"),
+    }
+}
+
+pub async fn cmd_create_board(
+    client: &BuzzClient,
+    name: &str,
+    description: Option<&str>,
+    columns: Option<&str>,
+    template: Option<&str>,
+) -> Result<(), CliError> {
+    let board_id = Uuid::new_v4().to_string();
+    let owner = self_hex(client);
+    let cols_raw: Vec<(String, Option<u32>)> = match columns {
+        Some(cs) => parse_columns(cs)?,
+        None => template_columns(template.unwrap_or("blank"))
+            .into_iter()
+            .map(|(n, w)| (n.to_string(), w))
+            .collect(),
+    };
+    let meta_cols: Vec<KanbanColumnDef> = cols_raw
+        .iter()
+        .enumerate()
+        .map(|(i, (n, w))| KanbanColumnDef {
+            id: new_colid(),
+            name: n.clone(),
+            wip: *w,
+            order: i as u32,
+        })
+        .collect();
+    let content = board_content(name, description);
+    let meta = KanbanBoardMeta { columns: meta_cols.clone(), channels: vec![], invites: vec![] };
+    let _ = submit_board(client, &board_id, &owner, name, &content, &meta).await?;
+    let cols_json: Vec<Value> = meta_cols
+        .iter()
+        .map(|c| json!({ "id": c.id, "name": c.name, "wip": c.wip, "order": c.order }))
+        .collect();
+    println!("{}", json!({ "board_id": board_id, "columns": cols_json, "owner": owner }));
+    Ok(())
+}
+
+pub async fn cmd_get_board(client: &BuzzClient, board_id: &str) -> Result<(), CliError> {
+    let (ev, _) = fetch_board(client, board_id).await?;
+    println!("{ev}");
+    Ok(())
+}
+
+pub async fn cmd_list_boards(client: &BuzzClient) -> Result<(), CliError> {
+    let me = self_hex(client);
+    let filter = json!({ "kinds": [KIND_KANBAN_BOARD], "authors": [me], "limit": 1000 });
+    let events = query_events(client, &filter).await?;
+    println!("{}", json!(events));
+    Ok(())
+}
+
+pub async fn cmd_update_board(
+    client: &BuzzClient,
+    board_id: &str,
+    name: Option<&str>,
+    description: Option<&str>,
+) -> Result<(), CliError> {
+    let (ev, meta) = fetch_board(client, board_id).await?;
+    let owner = tag(&ev, "p").unwrap_or_else(|| self_hex(client));
+    let cur_name = tag(&ev, "name").unwrap_or_default();
+    let new_name = name.unwrap_or(&cur_name);
+    let content = match description {
+        Some(d) if !d.trim().is_empty() => board_content(new_name, Some(d)),
+        _ => ev.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string(),
+    };
+    let _ = submit_board(client, board_id, &owner, new_name, &content, &meta).await?;
+    println!("{}", json!({ "board_id": board_id, "name": new_name }));
+    Ok(())
+}
+
+pub async fn cmd_add_column(
+    client: &BuzzClient,
+    board_id: &str,
+    name: &str,
+    wip: Option<u32>,
+) -> Result<(), CliError> {
+    if name.trim().is_empty() {
+        return Err(CliError::Usage("column name must not be empty".into()));
+    }
+    let (ev, mut meta) = fetch_board(client, board_id).await?;
+    let owner = tag(&ev, "p").unwrap_or_else(|| self_hex(client));
+    let next_order = meta.columns.len() as u32;
+    meta.columns.push(KanbanColumnDef {
+        id: new_colid(),
+        name: name.to_string(),
+        wip,
+        order: next_order,
+    });
+    let cur_name = tag(&ev, "name").unwrap_or_default();
+    let content = ev.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string();
+    let _ = submit_board(client, board_id, &owner, &cur_name, &content, &meta).await?;
+    println!("{}", json!({ "board_id": board_id, "column": { "name": name, "wip": wip, "order": next_order } }));
+    Ok(())
+}
+
+pub async fn cmd_rename_column(
+    client: &BuzzClient,
+    board_id: &str,
+    colid: &str,
+    new_name: &str,
+) -> Result<(), CliError> {
+    if new_name.trim().is_empty() {
+        return Err(CliError::Usage("column name must not be empty".into()));
+    }
+    let (ev, mut meta) = fetch_board(client, board_id).await?;
+    let owner = tag(&ev, "p").unwrap_or_else(|| self_hex(client));
+    let mut found = false;
+    for c in &mut meta.columns {
+        if c.id == colid {
+            c.name = new_name.to_string();
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        return Err(CliError::Usage(format!("column {colid} not found on board {board_id}")));
+    }
+    let cur_name = tag(&ev, "name").unwrap_or_default();
+    let content = ev.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string();
+    let _ = submit_board(client, board_id, &owner, &cur_name, &content, &meta).await?;
+    println!("{}", json!({ "board_id": board_id, "column": colid, "name": new_name }));
+    Ok(())
+}
+
+pub async fn dispatch(cmd: crate::BoardsCmd, client: &BuzzClient) -> Result<(), CliError> {
+    use crate::BoardsCmd;
+    match cmd {
+        BoardsCmd::Create { name, description, columns, template } => {
+            cmd_create_board(client, &name, description.as_deref(), columns.as_deref(), template.as_deref()).await
+        }
+        BoardsCmd::Get { board } => cmd_get_board(client, &board).await,
+        BoardsCmd::List => cmd_list_boards(client).await,
+        BoardsCmd::Update { board, name, description } => {
+            cmd_update_board(client, &board, name.as_deref(), description.as_deref()).await
+        }
+        BoardsCmd::AddColumn { board, name, wip } => cmd_add_column(client, &board, &name, wip).await,
+        BoardsCmd::RenameColumn { board, column, name } => {
+            cmd_rename_column(client, &board, &column, &name).await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // Mirrors the SDK's emitted column tags (builders.rs build_kanban_board):
+    //   with wip: ["column", id, "name", <name>, "wip", <n>, "order", <n>]
+    //   no wip:   ["column", id, "name", <name>, "order", <n>]
+    fn make_board_event(col_tags: Vec<Vec<&str>>) -> Value {
+        let tags: Vec<Value> = col_tags.into_iter().map(|t| json!(t)).collect();
+        json!({ "tags": tags })
+    }
+
+    #[test]
+    fn columns_parses_wip_and_no_wip_by_key() {
+        let ev = make_board_event(vec![
+            vec!["column", "col-a", "name", "Backlog", "wip", "5", "order", "0"],
+            vec!["column", "col-b", "name", "In Progress", "wip", "3", "order", "1"],
+            vec!["column", "col-c", "name", "Review", "order", "2"],
+            vec!["column", "col-d", "name", "Done", "order", "3"],
+        ]);
+        let cols = columns(&ev);
+        assert_eq!(cols.len(), 4);
+        assert_eq!(
+            cols.iter().map(|c| c.order).collect::<Vec<_>>(),
+            vec![0, 1, 2, 3],
+            "no-wip columns must keep their real order (regression: fixed-index parser dropped it to 0)"
+        );
+        let c = &cols[2];
+        assert_eq!(c.id, "col-c");
+        assert_eq!(c.name, "Review");
+        assert_eq!(c.wip, None, "no-wip column must not leak the order value into wip");
+        assert_eq!(cols[3].wip, None);
+        assert_eq!(cols[0].wip, Some(5));
+        assert_eq!(cols[1].wip, Some(3));
+    }
+
+    #[test]
+    fn columns_roundtrips_after_rename_shape() {
+        // Same shape a rename writes back: mixed wip/no-wip columns.
+        let ev = make_board_event(vec![
+            vec!["column", "col-a", "name", "Backlog", "wip", "5", "order", "0"],
+            vec!["column", "col-b", "name", "Code Review", "wip", "3", "order", "1"],
+            vec!["column", "col-c", "name", "Done", "order", "2"],
+        ]);
+        let cols = columns(&ev);
+        assert_eq!(cols[1].name, "Code Review");
+        assert_eq!(cols[1].order, 1);
+        assert_eq!(cols[2].order, 2);
+        assert_eq!(cols[2].wip, None);
+    }
+}
+

--- a/crates/buzz-cli/src/commands/cards.rs
+++ b/crates/buzz-cli/src/commands/cards.rs
@@ -1,0 +1,297 @@
+use crate::client::BuzzClient;
+use crate::error::CliError;
+use crate::validate::sdk_err;
+use buzz_core::kanban;
+use buzz_core::kind::KIND_KANBAN_BOARD;
+use buzz_sdk::{build_kanban_card, KanbanCardMeta, KanbanColumnDef};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use super::boards::{columns, tag};
+
+async fn query_events(client: &BuzzClient, filter: &Value) -> Result<Vec<Value>, CliError> {
+    let raw = client.query(filter).await?;
+    Ok(serde_json::from_str(&raw).unwrap_or_default())
+}
+
+fn self_hex(client: &BuzzClient) -> String {
+    client.keys().public_key().to_hex()
+}
+
+/// Fetch the board event + its column meta for `board_id`.
+async fn get_board(client: &BuzzClient, board_id: &str) -> Result<(Value, Vec<KanbanColumnDef>), CliError> {
+    let me = self_hex(client);
+    let filter = json!({ "kinds": [KIND_KANBAN_BOARD], "authors": [me], "limit": 1000 });
+    let events = query_events(client, &filter).await?;
+    let ev = events
+        .into_iter()
+        .find(|e| tag(e, "d").as_deref() == Some(board_id))
+        .ok_or_else(|| CliError::Usage(format!("board {board_id} not found for this key")))?;
+    let cols = columns(&ev);
+    Ok((ev, cols))
+}
+
+fn board_ref(owner: &str, board_id: &str) -> String {
+    format!("31001:{owner}:{board_id}")
+}
+
+/// All cards on a board (by `#a` board ref).
+async fn list_cards_by_board(client: &BuzzClient, board_ref: &str) -> Result<Vec<Value>, CliError> {
+    let filter = json!({ "kinds": [31002], "#a": [board_ref], "limit": 1000 });
+    query_events(client, &filter).await
+}
+
+fn card_tag(ev: &Value, name: &str) -> Option<String> {
+    tag(ev, name)
+}
+
+fn card_multi_tag(ev: &Value, name: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(tags) = ev.get("tags").and_then(|t| t.as_array()) {
+        for t in tags {
+            if let Some(a) = t.as_array() {
+                if a.first().and_then(|s| s.as_str()) == Some(name) {
+                    if let Some(v) = a.get(1).and_then(|s| s.as_str()) {
+                        out.push(v.to_string());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Labels are NIP-32 namespaced `["l",<label>,"kanban"]`; strip the namespace.
+fn card_labels(ev: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(tags) = ev.get("tags").and_then(|t| t.as_array()) {
+        for t in tags {
+            if let Some(a) = t.as_array() {
+                if a.first().and_then(|s| s.as_str()) == Some("l")
+                    && a.get(2).and_then(|s| s.as_str()) == Some("kanban")
+                {
+                    if let Some(v) = a.get(1).and_then(|s| s.as_str()) {
+                        out.push(v.to_string());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Rebuild a card's meta from an existing event (preserves fields not being changed).
+fn meta_from_event(ev: &Value, board_ref: &str, column: Option<&str>, rank: Option<&str>) -> KanbanCardMeta {
+    KanbanCardMeta {
+        board: board_ref.to_string(),
+        column: column.map(str::to_string).unwrap_or_else(|| card_tag(ev, "column").unwrap_or_default()),
+        rank: rank.map(str::to_string).or_else(|| card_tag(ev, "rank")),
+        assignees: card_multi_tag(ev, "p"),
+        labels: card_labels(ev),
+        due: card_tag(ev, "due"),
+        thread: card_tag(ev, "e"),
+    }
+}
+
+/// Highest rank string among the given cards (that are in `column`), if any.
+fn max_rank(cards: &[Value], column: &str) -> Option<String> {
+    cards
+        .iter()
+        .filter(|c| card_tag(c, "column").as_deref() == Some(column))
+        .filter_map(|c| card_tag(c, "rank"))
+        .max()
+}
+
+fn validate_rank(r: &str) -> Result<(), CliError> {
+    if !kanban::is_valid(r) {
+        return Err(CliError::Usage(format!("invalid rank {r:?}: must be a base-36 rank string not ending in '0'")));
+    }
+    Ok(())
+}
+
+async fn submit_card(
+    client: &BuzzClient,
+    card_id: &str,
+    content: &str,
+    meta: KanbanCardMeta,
+) -> Result<(), CliError> {
+    let builder = build_kanban_card(card_id, content, &meta).map_err(sdk_err)?;
+    let event = client.sign_event(builder)?;
+    crate::commands::boards::submit_lww_event(client, event).await?;
+    Ok(())
+}
+
+pub async fn cmd_create_card(
+    client: &BuzzClient,
+    board_id: &str,
+    column: Option<&str>,
+    title: &str,
+    body: Option<&str>,
+    labels: &[String],
+    assignees: &[String],
+) -> Result<(), CliError> {
+    if title.trim().is_empty() {
+        return Err(CliError::Usage("card title must not be empty".into()));
+    }
+    let (board_ev, cols) = get_board(client, board_id).await?;
+    let owner = board_ev.get("pubkey").and_then(|p| p.as_str()).unwrap_or(&self_hex(client)).to_string();
+    let refv = board_ref(&owner, board_id);
+    let colid = match column {
+        Some(c) => {
+            if !cols.iter().any(|c2| c2.id == c) {
+                return Err(CliError::Usage(format!("column {c} not found on board {board_id}")));
+            }
+            c.to_string()
+        }
+        None => cols
+            .iter()
+            .find(|c| c.order == 0)
+            .or_else(|| cols.first())
+            .map(|c| c.id.clone())
+            .ok_or_else(|| CliError::Usage(format!("board {board_id} has no columns")))?,
+    };
+
+    let cards = list_cards_by_board(client, &refv).await?;
+    let rank = match max_rank(&cards, &colid) {
+        Some(r) => kanban::rank_after(&r),
+        None => kanban::first_rank(),
+    };
+
+    let content = match body {
+        Some(b) if !b.trim().is_empty() => format!("{title}\n\n{}", b.trim()),
+        _ => title.to_string(),
+    };
+    let card_id = Uuid::new_v4().to_string();
+    let meta = KanbanCardMeta {
+        board: refv,
+        column: colid.clone(),
+        rank: Some(rank.clone()),
+        assignees: assignees.to_vec(),
+        labels: labels.to_vec(),
+        due: None,
+        thread: None,
+    };
+    let _ = submit_card(client, &card_id, &content, meta).await?;
+    println!("{}", json!({ "card_id": card_id, "board": board_id, "column": colid, "rank": rank }));
+    Ok(())
+}
+
+pub async fn cmd_list_cards(
+    client: &BuzzClient,
+    board_id: &str,
+    column: Option<&str>,
+) -> Result<(), CliError> {
+    let (board_ev, cols) = get_board(client, board_id).await?;
+    let owner = board_ev.get("pubkey").and_then(|p| p.as_str()).unwrap_or(&self_hex(client)).to_string();
+    let refv = board_ref(&owner, board_id);
+    let mut cards = list_cards_by_board(client, &refv).await?;
+    if let Some(c) = column {
+        cards.retain(|c2| card_tag(c2, "column").as_deref() == Some(c));
+    }
+    // sort by column order, then lexicographic rank
+    let order_of = |ev: &Value| -> (usize, String) {
+        let c = card_tag(ev, "column").unwrap_or_default();
+        let order = cols.iter().position(|col| col.id == c).unwrap_or(usize::MAX);
+        let r = card_tag(ev, "rank").unwrap_or_default();
+        (order, r)
+    };
+    cards.sort_by(|a, b| order_of(a).cmp(&order_of(b)));
+    println!("{}", json!(cards));
+    Ok(())
+}
+
+pub async fn cmd_get_card(client: &BuzzClient, board_id: &str, card_id: &str) -> Result<(), CliError> {
+    let (board_ev, _) = get_board(client, board_id).await?;
+    let owner = board_ev.get("pubkey").and_then(|p| p.as_str()).unwrap_or(&self_hex(client)).to_string();
+    let refv = board_ref(&owner, board_id);
+    let cards = list_cards_by_board(client, &refv).await?;
+    let ev = cards
+        .into_iter()
+        .find(|c| card_tag(c, "d").as_deref() == Some(card_id))
+        .ok_or_else(|| CliError::Usage(format!("card {card_id} not found on board {board_id}")))?;
+    println!("{ev}");
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn cmd_move_card(
+    client: &BuzzClient,
+    board_id: &str,
+    card_id: &str,
+    column: &str,
+    rank: Option<&str>,
+) -> Result<(), CliError> {
+    let (board_ev, cols) = get_board(client, board_id).await?;
+    if !cols.iter().any(|c| c.id == column) {
+        return Err(CliError::Usage(format!("column {column} not found on board {board_id}")));
+    }
+    let owner = board_ev.get("pubkey").and_then(|p| p.as_str()).unwrap_or(&self_hex(client)).to_string();
+    let refv = board_ref(&owner, board_id);
+    let cards = list_cards_by_board(client, &refv).await?;
+    let old = cards
+        .iter()
+        .find(|c| card_tag(c, "d").as_deref() == Some(card_id))
+        .ok_or_else(|| CliError::Usage(format!("card {card_id} not found on board {board_id}")))?;
+
+    let new_rank = match rank {
+        Some(r) => {
+            validate_rank(r)?;
+            r.to_string()
+        }
+        None => match max_rank(&cards, column) {
+            Some(r) => kanban::rank_after(&r),
+            None => kanban::first_rank(),
+        },
+    };
+    let content = old.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string();
+    let meta = meta_from_event(old, &refv, Some(column), Some(&new_rank));
+    let _ = submit_card(client, card_id, &content, meta).await?;
+    println!("{}", json!({ "card_id": card_id, "board": board_id, "column": column, "rank": new_rank }));
+    Ok(())
+}
+
+pub async fn cmd_update_card(
+    client: &BuzzClient,
+    board_id: &str,
+    card_id: &str,
+    title: Option<&str>,
+    body: Option<&str>,
+) -> Result<(), CliError> {
+    let (board_ev, _) = get_board(client, board_id).await?;
+    let owner = board_ev.get("pubkey").and_then(|p| p.as_str()).unwrap_or(&self_hex(client)).to_string();
+    let refv = board_ref(&owner, board_id);
+    let cards = list_cards_by_board(client, &refv).await?;
+    let old = cards
+        .iter()
+        .find(|c| card_tag(c, "d").as_deref() == Some(card_id))
+        .ok_or_else(|| CliError::Usage(format!("card {card_id} not found on board {board_id}")))?;
+
+    let old_content = old.get("content").and_then(|c| c.as_str()).unwrap_or("").to_string();
+    let content = match (title, body) {
+        (Some(t), Some(b)) if !b.trim().is_empty() => format!("{t}\n\n{}", b.trim()),
+        (Some(t), None) => t.to_string(),
+        (None, Some(b)) if !b.trim().is_empty() => b.trim().to_string(),
+        _ => old_content,
+    };
+    let meta = meta_from_event(old, &refv, None, None);
+    let _ = submit_card(client, card_id, &content, meta).await?;
+    println!("{}", json!({ "card_id": card_id, "board": board_id }));
+    Ok(())
+}
+
+pub async fn dispatch(cmd: crate::CardsCmd, client: &BuzzClient) -> Result<(), CliError> {
+    use crate::CardsCmd;
+    match cmd {
+        CardsCmd::Create { board, column, title, body, label, assignee } => {
+            cmd_create_card(client, &board, column.as_deref(), &title, body.as_deref(), &label, &assignee).await
+        }
+        CardsCmd::List { board, column } => cmd_list_cards(client, &board, column.as_deref()).await,
+        CardsCmd::Get { board, card } => cmd_get_card(client, &board, &card).await,
+        CardsCmd::Move { board, card, column, rank } => {
+            cmd_move_card(client, &board, &card, &column, rank.as_deref()).await
+        }
+        CardsCmd::Update { board, card, title, body } => {
+            cmd_update_card(client, &board, &card, title.as_deref(), body.as_deref()).await
+        }
+    }
+}

--- a/crates/buzz-cli/src/commands/mod.rs
+++ b/crates/buzz-cli/src/commands/mod.rs
@@ -1,4 +1,6 @@
 pub mod agents;
+pub mod boards;
+pub mod cards;
 pub mod channel_templates;
 pub mod channels;
 pub mod dms;

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -218,6 +218,12 @@ enum Cmd {
     /// Create, get, list, and set status on git issues (NIP-34)
     #[command(subcommand)]
     Issues(IssuesCmd),
+    /// Create, list, and manage Kanban boards
+    #[command(subcommand)]
+    Boards(BoardsCmd),
+    /// Create, list, and move Kanban cards
+    #[command(subcommand)]
+    Cards(CardsCmd),
     /// Open, update, list, and set status on git pull requests (NIP-34)
     #[command(subcommand)]
     Pr(PrCmd),
@@ -1553,6 +1559,142 @@ pub enum IssuesCmd {
 }
 
 #[derive(Subcommand)]
+pub enum BoardsCmd {
+    /// Create a Kanban board (kind:31001, NIP-33 replaceable)
+    Create {
+        /// Board title
+        #[arg(long)]
+        name: String,
+        /// Optional description, markdown ('-' to read from stdin)
+        #[arg(long)]
+        description: Option<String>,
+        /// Explicit column set "Name:wip,Name2" (overrides --template)
+        #[arg(long)]
+        columns: Option<String>,
+        /// Starter column template: kanban | sprint | sales | blank
+        #[arg(long, value_parser = ["kanban", "sprint", "sales", "blank"])]
+        template: Option<String>,
+    },
+    /// Get a board by id
+    Get {
+        /// Board id (d-tag)
+        #[arg(long)]
+        board: String,
+    },
+    /// List the signed-in user's boards
+    List,
+    /// Update a board's title/description
+    Update {
+        /// Board id (d-tag)
+        #[arg(long)]
+        board: String,
+        /// New title
+        #[arg(long)]
+        name: Option<String>,
+        /// New description, markdown
+        #[arg(long)]
+        description: Option<String>,
+    },
+    /// Add a column to a board
+    AddColumn {
+        /// Board id (d-tag)
+        #[arg(long)]
+        board: String,
+        /// New column name
+        #[arg(long)]
+        name: String,
+        /// Advisory WIP limit
+        #[arg(long)]
+        wip: Option<u32>,
+    },
+    /// Rename a board column (stable colid keeps card order)
+    RenameColumn {
+        /// Board id (d-tag)
+        #[arg(long)]
+        board: String,
+        /// Column id (colid)
+        #[arg(long)]
+        column: String,
+        /// New column name
+        #[arg(long)]
+        name: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum CardsCmd {
+    /// Create a Kanban card (kind:31002, NIP-33 replaceable)
+    Create {
+        /// Board id (d-tag)
+        #[arg(long)]
+        board: String,
+        /// Destination column id (defaults to the board's first column)
+        #[arg(long)]
+        column: Option<String>,
+        /// Card title
+        #[arg(long)]
+        title: String,
+        /// Card body, markdown
+        #[arg(long)]
+        body: Option<String>,
+        /// Label — repeatable (NIP-32 namespaced to 'kanban')
+        #[arg(long = "label")]
+        label: Vec<String>,
+        /// Assignee pubkey — repeatable
+        #[arg(long = "assignee")]
+        assignee: Vec<String>,
+    },
+    /// List cards on a board, sorted by column then rank
+    List {
+        /// Board id (d-tag)
+        #[arg(long)]
+        board: String,
+        /// Filter to a single column id
+        #[arg(long)]
+        column: Option<String>,
+    },
+    /// Get a card by id
+    Get {
+        /// Board id (d-tag)
+        #[arg(long)]
+        board: String,
+        /// Card id (d-tag)
+        #[arg(long)]
+        card: String,
+    },
+    /// Move a card to a column (replaces the card event — LWW via NIP-33)
+    Move {
+        /// Board id (d-tag)
+        #[arg(long)]
+        board: String,
+        /// Card id (d-tag)
+        #[arg(long)]
+        card: String,
+        /// Destination column id
+        #[arg(long)]
+        column: String,
+        /// Explicit rank (defaults to the tail of the destination column)
+        #[arg(long)]
+        rank: Option<String>,
+    },
+    /// Update a card's title/body
+    Update {
+        /// Board id (d-tag)
+        #[arg(long)]
+        board: String,
+        /// Card id (d-tag)
+        #[arg(long)]
+        card: String,
+        /// New title
+        #[arg(long)]
+        title: Option<String>,
+        /// New body, markdown
+        #[arg(long)]
+        body: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum UploadCmd {
     /// Upload a file to the relay's Blossom store
     File {
@@ -1821,6 +1963,8 @@ async fn run(cli: Cli) -> Result<(), CliError> {
         Cmd::Repos(sub) => commands::repos::dispatch(sub, &client).await,
         Cmd::Patches(sub) => commands::patches::dispatch(sub, &client).await,
         Cmd::Issues(sub) => commands::issues::dispatch(sub, &client).await,
+        Cmd::Boards(sub) => commands::boards::dispatch(sub, &client).await,
+        Cmd::Cards(sub) => commands::cards::dispatch(sub, &client).await,
         Cmd::Pr(sub) => commands::pr::dispatch(sub, &client).await,
         Cmd::Media(sub) => commands::upload::dispatch_media(sub, &client).await,
         Cmd::Upload(sub) => commands::upload::dispatch(sub, &client).await,
@@ -1869,7 +2013,9 @@ mod tests {
     fn command_inventory_is_stable() {
         let expected_groups: Vec<&str> = vec![
             "agents",
+            "boards",
             "canvas",
+            "cards",
             "channels",
             "dms",
             "emoji",

--- a/crates/buzz-core/src/kanban.rs
+++ b/crates/buzz-core/src/kanban.rs
@@ -1,0 +1,207 @@
+//! Kanban rank ordering — base-36 order-preserving fractional ranks.
+//!
+//! Card ordering within a Kanban column is a `rank` string. Using raw decimal
+//! "midpoints" misorders (`"0.10" < "0.9"` as text but `0.10 > 0.9` as
+//! numbers). Instead we use a base-36 fractional rank with the invariant that
+//! a valid rank never ends in the smallest digit `'0'` (canonical, injective).
+//! With that invariant, plain lexicographic string comparison EQUALS numeric
+//! value order, so the comparator is an ordinary string `<`.
+//!
+//! Operations produce unbounded interstitial insertion with no mass
+//! renumbering: `first` (a column's first card), `rank_after`/`rank_before`
+//! (insert at head/tail), and `rank_between` (reorder between two cards).
+//! Ported from the validated reference at
+//! `PLANS/KANBAN_RANK_CODEC/rank.js` (5/5 tests there).
+
+const DIGITS: &str = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+fn digit_index(c: u8) -> usize {
+    DIGITS
+        .find(c as char)
+        .unwrap_or_else(|| panic!("kanban rank digit out of alphabet: {c}"))
+}
+
+fn digit_char(i: usize) -> char {
+    DIGITS.as_bytes()[i] as char
+}
+
+/// A valid canonical rank: non-empty, all in the alphabet, not ending in '0'.
+pub fn is_valid(rank: &str) -> bool {
+    !rank.is_empty()
+        && !rank.ends_with(DIGITS.as_bytes()[0] as char)
+        && rank.bytes().all(|b| DIGITS.find(b as char).is_some())
+}
+
+/// Smallest (non-empty, canonical) valid rank strictly below `x`.
+/// `x` must be a valid rank (never called with the open boundary on this path).
+fn below(x: &str) -> String {
+    let first = x.as_bytes()[0];
+    if first == DIGITS.as_bytes()[0] {
+        // Prepend a '0' and go deeper: "0" + below(rest)
+        let mut out = String::from("0");
+        out.push_str(&below(&x[1..]));
+        out
+    } else if first == b'1' {
+        // "01" < any "1...."
+        String::from("01")
+    } else {
+        digit_char(digit_index(first) - 1).to_string()
+    }
+}
+
+/// A valid canonical rank strictly above `x` (compact successor).
+fn above(x: &str) -> String {
+    let bytes = x.as_bytes();
+    let max = DIGITS.as_bytes()[DIGITS.len() - 1];
+    for i in (0..bytes.len()).rev() {
+        if bytes[i] < max {
+            let mut out = String::from(&x[..i]);
+            out.push(digit_char(digit_index(bytes[i]) + 1));
+            return out;
+        }
+    }
+    // all max chars -> extend
+    let mut out = String::from(x);
+    out.push('1');
+    out
+}
+
+/// Valid rank strictly between `lo` and `hi` (open bounds passed as `""`).
+pub fn between(lo: &str, hi: &str) -> String {
+    if lo.is_empty() && hi.is_empty() {
+        return digit_char(DIGITS.len() >> 1).to_string(); // 'i' (mid of alphabet)
+    }
+    if lo.is_empty() {
+        return below(hi);
+    }
+    if hi.is_empty() {
+        return above(lo);
+    }
+
+    let lb = lo.as_bytes();
+    let hb = hi.as_bytes();
+    let n = lb.len().min(hb.len());
+    let mut p = 0;
+    while p < n && lb[p] == hb[p] {
+        p += 1;
+    }
+
+    let tail_lo = &lo[p..];
+    if tail_lo.is_empty() {
+        // lo is a prefix of hi; extend lo below hi's remainder
+        let mut out = String::from(&lo[..p]);
+        out.push_str(&below(&hi[p..]));
+        return out;
+    }
+    // diverge: lo[p] < hi[p] (since lo < hi); extending lo stays < hi
+    let mut out = String::from(lo);
+    out.push('1');
+    out
+}
+
+/// The rank of a column's first card.
+pub fn first_rank() -> String {
+    between("", "")
+}
+
+/// A rank strictly before `rank` (insert at head of a column).
+pub fn rank_before(rank: &str) -> String {
+    between("", rank)
+}
+
+/// A rank strictly after `rank` (insert at tail of a column).
+pub fn rank_after(rank: &str) -> String {
+    between(rank, "")
+}
+
+/// A rank strictly between `a` and `b` (reorder between two adjacent cards).
+pub fn rank_between(a: &str, b: &str) -> String {
+    between(a, b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_canonical(r: &str) {
+        assert!(is_valid(r), "not canonical/valid: {r:?}");
+    }
+
+    #[test]
+    fn validity() {
+        assert!(is_valid("i"));
+        assert!(is_valid("ab1"));
+        assert!(is_valid("001"));
+        assert!(!is_valid(""));
+        assert!(!is_valid("a0")); // trailing smallest digit
+        assert!(!is_valid("a!")); // out of alphabet
+    }
+
+    #[test]
+    fn first_and_bounds() {
+        let f = first_rank();
+        assert_canonical(&f);
+        let mut prev = f.clone();
+        for _ in 0..200 {
+            let y = rank_before(&prev);
+            assert_canonical(&y);
+            assert!(y.as_str() < prev.as_str());
+            prev = y;
+        }
+        prev = first_rank();
+        for _ in 0..200 {
+            let y = rank_after(&prev);
+            assert_canonical(&y);
+            assert!(y.as_str() > prev.as_str());
+            prev = y;
+        }
+    }
+
+    #[test]
+    fn strict_betweenness() {
+        let keys = ["i", "h", "g", "01", "001", "j", "ab", "ac", "az", "ab1", "zz1", "z", "0a9", "i1"];
+        for a in keys {
+            for b in keys {
+                if a == b {
+                    continue;
+                }
+                let (lo, hi) = if a < b { (a, b) } else { (b, a) };
+                let c = rank_between(lo, hi);
+                assert_canonical(&c);
+                assert!(c.as_str() > lo, "c={c} not > lo={lo}");
+                assert!(c.as_str() < hi, "c={c} not < hi={hi}");
+            }
+        }
+    }
+
+    #[test]
+    fn fuzz_interleaved_inserts() {
+        // deterministic LCG fuzz
+        let mut seed: u64 = 123456789;
+        let mut rnd = move || {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            (seed >> 33) as usize
+        };
+        let mut keys: Vec<String> = vec![first_rank()];
+        for _ in 0..5000 {
+            let idx = rnd() % (keys.len() + 1);
+            let lo = if idx == 0 { String::new() } else { keys[idx - 1].clone() };
+            let hi = if idx == keys.len() { String::new() } else { keys[idx].clone() };
+            let nk = between(&lo, &hi);
+            assert_canonical(&nk);
+            if !lo.is_empty() {
+                assert!(nk.as_str() > lo.as_str());
+            }
+            if !hi.is_empty() {
+                assert!(nk.as_str() < hi.as_str());
+            }
+            keys.insert(idx, nk);
+        }
+        for i in 0..keys.len() {
+            assert_canonical(&keys[i]);
+            if i > 0 {
+                assert!(keys[i].as_str() > keys[i - 1].as_str(), "unsorted at {i}");
+            }
+        }
+    }
+}

--- a/crates/buzz-core/src/kind.rs
+++ b/crates/buzz-core/src/kind.rs
@@ -108,6 +108,31 @@ pub const KIND_EVENT_REMINDER: u32 = 30300;
 /// dedicated push lease tables.
 pub const KIND_PUSH_LEASE: u32 = 30350;
 
+/// Buzz Kanban: board container (parameterized replaceable, NIP-33).
+///
+/// `d` = board uuid (stable for the board's life). Content is markdown
+/// (title + description). Tags carry `name` (title), `p` (owner, role=owner),
+/// repeating ordered `column` tags
+/// (`["column",colid,"name",<name>,"wip",<n>,"order",<n>]`), and optional
+/// `h` (shared channel) / `invite` (shared member) tags. Addressed by
+/// `(pubkey, kind, d_tag)`; owner-scoped, default only-me, channel-shareable.
+pub const KIND_KANBAN_BOARD: u32 = 31001;
+
+/// Buzz Kanban: card (parameterized replaceable, NIP-33).
+///
+/// `d` = card uuid. `a` = board ref (`31001:<owner>:<boardid>`), `column` =
+/// the single current lane (must exist on the board), `rank` = base-36
+/// order-preserving order within a column, optional `p` assignees, NIP-32
+/// namespaced `l` labels, `due`, and `e` (comment thread root). Moving a card
+/// replaces this event with new `column`/`rank` (LWW via NIP-33).
+pub const KIND_KANBAN_CARD: u32 = 31002;
+
+/// Buzz Kanban: card move audit trail (non-replaceable), OFF by default.
+///
+/// Only emitted when a board opts in. Tags: `a` (board ref), `e` (card id),
+/// `from`, `to`. Keep event volume low by not emitting by default.
+pub const KIND_KANBAN_CARD_MOVE: u32 = 31003;
+
 /// Kinds whose stored events are readable only by their author.
 ///
 /// The relay must never reveal the existence, count, tags, content, schedule,

--- a/crates/buzz-core/src/lib.rs
+++ b/crates/buzz-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod git_perms;
 /// Shared invite-link contract constants.
 pub mod invite;
 /// Buzz kind number registry — custom event type constants.
+pub mod kanban;
 pub mod kind;
 /// Network utilities — SSRF-safe IP classification.
 pub mod network;

--- a/crates/buzz-relay/src/handlers/ingest.rs
+++ b/crates/buzz-relay/src/handlers/ingest.rs
@@ -21,7 +21,8 @@ use buzz_core::kind::{
     KIND_GIT_STATUS_CLOSED, KIND_GIT_STATUS_DRAFT, KIND_GIT_STATUS_MERGED, KIND_GIT_STATUS_OPEN,
     KIND_HUDDLE_ENDED, KIND_HUDDLE_GUIDELINES, KIND_HUDDLE_PARTICIPANT_JOINED,
     KIND_HUDDLE_PARTICIPANT_LEFT, KIND_HUDDLE_STARTED, KIND_IA_ARCHIVE_REQUEST,
-    KIND_IA_UNARCHIVE_REQUEST, KIND_LONG_FORM, KIND_MANAGED_AGENT, KIND_MEMBER_ADDED_NOTIFICATION,
+    KIND_IA_UNARCHIVE_REQUEST, KIND_KANBAN_BOARD, KIND_KANBAN_CARD, KIND_KANBAN_CARD_MOVE,
+    KIND_LONG_FORM, KIND_MANAGED_AGENT, KIND_MEMBER_ADDED_NOTIFICATION,
     KIND_MEMBER_REMOVED_NOTIFICATION, KIND_MODERATION_BAN, KIND_MODERATION_RESOLVE_REPORT,
     KIND_MODERATION_TIMEOUT, KIND_MODERATION_UNBAN, KIND_MODERATION_UNTIMEOUT, KIND_MUTE_LIST,
     KIND_NIP29_CREATE_GROUP, KIND_NIP29_DELETE_EVENT, KIND_NIP29_DELETE_GROUP,
@@ -293,6 +294,12 @@ fn required_scope_for_kind(kind: u32, event: &Event) -> Result<Scope, &'static s
         KIND_NIP29_JOIN_REQUEST | KIND_NIP29_LEAVE_REQUEST | KIND_NIP43_LEAVE_REQUEST => {
             Ok(Scope::ChannelsRead)
         }
+        // Buzz Kanban: boards (31001) and cards (31002) are owner-authored
+        // parameterized-replaceable global state, keyed by (pubkey, kind,
+        // d_tag) — the author writes their own board/cards (default only-me;
+        // sharing toggles `h`/`invite` tags, Phase 3). The move-audit kind
+        // (31003, non-replaceable) is emitted by the actor who moved the card.
+        KIND_KANBAN_BOARD | KIND_KANBAN_CARD | KIND_KANBAN_CARD_MOVE => Ok(Scope::UsersWrite),
         // Huddle lifecycle events + guidelines
         KIND_HUDDLE_STARTED
         | KIND_HUDDLE_PARTICIPANT_JOINED
@@ -444,6 +451,12 @@ pub(crate) fn is_global_only_kind(kind: u32) -> bool {
             // `buzz-channel` tag is a metadata reference, not a routing directive,
             // so a project's state is never channel-scoped.
             | KIND_PROJECT
+            // Buzz Kanban: boards/cards are owner-authored, addressed by
+            // (pubkey, kind, d_tag). A stray `h` tag is a *share* reference, not
+            // a routing directive, so their state is never channel-scoped.
+            | KIND_KANBAN_BOARD
+            | KIND_KANBAN_CARD
+            | KIND_KANBAN_CARD_MOVE
             // Community moderation commands (9040–9044): community-global
             // direct commands, same model as the NIP-43 9030-series. A stray
             // `h` tag must never channel-scope them (pinned contract —
@@ -3129,6 +3142,32 @@ mod tests {
     fn user_status_is_global_only() {
         assert!(is_global_only_kind(KIND_USER_STATUS));
     }
+
+    #[test]
+    fn kanban_kinds_require_users_write_scope() {
+        let dummy = make_dummy_event();
+        for kind in [KIND_KANBAN_BOARD, KIND_KANBAN_CARD, KIND_KANBAN_CARD_MOVE] {
+            assert_eq!(
+                required_scope_for_kind(kind, &dummy).unwrap(),
+                Scope::UsersWrite,
+                "kind {kind} should require UsersWrite scope"
+            );
+        }
+    }
+
+    #[test]
+    fn kanban_kinds_are_global_only() {
+        // Board/card/move events are author-owned, non-channel scoped:
+        // a stray `h` tag is a share reference, never channel scoping.
+        for kind in [KIND_KANBAN_BOARD, KIND_KANBAN_CARD, KIND_KANBAN_CARD_MOVE] {
+            assert!(is_global_only_kind(kind), "kind {kind} must be global-only");
+            assert!(
+                !requires_h_channel_scope(kind),
+                "kind {kind} must not require an h tag"
+            );
+        }
+    }
+
 
     #[test]
     fn user_status_does_not_require_h_tag() {

--- a/crates/buzz-sdk/src/builders.rs
+++ b/crates/buzz-sdk/src/builders.rs
@@ -10,8 +10,9 @@ use buzz_core::{
         KIND_GIT_PR_UPDATE, KIND_GIT_PULL_REQUEST, KIND_GIT_REPO_ANNOUNCEMENT,
         KIND_GIT_STATUS_CLOSED, KIND_GIT_STATUS_DRAFT, KIND_GIT_STATUS_MERGED,
         KIND_GIT_STATUS_OPEN, KIND_IA_ARCHIVE_REQUEST, KIND_IA_UNARCHIVE_REQUEST,
-        KIND_MODERATION_BAN, KIND_MODERATION_RESOLVE_REPORT, KIND_MODERATION_TIMEOUT,
-        KIND_MODERATION_UNBAN, KIND_MODERATION_UNTIMEOUT, KIND_PRESENCE_UPDATE, KIND_USER_STATUS,
+        KIND_KANBAN_BOARD, KIND_KANBAN_CARD, KIND_KANBAN_CARD_MOVE, KIND_MODERATION_BAN,
+        KIND_MODERATION_RESOLVE_REPORT, KIND_MODERATION_TIMEOUT, KIND_MODERATION_UNBAN,
+        KIND_MODERATION_UNTIMEOUT, KIND_PRESENCE_UPDATE, KIND_USER_STATUS,
         KIND_WORKFLOW_DEF, KIND_WORKFLOW_TRIGGER,
     },
     observer::{
@@ -3883,5 +3884,289 @@ mod tests {
             .tags
             .iter()
             .any(|t| t.as_slice().first().map(String::as_str) == Some("replaced-by")));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Buzz Kanban — board (31001), card (31002), move-audit (31003)
+// ---------------------------------------------------------------------------
+
+/// A Kanban board column definition (carried on the board event as a
+/// repeatable `column` tag). `id` is a stable colid (renaming a lane must not
+/// renumber cards), `order` positions the column (WIP limits are advisory).
+#[derive(Debug, Clone)]
+pub struct KanbanColumnDef {
+    /// Stable column id (colid).
+    pub id: String,
+    /// Display name.
+    pub name: String,
+    /// Advisory WIP limit (badge only in v1). `None` = unbounded.
+    pub wip: Option<u32>,
+    /// Position in the board (0-based, contiguous).
+    pub order: u32,
+}
+
+/// Metadata for a Kanban board event (kind:31001).
+#[derive(Default)]
+pub struct KanbanBoardMeta {
+    /// Ordered column definitions (sorted by `order` on build).
+    pub columns: Vec<KanbanColumnDef>,
+    /// Channel shares (`h` tags) — owner shares the board to these channels.
+    pub channels: Vec<String>,
+    /// Direct member shares (`invite` tags).
+    pub invites: Vec<String>,
+}
+
+/// Build a Kanban board event (kind:31001). `board_id` is the `d` tag,
+/// `owner` the author/owner pubkey, `name` the board title, `content` markdown.
+pub fn build_kanban_board(
+    board_id: &str,
+    owner: &str,
+    name: &str,
+    content: &str,
+    meta: &KanbanBoardMeta,
+) -> Result<EventBuilder, SdkError> {
+    check_content(content, 64 * 1024)?;
+    let owner = check_pubkey_hex(owner, "board owner")?;
+    if name.trim().is_empty() {
+        return Err(SdkError::InvalidInput("board name must not be empty".into()));
+    }
+    if board_id.trim().is_empty() {
+        return Err(SdkError::InvalidInput("board id must not be empty".into()));
+    }
+
+    let mut tags = vec![
+        tag(&["d", board_id])?,
+        tag(&["name", name])?,
+        tag(&["p", &owner, "owner"])?,
+    ];
+
+    let mut columns = meta.columns.clone();
+    columns.sort_by_key(|c| c.order);
+    for c in &columns {
+        let mut parts: Vec<String> = vec![
+            "column".into(),
+            c.id.clone(),
+            "name".into(),
+            c.name.clone(),
+        ];
+        if let Some(w) = c.wip {
+            parts.push("wip".into());
+            parts.push(w.to_string());
+        }
+        parts.push("order".into());
+        parts.push(c.order.to_string());
+        let refs: Vec<&str> = parts.iter().map(|s| s.as_str()).collect();
+        tags.push(tag(&refs)?);
+    }
+    for ch in &meta.channels {
+        tags.push(tag(&["h", ch])?);
+    }
+    for pk in &meta.invites {
+        tags.push(tag(&["invite", pk])?);
+    }
+
+    Ok(EventBuilder::new(Kind::Custom(KIND_KANBAN_BOARD as u16), content).tags(tags))
+}
+
+/// Metadata for a Kanban card event (kind:31002).
+#[derive(Default)]
+pub struct KanbanCardMeta {
+    /// Board ref value (`31001:<owner>:<boardid>`).
+    pub board: String,
+    /// The single current column (colid) the card sits in.
+    pub column: String,
+    /// Base-36 order-preserving rank string within the column.
+    pub rank: Option<String>,
+    /// Assignee pubkeys (`p` tags).
+    pub assignees: Vec<String>,
+    /// Labels (NIP-32 namespaced `["l",<label>,"kanban"]`).
+    pub labels: Vec<String>,
+    /// Optional due date (`YYYY-MM-DD`).
+    pub due: Option<String>,
+    /// Optional comment thread root event id (`e`).
+    pub thread: Option<String>,
+}
+
+/// Build a Kanban card event (kind:31002). `card_id` is the `d` tag, `content`
+/// the markdown body (title + description). Replacing this event (new column /
+/// rank) performs a move via NIP-33 last-write-wins.
+pub fn build_kanban_card(
+    card_id: &str,
+    content: &str,
+    meta: &KanbanCardMeta,
+) -> Result<EventBuilder, SdkError> {
+    check_content(content, 64 * 1024)?;
+    if card_id.trim().is_empty() {
+        return Err(SdkError::InvalidInput("card id must not be empty".into()));
+    }
+    if meta.board.trim().is_empty() {
+        return Err(SdkError::InvalidInput("board ref is required".into()));
+    }
+    if meta.column.trim().is_empty() {
+        return Err(SdkError::InvalidInput("column is required".into()));
+    }
+
+    let mut tags = vec![
+        tag(&["d", card_id])?,
+        tag(&["a", &meta.board])?,
+        tag(&["column", &meta.column])?,
+    ];
+    if let Some(rank) = &meta.rank {
+        tags.push(tag(&["rank", rank])?);
+    }
+    for pk in &meta.assignees {
+        let pk = check_pubkey_hex(pk, "card assignee")?;
+        tags.push(tag(&["p", &pk])?);
+    }
+    for label in &meta.labels {
+        tags.push(tag(&["l", label, "kanban"])?);
+    }
+    if let Some(due) = &meta.due {
+        tags.push(tag(&["due", due])?);
+    }
+    if let Some(thread) = &meta.thread {
+        tags.push(tag(&["e", thread])?);
+    }
+
+    Ok(EventBuilder::new(Kind::Custom(KIND_KANBAN_CARD as u16), content).tags(tags))
+}
+
+/// Metadata for a Kanban card move audit event (kind:31003, non-replaceable).
+#[derive(Default)]
+pub struct KanbanCardMoveMeta {
+    /// Board ref value (`31001:<owner>:<boardid>`).
+    pub board: String,
+    /// Card id (`d` tag of the moved card).
+    pub card: String,
+    /// Source column colid.
+    pub from: String,
+    /// Destination column colid.
+    pub to: String,
+}
+
+/// Build a Kanban card move audit event (kind:31003). Only emitted when a board
+/// opts in (default OFF) to keep event volume low.
+pub fn build_kanban_card_move(meta: &KanbanCardMoveMeta) -> Result<EventBuilder, SdkError> {
+    let mut tags = vec![tag(&["a", &meta.board])?, tag(&["e", &meta.card])?];
+    if !meta.from.is_empty() {
+        tags.push(tag(&["from", &meta.from])?);
+    }
+    tags.push(tag(&["to", &meta.to])?);
+    Ok(EventBuilder::new(
+        Kind::Custom(KIND_KANBAN_CARD_MOVE as u16),
+        "",
+    )
+    .tags(tags))
+}
+
+#[cfg(test)]
+mod kanban_tests {
+    use super::*;
+    use nostr::EventBuilder;
+
+    const OWNER: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const BOARD_ID: &str = "ab12cd34-ab12-4bcd-8ef0-ab12cd34ab12";
+    const CARD_ID: &str = "cd34ef56-cd34-4def-9ef0-cd34ef56cd34";
+
+    fn build_and_inspect(builder: EventBuilder) -> nostr::Event {
+        let keys = nostr::Keys::generate();
+        builder.sign_with_keys(&keys).unwrap()
+    }
+
+    #[test]
+    fn board_builds_expected_tags() {
+        let meta = KanbanBoardMeta {
+            columns: vec![
+                KanbanColumnDef { id: "col-b".into(), name: "Backlog".into(), wip: Some(5), order: 0 },
+                KanbanColumnDef { id: "col-d".into(), name: "Done".into(), wip: None, order: 1 },
+            ],
+            channels: vec!["ch-abc".into()],
+            invites: vec![OWNER.into()],
+        };
+        let builder = build_kanban_board(BOARD_ID, OWNER, "Launch", "## Launch", &meta).unwrap();
+        let ev = build_and_inspect(builder);
+        let tags: Vec<Vec<String>> = ev
+            .tags
+            .iter()
+            .map(|t| t.as_slice().iter().map(|s| s.to_string()).collect())
+            .collect();
+        assert_eq!(ev.kind.as_u16(), 31001);
+        // columns sorted by order with stable colid
+        let col: Vec<&Vec<String>> = tags.iter().filter(|t| t[0] == "column").collect();
+        assert_eq!(col[0][1], "col-b");
+        assert_eq!(col[0][3], "Backlog");
+        assert_eq!(col[0][5], "5");
+        assert_eq!(col[1][1], "col-d"); // order 1 after sort; no wip
+        // no-wip column: ["column",colid,"name",<name>,"order",<n>] (6 elements, no "wip")
+        assert_eq!(col[1].len(), 6, "col-d should omit wip: {:?}", col[1]);
+        assert_eq!(col[1][4], "order");
+        assert!(tags.iter().any(|t| t[0] == "p" && t[1] == OWNER && t[2] == "owner"));
+        assert!(tags.iter().any(|t| t[0] == "h" && t[1] == "ch-abc"));
+        assert!(tags.iter().any(|t| t[0] == "invite" && t[1] == OWNER));
+    }
+
+    #[test]
+    fn board_rejects_empty_name() {
+        let err = build_kanban_board(BOARD_ID, OWNER, "  ", "x", &KanbanBoardMeta::default()).unwrap_err();
+        assert!(matches!(err, SdkError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn card_builds_expected_tags() {
+        let meta = KanbanCardMeta {
+            board: format!("31001:{OWNER}:{BOARD_ID}"),
+            column: "col-b".into(),
+            rank: Some("i".into()),
+            assignees: vec![OWNER.into()],
+            labels: vec!["feature".into(), "p1".into()],
+            due: Some("2026-09-01".into()),
+            thread: None,
+        };
+        let builder = build_kanban_card(CARD_ID, "## Ship DnD", &meta).unwrap();
+        let ev = build_and_inspect(builder);
+        let tags: Vec<Vec<String>> = ev
+            .tags
+            .iter()
+            .map(|t| t.as_slice().iter().map(|s| s.to_string()).collect())
+            .collect();
+        assert_eq!(ev.kind.as_u16(), 31002);
+        assert!(tags.iter().any(|t| t[0] == "a" && t[1] == format!("31001:{OWNER}:{BOARD_ID}")));
+        assert!(tags.iter().any(|t| t[0] == "column" && t[1] == "col-b"));
+        assert!(tags.iter().any(|t| t[0] == "rank" && t[1] == "i"));
+        assert!(tags.iter().any(|t| t[0] == "p" && t[1] == OWNER));
+        // NIP-32 namespaced labels
+        assert!(tags.iter().any(|t| t[0] == "l" && t[1] == "feature" && t[2] == "kanban"));
+        assert!(tags.iter().any(|t| t[0] == "due" && t[1] == "2026-09-01"));
+    }
+
+    #[test]
+    fn card_requires_column_and_board() {
+        let mut meta = KanbanCardMeta::default();
+        meta.board = format!("31001:{OWNER}:{BOARD_ID}");
+        assert!(build_kanban_card(CARD_ID, "x", &meta).is_err()); // no column
+        meta.column = "col-b".into();
+        assert!(build_kanban_card(CARD_ID, "x", &meta).is_ok());
+    }
+
+    #[test]
+    fn move_audit_builds() {
+        let meta = KanbanCardMoveMeta {
+            board: format!("31001:{OWNER}:{BOARD_ID}"),
+            card: CARD_ID.into(),
+            from: "col-b".into(),
+            to: "col-d".into(),
+        };
+        let builder = build_kanban_card_move(&meta).unwrap();
+        let ev = build_and_inspect(builder);
+        let tags: Vec<Vec<String>> = ev
+            .tags
+            .iter()
+            .map(|t| t.as_slice().iter().map(|s| s.to_string()).collect())
+            .collect();
+        assert_eq!(ev.kind.as_u16(), 31003);
+        assert!(tags.iter().any(|t| t[0] == "e" && t[1] == CARD_ID));
+        assert!(tags.iter().any(|t| t[0] == "from" && t[1] == "col-b"));
+        assert!(tags.iter().any(|t| t[0] == "to" && t[1] == "col-d"));
     }
 }

--- a/desktop/src/app/routeTree.gen.ts
+++ b/desktop/src/app/routeTree.gen.ts
@@ -10,12 +10,14 @@ import { Route as settingsRouteImport } from "./routes/settings";
 import { Route as remindersRouteImport } from "./routes/reminders";
 import { Route as pulseRouteImport } from "./routes/pulse";
 import { Route as projectsRouteImport } from "./routes/projects";
+import { Route as boardsRouteImport } from "./routes/boards";
 import { Route as agentsRouteImport } from "./routes/agents";
 import { Route as indexRouteImport } from "./routes/index";
 import { Route as workflowsDotworkflowIdRouteImport } from "./routes/workflows.$workflowId";
 import { Route as projectsDotprojectIdRouteImport } from "./routes/projects.$projectId";
 import { Route as messagesDotnewRouteImport } from "./routes/messages.new";
 import { Route as channelsDotchannelIdRouteImport } from "./routes/channels.$channelId";
+import { Route as boardsDotboardIdRouteImport } from "./routes/boards.$boardId";
 import { Route as channelsDotchannelIdDotpostsDotpostIdRouteImport } from "./routes/channels.$channelId.posts.$postId";
 
 const workflowsRoute = workflowsRouteImport.update({
@@ -41,6 +43,11 @@ const pulseRoute = pulseRouteImport.update({
 const projectsRoute = projectsRouteImport.update({
   id: "/projects",
   path: "/projects",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const boardsRoute = boardsRouteImport.update({
+  id: "/boards",
+  path: "/boards",
   getParentRoute: () => rootRouteImport,
 } as any);
 const agentsRoute = agentsRouteImport.update({
@@ -73,6 +80,11 @@ const channelsDotchannelIdRoute = channelsDotchannelIdRouteImport.update({
   path: "/channels/$channelId",
   getParentRoute: () => rootRouteImport,
 } as any);
+const boardsDotboardIdRoute = boardsDotboardIdRouteImport.update({
+  id: "/boards/$boardId",
+  path: "/boards/$boardId",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const channelsDotchannelIdDotpostsDotpostIdRoute =
   channelsDotchannelIdDotpostsDotpostIdRouteImport.update({
     id: "/channels/$channelId/posts/$postId",
@@ -83,11 +95,13 @@ const channelsDotchannelIdDotpostsDotpostIdRoute =
 export interface FileRoutesByFullPath {
   "/": typeof indexRoute;
   "/agents": typeof agentsRoute;
+  "/boards": typeof boardsRoute;
   "/projects": typeof projectsRoute;
   "/pulse": typeof pulseRoute;
   "/reminders": typeof remindersRoute;
   "/settings": typeof settingsRoute;
   "/workflows": typeof workflowsRoute;
+  "/boards/$boardId": typeof boardsDotboardIdRoute;
   "/channels/$channelId": typeof channelsDotchannelIdRoute;
   "/messages/new": typeof messagesDotnewRoute;
   "/projects/$projectId": typeof projectsDotprojectIdRoute;
@@ -97,11 +111,13 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   "/": typeof indexRoute;
   "/agents": typeof agentsRoute;
+  "/boards": typeof boardsRoute;
   "/projects": typeof projectsRoute;
   "/pulse": typeof pulseRoute;
   "/reminders": typeof remindersRoute;
   "/settings": typeof settingsRoute;
   "/workflows": typeof workflowsRoute;
+  "/boards/$boardId": typeof boardsDotboardIdRoute;
   "/channels/$channelId": typeof channelsDotchannelIdRoute;
   "/messages/new": typeof messagesDotnewRoute;
   "/projects/$projectId": typeof projectsDotprojectIdRoute;
@@ -112,11 +128,13 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport;
   "/": typeof indexRoute;
   "/agents": typeof agentsRoute;
+  "/boards": typeof boardsRoute;
   "/projects": typeof projectsRoute;
   "/pulse": typeof pulseRoute;
   "/reminders": typeof remindersRoute;
   "/settings": typeof settingsRoute;
   "/workflows": typeof workflowsRoute;
+  "/boards/$boardId": typeof boardsDotboardIdRoute;
   "/channels/$channelId": typeof channelsDotchannelIdRoute;
   "/messages/new": typeof messagesDotnewRoute;
   "/projects/$projectId": typeof projectsDotprojectIdRoute;
@@ -128,11 +146,13 @@ export interface FileRouteTypes {
   fullPaths:
     | "/"
     | "/agents"
+    | "/boards"
     | "/projects"
     | "/pulse"
     | "/reminders"
     | "/settings"
     | "/workflows"
+    | "/boards/$boardId"
     | "/channels/$channelId"
     | "/messages/new"
     | "/projects/$projectId"
@@ -142,11 +162,13 @@ export interface FileRouteTypes {
   to:
     | "/"
     | "/agents"
+    | "/boards"
     | "/projects"
     | "/pulse"
     | "/reminders"
     | "/settings"
     | "/workflows"
+    | "/boards/$boardId"
     | "/channels/$channelId"
     | "/messages/new"
     | "/projects/$projectId"
@@ -156,11 +178,13 @@ export interface FileRouteTypes {
     | "__root__"
     | "/"
     | "/agents"
+    | "/boards"
     | "/projects"
     | "/pulse"
     | "/reminders"
     | "/settings"
     | "/workflows"
+    | "/boards/$boardId"
     | "/channels/$channelId"
     | "/messages/new"
     | "/projects/$projectId"
@@ -171,11 +195,13 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   indexRoute: typeof indexRoute;
   agentsRoute: typeof agentsRoute;
+  boardsRoute: typeof boardsRoute;
   projectsRoute: typeof projectsRoute;
   pulseRoute: typeof pulseRoute;
   remindersRoute: typeof remindersRoute;
   settingsRoute: typeof settingsRoute;
   workflowsRoute: typeof workflowsRoute;
+  boardsDotboardIdRoute: typeof boardsDotboardIdRoute;
   channelsDotchannelIdRoute: typeof channelsDotchannelIdRoute;
   messagesDotnewRoute: typeof messagesDotnewRoute;
   projectsDotprojectIdRoute: typeof projectsDotprojectIdRoute;
@@ -220,6 +246,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof projectsRouteImport;
       parentRoute: typeof rootRouteImport;
     };
+    "/boards": {
+      id: "/boards";
+      path: "/boards";
+      fullPath: "/boards";
+      preLoaderRoute: typeof boardsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     "/agents": {
       id: "/agents";
       path: "/agents";
@@ -262,6 +295,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof channelsDotchannelIdRouteImport;
       parentRoute: typeof rootRouteImport;
     };
+    "/boards/$boardId": {
+      id: "/boards/$boardId";
+      path: "/boards/$boardId";
+      fullPath: "/boards/$boardId";
+      preLoaderRoute: typeof boardsDotboardIdRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     "/channels/$channelId/posts/$postId": {
       id: "/channels/$channelId/posts/$postId";
       path: "/channels/$channelId/posts/$postId";
@@ -275,11 +315,13 @@ declare module "@tanstack/react-router" {
 const rootRouteChildren: RootRouteChildren = {
   indexRoute: indexRoute,
   agentsRoute: agentsRoute,
+  boardsRoute: boardsRoute,
   projectsRoute: projectsRoute,
   pulseRoute: pulseRoute,
   remindersRoute: remindersRoute,
   settingsRoute: settingsRoute,
   workflowsRoute: workflowsRoute,
+  boardsDotboardIdRoute: boardsDotboardIdRoute,
   channelsDotchannelIdRoute: channelsDotchannelIdRoute,
   messagesDotnewRoute: messagesDotnewRoute,
   projectsDotprojectIdRoute: projectsDotprojectIdRoute,

--- a/desktop/src/app/routes.ts
+++ b/desktop/src/app/routes.ts
@@ -10,6 +10,8 @@ export const routes = rootRoute("root.tsx", [
   route("/workflows/$workflowId", "workflows.$workflowId.tsx"),
   route("/projects", "projects.tsx"),
   route("/projects/$projectId", "projects.$projectId.tsx"),
+  route("/boards", "boards.tsx"),
+  route("/boards/$boardId", "boards.$boardId.tsx"),
   route("/messages/new", "messages.new.tsx"),
   route("/channels/$channelId", "channels.$channelId.tsx"),
   route(

--- a/desktop/src/app/routes/boards.$boardId.tsx
+++ b/desktop/src/app/routes/boards.$boardId.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { BoardView } from "@/features/kanban/ui/BoardView";
+
+export const Route = createFileRoute("/boards/$boardId")({
+  component: BoardIdRouteComponent,
+});
+
+function BoardIdRouteComponent() {
+  const { boardId } = Route.useParams();
+  return (
+    <React.Suspense fallback={null}>
+      <BoardView boardId={boardId} />
+    </React.Suspense>
+  );
+}

--- a/desktop/src/app/routes/boards.tsx
+++ b/desktop/src/app/routes/boards.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { BoardList } from "@/features/kanban/ui/BoardList";
+
+export const Route = createFileRoute("/boards")({
+  component: BoardsRouteComponent,
+});
+
+function BoardsRouteComponent() {
+  return (
+    <React.Suspense fallback={null}>
+      <BoardList />
+    </React.Suspense>
+  );
+}

--- a/desktop/src/features/kanban/lib/boardQueries.ts
+++ b/desktop/src/features/kanban/lib/boardQueries.ts
@@ -4,8 +4,10 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { relayClient } from "@/shared/api/relayClient";
 import type { RelaySubscriptionFilter } from "@/shared/api/relayClientShared";
 import { KIND_KANBAN_BOARD, KIND_KANBAN_CARD } from "@/shared/constants/kinds";
+import { useChannelsQuery } from "@/features/channels/hooks";
 import type { RelayEvent } from "@/shared/api/types";
 import {
+  boardIsAccessible,
   collapseBoards,
   collapseCards,
   type KanbanBoard,
@@ -18,43 +20,47 @@ export const boardQueryKey = (boardId: string) =>
 export const cardsQueryKey = (boardRef: string) =>
   ["kanban", "cards", boardRef] as const;
 
+/**
+ * Ids of the channels the current user is a member of. Used to resolve
+ * channel-shared (`h`) board visibility — a board shared to a channel you
+ * belong to is readable.
+ */
+export function useMemberChannelIds(): string[] {
+  const { data: channels } = useChannelsQuery();
+  return (channels ?? [])
+    .filter((channel) => channel.isMember === true)
+    .map((channel) => channel.id);
+}
+
 const BOARD_SCAN_LIMIT = 500;
 const CARD_SCAN_LIMIT = 1_000;
 
-function samePubkey(left: string, right: string): boolean {
-  return left.toLowerCase() === right.toLowerCase();
-}
-
-function boardIsAccessible(
-  board: KanbanBoard,
-  me: string | undefined,
-): boolean {
-  if (!me) return false;
-  if (samePubkey(board.owner, me)) return true;
-  return board.invites.some((invite) => samePubkey(invite, me));
-}
-
 /**
  * Fetch every board head currently on the relay, then narrow client-side to
- * the ones the current user can see: boards they own plus boards whose
- * `invite` tag names them. Channel-shared boards (`h` tags) may not be found
- * by a plain `{kinds:[31001]}` scan because the relay index is
- * author/kind-based and may not index custom tags — see the P2 review flag in
- * the build notes. Scheduling a follow-up `#invite`-indexed REQ is a P3+
- * improvement once relay indexing of `invite` is confirmed.
+ * the ones the current user can see: boards they own, boards whose `invite`
+ * tag names them, and boards shared to a channel they are a member of (`h`).
+ * The P3 entry-gate confirmed the bare `{kinds:[31001]}` scan returns ALL
+ * community boards (global-only, ungated), so this filter is the access
+ * boundary — keep it authoritative.
  */
-async function fetchBoards(me: string | undefined): Promise<KanbanBoard[]> {
+async function fetchBoards(
+  me: string | undefined,
+  memberChannelIds: readonly string[],
+): Promise<KanbanBoard[]> {
   if (!me) return [];
   const events = await relayClient.fetchEvents({
     kinds: [KIND_KANBAN_BOARD],
     limit: BOARD_SCAN_LIMIT,
   });
-  return collapseBoards(events).filter((board) => boardIsAccessible(board, me));
+  return collapseBoards(events).filter((board) =>
+    boardIsAccessible(board, me, memberChannelIds),
+  );
 }
 
 async function fetchBoard(
   boardId: string,
   me: string | undefined,
+  memberChannelIds: readonly string[],
 ): Promise<KanbanBoard | null> {
   if (!me) return null;
   const events = await relayClient.fetchEvents({
@@ -63,7 +69,10 @@ async function fetchBoard(
     limit: 20,
   });
   const boards = collapseBoards(events);
-  return boards.find((board) => boardIsAccessible(board, me)) ?? null;
+  return (
+    boards.find((board) => boardIsAccessible(board, me, memberChannelIds)) ??
+    null
+  );
 }
 
 async function fetchCards(
@@ -139,22 +148,29 @@ function useBoardLiveUpdates(
   }, [boardId, boardRef, queryClient]);
 }
 
-/** Every board the current user can see (own + invited). */
-export function useBoardsQuery(me: string | undefined) {
+/** Every board the current user can see (own + invited + channel-shared). */
+export function useBoardsQuery(
+  me: string | undefined,
+  memberChannelIds: readonly string[],
+) {
   return useQuery({
     enabled: Boolean(me),
     queryKey: boardsQueryKey(),
-    queryFn: () => fetchBoards(me),
+    queryFn: () => fetchBoards(me, memberChannelIds),
     staleTime: 15_000,
   });
 }
 
 /** A single board head by id. */
-export function useBoardQuery(boardId: string, me: string | undefined) {
+export function useBoardQuery(
+  boardId: string,
+  me: string | undefined,
+  memberChannelIds: readonly string[],
+) {
   return useQuery({
     enabled: Boolean(me),
     queryKey: boardQueryKey(boardId),
-    queryFn: () => fetchBoard(boardId, me),
+    queryFn: () => fetchBoard(boardId, me, memberChannelIds),
     staleTime: 30_000,
   });
 }

--- a/desktop/src/features/kanban/lib/boardQueries.ts
+++ b/desktop/src/features/kanban/lib/boardQueries.ts
@@ -1,0 +1,176 @@
+import * as React from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { relayClient } from "@/shared/api/relayClient";
+import type { RelaySubscriptionFilter } from "@/shared/api/relayClientShared";
+import { KIND_KANBAN_BOARD, KIND_KANBAN_CARD } from "@/shared/constants/kinds";
+import type { RelayEvent } from "@/shared/api/types";
+import {
+  collapseBoards,
+  collapseCards,
+  type KanbanBoard,
+  type KanbanCard,
+} from "@/features/kanban/lib/kanbanTypes";
+
+export const boardsQueryKey = () => ["kanban", "boards"] as const;
+export const boardQueryKey = (boardId: string) =>
+  ["kanban", "board", boardId] as const;
+export const cardsQueryKey = (boardRef: string) =>
+  ["kanban", "cards", boardRef] as const;
+
+const BOARD_SCAN_LIMIT = 500;
+const CARD_SCAN_LIMIT = 1_000;
+
+function samePubkey(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function boardIsAccessible(
+  board: KanbanBoard,
+  me: string | undefined,
+): boolean {
+  if (!me) return false;
+  if (samePubkey(board.owner, me)) return true;
+  return board.invites.some((invite) => samePubkey(invite, me));
+}
+
+/**
+ * Fetch every board head currently on the relay, then narrow client-side to
+ * the ones the current user can see: boards they own plus boards whose
+ * `invite` tag names them. Channel-shared boards (`h` tags) may not be found
+ * by a plain `{kinds:[31001]}` scan because the relay index is
+ * author/kind-based and may not index custom tags — see the P2 review flag in
+ * the build notes. Scheduling a follow-up `#invite`-indexed REQ is a P3+
+ * improvement once relay indexing of `invite` is confirmed.
+ */
+async function fetchBoards(me: string | undefined): Promise<KanbanBoard[]> {
+  if (!me) return [];
+  const events = await relayClient.fetchEvents({
+    kinds: [KIND_KANBAN_BOARD],
+    limit: BOARD_SCAN_LIMIT,
+  });
+  return collapseBoards(events).filter((board) => boardIsAccessible(board, me));
+}
+
+async function fetchBoard(
+  boardId: string,
+  me: string | undefined,
+): Promise<KanbanBoard | null> {
+  if (!me) return null;
+  const events = await relayClient.fetchEvents({
+    kinds: [KIND_KANBAN_BOARD],
+    "#d": [boardId],
+    limit: 20,
+  });
+  const boards = collapseBoards(events);
+  return boards.find((board) => boardIsAccessible(board, me)) ?? null;
+}
+
+async function fetchCards(
+  boardOwner: string | undefined,
+  boardId: string | undefined,
+): Promise<KanbanCard[]> {
+  if (!boardOwner || !boardId) return [];
+  // Same `#a` REQ filter pattern the CLI `issues list` uses.
+  const boardRef = `31001:${boardOwner}:${boardId}`;
+  const events: RelayEvent[] = await relayClient.fetchEvents({
+    kinds: [KIND_KANBAN_CARD],
+    "#a": [boardRef],
+    limit: CARD_SCAN_LIMIT,
+  });
+  return collapseCards(events);
+}
+
+function useBoardLiveUpdates(
+  boardId: string | undefined,
+  boardRef: string | undefined,
+): void {
+  const queryClient = useQueryClient();
+
+  React.useEffect(() => {
+    if (!boardId) return;
+    let disposed = false;
+    let disposeBoard: (() => Promise<void>) | null = null;
+    let disposeCards: (() => Promise<void>) | null = null;
+
+    const subscribe = (filter: RelaySubscriptionFilter) =>
+      relayClient.subscribeLive(filter, () => {
+        void queryClient.invalidateQueries({
+          queryKey: ["kanban"],
+        });
+      });
+
+    void subscribe({ kinds: [KIND_KANBAN_BOARD], "#d": [boardId], limit: 0 })
+      .then((unsubscribe) => {
+        if (disposed) {
+          void unsubscribe();
+        } else {
+          disposeBoard = unsubscribe;
+        }
+      })
+      .catch((error) => {
+        console.error("Couldn’t subscribe to board updates", error);
+      });
+
+    if (boardRef) {
+      void subscribe({ kinds: [KIND_KANBAN_CARD], "#a": [boardRef], limit: 0 })
+        .then((unsubscribe) => {
+          if (disposed) {
+            void unsubscribe();
+          } else {
+            disposeCards = unsubscribe;
+          }
+        })
+        .catch((error) => {
+          console.error("Couldn’t subscribe to card updates", error);
+        });
+    }
+
+    const unsubscribeReconnect = relayClient.subscribeToReconnects(() => {
+      void queryClient.invalidateQueries({ queryKey: ["kanban"] });
+    });
+
+    return () => {
+      disposed = true;
+      unsubscribeReconnect();
+      if (disposeBoard) void disposeBoard();
+      if (disposeCards) void disposeCards();
+    };
+  }, [boardId, boardRef, queryClient]);
+}
+
+/** Every board the current user can see (own + invited). */
+export function useBoardsQuery(me: string | undefined) {
+  return useQuery({
+    enabled: Boolean(me),
+    queryKey: boardsQueryKey(),
+    queryFn: () => fetchBoards(me),
+    staleTime: 15_000,
+  });
+}
+
+/** A single board head by id. */
+export function useBoardQuery(boardId: string, me: string | undefined) {
+  return useQuery({
+    enabled: Boolean(me),
+    queryKey: boardQueryKey(boardId),
+    queryFn: () => fetchBoard(boardId, me),
+    staleTime: 30_000,
+  });
+}
+
+/** All cards for a board, keyed by its `a` ref. */
+export function useCardsQuery(
+  boardOwner: string | undefined,
+  boardId: string | undefined,
+) {
+  const boardRef =
+    boardOwner && boardId ? `31001:${boardOwner}:${boardId}` : undefined;
+  useBoardLiveUpdates(boardId, boardRef);
+  return useQuery({
+    enabled: Boolean(boardRef),
+    queryKey: cardsQueryKey(boardRef ?? ""),
+    queryFn: () => fetchCards(boardOwner, boardId),
+    staleTime: 15_000,
+  });
+}

--- a/desktop/src/features/kanban/lib/boardWrite.test.mjs
+++ b/desktop/src/features/kanban/lib/boardWrite.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildBoardEvent, KANBAN_TEMPLATES } from "./boardWrite.ts";
+
+const OWNER =
+  "5E869EE84d093c181b415e96695ac1ff0e377c501bb8f6d0880b445e030698dc";
+
+function tags(event) {
+  return event.tags;
+}
+
+function tagValue(event, name) {
+  const found = event.tags.find((tag) => tag[0] === name);
+  return found?.[1];
+}
+
+function columnTags(event) {
+  return event.tags.filter((tag) => tag[0] === "column");
+}
+
+test("buildBoardEvent: emits kind 31001 with d/name/p(owner) tags", () => {
+  const draft = buildBoardEvent({
+    owner: OWNER,
+    name: "  Team Board  ",
+    template: "kanban",
+    description: "Ship things faster.",
+  });
+
+  assert.equal(draft.kind, 31001);
+  assert.equal(tagValue(draft, "d").length > 0, true);
+  assert.match(tagValue(draft, "d"), /^[0-9a-f-]{36}$/u);
+  assert.equal(tagValue(draft, "name"), "Team Board"); // trimmed
+  // owner is lowercased (canonical source for case-insensitive ownership checks)
+  assert.deepEqual(
+    tags(draft).find((tag) => tag[0] === "p"),
+    ["p", OWNER.toLowerCase(), "owner"],
+  );
+});
+
+test("buildBoardEvent: kanban template → 4 columns, order 0..3, wip only where set", () => {
+  const draft = buildBoardEvent({
+    owner: OWNER,
+    name: "Team Board",
+    template: "kanban",
+  });
+
+  assert.equal(KANBAN_TEMPLATES.kanban.length, 4);
+  const cols = columnTags(draft);
+  assert.equal(cols.length, 4);
+
+  // order is 0-based, contiguous, in template order
+  assert.deepEqual(
+    cols.map((c) => Number(c[c.indexOf("order") + 1])),
+    [0, 1, 2, 3],
+  );
+
+  // name field, present on every column in template order
+  assert.deepEqual(
+    cols.map((c) => c[c.indexOf("name") + 1]),
+    ["Backlog", "In Progress", "Review", "Done"],
+  );
+
+  // wip present only where bounded (Backlog=5, In Progress=3; Review/Done none)
+  const wipByName = Object.fromEntries(
+    cols.map((c) => {
+      const wipIndex = c.indexOf("wip");
+      return [
+        c[c.indexOf("name") + 1],
+        wipIndex === -1 ? null : Number(c[wipIndex + 1]),
+      ];
+    }),
+  );
+  assert.deepEqual(wipByName, {
+    Backlog: 5,
+    "In Progress": 3,
+    Review: null,
+    Done: null,
+  });
+});
+
+test("buildBoardEvent: no h/invite (private by default), content starts ## name", () => {
+  const draft = buildBoardEvent({
+    owner: OWNER,
+    name: "Team Board",
+    template: "kanban",
+  });
+
+  assert.equal(
+    tags(draft).some((tag) => tag[0] === "h"),
+    false,
+  );
+  assert.equal(
+    tags(draft).some((tag) => tag[0] === "invite"),
+    false,
+  );
+  assert.equal(draft.content, "## Team Board");
+
+  const withDescription = buildBoardEvent({
+    owner: OWNER,
+    name: "Team Board",
+    description: "  Roadmap  ",
+    template: "blank",
+  });
+  assert.equal(withDescription.content, "## Team Board\n\nRoadmap");
+});
+
+test("buildBoardEvent: every generated colid matches ^col-[0-9a-f]{8}$", () => {
+  const draft = buildBoardEvent({
+    owner: OWNER,
+    name: "Team Board",
+    template: "blank",
+  });
+  for (const col of columnTags(draft)) {
+    assert.match(col[1], /^col-[0-9a-f]{8}$/u);
+  }
+
+  // templates emit distinct colids across all sets (spot-check a multi-column one)
+  const sales = buildBoardEvent({
+    owner: OWNER,
+    name: "Pipeline",
+    template: "sales",
+  });
+  const ids = columnTags(sales).map((c) => c[1]);
+  assert.equal(
+    new Set(ids).size,
+    ids.length,
+    "colids must be unique within a board",
+  );
+});

--- a/desktop/src/features/kanban/lib/boardWrite.ts
+++ b/desktop/src/features/kanban/lib/boardWrite.ts
@@ -1,0 +1,130 @@
+import { KIND_KANBAN_BOARD } from "@/shared/constants/kinds";
+import { relayClient } from "@/shared/api/relayClient";
+import { signRelayEvent } from "@/shared/api/tauri";
+
+export type KanbanTemplateName = "kanban" | "sprint" | "sales" | "blank";
+
+export type KanbanTemplateColumn = { name: string; wip: number | null };
+
+/**
+ * Column definitions per template, mirroring the CLI's `template_columns()`
+ * (crates/buzz-cli/src/commands/boards.rs). `wip: null` = unbounded and must
+ * **not** emit a `wip` tag pair (the same no-WIP contract the P1/P2 parsers
+ * guard on read).
+ */
+export const KANBAN_TEMPLATES: Record<
+  KanbanTemplateName,
+  readonly KanbanTemplateColumn[]
+> = {
+  kanban: [
+    { name: "Backlog", wip: 5 },
+    { name: "In Progress", wip: 3 },
+    { name: "Review", wip: null },
+    { name: "Done", wip: null },
+  ],
+  sprint: [
+    { name: "To Do", wip: 5 },
+    { name: "In Progress", wip: 3 },
+    { name: "Blocked", wip: null },
+    { name: "Done", wip: null },
+  ],
+  sales: [
+    { name: "Lead", wip: null },
+    { name: "Qualified", wip: null },
+    { name: "Proposal", wip: null },
+    { name: "Won", wip: null },
+    { name: "Lost", wip: null },
+  ],
+  blank: [{ name: "Backlog", wip: null }],
+};
+
+export type BoardDraft = {
+  name: string;
+  description?: string;
+  template: KanbanTemplateName;
+  /** Owner pubkey (lowercased) — the Desktop identity the board is created under. */
+  owner: string;
+};
+
+export type BoardEventDraft = {
+  kind: number;
+  content: string;
+  tags: string[][];
+  boardId: string;
+};
+
+/** `col-` + the first 8 hex chars of a fresh UUID (mirrors the CLI `new_colid()`). */
+function newColid(): string {
+  // strip the UUID dashes, keep the first 8 hex chars
+  return `col-${crypto.randomUUID().replaceAll("-", "").slice(0, 8)}`;
+}
+
+function boardContent(name: string, description?: string): string {
+  const trimmedDescription = description?.trim();
+  return trimmedDescription
+    ? `## ${name}\n\n${trimmedDescription}`
+    : `## ${name}`;
+}
+
+/**
+ * Produce the canonical kind-31001 board event shape (tags + content) exactly
+ * as the CLI/SDK `build_kanban_board` emits it: `d` / `name` / `p(owner)`
+ * tags, one `column` tag per template column (`wip` omitted when unbounded,
+ * `order` 0-based contiguous), and **no** `h` / `invite` tags (private by
+ * default — matches the CLI). Pure: no signing or network here; callers sign
+ * and publish the returned shape.
+ */
+export function buildBoardEvent(draft: BoardDraft): BoardEventDraft {
+  const name = draft.name.trim();
+  const boardId = crypto.randomUUID();
+  const columns = KANBAN_TEMPLATES[draft.template];
+
+  const tags: string[][] = [
+    ["d", boardId],
+    ["name", name],
+    ["p", draft.owner.toLowerCase(), "owner"],
+  ];
+  columns.forEach((column, index) => {
+    const parts: string[] = ["column", newColid(), "name", column.name];
+    if (column.wip !== null) {
+      parts.push("wip", String(column.wip));
+    }
+    parts.push("order", String(index));
+    tags.push(parts);
+  });
+
+  return {
+    kind: KIND_KANBAN_BOARD,
+    content: boardContent(name, draft.description),
+    tags,
+    boardId,
+  };
+}
+
+/**
+ * Sign (under the Desktop identity) and publish a new board, returning its id
+ * for navigation.
+ *
+ * A fresh random board id makes a NIP-33 collision effectively impossible, so
+ * publish-to-OK is sufficient here. This helper is the template for inline
+ * card create/move where LWW conflicts are real — that path must also inspect
+ * the relay's `duplicate:`/dominated response the way the CLI's
+ * `submit_lww_event` does (relay rejection is exit 5 in the CLI) rather than
+ * assuming success.
+ */
+export async function createBoard(
+  draft: BoardDraft,
+): Promise<{ boardId: string }> {
+  const built = buildBoardEvent(draft);
+  const event = await signRelayEvent({
+    kind: built.kind,
+    content: built.content,
+    tags: built.tags,
+  });
+  await relayClient.publishEvent(
+    event,
+    "Timed out while creating the board.",
+    "Failed to create the board.",
+  );
+  return { boardId: built.boardId };
+}

--- a/desktop/src/features/kanban/lib/kanbanTypes.test.mjs
+++ b/desktop/src/features/kanban/lib/kanbanTypes.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  boardIsAccessible,
   collapseBoards,
   collapseCards,
   parseBoard,
@@ -174,4 +175,70 @@ test("collapseBoards/collapseCards: latest-created_at head wins per coordinate",
   const cards = collapseCards([cardOldEv, cardNewEv]);
   assert.equal(cards.length, 1);
   assert.equal(cards[0].column, "done");
+});
+
+function accessBoard(overrides = {}) {
+  return {
+    id: "b1",
+    owner: "0owner",
+    name: "b",
+    description: "",
+    columns: [],
+    channels: [],
+    invites: [],
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+test("boardIsAccessible: no identity → always denied", () => {
+  assert.equal(boardIsAccessible(accessBoard(), undefined, []), false);
+  assert.equal(
+    boardIsAccessible(accessBoard({ owner: "0owner" }), undefined, []),
+    false,
+  );
+});
+
+test("boardIsAccessible: owner is visible (case-insensitive)", () => {
+  assert.equal(
+    boardIsAccessible(accessBoard({ owner: "AbC123" }), "abc123", []),
+    true,
+  );
+});
+
+test("boardIsAccessible: invite-named reader is visible", () => {
+  assert.equal(
+    boardIsAccessible(
+      accessBoard({ owner: "0other", invites: ["0reader"] }),
+      "0reader",
+      [],
+    ),
+    true,
+  );
+});
+
+test("boardIsAccessible: channel-shared board visible to a member", () => {
+  assert.equal(
+    boardIsAccessible(
+      accessBoard({ owner: "0other", channels: ["chan-a", "chan-b"] }),
+      "0reader",
+      ["chan-b"],
+    ),
+    true,
+  );
+});
+
+test("boardIsAccessible: unrelated reader denied across all paths", () => {
+  assert.equal(
+    boardIsAccessible(
+      accessBoard({
+        owner: "0other",
+        invites: ["0invitee"],
+        channels: ["chan-a"],
+      }),
+      "0stranger",
+      ["chan-b"],
+    ),
+    false,
+  );
 });

--- a/desktop/src/features/kanban/lib/kanbanTypes.test.mjs
+++ b/desktop/src/features/kanban/lib/kanbanTypes.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  collapseBoards,
+  collapseCards,
+  parseBoard,
+  parseCard,
+  parseColumnTag,
+} from "./kanbanTypes.ts";
+
+function ev(overrides = {}, tags = []) {
+  return {
+    id: "event-id",
+    pubkey: "abc123",
+    created_at: 1000,
+    kind: 31001,
+    content: "",
+    sig: "sig",
+    tags,
+    ...overrides,
+  };
+}
+
+test("parseColumnTag: parses by name, tolerates a missing wip pair", () => {
+  const withWip = parseColumnTag([
+    "column",
+    "todo",
+    "name",
+    "To Do",
+    "wip",
+    "3",
+    "order",
+    "0",
+  ]);
+  assert.deepEqual(withWip, { id: "todo", name: "To Do", wip: 3, order: 0 });
+
+  // No `wip` pair — the same bug class as P1's no-WIP CLI parse. Must still
+  // read `name` + `order` and default wip to null.
+  const noWip = parseColumnTag([
+    "column",
+    "done",
+    "name",
+    "Done",
+    "order",
+    "2",
+  ]);
+  assert.deepEqual(noWip, { id: "done", name: "Done", wip: null, order: 2 });
+
+  assert.equal(parseColumnTag(["column", "x"]), null);
+  assert.equal(parseColumnTag(["not-a-column"]), null);
+});
+
+test("parseBoard: reads name, owner, ordered columns, shares", () => {
+  const board = parseBoard(
+    ev(
+      {
+        kind: 31001,
+        created_at: 500,
+        content: "## Launch\n\nShip it.",
+        pubkey: "ownerpub",
+      },
+      [
+        ["d", "b1"],
+        ["name", "Launch"],
+        ["p", "ownerpub", "owner"],
+        ["column", "done", "name", "Done", "order", "1"],
+        ["column", "todo", "name", "To Do", "order", "0"],
+        ["column", "blocked", "name", "Blocked", "wip", "2", "order", "2"],
+        ["h", "channel-1"],
+        ["invite", "guestpub"],
+      ],
+    ),
+  );
+  assert.equal(board.name, "Launch");
+  assert.equal(board.owner, "ownerpub");
+  assert.equal(board.description, "## Launch\n\nShip it.");
+  assert.deepEqual(
+    board.columns.map((c) => [c.id, c.order, c.wip]),
+    [
+      ["todo", 0, null],
+      ["done", 1, null],
+      ["blocked", 2, 2],
+    ],
+  );
+  assert.deepEqual(board.channels, ["channel-1"]);
+  assert.deepEqual(board.invites, ["guestpub"]);
+});
+
+test("parseCard: reads column/rank/assignees/labels/due + derives title", () => {
+  const card = parseCard(
+    ev(
+      {
+        kind: 31002,
+        pubkey: "ownerpub",
+        content: "## Ship DnD\n\nAdd drag and drop.",
+      },
+      [
+        ["d", "c1"],
+        ["a", "31001:ownerpub:b1"],
+        ["column", "todo"],
+        ["rank", "a1b2"],
+        ["p", "assignee1"],
+        ["p", "assignee2"],
+        ["l", "frontend", "kanban"],
+        ["l", "urgent", "kanban"],
+        ["due", "2026-09-01"],
+      ],
+    ),
+  );
+  assert.equal(card.id, "c1");
+  assert.equal(card.boardOwner, "ownerpub");
+  assert.equal(card.boardId, "b1");
+  assert.equal(card.column, "todo");
+  assert.equal(card.rank, "a1b2");
+  assert.deepEqual(card.assignees, ["assignee1", "assignee2"]);
+  assert.deepEqual(card.labels, ["frontend", "urgent"]);
+  assert.equal(card.due, "2026-09-01");
+  assert.equal(card.title, "Ship DnD");
+});
+
+test("parseCard: missing optionals are null/empty, not misread", () => {
+  const card = parseCard(
+    ev({ kind: 31002, pubkey: "ownerpub", content: "no heading here" }, [
+      ["d", "c2"],
+      ["a", "31001:ownerpub:b1"],
+      ["column", "todo"],
+    ]),
+  );
+  assert.equal(card.rank, null);
+  assert.equal(card.due, null);
+  assert.deepEqual(card.assignees, []);
+  assert.deepEqual(card.labels, []);
+  assert.equal(card.title, "c2"); // fallback to id when no heading
+});
+
+test("collapseBoards/collapseCards: latest-created_at head wins per coordinate", () => {
+  const older = ev(
+    { kind: 31001, id: "old", created_at: 100, pubkey: "owner" },
+    [
+      ["d", "b1"],
+      ["name", "Old name"],
+      ["p", "owner", "owner"],
+    ],
+  );
+  const newer = ev(
+    { kind: 31001, id: "new", created_at: 200, pubkey: "owner" },
+    [
+      ["d", "b1"],
+      ["name", "New name"],
+      ["p", "owner", "owner"],
+    ],
+  );
+  const boards = collapseBoards([older, newer]);
+  assert.equal(boards.length, 1);
+  assert.equal(boards[0].name, "New name");
+
+  const cardOldEv = ev(
+    { kind: 31002, id: "cOld", created_at: 100, pubkey: "owner" },
+    [
+      ["d", "c1"],
+      ["a", "31001:owner:b1"],
+      ["column", "todo"],
+    ],
+  );
+  const cardNewEv = ev(
+    { kind: 31002, id: "cNew", created_at: 300, pubkey: "owner" },
+    [
+      ["d", "c1"],
+      ["a", "31001:owner:b1"],
+      ["column", "done"],
+    ],
+  );
+  const cards = collapseCards([cardOldEv, cardNewEv]);
+  assert.equal(cards.length, 1);
+  assert.equal(cards[0].column, "done");
+});

--- a/desktop/src/features/kanban/lib/kanbanTypes.ts
+++ b/desktop/src/features/kanban/lib/kanbanTypes.ts
@@ -131,6 +131,36 @@ function boardOwnerFromEvent(event: RelayEvent): string {
   return (owner ?? event.pubkey).toLowerCase();
 }
 
+function samePubkey(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+/**
+ * A board is visible to the reader when they own it, are named in an
+ * `invite` tag, OR are a member of any channel the board was shared to via an
+ * `h` tag.
+ *
+ * Kanban kinds are stored globally (`channel_id = NULL`) and are in no
+ * relay-gated set (see the P3 entry-gate finding in WORK_LOGS), so a bare
+ * `{kinds:[31001]}` REQ returns *every* community board. This client-side
+ * check — own + `invite` + channel-shared (`h`) membership — is the only
+ * access boundary keeping private boards out of a reader's list, so it must
+ * coincide with the P3 write gate (owner + invited + channel members).
+ */
+export function boardIsAccessible(
+  board: KanbanBoard,
+  me: string | undefined,
+  memberChannelIds: readonly string[],
+): boolean {
+  if (!me) return false;
+  if (samePubkey(board.owner, me)) return true;
+  if (board.invites.some((invite) => samePubkey(invite, me))) return true;
+  // Channel-shared: visible iff the reader belongs to one of the shared `h` channels.
+  return board.channels.some((channelId) =>
+    memberChannelIds.some((memberId) => samePubkey(memberId, channelId)),
+  );
+}
+
 /** Parse a board (31001) event into the read model. */
 export function parseBoard(event: RelayEvent): KanbanBoard | null {
   if (event.kind !== KIND_KANBAN_BOARD) return null;

--- a/desktop/src/features/kanban/lib/kanbanTypes.ts
+++ b/desktop/src/features/kanban/lib/kanbanTypes.ts
@@ -1,0 +1,281 @@
+import { KIND_KANBAN_BOARD, KIND_KANBAN_CARD } from "@/shared/constants/kinds";
+import type { RelayEvent } from "@/shared/api/types";
+
+/**
+ * Kanban read-model types + tag parsers.
+ *
+ * Tag parsing is always **keyed by tag name**, never by fixed index — the
+ * same requirement as the P1 no-WIP CLI fix. Tags arrive in arbitrary order,
+ * and optional sub-fields (`wip`, `rank`, `due`, `invite`…) may be absent, so
+ * a parser that assumes "the 4th element is the WIP" silently misreads boards
+ * without a WIP limit. Every field here is located by name.
+ */
+
+export type KanbanColumn = {
+  /** Stable column id (colid). Renaming a lane never renumbers cards. */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** Advisory WIP limit; `null` = unbounded. */
+  wip: number | null;
+  /** Position in the board (0-based, contiguous). */
+  order: number;
+};
+
+export type KanbanBoard = {
+  /** `d` tag — the board id and the `:id` in the `#a` card ref. */
+  id: string;
+  /** Owner pubkey (from the `p` tag with role "owner"). */
+  owner: string;
+  /** `name` tag — the board title shown in rail / list / view. */
+  name: string;
+  /** Markdown description (event `content`). */
+  description: string;
+  /** Ordered column definitions. */
+  columns: KanbanColumn[];
+  /** `h` tags — channels the owner shared the board to. */
+  channels: string[];
+  /** `invite` tags — pubkeys directly shared on the board. */
+  invites: string[];
+  createdAt: number;
+};
+
+export type KanbanCard = {
+  /** `d` tag — the card id. */
+  id: string;
+  /** Event id (useful for optimistic/audit tie-ins later). */
+  eventId: string;
+  /** Raw `a` board ref, `31001:<owner>:<boardId>`. */
+  board: string;
+  /** `31001:<owner>:<boardId>` */
+  boardOwner: string;
+  /** The board id portion of the `a` ref. */
+  boardId: string;
+  /** `column` tag — the colid the card currently sits in. */
+  column: string;
+  /** Base-36 order-preserving rank string; `null` = unsorted (goes last). */
+  rank: string | null;
+  /** Title derived from the first markdown heading in `content`. */
+  title: string;
+  /** Full markdown body. */
+  content: string;
+  /** `p` tags — assignee pubkeys. */
+  assignees: string[];
+  /** `l` tags (namespaced `["l", <label>, "kanban"]`). */
+  labels: string[];
+  /** `due` tag — `YYYY-MM-DD`, or `null`. */
+  due: string | null;
+  createdAt: number;
+};
+
+function firstTagValue(event: RelayEvent, name: string): string | null {
+  for (const tag of event.tags) {
+    if (tag.length >= 2 && tag[0] === name && typeof tag[1] === "string") {
+      return tag[1];
+    }
+  }
+  return null;
+}
+
+function allTagValues(
+  event: RelayEvent,
+  name: string,
+  predicate?: (tag: string[]) => boolean,
+): string[] {
+  const values: string[] = [];
+  for (const tag of event.tags) {
+    if (tag[0] !== name || tag.length < 2) continue;
+    if (predicate && !predicate(tag)) continue;
+    if (typeof tag[1] === "string" && tag[1].trim().length > 0) {
+      values.push(tag[1]);
+    }
+  }
+  return values;
+}
+
+/** Parse a repeatable `["column", id, "name", name, ("wip", w), "order", n]` tag. */
+export function parseColumnTag(tag: string[]): KanbanColumn | null {
+  if (tag[0] !== "column" || tag.length < 5 || typeof tag[1] !== "string") {
+    return null;
+  }
+  const id = tag[1];
+  if (id.trim().length === 0) return null;
+
+  // Walk the key/value pairs that follow the tag name + id. Locating by name
+  // means a column without a `wip` pair still parses correctly.
+  const fields: Record<string, string> = {};
+  for (let i = 2; i + 1 < tag.length; i += 2) {
+    const key = tag[i];
+    const value = tag[i + 1];
+    if (typeof key === "string" && typeof value === "string") {
+      fields[key] = value;
+    }
+  }
+  if (fields.name === undefined) return null;
+
+  const order = Number(fields.order);
+  const wip = fields.wip === undefined ? null : Number(fields.wip);
+  return {
+    id,
+    name: fields.name,
+    order: Number.isFinite(order) ? order : Number.MAX_SAFE_INTEGER,
+    wip: wip === null || !Number.isFinite(wip) ? null : wip,
+  };
+}
+
+function boardOwnerFromEvent(event: RelayEvent): string {
+  const ownerTag = event.tags.find(
+    (tag) => tag[0] === "p" && tag.length >= 3 && tag[2] === "owner",
+  );
+  const owner = ownerTag?.[1] ?? firstTagValue(event, "p");
+  return (owner ?? event.pubkey).toLowerCase();
+}
+
+/** Parse a board (31001) event into the read model. */
+export function parseBoard(event: RelayEvent): KanbanBoard | null {
+  if (event.kind !== KIND_KANBAN_BOARD) return null;
+  const id = firstTagValue(event, "d");
+  const name = firstTagValue(event, "name") ?? "Untitled board";
+  if (!id) return null;
+
+  const columns: KanbanColumn[] = [];
+  for (const tag of event.tags) {
+    const column = parseColumnTag(tag);
+    if (column) columns.push(column);
+  }
+  columns.sort((left, right) => left.order - right.order);
+
+  return {
+    id,
+    owner: boardOwnerFromEvent(event),
+    name,
+    description: event.content,
+    columns,
+    channels: allTagValues(event, "h"),
+    invites: allTagValues(event, "invite"),
+    createdAt: event.created_at,
+  };
+}
+
+/** Parse a card (31002) event into the read model. */
+export function parseCard(event: RelayEvent): KanbanCard | null {
+  if (event.kind !== KIND_KANBAN_CARD) return null;
+  const id = firstTagValue(event, "d");
+  const board = firstTagValue(event, "a");
+  const column = firstTagValue(event, "column");
+  if (!id || !board || !column) return null;
+
+  const boardParts = board.split(":");
+  const boardOwner = boardParts[1]?.toLowerCase() ?? event.pubkey.toLowerCase();
+  const boardId = boardParts.slice(2).join(":");
+  const rank = firstTagValue(event, "rank");
+  const due = firstTagValue(event, "due");
+
+  return {
+    id,
+    eventId: event.id,
+    board,
+    boardOwner,
+    boardId,
+    column,
+    rank,
+    title: cardTitleFromContent(event.content, id),
+    content: event.content,
+    assignees: allTagValues(event, "p"),
+    labels: allTagValues(event, "l", (tag) => tag[2] === "kanban"),
+    due,
+    createdAt: event.created_at,
+  };
+}
+
+function cardTitleFromContent(content: string, fallback: string): string {
+  const heading = content
+    .split(/\r?\n/)
+    .find((line) => /^\s{0,3}#{1,6}\s+\S/u.test(line));
+  if (heading) {
+    const title = heading.replace(/^\s{0,3}#{1,6}\s+/u, "").trim();
+    if (title.length > 0) return title;
+  }
+  return fallback;
+}
+
+/**
+ * Collapse replaceable events to the canonical NIP-33 head per
+ * `owner:d` coordinate (latest `created_at` wins, id as tiebreak). Defense in
+ * depth — the relay normally returns one head; older/edge relays may not.
+ */
+function collapseByCoordinate<T>(
+  events: readonly RelayEvent[],
+  parse: (event: RelayEvent) => T | null,
+  coordinate: (event: RelayEvent, value: T) => string,
+): T[] {
+  const sorted = [...events].sort(
+    (left, right) =>
+      right.created_at - left.created_at || left.id.localeCompare(right.id),
+  );
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const event of sorted) {
+    const value = parse(event);
+    if (!value) continue;
+    const key = coordinate(event, value);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(value);
+  }
+  return result;
+}
+
+export function collapseBoards(events: readonly RelayEvent[]): KanbanBoard[] {
+  return collapseByCoordinate(
+    events,
+    parseBoard,
+    (_event, board) => `${board.owner}:${board.id}`,
+  );
+}
+
+export function collapseCards(events: readonly RelayEvent[]): KanbanCard[] {
+  return collapseByCoordinate(
+    events,
+    parseCard,
+    (event, card) => `${event.pubkey.toLowerCase()}:${card.id}`,
+  );
+}
+
+/**
+ * Sort cards by their base-36 order-preserving rank, then by id as a stable
+ * tiebreak. Cardinal trumps ordinal: a card with no rank goes last.
+ * Comparing the *canonical* rank strings with `<` maps directly to numeric
+ * order (the P1 codec guarantees plain lexicographic ordering), so no numeric
+ * decode or custom comparator is needed.
+ */
+export function sortCardsByRank(cards: readonly KanbanCard[]): KanbanCard[] {
+  return [...cards].sort((left, right) => {
+    if (left.rank === null && right.rank === null) {
+      return left.id.localeCompare(right.id);
+    }
+    if (left.rank === null) return 1;
+    if (right.rank === null) return -1;
+    if (left.rank === right.rank) return left.id.localeCompare(right.id);
+    return left.rank < right.rank ? -1 : 1;
+  });
+}
+
+/** Group cards by their single `column` colid, each bucket rank-sorted. */
+export function groupCardsByColumn(
+  cards: readonly KanbanCard[],
+): Map<string, KanbanCard[]> {
+  const grouped = new Map<string, KanbanCard[]>();
+  for (const card of cards) {
+    const bucket = grouped.get(card.column);
+    if (bucket) {
+      bucket.push(card);
+    } else {
+      grouped.set(card.column, [card]);
+    }
+  }
+  for (const bucket of grouped.values()) {
+    sortCardsByRank(bucket);
+  }
+  return grouped;
+}

--- a/desktop/src/features/kanban/lib/useLiveBoard.ts
+++ b/desktop/src/features/kanban/lib/useLiveBoard.ts
@@ -1,0 +1,36 @@
+import { useIdentityQuery } from "@/shared/api/hooks";
+import {
+  useBoardQuery,
+  useCardsQuery,
+} from "@/features/kanban/lib/boardQueries";
+import type {
+  KanbanBoard,
+  KanbanCard,
+} from "@/features/kanban/lib/kanbanTypes";
+import { groupCardsByColumn } from "@/features/kanban/lib/kanbanTypes";
+
+/**
+ * Live board + card subscription for one board.
+ *
+ * Column renames and reorders (board 31001 updates) and card adds/moves
+ * (card 31002 updates) all flow in over the live subscriptions wired inside
+ * `useCardsQuery`, invalidating the TanStack queries so the view re-renders
+ * with no polling and no manual refresh.
+ */
+export function useLiveBoard(boardId: string) {
+  const { data: identity } = useIdentityQuery();
+  const me = identity?.pubkey;
+
+  const boardQuery = useBoardQuery(boardId, me);
+  const board: KanbanBoard | null = boardQuery.data ?? null;
+  const cardsQuery = useCardsQuery(board?.owner, boardId);
+  const cards: KanbanCard[] = cardsQuery.data ?? [];
+
+  return {
+    board,
+    cards,
+    cardsByColumn: groupCardsByColumn(cards),
+    isLoading: boardQuery.isLoading || cardsQuery.isLoading,
+    isError: boardQuery.isError || cardsQuery.isError,
+  };
+}

--- a/desktop/src/features/kanban/lib/useLiveBoard.ts
+++ b/desktop/src/features/kanban/lib/useLiveBoard.ts
@@ -2,6 +2,7 @@ import { useIdentityQuery } from "@/shared/api/hooks";
 import {
   useBoardQuery,
   useCardsQuery,
+  useMemberChannelIds,
 } from "@/features/kanban/lib/boardQueries";
 import type {
   KanbanBoard,
@@ -20,8 +21,9 @@ import { groupCardsByColumn } from "@/features/kanban/lib/kanbanTypes";
 export function useLiveBoard(boardId: string) {
   const { data: identity } = useIdentityQuery();
   const me = identity?.pubkey;
+  const memberChannelIds = useMemberChannelIds();
 
-  const boardQuery = useBoardQuery(boardId, me);
+  const boardQuery = useBoardQuery(boardId, me, memberChannelIds);
   const board: KanbanBoard | null = boardQuery.data ?? null;
   const cardsQuery = useCardsQuery(board?.owner, boardId);
   const cards: KanbanCard[] = cardsQuery.data ?? [];

--- a/desktop/src/features/kanban/ui/BoardList.tsx
+++ b/desktop/src/features/kanban/ui/BoardList.tsx
@@ -1,0 +1,164 @@
+import * as React from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Plus, Search } from "lucide-react";
+
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { Badge } from "@/shared/ui/badge";
+import { Skeleton } from "@/shared/ui/skeleton";
+import { useBoardsQuery } from "@/features/kanban/lib/boardQueries";
+import type { KanbanBoard } from "@/features/kanban/lib/kanbanTypes";
+
+type BoardScope = "all" | "owned" | "shared";
+
+export function BoardList() {
+  const { data: identity } = useIdentityQuery();
+  const me = identity?.pubkey;
+  const boardsQuery = useBoardsQuery(me);
+  const boards = boardsQuery.data ?? [];
+
+  const [scope, setScope] = React.useState<BoardScope>("all");
+  const [query, setQuery] = React.useState("");
+  const navigate = useNavigate();
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const filtered = boards.filter((board) => {
+    const isOwned = me ? board.owner.toLowerCase() === me.toLowerCase() : false;
+    if (scope === "owned" && !isOwned) return false;
+    if (scope === "shared" && isOwned) return false;
+    if (
+      normalizedQuery.length > 0 &&
+      !board.name.toLowerCase().includes(normalizedQuery)
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-6 py-6">
+      <header className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold">Boards</h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            Boards you own or were invited to.
+          </p>
+        </div>
+        {/* Creation ships in P3 — the button is present but disabled. */}
+        <Button disabled title="New boards ship in P3" type="button">
+          <Plus className="size-4" />
+          New board
+        </Button>
+      </header>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <div className="relative min-w-56 flex-1">
+          <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            className="pl-9"
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search boards by title"
+            value={query}
+          />
+        </div>
+        <div className="flex items-center gap-1 rounded-lg border p-1">
+          {(["all", "owned", "shared"] as const).map((option) => (
+            <button
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                scope === option
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              key={option}
+              onClick={() => setScope(option)}
+              type="button"
+            >
+              {option === "all"
+                ? "All"
+                : option === "owned"
+                  ? "Owned by me"
+                  : "Shared with me"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-5">
+        {boardsQuery.isLoading ? (
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Skeleton className="h-28" />
+            <Skeleton className="h-28" />
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
+            {boards.length === 0
+              ? "No boards yet. Create one from the CLI (`buzz boards create`) — inline creation ships in P3."
+              : "No boards match this filter."}
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {filtered.map((board) => (
+              <BoardTile
+                board={board}
+                isOwned={
+                  me ? board.owner.toLowerCase() === me.toLowerCase() : false
+                }
+                key={board.id}
+                onClick={() =>
+                  navigate({
+                    to: "/boards/$boardId",
+                    params: { boardId: board.id },
+                  })
+                }
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function BoardTile({
+  board,
+  isOwned,
+  onClick,
+}: {
+  board: KanbanBoard;
+  isOwned: boolean;
+  onClick: () => void;
+}) {
+  const openCards = board.columns
+    .map((column) => column.name)
+    .filter((name) => name.toLowerCase() !== "done").length;
+
+  return (
+    <button
+      className="group flex flex-col gap-2 rounded-lg border bg-card p-4 text-left shadow-sm transition-colors hover:border-border hover:bg-accent/40"
+      data-testid={`board-tile-${board.id}`}
+      onClick={onClick}
+      type="button"
+    >
+      <span className="flex items-start justify-between gap-2">
+        <span className="min-w-0">
+          <span className="block truncate font-semibold" title={board.name}>
+            {board.name}
+          </span>
+          {board.description ? (
+            <span className="mt-0.5 line-clamp-2 block text-xs text-muted-foreground">
+              {board.description}
+            </span>
+          ) : null}
+        </span>
+        <Badge className="shrink-0" variant={isOwned ? "default" : "secondary"}>
+          {isOwned ? "Owned" : "Shared"}
+        </Badge>
+      </span>
+      <span className="mt-auto flex items-center gap-3 text-xs text-muted-foreground">
+        <span>{board.columns.length} columns</span>
+        <span>{openCards} open</span>
+      </span>
+    </button>
+  );
+}

--- a/desktop/src/features/kanban/ui/BoardList.tsx
+++ b/desktop/src/features/kanban/ui/BoardList.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import { Plus, Search } from "lucide-react";
 
 import { useIdentityQuery } from "@/shared/api/hooks";
@@ -8,9 +9,11 @@ import { Input } from "@/shared/ui/input";
 import { Badge } from "@/shared/ui/badge";
 import { Skeleton } from "@/shared/ui/skeleton";
 import {
+  boardsQueryKey,
   useBoardsQuery,
   useMemberChannelIds,
 } from "@/features/kanban/lib/boardQueries";
+import { NewBoardDialog } from "@/features/kanban/ui/NewBoardDialog";
 import type { KanbanBoard } from "@/features/kanban/lib/kanbanTypes";
 
 type BoardScope = "all" | "owned" | "shared";
@@ -24,7 +27,14 @@ export function BoardList() {
 
   const [scope, setScope] = React.useState<BoardScope>("all");
   const [query, setQuery] = React.useState("");
+  const [newBoardOpen, setNewBoardOpen] = React.useState(false);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  async function handleBoardCreated(boardId: string) {
+    await queryClient.invalidateQueries({ queryKey: boardsQueryKey() });
+    navigate({ to: "/boards/$boardId", params: { boardId } });
+  }
 
   const normalizedQuery = query.trim().toLowerCase();
   const filtered = boards.filter((board) => {
@@ -49,8 +59,12 @@ export function BoardList() {
             Boards you own or were invited to.
           </p>
         </div>
-        {/* Creation ships in P3 — the button is present but disabled. */}
-        <Button disabled title="New boards ship in P3" type="button">
+        {/* In-app board creation (P3 write path) — signs under the Desktop identity. */}
+        <Button
+          disabled={!me}
+          onClick={() => setNewBoardOpen(true)}
+          type="button"
+        >
           <Plus className="size-4" />
           New board
         </Button>
@@ -97,7 +111,7 @@ export function BoardList() {
         ) : filtered.length === 0 ? (
           <div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
             {boards.length === 0
-              ? "No boards yet. Create one from the CLI (`buzz boards create`) — inline creation ships in P3."
+              ? "No boards yet. Create your first board."
               : "No boards match this filter."}
           </div>
         ) : (
@@ -120,6 +134,15 @@ export function BoardList() {
           </div>
         )}
       </div>
+
+      {me ? (
+        <NewBoardDialog
+          onCreated={handleBoardCreated}
+          onOpenChange={setNewBoardOpen}
+          open={newBoardOpen}
+          owner={me}
+        />
+      ) : null}
     </div>
   );
 }

--- a/desktop/src/features/kanban/ui/BoardList.tsx
+++ b/desktop/src/features/kanban/ui/BoardList.tsx
@@ -7,7 +7,10 @@ import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { Badge } from "@/shared/ui/badge";
 import { Skeleton } from "@/shared/ui/skeleton";
-import { useBoardsQuery } from "@/features/kanban/lib/boardQueries";
+import {
+  useBoardsQuery,
+  useMemberChannelIds,
+} from "@/features/kanban/lib/boardQueries";
 import type { KanbanBoard } from "@/features/kanban/lib/kanbanTypes";
 
 type BoardScope = "all" | "owned" | "shared";
@@ -15,7 +18,8 @@ type BoardScope = "all" | "owned" | "shared";
 export function BoardList() {
   const { data: identity } = useIdentityQuery();
   const me = identity?.pubkey;
-  const boardsQuery = useBoardsQuery(me);
+  const memberChannelIds = useMemberChannelIds();
+  const boardsQuery = useBoardsQuery(me, memberChannelIds);
   const boards = boardsQuery.data ?? [];
 
   const [scope, setScope] = React.useState<BoardScope>("all");

--- a/desktop/src/features/kanban/ui/BoardRail.tsx
+++ b/desktop/src/features/kanban/ui/BoardRail.tsx
@@ -11,7 +11,10 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/shared/ui/sidebar";
-import { useBoardsQuery } from "@/features/kanban/lib/boardQueries";
+import {
+  useBoardsQuery,
+  useMemberChannelIds,
+} from "@/features/kanban/lib/boardQueries";
 
 type BoardRailProps = {
   isCollapsed: boolean;
@@ -30,7 +33,8 @@ const SECTION_LABEL_CLASS =
 export function BoardRail({ isCollapsed, onToggleCollapsed }: BoardRailProps) {
   const { data: identity } = useIdentityQuery();
   const me = identity?.pubkey;
-  const boardsQuery = useBoardsQuery(me);
+  const memberChannelIds = useMemberChannelIds();
+  const boardsQuery = useBoardsQuery(me, memberChannelIds);
   const boards = boardsQuery.data ?? [];
   const navigate = useNavigate();
 

--- a/desktop/src/features/kanban/ui/BoardRail.tsx
+++ b/desktop/src/features/kanban/ui/BoardRail.tsx
@@ -1,0 +1,96 @@
+import { useNavigate } from "@tanstack/react-router";
+import { ChevronDown, LayoutGrid } from "lucide-react";
+
+import { useIdentityQuery } from "@/shared/api/hooks";
+import { cn } from "@/shared/lib/cn";
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/shared/ui/sidebar";
+import { useBoardsQuery } from "@/features/kanban/lib/boardQueries";
+
+type BoardRailProps = {
+  isCollapsed: boolean;
+  onToggleCollapsed: () => void;
+};
+
+const SECTION_LABEL_CLASS =
+  "group/section-label group-data-[collapsible=icon]:hidden flex w-fit max-w-full cursor-pointer appearance-none items-center gap-1 text-left transition-colors hover:text-sidebar-foreground focus-visible:text-sidebar-foreground";
+
+/**
+ * "Boards" rail section, shown immediately after Direct messages.
+ *
+ * Lists the boards the current user can see (own + invited), each linking to
+ * `/boards/:id`. Collapse state is owned by AppSidebar.
+ */
+export function BoardRail({ isCollapsed, onToggleCollapsed }: BoardRailProps) {
+  const { data: identity } = useIdentityQuery();
+  const me = identity?.pubkey;
+  const boardsQuery = useBoardsQuery(me);
+  const boards = boardsQuery.data ?? [];
+  const navigate = useNavigate();
+
+  return (
+    <SidebarGroup data-sidebar-rail="boards">
+      <SidebarGroupLabel asChild>
+        <button
+          aria-expanded={!isCollapsed}
+          className={SECTION_LABEL_CLASS}
+          data-testid="boards-section-label"
+          onClick={onToggleCollapsed}
+          type="button"
+        >
+          <span data-sidebar-section-title>Boards</span>
+          <span aria-hidden="true" className="flex items-center">
+            <ChevronDown
+              className={cn(
+                "size-2.5 transition-transform",
+                isCollapsed ? "-rotate-90" : "rotate-0",
+              )}
+            />
+          </span>
+        </button>
+      </SidebarGroupLabel>
+
+      {!isCollapsed ? (
+        <SidebarGroupContent>
+          <SidebarMenu data-testid="boards-list">
+            {boards.length === 0 ? (
+              <div
+                className="px-2 py-1 text-sm text-sidebar-foreground/60"
+                data-testid="boards-list-empty"
+              >
+                No boards yet
+              </div>
+            ) : (
+              boards.map((board) => (
+                <SidebarMenuItem className="group/menu-item" key={board.id}>
+                  <SidebarMenuButton
+                    data-testid={`board-${board.id}`}
+                    onClick={() =>
+                      navigate({
+                        to: "/boards/$boardId",
+                        params: { boardId: board.id },
+                      })
+                    }
+                    tooltip={board.name}
+                    type="button"
+                  >
+                    <LayoutGrid className="size-4 shrink-0" />
+                    <span className="min-w-0 flex-1 truncate">
+                      {board.name}
+                    </span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))
+            )}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      ) : null}
+    </SidebarGroup>
+  );
+}

--- a/desktop/src/features/kanban/ui/BoardView.tsx
+++ b/desktop/src/features/kanban/ui/BoardView.tsx
@@ -1,0 +1,98 @@
+import * as React from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { ArrowLeft, Share2, SlidersHorizontal } from "lucide-react";
+
+import { Button } from "@/shared/ui/button";
+import { Skeleton } from "@/shared/ui/skeleton";
+import { useLiveBoard } from "@/features/kanban/lib/useLiveBoard";
+import { KanbanColumn } from "@/features/kanban/ui/KanbanColumn";
+import { CardDetailModal } from "@/features/kanban/ui/CardDetailModal";
+import type { KanbanCard } from "@/features/kanban/lib/kanbanTypes";
+
+type BoardViewProps = {
+  boardId: string;
+};
+
+export function BoardView({ boardId }: BoardViewProps) {
+  const navigate = useNavigate();
+  const { board, cardsByColumn, isLoading } = useLiveBoard(boardId);
+  const [detailCard, setDetailCard] = React.useState<KanbanCard | null>(null);
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex items-center gap-2 border-b px-4 py-2.5">
+        <Button
+          aria-label="Back to all boards"
+          onClick={() => navigate({ to: "/boards" })}
+          size="icon"
+          type="button"
+          variant="ghost"
+        >
+          <ArrowLeft className="size-4" />
+        </Button>
+        <div className="min-w-0 flex-1">
+          {isLoading ? (
+            <Skeleton className="h-6 w-40" />
+          ) : (
+            <h1 className="truncate text-base font-semibold">
+              {board?.name ?? "Board"}
+            </h1>
+          )}
+        </div>
+        <Button
+          className="text-muted-foreground"
+          disabled
+          title="Sharing ships in P3"
+          type="button"
+          variant="ghost"
+        >
+          <Share2 className="size-4" />
+          Share
+        </Button>
+        <Button
+          className="text-muted-foreground"
+          disabled
+          title="Filter ships in P4"
+          type="button"
+          variant="ghost"
+        >
+          <SlidersHorizontal className="size-4" />
+          Filter
+        </Button>
+      </header>
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <Skeleton className="h-32 w-72" />
+        </div>
+      ) : !board ? (
+        <div className="flex flex-1 items-center justify-center p-8 text-sm text-muted-foreground">
+          Board not found, or you don&apos;t have access to it.
+        </div>
+      ) : (
+        <div className="flex flex-1 gap-3 overflow-x-auto p-4">
+          {board.columns.map((column) => (
+            <KanbanColumn
+              cards={cardsByColumn.get(column.id) ?? []}
+              column={column}
+              key={column.id}
+              onCardClick={setDetailCard}
+            />
+          ))}
+          {board.columns.length === 0 ? (
+            <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+              This board has no columns yet.
+            </div>
+          ) : null}
+        </div>
+      )}
+
+      <CardDetailModal
+        card={detailCard}
+        onOpenChange={(open) => {
+          if (!open) setDetailCard(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/desktop/src/features/kanban/ui/CardDetailModal.tsx
+++ b/desktop/src/features/kanban/ui/CardDetailModal.tsx
@@ -1,0 +1,88 @@
+import { CalendarDays, User } from "lucide-react";
+
+import { Markdown } from "@/shared/ui/markdown";
+import { Badge } from "@/shared/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+import { Avatar, AvatarFallback } from "@/shared/ui/avatar";
+import type { KanbanCard } from "@/features/kanban/lib/kanbanTypes";
+
+type CardDetailModalProps = {
+  card: KanbanCard | null;
+  onOpenChange: (open: boolean) => void;
+};
+
+/**
+ * Read-only card detail (P2). Markdown body + labels + assignees + due.
+ * Comments and reactions on the card thread arrive in P4.
+ */
+export function CardDetailModal({ card, onOpenChange }: CardDetailModalProps) {
+  return (
+    <Dialog open={card !== null} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="text-base">{card?.title}</DialogTitle>
+          <DialogDescription asChild>
+            <span className="sr-only">Kanban card detail</span>
+          </DialogDescription>
+        </DialogHeader>
+
+        {card ? (
+          <div className="space-y-4 text-sm">
+            {card.labels.length > 0 ? (
+              <div className="flex flex-wrap items-center gap-1.5">
+                {card.labels.map((label) => (
+                  <Badge key={label} variant="outline">
+                    {label}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
+
+            <div className="max-h-[50vh] overflow-y-auto">
+              <Markdown className="text-sm" content={card.content} />
+            </div>
+
+            <div className="flex items-center justify-between gap-3 border-t pt-3">
+              <span className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">Assignees</span>
+                <span className="flex -space-x-1.5">
+                  {card.assignees.length === 0 ? (
+                    <span className="text-xs text-muted-foreground/70">
+                      None
+                    </span>
+                  ) : (
+                    card.assignees.map((assignee) => (
+                      <Avatar
+                        className="size-6 border-2 border-background"
+                        key={assignee}
+                      >
+                        <AvatarFallback>
+                          <User className="size-3.5" />
+                        </AvatarFallback>
+                      </Avatar>
+                    ))
+                  )}
+                </span>
+              </span>
+              {card.due ? (
+                <span
+                  className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+                  title={`Due ${card.due}`}
+                >
+                  <CalendarDays className="size-3.5" />
+                  {card.due}
+                </span>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/desktop/src/features/kanban/ui/CardTile.tsx
+++ b/desktop/src/features/kanban/ui/CardTile.tsx
@@ -1,0 +1,71 @@
+import { CalendarDays, User } from "lucide-react";
+
+import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
+import { Avatar, AvatarFallback } from "@/shared/ui/avatar";
+import { cn } from "@/shared/lib/cn";
+import type { KanbanCard } from "@/features/kanban/lib/kanbanTypes";
+
+type CardTileProps = {
+  card: KanbanCard;
+  onClick: (card: KanbanCard) => void;
+};
+
+export function CardTile({ card, onClick }: CardTileProps) {
+  return (
+    <Button
+      asChild={false}
+      className={cn(
+        "h-auto w-full flex-col items-stretch gap-2 rounded-lg border bg-card p-3 text-left shadow-sm transition-colors",
+        "hover:border-border hover:bg-accent/40",
+      )}
+      onClick={() => onClick(card)}
+      type="button"
+      variant="ghost"
+    >
+      <span className="line-clamp-2 text-sm font-medium text-foreground">
+        {card.title}
+      </span>
+
+      {card.labels.length > 0 ? (
+        <span className="flex flex-wrap items-center gap-1">
+          {card.labels.map((label) => (
+            <Badge className="inline-flex" key={label} variant="outline">
+              {label}
+            </Badge>
+          ))}
+        </span>
+      ) : null}
+
+      {card.assignees.length > 0 || card.due ? (
+        <span className="flex items-center justify-between gap-2">
+          <span className="flex -space-x-1.5">
+            {card.assignees.slice(0, 3).map((assignee) => (
+              <Avatar className="size-5 border-2 border-card" key={assignee}>
+                <AvatarFallback>
+                  <User className="size-3" />
+                </AvatarFallback>
+              </Avatar>
+            ))}
+            {card.assignees.length > 3 ? (
+              <Avatar className="size-5 border-2 border-card">
+                <AvatarFallback>
+                  <User className="size-3" />
+                </AvatarFallback>
+              </Avatar>
+            ) : null}
+          </span>
+          {card.due ? (
+            <span
+              className="inline-flex items-center gap-1 text-2xs text-muted-foreground"
+              title={`Due ${card.due}`}
+            >
+              <CalendarDays className="size-3" />
+              {card.due}
+            </span>
+          ) : null}
+        </span>
+      ) : null}
+    </Button>
+  );
+}

--- a/desktop/src/features/kanban/ui/KanbanColumn.tsx
+++ b/desktop/src/features/kanban/ui/KanbanColumn.tsx
@@ -1,0 +1,66 @@
+import { Plus } from "lucide-react";
+
+import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
+import { CardTile } from "@/features/kanban/ui/CardTile";
+import type { KanbanCard } from "@/features/kanban/lib/kanbanTypes";
+import type { KanbanColumn as KanbanColumnModel } from "@/features/kanban/lib/kanbanTypes";
+
+type KanbanColumnProps = {
+  column: KanbanColumnModel;
+  cards: KanbanCard[];
+  onCardClick: (card: KanbanCard) => void;
+};
+
+export function KanbanColumn({
+  column,
+  cards,
+  onCardClick,
+}: KanbanColumnProps) {
+  return (
+    <section
+      className="flex w-72 shrink-0 flex-col rounded-lg border bg-muted/30"
+      data-testid={`kanban-column-${column.id}`}
+    >
+      <header className="flex items-center justify-between gap-2 border-b px-3 py-2.5">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm font-semibold" title={column.name}>
+            {column.name}
+          </span>
+          <span className="rounded-full bg-muted px-1.5 py-0.5 text-2xs tabular-nums text-muted-foreground">
+            {cards.length}
+          </span>
+        </span>
+        {column.wip !== null ? (
+          <Badge
+            className="shrink-0"
+            title={`WIP limit ${column.wip}`}
+            variant="secondary"
+          >
+            WIP {column.wip}
+          </Badge>
+        ) : null}
+      </header>
+
+      <div
+        className="flex flex-col gap-2 overflow-y-auto p-2"
+        data-testid={`kanban-column-cards-${column.id}`}
+      >
+        {cards.map((card) => (
+          <CardTile card={card} key={card.id} onClick={onCardClick} />
+        ))}
+
+        {/* "+ New card" is disabled in P2; creation ships in P3. */}
+        <Button
+          className="w-full justify-start text-muted-foreground"
+          disabled
+          type="button"
+          variant="ghost"
+        >
+          <Plus className="size-4" />
+          New card
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/desktop/src/features/kanban/ui/NewBoardDialog.tsx
+++ b/desktop/src/features/kanban/ui/NewBoardDialog.tsx
@@ -1,0 +1,165 @@
+import * as React from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { Textarea } from "@/shared/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+import {
+  createBoard,
+  KANBAN_TEMPLATES,
+  type KanbanTemplateName,
+} from "@/features/kanban/lib/boardWrite";
+
+type NewBoardDialogProps = {
+  /** Current identity pubkey — the board is created under this owner. */
+  owner: string;
+  onCreated: (boardId: string) => void | Promise<void>;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+};
+
+/**
+ * Inline board creation (P3 write path). The board is signed under the
+ * Desktop's own identity and published to the relay, so it renders in
+ * `/boards` immediately — no CLI, no key handling.
+ */
+export function NewBoardDialog({
+  owner,
+  onCreated,
+  onOpenChange,
+  open,
+}: NewBoardDialogProps) {
+  const [name, setName] = React.useState("");
+  const [description, setDescription] = React.useState("");
+  const [template, setTemplate] = React.useState<KanbanTemplateName>("kanban");
+  const [creating, setCreating] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed || creating) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const { boardId } = await createBoard({
+        owner,
+        name: trimmed,
+        description,
+        template,
+      });
+      toast.success("Board created.");
+      setName("");
+      setDescription("");
+      setTemplate("kanban");
+      onOpenChange(false);
+      await onCreated(boardId);
+    } catch (caught) {
+      const message =
+        caught instanceof Error
+          ? caught.message
+          : "Failed to create the board.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-base">New board</DialogTitle>
+          <DialogDescription asChild>
+            <span className="sr-only">Create a kanban board</span>
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-4 text-sm" onSubmit={handleSubmit}>
+          <label
+            className="block space-y-1.5 font-medium"
+            htmlFor="new-board-name"
+          >
+            <span>Name</span>
+            <Input
+              autoFocus
+              data-testid="new-board-name"
+              disabled={creating}
+              id="new-board-name"
+              onChange={(event) => setName(event.target.value)}
+              placeholder="My board"
+              value={name}
+            />
+          </label>
+
+          <label
+            className="block space-y-1.5 font-medium"
+            htmlFor="new-board-description"
+          >
+            <span>Description (optional)</span>
+            <Textarea
+              data-testid="new-board-description"
+              disabled={creating}
+              id="new-board-description"
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="What is this board for?"
+              value={description}
+            />
+          </label>
+
+          <label
+            className="block space-y-1.5 font-medium"
+            htmlFor="new-board-template"
+          >
+            <span>Template</span>
+            <select
+              className="h-10 w-full rounded-lg border border-input/40 bg-background px-3 text-sm font-normal outline-hidden focus:ring-1 focus:ring-ring"
+              data-testid="new-board-template"
+              disabled={creating}
+              id="new-board-template"
+              onChange={(event) =>
+                setTemplate(event.target.value as KanbanTemplateName)
+              }
+              value={template}
+            >
+              {Object.keys(KANBAN_TEMPLATES).map((key) => (
+                <option key={key} value={key}>
+                  {key[0].toUpperCase() + key.slice(1)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+
+          <DialogFooter>
+            <Button
+              disabled={creating}
+              onClick={() => onOpenChange(false)}
+              type="button"
+              variant="ghost"
+            >
+              Cancel
+            </Button>
+            <Button
+              data-testid="new-board-submit"
+              disabled={creating || name.trim().length === 0}
+              type="submit"
+            >
+              {creating ? "Creating…" : "Create board"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/desktop/src/features/sidebar/ui/AppSidebar.tsx
+++ b/desktop/src/features/sidebar/ui/AppSidebar.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/features/sidebar/ui/AppSidebarPinnedHeader";
 import { MoreUnreadButton } from "@/features/sidebar/ui/MoreUnreadButton";
 import { SidebarSection } from "@/features/sidebar/ui/SidebarSection";
+import { BoardRail } from "@/features/kanban/ui/BoardRail";
 import {
   ChannelGroupSection,
   CustomChannelSection,
@@ -847,6 +848,10 @@ export function AppSidebar({
                 </>
               ) : null}
 
+              <BoardRail
+                isCollapsed={Boolean(collapsedSections.boards)}
+                onToggleCollapsed={() => toggleCollapsedSection("boards")}
+              />
               {errorMessage && !relayConnectionCard.hasRelayUnreachableError ? (
                 <div className="px-3 py-2 text-sm text-destructive">
                   {errorMessage}

--- a/desktop/src/shared/constants/kinds.ts
+++ b/desktop/src/shared/constants/kinds.ts
@@ -69,6 +69,12 @@ export const KIND_GIT_STATUS_DRAFT = 1633;
 // NIP-DV: relay-signed per-viewer DM visibility snapshot (d=viewer pubkey,
 // h-tags = currently-hidden DM channel ids).
 export const KIND_DM_VISIBILITY = 30622;
+// Kanban (NIP-33 param-replaceable, mirror of buzz-core kind.rs): a board
+// (31001, root `d` tag), a card (31002, `#a` board ref), and an optional
+// card-move audit event (31003, ignored in P2 render).
+export const KIND_KANBAN_BOARD = 31001;
+export const KIND_KANBAN_CARD = 31002;
+export const KIND_KANBAN_CARD_MOVE = 31003;
 
 // Human-visible "new content" message kinds. Used as the unread trigger set
 // (sidebar badges, catch-up queries) and as the Home-feed mention query.


### PR DESCRIPTION
## P3 — In-app board creation (inline create, write path)

Turns the disabled "New board" button on `/boards` into a working dialog. The board is **signed under the Desktop's own identity** and published to the relay, so it renders in `/boards` immediately — no CLI, no key handling. Stacks on #4200 (P1), #4208 (P2), #4218 (P3 read-gate).

### What's here
- `lib/boardWrite.ts` — pure `buildBoardEvent({ name, description?, template, owner })` producing kind **31001** exactly as the SDK/CLI `build_kanban_board` does: `d`/`name`/`p(owner)` tags + one `column` tag per template column (`wip` pair omitted when unbounded, `order` 0-based contiguous), no `h`/`invite` (private by default). `createBoard()` signs via `signRelayEvent` and publishes via `relayClient.publishEvent`, returning the `boardId` for navigation. Documented that a fresh random UUID makes a NIP-33 collision effectively impossible, so publish-to-OK suffices here — and that the helper becomes the template for inline card create/move where LWW conflicts are real (that path must inspect the relay's `duplicate:` response like the CLI's exit-5 path).
- `ui/NewBoardDialog.tsx` — Radix dialog (name required, description optional, template select defaulting to `kanban`), pending + error states with toasts.
- `ui/BoardList.tsx` — button now live (`disabled` only while identity isn't loaded); `onCreated` invalidates `boardsQueryKey()` and navigates to `/boards/$boardId`. Empty-state copy updated.
- `KANBAN_TEMPLATES` mirrors the CLI `template_columns()` (kanban/sprint/sales/blank).

### Verification (full suite, never scoped)
- `tsc` clean; desktop suite **3920 pass / 0 fail** (was 3916; +4 new `boardWrite` tests: kind/d/name/p tags, kanban wip-presence + no-wip columns, no h/invite + content, colid `^col-[0-9a-f]{8}$`).
- Biome check clean; production `vite build` succeeds; file-sizes / px-text / pubkey-truncation guards pass.
- Pre-push hooks green: branch-skew, desktop-check, desktop-test, rust-tests, desktop-tauri-checks.

### Out of scope (explicit follow-ups)
- Inline **card** creation, `@dnd-kit` drag-drop + optimistic exit-5 rollback, board/card sharing UI (`h`/`invite`), card comments.

Co-authored-by: Alex Moore <mooorealexandert@gmail.com>
Signed-off-by: Alex Moore <mooorealexandert@gmail.com>
