### PR TITLE
fix: extend WebKit dmabuf workaround to COSMIC Wayland sessions

### DIFF
--- a/desktop/src-tauri/src/webkit_rendering.rs
+++ b/desktop/src-tauri/src/webkit_rendering.rs
@@ -140,6 +140,7 @@ fn plan(
     let signals = [
         (nvidia_gpu(drm_root), "NVIDIA GPU"),
         (env("APPIMAGE").is_some(), "AppImage"),
+        (cosmic_desktop(env), "COSMIC desktop"),
     ];
     let hits: Vec<&str> = signals
         .iter()
@@ -148,7 +149,7 @@ fn plan(
 
     match hits.is_empty() {
         true => Plan::Leave {
-            why: "no NVIDIA GPU and not an AppImage".to_string(),
+            why: "no NVIDIA GPU, AppImage, or COSMIC desktop".to_string(),
         },
         false => Plan::Apply {
             vars: &HEURISTIC,
@@ -187,6 +188,26 @@ fn nvidia_gpu(drm_root: &Path) -> bool {
         std::fs::read_to_string(entry.path().join("device/vendor"))
             .is_ok_and(|vendor| vendor.trim().eq_ignore_ascii_case(NVIDIA_PCI_VENDOR))
     })
+}
+
+/// Whether the session is running System76's COSMIC DE under Wayland.
+///
+/// Pop!_OS COSMIC ships Wayland by default and its compositor is the second
+/// reproducible freeze report (#4305) after NVIDIA/AppImage — same dmabuf
+/// desync, same symptoms (frozen UI, frame rendered but never handed off to
+/// the compositor, min/max forces a one-frame redraw). Detection goes through
+/// `XDG_CURRENT_DESKTOP`, the standard freedesktop probe, which COSMIC sets
+/// to `COSMIC`. Multi-value sessions (`Hyprland:COSMIC`) deliberately match
+/// too: the workaround is the kind one such session can inherit, not a
+/// judgment about which DE owns what.
+fn cosmic_desktop(env: EnvLookup<'_>) -> bool {
+    let Some(desktop) = env("XDG_CURRENT_DESKTOP") else {
+        return false;
+    };
+    desktop
+        .to_string_lossy()
+        .split(':')
+        .any(|entry| entry.trim().eq_ignore_ascii_case("cosmic"))
 }
 
 /// The diagnostic for `--safe-rendering` against a user-set owned variable.

--- a/desktop/src-tauri/src/webkit_rendering/tests.rs
+++ b/desktop/src-tauri/src/webkit_rendering/tests.rs
@@ -99,6 +99,57 @@ fn test_an_appimage_launch_disables_the_dmabuf_renderer() {
 }
 
 #[test]
+fn test_a_cosmic_wayland_session_disables_the_dmabuf_renderer() {
+    // #4305: Pop!_OS COSMIC ships Wayland by default and its compositor loses
+    // sync with the dmabuf renderer the same way NVIDIA's does — frozen UI,
+    // frames rendered but never handed off, min/max forces a one-frame
+    // redraw. `WEBKIT_DISABLE_DMABUF_RENDERER=1` is the reporter's verified
+    // workaround.
+    let drm = drm(&["0x8086"]);
+    let env = env_from(&[("XDG_CURRENT_DESKTOP", "COSMIC")]);
+    let plan = plan(NO_ARGS, &env, drm.path());
+
+    assert_eq!(
+        applied(&plan),
+        Some(&["WEBKIT_DISABLE_DMABUF_RENDERER"][..])
+    );
+    let Plan::Apply { why, .. } = &plan else {
+        unreachable!()
+    };
+    assert!(why.contains("COSMIC"), "{why}");
+}
+
+#[test]
+fn test_a_cosmic_entry_in_a_multi_desktop_value_still_counts() {
+    // Sessions composed by nested compositors or wrappers report a
+    // colon-separated list (`sway:COSMIC`, `Hyprland:COSMIC`). The workaround
+    // targets the dmabuf desync, not the DE itself, so any COSMIC entry is a
+    // hit.
+    let drm = drm(&["0x8086"]);
+    let env = env_from(&[("XDG_CURRENT_DESKTOP", "sway:COSMIC")]);
+
+    assert_eq!(
+        applied(&plan(NO_ARGS, &env, drm.path())),
+        Some(&["WEBKIT_DISABLE_DMABUF_RENDERER"][..])
+    );
+}
+
+#[test]
+fn test_a_non_cosmic_desktop_alone_changes_nothing() {
+    // KDE/GNOME do not exhibit the freeze — the workaround's real rendering
+    // cost means we apply it only where there is evidence of the desync.
+    let drm = drm(&["0x8086"]);
+
+    for desktop in ["KDE", "GNOME", "sway", "Hyprland"] {
+        let env = env_from(&[("XDG_CURRENT_DESKTOP", desktop)]);
+        assert!(
+            matches!(plan(NO_ARGS, &env, drm.path()), Plan::Leave { .. }),
+            "{desktop} must not trigger the workaround"
+        );
+    }
+}
+
+#[test]
 fn test_a_plain_non_nvidia_launch_changes_nothing() {
     let drm = drm(&["0x8086", "0x1002"]);
 


### PR DESCRIPTION
## Summary

Fixes #4305: Desktop UI freezes on Pop!_OS COSMIC (Wayland) — WebKitGTK's dmabuf hardware renderer loses synchronization with the COSMIC compositor.

## Root cause

Same failure class as the existing NVIDIA/AppImage workaround (#2338): frames are rendered by WebKit but never handed off to the compositor. Minimizing and restoring the window forces a single-frame redraw, which is the signature of a compositor-sync desync rather than an application deadlock.

## Fix

Extend the existing `webkit_rendering.rs` heuristic with a third signal: **`XDG_CURRENT_DESKTOP` contains `cosmic`** (case-insensitive).

- COSMIC is System76's Wayland compositor (default on Pop!_OS).
- Multi-value sessions (colon-separated, e.g. `sway:COSMIC`, `Hyprland:COSMIC`) deliberately match — the workaround targets the dmabuf desync, not the DE.
- The existing `EnvLookup` dependency injection keeps the decision pure and unit-testable.

## Tests

Three new regression tests:

1. **`test_a_cosmic_wayland_session_disables_the_dmabuf_renderer`** — bare `XDG_CURRENT_DESKTOP=COSMIC` triggers `WEBKIT_DISABLE_DMABUF_RENDERER=1`.
2. **`test_a_cosmic_entry_in_a_multi_desktop_value_still_counts`** — `sway:COSMIC` also triggers.
3. **`test_a_non_cosmic_desktop_alone_changes_nothing`** — `KDE`, `GNOME`, `sway`, `Hyprland` do NOT trigger (negative space).

All existing tests pass. Rust compiles clean (the module is `#[cfg(target_os = "linux")]`-gated in `lib.rs`, so it compiles only on Linux, which is correct).

Closes #4305.
