### PR TITLE
Register Hermes as an ACP harness

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -616,7 +616,7 @@ pub(crate) fn normalize_agent_command_identity(command: &str) -> String {
 
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
-        "goose" => Some(vec!["acp".to_string()]),
+        "goose" | "hermes" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,
@@ -1438,6 +1438,17 @@ mod tests {
     fn normalizes_goose_args_to_acp() {
         assert_eq!(normalize_agent_args("goose", Vec::new()), vec!["acp"]);
         assert_eq!(normalize_agent_args("goose", vec!["".into()]), vec!["acp"]);
+    }
+
+    #[test]
+    fn normalizes_hermes_args_to_acp() {
+        // `hermes acp` is the ACP entry point, the same shape as `goose acp`.
+        assert_eq!(normalize_agent_args("hermes", Vec::new()), vec!["acp"]);
+        assert_eq!(normalize_agent_args("hermes", vec!["".into()]), vec!["acp"]);
+        assert_eq!(
+            normalize_agent_args("/Users/me/.local/bin/hermes", Vec::new()),
+            vec!["acp"]
+        );
     }
 
     #[test]

--- a/desktop/scripts/check-file-sizes.mjs
+++ b/desktop/scripts/check-file-sizes.mjs
@@ -296,7 +296,9 @@ const overrides = new Map([
   // Buzz-managed Node path helpers and resolution tests moved to
   // managed_node_paths.rs and discovery/tests/managed_path_resolution.rs;
   // ratcheting 1366 -> 1392 after adding the managed-path probes to discovery.
-  ["src-tauri/src/managed_agents/discovery.rs", 1393],
+  // +5: the Hermes KnownAcpRuntime entry — one element of the static catalog
+  // array, so there is nothing to split out of it.
+  ["src-tauri/src/managed_agents/discovery.rs", 1398],
   // rebase over codex-acp-package-swap: its version-probe tests union with the
   // doctor-install-reliability nvm/login-shell/semver tests — each side alone
   // stayed under the 1000 default; the union exceeds it.
@@ -307,6 +309,8 @@ const overrides = new Map([
   // None regression, .cmd shim resolution, no-git-bash error hint.
   // +32: deterministic .cmd resolver + no-registry + install_shell_from tests.
   // Managed-path resolution test split to discovery/tests/managed_path_resolution.rs.
+  // Hermes runtime registration tests split to discovery/tests/hermes_runtime.rs,
+  // holding this file at its existing limit rather than ratcheting it again.
   ["src-tauri/src/managed_agents/discovery/tests.rs", 1273],
   // identity-import-keyring: the identity resolution state machine's behavioral
   // matrix (46 tests over FakeIdentityStore — probe × marker × file cells,

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -16,6 +16,8 @@ pub(crate) use runtime_metadata::KnownAcpRuntime;
 const GOOSE_AVATAR_URL: &str = "https://goose-docs.ai/img/logo_dark.png";
 const CLAUDE_CODE_AVATAR_URL: &str = "https://anthropic.gallerycdn.vsassets.io/extensions/anthropic/claude-code/2.1.77/1773707456892/Microsoft.VisualStudio.Services.Icons.Default";
 const CODEX_AVATAR_URL: &str = "https://openai.gallerycdn.vsassets.io/extensions/openai/chatgpt/26.5313.41514/1773706730621/Microsoft.VisualStudio.Services.Icons.Default";
+const HERMES_AVATAR_URL: &str =
+    "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/website/static/img/apple-touch-icon.png";
 const BUZZ_AGENT_AVATAR_URL: &str =
     "https://raw.githubusercontent.com/block/buzz/refs/heads/main/crates/buzz-agent/buzz-agent.png";
 
@@ -161,6 +163,50 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         login_hint: Some("Run `codex login` to authenticate."),
         // Verified: `codex login status` exits 0 when logged in, non-zero otherwise.
         auth_probe_args: Some(&["codex", "login", "status"]),
+    },
+    KnownAcpRuntime {
+        id: "hermes",
+        label: "Hermes",
+        // `hermes acp` is built into the CLI — there is no separate adapter
+        // package, so the runtime command and the underlying CLI are the same
+        // binary (the Goose shape, not the Claude/Codex adapter shape).
+        commands: &["hermes"],
+        aliases: &["hermes-agent"],
+        avatar_url: HERMES_AVATAR_URL,
+        mcp_command: None,
+        mcp_hooks: false,
+        underlying_cli: Some("hermes"),
+        cli_install_commands: &["curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash"],
+        cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"iex (irm https://hermes-agent.nousresearch.com/install.ps1)\""],
+        adapter_install_commands: &[],
+        cli_install_instructions_url: "https://hermes-agent.nousresearch.com/docs/getting-started/quickstart",
+        adapter_install_instructions_url: "",
+        cli_install_hint: "Buzz requires the Hermes CLI; run `hermes portal` or `hermes model` once to configure a provider.",
+        adapter_install_hint: "",
+        // Hermes resolves skills from `~/.hermes/skills` plus the
+        // `skills.external_dirs` entries in its own config.yaml — it has no
+        // nest-relative skill directory for Buzz to symlink into.
+        skill_dir: None,
+        supports_acp_model_switching: false,
+        // Hermes has no model/provider env vars: both live under the `model`
+        // key in `~/.hermes/config.yaml` and are owned by `hermes model` /
+        // `hermes portal`, so Buzz does not drive provider selection.
+        model_env_var: None,
+        provider_env_var: None,
+        provider_locked: true,
+        default_env: &[],
+        config_file_path: Some("~/.hermes/config.yaml"),
+        config_file_format: Some("yaml"),
+        supports_acp_native_config: false,
+        thinking_env_var: None,
+        max_tokens_env_var: None,
+        context_limit_env_var: None,
+        required_normalized_fields: &[],
+        // No auth probe: `hermes auth status` requires a provider argument and
+        // `hermes doctor` exits 0 regardless of provider auth, so there is no
+        // fixed argv that reports login state. Same posture as Goose.
+        login_hint: None,
+        auth_probe_args: None,
     },
     KnownAcpRuntime {
         id: "buzz-agent",
@@ -348,7 +394,7 @@ pub use overrides::{apply_agent_command_update, create_time_agent_command_overri
 
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_command_identity(command).as_str() {
-        "goose" => Some(vec!["acp".to_string()]),
+        "goose" | "hermes" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
         | "claudecode" | "buzz-agent" => Some(Vec::new()),
         _ => None,

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -634,6 +634,7 @@ fn probe_codex_acp_major_version_parses_1x_output() {
 }
 
 mod codex_version;
+mod hermes_runtime;
 
 #[cfg(unix)]
 #[test]
@@ -1267,72 +1268,5 @@ fn test_install_shell_from_some_returns_path() {
         result,
         Ok(path),
         "install_shell_from(Some) must return the path as Ok"
-    );
-}
-
-// ── Hermes runtime registration ─────────────────────────────────────────────
-
-/// Hermes is registered, resolvable by id, primary command, and alias.
-#[test]
-fn test_hermes_runtime_is_registered_and_resolvable() {
-    let hermes = super::known_acp_runtime_exact("hermes").expect("hermes must be in the catalog");
-    assert_eq!(hermes.commands, &["hermes"]);
-    assert_eq!(
-        super::known_acp_runtime("hermes").map(|r| r.id),
-        Some("hermes")
-    );
-    assert_eq!(
-        super::known_acp_runtime("hermes-agent").map(|r| r.id),
-        Some("hermes"),
-        "the hermes-agent alias must resolve to the hermes runtime"
-    );
-}
-
-/// `hermes acp` is built into the CLI, so the runtime declares no separate
-/// adapter but still needs CLI install commands on every platform.
-#[test]
-fn test_hermes_has_cli_install_but_no_adapter() {
-    let hermes = super::known_acp_runtime_exact("hermes").unwrap();
-    assert!(
-        !hermes.cli_install_commands_for_os().is_empty(),
-        "hermes must have install commands on every platform"
-    );
-    assert!(
-        hermes.adapter_install_commands.is_empty(),
-        "hermes ships ACP mode in the CLI — no adapter package"
-    );
-    assert!(hermes.adapter_install_instructions_url.is_empty());
-}
-
-/// Hermes owns provider/model selection in its own config.yaml, so Buzz must
-/// not advertise env-var-driven model or provider injection for it.
-#[test]
-fn test_hermes_does_not_expose_model_or_provider_env() {
-    let hermes = super::known_acp_runtime_exact("hermes").unwrap();
-    assert!(hermes.model_env_var.is_none());
-    assert!(hermes.provider_env_var.is_none());
-    assert!(hermes.provider_locked);
-    assert!(hermes.required_normalized_fields.is_empty());
-    assert_eq!(hermes.config_file_path, Some("~/.hermes/config.yaml"));
-}
-
-/// Hermes resolves skills from `~/.hermes/skills` and `skills.external_dirs`,
-/// so it declares no nest-relative skill directory for Buzz to symlink into.
-#[test]
-fn test_hermes_declares_no_nest_skill_dir() {
-    let hermes = super::known_acp_runtime_exact("hermes").unwrap();
-    assert!(hermes.skill_dir.is_none());
-}
-
-/// The Hermes CLI is launched as `hermes acp`, the same shape as Goose.
-#[test]
-fn test_hermes_defaults_to_acp_subcommand() {
-    assert_eq!(
-        normalize_agent_args("hermes", Vec::new()),
-        vec!["acp".to_string()]
-    );
-    assert_eq!(
-        normalize_agent_args("hermes", vec!["".into()]),
-        vec!["acp".to_string()]
     );
 }

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -1269,3 +1269,70 @@ fn test_install_shell_from_some_returns_path() {
         "install_shell_from(Some) must return the path as Ok"
     );
 }
+
+// ── Hermes runtime registration ─────────────────────────────────────────────
+
+/// Hermes is registered, resolvable by id, primary command, and alias.
+#[test]
+fn test_hermes_runtime_is_registered_and_resolvable() {
+    let hermes = super::known_acp_runtime_exact("hermes").expect("hermes must be in the catalog");
+    assert_eq!(hermes.commands, &["hermes"]);
+    assert_eq!(
+        super::known_acp_runtime("hermes").map(|r| r.id),
+        Some("hermes")
+    );
+    assert_eq!(
+        super::known_acp_runtime("hermes-agent").map(|r| r.id),
+        Some("hermes"),
+        "the hermes-agent alias must resolve to the hermes runtime"
+    );
+}
+
+/// `hermes acp` is built into the CLI, so the runtime declares no separate
+/// adapter but still needs CLI install commands on every platform.
+#[test]
+fn test_hermes_has_cli_install_but_no_adapter() {
+    let hermes = super::known_acp_runtime_exact("hermes").unwrap();
+    assert!(
+        !hermes.cli_install_commands_for_os().is_empty(),
+        "hermes must have install commands on every platform"
+    );
+    assert!(
+        hermes.adapter_install_commands.is_empty(),
+        "hermes ships ACP mode in the CLI — no adapter package"
+    );
+    assert!(hermes.adapter_install_instructions_url.is_empty());
+}
+
+/// Hermes owns provider/model selection in its own config.yaml, so Buzz must
+/// not advertise env-var-driven model or provider injection for it.
+#[test]
+fn test_hermes_does_not_expose_model_or_provider_env() {
+    let hermes = super::known_acp_runtime_exact("hermes").unwrap();
+    assert!(hermes.model_env_var.is_none());
+    assert!(hermes.provider_env_var.is_none());
+    assert!(hermes.provider_locked);
+    assert!(hermes.required_normalized_fields.is_empty());
+    assert_eq!(hermes.config_file_path, Some("~/.hermes/config.yaml"));
+}
+
+/// Hermes resolves skills from `~/.hermes/skills` and `skills.external_dirs`,
+/// so it declares no nest-relative skill directory for Buzz to symlink into.
+#[test]
+fn test_hermes_declares_no_nest_skill_dir() {
+    let hermes = super::known_acp_runtime_exact("hermes").unwrap();
+    assert!(hermes.skill_dir.is_none());
+}
+
+/// The Hermes CLI is launched as `hermes acp`, the same shape as Goose.
+#[test]
+fn test_hermes_defaults_to_acp_subcommand() {
+    assert_eq!(
+        normalize_agent_args("hermes", Vec::new()),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("hermes", vec!["".into()]),
+        vec!["acp".to_string()]
+    );
+}

--- a/desktop/src-tauri/src/managed_agents/discovery/tests/hermes_runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests/hermes_runtime.rs
@@ -1,0 +1,65 @@
+use crate::managed_agents::discovery::{
+    known_acp_runtime, known_acp_runtime_exact, normalize_agent_args,
+};
+
+/// Hermes is registered, resolvable by id, primary command, and alias.
+#[test]
+fn test_hermes_runtime_is_registered_and_resolvable() {
+    let hermes = known_acp_runtime_exact("hermes").expect("hermes must be in the catalog");
+    assert_eq!(hermes.commands, &["hermes"]);
+    assert_eq!(known_acp_runtime("hermes").map(|r| r.id), Some("hermes"));
+    assert_eq!(
+        known_acp_runtime("hermes-agent").map(|r| r.id),
+        Some("hermes"),
+        "the hermes-agent alias must resolve to the hermes runtime"
+    );
+}
+
+/// `hermes acp` is built into the CLI, so the runtime declares no separate
+/// adapter but still needs CLI install commands on every platform.
+#[test]
+fn test_hermes_has_cli_install_but_no_adapter() {
+    let hermes = known_acp_runtime_exact("hermes").unwrap();
+    assert!(
+        !hermes.cli_install_commands_for_os().is_empty(),
+        "hermes must have install commands on every platform"
+    );
+    assert!(
+        hermes.adapter_install_commands.is_empty(),
+        "hermes ships ACP mode in the CLI — no adapter package"
+    );
+    assert!(hermes.adapter_install_instructions_url.is_empty());
+}
+
+/// Hermes owns provider/model selection in its own config.yaml, so Buzz must
+/// not advertise env-var-driven model or provider injection for it.
+#[test]
+fn test_hermes_does_not_expose_model_or_provider_env() {
+    let hermes = known_acp_runtime_exact("hermes").unwrap();
+    assert!(hermes.model_env_var.is_none());
+    assert!(hermes.provider_env_var.is_none());
+    assert!(hermes.provider_locked);
+    assert!(hermes.required_normalized_fields.is_empty());
+    assert_eq!(hermes.config_file_path, Some("~/.hermes/config.yaml"));
+}
+
+/// Hermes resolves skills from `~/.hermes/skills` and `skills.external_dirs`,
+/// so it declares no nest-relative skill directory for Buzz to symlink into.
+#[test]
+fn test_hermes_declares_no_nest_skill_dir() {
+    let hermes = known_acp_runtime_exact("hermes").unwrap();
+    assert!(hermes.skill_dir.is_none());
+}
+
+/// The Hermes CLI is launched as `hermes acp`, the same shape as Goose.
+#[test]
+fn test_hermes_defaults_to_acp_subcommand() {
+    assert_eq!(
+        normalize_agent_args("hermes", Vec::new()),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("hermes", vec!["".into()]),
+        vec!["acp".to_string()]
+    );
+}

--- a/desktop/src/features/agents/ui/personaRuntimeModel.test.mjs
+++ b/desktop/src/features/agents/ui/personaRuntimeModel.test.mjs
@@ -196,6 +196,9 @@ test("resolveRuntimeProviderCapability classifies known CLI-login runtimes as lo
   assert.equal(resolveRuntimeProviderCapability("claude", false), "locked");
   assert.equal(resolveRuntimeProviderCapability("codex", false), "locked");
   assert.equal(resolveRuntimeProviderCapability(" claude ", false), "locked");
+  // Hermes owns provider/model in its own ~/.hermes/config.yaml and exposes no
+  // provider env var, so Buzz must not offer provider selection for it.
+  assert.equal(resolveRuntimeProviderCapability("hermes", false), "locked");
 });
 
 test("resolveRuntimeProviderCapability leaves genuinely unknown/custom runtimes as unknown", () => {

--- a/desktop/src/features/agents/ui/personaRuntimeModel.ts
+++ b/desktop/src/features/agents/ui/personaRuntimeModel.ts
@@ -18,7 +18,8 @@ export type ProviderRuntimeCapability = "capable" | "locked" | "unknown";
  * provider. To avoid that, we resolve capability STATICALLY for known ids:
  *
  * - buzz-agent / goose → "capable" (`isProviderCapable`, id-based).
- * - claude / codex → "locked" (CLI-login runtimes; no LLM provider selection).
+ * - claude / codex / hermes → "locked" (the runtime owns its own provider
+ *   config, so Buzz offers no LLM provider selection).
  * - anything else (custom, empty, genuinely unknown) → "unknown".
  *
  * `isProviderCapable` is the caller-supplied {@link
@@ -33,7 +34,7 @@ export function resolveRuntimeProviderCapability(
     return "capable";
   }
   const id = runtimeId.trim();
-  if (id === "claude" || id === "codex") {
+  if (id === "claude" || id === "codex" || id === "hermes") {
     return "locked";
   }
   return "unknown";


### PR DESCRIPTION
## What

Registers **Hermes Agent** as a known ACP runtime so a Buzz agent can be created against a Hermes harness the same way it can against Goose, Claude Code, or Codex.

Hermes ships ACP mode inside its own CLI (`hermes acp`) — the same protocol `buzz-acp` already speaks — so this is catalog registration and arg normalization, not a new transport.

## Shape

Hermes follows the **Goose** shape, not the Claude/Codex adapter shape: the runtime command and the underlying CLI are one binary, so there is no adapter package to install and `default_agent_args` appends the `acp` subcommand. That default lives in two places, which each carry their own copy:

- `crates/buzz-acp/src/config.rs`
- `desktop/src-tauri/src/managed_agents/discovery.rs`

## Two constraints, both read out of the Hermes source

- **Provider and model are not env-driven.** They live under the `model` key in `~/.hermes/config.yaml` and are owned by `hermes model` / `hermes portal`; there are no `HERMES_MODEL` / `HERMES_PROVIDER` variables. So the catalog entry is `provider_locked` with no model/provider env injection, and `personaRuntimeModel.ts` classifies `hermes` as `"locked"` alongside Claude and Codex.
- **Skills have no nest-relative directory.** Hermes resolves them from `~/.hermes/skills` plus `skills.external_dirs` (`agent/skill_utils.py`), so `skill_dir` is `None` rather than `.hermes/skills`.

**No auth probe.** `hermes auth status` requires a provider argument and `hermes doctor` exits 0 regardless of provider auth, so there is no fixed argv that reports login state. Same posture as Goose.

## Tests

Six new tests — five in `desktop/src-tauri/src/managed_agents/discovery/tests/hermes_runtime.rs` covering registration/alias resolution, CLI-install-without-adapter, provider/model env absence, skill-dir absence, and the `acp` subcommand default; plus `normalizes_hermes_args_to_acp` in `buzz-acp`. `personaRuntimeModel.test.mjs` gains the `hermes` → `"locked"` case.

The Hermes tests are a separate file under the existing `discovery/tests/` directory (prior art: `managed_path_resolution.rs`, `codex_version.rs`) so `discovery/tests.rs` stays at its current size baseline instead of being ratcheted again. `discovery.rs` ratchets 1393 → 1398 for the `KnownAcpRuntime` entry itself, which is one element of a static array and has nothing to split out.

## Verification

Verified locally against a real Hermes install (v0.19.0):

- `hermes acp --check` → `Hermes ACP check OK`
- All four external URLs in the catalog entry return 200 (avatar, `install.sh`, `install.ps1`, quickstart docs)

## Known follow-up (not addressed here)

`desktop/src/features/onboarding/ui/agentReadiness.ts` returns `ready: false` for any runtime that is not `buzz-agent` or `goose`, and its CLI-login fast path lists only `claude` and `codex`. If `hermes` were ever set as `preferred_runtime`, readiness would report not-ready. It does not bite today because the only production caller (`welcomeKickoff.ts`) uses the default `"any"` scope, which Hermes passes. Left out of this PR to keep it to registration.
