### PR TITLE
feat(desktop): support local Ollama on Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,21 @@ error such as:
 The system library `gdk-pixbuf-2.0` required by crate `gdk-pixbuf-sys` was not found.
 ```
 
+#### Windows: native desktop development
+
+Install the standard Tauri prerequisites (Microsoft C++ Build Tools and
+WebView2), Git for Windows, and Python 3. Run Buzz commands from Git Bash so
+the repository's Bash recipes use Git for Windows rather than WSL:
+
+```bash
+cd /c/path/to/buzz
+just desktop-standalone
+```
+
+The standalone recipe builds the native agent sidecars and launches the
+desktop without Docker or a local relay. Python may be installed as either
+`python3` or `python`; the launcher detects both names.
+
 If you're only touching the relay, CLI, or other server-side crates, you can
 skip this and run the narrower recipes instead — `just fmt-check`, `just
 clippy`, `just test-unit`, and `just test` need no GTK.

--- a/crates/buzz-agent/README.md
+++ b/crates/buzz-agent/README.md
@@ -135,14 +135,14 @@ Everything is environment variables. No flags, no config files. (We are a subpro
 
 | Variable | Default | Notes |
 |---|---|---|
-| `BUZZ_AGENT_PROVIDER` | — | Required. `anthropic`, `openai`, `openrouter`, `databricks`, or `databricks_v2`. No implicit fallback — the agent errors at startup when this is unset. |
+| `BUZZ_AGENT_PROVIDER` | — | Required. `anthropic`, `openai`, `ollama`, `openrouter`, `databricks`, or `databricks_v2`. No implicit fallback — the agent errors at startup when this is unset. |
 | `ANTHROPIC_API_KEY` | — | Required when provider=anthropic. |
 | `ANTHROPIC_MODEL` | — | Required when provider=anthropic. |
 | `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` | |
 | `ANTHROPIC_API_VERSION` | `2023-06-01` | |
-| `OPENAI_COMPAT_API_KEY` | — | Required when provider=openai. |
-| `OPENAI_COMPAT_MODEL` | — | Required when provider=openai. |
-| `OPENAI_COMPAT_BASE_URL` | `https://api.openai.com/v1` | Point at vLLM, llama.cpp, Ollama, etc. |
+| `OPENAI_COMPAT_API_KEY` | — | Required when provider=openai; optional when provider=ollama. |
+| `OPENAI_COMPAT_MODEL` | — | Required when provider=openai or provider=ollama. |
+| `OPENAI_COMPAT_BASE_URL` | provider default | `https://api.openai.com/v1` for openai; `http://127.0.0.1:11434/v1` for ollama. |
 | `OPENAI_COMPAT_API` | `auto` | `auto` \| `chat` \| `responses`. `auto` picks Responses for `*.openai.com`, Chat Completions everywhere else. |
 | `OPENROUTER_API_KEY` | — | Required when provider=openrouter. |
 | `OPENROUTER_MODEL` | — | Required when provider=openrouter. Use OpenRouter's `vendor/model` id, e.g. `anthropic/claude-sonnet-4.5`. |
@@ -236,7 +236,7 @@ lifecycle hook — see [MCP_DRIVEN_HOOKS.md](../../docs/MCP_DRIVEN_HOOKS.md).
 | OpenAI | `openai` | `POST {base}/responses` | gpt-5, gpt-5-mini, o4-mini, gpt-4o |
 | vLLM | `openai` | `POST {base}/chat/completions` | any tool-calling model |
 | llama.cpp | `openai` | `POST {base}/chat/completions` | any tool-calling GGUF |
