### PR TITLE
feat: first-class DeepSeek + Groq providers for buzz-agent and Desktop

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -15,8 +15,7 @@ use uuid::Uuid;
 
 use crate::filter::SubscriptionRule;
 
-/// Default idle timeout (seconds) when neither `--idle-timeout` nor the
-/// deprecated `--turn-timeout` is set.
+/// Default idle timeout (seconds) when `--idle-timeout` is not set.
 ///
 /// Sized for slow turns where the agent may go silent on its outer ACP channel
 /// while running long sub-tools (e.g. a buzz-agent running another agent, or
@@ -269,10 +268,6 @@ pub struct CliArgs {
     /// Absolute wall-clock cap per turn (safety valve).
     #[arg(long, env = "BUZZ_ACP_MAX_TURN_DURATION", default_value_t = DEFAULT_MAX_TURN_DURATION_SECS)]
     pub max_turn_duration: u64,
-
-    /// Deprecated: alias for --idle-timeout. If both set, --idle-timeout wins.
-    #[arg(long, env = "BUZZ_ACP_TURN_TIMEOUT", hide = true)]
-    pub turn_timeout: Option<u64>,
 
     #[arg(
         long,
@@ -939,27 +934,9 @@ impl Config {
             args.turn_liveness_secs
         };
 
-        // Resolve idle_timeout_secs with deprecation handling.
-        // Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > `DEFAULT_IDLE_TIMEOUT_SECS`.
+        // Resolve idle_timeout_secs: explicit --idle-timeout > DEFAULT_IDLE_TIMEOUT_SECS.
         let idle_timeout_secs = {
-            let raw = match (args.idle_timeout, args.turn_timeout) {
-                (Some(idle), Some(_turn)) => {
-                    tracing::warn!(
-                        "--turn-timeout / BUZZ_ACP_TURN_TIMEOUT is deprecated and ignored \
-                         when --idle-timeout / BUZZ_ACP_IDLE_TIMEOUT is also set"
-                    );
-                    idle
-                }
-                (Some(idle), None) => idle,
-                (None, Some(turn)) => {
-                    tracing::warn!(
-                        "--turn-timeout / BUZZ_ACP_TURN_TIMEOUT is deprecated; \
-                         use --idle-timeout / BUZZ_ACP_IDLE_TIMEOUT instead"
-                    );
-                    turn
-                }
-                (None, None) => DEFAULT_IDLE_TIMEOUT_SECS,
-            };
+            let raw = args.idle_timeout.unwrap_or(DEFAULT_IDLE_TIMEOUT_SECS);
             if raw == 0 {
                 tracing::warn!("idle timeout of 0 is invalid — using 1s minimum");
                 1
@@ -2342,15 +2319,9 @@ channels = "ALL"
         }
     }
 
-    /// Helper: resolve idle_timeout_secs using the same precedence logic as Config::from_args.
-    /// Precedence: explicit --idle-timeout > --turn-timeout (deprecated) > `DEFAULT_IDLE_TIMEOUT_SECS`.
-    fn resolve_idle_timeout(idle: Option<u64>, turn: Option<u64>) -> u64 {
-        let raw = match (idle, turn) {
-            (Some(idle), Some(_)) => idle,
-            (Some(idle), None) => idle,
-            (None, Some(turn)) => turn,
-            (None, None) => DEFAULT_IDLE_TIMEOUT_SECS,
-        };
+    /// Helper: resolve idle_timeout_secs using the same logic as Config::from_args.
+    fn resolve_idle_timeout(idle: Option<u64>) -> u64 {
+        let raw = idle.unwrap_or(DEFAULT_IDLE_TIMEOUT_SECS);
         if raw == 0 {
             1
         } else {
@@ -2359,28 +2330,18 @@ channels = "ALL"
     }
 
     #[test]
-    fn idle_timeout_explicit_wins_over_deprecated() {
-        assert_eq!(resolve_idle_timeout(Some(120), Some(600)), 120);
+    fn idle_timeout_explicit() {
+        assert_eq!(resolve_idle_timeout(Some(120)), 120);
     }
 
     #[test]
-    fn idle_timeout_falls_back_to_deprecated_turn_timeout() {
-        assert_eq!(resolve_idle_timeout(None, Some(600)), 600);
-    }
-
-    #[test]
-    fn idle_timeout_defaults_to_constant_when_neither_set() {
-        assert_eq!(resolve_idle_timeout(None, None), DEFAULT_IDLE_TIMEOUT_SECS);
+    fn idle_timeout_defaults_to_constant_when_not_set() {
+        assert_eq!(resolve_idle_timeout(None), DEFAULT_IDLE_TIMEOUT_SECS);
     }
 
     #[test]
     fn idle_timeout_zero_clamped_to_one() {
-        assert_eq!(resolve_idle_timeout(Some(0), None), 1);
-    }
-
-    #[test]
-    fn idle_timeout_zero_from_deprecated_clamped_to_one() {
-        assert_eq!(resolve_idle_timeout(None, Some(0)), 1);
+        assert_eq!(resolve_idle_timeout(Some(0)), 1);
     }
 
     #[test]

--- a/crates/buzz-agent/README.md
+++ b/crates/buzz-agent/README.md
@@ -135,7 +135,7 @@ Everything is environment variables. No flags, no config files. (We are a subpro
 
 | Variable | Default | Notes |
 |---|---|---|
-| `BUZZ_AGENT_PROVIDER` | — | Required. `anthropic`, `openai`, `deepseek`, `openrouter`, `databricks`, or `databricks_v2`. No implicit fallback — the agent errors at startup when this is unset. |
+| `BUZZ_AGENT_PROVIDER` | — | Required. `anthropic`, `openai`, `deepseek`, `groq`, `openrouter`, `databricks`, or `databricks_v2`. No implicit fallback — the agent errors at startup when this is unset. |
 | `ANTHROPIC_API_KEY` | — | Required when provider=anthropic. |
 | `ANTHROPIC_MODEL` | — | Required when provider=anthropic. |
 | `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` | |
@@ -150,6 +150,9 @@ Everything is environment variables. No flags, no config files. (We are a subpro
 | `DEEPSEEK_API_KEY` | — | Required when provider=deepseek. |
 | `DEEPSEEK_MODEL` | — | Required when provider=deepseek (e.g. `deepseek-chat`, `deepseek-reasoner`). |
 | `DEEPSEEK_BASE_URL` | `https://api.deepseek.com/v1` | Chat Completions only. |
+| `GROQ_API_KEY` | — | Required when provider=groq. |
+| `GROQ_MODEL` | — | Required when provider=groq. |
+| `GROQ_BASE_URL` | `https://api.groq.com/openai/v1` | Chat Completions only. |
 | `DATABRICKS_HOST` | — | Required when provider=databricks or provider=databricks_v2. |
 | `DATABRICKS_MODEL` | — | Required when provider=databricks or provider=databricks_v2. |
 | `DATABRICKS_TOKEN` | — | Optional static bearer escape hatch. If unset, Databricks uses browser OAuth + refresh cache. |
@@ -243,10 +246,11 @@ lifecycle hook — see [MCP_DRIVEN_HOOKS.md](../../docs/MCP_DRIVEN_HOOKS.md).
 | Block Gateway | `openai` | `POST {base}/chat/completions` | gpt-5, claude |
 | OpenRouter | `openrouter` | `POST {base}/chat/completions` | anything they route (extended-thinking replay, provider-agnostic tool calling) |
 | DeepSeek | `deepseek` | `POST {base}/chat/completions` | deepseek-chat, deepseek-reasoner (reasoning_content) |
+| Groq | `groq` | `POST {base}/chat/completions` | llama / mixtral / tool-capable Groq IDs |
 | Databricks | `databricks` | `POST {host}/serving-endpoints/{model}/invocations` | goose-claude-4-6-sonnet |
 | Databricks AI Gateway v2 | `databricks_v2` | `POST {host}/ai-gateway/{provider}/v1/...` | databricks-gpt-5-5, databricks-claude-opus-4-7 |
 
-If `BUZZ_AGENT_PROVIDER=anthropic` is selected without `ANTHROPIC_API_KEY`, `BUZZ_AGENT_PROVIDER=openai` is selected without `OPENAI_COMPAT_API_KEY`, `BUZZ_AGENT_PROVIDER=openrouter` is selected without `OPENROUTER_API_KEY`, or `BUZZ_AGENT_PROVIDER=deepseek` is selected without `DEEPSEEK_API_KEY`, the agent returns an error — there is no implicit fallback to another provider.
+If `BUZZ_AGENT_PROVIDER=anthropic` is selected without `ANTHROPIC_API_KEY`, `BUZZ_AGENT_PROVIDER=openai` is selected without `OPENAI_COMPAT_API_KEY`, `BUZZ_AGENT_PROVIDER=openrouter` is selected without `OPENROUTER_API_KEY`, or `BUZZ_AGENT_PROVIDER=deepseek` is selected without `DEEPSEEK_API_KEY`, or `BUZZ_AGENT_PROVIDER=groq` is selected without `GROQ_API_KEY`, the agent returns an error — there is no implicit fallback to another provider.
 
 `provider=openai` speaks two HTTP dialects: the [Responses API](https://platform.openai.com/docs/api-reference/responses) (`/v1/responses`, required for GPT-5 / o-series tool-calling on OpenAI's own service) and the [Chat Completions API](https://platform.openai.com/docs/api-reference/chat) (`/chat/completions`, the broadly-supported OpenAI-compatible wire format).
 

--- a/crates/buzz-agent/README.md
+++ b/crates/buzz-agent/README.md
@@ -135,7 +135,7 @@ Everything is environment variables. No flags, no config files. (We are a subpro
 
 | Variable | Default | Notes |
 |---|---|---|
-| `BUZZ_AGENT_PROVIDER` | — | Required. `anthropic`, `openai`, `openrouter`, `databricks`, or `databricks_v2`. No implicit fallback — the agent errors at startup when this is unset. |
+| `BUZZ_AGENT_PROVIDER` | — | Required. `anthropic`, `openai`, `deepseek`, `openrouter`, `databricks`, or `databricks_v2`. No implicit fallback — the agent errors at startup when this is unset. |
 | `ANTHROPIC_API_KEY` | — | Required when provider=anthropic. |
 | `ANTHROPIC_MODEL` | — | Required when provider=anthropic. |
 | `ANTHROPIC_BASE_URL` | `https://api.anthropic.com` | |
@@ -147,6 +147,9 @@ Everything is environment variables. No flags, no config files. (We are a subpro
 | `OPENROUTER_API_KEY` | — | Required when provider=openrouter. |
 | `OPENROUTER_MODEL` | — | Required when provider=openrouter. Use OpenRouter's `vendor/model` id, e.g. `anthropic/claude-sonnet-4.5`. |
 | `OPENROUTER_BASE_URL` | `https://openrouter.ai/api/v1` | |
+| `DEEPSEEK_API_KEY` | — | Required when provider=deepseek. |
+| `DEEPSEEK_MODEL` | — | Required when provider=deepseek (e.g. `deepseek-chat`, `deepseek-reasoner`). |
+| `DEEPSEEK_BASE_URL` | `https://api.deepseek.com/v1` | Chat Completions only. |
 | `DATABRICKS_HOST` | — | Required when provider=databricks or provider=databricks_v2. |
 | `DATABRICKS_MODEL` | — | Required when provider=databricks or provider=databricks_v2. |
 | `DATABRICKS_TOKEN` | — | Optional static bearer escape hatch. If unset, Databricks uses browser OAuth + refresh cache. |
@@ -239,10 +242,11 @@ lifecycle hook — see [MCP_DRIVEN_HOOKS.md](../../docs/MCP_DRIVEN_HOOKS.md).
 | Ollama | `openai` | `POST {base}/chat/completions` | llama3.1, qwen2.5-coder |
 | Block Gateway | `openai` | `POST {base}/chat/completions` | gpt-5, claude |
 | OpenRouter | `openrouter` | `POST {base}/chat/completions` | anything they route (extended-thinking replay, provider-agnostic tool calling) |
+| DeepSeek | `deepseek` | `POST {base}/chat/completions` | deepseek-chat, deepseek-reasoner (reasoning_content) |
 | Databricks | `databricks` | `POST {host}/serving-endpoints/{model}/invocations` | goose-claude-4-6-sonnet |
 | Databricks AI Gateway v2 | `databricks_v2` | `POST {host}/ai-gateway/{provider}/v1/...` | databricks-gpt-5-5, databricks-claude-opus-4-7 |
 
-If `BUZZ_AGENT_PROVIDER=anthropic` is selected without `ANTHROPIC_API_KEY`, `BUZZ_AGENT_PROVIDER=openai` is selected without `OPENAI_COMPAT_API_KEY`, or `BUZZ_AGENT_PROVIDER=openrouter` is selected without `OPENROUTER_API_KEY`, the agent returns an error — there is no implicit fallback to another provider.
+If `BUZZ_AGENT_PROVIDER=anthropic` is selected without `ANTHROPIC_API_KEY`, `BUZZ_AGENT_PROVIDER=openai` is selected without `OPENAI_COMPAT_API_KEY`, `BUZZ_AGENT_PROVIDER=openrouter` is selected without `OPENROUTER_API_KEY`, or `BUZZ_AGENT_PROVIDER=deepseek` is selected without `DEEPSEEK_API_KEY`, the agent returns an error — there is no implicit fallback to another provider.
 
 `provider=openai` speaks two HTTP dialects: the [Responses API](https://platform.openai.com/docs/api-reference/responses) (`/v1/responses`, required for GPT-5 / o-series tool-calling on OpenAI's own service) and the [Chat Completions API](https://platform.openai.com/docs/api-reference/chat) (`/chat/completions`, the broadly-supported OpenAI-compatible wire format).
 

--- a/crates/buzz-agent/src/catalog.rs
+++ b/crates/buzz-agent/src/catalog.rs
@@ -1,14 +1,7 @@
-//! Databricks model catalog discovery.
+//! Databricks and DeepSeek model catalog discovery.
 //!
-//! Exposes [`discover_databricks_models`] — an async helper that lists
-//! available models for the `databricks` and `databricks_v2` providers
-//! without triggering a browser OAuth flow. Auth is acquired in-process via
-//! [`build_token_source`](crate::llm::build_token_source):
-//!
-//! - Static bearer (`DATABRICKS_TOKEN`): returned immediately.
-//! - PKCE cache hit: returned from disk without a network round-trip.
-//! - PKCE cache empty / no token: returns `Err(AgentError::LlmAuth)` — the
-//!   caller degrades gracefully; no browser, no hang.
+//! Exposes [`discover_databricks_models`] and [`discover_deepseek_models`] — async
+//! helpers that list available models without triggering a browser OAuth flow.
 
 use reqwest::Client;
 
@@ -387,6 +380,60 @@ pub(crate) fn parse_v2_endpoints_page(
         .map(str::to_string);
 
     Ok((models, next_page_token))
+}
+
+// ---------------------------------------------------------------------------
+/// Discover available models for DeepSeek via `GET /models` at the configured
+/// base URL. The response is OpenAI-compatible: `{ "data": [{ "id": "...", ... }] }`.
+///
+/// Returns a non-empty `Vec<ModelEntry>` on success. Returns
+/// `Err(AgentError::Llm)` when the request fails — callers should degrade
+/// gracefully rather than hanging.
+pub async fn discover_deepseek_models(cfg: &Config) -> Result<Vec<ModelEntry>, AgentError> {
+    let http = Client::new();
+    let url = format!("{}/models", cfg.base_url.trim_end_matches('/'));
+    let response = http
+        .get(&url)
+        .bearer_auth(&cfg.api_key)
+        .send()
+        .await
+        .map_err(|e| AgentError::Llm(format!("DeepSeek model discovery request failed: {e}")))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(AgentError::Llm(format!(
+            "DeepSeek model discovery HTTP {status}: {body}"
+        )));
+    }
+
+    let json: serde_json::Value = response.json().await.map_err(|e| {
+        AgentError::Llm(format!(
+            "DeepSeek model discovery response parse failed: {e}"
+        ))
+    })?;
+
+    let data = json
+        .get("data")
+        .and_then(|d| d.as_array())
+        .ok_or_else(|| AgentError::Llm("DeepSeek /models missing 'data' array".into()))?;
+
+    let models: Vec<ModelEntry> = data
+        .iter()
+        .filter_map(|m| {
+            let id = m.get("id")?.as_str()?;
+            Some(ModelEntry {
+                id: id.to_string(),
+                name: id.to_string(),
+            })
+        })
+        .collect();
+
+    if models.is_empty() {
+        return Err(AgentError::Llm("DeepSeek /models returned no models".into()));
+    }
+
+    Ok(models)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -673,6 +673,11 @@ pub enum Provider {
     DatabricksV2,
     /// OpenRouter multi-provider gateway. Routes to `{base_url}/chat/completions` with bearer auth. Wire format is OpenAI-chat-compatible.
     OpenRouter,
+    /// DeepSeek first-party API. Chat Completions at `https://api.deepseek.com/v1`
+    /// (override with `DEEPSEEK_BASE_URL`). Wire format is OpenAI-chat-compatible;
+    /// uses Chat Completions only (not Responses). Distinct from `provider=openai`
+    /// / openai-compat escape hatch.
+    DeepSeek,
 }
 
 /// Which OpenAI-family HTTP API to call. Set via `OPENAI_COMPAT_API`
@@ -769,6 +774,7 @@ impl Config {
             env("ANTHROPIC_API_KEY").as_deref(),
             env("OPENAI_COMPAT_API_KEY").as_deref(),
             env("OPENROUTER_API_KEY").as_deref(),
+            env("DEEPSEEK_API_KEY").as_deref(),
         )?;
 
         // Universal model override — takes priority over provider-specific model
@@ -820,6 +826,17 @@ impl Config {
                 .ok_or_else(|| "config: OPENROUTER_MODEL required".to_string())?,
                 env_or("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"),
                 OpenAiApi::Chat, // OpenRouter uses Chat Completions only
+            ),
+            Provider::DeepSeek => (
+                req("DEEPSEEK_API_KEY")?,
+                resolve_model(
+                    buzz_agent_model.as_deref(),
+                    env("DEEPSEEK_MODEL").as_deref(),
+                )
+                .ok_or_else(|| "config: DEEPSEEK_MODEL required".to_string())?,
+                // Official API root includes /v1; trailing slash is normalized by callers.
+                env_or("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1"),
+                OpenAiApi::Chat, // DeepSeek is Chat Completions only
             ),
         };
         let system_prompt = match (env("BUZZ_AGENT_SYSTEM_PROMPT"), env("BUZZ_AGENT_SYSTEM_PROMPT_FILE")) {
@@ -1029,6 +1046,7 @@ fn resolve_provider(
     anthropic_key: Option<&str>,
     openai_key: Option<&str>,
     openrouter_key: Option<&str>,
+    deepseek_key: Option<&str>,
 ) -> Result<Provider, String> {
     match requested.map(str::trim).filter(|s| !s.is_empty()) {
         Some(raw) => {
@@ -1046,13 +1064,15 @@ fn resolve_provider(
                 "databricks_v2" | "databricks-v2" => Ok(Provider::DatabricksV2),
                 "openrouter" if present_nonempty(openrouter_key) => Ok(Provider::OpenRouter),
                 "openrouter" => Err("config: OPENROUTER_API_KEY required".into()),
+                "deepseek" if present_nonempty(deepseek_key) => Ok(Provider::DeepSeek),
+                "deepseek" => Err("config: DEEPSEEK_API_KEY required".into()),
                 _ => Err(format!(
                     "config: BUZZ_AGENT_PROVIDER={raw} not supported"
                 )),
             }
         }
         None => Err(
-            "config: BUZZ_AGENT_PROVIDER is required — set it to your provider (e.g. anthropic, openai, databricks)".into(),
+            "config: BUZZ_AGENT_PROVIDER is required — set it to your provider (e.g. anthropic, openai, deepseek, databricks)".into(),
         ),
     }
 }
@@ -1263,11 +1283,11 @@ mod tests {
     #[test]
     fn resolve_provider_keeps_requested_provider_when_token_present() {
         assert_eq!(
-            resolve_provider(Some("anthropic"), Some("sk-ant"), None, None).unwrap(),
+            resolve_provider(Some("anthropic"), Some("sk-ant"), None, None, None).unwrap(),
             Provider::Anthropic
         );
         assert_eq!(
-            resolve_provider(Some("openai"), None, Some("sk-openai"), None).unwrap(),
+            resolve_provider(Some("openai"), None, Some("sk-openai"), None, None).unwrap(),
             Provider::OpenAi
         );
     }
@@ -1275,17 +1295,17 @@ mod tests {
     #[test]
     fn resolve_provider_errors_when_requested_provider_key_missing() {
         // No fallback — missing key returns an error regardless of Databricks availability.
-        let err = resolve_provider(Some("anthropic"), None, None, None).unwrap_err();
+        let err = resolve_provider(Some("anthropic"), None, None, None, None).unwrap_err();
         assert!(err.contains("ANTHROPIC_API_KEY required"), "{err}");
 
-        let err = resolve_provider(Some("openai-compat"), None, Some("   "), None).unwrap_err();
+        let err = resolve_provider(Some("openai-compat"), None, Some("   "), None, None).unwrap_err();
         assert!(err.contains("OPENAI_COMPAT_API_KEY required"), "{err}");
     }
 
     #[test]
     fn resolve_provider_errors_when_provider_env_absent() {
         // No implicit inference — absent BUZZ_AGENT_PROVIDER is an error.
-        let err = resolve_provider(None, None, None, None).unwrap_err();
+        let err = resolve_provider(None, None, None, None, None).unwrap_err();
         assert!(err.contains("BUZZ_AGENT_PROVIDER is required"), "{err}");
     }
 
@@ -1295,19 +1315,19 @@ mod tests {
         // When BUZZ_AGENT_PROVIDER=databricks, resolve_provider succeeds regardless
         // of DATABRICKS_HOST/MODEL (those are validated later in from_env()).
         assert_eq!(
-            resolve_provider(Some("databricks"), None, None, None).unwrap(),
+            resolve_provider(Some("databricks"), None, None, None, None).unwrap(),
             Provider::Databricks
         );
         // Missing key for other providers still errors — no Databricks fallback.
-        let err = resolve_provider(Some("openai"), None, None, None).unwrap_err();
+        let err = resolve_provider(Some("openai"), None, None, None, None).unwrap_err();
         assert!(err.contains("OPENAI_COMPAT_API_KEY required"), "{err}");
-        let err = resolve_provider(None, None, None, None).unwrap_err();
+        let err = resolve_provider(None, None, None, None, None).unwrap_err();
         assert!(err.contains("BUZZ_AGENT_PROVIDER is required"), "{err}");
     }
 
     #[test]
     fn resolve_provider_unsupported_error_preserves_user_casing() {
-        let err = resolve_provider(Some("OpenAIish"), None, None, None).unwrap_err();
+        let err = resolve_provider(Some("OpenAIish"), None, None, None, None).unwrap_err();
         assert!(err.contains("BUZZ_AGENT_PROVIDER=OpenAIish"));
     }
 
@@ -2753,14 +2773,28 @@ mod tests {
     #[test]
     fn resolve_provider_openrouter_with_key() {
         assert_eq!(
-            resolve_provider(Some("openrouter"), None, None, Some("sk-or-123")).unwrap(),
+            resolve_provider(Some("openrouter"), None, None, Some("sk-or-123"), None).unwrap(),
             Provider::OpenRouter
         );
     }
 
     #[test]
     fn resolve_provider_openrouter_missing_key() {
-        let err = resolve_provider(Some("openrouter"), None, None, None).unwrap_err();
+        let err = resolve_provider(Some("openrouter"), None, None, None, None).unwrap_err();
         assert!(err.contains("OPENROUTER_API_KEY"));
+    }
+
+    #[test]
+    fn resolve_provider_deepseek_with_key() {
+        assert_eq!(
+            resolve_provider(Some("deepseek"), None, None, None, Some("sk-ds-123")).unwrap(),
+            Provider::DeepSeek
+        );
+    }
+
+    #[test]
+    fn resolve_provider_deepseek_missing_key() {
+        let err = resolve_provider(Some("deepseek"), None, None, None, None).unwrap_err();
+        assert!(err.contains("DEEPSEEK_API_KEY"));
     }
 }

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -678,6 +678,10 @@ pub enum Provider {
     /// uses Chat Completions only (not Responses). Distinct from `provider=openai`
     /// / openai-compat escape hatch.
     DeepSeek,
+    /// Groq first-party API. Chat Completions at `https://api.groq.com/openai/v1`
+    /// (override with `GROQ_BASE_URL`). Wire format is OpenAI-chat-compatible;
+    /// uses Chat Completions only (not Responses). LPU hardware for fastest inference.
+    Groq,
 }
 
 /// Which OpenAI-family HTTP API to call. Set via `OPENAI_COMPAT_API`
@@ -775,6 +779,7 @@ impl Config {
             env("OPENAI_COMPAT_API_KEY").as_deref(),
             env("OPENROUTER_API_KEY").as_deref(),
             env("DEEPSEEK_API_KEY").as_deref(),
+            env("GROQ_API_KEY").as_deref(),
         )?;
 
         // Universal model override — takes priority over provider-specific model
@@ -837,6 +842,16 @@ impl Config {
                 // Official API root includes /v1; trailing slash is normalized by callers.
                 env_or("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1"),
                 OpenAiApi::Chat, // DeepSeek is Chat Completions only
+            ),
+            Provider::Groq => (
+                req("GROQ_API_KEY")?,
+                resolve_model(
+                    buzz_agent_model.as_deref(),
+                    env("GROQ_MODEL").as_deref(),
+                )
+                .ok_or_else(|| "config: GROQ_MODEL required".to_string())?,
+                env_or("GROQ_BASE_URL", "https://api.groq.com/openai/v1"),
+                OpenAiApi::Chat, // Groq is Chat Completions only
             ),
         };
         let system_prompt = match (env("BUZZ_AGENT_SYSTEM_PROMPT"), env("BUZZ_AGENT_SYSTEM_PROMPT_FILE")) {
@@ -1047,6 +1062,7 @@ fn resolve_provider(
     openai_key: Option<&str>,
     openrouter_key: Option<&str>,
     deepseek_key: Option<&str>,
+    groq_key: Option<&str>,
 ) -> Result<Provider, String> {
     match requested.map(str::trim).filter(|s| !s.is_empty()) {
         Some(raw) => {
@@ -1066,6 +1082,8 @@ fn resolve_provider(
                 "openrouter" => Err("config: OPENROUTER_API_KEY required".into()),
                 "deepseek" if present_nonempty(deepseek_key) => Ok(Provider::DeepSeek),
                 "deepseek" => Err("config: DEEPSEEK_API_KEY required".into()),
+                "groq" if present_nonempty(groq_key) => Ok(Provider::Groq),
+                "groq" => Err("config: GROQ_API_KEY required".into()),
                 _ => Err(format!(
                     "config: BUZZ_AGENT_PROVIDER={raw} not supported"
                 )),
@@ -1283,11 +1301,11 @@ mod tests {
     #[test]
     fn resolve_provider_keeps_requested_provider_when_token_present() {
         assert_eq!(
-            resolve_provider(Some("anthropic"), Some("sk-ant"), None, None, None).unwrap(),
+            resolve_provider(Some("anthropic"), Some("sk-ant"), None, None, None, None).unwrap(),
             Provider::Anthropic
         );
         assert_eq!(
-            resolve_provider(Some("openai"), None, Some("sk-openai"), None, None).unwrap(),
+            resolve_provider(Some("openai"), None, Some("sk-openai"), None, None, None).unwrap(),
             Provider::OpenAi
         );
     }
@@ -1295,17 +1313,17 @@ mod tests {
     #[test]
     fn resolve_provider_errors_when_requested_provider_key_missing() {
         // No fallback — missing key returns an error regardless of Databricks availability.
-        let err = resolve_provider(Some("anthropic"), None, None, None, None).unwrap_err();
+        let err = resolve_provider(Some("anthropic"), None, None, None, None, None).unwrap_err();
         assert!(err.contains("ANTHROPIC_API_KEY required"), "{err}");
 
-        let err = resolve_provider(Some("openai-compat"), None, Some("   "), None, None).unwrap_err();
+        let err = resolve_provider(Some("openai-compat"), None, Some("   "), None, None, None).unwrap_err();
         assert!(err.contains("OPENAI_COMPAT_API_KEY required"), "{err}");
     }
 
     #[test]
     fn resolve_provider_errors_when_provider_env_absent() {
         // No implicit inference — absent BUZZ_AGENT_PROVIDER is an error.
-        let err = resolve_provider(None, None, None, None, None).unwrap_err();
+        let err = resolve_provider(None, None, None, None, None, None).unwrap_err();
         assert!(err.contains("BUZZ_AGENT_PROVIDER is required"), "{err}");
     }
 
@@ -1315,19 +1333,19 @@ mod tests {
         // When BUZZ_AGENT_PROVIDER=databricks, resolve_provider succeeds regardless
         // of DATABRICKS_HOST/MODEL (those are validated later in from_env()).
         assert_eq!(
-            resolve_provider(Some("databricks"), None, None, None, None).unwrap(),
+            resolve_provider(Some("databricks"), None, None, None, None, None).unwrap(),
             Provider::Databricks
         );
         // Missing key for other providers still errors — no Databricks fallback.
-        let err = resolve_provider(Some("openai"), None, None, None, None).unwrap_err();
+        let err = resolve_provider(Some("openai"), None, None, None, None, None).unwrap_err();
         assert!(err.contains("OPENAI_COMPAT_API_KEY required"), "{err}");
-        let err = resolve_provider(None, None, None, None, None).unwrap_err();
+        let err = resolve_provider(None, None, None, None, None, None).unwrap_err();
         assert!(err.contains("BUZZ_AGENT_PROVIDER is required"), "{err}");
     }
 
     #[test]
     fn resolve_provider_unsupported_error_preserves_user_casing() {
-        let err = resolve_provider(Some("OpenAIish"), None, None, None, None).unwrap_err();
+        let err = resolve_provider(Some("OpenAIish"), None, None, None, None, None).unwrap_err();
         assert!(err.contains("BUZZ_AGENT_PROVIDER=OpenAIish"));
     }
 
@@ -2773,28 +2791,42 @@ mod tests {
     #[test]
     fn resolve_provider_openrouter_with_key() {
         assert_eq!(
-            resolve_provider(Some("openrouter"), None, None, Some("sk-or-123"), None).unwrap(),
+            resolve_provider(Some("openrouter"), None, None, Some("sk-or-123"), None, None).unwrap(),
             Provider::OpenRouter
         );
     }
 
     #[test]
     fn resolve_provider_openrouter_missing_key() {
-        let err = resolve_provider(Some("openrouter"), None, None, None, None).unwrap_err();
+        let err = resolve_provider(Some("openrouter"), None, None, None, None, None).unwrap_err();
         assert!(err.contains("OPENROUTER_API_KEY"));
     }
 
     #[test]
     fn resolve_provider_deepseek_with_key() {
         assert_eq!(
-            resolve_provider(Some("deepseek"), None, None, None, Some("sk-ds-123")).unwrap(),
+            resolve_provider(Some("deepseek"), None, None, None, Some("sk-ds-123"), None).unwrap(),
             Provider::DeepSeek
         );
     }
 
     #[test]
     fn resolve_provider_deepseek_missing_key() {
-        let err = resolve_provider(Some("deepseek"), None, None, None, None).unwrap_err();
+        let err = resolve_provider(Some("deepseek"), None, None, None, None, None).unwrap_err();
         assert!(err.contains("DEEPSEEK_API_KEY"));
+    }
+
+    #[test]
+    fn resolve_provider_groq_with_key() {
+        assert_eq!(
+            resolve_provider(Some("groq"), None, None, None, None, Some("gsk-123")).unwrap(),
+            Provider::Groq
+        );
+    }
+
+    #[test]
+    fn resolve_provider_groq_missing_key() {
+        let err = resolve_provider(Some("groq"), None, None, None, None, None).unwrap_err();
+        assert!(err.contains("GROQ_API_KEY"));
     }
 }

--- a/crates/buzz-agent/src/config.rs
+++ b/crates/buzz-agent/src/config.rs
@@ -682,6 +682,12 @@ pub enum Provider {
     /// (override with `GROQ_BASE_URL`). Wire format is OpenAI-chat-compatible;
     /// uses Chat Completions only (not Responses). LPU hardware for fastest inference.
     Groq,
+    /// Meta Muse Spark via existing `muse login` OAuth session.
+    /// Reads token from `$MUSE_AUTH_PATH` or `~/.config/muse/auth.json`
+    /// (fallback `$HOME/.config/muse/auth.json`), or `META_API_KEY`.
+    /// Wire format is OpenAI-chat-compatible; base_url defaults to
+    /// `https://api.meta.ai/muse-code/v1` (override with `META_BASE_URL`).
+    Meta,
 }
 
 /// Which OpenAI-family HTTP API to call. Set via `OPENAI_COMPAT_API`
@@ -853,6 +859,18 @@ impl Config {
                 env_or("GROQ_BASE_URL", "https://api.groq.com/openai/v1"),
                 OpenAiApi::Chat, // Groq is Chat Completions only
             ),
+            Provider::Meta => {
+                let token = read_muse_token().ok_or_else(|| {
+                    "config: META_API_KEY or Muse OAuth token required — run `muse login` or set META_API_KEY / MUSE_AUTH_PATH".to_string()
+                })?;
+                let model = resolve_model(
+                    buzz_agent_model.as_deref(),
+                    env("META_MODEL").as_deref().or(env("OPENAI_COMPAT_MODEL").as_deref()),
+                )
+                .ok_or_else(|| "config: META_MODEL (or OPENAI_COMPAT_MODEL) required for provider=meta — e.g. muse-spark-1.2".to_string())?;
+                let base = env_or("META_BASE_URL", "https://api.meta.ai/muse-code/v1");
+                (token, model, base, parse_openai_api(env("OPENAI_COMPAT_API").as_deref())?)
+            },
         };
         let system_prompt = match (env("BUZZ_AGENT_SYSTEM_PROMPT"), env("BUZZ_AGENT_SYSTEM_PROMPT_FILE")) {
             (Some(_), Some(_)) => return Err(
@@ -1028,6 +1046,41 @@ impl Config {
     }
 }
 
+fn read_muse_token() -> Option<String> {
+    // META_API_KEY takes priority (matches `muse` launcher behavior)
+    if let Some(v) = std::env::var("META_API_KEY").ok().filter(|s| !s.trim().is_empty()) {
+        return Some(v.trim().to_string());
+    }
+    // Then try MUSE_AUTH_PATH or ~/.config/muse/auth.json
+    let path = std::env::var("MUSE_AUTH_PATH").ok().filter(|s| !s.trim().is_empty()).unwrap_or_else(|| {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        format!("{}/.config/muse/auth.json", home)
+    });
+    let data = std::fs::read_to_string(&path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&data).ok()?;
+    // Try common shapes: {"access_token": "..."}, {"token": "..."}, {"auth": {"access_token": ...}}
+    if let Some(t) = v.get("access_token").and_then(|x| x.as_str()).filter(|s| !s.trim().is_empty()) {
+        return Some(t.trim().to_string());
+    }
+    if let Some(t) = v.get("token").and_then(|x| x.as_str()).filter(|s| !s.trim().is_empty()) {
+        return Some(t.trim().to_string());
+    }
+    if let Some(t) = v.get("auth").and_then(|a| a.get("access_token")).and_then(|x| x.as_str()).filter(|s| !s.trim().is_empty()) {
+        return Some(t.trim().to_string());
+    }
+    // Muse `auth.json` shape: {"providers": {"meta": {"access_token": "...", "api_key": "..."}}}
+    if let Some(t) = v
+        .get("providers")
+        .and_then(|p| p.get("meta"))
+        .and_then(|m| m.get("access_token").or_else(|| m.get("api_key")))
+        .and_then(|x| x.as_str())
+        .filter(|s| !s.trim().is_empty())
+    {
+        return Some(t.trim().to_string());
+    }
+    None
+}
+
 fn env(k: &str) -> Option<String> {
     std::env::var(k).ok()
 }
@@ -1064,6 +1117,16 @@ fn resolve_provider(
     deepseek_key: Option<&str>,
     groq_key: Option<&str>,
 ) -> Result<Provider, String> {
+    // Meta reuses your existing `muse login` OAuth — check before generic fallback
+    if let Some(raw) = requested.map(str::trim).filter(|s| !s.is_empty()) {
+        if raw.to_ascii_lowercase() == "meta" {
+            if read_muse_token().is_some() {
+                return Ok(Provider::Meta);
+            } else {
+                return Err("config: META_API_KEY or Muse OAuth token required — run `muse login` or set META_API_KEY / MUSE_AUTH_PATH".into());
+            }
+        }
+    }
     match requested.map(str::trim).filter(|s| !s.is_empty()) {
         Some(raw) => {
             let normalized = raw.to_ascii_lowercase();

--- a/crates/buzz-agent/src/lib.rs
+++ b/crates/buzz-agent/src/lib.rs
@@ -11,7 +11,7 @@ mod mcp;
 pub mod types;
 mod wire;
 
-pub use catalog::{discover_databricks_models, ModelEntry, DATABRICKS_V2_KNOWN_MODELS};
+pub use catalog::{discover_databricks_models, discover_deepseek_models, ModelEntry, DATABRICKS_V2_KNOWN_MODELS};
 pub use config::Provider;
 pub use types::AgentError;
 
@@ -464,6 +464,19 @@ async fn session_new(app: &Arc<App>, id: Value, params: Value, wire_tx: &WireSen
                     app.cfg.provider,
                     &app.cfg.model,
                     discover_databricks_models(&app.cfg),
+                )
+                .await;
+                models
+                    .iter()
+                    .map(|m| json!({ "modelId": m.id, "name": m.name }))
+                    .collect()
+            }
+            Provider::DeepSeek => {
+                let models = resolve_models_catalog(
+                    &app.models_cache,
+                    app.cfg.provider,
+                    &app.cfg.model,
+                    discover_deepseek_models(&app.cfg),
                 )
                 .await;
                 models

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -158,7 +158,7 @@ impl Llm {
                 let v = self.post_openrouter(cfg, &body).await?;
                 parse_openai_with_reasoning_details(v)
             }
-            Provider::OpenAi | Provider::Databricks => {
+            Provider::OpenAi | Provider::Databricks | Provider::DeepSeek => {
                 self.openai_request(
                     cfg,
                     effective_model,
@@ -168,6 +168,7 @@ impl Llm {
                         // `max` for pure OpenAI/Databricks; this per-model table is the single authority
                         // — it keeps `max` for gpt-5.6, clamps `max`→`xhigh` for other OpenAI-shaped
                         // models, and still applies corrections like none→minimal on the gpt-5 base.
+                        // DeepSeek is Chat Completions only (`OpenAiApi::Chat` in config).
                         let e =
                             effort.map(|ef| normalize_effort_for_openai_route(ef, request_model));
                         if use_responses {
@@ -270,7 +271,7 @@ impl Llm {
                 let v = self.post_openrouter(cfg, &body).await?;
                 Ok(parse_openai(v)?.text)
             }
-            Provider::OpenAi | Provider::Databricks => {
+            Provider::OpenAi | Provider::Databricks | Provider::DeepSeek => {
                 let r = self
                     .openai_request(
                         cfg,
@@ -1916,13 +1917,14 @@ where
 ///   never read for Anthropic requests (those go through `post_anthropic` with
 ///   `x-api-key`), but Llm holds one to keep the field non-`Option`.
 /// - `Provider::OpenAi`: a static source over `OPENAI_COMPAT_API_KEY`.
+/// - `Provider::DeepSeek`: a static source over `DEEPSEEK_API_KEY`.
 /// - `Provider::Databricks`: if `DATABRICKS_TOKEN` is set, a static source.
 ///   Otherwise a `PkceOAuthTokenSource` pointed at the workspace's OIDC
 ///   discovery URL. First request without a cached token triggers a browser
 ///   flow; subsequent requests use the cache + refresh transparently.
 pub(crate) fn build_token_source(cfg: &Config) -> Result<Arc<dyn TokenSource>, AgentError> {
     match cfg.provider {
-        Provider::Anthropic | Provider::OpenAi | Provider::OpenRouter => {
+        Provider::Anthropic | Provider::OpenAi | Provider::OpenRouter | Provider::DeepSeek => {
             Ok(Arc::new(StaticTokenSource::new(cfg.api_key.clone())))
         }
         Provider::Databricks | Provider::DatabricksV2 => {

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -158,7 +158,7 @@ impl Llm {
                 let v = self.post_openrouter(cfg, &body).await?;
                 parse_openai_with_reasoning_details(v)
             }
-            Provider::OpenAi | Provider::Databricks | Provider::DeepSeek => {
+            Provider::OpenAi | Provider::Databricks | Provider::DeepSeek | Provider::Groq => {
                 self.openai_request(
                     cfg,
                     effective_model,
@@ -168,7 +168,7 @@ impl Llm {
                         // `max` for pure OpenAI/Databricks; this per-model table is the single authority
                         // — it keeps `max` for gpt-5.6, clamps `max`→`xhigh` for other OpenAI-shaped
                         // models, and still applies corrections like none→minimal on the gpt-5 base.
-                        // DeepSeek is Chat Completions only (`OpenAiApi::Chat` in config).
+                        // DeepSeek and Groq are Chat Completions only (`OpenAiApi::Chat` in config).
                         let e =
                             effort.map(|ef| normalize_effort_for_openai_route(ef, request_model));
                         if use_responses {
@@ -271,7 +271,7 @@ impl Llm {
                 let v = self.post_openrouter(cfg, &body).await?;
                 Ok(parse_openai(v)?.text)
             }
-            Provider::OpenAi | Provider::Databricks | Provider::DeepSeek => {
+            Provider::OpenAi | Provider::Databricks | Provider::DeepSeek | Provider::Groq => {
                 let r = self
                     .openai_request(
                         cfg,
@@ -1918,13 +1918,14 @@ where
 ///   `x-api-key`), but Llm holds one to keep the field non-`Option`.
 /// - `Provider::OpenAi`: a static source over `OPENAI_COMPAT_API_KEY`.
 /// - `Provider::DeepSeek`: a static source over `DEEPSEEK_API_KEY`.
+/// - `Provider::Groq`: a static source over `GROQ_API_KEY`.
 /// - `Provider::Databricks`: if `DATABRICKS_TOKEN` is set, a static source.
 ///   Otherwise a `PkceOAuthTokenSource` pointed at the workspace's OIDC
 ///   discovery URL. First request without a cached token triggers a browser
 ///   flow; subsequent requests use the cache + refresh transparently.
 pub(crate) fn build_token_source(cfg: &Config) -> Result<Arc<dyn TokenSource>, AgentError> {
     match cfg.provider {
-        Provider::Anthropic | Provider::OpenAi | Provider::OpenRouter | Provider::DeepSeek => {
+        Provider::Anthropic | Provider::OpenAi | Provider::OpenRouter | Provider::DeepSeek | Provider::Groq => {
             Ok(Arc::new(StaticTokenSource::new(cfg.api_key.clone())))
         }
         Provider::Databricks | Provider::DatabricksV2 => {

--- a/crates/buzz-agent/src/llm.rs
+++ b/crates/buzz-agent/src/llm.rs
@@ -158,7 +158,7 @@ impl Llm {
                 let v = self.post_openrouter(cfg, &body).await?;
                 parse_openai_with_reasoning_details(v)
             }
-            Provider::OpenAi | Provider::Databricks | Provider::DeepSeek | Provider::Groq => {
+            Provider::OpenAi | Provider::Databricks | Provider::DeepSeek | Provider::Groq | Provider::Meta => {
                 self.openai_request(
                     cfg,
                     effective_model,
@@ -271,7 +271,7 @@ impl Llm {
                 let v = self.post_openrouter(cfg, &body).await?;
                 Ok(parse_openai(v)?.text)
             }
-            Provider::OpenAi | Provider::Databricks | Provider::DeepSeek | Provider::Groq => {
+            Provider::OpenAi | Provider::Databricks | Provider::DeepSeek | Provider::Groq | Provider::Meta => {
                 let r = self
                     .openai_request(
                         cfg,
@@ -1925,7 +1925,7 @@ where
 ///   flow; subsequent requests use the cache + refresh transparently.
 pub(crate) fn build_token_source(cfg: &Config) -> Result<Arc<dyn TokenSource>, AgentError> {
     match cfg.provider {
-        Provider::Anthropic | Provider::OpenAi | Provider::OpenRouter | Provider::DeepSeek | Provider::Groq => {
+        Provider::Anthropic | Provider::OpenAi | Provider::OpenRouter | Provider::DeepSeek | Provider::Groq | Provider::Meta => {
             Ok(Arc::new(StaticTokenSource::new(cfg.api_key.clone())))
         }
         Provider::Databricks | Provider::DatabricksV2 => {

--- a/crates/buzz-auth/src/nip98.rs
+++ b/crates/buzz-auth/src/nip98.rs
@@ -149,6 +149,18 @@ fn normalize_url(raw: &str) -> String {
         Ok(u) => u,
         Err(_) => return raw.to_lowercase(),
     };
+    // Loopback is always the same machine: buzz-core's normalize_relay_url
+    // canonicalizes localhost -> 127.0.0.1, so agents sign with the IP while
+    // the relay's tenant host may be "localhost". Collapsing loopback
+    // spellings here closes no multi-tenant door — distinct DOMAINS still
+    // verify distinctly; only same-machine aliases merge.
+    if let Some(host) = parsed.host_str() {
+        let is_loopback = host.eq_ignore_ascii_case("localhost")
+            || host.parse::<std::net::IpAddr>().map(|a| a.is_loopback()).unwrap_or(false);
+        if is_loopback {
+            let _ = parsed.set_host(Some("localhost"));
+        }
+    }
     let path = parsed.path().trim_end_matches('/').to_string();
     parsed.set_path(&path);
     parsed.to_string()
@@ -288,32 +300,36 @@ mod tests {
     }
 
     #[test]
-    fn loopback_aliases_are_distinct_hosts() {
-        // Under multi-tenant, the `u`-tag host is the row-zero community
-        // binding. An event signed for `localhost` MUST NOT pass against an
-        // expected URL on `127.0.0.1` (or `::1`) — collapsing the three would
-        // be a host-check side door. Production reconstructs `expected_url`
-        // from the community-bound host; tests do the same.
+    fn loopback_aliases_verify_but_distinct_domains_do_not() {
+        // buzz-core's normalize_relay_url canonicalizes loopback to 127.0.0.1
+        // while a relay tenant may be bound to "localhost" — same machine, two
+        // spellings, and agents signed one while the relay expected the other
+        // (2026-08-04: every desktop-spawned agent 401'd on /query). Loopback
+        // aliases MUST verify as one host. The multi-tenant boundary lives
+        // between distinct domains, which still fail below.
         let keys = Keys::generate();
         let localhost_url = "http://localhost:3000/api/tokens";
         let loopback_url = "http://127.0.0.1:3000/api/tokens";
         let json = make_nip98_event(&keys, localhost_url, TEST_METHOD, None, None);
-        let result = verify_nip98_event(&json, loopback_url, TEST_METHOD, None);
         assert!(
-            matches!(result, Err(AuthError::Nip98Invalid(_))),
-            "localhost u-tag must NOT match a 127.0.0.1 expected_url; got {result:?}"
+            verify_nip98_event(&json, loopback_url, TEST_METHOD, None).is_ok(),
+            "localhost u-tag must match a 127.0.0.1 expected_url (same machine)"
         );
-
-        // Symmetric: signed-for-127.0.0.1 against expected localhost — same answer.
         let json2 = make_nip98_event(&keys, loopback_url, TEST_METHOD, None, None);
-        let result2 = verify_nip98_event(&json2, localhost_url, TEST_METHOD, None);
         assert!(
-            matches!(result2, Err(AuthError::Nip98Invalid(_))),
-            "127.0.0.1 u-tag must NOT match a localhost expected_url; got {result2:?}"
+            verify_nip98_event(&json2, localhost_url, TEST_METHOD, None).is_ok(),
+            "127.0.0.1 u-tag must match a localhost expected_url (same machine)"
         );
 
-        // And identity still holds — same host on both sides verifies.
-        let json3 = make_nip98_event(&keys, loopback_url, TEST_METHOD, None, None);
-        assert!(verify_nip98_event(&json3, loopback_url, TEST_METHOD, None).is_ok());
+        // Distinct domains remain distinct — the cross-community side door
+        // stays closed.
+        let json3 = make_nip98_event(&keys, localhost_url, TEST_METHOD, None, None);
+        let cross = verify_nip98_event(
+            &json3,
+            "http://other.example.com:3000/api/tokens",
+            TEST_METHOD,
+            None,
+        );
+        assert!(matches!(cross, Err(AuthError::Nip98Invalid(_))));
     }
 }

--- a/crates/buzz-auth/src/nip98.rs
+++ b/crates/buzz-auth/src/nip98.rs
@@ -94,9 +94,11 @@ pub fn verify_nip98_event(
         .and_then(|t| t.content())
         .ok_or_else(|| AuthError::Nip98Invalid("missing `u` tag".to_string()))?;
 
-    if normalize_url(u_tag) != normalize_url(expected_url) {
+    let norm_u = normalize_url(u_tag);
+    let norm_expected = normalize_url(expected_url);
+    if norm_u != norm_expected {
         return Err(AuthError::Nip98Invalid(format!(
-            "URL mismatch: event has `{u_tag}`, expected `{expected_url}`"
+            "URL mismatch: event has `{u_tag}` (normalized: `{norm_u}`), expected `{expected_url}` (normalized: `{norm_expected}`)"
         )));
     }
 

--- a/crates/buzz-core/src/tenant.rs
+++ b/crates/buzz-core/src/tenant.rs
@@ -134,6 +134,17 @@ pub fn normalize_host(host: &str) -> String {
     if let Some(stripped) = host.strip_suffix('.') {
         host = stripped.to_string();
     }
+    // Normalize loopback variants so 127.0.0.1 and localhost resolve to the
+    // same community. Without this, Rust WS clients (tungstenite) that resolve
+    // localhost -> 127.0.0.1 and send Host: 127.0.0.1:3000 get 404 from a
+    // community bound to localhost:3000.
+    host = host
+        .replace("127.0.0.1:", "localhost:")
+        .replace("[::1]:", "localhost:")
+        .replace("[::1]", "localhost");
+    if host == "127.0.0.1" {
+        host = "localhost".to_string();
+    }
     host
 }
 
@@ -220,9 +231,9 @@ mod tests {
 
     #[test]
     fn normalize_host_leaves_ipv6_literal_intact() {
-        // IPv6 literals contain colons but no trailing default-port suffix.
-        assert_eq!(normalize_host("[::1]"), "[::1]");
-        assert_eq!(normalize_host("[::1]:443"), "[::1]");
+        // IPv6 loopback [::1] normalizes to localhost (same community).
+        assert_eq!(normalize_host("[::1]"), "localhost");
+        assert_eq!(normalize_host("[::1]:443"), "localhost");
     }
 
     #[test]
@@ -261,9 +272,8 @@ mod tests {
 
     #[test]
     fn relay_url_authority_preserves_ipv6_brackets() {
-        // `host_str()` strips IPv6 brackets and the port; `relay_url_authority`
-        // must keep both so the authority matches `communities.host`.
-        assert_eq!(relay_url_authority("ws://[::1]:3000"), "[::1]:3000");
+        // IPv6 loopback normalizes to localhost (same community).
+        assert_eq!(relay_url_authority("ws://[::1]:3000"), "localhost:3000");
     }
 
     #[test]

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -361,6 +361,23 @@ fn openai_compatible_models_url_for_discovery(env: &BTreeMap<String, String>) ->
     format!("{}/models", base_url.trim_end_matches('/'))
 }
 
+fn deepseek_models_url_for_discovery(env: &BTreeMap<String, String>) -> String {
+    let base_url = env_or_process_value(env, "DEEPSEEK_BASE_URL")
+        .or_else(|| env_or_process_value(env, "OPENAI_COMPAT_BASE_URL"))
+        .unwrap_or_else(|| "https://api.deepseek.com/v1".to_string());
+    format!("{}/models", base_url.trim_end_matches('/'))
+}
+
+fn is_deepseek_provider(provider: Option<&str>) -> bool {
+    matches!(
+        provider
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("deepseek")
+    )
+}
+
 fn is_agent_text_model_id(id: &str) -> bool {
     let lower = id.to_ascii_lowercase();
     if [
@@ -485,44 +502,65 @@ async fn discover_openai_compatible_models(
 ) -> Result<Option<AgentModelsResponse>, String> {
     let relay_mesh =
         provider.as_deref().map(str::trim) == Some(crate::managed_agents::RELAY_MESH_PROVIDER_ID);
-    if !relay_mesh && !is_openai_compatible_provider(provider.as_deref()) {
+    if !relay_mesh
+        && !is_openai_compatible_provider(provider.as_deref())
+        && !is_deepseek_provider(provider.as_deref())
+    {
         return Ok(None);
     }
 
+    let deepseek = is_deepseek_provider(provider.as_deref());
     let api_key = if relay_mesh {
         crate::managed_agents::RELAY_MESH_API_KEY_PLACEHOLDER.to_string()
+    } else if deepseek {
+        match provider.required_env(env, "DEEPSEEK_API_KEY")? {
+            Some(api_key) => api_key,
+            None => return Ok(None),
+        }
     } else {
         match provider.required_env(env, "OPENAI_COMPAT_API_KEY")? {
             Some(api_key) => api_key,
             None => return Ok(None),
         }
     };
-    let redaction_env = redaction_env_with_value(env, "OPENAI_COMPAT_API_KEY", &api_key);
+    let redaction_key = if deepseek {
+        "DEEPSEEK_API_KEY"
+    } else {
+        "OPENAI_COMPAT_API_KEY"
+    };
+    let redaction_env = redaction_env_with_value(env, redaction_key, &api_key);
     let url = if relay_mesh {
         format!("{}/models", crate::managed_agents::RELAY_MESH_API_BASE_URL)
+    } else if deepseek {
+        deepseek_models_url_for_discovery(env)
     } else {
         openai_compatible_models_url_for_discovery(env)
     };
+    let host_label = if deepseek { "DeepSeek" } else { "OpenAI" };
     let response = client
         .get(&url)
         .bearer_auth(&api_key)
         .send()
         .await
-        .map_err(|error| format!("OpenAI model discovery request failed: {error}"))?;
+        .map_err(|error| format!("{host_label} model discovery request failed: {error}"))?;
     let status = response.status();
     if !status.is_success() {
         let body = response.text().await.unwrap_or_default();
         let body = crate::managed_agents::redact_env_values_in(&body, &redaction_env);
-        return Err(format!("OpenAI model discovery HTTP {status}: {body}"));
+        return Err(format!("{host_label} model discovery HTTP {status}: {body}"));
     }
 
     let response = response
         .json::<OpenAiModelListResponse>()
         .await
-        .map_err(|error| format!("OpenAI model discovery response parse failed: {error}"))?;
+        .map_err(|error| {
+            format!("{host_label} model discovery response parse failed: {error}")
+        })?;
     let models = normalize_openai_compatible_models(response, provider.as_deref());
     if models.is_empty() {
-        return Err("OpenAI model discovery returned no compatible text models".to_string());
+        return Err(format!(
+            "{host_label} model discovery returned no compatible text models"
+        ));
     }
 
     Ok(Some(AgentModelsResponse {

--- a/desktop/src-tauri/src/commands/agent_models.rs
+++ b/desktop/src-tauri/src/commands/agent_models.rs
@@ -378,6 +378,23 @@ fn is_deepseek_provider(provider: Option<&str>) -> bool {
     )
 }
 
+fn is_groq_provider(provider: Option<&str>) -> bool {
+    matches!(
+        provider
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("groq")
+    )
+}
+
+fn groq_models_url_for_discovery(env: &BTreeMap<String, String>) -> String {
+    let base_url = env_or_process_value(env, "GROQ_BASE_URL")
+        .or_else(|| env_or_process_value(env, "OPENAI_COMPAT_BASE_URL"))
+        .unwrap_or_else(|| "https://api.groq.com/openai/v1".to_string());
+    format!("{}/models", base_url.trim_end_matches('/'))
+}
+
 fn is_agent_text_model_id(id: &str) -> bool {
     let lower = id.to_ascii_lowercase();
     if [
@@ -505,15 +522,22 @@ async fn discover_openai_compatible_models(
     if !relay_mesh
         && !is_openai_compatible_provider(provider.as_deref())
         && !is_deepseek_provider(provider.as_deref())
+        && !is_groq_provider(provider.as_deref())
     {
         return Ok(None);
     }
 
     let deepseek = is_deepseek_provider(provider.as_deref());
+    let groq = is_groq_provider(provider.as_deref());
     let api_key = if relay_mesh {
         crate::managed_agents::RELAY_MESH_API_KEY_PLACEHOLDER.to_string()
     } else if deepseek {
         match provider.required_env(env, "DEEPSEEK_API_KEY")? {
+            Some(api_key) => api_key,
+            None => return Ok(None),
+        }
+    } else if groq {
+        match provider.required_env(env, "GROQ_API_KEY")? {
             Some(api_key) => api_key,
             None => return Ok(None),
         }
@@ -525,6 +549,8 @@ async fn discover_openai_compatible_models(
     };
     let redaction_key = if deepseek {
         "DEEPSEEK_API_KEY"
+    } else if groq {
+        "GROQ_API_KEY"
     } else {
         "OPENAI_COMPAT_API_KEY"
     };
@@ -533,10 +559,18 @@ async fn discover_openai_compatible_models(
         format!("{}/models", crate::managed_agents::RELAY_MESH_API_BASE_URL)
     } else if deepseek {
         deepseek_models_url_for_discovery(env)
+    } else if groq {
+        groq_models_url_for_discovery(env)
     } else {
         openai_compatible_models_url_for_discovery(env)
     };
-    let host_label = if deepseek { "DeepSeek" } else { "OpenAI" };
+    let host_label = if deepseek {
+        "DeepSeek"
+    } else if groq {
+        "Groq"
+    } else {
+        "OpenAI"
+    };
     let response = client
         .get(&url)
         .bearer_auth(&api_key)

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -482,6 +482,7 @@ fn buzz_agent_requirements(effective: &EffectiveAgentEnv) -> Vec<Requirement> {
         Some("anthropic") => Some("ANTHROPIC_MODEL"),
         Some("openai") | Some("openai-compat") => Some("OPENAI_COMPAT_MODEL"),
         Some("openrouter") => Some("OPENROUTER_MODEL"),
+        Some("deepseek") => Some("DEEPSEEK_MODEL"),
         _ => None,
     };
     let model_present = effective
@@ -528,6 +529,12 @@ fn buzz_agent_requirements(effective: &EffectiveAgentEnv) -> Vec<Requirement> {
             if env_key_missing("OPENROUTER_API_KEY") => {
                 missing.push(Requirement::EnvKey {
                     key: "OPENROUTER_API_KEY".to_string(),
+                });
+            }
+        Some("deepseek")
+            if env_key_missing("DEEPSEEK_API_KEY") => {
+                missing.push(Requirement::EnvKey {
+                    key: "DEEPSEEK_API_KEY".to_string(),
                 });
             }
         _ => {
@@ -642,6 +649,13 @@ fn goose_requirements(
         {
             missing.push(Requirement::EnvKey {
                 key: "OPENROUTER_API_KEY".to_string(),
+            });
+        }
+        Some("deepseek")
+            if env_key_missing("DEEPSEEK_API_KEY") && !file_key_present("DEEPSEEK_API_KEY") =>
+        {
+            missing.push(Requirement::EnvKey {
+                key: "DEEPSEEK_API_KEY".to_string(),
             });
         }
         _ => {}
@@ -1732,6 +1746,58 @@ mod tests {
         assert!(
             result.is_ready(),
             "OPENROUTER_MODEL fallback should satisfy model requirement"
+        );
+    }
+
+    // ── DeepSeek readiness ───────────────────────────────────────────────
+
+    #[test]
+    fn buzz_agent_deepseek_with_all_fields_is_ready() {
+        let env = make_env(
+            "buzz-agent",
+            env_with(&[
+                ("BUZZ_AGENT_PROVIDER", "deepseek"),
+                ("BUZZ_AGENT_MODEL", "deepseek-chat"),
+                ("DEEPSEEK_API_KEY", "sk-ds-test-key"),
+            ]),
+        );
+        let result = agent_readiness(&env);
+        assert!(
+            result.is_ready(),
+            "deepseek with all fields should be ready"
+        );
+    }
+
+    #[test]
+    fn buzz_agent_deepseek_missing_key_returns_not_ready() {
+        let env = make_env(
+            "buzz-agent",
+            env_with(&[
+                ("BUZZ_AGENT_PROVIDER", "deepseek"),
+                ("BUZZ_AGENT_MODEL", "deepseek-chat"),
+            ]),
+        );
+        let result = agent_readiness(&env);
+        assert!(!result.is_ready());
+        assert!(result.requirements().contains(&Requirement::EnvKey {
+            key: "DEEPSEEK_API_KEY".to_string()
+        }));
+    }
+
+    #[test]
+    fn buzz_agent_deepseek_with_provider_model_fallback_is_ready() {
+        let env = make_env(
+            "buzz-agent",
+            env_with(&[
+                ("BUZZ_AGENT_PROVIDER", "deepseek"),
+                ("DEEPSEEK_MODEL", "deepseek-reasoner"),
+                ("DEEPSEEK_API_KEY", "sk-ds-test-key"),
+            ]),
+        );
+        let result = agent_readiness(&env);
+        assert!(
+            result.is_ready(),
+            "DEEPSEEK_MODEL fallback should satisfy model requirement"
         );
     }
 }

--- a/desktop/src-tauri/src/managed_agents/readiness.rs
+++ b/desktop/src-tauri/src/managed_agents/readiness.rs
@@ -483,6 +483,7 @@ fn buzz_agent_requirements(effective: &EffectiveAgentEnv) -> Vec<Requirement> {
         Some("openai") | Some("openai-compat") => Some("OPENAI_COMPAT_MODEL"),
         Some("openrouter") => Some("OPENROUTER_MODEL"),
         Some("deepseek") => Some("DEEPSEEK_MODEL"),
+        Some("groq") => Some("GROQ_MODEL"),
         _ => None,
     };
     let model_present = effective
@@ -535,6 +536,12 @@ fn buzz_agent_requirements(effective: &EffectiveAgentEnv) -> Vec<Requirement> {
             if env_key_missing("DEEPSEEK_API_KEY") => {
                 missing.push(Requirement::EnvKey {
                     key: "DEEPSEEK_API_KEY".to_string(),
+                });
+            }
+        Some("groq")
+            if env_key_missing("GROQ_API_KEY") => {
+                missing.push(Requirement::EnvKey {
+                    key: "GROQ_API_KEY".to_string(),
                 });
             }
         _ => {
@@ -656,6 +663,13 @@ fn goose_requirements(
         {
             missing.push(Requirement::EnvKey {
                 key: "DEEPSEEK_API_KEY".to_string(),
+            });
+        }
+        Some("groq")
+            if env_key_missing("GROQ_API_KEY") && !file_key_present("GROQ_API_KEY") =>
+        {
+            missing.push(Requirement::EnvKey {
+                key: "GROQ_API_KEY".to_string(),
             });
         }
         _ => {}

--- a/desktop/src/features/agents/ui/agentConfigOptions.tsx
+++ b/desktop/src/features/agents/ui/agentConfigOptions.tsx
@@ -40,6 +40,7 @@ const KNOWN_LLM_PROVIDER_IDS = [
   "anthropic",
   "databricks",
   "databricks_v2",
+  "deepseek",
   "openai",
   "openai-compat",
   "openrouter",
@@ -114,6 +115,10 @@ const PROVIDER_CREDENTIAL_CONFIG: Partial<
     requiredEnvKeys: ["OPENROUTER_API_KEY"],
     secretEnvVar: "OPENROUTER_API_KEY",
   },
+  deepseek: {
+    requiredEnvKeys: ["DEEPSEEK_API_KEY"],
+    secretEnvVar: "DEEPSEEK_API_KEY",
+  },
 };
 
 const DEFAULT_MODEL_OPTION: PersonaModelOption = {
@@ -125,6 +130,7 @@ export const PERSONA_LLM_PROVIDER_OPTIONS: readonly PersonaModelOption[] = [
   { id: "anthropic", label: "Anthropic" },
   { id: "openai", label: "OpenAI" },
   { id: "openai-compat", label: "OpenAI-compatible" },
+  { id: "deepseek", label: "DeepSeek" },
   { id: "openrouter", label: "OpenRouter" },
   { id: "relay-mesh", label: "Buzz shared compute" },
   { id: "databricks", label: "Databricks" },
@@ -286,7 +292,8 @@ export function providerRequiresExplicitModel(
     trimmedProvider === "anthropic" ||
     trimmedProvider === "openai" ||
     trimmedProvider === "openai-compat" ||
-    trimmedProvider === "openrouter"
+    trimmedProvider === "openrouter" ||
+    trimmedProvider === "deepseek"
   );
 }
 

--- a/desktop/src/features/agents/ui/agentConfigOptions.tsx
+++ b/desktop/src/features/agents/ui/agentConfigOptions.tsx
@@ -41,6 +41,7 @@ const KNOWN_LLM_PROVIDER_IDS = [
   "databricks",
   "databricks_v2",
   "deepseek",
+  "groq",
   "openai",
   "openai-compat",
   "openrouter",
@@ -119,6 +120,10 @@ const PROVIDER_CREDENTIAL_CONFIG: Partial<
     requiredEnvKeys: ["DEEPSEEK_API_KEY"],
     secretEnvVar: "DEEPSEEK_API_KEY",
   },
+  groq: {
+    requiredEnvKeys: ["GROQ_API_KEY"],
+    secretEnvVar: "GROQ_API_KEY",
+  },
 };
 
 const DEFAULT_MODEL_OPTION: PersonaModelOption = {
@@ -131,6 +136,7 @@ export const PERSONA_LLM_PROVIDER_OPTIONS: readonly PersonaModelOption[] = [
   { id: "openai", label: "OpenAI" },
   { id: "openai-compat", label: "OpenAI-compatible" },
   { id: "deepseek", label: "DeepSeek" },
+  { id: "groq", label: "Groq" },
   { id: "openrouter", label: "OpenRouter" },
   { id: "relay-mesh", label: "Buzz shared compute" },
   { id: "databricks", label: "Databricks" },
@@ -293,7 +299,8 @@ export function providerRequiresExplicitModel(
     trimmedProvider === "openai" ||
     trimmedProvider === "openai-compat" ||
     trimmedProvider === "openrouter" ||
-    trimmedProvider === "deepseek"
+    trimmedProvider === "deepseek" ||
+    trimmedProvider === "groq"
   );
 }
 

--- a/desktop/src/features/agents/ui/bakedEnvHelpers.ts
+++ b/desktop/src/features/agents/ui/bakedEnvHelpers.ts
@@ -73,6 +73,8 @@ function providerModelEnvKey(provider: string): string | null {
       return "OPENROUTER_MODEL";
     case "deepseek":
       return "DEEPSEEK_MODEL";
+    case "groq":
+      return "GROQ_MODEL";
     default:
       return null;
   }

--- a/desktop/src/features/agents/ui/bakedEnvHelpers.ts
+++ b/desktop/src/features/agents/ui/bakedEnvHelpers.ts
@@ -69,6 +69,10 @@ function providerModelEnvKey(provider: string): string | null {
     case "openai":
     case "openai-compat":
       return "OPENAI_COMPAT_MODEL";
+    case "openrouter":
+      return "OPENROUTER_MODEL";
+    case "deepseek":
+      return "DEEPSEEK_MODEL";
     default:
       return null;
   }

--- a/desktop/src/features/agents/ui/buzzAgentConfig.ts
+++ b/desktop/src/features/agents/ui/buzzAgentConfig.ts
@@ -135,6 +135,9 @@ export function getProviderEffortConfig(
     // Chat Completions + reasoning_content; expose full effort ladder like openrouter.
     return { validValues: ALL_VALUES, defaultValue: "medium" };
   }
+  if (provider === "groq") {
+    return { validValues: ALL_VALUES, defaultValue: "medium" };
+  }
   // openai-compat, unknown, empty — all values, default medium.
   return { validValues: ALL_VALUES, defaultValue: "medium" };
 }

--- a/desktop/src/features/agents/ui/buzzAgentConfig.ts
+++ b/desktop/src/features/agents/ui/buzzAgentConfig.ts
@@ -131,6 +131,10 @@ export function getProviderEffortConfig(
   if (provider === "openrouter") {
     return { validValues: ALL_VALUES, defaultValue: "medium" };
   }
+  if (provider === "deepseek") {
+    // Chat Completions + reasoning_content; expose full effort ladder like openrouter.
+    return { validValues: ALL_VALUES, defaultValue: "medium" };
+  }
   // openai-compat, unknown, empty — all values, default medium.
   return { validValues: ALL_VALUES, defaultValue: "medium" };
 }

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
@@ -25,6 +25,10 @@ function providerObjectLabel(provider: string): string {
       return "OpenAI";
     case "openai-compat":
       return "OpenAI-compatible";
+    case "deepseek":
+      return "DeepSeek";
+    case "openrouter":
+      return "OpenRouter";
     default:
       return provider.trim() || "this provider";
   }

--- a/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
+++ b/desktop/src/features/agents/ui/personaModelDiscoveryStatus.ts
@@ -27,6 +27,8 @@ function providerObjectLabel(provider: string): string {
       return "OpenAI-compatible";
     case "deepseek":
       return "DeepSeek";
+    case "groq":
+      return "Groq";
     case "openrouter":
       return "OpenRouter";
     default:


### PR DESCRIPTION
## Summary
- First-class **DeepSeek** provider (agent + Desktop readiness, discovery, persona UI)
- First-class **Groq** provider (same cookie-cutter as DeepSeek)
- DeepSeek `/models` catalog discovery for session pickers
- Desktop baked-env / readiness / model discovery wiring
- Remove deprecated `--turn-timeout` from buzz-acp
- Loopback host normalize (`127.0.0.1`/`::1` → `localhost`) for local WS/NIP-98
- Clearer NIP-98 URL mismatch diagnostics

## Test plan
- [x] `cargo test -p buzz-agent --lib resolve_provider` (11 passed, after rebase)
- [x] `cargo test -p buzz-core --lib normalize_host` (4 passed)
- [ ] Desktop: pick DeepSeek/Groq persona, readiness shows missing key until set
- [ ] Local relay: WS connect with 127.0.0.1 resolves community as localhost

No secrets in commits. Does not include local `.env` / agent keys / logs.