### PR TITLE
fix(desktop): expose project creation in empty state

### DIFF
--- a/desktop/src/features/projects/ui/ProjectsView.tsx
+++ b/desktop/src/features/projects/ui/ProjectsView.tsx
@@ -447,10 +447,6 @@ export function ProjectsView() {
     );
   }
 
-  if (projects.length === 0) {
-    return <EmptyState />;
-  }
-
   const repositoryItems =
     visibleProjects.length === 0 ? (
       <EmptyFilteredState />
@@ -649,7 +645,9 @@ export function ProjectsView() {
           </div>
           <div className="mx-auto w-full max-w-6xl">
             <div className="w-full min-w-0 pb-4 pt-4">
-              {filter === "all" ? (
+              {projects.length === 0 ? (
+                <EmptyState />
+              ) : filter === "all" ? (
                 <ProjectsOverviewPanel
                   localRepositoryCount={localProjectCount}
                   metadata={

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -170,6 +170,8 @@ type E2eConfig = {
     pocketVoiceImportResult?: "success" | "cancel" | "invalid";
     /** Advertised HEAD for the first mock project without adding that branch. */
     projectHeadBranch?: string;
+    /** Return no seeded repository events so the first-project flow can be tested. */
+    emptyProjects?: boolean;
     /** Builderlab account returned by hosted-community onboarding. Null/omitted = signed out. */
     builderlabAuth?: {
       email?: string;
@@ -5125,6 +5127,10 @@ function writeMockProjectBranch(
 }
 
 function buildMockProjectEvents(): RelayEvent[] {
+  if (getConfig()?.mock?.emptyProjects) {
+    return [];
+  }
+
   const events: RelayEvent[] = [];
   const daySeconds = 86_400;
   const now = Math.floor(Date.now() / 1000);

--- a/desktop/tests/e2e/project-commit-detail.spec.ts
+++ b/desktop/tests/e2e/project-commit-detail.spec.ts
@@ -17,6 +17,23 @@ async function enableProjectsFeature(page: import("@playwright/test").Page) {
   });
 }
 
+test("empty projects view exposes the first-project creation flow", async ({
+  page,
+}) => {
+  await enableProjectsFeature(page);
+  await installMockBridge(page, { emptyProjects: true });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.getByTestId("open-projects-view").click();
+
+  await expect(page.getByText("No projects yet")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Projects" }),
+  ).toBeVisible();
+  await page.getByTestId("projects-create-menu").click();
+  await page.getByRole("menuitem", { name: "Repository" }).click();
+  await expect(page.getByTestId("create-project-dialog")).toBeVisible();
+});
+
 test("top-level project lists align dates and overflow actions", async ({
   page,
 }) => {

--- a/desktop/tests/helpers/bridge.ts
+++ b/desktop/tests/helpers/bridge.ts
@@ -168,6 +168,8 @@ type MockBridgeOptions = {
   pocketVoiceImportResult?: "success" | "cancel" | "invalid";
   /** Advertised HEAD for the first mock project without adding that branch. */
   projectHeadBranch?: string;
+  /** Return no seeded repository events so the first-project flow can be tested. */
+  emptyProjects?: boolean;
   /** Relay NIP-11 identity used to sign authoritative repository state. */
   relaySelf?: string | null;
   /** Native-like huddle state seeded from authoritative role-bearing membership. */


### PR DESCRIPTION
## Summary

- keep the Projects page shell mounted when the relay has no project announcements
- expose the existing create menu and repository dialog from the zero-project state
- add an E2E bridge option and regression test for the first-project flow

## Tests

- `pnpm --dir desktop check`
- `pnpm --dir desktop test` (3,906 passed)
- `pnpm --dir desktop exec playwright test tests/e2e/project-commit-detail.spec.ts` (4 passed)
- `pnpm --dir desktop build:e2e`
- `git diff --check`

`just ci` progressed through workspace formatting/clippy and Desktop checks, then stopped at Desktop Tauri clippy because this sandbox does not have the required system `glib-2.0` development package and cannot elevate via `sudo`.

## Duplicate search

No matching open issue or pull request found for the Projects zero-state creation bug.

Buzz channel: `952d1077-7db6-5bf4-badc-220cdc5c2863`
