### PR TITLE
feat(workflow): support nested dot-notation in webhook trigger fields (#4235)

### DIFF
--- a/crates/buzz-relay/src/api/bridge.rs
+++ b/crates/buzz-relay/src/api/bridge.rs
@@ -1882,13 +1882,9 @@ pub async fn workflow_webhook(
         ..Default::default()
     };
     if let Some(Value::Object(ref map)) = body_json {
-        for (k, v) in map {
-            let val_str = match v {
-                Value::String(s) => s.clone(),
-                other => other.to_string(),
-            };
-            trigger_ctx.webhook_fields.insert(k.clone(), val_str);
-        }
+        // Flatten nested objects/arrays so `{{trigger.data.title}}` resolves
+        // (previously nested values were stringified whole; see #4235).
+        trigger_ctx.webhook_fields = buzz_workflow::executor::flatten_webhook_fields(map);
     }
     let trigger_ctx_json = serde_json::to_value(&trigger_ctx).ok();
 

--- a/crates/buzz-relay/src/handlers/command_executor.rs
+++ b/crates/buzz-relay/src/handlers/command_executor.rs
@@ -911,13 +911,9 @@ async fn handle_workflow_trigger(
     };
     if !event.content.is_empty() {
         if let Ok(serde_json::Value::Object(map)) = serde_json::from_str(&event.content) {
-            for (k, v) in map {
-                let val_str = match v {
-                    serde_json::Value::String(s) => s,
-                    other => other.to_string(),
-                };
-                trigger_ctx.webhook_fields.insert(k, val_str);
-            }
+            // Flatten nested fields so `{{trigger.data.title}}` resolves
+            // (previously nested values were stringified whole; see #4235).
+            trigger_ctx.webhook_fields = buzz_workflow::executor::flatten_webhook_fields(&map);
         }
     }
     let trigger_ctx_json = serde_json::to_value(&trigger_ctx).ok();

--- a/crates/buzz-workflow/src/executor.rs
+++ b/crates/buzz-workflow/src/executor.rs
@@ -59,6 +59,54 @@ impl TriggerContext {
     }
 }
 
+/// Flatten a JSON object into dotted-key webhook_fields entries.
+///
+/// Called by every webhook-population site (HTTP bridge, internal executor).
+/// Top-level keys seed `HashMap`; nested objects/arrays are recursively
+/// flattened to dot notation. Scalar values are stored as strings; objects
+/// and arrays are re-serialized to JSON.
+///
+/// Example input:
+/// ```json
+/// {"type":"workflow.failed","data":{"title":"Deploy","meta":{"attempt":3}}}
+/// ```
+/// Produces `webhook_fields` keys `type`, `data`, `data.title`,
+/// `data.meta`, `data.meta.attempt`.
+pub fn flatten_webhook_fields(map: &serde_json::Map<String, serde_json::Value>) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for (k, v) in map {
+        flatten_into(&mut out, k.clone(), v);
+    }
+    out
+}
+
+fn flatten_into(out: &mut HashMap<String, String>, prefix: String, value: &serde_json::Value) {
+    use serde_json::Value;
+    match value {
+        Value::Object(map) => {
+            // Store the serialized JSON at the prefix as well so
+            // `{{trigger.data}}` still resolves to the raw JSON for
+            // nested objects (existing behavior for top-level values).
+            out.insert(prefix.clone(), Value::Object(map.clone()).to_string());
+            for (k, v) in map {
+                flatten_into(out, format!("{prefix}.{k}"), v);
+            }
+        }
+        Value::Array(items) => {
+            out.insert(prefix.clone(), Value::Array(items.clone()).to_string());
+            for (i, v) in items.iter().enumerate() {
+                flatten_into(out, format!("{prefix}.{i}"), v);
+            }
+        }
+        Value::String(s) => {
+            out.insert(prefix, s.clone());
+        }
+        v @ (Value::Number(_) | Value::Bool(_) | Value::Null) => {
+            out.insert(prefix, v.to_string());
+        }
+    }
+}
+
 /// Resolve `{{trigger.X}}` and `{{steps.ID.output.X}}` placeholders in a string.
 ///
 /// Supports filters:
