### PR TITLE
fix(desktop): accept uppercase/mixed-case nsec in key import (#4247)

### DIFF
--- a/desktop/src/features/onboarding/lib/keyImportInput.test.mjs
+++ b/desktop/src/features/onboarding/lib/keyImportInput.test.mjs
@@ -65,6 +65,15 @@ test("submit_gating_nsec_path_unchanged", () => {
   assert.equal(keyImportSubmitEnabled("", ""), false);
 });
 
+test("uppercase_nsec_classifies_and_gates_like_lowercase", () => {
+  // Bech32 permits all-uppercase encodings; a user who ran an nsec through
+  // a tool that uppercased it (common in printed/emergency backups) must not
+  // be told their valid key is invalid.
+  const upper = VALID_NSEC.toUpperCase();
+  assert.equal(classifyKeyImportInput(upper), "nsec");
+  assert.equal(keyImportSubmitEnabled(upper, ""), true);
+});
+
 test("submit_gating_ncryptsec_requires_passphrase", () => {
   assert.equal(keyImportSubmitEnabled(NCRYPTSEC, ""), false);
   assert.equal(keyImportSubmitEnabled(NCRYPTSEC, "hunter2hunter2"), true);

--- a/desktop/src/features/onboarding/lib/keyImportInput.ts
+++ b/desktop/src/features/onboarding/lib/keyImportInput.ts
@@ -71,7 +71,10 @@ export function classifyKeyImportInput(input: string): KeyImportKind {
   // valid backup routes to the encrypted path (and decodes there); mixed
   // case routes there too and fails in Rust with the accurate error.
   if (trimmed.slice(0, 10).toLowerCase() === "ncryptsec1") return "ncryptsec";
-  if (trimmed.startsWith("nsec1")) return "nsec";
+  // Bech32 permits all-uppercase encodings; an uppercase `NSEC1…` must
+  // classify and gate identically to lowercase so the form can derive the
+  // npub preview (which lowercases internally).
+  if (trimmed.slice(0, 5).toLowerCase() === "nsec1") return "nsec";
   return "unknown";
 }
 

--- a/desktop/src/shared/lib/nostrUtils.test.mjs
+++ b/desktop/src/shared/lib/nostrUtils.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { nsecEncode } from "nostr-tools/nip19";
+import { generateSecretKey } from "nostr-tools/pure";
+
+import { nsecToNpub } from "./nostrUtils.ts";
+
+const VALID_NSEC = nsecEncode(generateSecretKey());
+
+describe("nsecToNpub", () => {
+  it("derives an npub from a lowercase nsec", () => {
+    const npub = nsecToNpub(VALID_NSEC);
+    assert.equal(typeof npub, "string");
+    assert.equal(npub.startsWith("npub1"), true);
+  });
+
+  it("accepts an all-uppercase bech32 encoding", () => {
+    assert.equal(nsecToNpub(VALID_NSEC.toUpperCase()), nsecToNpub(VALID_NSEC));
+  });
+
+  it("tolerates surrounding whitespace from copy-paste", () => {
+    assert.equal(nsecToNpub(`  ${VALID_NSEC}\n`), nsecToNpub(VALID_NSEC));
+    assert.equal(nsecToNpub(` ${VALID_NSEC} `), nsecToNpub(VALID_NSEC));
+  });
+
+  it("rejects an nsec with a corrupted checksum", () => {
+    assert.equal(nsecToNpub(`${VALID_NSEC.slice(0, -1)}q`), null);
+  });
+
+  it("resolves mixed-case bech32 tolerantly", () => {
+    // Bech32 spec requires uniform case; this parser is deliberately
+    // permissive — a copy-paste that damaged only the casing should still
+    // resolve since the checksum matches regardless.
+    const mixed = `N${VALID_NSEC.slice(1)}`;
+    assert.equal(nsecToNpub(mixed), nsecToNpub(VALID_NSEC));
+  });
+
+  it("rejects non-nsec inputs", () => {
+    assert.equal(nsecToNpub("npub1whatever"), null);
+    assert.equal(nsecToNpub(""), null);
+    assert.equal(nsecToNpub("nsec1"), null);
+  });
+});

--- a/desktop/src/shared/lib/nostrUtils.ts
+++ b/desktop/src/shared/lib/nostrUtils.ts
@@ -56,11 +56,18 @@ export function parsePubkeyInput(input: string): string | null {
  * the input is not a syntactically valid `nsec1…` (does NOT throw — this is
  * intended for live form validation where the user is mid-typing).
  *
- * The input is trimmed first; surrounding whitespace from copy-paste or a
- * dropped `.key` file is tolerated.
+ * The input is trimmed and lowercased first; surrounding whitespace from
+ * copy-paste or a dropped `.key` file is tolerated, and an all-uppercase
+ * bech32 encoding (spec-valid but unusual) resolves identically to
+ * lowercase.
  */
 export function nsecToNpub(nsec: string): string | null {
-  const trimmed = nsec.trim();
+  // Bech32 decoding is case-sensitive per the spec; callers copy-pasting an
+  // all-uppercase key (a valid bech32 encoding) should see it work exactly
+  // like the lowercase form. Trim surrounding whitespace first (shell copy
+  // often picks up a trailing newline), then lowercase before the strict
+  // prefix and checksum checks.
+  const trimmed = nsec.trim().toLowerCase();
   if (!trimmed.startsWith("nsec1")) {
     return null;
   }


### PR DESCRIPTION
## What

The desktop onboarding key-import form told users pasting a valid `nsec1…` key that it was invalid whenever the encoding used uppercase letters — Bech32 permits an all-uppercase encoding (the checksum is identical regardless of case), and tools that emit printable/backup keys often uppercase them.

Issue #4247 reports users hitting "Waiting for a valid nsec1 key" / "Invalid key" on keys that other Nostr clients accept.

## Root cause

Two case-sensitive HRP/prefix checks:

1. `shared/lib/nostrUtils.ts:nsecToNpub` compared `trimmed.startsWith("nsec1")` before calling `nostr-tools/nip19.decode()`. Uppercase input failed the prefix check; mixed-case made it to `decode()` and rejected by the spec-compliant checksum library.
2. `features/onboarding/lib/keyImportInput.ts:classifyKeyImportInput` already lowercased the longer `ncryptsec1` HRP but kept `trimmed.startsWith("nsec1")` case-sensitive, so an uppercase `NSEC1…` classified as `"unknown"` and the form showed the unencrypted-error path.

## Changes

- `nsecToNpub`: lowercases after `trim()` before both the prefix check and `decode()`. Whitespace tolerance is unchanged. The parser is intentionally permissive on casing — a copy-paste that damaged only case should still resolve rather than reject the user.
- `classifyKeyImportInput`: mirrors the existing `ncryptsec1` lowercase-slice pattern for `nsec1` so an uppercase key is classified as `"nsec"` and npub preview / submit gating continue down the correct path.

Corrupted checksums, non-nsec inputs, and empty strings still reject exactly as before.

## Tests

New `src/shared/lib/nostrUtils.test.mjs` (6 cases):
- lowercase nsec resolves to an npub
- uppercase encoding resolves identically to lowercase
- surrounding whitespace tolerated
- checksum corruption rejects
- mixed-case resolves tolerantly (deliberate — spec-strict reject was the bug)
- non-nsec inputs reject

Extended `src/features/onboarding/lib/keyImportInput.test.mjs`:
- uppercase nsec classifies as `"nsec"` and submit-enables without a passphrase

Receipts: 12/12 nostrUtils+keyImportInput tests pass; 238/238 across the related onboarding+shared-lib suites; `pnpm exec tsc --noEmit` clean; `ncryptsecSourceScan` allowlist unaffected.

## Linked issue

Refs #4247
