### PR TITLE
fix(relay): materialize NIP-OA owner for direct members on closed relays (#4223)

### DIFF
--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -809,12 +809,14 @@ async fn submit_event_authed(
     )
     .await
     {
+        // On closed relays, direct members return Ok(None) — but a valid
+        // NIP-OA auth tag is still cryptographically self-proving. Hoist
+        // the extraction out of the `require_relay_membership` conditional
+        // so the owner is materialized regardless of which membership
+        // branch granted access. (Previously, closed-relay + direct-member
+        // silently dropped the attestation; see #4223.)
         Ok(owner) => owner.or_else(|| {
-            if !state.config.require_relay_membership {
-                super::relay_members::extract_nip_oa_owner(&pubkey_bytes, auth_tag)
-            } else {
-                None
-            }
+            super::relay_members::extract_nip_oa_owner(&pubkey_bytes, auth_tag)
         }),
         Err(e) => {
             return SubmitOutcome::Err {


### PR DESCRIPTION
## What

On a closed relay (`require_relay_membership = true`), an agent that is already a direct relay member has its NIP-OA auth tag silently dropped. `enforce_relay_membership` returns `Ok(None)` for direct members (the `Member` branch), and the `or_else` in `bridge.rs:812-818` skipped `extract_nip_oa_owner` when `require_relay_membership` was true — so `agent_owner_pubkey` was never materialized in `users`.

This made `channel_add_policy: owner_only` unenforceable in the intended direction (no owner on record to match against), and owner-scoped lookups (`buzz users get --owner <hex>`) returned nothing. The issue author's reproduction is unambiguous: removing the direct relay membership and republishing the identical event materializes the owner correctly.

## Fix

The NIP-OA auth tag is cryptographically self-proving — if `verify_auth_tag` succeeds, the owner relationship is authentic regardless of which membership branch granted access. Hoist `extract_nip_oa_owner` out of the `require_relay_membership` conditional so it runs unconditionally when `enforce_relay_membership` returns `Ok(None)`:

```rust
// Before:
Ok(owner) => owner.or_else(|| {
    if !state.config.require_relay_membership {
        super::relay_members::extract_nip_oa_owner(&pubkey_bytes, auth_tag)
    } else {
        None  // closed relay + direct member => owner never extracted
    }
}),

// After:
Ok(owner) => owner.or_else(|| {
    super::relay_members::extract_nip_oa_owner(&pubkey_bytes, auth_tag)
}),
```

The `if !require_relay_membership` guard was originally there because `extract_nip_oa_owner` was the open-relay fallback path. But the function itself has no dependency on the relay mode — it just verifies the auth tag signature. The guard was excluding exactly the case where it matters most.

## Behavioral matrix (after fix)

| Relay mode | Membership path | Auth tag | Owner materialized? |
|---|---|---|---|
| Open | (no check) | absent | No (unchanged) |
| Open | (no check) | valid | Yes (unchanged) |
| Closed | Direct member | absent | No (unchanged) |
| Closed | Direct member | valid | **Yes (fixed)** |
| Closed | Via owner | valid | Yes (unchanged — `or_else` not called) |
| Closed | Denied | — | Err (unchanged) |

## Tests

- `cargo check -p buzz-relay` — clean
- `cargo test -p buzz-relay --lib nip_oa` — 1/1 passed (existing `extract_nip_oa_owner` unit test)
- `cargo test -p buzz-relay --lib bridge` — 59/59 passed, 0 failed

The existing `extract_nip_oa_owner` unit tests (valid tag → Some(owner), no tag → None, invalid tag → None) already cover the function being called in the new position. The bridge handler tests that require Postgres are `#[ignore]` and not run here, but the 59 non-ignored bridge tests all pass.

## Linked issue

Refs #4223
