### PR TITLE
fix(git): allow + and @ in is_safe_refname (#4194)

### DIFF
--- a/crates/buzz-relay/src/api/git/hydrate.rs
+++ b/crates/buzz-relay/src/api/git/hydrate.rs
@@ -488,6 +488,8 @@ mod tests {
         assert!(is_safe_refname("refs/heads/main"));
         assert!(is_safe_refname("refs/tags/v1.0.0"));
         assert!(is_safe_refname("refs/heads/feat/cas-publish"));
+        assert!(is_safe_refname("refs/heads/test/842+841-devnet"));
+        assert!(is_safe_refname("refs/heads/feature@workspace"));
         assert!(!is_safe_refname("refs/heads/../escape"));
         assert!(!is_safe_refname("HEAD"));
         assert!(!is_safe_refname("refs/heads/"));

--- a/crates/buzz-relay/src/api/git/manifest.rs
+++ b/crates/buzz-relay/src/api/git/manifest.rs
@@ -134,8 +134,8 @@ pub enum ManifestError {
 /// `api::git::hydrate`, before writing the ref to disk).
 ///
 /// Refuses traversal (`..`), null/newline/control chars, non-`refs/` prefixes,
-/// and leading/trailing/double slashes. Allowed alphabet:
-/// `[a-zA-Z0-9_./-]`.
+/// and leading/trailing/double slashes. Allowed alphabet is a conservative
+/// subset of git-legal ref characters: `[a-zA-Z0-9_./-+@]`.
 ///
 /// Sharing one predicate is load-bearing: any divergence creates the
 /// "valid CAS, un-clone-able output" hazard.

--- a/crates/buzz-relay/src/api/git/manifest.rs
+++ b/crates/buzz-relay/src/api/git/manifest.rs
@@ -361,6 +361,22 @@ mod tests {
         sample().validate().expect("sample manifest must validate");
     }
 
+    #[test]
+    fn validate_accepts_git_legal_plus_refname() {
+        let oid = "a".repeat(40);
+        let mut refs = BTreeMap::new();
+        refs.insert("refs/heads/test/842+841-devnet".into(), oid.clone());
+        let m = Manifest {
+            version: MANIFEST_VERSION,
+            head: "refs/heads/test/842+841-devnet".into(),
+            refs,
+            packs: vec![pack_key('c')],
+            parent: None,
+        };
+        m.validate()
+            .expect("git-legal plus refname must validate (#4194)");
+    }
+
     /// The empty manifest is the announce-time seed (`side_effects.rs::
     /// seed_manifest_pointer`). It must validate — otherwise repo announce
     /// would fail before the pointer can be seeded, and the read path would

--- a/crates/buzz-relay/src/api/git/manifest.rs
+++ b/crates/buzz-relay/src/api/git/manifest.rs
@@ -336,6 +336,8 @@ mod tests {
         assert!(is_safe_refname("refs/heads/main"));
         assert!(is_safe_refname("refs/tags/v1.0.0"));
         assert!(is_safe_refname("refs/heads/feat/cas-publish"));
+        assert!(is_safe_refname("refs/heads/test/842+841-devnet"));
+        assert!(is_safe_refname("refs/heads/feature@workspace"));
         assert!(!is_safe_refname("refs/heads/../escape"));
         assert!(!is_safe_refname("HEAD"));
         assert!(!is_safe_refname(""));

--- a/crates/buzz-relay/src/api/git/manifest.rs
+++ b/crates/buzz-relay/src/api/git/manifest.rs
@@ -147,7 +147,7 @@ pub fn is_safe_refname(s: &str) -> bool {
         return false;
     }
     s.chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '.' | '-'))
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '.' | '-' | '+' | '@'))
 }
 
 /// Hex-OID predicate. Accepts both SHA-1 (40 chars) and SHA-256 (64 chars) —


### PR DESCRIPTION
## Summary
- Widen `is_safe_refname` to accept git-legal `+` and `@` characters while keeping structural guards (`..`, control chars, `refs/` prefix).
- Add manifest, hydrate, and `validate()` coverage for refs like `refs/heads/test/842+841-devnet` (observed blocking OriginTrail/dkg mirrors).
- Update the predicate doc comment to reflect the expanded alphabet.

Fixes #4194.

## Test plan
- [x] `cargo test -p buzz-relay safe_refnames`
- [x] `cargo test -p buzz-relay validate_accepts_git_legal_plus_refname`
- [ ] Push `git branch test/842+841-devnet && git push <buzz-remote>` and confirm HTTP 400 is gone


Made with [Cursor](https://cursor.com)