### PR TITLE
fix(buzz-acp): carry JSON-RPC error.data into AgentError message (#2422)

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -111,11 +111,21 @@ pub enum AcpError {
 /// Build an [`AcpError::AgentError`] from a JSON-RPC error object,
 /// preserving the numeric code. When the `message` field is missing or
 /// non-string, fall back to the full JSON object so provider-specific
-/// detail (e.g. a `data` field) is not lost.
+/// detail (e.g. a `data` field) is not lost. When both `message` and a
+/// provider-attached `data` field are present, append the `data` payload
+/// so actionable detail (e.g. the Claude CLI's "unknown option '--tools'"
+/// stderr) reaches logs and user-facing error strings instead of being
+/// silently dropped. See #2422.
 fn agent_error_from_json(error: &serde_json::Value) -> AcpError {
     let code = error.get("code").and_then(|c| c.as_i64()).unwrap_or(-32000);
     let message = match error.get("message").and_then(|m| m.as_str()) {
-        Some(m) => m.to_string(),
+        Some(m) => {
+            if let Some(data) = error.get("data") {
+                format!("{m} (data: {})", data)
+            } else {
+                m.to_string()
+            }
+        }
         None => error.to_string(),
     };
     AcpError::AgentError { code, message }
@@ -4256,6 +4266,35 @@ mod tests {
             AcpError::AgentError { code, message } => {
                 assert_eq!(code, -32001);
                 assert_eq!(message, "auth denied");
+            }
+            other => panic!("expected AgentError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_error_from_json_appends_data_when_present() {
+        // Regression guard for #2422. The Claude CLI's `--tools` unknown-option
+        // incompatibility with the adapter surfaces to the user only via the
+        // JSON-RPC error's `data.details` field; discarding `data` reduces the
+        // user-facing notice to "code -32603: Internal error" with no clue.
+        let error = serde_json::json!({
+            "code": -32603,
+            "message": "Internal error",
+            "data": {
+                "details": "Claude Code process exited with code 1. stderr: error: unknown option '--tools'"
+            }
+        });
+        match super::agent_error_from_json(&error) {
+            AcpError::AgentError { code, message } => {
+                assert_eq!(code, -32603);
+                assert!(
+                    message.contains("Internal error"),
+                    "message must retain the original: {message}"
+                );
+                assert!(
+                    message.contains("unknown option '--tools'"),
+                    "message must include the data payload: {message}"
+                );
             }
             other => panic!("expected AgentError, got {other:?}"),
         }


### PR DESCRIPTION
Fixes #2422.

## What was broken

When the bundled `claude-agent-acp` adapter and the user's CLI get out of
version-sync (e.g. adapter `0.60.0` passes `--tools` but CLI `2.0.25`
doesn't recognise it), every `session/new` fails with a JSON-RPC error
whose `data` field carries the actionable cause:

```json
{"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"Internal error",
 "data":{"details":"Claude Code process exited with code 1.
                    stderr: error: unknown option '--tools'"}}}
```

`agent_error_from_json` in `crates/buzz-acp/src/acp.rs:119` extracted only
`code` and `message`, silently dropping `data`. The user-facing notice
then read:

> ⚠️ I couldn't process the last request after multiple retries (Agent
> reported error (code -32603): Internal error).

…and the harness's 10-attempt retry loop looked like an unrecoverable bug
in the adapter, when the actionable fix was `bun upgrade` (or pinning the
CLI version).

## The fix

One-line extension to `agent_error_from_json`: when both `message` and a
`data` field are present, append the `data` payload to the constructed
`message` as ` (data: {...})`. The `AcpError::AgentError` struct shape is
unchanged, so all 10+ pattern-match sites across `crates/buzz-acp` (pool
retry classification, auth-error detection, lib auth codepath, etc.) keep
their `{ code, message }` destructuring — only the content of `message`
gains the extra context.

Failure strings that previously read as

```
Agent reported error (code -32603): Internal error
```

now read as

```
Agent reported error (code -32603): Internal error (data: {"details":"Claude
Code process exited with code 1. stderr: error: unknown option '--tools'"})
```

…which makes immediately obvious which CLI/adapter version mismatch to
fix.

## Test plan

`cargo test -p buzz-acp --lib agent_error_from_json` passes all three
`agent_error_*` unit tests:

1. `agent_error_from_json_falls_back_to_full_json_when_message_missing`
   (pre-existing) — covers missing `message` field.
2. `agent_error_from_json_uses_message_field_when_present` (pre-existing)
   — message-only shape unchanged by this fix (no `data` in test fixture).
3. `agent_error_from_json_appends_data_when_present` (new) — regression
   guard for #2422: asserts both the original `Internal error` substring
   AND the `unknown option '--tools'` subgraph reach the final message.

Full `cargo test -p buzz-acp --lib`: **662/662 pass.**

## Blast radius

- **Files touched**: `crates/buzz-acp/src/acp.rs` (one function.
  + new test).
- **Struct shape**: unchanged — `AcpError::AgentError { code, message }`;
  all pattern-match sites compile as before.
- **User-visible behaviour**: error strings in the agent harness log +
  channel notice now include the provider-attached `data` payload when
  present. No other runtime path changes.
- **No new dependencies**, no changes to retry/health classification.

## Out of scope

Whether a *specific* `data.details` shape (e.g. adapter-vs-CLI mismatch)
should ALSO flip the error into a fatal-no-retry class is a policy call
for the maintainers; this fix makes the raw evidence visible so that
discussion is grounded.
