### PR TITLE
feat(desktop): add routed onboarding history

### DIFF
--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -642,7 +642,7 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
       if (postOnboardingNavRef.current) {
         onboardingHistory.exit("/");
       } else if (!activeCommunity) {
-        onboardingHistory.push("community");
+        onboardingHistory.reset("community");
       } else if (onboardingHistory.step) {
         onboardingHistory.exit("/");
       }

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -31,6 +31,14 @@ import {
   resolveProfileCheckAction,
   isTransactionStillConnecting,
 } from "@/features/onboarding/communityOnboarding";
+import {
+  OnboardingHistoryProvider,
+  useOnboardingHistory,
+} from "@/features/onboarding/OnboardingHistory";
+import {
+  isMachineOnboardingRouteStep,
+  type MachineOnboardingRouteStep,
+} from "@/features/onboarding/onboardingRoute";
 import { CommunityOnboardingFlow } from "@/features/onboarding/ui/CommunityOnboardingFlow";
 import {
   MachineOnboardingFlow,
@@ -291,11 +299,9 @@ function AppReady({
 
 function CommunityApp({
   currentPubkey,
-  onBackToMachineConfig,
   sharedIdentity,
 }: {
   currentPubkey: string | null;
-  onBackToMachineConfig: () => void;
   sharedIdentity: boolean;
 }) {
   const {
@@ -515,11 +521,9 @@ function CommunityApp({
     if (community.needsSetup) {
       // Show welcome setup for first-run users with no communities
       appContent = (
-        <WelcomeSetup
+<WelcomeSetup
+          canReturnToMachineConfig={!isFindingCommunityAfterLeave}
           initialPage={resumeFirstCommunityPage ?? undefined}
-          onBack={
-            isFindingCommunityAfterLeave ? undefined : onBackToMachineConfig
-          }
         />
       );
     } else if ("error" in community && community.error) {
@@ -601,9 +605,25 @@ function CommunityApp({
   );
 }
 
+function machinePageForRoute(
+  step: MachineOnboardingRouteStep,
+): MachineOnboardingPage {
+  if (step === "identity") return "identity";
+  if (step === "key-import") return "key-import";
+  if (
+    step === "backup" ||
+    step === "backup-options" ||
+    step === "backup-password"
+  ) {
+    return "backup";
+  }
+  return step === "agents" ? "setup" : "config";
+}
+
 function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
   const { activeCommunity } = useCommunities();
   const communityOnboarding = useCommunityOnboarding();
+  const onboardingHistory = useOnboardingHistory();
   const machine = useMachineOnboardingState({
     activeCommunityPubkey: activeCommunity
       ? (activeCommunity.pubkey ?? null)
@@ -614,26 +634,53 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
     useState<MachineOnboardingPage>();
   const [postOnboardingNav, setPostOnboardingNav] =
     useState<PostOnboardingNavigation | null>(null);
-
-  const reopenMachineConfig = useCallback(() => {
-    setMachineInitialPage("config");
-    machine.reopen();
-  }, [machine.reopen]);
+  const postOnboardingNavRef = useRef<PostOnboardingNavigation | null>(null);
 
   const completeMachineOnboarding = useCallback(
     (pubkey?: string) => {
       setMachineInitialPage(undefined);
+      if (postOnboardingNavRef.current) {
+        onboardingHistory.exit("/");
+      } else if (!activeCommunity) {
+        onboardingHistory.push("community");
+      } else if (onboardingHistory.step) {
+        onboardingHistory.exit("/");
+      }
       machine.complete(pubkey);
     },
-    [machine.complete],
+    [activeCommunity, machine.complete, onboardingHistory],
   );
 
   const navigateAfterOnboarding = useCallback(
     (nav: PostOnboardingNavigation) => {
+      postOnboardingNavRef.current = nav;
       setPostOnboardingNav(nav);
     },
     [],
   );
+
+  useEffect(() => {
+    const step = onboardingHistory.step;
+    if (machine.stage === "ready" && isMachineOnboardingRouteStep(step)) {
+      setMachineInitialPage(machinePageForRoute(step));
+      machine.reopen();
+      return;
+    }
+    if (
+      machine.stage === "onboarding" &&
+      step &&
+      !isMachineOnboardingRouteStep(step)
+    ) {
+      setMachineInitialPage(undefined);
+      machine.complete(machine.currentPubkey ?? undefined);
+    }
+  }, [
+    machine.complete,
+    machine.currentPubkey,
+    machine.reopen,
+    machine.stage,
+    onboardingHistory.step,
+  ]);
 
   // Execute the pending navigation once the RouterProvider is mounted (i.e.
   // machine.stage transitions to "ready").  We wait for the ready stage rather
@@ -645,6 +692,7 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
         to: postOnboardingNav.to,
         search: postOnboardingNav.search ?? {},
       });
+      postOnboardingNavRef.current = null;
       setPostOnboardingNav(null);
     }
   }, [machine.stage, postOnboardingNav]);
@@ -686,7 +734,6 @@ function MachineBootstrap({ sharedIdentity }: { sharedIdentity: boolean }) {
     return (
       <CommunityApp
         currentPubkey={machine.currentPubkey}
-        onBackToMachineConfig={reopenMachineConfig}
         sharedIdentity={sharedIdentity}
       />
     );
@@ -736,7 +783,9 @@ export function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <MachineBootstrap sharedIdentity={sharedIdentity} />
+      <OnboardingHistoryProvider>
+        <MachineBootstrap sharedIdentity={sharedIdentity} />
+      </OnboardingHistoryProvider>
     </QueryClientProvider>
   );
 }

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -521,7 +521,7 @@ function CommunityApp({
     if (community.needsSetup) {
       // Show welcome setup for first-run users with no communities
       appContent = (
-<WelcomeSetup
+        <WelcomeSetup
           canReturnToMachineConfig={!isFindingCommunityAfterLeave}
           initialPage={resumeFirstCommunityPage ?? undefined}
         />

--- a/desktop/src/app/routeTree.gen.ts
+++ b/desktop/src/app/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as agentsRouteImport } from "./routes/agents";
 import { Route as indexRouteImport } from "./routes/index";
 import { Route as workflowsDotworkflowIdRouteImport } from "./routes/workflows.$workflowId";
 import { Route as projectsDotprojectIdRouteImport } from "./routes/projects.$projectId";
+import { Route as onboardingRouteImport } from "./routes/onboarding";
 import { Route as messagesDotnewRouteImport } from "./routes/messages.new";
 import { Route as channelsDotchannelIdRouteImport } from "./routes/channels.$channelId";
 import { Route as channelsDotchannelIdDotpostsDotpostIdRouteImport } from "./routes/channels.$channelId.posts.$postId";
@@ -63,6 +64,11 @@ const projectsDotprojectIdRoute = projectsDotprojectIdRouteImport.update({
   path: "/projects/$projectId",
   getParentRoute: () => rootRouteImport,
 } as any);
+const onboardingRoute = onboardingRouteImport.update({
+  id: "/onboarding/$step",
+  path: "/onboarding/$step",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const messagesDotnewRoute = messagesDotnewRouteImport.update({
   id: "/messages/new",
   path: "/messages/new",
@@ -90,6 +96,7 @@ export interface FileRoutesByFullPath {
   "/workflows": typeof workflowsRoute;
   "/channels/$channelId": typeof channelsDotchannelIdRoute;
   "/messages/new": typeof messagesDotnewRoute;
+  "/onboarding/$step": typeof onboardingRoute;
   "/projects/$projectId": typeof projectsDotprojectIdRoute;
   "/workflows/$workflowId": typeof workflowsDotworkflowIdRoute;
   "/channels/$channelId/posts/$postId": typeof channelsDotchannelIdDotpostsDotpostIdRoute;
@@ -104,6 +111,7 @@ export interface FileRoutesByTo {
   "/workflows": typeof workflowsRoute;
   "/channels/$channelId": typeof channelsDotchannelIdRoute;
   "/messages/new": typeof messagesDotnewRoute;
+  "/onboarding/$step": typeof onboardingRoute;
   "/projects/$projectId": typeof projectsDotprojectIdRoute;
   "/workflows/$workflowId": typeof workflowsDotworkflowIdRoute;
   "/channels/$channelId/posts/$postId": typeof channelsDotchannelIdDotpostsDotpostIdRoute;
@@ -119,6 +127,7 @@ export interface FileRoutesById {
   "/workflows": typeof workflowsRoute;
   "/channels/$channelId": typeof channelsDotchannelIdRoute;
   "/messages/new": typeof messagesDotnewRoute;
+  "/onboarding/$step": typeof onboardingRoute;
   "/projects/$projectId": typeof projectsDotprojectIdRoute;
   "/workflows/$workflowId": typeof workflowsDotworkflowIdRoute;
   "/channels/$channelId/posts/$postId": typeof channelsDotchannelIdDotpostsDotpostIdRoute;
@@ -135,6 +144,7 @@ export interface FileRouteTypes {
     | "/workflows"
     | "/channels/$channelId"
     | "/messages/new"
+    | "/onboarding/$step"
     | "/projects/$projectId"
     | "/workflows/$workflowId"
     | "/channels/$channelId/posts/$postId";
@@ -149,6 +159,7 @@ export interface FileRouteTypes {
     | "/workflows"
     | "/channels/$channelId"
     | "/messages/new"
+    | "/onboarding/$step"
     | "/projects/$projectId"
     | "/workflows/$workflowId"
     | "/channels/$channelId/posts/$postId";
@@ -163,6 +174,7 @@ export interface FileRouteTypes {
     | "/workflows"
     | "/channels/$channelId"
     | "/messages/new"
+    | "/onboarding/$step"
     | "/projects/$projectId"
     | "/workflows/$workflowId"
     | "/channels/$channelId/posts/$postId";
@@ -178,6 +190,7 @@ export interface RootRouteChildren {
   workflowsRoute: typeof workflowsRoute;
   channelsDotchannelIdRoute: typeof channelsDotchannelIdRoute;
   messagesDotnewRoute: typeof messagesDotnewRoute;
+  onboardingRoute: typeof onboardingRoute;
   projectsDotprojectIdRoute: typeof projectsDotprojectIdRoute;
   workflowsDotworkflowIdRoute: typeof workflowsDotworkflowIdRoute;
   channelsDotchannelIdDotpostsDotpostIdRoute: typeof channelsDotchannelIdDotpostsDotpostIdRoute;
@@ -248,6 +261,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof projectsDotprojectIdRouteImport;
       parentRoute: typeof rootRouteImport;
     };
+    "/onboarding/$step": {
+      id: "/onboarding/$step";
+      path: "/onboarding/$step";
+      fullPath: "/onboarding/$step";
+      preLoaderRoute: typeof onboardingRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     "/messages/new": {
       id: "/messages/new";
       path: "/messages/new";
@@ -282,6 +302,7 @@ const rootRouteChildren: RootRouteChildren = {
   workflowsRoute: workflowsRoute,
   channelsDotchannelIdRoute: channelsDotchannelIdRoute,
   messagesDotnewRoute: messagesDotnewRoute,
+  onboardingRoute: onboardingRoute,
   projectsDotprojectIdRoute: projectsDotprojectIdRoute,
   workflowsDotworkflowIdRoute: workflowsDotworkflowIdRoute,
   channelsDotchannelIdDotpostsDotpostIdRoute:

--- a/desktop/src/app/routes.ts
+++ b/desktop/src/app/routes.ts
@@ -11,6 +11,7 @@ export const routes = rootRoute("root.tsx", [
   route("/projects", "projects.tsx"),
   route("/projects/$projectId", "projects.$projectId.tsx"),
   route("/messages/new", "messages.new.tsx"),
+  route("/onboarding/$step", "onboarding.tsx"),
   route("/channels/$channelId", "channels.$channelId.tsx"),
   route(
     "/channels/$channelId/posts/$postId",

--- a/desktop/src/app/routes/onboarding.tsx
+++ b/desktop/src/app/routes/onboarding.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 // Onboarding is rendered by startup gates before RouterProvider mounts. If a
 // stale session-only onboarding URL reaches the normal app router, repair it
 // instead of rendering onboarding without its required in-memory state.
-export const Route = createFileRoute("/onboarding/$step" as never)({
+export const Route = createFileRoute("/onboarding/$step")({
   beforeLoad: () => {
     throw redirect({ to: "/", replace: true });
   },

--- a/desktop/src/app/routes/onboarding.tsx
+++ b/desktop/src/app/routes/onboarding.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+// Onboarding is rendered by startup gates before RouterProvider mounts. If a
+// stale session-only onboarding URL reaches the normal app router, repair it
+// instead of rendering onboarding without its required in-memory state.
+export const Route = createFileRoute("/onboarding/$step" as never)({
+  beforeLoad: () => {
+    throw redirect({ to: "/", replace: true });
+  },
+});

--- a/desktop/src/features/communities/ui/HostedCommunityOnboarding.tsx
+++ b/desktop/src/features/communities/ui/HostedCommunityOnboarding.tsx
@@ -173,10 +173,7 @@ export function HostedCommunityOnboarding({
     });
 
   const goBack = () => {
-    void run("Signing out…", async () => {
-      await clearBuilderlabAuth();
-      onBack();
-    });
+    onBack();
   };
 
   const connectIdentity = () =>

--- a/desktop/src/features/communities/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/communities/ui/WelcomeSetup.tsx
@@ -285,7 +285,7 @@ export function WelcomeSetup({
               transitionKey={`owned-${transitionDirection}`}
             >
               <HostedCommunityOnboarding
-                onBack={() => onboardingHistory.push("community")}
+                onBack={() => onboardingHistory.back("community")}
               />
             </OnboardingSlideTransition>
           ) : (
@@ -373,7 +373,7 @@ export function WelcomeSetup({
             <HostedCommunityOnboarding
               onBack={() => onboardingHistory.back(routeForWelcomePage(page))}
               onReady={() => {
-                onboardingHistory.push("community-owned");
+                onboardingHistory.replace("community-owned");
               }}
               stageHidden
             />

--- a/desktop/src/features/communities/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/communities/ui/WelcomeSetup.tsx
@@ -80,7 +80,14 @@ export function WelcomeSetup({
   React.useEffect(() => {
     const step = onboardingHistory.step;
     if (!step) {
-      onboardingHistory.replace(routeForWelcomePage(page));
+      if (canReturnToMachineConfig) {
+        onboardingHistory.replace(routeForWelcomePage(page));
+      } else {
+        // Leaving the final community starts a new discovery flow. Retire the
+        // app history behind it so browser Back cannot escape to a route that
+        // no longer has an active community.
+        onboardingHistory.reset(routeForWelcomePage(page));
+      }
       return;
     }
     if (isMachineOnboardingRouteStep(step)) return;
@@ -97,8 +104,10 @@ export function WelcomeSetup({
     setIsHostedSignInOpen(false);
     setPage(pageForWelcomeRoute(step));
   }, [
+    canReturnToMachineConfig,
     onboardingHistory.direction,
     onboardingHistory.replace,
+    onboardingHistory.reset,
     onboardingHistory.step,
     page,
   ]);
@@ -209,7 +218,7 @@ export function WelcomeSetup({
                   </button>
                 </Card>
               </div>
-{canReturnToMachineConfig ? (
+              {canReturnToMachineConfig ? (
                 <OnboardingFooter>
                   <Button
                     className="h-9 rounded-full bg-foreground/10 px-6 hover:bg-foreground/15"

--- a/desktop/src/features/communities/ui/WelcomeSetup.tsx
+++ b/desktop/src/features/communities/ui/WelcomeSetup.tsx
@@ -3,6 +3,12 @@ import { Check, Copy } from "lucide-react";
 
 import { HostedCommunityOnboarding } from "@/features/communities/ui/HostedCommunityOnboarding";
 import { useCommunityOnboarding } from "@/features/onboarding/communityOnboarding";
+import { useOnboardingHistory } from "@/features/onboarding/OnboardingHistory";
+import {
+  isCommunitySetupRouteStep,
+  isMachineOnboardingRouteStep,
+  type CommunitySetupRouteStep,
+} from "@/features/onboarding/onboardingRoute";
 import { InviteRedeemForm } from "@/features/onboarding/ui/InviteRedeemForm";
 import { OnboardingChrome } from "@/features/onboarding/ui/OnboardingChrome";
 import {
@@ -27,16 +33,28 @@ type WelcomeTransitionMode = "initial" | OnboardingTransitionDirection;
 type WelcomeSetupProps = {
   initialPage?: WelcomeSetupPage;
   initialTransitionMode?: WelcomeTransitionMode;
-  onBack?: () => void;
+  canReturnToMachineConfig?: boolean;
 };
+
+function routeForWelcomePage(page: WelcomeSetupPage): CommunitySetupRouteStep {
+  if (page === "welcome") return "community";
+  return `community-${page}` as CommunitySetupRouteStep;
+}
+
+function pageForWelcomeRoute(
+  step: Exclude<CommunitySetupRouteStep, "community-hosted">,
+): WelcomeSetupPage {
+  if (step === "community") return "welcome";
+  return step.slice("community-".length) as WelcomeSetupPage;
+}
 
 const COMMUNITY_OPTION_CARD_CLASS =
   "w-full max-w-[320px] items-center px-6 py-4 text-center text-sm font-normal leading-6 text-foreground [--buzz-card-textured-min-height:88px] transition-[filter] duration-150 ease-out hover:brightness-[0.98] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-foreground/35";
 
 export function WelcomeSetup({
+  canReturnToMachineConfig = true,
   initialPage = "welcome",
   initialTransitionMode = "initial",
-  onBack,
 }: WelcomeSetupProps) {
   const [page, setPage] = React.useState<WelcomeSetupPage>(initialPage);
   const [transitionMode, setTransitionMode] =
@@ -47,6 +65,7 @@ export function WelcomeSetup({
   const [isHostedSignInOpen, setIsHostedSignInOpen] = React.useState(false);
   const [copiedNpub, setCopiedNpub] = React.useState(false);
   const communityOnboarding = useCommunityOnboarding();
+  const onboardingHistory = useOnboardingHistory();
   const identityQuery = useIdentityQuery();
   const systemColorScheme = useSystemColorScheme();
   const npub = identityQuery.data?.pubkey
@@ -58,14 +77,40 @@ export function WelcomeSetup({
       : "Could not load your public key."
     : null;
 
+  React.useEffect(() => {
+    const step = onboardingHistory.step;
+    if (!step) {
+      onboardingHistory.replace(routeForWelcomePage(page));
+      return;
+    }
+    if (isMachineOnboardingRouteStep(step)) return;
+    if (!isCommunitySetupRouteStep(step)) {
+      onboardingHistory.replace(routeForWelcomePage(page));
+      return;
+    }
+
+    setTransitionMode(onboardingHistory.direction);
+    if (step === "community-hosted") {
+      setIsHostedSignInOpen(true);
+      return;
+    }
+    setIsHostedSignInOpen(false);
+    setPage(pageForWelcomeRoute(step));
+  }, [
+    onboardingHistory.direction,
+    onboardingHistory.replace,
+    onboardingHistory.step,
+    page,
+  ]);
+
   const showPage = React.useCallback(
     (nextPage: WelcomeSetupPage, direction?: OnboardingTransitionDirection) => {
       setTransitionMode(
         direction ?? (nextPage === "welcome" ? "backward" : "forward"),
       );
-      setPage(nextPage);
+      onboardingHistory.push(routeForWelcomePage(nextPage));
     },
-    [],
+    [onboardingHistory],
   );
 
   const startConnection = React.useCallback(
@@ -144,7 +189,7 @@ export function WelcomeSetup({
                 >
                   <button
                     data-testid="community-choice-create"
-                    onClick={() => setIsHostedSignInOpen(true)}
+                    onClick={() => onboardingHistory.push("community-hosted")}
                     type="button"
                   >
                     Create a community
@@ -164,12 +209,12 @@ export function WelcomeSetup({
                   </button>
                 </Card>
               </div>
-              {onBack ? (
+{canReturnToMachineConfig ? (
                 <OnboardingFooter>
                   <Button
                     className="h-9 rounded-full bg-foreground/10 px-6 hover:bg-foreground/15"
                     data-testid="welcome-setup-back"
-                    onClick={onBack}
+                    onClick={() => onboardingHistory.back("defaults")}
                     type="button"
                     variant="ghost"
                   >
@@ -201,7 +246,7 @@ export function WelcomeSetup({
                 >
                   <button
                     data-testid="existing-choice-owner"
-                    onClick={() => setIsHostedSignInOpen(true)}
+                    onClick={() => onboardingHistory.push("community-hosted")}
                     type="button"
                   >
                     I own the community
@@ -225,7 +270,7 @@ export function WelcomeSetup({
                 <Button
                   className="h-9 rounded-full bg-foreground/10 px-6 hover:bg-foreground/15"
                   data-testid="existing-back"
-                  onClick={() => showPage("welcome")}
+                  onClick={() => onboardingHistory.back("community")}
                   type="button"
                   variant="ghost"
                 >
@@ -239,7 +284,9 @@ export function WelcomeSetup({
               direction={transitionDirection}
               transitionKey={`owned-${transitionDirection}`}
             >
-              <HostedCommunityOnboarding onBack={() => showPage("welcome")} />
+              <HostedCommunityOnboarding
+                onBack={() => onboardingHistory.push("community")}
+              />
             </OnboardingSlideTransition>
           ) : (
             <OnboardingSlideTransition
@@ -264,7 +311,9 @@ export function WelcomeSetup({
                   error={null}
                   isRedeeming={false}
                   onCancel={() =>
-                    showPage(page === "member" ? "existing" : "welcome")
+                    onboardingHistory.back(
+                      page === "member" ? "community-existing" : "community",
+                    )
                   }
                   onConnect={startConnection}
                   onRedeem={redeemInvite}
@@ -322,10 +371,9 @@ export function WelcomeSetup({
           )}
           {isHostedSignInOpen && page !== "owned" ? (
             <HostedCommunityOnboarding
-              onBack={() => setIsHostedSignInOpen(false)}
+              onBack={() => onboardingHistory.back(routeForWelcomePage(page))}
               onReady={() => {
-                setIsHostedSignInOpen(false);
-                showPage("owned");
+                onboardingHistory.push("community-owned");
               }}
               stageHidden
             />

--- a/desktop/src/features/onboarding/OnboardingHistory.tsx
+++ b/desktop/src/features/onboarding/OnboardingHistory.tsx
@@ -1,0 +1,148 @@
+import * as React from "react";
+
+import { router } from "@/app/router";
+import {
+  createOnboardingHistoryState,
+  onboardingRoutePath,
+  readOnboardingHistoryEntry,
+  type OnboardingHistoryEntry,
+  type OnboardingRouteStep,
+} from "./onboardingRoute";
+
+const ONBOARDING_HISTORY_SESSION_ID = crypto.randomUUID();
+
+type HistoryAction = "initial" | "PUSH" | "REPLACE" | "BACK" | "FORWARD" | "GO";
+
+type OnboardingHistorySnapshot = {
+  action: HistoryAction;
+  depth: number;
+  direction: "backward" | "forward";
+  step: OnboardingRouteStep | null;
+};
+
+type OnboardingHistoryContextValue = OnboardingHistorySnapshot & {
+  back: (fallback: OnboardingRouteStep) => void;
+  backBy: (steps: number, fallback: OnboardingRouteStep) => void;
+  exit: (path: string) => void;
+  push: (step: OnboardingRouteStep) => void;
+  replace: (step: OnboardingRouteStep) => void;
+};
+
+const OnboardingHistoryContext =
+  React.createContext<OnboardingHistoryContextValue | null>(null);
+
+function currentEntry(): OnboardingHistoryEntry | null {
+  return readOnboardingHistoryEntry(
+    router.history.location.pathname,
+    router.history.location.state,
+    ONBOARDING_HISTORY_SESSION_ID,
+  );
+}
+
+function readSnapshot(
+  action: HistoryAction,
+  goIndex?: number,
+): OnboardingHistorySnapshot {
+  const entry = currentEntry();
+  const direction =
+    action === "BACK" || (action === "GO" && (goIndex ?? 0) < 0)
+      ? "backward"
+      : "forward";
+  return {
+    action,
+    depth: entry?.depth ?? 0,
+    direction,
+    step: entry?.step ?? null,
+  };
+}
+
+export function OnboardingHistoryProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [snapshot, setSnapshot] = React.useState(() => readSnapshot("initial"));
+
+  React.useEffect(
+    () =>
+      router.history.subscribe(({ action }) => {
+        setSnapshot(
+          readSnapshot(
+            action.type,
+            action.type === "GO" ? action.index : undefined,
+          ),
+        );
+      }),
+    [],
+  );
+
+  const replace = React.useCallback((step: OnboardingRouteStep) => {
+    const entry = currentEntry();
+    router.history.replace(
+      onboardingRoutePath(step),
+      createOnboardingHistoryState(
+        ONBOARDING_HISTORY_SESSION_ID,
+        entry?.depth ?? 0,
+      ),
+    );
+  }, []);
+
+  const push = React.useCallback((step: OnboardingRouteStep) => {
+    const entry = currentEntry();
+    router.history.push(
+      onboardingRoutePath(step),
+      createOnboardingHistoryState(
+        ONBOARDING_HISTORY_SESSION_ID,
+        (entry?.depth ?? 0) + 1,
+      ),
+    );
+  }, []);
+
+  const backBy = React.useCallback(
+    (steps: number, fallback: OnboardingRouteStep) => {
+      if (snapshot.step && steps > 0 && snapshot.depth >= steps) {
+        router.history.go(-steps);
+        return;
+      }
+      replace(fallback);
+    },
+    [replace, snapshot.depth, snapshot.step],
+  );
+
+  const back = React.useCallback(
+    (fallback: OnboardingRouteStep) => backBy(1, fallback),
+    [backBy],
+  );
+
+  const exit = React.useCallback((path: string) => {
+    router.history.replace(path, {});
+  }, []);
+
+  const value = React.useMemo<OnboardingHistoryContextValue>(
+    () => ({
+      ...snapshot,
+      back,
+      backBy,
+      exit,
+      push,
+      replace,
+    }),
+    [back, backBy, exit, push, replace, snapshot],
+  );
+
+  return (
+    <OnboardingHistoryContext.Provider value={value}>
+      {children}
+    </OnboardingHistoryContext.Provider>
+  );
+}
+
+export function useOnboardingHistory() {
+  const value = React.useContext(OnboardingHistoryContext);
+  if (!value) {
+    throw new Error(
+      "useOnboardingHistory must be used within OnboardingHistoryProvider",
+    );
+  }
+  return value;
+}

--- a/desktop/src/features/onboarding/OnboardingHistory.tsx
+++ b/desktop/src/features/onboarding/OnboardingHistory.tsx
@@ -9,8 +9,6 @@ import {
   type OnboardingRouteStep,
 } from "./onboardingRoute";
 
-const ONBOARDING_HISTORY_SESSION_ID = crypto.randomUUID();
-
 type HistoryAction = "initial" | "PUSH" | "REPLACE" | "BACK" | "FORWARD" | "GO";
 
 type OnboardingHistorySnapshot = {
@@ -25,25 +23,27 @@ type OnboardingHistoryContextValue = OnboardingHistorySnapshot & {
   backBy: (steps: number, fallback: OnboardingRouteStep) => void;
   exit: (path: string) => void;
   push: (step: OnboardingRouteStep) => void;
+  reset: (step: OnboardingRouteStep) => void;
   replace: (step: OnboardingRouteStep) => void;
 };
 
 const OnboardingHistoryContext =
   React.createContext<OnboardingHistoryContextValue | null>(null);
 
-function currentEntry(): OnboardingHistoryEntry | null {
+function currentEntry(sessionId: string): OnboardingHistoryEntry | null {
   return readOnboardingHistoryEntry(
     router.history.location.pathname,
     router.history.location.state,
-    ONBOARDING_HISTORY_SESSION_ID,
+    sessionId,
   );
 }
 
 function readSnapshot(
+  sessionId: string,
   action: HistoryAction,
   goIndex?: number,
 ): OnboardingHistorySnapshot {
-  const entry = currentEntry();
+  const entry = currentEntry(sessionId);
   const direction =
     action === "BACK" || (action === "GO" && (goIndex ?? 0) < 0)
       ? "backward"
@@ -61,13 +61,17 @@ export function OnboardingHistoryProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [snapshot, setSnapshot] = React.useState(() => readSnapshot("initial"));
+  const sessionIdRef = React.useRef(crypto.randomUUID());
+  const [snapshot, setSnapshot] = React.useState(() =>
+    readSnapshot(sessionIdRef.current, "initial"),
+  );
 
   React.useEffect(
     () =>
       router.history.subscribe(({ action }) => {
         setSnapshot(
           readSnapshot(
+            sessionIdRef.current,
             action.type,
             action.type === "GO" ? action.index : undefined,
           ),
@@ -77,24 +81,29 @@ export function OnboardingHistoryProvider({
   );
 
   const replace = React.useCallback((step: OnboardingRouteStep) => {
-    const entry = currentEntry();
+    const sessionId = sessionIdRef.current;
+    const entry = currentEntry(sessionId);
     router.history.replace(
       onboardingRoutePath(step),
-      createOnboardingHistoryState(
-        ONBOARDING_HISTORY_SESSION_ID,
-        entry?.depth ?? 0,
-      ),
+      createOnboardingHistoryState(sessionId, entry?.depth ?? 0),
     );
   }, []);
 
   const push = React.useCallback((step: OnboardingRouteStep) => {
-    const entry = currentEntry();
+    const sessionId = sessionIdRef.current;
+    const entry = currentEntry(sessionId);
     router.history.push(
       onboardingRoutePath(step),
-      createOnboardingHistoryState(
-        ONBOARDING_HISTORY_SESSION_ID,
-        (entry?.depth ?? 0) + 1,
-      ),
+      createOnboardingHistoryState(sessionId, (entry?.depth ?? 0) + 1),
+    );
+  }, []);
+
+  const reset = React.useCallback((step: OnboardingRouteStep) => {
+    const sessionId = crypto.randomUUID();
+    sessionIdRef.current = sessionId;
+    router.history.replace(
+      onboardingRoutePath(step),
+      createOnboardingHistoryState(sessionId, 0),
     );
   }, []);
 
@@ -115,6 +124,10 @@ export function OnboardingHistoryProvider({
   );
 
   const exit = React.useCallback((path: string) => {
+    // Retire every entry from the completed flow before replacing the current
+    // route. A later browser Back can still reach an old URL, but its marker no
+    // longer belongs to the active session and cannot reopen onboarding.
+    sessionIdRef.current = crypto.randomUUID();
     router.history.replace(path, {});
   }, []);
 
@@ -125,9 +138,10 @@ export function OnboardingHistoryProvider({
       backBy,
       exit,
       push,
+      reset,
       replace,
     }),
-    [back, backBy, exit, push, replace, snapshot],
+    [back, backBy, exit, push, reset, replace, snapshot],
   );
 
   return (

--- a/desktop/src/features/onboarding/OnboardingHistory.tsx
+++ b/desktop/src/features/onboarding/OnboardingHistory.tsx
@@ -101,10 +101,13 @@ export function OnboardingHistoryProvider({
   const reset = React.useCallback((step: OnboardingRouteStep) => {
     const sessionId = crypto.randomUUID();
     sessionIdRef.current = sessionId;
-    router.history.replace(
-      onboardingRoutePath(step),
-      createOnboardingHistoryState(sessionId, 0),
-    );
+    const path = onboardingRoutePath(step);
+    const state = createOnboardingHistoryState(sessionId, 0);
+    // Replace the route being retired, then leave an equivalent current entry.
+    // Browser Back lands on the fresh session boundary instead of reviving the
+    // app or completed onboarding route that preceded it.
+    router.history.replace(path, state);
+    router.history.push(path, state);
   }, []);
 
   const backBy = React.useCallback(

--- a/desktop/src/features/onboarding/onboardingRoute.test.mjs
+++ b/desktop/src/features/onboarding/onboardingRoute.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createOnboardingHistoryState,
+  isCommunitySetupRouteStep,
+  isMachineOnboardingRouteStep,
+  ONBOARDING_ROUTE_STEPS,
+  onboardingRoutePath,
+  parseOnboardingRouteStep,
+  readOnboardingHistoryEntry,
+} from "./onboardingRoute.ts";
+
+test("all onboarding route steps round-trip through their paths", () => {
+  for (const step of ONBOARDING_ROUTE_STEPS) {
+    assert.equal(parseOnboardingRouteStep(onboardingRoutePath(step)), step);
+  }
+});
+
+test("unknown and nested onboarding paths are rejected", () => {
+  assert.equal(parseOnboardingRouteStep("/onboarding/not-a-step"), null);
+  assert.equal(parseOnboardingRouteStep("/onboarding/backup/password"), null);
+  assert.equal(parseOnboardingRouteStep("/channels/general"), null);
+});
+
+test("machine and community route groups do not overlap", () => {
+  const machineSteps = ONBOARDING_ROUTE_STEPS.filter((step) =>
+    isMachineOnboardingRouteStep(step),
+  );
+  const communitySteps = ONBOARDING_ROUTE_STEPS.filter((step) =>
+    isCommunitySetupRouteStep(step),
+  );
+
+  assert.deepEqual(machineSteps, [
+    "identity",
+    "key-import",
+    "backup",
+    "backup-options",
+    "backup-password",
+    "agents",
+    "defaults",
+  ]);
+  assert.deepEqual(communitySteps, [
+    "community",
+    "community-existing",
+    "community-join",
+    "community-member",
+    "community-hosted",
+    "community-owned",
+  ]);
+  assert.equal(
+    machineSteps.some((step) => communitySteps.includes(step)),
+    false,
+  );
+});
+
+test("history entries are accepted only for the active session", () => {
+  const state = createOnboardingHistoryState("session-a", 3);
+
+  assert.deepEqual(
+    readOnboardingHistoryEntry(
+      "/onboarding/backup-options",
+      state,
+      "session-a",
+    ),
+    { depth: 3, step: "backup-options" },
+  );
+  assert.equal(
+    readOnboardingHistoryEntry(
+      "/onboarding/backup-options",
+      state,
+      "session-b",
+    ),
+    null,
+  );
+});
+
+test("direct, malformed, and stale entries require canonical repair", () => {
+  assert.equal(
+    readOnboardingHistoryEntry("/onboarding/identity", {}, "session-a"),
+    null,
+  );
+  assert.equal(
+    readOnboardingHistoryEntry(
+      "/onboarding/identity",
+      createOnboardingHistoryState("session-a", -1),
+      "session-a",
+    ),
+    null,
+  );
+  assert.equal(
+    readOnboardingHistoryEntry(
+      "/onboarding/unknown",
+      createOnboardingHistoryState("session-a", 0),
+      "session-a",
+    ),
+    null,
+  );
+});
+
+test("restored entry depths preserve the active branch position", () => {
+  const earlier = createOnboardingHistoryState("session-a", 2);
+  const later = createOnboardingHistoryState("session-a", 3);
+
+  assert.equal(
+    readOnboardingHistoryEntry("/onboarding/agents", earlier, "session-a")
+      ?.depth,
+    2,
+  );
+  assert.equal(
+    readOnboardingHistoryEntry("/onboarding/defaults", later, "session-a")
+      ?.depth,
+    3,
+  );
+});

--- a/desktop/src/features/onboarding/onboardingRoute.ts
+++ b/desktop/src/features/onboarding/onboardingRoute.ts
@@ -1,0 +1,131 @@
+export const ONBOARDING_ROUTE_STEPS = [
+  "identity",
+  "key-import",
+  "backup",
+  "backup-options",
+  "backup-password",
+  "agents",
+  "defaults",
+  "community",
+  "community-existing",
+  "community-join",
+  "community-member",
+  "community-hosted",
+  "community-owned",
+  "profile",
+  "team",
+] as const;
+
+export type OnboardingRouteStep = (typeof ONBOARDING_ROUTE_STEPS)[number];
+
+export type MachineOnboardingRouteStep = Extract<
+  OnboardingRouteStep,
+  | "identity"
+  | "key-import"
+  | "backup"
+  | "backup-options"
+  | "backup-password"
+  | "agents"
+  | "defaults"
+>;
+
+export type CommunitySetupRouteStep = Extract<
+  OnboardingRouteStep,
+  | "community"
+  | "community-existing"
+  | "community-join"
+  | "community-member"
+  | "community-hosted"
+  | "community-owned"
+>;
+
+const ONBOARDING_PATH_PREFIX = "/onboarding/";
+const ONBOARDING_ROUTE_STEP_SET = new Set<string>(ONBOARDING_ROUTE_STEPS);
+const ONBOARDING_HISTORY_STATE_KEY = "buzzOnboarding";
+
+export type OnboardingHistoryMarker = {
+  depth: number;
+  sessionId: string;
+};
+
+export type OnboardingHistoryEntry = {
+  depth: number;
+  step: OnboardingRouteStep;
+};
+
+export function onboardingRoutePath(step: OnboardingRouteStep) {
+  return `${ONBOARDING_PATH_PREFIX}${step}` as const;
+}
+
+export function parseOnboardingRouteStep(
+  pathname: string,
+): OnboardingRouteStep | null {
+  if (!pathname.startsWith(ONBOARDING_PATH_PREFIX)) return null;
+  const step = pathname.slice(ONBOARDING_PATH_PREFIX.length);
+  return ONBOARDING_ROUTE_STEP_SET.has(step)
+    ? (step as OnboardingRouteStep)
+    : null;
+}
+
+export function createOnboardingHistoryState(
+  sessionId: string,
+  depth: number,
+): Record<string, OnboardingHistoryMarker> {
+  return {
+    [ONBOARDING_HISTORY_STATE_KEY]: {
+      depth,
+      sessionId,
+    },
+  };
+}
+
+export function readOnboardingHistoryEntry(
+  pathname: string,
+  state: unknown,
+  sessionId: string,
+): OnboardingHistoryEntry | null {
+  if (!state || typeof state !== "object") return null;
+  const marker = (state as Record<string, unknown>)[
+    ONBOARDING_HISTORY_STATE_KEY
+  ];
+  if (!marker || typeof marker !== "object") return null;
+  const { depth, sessionId: markerSessionId } =
+    marker as Partial<OnboardingHistoryMarker>;
+  if (
+    markerSessionId !== sessionId ||
+    typeof depth !== "number" ||
+    !Number.isInteger(depth) ||
+    depth < 0
+  ) {
+    return null;
+  }
+  const step = parseOnboardingRouteStep(pathname);
+  return step ? { depth, step } : null;
+}
+
+export function isMachineOnboardingRouteStep(
+  step: OnboardingRouteStep | null,
+): step is MachineOnboardingRouteStep {
+  return (
+    step === "identity" ||
+    step === "key-import" ||
+    step === "backup" ||
+    step === "backup-options" ||
+    step === "backup-password" ||
+    step === "agents" ||
+    step === "defaults"
+  );
+}
+
+export function isCommunitySetupRouteStep(
+  step: OnboardingRouteStep | null,
+): step is CommunitySetupRouteStep {
+  return (
+    step === "community" ||
+    step === "community-existing" ||
+    step === "community-join" ||
+    step === "community-member" ||
+    step === "community-hosted" ||
+    step === "community-owned"
+  );
+}

--- a/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
@@ -299,10 +299,19 @@ export function CommunityOnboardingFlow({
   }, [finish, isPending, onboardingHistory, queryClient, relayUrl, update]);
 
   const backToProfile = React.useCallback(() => {
-    if (isPending) return;
+    if (isPending || !transaction) return;
     setStarterChannelFailureCount(0);
+    update({ stage: "profile", error: undefined }, transaction.id);
     onboardingHistory.back("profile");
-  }, [isPending, onboardingHistory]);
+  }, [isPending, onboardingHistory, transaction, update]);
+
+  const backToCommunitySetup = React.useCallback(() => {
+    if (isPending || !transaction) return;
+    onboardingHistory.back(
+      routeForFirstCommunityPage(transaction.firstCommunityPage),
+    );
+    void onCancel();
+  }, [isPending, onboardingHistory, onCancel, transaction]);
 
   const isProfileStage = transaction?.stage === "profile";
   React.useEffect(() => {
@@ -671,13 +680,7 @@ export function CommunityOnboardingFlow({
                   className="h-9 w-20 rounded-full bg-foreground/10 px-6 hover:bg-foreground/15"
                   data-testid="community-profile-back"
                   disabled={isPending || isUploadingAvatar}
-                  onClick={() =>
-                    onboardingHistory.back(
-                      routeForFirstCommunityPage(
-                        transaction.firstCommunityPage,
-                      ),
-                    )
-                  }
+                  onClick={backToCommunitySetup}
                   type="button"
                   variant="ghost"
                 >

--- a/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
@@ -6,6 +6,12 @@ import {
   markCommunityOnboardingComplete,
   useCommunityOnboarding,
 } from "@/features/onboarding/communityOnboarding";
+import { useOnboardingHistory } from "@/features/onboarding/OnboardingHistory";
+import {
+  isCommunitySetupRouteStep,
+  isMachineOnboardingRouteStep,
+  type CommunitySetupRouteStep,
+} from "@/features/onboarding/onboardingRoute";
 import { initializeStarterChannels } from "@/features/onboarding/hooks";
 import { useClaimInvite } from "@/features/onboarding/useClaimInvite";
 import { CommunityChangeOverlay } from "@/features/communities/ui/CommunityChangeOverlay";
@@ -62,6 +68,14 @@ const ENTERING_CURTAIN_FADE_MS = 500;
  * fade anyway rather than stranding the user on the onboarding screen.
  */
 const ENTERING_CURTAIN_MAX_WAIT_MS = 8_000;
+
+function routeForFirstCommunityPage(
+  page: "join" | "member" | "owned" | undefined,
+): CommunitySetupRouteStep {
+  if (page === "member") return "community-member";
+  if (page === "owned") return "community-owned";
+  return "community-join";
+}
 
 const NEUTRAL_EMOJI_PICKER_THEME_VARS = {
   "--buzz-emoji-picker-rgb-background":
@@ -149,6 +163,7 @@ export function CommunityOnboardingFlow({
   onConnect: () => void;
 }) {
   const { transaction, update, clear } = useCommunityOnboarding();
+  const onboardingHistory = useOnboardingHistory();
   const queryClient = useQueryClient();
   const systemColorScheme = useSystemColorScheme();
   const [displayName, setDisplayName] = React.useState("");
@@ -173,6 +188,11 @@ export function CommunityOnboardingFlow({
   const avatarEditorContentRef = React.useRef<HTMLDivElement | null>(null);
   const [avatarEditorDialogHeight, setAvatarEditorDialogHeight] =
     React.useState<number | null>(null);
+  const hasReachedTeamRef = React.useRef(
+    transaction?.stage === "team-intro" ||
+      transaction?.stage === "finalizing" ||
+      transaction?.stage === "entering",
+  );
 
   // Also fetch on "entering": the curtain is a fresh mount of this component,
   // so the team-intro fetch from the pre-curtain instance isn't in this state.
@@ -240,8 +260,9 @@ export function CommunityOnboardingFlow({
     if (!relayUrl) return;
     const identity = await getIdentity();
     markCommunityOnboardingComplete(identity.pubkey, relayUrl);
+    onboardingHistory.exit("/");
     clear();
-  }, [clear, relayUrl]);
+  }, [clear, onboardingHistory, relayUrl]);
   const finalize = React.useCallback(async () => {
     if (isPending || !relayUrl) return;
     setIsPending(true);
@@ -260,7 +281,7 @@ export function CommunityOnboardingFlow({
         // entry — it exists for the Home-route fallback, and leaving it would
         // yank a later Home visit back to Welcome.
         takePendingWelcomeChannelForDirectEntry();
-        window.location.hash = `/channels/${result.focusChannelId}`;
+        onboardingHistory.exit(`/channels/${result.focusChannelId}`);
         markCommunityOnboardingComplete(identity.pubkey, relayUrl);
         // Keep this screen mounted as a curtain over the loading app; the
         // "entering" stage fades it out once Welcome reports ready.
@@ -275,13 +296,13 @@ export function CommunityOnboardingFlow({
       });
       setIsPending(false);
     }
-  }, [finish, isPending, queryClient, relayUrl, update]);
+  }, [finish, isPending, onboardingHistory, queryClient, relayUrl, update]);
 
   const backToProfile = React.useCallback(() => {
     if (isPending) return;
     setStarterChannelFailureCount(0);
-    update({ stage: "profile", error: undefined });
-  }, [isPending, update]);
+    onboardingHistory.back("profile");
+  }, [isPending, onboardingHistory]);
 
   const isProfileStage = transaction?.stage === "profile";
   React.useEffect(() => {
@@ -304,6 +325,70 @@ export function CommunityOnboardingFlow({
     transaction?.stage === "team-intro" ||
     transaction?.stage === "finalizing" ||
     transaction?.stage === "entering";
+
+  React.useEffect(() => {
+    if (!transaction) return;
+    const step = onboardingHistory.step;
+
+    if (transaction.stage === "profile") {
+      if (step === "profile") return;
+      if (step === "team" && hasReachedTeamRef.current) {
+        update({ stage: "team-intro", error: undefined }, transaction.id);
+        return;
+      }
+      if (isMachineOnboardingRouteStep(step)) return;
+      if (
+        onboardingHistory.direction === "backward" &&
+        (step === null || isCommunitySetupRouteStep(step))
+      ) {
+        onCancel();
+        return;
+      }
+      if (step === null && transaction.source !== "first-community") {
+        onboardingHistory.push("profile");
+        return;
+      }
+      if (step === null) {
+        onboardingHistory.replace("profile");
+        return;
+      }
+      if (isCommunitySetupRouteStep(step)) {
+        onboardingHistory.push("profile");
+        return;
+      }
+      onboardingHistory.replace("profile");
+      return;
+    }
+
+    if (transaction.stage !== "team-intro") return;
+    hasReachedTeamRef.current = true;
+    if (step === "team") return;
+    if (isMachineOnboardingRouteStep(step)) return;
+    if (step === "profile" && onboardingHistory.direction === "backward") {
+      update({ stage: "profile", error: undefined }, transaction.id);
+      return;
+    }
+    if (
+      onboardingHistory.direction === "backward" &&
+      (step === null || isCommunitySetupRouteStep(step))
+    ) {
+      onCancel();
+      return;
+    }
+    if (step === null) {
+      onboardingHistory.replace("team");
+      return;
+    }
+    onboardingHistory.push("team");
+  }, [
+    onboardingHistory.direction,
+    onboardingHistory.push,
+    onboardingHistory.replace,
+    onboardingHistory.step,
+    onCancel,
+    transaction,
+    update,
+  ]);
 
   // Seed display name and avatar from the relay profile when the profile step
   // is shown. This covers the case where the skip raced or was bypassed (e.g.,
@@ -427,6 +512,8 @@ export function CommunityOnboardingFlow({
         deferredAvatar?.cancel();
         throw error;
       }
+      hasReachedTeamRef.current = true;
+      onboardingHistory.push("team");
       update({ stage: "team-intro", error: undefined });
     } catch (error) {
       if (isRelayMembershipDeniedError(error)) {
@@ -584,7 +671,13 @@ export function CommunityOnboardingFlow({
                   className="h-9 w-20 rounded-full bg-foreground/10 px-6 hover:bg-foreground/15"
                   data-testid="community-profile-back"
                   disabled={isPending || isUploadingAvatar}
-                  onClick={onCancel}
+                  onClick={() =>
+                    onboardingHistory.back(
+                      routeForFirstCommunityPage(
+                        transaction.firstCommunityPage,
+                      ),
+                    )
+                  }
                   type="button"
                   variant="ghost"
                 >

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -17,6 +17,11 @@ import {
   DialogTitle,
 } from "@/shared/ui/dialog";
 import { StartupWindowDragRegion } from "@/shared/ui/StartupWindowDragRegion";
+import { useOnboardingHistory } from "../OnboardingHistory";
+import {
+  isMachineOnboardingRouteStep,
+  type MachineOnboardingRouteStep,
+} from "../onboardingRoute";
 import { BackupStep } from "./BackupStep";
 import { DefaultConfigStep } from "./DefaultConfigStep";
 import { DownloadKeyStep } from "./DownloadKeyStep";
@@ -51,6 +56,19 @@ export type MachineOnboardingPage =
   | "config";
 
 type BackupSubview = "created" | "options" | "password";
+
+function routeForMachinePage(
+  page: MachineOnboardingPage,
+  backupSubview: BackupSubview,
+): MachineOnboardingRouteStep {
+  if (page === "identity") return "identity";
+  if (page === "key-import") return "key-import";
+  if (page === "setup") return "agents";
+  if (page === "config") return "defaults";
+  if (backupSubview === "options") return "backup-options";
+  if (backupSubview === "password") return "backup-password";
+  return "backup";
+}
 
 /** A pending navigation the parent should execute after RouterProvider mounts. */
 export type PostOnboardingNavigation = {
@@ -113,6 +131,8 @@ export function MachineOnboardingFlow({
   // security subview keeps the created backup, password, and test progress.
   const backupSession = useEncryptedBackupSession();
   const reduceMotion = useReducedMotion() ?? false;
+  const onboardingHistory = useOnboardingHistory();
+  const previousRouteRef = React.useRef(onboardingHistory.step);
   const isSecuritySubview = page === "backup" && backupSubview !== "created";
   const handleReadyRuntimeIdsChange = React.useCallback(
     (runtimeIds: readonly string[]) => {
@@ -120,6 +140,69 @@ export function MachineOnboardingFlow({
     },
     [],
   );
+
+  React.useEffect(() => {
+    const step = onboardingHistory.step;
+    if (!step) {
+      onboardingHistory.replace(routeForMachinePage(page, backupSubview));
+      return;
+    }
+    if (!isMachineOnboardingRouteStep(step)) return;
+    if (identityLost && step === "identity") {
+      onboardingHistory.replace("key-import");
+      return;
+    }
+
+    const previousStep = previousRouteRef.current;
+    previousRouteRef.current = step;
+    setBackupDirection(onboardingHistory.direction);
+
+    if (step === "identity") {
+      setPage("identity");
+      return;
+    }
+    if (step === "key-import") {
+      setKeyImportStage("key-entry");
+      setPage("key-import");
+      return;
+    }
+    if (
+      step === "backup" ||
+      step === "backup-options" ||
+      step === "backup-password"
+    ) {
+      if (step === "backup-password" && previousStep === "agents") {
+        backupSessionToPasswordEntry(backupSession);
+      }
+      setReturningFromSecurity(
+        step === "backup" &&
+          (previousStep === "backup-options" ||
+            previousStep === "backup-password"),
+      );
+      setBackupSubview(
+        step === "backup-options"
+          ? "options"
+          : step === "backup-password"
+            ? "password"
+            : "created",
+      );
+      setPage("backup");
+      return;
+    }
+    if (step === "agents") {
+      setPage("setup");
+      return;
+    }
+    setPage("config");
+  }, [
+    backupSession,
+    backupSubview,
+    identityLost,
+    onboardingHistory.direction,
+    onboardingHistory.replace,
+    onboardingHistory.step,
+    page,
+  ]);
 
   const loadFreshIdentity = React.useCallback(async () => {
     setIsPending(true);
@@ -132,7 +215,7 @@ export function MachineOnboardingFlow({
       setBackupDirection("forward");
       setReturningFromSecurity(false);
       setBackupSubview("created");
-      setPage("backup");
+      onboardingHistory.push("backup");
     } catch (cause) {
       setError(
         cause instanceof Error ? cause.message : "Failed to load identity",
@@ -140,7 +223,7 @@ export function MachineOnboardingFlow({
     } finally {
       setIsPending(false);
     }
-  }, [queryClient]);
+  }, [onboardingHistory, queryClient]);
 
   const loadRecoveredIdentity = React.useCallback(async () => {
     setIsPending(true);
@@ -152,7 +235,7 @@ export function MachineOnboardingFlow({
       setIdentityWasImported(true);
       setSelectedPubkey(identity.pubkey);
       setIdentityStorage(identity.storage);
-      setPage("setup");
+      onboardingHistory.push("agents");
     } catch (cause) {
       setError(
         cause instanceof Error ? cause.message : "Failed to load identity",
@@ -160,7 +243,7 @@ export function MachineOnboardingFlow({
     } finally {
       setIsPending(false);
     }
-  }, [continueWithRecoveredIdentity, queryClient]);
+  }, [continueWithRecoveredIdentity, onboardingHistory, queryClient]);
 
   const replaceLostIdentity = React.useCallback(async () => {
     const confirmed = window.confirm(
@@ -178,7 +261,7 @@ export function MachineOnboardingFlow({
       setBackupDirection("forward");
       setReturningFromSecurity(false);
       setBackupSubview("created");
-      setPage("backup");
+      onboardingHistory.push("backup");
     } catch (cause) {
       setError(
         cause instanceof Error ? cause.message : "Failed to save identity",
@@ -186,7 +269,7 @@ export function MachineOnboardingFlow({
     } finally {
       setIsPending(false);
     }
-  }, [queryClient]);
+  }, [onboardingHistory, queryClient]);
 
   const importExistingIdentity = React.useCallback(
     async (nsec: string, password?: string) => {
@@ -195,9 +278,9 @@ export function MachineOnboardingFlow({
       queryClient.setQueryData(["identity"], identity);
       setIdentityWasImported(true);
       setSelectedPubkey(identity.pubkey);
-      setPage("setup");
+      onboardingHistory.push("agents");
     },
-    [continueWithIdentity, queryClient],
+    [continueWithIdentity, onboardingHistory, queryClient],
   );
 
   return (
@@ -221,7 +304,10 @@ export function MachineOnboardingFlow({
             onClick={() => {
               setBackupDirection("backward");
               setReturningFromSecurity(true);
-              setBackupSubview("created");
+              onboardingHistory.backBy(
+                onboardingHistory.step === "backup-password" ? 2 : 1,
+                "backup",
+              );
             }}
             type="button"
             variant="ghost"
@@ -279,7 +365,7 @@ export function MachineOnboardingFlow({
                   onClick={() => {
                     setKeyImportDialog(null);
                     setKeyImportStage("key-entry");
-                    setPage("key-import");
+                    onboardingHistory.push("key-import");
                   }}
                   type="button"
                   variant="ghost"
@@ -294,7 +380,7 @@ export function MachineOnboardingFlow({
           ) : page === "key-import" ? (
             <OnboardingSlideTransition
               className="flex min-h-[calc(100dvh-13.25rem)] w-full max-w-[837px] flex-col items-center text-center"
-              direction="forward"
+              direction={onboardingHistory.direction}
               effect="fade"
               transitionKey="machine-key-import"
             >
@@ -345,15 +431,13 @@ export function MachineOnboardingFlow({
                 </div>
               </motion.div>
               <div className="buzz-onboarding-key-import-position w-full">
-                <div className="flex flex-col items-center">
+<div className="flex flex-col items-center">
                   <NostrKeyImportForm
                     backLabel="Back"
                     onBack={() => {
                       setKeyImportStage("key-entry");
-                      if (identityLost) {
-                        return;
-                      }
-                      setPage("identity");
+                      if (identityLost) return;
+                      onboardingHistory.back("identity");
                     }}
                     onImport={importExistingIdentity}
                     onStageChange={setKeyImportStage}
@@ -444,9 +528,8 @@ export function MachineOnboardingFlow({
                 direction={backupDirection}
                 onBack={() => {
                   resetEncryptedBackupSession(backupSession);
-                  setBackupDirection("backward");
                   setReturningFromSecurity(false);
-                  setBackupSubview("options");
+                  onboardingHistory.back("backup-options");
                 }}
                 session={backupSession}
               />
@@ -454,18 +537,18 @@ export function MachineOnboardingFlow({
               <BackupStep
                 direction={backupDirection}
                 identityStorage={identityStorage}
-                onBack={() => setPage("identity")}
-                onNext={() => setPage("setup")}
+                onBack={() => onboardingHistory.back("identity")}
+                onNext={() => onboardingHistory.push("agents")}
                 onOpenPasswordBackup={() => {
                   resetEncryptedBackupSession(backupSession);
                   setBackupDirection("forward");
                   setReturningFromSecurity(false);
-                  setBackupSubview("password");
+                  onboardingHistory.push("backup-password");
                 }}
                 onShowOptions={() => {
                   setBackupDirection("forward");
                   setReturningFromSecurity(false);
-                  setBackupSubview("options");
+                  onboardingHistory.push("backup-options");
                 }}
                 optionsExpanded={backupSubview === "options"}
                 returningFromSecurity={returningFromSecurity}
@@ -477,17 +560,15 @@ export function MachineOnboardingFlow({
                 // Fresh-key users return to whichever identity backup subview
                 // they used to reach setup; imported keys skip backup entirely.
                 back: () => {
-                  if (identityWasImported) {
-                    setKeyImportStage("key-entry");
-                    setPage("key-import");
-                    return;
-                  }
                   if (backupSubview === "password") {
                     backupSessionToPasswordEntry(backupSession);
                   }
-                  setBackupDirection("backward");
                   setReturningFromSecurity(false);
-                  setPage("backup");
+                  onboardingHistory.back(
+                    identityWasImported
+                      ? "key-import"
+                      : routeForMachinePage("backup", backupSubview),
+                  );
                 },
                 next: (runtimeIds) => {
                   const ids = Array.from(runtimeIds);
@@ -498,32 +579,32 @@ export function MachineOnboardingFlow({
                     complete(selectedPubkey ?? undefined);
                     return;
                   }
-                  setPage("config");
+                  onboardingHistory.push("defaults");
                 },
                 navigateToAgentSettings: () => {
                   // Complete onboarding first, then delegate the Settings → Agents
                   // navigation to the parent.  The parent owns RouterProvider, so
                   // navigation from within the onboarding flow races with the
                   // router mounting — calling router.navigate() here is unsafe.
-                  complete(selectedPubkey ?? undefined);
                   navigateAfterComplete?.({
                     to: "/settings",
                     search: { section: "agents" },
                   });
+                  complete(selectedPubkey ?? undefined);
                 },
               }}
-              direction="forward"
+              direction={onboardingHistory.direction}
               onReadyRuntimeIdsChange={handleReadyRuntimeIdsChange}
             />
           ) : (
             <DefaultConfigStep
               actions={{
-                back: () => setPage("setup"),
+                back: () => onboardingHistory.back("agents"),
                 complete: () => complete(selectedPubkey ?? undefined),
                 discardDraft: () => setDefaultConfigDraft(null),
                 updateDraft: setDefaultConfigDraft,
               }}
-              direction="forward"
+              direction={onboardingHistory.direction}
               draft={defaultConfigDraft}
               readyRuntimeIds={readyRuntimeIds}
             />

--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -431,7 +431,7 @@ export function MachineOnboardingFlow({
                 </div>
               </motion.div>
               <div className="buzz-onboarding-key-import-position w-full">
-<div className="flex flex-col items-center">
+                <div className="flex flex-col items-center">
                   <NostrKeyImportForm
                     backLabel="Back"
                     onBack={() => {

--- a/desktop/tests/e2e/community-rail.spec.ts
+++ b/desktop/tests/e2e/community-rail.spec.ts
@@ -851,6 +851,12 @@ test.describe("community rail", () => {
       .click();
 
     await expect(page.getByText("Join or create a community")).toBeVisible();
+    await expect(page).toHaveURL(/#\/onboarding\/community$/);
+    await expect(page.getByTestId("welcome-setup-back")).toHaveCount(0);
+    await expect(page.getByTestId("community-choice-join")).toBeVisible();
+    await page.goBack();
+    await expect(page.getByText("Join or create a community")).toBeVisible();
+    await expect(page).toHaveURL(/#\/onboarding\/community$/);
     await expect(page.getByTestId("welcome-setup-back")).toHaveCount(0);
     await expect(page.getByTestId("community-choice-join")).toBeVisible();
     await expect

--- a/desktop/tests/e2e/identity-lost.spec.ts
+++ b/desktop/tests/e2e/identity-lost.spec.ts
@@ -272,6 +272,7 @@ test("phone recovery continues to harness setup without creating or restarting",
     { skipOnboardingSeed: true },
   );
   await page.goto("/");
+  await expect(page).toHaveURL(/#\/onboarding\/key-import$/);
   await page.getByTestId("nostr-import-phone-link").click();
   await expect(page.getByTestId("identity-recovery-qr")).toBeVisible();
 
@@ -281,6 +282,15 @@ test("phone recovery continues to harness setup without creating or restarting",
     );
   });
 
+  await expect(
+    page.getByRole("heading", { name: "Set up your agent harnesses" }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/#\/onboarding\/agents$/);
+  await page.goBack();
+  await expect(page).toHaveURL(/#\/onboarding\/key-import$/);
+  await expect(page.getByTestId("nostr-import-card")).toBeVisible();
+  await page.goForward();
+  await expect(page).toHaveURL(/#\/onboarding\/agents$/);
   await expect(
     page.getByRole("heading", { name: "Set up your agent harnesses" }),
   ).toBeVisible();

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -75,6 +75,39 @@ async function readGlobalConfigSetterCallCount(
   });
 }
 
+test("mouse history traverses machine onboarding routes", async ({ page }) => {
+  await installMockBridge(
+    page,
+    {
+      acpRuntimesCatalog: [
+        runtime("claude", "available", { status: "logged_in" }),
+      ],
+    },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Create a new identity key" }).click();
+  await expect(page).toHaveURL(/#\/onboarding\/backup$/);
+  await passThroughBackupStep(page);
+  await expect(page.getByTestId("onboarding-page-2")).toBeVisible();
+  await expect(page).toHaveURL(/#\/onboarding\/agents$/);
+
+  await page.goBack();
+  await expect(page.getByTestId("onboarding-page-backup")).toBeVisible();
+  await expect(page).toHaveURL(/#\/onboarding\/backup$/);
+  await page.goForward();
+  await expect(page.getByTestId("onboarding-page-2")).toBeVisible();
+
+  await page.getByTestId("onboarding-setup-next").click();
+  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
+  await expect(page).toHaveURL(/#\/onboarding\/defaults$/);
+  await page.goBack();
+  await expect(page.getByTestId("onboarding-page-2")).toBeVisible();
+  await page.goForward();
+  await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
+});
+
 test("setup shows all bundled harnesses as detected", async ({ page }) => {
   await installMockBridge(
     page,

--- a/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
+++ b/desktop/tests/e2e/onboarding-agent-defaults.spec.ts
@@ -108,6 +108,55 @@ test("mouse history traverses machine onboarding routes", async ({ page }) => {
   await expect(page.getByTestId("onboarding-page-config")).toBeVisible();
 });
 
+test("completed machine onboarding cannot be reopened from browser history", async ({
+  page,
+}) => {
+  await installMockBridge(
+    page,
+    { acpRuntimesCatalog: [] },
+    { skipCommunitySeed: true, skipOnboardingSeed: true },
+  );
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Create a new identity key" }).click();
+  await expect(page).toHaveURL(/#\/onboarding\/backup$/);
+  await passThroughBackupStep(page);
+  await expect(page).toHaveURL(/#\/onboarding\/agents$/);
+  await page.getByTestId("onboarding-setup-skip").click();
+
+  await expect(
+    page.getByRole("heading", { name: "Join or create a community" }),
+  ).toBeVisible();
+  const completionKey = await page.evaluate(() =>
+    Object.keys(window.localStorage).find((key) =>
+      key.startsWith("buzz-machine-onboarding-complete.v2:"),
+    ),
+  );
+  expect(completionKey).not.toBeNull();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (key) => (key ? window.localStorage.getItem(key) : null),
+        completionKey,
+      ),
+    )
+    .toBe("true");
+
+  await page.goBack();
+  await expect(
+    page.getByRole("heading", { name: "Join or create a community" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("onboarding-page-backup")).toHaveCount(0);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (key) => (key ? window.localStorage.getItem(key) : null),
+        completionKey,
+      ),
+    )
+    .toBe("true");
+});
+
 test("setup shows all bundled harnesses as detected", async ({ page }) => {
   await installMockBridge(
     page,

--- a/desktop/tests/e2e/onboarding-backup.spec.ts
+++ b/desktop/tests/e2e/onboarding-backup.spec.ts
@@ -117,6 +117,17 @@ test("key view reveals explicitly; options copy explicitly", async ({
   await page.getByTestId("backup-return-to-onboarding").click();
   await expect(page.getByTestId("onboarding-page-backup")).toBeVisible();
   await expect(page.getByTestId("onboarding-next")).toBeEnabled();
+
+  // The visible Back control returns to identity, not the options screen that
+  // was opened temporarily. Browser Forward still restores this key view.
+  await page.getByTestId("onboarding-back").click();
+  await expect(
+    page.getByRole("button", { name: "Continue setup" }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/#\/onboarding\/identity$/);
+  await page.goForward();
+  await expect(page.getByTestId("onboarding-page-backup")).toBeVisible();
+
   await page.getByTestId("onboarding-next").click();
   await expect(page.getByTestId("onboarding-page-2")).toBeVisible();
 });

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -1036,6 +1036,64 @@ test("first-community choices route join, create, owner, and member intents", as
   await expect(page.getByTestId("invite-redeem-submit")).toBeEnabled();
 });
 
+test("hosted onboarding collapses transient history and goes back without pushing", async ({
+  page,
+}) => {
+  await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
+  await page.addInitScript((pubkey) => {
+    window.localStorage.setItem(
+      `buzz-machine-onboarding-complete.v2:${pubkey}`,
+      "true",
+    );
+  }, BLANK_TYLER_IDENTITY.pubkey);
+  await installMockBridge(
+    page,
+    {
+      builderlabAuth: {
+        email: "owner@example.com",
+        expiresAt: "2099-01-01T00:00:00Z",
+      },
+      builderlabIdentity: { pubkey_hex: BLANK_TYLER_IDENTITY.pubkey },
+      builderlabCommunities: [
+        {
+          id: "owned-community",
+          name: "North Star",
+          normalized_host: "north-star.communities.buzz.xyz",
+        },
+      ],
+    },
+    {
+      relayWsUrl: "ws://localhost:3000",
+      skipOnboardingSeed: true,
+      skipCommunitySeed: true,
+    },
+  );
+  await page.goto("/");
+  await expect(page).toHaveURL(/#\/onboarding\/community$/);
+
+  await page.getByTestId("community-choice-create").click();
+  await expect(page.getByText("North Star")).toBeVisible();
+  await expect(page).toHaveURL(/#\/onboarding\/community-owned$/);
+
+  await page.goBack();
+  await expect(
+    page.getByRole("heading", { name: "Join or create a community" }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/#\/onboarding\/community$/);
+
+  await page.goForward();
+  await expect(page.getByText("North Star")).toBeVisible();
+  const historyLength = await page.evaluate(() => window.history.length);
+  await page.getByRole("button", { name: "Back" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Join or create a community" }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/#\/onboarding\/community$/);
+  await expect
+    .poll(() => page.evaluate(() => window.history.length))
+    .toBe(historyLength);
+});
+
 test("first-community owner can connect an existing hosted community", async ({
   page,
 }) => {

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -1468,7 +1468,7 @@ test("first-community explains when the local identity belongs to another accoun
   ).toBeVisible();
 });
 
-test("back clears Builderlab auth before returning to first-community choices", async ({
+test("back preserves Builderlab auth when returning to first-community choices", async ({
   page,
 }) => {
   await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
@@ -1497,8 +1497,17 @@ test("back clears Builderlab auth before returning to first-community choices", 
 
   await page.getByTestId("community-choice-create").click();
   await page.getByRole("button", { name: "Back" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Join or create a community" }),
+  ).toBeVisible();
   await page.getByTestId("community-choice-create").click();
-  await expect(page.getByRole("button", { name: "Continue" })).toBeVisible();
+  await expect(
+    page.getByRole("textbox", { name: "Community name" }),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Continue" })).toHaveCount(0);
+  await expect
+    .poll(() => page.evaluate(() => window.__BUZZ_E2E_COMMANDS__ ?? []))
+    .not.toContain("clear_builderlab_auth");
 });
 
 test("first-community shows the scenario cards for localhost", async ({

--- a/desktop/tests/e2e/onboarding.spec.ts
+++ b/desktop/tests/e2e/onboarding.spec.ts
@@ -1559,6 +1559,58 @@ test("first-community direct join reaches profile", async ({ page }) => {
     .toEqual({ communityCount: 1, transactionMatchesOnlyCommunity: true });
 });
 
+test("mouse history traverses community choice, profile, and team routes", async ({
+  page,
+}) => {
+  await seedActiveIdentity(page, BLANK_TYLER_IDENTITY);
+  await page.addInitScript((pubkey) => {
+    window.localStorage.setItem(
+      `buzz-machine-onboarding-complete.v2:${pubkey}`,
+      "true",
+    );
+  }, BLANK_TYLER_IDENTITY.pubkey);
+  await installMockBridge(page, undefined, {
+    relayWsUrl: "ws://localhost:3000",
+    skipOnboardingSeed: true,
+    skipCommunitySeed: true,
+  });
+  await page.goto("/");
+
+  await expect(page).toHaveURL(/#\/onboarding\/community$/);
+  await page.getByRole("button", { name: /Join a community/ }).click();
+  await expect(page).toHaveURL(/#\/onboarding\/community-join$/);
+  await page.goBack();
+  await expect(
+    page.getByRole("heading", { name: "Join or create a community" }),
+  ).toBeVisible();
+  await page.goForward();
+  await expect(page.getByTestId("invite-redeem-input")).toBeVisible();
+
+  await page
+    .getByTestId("invite-redeem-input")
+    .fill("wss://history.communities.buzz.xyz");
+  await page.getByTestId("invite-redeem-submit").click();
+  await expect(
+    page.getByRole("heading", { name: "Build your profile" }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/#\/onboarding\/profile$/);
+  await page.getByTestId("community-profile-name-key").fill("Tyler");
+  await page.getByTestId("community-profile-next").click();
+  await expect(
+    page.getByRole("heading", { name: "Meet your starter team" }),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/#\/onboarding\/team$/);
+
+  await page.goBack();
+  await expect(
+    page.getByRole("heading", { name: "Build your profile" }),
+  ).toBeVisible();
+  await page.goForward();
+  await expect(
+    page.getByRole("heading", { name: "Meet your starter team" }),
+  ).toBeVisible();
+});
+
 test("community onboarding reuses an existing relay profile", async ({
   page,
 }) => {


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Onboarding stages become dependable navigation destinations, giving us a safe foundation for finer-grained onboarding and logout behavior. Browser and mouse Back/Forward support is an immediate benefit.

**Problem:** An onboarding URL cannot reliably identify a screen by itself. Whether a stage is valid—and what it should show—depends on client state such as identity setup, community connection, and the active onboarding transaction. Today that state is spread across component-local transitions, so stages are neither safely addressable nor reusable as navigation targets. This blocks more deliberate entry, resume, recovery, and logout flows.

**Solution:** Introduce a session-scoped navigation model that maps `/onboarding/*` destinations onto the user's current client state. The route represents intent, while validated session markers and the existing onboarding state machines determine whether that destination can be restored. Invalid, stale, or direct entries are repaired safely. This abstraction makes onboarding stages dependable enough for future fine-tuned flow changes without pretending the URL alone is the source of truth.

<details>
<summary>File changes</summary>

**desktop/src/app/App.tsx**
Hosts the onboarding history provider, coordinates transitions between machine and community onboarding, and safely exits onboarding before normal app navigation resumes.

**desktop/src/app/routes.ts**
Registers the onboarding route shape with the desktop router.

**desktop/src/app/routes/onboarding.tsx**
Repairs stale onboarding URLs that reach the normal app router without their required session state.

**desktop/src/features/communities/ui/WelcomeSetup.tsx**
Maps community choice, join, member, hosted, and owned screens onto onboarding history so Back and Forward restore the correct view.

**desktop/src/features/onboarding/OnboardingHistory.tsx**
Adds the session-scoped history provider and its push, replace, back, multi-step back, and exit operations.

**desktop/src/features/onboarding/onboardingRoute.test.mjs**
Covers route parsing, route-group boundaries, session validation, malformed entries, and restored history depth.

**desktop/src/features/onboarding/onboardingRoute.ts**
Defines the supported onboarding destinations and validates the session markers that make them safe to restore.

**desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx**
Synchronizes profile and starter-team transaction stages with history, including cancellation, backtracking, and final handoff into the app.

**desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx**
Synchronizes identity, import, backup, harness, and defaults screens with history while preserving existing setup side effects.

**desktop/tests/e2e/onboarding-agent-defaults.spec.ts**
Verifies browser history across backup, harness setup, and default model configuration.

**desktop/tests/e2e/onboarding-backup.spec.ts**
Verifies backup subview history and deterministic return to the identity step.

**desktop/tests/e2e/onboarding.spec.ts**
Verifies browser history across community selection, profile setup, and starter-team introduction.

</details>

## Reproduction steps

1. Start fresh desktop onboarding and create a new identity.
2. Advance from identity backup to agent setup, then use browser or mouse Back and Forward; confirm the URL and visible screen move between `/onboarding/backup` and `/onboarding/agents`.
3. Advance to default model settings and repeat Back and Forward; confirm the setup state remains intact.
4. Continue to community selection, enter the join flow, and use Back and Forward; confirm the community choice and join screens restore correctly.
5. Connect a community, proceed from profile setup to the starter-team screen, and use Back and Forward; confirm both transaction stages restore safely.
6. Finish onboarding and confirm the onboarding history entry is replaced by the intended app destination.

