### PR TITLE
fix(acp): state the reply delivery contract in the turn prompt

### DIFF
--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -1148,11 +1148,13 @@ pub(crate) fn format_event_block(
 /// top level.
 fn append_reply_instruction(s: &mut String, event_id: &str) {
     s.push_str(&format!(
-        "\nIMPORTANT: For ordinary replies in this turn, use `--reply-to {event_id}` \
-         on `buzz messages send` so the conversation stays threaded. \
-         If the human explicitly asks for a channel-root, top-level, \
-         or broadcast post, send that message without `--reply-to`. \
-         If the requested destination is ambiguous, ask before sending."
+        "\nIMPORTANT: Your session text is NOT delivered to the channel — \
+         nothing you type here reaches the human unless you send it. To reply, \
+         run `buzz messages send --reply-to {event_id}` (or pipe content via \
+         `--content -`) so the conversation stays threaded. If the human \
+         explicitly asks for a channel-root, top-level, or broadcast post, \
+         send that message without `--reply-to`. If the requested destination \
+         is ambiguous, ask before sending."
     ));
 }
 
@@ -1163,11 +1165,13 @@ fn append_reply_instruction(s: &mut String, event_id: &str) {
 /// choice open) prevents replying into a stale/unrelated prior thread.
 fn append_new_thread_reply_instruction(s: &mut String, event_id: &str) {
     s.push_str(&format!(
-        "\nIMPORTANT: This is a new top-level message. For ordinary replies in \
-         this turn, use `--reply-to {event_id}` on `buzz messages send` — the \
-         triggering message is the thread root. Do NOT reply into any other \
-         (older) thread. If the human explicitly asks for a channel-root, \
-         top-level, or broadcast post, send that message without `--reply-to`."
+        "\nIMPORTANT: Your session text is NOT delivered to the channel — \
+         nothing you type here reaches the human unless you send it. This is a \
+         new top-level message. For ordinary replies in this turn, use \
+         `--reply-to {event_id}` on `buzz messages send` — the triggering \
+         message is the thread root. Do NOT reply into any other (older) \
+         thread. If the human explicitly asks for a channel-root, top-level, \
+         or broadcast post, send that message without `--reply-to`."
     ));
 }
 
@@ -3890,8 +3894,8 @@ mod tests {
             "human-facing thread reply should anchor to the thread root"
         );
         assert!(
-            prompt.contains("For ordinary replies in this turn"),
-            "channel thread reply should describe reply-to as the default"
+            prompt.contains("Your session text is NOT delivered to the channel"),
+            "channel thread reply should state the delivery contract: session text is not delivered"
         );
         assert!(
             prompt.contains("send that message without `--reply-to`"),


### PR DESCRIPTION
## Problem

A managed agent's reply reaches the channel **only if the model spontaneously decides to run `buzz messages send`**. The turn prompt told agents to use `--reply-to` on `buzz messages send`, but never stated that session text is not delivered — so weaker models answered in plain session text and every reply was silently dropped: the turn ran, tokens were billed, the Activity panel streamed the answer, and the channel stayed empty with nothing logged. Reproduces #2698.

## Root cause

The delivery contract is implicit. `append_reply_instruction` and `append_new_thread_reply_instruction` (`crates/buzz-acp/src/queue.rs`) describe `--reply-to` threading and name `buzz messages send` as the mechanism, but never state the negative: **session text is not delivered**. Models that don't infer this convention (the issue reproduces with Sonnet 5 vs Fable 5 on an otherwise identical turn) lose every reply.

## Fix

State the contract explicitly at the top of both instructions:

\`\`\`
Your session text is NOT delivered to the channel —
nothing you type here reaches the human unless you send it.
To reply, run `buzz messages send --reply-to {event_id}` ...
\`\`\`

This is the model-agnostic, immediately effective direction the issue author verified locally ("adding the equivalent instruction to the agent's system prompt makes Sonnet 5 post correctly"). The larger harness fallback (auto-posting final session text when no send was observed during the turn) is intentionally **not** included here — it's a bigger change worth its own PR.

## Test

- Updated `test_reply_instruction_present_for_channel_thread_reply` to assert the delivery contract is stated.
- 648 buzz-acp unit tests pass (one unrelated `keepalive_resets_idle_past_deadline` fails on this WSL host due to ms-scale timer jitter — it fails identically on unmodified `main`, not caused by this change).
- `cargo fmt --check` and `cargo clippy` clean.

Closes #2698