### PR TITLE
fix(desktop): resurrect projects after delete + same-id re-announce

### DIFF
--- a/desktop/src/features/projects/hooks.ts
+++ b/desktop/src/features/projects/hooks.ts
@@ -41,6 +41,7 @@ import type {
 import { summarizeProjectActivityEvents } from "./projectActivity.mjs";
 import { resolveProjectDefaultBranch } from "./lib/projectBranches";
 import { effectiveCloneUrls } from "./lib/projectCloneUrl";
+import { isProjectDeletedByAddress } from "./lib/projectDeletion";
 import type { ProjectIssue } from "./projectIssues.mjs";
 import { projectIssueEventsToIssues } from "./projectIssues.mjs";
 import type {
@@ -170,13 +171,18 @@ function isHiddenLocally(project: Project): boolean {
 }
 
 function isDeletedByA(project: Project, deletionEvents: RelayEvent[]): boolean {
-  const coordinate = projectCoordinate(project);
-  // NIP-09: a deletion is only valid when signed by the author of the
-  // referenced event — otherwise anyone could hide someone else's project.
-  return deletionEvents.some(
-    (event) =>
-      event.pubkey.toLowerCase() === project.owner.toLowerCase() &&
-      event.tags.some((tag) => tag[0] === "a" && tag[1] === coordinate),
+  // NIP-09: only the announcement author can tombstone the address, and only
+  // while the delete is at least as new as the current announcement. An older
+  // delete must not hide a later re-announce of the same d-tag (delete →
+  // recreate with the same name).
+  return isProjectDeletedByAddress(
+    KIND_REPO_ANNOUNCEMENT,
+    {
+      owner: project.owner,
+      dtag: project.dtag,
+      createdAt: project.createdAt,
+    },
+    deletionEvents,
   );
 }
 

--- a/desktop/src/features/projects/lib/projectDeletion.test.mjs
+++ b/desktop/src/features/projects/lib/projectDeletion.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  isProjectDeletedByAddress,
+  projectRepoAddress,
+} from "./projectDeletion.ts";
+
+const KIND = 30617;
+const OWNER = "a".repeat(64);
+const OTHER = "b".repeat(64);
+const DTAG = "bimblepath";
+const COORD = `${KIND}:${OWNER}:${DTAG}`;
+
+function project(createdAt) {
+  return { owner: OWNER, dtag: DTAG, createdAt };
+}
+
+function deletion({ pubkey = OWNER, createdAt, a = COORD }) {
+  return {
+    pubkey,
+    created_at: createdAt,
+    tags: [["a", a]],
+  };
+}
+
+test("projectRepoAddress builds 30617:owner:dtag", () => {
+  assert.equal(projectRepoAddress(KIND, { owner: OWNER, dtag: DTAG }), COORD);
+});
+
+test("no deletions → not deleted", () => {
+  assert.equal(isProjectDeletedByAddress(KIND, project(100), []), false);
+});
+
+test("owner delete at or after announcement hides the project", () => {
+  assert.equal(
+    isProjectDeletedByAddress(KIND, project(100), [
+      deletion({ createdAt: 100 }),
+    ]),
+    true,
+  );
+  assert.equal(
+    isProjectDeletedByAddress(KIND, project(100), [
+      deletion({ createdAt: 101 }),
+    ]),
+    true,
+  );
+});
+
+test("older owner delete does not hide a newer re-announce (resurrect)", () => {
+  // Real pyxe case: delete at T, re-create same d-tag at T+104.
+  assert.equal(
+    isProjectDeletedByAddress(KIND, project(204), [
+      deletion({ createdAt: 100 }),
+    ]),
+    false,
+  );
+});
+
+test("foreign pubkey delete cannot hide the project", () => {
+  assert.equal(
+    isProjectDeletedByAddress(KIND, project(100), [
+      deletion({ pubkey: OTHER, createdAt: 200 }),
+    ]),
+    false,
+  );
+});
+
+test("delete for a different address is ignored", () => {
+  assert.equal(
+    isProjectDeletedByAddress(KIND, project(100), [
+      deletion({
+        createdAt: 200,
+        a: `${KIND}:${OWNER}:other-repo`,
+      }),
+    ]),
+    false,
+  );
+});
+
+test("owner case is compared case-insensitively", () => {
+  assert.equal(
+    isProjectDeletedByAddress(
+      KIND,
+      { owner: OWNER.toUpperCase(), dtag: DTAG, createdAt: 100 },
+      [deletion({ pubkey: OWNER.toLowerCase(), createdAt: 100 })],
+    ),
+    true,
+  );
+});

--- a/desktop/src/features/projects/lib/projectDeletion.ts
+++ b/desktop/src/features/projects/lib/projectDeletion.ts
@@ -1,0 +1,55 @@
+/**
+ * NIP-09 address deletion for NIP-34 repo announcements (kind:30617).
+ *
+ * Desktop loads bare kind:5 history and filters projects client-side. A delete
+ * targets the replaceable address `30617:<owner>:<dtag>`. After the owner
+ * deletes and later re-announces the same d-tag, the new announcement must
+ * surface again — an older tombstone must not hide it forever.
+ */
+
+export type ProjectDeletionTarget = {
+  owner: string;
+  dtag: string;
+  /** Announcement `created_at` (unix seconds). */
+  createdAt: number;
+};
+
+export type ProjectDeletionEvent = {
+  pubkey: string;
+  created_at: number;
+  tags: string[][];
+};
+
+/** Canonical NIP-33/34 address for a repo announcement. */
+export function projectRepoAddress(
+  kind: number,
+  project: Pick<ProjectDeletionTarget, "owner" | "dtag">,
+): string {
+  // Owner pubkeys are hex; normalize so address matches are case-stable.
+  return `${kind}:${project.owner.toLowerCase()}:${project.dtag}`;
+}
+
+/**
+ * Returns true when an owner-signed kind:5 with `a` = the project coordinate
+ * is at least as new as the current announcement.
+ *
+ * - Foreign pubkeys cannot hide someone else's project.
+ * - A deletion older than the current announcement does not apply (resurrect
+ *   after delete + re-announce with the same d-tag).
+ * - Equal timestamps treat the deletion as winning (fail closed on same-second races).
+ */
+export function isProjectDeletedByAddress(
+  kind: number,
+  project: ProjectDeletionTarget,
+  deletionEvents: ProjectDeletionEvent[],
+): boolean {
+  const coordinate = projectRepoAddress(kind, project);
+  const owner = project.owner.toLowerCase();
+
+  return deletionEvents.some(
+    (event) =>
+      event.pubkey.toLowerCase() === owner &&
+      event.created_at >= project.createdAt &&
+      event.tags.some((tag) => tag[0] === "a" && tag[1] === coordinate),
+  );
+}


### PR DESCRIPTION
## Summary
Desktop hid NIP-34 project cards whenever **any** owner-signed kind:5 targeted `30617:<owner>:<dtag>`, without comparing timestamps to the current announcement.

After **Delete project** → create again with the **same name**, the new kind:30617 stayed on the relay but never reappeared in Projects (Repositories count stayed wrong; only unrelated cards showed).

### Fix
- Extract `isProjectDeletedByAddress` and only apply a tombstone when `deletion.created_at >= announcement.created_at`.
- Unit tests cover resurrect, foreign delete, wrong address, and owner case.

### Reproduction (pyxe)
1. Create project `bimblepath`
2. Delete it (NIP-09 `a` = `30617:<you>:bimblepath`)
3. Create `bimblepath` again
4. Before: list omits it; after: list shows it

## Test plan
- [x] `node --import ./test-loader.mjs --experimental-strip-types --test src/features/projects/lib/projectDeletion.test.mjs` (7/7)
- [ ] Manual: delete project → recreate same id → card returns on Projects → Repositories

Related Buzz DM channel: `8b3aa66d-6ce0-4643-b142-99c37ce83a34`