### PR TITLE
docs(git-credential-nostr): document large-push (>1 MiB) 401 trap (#4195)

### DIFF
--- a/crates/git-credential-nostr/README.md
+++ b/crates/git-credential-nostr/README.md
@@ -57,6 +57,35 @@ git ──stdin──▶ git-credential-nostr ──stdout──▶ git
               (NIP-98 HTTP Auth)
 ```
 
+## Large pushes (> 1 MiB)
+
+Pushing a pack larger than git's `http.postBuffer` (default **1 MiB**) fails
+with a misleading `HTTP 401` followed by `send-pack: unexpected disconnect`
+and `Everything up-to-date` — even though nothing was pushed. Three
+correct-in-isolation behaviors compose into the failure:
+
+1. This helper returns `ephemeral=true`, so git caches nothing and sends the
+   `git-receive-pack` POST **unauthenticated first**, expecting to retry
+   after the 401 challenge.
+2. The Buzz server (correctly) answers the unauthenticated POST with 401.
+3. Git can only replay a challenged POST if the body is buffered; packs
+   larger than `http.postBuffer` are streamed chunked and cannot be
+   replayed → hard failure.
+
+**Workaround** — buffer the pack so the 401 retry can replay it:
+
+```bash
+git config --global http.postBuffer 524288000   # 500 MiB
+```
+
+The ±60 s NIP-98 window is not a problem: the helper mints the token at
+challenge time, after the buffered body is already in memory, so a 90 MB
+pack pushes fine once `http.postBuffer` is large enough.
+
+> **Note:** every fresh `git clone` initially hits this on the *first* push
+> that includes history > 1 MiB. The workaround is a per-user git config,
+> not a server-side change.
+
 ## Troubleshooting
 
 | Error | Cause | Fix |
@@ -65,5 +94,6 @@ git ──stdin──▶ git-credential-nostr ──stdout──▶ git
 | `insecure permissions` | Key file is readable by group/others | `chmod 600 ~/.nostr/key` |
 | `method hint` | Server's `WWW-Authenticate` header is missing `method="..."` | Upgrade the Buzz server |
 | `useHttpPath` | `credential.useHttpPath` is not set | `git config --global credential.useHttpPath true` |
+| `HTTP 401` + `send-pack: unexpected disconnect` + `Everything up-to-date` on first push | Pack > `http.postBuffer` (1 MiB) — streamed body cannot be replayed after the auth challenge | See [Large pushes](#large-pushes--1-mib) above |
 | Empty output / no auth | git version is older than 2.46 | Upgrade git |
 | `clock skew` / auth rejected | System clock is off by more than 60 s | Sync your system clock (`ntpdate`, `timedatectl`) |


### PR DESCRIPTION
## What

First push of any pack larger than ~1 MiB to Buzz git dies with a misleading `HTTP 401` → `send-pack: unexpected disconnect` → `Everything up-to-date` (nothing was actually pushed). Three correct-in-isolation behaviors compose into a guaranteed failure:

1. `git-credential-nostr` returns `ephemeral=true`, so git sends the `git-receive-pack` POST **unauthenticated first**, expecting to retry after the 401 challenge.
2. The Buzz server (correctly) answers the unauthenticated POST with 401.
3. Git can only replay a challenged POST if the body is buffered; packs larger than `http.postBuffer` (default **1 MiB**) are streamed chunked and cannot be replayed → hard failure.

This PR implements the issue's preferred fix (option 1, doc-only): a new **Large pushes** section in `crates/git-credential-nostr/README.md` explaining the composition trap and the verified workaround:

```bash
git config --global http.postBuffer 524288000   # 500 MiB
```

Also adds a Troubleshooting table row pointing at the new section.

Options 2 (preemptive auth within a single git invocation) and 3 (server-side `Expect: 100-continue`) are noted in the issue as follow-up if the doc proves insufficient; both are larger surface changes and the workaround is a one-line per-user config.

## Why doc-only

The failure is a composition of three correct behaviors — none of the three is a bug in isolation. The helper's `ephemeral=true` is correct (NIP-98 tokens are short-lived and must not be cached across invocations). The server's 401 on unauthenticated POST is correct (that's the challenge-response handshake). Git's streaming behavior is correct for large bodies. The doc surfaces the one knob (`http.postBuffer`) that makes the composition work, at near-zero risk.

## Verified against the issue

- Repro: 101 MB repo, first push fails at ~1 MiB threshold — matches the `http.postBuffer` default exactly.
- Workaround verified by issue author: 90 MB pack pushes fine after `git config http.postBuffer 524288000`.
- The ±60s NIP-98 window is not a problem: the helper mints the token at challenge time, after the buffered body is ready.

## Linked issue

Refs #4195
