### PR TITLE
fix(acp): keep all direct-message replies flat

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -53,7 +53,9 @@ For explicit changes to an existing personal agent, use `buzz agents draft-updat
 
 Use the reply destination supplied in the `[Context]` block for ordinary replies in this turn. Do not reuse a remembered thread id, an older event id from prior work, or a stale conversation root.
 
-For human-facing work, keep the conversation flat and easy to read. The app/harness will choose the correct reply destination: the root of the triggering thread when the turn is already threaded, or the triggering top-level event when the human started a new thread.
+Direct messages are always flat. Send each ordinary DM response as a top-level message in the conversation. Do not pass `--reply-to` in a DM, even when the incoming DM carries thread tags from an earlier exchange.
+
+For human-facing channel work, keep the conversation flat and easy to read. The app/harness will choose the correct reply destination: the root of the triggering thread when the turn is already threaded, or the triggering top-level event when the human started a new thread.
 
 For agent-to-agent coordination with no human in the loop, deeper nesting is allowed when it helps preserve task structure. Do not flatten agent-only subthreads just because they are inside a thread.
 

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3627,6 +3627,13 @@ mod agent_draft_prompt_tests {
     }
 
     #[test]
+    fn shared_base_prompt_teaches_flat_dm_replies() {
+        let prompt = include_str!("base_prompt.md");
+        assert!(prompt.contains("Direct messages are always flat"));
+        assert!(prompt.contains("Do not pass `--reply-to` in a DM"));
+    }
+
+    #[test]
     fn shared_base_prompt_teaches_single_command_mentions_and_preflight() {
         let prompt = include_str!("base_prompt.md");
         assert!(prompt.contains("--mention <hex-or-npub>"));

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1156,6 +1156,18 @@ fn append_reply_instruction(s: &mut String, event_id: &str) {
     ));
 }
 
+/// Append the reply instruction for direct messages.
+///
+/// DMs use a flat timeline instead of threads, even when the triggering event
+/// carries legacy thread tags.
+fn append_dm_reply_instruction(s: &mut String) {
+    s.push_str(
+        "\nIMPORTANT: DMs are a flat conversation. Send an ordinary message to \
+         this channel and keep it at the top level. Do not pass `--reply-to` to \
+         `buzz messages send`.",
+    );
+}
+
 /// Append a new-thread reply instruction for a human-facing top-level mention.
 ///
 /// The triggering mention has no thread tags, so the agent's reply becomes the
@@ -1226,10 +1238,10 @@ fn resolve_reply_anchor(
 /// Format a `[Context]` hints section based on event scope.
 ///
 /// `reply_anchor` is the pre-resolved `--reply-to` target for this turn (see
-/// [`resolve_reply_anchor`]). In the thread/DM branches it threads ordinary
-/// replies; in the channel branch a `Some` anchor means a human-facing
-/// top-level mention whose reply should open a new thread rooted at the
-/// triggering event.
+/// [`resolve_reply_anchor`]). In the thread branch it threads ordinary replies;
+/// in the channel branch a `Some` anchor means a human-facing top-level mention
+/// whose reply should open a new thread rooted at the triggering event. DMs
+/// always remain flat and ignore reply anchors.
 fn format_context_hints(
     channel_id: Uuid,
     channel_info: Option<&PromptChannelInfo>,
@@ -1272,10 +1284,8 @@ fn format_context_hints(
                     s.push_str(&format!("\nParent: {parent}"));
                 }
             }
-            if let Some(event_id) = reply_anchor {
-                append_reply_instruction(&mut s, event_id);
-            }
         }
+        append_dm_reply_instruction(&mut s);
         s
     } else if let Some(ref root) = thread_tags.root_event_id {
         let ctx_hint = if has_conversation_context {
@@ -1463,13 +1473,10 @@ pub fn format_prompt(batch: &FlushBatch, args: &FormatPromptArgs<'_>) -> Vec<Str
     //   - in a thread  → anchor to the thread ROOT (no depth-2 nesting)
     //   - top-level     → anchor to the triggering event (it becomes the root)
     // Agent↔agent turns get no forced anchor — deep nesting is intentional
-    // there. DMs are always 1:1 with a human, so they always anchor.
+    // there. DMs remain flat and never receive a reply anchor.
     let sender_pubkey = last_event.event.pubkey.to_hex();
     let reply_anchor = if is_dm {
-        thread_tags
-            .root_event_id
-            .is_some()
-            .then(|| last_event.event.id.to_hex())
+        None
     } else {
         resolve_reply_anchor(
             &sender_pubkey,
@@ -3904,14 +3911,13 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_instruction_present_for_dm_thread_reply() {
+    fn test_dm_thread_reply_instruction_uses_flat_message() {
         let ch = Uuid::new_v4();
         let root_id = "b".repeat(64);
         let event = make_event_with_tags(
             "thanks",
             vec![vec!["e".into(), root_id, "".into(), "reply".into()]],
         );
-        let event_id = event.id.to_hex();
         let batch = FlushBatch {
             channel_id: ch,
             events: vec![BatchEvent {
@@ -3936,8 +3942,12 @@ mod tests {
         )
         .join("\n\n");
         assert!(
-            prompt.contains(&format!("--reply-to {event_id}")),
-            "DM thread reply should include reply instruction"
+            prompt.contains("DMs are a flat conversation"),
+            "DM reply should instruct the agent to keep the conversation flat"
+        );
+        assert!(
+            prompt.contains("Do not pass `--reply-to`"),
+            "DM reply should explicitly omit the thread flag"
         );
     }
 
@@ -3972,7 +3982,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reply_instruction_absent_for_dm_non_reply() {
+    fn test_dm_top_level_reply_instruction_uses_flat_message() {
         let ch = Uuid::new_v4();
         let event = make_event("hey there");
         let batch = FlushBatch {
@@ -3999,8 +4009,12 @@ mod tests {
         )
         .join("\n\n");
         assert!(
-            !prompt.contains("--reply-to"),
-            "DM non-reply should NOT include reply instruction"
+            prompt.contains("DMs are a flat conversation"),
+            "top-level DM should instruct the agent to keep the conversation flat"
+        );
+        assert!(
+            prompt.contains("Do not pass `--reply-to`"),
+            "top-level DM should explicitly omit the thread flag"
         );
     }
 


### PR DESCRIPTION
## Summary

Keep managed-agent direct messages as a normal flat conversation. Every ordinary DM response is sent at the channel top level, even when the incoming DM carries legacy thread tags. Human-facing channel replies retain their existing thread-root behavior.

This intentionally applies the flat behavior more broadly than #3077. It resolves the top-level case in #3075 and removes the compounding nested-DM behavior described in #2748 by eliminating DM reply anchors rather than moving them to a root.

## Implementation

- Add a DM-specific prompt instruction that forbids `--reply-to` for both top-level and previously threaded DM events.
- Remove DM reply-anchor generation while leaving non-DM anchor resolution unchanged.
- Align the shared base prompt with the flat-DM contract.
- Cover top-level DMs, legacy threaded DMs, and the shared prompt contract with regression tests.

## Verification

- `cargo fmt --all -- --check`
- `env -u BUZZ_ACP_LAZY_POOL cargo test -p buzz-acp`: 662 unit tests and 9 integration tests passed
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- Existing channel-thread anchoring tests pass

`just ci` reached the mobile suite, where the unrelated `ChannelDetailPage keeps follow mode off while a tall newest message stays visible` test failed. This change does not touch mobile code.

Fixes #3075.
Addresses #2748 with the product behavior requested here: no threads in direct messages.
