### PR TITLE
fix(desktop): remove nested focusable elements from profile popover call sites

### DIFF
--- a/desktop/src/features/forum/ui/ForumThreadPanel.tsx
+++ b/desktop/src/features/forum/ui/ForumThreadPanel.tsx
@@ -83,20 +83,18 @@ function ReplyRow({
       data-forum-event-id={reply.eventId}
     >
       <div className="flex items-center gap-2">
-        <UserProfilePopover pubkey={reply.pubkey}>
-          <button
-            className="flex items-center gap-2 rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-            type="button"
-          >
-            <UserAvatar
-              avatarUrl={replyAvatarUrl}
-              displayName={replyAuthorLabel}
-              size="sm"
-            />
-            <span className="text-sm font-medium text-foreground hover:underline">
-              {replyAuthorLabel}
-            </span>
-          </button>
+        <UserProfilePopover
+          pubkey={reply.pubkey}
+          triggerClassName="flex items-center gap-2 rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <UserAvatar
+            avatarUrl={replyAvatarUrl}
+            displayName={replyAuthorLabel}
+            size="sm"
+          />
+          <span className="text-sm font-medium text-foreground hover:underline">
+            {replyAuthorLabel}
+          </span>
         </UserProfilePopover>
         <span className="text-xs text-muted-foreground">
           {formatRelativeTime(reply.createdAt)}
@@ -228,19 +226,17 @@ export function ForumThreadPanel({
           data-forum-event-id={post.eventId}
         >
           <div className="flex items-center gap-2">
-            <UserProfilePopover pubkey={post.pubkey}>
-              <button
-                className="flex items-center gap-2 rounded-xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-                type="button"
-              >
-                <UserAvatar
-                  avatarUrl={postAvatarUrl}
-                  displayName={postAuthorLabel}
-                />
-                <span className="text-sm font-semibold text-foreground hover:underline">
-                  {postAuthorLabel}
-                </span>
-              </button>
+            <UserProfilePopover
+              pubkey={post.pubkey}
+              triggerClassName="flex items-center gap-2 rounded-xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <UserAvatar
+                avatarUrl={postAvatarUrl}
+                displayName={postAuthorLabel}
+              />
+              <span className="text-sm font-semibold text-foreground hover:underline">
+                {postAuthorLabel}
+              </span>
             </UserProfilePopover>
             <span className="text-xs text-muted-foreground">
               {formatRelativeTime(post.createdAt)}

--- a/desktop/src/features/messages/ui/MessageRow.tsx
+++ b/desktop/src/features/messages/ui/MessageRow.tsx
@@ -455,16 +455,12 @@ export const MessageRow = React.memo(
         pubkey={message.pubkey}
         role={profilePopoverRole}
         botIdenticonValue={message.author}
+        triggerClassName={cn(
+          "flex shrink-0 items-start focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+          avatarButtonRadiusClass,
+        )}
       >
-        <button
-          className={cn(
-            "flex shrink-0 items-start focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
-            avatarButtonRadiusClass,
-          )}
-          type="button"
-        >
-          {avatarNode}
-        </button>
+        {avatarNode}
       </UserProfilePopover>
     ) : (
       <div className="flex shrink-0 items-start">{avatarNode}</div>
@@ -561,13 +557,9 @@ export const MessageRow = React.memo(
             pubkey={message.pubkey}
             role={profilePopoverRole}
             botIdenticonValue={message.author}
+            triggerClassName="truncate rounded leading-4 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
           >
-            <button
-              className="truncate rounded leading-4 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-              type="button"
-            >
-              {authorNode}
-            </button>
+            {authorNode}
           </UserProfilePopover>
         ) : (
           authorNode

--- a/desktop/src/features/messages/ui/SystemMessageRow.tsx
+++ b/desktop/src/features/messages/ui/SystemMessageRow.tsx
@@ -327,14 +327,9 @@ function SystemMessageAvatar({
           botIdenticonValue={isSingleAgent ? actorLabel : undefined}
           pubkey={singlePubkey}
           role={isSingleAgent ? "bot" : undefined}
+          triggerClassName="shrink-0 rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
         >
-          <button
-            className="shrink-0 rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-            data-testid="system-message-avatar"
-            type="button"
-          >
-            {avatar}
-          </button>
+          <span data-testid="system-message-avatar">{avatar}</span>
         </UserProfilePopover>
       );
     }

--- a/desktop/src/features/profile/ui/UserProfilePopover.tsx
+++ b/desktop/src/features/profile/ui/UserProfilePopover.tsx
@@ -58,6 +58,8 @@ type UserProfilePopoverProps = {
   triggerElement?: "div" | "span";
   /** Accessible name for interactive trigger content that is visually hidden. */
   triggerAriaLabel?: string;
+  /** Extra classes merged onto the trigger wrapper (focus rings, etc.). */
+  triggerClassName?: string;
   /** Set false when the trigger is inside another interactive control. */
   enableProfilePanel?: boolean;
   /** When set to "bot", a BotIdenticon badge renders next to the display name. */
@@ -173,6 +175,7 @@ export function UserProfilePopover({
   pubkey,
   triggerElement = "div",
   triggerAriaLabel,
+  triggerClassName,
   enableProfilePanel = true,
   role,
   botIdenticonValue,
@@ -582,6 +585,7 @@ export function UserProfilePopover({
           className={cn(
             "inline-flex",
             canOpenProfilePanel && "cursor-pointer [&_*]:cursor-pointer",
+            triggerClassName,
           )}
         >
           {children}

--- a/desktop/src/features/projects/ui/ProjectCards.tsx
+++ b/desktop/src/features/projects/ui/ProjectCards.tsx
@@ -111,22 +111,21 @@ function ProjectPeopleStack({
             key={pubkey}
             style={{ zIndex: visible.length - index }}
           >
-            <UserProfilePopover pubkey={pubkey} triggerElement="span">
-              <button
-                aria-label={`View ${label}'s profile`}
-                className="inline-flex rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-                type="button"
-              >
-                <UserAvatar
-                  accent={
-                    normalizePubkey(pubkey) === normalizePubkey(workOwnerPubkey)
-                  }
-                  avatarUrl={profile?.avatarUrl ?? null}
-                  className="ring-2 ring-card"
-                  displayName={label}
-                  size="xs"
-                />
-              </button>
+            <UserProfilePopover
+              pubkey={pubkey}
+              triggerElement="span"
+              triggerAriaLabel={`View ${label}'s profile`}
+              triggerClassName="inline-flex rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <UserAvatar
+                accent={
+                  normalizePubkey(pubkey) === normalizePubkey(workOwnerPubkey)
+                }
+                avatarUrl={profile?.avatarUrl ?? null}
+                className="ring-2 ring-card"
+                displayName={label}
+                size="xs"
+              />
             </UserProfilePopover>
           </span>
         );

--- a/desktop/src/features/projects/ui/ProjectProfileIdentity.tsx
+++ b/desktop/src/features/projects/ui/ProjectProfileIdentity.tsx
@@ -78,10 +78,12 @@ export function ProfileIdentityButton({
   }
 
   return (
-    <UserProfilePopover pubkey={pubkey} triggerElement="span">
-      <button className={className} type="button">
-        {inner}
-      </button>
+    <UserProfilePopover
+      pubkey={pubkey}
+      triggerElement="span"
+      triggerClassName={className}
+    >
+      {inner}
     </UserProfilePopover>
   );
 }
@@ -98,13 +100,12 @@ export function ProfileAuthorName({
   }
 
   return (
-    <UserProfilePopover pubkey={pubkey} triggerElement="span">
-      <button
-        className="rounded-md font-semibold text-foreground hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-        type="button"
-      >
-        {children}
-      </button>
+    <UserProfilePopover
+      pubkey={pubkey}
+      triggerElement="span"
+      triggerClassName="rounded-md font-semibold text-foreground hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      {children}
     </UserProfilePopover>
   );
 }

--- a/desktop/src/features/projects/ui/ProjectsActivityFeed.tsx
+++ b/desktop/src/features/projects/ui/ProjectsActivityFeed.tsx
@@ -270,19 +270,18 @@ function ActivityCard({
       />
       <div className="pointer-events-none relative flex min-w-0 items-start gap-3">
         {item.actorPubkey ? (
-          <UserProfilePopover pubkey={item.actorPubkey} triggerElement="span">
-            <button
-              aria-label={`View ${actorLabel}'s profile`}
-              className="pointer-events-auto relative z-10 shrink-0 rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-              type="button"
-            >
-              <UserAvatar
-                accent={profile?.isAgent === true}
-                avatarUrl={profile?.avatarUrl ?? null}
-                displayName={actorLabel}
-                size={compact ? "xs" : "md"}
-              />
-            </button>
+          <UserProfilePopover
+            pubkey={item.actorPubkey}
+            triggerElement="span"
+            triggerAriaLabel={`View ${actorLabel}'s profile`}
+            triggerClassName="pointer-events-auto relative z-10 shrink-0 rounded-full focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <UserAvatar
+              accent={profile?.isAgent === true}
+              avatarUrl={profile?.avatarUrl ?? null}
+              displayName={actorLabel}
+              size={compact ? "xs" : "md"}
+            />
           </UserProfilePopover>
         ) : (
           <UserAvatar
@@ -301,13 +300,9 @@ function ActivityCard({
                   <UserProfilePopover
                     pubkey={item.actorPubkey}
                     triggerElement="span"
+                    triggerClassName="pointer-events-auto relative z-10 rounded-sm hover:underline focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
                   >
-                    <button
-                      className="pointer-events-auto relative z-10 rounded-sm hover:underline focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
-                      type="button"
-                    >
-                      {actorLabel}
-                    </button>
+                    {actorLabel}
                   </UserProfilePopover>
                 ) : (
                   actorLabel

--- a/desktop/src/features/projects/ui/ProjectsIssuesList.tsx
+++ b/desktop/src/features/projects/ui/ProjectsIssuesList.tsx
@@ -70,13 +70,12 @@ function IssueHeader({
         {project.name}
         {includeDate ? ` · created ${relativeTime(issue.createdAt)}` : null} ·
         by{" "}
-        <UserProfilePopover pubkey={issue.author} triggerElement="span">
-          <button
-            className="relative z-10 rounded-sm hover:underline focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
-            type="button"
-          >
-            {authorLabel}
-          </button>
+        <UserProfilePopover
+          pubkey={issue.author}
+          triggerElement="span"
+          triggerClassName="relative z-10 rounded-sm hover:underline focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          {authorLabel}
         </UserProfilePopover>
         {includeDate ? (
           ` · ${issue.status}`

--- a/desktop/src/features/projects/ui/ProjectsPullRequestsList.tsx
+++ b/desktop/src/features/projects/ui/ProjectsPullRequestsList.tsx
@@ -38,13 +38,12 @@ function AuthorNameButton({
   pubkey: string;
 }) {
   return (
-    <UserProfilePopover pubkey={pubkey} triggerElement="span">
-      <button
-        className="relative z-10 rounded-sm hover:underline focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
-        type="button"
-      >
-        {label}
-      </button>
+    <UserProfilePopover
+      pubkey={pubkey}
+      triggerElement="span"
+      triggerClassName="relative z-10 rounded-sm hover:underline focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+    >
+      {label}
     </UserProfilePopover>
   );
 }

--- a/desktop/src/features/pulse/ui/AgentActivityCard.tsx
+++ b/desktop/src/features/pulse/ui/AgentActivityCard.tsx
@@ -60,15 +60,11 @@ export function AgentActivityCard({
           botIdenticonValue={displayName}
           pubkey={group.pubkey}
           role={"bot" as const}
+          triggerAriaLabel={`Open profile for ${displayName}`}
+          triggerClassName="relative flex shrink-0 rounded-xl pt-1 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
         >
-          <button
-            aria-label={`Open profile for ${displayName}`}
-            className="relative flex shrink-0 rounded-xl pt-1 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-            type="button"
-          >
-            <UserAvatar avatarUrl={avatarUrl} displayName={displayName} />
-            <Bot className="absolute -bottom-0.5 -right-0.5 h-4 w-4 rounded-full bg-background p-0.5 text-muted-foreground" />
-          </button>
+          <UserAvatar avatarUrl={avatarUrl} displayName={displayName} />
+          <Bot className="absolute -bottom-0.5 -right-0.5 h-4 w-4 rounded-full bg-background p-0.5 text-muted-foreground" />
         </UserProfilePopover>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">

--- a/desktop/src/features/pulse/ui/NoteCard.tsx
+++ b/desktop/src/features/pulse/ui/NoteCard.tsx
@@ -77,29 +77,24 @@ function ReplyParentContext({
     <div className="mt-2 truncate rounded-xl border border-border/50 bg-muted/25 px-3 py-2 text-xs text-muted-foreground">
       {parentNote ? (
         <div className="flex min-w-0 items-center gap-1.5">
-          <UserProfilePopover pubkey={parentNote.pubkey} triggerElement="span">
-            <button
-              className="flex shrink-0 rounded-md focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-              type="button"
-            >
-              <UserAvatar
-                avatarUrl={parentAvatarUrl}
-                className="!h-4 !w-4 shrink-0"
-                displayName={parentDisplayName ?? "Parent note author"}
-              />
-            </button>
+          <UserProfilePopover
+            pubkey={parentNote.pubkey}
+            triggerElement="span"
+            triggerClassName="flex shrink-0 rounded-md focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <UserAvatar
+              avatarUrl={parentAvatarUrl}
+              className="!h-4 !w-4 shrink-0"
+              displayName={parentDisplayName ?? "Parent note author"}
+            />
           </UserProfilePopover>
           <span className="min-w-0 truncate">
             <UserProfilePopover
               pubkey={parentNote.pubkey}
               triggerElement="span"
+              triggerClassName="rounded font-medium text-foreground/80 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
             >
-              <button
-                className="rounded font-medium text-foreground/80 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-                type="button"
-              >
-                {parentDisplayName}
-              </button>
+              {parentDisplayName}
             </UserProfilePopover>
             : {parentSnippet || "No text"}
           </span>
@@ -161,20 +156,16 @@ export function NoteCard({
         botIdenticonValue={displayName}
         pubkey={note.pubkey}
         role={isAgent ? "bot" : undefined}
+        triggerClassName="relative flex shrink-0 rounded-xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
       >
-        <button
-          className="relative flex shrink-0 rounded-xl focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-          type="button"
-        >
-          <UserAvatar
-            avatarUrl={avatarUrl}
-            className="!h-9 !w-9 shrink-0"
-            displayName={displayName}
-          />
-          {isAgent ? (
-            <Bot className="absolute -bottom-0.5 -right-0.5 h-4 w-4 rounded-full bg-background p-0.5 text-muted-foreground" />
-          ) : null}
-        </button>
+        <UserAvatar
+          avatarUrl={avatarUrl}
+          className="!h-9 !w-9 shrink-0"
+          displayName={displayName}
+        />
+        {isAgent ? (
+          <Bot className="absolute -bottom-0.5 -right-0.5 h-4 w-4 rounded-full bg-background p-0.5 text-muted-foreground" />
+        ) : null}
       </UserProfilePopover>
 
       <div className="min-w-0 flex-1">
@@ -183,13 +174,9 @@ export function NoteCard({
             botIdenticonValue={displayName}
             pubkey={note.pubkey}
             role={isAgent ? "bot" : undefined}
+            triggerClassName="truncate rounded text-sm font-semibold leading-none tracking-tight focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
           >
-            <button
-              className="truncate rounded text-sm font-semibold leading-none tracking-tight focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
-              type="button"
-            >
-              {displayName}
-            </button>
+            {displayName}
           </UserProfilePopover>
           {isAgent ? (
             <span className="inline-flex h-4 items-center rounded bg-muted px-1 text-2xs font-medium text-muted-foreground">


### PR DESCRIPTION
## What

Eliminates the nested-focusable-elements anti-pattern in every `UserProfilePopover` call site identified in #2394 — desktop timeline, project cards, forum threads, pulse feed.

## Why

The popover's trigger wrapper gets `role="button"` + `tabIndex={0}` when `enableProfilePanel` (default `true`) lets it open the profile panel. Several callers wrapped their avatar/author name in a decorative `<button>` that had no `onClick` — so the button was reachable by Tab but dead to activation, while the *wrapper* handled the actual profile-panel open. Each avatar/name became **two Tab stops** for what is one visual control.

## How

One root-cause mechanism, uniform per call site:

- **`UserProfilePopover` gains an optional `triggerClassName` prop** so the layout / focus-ring classes the inner button carried can move to the wrapper, where Tab focus now actually lands.
- Every call site that had a `<button>` child **loses the inner `<button>`** — the wrapper is the tab stop, the click handler still fires via the wrapper's `onClick`, and Hover→popover still works unchanged.
- Where the inner button carried an `aria-label` (e.g. `View ${label}'s profile`), it moves to `triggerAriaLabel` on the popover.

Net effect: one Tab stop per avatar/name across the entire app, focus rings still visible, zero behavior change for clicks or hovers.

## Files

- `desktop/src/features/profile/ui/UserProfilePopover.tsx` — adds `triggerClassName` prop, merges it onto the TriggerElement's `cn(...)` call.
- `desktop/src/features/messages/ui/MessageRow.tsx` — avatar + author name call sites.
- `desktop/src/features/messages/ui/SystemMessageRow.tsx` — system-message avatar.
- `desktop/src/features/projects/ui/ProjectCards.tsx` — project-card owner avatar.
- `desktop/src/features/projects/ui/ProjectProfileIdentity.tsx` — inline `ProfileIdentityAvatar` + standalone `ProfileAuthorName`.
- `desktop/src/features/projects/ui/ProjectsActivityFeed.tsx` — actor avatar + actor name.
- `desktop/src/features/projects/ui/ProjectsIssuesList.tsx` — issue author.
- `desktop/src/features/projects/ui/ProjectsPullRequestsList.tsx` — PR author.
- `desktop/src/features/pulse/ui/AgentActivityCard.tsx` — agent group avatar.
- `desktop/src/features/pulse/ui/NoteCard.tsx` — parent-note avatar, parent-note author, note avatar, note author.
- `desktop/src/features/forum/ui/ForumThreadPanel.tsx` — post author + reply author.

(11 files total, −153 / +116 lines.)

## Verification

- `pnpm typecheck` — 0 errors.
- `pnpm test` — 3906/3906 pass.
- `pnpm lint` — 0 errors (same 2 infos as baseline).
- Manual inspection: no `<button>` element remains inside `<UserProfilePopover>` anywhere it was observed; the trigger wrapper is now the only Tab stop.

Closes #2394.
