### PR TITLE
feat(projects): add pinned repository artifact links

### DIFF
--- a/crates/buzz-acp/src/base_prompt.md
+++ b/crates/buzz-acp/src/base_prompt.md
@@ -16,7 +16,7 @@ The `buzz` CLI is your primary interface. Auth env vars: `BUZZ_RELAY_URL`, `BUZZ
 | `buzz workflows` | `list`, `trigger`, `runs` |
 | `buzz feed` | `get` |
 | `buzz social` | `publish`, `notes` |
-| `buzz repos` | `create`, `get`, `list` |
+| `buzz repos` | `create`, `get`, `list`, `link` |
 | `buzz pr` | `open`, `update`, `get`, `list`, `status` |
 | `buzz upload` | `file` |
 
@@ -62,6 +62,8 @@ When in doubt, prefer the reply destination explicitly supplied in `[Context]`. 
 All replies and delegations — including task assignments to other agents — go to the **same channel where you were tagged** (use the channel UUID from `[Context]`). Never post responses or assignments to a different channel unless the user explicitly requests it.
 
 ### General
+
+- **Make review artifacts clickable.** When work creates a file the user may want to inspect, use `buzz repos link --id <repo> --path <path> --ref HEAD` from the repository and include its Markdown output in the completion message. The link pins the current commit. Quick answers and work with no review artifact need no link.
 
 - Respond promptly to @mentions. Be direct — no preamble. Name what you did, what you found, or what you need.
 - **If your turn produced anything worth knowing, you MUST publish it.** Use `buzz messages send`. Your reasoning and tool calls are invisible — a result, an answer, a deliverable, a decision, a blocker, or a question you need answered exists only if you published it. Work or an answer that someone asked you for always counts. Ending that kind of turn without a message is a silent failure.

--- a/crates/buzz-cli/src/commands/repos.rs
+++ b/crates/buzz-cli/src/commands/repos.rs
@@ -1,8 +1,11 @@
+use std::{collections::BTreeSet, process::Command};
+
 use buzz_core::{
     git_perms::{parse_protection_tag, parse_protection_tags, RefPattern},
     kind::KIND_GIT_REPO_ANNOUNCEMENT,
 };
 use nostr::{Event, EventBuilder, Tag, Timestamp};
+use url::Url;
 
 use crate::client::{normalize_write_response, BuzzClient};
 use crate::error::CliError;
@@ -27,6 +30,144 @@ async fn fetch_own_repo_announcement(
     let mut events = parse_events(&raw)?;
     events.sort_by_key(|event| std::cmp::Reverse(event.created_at));
     Ok(events.into_iter().next())
+}
+
+fn validate_artifact_path(path: &str) -> Result<(), CliError> {
+    if path.is_empty()
+        || path.starts_with('/')
+        || path.contains('\\')
+        || path
+            .split('/')
+            .any(|segment| segment.is_empty() || segment == "." || segment == "..")
+    {
+        return Err(CliError::Usage(
+            "--path must be a safe repository-relative file path".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn resolve_git_commit(git_ref: &str) -> Result<String, CliError> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", &format!("{git_ref}^{{commit}}")])
+        .output()
+        .map_err(|error| CliError::Other(format!("failed to run git rev-parse: {error}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(CliError::Usage(format!(
+            "could not resolve --ref {git_ref:?} to a commit: {stderr}"
+        )));
+    }
+    let commit = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .to_ascii_lowercase();
+    if !matches!(commit.len(), 40 | 64) || !commit.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(CliError::Other(
+            "git returned an invalid full commit hash".into(),
+        ));
+    }
+    Ok(commit)
+}
+
+fn ensure_path_exists_at_commit(commit: &str, path: &str) -> Result<(), CliError> {
+    let object = format!("{commit}:{path}");
+    let output = Command::new("git")
+        .args(["cat-file", "-e", &object])
+        .output()
+        .map_err(|error| CliError::Other(format!("failed to run git cat-file: {error}")))?;
+    if !output.status.success() {
+        return Err(CliError::NotFound(format!(
+            "file {path:?} does not exist at commit {commit}"
+        )));
+    }
+    Ok(())
+}
+
+fn default_artifact_label(path: &str) -> &'static str {
+    let path = path.to_ascii_lowercase();
+    if path.ends_with(".html") || path.ends_with(".htm") {
+        "Open report"
+    } else {
+        "View file"
+    }
+}
+
+fn build_artifact_markdown_link(
+    repo_id: &str,
+    owner: &str,
+    commit: &str,
+    path: &str,
+    label: Option<&str>,
+) -> Result<String, CliError> {
+    validate_repo_id(repo_id)?;
+    crate::validate::validate_hex64(owner)?;
+    validate_artifact_path(path)?;
+    if !matches!(commit.len(), 40 | 64) || !commit.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(CliError::Usage("commit must be a full git hash".into()));
+    }
+    let mut url = Url::parse("buzz://repo")
+        .map_err(|error| CliError::Other(format!("failed to build repo link: {error}")))?;
+    url.query_pairs_mut()
+        .append_pair("repo", repo_id)
+        .append_pair("owner", &owner.to_ascii_lowercase())
+        .append_pair("ref", &commit.to_ascii_lowercase())
+        .append_pair("path", path);
+    let label = label
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| default_artifact_label(path));
+    Ok(format!("[{label}]({url})"))
+}
+
+async fn resolve_repo_owner(
+    client: &BuzzClient,
+    repo_id: &str,
+    owner: Option<&str>,
+) -> Result<String, CliError> {
+    validate_repo_id(repo_id)?;
+    if let Some(owner) = owner {
+        crate::validate::validate_hex64(owner)?;
+    }
+    let mut filter = serde_json::json!({
+        "kinds": [KIND_GIT_REPO_ANNOUNCEMENT],
+        "#d": [repo_id],
+        "limit": 100,
+    });
+    if let Some(owner) = owner {
+        filter["authors"] = serde_json::json!([owner]);
+    }
+    let events = parse_events(&client.query(&filter).await?)?;
+    let owners: BTreeSet<String> = events
+        .into_iter()
+        .map(|event| event.pubkey.to_hex())
+        .collect();
+    match owners.len() {
+        0 => Err(CliError::NotFound(format!(
+            "repository {repo_id:?} was not found"
+        ))),
+        1 => Ok(owners.into_iter().next().expect("one owner")),
+        _ => Err(CliError::Usage(format!(
+            "repository {repo_id:?} has multiple owners; pass --owner <hex-pubkey>"
+        ))),
+    }
+}
+
+async fn cmd_link_repo(
+    client: &BuzzClient,
+    repo_id: &str,
+    owner: Option<&str>,
+    path: &str,
+    git_ref: &str,
+    label: Option<&str>,
+) -> Result<(), CliError> {
+    validate_artifact_path(path)?;
+    let commit = resolve_git_commit(git_ref)?;
+    ensure_path_exists_at_commit(&commit, path)?;
+    let owner = resolve_repo_owner(client, repo_id, owner).await?;
+    println!(
+        "{}",
+        build_artifact_markdown_link(repo_id, &owner, &commit, path, label)?
+    );
+    Ok(())
 }
 
 fn repo_id_from_event(event: &Event) -> Result<&str, CliError> {
@@ -443,6 +584,23 @@ pub async fn dispatch(cmd: crate::ReposCmd, client: &BuzzClient) -> Result<(), C
         }
         ReposCmd::Get { id, owner } => cmd_get_repo(client, &id, owner.as_deref()).await,
         ReposCmd::List { owner, limit } => cmd_list_repos(client, owner.as_deref(), limit).await,
+        ReposCmd::Link {
+            id,
+            owner,
+            path,
+            git_ref,
+            label,
+        } => {
+            cmd_link_repo(
+                client,
+                &id,
+                owner.as_deref(),
+                &path,
+                &git_ref,
+                label.as_deref(),
+            )
+            .await
+        }
         ReposCmd::Bind { id, channel } => cmd_bind_repo(client, &id, &channel).await,
         ReposCmd::Protect(command) => match command {
             ReposProtectCmd::List { id } => cmd_protect_list(client, &id).await,
@@ -477,8 +635,9 @@ mod tests {
     use nostr::{EventBuilder, Keys, Kind, Tag, Timestamp};
 
     use super::{
-        build_create_announcement, build_protection_tag, build_updated_repo_announcement,
-        protection_rules_json, validate_write_response, RepoChange,
+        build_artifact_markdown_link, build_create_announcement, build_protection_tag,
+        build_updated_repo_announcement, protection_rules_json, validate_artifact_path,
+        validate_write_response, RepoChange,
     };
 
     fn signed_repo(tags: Vec<Tag>, content: &str, created_at: u64) -> nostr::Event {
@@ -491,6 +650,38 @@ mod tests {
 
     fn tag(parts: &[&str]) -> Tag {
         Tag::parse(parts.iter().copied()).expect("valid test tag")
+    }
+
+    #[test]
+    fn artifact_link_is_owner_qualified_and_commit_pinned() {
+        let owner = "a".repeat(64);
+        let commit = "b".repeat(40);
+        let link = build_artifact_markdown_link(
+            "boosh",
+            &owner,
+            &commit,
+            "reports/weekly report.html",
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            link,
+            format!(
+                "[Open report](buzz://repo?repo=boosh&owner={owner}&ref={commit}&path=reports%2Fweekly+report.html)"
+            )
+        );
+    }
+
+    #[test]
+    fn artifact_path_rejects_traversal_and_absolute_paths() {
+        for path in [
+            "../secret",
+            "/etc/passwd",
+            "reports//weekly.html",
+            "reports\\weekly.html",
+        ] {
+            assert!(validate_artifact_path(path).is_err());
+        }
     }
 
     #[test]

--- a/crates/buzz-cli/src/lib.rs
+++ b/crates/buzz-cli/src/lib.rs
@@ -1156,6 +1156,24 @@ pub enum ReposCmd {
         #[arg(long)]
         limit: Option<u32>,
     },
+    /// Create a clickable Markdown link to a file at an exact git commit.
+    Link {
+        /// Repository identifier (d-tag).
+        #[arg(long)]
+        id: String,
+        /// Owner pubkey. Required only when the repository identifier is ambiguous.
+        #[arg(long)]
+        owner: Option<String>,
+        /// Repository-relative file path.
+        #[arg(long)]
+        path: String,
+        /// Git ref to resolve to an exact commit.
+        #[arg(long = "ref", default_value = "HEAD")]
+        git_ref: String,
+        /// Markdown link label. Defaults to Open report for HTML, otherwise View file.
+        #[arg(long)]
+        label: Option<String>,
+    },
     /// Bind (or rebind) one of your repositories to a channel.
     ///
     /// The `buzz-channel` tag on the announcement is the git ACL: the relay
@@ -2104,7 +2122,7 @@ mod tests {
         );
         assert_eq!(
             names(&cmd, "repos"),
-            vec!["bind", "create", "get", "list", "protect"]
+            vec!["bind", "create", "get", "link", "list", "protect"]
         );
         let repos = cmd
             .get_subcommands()
@@ -2167,7 +2185,7 @@ mod tests {
             ("patches", 4),
             ("pr", 5),
             ("reactions", 3),
-            ("repos", 5),
+            ("repos", 6),
             ("social", 7),
             ("upload", 1),
             ("users", 5),

--- a/desktop/src-tauri/src/deep_link.rs
+++ b/desktop/src-tauri/src/deep_link.rs
@@ -136,6 +136,46 @@ fn parse_message_deep_link(url: &Url) -> Option<serde_json::Value> {
     }))
 }
 
+fn is_safe_repo_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.starts_with('/')
+        && !path.contains('\\')
+        && path
+            .split('/')
+            .all(|segment| !segment.is_empty() && segment != "." && segment != "..")
+}
+
+/// Parse a stable repository artifact link. The ref is deliberately a full
+/// commit hash so the file the user opens cannot drift after it is shared.
+fn parse_repo_deep_link(url: &Url) -> Option<serde_json::Value> {
+    let repo_id = optional_non_empty_param(url, "repo")?;
+    let owner = optional_non_empty_param(url, "owner");
+    let commit = optional_non_empty_param(url, "ref")?;
+    let path = optional_non_empty_param(url, "path")?;
+
+    let repo_valid = !repo_id.starts_with('.')
+        && !repo_id.contains("..")
+        && repo_id.len() <= 64
+        && repo_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
+    let owner_valid = owner.as_deref().is_none_or(|value| {
+        value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+    });
+    let commit_valid =
+        matches!(commit.len(), 40 | 64) && commit.bytes().all(|byte| byte.is_ascii_hexdigit());
+    if !repo_valid || !owner_valid || !commit_valid || !is_safe_repo_path(&path) {
+        return None;
+    }
+
+    Some(serde_json::json!({
+        "repoId": repo_id,
+        "owner": owner.map(|value| value.to_ascii_lowercase()),
+        "ref": commit.to_ascii_lowercase(),
+        "path": path,
+    }))
+}
+
 /// Parse the query string of a `buzz://join?…` URL into the JSON payload
 /// emitted on `deep-link-join`. Requires a ws(s) `relay` URL and a non-empty
 /// `code`; returns `None` otherwise so the frontend never sees a half-formed
