### PR TITLE
docs(git-credential-nostr): document http.postBuffer workaround for pushes > 1 MiB

### DIFF
--- a/crates/git-credential-nostr/README.md
+++ b/crates/git-credential-nostr/README.md
@@ -67,3 +67,25 @@ git ──stdin──▶ git-credential-nostr ──stdout──▶ git
 | `useHttpPath` | `credential.useHttpPath` is not set | `git config --global credential.useHttpPath true` |
 | Empty output / no auth | git version is older than 2.46 | Upgrade git |
 | `clock skew` / auth rejected | System clock is off by more than 60 s | Sync your system clock (`ntpdate`, `timedatectl`) |
+
+## Large pushes (> 1 MiB)
+
+Pushing a pack larger than `http.postBuffer` (default **1 MiB**) fails the
+first time with a misleading `HTTP 401 … RPC failed` followed by
+`Everything up-to-date` — nothing was actually pushed.
+
+Why: the helper returns `ephemeral=true`, so git sends the
+`git-receive-pack` POST unauthenticated, gets a 401 challenge, and retries
+with the signed credential. The retry only works if the body is buffered;
+packs bigger than `http.postBuffer` are streamed chunked and cannot be
+replayed, so the retry never happens.
+
+Workaround (verified against a 90 MB push):
+
+```bash
+git config --global http.postBuffer 524288000   # 500 MiB
+```
+
+The fix threshold matches your largest repo. The ±60 s NIP-98 validity
+window is not a concern — the token is minted at challenge time, after
+the buffered body is written.


### PR DESCRIPTION
## Summary
Addresses the docs portion of #4195.

The reporter identified a deterministic composition failure for pushes
larger than `http.postBuffer` (default 1 MiB):

1. `git-credential-nostr` returns `ephemeral=true`, so git sends the
   `git-receive-pack` POST unauthenticated, expecting to retry after a
   401 challenge.
2. Buzz answers the unauthenticated POST with 401 (correctly).
3. git can only replay a challenged POST if the body is buffered; packs
   larger than `http.postBuffer` are streamed chunked and cannot be
   replayed → hard failure with a misleading `Everything up-to-date`.

The reporter verified `git config http.postBuffer 524288000` overcomes it
(a 90 MB pack pushes cleanly).

## Changes
- `crates/git-credential-nostr/README.md`
  - New **"Large pushes (> 1 MiB)"** section explaining the mechanism and
    the one-line workaround.
  - Mirrors the issue's verified reproduction and the workaround quoted
    verbatim from the issue thread.

## Out of scope
- Pre-emptive auth (option 2 in the issue): behavioral change to the
  helper's `ephemeral=true` flow; needs maintainer sign-off.
- Server-side `Expect: 100-continue` (option 3): more invasive; per the
  issue, subsumed if option 2 lands.

## Verification
- Docs-only; no code compiled, no tests affected.
