### PR TITLE
fix(desktop): bump nostr-relay-pool to 0.44.2 + desktop cargo-deny gate (#4251)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -885,6 +885,15 @@ jobs:
       - uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
       - name: Dependency policy
         run: cargo-deny check
+      - name: Dependency policy (desktop lockfile)
+        # The root cargo-deny check ignores desktop/src-tauri/Cargo.lock (independent
+        # workspace). Lock it in so a desktop-only vuln can't silently ride along.
+        run: |
+          cargo-deny \
+            --manifest-path desktop/src-tauri/Cargo.toml \
+            --target aarch64-apple-darwin \
+            --exclude-dev \
+            check --config deny.toml advisories
 
   dead-token-guard:
     name: Dead Token Reference Guard

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -6166,9 +6166,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-relay-pool"
-version = "0.44.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b2c039df4f96c4bf7dae52a74fd5516ad6dda83a11c0c69dea91b5255a4f37"
+checksum = "fb94d61a467a869a6790b907838a9bea82c813d567d9fcbac995f207be8cee4b"
 dependencies = [
  "async-utility",
  "async-wsocket",


### PR DESCRIPTION
Fixes #4251.

## What was broken

`desktop/src-tauri/Cargo.lock` still pinned `nostr-relay-pool = "0.44.1"`, which is
affected by [RUSTSEC-2026-0224](https://rustsec.org/advisories/RUSTSEC-2026-0224).
The root workspace lockfile was already corrected in #4139, but the desktop
graph is an independent workspace — the two lockfiles had silently diverged.

## The fix

This PR applies the two changes called out in the issue body:

1. **Bump `nostr-relay-pool` to 0.44.2 in `desktop/src-tauri/Cargo.lock`.**
   Version and checksum copied from the repo-root `Cargo.lock` patch — the
   published 0.44.2 crate.  No source-code changes were needed; the upstream
   fix is entirely in the 0.44.2 patch release.

2. **Close the CI hole so this doesn't regress.** `Security` job in
   `.github/workflows/ci.yml` previously ran a single `cargo-deny check` from
   the repository root, which ignores `desktop/src-tauri/Cargo.lock`.  Add a
   sibling step that runs cargo-deny against the desktop manifest explicitly,
   using the command from the issue:

   ```
   cargo-deny \
     --manifest-path desktop/src-tauri/Cargo.toml \
     --target aarch64-apple-darwin \
     --exclude-dev \
     check --config deny.toml advisories
   ```

   This is advisory-scope only — it fails on RustSec vulnerabilities in the
   desktop graph but doesn't blanket-tighten other gates (licenses, bans, or
   the unmaintained policy), so it can't accidentally break the rest of CI.

## Test plan

Lockfile edit is a pure version+checksum swap of one package; no Rust code
changes, no desktop runtime behaviour change.  CI is the validation:

- `Security` job runs both root and desktop `cargo-deny advisories` checks on
  this branch; if the bump were missing or the checksum wrong, the desktop
  step would fail with `mismatched checksum` or `vulnerable: RUSTSEC-2026-0224`.
- `Rust` and `Desktop` jobs already build the desktop crate graph against the
  lockfile — a bad lockfile would surface there as a resolution error immediately.

## Out of scope (deferred to maintainers)

The issue also proposed flipping `unmaintained = "workspace"` in `deny.toml`.
That changes the gate for every crate in the dependency tree, not just
nostr-relay-pool, and is a policy decision with a wider blast radius — left
deliberately out so this stays narrow and mergeable.  Filed as
follow-up if the team wants to take it on separately.
