### PR TITLE
fix(desktop): update vulnerable nostr relay pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -884,7 +884,13 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
       - name: Dependency policy
-        run: cargo-deny check
+        run: |
+          cargo-deny check
+          cargo-deny --locked \
+            --manifest-path desktop/src-tauri/Cargo.toml \
+            --target aarch64-apple-darwin \
+            --exclude-dev \
+            check --config deny.toml advisories
 
   dead-token-guard:
     name: Dead Token Reference Guard

--- a/deny.toml
+++ b/deny.toml
@@ -1,4 +1,8 @@
 [advisories]
+# Vulnerabilities remain fatal. Limit no-fix unmaintained notices to direct
+# workspace dependencies so target-specific transitive notices stay visible
+# without masking actionable vulnerability results.
+unmaintained = "workspace"
 ignore = [
     # instant 0.1.13 — unmaintained crate. Transitive dep: nostr → instant.
     # Will be resolved when nostr crate updates its dependencies.

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -6166,9 +6166,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-relay-pool"
-version = "0.44.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b2c039df4f96c4bf7dae52a74fd5516ad6dda83a11c0c69dea91b5255a4f37"
+checksum = "fb94d61a467a869a6790b907838a9bea82c813d567d9fcbac995f207be8cee4b"
 dependencies = [
  "async-utility",
  "async-wsocket",


### PR DESCRIPTION
## Summary

- update the independent desktop lockfile from `nostr-relay-pool` 0.44.1 to 0.44.2, fixing RUSTSEC-2026-0224
- scan the Apple Silicon desktop dependency graph in the Security job in addition to the root workspace graph
- keep vulnerabilities fatal while limiting no-fix `unmaintained` findings to direct workspace dependencies

Fixes #4251.

## Reproduction

At upstream commit `28ae6cd2174309529305724e455c7ca082f6fe4b`, the root `Cargo.lock` contains the fixed 0.44.2 release, but the separately resolved desktop lockfile still contains 0.44.1:

```console
$ cargo-deny --locked \
    --manifest-path desktop/src-tauri/Cargo.toml \
    --target aarch64-apple-darwin \
    --exclude-dev \
    check --config deny.toml advisories
error[vulnerability]: Signature verification bypass
  ID: RUSTSEC-2026-0224
  Crate: nostr-relay-pool 0.44.1
```

The existing root-only `cargo-deny check` does not inspect this independent lockfile.

## Solution

The desktop lockfile is pinned to 0.44.2, the first patched release. CI now runs a locked advisory scan for the supported Apple Silicon desktop target and excludes development-only dependencies. Vulnerabilities remain errors; `unmaintained = "workspace"` prevents unrelated, no-fix transitive notices from blocking the target-specific scan while preserving direct-dependency enforcement.

## Validation

- `cargo-deny check` — passed
- `cargo-deny --locked --manifest-path desktop/src-tauri/Cargo.toml --target aarch64-apple-darwin --exclude-dev check --config deny.toml advisories` — passed
- `cargo metadata --locked --manifest-path desktop/src-tauri/Cargo.toml --format-version 1 --no-deps` — passed
- workflow YAML parse and `git diff --check` — passed
- `just ci` — root checks, clippy, web/desktop checks and builds, Rust unit suites, and 2,087 desktop tests passed; one unrelated paused-clock timing test failed in the parallel suite, then passed in isolation:
  `cargo test --manifest-path desktop/src-tauri/Cargo.toml relay_admission::tests::concurrent_429_extends_the_window_for_parked_waiters -- --exact --nocapture`

## Scope

This intentionally does not change `nostr-sdk`; the bounded advisory fix is the patched `nostr-relay-pool` release already accepted in the root lockfile by #4139.
