### PR TITLE
fix(admin): stop reconcile-channels from un-archiving every channel it touches

### DIFF
--- a/crates/buzz-admin/src/main.rs
+++ b/crates/buzz-admin/src/main.rs
@@ -81,7 +81,7 @@ enum Command {
         #[command(subcommand)]
         command: ProductFeedbackCommand,
     },
-    /// Emit kind:39000/39002 events for channels missing them.
+    /// Emit kind:39000/39001/39002 events for channels missing them.
     ///
     /// Channels created via direct SQL (seed scripts, pre-migration data) won't
     /// have Nostr discovery events. This command creates them so pure-nostr
@@ -92,6 +92,14 @@ enum Command {
         /// an ephemeral key (events will be unverifiable after restart).
         #[arg(long)]
         relay_key: Option<String>,
+        /// Also republish channels that already have discovery events.
+        ///
+        /// Use this to repair events written by an older build whose tags have
+        /// since drifted from the database — a stale kind:39000 is not visibly
+        /// broken, it just tells every client something the channel row no
+        /// longer says.
+        #[arg(long)]
+        rebuild: bool,
     },
 }
 
@@ -148,8 +156,8 @@ async fn run(cli: Cli) -> Result<i32> {
         Command::ProductFeedback {
             command: ProductFeedbackCommand::List { limit },
         } => cmd_list_product_feedback(limit).await,
-        Command::ReconcileChannels { relay_key } => {
-            reconcile_channels(relay_key).await?;
+        Command::ReconcileChannels { relay_key, rebuild } => {
+            reconcile_channels(relay_key, rebuild).await?;
             Ok(0)
         }
     }
@@ -458,8 +466,11 @@ async fn resolve_admin_tenant(db: &Db) -> Result<TenantContext> {
     Ok(TenantContext::resolved(record.id, record.host))
 }
 
-async fn reconcile_channels(relay_key_arg: Option<String>) -> Result<()> {
-    use buzz_core::kind::KIND_NIP29_GROUP_ADMINS;
+async fn reconcile_channels(relay_key_arg: Option<String>, rebuild: bool) -> Result<()> {
+    use buzz_core::kind::{
+        KIND_NIP29_GROUP_ADMINS, KIND_NIP29_GROUP_MEMBERS, KIND_NIP29_GROUP_METADATA,
+    };
+    use buzz_db::channel_discovery::{nip29_admins_tags, nip29_members_tags, nip29_metadata_tags};
     use buzz_db::event::EventQuery;
 
     let db = connect_db().await?;
@@ -505,70 +516,39 @@ async fn reconcile_channels(relay_key_arg: Option<String>) -> Result<()> {
             .await
             .unwrap_or_default();
 
-        if !existing.is_empty() {
+        if !existing.is_empty() && !rebuild {
             skipped += 1;
             continue;
         }
 
         let members = db.get_members(tenant.community(), channel.id).await?;
 
-        // kind:39000 — channel metadata
-        {
-            let mut tags: Vec<Tag> = vec![Tag::parse(["d", &channel_id_str])?];
-            tags.push(Tag::parse(["name", &channel.name])?);
-            if let Some(ref desc) = channel.description {
-                if !desc.is_empty() {
-                    tags.push(Tag::parse(["about", desc])?);
-                }
-            }
-            if channel.visibility == "private" {
-                tags.push(Tag::parse(["private"])?);
-            } else {
-                tags.push(Tag::parse(["public"])?);
-            }
-            if channel.channel_type == "dm" {
-                tags.push(Tag::parse(["hidden"])?);
-            }
-            tags.push(Tag::parse(["closed"])?);
-            tags.push(Tag::parse(["t", &channel.channel_type])?);
-
-            let event = EventBuilder::new(Kind::Custom(39000), "")
+        // Same builders the relay signs with — see buzz_db::channel_discovery.
+        // Reconcile once carried its own copy of these tag shapes and lost the
+        // `archived` tag, which un-hid archived channels in every client while
+        // the database still said archived.
+        for (kind, tags) in [
+            (
+                KIND_NIP29_GROUP_METADATA,
+                nip29_metadata_tags(channel, &members),
+            ),
+            (
+                KIND_NIP29_GROUP_ADMINS,
+                nip29_admins_tags(channel.id, &members),
+            ),
+            (
+                KIND_NIP29_GROUP_MEMBERS,
+                nip29_members_tags(channel.id, &members),
+            ),
+        ] {
+            let tags: Vec<Tag> = tags
+                .into_iter()
+                .map(Tag::parse)
+                .collect::<std::result::Result<_, _>>()?;
+            let event = EventBuilder::new(Kind::Custom(kind as u16), "")
                 .tags(tags)
                 .sign_with_keys(&relay_keys)
-                .map_err(|e| anyhow::anyhow!("sign kind:39000: {e}"))?;
-            db.replace_addressable_event(tenant.community(), &event, Some(channel.id))
-                .await?;
-        }
-
-        // kind:39001 — admins
-        {
-            let mut tags: Vec<Tag> = vec![Tag::parse(["d", &channel_id_str])?];
-            for m in members
-                .iter()
-                .filter(|m| m.role == "owner" || m.role == "admin")
-            {
-                let pk = hex::encode(&m.pubkey);
-                tags.push(Tag::parse(["p", &pk, &m.role])?);
-            }
-            let event = EventBuilder::new(Kind::Custom(KIND_NIP29_GROUP_ADMINS as u16), "")
-                .tags(tags)
-                .sign_with_keys(&relay_keys)
-                .map_err(|e| anyhow::anyhow!("sign kind:39001: {e}"))?;
-            db.replace_addressable_event(tenant.community(), &event, Some(channel.id))
-                .await?;
-        }
-
-        // kind:39002 — members
-        {
-            let mut tags: Vec<Tag> = vec![Tag::parse(["d", &channel_id_str])?];
-            for m in &members {
-                let pk = hex::encode(&m.pubkey);
-                tags.push(Tag::parse(["p", &pk, "", &m.role])?);
-            }
-            let event = EventBuilder::new(Kind::Custom(39002), "")
-                .tags(tags)
-                .sign_with_keys(&relay_keys)
-                .map_err(|e| anyhow::anyhow!("sign kind:39002: {e}"))?;
+                .map_err(|e| anyhow::anyhow!("sign kind:{kind}: {e}"))?;
             db.replace_addressable_event(tenant.community(), &event, Some(channel.id))
                 .await?;
         }
@@ -576,8 +556,9 @@ async fn reconcile_channels(relay_key_arg: Option<String>) -> Result<()> {
         reconciled += 1;
     }
 
+    let verb = if rebuild { "Republished" } else { "Reconciled" };
     println!(
-        "Reconciled {reconciled} channels ({skipped} already had events, {} total).",
+        "{verb} {reconciled} channels ({skipped} already had events, {} total).",
         channels.len()
     );
     Ok(())

--- a/crates/buzz-db/src/channel_discovery.rs
+++ b/crates/buzz-db/src/channel_discovery.rs
@@ -1,0 +1,242 @@
+//! NIP-29 discovery-event tags derived from channel rows.
+//!
+//! kind:39000 is what every client reads to decide whether a channel is
+//! archived, ephemeral, or has a topic — so any writer that builds those tags
+//! by hand becomes a second source of truth. When the two disagree the loser is
+//! silent: a re-emit that forgets `archived` un-hides a channel in every
+//! sidebar while the database still says it is archived, and nothing logs.
+//!
+//! Tags are returned as raw string arrays so this stays a pure function of the
+//! rows — callers own the `Tag::parse` and the signing.
+
+use uuid::Uuid;
+
+use crate::channel::{ChannelRecord, MemberRecord};
+
+/// kind:39000 (NIP-29 group metadata) tags for `channel`.
+///
+/// `members` is only read for DM channels, whose participants are inlined so
+/// clients can resolve display names without a second kind:39002 fetch.
+pub fn nip29_metadata_tags(channel: &ChannelRecord, members: &[MemberRecord]) -> Vec<Vec<String>> {
+    let group_id = channel.id.to_string();
+    let mut tags: Vec<Vec<String>> = vec![vec!["d".into(), group_id]];
+
+    tags.push(vec!["name".into(), channel.name.clone()]);
+    if let Some(desc) = channel.description.as_ref().filter(|d| !d.is_empty()) {
+        tags.push(vec!["about".into(), desc.clone()]);
+    }
+    if channel.visibility == "private" {
+        tags.push(vec!["private".into()]);
+    } else {
+        // Explicit "public" tag complements NIP-29's absence-of-"private"
+        // convention, making channel visibility self-describing for clients.
+        tags.push(vec!["public".into()]);
+    }
+    // NIP-29 hidden tag: hint to clients not to show DMs in public group lists.
+    // Not a security boundary — access control is channel-scoped storage.
+    if channel.channel_type == "dm" {
+        tags.push(vec!["hidden".into()]);
+        for m in members {
+            tags.push(vec!["p".into(), hex::encode(&m.pubkey)]);
+        }
+    }
+    // Buzz channels always require explicit membership.
+    tags.push(vec!["closed".into()]);
+    // Channel type so clients can distinguish stream/forum/dm without inference.
+    tags.push(vec!["t".into(), channel.channel_type.clone()]);
+    if let Some(topic) = channel.topic.as_ref().filter(|t| !t.is_empty()) {
+        tags.push(vec!["topic".into(), topic.clone()]);
+    }
+    if let Some(purpose) = channel.purpose.as_ref().filter(|p| !p.is_empty()) {
+        tags.push(vec!["purpose".into(), purpose.clone()]);
+    }
+    // Archived state — clients use this to hide channels from the sidebar.
+    if channel.archived_at.is_some() {
+        tags.push(vec!["archived".into(), "true".into()]);
+    }
+    // Ephemeral channel TTL — clients use this to show countdown timers.
+    if let Some(ttl) = channel.ttl_seconds {
+        tags.push(vec!["ttl".into(), ttl.to_string()]);
+    }
+    if let Some(deadline) = channel.ttl_deadline {
+        tags.push(vec!["ttl_deadline".into(), deadline.to_rfc3339()]);
+    }
+
+    tags
+}
+
+/// kind:39001 (NIP-29 group admins) tags — owners and admins only.
+pub fn nip29_admins_tags(channel_id: Uuid, members: &[MemberRecord]) -> Vec<Vec<String>> {
+    let mut tags: Vec<Vec<String>> = vec![vec!["d".into(), channel_id.to_string()]];
+    for m in members
+        .iter()
+        .filter(|m| m.role == "owner" || m.role == "admin")
+    {
+        tags.push(vec!["p".into(), hex::encode(&m.pubkey), m.role.clone()]);
+    }
+    tags
+}
+
+/// kind:39002 (NIP-29 group members) tags — every member, with role.
+pub fn nip29_members_tags(channel_id: Uuid, members: &[MemberRecord]) -> Vec<Vec<String>> {
+    let mut tags: Vec<Vec<String>> = vec![vec!["d".into(), channel_id.to_string()]];
+    for m in members {
+        // NIP-29 convention: ["p", pubkey, relay_url, role]. Empty relay_url
+        // because the canonical relay is implicit (this event is signed by it).
+        tags.push(vec![
+            "p".into(),
+            hex::encode(&m.pubkey),
+            String::new(),
+            m.role.clone(),
+        ]);
+    }
+    tags
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn channel() -> ChannelRecord {
+        let now = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        ChannelRecord {
+            id: Uuid::nil(),
+            name: "general".into(),
+            channel_type: "stream".into(),
+            visibility: "private".into(),
+            description: None,
+            canvas: None,
+            created_by: vec![1],
+            created_at: now,
+            updated_at: now,
+            archived_at: None,
+            deleted_at: None,
+            nip29_group_id: None,
+            topic_required: false,
+            max_members: None,
+            topic: None,
+            topic_set_by: None,
+            topic_set_at: None,
+            purpose: None,
+            purpose_set_by: None,
+            purpose_set_at: None,
+            ttl_seconds: None,
+            ttl_deadline: None,
+        }
+    }
+
+    fn has(tags: &[Vec<String>], key: &str) -> bool {
+        tags.iter().any(|t| t[0] == key)
+    }
+
+    fn value(tags: &[Vec<String>], key: &str) -> Option<String> {
+        tags.iter()
+            .find(|t| t[0] == key)
+            .and_then(|t| t.get(1))
+            .cloned()
+    }
+
+    #[test]
+    fn live_channel_carries_no_archived_tag() {
+        let tags = nip29_metadata_tags(&channel(), &[]);
+        assert!(!has(&tags, "archived"));
+        assert_eq!(
+            value(&tags, "d").as_deref(),
+            Some(Uuid::nil().to_string().as_str())
+        );
+        assert!(has(&tags, "private"));
+        assert!(has(&tags, "closed"));
+    }
+
+    #[test]
+    fn archived_channel_says_so() {
+        let mut c = channel();
+        c.archived_at = Some(Utc.with_ymd_and_hms(2026, 2, 2, 0, 0, 0).unwrap());
+        let tags = nip29_metadata_tags(&c, &[]);
+        assert_eq!(value(&tags, "archived").as_deref(), Some("true"));
+    }
+
+    #[test]
+    fn ephemeral_channel_carries_its_ttl() {
+        let mut c = channel();
+        c.ttl_seconds = Some(3600);
+        c.ttl_deadline = Some(Utc.with_ymd_and_hms(2026, 2, 2, 3, 4, 5).unwrap());
+        let tags = nip29_metadata_tags(&c, &[]);
+        assert_eq!(value(&tags, "ttl").as_deref(), Some("3600"));
+        assert_eq!(
+            value(&tags, "ttl_deadline").as_deref(),
+            Some("2026-02-02T03:04:05+00:00")
+        );
+    }
+
+    #[test]
+    fn topic_and_purpose_survive_when_set() {
+        let mut c = channel();
+        c.topic = Some("ship it".into());
+        c.purpose = Some("release coordination".into());
+        c.description = Some("".into());
+        let tags = nip29_metadata_tags(&c, &[]);
+        assert_eq!(value(&tags, "topic").as_deref(), Some("ship it"));
+        assert_eq!(
+            value(&tags, "purpose").as_deref(),
+            Some("release coordination")
+        );
+        assert!(!has(&tags, "about"), "an empty description is not a tag");
+    }
+
+    fn member(byte: u8, role: &str) -> MemberRecord {
+        MemberRecord {
+            channel_id: Uuid::nil(),
+            pubkey: vec![byte],
+            role: role.into(),
+            joined_at: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+            invited_by: None,
+            removed_at: None,
+        }
+    }
+
+    #[test]
+    fn dm_inlines_its_participants() {
+        let mut c = channel();
+        c.channel_type = "dm".into();
+        let tags = nip29_metadata_tags(&c, &[member(0xab, "member")]);
+        assert!(has(&tags, "hidden"));
+        assert_eq!(value(&tags, "p").as_deref(), Some("ab"));
+    }
+
+    #[test]
+    fn a_non_dm_never_inlines_members() {
+        let tags = nip29_metadata_tags(&channel(), &[member(0xab, "owner")]);
+        assert!(!has(&tags, "hidden"));
+        assert!(!has(&tags, "p"), "only DMs inline participants");
+    }
+
+    #[test]
+    fn admins_tags_hold_only_owners_and_admins() {
+        let members = [
+            member(0x01, "owner"),
+            member(0x02, "member"),
+            member(0x03, "admin"),
+        ];
+        let tags = nip29_admins_tags(Uuid::nil(), &members);
+        let listed: Vec<_> = tags.iter().filter(|t| t[0] == "p").collect();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0][1..], ["01".to_string(), "owner".to_string()]);
+        assert_eq!(listed[1][1..], ["03".to_string(), "admin".to_string()]);
+    }
+
+    #[test]
+    fn members_tags_hold_everyone_with_an_empty_relay_slot() {
+        let tags = nip29_members_tags(
+            Uuid::nil(),
+            &[member(0x01, "owner"), member(0x02, "member")],
+        );
+        let listed: Vec<_> = tags.iter().filter(|t| t[0] == "p").collect();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(
+            listed[1][1..],
+            ["02".to_string(), String::new(), "member".to_string()]
+        );
+    }
+}

--- a/crates/buzz-db/src/lib.rs
+++ b/crates/buzz-db/src/lib.rs
@@ -17,6 +17,8 @@ pub mod api_token;
 pub mod archived_identities;
 /// Channel and membership persistence.
 pub mod channel;
+/// NIP-29 discovery-event tags derived from channel rows.
+pub mod channel_discovery;
 /// Direct message channel persistence.
 pub mod dm;
 /// Database error types.

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -15,6 +15,7 @@ use buzz_core::kind::{
 };
 use buzz_core::StoredEvent;
 use buzz_db::channel::{MemberRecord, MemberRole};
+use buzz_db::channel_discovery::{nip29_admins_tags, nip29_members_tags, nip29_metadata_tags};
 
 use super::event::dispatch_persistent_event;
 use crate::protocol::RelayMessage;
@@ -1051,108 +1052,28 @@ pub async fn emit_group_discovery_events(
     let members = state.db.get_members(tenant.community(), channel_id).await?;
 
     let relay_pubkey_hex = hex::encode(state.relay_keypair.public_key().to_bytes());
-    let group_id = channel_id.to_string();
 
-    {
-        let mut tags: Vec<Tag> = vec![Tag::parse(["d", &group_id])?];
-        tags.push(Tag::parse(["name", &channel.name])?);
-        if let Some(ref desc) = channel.description {
-            if !desc.is_empty() {
-                tags.push(Tag::parse(["about", desc])?);
-            }
-        }
-        if channel.visibility == "private" {
-            tags.push(Tag::parse(["private"])?);
-        } else {
-            // Explicit "public" tag complements NIP-29's absence-of-"private" convention,
-            // making channel visibility self-describing for clients.
-            tags.push(Tag::parse(["public"])?);
-        }
-        // NIP-29 hidden tag: hint to clients not to show DMs in public group lists.
-        // Not a security boundary — access control is handled by channel-scoped storage.
-        if channel.channel_type == "dm" {
-            tags.push(Tag::parse(["hidden"])?);
-            // Include participant pubkeys in kind:39000 for DMs so clients can
-            // resolve display names without a separate kind:39002 fetch.
-            for m in &members {
-                let pubkey_hex = hex::encode(&m.pubkey);
-                tags.push(Tag::parse(["p", &pubkey_hex])?);
-            }
-        }
-        // Buzz channels always require explicit membership
-        tags.push(Tag::parse(["closed"])?);
-        // Channel type tag so clients can distinguish stream/forum/dm without inference
-        tags.push(Tag::parse(["t", &channel.channel_type])?);
-        // Optional topic / purpose for richer client UX
-        if let Some(ref topic) = channel.topic {
-            if !topic.is_empty() {
-                tags.push(Tag::parse(["topic", topic])?);
-            }
-        }
-        if let Some(ref purpose) = channel.purpose {
-            if !purpose.is_empty() {
-                tags.push(Tag::parse(["purpose", purpose])?);
-            }
-        }
-        // Archived state — clients use this to hide channels from the sidebar.
-        if channel.archived_at.is_some() {
-            tags.push(Tag::parse(["archived", "true"])?);
-        }
-        // Ephemeral channel TTL — clients use this to show countdown timers.
-        if let Some(ttl) = channel.ttl_seconds {
-            tags.push(Tag::parse(["ttl", &ttl.to_string()])?);
-        }
-        if let Some(ref deadline) = channel.ttl_deadline {
-            tags.push(Tag::parse(["ttl_deadline", &deadline.to_rfc3339()])?);
-        }
-        emit_addressable_discovery_event(
-            tenant,
-            state,
-            channel_id,
+    // The tag shapes live in buzz-db so `buzz-admin reconcile-channels` republishes
+    // exactly what the relay emits. They drifted once, and the symptom was silent:
+    // reconcile dropped the `archived` tag, so archived channels came back in every
+    // sidebar while the database still said archived.
+    for (kind, tags) in [
+        (
             KIND_NIP29_GROUP_METADATA,
-            tags,
-            &relay_pubkey_hex,
-        )
-        .await?;
-    }
-
-    {
-        let mut tags: Vec<Tag> = vec![Tag::parse(["d", &group_id])?];
-        for m in members
-            .iter()
-            .filter(|m| m.role == "owner" || m.role == "admin")
-        {
-            let pubkey_hex = hex::encode(&m.pubkey);
-            tags.push(Tag::parse(["p", &pubkey_hex, &m.role])?);
-        }
-        emit_addressable_discovery_event(
-            tenant,
-            state,
-            channel_id,
+            nip29_metadata_tags(&channel, &members),
+        ),
+        (
             KIND_NIP29_GROUP_ADMINS,
-            tags,
-            &relay_pubkey_hex,
-        )
-        .await?;
-    }
-
-    {
-        let mut tags: Vec<Tag> = vec![Tag::parse(["d", &group_id])?];
-        for m in &members {
-            let pubkey_hex = hex::encode(&m.pubkey);
-            // NIP-29 convention: ["p", pubkey, relay_url, role]. Empty relay_url
-            // because the canonical relay is implicit (this event is signed by it).
-            tags.push(Tag::parse(["p", &pubkey_hex, "", &m.role])?);
-        }
-        emit_addressable_discovery_event(
-            tenant,
-            state,
-            channel_id,
+            nip29_admins_tags(channel_id, &members),
+        ),
+        (
             KIND_NIP29_GROUP_MEMBERS,
-            tags,
-            &relay_pubkey_hex,
-        )
-        .await?;
+            nip29_members_tags(channel_id, &members),
+        ),
+    ] {
+        let tags: Vec<Tag> = tags.into_iter().map(Tag::parse).collect::<Result<_, _>>()?;
+        emit_addressable_discovery_event(tenant, state, channel_id, kind, tags, &relay_pubkey_hex)
+            .await?;
     }
 
     Ok(())


### PR DESCRIPTION
## Problem

`buzz-admin reconcile-channels` builds kind:39000 tags from its own copy of the
relay's list. The copy fell behind `emit_group_discovery_events`: it emits
`d`/`name`/`about`/`private|public`/`hidden`/`closed`/`t` and nothing else, so

- `archived`
- `topic`
- `purpose`
- `ttl` / `ttl_deadline`
- a DM's participant `p` tags

are all dropped from any channel it republishes.

The archived one causes visible damage. `channels.archived_at` is not what
clients read — `["archived","true"]` on kind:39000 is
(`desktop/src-tauri/src/nostr_convert.rs` maps it to `archivedAt`, and
`AppShell.tsx` filters the sidebar on it). Its absence is indistinguishable
from a live channel, so running reconcile over a deployment that has archived
channels brings them back in every sidebar while the database still says
archived. Nothing logs on either side.

Reproduced on a live deployment: a sweep republished 58 channels' kind:39000,
and the two archived ones reappeared for every member.

## Change

- New `buzz_db::channel_discovery` owns the kind:39000/39001/39002 tag shapes
  as pure functions of `ChannelRecord` + `MemberRecord`, with unit tests for
  the archived / ttl / topic+purpose / DM-participant cases that regressed.
- `emit_group_discovery_events` (relay) and `reconcile_channels` (admin) both
  call it. Relay output is unchanged — the shared functions were lifted from
  it verbatim.
- `reconcile-channels --rebuild` republishes channels that already have events.
  Without it, reconcile skips exactly the channels whose events are wrong, so
  there is no in-band way to repair the damage.

## Test plan

- `cargo test -p buzz-db --lib channel_discovery` — 8 new tests
- `cargo test -p buzz-db --lib` — 102 pass
- `cargo clippy -p buzz-relay -p buzz-admin --all-targets` — clean
- `just ci`