-| Ollama | `openai` | `POST {base}/chat/completions` | llama3.1, qwen2.5-coder |
+| Ollama (local) | `ollama` | `POST http://127.0.0.1:11434/v1/chat/completions` | llama3.1, qwen2.5-coder |
 | Block Gateway | `openai` | `POST {base}/chat/completions` | gpt-5, claude |
 | OpenRouter | `openrouter` | `POST {base}/chat/completions` | anything they route (extended-thinking replay, provider-agnostic tool calling) |
 | Databricks | `databricks` | `POST {host}/serving-endpoints/{model}/invocations` | goose-claude-4-6-sonnet |

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -764,8 +764,12 @@ impl Config {
     pub fn from_env() -> Result<Self, String> {
         let databricks_host = env("DATABRICKS_HOST");
         let databricks_model = env("DATABRICKS_MODEL");
+        let requested_provider = env("BUZZ_AGENT_PROVIDER");
+        let is_ollama = requested_provider
+            .as_deref()
+            .is_some_and(|value| value.trim().eq_ignore_ascii_case("ollama"));
         let provider = resolve_provider(
-            env("BUZZ_AGENT_PROVIDER").as_deref(),
+            requested_provider.as_deref(),
             env("ANTHROPIC_API_KEY").as_deref(),
             env("OPENAI_COMPAT_API_KEY").as_deref(),
             env("OPENROUTER_API_KEY").as_deref(),
@@ -794,16 +798,32 @@ impl Config {
                 env_or("ANTHROPIC_BASE_URL", "https://api.anthropic.com"),
                 OpenAiApi::Auto, // unused for Anthropic
             ),
-            Provider::OpenAi => (
-                req("OPENAI_COMPAT_API_KEY")?,
-                resolve_model(
+            Provider::OpenAi => {
+                let api_key = if is_ollama {
+                    env("OPENAI_COMPAT_API_KEY").unwrap_or_else(|| "ollama".to_string())
+                } else {
+                    req("OPENAI_COMPAT_API_KEY")?
+                };
+                let model = resolve_model(
                     buzz_agent_model.as_deref(),
                     env("OPENAI_COMPAT_MODEL").as_deref(),
                 )
-                .ok_or_else(|| "config: OPENAI_COMPAT_MODEL required".to_string())?,
-                env_or("OPENAI_COMPAT_BASE_URL", "https://api.openai.com/v1"),
-                parse_openai_api(env("OPENAI_COMPAT_API").as_deref())?,
-            ),
+                .ok_or_else(|| "config: OPENAI_COMPAT_MODEL required".to_string())?;
+                let base_url = env_or(
+                    "OPENAI_COMPAT_BASE_URL",
+                    if is_ollama {
+                        "http://127.0.0.1:11434/v1"
+                    } else {
+                        "https://api.openai.com/v1"
+                    },
+                );
+                let openai_api = if is_ollama {
+                    OpenAiApi::Chat
+                } else {
+                    parse_openai_api(env("OPENAI_COMPAT_API").as_deref())?
+                };
+                (api_key, model, base_url, openai_api)
+            }
             Provider::Databricks | Provider::DatabricksV2 => (
                 env("DATABRICKS_TOKEN").unwrap_or_default(),
                 resolve_model(buzz_agent_model.as_deref(), databricks_model.as_deref())
@@ -1042,6 +1062,7 @@ fn resolve_provider(
                 "openai" | "openai-compat" => Err(
                     "config: OPENAI_COMPAT_API_KEY required".into(),
                 ),
+                "ollama" => Ok(Provider::OpenAi),
                 "databricks" => Ok(Provider::Databricks),
                 "databricks_v2" | "databricks-v2" => Ok(Provider::DatabricksV2),
                 "openrouter" if present_nonempty(openrouter_key) => Ok(Provider::OpenRouter),
@@ -1268,6 +1289,14 @@ mod tests {
         );
         assert_eq!(
             resolve_provider(Some("openai"), None, Some("sk-openai"), None).unwrap(),
+            Provider::OpenAi
+        );
+    }
+
+    #[test]
+    fn resolve_provider_accepts_local_ollama_without_api_key() {
+        assert_eq!(
+            resolve_provider(Some("ollama"), None, None, None).unwrap(),
             Provider::OpenAi
         );
     }

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -344,7 +344,7 @@ fn is_openai_compatible_provider(provider: Option<&str>) -> bool {
             .map(str::trim)
             .map(str::to_ascii_lowercase)
             .as_deref(),
-        Some("openai" | "openai-compat")
+        Some("openai" | "openai-compat" | "ollama")
     )
 }
 
@@ -489,8 +489,13 @@ async fn discover_openai_compatible_models(
         return Ok(None);
     }
 
+    let ollama = provider
+        .as_deref()
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("ollama"));
     let api_key = if relay_mesh {
         crate::managed_agents::RELAY_MESH_API_KEY_PLACEHOLDER.to_string()
+    } else if ollama {
+        env_or_process_value(env, "OPENAI_COMPAT_API_KEY").unwrap_or_else(|| "ollama".to_string())
     } else {
         match provider.required_env(env, "OPENAI_COMPAT_API_KEY")? {
             Some(api_key) => api_key,
@@ -500,6 +505,8 @@ async fn discover_openai_compatible_models(
     let redaction_env = redaction_env_with_value(env, "OPENAI_COMPAT_API_KEY", &api_key);
     let url = if relay_mesh {
         format!("{}/models", crate::managed_agents::RELAY_MESH_API_BASE_URL)
+    } else if ollama && env_or_process_value(env, "OPENAI_COMPAT_BASE_URL").is_none() {
+        "http://127.0.0.1:11434/v1/models".to_string()
     } else {
         openai_compatible_models_url_for_discovery(env)
     };

--- a/desktop/src-tauri/src/commands/agent_models_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_models_tests.rs
@@ -1,6 +1,12 @@
 use super::*;
 
 #[test]
+fn ollama_uses_openai_compatible_model_discovery() {
+    assert!(is_openai_compatible_provider(Some("ollama")));
+    assert!(!is_openai_compatible_provider(Some("ollama-cloud")));
+}
+
+#[test]
 fn openai_model_normalization_keeps_agent_text_models() {
     let models = normalize_openai_compatible_models(
         OpenAiModelListResponse {

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -388,6 +388,7 @@ impl AgentReadiness {
 ///   provider-specific credentials are required:
 ///   - `anthropic` → `ANTHROPIC_API_KEY`
 ///   - `openai` → `OPENAI_COMPAT_API_KEY`
+///   - `ollama` → no credential (local loopback service)
 ///   - `databricks` / `databricks_v2` → `DATABRICKS_HOST` (token optional —
 ///     OAuth PKCE is the fallback)
 /// * **claude**: a successful `claude auth status` probe.
@@ -480,7 +481,7 @@ fn buzz_agent_requirements(effective: &EffectiveAgentEnv) -> Vec<Requirement> {
             Some("DATABRICKS_MODEL")
         }
         Some("anthropic") => Some("ANTHROPIC_MODEL"),
-        Some("openai") | Some("openai-compat") => Some("OPENAI_COMPAT_MODEL"),
+        Some("openai") | Some("openai-compat") | Some("ollama") => Some("OPENAI_COMPAT_MODEL"),
         Some("openrouter") => Some("OPENROUTER_MODEL"),
         _ => None,
     };
@@ -1657,6 +1658,21 @@ mod tests {
         assert!(
             agent_readiness(&env).is_ready(),
             "OPENAI_COMPAT_MODEL must satisfy the model requirement for openai"
+        );
+    }
+
+    #[test]
+    fn buzz_agent_ollama_with_local_model_and_no_api_key_is_ready() {
+        let env = make_env(
+            "buzz-agent",
+            env_with(&[
+                ("BUZZ_AGENT_PROVIDER", "ollama"),
+                ("OPENAI_COMPAT_MODEL", "qwen3.5:4b"),
+            ]),
+        );
+        assert!(
+            agent_readiness(&env).is_ready(),
+            "local Ollama must not require an API key"
         );
     }
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "xyz.block.buzz.app",
   "build": {
     "beforeDevCommand": {
-      "script": "exec ./node_modules/.bin/vite",
+      "script": "pnpm exec vite",
       "cwd": "..",
       "wait": false
     },

--- a/desktop/src/features/agents/AGENTS.md
+++ b/desktop/src/features/agents/AGENTS.md
@@ -147,6 +147,11 @@ with a TypeScript lookup table or an id comparison in a component.
    themselves. Never synthesize a run location a surface doesn't have. Don't
    expose `respond-to`, `allowlist`, Nostr, or harness jargon in primary UI
    copy.
+12. **Ollama is a local preset over the OpenAI-compatible transport.** The
+    provider id is `ollama`; it requires no API key, defaults to
+    `http://127.0.0.1:11434/v1`, and discovers models from that local endpoint.
+    Keep custom OpenAI-compatible endpoints key-driven and configurable; do not
+    make their credential semantics inherit Ollama's local-only exception.
 
 ## The tests that enforce this
 

--- a/desktop/src/features/agents/ui/agentConfigOptions.test.mjs
+++ b/desktop/src/features/agents/ui/agentConfigOptions.test.mjs
@@ -5,6 +5,7 @@ import {
   getDefaultPersonaRuntime,
   getPersonaModelOptions,
   getPersonaProviderOptions,
+  requiredCredentialEnvKeys,
   resetConfigForHarnessChange,
   runtimeSupportsLlmProviderSelection,
 } from "./agentConfigOptions.tsx";
@@ -65,6 +66,15 @@ test("getPersonaProviderOptions with no hideProviderIds omits the tail for a kno
     tail?.id !== "anthropic" || tail?.label === "Anthropic",
     "no duplicate tail for known provider",
   );
+});
+
+test("getPersonaProviderOptions includes local Ollama without a credential requirement", () => {
+  const options = getPersonaProviderOptions("", "buzz-agent");
+  assert.equal(
+    options.some((option) => option.id === "ollama" && option.label === "Ollama (local)"),
+    true,
+  );
+  assert.deepEqual(requiredCredentialEnvKeys("buzz-agent", "ollama"), []);
 });
 
 test("getPersonaProviderOptions appends (current) tail for an unknown saved provider", () => {

--- a/desktop/src/features/agents/ui/agentConfigOptions.tsx
+++ b/desktop/src/features/agents/ui/agentConfigOptions.tsx
@@ -42,6 +42,7 @@ const KNOWN_LLM_PROVIDER_IDS = [
   "databricks_v2",
   "openai",
   "openai-compat",
+  "ollama",
   "openrouter",
 ] as const;
 
@@ -96,6 +97,11 @@ const PROVIDER_CREDENTIAL_CONFIG: Partial<
     requiredEnvKeys: ["OPENAI_COMPAT_API_KEY"],
     secretEnvVar: "OPENAI_COMPAT_API_KEY",
   },
+  ollama: {
+    // Local Ollama uses its loopback OpenAI-compatible endpoint and does not
+    // require a secret. The Rust runtime supplies the endpoint default.
+    requiredEnvKeys: [],
+  },
   databricks: {
     // DATABRICKS_TOKEN is NOT required — OAuth PKCE is the normal path.
     requiredEnvKeys: ["DATABRICKS_HOST"],
@@ -125,6 +131,7 @@ export const PERSONA_LLM_PROVIDER_OPTIONS: readonly PersonaModelOption[] = [
   { id: "anthropic", label: "Anthropic" },
   { id: "openai", label: "OpenAI" },
   { id: "openai-compat", label: "OpenAI-compatible" },
+  { id: "ollama", label: "Ollama (local)" },
   { id: "openrouter", label: "OpenRouter" },
   { id: "relay-mesh", label: "Buzz shared compute" },
   { id: "databricks", label: "Databricks" },
@@ -286,6 +293,7 @@ export function providerRequiresExplicitModel(
     trimmedProvider === "anthropic" ||
     trimmedProvider === "openai" ||
     trimmedProvider === "openai-compat" ||
+    trimmedProvider === "ollama" ||
     trimmedProvider === "openrouter"
   );
 }

--- a/desktop/src/features/agents/ui/bakedEnvHelpers.ts
+++ b/desktop/src/features/agents/ui/bakedEnvHelpers.ts
@@ -68,6 +68,7 @@ function providerModelEnvKey(provider: string): string | null {
       return "ANTHROPIC_MODEL";
     case "openai":
     case "openai-compat":
+    case "ollama":
       return "OPENAI_COMPAT_MODEL";
     default:
       return null;

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
@@ -25,6 +25,8 @@ function providerObjectLabel(provider: string): string {
       return "OpenAI";
     case "openai-compat":
       return "OpenAI-compatible";
+    case "ollama":
+      return "Ollama";
     default:
       return provider.trim() || "this provider";
   }

--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -12,7 +12,16 @@ WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 # Derive a stable base port from the worktree root so the same worktree always
 # gets the same ports. This keeps the Tauri dev config stable between runs and
 # preserves Cargo's build cache.
-BASE_PORT=$(python3 -c "import hashlib,sys; h=int(hashlib.sha256(sys.argv[1].encode()).hexdigest(), 16); print(10000 + h % 55000)" "$WORKTREE_ROOT")
+if command -v python3 >/dev/null 2>&1 && python3 -c "import sys" >/dev/null 2>&1; then
+    PYTHON_BIN=python3
+elif command -v python >/dev/null 2>&1 && python -c "import sys" >/dev/null 2>&1; then
+    PYTHON_BIN=python
+else
+    echo "Python 3 is required to configure the desktop development environment" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+BASE_PORT=$($PYTHON_BIN -c "import hashlib,sys; h=int(hashlib.sha256(sys.argv[1].encode()).hexdigest(), 16); print(10000 + h % 55000)" "$WORKTREE_ROOT")
 export BUZZ_VITE_PORT=$BASE_PORT
 export BUZZ_HMR_PORT=$((BASE_PORT + 1))
 export BUZZ_RELAY_PORT=3000
@@ -25,7 +34,7 @@ if [[ "${BUZZ_RESET_WEBVIEW_STATE:-0}" == "1" ]]; then
     DEV_URL="${DEV_URL}?resetDevState=1"
 fi
 
-BUZZ_TAURI_CONFIG="{\"build\":{\"devUrl\":\"${DEV_URL}\",\"beforeDevCommand\":\"exec ./node_modules/.bin/vite --port ${BUZZ_VITE_PORT} --strictPort\"},\"identifier\":\"xyz.block.buzz.app.dev\",\"productName\":\"Buzz Dev\"}"
+BUZZ_TAURI_CONFIG="{\"build\":{\"devUrl\":\"${DEV_URL}\",\"beforeDevCommand\":\"pnpm exec vite --port ${BUZZ_VITE_PORT} --strictPort\"},\"identifier\":\"xyz.block.buzz.app.dev\",\"productName\":\"Buzz Dev\"}"
 unset VITE_DEV_BRANCH
 
 # In worktrees, extract a label from the branch name and derive a unique app
@@ -86,10 +95,10 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
         GENERATE_DEV_ICON="$WORKTREE_ROOT/scripts/generate-dev-icon.swift"
         BASE_ICON="$WORKTREE_ROOT/desktop/src-tauri/icons/icon.icns"
 
-        if swift "$GENERATE_DEV_ICON" "$BASE_ICON" "$DEV_ICON" "$BUZZ_WORKTREE_LABEL"; then
+        if command -v swift >/dev/null 2>&1 && swift "$GENERATE_DEV_ICON" "$BASE_ICON" "$DEV_ICON" "$BUZZ_WORKTREE_LABEL"; then
             echo "🌳 Worktree: ${BUZZ_WORKTREE_LABEL}"
             export VITE_DEV_BRANCH="$BUZZ_WORKTREE_LABEL"
-            BUZZ_TAURI_CONFIG="{\"build\":{\"devUrl\":\"${DEV_URL}\",\"beforeDevCommand\":\"exec ./node_modules/.bin/vite --port ${BUZZ_VITE_PORT} --strictPort\"},\"identifier\":\"xyz.block.buzz.app.dev.${BUZZ_INSTANCE_SLUG}\",\"productName\":\"Buzz Dev (${BUZZ_WORKTREE_LABEL})\",\"bundle\":{\"icon\":[\"$DEV_ICON\"]}}"
+            BUZZ_TAURI_CONFIG="{\"build\":{\"devUrl\":\"${DEV_URL}\",\"beforeDevCommand\":\"pnpm exec vite --port ${BUZZ_VITE_PORT} --strictPort\"},\"identifier\":\"xyz.block.buzz.app.dev.${BUZZ_INSTANCE_SLUG}\",\"productName\":\"Buzz Dev (${BUZZ_WORKTREE_LABEL})\",\"bundle\":{\"icon\":[\"$DEV_ICON\"]}}"
         fi
     fi
 fi


### PR DESCRIPTION
## Summary

- add a first-class local Ollama provider preset backed by the existing OpenAI-compatible transport
- discover installed models from `http://127.0.0.1:11434/v1/models` without requiring an API key
- make the standalone desktop launcher work in native Git Bash on Windows by accepting `python`, using a cross-platform Vite command, and guarding the optional Swift icon tool
- document native Windows desktop development and the Ollama environment defaults

## Testing

- `node --import ./test-loader.mjs --experimental-strip-types --test src/features/agents/ui/agentConfigOptions.test.mjs`
- `cargo test -p buzz-agent resolve_provider_accepts_local_ollama_without_api_key`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml ollama_`
- verified `just desktop-standalone` launches successfully in Git for Windows
- verified local Ollama `/v1/models` discovery against installed Gemma and Qwen models

## Related issues / PRs

None found.