### PR TITLE
feat: show relay-hosted agents in Agents tab

### DIFF
--- a/crates/buzz-cli/src/commands/agents.rs
+++ b/crates/buzz-cli/src/commands/agents.rs
@@ -1,6 +1,7 @@
 use buzz_core::kind::KIND_IA_ARCHIVED_LIST;
 use buzz_sdk::builders::{build_archive_identity_request, build_unarchive_identity_request};
 use nostr::PublicKey;
+use nostr::{EventBuilder, Kind};
 use serde_json::json;
 
 use crate::agent_management::{build_create, build_update, CreateAgentDraft, UpdateAgentDraft};
@@ -11,6 +12,43 @@ use crate::{AgentsCmd, RespondToArg};
 
 pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), CliError> {
     match command {
+        AgentsCmd::PublishProfile {
+            name,
+            agent_type,
+            channels,
+            channel_ids,
+            capabilities,
+            status,
+            respond_to,
+        } => {
+            if !matches!(status.as_str(), "online" | "away" | "offline") {
+                return Err(CliError::Usage(
+                    "--status must be online, away, or offline".into(),
+                ));
+            }
+            if !channel_ids.is_empty() && channel_ids.len() != channels.len() {
+                return Err(CliError::Usage(
+                    "--channel-ids must have the same number of entries as --channels".into(),
+                ));
+            }
+            let mut content = json!({
+                "name": name,
+                "agent_type": agent_type,
+                "channels": channels,
+                "channel_ids": channel_ids,
+                "capabilities": capabilities,
+                "status": status,
+                "channel_add_policy": "owner_only",
+            });
+            if let Some(mode) = respond_to {
+                content["respond_to"] = mode.to_wire().into();
+            }
+            let event = client
+                .sign_event(EventBuilder::new(Kind::Custom(10100), content.to_string()).tags([]))?;
+            let response = client.submit_event(event).await?;
+            println!("{}", response);
+            Ok(())
+        }
         AgentsCmd::DraftCreate {
             channel,
             display_name,

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -258,6 +258,31 @@ impl RespondToArg {
 
 #[derive(Subcommand)]
 pub enum AgentsCmd {
+    /// Publish a relay-visible profile for a remote agent (kind 10100)
+    #[command(name = "publish-profile")]
+    PublishProfile {
+        /// Agent display name
+        #[arg(long)]
+        name: String,
+        /// Agent implementation type
+        #[arg(long, default_value = "agent")]
+        agent_type: String,
+        /// Channel names, comma-separated
+        #[arg(long, value_delimiter = ',')]
+        channels: Vec<String>,
+        /// Channel UUIDs, comma-separated and aligned with --channels
+        #[arg(long, value_delimiter = ',')]
+        channel_ids: Vec<String>,
+        /// Public capability labels, comma-separated
+        #[arg(long, value_delimiter = ',')]
+        capabilities: Vec<String>,
+        /// Current status: online, away, or offline
+        #[arg(long, default_value = "online")]
+        status: String,
+        /// Public response policy
+        #[arg(long, value_enum)]
+        respond_to: Option<RespondToArg>,
+    },
     /// Open a prefilled create-agent form in the owner's Buzz Desktop
     DraftCreate {
         /// Current channel UUID; the new agent is added here after save
@@ -2028,6 +2053,7 @@ mod tests {
                 "archived",
                 "draft-create",
                 "draft-update",
+                "publish-profile",
                 "unarchive"
             ]
         );
@@ -2154,7 +2180,7 @@ mod tests {
     #[test]
     fn subcommand_counts_are_stable() {
         let expected: Vec<(&str, usize)> = vec![
-            ("agents", 5),
+            ("agents", 6),
             ("canvas", 2),
             ("channels", 16),
             ("dms", 4),

--- a/desktop/src/features/agents/ui/AgentIdentityCard.tsx
+++ b/desktop/src/features/agents/ui/AgentIdentityCard.tsx
@@ -9,6 +9,7 @@ type AgentIdentityCardProps = {
   ariaLabel: string;
   avatar?: ReactNode;
   avatarUrl?: string | null;
+  compact?: boolean;
   dataTestId: string;
   label: string;
   modelLabel?: string | null;
@@ -22,6 +23,7 @@ export function AgentIdentityCard({
   ariaLabel,
   avatar,
   avatarUrl,
+  compact = false,
   dataTestId,
   label,
   modelLabel,
@@ -33,19 +35,33 @@ export function AgentIdentityCard({
   return (
     <div
       className={cn(
-        "group relative aspect-[4/5] w-full min-w-0 overflow-hidden rounded-2xl border border-border/70 bg-muted/50 text-left shadow-xs transition-colors hover:border-border hover:bg-muted/65",
+        compact
+          ? "group relative flex min-h-16 w-full min-w-0 items-center overflow-hidden rounded-xl border border-border/70 bg-muted/50 text-left shadow-xs transition-colors hover:border-border hover:bg-muted/65"
+          : "group relative aspect-[4/5] w-full min-w-0 overflow-hidden rounded-2xl border border-border/70 bg-muted/50 text-left shadow-xs transition-colors hover:border-border hover:bg-muted/65",
       )}
       data-testid={dataTestId}
     >
       <button
         aria-label={ariaLabel}
-        className="absolute inset-0 z-10 rounded-2xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+        className="absolute inset-0 z-10 rounded-xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
         onClick={onClick}
         type="button"
       />
 
-      <div className="pointer-events-none relative z-20 flex h-full w-full min-w-0 flex-col items-center justify-center gap-5 px-4 pb-12 text-center">
-        <div className="flex h-24 w-24 items-center justify-center">
+      <div
+        className={cn(
+          "pointer-events-none relative z-20 flex min-w-0",
+          compact
+            ? "h-16 w-full items-center gap-3 px-3 text-left"
+            : "h-full w-full flex-col items-center justify-center gap-5 px-4 pb-12 text-center",
+        )}
+      >
+        <div
+          className={cn(
+            "flex shrink-0 items-center justify-center",
+            compact ? "h-10 w-10" : "h-24 w-24",
+          )}
+        >
           {avatar ??
             (trimmedAvatarUrl ? (
               <ProfileAvatar
@@ -68,7 +84,14 @@ export function AgentIdentityCard({
         <div className="absolute top-3 right-3 z-40">{actions}</div>
       ) : null}
 
-      <div className="pointer-events-none absolute right-3 bottom-3 left-3 z-30 flex min-w-0 flex-col gap-0.5 text-left text-sm leading-5">
+      <div
+        className={cn(
+          "pointer-events-none z-30 flex min-w-0 flex-col gap-0.5 text-left text-sm leading-5",
+          compact
+            ? "relative right-auto bottom-auto left-auto flex-1 pr-10"
+            : "absolute right-3 bottom-3 left-3",
+        )}
+      >
         <span className="min-w-0 truncate font-semibold text-foreground tracking-normal">
           {label}
         </span>

--- a/desktop/src/features/agents/ui/AgentsView.tsx
+++ b/desktop/src/features/agents/ui/AgentsView.tsx
@@ -217,6 +217,7 @@ export function AgentsView() {
               actionErrorMessage={agents.actionErrorMessage}
               actionNoticeMessage={agents.actionNoticeMessage}
               agents={agents.managedAgents}
+              remoteAgents={agents.relayAgentsQuery.data ?? []}
               agentsError={
                 agents.managedAgentsQuery.error instanceof Error
                   ? agents.managedAgentsQuery.error

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -1,8 +1,14 @@
 import * as React from "react";
 import {
   AlertTriangle,
+  Bot,
   ChevronDown,
   ChevronRight,
+  Grid2X2,
+  ImageIcon,
+  List,
+  Music2,
+  Newspaper,
   RefreshCw,
 } from "lucide-react";
 
@@ -10,6 +16,7 @@ import { resolveAgentCardModelLabel } from "@/features/agents/lib/agentCardModel
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import { useUserProfileQuery } from "@/features/profile/hooks";
+import { ProfileAvatar } from "@/features/profile/ui/ProfileAvatar";
 import type {
   AgentPersona,
   ManagedAgent,
@@ -19,6 +26,7 @@ import type { ProfilePanelOpenOptions } from "@/shared/context/ProfilePanelConte
 import { useFeedbackToasts } from "@/shared/hooks/useToastEffect";
 import { useFileImportZone } from "@/shared/hooks/useFileImportZone";
 import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -112,6 +120,9 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     [personas, agents],
   );
   const [collapsed, setCollapsed] = React.useState<Set<string>>(new Set());
+  const [remoteView, setRemoteView] = React.useState<"cards" | "list">(
+    "cards",
+  );
   const {
     fileInputRef,
     isDragOver,
@@ -234,17 +245,54 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
       {remoteAgents.length > 0 ? (
         <section className="space-y-3" data-testid="remote-agents-section">
           <div>
-            <h2 className="font-semibold text-foreground text-lg">
-              Remote / DGX agents
-            </h2>
-            <p className="text-secondary-foreground text-sm">
-              Agents running on your relay or another machine.
-            </p>
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h2 className="font-semibold text-foreground text-lg">
+                  Remote / DGX agents
+                </h2>
+                <p className="text-secondary-foreground text-sm">
+                  Agents running on your relay or another machine.
+                </p>
+              </div>
+              <div
+                aria-label="Remote agent view"
+                className="flex shrink-0 rounded-lg border border-border/70 p-0.5"
+                role="group"
+              >
+                <Button
+                  aria-label="Show remote agents as cards"
+                  aria-pressed={remoteView === "cards"}
+                  className="h-7 w-7"
+                  onClick={() => setRemoteView("cards")}
+                  size="icon"
+                  variant={remoteView === "cards" ? "secondary" : "ghost"}
+                >
+                  <Grid2X2 className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  aria-label="Show remote agents as a list"
+                  aria-pressed={remoteView === "list"}
+                  className="h-7 w-7"
+                  onClick={() => setRemoteView("list")}
+                  size="icon"
+                  variant={remoteView === "list" ? "secondary" : "ghost"}
+                >
+                  <List className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
           </div>
-          <div className={IDENTITY_CARD_GRID_CLASS}>
+          <div
+            className={
+              remoteView === "cards"
+                ? IDENTITY_CARD_GRID_CLASS
+                : "grid w-full grid-cols-1 gap-2"
+            }
+          >
             {remoteAgents.map((agent) => (
               <RemoteAgentCard
                 agent={agent}
+                compact={remoteView === "list"}
                 key={agent.pubkey}
                 onOpenProfile={onOpenAgentProfile}
               />
@@ -273,18 +321,34 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
 
 function RemoteAgentCard({
   agent,
+  compact,
   onOpenProfile,
 }: {
   agent: RelayAgent;
+  compact: boolean;
   onOpenProfile: (pubkey: string) => void;
 }) {
   const profileQuery = useUserProfileQuery(agent.pubkey);
   const statusLabel = agent.status === "online" ? "Online" : agent.status;
+  const avatarUrl = profileQuery.data?.avatarUrl;
 
   return (
     <AgentIdentityCard
       ariaLabel={`${agent.name} remote agent profile`}
-      avatarUrl={profileQuery.data?.avatarUrl}
+      avatar={
+        avatarUrl ? (
+          <ProfileAvatar
+            avatarUrl={avatarUrl}
+            className="h-full w-full border-[3px] border-background bg-muted shadow-none"
+            iconClassName="h-8 w-8"
+            label={agent.name}
+          />
+        ) : (
+          <RemoteAgentIcon seed={agent.pubkey} type={agent.agentType} />
+        )
+      }
+      avatarUrl={avatarUrl}
+      compact={compact}
       dataTestId={`remote-agent-${agent.pubkey}`}
       label={agent.name}
       modelLabel={agent.agentType || "DGX agent"}
@@ -296,6 +360,31 @@ function RemoteAgentCard({
       }
     />
   );
+}
+
+function RemoteAgentIcon({ seed, type }: { seed: string; type: string }) {
+  const normalizedType = type.toLowerCase();
+  const Icon = normalizedType.includes("image")
+    ? ImageIcon
+    : normalizedType.includes("music") || normalizedType.includes("audio")
+      ? Music2
+      : normalizedType.includes("news") || normalizedType.includes("research")
+        ? Newspaper
+        : [Bot, ImageIcon, Music2, Newspaper][stableIconIndex(seed)];
+
+  return (
+    <span className="flex h-full w-full items-center justify-center rounded-full border-[3px] border-background bg-primary/15 text-primary shadow-sm">
+      <Icon className="h-10 w-10" />
+    </span>
+  );
+}
+
+function stableIconIndex(seed: string) {
+  let hash = 0;
+  for (const character of seed) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
+  }
+  return hash % 4;
 }
 
 function AgentPersonaCard({

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -2,14 +2,20 @@ import * as React from "react";
 import {
   AlertTriangle,
   Bot,
+  Code2,
   ChevronDown,
   ChevronRight,
+  Globe2,
   Grid2X2,
   ImageIcon,
   List,
   Music2,
   Newspaper,
   RefreshCw,
+  ShieldCheck,
+  Sparkles,
+  Terminal,
+  Zap,
 } from "lucide-react";
 
 import { resolveAgentCardModelLabel } from "@/features/agents/lib/agentCardModelLabel";
@@ -77,6 +83,21 @@ type UnifiedAgentsSectionProps = {
   onDeletePersona: (persona: AgentPersona) => void;
   onImportSnapshotFile: (fileBytes: number[], fileName: string) => void;
 };
+
+const REMOTE_AGENT_ICON_STORAGE_KEY = "buzz.remote-agent-icons";
+const REMOTE_AGENT_ICON_OPTIONS = [
+  { id: "bot", label: "Bot", icon: Bot },
+  { id: "image", label: "Image", icon: ImageIcon },
+  { id: "music", label: "Music", icon: Music2 },
+  { id: "news", label: "News", icon: Newspaper },
+  { id: "code", label: "Code", icon: Code2 },
+  { id: "sparkles", label: "Creative", icon: Sparkles },
+  { id: "shield", label: "Security", icon: ShieldCheck },
+  { id: "terminal", label: "Terminal", icon: Terminal },
+  { id: "globe", label: "Web", icon: Globe2 },
+  { id: "zap", label: "Fast", icon: Zap },
+] as const;
+type RemoteAgentIconId = (typeof REMOTE_AGENT_ICON_OPTIONS)[number]["id"];
 
 const AGENT_CARD_COLUMN_CLASS = "w-full";
 export const AGENT_CARD_GRID_COLUMNS_CLASS =
@@ -331,12 +352,31 @@ function RemoteAgentCard({
   const profileQuery = useUserProfileQuery(agent.pubkey);
   const statusLabel = agent.status === "online" ? "Online" : agent.status;
   const avatarUrl = profileQuery.data?.avatarUrl;
+  const [selectedIcon, setSelectedIcon] = React.useState<RemoteAgentIconId | null>(
+    () => readRemoteAgentIcon(agent.pubkey),
+  );
+
+  React.useEffect(() => {
+    writeRemoteAgentIcon(agent.pubkey, selectedIcon);
+  }, [agent.pubkey, selectedIcon]);
 
   return (
     <AgentIdentityCard
       ariaLabel={`${agent.name} remote agent profile`}
+      actions={
+        <RemoteAgentIconPicker
+          selectedIcon={selectedIcon}
+          onSelect={setSelectedIcon}
+        />
+      }
       avatar={
-        avatarUrl ? (
+        selectedIcon ? (
+          <RemoteAgentIcon
+            iconId={selectedIcon}
+            seed={agent.pubkey}
+            type={agent.agentType}
+          />
+        ) : avatarUrl ? (
           <ProfileAvatar
             avatarUrl={avatarUrl}
             className="h-full w-full border-[3px] border-background bg-muted shadow-none"
@@ -362,21 +402,104 @@ function RemoteAgentCard({
   );
 }
 
-function RemoteAgentIcon({ seed, type }: { seed: string; type: string }) {
+function RemoteAgentIcon({
+  iconId,
+  seed,
+  type,
+}: {
+  iconId?: RemoteAgentIconId;
+  seed: string;
+  type: string;
+}) {
   const normalizedType = type.toLowerCase();
-  const Icon = normalizedType.includes("image")
-    ? ImageIcon
-    : normalizedType.includes("music") || normalizedType.includes("audio")
-      ? Music2
-      : normalizedType.includes("news") || normalizedType.includes("research")
-        ? Newspaper
-        : [Bot, ImageIcon, Music2, Newspaper][stableIconIndex(seed)];
+  const Icon = iconId
+    ? iconForId(iconId)
+    : normalizedType.includes("image")
+      ? ImageIcon
+      : normalizedType.includes("music") || normalizedType.includes("audio")
+        ? Music2
+        : normalizedType.includes("news") || normalizedType.includes("research")
+          ? Newspaper
+          : [Bot, ImageIcon, Music2, Newspaper][stableIconIndex(seed)];
 
   return (
     <span className="flex h-full w-full items-center justify-center rounded-full border-[3px] border-background bg-primary/15 text-primary shadow-sm">
       <Icon className="h-10 w-10" />
     </span>
   );
+}
+
+function RemoteAgentIconPicker({
+  selectedIcon,
+  onSelect,
+}: {
+  selectedIcon: RemoteAgentIconId | null;
+  onSelect: (iconId: RemoteAgentIconId | null) => void;
+}) {
+  const SelectedIcon = selectedIcon ? iconForId(selectedIcon) : Sparkles;
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          aria-label="Choose agent icon"
+          className="h-7 w-7 rounded-full bg-background/80 shadow-sm backdrop-blur-sm"
+          onClick={(event) => event.stopPropagation()}
+          size="icon"
+          variant="ghost"
+        >
+          <SelectedIcon className="h-3.5 w-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-40">
+        <DropdownMenuItem onClick={() => onSelect(null)}>
+          <Sparkles className="h-4 w-4" />
+          Auto
+        </DropdownMenuItem>
+        {REMOTE_AGENT_ICON_OPTIONS.map(({ icon: Icon, id, label }) => (
+          <DropdownMenuItem key={id} onClick={() => onSelect(id)}>
+            <Icon className="h-4 w-4" />
+            {label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function iconForId(iconId: RemoteAgentIconId) {
+  return REMOTE_AGENT_ICON_OPTIONS.find((option) => option.id === iconId)?.icon ?? Bot;
+}
+
+function readRemoteAgentIcon(pubkey: string): RemoteAgentIconId | null {
+  try {
+    const saved = JSON.parse(
+      window.localStorage.getItem(REMOTE_AGENT_ICON_STORAGE_KEY) ?? "{}",
+    ) as Record<string, string>;
+    return REMOTE_AGENT_ICON_OPTIONS.some((option) => option.id === saved[pubkey])
+      ? (saved[pubkey] as RemoteAgentIconId)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeRemoteAgentIcon(
+  pubkey: string,
+  iconId: RemoteAgentIconId | null,
+) {
+  try {
+    const saved = JSON.parse(
+      window.localStorage.getItem(REMOTE_AGENT_ICON_STORAGE_KEY) ?? "{}",
+    ) as Record<string, string>;
+    if (iconId) saved[pubkey] = iconId;
+    else delete saved[pubkey];
+    window.localStorage.setItem(
+      REMOTE_AGENT_ICON_STORAGE_KEY,
+      JSON.stringify(saved),
+    );
+  } catch {
+    // Local icon preferences are optional; the UI still works if storage is unavailable.
+  }
 }
 
 function stableIconIndex(seed: string) {

--- a/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
+++ b/desktop/src/features/agents/ui/UnifiedAgentsSection.tsx
@@ -10,7 +10,11 @@ import { resolveAgentCardModelLabel } from "@/features/agents/lib/agentCardModel
 import { friendlyAgentLastError } from "@/features/agents/lib/friendlyAgentLastError";
 import { isManagedAgentActive } from "@/features/agents/lib/managedAgentControlActions";
 import { useUserProfileQuery } from "@/features/profile/hooks";
-import type { AgentPersona, ManagedAgent } from "@/shared/api/types";
+import type {
+  AgentPersona,
+  ManagedAgent,
+  RelayAgent,
+} from "@/shared/api/types";
 import type { ProfilePanelOpenOptions } from "@/shared/context/ProfilePanelContext";
 import { useFeedbackToasts } from "@/shared/hooks/useToastEffect";
 import { useFileImportZone } from "@/shared/hooks/useFileImportZone";
@@ -33,6 +37,7 @@ type UnifiedAgentsSectionProps = {
   actionErrorMessage: string | null;
   actionNoticeMessage: string | null;
   agents: ManagedAgent[];
+  remoteAgents: RelayAgent[];
   agentsError: Error | null;
   isActionPending: boolean;
   isAgentsLoading: boolean;
@@ -76,6 +81,7 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
     actionNoticeMessage,
     defaultModel,
     agents,
+    remoteAgents,
     agentsError,
     isActionPending,
     isAgentsLoading,
@@ -225,6 +231,28 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
         </div>
       ) : null}
 
+      {remoteAgents.length > 0 ? (
+        <section className="space-y-3" data-testid="remote-agents-section">
+          <div>
+            <h2 className="font-semibold text-foreground text-lg">
+              Remote / DGX agents
+            </h2>
+            <p className="text-secondary-foreground text-sm">
+              Agents running on your relay or another machine.
+            </p>
+          </div>
+          <div className={IDENTITY_CARD_GRID_CLASS}>
+            {remoteAgents.map((agent) => (
+              <RemoteAgentCard
+                agent={agent}
+                key={agent.pubkey}
+                onOpenProfile={onOpenAgentProfile}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
       {agentsError ? (
         <p
           className={`${AGENT_CARD_COLUMN_CLASS} rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive`}
@@ -240,6 +268,33 @@ export function UnifiedAgentsSection(props: UnifiedAgentsSectionProps) {
         </p>
       ) : null}
     </section>
+  );
+}
+
+function RemoteAgentCard({
+  agent,
+  onOpenProfile,
+}: {
+  agent: RelayAgent;
+  onOpenProfile: (pubkey: string) => void;
+}) {
+  const profileQuery = useUserProfileQuery(agent.pubkey);
+  const statusLabel = agent.status === "online" ? "Online" : agent.status;
+
+  return (
+    <AgentIdentityCard
+      ariaLabel={`${agent.name} remote agent profile`}
+      avatarUrl={profileQuery.data?.avatarUrl}
+      dataTestId={`remote-agent-${agent.pubkey}`}
+      label={agent.name}
+      modelLabel={agent.agentType || "DGX agent"}
+      onClick={() => onOpenProfile(agent.pubkey)}
+      statusBadge={
+        <span className="text-secondary-foreground/75 text-xs">
+          {statusLabel}
+        </span>
+      }
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

Buzz already discovers relay-hosted agent profiles, but the Agents tab only rendered locally managed agents and personas. This adds a Remote agents section that shows discovered relay agents with status, model/type, avatar fallback, and profile navigation.

It also adds `buzz agents publish-profile` so a headless agent can publish a kind 10100 relay-visible profile with its public metadata, capabilities, status, and response policy.

## Implementation notes

- Relay agent profiles are already discovered through the existing relay-agent query; the UI now renders those records instead of omitting them.
- Remote cards reuse the existing identity/profile panel and avatar fallback.
- `publish-profile` validates status and aligned channel metadata before signing and submitting the profile event.
- The Tauri release build validates external sidecars; the existing sidecar build process must run before packaging.

## Validation

- `cargo check -p buzz-cli`
- `cargo test -p buzz-cli` — 274 passed, 1 ignored
- Biome check for the changed desktop files
- `git diff --check`
- Windows x64 desktop build completed successfully and produced MSI and NSIS installers.

The repository pre-commit/pre-push hooks currently fail before running their checks because upstream main has an unrelated Justfile parse error at line 68; the focused checks above pass.