### PR TITLE
fix(relay): soft-delete workflow definition event on workflow delete

### DIFF
--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -2103,7 +2103,7 @@ async fn handle_a_tag_deletion(
         }
         buzz_core::kind::KIND_WORKFLOW_DEF => {
             // Try UUID first (workflow_id); fall back to name-based lookup.
-            if let Ok(wf_id) = uuid::Uuid::parse_str(d_tag) {
+            let workflow_deleted: Option<uuid::Uuid> = if let Ok(wf_id) = uuid::Uuid::parse_str(d_tag) {
                 let channel_id = state
                     .db
                     .delete_workflow_for_owner(tenant.community(), wf_id, &actor_bytes)
@@ -2115,6 +2115,7 @@ async fn handle_a_tag_deletion(
                         .invalidate_channel_workflows(tenant.community(), channel_id);
                 }
                 tracing::info!(workflow_id = %wf_id, "Workflow deleted via NIP-09 a-tag (UUID)");
+                Some(wf_id)
             } else {
                 // Name-based lookup
                 match state
@@ -2136,14 +2137,66 @@ async fn handle_a_tag_deletion(
                                 .invalidate_channel_workflows(tenant.community(), channel_id);
                         }
                         tracing::info!(workflow_id = %wf.id, name = d_tag, "Workflow deleted via NIP-09 a-tag (name)");
+                        Some(wf.id)
                     }
                     Ok(None) => {
                         tracing::warn!(
                             "NIP-09 a-tag deletion: no workflow '{d_tag}' found for owner"
                         );
+                        None
                     }
                     Err(e) => {
                         tracing::warn!("NIP-09 a-tag deletion: DB lookup failed: {e}");
+                        None
+                    }
+                }
+            };
+
+            // Soft-delete the kind:30620 definition event so REQs (CLI
+            // `workflows list` / `workflows get`) stop returning it. Without
+            // this the workflow row is gone but the definition event stayed
+            // live and every read path disagreed with triggers — see #2879.
+            // Only do this when the row delete actually succeeded above, so
+            // a failed delete (e.g. owner mismatch) can't tombstone a live
+            // workflow's event out from under it.
+            if workflow_deleted.is_some() {
+                let pubkey_bytes = match hex::decode(pubkey_hex) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::warn!("NIP-09 a-tag deletion: invalid pubkey hex {pubkey_hex}: {e}");
+                        Vec::new()
+                    }
+                };
+                if !pubkey_bytes.is_empty() {
+                    match state
+                        .db
+                        .soft_delete_by_coordinate(
+                            tenant.community(),
+                            buzz_core::kind::KIND_WORKFLOW_DEF as i32,
+                            &pubkey_bytes,
+                            d_tag,
+                            event.created_at.as_secs() as i64,
+                        )
+                        .await
+                    {
+                        Ok(true) => {
+                            tracing::info!(
+                                d_tag = d_tag,
+                                "kind:30620 workflow definition event soft-deleted"
+                            )
+                        }
+                        Ok(false) => {
+                            tracing::debug!(
+                                d_tag = d_tag,
+                                "no live kind:30620 event row matched coordinate"
+                            )
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                d_tag = d_tag,
+                                "soft-delete of kind:30620 event failed: {e}"
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What

Makes `buzz workflows delete` actually hide the workflow from every read path — not just from triggers.

## Why (bug report)

Filer verified end-to-end on v0.4.26 against the live relay:

```
$ buzz workflows delete --workflow <id>            # accepted
$ buzz workflows list                              # <id> still present, full YAML
$ buzz workflows get --workflow <id>               # full YAML returned
$ buzz workflows trigger --workflow <id>           # 400: workflow not found
```

The row delete succeeded; only the trigger endpoint knew. Operators monitoring the relay via `list`/`get` couldn't tell deleted from live without attempting a trigger.

## Root cause

`handle_a_tag_deletion` in `crates/buzz-relay/src/handlers/side_effects.rs` dispatches on the `kind` in the `a` tag. The `KIND_WORKFLOW_DEF` arm called `delete_workflow_for_owner` and `invalidate_channel_workflows`, then returned — it never soft-deleted the kind:30620 event row itself. The generic addressable-events arm below it (`is_parameterized_replaceable`) does call `soft_delete_by_coordinate`, but the workflow branch returns first.

The generic arm's doc comment even called this out:

> "Listed after the workflow branch so workflow's bespoke deletion (which doesn't soft-delete the `events` row by design — that's a separate concern) takes precedence."

That "separate concern" is exactly this bug. The "by design" doesn't survive contact with the actual read paths: `workflows list` and `workflows get` both query the kind:30620 event via REQ, so a live event row made the relay keep reporting the deleted workflow.

## How

- Refactored the workflow arm to return the deleted workflow's UUID (instead of `()`).
- Added a follow-up step gated on that UUID being `Some`: decode the `pubkey_hex` from the `a` tag and call `soft_delete_by_coordinate(30620, pubkey, d_tag)` on the live event row, with the standard `created_at` cutoff so a stale deletion event cannot tombstone a newer replacement head.
- The gate matters: if `delete_workflow_for_owner` fails (owner mismatch, etc.), the event row is left alone. A failed delete must not be able to hide a live workflow.
- Tracing logs success/no-op/error paths to match the rest of the module's observability.

## Files

- `crates/buzz-relay/src/handlers/side_effects.rs` — `handle_a_tag_deletion` workflow arm, +54 / −1.

## Verification

- `cargo check -p buzz-relay --lib` — clean.
- `cargo test -p buzz-relay --lib workflow` — 17/17 pass.
- Full `cargo test -p buzz-relay --lib` — 827 pass, 9 fail (identical to baseline `main`; pre-existing media/admin/env-gated tests unrelated to this change).

## Behavior

| Action | Before | After |
|---|---|---|
| `workflows delete` (row + event) | Row gone, event still live | Both gone |
| `workflows list` after delete | Still returns the workflow | Stops returning it |
| `workflows get` after delete | Still returns full YAML | Returns "not found" |
| `workflows trigger` after delete | `400 workflow not found` | `400 workflow not found` (unchanged) |
| Delete with owner mismatch | Row intact, event live (error surfaced) | Row intact, event live (unchanged) |

Closes #2879.
