### PR TITLE
docs(acp): clarify buzz CLI auth scope in base_prompt

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -2,7 +2,7 @@ You are operating inside the Buzz platform — a Nostr-based messaging platform 
 
 ## Buzz CLI
 
-The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`. Exit codes: 0 ok, 1 user error, 2 network, 3 auth, 4 other. Output is structured JSON.
+The `buzz` CLI is your primary interface. It is pre-authenticated **inside the Buzz MCP shell tool**; your runtime's own built-in terminal may not carry `BUZZ_PRIVATE_KEY` (some runtimes scrub credentials from tool subprocesses). Auth env vars, when present: `BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`. Exit codes: 0 ok, 1 user error, 2 network, 3 auth, 4 other. Output is structured JSON. If `buzz` returns `auth_error`, re-run the command through the Buzz MCP shell tool rather than trying to export credentials yourself.
 
 | Group | Key commands |
 |-------|-------------|


### PR DESCRIPTION
Fixes #4224.

**Category:** documentation (prompt-only fix)
**User impact:** Agents running in runtimes that strip credential env vars from tool subprocesses (e.g. Hermes) previously got stuck on `auth_error` and falsely self-reported "Buzz is down." They now route through the Buzz MCP shell tool, which is the actual auth carrier.

## Problem

`crates/buzz-acp/src/base_prompt.md:5` reads:

> The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`.

Those vars are authentic **only** inside the MCP server spawned by `buzz-acp` (`build_mcp_servers` injects them). An agent using its runtime's native terminal (Hermes strips `BUZZ_*` citing GHSA-rhgp-j443-p4rf) sees none of them. The prompt gave no hint that the MCP shell tool was the working path, so the agent follows its own instructions into a failure it cannot diagnose.

## Fix

Update the prompt to (a) name the MCP shell tool as the auth carrier, (b) keep the env-var list for runtimes that DO carry credentials, (c) tell the agent to re-run via MCP shell on `auth_error`. One line of actual prompt text (before/after in the diff), the wording adapted from the reporter's suggested copy.

## Validation

- `cargo check -p buzz-acp` clean (4.1s)
- `cargo clippy -p buzz-acp --lib` zero warnings
- `cargo test -p buzz-acp --lib` 661/661 passing

No behavior change; prompt text only. (The `base_prompt.md` file is `include_str!`'d into the binary, so a change here flows into every newly-spawned agent session.)