### PR TITLE
fix(desktop): keep workflow save errors visible in the dialog footer

### DIFF
--- a/desktop/src/features/workflows/ui/WorkflowDialog.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowDialog.tsx
@@ -205,33 +205,36 @@ export function WorkflowDialog({
               }}
               yaml={yamlDefinition}
             />
+          </div>
 
+          <div className="flex-shrink-0 space-y-2 border-t border-border pt-4">
             {mutation.error instanceof Error ? (
               <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
                 {mutation.error.message}
               </p>
             ) : null}
-          </div>
-
-          <div className="flex flex-shrink-0 justify-end gap-2 border-t border-border pt-4">
-            <Button
-              onClick={() => handleOpenChange(false)}
-              type="button"
-              variant="outline"
-            >
-              Cancel
-            </Button>
-            <Button
-              disabled={
-                !selectedChannelId ||
-                !yamlDefinition.trim() ||
-                mutation.isPending
-              }
-              onClick={handleSubmit}
-              type="button"
-            >
-              {mutation.isPending ? PENDING_LABELS[mode] : SUBMIT_LABELS[mode]}
-            </Button>
+            <div className="flex justify-end gap-2">
+              <Button
+                onClick={() => handleOpenChange(false)}
+                type="button"
+                variant="outline"
+              >
+                Cancel
+              </Button>
+              <Button
+                disabled={
+                  !selectedChannelId ||
+                  !yamlDefinition.trim() ||
+                  mutation.isPending
+                }
+                onClick={handleSubmit}
+                type="button"
+              >
+                {mutation.isPending
+                  ? PENDING_LABELS[mode]
+                  : SUBMIT_LABELS[mode]}
+              </Button>
+            </div>
           </div>
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
## Summary

Moves the workflow save error message out of the dialog's scrollable form area into the fixed footer, next to the Create/Save buttons.

## Problem

In `WorkflowDialog`, a failed save renders the relay error as the **last element inside the scrollable form container** (`overflow-y-auto`). With a realistic workflow (trigger + filter + a webhook step with headers and body), the form is taller than the dialog viewport, so when the user clicks **Create** in the fixed footer and the relay rejects the save (e.g. `forbidden: workflows with call_webhook actions require the owner or admin role`), the error appears below the fold. The user sees the button return to "Create" with no visible feedback — an apparent silent failure.

This is not hypothetical: it cost a real user (and two agents assisting them) an afternoon of debugging that ended with relay-side CLI reproduction, because Desktop appeared to swallow the error. Related diagnosis in #4288 (different root cause for the trigger side, but the invisible save error is what sent everyone down the wrong path).

## Change

- The `mutation.error` block now renders in the fixed footer section, above the Cancel/Create buttons, so it is always visible regardless of form scroll position.
- No change to error content or the mutation flow; purely a placement fix.

## Testing

- `pnpm typecheck`, `pnpm check`, `pnpm test` in `desktop/` — all passing.
- Manually verified the layout change renders the error adjacent to the action buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
