### PR TITLE
fix(buzz-audit): close object_id/detail field-boundary collision in compute_hash (#4173)

### DIFF
--- a/crates/buzz-audit/src/hash.rs
+++ b/crates/buzz-audit/src/hash.rs
@@ -64,11 +64,20 @@ pub fn compute_hash(entry: &AuditEntry) -> Result<[u8; 32], AuditError> {
         }
         None => hasher.update([0u8]),
     }
-    hasher.update(canonical_json(&entry.detail)?.as_bytes());
+    // Fixed-width `prev_hash` sits between the two variable-length fields
+    // (`object_id`, `canonical_json(detail)`) so no byte shift across their
+    // boundary can leave the preimage unchanged. Both were previously adjacent:
+    // `hasher.update(object_id)` then `hasher.update(canonical_json(detail))`,
+    // and any pair `(oid="x", detail=12)` / `(oid="x1", detail=2)` hashed
+    // identically — a detail edit survived `verify_chain` (#4173). Moving
+    // `prev_hash` here makes the encoding unambiguous without length-prefix
+    // framing. This is a field-order change to `compute_hash` and invalidates
+    // existing chains by design, like any other.
     match &entry.prev_hash {
         Some(h) => hasher.update(h),
         None => hasher.update(GENESIS_HASH),
     }
+    hasher.update(canonical_json(&entry.detail)?.as_bytes());
     Ok(hasher.finalize().into())
 }
 
@@ -251,6 +260,40 @@ mod tests {
         let mut e = base.clone();
         e.prev_hash = Some(vec![0xff; 32]);
         assert_ne!(h0, compute_hash(&e).unwrap());
+    }
+
+    /// Issue #4173: `object_id` and `detail` are both variable-length and
+    /// were adjacent in the preimage, so a byte shift across their boundary
+    /// could keep the concatenated tail identical while the entry differs.
+    /// Both `("x", 12)` and `("x1", 2)` hashed to the same chain tail — an
+    /// entry could be substituted for a different one and `verify_chain`
+    /// still passed. The fixed-width `prev_hash` now sits between them, so no
+    /// such shift can keep the full preimage unchanged.
+    #[test]
+    fn object_id_detail_boundary_is_unambiguous() {
+        // Bare-scalar `detail` — the case that made the boundary shift live:
+        // a JSON scalar has no framing byte of its own.
+        let mut a = sample_entry();
+        a.object_id = Some("x".into());
+        a.detail = serde_json::json!(12);
+
+        let mut b = sample_entry();
+        b.object_id = Some("x1".into());
+        b.detail = serde_json::json!(2);
+
+        assert_ne!(compute_hash(&a).unwrap(), compute_hash(&b).unwrap());
+
+        // A second, string-skewed pair to exercise the same boundary with
+        // different byte lengths on each side.
+        let mut c = sample_entry();
+        c.object_id = Some("ab".into());
+        c.detail = serde_json::json!("c");
+
+        let mut d = sample_entry();
+        d.object_id = Some("a".into());
+        d.detail = serde_json::json!("bc");
+
+        assert_ne!(compute_hash(&c).unwrap(), compute_hash(&d).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #4173 — takes the issue author's suggested fix #2 (move a fixed-width field between the two variable-length fields).

`compute_hash` in `crates/buzz-audit/src/hash.rs` hashed `object_id` (`Option<String>`, free text) immediately followed by `canonical_json(detail)` (arbitrary `serde_json::Value`, possibly a bare scalar), **unframed**. Any byte shift across their boundary left the preimage identical:

| | `object_id` | `detail` | concatenated tail |
|---|---|---|---|
| A | `"x"` | `12` | `x` ‖ `12` = `x12` |
| B | `"x1"` | `2` | `x1` ‖ `2` = `x12` |

Both entries hashed to the same digest. A detail edit survived `verify_chain` — the property `entry.rs` documents ("*Arbitrary JSON context. **Included in the hash** (serialized with sorted keys for determinism) so tampering with it is detectable.*") was violated.

## Fix

Move the fixed-width `prev_hash` into the preimage between `object_id` and `detail`:

```
…community_id, seq, created_at, action,
actor_pubkey, object_id, prev_hash, canonical_json(detail)
```

The 32-byte `prev_hash` can't slide, so no byte shift across the (now separated) `object_id`/`detail` boundary can preserve the full preimage.

This is a **chain-invalidating field-order change**, by design — the same migration treatment any change to `compute_hash`'s fixed field order requires. Existing chains must be re-hashed, or the deployment must wipe and rebuild its audit chain. Maintenance of existing chains is the relay operator's responsibility, as documented on the issue.

Picked fix #2 over length-prefixing because it is the smallest structural change with no framing format to spec, parse, or bug on, and it composes with the existing `Some(vec![tag])` / `None` presence tags unchanged. Length-prefixing every variable-length field is a strictly stronger option if a future format revision is planned.

## Why this is safe

- Only `crates/buzz-audit/src/hash.rs` changes — 44 insertions, 1 deletion.
- All other `compute_hash` callers (`service`, `lib`, `entry`, `error`) pass entries, not preimages — they don't depend on field order.
- `prev_hash` was already part of the hash; only its **position** changed.

## Testing

New regression test `hash::tests::object_id_detail_boundary_is_unambiguous` pins both the exact repro pair from the issue (`object_id="x"`/`detail=12` versus `object_id="x1"`/`detail=2`) and a second string-skewed pair (`"ab"`+`"c"` versus `"a"`+`"bc"`) that exercises the same boundary at different byte lengths.

```
$ cargo test -p buzz-audit
running 20 tests
test hash::tests::object_id_detail_boundary_is_unambiguous ... ok
test hash::tests::sensitive_to_each_field ... ok
test hash::tests::canonical_json_key_order_is_stable ... ok
... (14/14 pass, 6 ignore — require Postgres)
test result: ok. 14 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
