### PR TITLE
fix(desktop): show shared invocable agents in mentions

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -5,7 +5,7 @@ import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isAgentIdentityInAllowedList,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
@@ -136,27 +136,27 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
-test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
-  const managedAgentPubkeys = new Set([PUB_A]);
+test("isAgentIdentityInAllowedList: keeps people and only listed agent identities", () => {
+  const allowedAgentPubkeys = new Set([PUB_A]);
 
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentIdentityInAllowedList(
       { isAgent: false, pubkey: PUB_B },
-      managedAgentPubkeys,
+      allowedAgentPubkeys,
     ),
     true,
   );
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentIdentityInAllowedList(
       { isAgent: true, pubkey: PUB_A.toUpperCase() },
-      managedAgentPubkeys,
+      allowedAgentPubkeys,
     ),
     true,
   );
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentIdentityInAllowedList(
       { isAgent: true, pubkey: PUB_B },
-      managedAgentPubkeys,
+      allowedAgentPubkeys,
     ),
     false,
   );

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -4,7 +4,6 @@ import test from "node:test";
 import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
-  getSharedChannelIds,
   isAgentIdentityInAllowedList,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
@@ -36,24 +35,11 @@ function makeAgent(overrides = {}) {
   };
 }
 
-test("getSharedChannelIds: includes only active joined channels", () => {
-  assert.deepEqual(
-    getSharedChannelIds([
-      { id: "joined", isMember: true, archivedAt: null },
-      { id: "not-joined", isMember: false, archivedAt: null },
-      { id: "archived", isMember: true, archivedAt: "2026-01-01T00:00:00Z" },
-    ]),
-    new Set(["joined"]),
-  );
-});
-
-test("relayAgentIsSharedWithUser: accepts shared anyone agents and rejects unshared ones", () => {
-  const sharedChannelIds = new Set(["general"]);
-
+test("relayAgentIsSharedWithUser: accepts anyone agents only in the current channel", () => {
   assert.equal(
     relayAgentIsSharedWithUser(
       { respondTo: "anyone", respondToAllowlist: [], channelIds: ["general"] },
-      sharedChannelIds,
+      "general",
     ),
     true,
   );
@@ -64,30 +50,42 @@ test("relayAgentIsSharedWithUser: accepts shared anyone agents and rejects unsha
         respondToAllowlist: [],
         channelIds: ["general"],
       },
-      sharedChannelIds,
+      "general",
     ),
     false,
   );
   assert.equal(
     relayAgentIsSharedWithUser(
       { respondTo: "anyone", respondToAllowlist: [], channelIds: ["other"] },
-      sharedChannelIds,
+      "general",
+    ),
+    false,
+  );
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      { respondTo: "anyone", respondToAllowlist: [], channelIds: [] },
+      "general",
+    ),
+    false,
+  );
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      { respondTo: "anyone", respondToAllowlist: [], channelIds: ["general"] },
+      null,
     ),
     false,
   );
 });
 
 test("relayAgentIsSharedWithUser: accepts allowlist agents for the current user", () => {
-  const sharedChannelIds = new Set(["general"]);
-
   assert.equal(
     relayAgentIsSharedWithUser(
       {
         respondTo: "allowlist",
         respondToAllowlist: [OTHER_OWNER_PUBKEY, CURRENT_PUBKEY.toUpperCase()],
-        channelIds: ["other"],
+        channelIds: ["general"],
       },
-      sharedChannelIds,
+      "general",
       CURRENT_PUBKEY,
     ),
     true,
@@ -96,10 +94,22 @@ test("relayAgentIsSharedWithUser: accepts allowlist agents for the current user"
     relayAgentIsSharedWithUser(
       {
         respondTo: "allowlist",
+        respondToAllowlist: [CURRENT_PUBKEY],
+        channelIds: ["other"],
+      },
+      "general",
+      CURRENT_PUBKEY,
+    ),
+    false,
+  );
+  assert.equal(
+    relayAgentIsSharedWithUser(
+      {
+        respondTo: "allowlist",
         respondToAllowlist: [OTHER_OWNER_PUBKEY],
         channelIds: ["general"],
       },
-      sharedChannelIds,
+      "general",
       CURRENT_PUBKEY,
     ),
     false,
@@ -108,6 +118,7 @@ test("relayAgentIsSharedWithUser: accepts allowlist agents for the current user"
 
 test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents", () => {
   const result = getMentionableAgentPubkeys({
+    currentChannelId: "general",
     managedAgentPubkeys: [PUB_A],
     currentPubkey: CURRENT_PUBKEY,
     relayAgents: [
@@ -121,7 +132,7 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
         pubkey: PUB_C,
         respondTo: "allowlist",
         respondToAllowlist: [CURRENT_PUBKEY],
-        channelIds: ["other"],
+        channelIds: ["general"],
       },
       {
         pubkey: PUB_D,
@@ -130,7 +141,6 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
         channelIds: ["other"],
       },
     ],
-    sharedChannelIds: new Set(["general"]),
   });
 
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -54,13 +54,13 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
-export function isAgentIdentityInManagedList(
+export function isAgentIdentityInAllowedList(
   candidate: { isAgent?: boolean; pubkey: string },
-  managedAgentPubkeys: ReadonlySet<string>,
+  allowedAgentPubkeys: ReadonlySet<string>,
 ) {
   return (
     candidate.isAgent !== true ||
-    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
+    allowedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
   );
 }
 

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -1,19 +1,15 @@
-import type { Channel, RelayAgent } from "@/shared/api/types";
+import type { RelayAgent } from "@/shared/api/types";
 import { normalizePubkey } from "@/shared/lib/pubkey";
-
-export function getSharedChannelIds(channels: readonly Channel[] | undefined) {
-  return new Set(
-    (channels ?? [])
-      .filter((channel) => channel.isMember && channel.archivedAt === null)
-      .map((channel) => channel.id),
-  );
-}
 
 export function relayAgentIsSharedWithUser(
   agent: Pick<RelayAgent, "channelIds" | "respondTo" | "respondToAllowlist">,
-  sharedChannelIds: ReadonlySet<string>,
+  currentChannelId: string | null,
   currentPubkey?: string | null,
 ) {
+  if (!currentChannelId || !agent.channelIds.includes(currentChannelId)) {
+    return false;
+  }
+
   const normalizedCurrentPubkey = currentPubkey
     ? normalizePubkey(currentPubkey)
     : null;
@@ -24,29 +20,26 @@ export function relayAgentIsSharedWithUser(
       .includes(normalizedCurrentPubkey);
   }
 
-  return (
-    agent.respondTo === "anyone" &&
-    agent.channelIds.some((channelId) => sharedChannelIds.has(channelId))
-  );
+  return agent.respondTo === "anyone";
 }
 
 export function getMentionableAgentPubkeys({
+  currentChannelId,
   currentPubkey,
   managedAgentPubkeys,
   relayAgents,
-  sharedChannelIds,
 }: {
+  currentChannelId: string | null;
   currentPubkey?: string | null;
   managedAgentPubkeys: Iterable<string>;
   relayAgents: readonly RelayAgent[] | undefined;
-  sharedChannelIds: ReadonlySet<string>;
 }) {
   const pubkeys = new Set(
     [...managedAgentPubkeys].map((pubkey) => normalizePubkey(pubkey)),
   );
 
   for (const agent of relayAgents ?? []) {
-    if (relayAgentIsSharedWithUser(agent, sharedChannelIds, currentPubkey)) {
+    if (relayAgentIsSharedWithUser(agent, currentChannelId, currentPubkey)) {
       pubkeys.add(normalizePubkey(agent.pubkey));
     }
   }

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -9,7 +9,7 @@ import {
 import { attachManagedAgentToChannel } from "@/features/agents/channelAgents";
 import {
   coalesceAgentAutocompleteCandidates,
-  isAgentIdentityInManagedList,
+  isAgentIdentityInAllowedList,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
@@ -282,7 +282,7 @@ export function MembersSidebar({
           )) ||
         memberPubkeys.has(pubkey) ||
         isArchivedDiscovery(pubkey) ||
-        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+        !isAgentIdentityInAllowedList(candidate, managedAgentPubkeys)
       ) {
         return;
       }

--- a/desktop/src/features/forum/ui/ForumComposer.tsx
+++ b/desktop/src/features/forum/ui/ForumComposer.tsx
@@ -36,6 +36,7 @@ import { useCompactComposerInteractions } from "./useCompactComposerInteractions
 
 export function ForumComposer({
   channelId = null,
+  channelType,
   members,
   className,
   placeholder,
@@ -69,7 +70,7 @@ export function ForumComposer({
     if (compact) setIsCompactExpanded(true);
   }, [compact]);
 
-  const mentions = useMentions(channelId, members, profiles);
+  const mentions = useMentions(channelId, members, profiles, { channelType });
   const channelLinks = useChannelLinks();
   const media = useMediaUpload();
   const { handlePaperclipClick, handleToolbarMouseDown, shouldIgnoreBlur } =

--- a/desktop/src/features/forum/ui/ForumComposer.types.ts
+++ b/desktop/src/features/forum/ui/ForumComposer.types.ts
@@ -1,10 +1,12 @@
 import type * as React from "react";
 
 import type { UserProfileLookup } from "@/features/profile/lib/identity";
-import type { ChannelMember } from "@/shared/api/types";
+import type { ChannelMember, ChannelType } from "@/shared/api/types";
 
 export type ForumComposerProps = {
   channelId?: string | null;
+  /** Known channel type for channel-backed composers; omitted uses fail closed. */
+  channelType?: ChannelType | null;
   /** Override mention source when no channel is available (e.g. Pulse). */
   members?: ChannelMember[];
   className?: string;

--- a/desktop/src/features/forum/ui/ForumThreadPanel.tsx
+++ b/desktop/src/features/forum/ui/ForumThreadPanel.tsx
@@ -293,6 +293,7 @@ export function ForumThreadPanel({
       <div className="border-t border-border/60 p-4">
         <ForumComposer
           channelId={channelId}
+          channelType="forum"
           isSending={isSendingReply}
           onSubmit={onReply}
           placeholder="Reply to this post..."

--- a/desktop/src/features/forum/ui/ForumView.tsx
+++ b/desktop/src/features/forum/ui/ForumView.tsx
@@ -168,6 +168,7 @@ export function ForumView({
           <ForumComposer
             autocompleteBelow
             channelId={channel.id}
+            channelType="forum"
             isSending={createPostMutation.isPending}
             onCancel={() => setIsComposerOpen(false)}
             onSubmit={async (content, mentionPubkeys, mediaTags) => {

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,7 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isAgentIdentityInAllowedList,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -93,7 +93,6 @@ export function useMentions(
   const mentionMapRef = React.useRef<Map<string, string>>(new Map());
   const personaMentionMapRef = React.useRef<Map<string, string>>(new Map());
   const previousSuggestionsRef = React.useRef<MentionSuggestion[]>([]);
-  void options?.channelType;
   const mentionSearchQuery = mentionQuery?.trim() ?? "";
   const canSearchGlobalPeople = mentionSearchQuery.length > 0;
   const identityQuery = useIdentityQuery();
@@ -238,15 +237,18 @@ export function useMentions(
       new Set((members ?? []).map((member) => normalizePubkey(member.pubkey))),
     [members],
   );
+  const allowedAgentPubkeys =
+    options?.channelType === "dm"
+      ? managedAgentPubkeys
+      : mentionableAgentPubkeys;
   const mentionCandidates = React.useMemo<MentionCandidate[]>(() => {
     const candidatesByPubkey = new Map<string, MentionCandidate>();
-
     const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {
       const pubkey = normalizePubkey(candidate.pubkey);
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (!isAgentIdentityInAllowedList(candidate, allowedAgentPubkeys)) {
         return;
       }
       if (
@@ -265,7 +267,6 @@ export function useMentions(
         candidatesByPubkey.set(pubkey, { ...candidate, pubkey });
         return;
       }
-
       candidatesByPubkey.set(pubkey, {
         ...current,
         avatarUrl: current.avatarUrl ?? candidate.avatarUrl ?? null,
@@ -330,7 +331,6 @@ export function useMentions(
             : null,
       });
     }
-
     for (const agent of relayAgentsQuery.data ?? []) {
       const pubkey = normalizePubkey(agent.pubkey);
       addCandidate({
@@ -412,6 +412,7 @@ export function useMentions(
   }, [
     activePersonaById,
     activePersonas,
+    allowedAgentPubkeys,
     userSearchResults,
     canSearchGlobalUsers,
     currentPubkey,
@@ -420,7 +421,6 @@ export function useMentions(
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,
     managedAgentPersonaIdsByPubkey,
-    managedAgentPubkeys,
     managedAgentsQuery.data,
     memberPubkeys,
     members,

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -238,9 +238,9 @@ export function useMentions(
     [members],
   );
   const allowedAgentPubkeys =
-    options?.channelType === "dm"
-      ? managedAgentPubkeys
-      : mentionableAgentPubkeys;
+    options?.channelType === "stream" || options?.channelType === "forum"
+      ? mentionableAgentPubkeys
+      : managedAgentPubkeys;
   const mentionCandidates = React.useMemo<MentionCandidate[]>(() => {
     const candidatesByPubkey = new Map<string, MentionCandidate>();
     const addCandidate = (candidate: MentionCandidate & { pubkey: string }) => {

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -5,17 +5,13 @@ import {
   useRelayAgentsQuery,
   useTeamsQuery,
 } from "@/features/agents/hooks";
-import {
-  useChannelMembersQuery,
-  useChannelsQuery,
-} from "@/features/channels/hooks";
+import { useChannelMembersQuery } from "@/features/channels/hooks";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import type { MentionSuggestion } from "@/features/messages/ui/MentionAutocomplete";
 import {
   coalesceAgentAutocompleteCandidates,
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
-  getSharedChannelIds,
   isAgentIdentityInAllowedList,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
@@ -104,7 +100,6 @@ export function useMentions(
   const isArchivedDiscovery = useIsArchivedPredicate();
   const managedAgentsQuery = useManagedAgentsQuery();
   const relayAgentsQuery = useRelayAgentsQuery();
-  const channelsQuery = useChannelsQuery();
   const personasQuery = usePersonasQuery();
   const teamsQuery = useTeamsQuery();
   const managedAgentDirectoryReady =
@@ -187,23 +182,23 @@ export function useMentions(
       ),
     [relayAgentsQuery.data],
   );
-  const sharedChannelIds = React.useMemo(
-    () => getSharedChannelIds(channelsQuery.data),
-    [channelsQuery.data],
-  );
+  const currentChannelId =
+    options?.channelType === "stream" || options?.channelType === "forum"
+      ? channelId
+      : null;
   const mentionableAgentPubkeys = React.useMemo(
     () =>
       getMentionableAgentPubkeys({
+        currentChannelId,
         currentPubkey,
         managedAgentPubkeys,
         relayAgents: relayAgentsQuery.data,
-        sharedChannelIds,
       }),
     [
+      currentChannelId,
       currentPubkey,
       managedAgentPubkeys,
       relayAgentsQuery.data,
-      sharedChannelIds,
     ],
   );
   const personaNameByPubkey = React.useMemo(() => {
@@ -430,7 +425,6 @@ export function useMentions(
     relayAgentNamesByPubkey,
     relayAgentsQuery.data,
   ]);
-
   const mentionCandidatesWithTeams = React.useMemo(
     () => [
       ...mentionCandidates,
@@ -442,7 +436,17 @@ export function useMentions(
     ],
     [mentionCandidates, personasQuery.data, teamsQuery.data],
   );
-
+  const admittedAgentPubkeys = React.useMemo(
+    () =>
+      new Set(
+        mentionCandidatesWithTeams.flatMap((candidate) =>
+          candidate.isAgent && candidate.pubkey
+            ? [normalizePubkey(candidate.pubkey)]
+            : [],
+        ),
+      ),
+    [mentionCandidatesWithTeams],
+  );
   const ownerPubkeys = React.useMemo(
     () => [
       ...new Set(
@@ -456,11 +460,9 @@ export function useMentions(
   const ownerProfilesQuery = useUsersBatchQuery(ownerPubkeys, {
     enabled: ownerPubkeys.length > 0,
   });
-
   const searchableNames = React.useMemo<string[]>(() => {
     const names: string[] = [];
     const seen = new Set<string>();
-
     for (const candidate of mentionCandidatesWithTeams) {
       for (const name of [
         candidate.displayName,
@@ -474,10 +476,8 @@ export function useMentions(
         }
       }
     }
-
     return names;
   }, [mentionCandidatesWithTeams]);
-
   const highlightNames = React.useMemo<string[]>(() => {
     const names: string[] = [];
     const seen = new Set<string>();
@@ -492,7 +492,6 @@ export function useMentions(
 
     return names;
   }, [selectedMentionNames]);
-
   const agentHighlightNames = React.useMemo<string[]>(() => {
     const names: string[] = [];
     const seen = new Set<string>();
@@ -507,7 +506,6 @@ export function useMentions(
 
     return names;
   }, [selectedAgentMentionNames]);
-
   const searchableNamesLower = React.useMemo<string[]>(
     () => searchableNames.map((n) => n.toLowerCase()),
     [searchableNames],
@@ -574,39 +572,41 @@ export function useMentions(
     if (mentionQuery === null) {
       return [];
     }
-
     if (matchingSuggestions.length > 0) {
       return matchingSuggestions;
     }
-
     if (userSearchQuery.isFetching) {
-      return previousSuggestionsRef.current;
+      return previousSuggestionsRef.current.filter(
+        (suggestion) =>
+          !suggestion.isAgent ||
+          !suggestion.pubkey ||
+          admittedAgentPubkeys.has(normalizePubkey(suggestion.pubkey)),
+      );
     }
-
     return [];
-  }, [matchingSuggestions, mentionQuery, userSearchQuery.isFetching]);
-
+  }, [
+    admittedAgentPubkeys,
+    matchingSuggestions,
+    mentionQuery,
+    userSearchQuery.isFetching,
+  ]);
   React.useEffect(() => {
     if (mentionQuery === null) {
       previousSuggestionsRef.current = [];
       return;
     }
-
     if (matchingSuggestions.length > 0) {
       previousSuggestionsRef.current = matchingSuggestions;
     } else if (!userSearchQuery.isFetching) {
       previousSuggestionsRef.current = [];
     }
   }, [matchingSuggestions, mentionQuery, userSearchQuery.isFetching]);
-
   React.useEffect(() => {
     setMentionSelectedIndex((current) =>
       suggestions.length === 0 ? 0 : Math.min(current, suggestions.length - 1),
     );
   }, [suggestions.length]);
-
   const isMentionOpen = mentionQuery !== null && suggestions.length > 0;
-
   const insertMention = React.useCallback(
     (suggestion: MentionSuggestion, selectionEnd: number): AutocompleteEdit => {
       if (debounceTimerRef.current !== null) {

--- a/desktop/src/features/messages/ui/useNewMessageRecipients.ts
+++ b/desktop/src/features/messages/ui/useNewMessageRecipients.ts
@@ -7,9 +7,7 @@ import {
 import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
-  getSharedChannelIds,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
-import { useChannelsQuery } from "@/features/channels/hooks";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import {
   useFlattenedUserSearchResults,
@@ -88,7 +86,6 @@ export function useNewMessageRecipients({
   const identityQuery = useIdentityQuery();
   const managedAgentsQuery = useManagedAgentsQuery({ enabled: active });
   const relayAgentsQuery = useRelayAgentsQuery({ enabled: active });
-  const channelsQuery = useChannelsQuery({ enabled: active });
   const userSearchQuery = useInfiniteUserSearchQuery(deferredSearchQuery, {
     allowEmpty: true,
     enabled:
@@ -97,6 +94,15 @@ export function useNewMessageRecipients({
   });
   const userSearchResults = useFlattenedUserSearchResults(userSearchQuery.data);
   const isArchivedDiscovery = useIsArchivedPredicate();
+  const relayAgentPubkeys = React.useMemo(
+    () =>
+      new Set(
+        (relayAgentsQuery.data ?? []).map((agent) =>
+          normalizePubkey(agent.pubkey),
+        ),
+      ),
+    [relayAgentsQuery.data],
+  );
 
   const searchResults = React.useMemo(() => {
     const candidatesByPubkey = new Map<string, NewMessageRecipientCandidate>();
@@ -110,12 +116,12 @@ export function useNewMessageRecipients({
       ? normalizePubkey(currentPubkey)
       : null;
     const eligibleAgentPubkeys = getMentionableAgentPubkeys({
+      currentChannelId: null,
       currentPubkey,
       managedAgentPubkeys: (managedAgentsQuery.data ?? []).map(
         (agent) => agent.pubkey,
       ),
       relayAgents: relayAgentsQuery.data,
-      sharedChannelIds: getSharedChannelIds(channelsQuery.data),
     });
 
     const addCandidate = (
@@ -123,19 +129,20 @@ export function useNewMessageRecipients({
       options: { includeSelected?: boolean } = {},
     ) => {
       const pubkey = normalizePubkey(candidate.pubkey);
+      const isAgent = candidate.isAgent || relayAgentPubkeys.has(pubkey);
 
       if (
         pubkey === currentPubkeyNormalized ||
         (!options.includeSelected && selectedPubkeys.has(pubkey)) ||
         isArchivedDiscovery(pubkey) ||
-        (candidate.isAgent && !eligibleAgentPubkeys.has(pubkey))
+        (isAgent && !eligibleAgentPubkeys.has(pubkey))
       ) {
         return;
       }
 
       const current = candidatesByPubkey.get(pubkey);
       if (!current) {
-        candidatesByPubkey.set(pubkey, { ...candidate, pubkey });
+        candidatesByPubkey.set(pubkey, { ...candidate, pubkey, isAgent });
         return;
       }
 
@@ -153,7 +160,7 @@ export function useNewMessageRecipients({
               : (currentName ?? candidateName),
         nip05Handle: current.nip05Handle ?? candidate.nip05Handle ?? null,
         ownerPubkey: current.ownerPubkey ?? candidate.ownerPubkey ?? null,
-        isAgent: current.isAgent || candidate.isAgent,
+        isAgent: current.isAgent || isAgent,
         isManagedAgent: current.isManagedAgent || candidate.isManagedAgent,
         isMember: current.isMember || candidate.isMember,
         personaId: current.personaId ?? candidate.personaId,
@@ -216,11 +223,11 @@ export function useNewMessageRecipients({
       query: deferredSearchQuery,
     });
   }, [
-    channelsQuery.data,
     currentPubkey,
     deferredSearchQuery,
     isArchivedDiscovery,
     managedAgentsQuery.data,
+    relayAgentPubkeys,
     relayAgentsQuery.data,
     selectedPubkeys,
     userSearchResults,
@@ -229,8 +236,7 @@ export function useNewMessageRecipients({
   const isDirectoryLoading =
     userSearchQuery.isLoading ||
     managedAgentsQuery.isLoading ||
-    relayAgentsQuery.isLoading ||
-    channelsQuery.isLoading;
+    relayAgentsQuery.isLoading;
   React.useEffect(() => {
     if (isDirectoryLoading) {
       return;

--- a/desktop/src/features/projects/ui/ProjectsAgentPromptPage.tsx
+++ b/desktop/src/features/projects/ui/ProjectsAgentPromptPage.tsx
@@ -15,10 +15,7 @@ import {
   useRelayAgentsQuery,
   useStartManagedAgentMutation,
 } from "@/features/agents/hooks";
-import {
-  getMentionableAgentPubkeys,
-  getSharedChannelIds,
-} from "@/features/agents/lib/agentAutocompleteEligibility";
+import { getMentionableAgentPubkeys } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import { useChannelsQuery, useOpenDmMutation } from "@/features/channels/hooks";
 import {
@@ -129,7 +126,6 @@ function useAgentCandidates() {
   const identityQuery = useIdentityQuery();
   const managedAgentsQuery = useManagedAgentsQuery();
   const relayAgentsQuery = useRelayAgentsQuery();
-  const channelsQuery = useChannelsQuery();
 
   return React.useMemo(() => {
     const managed = managedAgentsQuery.data ?? [];
@@ -138,10 +134,10 @@ function useAgentCandidates() {
       managed.map((agent) => [normalizePubkey(agent.pubkey), agent]),
     );
     const mentionable = getMentionableAgentPubkeys({
+      currentChannelId: null,
       currentPubkey: identityQuery.data?.pubkey,
       managedAgentPubkeys: managedByPubkey.keys(),
       relayAgents,
-      sharedChannelIds: getSharedChannelIds(channelsQuery.data),
     });
 
     const candidates: AgentCandidate[] = managed.map((agent) => ({
@@ -167,7 +163,6 @@ function useAgentCandidates() {
       return left.name.localeCompare(right.name);
     });
   }, [
-    channelsQuery.data,
     identityQuery.data?.pubkey,
     managedAgentsQuery.data,
     relayAgentsQuery.data,

--- a/desktop/tests/e2e/channels.spec.ts
+++ b/desktop/tests/e2e/channels.spec.ts
@@ -595,6 +595,39 @@ test("start a new direct message from the sidebar", async ({ page }) => {
   await expect(page.getByTestId("section-actions-dms")).not.toBeFocused();
 });
 
+test("new message search hides relay-only agents misclassified as people", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: DM_RELAY_AGENT_PUBKEY,
+        name: "quinn",
+        respondTo: "anyone",
+        channelIds: [GENERAL_CHANNEL_ID],
+      },
+    ],
+    searchProfiles: [
+      {
+        pubkey: DM_RELAY_AGENT_PUBKEY,
+        displayName: "quinn",
+        isAgent: false,
+      },
+    ],
+  });
+  await page.goto("/");
+  await openNewMessagePage(page);
+
+  await page.getByTestId("new-dm-search").fill("quinn");
+
+  await expect(page.getByTestId("new-dm-empty")).toContainText(
+    "No matching users.",
+  );
+  await expect(
+    page.getByTestId(`new-dm-result-${DM_RELAY_AGENT_PUBKEY}`),
+  ).toHaveCount(0);
+});
+
 test("keeps typing focus while arrow keys traverse and select DM recipients", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -511,6 +511,31 @@ test("relay-only shared agents stay hidden from DM mentions", async ({
   await expect(autocomplete(page).getByText("alice")).toHaveCount(0);
 });
 
+test("relay-only shared agents stay hidden while channel type is unresolved", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-alice-tyler").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("alice-tyler");
+
+  await page.evaluate(async (channelId) => {
+    const bridge = window as Window & {
+      __BUZZ_E2E_INVALIDATE_CHANNELS__?: () => Promise<void>;
+      __BUZZ_E2E_MUTATE_CHANNEL__?: (opts: {
+        channelId: string;
+        channelType: null;
+      }) => void;
+    };
+    bridge.__BUZZ_E2E_MUTATE_CHANNEL__?.({ channelId, channelType: null });
+    await bridge.__BUZZ_E2E_INVALIDATE_CHANNELS__?.();
+  }, "f48efb06-0c93-5025-aac9-2e646bb6bfa8");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@alice");
+
+  await expect(autocomplete(page).getByText("alice")).toHaveCount(0);
+});
+
 test("autocomplete filters managed-agent suggestions as user types", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -7,6 +7,7 @@ import {
 } from "../helpers/bridge";
 
 const MOCK_VIEWER_PUBKEY = "deadbeef".repeat(8);
+const GENERAL_CHANNEL_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
 
 test.beforeEach(async ({ page }) => {
   await installMockBridge(page);
@@ -506,17 +507,33 @@ test("relay-only shared agents stay hidden from DM mentions", async ({
   await expect(page.getByTestId("chat-title")).toHaveText("alice-tyler");
 
   const input = page.getByTestId("message-input");
-  await input.fill("@ali");
+  await input.fill("@");
 
-  await expect(autocomplete(page).getByText("alice")).toHaveCount(0);
+  await expect(
+    autocomplete(page).getByTestId(`mention-suggestion-${MOCK_VIEWER_PUBKEY}`),
+  ).toBeVisible();
+  await expect(
+    autocomplete(page).getByTestId(
+      `mention-suggestion-${TEST_IDENTITIES.alice.pubkey}`,
+    ),
+  ).toHaveCount(0);
 });
 
 test("relay-only shared agents stay hidden while channel type is unresolved", async ({
   page,
 }) => {
   await page.goto("/");
-  await page.getByTestId("channel-alice-tyler").click();
-  await expect(page.getByTestId("chat-title")).toHaveText("alice-tyler");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@alice");
+  await expect(
+    autocomplete(page).getByTestId(
+      `mention-suggestion-${TEST_IDENTITIES.alice.pubkey}`,
+    ),
+  ).toBeVisible();
+  await input.fill("");
 
   await page.evaluate(async (channelId) => {
     const bridge = window as Window & {
@@ -528,12 +545,34 @@ test("relay-only shared agents stay hidden while channel type is unresolved", as
     };
     bridge.__BUZZ_E2E_MUTATE_CHANNEL__?.({ channelId, channelType: null });
     await bridge.__BUZZ_E2E_INVALIDATE_CHANNELS__?.();
-  }, "f48efb06-0c93-5025-aac9-2e646bb6bfa8");
+  }, GENERAL_CHANNEL_ID);
+
+  await input.fill("@");
+
+  await expect(
+    autocomplete(page).getByTestId(`mention-suggestion-${MOCK_VIEWER_PUBKEY}`),
+  ).toBeVisible();
+  await expect(
+    autocomplete(page).getByTestId(
+      `mention-suggestion-${TEST_IDENTITIES.alice.pubkey}`,
+    ),
+  ).toHaveCount(0);
+});
+
+test("relay-only shared agents appear in forum mentions", async ({ page }) => {
+  await page.goto("/");
+  await page.getByTestId("channel-watercooler").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("watercooler");
+  await page.getByRole("button", { name: "Start a new post..." }).click();
 
   const input = page.getByTestId("message-input");
   await input.fill("@alice");
 
-  await expect(autocomplete(page).getByText("alice")).toHaveCount(0);
+  const aliceRow = page
+    .getByTestId("mention-autocomplete")
+    .getByTestId(`mention-suggestion-${TEST_IDENTITIES.alice.pubkey}`);
+  await expect(aliceRow).toBeVisible();
+  await expect(aliceRow.getByTestId("mention-agent-icon")).toBeVisible();
 });
 
 test("autocomplete filters managed-agent suggestions as user types", async ({

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -67,6 +67,46 @@ async function readCommandPayloadLog(page: import("@playwright/test").Page) {
   });
 }
 
+async function readOutgoingMentionPubkeys(
+  page: import("@playwright/test").Page,
+  content: string,
+) {
+  return page.evaluate((expectedContent) => {
+    const entries =
+      (
+        window as Window & {
+          __BUZZ_E2E_COMMAND_LOG__?: Array<{
+            command: string;
+            payload: unknown;
+          }>;
+        }
+      ).__BUZZ_E2E_COMMAND_LOG__ ?? [];
+
+    for (const entry of entries) {
+      if (entry.command !== "plugin:websocket|send") continue;
+      const data = (
+        entry.payload as { message?: { data?: string } } | undefined
+      )?.message?.data;
+      if (!data) continue;
+
+      try {
+        const frame = JSON.parse(data) as [
+          string,
+          { content?: string; tags?: string[][] },
+        ];
+        if (frame[0] !== "EVENT" || frame[1]?.content !== expectedContent) {
+          continue;
+        }
+        return (frame[1].tags ?? [])
+          .filter((tag) => tag[0] === "p" && tag[1])
+          .map((tag) => tag[1]);
+      } catch {}
+    }
+
+    return null;
+  }, content);
+}
+
 function commandCount(commands: string[], command: string) {
   return commands.filter((entry) => entry === command).length;
 }
@@ -209,7 +249,7 @@ test("@ trigger prioritizes channel members before runnable personas and other m
 
   const dropdown = autocomplete(page);
   await expect(dropdown).toBeVisible();
-  await expect(dropdown.getByText("alice")).toHaveCount(0);
+  await expect(dropdown.getByText("alice")).toBeVisible();
   await expect(dropdown.getByText("bob")).toBeVisible();
   await expect(dropdown.getByText("Fizz")).toBeVisible();
   await expect(dropdown.getByText("charlie")).toBeVisible();
@@ -226,6 +266,7 @@ test("@ trigger prioritizes channel members before runnable personas and other m
   const suggestions = dropdown.locator("button");
   const suggestionText = await suggestions.allInnerTexts();
   const fizzIndex = suggestionText.findIndex((text) => text.includes("Fizz"));
+  const aliceIndex = suggestionText.findIndex((text) => text.includes("alice"));
   const bobIndex = suggestionText.findIndex((text) => text.includes("bob"));
   const charlieIndex = suggestionText.findIndex((text) =>
     text.includes("charlie"),
@@ -234,9 +275,11 @@ test("@ trigger prioritizes channel members before runnable personas and other m
     text.includes("outsider"),
   );
   expect(fizzIndex).toBeGreaterThanOrEqual(0);
+  expect(aliceIndex).toBeGreaterThanOrEqual(0);
   expect(bobIndex).toBeGreaterThanOrEqual(0);
   expect(charlieIndex).toBeGreaterThanOrEqual(0);
   expect(outsiderIndex).toEqual(-1);
+  expect(aliceIndex).toBeLessThan(fizzIndex);
   expect(bobIndex).toBeLessThan(fizzIndex);
   expect(fizzIndex).toBeLessThan(charlieIndex);
 });
@@ -427,6 +470,19 @@ test("defers agent mentions until DM members finish loading", async ({
   );
   await expect(input).toBeEmpty();
   await expect(threadPanel).toContainText("before members resolve");
+});
+
+test("relay-only shared agents stay hidden from DM mentions", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-alice-tyler").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("alice-tyler");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("@ali");
+
+  await expect(autocomplete(page).getByText("alice")).toHaveCount(0);
 });
 
 test("autocomplete filters managed-agent suggestions as user types", async ({
@@ -819,14 +875,24 @@ test("managed relay agents are visible in channel mentions regardless of relay p
   await expect(page.getByTestId("chat-title")).toHaveText("general");
 
   const input = page.getByTestId("message-input");
-  await input.fill("@quinn");
+  await input.fill("Ask @quinn");
 
   const dropdown = autocomplete(page);
   await expect(dropdown.getByText("quinn")).toBeVisible();
   await expect(dropdown.getByText("agent")).toBeVisible();
+  await dropdown.getByText("quinn").click();
+  await page.keyboard.type("please reply");
+
+  const content = "Ask @quinn please reply";
+  await expect(input).toHaveText(content);
+  await page.getByTestId("send-message").click();
+
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, content))
+    .toContain(ALLOWLIST_RELAY_AGENT_PUBKEY);
 });
 
-test("relay-only agents stay hidden from channel mentions even when allowlisted", async ({
+test("relay-only agents are visible in channel mentions when allowlisted", async ({
   page,
 }) => {
   await installMockBridge(page, {
@@ -846,7 +912,9 @@ test("relay-only agents stay hidden from channel mentions even when allowlisted"
   const input = page.getByTestId("message-input");
   await input.fill("@quinn");
 
-  await expect(autocomplete(page)).toHaveCount(0);
+  const dropdown = autocomplete(page);
+  await expect(dropdown.getByText("quinn")).toBeVisible();
+  await expect(dropdown.getByText("agent")).toBeVisible();
 });
 
 test("mentioning an in-channel stopped managed agent starts it before sending", async ({

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -284,6 +284,32 @@ test("@ trigger prioritizes channel members before runnable personas and other m
   expect(fizzIndex).toBeLessThan(charlieIndex);
 });
 
+test("relay-only shared agents emit an outbound mention tag when selected", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  const input = page.getByTestId("message-input");
+  await input.fill("Ask @alice");
+
+  const dropdown = autocomplete(page);
+  const aliceRow = dropdown.locator("button", { hasText: "alice" });
+  await expect(aliceRow).toBeVisible();
+  await expect(aliceRow.getByTestId("mention-agent-icon")).toBeVisible();
+  await aliceRow.click();
+  await page.keyboard.type("please reply");
+
+  const content = "Ask @alice please reply";
+  await expect(input).toHaveText(content);
+  await page.getByTestId("send-message").click();
+
+  await expect
+    .poll(() => readOutgoingMentionPubkeys(page, content))
+    .toContain(TEST_IDENTITIES.alice.pubkey);
+});
+
 test("thread autocomplete keeps multiple long names readable in a narrow panel", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/mentions.spec.ts
+++ b/desktop/tests/e2e/mentions.spec.ts
@@ -522,6 +522,7 @@ test("relay-only shared agents stay hidden from DM mentions", async ({
 test("relay-only shared agents stay hidden while channel type is unresolved", async ({
   page,
 }) => {
+  await installMockBridge(page, { userSearchDelayMs: 10_000 });
   await page.goto("/");
   await page.getByTestId("channel-general").click();
   await expect(page.getByTestId("chat-title")).toHaveText("general");
@@ -533,7 +534,15 @@ test("relay-only shared agents stay hidden while channel type is unresolved", as
       `mention-suggestion-${TEST_IDENTITIES.alice.pubkey}`,
     ),
   ).toBeVisible();
-  await input.fill("");
+  await expect
+    .poll(async () =>
+      (await readCommandPayloadLog(page)).some(
+        (entry) =>
+          entry.command === "search_users" &&
+          (entry.payload as { query?: string }).query === "alice",
+      ),
+    )
+    .toBe(true);
 
   await page.evaluate(async (channelId) => {
     const bridge = window as Window & {
@@ -547,11 +556,7 @@ test("relay-only shared agents stay hidden while channel type is unresolved", as
     await bridge.__BUZZ_E2E_INVALIDATE_CHANNELS__?.();
   }, GENERAL_CHANNEL_ID);
 
-  await input.fill("@");
-
-  await expect(
-    autocomplete(page).getByTestId(`mention-suggestion-${MOCK_VIEWER_PUBKEY}`),
-  ).toBeVisible();
+  await expect(input).toContainText("@alice");
   await expect(
     autocomplete(page).getByTestId(
       `mention-suggestion-${TEST_IDENTITIES.alice.pubkey}`,
@@ -560,19 +565,30 @@ test("relay-only shared agents stay hidden while channel type is unresolved", as
 });
 
 test("relay-only shared agents appear in forum mentions", async ({ page }) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: ALLOWLIST_RELAY_AGENT_PUBKEY,
+        name: "quinn",
+        respondTo: "allowlist",
+        respondToAllowlist: [MOCK_VIEWER_PUBKEY],
+        channelNames: ["watercooler"],
+      },
+    ],
+  });
   await page.goto("/");
   await page.getByTestId("channel-watercooler").click();
   await expect(page.getByTestId("chat-title")).toHaveText("watercooler");
   await page.getByRole("button", { name: "Start a new post..." }).click();
 
   const input = page.getByTestId("message-input");
-  await input.fill("@alice");
+  await input.fill("@quinn");
 
-  const aliceRow = page
+  const quinnRow = page
     .getByTestId("mention-autocomplete")
-    .getByTestId(`mention-suggestion-${TEST_IDENTITIES.alice.pubkey}`);
-  await expect(aliceRow).toBeVisible();
-  await expect(aliceRow.getByTestId("mention-agent-icon")).toBeVisible();
+    .getByTestId(`mention-suggestion-${ALLOWLIST_RELAY_AGENT_PUBKEY}`);
+  await expect(quinnRow).toBeVisible();
+  await expect(quinnRow.getByTestId("mention-agent-icon")).toBeVisible();
 });
 
 test("autocomplete filters managed-agent suggestions as user types", async ({
@@ -992,6 +1008,7 @@ test("relay-only agents are visible in channel mentions when allowlisted", async
         name: "quinn",
         respondTo: "allowlist",
         respondToAllowlist: [MOCK_VIEWER_PUBKEY],
+        channelIds: [GENERAL_CHANNEL_ID],
       },
     ],
   });
@@ -1005,6 +1022,39 @@ test("relay-only agents are visible in channel mentions when allowlisted", async
   const dropdown = autocomplete(page);
   await expect(dropdown.getByText("quinn")).toBeVisible();
   await expect(dropdown.getByText("agent")).toBeVisible();
+});
+
+test("relay-only allowlisted agents stay hidden outside their channel", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    relayAgents: [
+      {
+        pubkey: ALLOWLIST_RELAY_AGENT_PUBKEY,
+        name: "quinn",
+        respondTo: "allowlist",
+        respondToAllowlist: [MOCK_VIEWER_PUBKEY],
+        channelNames: ["agents"],
+      },
+    ],
+  });
+  await page.goto("/");
+  await page.getByTestId("channel-agents").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("agents");
+
+  await page.getByTestId("message-input").fill("@quinn");
+  const quinnRow = autocomplete(page).getByTestId(
+    `mention-suggestion-${ALLOWLIST_RELAY_AGENT_PUBKEY}`,
+  );
+  await expect(quinnRow).toBeVisible();
+  await expect(quinnRow.getByTestId("mention-agent-icon")).toBeVisible();
+
+  await page.getByTestId("channel-general").click();
+  await expect(page.getByTestId("chat-title")).toHaveText("general");
+
+  await page.getByTestId("message-input").fill("@quinn");
+
+  await expect(quinnRow).toHaveCount(0);
 });
 
 test("mentioning an in-channel stopped managed agent starts it before sending", async ({


### PR DESCRIPTION
## Summary

- show shared relay agents in mention autocomplete only when they advertise the exact active stream or forum and their `respond_to` policy permits the current viewer
- keep DMs, unresolved channel types, new-message recipients, and project-agent pickers fail closed for other-owned relay agents
- revalidate cached autocomplete rows when channel or relay policy changes
- prevent relay-directory identities from reappearing as ordinary people through global search
- preserve picker-selected outbound Nostr `p` tags and forum mention support

## Root cause

Desktop treated relay-agent eligibility as profile-wide. An allowlisted agent could be suggested without belonging to the active channel, while an `anyone` agent could be suggested because it overlapped some other joined channel. That exposed identities and advertised actions that ACP would not dispatch.

## Security and privacy

The picker now requires all of these for an other-owned relay agent:

1. the composer is for a known stream or forum
2. the agent's `channel_ids` contains that exact channel
3. `respond_to` is `anyone`, or the current viewer is explicitly allowlisted

DMs remain managed-only because ACP's DM author gate permits only the owner or same-owner sibling agents. Cached suggestions are rechecked against current eligible candidates before display.

## Validation

- `pnpm test`: 3,905 passed, 0 failed
- `pnpm check`: passed
- `pnpm build`: passed
- `pnpm build:e2e`: passed
- `playwright tests/e2e/mentions.spec.ts`: 54 passed
- new-message relay misclassification regression: passed
- targeted exact-channel, cross-channel, DM, unresolved-type, stale-cache, forum, and outbound `p`-tag coverage: passed
- independent privacy and correctness review: approved, with one non-blocking future test-coverage suggestion
- local `aarch64-apple-darwin` Tauri app bundle: built successfully

Fixes #3971

Originating Buzz channel: `1e408238-c672-4d83-ab5c-25ff3f7401eb`
