### PR TITLE
feat(acp): optionally publish constrained final replies

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -211,6 +211,9 @@ pub struct AcpClient {
     /// deltas. Both goose and buzz-agent emit this notification; goose gates
     /// on client capability advertisement, buzz-agent emits unconditionally.
     goose_usage: UsageTracker,
+    /// Final visible agent output accumulated for the current prompt. Thoughts
+    /// and tool calls are deliberately excluded.
+    agent_message: String,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -550,6 +553,7 @@ impl AcpClient {
             steering_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
+            agent_message: String::new(),
         })
     }
 
@@ -1715,6 +1719,17 @@ impl AcpClient {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::info!(target: "acp::stream", "{text}");
+                    // Keep a bounded, visible-only final response. The bound is
+                    // below Buzz's 64KiB message limit and preserves UTF-8.
+                    const MAX_AUTO_REPLY_BYTES: usize = 16 * 1024;
+                    let remaining = MAX_AUTO_REPLY_BYTES.saturating_sub(self.agent_message.len());
+                    if remaining > 0 {
+                        let mut end = text.len().min(remaining);
+                        while end > 0 && !text.is_char_boundary(end) {
+                            end -= 1;
+                        }
+                        self.agent_message.push_str(&text[..end]);
+                    }
                 }
                 false
             }
@@ -1806,6 +1821,16 @@ impl AcpClient {
                 false
             }
         }
