### PR TITLE
feat(desktop): add Files tab with folders, bulk select, and drag-and-drop

### DIFF
--- a/desktop/src/features/channel-files/ChannelFilesTab.tsx
+++ b/desktop/src/features/channel-files/ChannelFilesTab.tsx
@@ -1,0 +1,636 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  Search,
+  ArrowUpDown,
+  FolderPlus,
+  Folder,
+  ChevronRight,
+  ChevronDown,
+  Trash2,
+  X,
+  Undo2,
+  FolderInput,
+} from "lucide-react";
+import { FileRow, FileRowSkeleton } from "./FileCard";
+import { type FileFolder } from "./useFileFolders";
+import {
+  categorizeFile,
+  sortFiles,
+  type ChannelFile,
+  type FileCategory,
+  type FileSort,
+} from "./useChannelFiles";
+import { Button } from "@/shared/ui/button";
+
+const CATEGORY_TABS: { value: FileCategory; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "image", label: "Images" },
+  { value: "video", label: "Videos" },
+  { value: "document", label: "Documents" },
+  { value: "other", label: "Other" },
+];
+
+const SORT_OPTIONS: { value: FileSort; label: string }[] = [
+  { value: "newest", label: "Newest" },
+  { value: "oldest", label: "Oldest" },
+  { value: "name", label: "Name" },
+  { value: "size", label: "Size" },
+];
+
+export type ChannelFilesTabProps = {
+  files: ChannelFile[];
+  isLoading: boolean;
+  senderNames?: Map<string, string>;
+  senderAvatarUrls?: Map<string, string | null>;
+  onJumpToMessage?: (eventId: string) => void;
+  folders?: FileFolder[];
+  foldersLoading?: boolean;
+  fileFolderMap?: Map<string, string>;
+  onCreateFolder?: (name: string) => Promise<unknown>;
+  onDeleteFolder?: (folder: FileFolder) => Promise<unknown>;
+  onRenameFolder?: (folder: FileFolder, name: string) => Promise<unknown>;
+  onAddFileToFolder?: (folder: FileFolder, eventId: string) => Promise<unknown>;
+  onAddFilesToFolder?: (folder: FileFolder, eventIds: string[]) => Promise<unknown>;
+  onRemoveFileFromFolder?: (folder: FileFolder, eventId: string) => Promise<unknown>;
+  onSetFolderParent?: (folder: FileFolder, parentDTag?: string) => Promise<unknown>;
+};
+
+export function ChannelFilesTab({
+  files,
+  isLoading,
+  senderNames,
+  senderAvatarUrls,
+  onJumpToMessage,
+  folders = [],
+  fileFolderMap,
+  onCreateFolder,
+  onDeleteFolder,
+  onAddFileToFolder,
+  onAddFilesToFolder,
+  onRemoveFileFromFolder,
+  onSetFolderParent,
+}: ChannelFilesTabProps) {
+  const [category, setCategory] = useState<FileCategory>("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sort, setSort] = useState<FileSort>("newest");
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [isCreatingFolder, setIsCreatingFolder] = useState(false);
+  const [newFolderName, setNewFolderName] = useState("");
+  const [dragOverFolder, setDragOverFolder] = useState<string | null>(null);
+
+  // Selection
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const lastClickedRef = useRef<string | null>(null);
+
+  const filtered = useMemo(() => {
+    let result = files;
+    if (category !== "all") {
+      result = result.filter((f) => categorizeFile(f.mimeType) === category);
+    }
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase().trim();
+      result = result.filter(
+        (f) =>
+          (f.filename ?? "").toLowerCase().includes(q) ||
+          (f.caption ?? "").toLowerCase().includes(q),
+      );
+    }
+    return sortFiles(result, sort);
+  }, [files, category, searchQuery, sort]);
+
+  const counts = useMemo(() => {
+    const c: Record<FileCategory, number> = {
+      all: files.length,
+      image: 0,
+      video: 0,
+      document: 0,
+      other: 0,
+    };
+    for (const f of files) {
+      c[categorizeFile(f.mimeType)]++;
+    }
+    return c;
+  }, [files]);
+
+  const filesByFolder = useMemo(() => {
+    const map = new Map<string, ChannelFile[]>();
+    if (!fileFolderMap) return map;
+    for (const file of filtered) {
+      const dTag = fileFolderMap.get(file.eventId);
+      if (dTag) {
+        const list = map.get(dTag) ?? [];
+        list.push(file);
+        map.set(dTag, list);
+      }
+    }
+    return map;
+  }, [filtered, fileFolderMap]);
+
+  const unfiledFiles = useMemo(
+    () =>
+      fileFolderMap
+        ? filtered.filter((f) => !fileFolderMap.has(f.eventId))
+        : filtered,
+    [filtered, fileFolderMap],
+  );
+
+  const allVisibleIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const f of unfiledFiles) ids.push(f.eventId);
+    for (const dTag of expandedFolders) {
+      for (const f of filesByFolder.get(dTag) ?? []) ids.push(f.eventId);
+    }
+    return ids;
+  }, [unfiledFiles, expandedFolders, filesByFolder]);
+
+  // Determine which selected files are inside a folder (for bulk remove)
+  const selectedInFolder = useMemo(() => {
+    if (!fileFolderMap || selectedIds.size === 0) return null;
+    let commonDTag: string | null = null;
+    for (const id of selectedIds) {
+      const dTag = fileFolderMap.get(id);
+      if (dTag) {
+        if (commonDTag === null) commonDTag = dTag;
+        else if (commonDTag !== dTag) return null;
+      } else {
+        return null;
+      }
+    }
+    return commonDTag;
+  }, [fileFolderMap, selectedIds]);
+
+  // Tree structure: parent → children
+  const folderTree = useMemo(() => {
+    const children = new Map<string | "root", FileFolder[]>();
+    for (const f of folders) {
+      const parent = f.parentDTag ?? "root";
+      const list = children.get(parent) ?? [];
+      list.push(f);
+      children.set(parent, list);
+    }
+    return children;
+  }, [folders]);
+
+  // Flat list with depth for rendering — only includes children of expanded folders
+  const flatFolders = useMemo(() => {
+    const result: { folder: FileFolder; depth: number }[] = [];
+    const root = folderTree.get("root") ?? [];
+    function walk(parentDTag: string | undefined, depth: number) {
+      const children = parentDTag
+        ? folderTree.get(parentDTag) ?? []
+        : root;
+      for (const f of children) {
+        result.push({ folder: f, depth });
+        // Only recurse into children if this folder is expanded
+        if (expandedFolders.has(f.dTag)) {
+          walk(f.dTag, depth + 1);
+        }
+      }
+    }
+    walk(undefined, 0);
+    return result;
+  }, [folderTree, expandedFolders]);
+
+  function toggleFolder(dTag: string) {
+    setExpandedFolders((prev) => {
+      const next = new Set(prev);
+      if (next.has(dTag)) next.delete(dTag);
+      else next.add(dTag);
+      return next;
+    });
+  }
+
+  async function handleCreateFolder() {
+    if (!newFolderName.trim() || !onCreateFolder) return;
+    await onCreateFolder(newFolderName.trim());
+    setNewFolderName("");
+    setIsCreatingFolder(false);
+  }
+
+  const handleDragStart = useCallback(
+    (e: React.DragEvent, eventId: string) => {
+      e.dataTransfer.setData("text/plain", eventId);
+      e.dataTransfer.effectAllowed = "move";
+    },
+    [],
+  );
+
+  const handleFolderDragOver = useCallback(
+    (e: React.DragEvent, dTag: string) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      setDragOverFolder(dTag);
+    },
+    [],
+  );
+
+  const handleFolderDragLeave = useCallback(() => {
+    setDragOverFolder(null);
+  }, []);
+
+  const handleFolderDrop = useCallback(
+    async (e: React.DragEvent, folder: FileFolder) => {
+      e.preventDefault();
+      setDragOverFolder(null);
+      // Check if a folder is being dragged (nesting) vs a file
+      const folderDTag = e.dataTransfer.getData("application/x-folder");
+      if (folderDTag) {
+        // Don't nest a folder into itself or its children
+        if (folderDTag === folder.dTag) return;
+        onSetFolderParent?.(folders.find((f) => f.dTag === folderDTag)!, folder.dTag);
+        return;
+      }
+      const eventId = e.dataTransfer.getData("text/plain");
+      if (!eventId || !onAddFileToFolder) return;
+      if (fileFolderMap?.get(eventId) === folder.dTag) return;
+      await onAddFileToFolder(folder, eventId);
+    },
+    [fileFolderMap, onAddFileToFolder, onSetFolderParent, folders],
+  );
+
+  // ── Selection ────────────────────────────────────────────────────
+
+  function handleToggleSelect(eventId: string, e?: React.MouseEvent) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      const shift = e?.shiftKey ?? false;
+
+      if (shift && lastClickedRef.current) {
+        const lastIdx = allVisibleIds.indexOf(lastClickedRef.current);
+        const thisIdx = allVisibleIds.indexOf(eventId);
+        if (lastIdx !== -1 && thisIdx !== -1) {
+          const [start, end] = lastIdx < thisIdx ? [lastIdx, thisIdx] : [thisIdx, lastIdx];
+          for (let i = start; i <= end; i++) {
+            next.add(allVisibleIds[i]);
+          }
+        }
+      } else if (next.has(eventId)) {
+        next.delete(eventId);
+      } else {
+        next.add(eventId);
+      }
+
+      lastClickedRef.current = eventId;
+      return next;
+    });
+  }
+
+  function selectAll() {
+    setSelectedIds(new Set(allVisibleIds));
+  }
+
+  async function handleBulkMoveToFolder(dTag: string) {
+    if (!onAddFilesToFolder) return;
+    const folder = folders.find((f) => f.dTag === dTag);
+    if (!folder) return;
+    const ids = Array.from(selectedIds);
+    await onAddFilesToFolder(folder, ids);
+    toast(`Moved ${ids.length} file${ids.length !== 1 ? "s" : ""} to ${folder.name}`);
+    setSelectedIds(new Set());
+  }
+
+  async function handleBulkRemoveFromFolder() {
+    if (!onRemoveFileFromFolder || !selectedInFolder) return;
+    const folder = folders.find((f) => f.dTag === selectedInFolder);
+    if (!folder) return;
+    const count = selectedIds.size;
+    for (const eventId of selectedIds) {
+      await onRemoveFileFromFolder(folder, eventId);
+    }
+    toast(`Removed ${count} file${count !== 1 ? "s" : ""} from ${folder.name}`);
+    setSelectedIds(new Set());
+  }
+
+  function toast(msg: string) {
+    import("sonner").then(({ toast: t }) => t.success(msg)).catch(() => {});
+  }
+
+  const selectedCount = selectedIds.size;
+
+  function renderFileRow(file: ChannelFile) {
+    return (
+      <FileRow
+        file={file}
+        key={file.key}
+        onDragStart={handleDragStart}
+        onJumpToMessage={onJumpToMessage}
+        onToggleSelect={(id) => handleToggleSelect(id)}
+        selected={selectedIds.has(file.eventId)}
+        selecting={true}
+        senderAvatarUrl={senderAvatarUrls?.get(file.pubkey) ?? null}
+        senderName={senderNames?.get(file.pubkey)}
+      />
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 overflow-y-auto p-4">
+        <div className="divide-y divide-border">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <FileRowSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Toolbar */}
+      <div className="shrink-0 space-y-2 border-b border-border px-4 pb-3 pt-3">
+        <div className="flex items-center gap-1 overflow-x-auto [scrollbar-width:none]">
+          {CATEGORY_TABS.map((tab) => (
+            <Button
+              className="h-7 shrink-0 rounded-full px-3 text-xs"
+              data-active={category === tab.value}
+              key={tab.value}
+              onClick={() => setCategory(tab.value)}
+              size="sm"
+              variant={category === tab.value ? "secondary" : "ghost"}
+            >
+              {tab.label}
+              {counts[tab.value] > 0 ? (
+                <span className="ml-1 text-muted-foreground">
+                  {counts[tab.value]}
+                </span>
+              ) : null}
+            </Button>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1">
+            <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <input
+              className="h-8 w-full rounded-md border border-border bg-background pl-8 pr-3 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search files..."
+              type="text"
+              value={searchQuery}
+            />
+            {searchQuery ? (
+              <button
+                aria-label="Clear search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                onClick={() => setSearchQuery("")}
+                type="button"
+              >
+                ×
+              </button>
+            ) : null}
+          </div>
+
+          <div className="relative">
+            <select
+              aria-label="Sort files"
+              className="h-8 appearance-none rounded-md border border-border bg-background px-7 py-0 pr-6 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+              onChange={(e) => setSort(e.target.value as FileSort)}
+              value={sort}
+            >
+              {SORT_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <ArrowUpDown className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+          </div>
+
+          {onCreateFolder ? (
+            <Button
+              className="h-8 shrink-0 gap-1 px-2 text-xs"
+              onClick={() => setIsCreatingFolder(true)}
+              size="sm"
+              variant="outline"
+            >
+              <FolderPlus className="h-3.5 w-3.5" />
+              New
+            </Button>
+          ) : null}
+        </div>
+
+        {isCreatingFolder ? (
+          <div className="flex items-center gap-2">
+            <input
+              autoFocus
+              className="h-8 flex-1 rounded-md border border-border bg-background px-3 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+              onChange={(e) => setNewFolderName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleCreateFolder();
+                if (e.key === "Escape") setIsCreatingFolder(false);
+              }}
+              placeholder="Folder name..."
+              type="text"
+              value={newFolderName}
+            />
+            <Button
+              className="h-8 px-3 text-xs"
+              disabled={!newFolderName.trim()}
+              onClick={() => void handleCreateFolder()}
+              size="sm"
+            >
+              Create
+            </Button>
+            <Button
+              className="h-8 px-2 text-xs"
+              onClick={() => setIsCreatingFolder(false)}
+              size="sm"
+              variant="ghost"
+            >
+              Cancel
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      {/* Bulk action bar — below toolbar, above file list */}
+      {selectedCount > 0 ? (
+        <div className="flex shrink-0 items-center gap-2 border-b border-primary/20 bg-primary/5 px-4 py-2">
+          <span className="text-xs font-medium">
+            {selectedCount} selected
+          </span>
+          <Button
+            className="h-7 px-2 text-xs"
+            onClick={selectAll}
+            size="sm"
+            variant="ghost"
+          >
+            Select all
+          </Button>
+          <div className="flex-1" />
+          {selectedInFolder ? (
+            <Button
+              className="h-7 gap-1 px-2 text-xs"
+              onClick={() => void handleBulkRemoveFromFolder()}
+              size="sm"
+              variant="outline"
+            >
+              <Undo2 className="h-3.5 w-3.5" />
+              Remove from folder
+            </Button>
+          ) : (
+            <div className="relative">
+              <select
+                aria-label="Move selected files to folder"
+                className="h-7 appearance-none rounded border border-border bg-background pl-2 pr-6 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                onChange={(e) => {
+                  if (e.target.value) void handleBulkMoveToFolder(e.target.value);
+                }}
+                value=""
+              >
+                <option disabled value="">
+                  Move to folder…
+                </option>
+                {folders.map((f) => (
+                  <option key={f.dTag} value={f.dTag}>
+                    {f.name}
+                  </option>
+                ))}
+              </select>
+              <FolderInput className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+            </div>
+          )}
+          <Button
+            className="h-7 px-2 text-xs"
+            onClick={() => setSelectedIds(new Set())}
+            size="sm"
+            variant="ghost"
+          >
+            <X className="mr-1 h-3.5 w-3.5" />
+            Clear
+          </Button>
+        </div>
+      ) : null}
+
+      {/* File list */}
+      <div
+        className="flex-1 overflow-y-auto"
+        onDragOver={(e) => {
+          // Accept folder drops to un-nest (move to root)
+          if (e.dataTransfer.types.includes("application/x-folder")) {
+            e.preventDefault();
+            e.dataTransfer.dropEffect = "move";
+          }
+        }}
+        onDrop={(e) => {
+          const folderDTag = e.dataTransfer.getData("application/x-folder");
+          if (folderDTag) {
+            e.preventDefault();
+            const folder = folders.find((f) => f.dTag === folderDTag);
+            if (folder?.parentDTag) {
+              void onSetFolderParent?.(folder, undefined);
+            }
+          }
+        }}
+      >
+        {filtered.length === 0 && folders.length === 0 ? (
+          <div className="flex items-center justify-center p-12">
+            <div className="flex max-w-xs flex-col items-center gap-2 text-center">
+              <p className="text-sm font-medium">No files yet</p>
+              <p className="text-xs text-muted-foreground">
+                Files shared in this channel will appear here.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="divide-y divide-border py-1">
+            {flatFolders.map(({ folder, depth }) => {
+              const folderFiles = filesByFolder.get(folder.dTag) ?? [];
+              const isExpanded = expandedFolders.has(folder.dTag);
+
+              return (
+                <div key={folder.dTag}>
+                  <div
+                    className={`flex items-center gap-2 px-3 py-2 transition-colors ${
+                      dragOverFolder === folder.dTag
+                        ? "bg-primary/10 ring-2 ring-primary/30"
+                        : "hover:bg-muted/50"
+                    }`}
+                    draggable
+                    onDragLeave={handleFolderDragLeave}
+                    onDragOver={(e) => handleFolderDragOver(e, folder.dTag)}
+                    onDragStart={(e) => {
+                      e.dataTransfer.setData("application/x-folder", folder.dTag);
+                      e.dataTransfer.effectAllowed = "move";
+                    }}
+                    onDrop={(e) => void handleFolderDrop(e, folder)}
+                    style={{ paddingLeft: `${12 + depth * 20}px` }}
+                  >
+                    <button
+                      className="flex flex-1 items-center gap-2 text-sm font-medium"
+                      onClick={() => toggleFolder(folder.dTag)}
+                      type="button"
+                    >
+                      {isExpanded ? (
+                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                      )}
+                      <Folder className="h-4 w-4 text-muted-foreground" />
+                      {folder.name}
+                      <span className="text-xs text-muted-foreground">
+                        ({folderFiles.length})
+                      </span>
+                    </button>
+                    {onDeleteFolder ? (
+                      <Button
+                        aria-label={`Delete folder ${folder.name}`}
+                        className="h-7 w-7 opacity-50 hover:opacity-100"
+                        onClick={() => void onDeleteFolder(folder)}
+                        size="icon-xs"
+                        variant="ghost"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    ) : null}
+                  </div>
+                  {isExpanded ? (
+                    <div className="divide-y divide-border border-l-2 border-l-muted ml-6">
+                      {folderFiles.length === 0 && !folderTree.has(folder.dTag) ? (
+                        <p className="px-3 py-4 text-xs text-muted-foreground">
+                          Empty folder — drag files here or use checkboxes to add them.
+                        </p>
+                      ) : (
+                        folderFiles.map((file) => (
+                          <div className="group flex items-center" key={file.key}>
+                            <div className="flex-1">
+                              {renderFileRow(file)}
+                            </div>
+                            {onRemoveFileFromFolder ? (
+                              <Button
+                                aria-label="Remove from folder"
+                                className="mr-2 h-7 w-7 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+                                onClick={() =>
+                                  void onRemoveFileFromFolder(folder, file.eventId)
+                                }
+                                size="icon-xs"
+                                variant="ghost"
+                              >
+                                <Undo2 className="h-3.5 w-3.5" />
+                              </Button>
+                            ) : null}
+                          </div>
+                        ))
+                      )}
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })}
+
+            {dragOverFolder ? (
+              <div className="px-3 py-1.5 text-xs text-muted-foreground">
+                Drop file to add to folder
+              </div>
+            ) : null}
+
+            {unfiledFiles.map((file) => renderFileRow(file))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/features/channel-files/FileCard.tsx
+++ b/desktop/src/features/channel-files/FileCard.tsx
@@ -1,0 +1,274 @@
+import {
+  FileIcon,
+  ImageIcon,
+  VideoIcon,
+  Download,
+  Copy,
+  ArrowRight,
+  ShieldCheck,
+} from "lucide-react";
+import { toast } from "sonner";
+import type { ChannelFile } from "./useChannelFiles";
+import { UserAvatar } from "@/shared/ui/UserAvatar";
+
+function formatSize(bytes: number | undefined): string {
+  if (bytes == null || bytes === 0) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+function formatDate(unixSeconds: number): string {
+  const date = new Date(unixSeconds * 1000);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays}d ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function fileTypeLabel(mimeType: string): string {
+  if (mimeType.startsWith("image/")) return "Image";
+  if (mimeType.startsWith("video/")) return "Video";
+  if (mimeType.startsWith("audio/")) return "Audio";
+  if (mimeType.includes("pdf")) return "PDF";
+  if (mimeType.includes("zip") || mimeType.includes("tar")) return "Archive";
+  if (
+    mimeType.includes("text/") ||
+    mimeType.includes("json") ||
+    mimeType.includes("xml")
+  )
+    return "Text";
+  return "File";
+}
+
+async function copyToClipboard(text: string, label: string) {
+  try {
+    await navigator.clipboard.writeText(text);
+    toast.success(`${label} copied`);
+  } catch {
+    toast.error("Failed to copy");
+  }
+}
+
+function FileRowThumbnail({ file }: { file: ChannelFile }) {
+  if (file.mimeType.startsWith("image/")) {
+    return (
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted">
+        <img
+          alt=""
+          className="h-full w-full object-cover"
+          loading="lazy"
+          src={file.url}
+        />
+      </div>
+    );
+  }
+  if (file.mimeType.startsWith("video/")) {
+    return (
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted">
+        <VideoIcon className="h-5 w-5 text-muted-foreground" />
+      </div>
+    );
+  }
+  return (
+    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted">
+      <FileIcon className="h-5 w-5 text-muted-foreground" />
+    </div>
+  );
+}
+
+export type FileRowProps = {
+  file: ChannelFile;
+  senderName?: string;
+  senderAvatarUrl?: string | null;
+  onJumpToMessage?: (eventId: string) => void;
+  onDragStart?: (e: React.DragEvent, eventId: string) => void;
+  /** Selection mode */
+  selecting?: boolean;
+  selected?: boolean;
+  onToggleSelect?: (eventId: string) => void;
+};
+
+export function FileRow({
+  file,
+  senderName,
+  senderAvatarUrl,
+  onJumpToMessage,
+  onDragStart,
+  selecting,
+  selected,
+  onToggleSelect,
+}: FileRowProps) {
+  const filename = file.filename ?? file.rawUrl.split("/").pop() ?? "file";
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (selecting) {
+      e.preventDefault();
+      onToggleSelect?.(file.eventId);
+    }
+  };
+
+  const handleCheckboxClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onToggleSelect?.(file.eventId);
+  };
+
+  return (
+    <div
+      className={`group flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors ${
+        selected ? "bg-primary/5" : "hover:bg-muted/50"
+      } ${selecting ? "cursor-pointer" : ""}`}
+      draggable={!!onDragStart}
+      onClick={handleClick}
+      onDragStart={(e) => onDragStart?.(e, file.eventId)}
+    >
+      {selecting ? (
+        <div className="flex shrink-0 items-center" onClick={handleCheckboxClick}>
+          <div
+            className={`flex h-5 w-5 items-center justify-center rounded border-2 transition-colors ${
+              selected
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-muted-foreground/30 hover:border-muted-foreground/50"
+            }`}
+            role="checkbox"
+            aria-checked={selected}
+            aria-label={`Select ${filename}`}
+          >
+            {selected ? (
+              <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                <path d="M5 13l4 4L19 7" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      <a
+        className="contents"
+        download={filename}
+        href={file.url}
+        rel="noreferrer"
+        target="_blank"
+        onClick={(e) => { if (selecting) e.preventDefault(); }}
+      >
+        <FileRowThumbnail file={file} />
+      </a>
+
+      <div className="min-w-0 flex-1">
+        <a
+          className="truncate text-sm font-medium hover:underline"
+          download={filename}
+          href={file.url}
+          rel="noreferrer"
+          target="_blank"
+          onClick={(e) => { if (selecting) e.preventDefault(); }}
+          title={filename}
+        >
+          {filename}
+        </a>
+        <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span>{fileTypeLabel(file.mimeType)}</span>
+          {file.dim ? (
+            <>
+              <span aria-hidden="true">·</span>
+              <span>{file.dim}</span>
+            </>
+          ) : null}
+          {file.size != null ? (
+            <>
+              <span aria-hidden="true">·</span>
+              <span>{formatSize(file.size)}</span>
+            </>
+          ) : null}
+          {file.sha256 ? (
+            <span
+              className="inline-flex items-center gap-0.5 text-green-600 dark:text-green-400"
+              title="SHA-256 verified"
+            >
+              <ShieldCheck className="h-3 w-3" />
+            </span>
+          ) : null}
+        </p>
+        {file.caption ? (
+          <p className="mt-0.5 truncate text-xs text-muted-foreground/70">
+            {file.caption}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
+        <div className="flex items-center gap-1.5">
+          <UserAvatar
+            avatarUrl={senderAvatarUrl ?? null}
+            className="h-5 w-5"
+            displayName={senderName ?? file.pubkey.slice(0, 8)}
+            size="xs"
+          />
+          {senderName ? (
+            <span className="hidden max-w-[100px] truncate sm:inline">
+              {senderName}
+            </span>
+          ) : null}
+        </div>
+        <span className="w-16 text-right">{formatDate(file.createdAt)}</span>
+
+        <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+            <button
+              aria-label={`Copy link for ${filename}`}
+              className="rounded p-1 hover:bg-muted"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                void copyToClipboard(file.url, "Link");
+              }}
+              type="button"
+            >
+              <Copy className="h-3.5 w-3.5" />
+            </button>
+            <a
+              aria-label={`Download ${filename}`}
+              className="rounded p-1 hover:bg-muted"
+              download={filename}
+              href={file.url}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Download className="h-3.5 w-3.5" />
+            </a>
+            {onJumpToMessage ? (
+              <button
+                aria-label="Jump to message"
+                className="rounded p-1 hover:bg-muted"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onJumpToMessage(file.eventId);
+                }}
+                type="button"
+              >
+                <ArrowRight className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
+          </div>
+      </div>
+    </div>
+  );
+}
+
+export function FileRowSkeleton() {
+  return (
+    <div className="flex animate-pulse items-center gap-3 rounded-lg px-3 py-2.5">
+      <div className="h-10 w-10 shrink-0 rounded-md bg-muted" />
+      <div className="flex-1 space-y-1.5">
+        <div className="h-4 w-48 rounded bg-muted" />
+        <div className="h-3 w-24 rounded bg-muted" />
+      </div>
+      <div className="h-5 w-5 rounded-full bg-muted" />
+      <div className="h-3 w-16 rounded bg-muted" />
+    </div>
+  );
+}

--- a/desktop/src/features/channel-files/useChannelFiles.ts
+++ b/desktop/src/features/channel-files/useChannelFiles.ts
@@ -1,0 +1,147 @@
+import { useMemo } from "react";
+import { useChannelMessagesQuery } from "@/features/messages/hooks";
+import { parseImetaTags } from "@/shared/ui/markdown/parseImeta";
+import { rewriteRelayUrl } from "@/shared/lib/mediaUrl";
+import type { Channel, RelayEvent } from "@/shared/api/types";
+import type { ParsedImetaEntry } from "@/shared/ui/markdown/parseImeta";
+
+export type ChannelFile = {
+  /** Unique key (event id + url). */
+  key: string;
+  /** The relay-rewritten media URL for download/display. */
+  url: string;
+  /** Raw media URL from imeta. */
+  rawUrl: string;
+  /** MIME type (e.g. "image/png", "application/pdf"). */
+  mimeType: string;
+  /** File size in bytes, if available. */
+  size: number | undefined;
+  /** Original filename. */
+  filename: string | undefined;
+  /** SHA-256 hex, if available. */
+  sha256: string | undefined;
+  /** Thumbnail URL, if available. */
+  thumb: string | undefined;
+  /** Dimensions string (WxH), if available. */
+  dim: string | undefined;
+  /** Blurhash, if available. */
+  blurhash: string | undefined;
+  /** Sender pubkey. */
+  pubkey: string;
+  /** When the message was created (Unix seconds). */
+  createdAt: number;
+  /** The parent message event ID. */
+  eventId: string;
+  /** First line of the message body (caption/description). */
+  caption: string | undefined;
+  /** All parsed imeta fields. */
+  imeta: ParsedImetaEntry;
+};
+
+/** File type categories for filtering. */
+export type FileCategory = "all" | "image" | "video" | "document" | "other";
+
+export function categorizeFile(mimeType: string): FileCategory {
+  if (mimeType.startsWith("image/")) return "image";
+  if (mimeType.startsWith("video/")) return "video";
+  if (
+    mimeType.includes("pdf") ||
+    mimeType.includes("document") ||
+    mimeType.includes("spreadsheet") ||
+    mimeType.includes("presentation") ||
+    mimeType.startsWith("text/") ||
+    mimeType.includes("json") ||
+    mimeType.includes("xml")
+  )
+    return "document";
+  return "other";
+}
+
+export type FileSort = "newest" | "oldest" | "name" | "size";
+
+export function sortFiles(files: ChannelFile[], sort: FileSort): ChannelFile[] {
+  const sorted = [...files];
+  switch (sort) {
+    case "oldest":
+      sorted.sort((a, b) => a.createdAt - b.createdAt);
+      break;
+    case "name":
+      sorted.sort((a, b) => {
+        const na = (a.filename ?? "").toLowerCase();
+        const nb = (b.filename ?? "").toLowerCase();
+        return na.localeCompare(nb);
+      });
+      break;
+    case "size":
+      sorted.sort((a, b) => (b.size ?? 0) - (a.size ?? 0));
+      break;
+    case "newest":
+    default:
+      sorted.sort((a, b) => b.createdAt - a.createdAt);
+      break;
+  }
+  return sorted;
+}
+
+/**
+ * Extract all file-bearing events from a channel and parse their imeta tags
+ * into a flat list of {@link ChannelFile} objects, ordered newest-first.
+ */
+export function useChannelFiles(
+  activeChannel: Channel | null,
+): { files: ChannelFile[]; isLoading: boolean } {
+  const messagesQuery = useChannelMessagesQuery(activeChannel);
+
+  const files = useMemo(() => {
+    const events: RelayEvent[] = messagesQuery.data ?? [];
+    const result: ChannelFile[] = [];
+
+    for (let i = events.length - 1; i >= 0; i--) {
+      const event = events[i];
+      const tags = event.tags;
+      if (!tags || tags.length === 0) continue;
+
+      const entries = parseImetaTags(tags as string[][]);
+      if (entries.size === 0) continue;
+
+      // Extract first non-empty line of content as caption
+      let caption: string | undefined;
+      const content = event.content;
+      if (content != null) {
+        const firstLine = content.trim().split("\n")[0];
+        if (firstLine) {
+          caption = firstLine.replace(/!\[(?:image|video)\]\([^)]+\)/g, "").trim() || undefined;
+        }
+      }
+
+      for (const [, entry] of entries) {
+        result.push({
+          key: `${event.id}-${entry.url}`,
+          url: rewriteRelayUrl(entry.url),
+          rawUrl: entry.url,
+          mimeType: entry.m ?? "application/octet-stream",
+          size: entry.size != null && entry.size > 0 ? entry.size : undefined,
+          filename: entry.filename,
+          sha256: entry.x,
+          thumb: entry.thumb ? rewriteRelayUrl(entry.thumb) : undefined,
+          dim: entry.dim,
+          blurhash: entry.blurhash,
+          pubkey: event.pubkey,
+          createdAt: event.created_at,
+          eventId: event.id,
+          caption: caption || undefined,
+          imeta: entry,
+        });
+      }
+    }
+
+    return result;
+  }, [messagesQuery.data]);
+
+  return {
+    files,
+    isLoading: messagesQuery.isPending,
+    categorizeFile,
+    sortFiles,
+  };
+}

--- a/desktop/src/features/channel-files/useFileFolders.ts
+++ b/desktop/src/features/channel-files/useFileFolders.ts
@@ -1,0 +1,281 @@
+import { useCallback, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { relayClient } from "@/shared/api/relayClient";
+import { signRelayEvent } from "@/shared/api/tauri";
+import type { RelayEvent } from "@/shared/api/types";
+
+const FILE_FOLDER_KIND = 30078;
+const FILE_FOLDER_TAG = "file-folder";
+const FOLDER_QUERY_KEY_PREFIX = "channel-file-folders";
+
+export type FileFolder = {
+  dTag: string;
+  name: string;
+  fileEventIds: string[];
+  /** Parent folder d-tag, if nested. */
+  parentDTag?: string;
+  event: RelayEvent;
+};
+
+function folderSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function folderDTag(channelId: string, slug: string): string {
+  return `files-${channelId}:${slug}`;
+}
+
+function parseFolder(event: RelayEvent): FileFolder | null {
+  const dTag = event.tags.find((t) => t[0] === "d")?.[1];
+  const typeTag = event.tags.find((t) => t[0] === "t");
+  if (!dTag || typeTag?.[1] !== FILE_FOLDER_TAG) return null;
+
+  const name = event.tags.find((t) => t[0] === "name")?.[1] ?? "Untitled";
+  const parentDTag = event.tags.find((t) => t[0] === "parent")?.[1];
+  const fileEventIds = event.tags
+    .filter((t) => t[0] === "e")
+    .map((t) => t[1])
+    .filter(Boolean);
+
+  return { dTag, name, fileEventIds, parentDTag, event };
+}
+
+function folderQueryKey(channelId: string) {
+  return [FOLDER_QUERY_KEY_PREFIX, channelId] as const;
+}
+
+export function useFileFolders(
+  channelId: string | null,
+  currentPubkey?: string,
+) {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: folderQueryKey(channelId ?? ""),
+    queryFn: async () => {
+      if (!channelId || !currentPubkey) return [];
+      const events = await relayClient.requestHistory({
+        kinds: [FILE_FOLDER_KIND],
+        authors: [currentPubkey],
+        limit: 50,
+      });
+      return events
+        .map(parseFolder)
+        .filter(
+          (f): f is FileFolder =>
+            f !== null && f.dTag.startsWith(`files-${channelId}:`),
+        );
+    },
+    enabled: !!channelId && !!currentPubkey,
+    staleTime: 30_000,
+  });
+
+  const folders = query.data ?? [];
+
+  /** Group file event IDs by folder dTag for fast lookup. */
+  const fileFolderMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const folder of folders) {
+      for (const eventId of folder.fileEventIds) {
+        map.set(eventId, folder.dTag);
+      }
+    }
+    return map;
+  }, [folders]);
+
+  const createFolder = useCallback(
+    async (name: string, parentDTag?: string): Promise<FileFolder | null> => {
+      if (!channelId || !currentPubkey) return null;
+      const slug = folderSlug(name);
+      const dTag = folderDTag(channelId, slug);
+      const tags: string[][] = [
+        ["d", dTag],
+        ["t", FILE_FOLDER_TAG],
+        ["name", name],
+      ];
+      if (parentDTag) tags.push(["parent", parentDTag]);
+      const event = await signRelayEvent({
+        kind: FILE_FOLDER_KIND,
+        content: "",
+        tags,
+      });
+      relayClient.publishEvent(event);
+      await queryClient.invalidateQueries({
+        queryKey: folderQueryKey(channelId),
+      });
+      return parseFolder(event);
+    },
+    [channelId, currentPubkey, queryClient],
+  );
+
+  const addFileToFolder = useCallback(
+    async (folder: FileFolder, eventId: string) => {
+      if (!currentPubkey) return;
+      if (folder.fileEventIds.includes(eventId)) return;
+      const newTags = [
+        ...folder.event.tags.filter(
+          (t) => t[0] !== "e" || t[1] !== eventId,
+        ),
+        ["e", eventId],
+      ];
+      const event = await signRelayEvent({
+        kind: FILE_FOLDER_KIND,
+        content: "",
+        tags: newTags,
+        createdAt: Math.floor(Date.now() / 1000),
+      });
+      relayClient.publishEvent(event);
+      await queryClient.invalidateQueries({
+        queryKey: folderQueryKey(channelId!),
+      });
+    },
+    [channelId, currentPubkey, queryClient],
+  );
+
+  /** Add multiple files to a folder in a single event — avoids race conditions. */
+  const addFilesToFolder = useCallback(
+    async (folder: FileFolder, eventIds: string[]) => {
+      if (!currentPubkey || eventIds.length === 0) return;
+      // Merge: keep existing e-tags that aren't being re-added, then add all new ones
+      const existingIds = new Set(folder.fileEventIds);
+      const newIds = eventIds.filter((id) => !existingIds.has(id));
+      if (newIds.length === 0) return;
+      const newTags = [
+        ...folder.event.tags.filter(
+          (t) => t[0] !== "e" || existingIds.has(t[1]),
+        ),
+        ...newIds.map((id) => ["e", id] as [string, string]),
+      ];
+      const event = await signRelayEvent({
+        kind: FILE_FOLDER_KIND,
+        content: "",
+        tags: newTags,
+        createdAt: Math.floor(Date.now() / 1000),
+      });
+      relayClient.publishEvent(event);
+      await queryClient.invalidateQueries({
+        queryKey: folderQueryKey(channelId!),
+      });
+    },
+    [channelId, currentPubkey, queryClient],
+  );
+
+  const removeFileFromFolder = useCallback(
+    async (folder: FileFolder, eventId: string) => {
+      if (!currentPubkey) return;
+      const newTags = folder.event.tags.filter(
+        (t) => !(t[0] === "e" && t[1] === eventId),
+      );
+      const event = await signRelayEvent({
+        kind: FILE_FOLDER_KIND,
+        content: "",
+        tags: newTags,
+        createdAt: Math.floor(Date.now() / 1000),
+      });
+      relayClient.publishEvent(event);
+      await queryClient.invalidateQueries({
+        queryKey: folderQueryKey(channelId!),
+      });
+    },
+    [channelId, currentPubkey, queryClient],
+  );
+
+  const deleteFolder = useCallback(
+    async (folder: FileFolder) => {
+      if (!currentPubkey) return;
+      // NIP-09 deletion: publish kind:5 referencing the folder event
+      const event = await signRelayEvent({
+        kind: 5,
+        content: "deleting file folder",
+        tags: [
+          ["e", folder.event.id],
+          ["k", String(FILE_FOLDER_KIND)],
+        ],
+      });
+      relayClient.publishEvent(event);
+      await queryClient.invalidateQueries({
+        queryKey: folderQueryKey(channelId!),
+      });
+    },
+    [channelId, currentPubkey, queryClient],
+  );
+
+  const renameFolder = useCallback(
+    async (folder: FileFolder, newName: string) => {
+      if (!channelId || !currentPubkey) return;
+      const slug = folderSlug(newName);
+      const newDTag = folderDTag(channelId, slug);
+
+      // Replace d-tag and name, keep file refs
+      const tags = folder.event.tags
+        .filter((t) => t[0] !== "d" && t[0] !== "name")
+        .concat([
+          ["d", newDTag],
+          ["name", newName],
+        ]);
+
+      const event = await signRelayEvent({
+        kind: FILE_FOLDER_KIND,
+        content: "",
+        tags,
+        createdAt: Math.floor(Date.now() / 1000),
+      });
+      relayClient.publishEvent(event);
+
+      // If the d-tag changed, also delete the old event
+      if (newDTag !== folder.dTag) {
+        const deleteEvent = await signRelayEvent({
+          kind: 5,
+          content: "",
+          tags: [
+            ["e", folder.event.id],
+            ["k", String(FILE_FOLDER_KIND)],
+          ],
+        });
+        relayClient.publishEvent(deleteEvent);
+      }
+
+      await queryClient.invalidateQueries({
+        queryKey: folderQueryKey(channelId),
+      });
+    },
+    [channelId, currentPubkey, queryClient],
+  );
+
+  /** Move a folder under another folder (or to root when parentDTag=undefined). */
+  const setFolderParent = useCallback(
+    async (folder: FileFolder, parentDTag?: string) => {
+      if (!channelId || !currentPubkey) return;
+      const tags = folder.event.tags
+        .filter((t) => t[0] !== "parent")
+        .concat(parentDTag ? [["parent", parentDTag]] : []);
+      const event = await signRelayEvent({
+        kind: FILE_FOLDER_KIND,
+        content: "",
+        tags,
+        createdAt: Math.floor(Date.now() / 1000),
+      });
+      relayClient.publishEvent(event);
+      await queryClient.invalidateQueries({
+        queryKey: folderQueryKey(channelId),
+      });
+    },
+    [channelId, currentPubkey, queryClient],
+  );
+
+  return {
+    folders,
+    fileFolderMap,
+    isLoading: query.isPending,
+    createFolder,
+    addFileToFolder,
+    addFilesToFolder,
+    removeFileFromFolder,
+    deleteFolder,
+    renameFolder,
+    setFolderParent,
+  };
+}

--- a/desktop/src/features/channels/ui/ChannelScreen.tsx
+++ b/desktop/src/features/channels/ui/ChannelScreen.tsx
@@ -82,7 +82,12 @@ import { useChannelProfilePanel } from "./useChannelProfilePanel";
 import { useChannelRouteTarget } from "./useChannelRouteTarget";
 import { useChannelUnreadState } from "./useChannelUnreadState";
 import type { ChannelScreenProps } from "./ChannelScreen.types";
+import { ChannelFilesTab } from "@/features/channel-files/ChannelFilesTab";
+import { useChannelFiles } from "@/features/channel-files/useChannelFiles";
+import { useFileFolders } from "@/features/channel-files/useFileFolders";
 const HEADER_ACTIONS_COMPACT_BREAKPOINT_PX = 760,
+  CHANNEL_TAB_CHAT = "chat",
+  CHANNEL_TAB_FILES = "files",
   EMPTY_RELAY_EVENTS: RelayEvent[] = [];
 export function ChannelScreen({
   activeChannel,
@@ -96,7 +101,7 @@ export function ChannelScreen({
   targetMessageEvents,
   targetMessageId,
 }: ChannelScreenProps) {
-  const { goHome } = useAppNavigation();
+  const { goHome, goChannel } = useAppNavigation();
   const { activeCommunity } = useCommunities();
   const {
     markChannelRead,
@@ -141,6 +146,7 @@ export function ChannelScreen({
   } = useThreadPanelWidth();
   const [isMembersSidebarOpen, setIsMembersSidebarOpen] = React.useState(false);
   const [isAddBotOpen, setIsAddBotOpen] = React.useState(false);
+  const [activeTab, setActiveTab] = React.useState<string>(CHANNEL_TAB_CHAT);
   const [channelContentRef, channelContentWidthPx] =
     useElementWidth<HTMLDivElement>();
   const [expandedThreadReplyIds, setExpandedThreadReplyIds] = React.useState(
@@ -192,6 +198,12 @@ export function ChannelScreen({
     effectiveOpenThreadHeadId,
   );
   useChannelSubscription(activeChannel);
+  const channelFiles = useChannelFiles(activeChannel);
+  const fileFoldersHook = useFileFolders(activeChannelId, currentPubkey);
+  // Reset to chat tab when switching channels
+  React.useEffect(() => {
+    setActiveTab(CHANNEL_TAB_CHAT);
+  }, [activeChannelId]);
   const { fetchOlder, hasOlderMessages, historyExhausted, isFetchingOlder } =
     useFetchOlderMessages(activeChannel);
   const latestActiveMessage = React.useMemo(() => {
@@ -355,6 +367,42 @@ export function ChannelScreen({
     relayAgents,
   });
   const messageOwnerProfiles = useMessageOwnerProfiles(messageProfiles);
+  // Build a pubkey -> display name map for the Files tab attribution
+  const fileSenderNames = React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const file of channelFiles.files) {
+      if (map.has(file.pubkey)) continue;
+      const profile = messageProfiles[file.pubkey];
+      if (profile) {
+        map.set(
+          file.pubkey,
+          profile.displayName ?? profile.name ?? profile.nip05 ?? "",
+        );
+      }
+    }
+    return map;
+  }, [channelFiles.files, messageProfiles]);
+
+  // Build a pubkey -> avatar URL map for the Files tab
+  const fileSenderAvatarUrls = React.useMemo(() => {
+    const map = new Map<string, string | null>();
+    for (const file of channelFiles.files) {
+      if (map.has(file.pubkey)) continue;
+      const profile = messageProfiles[file.pubkey];
+      map.set(file.pubkey, profile?.avatarUrl ?? null);
+    }
+    return map;
+  }, [channelFiles.files, messageProfiles]);
+
+  const handleJumpToMessage = React.useCallback(
+    (eventId: string) => {
+      if (activeChannelId) {
+        void goChannel(activeChannelId, { messageId: eventId });
+        setActiveTab(CHANNEL_TAB_CHAT);
+      }
+    },
+    [activeChannelId, goChannel],
+  );
   // Agent set for ChannelPane's own consumers (DM huddle member resolution,
   // the agents list): the community-scoped baseline shared by every surface,
   // widened with channel-member roles and this screen's profile lookup.
@@ -795,6 +843,7 @@ export function ChannelScreen({
       isSinglePanelView,
     ],
   );
+
   return (
     <AgentSessionProvider onOpenAgentSession={handleOpenAgentSession}>
       <ProfilePanelProvider onOpenProfilePanel={handleOpenProfilePanel}>
@@ -848,137 +897,195 @@ export function ChannelScreen({
                 targetReplyId={targetForumReplyId}
               />
             ) : (
-              <React.Suspense
-                fallback={<ViewLoadingFallback includeHeader kind="channel" />}
-              >
-                <ChannelPane
-                  activeChannel={activeChannel}
-                  activityAgents={channelAgentSessionAgents}
-                  agentPubkeys={agentPubkeys}
-                  agentPubkeysPending={agentPubkeysPending}
-                  agentSessionAgents={agentSessionAgents}
-                  autoSendDraftKey={autoSendDraftKey}
-                  onAutoSendComplete={clearAutoSend}
-                  botTypingEntries={botTypingEntries}
-                  channelFind={channelFind}
-                  channelManagementOpen={channelManagementOpen}
-                  currentPubkey={currentPubkey}
-                  canResetThreadPanelWidth={canResetThreadPanelWidth}
-                  fetchOlder={fetchOlder}
-                  header={channelHeader}
-                  hasOlderMessages={hasOlderMessages}
-                  historyExhausted={historyExhausted}
-                  onAddAgent={handleOpenAddBot}
-                  onBrowseChannels={openBrowseChannels}
-                  onCreateChannel={openCreateChannel}
-                  onOpenMembers={handleOpenMembersSidebar}
-                  isFetchingOlder={isFetchingOlder}
-                  entranceMessageId={welcomeEntranceMessageId}
-                  onEntranceMessageComplete={handleWelcomeEntranceComplete}
-                  welcomeKickoffStage={welcomeKickoffStage}
-                  welcomeKickoffSettingUp={welcomeKickoffSettingUp}
-                  editTarget={
-                    editTargetMessage
-                      ? {
-                          author: editTargetMessage.author,
-                          body: editTargetMessage.body,
-                          id: editTargetMessage.id,
-                          imetaMedia: imetaMediaFromTags(
-                            editTargetMessage.tags,
-                          ),
-                        }
-                      : null
-                  }
-                  followThreadById={followThread}
-                  unfollowThreadById={unfollowThread}
-                  isFollowingThreadById={isFollowingThread}
-                  isMessageUnreadById={isMessageUnread}
-                  isFollowingThread={isNotifiedForEffectiveThread}
-                  isSending={sendMessageMutation.isPending}
-                  isSinglePanelView={isSinglePanelView}
-                  isTimelineLoading={isTimelineLoading}
-                  messages={timelineMessages}
-                  threadSummaries={threadSummaries}
-                  onCancelEdit={handleCancelEdit}
-                  onCancelThreadReply={handleCancelThreadReply}
-                  onChannelManagementDeleted={handleChannelManagementDeleted}
-                  onFollowThread={
-                    effectiveOpenThreadHeadId != null &&
-                    !isNotifiedForEffectiveThread
-                      ? () => followThread(effectiveOpenThreadHeadId)
-                      : undefined
-                  }
-                  onUnfollowThread={
-                    effectiveOpenThreadHeadId != null &&
-                    isNotifiedForEffectiveThread
-                      ? () => unfollowThread(effectiveOpenThreadHeadId)
-                      : undefined
-                  }
-                  onCloseAgentSession={handleCloseAgentSession}
-                  onBackFromAgentSession={
-                    hasAgentSessionReturnTarget
-                      ? handleBackFromAgentSession
-                      : undefined
-                  }
-                  onCloseChannelManagement={handleCloseChannelManagement}
-                  onCloseThread={handleCloseThread}
-                  onDelete={
-                    activeChannel?.archivedAt ? undefined : handleDelete
-                  }
-                  onEdit={activeChannel?.archivedAt ? undefined : handleEdit}
-                  onEditSave={
-                    activeChannel?.archivedAt ? undefined : handleEditSave
-                  }
-                  onMarkUnread={handleMessageMarkUnread}
-                  onMarkRead={handleMessageMarkRead}
-                  onExpandThreadReplies={handleExpandThreadReplies}
-                  onOpenAgentSession={handleOpenAgentSession}
-                  onOpenDm={handleOpenDm}
-                  onOpenProfilePanel={handleOpenProfilePanel}
-                  onResetThreadPanelWidth={handleThreadPanelWidthReset}
-                  onCloseProfilePanel={handleCloseProfilePanel}
-                  onOpenThread={handleOpenThreadAndCloseAgentSession}
-                  onSelectThreadReplyTarget={handleSelectThreadReplyTarget}
-                  onSendMessage={handleSendMessage}
-                  onSendVideoReviewComment={effectiveSendVideoReviewComment}
-                  onSendThreadReply={handleSendThreadReply}
-                  onThreadScrollTargetResolved={
-                    handleThreadScrollTargetResolved
-                  }
-                  onThreadPanelResizeStart={handleThreadPanelResizeStart}
-                  onTargetReached={handleTargetReached}
-                  onToggleReaction={effectiveToggleReaction}
-                  openAgentSessionChannelId={openAgentSessionChannelId}
-                  openAgentSessionPubkey={openAgentSessionPubkey}
-                  openThreadHeadId={effectiveOpenThreadHeadId}
-                  shouldShowThreadSkeleton={shouldShowThreadSkeleton}
-                  onProfilePanelViewChange={setProfilePanelView}
-                  onProfilePanelTabChange={setProfilePanelTab}
-                  profilePanelPubkey={profilePanelPubkey}
-                  profilePanelTab={profilePanelTab}
-                  profilePanelView={profilePanelView}
-                  personaLookup={personaLookup}
-                  profiles={messageProfiles}
-                  ownerProfiles={messageOwnerProfiles}
-                  firstUnreadMessageId={firstUnreadMessageId}
-                  unreadCount={unreadCount}
-                  targetMessageId={mainTimelineTargetMessageId}
-                  threadAllMessages={displayedThreadAllMessages}
-                  threadHeadMessage={displayedThreadHeadMessage}
-                  threadMessages={displayedThreadMessages}
-                  threadMessagesPending={threadRepliesQuery.isPending}
-                  threadPanelWidthPx={threadPanelWidthPx}
-                  threadTypingPubkeys={threadTypingPubkeys}
-                  threadReplyTargetMessage={displayedThreadReplyTargetMessage}
-                  threadScrollTargetId={threadScrollTargetId}
-                  threadUnreadCounts={threadUnreadCounts}
-                  threadReplyUnreadCounts={threadReplyUnreadCounts}
-                  threadFirstUnreadReplyId={displayedThreadFirstUnreadReplyId}
-                  isJoining={joinChannelMutation.isPending}
-                  onJoinChannel={joinChannelMutation.mutateAsync}
-                  typingPubkeys={humanTypingPubkeys}
-                />
-              </React.Suspense>
+              <>
+                {channelHeader}
+                {/* Tab bar */}
+                <div
+                  className="shrink-0"
+                  style={{ marginTop: "var(--buzz-channel-content-top-padding, 5.75rem)" }}
+                >
+                  <div className="border-b border-border bg-background px-4">
+                    <div className="flex gap-0" role="tablist">
+                      <button
+                        aria-selected={activeTab === CHANNEL_TAB_CHAT}
+                        className={`px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                          activeTab === CHANNEL_TAB_CHAT
+                            ? "border-foreground text-foreground"
+                            : "border-transparent text-muted-foreground hover:text-foreground"
+                        }`}
+                        onClick={() => setActiveTab(CHANNEL_TAB_CHAT)}
+                        role="tab"
+                        type="button"
+                      >
+                        Chat
+                      </button>
+                      <button
+                        aria-selected={activeTab === CHANNEL_TAB_FILES}
+                        className={`px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                          activeTab === CHANNEL_TAB_FILES
+                            ? "border-foreground text-foreground"
+                            : "border-transparent text-muted-foreground hover:text-foreground"
+                        }`}
+                        onClick={() => setActiveTab(CHANNEL_TAB_FILES)}
+                        role="tab"
+                        type="button"
+                      >
+                        Files
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                {activeTab === CHANNEL_TAB_CHAT ? (
+                  <React.Suspense
+                    fallback={<ViewLoadingFallback includeHeader kind="channel" />}
+                  >
+                    <ChannelPane
+                      activeChannel={activeChannel}
+                      activityAgents={channelAgentSessionAgents}
+                      agentPubkeys={agentPubkeys}
+                      agentPubkeysPending={agentPubkeysPending}
+                      agentSessionAgents={agentSessionAgents}
+                      autoSendDraftKey={autoSendDraftKey}
+                      onAutoSendComplete={clearAutoSend}
+                      botTypingEntries={botTypingEntries}
+                      channelFind={channelFind}
+                      channelManagementOpen={channelManagementOpen}
+                      currentPubkey={currentPubkey}
+                      canResetThreadPanelWidth={canResetThreadPanelWidth}
+                      fetchOlder={fetchOlder}
+                      hasOlderMessages={hasOlderMessages}
+                      historyExhausted={historyExhausted}
+                      onAddAgent={handleOpenAddBot}
+                      onBrowseChannels={openBrowseChannels}
+                      onCreateChannel={openCreateChannel}
+                      onOpenMembers={handleOpenMembersSidebar}
+                      isFetchingOlder={isFetchingOlder}
+                      entranceMessageId={welcomeEntranceMessageId}
+                      onEntranceMessageComplete={handleWelcomeEntranceComplete}
+                      welcomeKickoffStage={welcomeKickoffStage}
+                      welcomeKickoffSettingUp={welcomeKickoffSettingUp}
+                      editTarget={
+                        editTargetMessage
+                          ? {
+                              author: editTargetMessage.author,
+                              body: editTargetMessage.body,
+                              id: editTargetMessage.id,
+                              imetaMedia: imetaMediaFromTags(
+                                editTargetMessage.tags,
+                              ),
+                            }
+                          : null
+                      }
+                      followThreadById={followThread}
+                      unfollowThreadById={unfollowThread}
+                      isFollowingThreadById={isFollowingThread}
+                      isMessageUnreadById={isMessageUnread}
+                      isFollowingThread={isNotifiedForEffectiveThread}
+                      isSending={sendMessageMutation.isPending}
+                      isSinglePanelView={isSinglePanelView}
+                      isTimelineLoading={isTimelineLoading}
+                      messages={timelineMessages}
+                      threadSummaries={threadSummaries}
+                      onCancelEdit={handleCancelEdit}
+                      onCancelThreadReply={handleCancelThreadReply}
+                      onChannelManagementDeleted={handleChannelManagementDeleted}
+                      onFollowThread={
+                        effectiveOpenThreadHeadId != null &&
+                        !isNotifiedForEffectiveThread
+                          ? () => followThread(effectiveOpenThreadHeadId)
+                          : undefined
+                      }
+                      onUnfollowThread={
+                        effectiveOpenThreadHeadId != null &&
+                        isNotifiedForEffectiveThread
+                          ? () => unfollowThread(effectiveOpenThreadHeadId)
+                          : undefined
+                      }
+                      onCloseAgentSession={handleCloseAgentSession}
+                      onBackFromAgentSession={
+                        hasAgentSessionReturnTarget
+                          ? handleBackFromAgentSession
+                          : undefined
+                      }
+                      onCloseChannelManagement={handleCloseChannelManagement}
+                      onCloseThread={handleCloseThread}
+                      onDelete={
+                        activeChannel?.archivedAt ? undefined : handleDelete
+                      }
+                      onEdit={activeChannel?.archivedAt ? undefined : handleEdit}
+                      onEditSave={
+                        activeChannel?.archivedAt ? undefined : handleEditSave
+                      }
+                      onMarkUnread={handleMessageMarkUnread}
+                      onMarkRead={handleMessageMarkRead}
+                      onExpandThreadReplies={handleExpandThreadReplies}
+                      onOpenAgentSession={handleOpenAgentSession}
+                      onOpenDm={handleOpenDm}
+                      onOpenProfilePanel={handleOpenProfilePanel}
+                      onResetThreadPanelWidth={handleThreadPanelWidthReset}
+                      onCloseProfilePanel={handleCloseProfilePanel}
+                      onOpenThread={handleOpenThreadAndCloseAgentSession}
+                      onSelectThreadReplyTarget={handleSelectThreadReplyTarget}
+                      onSendMessage={handleSendMessage}
+                      onSendVideoReviewComment={effectiveSendVideoReviewComment}
+                      onSendThreadReply={handleSendThreadReply}
+                      onThreadScrollTargetResolved={
+                        handleThreadScrollTargetResolved
+                      }
+                      onThreadPanelResizeStart={handleThreadPanelResizeStart}
+                      onTargetReached={handleTargetReached}
+                      onToggleReaction={effectiveToggleReaction}
+                      openAgentSessionChannelId={openAgentSessionChannelId}
+                      openAgentSessionPubkey={openAgentSessionPubkey}
+                      openThreadHeadId={effectiveOpenThreadHeadId}
+                      shouldShowThreadSkeleton={shouldShowThreadSkeleton}
+                      onProfilePanelViewChange={setProfilePanelView}
+                      onProfilePanelTabChange={setProfilePanelTab}
+                      profilePanelPubkey={profilePanelPubkey}
+                      profilePanelTab={profilePanelTab}
+                      profilePanelView={profilePanelView}
+                      personaLookup={personaLookup}
+                      profiles={messageProfiles}
+                      ownerProfiles={messageOwnerProfiles}
+                      firstUnreadMessageId={firstUnreadMessageId}
+                      unreadCount={unreadCount}
+                      targetMessageId={mainTimelineTargetMessageId}
+                      threadAllMessages={displayedThreadAllMessages}
+                      threadHeadMessage={displayedThreadHeadMessage}
+                      threadMessages={displayedThreadMessages}
+                      threadMessagesPending={threadRepliesQuery.isPending}
+                      threadPanelWidthPx={threadPanelWidthPx}
+                      threadTypingPubkeys={threadTypingPubkeys}
+                      threadReplyTargetMessage={displayedThreadReplyTargetMessage}
+                      threadScrollTargetId={threadScrollTargetId}
+                      threadUnreadCounts={threadUnreadCounts}
+                      threadReplyUnreadCounts={threadReplyUnreadCounts}
+                      threadFirstUnreadReplyId={displayedThreadFirstUnreadReplyId}
+                      isJoining={joinChannelMutation.isPending}
+                      onJoinChannel={joinChannelMutation.mutateAsync}
+                      typingPubkeys={humanTypingPubkeys}
+                    />
+                  </React.Suspense>
+                ) : (
+                  <ChannelFilesTab
+                    files={channelFiles.files}
+                    fileFolderMap={fileFoldersHook.fileFolderMap}
+                    folders={fileFoldersHook.folders}
+                    foldersLoading={fileFoldersHook.isLoading}
+                    isLoading={channelFiles.isLoading}
+                    onAddFileToFolder={fileFoldersHook.addFileToFolder}
+                    onAddFilesToFolder={fileFoldersHook.addFilesToFolder}
+                    onCreateFolder={fileFoldersHook.createFolder}
+                    onDeleteFolder={fileFoldersHook.deleteFolder}
+                    onJumpToMessage={handleJumpToMessage}
+                    onRemoveFileFromFolder={fileFoldersHook.removeFileFromFolder}
+                    onRenameFolder={fileFoldersHook.renameFolder}
+                    onSetFolderParent={fileFoldersHook.setFolderParent}
+                    senderAvatarUrls={fileSenderAvatarUrls}
+                    senderNames={fileSenderNames}
+                  />
+                )}
+              </>
             )
           ) : (
             <ChannelScreenEmptyState />


### PR DESCRIPTION
## Summary
Adds a Files tab to the channel view for browsing and organizing all file attachments shared in a channel. Includes synced file folders stored as Nostr kind:30078 events, bulk select with always-visible checkboxes, drag-and-drop file organization, and nested folder support.

## Screenshots

### Before (Chat tab only — no file browser)
![Chat tab before](https://raw.githubusercontent.com/block/buzz/c97486b8c71d2c3bdd01d4de8b7b61234e5b2dab/pr-4316--01-chat-before.png)

### After (Files tab with folders, bulk select, drag-and-drop)
![Files tab after](https://raw.githubusercontent.com/block/buzz/e7dea80ef29b3affe0461fde3e4770de8f5e559b/pr-4316--01-before-chat.png)

## What it does
- **Files tab**: List view with file type, size, dimensions, SHA-256 verification, sender info, and message captions
- **Filters & sort**: Category tabs (All/Images/Videos/Documents/Other), text search, and sort options
- **Synced folders**: Collaborative folders stored as kind:30078 replaceable events — syncs across team members via the relay
- **Drag-and-drop**: Drag files into folders, drag folders to nest/un-nest
- **Bulk select**: Always-visible checkboxes, shift-click range selection, bulk move to folder, bulk remove from folder

## Related issue
None found — this is a new feature.

## Testing
- Verified on Windows desktop build
- Tested: file list, search, sort, category filters
- Tested: folder create/delete, drag-and-drop, nested folders
- Tested: bulk select, shift-click range, bulk move/remove
- Tested: tab switching (Chat ↔ Files) preserves state