### PR TITLE
feat(buzz-acp): add strict owner pubkey gate

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -453,6 +453,17 @@ pub struct CliArgs {
     )]
     pub respond_to: RespondTo,
 
+    /// Require the raw event author pubkey to equal the configured owner pubkey.
+    /// This security override excludes NIP-OA same-owner sibling agents from
+    /// every responding mode. `nobody` still rejects all authors.
+    #[arg(
+        long,
+        env = "BUZZ_ACP_STRICT_OWNER_PUBKEY",
+        default_value_t = false,
+        hide_env_values = true
+    )]
+    pub strict_owner_pubkey: bool,
+
     /// Comma-separated 64-char hex pubkeys for allowlist mode.
     /// Owner pubkey is always implicitly included.
     #[arg(long, env = "BUZZ_ACP_RESPOND_TO_ALLOWLIST", value_delimiter = ',')]
@@ -535,6 +546,9 @@ pub struct Config {
     pub permission_mode: PermissionMode,
     /// Inbound author gate mode.
     pub respond_to: RespondTo,
+    /// When true, accept only events authored by the owner's raw pubkey and do
+    /// not trust NIP-OA same-owner sibling agents as instruction senders.
+    pub strict_owner_pubkey: bool,
     /// Validated allowlist of pubkey hex strings (used when respond_to == Allowlist).
     pub respond_to_allowlist: HashSet<String>,
     /// Allowed `respond_to` modes. Empty = all modes allowed.
@@ -1093,6 +1107,7 @@ impl Config {
                 .and_then(sanitize_session_title),
             permission_mode: args.permission_mode,
             respond_to: args.respond_to,
+            strict_owner_pubkey: args.strict_owner_pubkey,
             respond_to_allowlist,
             allowed_respond_to,
             persona_env_vars,
@@ -1123,7 +1138,7 @@ impl Config {
             format!(" allowed_respond_to=[{}]", modes.join(","))
         };
         format!(
-            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {}{}",
+            "relay={} pubkey={} agent_cmd={} {} mcp_cmd={} idle_timeout={}s max_turn={}s agents={} heartbeat={}s subscribe={:?} dedup={:?} meh={:?} ignore_self={} context_limit={} max_turns_per_session={} presence={} typing={} memory={} model={} permission_mode={} {} strict_owner_pubkey={}{}",
             self.relay_url,
             self.keys.public_key().to_hex(),
             self.agent_command,
@@ -1145,6 +1160,7 @@ impl Config {
             self.model.as_deref().unwrap_or("(agent default)"),
             self.permission_mode,
             respond_to_detail,
+            self.strict_owner_pubkey,
             allowed_respond_to_detail,
         )
     }
@@ -1463,6 +1479,7 @@ mod tests {
             session_title: None,
             permission_mode: PermissionMode::BypassPermissions,
             respond_to: RespondTo::Anyone,
+            strict_owner_pubkey: false,
             respond_to_allowlist: HashSet::new(),
             allowed_respond_to: Vec::new(),
             persona_env_vars: vec![],

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -257,6 +257,35 @@ async fn author_allowed(
     }
 }
 
+/// Apply the optional raw-owner-pubkey security override before the standard
+/// owner/sibling policy. This lets deployments that require a human-only
+/// instruction boundary reject managed sibling identities even when their
+/// NIP-OA attestations prove the same owner.
+async fn author_allowed_with_strict_owner(
+    strict_owner_pubkey: bool,
+    respond_to: &RespondTo,
+    allowlist: &HashSet<String>,
+    author: &str,
+    is_dm: bool,
+    owner_cache: &OwnerCache,
+    rest_client: &relay::RestClient,
+) -> bool {
+    if strict_owner_pubkey {
+        return !matches!(respond_to, RespondTo::Nobody)
+            && owner_cache.get().is_some_and(|owner| owner == author);
+    }
+
+    author_allowed(
+        respond_to,
+        allowlist,
+        author,
+        is_dm,
+        owner_cache,
+        rest_client,
+    )
+    .await
+}
+
 /// Resolve whether `channel_id` is a DM, for the inbound author gate.
 ///
 /// Resolution order:
@@ -2149,7 +2178,8 @@ async fn tokio_main() -> Result<()> {
                                 // exercised by non-owner authors inside DMs.
                                 let is_dm =
                                     is_dm_channel(buzz_event.channel_id, &ctx.channel_info).await;
-                                let allowed = author_allowed(
+                                let allowed = author_allowed_with_strict_owner(
+                                    config.strict_owner_pubkey,
                                     &config.respond_to,
                                     &config.respond_to_allowlist,
                                     &author,
@@ -4558,6 +4588,37 @@ mod author_gate_tests {
         }
     }
 
+    #[tokio::test]
+    async fn strict_owner_pubkey_accepts_owner_but_rejects_same_owner_sibling() {
+        let cache = cache_with_sibling();
+
+        assert!(
+            author_allowed_with_strict_owner(
+                true,
+                &RespondTo::OwnerOnly,
+                &HashSet::new(),
+                OWNER,
+                false,
+                &cache,
+                &dummy_rest_client()
+            )
+            .await
+        );
+        assert!(
+            !author_allowed_with_strict_owner(
+                true,
+                &RespondTo::OwnerOnly,
+                &HashSet::new(),
+                SIBLING,
+                false,
+                &cache,
+                &dummy_rest_client()
+            )
+            .await,
+            "strict owner mode must compare the raw event author pubkey and reject NIP-OA siblings"
+        );
+    }
+
     // ── DM hardening ──────────────────────────────────────────────────────
     //
     // In a DM, clients auto-p-tag every participant, and an agent can be
@@ -5026,6 +5087,7 @@ mod build_mcp_servers_tests {
             session_title: None,
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,
+            strict_owner_pubkey: false,
             respond_to_allowlist: std::collections::HashSet::new(),
             allowed_respond_to: vec![],
             persona_env_vars: vec![],
@@ -5247,6 +5309,7 @@ mod error_outcome_emission_tests {
             session_title: None,
             permission_mode: config::PermissionMode::BypassPermissions,
             respond_to: config::RespondTo::Anyone,
+            strict_owner_pubkey: false,
             respond_to_allowlist: HashSet::new(),
             allowed_respond_to: vec![],
             persona_env_vars: vec![],

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -71,7 +71,7 @@ pub(crate) enum AcpAvailabilityStatus {
 }
 
 use crate::{
-    author_allowed,
+    author_allowed_with_strict_owner,
     config::Config,
     event_mentions_agent, filter,
     relay::{HarnessRelay, RelayEventPublisher},
@@ -430,7 +430,8 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         // in DMs only owner/siblings get a nudge (fail-closed on unknown type).
         let author_hex = buzz_event.event.pubkey.to_hex();
         let is_dm = crate::is_dm_channel(buzz_event.channel_id, &channel_info).await;
-        let allowed = author_allowed(
+        let allowed = author_allowed_with_strict_owner(
+            config.strict_owner_pubkey,
             &config.respond_to,
             &config.respond_to_allowlist,
             &author_hex,


### PR DESCRIPTION
## Summary

Adds an opt-in `buzz-acp` author-gate override for deployments that need the raw event author to be the configured owner pubkey.

Today, `owner-only` intentionally accepts NIP-OA same-owner sibling agents through `is_owner_or_sibling`. That is useful for agent teams, but some deployments require a human-only instruction boundary where sibling agent identities must not initiate turns.

## Changes

- adds `--strict-owner-pubkey` / `BUZZ_ACP_STRICT_OWNER_PUBKEY` (default `false`)
- when enabled, compares the event author directly with the resolved owner cache before the existing owner/sibling policy
- preserves `respond-to=nobody` as deny-all
- applies the override in both normal and setup-listener paths
- surfaces `strict_owner_pubkey` in the sanitized startup summary
- adds a unit test proving the owner is accepted while a verified same-owner sibling is rejected

The default remains unchanged and backward compatible.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p buzz-acp strict_owner_pubkey_accepts_owner_but_rejects_same_owner_sibling`
- `cargo test -p buzz-acp secret_env_args_hide_their_values_in_help`
- `cargo build --release -p buzz-acp`

All commands passed under the repository Hermit toolchain.