@@ -366,6 +406,14 @@ pub(crate) fn handle_deep_link_url(app: &tauri::AppHandle, url_str: &str) {
             activate_main_window(app);
             let _ = app.emit("deep-link-message", payload);
         }
+        Some("repo") => {
+            let Some(payload) = parse_repo_deep_link(&url) else {
+                eprintln!("buzz-desktop: invalid repo deep link: {url_str}");
+                return;
+            };
+            activate_main_window(app);
+            let _ = app.emit("deep-link-repo", payload);
+        }
         Some("nostr-bind") => match parse_nostr_bind_deep_link(&url) {
             Ok(payload) => {
                 activate_main_window(app);
@@ -390,7 +438,8 @@ mod tests {
 
     use super::{
         parse_add_community_deep_link, parse_join_deep_link, parse_message_deep_link,
-        parse_nostr_bind_deep_link, PendingCommunityDeepLink, PendingCommunityDeepLinks,
+        parse_nostr_bind_deep_link, parse_repo_deep_link, PendingCommunityDeepLink,
+        PendingCommunityDeepLinks,
     };
 
     fn pending(id: &str, relay_url: &str, code: Option<&str>) -> PendingCommunityDeepLink {
@@ -525,6 +574,31 @@ mod tests {
         let url = Url::parse("buzz://message?channel=abc&id=xyz&thread=").unwrap();
         let payload = parse_message_deep_link(&url).expect("required params present");
         assert!(payload["threadRootId"].is_null());
+    }
+
+    #[test]
+    fn parse_repo_deep_link_extracts_pinned_artifact() {
+        let owner = "a".repeat(64);
+        let commit = "b".repeat(40);
+        let url = Url::parse(&format!(
+            "buzz://repo?repo=boosh&owner={owner}&ref={commit}&path=reports%2Fweekly.html"
+        ))
+        .unwrap();
+        let payload = parse_repo_deep_link(&url).unwrap();
+        assert_eq!(payload["repoId"], "boosh");
+        assert_eq!(payload["owner"], owner);
+        assert_eq!(payload["ref"], commit);
+        assert_eq!(payload["path"], "reports/weekly.html");
+    }
+
+    #[test]
+    fn parse_repo_deep_link_rejects_traversal_and_short_refs() {
+        for raw in [
+            "buzz://repo?repo=boosh&ref=abc123&path=README.md",
+            "buzz://repo?repo=boosh&ref=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb&path=..%2Fsecret",
+        ] {
+            assert!(parse_repo_deep_link(&Url::parse(raw).unwrap()).is_none());
+        }
     }
 
     #[test]

--- a/desktop/src/app/navigation/useAppNavigation.ts
+++ b/desktop/src/app/navigation/useAppNavigation.ts
@@ -109,6 +109,8 @@ export function useAppNavigation() {
         commitHash?: string;
         pullRequestId?: string;
         issueId?: string;
+        filePath?: string;
+        repoRef?: string;
       },
     ) =>
       commitNavigation(
@@ -125,6 +127,8 @@ export function useAppNavigation() {
               ? { pullRequestId: behavior.pullRequestId }
               : {}),
             ...(behavior?.issueId ? { issueId: behavior.issueId } : {}),
+            ...(behavior?.filePath ? { filePath: behavior.filePath } : {}),
+            ...(behavior?.repoRef ? { repoRef: behavior.repoRef } : {}),
           },
         },
         behavior,

--- a/desktop/src/app/routes/projects.$projectId.tsx
+++ b/desktop/src/app/routes/projects.$projectId.tsx
@@ -19,21 +19,27 @@ export const Route = createFileRoute("/projects/$projectId")({
         ? search.pullRequestId
         : undefined,
     issueId: typeof search.issueId === "string" ? search.issueId : undefined,
+    filePath: typeof search.filePath === "string" ? search.filePath : undefined,
+    repoRef: typeof search.repoRef === "string" ? search.repoRef : undefined,
   }),
 });
 
 function ProjectDetailRouteComponent() {
   usePreviewFeatureWarning("projects");
   const { projectId } = Route.useParams();
-  const { commitHash, pullRequestId, issueId } = Route.useSearch();
+  const { commitHash, pullRequestId, issueId, filePath, repoRef } =
+    Route.useSearch();
 
   return (
     <React.Suspense fallback={<ViewLoadingFallback kind="projects" />}>
       <ProjectDetailScreen
         commitHash={commitHash}
+        filePath={filePath}
         issueId={issueId}
+        key={`${projectId}:${repoRef ?? "branch"}`}
         projectId={projectId}
         pullRequestId={pullRequestId}
+        repoRef={repoRef}
       />
     </React.Suspense>
   );

--- a/desktop/src/features/messages/lib/openPopoverLink.test.mjs
+++ b/desktop/src/features/messages/lib/openPopoverLink.test.mjs
@@ -6,17 +6,22 @@ import { openPopoverLink } from "./openPopoverLink.ts";
 const CHANNEL = "f570339f-8f8a-4e08-a779-8d954aa44109";
 const MESSAGE =
   "b04819ffc1f7c8ffb49c6d30b5899f470198264680d02e78894a658e30a9059f";
+const OWNER = "a".repeat(64);
+const COMMIT = "b".repeat(40);
 
 function makeSpies() {
   const external = [];
   const inApp = [];
+  const repos = [];
   return {
     handlers: {
       openExternal: (url) => external.push(url),
       openMessageLink: (link) => inApp.push(link),
+      openRepoLink: (link) => repos.push(link),
     },
     external,
     inApp,
+    repos,
   };
 }
 
@@ -26,6 +31,24 @@ test("buzz://message deep-link routes in-app, not the OS opener", () => {
   assert.equal(external.length, 0);
   assert.deepEqual(inApp, [
     { channelId: CHANNEL, messageId: MESSAGE, threadRootId: null },
+  ]);
+});
+
+test("buzz://repo deep-link routes in-app, not the OS opener", () => {
+  const { handlers, external, repos } = makeSpies();
+  openPopoverLink(
+    `buzz://repo?repo=boosh&owner=${OWNER}&ref=${COMMIT}&path=reports%2Fweekly.html`,
+    handlers,
+  );
+  assert.equal(external.length, 0);
+  assert.deepEqual(repos, [
+    {
+      projectId: `${OWNER}:boosh`,
+      repoId: "boosh",
+      owner: OWNER,
+      ref: COMMIT,
+      path: "reports/weekly.html",
+    },
   ]);
 });
 

--- a/desktop/src/features/messages/lib/openPopoverLink.ts
+++ b/desktop/src/features/messages/lib/openPopoverLink.ts
@@ -1,23 +1,33 @@
 import { isMessageLink, parseMessageLink } from "./messageLink";
 import type { ParsedMessageLink } from "./messageLink";
+import { isRepoLink, parseRepoLink } from "@/features/projects/lib/repoLink";
+import type { ParsedRepoLink } from "@/features/projects/lib/repoLink";
 
 /**
  * Open a link the same way the rendered-message link path does:
- * `buzz://message?…` deep-links navigate in-app, everything else (http(s),
- * other buzz:// URLs) goes to the OS opener. Mirrors `markdown.tsx`'s `a`
- * renderer so the composer popover and the rendered link behave identically.
+ * Supported Buzz deep-links navigate in-app; everything else goes to the OS
+ * opener. Mirrors `markdown.tsx`'s anchor renderer so the composer popover and
+ * the rendered link behave identically.
  */
 export function openPopoverLink(
   url: string,
   handlers: {
     openExternal: (url: string) => void;
     openMessageLink: (link: ParsedMessageLink) => void;
+    openRepoLink: (link: ParsedRepoLink) => void;
   },
 ): void {
   if (isMessageLink(url)) {
     const parsed = parseMessageLink(url);
     if (parsed.ok) {
       handlers.openMessageLink(parsed.value);
+      return;
+    }
+  }
+  if (isRepoLink(url)) {
+    const parsed = parseRepoLink(url);
+    if (parsed.ok) {
+      handlers.openRepoLink(parsed.value);
       return;
     }
   }

--- a/desktop/src/features/messages/lib/useLinkEditor.tsx
+++ b/desktop/src/features/messages/lib/useLinkEditor.tsx
@@ -69,7 +69,7 @@ type LinkCardState = {
  */
 export function useLinkEditor(richText: UseRichTextEditorResult) {
   const { getLinkSelectionInfo, applyLink, removeLink } = richText;
-  const { goChannel } = useAppNavigation();
+  const { goChannel, goProject } = useAppNavigation();
   const [draft, setDraft] = React.useState<DraftState | null>(null);
   const [cardState, setCardState] = React.useState<LinkCardState | null>(null);
   const cardContentRef = React.useRef<HTMLDivElement>(null);
@@ -258,9 +258,14 @@ export function useLinkEditor(richText: UseRichTextEditorResult) {
             messageId: link.messageId,
             threadRootId: link.threadRootId,
           }),
+        openRepoLink: (link) =>
+          void goProject(link.projectId, {
+            filePath: link.path,
+            repoRef: link.ref,
+          }),
       });
     },
