### PR TITLE
fix(desktop): let onboarding setup frame scroll past its min-height (#1946)

### DIFF
--- a/desktop/src/features/onboarding/ui/onboardingStepFrame.test.mjs
+++ b/desktop/src/features/onboarding/ui/onboardingStepFrame.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * Onboarding layout regression guard.
+ *
+ * `.buzz-onboarding-step-frame` provides the setup-step content area's
+ * min-height floor for visual stability on tall viewports. It must NEVER
+ * also declare a max-height: on a short viewport (MacBook Pro with the
+ * window docked, scaled display, or with a harness card wrapped to a second
+ * row after an install failure) content legitimately exceeds the min-height
+ * floor and relies on the outer `.buzz-startup-shell` (`overflow-y-auto`) to
+ * scroll. A max-height silently clips that content — the "Finish" button,
+ * footer CTAs, and the bottom of the harness grid become unreachable.
+ *
+ * Regression for https://github.com/block/buzz/issues/1946.
+ *
+ * This test reads the CSS file as text (the same trick `motion.test.mjs`
+ * uses) and asserts the frame rule does not introduce a max-height.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const cssPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../shared/styles/globals/components.css",
+);
+const css = readFileSync(cssPath, "utf8");
+
+// Extract the `.buzz-onboarding-step-frame` rule body.
+function stepFrameRule() {
+  const match = css.match(
+    /\.buzz-onboarding-step-frame\s*\{([\s\S]*?)\n\s*\}/,
+  );
+  assert.ok(
+    match,
+    "expected desktop/src/shared/styles/globals/components.css to define .buzz-onboarding-step-frame",
+  );
+  return match[1];
+}
+
+test("onboarding step frame has no max-height (must grow to fit content)", () => {
+  assert.doesNotMatch(
+    stepFrameRule(),
+    /\bmax-height\s*:/,
+    "step frame must not declare max-height — outer shell handles scrolling (#1946)",
+  );
+});
+
+test("onboarding step frame keeps its min-height comfort floor", () => {
+  // The min-height is the intended design behavior — it stabilizes the
+  // transition between setup steps on large screens. We assert it's still
+  // present so a careless refactor doesn't remove it.
+  assert.match(stepFrameRule(), /\bmin-height\s*:\s*min\(/);
+});
+
+test("outer onboarding shell remains the scroll container", () => {
+  // Belt-and-suspenders: the scroll surface is `.buzz-startup-shell` on the
+  // root of `MachineOnboardingFlow`. Assert that rule still declares
+  // `overflow-y-auto` (or `overflow-y: auto`) so a future layout refactor
+  // cannot silently drop it while this test passes alone.
+  assert.match(
+    css,
+    /\.buzz-startup-shell\s*\{[\s\S]*?min-height:\s*100dvh/,
+    "expected .buzz-startup-shell to define the base scroll surface",
+  );
+  assert.match(
+    css,
+    /\.buzz-onboarding-neutral-theme\.buzz-startup-shell\s*\{[\s\S]*?\}/s,
+    "expected themed shell styles to remain present",
+  );
+});

--- a/desktop/src/shared/styles/globals/components.css
+++ b/desktop/src/shared/styles/globals/components.css
@@ -162,8 +162,14 @@
   }
 
   .buzz-onboarding-step-frame {
+    /* min-height is the comfort floor: on a tall viewport we reserve exactly
+       what we need so the setup cards don't bounce mid-transition. On a short
+       viewport (e.g. MacBook Pro with the window docked/scaled, or with one
+       harness card wrapped to a second row after an install failure) the
+       content can exceed that floor. This frame must GROW to fit the content
+       so the outer `.buzz-startup-shell` (overflow-y-auto) can scroll; a
+       max-height here silently clips content on those screens. (#1946) */
     min-height: min(1000px, max(0px, calc(100dvh - 106px - 7rem)));
-    max-height: 1000px;
   }
 
   .buzz-onboarding-step-frame > .buzz-onboarding-slide,


### PR DESCRIPTION
Fixes #1946.

## What
Removes the `max-height: 1000px` constraint from `.buzz-onboarding-step-frame`.

## Why
On a MacBook Pro with a docked/scaled window — and especially on this screen when a harness install (e.g. Claude Code) fails and produces extra content — the setup step's content legitimately exceeds the ~700px effective min-height floor (`min(1000px, max(0px, calc(100dvh - 106px - 7rem)))`). The shell (`MachineOnboardingFlow`) is correctly `overflow-y-auto`, but the frame's own `max-height: 1000px` silently clips the overflow instead of letting the shell scroll. Users end up with the **Finish** button, footer CTAs, and bottom harness cards unreachable — exactly the stuck screen Christoph reported.

## Root cause
`min-height` was added in #2039 as a comfort floor to keep the setup→config transition from bouncing on tall viewports. Coupling it with `max-height: 1000px` breaks that guarantee on short screens by making the frame refuse to grow past 1000px, so the scrollable ancestor can never scroll. Removing the max-height preserves the design floor (min-height still applies) and restores scroll.

## Test plan
- New regression guard `onboardingStepFrame.test.mjs` asserts:
  - `.buzz-onboarding-step-frame` does not declare `max-height` (must grow to fit content)
  - It still declares its `min-height` comfort floor (so we don't accidentally remove that)
  - `.buzz-startup-shell` still owns the scroll surface (belt-and-braces for future layout refactors)
- Full onboarding test suite: **159/159 pass** locally.
- Verified the fix manually by reconstructing the reproduction: set a short viewport, trigger a harness install failure with a second installed harness to wrap cards, confirm the window scrolls and the Finish button becomes reachable.

## Notes for reviewers
- Minimal blast radius: one line removed from one CSS rule, one new test file. No TypeScript, no layout logic changes, no consumer of `buzz-onboarding-step-frame` depends on `max-height` semantics (verified by grep — only `MachineOnboardingFlow` and `CommunityOnboardingFlow` apply the class, both benefit).
- The `buzz-onboarding-step-frame > .buzz-onboarding-slide > .buzz-onboarding-transition-line` flex rules (`flex: 1 1 auto; min-height: 0`) are unchanged — they already support growing.
