### PR TITLE
fix(buzz-acp): attest no_mention_filter in the startup config summary (#4228)

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -1123,7 +1123,7 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} no_mention_filter={} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1134,6 +1134,7 @@ impl Config {
             self.agents,
             self.heartbeat_interval_secs,
             self.subscribe_mode,
+            self.no_mention_filter,
             self.dedup_mode,
             self.multiple_event_handling,
             self.ignore_self,
@@ -2238,6 +2239,30 @@ channels = "ALL"
         assert!(
             s.contains("memory=true"),
             "summary should include memory=true when enabled, got: {s}"
+        );
+    }
+
+    #[test]
+    fn test_summary_includes_no_mention_filter_default_false() {
+        // Regression guard for #4228: the startup summary must attest the
+        // no_mention_filter state so operators can verify the flag took
+        // effect from the journal alone.
+        let config = test_config(SubscribeMode::Mentions);
+        let s = config.summary();
+        assert!(
+            s.contains("no_mention_filter=false"),
+            "summary should include no_mention_filter=false by default, got: {s}"
+        );
+    }
+
+    #[test]
+    fn test_summary_reflects_no_mention_filter() {
+        let mut config = test_config(SubscribeMode::Mentions);
+        config.no_mention_filter = true;
+        let s = config.summary();
+        assert!(
+            s.contains("no_mention_filter=true"),
+            "summary should include no_mention_filter=true when set, got: {s}"
         );
     }
 


### PR DESCRIPTION
Fixes #4228.

## What was broken

The one-line startup summary that `buzz-acp` logs to the journal — which
attests relay, pubkey, subscribe mode, dedup, respond_to, heartbeat, and
a dozen other operator-relevant config items — omitted the
`no_mention_filter` state. A deployment started with:

```
--subscribe mentions --no-mention-filter
```

logged exactly `subscribe=Mentions` — **byte-identical** to a plain
mention-gated deployment. The two flags diverge the relay subscription
(the `#p` filter is dropped) and the cost model (every allowed-author
message becomes a potential model turn), so the summary's silence on the
flag left operators with no journal-visible proof it took effect.

## The fix

Add `no_mention_filter={bool}` to the summary format string immediately
after the `subscribe={mode}` token — semantically paired, since the flag
relaxes the mention gate the mode selects. Relay log line for the
above invocation now reads:

```
relay=… pubkey=… agent_cmd=… … subscribe=Mentions no_mention_filter=true dedup=…
```

`no_mention_filter=false` is also explicitly attested so operators can
distinguish "flag missing/unset" from "flag explicitly off".

## Test plan

Two new regression tests in `crates/buzz-acp/src/config.rs`:

- `test_summary_includes_no_mention_filter_default_false` — the default
  config must explicitly attest `no_mention_filter=false` (guards against
  silent omission).
- `test_summary_reflects_no_mention_filter` — flipping the flag must
  produce `no_mention_filter=true` in the summary.

`cargo test -p buzz-acp --lib` → **663/663 pass** (661 before + 2 new).

## Blast radius

- **Files touched**: `crates/buzz-acp/src/config.rs` (one format-string
  argument + two test functions).
- **Struct shape**: unchanged; only the formatted output string gains one
  token.
- **User-visible behaviour**: operator journal gains one configuration
  attestation per agent startup. No API, relay protocol, or runtime path
  changes.
- **Log-format compatibility**: adds a token to a free-form line; any
  human reader or regexp log parser tolerant of token additions is
  unaffected.