@@ -1325,6 +1373,95 @@ mod tests {
             .insert("service".to_owned(), "api-gateway".to_owned());
         let out = resolve_template("Service: {{trigger.service}}", &ctx, &HashMap::new()).unwrap();
         assert_eq!(out, "Service: api-gateway");
+    }
+
+    #[test]
+    fn flatten_nested_object_produces_dotted_keys() {
+        // #4235: nested webhook payload like CloudEvents'
+        // `{"type":"workflow.failed","data":{"title":"Deploy","reason":"Timeout"}}`
+        // must resolve `{{trigger.data.title}}` and `{{trigger.data.reason}}`.
+        let map: serde_json::Map<String, serde_json::Value> = serde_json::json!({
+            "type": "workflow.failed",
+            "data": {
+                "title": "Deploy",
+                "reason": "Timeout"
+            }
+        })
+        .as_object()
+        .expect("object")
+        .clone();
+
+        let fields = flatten_webhook_fields(&map);
+
+        // Top-level keys preserved.
+        assert_eq!(
+            fields.get("type").map(|s| s.as_str()),
+            Some("workflow.failed")
+        );
+        // Nested dotted keys resolve.
+        assert_eq!(fields.get("data.title").map(|s| s.as_str()), Some("Deploy"));
+        assert_eq!(fields.get("data.reason").map(|s| s.as_str()), Some("Timeout"));
+        // Raw object retained under its prefix so existing `{{trigger.data}}`
+        // templates still resolve to JSON.
+        let raw = fields.get("data").expect("data key");
+        assert!(raw.contains("\"title\":\"Deploy\"") || raw.contains("\"title\": \"Deploy\""));
+    }
+
+    #[test]
+    fn flatten_scalar_types_convert_to_strings() {
+        let map: serde_json::Map<String, serde_json::Value> = serde_json::json!({
+            "count": 42,
+            "enabled": true,
+            "missing": null
+        })
+        .as_object()
+        .expect("object")
+        .clone();
+
+        let fields = flatten_webhook_fields(&map);
+
+        assert_eq!(fields.get("count").map(|s| s.as_str()), Some("42"));
+        assert_eq!(fields.get("enabled").map(|s| s.as_str()), Some("true"));
+        assert_eq!(fields.get("missing").map(|s| s.as_str()), Some("null"));
+    }
+
+    #[test]
+    fn flatten_array_produces_indexed_dotted_keys() {
+        let map: serde_json::Map<String, serde_json::Value> = serde_json::json!({
+            "items": ["a", "b", {"nested": 3}]
+        })
+        .as_object()
+        .expect("object")
+        .clone();
+
+        let fields = flatten_webhook_fields(&map);
+
+        assert_eq!(fields.get("items.0").map(|s| s.as_str()), Some("a"));
+        assert_eq!(fields.get("items.1").map(|s| s.as_str()), Some("b"));
+        assert_eq!(fields.get("items.2.nested").map(|s| s.as_str()), Some("3"));
+    }
+
+    #[test]
+    fn resolve_template_uses_nested_webhook_field() {
+        // End-to-end: flattened dot-notation fields resolve in templates.
+        let map: serde_json::Map<String, serde_json::Value> = serde_json::json!({
+            "type": "incident.created",
+            "data": {"service": "api", "severity": "high"}
+        })
+        .as_object()
+        .expect("object")
+        .clone();
+
+        let mut ctx = make_trigger();
+        ctx.webhook_fields = flatten_webhook_fields(&map);
+
+        let out = resolve_template(
+            "Workflow: {{trigger.type}} | service={{trigger.data.service}} svc={{trigger.data.severity}}",
+            &ctx,
+            &HashMap::new(),
+        )
+        .unwrap();
+        assert_eq!(out, "Workflow: incident.created | service=api svc=high");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Webhook-triggered workflows received only top-level JSON fields because nested objects were stringified into a single value. A CloudEvents-style body like

```json
{"type":"workflow.failed","data":{"title":"Deploy","reason":"Timeout"}}
```

surfaced `{{trigger.type}}` → `"workflow.failed"` but `{{trigger.data.title}}` was unreachable — `data` itself was the entire serialized JSON, unusable as a sub-template key. Senders had to duplicate useful fields at the top level just for Buzz.

Both webhook-population sites had the same flat-stringify pattern (bridge.rs /workflows HTTP endpoint, command_executor.rs message_posted trigger with JSON content). This PR introduces a shared `flatten_webhook_fields` helper in `buzz-workflow::executor` that recursively flattens nested JSON objects/arrays into dot-notation keys, and swaps both call sites to use it.

## Behavior

| Template | Before | After |
|---|---|---|
| `{{trigger.data.title}}` | unresolved literal | `"Deploy"` |
| `{{trigger.data}}` | serialized JSON string | serialized JSON string (unchanged) |
| `{{trigger.data.meta.attempt}}` | unresolved | `"3"` |
| `{{trigger.items.0.name}}` | unresolved | array index lookup |
| `{{trigger.count}}` (top-level scalar) | `"42"` | `"42"` (unchanged) |

Objects and arrays are still stored under their prefix as serialized JSON, so consumers who want the whole envelope continue to work. Existing top-level templates are bit-for-bit identical.

## Implementation

One new shared function `flatten_webhook_fields(map: &serde_json::Map<String, serde_json::Value>) -> HashMap<String, String>` in `crates/buzz-workflow/src/executor.rs`:
- Recursively walks objects/arrays → `data.title`, `items.0.nested`
- Stores serialized JSON at the parent prefix for compatibility
- Scalar values stringified; strings kept as-is

Both former inline loops replaced with one call:
- `bridge.rs:1889` (HTTP `/workflows/{id}/webhook`)
- `command_executor.rs:919` (message_posted trigger parsing `event.content` as JSON)

## Tests

Four new unit tests in `crates/buzz-workflow/src/executor.rs`:
- `flatten_nested_object_produces_dotted_keys` — CloudEvents-style shape
- `flatten_scalar_types_convert_to_strings` — `number`/`bool`/`null`
- `flatten_array_produces_indexed_dotted_keys` — `items.0` etc.
- `resolve_template_uses_nested_webhook_field` — end-to-end substitution

`cargo test -p buzz-workflow --lib` — **157 passed, 0 failed** (4 new + 153 existing).
`cargo test -p buzz-relay --lib bridge` — **59 passed, 0 failed**.
`cargo check -p buzz-workflow -p buzz-relay` — clean.

## Linked issue

Refs #4235
