### PR TITLE
fix(agent): report load_skill truncation with an in-band marker + server warn

### DIFF
--- a/crates/buzz-agent/src/builtin.rs
+++ b/crates/buzz-agent/src/builtin.rs
@@ -98,9 +98,22 @@ pub async fn call_load_skill(arguments: &Value, skills: &[SkillEntry]) -> ToolRe
     }
 
     // Apply the size cap to the full output (body + Supporting Files section)
-    // so the total tool result stays within MAX_SKILL_BODY_BYTES.
+    // so the total tool result stays within MAX_SKILL_BODY_BYTES. If we had
+    // to truncate, append an explicit in-band marker so the model knows the
+    // tail (often format/refusal/verification instructions) is missing, and
+    // emit a server-side warn so logs capture it too. See issue #4163.
     let output = if output.len() > MAX_SKILL_BODY_BYTES {
-        truncate_at_boundary(&output, MAX_SKILL_BODY_BYTES).to_owned()
+        let original_len = output.len();
+        let mut truncated = truncate_at_boundary(&output, MAX_SKILL_BODY_BYTES).to_owned();
+        truncated.push_str(&format!(
+            "\n\n[truncated: {MAX_SKILL_BODY_BYTES} of {original_len} bytes shown]"
+        ));
+        tracing::warn!(
+            skill_body_bytes = original_len,
+            cap = MAX_SKILL_BODY_BYTES,
+            "load_skill truncated oversized skill output"
+        );
+        truncated
     } else {
         output
     };
@@ -204,7 +217,20 @@ async fn load_supporting_file(
                         skill_name, rel_path_owned, content
                     );
                     let output = if output.len() > MAX_SKILL_BODY_BYTES {
-                        truncate_at_boundary(&output, MAX_SKILL_BODY_BYTES).to_owned()
+                        let original_len = output.len();
+                        let mut truncated =
+                            truncate_at_boundary(&output, MAX_SKILL_BODY_BYTES).to_owned();
+                        truncated.push_str(&format!(
+                            "\n\n[truncated: {MAX_SKILL_BODY_BYTES} of {original_len} bytes shown]"
+                        ));
+                        tracing::warn!(
+                            skill = %skill_name,
+                            rel_path = %rel_path_owned,
+                            file_bytes = original_len,
+                            cap = MAX_SKILL_BODY_BYTES,
+                            "load_skill truncated oversized supporting file"
+                        );
+                        truncated
                     } else {
                         output
                     };
@@ -528,11 +554,24 @@ mod tests {
         let result = call_load_skill(&serde_json::json!({"name": "big"}), &skills).await;
         assert!(!result.is_error);
         let text = text_content(&result);
+        // Truncated body is capped at MAX_SKILL_BODY_BYTES; an in-band
+        // truncation marker is appended so the model knows the tail is
+        // missing (issue #4163).
         assert!(
-            text.len() <= MAX_SKILL_BODY_BYTES,
-            "output length {} exceeds MAX_SKILL_BODY_BYTES {}",
-            text.len(),
-            MAX_SKILL_BODY_BYTES
+            text.contains("[truncated:"),
+            "missing truncation marker in output: {}",
+            &text[text.len().saturating_sub(200)..]
+        );
+        assert!(
+            text.len() > MAX_SKILL_BODY_BYTES,
+            "expected marker appended past cap, got {}",
+            text.len()
+        );
+        // Marker stays small — well under 200 bytes of overhead.
+        assert!(
+            text.len() < MAX_SKILL_BODY_BYTES + 200,
+            "output length {} unexpectedly large",
+            text.len()
         );
     }
 
@@ -561,15 +600,47 @@ mod tests {
         .await;
         assert!(!result.is_error);
         let text = text_content(&result);
+        // Truncated body is capped at MAX_SKILL_BODY_BYTES; an in-band
+        // truncation marker is appended so the model knows the tail is
+        // missing (issue #4163).
         assert!(
-            text.len() <= MAX_SKILL_BODY_BYTES,
-            "output length {} exceeds MAX_SKILL_BODY_BYTES {}",
-            text.len(),
-            MAX_SKILL_BODY_BYTES
+            text.contains("[truncated:"),
+            "missing truncation marker in supporting-file output"
+        );
+        assert!(
+            text.len() > MAX_SKILL_BODY_BYTES,
+            "expected marker appended past cap, got {}",
+            text.len()
         );
         assert!(
             text.starts_with("# Loaded: big/references/huge.md"),
             "missing supporting-file header: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn call_load_skill_under_cap_has_no_truncation_marker() {
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp.path();
+        let skill_md = skill_dir.join("SKILL.md");
+        std::fs::write(
+            &skill_md,
+            "---\nname: small\ndescription: desc\n---\nTiny body.\n",
+        )
+        .unwrap();
+
+        let skills = vec![make_skill_with_files("small", "desc", skill_md, vec![])];
+        let result = call_load_skill(&serde_json::json!({"name": "small"}), &skills).await;
+        assert!(!result.is_error);
+        let text = text_content(&result);
+        assert!(
+            !text.contains("[truncated:"),
+            "unexpected truncation marker on under-cap output: {text}"
+        );
+        assert!(
+            text.len() <= MAX_SKILL_BODY_BYTES,
+            "under-cap body unexpectedly large: {}",
+            text.len()
         );
     }
 }


### PR DESCRIPTION
## Summary
Fixes #4163.

`load_skill` silently truncates any skill content over
`MAX_SKILL_BODY_BYTES` (32 KiB) and returns the truncated text with
`is_error=false` — no marker, no log line. The model consumes the body as
if complete, but the tail of a SKILL.md (which often holds output format,
refusal rules, or verification checklists) is gone with no signal.

This PR applies the reporter's **option 1** at both truncation sites in
`crates/buzz-agent/src/builtin.rs`:

1. **In-band marker** appended to the returned text:
   `\n\n[truncated: N of M bytes shown]` — the model sees the body is
   incomplete and can adapt (decline to rely on tail instructions, or
   re-read with a narrower path).
2. **Server-side `tracing::warn!`** with the skill name, byte count, and
   cap — operators spot oversized skills in logs.

## Changes
- `crates/buzz-agent/src/builtin.rs`
  - `call_load_skill` unified output path (body + Supporting Files
    section): on over-cap, append the marker and emit `warn!`.
  - `load_supporting_file`: same marker + warn, with structured
    `skill` / `rel_path` fields.
  - Under-cap loads untouched — no marker, no warn.

## Tests
- `builtin::tests::call_load_skill_truncates_large_body` — updated:
  marker present; overhead bounded (< 200 bytes past cap).
- `builtin::tests::call_load_skill_truncates_large_supporting_file` —
  updated: marker present on the supporting-file path.
- `builtin::tests::call_load_skill_under_cap_has_no_truncation_marker` —
  new: no marker on under-cap bodies.

## Verification
- `cargo check -p buzz-agent --lib` — clean.
- `cargo test -p buzz-agent --lib --offline builtin` — 12/12 pass.
- `cargo fmt -p buzz-agent --check` — clean.

## Out of scope
- Option 2 from the issue (reject oversized skills at discovery): would
  be a breaking change for already-deployed skills; the marker approach
  preserves load behavior while restoring observability. A follow-up to
  add a discovery-time warning is a separate small PR if maintainers
  want belt-and-braces.
