### PR TITLE
fix(desktop): defer managed-agent pools by default

### DIFF
--- a/desktop/src-tauri/src/managed_agents/runtime.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime.rs
@@ -966,6 +966,10 @@ fn child_rust_log_filter() -> String {
     }
 }
 
+fn manual_start_uses_lazy_pool() -> bool {
+    true
+}
+
 pub fn start_managed_agent_process(
     app: &AppHandle,
     record: &mut ManagedAgentRecord,
@@ -998,7 +1002,16 @@ pub fn start_managed_agent_process(
     // Scalar PIDs are migration-only and never establish pair liveness.
     record.runtime_pid = None;
 
-    let mut process = spawn_agent_child(app, record, &key.relay_url, false, owner_hex)?;
+    // Manual starts and config-driven restarts must match launch restore's
+    // lazy behavior. Eager startup reserves every configured ACP slot before
+    // an event arrives, multiplying idle child processes across a fleet.
+    let mut process = spawn_agent_child(
+        app,
+        record,
+        &key.relay_url,
+        manual_start_uses_lazy_pool(),
+        owner_hex,
+    )?;
     let now = now_iso();
     let receipt = super::ManagedAgentRuntimeReceipt {
         key: key.clone(),

--- a/desktop/src-tauri/src/managed_agents/runtime/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/runtime/tests.rs
@@ -1,5 +1,10 @@
 use crate::managed_agents::known_acp_runtime;
 
+#[test]
+fn manual_start_defers_agent_pool_initialization() {
+    assert!(super::manual_start_uses_lazy_pool());
+}
+
 // ── desktop binary name tests ───────────────────────────────────────────
 
 #[test]

--- a/desktop/src-tauri/src/managed_agents/types.rs
+++ b/desktop/src-tauri/src/managed_agents/types.rs
@@ -811,7 +811,7 @@ pub struct UpdateTeamRequest {
 pub const DEFAULT_ACP_COMMAND: &str = "buzz-acp";
 /// ~5 min (320s) — matches the CLI harness default (BUZZ_ACP_IDLE_TIMEOUT).
 pub const DEFAULT_AGENT_TURN_TIMEOUT_SECONDS: u64 = 320;
-pub const DEFAULT_AGENT_PARALLELISM: u32 = 10;
+pub const DEFAULT_AGENT_PARALLELISM: u32 = 1;
 
 fn default_agent_parallelism() -> u32 {
     DEFAULT_AGENT_PARALLELISM

--- a/desktop/src-tauri/src/managed_agents/types/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/types/tests.rs
@@ -694,3 +694,12 @@ fn mint_rejects_out_of_range_input_parallelism() {
         "input-branch error must not blame the definition: {err}"
     );
 }
+
+#[test]
+fn managed_agent_parallelism_defaults_to_one() {
+    assert_eq!(
+        super::DEFAULT_AGENT_PARALLELISM,
+        1,
+        "one idle managed identity must not eagerly reserve multiple ACP runtimes",
+    );
+}


### PR DESCRIPTION
## Summary

- use the lazy ACP pool path for manual starts and config-driven restarts, matching launch restore
- lower default managed-agent parallelism from 10 to 1
- add policy regressions for both paths

## Why

Confirmed on Buzz 0.5.3 with a real multi-agent Hermes setup: 33 running `buzz-acp` parents each eagerly initialized 10 `hermes-acp` children. That produced 331 Hermes ACP processes using 7,634.4 MiB RSS before Buzz itself, with load average 32.72. The fleet was mostly idle.

Existing records with an explicit parallelism value are intentionally not rewritten. This changes safe defaults and prevents manual/config restarts from eagerly materializing every configured slot.

This adapts the designs from #2639 by @BrianSeong99 and #2676 by @Christian-Sidak onto current `main`; both earlier PRs currently conflict.

## Verification

- RED: focused runtime test failed because manual starts had no lazy-pool policy
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml -- --check`
- focused policy tests: 2 passed
- `cd desktop/src-tauri && cargo test`: 2,090 passed, 14 ignored; diagnostic integration tests 3 passed
- `cd desktop/src-tauri && cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- independent read-only review: no blocking findings

Fixes #2631.