+    }
+
+    /// Start collecting the visible final response for one prompt.
+    pub fn clear_agent_message(&mut self) {
+        self.agent_message.clear();
+    }
+
+    /// Consume the visible final response collected for the completed prompt.
+    pub fn take_agent_message(&mut self) -> String {
+        std::mem::take(&mut self.agent_message)
     }
 
     /// Parse a `_goose/unstable/session/update` notification and record the

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -474,6 +474,12 @@ pub struct CliArgs {
     #[arg(long, env = "BUZZ_ACP_RELAY_OBSERVER", default_value_t = false)]
     pub relay_observer: bool,
 
+    /// Publish the agent's final ACP response as one signed reply to the
+    /// triggering Buzz event. Disabled by default: this is intended for
+    /// constrained worker roles whose terminal sandbox cannot hold signing keys.
+    #[arg(long, env = "BUZZ_ACP_PUBLISH_FINAL_REPLY", default_value_t = false)]
+    pub publish_final_reply: bool,
+
     /// Connect and subscribe before starting the ACP/LLM subprocess pool.
     #[arg(long, env = "BUZZ_ACP_LAZY_POOL", default_value_t = false)]
     pub lazy_pool: bool,
@@ -550,6 +556,8 @@ pub struct Config {
     pub has_generated_codex_config: bool,
     /// Whether to publish encrypted observer frames through the relay.
     pub relay_observer: bool,
+    /// See [`CliArgs::publish_final_reply`].
+    pub publish_final_reply: bool,
     /// Whether ACP/LLM subprocess initialization is deferred until accepted work arrives.
     pub lazy_pool: bool,
     /// Agent owner pubkey (hex). Used for `--respond-to=owner-only` gate.
@@ -1098,6 +1106,7 @@ impl Config {
             persona_env_vars,
             has_generated_codex_config,
             relay_observer: args.relay_observer,
+            publish_final_reply: args.publish_final_reply,
             lazy_pool: args.lazy_pool,
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
             no_base_prompt: args.no_base_prompt,
@@ -1468,6 +1477,7 @@ mod tests {
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
+            publish_final_reply: false,
             lazy_pool: false,
             agent_owner: None,
             no_base_prompt: false,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1559,6 +1559,7 @@ async fn tokio_main() -> Result<()> {
         memory_enabled: config.memory_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
+        publish_final_reply: config.publish_final_reply,
     });
 
     if !config.memory_enabled {
@@ -5031,6 +5032,7 @@ mod build_mcp_servers_tests {
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
+            publish_final_reply: false,
             lazy_pool: false,
             agent_owner: None,
             no_base_prompt: false,
@@ -5252,6 +5254,7 @@ mod error_outcome_emission_tests {
             persona_env_vars: vec![],
             has_generated_codex_config: false,
             relay_observer: false,
+            publish_final_reply: false,
             lazy_pool: false,
             agent_owner: None,
             no_base_prompt: false,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -551,6 +551,58 @@ pub struct PromptContext {
     /// the desktop keys per (agent, relay) pair, e.g. `session_config_captured`,
     /// mirroring the `managed_agent_runtime_lifecycle` frames.
     pub relay_url: String,
+    /// Opt-in only; never enabled implicitly for interactive agents.
+    pub publish_final_reply: bool,
+}
+
+/// Build a response that can only target the current batch's channel and
+/// newest triggering event. No model-controlled destination or signing key is
+/// involved.
+fn build_final_reply(
+    batch: &FlushBatch,
+    content: &str,
+    keys: &nostr::Keys,
+) -> Option<nostr::Event> {
+    let content = content.trim();
+    let trigger = batch.events.last()?;
+    if content.is_empty() {
+        return None;
+    }
+    let tags = crate::queue::parse_thread_tags(&trigger.event);
+    let root = tags
+        .root_event_id
+        .unwrap_or_else(|| trigger.event.id.to_hex());
+    let root = nostr::EventId::from_hex(&root).ok()?;
+    let thread = buzz_sdk::ThreadRef {
+        root_event_id: root,
+        parent_event_id: trigger.event.id,
+    };
+    let builder =
+        buzz_sdk::build_message(batch.channel_id, content, Some(&thread), &[], false, &[]).ok()?;
+    builder.sign_with_keys(keys).ok()
+}
+
+async fn publish_final_reply(ctx: &PromptContext, batch: &FlushBatch, content: String) {
+    let Some(event) = build_final_reply(batch, &content, &ctx.agent_keys) else {
+        return;
+    };
+    let channel_id = batch.channel_id;
+    let reply_to = batch
+        .events
+        .last()
+        .map(|e| e.event.id.to_hex())
+        .unwrap_or_default();
+    match tokio::time::timeout(Duration::from_secs(5), ctx.rest_client.submit_event(&event)).await {
+        Ok(Ok(_)) => {
+            tracing::info!(channel_id = %channel_id, reply_to, "published constrained final agent reply")
+        }
+        Ok(Err(error)) => {
+            tracing::error!(channel_id = %channel_id, reply_to, "failed to publish constrained final agent reply: {error}")
+        }
+        Err(_) => {
+            tracing::error!(channel_id = %channel_id, reply_to, "timed out publishing constrained final agent reply")
+        }
+    }
 }
 
 impl AgentPool {
@@ -1797,6 +1849,8 @@ pub async fn run_prompt_task(
                     return;
                 }
             }
+            // Initial-message output is setup chatter, never a task result.
+            agent.acp.clear_agent_message();
         }
     }
 
@@ -2127,6 +2181,12 @@ pub async fn run_prompt_task(
                 Some(core_stop),
             )
             .await;
+
+            if ctx.publish_final_reply {
+                if let Some(batch) = batch.as_ref() {
+                    publish_final_reply(&ctx, batch, agent.acp.take_agent_message()).await;
+                }
+            }
 
             send_prompt_result(
                 &result_tx,
@@ -6365,6 +6425,38 @@ mod tests {
         make_prompt_context_impl(&agent_keys, None)
     }
 
+    #[test]
+    fn constrained_final_reply_is_bound_to_latest_trigger_and_channel() {
+        let channel_id = Uuid::new_v4();
+        let keys = nostr::Keys::generate();
+        let trigger = nostr::EventBuilder::new(nostr::Kind::TextNote, "work")
+            .tags([nostr::Tag::parse(["h", &channel_id.to_string()]).unwrap()])
+            .sign_with_keys(&keys)
+            .unwrap();
+        let batch = FlushBatch {
+            channel_id,
+            events: vec![crate::queue::BatchEvent {
+                event: trigger.clone(),
+                prompt_tag: "mention".to_owned(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let reply = build_final_reply(&batch, "done", &keys).expect("reply event");
+        assert_eq!(reply.content, "done");
+        let channel_tag = channel_id.to_string();
+        let trigger_id = trigger.id.to_hex();
+        assert!(reply
+            .tags
+            .iter()
+            .any(|tag| tag.as_slice() == ["h", channel_tag.as_str()]));
+        assert!(reply
+            .tags
+            .iter()
+            .any(|tag| tag.as_slice() == ["e", trigger_id.as_str(), "", "reply"]));
+    }
+
     fn make_prompt_context_with_owner(
         agent_keys: &nostr::Keys,
         owner_pubkey: nostr::PublicKey,
@@ -6413,6 +6505,7 @@ mod tests {
             memory_enabled: false,
             harness_name: "goose".to_string(),
             relay_url: "ws://127.0.0.1:3000".to_string(),
+            publish_final_reply: false,
         }
     }
 


### PR DESCRIPTION
## What changed

Adds an opt-in `BUZZ_ACP_PUBLISH_FINAL_REPLY` mode for constrained workers whose terminal sandbox intentionally cannot access the Buzz signing key.

When enabled, ACP collects only visible `agent_message_chunk` output and publishes it through the harness-owned relay client as one reply bound to the active batch channel and latest triggering event. The model does not receive a key and cannot choose a destination.

## Why

Hermes correctly strips `BUZZ_PRIVATE_KEY` from terminal/code sandboxes. That previously prevented it from returning a signed stage result even though the model and ACP worker were healthy.

## Safety

- Disabled by default.
- Empty output publishes nothing.
- Thoughts and tool calls are excluded.
- Message content is bounded below the Buzz message limit.
- Reply tags are structurally bound to the active channel and triggering event.

## Verification

- `cargo fmt --check`
- `cargo test -p buzz-acp --lib` on 5.101: 662 passed
- Live private-channel pilot: Hermes emitted `readiness.hermes.auto` as a signed reply to the exact controller probe event, without terminal access to the signing key. The normal Hermes service was restored afterwards.