### PR TITLE
docs(remote-agents): presence staleness bound is 180s since #3783

### DIFF
--- a/VISION_REMOTE_AGENTS.md
+++ b/VISION_REMOTE_AGENTS.md
@@ -56,7 +56,7 @@ Remote agents solve it from the inside. Because the desktop retains no substrate
 
 **The body's state is mortal.** Files, checkouts, half-finished working trees — gone with the body unless the substrate persists them. The agent survives; its scratch space doesn't. Durable knowledge belongs on the relay, and agents are built to put it there.
 
-**Presence can lag the truth, but not for long.** If the substrate kills a body without ceremony, the presence dot can outlive the agent — by seconds if the connection drops cleanly, by at most about ninety if it doesn't. Presence is a lease the agent renews, not a flag it sets: a dead agent stops renewing and the relay forgets it. Ninety seconds of a wrong dot, never an indefinite one.
+**Presence can lag the truth, but not for long.** If the substrate kills a body without ceremony, the presence dot can outlive the agent — by seconds if the connection drops cleanly, by at most about three minutes if it doesn't. Presence is a lease the agent renews, not a flag it sets: a dead agent stops renewing and the relay forgets it. Three minutes of a wrong dot, never an indefinite one.
 
 **A running agent finishes on the configuration it started with.** New keys, new models, new settings take effect on the next body. And an instance that never got far enough to run — a body that failed to start — is the substrate operator's residue to clear, with the substrate's own tools. Editing an agent mid-sentence was never on the menu.
 

--- a/docs/remote-agents.md
+++ b/docs/remote-agents.md
@@ -203,9 +203,9 @@ one.
   deployment axis (`deployed`/`not_deployed`, from the stored
   `backend_agent_id`) is bookkeeping, not liveness. Staleness bound: presence
   can be wrong for the window between an abnormal agent death (SIGKILL, node
-  loss) and the relay's presence expiry — **90 seconds**
+  loss) and the relay's presence expiry — **180 seconds**
   (`PRESENCE_TTL_SECS`, `buzz-pubsub/src/presence.rs:16`; the vision's
-  "ninety seconds of a wrong dot, never an indefinite one"), the accepted
+  "three minutes of a wrong dot, never an indefinite one"), the accepted
   cost of M1.
   The Kubernetes binding minimizes the *avoidable* part of that window by
   sizing the termination grace period to the harness's full graceful-shutdown
@@ -213,7 +213,7 @@ one.
   presence-suppression knob, `BUZZ_ACP_NO_PRESENCE`, MUST join
   `RESERVED_ENV_KEYS` — locally the knob is cosmetic (the process and UI
   remain visible), but remotely M1 makes presence the *only* signal, so an
-  unreserved user env var would convert "wrong for ≤90s" into "wrong
+  unreserved user env var would convert "wrong for ≤180s" into "wrong
   indefinitely" and silently disarm the one bound in print; (b) presence is
   scoped to a **community**: the relay derives community from its host, so
   the deploy-time `relay_url` binds the body to one community for its whole
@@ -925,7 +925,7 @@ I5's enforcement point. A new harness knob:
   could disable the reaper and reopen unbounded lifetime through the front
   door. `BUZZ_ACP_NO_PRESENCE` (`config.rs:378`) MUST join in the same
   change, for the same shape of reason at I3 instead of I5: unreserved, it
-  lets user env silently defeat the 90s presence bound (I3). One knob
+  lets user env silently defeat the 180s presence bound (I3). One knob
   guards "knows when to leave", the other "you can see that it left";
   both are promises users must not be able to un-make by typo.
 - Distinctness note: this is a **fourth** timeout concept, deliberately named


### PR DESCRIPTION
## Problem

VISION_REMOTE_AGENTS.md and the remote-agents spec both promise a dead remote agent's presence dot can be wrong "by at most about ninety" seconds. That was true against the old presence lease (90s `PRESENCE_TTL_SECS` renewed on a 30s/60s beat), but #3783 (merged 2026-07-30) raised the lease to 180s with all publishers on a 60s beat. Both documents landed after that change (#3924 on 07-30, #3748 on 08-02), so the stated staleness bound is half the real one.

The margin history is on #3795: the old 90s lease gave the agent harness a 1.5x margin (production capture in https://github.com/block/buzz/issues/3795#issuecomment-5139221532), #3783 restored 3x by doubling the TTL, and the doubled TTL is what these documents should state.

## Fix

Five lines, docs only:

- `VISION_REMOTE_AGENTS.md` "Honest Costs": ninety seconds becomes about three minutes.
- `docs/remote-agents.md` I3: the **90 seconds** bound becomes **180 seconds**, the quoted vision phrase follows, and the two downstream restatements ("wrong for <=90s", "the 90s presence bound") match.

The `presence.rs:16` line reference in the spec is still accurate; only the constant's value changed. I checked both files for any other statement derived from the old 90/30 pair and found none.

## Validation

- `PRESENCE_TTL_SECS = 180` at `crates/buzz-pubsub/src/presence.rs:16` on current main.
- Agent harness heartbeat 60s at `crates/buzz-acp/src/lib.rs:1583`, desktop 60s at `desktop/src/features/presence/lib/presence.ts:42`, so 180s = 3x the slowest publisher, and the worst-case wrong-dot window after an unceremonious kill is the full 180s lease.
- Docs-only change; no code touched.
