### PR TITLE
fix(desktop): repair stale Kimi `--acp` pin to `acp` subcommand on spawn

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -479,6 +479,21 @@ pub fn normalize_agent_args(command: &str, agent_args: Vec<String>) -> Vec<Strin
         .filter(|arg| !arg.is_empty())
         .collect::<Vec<_>>();
 
+    // Repair a stale `--acp` pin for the Kimi harness: the preset used to launch
+    // Kimi Code as `kimi --acp`, but the CLI's ACP mode is the subcommand
+    // `kimi acp`. Records created before the preset switched still carry
+    // `agent_args == ["--acp"]` and win over the definition at spawn time
+    // (instance args take precedence in `resolve_effective_harness_descriptor`),
+    // so those agents crash on every launch with "unknown option '--acp'".
+    // Canonicalize a sole `--acp` to `acp` only when the resolved command is
+    // Kimi — this is a harness-shape repair, not a blanket flag strip.
+    if normalize_command_identity(command) == "kimi"
+        && normalized.len() == 1
+        && normalized[0].eq_ignore_ascii_case("--acp")
+    {
+        return vec!["acp".to_string()];
+    }
+
     let Some(default_args) = default_agent_args(command) else {
         return normalized;
     };

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -95,6 +95,44 @@ fn normalizes_buzz_agent_args_to_empty() {
 }
 
 #[test]
+fn repairs_stale_kimi_acp_flag_to_subcommand() {
+    // Records created when the Kimi preset used `--acp` pin that stale flag in
+    // `agent_args`; at spawn, instance args win over the preset definition, so
+    // the agent still launches `kimi --acp` and the CLI rejects the unknown
+    // option. Normalization must rewrite the sole `--acp` to the `acp`
+    // subcommand for the Kimi command — and leave every other shape alone.
+    assert_eq!(
+        normalize_agent_args("kimi", vec!["--acp".into()]),
+        vec!["acp".to_string()]
+    );
+    // Path-pinned commands resolve to the same identity.
+    assert_eq!(
+        normalize_agent_args("/Users/a/.kimi-code/bin/kimi", vec!["--acp".into()]),
+        vec!["acp".to_string()]
+    );
+    // Other commands keep the flag verbatim — this is not a blanket strip.
+    assert_eq!(
+        normalize_agent_args("goose", vec!["--acp".into()]),
+        vec!["--acp".to_string()]
+    );
+    assert_eq!(
+        normalize_agent_args("custom-agent", vec!["--acp".into()]),
+        vec!["--acp".to_string()]
+    );
+    // Kimi with additional args is not a stale pin — left untouched.
+    assert_eq!(
+        normalize_agent_args("kimi", vec!["--acp".into(), "--verbose".into()]),
+        vec!["--acp".to_string(), "--verbose".to_string()]
+    );
+    // Already-correct shapes are idempotent.
+    assert_eq!(
+        normalize_agent_args("kimi", vec!["acp".into()]),
+        vec!["acp".to_string()]
+    );
+    assert_eq!(normalize_agent_args("kimi", Vec::new()), Vec::<String>::new());
+}
+
+#[test]
 fn login_shell_lookup_treats_command_as_data() {
     let marker =
         std::env::temp_dir().join(format!("buzz-discovery-marker-{}", uuid::Uuid::new_v4()));


### PR DESCRIPTION
## Summary
Fixes #4106.

The built-in Kimi harness must launch Kimi Code in ACP mode via the subcommand `kimi acp`, but agents created before the preset switched still carry the stale `--acp` flag pinned in their `agent_args`. At spawn time, explicit instance args take precedence over the preset definition in `resolve_effective_harness_descriptor`, so those records keep launching `kimi --acp`, the CLI rejects the unknown option, and every start fails.

This is the same class of harness-shape normalization the codebase already applies for the goose/claude/codex trip (`normalize_agent_args`).

## Root cause
`normalize_agent_args` canonicalizes arg shape but did not repair the Kimi `--acp` → `acp` flag→subcommand transition, so stale pinned records won over the current preset forever.

## Fix
Extend `normalize_agent_args` to rewrite a sole `--acp` to `acp` only when the resolved command identity is `kimi` (path-pinned commands resolve to the same identity via `normalize_command_identity`). This is a single canonical chokepoint used by the spawn, summary, hash, and dangling-harness fallback paths. Every other command and arg shape — including Kimi with additional flags, non-Kimi commands, and already-correct shapes — is left untouched.

## Reproduction
1. On a build predating the preset change, create a Kimi-harness agent (persisting `agent_args = ["--acp"]`).
2. Upgrade to current Buzz (preset now `kimi acp`).
3. Start the agent.
4. Observe `agent_cmd=...kimi --acp`, `error: unknown option '--acp'`, `all N agents failed to start`.

## Testing
- New unit test `managed_agents::discovery::tests::repairs_stale_kimi_acp_flag_to_subcommand` covers: bare `kimi` command, path-pinned command, non-Kimi commands preserved, Kimi with extra args untouched, already-correct shapes idempotent.
- Full `cargo test --lib` in `desktop/src-tauri`: **2089 passing, 0 failed**.

## Notes for reviewers
- No schema or store migration — the repair happens at the canonical spawn arg-normalization layer, so existing pinned records self-heal on next launch without touching user data.
- No changeset convention in this repo; single-file Rust fix + colocated tests.

Signed-off-by: Sarthak Singh <sarthak.singh@juspay.in>