### PR TITLE
fix(desktop): persist Edit Agent provider/model edits for linked personas (#4157)

### DIFF
--- a/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
+++ b/desktop/src/features/agents/ui/AgentInstanceEditDialog.tsx
@@ -10,6 +10,7 @@ import {
   usePersonasQuery,
   useStartManagedAgentMutation,
   useUpdateManagedAgentMutation,
+  useUpdatePersonaMutation,
 } from "@/features/agents/hooks";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import type {
@@ -49,6 +50,7 @@ import {
 } from "./relayMeshModelPicker";
 import {
   computeEditAgentFormValidity,
+  computeLinkedPersonaProviderModelPatch,
   envVarsEqual,
   isEditAgentProviderSaveValid,
   resolveAgentCommandUpdate,
@@ -113,6 +115,7 @@ export function AgentInstanceEditDialog({
   onUpdated?: (agent: ManagedAgent) => void;
 }) {
   const updateMutation = useUpdateManagedAgentMutation();
+  const updatePersonaMutation = useUpdatePersonaMutation();
   const startMutation = useStartManagedAgentMutation();
   const runtimesQuery = useAcpRuntimesQuery({ enabled: open });
   const configSurfaceQuery = useAgentConfigSurface(open ? agent.pubkey : null);
@@ -726,6 +729,28 @@ export function AgentInstanceEditDialog({
       };
 
       const result = await updateMutation.mutateAsync(input);
+      // #4157: for a linked persona, propagate provider/model edits to the
+      // definition so the config survives restart. Built-in personas (e.g.
+      // Honey, Bumble) ship with provider/model unset; without this write the
+      // edited value is silently dropped and the agent shows "needs
+      // configuration" after restart.
+      if (linkedPersona != null) {
+        const patch = computeLinkedPersonaProviderModelPatch({
+          hasLinkedPersona: linkedPersona != null,
+          provider,
+          model,
+          personaProvider: linkedPersona.provider,
+          personaModel: linkedPersona.model,
+        });
+        if (patch != null) {
+          await updatePersonaMutation.mutateAsync({
+            id: linkedPersona.id,
+            displayName: linkedPersona.displayName,
+            systemPrompt: linkedPersona.systemPrompt,
+            ...patch,
+          });
+        }
+      }
       if (autoRestartOnConfigChange !== agent.autoRestartOnConfigChange) {
         // Standalone setter (mirrors start-on-app-launch) — not part of
         // UpdateManagedAgentInput, so the frozen update shape stays frozen.

--- a/desktop/src/features/agents/ui/agentInstanceLinkedPersonaPatch.test.mjs
+++ b/desktop/src/features/agents/ui/agentInstanceLinkedPersonaPatch.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  computeLinkedPersonaProviderModelPatch,
+} from "./personaRuntimeModel.ts";
+
+// ── #4157: linked built-in persona provider/model propagation ─────────────
+//
+// Bug: editing a linked agent's provider or model in the Edit Agent dialog
+// silently discards the value for built-in personas because the submit path
+// defers provider/model to the persona definition (which ships with both
+// unset). The fix propagates the edited values to the definition via
+// computeLinkedPersonaProviderModelPatch + useUpdatePersonaMutation.
+//
+// These tests exercise the pure helper with the same call shape the dialog
+// uses, mirroring agentInstanceEditPinning.test.mjs's chain-the-component
+// discipline.
+
+test("linked: returns null when local provider and model match persona", () => {
+  const result = computeLinkedPersonaProviderModelPatch({
+    hasLinkedPersona: true,
+    provider: "anthropic",
+    model: "claude-sonnet-4-5",
+    personaProvider: "anthropic",
+    personaModel: "claude-sonnet-4-5",
+  });
+  assert.equal(result, null);
+});
+
+test("linked: returns null when local values are empty/whitespace", () => {
+  const result = computeLinkedPersonaProviderModelPatch({
+    hasLinkedPersona: true,
+    provider: "  ",
+    model: "   ",
+    personaProvider: "anthropic",
+    personaModel: "claude-sonnet-4-5",
+  });
+  assert.equal(result, null);
+});
+
+test("linked: patches only provider when model is unchanged", () => {
+  const result = computeLinkedPersonaProviderModelPatch({
+    hasLinkedPersona: true,
+    provider: "databricks",
+    model: "claude-sonnet-4-5",
+    personaProvider: null,
+    personaModel: "claude-sonnet-4-5",
+  });
+  assert.deepEqual(result, { provider: "databricks" });
+});
+
+test("linked: patches only model when provider is unchanged", () => {
+  const result = computeLinkedPersonaProviderModelPatch({
+    hasLinkedPersona: true,
+    provider: "anthropic",
+    model: "claude-haiku-4-5-20251001",
+    personaProvider: "anthropic",
+    personaModel: "claude-sonnet-4-5",
+  });
+  assert.deepEqual(result, { model: "claude-haiku-4-5-20251001" });
+});
+
+test("linked: patches both when both differ", () => {
+  const result = computeLinkedPersonaProviderModelPatch({
+    hasLinkedPersona: true,
+    provider: "databricks",
+    model: "claude-haiku-4-5-20251001",
+    personaProvider: "anthropic",
+    personaModel: "claude-sonnet-4-5",
+  });
+  assert.deepEqual(result, {
+    provider: "databricks",
+    model: "claude-haiku-4-5-20251001",
+  });
+});
+
+test("linked: fills unset persona fields from local edits", () => {
+  // Built-in personas ship with provider/model unset — the precise #4157
+  // scenario. Any non-empty local edit must propagate.
+  const result = computeLinkedPersonaProviderModelPatch({
+    hasLinkedPersona: true,
+    provider: "anthropic",
+    model: "claude-sonnet-4-5",
+    personaProvider: null,
+    personaModel: null,
+  });
+  assert.deepEqual(result, {
+    provider: "anthropic",
+    model: "claude-sonnet-4-5",
+  });
+});
+
+test("linked: trims whitespace before comparing", () => {
+  const result = computeLinkedPersonaProviderModelPatch({
+    hasLinkedPersona: true,
+    provider: " anthropic ",
+    model: "  claude-sonnet-4-5 ",
+    personaProvider: "anthropic",
+    personaModel: "claude-sonnet-4-5",
+  });
+  assert.equal(result, null);
+});
+
+test("unlinked: always returns null (instance path handles it)", () => {
+  const result = computeLinkedPersonaProviderModelPatch({
+    hasLinkedPersona: false,
+    provider: "databricks",
+    model: "claude-sonnet-4-5",
+    personaProvider: "anthropic",
+    personaModel: "claude-sonnet-4-5",
+  });
+  assert.equal(result, null);
+});

--- a/desktop/src/features/agents/ui/personaRuntimeModel.ts
+++ b/desktop/src/features/agents/ui/personaRuntimeModel.ts
@@ -301,3 +301,47 @@ export function envVarsEqual(
     aKeys.every((key) => a[key] === b[key])
   );
 }
+
+/**
+ * Compute the persona-definition patch needed when a linked agent's provider
+ * or model is edited in the Edit Agent dialog.
+ *
+ * For built-in linked personas (e.g. Honey, Bumble), the dialog deliberately
+ * drops `provider`/`model`/`systemPrompt` from the instance update because it
+ * defers to the persona definition. Built-in definitions ship with
+ * provider/model unset, so the edited values are silently discarded and the
+ * agent falls back to global defaults — surfacing as "needs configuration"
+ * after restart.
+ *
+ * Return `null` when no persona write is needed (all three below must hold):
+ * - hasLinkedPersona is false (unlinked instance, provider/model persist via
+ *   UpdateManagedAgentInput)
+ * - the local value is empty/whitespace (leave the definition's existing
+ *   value alone; never null out a persona field from the instance dialog)
+ * - the local value matches the persona's current value (no-op)
+ *
+ * Otherwise return the subset of `{ provider, model }` that differs, ready to
+ * spread into an `UpdatePersonaInput`.
+ */
+export function computeLinkedPersonaProviderModelPatch(input: {
+  hasLinkedPersona: boolean;
+  provider: string;
+  model: string;
+  personaProvider: string | null;
+  personaModel: string | null;
+}): { provider?: string; model?: string } | null {
+  if (!input.hasLinkedPersona) return null;
+
+  const patch: { provider?: string; model?: string } = {};
+  const localProvider = input.provider.trim();
+  const localModel = input.model.trim();
+
+  if (localProvider.length > 0 && localProvider !== (input.personaProvider ?? "")) {
+    patch.provider = localProvider;
+  }
+  if (localModel.length > 0 && localModel !== (input.personaModel ?? "")) {
+    patch.model = localModel;
+  }
+
+  return Object.keys(patch).length > 0 ? patch : null;
+}


### PR DESCRIPTION
## Problem

For linked built-in personas (e.g. Honey, Bumble), the Edit Agent dialog drops `provider`/`model`/`systemPrompt` from the instance update because it defers those fields to the persona definition. Built-in definitions ship with provider and model unset, so the edited values are silently discarded — the agent falls back to global defaults and surfaces as "needs configuration" after restart.

## Root cause

`AgentInstanceEditDialog.handleSubmit` sends `provider: undefined` and `model: undefined` whenever `linkedPersona != null`, deferring to the definition (see lines ~700-710). For built-in personas, the definition has no provider/model set, so the definition-first resolver in `resolve_linked` (`effective_config/mod.rs:74-109`) falls back to global defaults.

## Fix

1. **`computeLinkedPersonaProviderModelPatch()`** (new pure helper in `personaRuntimeModel.ts`) — returns the subset of `{provider, model}` that differs from the persona definition, or `null` when nothing changed. Empty/whitespace local values never propagate; linked-write fires only for linked personas.

2. **`handleSubmit` wiring** — after the instance mutation succeeds, calls `useUpdatePersonaMutation` with the patch (spread into `UpdatePersonaInput` with the persona's existing `displayName` and `systemPrompt` preserved) when `linkedPersona != null` and the patch is non-null.

Unlinked instances are completely unaffected.

## Tests

- `agentInstanceLinkedPersonaPatch.test.mjs` — 8 tests covering: no-op (values match), whitespace-only (never null out), provider-only/model-only/both-diff patches, built-in-unset-fills-local scenario, trim behavior, and the unlinked guard.
- All 3914 existing desktop webview tests pass.
- `cargo check --lib` on `desktop/src-tauri` clean.

Refs #4157