### PR TITLE
fix(mobile): restore accurate agent presence

### DIFF
--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -398,6 +398,7 @@ class ChannelDetailPage extends HookConsumerWidget {
                         channelId: channel.id,
                         content: content,
                         mentionPubkeys: mentionPubkeys,
+                        isDm: resolvedChannel.isDm,
                         mediaTags: mediaTags,
                       ),
             )

--- a/mobile/lib/features/channels/send_message_provider.dart
+++ b/mobile/lib/features/channels/send_message_provider.dart
@@ -45,16 +45,30 @@ class SendMessage {
     String? parentEventId,
     String? rootEventId,
     List<String>? mentionPubkeys,
+    bool isDm = false,
     List<List<String>> mediaTags = const [],
   }) async {
     // Use explicitly passed pubkeys, or resolve @mentions against
     // channel members to avoid matching the wrong user.
-    final resolvedMentions =
-        mentionPubkeys ?? await _resolveMentions(content, channelId);
+    final resolvedMentions = <String>[
+      ...?mentionPubkeys,
+      if (mentionPubkeys == null) ...await _resolveMentions(content, channelId),
+    ];
+    if (isDm) {
+      try {
+        resolvedMentions.addAll(
+          (await _fetchMembers(channelId)).map((member) => member.pubkey),
+        );
+      } catch (_) {
+        // The server still resolves canonical owner DMs by membership. Keep
+        // sending if a transient member lookup fails.
+      }
+    }
     final authorPubkey = _signedEventRelay.pubkey;
 
     // Normalize mentions: lowercase, deduplicate, exclude self (matching
-    // the desktop's normalizeMentionPubkeys).
+    // the desktop's normalizeMentionPubkeys). DMs tag every other participant
+    // so agent runtimes can address a root message without visible @text.
     final selfLower = authorPubkey?.toLowerCase();
     final seenMentions = <String>{?selfLower};
     final normalizedMentions = <String>[

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -75,6 +75,12 @@ class ThreadDetailPage extends HookConsumerWidget {
     final liveChannelEvents =
         ref.watch(channelMessagesProvider(channelId)).value ??
         const <NostrEvent>[];
+    final isDmChannel =
+        ref
+            .watch(channelsProvider)
+            .value
+            ?.any((channel) => channel.id == channelId && channel.isDm) ??
+        false;
     final replyMessages = repliesState.whenData((events) {
       return formatTimeline(
         mergeThreadEvents(events, liveChannelEvents),
@@ -409,6 +415,7 @@ class ThreadDetailPage extends HookConsumerWidget {
                         mentionPubkeys: mentionPubkeys,
                         parentEventId: threadHead.id,
                         rootEventId: effectiveRootId,
+                        isDm: isDmChannel,
                         mediaTags: mediaTags,
                       ),
             ),

--- a/mobile/lib/features/profile/presence_cache_provider.dart
+++ b/mobile/lib/features/profile/presence_cache_provider.dart
@@ -8,11 +8,17 @@ import '../../shared/relay/relay.dart';
 /// In-memory cache of other users' presence.
 ///
 /// Subscribes to kind:20001 presence events over the relay WebSocket for
-/// real-time updates. There is no longer a REST backstop — agents that
-/// publish presence purely over WS are fine, and TTL expiry will be handled
-/// by the relay-side `presence:true` filter extension when that lands.
+/// real-time updates and queries the relay's Redis-backed presence snapshot
+/// when a pubkey is first tracked. The snapshot closes the race where a newly
+/// paired mobile client otherwise shows everyone offline until the next live
+/// heartbeat.
 class PresenceCacheNotifier extends Notifier<Map<String, String>> {
+  static const _refreshInterval = Duration(seconds: 120);
+
   final Set<String> _tracked = {};
+  final Set<String> _pending = {};
+  Timer? _batchTimer;
+  Timer? _refreshTimer;
   void Function()? _presenceUnsub;
   int _subscriptionVersion = 0;
 
@@ -21,6 +27,10 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
     final sessionState = ref.watch(relaySessionProvider);
 
     ref.onDispose(() {
+      _batchTimer?.cancel();
+      _batchTimer = null;
+      _refreshTimer?.cancel();
+      _refreshTimer = null;
       _presenceUnsub?.call();
       _presenceUnsub = null;
     });
@@ -34,15 +44,22 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
 
   /// Track presence for [pubkeys].
   ///
-  /// Currently a no-op for the actual fetch — we rely on live kind:20001
-  /// events. The tracked set is still used to filter incoming events so the
-  /// cache doesn't grow unbounded.
+  /// Newly tracked pubkeys are fetched in a short batch while all tracked
+  /// pubkeys continue receiving live updates.
   void track(List<String> pubkeys) {
     final normalized = pubkeys.map((pk) => pk.toLowerCase()).toList();
+    final uncached = normalized
+        .where((pk) => !state.containsKey(pk) && !_pending.contains(pk))
+        .toList();
     _tracked.addAll(normalized);
-    // TODO(presence): once the relay supports a `presence:true` filter
-    // extension, issue a one-shot fetch here for the latest known state per
-    // pubkey. Until then, presence is "online whenever they publish".
+    _ensureRefreshTimer();
+    if (uncached.isEmpty) return;
+    _pending.addAll(uncached);
+    _batchTimer ??= Timer(const Duration(milliseconds: 50), _flushPending);
+  }
+
+  void _ensureRefreshTimer() {
+    _refreshTimer ??= Timer.periodic(_refreshInterval, (_) => _refreshAll());
   }
 
   /// Subscribe to kind:20001 presence events over WebSocket.
@@ -74,13 +91,58 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
 
   void _handlePresenceEvent(NostrEvent event) {
     final pubkey = event.pubkey.toLowerCase();
+    _applyPresence(pubkey, event.content);
+  }
+
+  void _applyPresence(String pubkey, String status) {
     if (!_tracked.contains(pubkey)) return;
-    final status = event.content;
     if (status != 'online' && status != 'away' && status != 'offline') return;
     if (state[pubkey] == status) return;
     final updated = Map<String, String>.from(state);
     updated[pubkey] = status;
     state = updated;
+  }
+
+  Future<void> _refreshAll() async {
+    if (_tracked.isEmpty) return;
+    await _fetchPresence(_tracked.toList());
+  }
+
+  Future<void> _flushPending() async {
+    _batchTimer = null;
+    if (_pending.isEmpty) return;
+    final pubkeys = _pending.toList();
+    _pending.clear();
+    await _fetchPresence(pubkeys);
+  }
+
+  Future<void> _fetchPresence(List<String> pubkeys) async {
+    try {
+      final events = await ref.read(relaySessionProvider.notifier).queryRelay([
+        NostrFilter(
+          kinds: const [EventKind.presenceUpdate],
+          authors: pubkeys,
+          limit: pubkeys.length,
+        ),
+      ]);
+      final statuses = <String, String>{
+        for (final pk in pubkeys) pk: 'offline',
+      };
+      for (final event in events) {
+        // Snapshot events are relay-signed and name the actual subject in p.
+        final subject = event.getTagValue('p')?.toLowerCase();
+        if (subject == null || !pubkeys.contains(subject)) continue;
+        if (event.content == 'online' ||
+            event.content == 'away' ||
+            event.content == 'offline') {
+          statuses[subject] = event.content;
+        }
+      }
+      final updated = Map<String, String>.from(state)..addAll(statuses);
+      state = updated;
+    } catch (error) {
+      debugPrint('[PresenceCacheNotifier] presence snapshot failed: $error');
+    }
   }
 }
 

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr/nostr.dart' as nostr;
 import 'package:buzz/features/channels/send_message_provider.dart';
+import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
 void main() {
@@ -65,6 +66,115 @@ void main() {
     await expectLater(result, throwsException);
     expect(completedIds, isEmpty);
     expect(removedIds, [localMessages.single.id]);
+  });
+
+  test(
+    'tags every other DM participant without visible mention text',
+    () async {
+      final session = _PendingPublishRelaySession();
+      final author = nostr.Keys.generate();
+      final recipient = nostr.Keys.generate().public;
+      final send = SendMessage(
+        signedEventRelay: SignedEventRelay(session: session, nsec: author.nsec),
+        fetchMembers: (_) async => [
+          ChannelMember(
+            pubkey: author.public,
+            role: 'member',
+            joinedAt: DateTime.utc(2026),
+          ),
+          ChannelMember(
+            pubkey: recipient,
+            role: 'member',
+            joinedAt: DateTime.utc(2026),
+          ),
+        ],
+        readUserCache: () => const {},
+        addLocalMessage: (_, __) {},
+        completeLocalMessage: (_, __) {},
+        removeLocalMessage: (_, __) {},
+      );
+
+      final result = send(channelId: _channelId, content: 'hi', isDm: true);
+      await session.published;
+
+      expect(
+        session.event.tags.any(
+          (tag) => tag.length >= 2 && tag[0] == 'p' && tag[1] == recipient,
+        ),
+        isTrue,
+      );
+      expect(
+        session.event.tags.any(
+          (tag) => tag.length >= 2 && tag[0] == 'p' && tag[1] == author.public,
+        ),
+        isFalse,
+      );
+      session.accept();
+      await result;
+    },
+  );
+
+  test('keeps the DM recipient tag on thread replies', () async {
+    final session = _PendingPublishRelaySession();
+    final author = nostr.Keys.generate();
+    final recipient = nostr.Keys.generate().public;
+    final send = SendMessage(
+      signedEventRelay: SignedEventRelay(session: session, nsec: author.nsec),
+      fetchMembers: (_) async => [
+        ChannelMember(
+          pubkey: author.public,
+          role: 'member',
+          joinedAt: DateTime.utc(2026),
+        ),
+        ChannelMember(
+          pubkey: recipient,
+          role: 'bot',
+          joinedAt: DateTime.utc(2026),
+        ),
+      ],
+      readUserCache: () => const {},
+      addLocalMessage: (_, __) {},
+      completeLocalMessage: (_, __) {},
+      removeLocalMessage: (_, __) {},
+    );
+
+    final result = send(
+      channelId: _channelId,
+      content: 'and in this thread?',
+      parentEventId: 'parent-event-id',
+      rootEventId: 'root-event-id',
+      isDm: true,
+    );
+    await session.published;
+
+    expect(
+      session.event.tags.any(
+        (tag) => tag.length >= 2 && tag[0] == 'p' && tag[1] == recipient,
+      ),
+      isTrue,
+    );
+    expect(
+      session.event.tags.any(
+        (tag) =>
+            tag.length >= 4 &&
+            tag[0] == 'e' &&
+            tag[1] == 'root-event-id' &&
+            tag[3] == 'root',
+      ),
+      isTrue,
+    );
+    expect(
+      session.event.tags.any(
+        (tag) =>
+            tag.length >= 4 &&
+            tag[0] == 'e' &&
+            tag[1] == 'parent-event-id' &&
+            tag[3] == 'reply',
+      ),
+      isTrue,
+    );
+    session.accept();
+    await result;
   });
 }
 

--- a/mobile/test/features/profile/presence_cache_provider_test.dart
+++ b/mobile/test/features/profile/presence_cache_provider_test.dart
@@ -4,14 +4,44 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:buzz/features/profile/presence_cache_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
-/// Tests for [PresenceCacheNotifier] in the pure-Nostr world.
-///
-/// The cache is now purely WS-driven: the notifier subscribes to kind:20001
-/// (presence updates) over the relay session and only mutates state for
-/// pubkeys that have been registered via [PresenceCacheNotifier.track].
-/// There is no longer a REST backstop — the previous test seeded state via
-/// a `GET /api/presence` call which has been removed.
+/// Tests for the live and Redis-backed snapshot presence paths.
 void main() {
+  test(
+    'initial snapshot prevents a tracked online agent appearing offline',
+    () async {
+      final relaySession = _RecordingRelaySessionNotifier()
+        ..queryResults = [_snapshotPresence('alice', 'online')];
+      final container = _buildContainer(relaySession: relaySession);
+      addTearDown(container.dispose);
+
+      container.read(presenceCacheProvider);
+      container.read(presenceCacheProvider.notifier).track(['Alice']);
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+
+      expect(container.read(presenceCacheProvider)['alice'], 'online');
+      expect(relaySession.queryFilters, hasLength(1));
+      expect(relaySession.queryFilters.single.authors, ['alice']);
+      expect(relaySession.queryFilters.single.kinds, [
+        EventKind.presenceUpdate,
+      ]);
+    },
+  );
+
+  test(
+    'missing snapshot entry initializes the tracked agent offline',
+    () async {
+      final relaySession = _RecordingRelaySessionNotifier();
+      final container = _buildContainer(relaySession: relaySession);
+      addTearDown(container.dispose);
+
+      container.read(presenceCacheProvider);
+      container.read(presenceCacheProvider.notifier).track(['alice']);
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+
+      expect(container.read(presenceCacheProvider)['alice'], 'offline');
+    },
+  );
+
   test('WS presence event updates cache for tracked pubkey', () async {
     final relaySession = _RecordingRelaySessionNotifier();
     final container = _buildContainer(relaySession: relaySession);
@@ -143,6 +173,18 @@ NostrEvent _presence(String pubkey, String status) => NostrEvent(
   sig: 'sig',
 );
 
+NostrEvent _snapshotPresence(String subjectPubkey, String status) => NostrEvent(
+  id: 'snapshot-$subjectPubkey-$status',
+  pubkey: 'relay',
+  createdAt: 1000,
+  kind: EventKind.presenceUpdate,
+  tags: [
+    ['p', subjectPubkey],
+  ],
+  content: status,
+  sig: 'sig',
+);
+
 Future<void> _pumpEventQueue() async {
   await Future<void>.delayed(Duration.zero);
   await Future<void>.delayed(Duration.zero);
@@ -161,7 +203,9 @@ ProviderContainer _buildContainer({
 
 class _RecordingRelaySessionNotifier extends RelaySessionNotifier {
   final List<NostrFilter> filters = [];
+  final List<NostrFilter> queryFilters = [];
   final List<void Function(NostrEvent)> _listeners = [];
+  List<NostrEvent> queryResults = [];
 
   @override
   SessionState build() => const SessionState(status: SessionStatus.connected);
@@ -178,6 +222,15 @@ class _RecordingRelaySessionNotifier extends RelaySessionNotifier {
       filters.remove(filter);
       _listeners.remove(onEvent);
     };
+  }
+
+  @override
+  Future<List<NostrEvent>> queryRelay(
+    List<NostrFilter> filters, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    queryFilters.addAll(filters);
+    return queryResults;
   }
 
   /// Emit an event synchronously to all live subscribers.


### PR DESCRIPTION
## Summary
- query the relay-backed presence snapshot when DM identities are first tracked
- keep live WebSocket heartbeats and a bounded periodic TTL refresh
- tag every other DM participant so root messages address cloud agents without visible mention text

## Test Plan
- [x] `flutter test test/features/channels/send_message_provider_test.dart test/features/profile/presence_cache_provider_test.dart`
- [x] 11 focused tests passed
- [x] current online agents do not initialize as offline
- [x] root DM events tag the recipient and exclude the sender