### PR TITLE
fix: surface workflow webhook auth errors

### DIFF
--- a/desktop/src/features/workflows/ui/WorkflowDialog.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowDialog.tsx
@@ -5,8 +5,10 @@ import {
   useCreateWorkflowMutation,
   useUpdateWorkflowMutation,
 } from "@/features/workflows/hooks";
+import { useIdentityQuery } from "@/shared/api/hooks";
 import type { Channel, Workflow } from "@/shared/api/types";
 import { getRelayHttpUrl } from "@/shared/api/tauri";
+import { useChannelMembersQuery } from "@/features/channels/hooks";
 import { Button } from "@/shared/ui/button";
 import {
   Dialog,
@@ -18,6 +20,11 @@ import {
 import { ChannelCombobox } from "./ChannelCombobox";
 import { WorkflowFormBuilder } from "./WorkflowFormBuilder";
 import { WorkflowWebhookSecretDialog } from "./WorkflowWebhookSecretDialog";
+import {
+  canAuthorWebhookWorkflow,
+  getChannelRoleForPubkey,
+  workflowUsesCallWebhook,
+} from "./workflowAuthz";
 import { FieldLabel } from "./workflowFormPrimitives";
 
 type DialogMode = "create" | "edit" | "duplicate";
@@ -88,6 +95,23 @@ export function WorkflowDialog({
 
   const selectedChannel =
     channels.find((c) => c.id === selectedChannelId) ?? null;
+  const identityQuery = useIdentityQuery();
+  const usesWebhookAction = React.useMemo(
+    () => workflowUsesCallWebhook(yamlDefinition),
+    [yamlDefinition],
+  );
+  const membersQuery = useChannelMembersQuery(
+    selectedChannelId || null,
+    open && usesWebhookAction,
+  );
+  const selectedChannelRole = getChannelRoleForPubkey(
+    membersQuery.data,
+    identityQuery.data?.pubkey,
+  );
+  const webhookAuthzBlocked =
+    usesWebhookAction &&
+    membersQuery.isSuccess &&
+    !canAuthorWebhookWorkflow(selectedChannelRole);
 
   const defaultChannelId = channels[0]?.id ?? "";
   const workflowChannelId = workflow?.channelId ?? null;
@@ -129,7 +153,9 @@ export function WorkflowDialog({
   );
 
   async function handleSubmit() {
-    if (!selectedChannelId || !yamlDefinition.trim()) return;
+    if (!selectedChannelId || !yamlDefinition.trim() || webhookAuthzBlocked) {
+      return;
+    }
 
     try {
       const saved = await mutation.mutateAsync(yamlDefinition);
@@ -206,32 +232,58 @@ export function WorkflowDialog({
               yaml={yamlDefinition}
             />
 
-            {mutation.error instanceof Error ? (
-              <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                {mutation.error.message}
+            {usesWebhookAction && membersQuery.isError ? (
+              <p className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-300">
+                Could not check your channel role before saving this webhook
+                workflow. If the relay rejects it, the exact relay error will
+                appear below.
               </p>
             ) : null}
           </div>
 
-          <div className="flex flex-shrink-0 justify-end gap-2 border-t border-border pt-4">
-            <Button
-              onClick={() => handleOpenChange(false)}
-              type="button"
-              variant="outline"
-            >
-              Cancel
-            </Button>
-            <Button
-              disabled={
-                !selectedChannelId ||
-                !yamlDefinition.trim() ||
-                mutation.isPending
-              }
-              onClick={handleSubmit}
-              type="button"
-            >
-              {mutation.isPending ? PENDING_LABELS[mode] : SUBMIT_LABELS[mode]}
-            </Button>
+          <div className="flex flex-shrink-0 flex-col gap-3 border-t border-border pt-4">
+            {webhookAuthzBlocked ? (
+              <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                This workflow uses <code>call_webhook</code>, which the relay
+                only allows channel owners or admins to save. Your current role
+                in {selectedChannel?.name ?? "this channel"} is{" "}
+                <code>{selectedChannelRole ?? "unknown"}</code>. Switch to the
+                owner identity or ask an owner/admin to save it.
+              </p>
+            ) : null}
+
+            {mutation.error instanceof Error ? (
+              <p
+                aria-live="polite"
+                className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              >
+                Save failed: {mutation.error.message}
+              </p>
+            ) : null}
+
+            <div className="flex justify-end gap-2">
+              <Button
+                onClick={() => handleOpenChange(false)}
+                type="button"
+                variant="outline"
+              >
+                Cancel
+              </Button>
+              <Button
+                disabled={
+                  !selectedChannelId ||
+                  !yamlDefinition.trim() ||
+                  mutation.isPending ||
+                  webhookAuthzBlocked
+                }
+                onClick={handleSubmit}
+                type="button"
+              >
+                {mutation.isPending
+                  ? PENDING_LABELS[mode]
+                  : SUBMIT_LABELS[mode]}
+              </Button>
+            </div>
           </div>
         </DialogContent>
       </Dialog>

--- a/desktop/src/features/workflows/ui/workflowAuthz.test.mjs
+++ b/desktop/src/features/workflows/ui/workflowAuthz.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  canAuthorWebhookWorkflow,
+  getChannelRoleForPubkey,
+  workflowUsesCallWebhook,
+} from "./workflowAuthz.ts";
+
+test("workflowUsesCallWebhook detects webhook actions in valid workflow YAML", () => {
+  assert.equal(
+    workflowUsesCallWebhook(`
+name: Send to n8n
+trigger:
+  on: message_posted
+steps:
+  - id: call
+    action: call_webhook
+    url: https://example.com/hook
+`),
+    true,
+  );
+});
+
+test("workflowUsesCallWebhook ignores workflows without webhook actions", () => {
+  assert.equal(
+    workflowUsesCallWebhook(`
+name: React
+trigger:
+  on: reaction_added
+steps:
+  - id: react
+    action: add_reaction
+    emoji: eyes
+`),
+    false,
+  );
+});
+
+test("workflowUsesCallWebhook lets malformed YAML fall through to relay validation", () => {
+  assert.equal(workflowUsesCallWebhook("{ name: broken"), false);
+});
+
+test("getChannelRoleForPubkey is case-insensitive", () => {
+  assert.equal(
+    getChannelRoleForPubkey(
+      [
+        {
+          pubkey: "ABCDEF",
+          role: "owner",
+          isAgent: false,
+          joinedAt: "",
+          displayName: null,
+        },
+      ],
+      "abcdef",
+    ),
+    "owner",
+  );
+});
+
+test("canAuthorWebhookWorkflow allows only owner and admin", () => {
+  assert.equal(canAuthorWebhookWorkflow("owner"), true);
+  assert.equal(canAuthorWebhookWorkflow("admin"), true);
+  assert.equal(canAuthorWebhookWorkflow("member"), false);
+  assert.equal(canAuthorWebhookWorkflow("bot"), false);
+  assert.equal(canAuthorWebhookWorkflow(null), false);
+});

--- a/desktop/src/features/workflows/ui/workflowAuthz.ts
+++ b/desktop/src/features/workflows/ui/workflowAuthz.ts
@@ -1,0 +1,43 @@
+import { parse as yamlParse } from "yaml";
+
+import type { ChannelMember, ChannelRole } from "@/shared/api/types";
+
+const WEBHOOK_AUTHOR_ROLES = new Set<ChannelRole>(["owner", "admin"]);
+
+export function workflowUsesCallWebhook(yaml: string): boolean {
+  try {
+    const parsed = yamlParse(yaml);
+    if (!parsed || typeof parsed !== "object") return false;
+
+    const steps = (parsed as { steps?: unknown }).steps;
+    if (!Array.isArray(steps)) return false;
+
+    return steps.some(
+      (step) =>
+        step !== null &&
+        typeof step === "object" &&
+        (step as { action?: unknown }).action === "call_webhook",
+    );
+  } catch {
+    // If the YAML is malformed, let the relay/schema validation report the
+    // parse error on submit rather than guessing about webhook permissions.
+    return false;
+  }
+}
+
+export function getChannelRoleForPubkey(
+  members: ChannelMember[] | undefined,
+  pubkey: string | undefined,
+): ChannelRole | null {
+  if (!members || !pubkey) return null;
+
+  const normalizedPubkey = pubkey.toLowerCase();
+  return (
+    members.find((member) => member.pubkey.toLowerCase() === normalizedPubkey)
+      ?.role ?? null
+  );
+}
+
+export function canAuthorWebhookWorkflow(role: ChannelRole | null): boolean {
+  return role !== null && WEBHOOK_AUTHOR_ROLES.has(role);
+}


### PR DESCRIPTION
## Summary

Workflows containing a `call_webhook` step could be authored by channel members whose role does not permit it, and the resulting auth failure was not surfaced in the workflow dialog. This change checks webhook-authoring permissions client-side and surfaces the error in the UI.

- New `workflowAuthz.ts` helpers:
  - `workflowUsesCallWebhook(yaml)` — detects `call_webhook` steps in the workflow YAML (malformed YAML defers to relay/schema validation on submit)
  - `getChannelRoleForPubkey(members, pubkey)` — resolves the current user's role in the target channel
  - `canAuthorWebhookWorkflow(role)` — restricts webhook workflows to `owner`/`admin` roles
- `WorkflowDialog` now resolves the user's identity and channel role and surfaces the auth error for webhook workflows instead of failing silently
- Unit tests added in `workflowAuthz.test.mjs`

## Test plan

- [x] `workflowAuthz.test.mjs` unit tests pass
- [ ] Manual: create/edit a workflow with a `call_webhook` step as a non-admin member and confirm the auth error is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
