### PR TITLE
fix(desktop): claim the invite when redeeming from membership-denied

### DIFF
--- a/desktop/src/features/onboarding/communityOnboarding.test.mjs
+++ b/desktop/src/features/onboarding/communityOnboarding.test.mjs
@@ -83,6 +83,56 @@ test("same-relay ingress resumes rather than replacing progress", () => {
   assert.equal(resumed.inviteCode, "new-code");
 });
 
+test("membership-recovery redeem re-enters claiming on the resumed transaction", () => {
+  const storage = createMemoryStorage();
+  const first = startCommunityOnboarding(
+    { source: "first-community", relayUrl: "wss://relay.example" },
+    storage,
+    new Date("2026-08-02T00:00:00Z"),
+  );
+  // The relay denies membership while the profile step is saving, so the
+  // transaction is parked on "profile" when the user pastes an invite.
+  const denied = updateCommunityOnboardingTransaction(
+    first,
+    { stage: "profile" },
+    storage,
+    new Date("2026-08-02T00:01:00Z"),
+  );
+  const redeemed = startCommunityOnboarding(
+    {
+      source: "membership-recovery",
+      relayUrl: "wss://relay.example",
+      inviteCode: "v2.some-invite-code",
+    },
+    storage,
+    new Date("2026-08-02T00:02:00Z"),
+  );
+  assert.equal(redeemed.id, denied.id);
+  assert.equal(redeemed.stage, "claiming");
+  assert.equal(redeemed.inviteCode, "v2.some-invite-code");
+});
+
+test("membership-recovery without a code leaves the stage alone", () => {
+  const storage = createMemoryStorage();
+  const first = startCommunityOnboarding(
+    { source: "first-community", relayUrl: "wss://relay.example" },
+    storage,
+    new Date("2026-08-02T00:00:00Z"),
+  );
+  updateCommunityOnboardingTransaction(
+    first,
+    { stage: "profile" },
+    storage,
+    new Date("2026-08-02T00:01:00Z"),
+  );
+  const resumed = startCommunityOnboarding(
+    { source: "membership-recovery", relayUrl: "wss://relay.example" },
+    storage,
+    new Date("2026-08-02T00:02:00Z"),
+  );
+  assert.equal(resumed.stage, "profile");
+});
+
 test("stale asynchronous updates cannot mutate a replacement transaction", () => {
   const storage = createMemoryStorage();
   const original = startCommunityOnboarding(

--- a/desktop/src/features/onboarding/communityOnboarding.tsx
+++ b/desktop/src/features/onboarding/communityOnboarding.tsx
@@ -154,8 +154,17 @@ export function startCommunityOnboarding(
   const relayUrl = canonicalRelayUrl(input.relayUrl);
   const existing = loadCommunityOnboardingTransaction(storage);
   if (existing?.relayUrl === relayUrl) {
+    // Resuming keeps the stored stage so a link opened mid-flow cannot rewind
+    // progress — except for a membership-recovery redeem, which is the user
+    // explicitly saying "claim this code now". That one has to re-enter
+    // `claiming`: the relay denied membership, so every later stage is
+    // unreachable, and parking the new code on the stored stage leaves
+    // `useClaimInvite` idle and the redeem button looking dead.
+    const isRecoveryRedeem =
+      input.source === "membership-recovery" && !!input.inviteCode?.trim();
     const updated = {
       ...existing,
+      stage: isRecoveryRedeem ? ("claiming" as const) : existing.stage,
       firstCommunityPage:
         input.firstCommunityPage ?? existing.firstCommunityPage,
       inviteCode: input.inviteCode?.trim() || existing.inviteCode,

--- a/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/CommunityOnboardingFlow.tsx
@@ -198,6 +198,13 @@ export function CommunityOnboardingFlow({
 
   useClaimInvite();
 
+  // Redeeming an invite from the membership-denied screen puts the
+  // transaction back into `claiming`. The denial is a local flag, so without
+  // this the claim would run behind a screen that still says "not a member".
+  React.useEffect(() => {
+    if (transaction?.stage === "claiming") setIsMembershipDenied(false);
+  }, [transaction?.stage]);
+
   React.useEffect(() => {
     if (transaction?.stage === "connecting") onConnect();
   }, [onConnect, transaction?.stage]);


### PR DESCRIPTION
## Summary

Redeeming an invite from the "Not a member yet" screen (`MembershipDenied` → **Have an invite?**) stores the code but never claims it. The button looks dead: no request leaves the app, no error appears, and the screen does not change.

`startCommunityOnboarding` resumes a same-relay transaction without touching `stage` (`communityOnboarding.tsx:156-174`). Membership is denied while the transaction sits on `profile` (`CommunityOnboardingFlow.tsx:430-440`), so the redeem writes `inviteCode` onto a `profile`-stage transaction while `useClaimInvite` only fires on `claiming` (`useClaimInvite.ts:25`). The claim never runs, so `POST /api/invites/claim` is never sent — which also makes the failure invisible from the relay side: no log line at any level, no row in `relay_invites`, `uses_remaining` unchanged. (Same invisibility as #3636, different cause — here the request is never made rather than blocked in flight.)

Preserving the stage on resume is deliberate: a link opened mid-flow should not rewind progress, and `communityOnboarding.test.mjs` asserts exactly that. This PR narrows the exception to the `membership-recovery` source, which is used only by the redeem on the denial screen (`MembershipDenied.tsx:87-97`) — a state where every stage past `claiming` is unreachable by definition, because the relay just refused membership.

Second change: `isMembershipDenied` is local component state, so with only the stage fixed the claim would run behind a screen still saying the user is not a member. Clearing the flag when the transaction enters `claiming` hands the user back to the normal onboarding flow.

### Related issue

None found for this exact bug. Adjacent but different root causes: #3636 (rejected CORS preflight is invisible on both sides), #1979 (mobile join retry silently no-ops after a claim error), #2902 and #4209 (invite UI on self-hosted relays).

### Reproduction

Against a self-hosted relay with closed membership, on a fresh desktop install:

1. First-run screen → enter the relay **URL** (not an invite link) → connect.
2. Complete the profile step. The relay denies membership → **Not a member yet**.
3. From an owner account, mint an invite for that relay.
4. On the denial screen: **Have an invite?** → paste `https://<relay>/invite/<code>` → submit.

**Observed:** nothing happens. The screen stays on "Not a member yet", the relay logs no claim attempt at any log level, and the invite's `uses_remaining` is unchanged.

**Expected:** the code is claimed and onboarding continues.

The relay is not at fault here — claiming the very same code out of band with a NIP-98-signed `POST /api/invites/claim` returns `{"status":"joined","role":"member"}`.

Pasting the same invite link on the first-run screen instead does work, because that path has no stored transaction and so takes the `stage: "claiming"` branch for a newly created one. Only the recovery path is broken.

### Testing

```
node --import ./test-loader.mjs --experimental-strip-types --test "src/features/onboarding/communityOnboarding.test.mjs"
# 21/21 pass (19 before this change)
```

Two regression tests added:

- `membership-recovery redeem re-enters claiming on the resumed transaction` — fails without the fix (stage stays `profile`).
- `membership-recovery without a code leaves the stage alone` — guards the narrowing, so a bare recovery start is not turned into a claim.

The existing `same-relay ingress resumes rather than replacing progress` test is untouched and still passes, so `deep-link-join` keeps its resume semantics.

No screenshots: the change is a state transition, and the visible result is simply that onboarding proceeds instead of the screen staying put.
