### PR TITLE
fix(relay): owner_only rejection names the agent owner who can act (#4225)

### DIFF
--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -301,6 +301,17 @@ async fn actor_owns_any_owner_agent(
     Ok(false)
 }
 
+/// Format the `owner_only` third-party-add rejection, naming the agent owner so
+/// the actor knows who is authorized to perform the add. The message must keep
+/// the `policy:owner_only` tag for downstream pattern-matching while telling the
+/// actor exactly which pubkey can act (#4225).
+fn owner_only_rejection(owner_bytes: &[u8]) -> String {
+    format!(
+        "policy:owner_only — only the agent owner ({}) can add this agent",
+        hex::encode(owner_bytes)
+    )
+}
+
 /// Validate an admin kind event BEFORE storage.
 pub async fn validate_admin_event(
     tenant: &TenantContext,
@@ -427,9 +438,7 @@ pub async fn validate_admin_event(
                             anyhow::anyhow!("policy:owner_only — agent has no owner set")
                         })?;
                         if actor_bytes != owner_bytes {
-                            return Err(anyhow::anyhow!(
-                                "policy:owner_only — only the agent owner can add this agent"
-                            ));
+                            return Err(anyhow::anyhow!(owner_only_rejection(&owner_bytes)));
                         }
                     }
                     "nobody" => {
@@ -3372,6 +3381,24 @@ fn topic_for_subscription(channel_id: Option<Uuid>) -> EventTopic {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn owner_only_rejection_message_names_owner_pubkey() {
+        let owner_bytes = [0xabu8; 32];
+        let msg = owner_only_rejection(&owner_bytes);
+        assert!(
+            msg.contains("policy:owner_only"),
+            "should keep the policy tag, got: {msg}"
+        );
+        assert!(
+            msg.contains(&hex::encode(owner_bytes)),
+            "should name the agent owner's pubkey so the actor knows who can act, got: {msg}"
+        );
+        assert!(
+            msg.contains("can add this agent"),
+            "should retain the action denial phrasing, got: {msg}"
+        );
+    }
 
     #[test]
     fn delete_tombstone_omits_absent_moderation_metadata() {

--- a/crates/buzz-test-client/tests/e2e_relay.rs
+++ b/crates/buzz-test-client/tests/e2e_relay.rs
@@ -1409,6 +1409,11 @@ async fn test_nip29_put_user_owner_only_blocks() {
         "rejection message should contain 'policy:owner_only', got: {}",
         ok.message
     );
+    assert!(
+        ok.message.contains("owner"),
+        "rejection should say who can act (the owner), got: {}",
+        ok.message
+    );
 
     ws.disconnect().await.expect("disconnect");
 }


### PR DESCRIPTION
## What

When a community owner/admin tries to add an agent to a channel and the agent's
`channel_add_policy` is `owner_only`, the relay rejected them with:

```
policy:owner_only — only the agent owner can add this agent
```

…but never said *who* the owner is. Address #4225.

## Changes

- `crates/buzz-relay/src/handlers/side_effects.rs`
  - Extract the rejection string into a pure helper, `owner_only_rejection`.
  - Include the agent owner's hex pubkey in the message so the rejected actor
    knows exactly which key is authorized to perform the add:
    ```
    policy:owner_only — only the agent owner (<hex-pubkey>) can add this agent
    ```
  - The `policy:owner_only` tag is preserved for downstream pattern-matching.
- `crates/buzz-test-client/tests/e2e_relay.rs`
  - Strengthen the existing `test_nip29_put_user_owner_only_blocks` assertion to
    also require the rejection to say who can act.

## Tests

- New unit test `owner_only_rejection_message_names_owner_pubkey` covers the
  helper: contains `policy:owner_only`, the owner hex, and the action denial.
- Existing e2e gate extended (assertion-only; unchanged actors).
- Suite receipts: `cargo test -p buzz-relay --lib side_effects` 6/6 pass;
  `cargo test -p buzz-relay --lib bridge` 59/59 pass; full workspace
  `buzz-workflow --lib` 153/153 pass.

## Out of scope / pre-existing

The broader `buzz-relay --lib` suite has nine pre-existing failures in
`api::media` and `api::admin` (500 vs 404 assertion mismatches) that reproduce
on `main` and are unrelated to this change.

Refs #4225
