### PR TITLE
fix(relay,desktop): surface CORS rejections and split invite mint/copy errors (#3636)

### DIFF
--- a/crates/buzz-relay/src/router.rs
+++ b/crates/buzz-relay/src/router.rs
@@ -439,8 +439,24 @@ fn build_cors_layer(cors_origins: &[String]) -> CorsLayer {
         return CorsLayer::new();
     }
 
+    // Log each rejected origin at `warn!` before falling through to the CORS
+    // denial. Without this, a non-allowlisted origin is silently refused by the
+    // outer CORS layer and never reaches the inner trace layer — turning a
+    // two-minute config fix into hours of invisible debugging (#3636).
+    let allow = AllowOrigin::predicate(move |origin: &axum::http::HeaderValue, _parts: &axum::http::request::Parts| {
+        let allowed = origins.contains(origin);
+        if !allowed {
+            tracing::warn!(
+                target: "buzz_relay",
+                origin = %origin.to_str().unwrap_or("<non-utf8>"),
+                "CORS rejected origin — not in BUZZ_CORS_ORIGINS"
+            );
+        }
+        allowed
+    });
+
     CorsLayer::new()
-        .allow_origin(AllowOrigin::list(origins))
+        .allow_origin(allow)
         .allow_methods(tower_http::cors::Any)
         .allow_headers(tower_http::cors::Any)
 }

--- a/desktop/src/features/community-members/ui/InviteLinkSection.tsx
+++ b/desktop/src/features/community-members/ui/InviteLinkSection.tsx
@@ -140,13 +140,29 @@ export function InviteLinkSection({
   async function handleCopy() {
     if (!inviteUrl || isGenerating || copyStatus === "copying") return;
     setCopyStatus("copying");
+
+    // Two distinct failure modes: network/NIP-98/auth errors from
+    // mintInvite (leave no clipboard state behind) versus clipboard-write
+    // failures (invite was minted — and relay_invites stores only the hash
+    // — so the code is unrecoverable, but at least the user knows to fix
+    // their clipboard). See #3636.
+    let invite;
     try {
-      await writeTextToClipboard(inviteUrl);
+      invite = await mintInvite({ ttlSecs, maxUses });
+    } catch (error) {
+      setCopyStatus("idle");
+      const message =
+        error instanceof Error ? error.message : "unknown error";
+      toast.error(`Couldn’t create the invite: ${message}`);
+      return;
+    }
+    try {
+      await writeTextToClipboard(invite.url);
       setCopyStatus("copied");
       toast.success("Invite link copied");
     } catch {
       setCopyStatus("idle");
-      toast.error("Couldn’t copy the invite link. Try again.");
+      toast.error("Invite created, but copying to the clipboard failed.");
     }
   }
 


### PR DESCRIPTION
Two independent fixes for the same failure class reported in #3636: a misconfigured `BUZZ_CORS_ORIGINS` produces invisible failures that cost self-hosters hours.

## Fix 1: warn-log rejected CORS origins (relay)

`crates/buzz-relay/src/router.rs`

Before, a non-allowlisted origin was silently refused by the outermost CORS layer and never reached the inner trace layer — no log line at any `RUST_LOG` level. Now every rejected origin is logged at `warn!` with the received origin value.

## Fix 2: split invite mint/copy error paths (desktop)

`desktop/src/features/community-members/ui/InviteLinkSection.tsx`

Before, the combined `try` around `mintInvite` + `writeTextToClipboard` collapsed any `mintInvite` failure (CORS, NIP-98 401/403, timeout, 5xx) into the misleading toast "Couldn't copy the invite link" — sending users to clipboard permissions instead of the actual network error. Mint failures now surface the underlying `error.message` from `invitePost`; clipboard failures keep a distinct message, which matters because the minted invite (stored only as `token_hash` in `relay_invites`) is unrecoverable after a failed clipboard write.

Fixes #3636.