### PR TITLE
fix(desktop): resolve bidi direction per block in message markdown

### DIFF
--- a/desktop/src/shared/styles/globals/markdown.css
+++ b/desktop/src/shared/styles/globals/markdown.css
@@ -16,6 +16,26 @@
   display: none;
 }
 
+/* Bidi — resolve direction per block from its first strong character, so RTL
+   scripts (Hebrew, Arabic) keep trailing punctuation, brackets and numbers on
+   the correct edge. The document is LTR, so without this every block resolves
+   at paragraph level 0 and neutrals at a run boundary take the wrong side.
+   LTR-only content is unaffected. Applies to reading and typing alike —
+   MESSAGE_MARKDOWN_CLASS is on both the rendered message and the editor root. */
+.message-markdown p,
+.message-markdown li,
+.message-markdown blockquote,
+.message-markdown h1,
+.message-markdown h2,
+.message-markdown h3,
+.message-markdown h4,
+.message-markdown h5,
+.message-markdown h6,
+.message-markdown td,
+.message-markdown th {
+  unicode-bidi: plaintext;
+}
+
 .message-markdown [data-link-preview] {
   --buzz-link-preview-icon-bg: hsl(var(--muted));
   --buzz-link-preview-icon-color: hsl(var(--foreground));


### PR DESCRIPTION
Fixes #4330.

Hebrew and Arabic currently render with trailing punctuation, brackets and numbers on the wrong edge of every line, in message bodies and in the composer.

### Cause

The desktop client has no bidi handling anywhere: `index.html` is `<html lang="en">` with no `dir`, `dir="auto"` appears 0 times in the repo, `markdown.css` sets no direction, and the markdown `p` renderer emits a bare `<p>`. Every block therefore resolves at bidi paragraph level 0 (LTR), so neutral characters at a run boundary take the paragraph direction instead of the surrounding text's.

### Change

One rule in `markdown.css` scoped to `.message-markdown`, setting `unicode-bidi: plaintext` on text blocks. Direction is then resolved per block from its first strong character. LTR-only content is unaffected, and code blocks are deliberately excluded so `pre` and `code` stay LTR.

`MESSAGE_MARKDOWN_CLASS` is applied both to the rendered message wrapper (`markdown.tsx`) and to the TipTap editor root (`useRichTextEditor.ts`), so this single rule covers reading and typing.

### Before

![before](https://raw.githubusercontent.com/netanelhibsh/buzz/9b526581dedd59d2f4e7ddac10d9c3b54ba3ca91/rtl-before.png)

### After

![after](https://raw.githubusercontent.com/netanelhibsh/buzz/9b526581dedd59d2f4e7ddac10d9c3b54ba3ca91/rtl-after.png)

### Verification

Both screenshots are from the actual desktop app via `just desktop-screenshot`, same message and same clip region, with and without the rule. The English line is unchanged in both.

`just desktop-check` passes (exit 0). Rust crates are untouched, so `cargo` gates are unaffected by this diff.

Reproduce locally:

```bash
cat > /tmp/rtl.json <<'EOF'
[{"channelName":"general","content":"מפגש #5 לא נקבע. היה אמור להיות \"תחילת השבוע\".\n79 מתוך 198 (40%).\nهذا نص عربي ينتهي بنقطة (مع أقواس).\nThis English line must stay left-aligned."}]
EOF
just desktop-screenshot --name rtl --messages /tmp/rtl.json --clip 330,455,930,135
```
