### PR TITLE
fix(desktop): extend dmabuf workaround to COSMIC-on-Wayland

### DIFF
--- a/desktop/src-tauri/src/webkit_rendering.rs
+++ b/desktop/src-tauri/src/webkit_rendering.rs
@@ -11,9 +11,11 @@
 //! no second chance later in the same process. This module therefore decides
 //! from cheap preflight signals instead of reacting to a crash:
 //!
-//! * an NVIDIA GPU, the driver family behind most upstream reports; and
+//! * an NVIDIA GPU, the driver family behind most upstream reports;
 //! * AppImage packaging, where linuxdeploy's AppRun hook pins `GDK_BACKEND=x11`
-//!   and the dmabuf renderer buys nothing on that XWayland path (#2338).
+//!   and the dmabuf renderer buys nothing on that XWayland path (#2338); and
+//! * COSMIC-on-Wayland, where the dmabuf frame sync with the compositor
+//!   silently freezes the UI while event handling keeps running (#4305).
 //!
 //! `--safe-rendering` is the manual escape hatch for a machine neither signal
 //! recognises; it also disables accelerated compositing, for that launch only.
@@ -140,6 +142,7 @@ fn plan(
     let signals = [
         (nvidia_gpu(drm_root), "NVIDIA GPU"),
         (env("APPIMAGE").is_some(), "AppImage"),
+        (cosmic_wayland(env), "COSMIC Wayland"),
     ];
     let hits: Vec<&str> = signals
         .iter()
@@ -148,13 +151,27 @@ fn plan(
 
     match hits.is_empty() {
         true => Plan::Leave {
-            why: "no NVIDIA GPU and not an AppImage".to_string(),
+            why: "no NVIDIA GPU, not an AppImage, not COSMIC Wayland".to_string(),
         },
         false => Plan::Apply {
             vars: &HEURISTIC,
             why: hits.join(", "),
         },
     }
+}
+
+/// Whether this launch is on COSMIC under Wayland. Pop!_OS / COSMIC has a
+/// known WebKitGTK dmabuf-frame sync failure (#4305) — frames render but are
+/// not presented to the compositor, freezing the UI while logic continues in
+/// the background. `XDG_CURRENT_DESKTOP` is the documented COSMIC detection
+/// signal (typically "COSMIC" or "pop:COSMIC"); `WAYLAND_DISPLAY` confirms
+/// Wayland rather than the X11 fallback session.
+fn cosmic_wayland(env: EnvLookup<'_>) -> bool {
+    let desktop_is_cosmic = env("XDG_CURRENT_DESKTOP")
+        .map(|value| value.to_string_lossy().to_uppercase().contains("COSMIC"))
+        .unwrap_or(false);
+    let wayland_active = env("WAYLAND_DISPLAY").is_some();
+    desktop_is_cosmic && wayland_active
 }
 
 /// Owned variables the environment already carries, keyed by name.

--- a/desktop/src-tauri/src/webkit_rendering/tests.rs
+++ b/desktop/src-tauri/src/webkit_rendering/tests.rs
@@ -109,6 +109,71 @@ fn test_a_plain_non_nvidia_launch_changes_nothing() {
 }
 
 #[test]
+fn test_cosmic_on_wayland_disables_the_dmabuf_renderer() {
+    // #4305: Pop!_OS / COSMIC Wayland — the dmabuf renderer loses sync with
+    // the compositor and the UI freezes while logic continues.
+    let drm = drm(&["0x8086"]);
+    let env = env_from(&[
+        ("XDG_CURRENT_DESKTOP", "COSMIC"),
+        ("WAYLAND_DISPLAY", "wayland-0"),
+    ]);
+    let plan = plan(NO_ARGS, &env, drm.path());
+
+    assert_eq!(
+        applied(&plan),
+        Some(&["WEBKIT_DISABLE_DMABUF_RENDERER"][..])
+    );
+    let Plan::Apply { why, .. } = &plan else {
+        unreachable!()
+    };
+    assert!(why.contains("COSMIC Wayland"), "{why}");
+}
+
+#[test]
+fn test_pop_cosmic_on_wayland_is_also_a_hit() {
+    // Pop!_OS reports XDG_CURRENT_DESKTOP as "pop:COSMIC" — a substring match
+    // keeps the signal tight while still catching the pre-release name.
+    let drm = drm(&["0x8086"]);
+    let env = env_from(&[
+        ("XDG_CURRENT_DESKTOP", "pop:COSMIC"),
+        ("WAYLAND_DISPLAY", "wayland-0"),
+    ]);
+
+    assert_eq!(
+        applied(&plan(NO_ARGS, &env, drm.path())),
+        Some(&["WEBKIT_DISABLE_DMABUF_RENDERER"][..])
+    );
+}
+
+#[test]
+fn test_cosmic_x11_does_not_trigger_the_workaround() {
+    // COSMIC's X11 fallback path does not hit the Wayland frame-sync bug, so
+    // the signal must require Wayland to be active rather than just COSMIC
+    // being the desktop.
+    let drm = drm(&["0x8086"]);
+    let env = env_from(&[("XDG_CURRENT_DESKTOP", "COSMIC")]);
+
+    assert!(matches!(
+        plan(NO_ARGS, &env, drm.path()),
+        Plan::Leave { .. }
+    ));
+}
+
+#[test]
+fn test_gnome_wayland_is_not_confused_for_cosmic() {
+    let drm = drm(&["0x8086"]);
+    let env = env_from(&[
+        ("XDG_CURRENT_DESKTOP", "GNOME"),
+        ("WAYLAND_DISPLAY", "wayland-0"),
+    ]);
+
+    assert!(matches!(
+        plan(NO_ARGS, &env, drm.path()),
+        Plan::Leave { .. }
+    ));
+}
+
+#[test]
 fn test_an_unreadable_drm_tree_is_not_treated_as_a_hit() {
     // Containers and hardened kernels can hide `/sys/class/drm` entirely. The
     // workaround costs real rendering performance, so absent evidence is not


### PR DESCRIPTION
## What

Extends the existing `webkit_rendering.rs` dmabuf-renderer heuristic to recognise COSMIC-on-Wayland as a third preflight signal that should set `WEBKIT_DISABLE_DMABUF_RENDERER=1`.

## Why

On Pop!_OS / COSMIC Wayland, the WebKitGTK dmabuf renderer loses frame sync with the compositor: the UI freezes completely while the underlying application logic (event subscriptions, Rust callbacks, agent harnesses) continues running. Minimizing/maximizing once forces a single redraw, proving the process isn't deadlocked. The reporter of #4305 already identified the workaround (`WEBKIT_DISABLE_DMABUF_RENDERER=1`) and the right module to extend — this PR wires that up.

The signal is intentionally narrow:
- `XDG_CURRENT_DESKTOP` contains `COSMIC` (case-insensitive — matches both `COSMIC` and Pop!_OS's `pop:COSMIC`); **and**
- `WAYLAND_DISPLAY` is present.

Requiring both avoids false positives on COSMIC's X11 fallback session (which doesn't hit this bug) and on GNOME/KDE Wayland (which don't either).

## How

- New `cosmic_wayland(env: EnvLookup)` helper, called from the same `signals` array that already covers NVIDIA GPU and AppImage.
- The existing `Leave` "why" string is updated to mention the third signal so the diagnostic still reads sensibly when no signal fires.
- Doc-comment header lists the new signal alongside the existing two.

## Tests

Four new tests alongside the existing ones in `webkit_rendering/tests.rs`:

| Test | Scenario | Expected |
|---|---|---|
| `test_cosmic_on_wayland_disables_the_dmabuf_renderer` | `XDG_CURRENT_DESKTOP=COSMIC`, `WAYLAND_DISPLAY=wayland-0`, Intel GPU | `Apply` with `WEBKIT_DISABLE_DMABUF_RENDERER`, why contains "COSMIC Wayland" |
| `test_pop_cosmic_on_wayland_is_also_a_hit` | `XDG_CURRENT_DESKTOP=pop:COSMIC`, Wayland active, Intel GPU | `Apply` (substring match catches pre-release name) |
| `test_cosmic_x11_does_not_trigger_the_workaround` | `XDG_CURRENT_DESKTOP=COSMIC`, no `WAYLAND_DISPLAY` | `Leave` (X11 fallback path not affected) |
| `test_gnome_wayland_is_not_confused_for_cosmic` | `XDG_CURRENT_DESKTOP=GNOME`, Wayland active | `Leave` (GNOME Wayland unaffected) |

Existing tests for NVIDIA / AppImage / `--safe-rendering` / user-set env / non-UTF-8 assignments are unchanged and still cover the same behaviour.

## Scope

- 2 files, +85/-3 lines
- No behavioural change for any platform other than COSMIC-on-Wayland
- No new dependencies, no API surface change, no configuration change
- `--safe-rendering` remains the manual escape hatch for machines no signal recognises

Closes #4305.