-    [cardState, goChannel],
+    [cardState, goChannel, goProject],
   );
 
   const refreshCardRect = React.useCallback(() => {

--- a/desktop/src/features/projects/hooks.ts
+++ b/desktop/src/features/projects/hooks.ts
@@ -569,15 +569,15 @@ async function fetchProjectRepoSnapshot(
   branchName?: string | null,
   pullRequest?: ProjectPullRequest | null,
   tag?: { name: string; commit: string } | null,
+  targetCommit?: string | null,
 ): Promise<ProjectRepoSnapshot | null> {
   const cloneUrl = pullRequest?.cloneUrls[0] ?? project.cloneUrls[0];
   if (!cloneUrl) return null;
-
   return getProjectRepoSnapshot({
     cloneUrl,
     defaultBranch: branchName ?? project.defaultBranch,
     baseBranch: project.defaultBranch,
-    targetCommit: tag?.commit ?? pullRequest?.commit ?? null,
+    targetCommit: targetCommit ?? tag?.commit ?? pullRequest?.commit ?? null,
     targetRef: tag
       ? `refs/tags/${tag.name}`
       : pullRequest
@@ -718,6 +718,7 @@ export function useProjectRepoSnapshotQuery(
   branchName?: string | null,
   pullRequest?: ProjectPullRequest | null,
   tag?: { name: string; commit: string } | null,
+  targetCommit?: string | null,
 ) {
   const selectedBranch = branchName ?? project?.defaultBranch ?? null;
 
@@ -731,15 +732,16 @@ export function useProjectRepoSnapshotQuery(
       pullRequest?.id ?? "none",
       pullRequest?.commit ?? "none",
       tag?.name ?? "no-tag",
-      tag?.commit ?? "no-tag-commit",
+      targetCommit ?? tag?.commit ?? "no-tag-commit",
     ],
     queryFn: () => {
       if (!project) throw new Error("No project selected.");
       return fetchProjectRepoSnapshot(
         project,
         selectedBranch,
-        pullRequest,
-        tag,
+        targetCommit ? null : pullRequest,
+        targetCommit ? null : tag,
+        targetCommit,
       );
     },
     staleTime: 30_000,

--- a/desktop/src/features/projects/lib/repoLink.test.mjs
+++ b/desktop/src/features/projects/lib/repoLink.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildRepoLink,
+  isRepoLink,
+  isSafeRepoPath,
+  parseRepoLink,
+} from "./repoLink.ts";
+
+const OWNER = "a".repeat(64);
+const COMMIT = "b".repeat(40);
+
+test("buildRepoLink produces a pinned owner-qualified link", () => {
+  assert.equal(
+    buildRepoLink({
+      repoId: "boosh",
+      owner: OWNER,
+      ref: COMMIT,
+      path: "reports/a b.html",
+    }),
+    `buzz://repo?repo=boosh&owner=${OWNER}&ref=${COMMIT}&path=reports%2Fa+b.html`,
+  );
+});
+
+test("parseRepoLink returns the exact project, commit, and path", () => {
+  const result = parseRepoLink(
+    `buzz://repo?repo=boosh&owner=${OWNER}&ref=${COMMIT}&path=reports%2Fweekly.html`,
+  );
+  assert.deepEqual(result, {
+    ok: true,
+    value: {
+      projectId: `${OWNER}:boosh`,
+      repoId: "boosh",
+      owner: OWNER,
+      ref: COMMIT,
+      path: "reports/weekly.html",
+    },
+  });
+});
+
+test("parseRepoLink accepts a legacy ownerless link", () => {
+  const result = parseRepoLink(
+    `buzz://repo?repo=boosh&ref=${COMMIT}&path=README.md`,
+  );
+  assert.equal(result.ok && result.value.projectId, "boosh");
+});
+
+test("repo links reject traversal, absolute paths, and abbreviated refs", () => {
+  for (const path of [
+    "../secret",
+    "/etc/passwd",
+    "reports//x.html",
+    "reports\\x.html",
+  ]) {
+    assert.equal(isSafeRepoPath(path), false);
+  }
+  assert.equal(
+    parseRepoLink(`buzz://repo?repo=boosh&ref=abc123&path=README.md`).ok,
+    false,
+  );
+});
+
+test("isRepoLink only recognizes the repo deep-link host", () => {
+  assert.equal(isRepoLink("buzz://repo?repo=boosh"), true);
+  assert.equal(isRepoLink("buzz://message?channel=x&id=y"), false);
+});

--- a/desktop/src/features/projects/lib/repoLink.ts
+++ b/desktop/src/features/projects/lib/repoLink.ts
@@ -1,0 +1,97 @@
+const REPO_LINK_SCHEME = "buzz:";
+const REPO_LINK_HOST = "repo";
+const REPO_ID_PATTERN = /^(?!\.)(?!.*\.\.)[A-Za-z0-9._-]{1,64}$/;
+const HEX_64_PATTERN = /^[0-9a-f]{64}$/i;
+const COMMIT_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+
+export type RepoLinkInput = {
+  repoId: string;
+  owner?: string | null;
+  ref: string;
+  path: string;
+};
+
+export type ParsedRepoLink = {
+  projectId: string;
+  repoId: string;
+  owner: string | null;
+  ref: string;
+  path: string;
+};
+
+export type RepoLinkParseResult =
+  | { ok: true; value: ParsedRepoLink }
+  | { ok: false; reason: string };
+
+export function isSafeRepoPath(path: string): boolean {
+  if (!path || path.startsWith("/") || path.includes("\\")) return false;
+  return path
+    .split("/")
+    .every((segment) => segment !== "" && segment !== "." && segment !== "..");
+}
+
+export function buildRepoLink(input: RepoLinkInput): string {
+  if (!REPO_ID_PATTERN.test(input.repoId)) {
+    throw new Error("buildRepoLink: invalid repoId");
+  }
+  if (input.owner && !HEX_64_PATTERN.test(input.owner)) {
+    throw new Error("buildRepoLink: invalid owner");
+  }
+  if (!COMMIT_PATTERN.test(input.ref)) {
+    throw new Error("buildRepoLink: ref must be a full commit hash");
+  }
+  if (!isSafeRepoPath(input.path)) {
+    throw new Error("buildRepoLink: path must be a safe relative path");
+  }
+
+  const params = new URLSearchParams();
+  params.set("repo", input.repoId);
+  if (input.owner) params.set("owner", input.owner.toLowerCase());
+  params.set("ref", input.ref.toLowerCase());
+  params.set("path", input.path);
+  return `${REPO_LINK_SCHEME}//${REPO_LINK_HOST}?${params.toString()}`;
+}
+
+export function parseRepoLink(url: string): RepoLinkParseResult {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, reason: "invalid-url" };
+  }
+  if (parsed.protocol !== REPO_LINK_SCHEME) {
+    return { ok: false, reason: "wrong-scheme" };
+  }
+  if (parsed.hostname !== REPO_LINK_HOST) {
+    return { ok: false, reason: "wrong-host" };
+  }
+
+  const repoId = parsed.searchParams.get("repo") ?? "";
+  const owner = parsed.searchParams.get("owner");
+  const ref = parsed.searchParams.get("ref") ?? "";
+  const path = parsed.searchParams.get("path") ?? "";
+  if (!REPO_ID_PATTERN.test(repoId))
+    return { ok: false, reason: "invalid-repo" };
+  if (owner !== null && !HEX_64_PATTERN.test(owner)) {
+    return { ok: false, reason: "invalid-owner" };
+  }
+  if (!COMMIT_PATTERN.test(ref)) return { ok: false, reason: "invalid-ref" };
+  if (!isSafeRepoPath(path)) return { ok: false, reason: "invalid-path" };
+
+  const normalizedOwner = owner?.toLowerCase() ?? null;
+  return {
+    ok: true,
+    value: {
+      projectId: normalizedOwner ? `${normalizedOwner}:${repoId}` : repoId,
+      repoId,
+      owner: normalizedOwner,
+      ref: ref.toLowerCase(),
+      path,
+    },
+  };
+}
+
+export function isRepoLink(href: string | undefined | null): boolean {
+  if (!href) return false;
+  return href.startsWith("buzz://repo?") || href === "buzz://repo";
+}

--- a/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
+++ b/desktop/src/features/projects/ui/ProjectDetailScreen.tsx
@@ -90,7 +90,7 @@ type ProjectDetailScreenProps = {
   projectId: string;
   pullRequestId?: string;
   issueId?: string;
-};
+} & Partial<Record<"filePath" | "repoRef", string>>;
 
 const PROJECT_DETAIL_PANEL_SEARCH_KEYS = [
   "profile",
@@ -99,7 +99,8 @@ const PROJECT_DETAIL_PANEL_SEARCH_KEYS = [
 ] as const;
 
 export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
-  const { commitHash, projectId, pullRequestId, issueId } = props;
+  const { commitHash, filePath, projectId, pullRequestId, repoRef, issueId } =
+    props;
   const { goChannel, goProject, goProjects } = useAppNavigation();
   const { activeCommunity } = useCommunities();
   const mainInsetRef = useMainInsetRef();
@@ -214,6 +215,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
     activeBranch,
     selectedTag ? null : selectedBranchPullRequest,
     activeTag,
+    repoRef,
   );
   const repoDiffQuery = useProjectRepoDiffQuery(
     project,
@@ -909,7 +911,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
               </section>
 
               <WorkspaceTabs
-                key={`${project.id}:${tabsResetKey}`}
+                key={`${project.id}:${repoRef ?? "branch"}:${filePath ?? "root"}:${tabsResetKey}`}
                 commitDiff={commitDiffQuery.data}
                 commitDiffError={commitDiffQuery.error}
                 commitDiffLoading={commitDiffQuery.isLoading}
@@ -938,6 +940,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                 localSnapshot={localRepoSnapshotQuery.data}
                 localSnapshotError={localRepoSnapshotQuery.error}
                 localSnapshotLoading={localRepoSnapshotQuery.isLoading}
+                initialFilePath={filePath}
                 onBranchChange={handleBranchChange}
                 onOpenMergeRecoveryTerminal={handleOpenMergeRecoveryTerminal}
                 onOpenTerminal={() => {
@@ -966,7 +969,7 @@ export function ProjectDetailScreen(props: ProjectDetailScreenProps) {
                 snapshot={repoSnapshotQuery.data}
                 snapshotError={repoSnapshotQuery.error}
                 snapshotLoading={repoSnapshotQuery.isLoading}
-                sourceControls={filesSourceControls}
+                sourceControls={repoRef ? undefined : filesSourceControls}
                 viewerGitIdentity={viewerGitIdentity}
               />
             </div>

--- a/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
+++ b/desktop/src/features/projects/ui/ProjectRepositoryPanel.tsx
@@ -17,6 +17,7 @@ import {
   FileVideo,
   FolderGit2,
   Package,
+  Play,
   Settings,
   Terminal,
 } from "lucide-react";
@@ -33,6 +34,7 @@ import type { UserSearchResult } from "@/shared/api/types";
 import { cn } from "@/shared/lib/cn";
 import { normalizePubkey } from "@/shared/lib/pubkey";
 import { SyntaxHighlightedCode } from "@/shared/ui/markdown";
+import { Button } from "@/shared/ui/button";
 import { UserAvatar } from "@/shared/ui/UserAvatar";
 import {
   PROJECT_DETAIL_PANEL_CLASS,
@@ -549,6 +551,8 @@ function FileContentPanel({
   onOpenPath: (path: string) => void;
 }) {
   const language = languageForPath(file.path);
+  const isHtml = /\.html?$/i.test(file.path);
+  const [runningHtml, setRunningHtml] = React.useState(false);
   const pathSegments = file.path.split("/").filter(Boolean);
   const fileName = pathSegments[pathSegments.length - 1] ?? file.path;
   const directorySegments = pathSegments.slice(0, -1);
@@ -575,6 +579,21 @@ function FileContentPanel({
         <span className="min-w-0 flex-1 truncate px-1.5 py-1 font-mono text-xs text-foreground">
           {fileName}
         </span>
+        {isHtml && file.previewContent ? (
+          <Button
+            onClick={() => setRunningHtml((current) => !current)}
+            size="xs"
+            type="button"
+            variant="outline"
+          >
+            {runningHtml ? (
+              <CodeXml className="h-3.5 w-3.5" />
+            ) : (
+              <Play className="h-3.5 w-3.5" />
+            )}
+            {runningHtml ? "Show source" : "Run HTML"}
+          </Button>
+        ) : null}
         <div className="hidden shrink-0 items-center gap-3 text-2xs text-muted-foreground sm:flex">
           <span>Last changed {formatLastChangedAt(file.lastChangedAt)}</span>
           <span>{formatFileSize(file.size)}</span>
@@ -586,7 +605,15 @@ function FileContentPanel({
       <div className="border-border/50 border-b bg-muted/10 px-4 py-2 text-2xs text-muted-foreground sm:hidden">
         Last changed {formatLastChangedAt(file.lastChangedAt)}
       </div>
-      {file.previewContent ? (
+      {file.previewContent && isHtml && runningHtml ? (
+        <iframe
+          className="h-[70vh] w-full border-0 bg-white"
+          referrerPolicy="no-referrer"
+          sandbox="allow-scripts"
+          srcDoc={file.previewContent}
+          title={`${fileName} (sandboxed)`}
+        />
+      ) : file.previewContent ? (
         <pre className="max-h-[36rem] overflow-auto bg-background/60 p-4">
           {language ? (
             <SyntaxHighlightedCode
@@ -618,6 +645,7 @@ export function RepositoryFilesPanel({
   profiles,
   fallbackAuthorPubkey,
   sourceControls,
+  initialFilePath,
 }: {
   files: ProjectRepoFile[];
   snapshot: ProjectRepoSnapshot | null | undefined;
@@ -627,6 +655,8 @@ export function RepositoryFilesPanel({
   fallbackAuthorPubkey?: string;
   /** Branch picker + remote/local toggle rendered in the panel header. */
   sourceControls?: RepoSourceHeaderControls;
+  /** Open this exact file once the pinned snapshot has loaded. */
+  initialFilePath?: string;
 }) {
   const [currentPath, setCurrentPath] = React.useState("");
   const [selectedFile, setSelectedFile] =
@@ -672,12 +702,21 @@ export function RepositoryFilesPanel({
     () => files.map((file) => file.path).join("\0"),
     [files],
   );
+  const initialFile = React.useMemo(
+    () =>
+      initialFilePath
+        ? files.find((file) => file.path === initialFilePath)
+        : undefined,
+    [files, initialFilePath],
+  );
 
   React.useEffect(() => {
     if (!filesKey) return;
-    setCurrentPath("");
-    setSelectedFile(null);
-  }, [filesKey]);
+    setCurrentPath(
+      initialFile ? initialFile.path.split("/").slice(0, -1).join("/") : "",
+    );
+    setSelectedFile(initialFile ?? null);
+  }, [filesKey, initialFile]);
 
   // Loading/error/empty states keep the header controls visible — the
   // remote/local toggle must stay reachable when one source fails to load.

--- a/desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx
+++ b/desktop/src/features/projects/ui/ProjectWorkspaceTabs.tsx
@@ -115,6 +115,7 @@ export function WorkspaceTabs({
   localSnapshot,
   localSnapshotError,
   localSnapshotLoading,
+  initialFilePath,
   project,
   repoDiff,
   repoDiffError,
@@ -151,6 +152,7 @@ export function WorkspaceTabs({
   localSnapshot: ProjectLocalRepoSnapshot | null | undefined;
   localSnapshotError: unknown;
   localSnapshotLoading: boolean;
+  initialFilePath?: string;
   project: Project;
   repoDiff: ProjectRepoDiff | null | undefined;
   repoDiffError: unknown;
@@ -200,7 +202,9 @@ export function WorkspaceTabs({
       (pullRequest) => pullRequest.id === selectedPullRequestId,
     ) ?? null;
   const isPullRequestSelected = Boolean(selectedPullRequest);
-  const [selectedTab, setSelectedTab] = React.useState("overview");
+  const [selectedTab, setSelectedTab] = React.useState(
+    initialFilePath ? "files" : "overview",
+  );
   const [pullRequestCommentTarget, setPullRequestCommentTarget] =
     React.useState<{
       anchor: ProjectPullRequestCommentAnchor;
@@ -477,6 +481,7 @@ export function WorkspaceTabs({
           fallbackAuthorPubkey={project.owner}
           files={files}
           isLoading={displayedSnapshotLoading}
+          initialFilePath={initialFilePath}
           profiles={profiles}
           snapshot={displayedSnapshot}
           sourceControls={sourceControls}

--- a/desktop/src/shared/deep-link.ts
+++ b/desktop/src/shared/deep-link.ts
@@ -25,6 +25,13 @@ export type MessageDeepLinkPayload = {
   threadRootId: string | null;
 };
 
+export type RepoDeepLinkPayload = {
+  repoId: string;
+  owner: string | null;
+  ref: string;
+  path: string;
+};
+
 export type NostrBindDeepLinkPayload = {
   challengeId: string;
   nonce: string;
@@ -161,6 +168,14 @@ export function listenForMessageDeepLinks(
   onOpen: (payload: MessageDeepLinkPayload) => void,
 ): Promise<UnlistenFn> {
   return listen<MessageDeepLinkPayload>("deep-link-message", (event) => {
+    onOpen(event.payload);
+  });
+}
+
+export function listenForRepoDeepLinks(
+  onOpen: (payload: RepoDeepLinkPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<RepoDeepLinkPayload>("deep-link-repo", (event) => {
     onOpen(event.payload);
   });
 }

--- a/desktop/src/shared/ui/markdown.test.mjs
+++ b/desktop/src/shared/ui/markdown.test.mjs
@@ -534,10 +534,11 @@ import { renderToStaticMarkup } from "react-dom/server";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 
 import { isMessageLink } from "../../features/messages/lib/messageLink.ts";
+import { isRepoLink } from "../../features/projects/lib/repoLink.ts";
 import remarkSpoilers from "../lib/remarkSpoilers.ts";
 
 function messageLinkUrlTransform(value, key) {
-  if (key === "href" && isMessageLink(value)) {
+  if (key === "href" && (isMessageLink(value) || isRepoLink(value))) {
     return value;
   }
   return defaultUrlTransform(value);
@@ -559,6 +560,13 @@ test("messageLinkUrlTransform: preserves buzz://message href", () => {
   );
   // HTML-encoded `&` in attributes is fine — the browser decodes back to `&`.
   assert.match(html, /href="buzz:\/\/message\?channel=abc&(?:amp;)?id=xyz"/);
+});
+
+test("messageLinkUrlTransform: preserves pinned buzz://repo href", () => {
+  const html = renderMarkdown(
+    `[Open report](buzz://repo?repo=boosh&owner=${"a".repeat(64)}&ref=${"b".repeat(40)}&path=reports%2Fweekly.html)`,
+  );
+  assert.match(html, /href="buzz:\/\/repo\?repo=boosh/);
 });
 
 test("messageLinkUrlTransform: preserves buzz://message autolink href", () => {

--- a/desktop/src/shared/ui/markdown.tsx
+++ b/desktop/src/shared/ui/markdown.tsx
@@ -1297,7 +1297,6 @@ function ExternalLinkAnchor({
   const [menu, setMenu] = React.useState<MediaContextMenuPosition | null>(null);
   const closeMenu = React.useCallback(() => setMenu(null), []);
   useDismissMediaContextMenu(Boolean(menu), closeMenu);
-
   const anchor = (
     <a
       {...anchorProps}
@@ -1306,6 +1305,11 @@ function ExternalLinkAnchor({
         isLinearLink ? "linear-link" : "text-primary hover:text-primary/80",
       )}
       href={href}
+      onClick={(event) => {
+        if (!href?.startsWith("buzz://repo?")) return;
+        event.preventDefault();
+        void openUrl(href);
+      }}
       onContextMenuCapture={(event) => {
         if (!href) return;
         event.preventDefault();
@@ -1317,7 +1321,6 @@ function ExternalLinkAnchor({
       {children}
     </a>
   );
-
   return (
     <>
       <MaskedLinkTooltip disabled={isLinearLink} href={href} label={label}>
@@ -1426,9 +1429,6 @@ function createMarkdownComponents(
       );
     }
 
-    // Intercept `buzz://message?channel=…&id=…` links so a click navigates
-    // in-app instead of opening the URL in the OS browser. http(s) links
-    // continue to use the existing target="_blank" behavior.
     if (href) {
       const messageLinkTarget = resolveMessageLinkRenderTarget({
         href,

--- a/desktop/src/shared/ui/markdown/utils.ts
+++ b/desktop/src/shared/ui/markdown/utils.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import { defaultUrlTransform } from "react-markdown";
 
 import { isMessageLink } from "@/features/messages/lib/messageLink";
+import { isRepoLink } from "@/features/projects/lib/repoLink";
 
 export function useStableArray<T>(arr: T[]): T[] {
   const ref = React.useRef(arr);
@@ -166,13 +167,13 @@ export function isInsideHiddenSpoiler(element: Element): boolean {
 }
 
 /**
- * `urlTransform` for `<ReactMarkdown>` that preserves `buzz://message?…`
+ * `urlTransform` for `<ReactMarkdown>` that preserves supported Buzz deep
  * links. The default transform strips unknown schemes (returns `""`) before
  * the `a` component override can see them, which would break copy → paste →
  * click end-to-end. Everything else delegates to `defaultUrlTransform`.
  */
 export function messageLinkUrlTransform(value: string, key: string): string {
-  if (key === "href" && isMessageLink(value)) {
+  if (key === "href" && (isMessageLink(value) || isRepoLink(value))) {
     return value;
   }
   return defaultUrlTransform(value);

--- a/desktop/src/shared/useMessageDeepLinks.ts
+++ b/desktop/src/shared/useMessageDeepLinks.ts
@@ -1,10 +1,13 @@
 import * as React from "react";
 
 import { useAppNavigation } from "@/app/navigation/useAppNavigation";
-import { listenForMessageDeepLinks } from "@/shared/deep-link";
+import {
+  listenForMessageDeepLinks,
+  listenForRepoDeepLinks,
+} from "@/shared/deep-link";
 
 /**
- * Subscribe to `buzz://message` deep links emitted by the Tauri backend
+ * Subscribe to message and repository deep links emitted by the Tauri backend
  * and route them through the app's navigation helpers.
  *
  * Lives in a hook (not inline in `AppShell`) so it can be unit-tested
@@ -18,20 +21,29 @@ import { listenForMessageDeepLinks } from "@/shared/deep-link";
  * resolve the target (works for both stream replies and forum threads).
  */
 export function useMessageDeepLinks() {
-  const { goChannel } = useAppNavigation();
+  const { goChannel, goProject } = useAppNavigation();
 
   React.useEffect(() => {
     let cancelled = false;
-    const unlistenPromise = listenForMessageDeepLinks((payload) => {
+    const messageUnlisten = listenForMessageDeepLinks((payload) => {
       if (cancelled) return;
       void goChannel(payload.channelId, {
         messageId: payload.messageId,
         threadRootId: payload.threadRootId,
       });
     });
+    const repoUnlisten = listenForRepoDeepLinks((payload) => {
+      if (cancelled) return;
+      void goProject(
+        payload.owner ? `${payload.owner}:${payload.repoId}` : payload.repoId,
+        { filePath: payload.path, repoRef: payload.ref },
+      );
+    });
     return () => {
       cancelled = true;
-      void unlistenPromise.then((fn) => fn());
+      void Promise.all([messageUnlisten, repoUnlisten]).then((unlistens) => {
+        for (const unlisten of unlistens) unlisten();
+      });
     };
-  }, [goChannel]);
+  }, [goChannel, goProject]);
 }


### PR DESCRIPTION
## Summary

- add `buzz repos link` to generate owner-qualified Markdown links pinned to a full git commit
- teach Buzz Desktop to route `buzz://repo` links to the exact repository snapshot and file
- add an explicit `Run HTML` action that renders HTML only after a click in a sandboxed iframe without same-origin access
- make clickable review artifacts part of the agent completion contract

### Related issue

N/A. No matching open issue or pull request was found.

### Testing

- `just ci`
- verified against commit `fc7e7d16459eef934b9ee2a899e9d9ab27305c77`
- 276 CLI tests passed
- 3,913 desktop tests passed
- 2,090 native desktop tests plus 3 diagnostic tests passed, with 14 environment-dependent tests ignored
- 1,022 mobile tests passed, with 1 environment-dependent test ignored

Manual flow:

1. From an announced repository checkout, run `buzz repos link --id <repo> --path <file> --ref HEAD`.
2. Paste the returned Markdown link into a Buzz message.
3. Click it and confirm Projects opens the exact pinned commit and file.
4. For an HTML file, click `Run HTML` and confirm it renders inside the sandbox; click `Show source` to return to source.

The automated macOS capture could not read the separately bundled development window, so no screenshot is attached. The UI change is limited to the `Run HTML` / `Show source` control and its sandboxed preview in the existing Files panel.

### Follow-up

PDF upload support remains separate from this repository-link flow.
