### PR TITLE
fix(mobile): default Channel.isMember to true when wire omits is_member (#4307)

### DIFF
--- a/mobile/lib/features/channels/channel.dart
+++ b/mobile/lib/features/channels/channel.dart
@@ -64,7 +64,7 @@ class Channel {
     participantPubkeys:
         (json['participant_pubkeys'] as List<dynamic>? ?? const [])
             .cast<String>(),
-    isMember: json['is_member'] as bool? ?? false,
+    isMember: json['is_member'] as bool? ?? true,
     ttlSeconds: json['ttl_seconds'] as int?,
     ttlDeadline: json['ttl_deadline'] != null
         ? DateTime.parse(json['ttl_deadline'] as String)

--- a/mobile/test/features/channels/channel_test.dart
+++ b/mobile/test/features/channels/channel_test.dart
@@ -68,7 +68,13 @@ void main() {
       expect(channel.isPrivate, isTrue);
     });
 
-    test('defaults is_member to false when missing', () {
+    test('defaults is_member to true when missing (aligns with desktop)', () {
+      // Desktop (`desktop/src-tauri/src/models.rs`) uses
+      // `#[serde(default = "default_true")]` for the same field, so legacy
+      // payloads that omit `is_member` land users as members on desktop and
+      // as non-members on mobile. The two platforms disagreeing on identity
+      // for the same wire data is the cross-platform symptom tracked as
+      // #4307; pin the same default here so the behaviour matches.
       final json = {
         'id': 'abc-123',
         'name': 'test',
@@ -81,7 +87,7 @@ void main() {
 
       final channel = Channel.fromJson(json);
 
-      expect(channel.isMember, isFalse);
+      expect(channel.isMember, isTrue);
       expect(channel.isForum, isTrue);
     });
   });


### PR DESCRIPTION
## Problem

When the wire payload for a channel omits `is_member`, desktop and mobile reach opposite conclusions about the viewer's membership on identical relay data:

- **Desktop** (`desktop/src-tauri/src/models.rs:131`) uses `#[serde(default = "default_true")]` → `is_member: true`
- **Mobile** (`mobile/lib/features/channels/channel.dart:67`) uses `json['is_member'] as bool? ?? false` → `isMember: false`

This is one of the concrete symptoms under #4307: a new joiner is in **zero** kind:39002 channel-membership events server-side, both clients have to render the channel, and desktop lands them in a (runnable, readable) community while mobile displays the same channel as one they haven't joined.

## Fix

Align mobile with desktop by pinning the same fallback. The single-line change:

```dart
- isMember: json['is_member'] as bool? ?? false,
+ isMember: json['is_member'] as bool? ?? true,
```

Plus flip the dedicated fallback test (`mobile/test/features/channels/channel_test.dart`) to assert `isTrue` and add a framing comment citing the desktop source so future readers see why the default matches.

## Scope

- **Only the fallback**. When the relay emits an explicit `is_member` (`true` or `false`), the wire value still wins — the existing explicit-`false` round-trip test (`'is_member': false` payload, same file) still passes.
- **Doesn't change join/leave affordances**. Both platforms gate the join button on `!channel.isMember` (e.g. `ChannelBrowserDialog`), which still works — the only thing that changes is the semantic when the field is absent.
- Direction **3** of #4307's reporter three options. Directions 1 (auto-join a welcome channel on claim) and 2 (list readable channels for non-members without `is_member` at all) are server-side policy decisions the maintainers should weigh in on; this PR only closes the cross-platform inconsistency the reporter flagged as suspicious.

## Verification

- Test file updated to assert the aligned default. The other explicit-false payload test continues to cover wire-value passthrough.
- Local `flutter test` unavailable (no Dart toolchain installed); CI will validate.
- No other repo consumers of `Channel.fromJson` rely on the `false` default — the mobile `_channelFromMeta` flow in `channels_provider.dart` already passes `isMember: true` explicitly for fetched channels, and the `fromJson` default only engages for stored/cached/legacy payloads where the field is missing.

Resolves part of #4307.

DCO-signed.
