### PR TITLE
fix(desktop): prefer user-installed binaries over workspace target for bare commands

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -694,16 +694,22 @@ fn resolve_buzz_managed_command(command: &str) -> Option<PathBuf> {
 }
 
 fn resolve_command_uncached(command: &str) -> Option<PathBuf> {
-    if let Some(path) = resolve_workspace_command(command) {
-        return Some(path);
+    // If the operator wrote an explicit path (absolute or multi-component),
+    // honor ONLY that path — never let it fall through to workspace target
+    // resolution. A bare command name, by contrast, gets resolved through the
+    // user/system order below, and only drops to workspace target/debug as a
+    // last-resort dev convenience.
+    if command_looks_like_path(command) {
+        let path = PathBuf::from(command);
+        if is_executable_file(&path) {
+            return Some(path);
+        }
+        // Path input but not executable — bail rather than fall through to
+        // bare-name workspace resolution (would silently mislead).
+        return None;
     }
 
     let basenames = command_basenames(command);
-
-    if command_looks_like_path(command) {
-        let path = PathBuf::from(command);
-        return path.exists().then_some(path);
-    }
 
     if let Some(managed) = resolve_buzz_managed_command(command) {
         return Some(managed);
@@ -713,6 +719,18 @@ fn resolve_command_uncached(command: &str) -> Option<PathBuf> {
         if is_executable_file(&candidate) {
             return Some(candidate);
         }
+    }
+
+    // Bare-name fallback for dev workflows: resolve to the workspace's
+    // target/{debug,release} build. This enables `buzz-acp` managed agents
+    // to work out-of-the-box during `cargo build` development without the
+    // operator needing to install to `~/.local/bin`. Workspace target is
+    // intentionally LAST so user-installed binaries always win — otherwise
+    // `cargo build` can clobber a pinned, known-good harness binary with
+    // a fresh but semantically different debug build and the agent's
+    // behavior silently regresses after `tauri dev` restart (#4233 item C).
+    if let Some(path) = resolve_workspace_command(command) {
+        return Some(path);
     }
 
     // On Windows, also scan PATH for .cmd/.bat shims (npm globals).

--- a/desktop/src-tauri/src/managed_agents/discovery/tests.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests.rs
@@ -1837,3 +1837,35 @@ fn discovery_publish_path_drops_mid_flight_delete() {
         "discovery's publish must not resurrect a harness deleted mid-discovery"
     );
 }
+
+/// Regression for #4233 item C: an absolute-path `acp_command` that the user
+/// pinned to a non-workspace location must NOT be silently redirected to the
+/// cargo workspace's `target/{debug,release}` build. The workspace target is
+/// a last-resort fallback for dev convenience — it must never override a
+/// real user-installed binary.
+#[test]
+fn path_pinned_command_skips_workspace_target_resolution() {
+    // The bug shape: `resolve_workspace_command` previously ran first in
+    // `resolve_command_uncached`, AND itself early-returned for path inputs.
+    // That early return was the only reason absolute pins worked. If the
+    // order had been inverted (workspace-first for ALL inputs), any repave
+    // of `target/debug` would silently clobber the user's pinned binary.
+    //
+    // This test documents the contract, not just the behavior:
+    // resolve_command_uncached on a path that doesn't exist on disk must
+    // return None, not fall through to a workspace binary.
+    let missing_abs_path = if cfg!(windows) {
+        "C:\\definitely-not-on-this-machine\\buzz-acp.exe"
+    } else {
+        "/definitely-not-on-this-machine/buzz-acp"
+    };
+    // Workspace target may coincidentally have a binary with this basename;
+    // the result is meaningful only if resolution does NOT route through the
+    // workspace search path for a path-input command.
+    let result = super::resolve_command_uncached(missing_abs_path);
+    assert!(
+        result.is_none(),
+        "resolve_command_uncached must return None for a non-existent absolute path \
+         (got {result:?}) — never redirect a pinned-absolute acp_command to workspace target"
+    );
+}


### PR DESCRIPTION
Partially addresses #4233 (item C — dev-workspace clobber).

**Category:** bug fix
**User impact:** Operators who pinned `acp_command: "buzz-acp"` (bare, no path) to a managed agent and had a user-installed binary in `PATH` or `~/.local/bin` were silently switched to the workspace's fresh `target/debug/buzz-acp` after every `cargo build`. A previously-known-good harness (with content-delivery fallback) could be silently replaced by a semantically different debug build, making agents look healthy while their publish path regressed.

## Root cause

`resolve_command_uncached` called `resolve_workspace_command` FIRST for every command. That function:
- For path-input: returns early if the specified path exists (good behavior).
- For bare-name input: searches `workspace_root/target/{debug,release}` FIRST, then `current_exe.parent` — neither of which honors user-installed binaries in the standard user/system locations (which came later in the resolver chain).

So a bare command found in the workspace target immediately short-circuited the user/system search.

## Fix

Reorder the resolver:

1. If `acp_command` is a **path** (`/abs/path` or `./rel/path`), honor it strictly; if it isn't executable on disk, fail (return `None`), don't fall through to workspace resolution.
2. Bare-name command: check `resolve_buzz_managed_command` → PATH candidates → workspace target (now LAST among the bare-name candidates) → login shell → common paths.

Workspace target remains the dev convenience (a contributor can `cargo build` and have `buzz` work without `cargo install`), but it's now strictly a fallback rather than an override.

## Validation

- `cargo check --lib`: clean
- `cargo clippy --lib`: zero warnings
- `cargo test --lib managed_agents::discovery`: **101/101 passing** (including the new regression test `path_pinned_command_skips_workspace_target_resolution`)
- `cargo test --lib` (full suite): **2089/2089 passing, 14 ignored**

## Scope

This PR only fixes item C of #4233. Item A (custom-provider secrets docs + wizard warning) and item B (content-delivery fallback for non-tool-calling models) are out of scope — see the issue thread for the proposed split rationale.