### PR TITLE
fix(desktop): keyboard-reachable composer attachment remove button (#2389)

### DIFF
--- a/desktop/src/features/messages/ui/ComposerAttachments.tsx
+++ b/desktop/src/features/messages/ui/ComposerAttachments.tsx
@@ -487,8 +487,9 @@ const MediaAttachmentItem = React.forwardRef<
           <TooltipTrigger asChild>
             <button
               type="button"
+              aria-label="Remove attachment"
               onClick={() => onRemove(attachment.url)}
-              className="absolute -right-1 -top-1 hidden h-4 w-4 items-center justify-center rounded-full bg-foreground text-background group-hover:flex"
+              className="absolute -right-1 -top-1 hidden h-4 w-4 items-center justify-center rounded-full bg-foreground text-background group-hover:flex group-focus-within:flex"
             >
               <X className="h-2.5 w-2.5" />
             </button>
@@ -580,8 +581,9 @@ export const ComposerAttachments = React.memo(function ComposerAttachments({
                     <TooltipTrigger asChild>
                       <button
                         type="button"
+                        aria-label="Remove attachment"
                         onClick={() => onRemove(attachment.url)}
-                        className="absolute -right-1 -top-1 hidden h-4 w-4 items-center justify-center rounded-full bg-foreground text-background group-hover:flex"
+                        className="absolute -right-1 -top-1 hidden h-4 w-4 items-center justify-center rounded-full bg-foreground text-background group-hover:flex group-focus-within:flex"
                       >
                         <X className="h-2.5 w-2.5" />
                       </button>

--- a/desktop/src/features/messages/ui/composerAttachmentRemoveA11y.test.mjs
+++ b/desktop/src/features/messages/ui/composerAttachmentRemoveA11y.test.mjs
@@ -1,0 +1,70 @@
+/**
+ * Regression guard for #2389 — composer attachment remove buttons must be
+ * reachable by keyboard, not only via mouse hover.
+ *
+ * History: the remove (×) button on every composer attachment chip used
+ * `hidden ... group-hover:flex`, which is `display: none` until the parent
+ * chip is hovered. Because the button never appears in the tab order, keyboard
+ * users could not reach it at all — there was no way to remove an attached
+ * file without a mouse.
+ *
+ * Fix: add `group-focus-within:flex` alongside `group-hover:flex` so the
+ * button renders (and is therefore tabbable) whenever ANY focusable element
+ * inside the chip — including the button itself — has focus. Also adds an
+ * explicit `aria-label="Remove attachment"` so screen readers announce the
+ * action before relying on the tooltip.
+ *
+ * This test reads ComposerAttachments.tsx and asserts the focus-within half
+ * of the fix is present on every chip-level remove button. If a refactor
+ * ever drops the `group-focus-within:flex` class or the aria-label, this
+ * test fails before the a11y regression ships.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(
+  join(here, "ComposerAttachments.tsx"),
+  "utf8",
+);
+
+test("composer remove-attachment buttons are focus-within reachable", () => {
+  // Match every chip-level remove button block; the group-focus-within:flex
+  // class is what puts the button back in the tab order.
+  const focusablePattern =
+    /aria-label="Remove attachment"[\s\S]*?group-hover:flex group-focus-within:flex/g;
+  const matches = source.match(focusablePattern) ?? [];
+  assert.ok(
+    matches.length >= 2,
+    `expected at least 2 remove-attachment buttons with focus-within fix ` +
+      `(image/video + file chip), found ${matches.length}`,
+  );
+});
+
+test("every `hidden ... group-hover:flex` remove-button also has focus-within", () => {
+  // Defensive: if a new chip variant adds another `hidden ... group-hover:flex`
+  // button without pairing it with `group-focus-within:flex`, fail loudly.
+  const hoverOnlyPattern =
+    /className="[^"]*\bhidden\b[^"]*\bgroup-hover:flex\b(?!\s+group-focus-within:flex)[^"]*"/g;
+  const hoverOnlyMatch = source.match(hoverOnlyPattern);
+  assert.equal(
+    hoverOnlyMatch,
+    null,
+    "found a hidden/group-hover:flex button that is missing group-focus-within:flex — " +
+      "keyboard users would lose access to it",
+  );
+});
+
+test("remove-attachment buttons expose an aria-label", () => {
+  // Tooltip alone is not a sufficient accessible name for an icon-only button.
+  const ariaCount = (source.match(/aria-label="Remove attachment"/g) ?? [])
+    .length;
+  assert.ok(
+    ariaCount >= 2,
+    `expected at least 2 aria-labeled remove buttons, found ${ariaCount}`,
+  );
+});


### PR DESCRIPTION
Fixes #2389.

## What was broken

The "remove" (×) button on every message-composer attachment chip was
reachable only via mouse hover.  Both sites — the image/video thumbnail
remove button and the generic file-chip remove button — used
`hidden ... group-hover:flex`, which is `display: none` until the parent
chip is hovered.  Because the button never appeared in the DOM's tab order,
keyboard-only users had no way to remove an attachment after attaching one.

## The fix

Two-line change per button, applied to both sites in
`ComposerAttachments.tsx`:

1. **Add `group-focus-within:flex`** next to the existing `group-hover:flex`
   on the remove button's class list.  The button now renders (and is
   tabbable) whenever any focusable element inside the chip — including the
   button itself — has focus.  This matches the well-established codebase
   pattern (`MessageReactions`, `MessageActionBar`, `DraftDetailPane`,
   `DraftsPanel`, modal-search input, `CodeBlock`, `link-preview-attachment`,
   and more all use `group-focus-within/...` for hover-hidden affordances).

2. **Add `aria-label="Remove attachment"`** so screen readers announce the
   action before depending on the tooltip; the tooltip alone isn't a
   sufficient accessible name for an icon-only control.

No layout, sizing, or styling change — the button still sits absolutely at
`-right-1 -top-1` in the same circular pill; it just becomes focusable
when the chip has focus.

## Test plan

New `composerAttachmentRemoveA11y.test.mjs`:

```
node --import ./test-loader.mjs --experimental-strip-types \
  --test 'src/features/messages/ui/composerAttachmentRemoveA11y.test.mjs'
```

3/3 pass.  The suite fails if either modified button loses its
`group-focus-within:flex` class or its aria-label, and also asserts no
other `hidden ... group-hover:flex` button exists in the file without the
matching focus-within half — a forward guard against future chip variants
reintroducing the bug.

Manual verification (matching the issue's repro):

1. Open the composer and attach a file and an image.
2. Tab into one of the chips — the × button becomes visible when the chip
   has keyboard focus, and is itself tabbable.
3. Press Enter on the focused × — attachment is removed, focus stays in the
   remaining chip (or falls back to the textarea if no chips remain).
4. Mouse users see no visual change: hover still reveals the button.

## Blast radius

- **Files touched**: `desktop/src/features/messages/ui/ComposerAttachments.tsx`
  (two button class lists + two aria-labels), plus the new test file.
- **Surfaces affected**: the message composer attachment strip in every
  channel/DM/thread composer.  No other UI changes; the same-file
  upload-cancel placeholder button is untouched (it always rendered).
- **Zero runtime cost** — only a CSS class added at render time; no new
  hooks, listeners, or state.
