### PR TITLE
fix(mobile): open threads pinned to the newest reply

### DIFF
--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -117,20 +117,20 @@ class ThreadDetailPage extends HookConsumerWidget {
     // Item 0 is the thread head; reply `i` lives at `i + 1`.
     const headIndex = 0;
     int indexForReply(int chronologicalIndex) => chronologicalIndex + 1;
+    int? indexForMessageId(String messageId) {
+      if (messageId == threadHead.id) return headIndex;
+      final chronologicalIndex = replies.indexWhere(
+        (reply) => reply.id == messageId,
+      );
+      return chronologicalIndex < 0 ? null : indexForReply(chronologicalIndex);
+    }
 
     useEffect(() {
       final messageId = initialMessageId;
       // Wait for the authoritative thread query before consuming the one-shot
       // jump; the fallback main-timeline list can contain only the linked reply.
       if (messageId == null || fetchedReplies == null) return null;
-      final chronologicalIndex = replies.indexWhere(
-        (reply) => reply.id == messageId,
-      );
-      final targetIndex = messageId == threadHead.id
-          ? headIndex
-          : chronologicalIndex < 0
-          ? null
-          : indexForReply(chronologicalIndex);
+      final targetIndex = indexForMessageId(messageId);
       if (targetIndex == null || didJumpToInitialMessage.value) return null;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!context.mounted || !itemScrollController.isAttached) return;
@@ -139,6 +139,45 @@ class ThreadDetailPage extends HookConsumerWidget {
       });
       return null;
     }, [initialMessageId, fetchedReplies, replies.length]);
+
+    // Desktop parity: the thread panel opens pinned to the newest reply
+    // (useAnchoredScroll's pinToBottomOnMount). A resolvable deep-link target
+    // wins; an unresolvable one falls back to the pin, matching desktop's
+    // missed-target behavior. One-shot and independent of the hydration
+    // baseline below, which a cache-hydrated reopen pre-satisfies on first
+    // build. When head and newest reply already fit the viewport, the pin is
+    // a no-op so short threads keep the head at the top.
+    final hasHydratedReplies = fetchedReplies != null;
+    final didPinInitialReplies = useRef(false);
+    useEffect(() {
+      if (!hasHydratedReplies || didPinInitialReplies.value) return null;
+      didPinInitialReplies.value = true;
+      final messageId = initialMessageId;
+      final hasResolvableTarget =
+          messageId != null && indexForMessageId(messageId) != null;
+      if (hasResolvableTarget || replies.isEmpty) return null;
+      final lastIndex = indexForReply(replies.length - 1);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted || !itemScrollController.isAttached) return;
+        final positions = itemPositionsListener.itemPositions.value;
+        final fitsViewport =
+            positions.any(
+              (position) =>
+                  position.index == headIndex && position.itemLeadingEdge >= 0,
+            ) &&
+            positions.any(
+              (position) =>
+                  position.index == lastIndex && position.itemTrailingEdge <= 1,
+            );
+        if (fitsViewport) return;
+        itemScrollController.scrollTo(
+          index: lastIndex,
+          duration: const Duration(milliseconds: 220),
+          curve: Curves.easeOutCubic,
+        );
+      });
+      return null;
+    }, [hasHydratedReplies, replies.length, initialMessageId]);
 
     // A top-anchored list doesn't stick to the newest item the way the old
     // reversed one did, so follow the tail explicitly: when a reply arrives
@@ -250,9 +289,11 @@ class ThreadDetailPage extends HookConsumerWidget {
                 itemScrollController: itemScrollController,
                 itemPositionsListener: itemPositionsListener,
                 // Top-anchored, head first, replies flowing down — matching
-                // desktop's thread panel. The old reversed list bottom-anchored
-                // the content, which jammed the head against the composer
-                // whenever a thread had only a handful of replies.
+                // desktop's thread panel, which pairs this layout with a
+                // bottom-pin on open (see the initial-pin effect above). The
+                // old reversed list bottom-anchored the content, which jammed
+                // the head against the composer whenever a thread had only a
+                // handful of replies.
                 padding: EdgeInsets.only(
                   left: Grid.gutter,
                   right: Grid.gutter,

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -160,15 +160,20 @@ class ThreadDetailPage extends HookConsumerWidget {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!context.mounted || !itemScrollController.isAttached) return;
         final positions = itemPositionsListener.itemPositions.value;
-        final fitsViewport =
+        // A head scrolled off the top means the user moved during a slow
+        // hydration (the deep-link jump is already suppressed above) — the
+        // pin is an open-position default, never a user override.
+        final atInitialPosition =
+            positions.isEmpty ||
             positions.any(
               (position) =>
                   position.index == headIndex && position.itemLeadingEdge >= 0,
-            ) &&
-            positions.any(
-              (position) =>
-                  position.index == lastIndex && position.itemTrailingEdge <= 1,
             );
+        if (!atInitialPosition) return;
+        final fitsViewport = positions.any(
+          (position) =>
+              position.index == lastIndex && position.itemTrailingEdge <= 1,
+        );
         if (fitsViewport) return;
         itemScrollController.scrollTo(
           index: lastIndex,

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -2361,33 +2361,118 @@ void main() {
       expect(oldestReplyY, lessThan(newestReplyY));
     });
 
+    // Shared fixtures for the open-at-latest contract: a head plus 30 replies
+    // (overflows the test viewport) or 2 replies (fits comfortably).
+    List<NostrEvent> longThreadReplies() => [
+      for (var i = 0; i < 30; i++)
+        _textMsg(
+          id: 'reply-$i',
+          pubkey: 'bob',
+          content: 'Reply $i',
+          createdAt: 1100 + i,
+          extraTags: const [
+            ['e', 'thread-root', '', 'reply'],
+          ],
+        ),
+    ];
+
+    Future<void> pushThread(
+      WidgetTester tester, {
+      required TimelineMessage threadHead,
+      String? initialMessageId,
+    }) async {
+      Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
+        MaterialPageRoute<void>(
+          builder: (_) => ThreadDetailPage(
+            threadHead: threadHead,
+            allMessages: [threadHead],
+            channelId: _channelId,
+            currentPubkey: 'self',
+            isMember: true,
+            isArchived: false,
+            initialMessageId: initialMessageId,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    // Desktop-parity bottom-pin: the newest reply is built and sits at the
+    // bottom edge of the list viewport (no trailing blank region), and the
+    // head has scrolled out of the built window.
+    void expectPinnedToNewestReply(WidgetTester tester, String newestKey) {
+      expect(find.byKey(ValueKey(newestKey)), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('thread-message-group-thread-root')),
+        findsNothing,
+      );
+      final listRect = tester.getRect(
+        find.byKey(const ValueKey('thread-message-list')),
+      );
+      final newestBottom = tester
+          .getBottomLeft(find.byKey(ValueKey(newestKey)))
+          .dy;
+      // Bottom-aligned within the list's own tail padding; anything further up
+      // means a blank region below the newest reply (jumpTo-style misplacement).
+      expect(newestBottom, lessThanOrEqualTo(listRect.bottom + 1));
+      expect(newestBottom, greaterThan(listRect.bottom - 120));
+    }
+
+    testWidgets('initial thread hydration opens pinned to the newest reply', (
+      tester,
+    ) async {
+      // Flipped from the pre-parity expectation (head kept visible): desktop's
+      // thread panel bottom-pins on open, and mobile now matches.
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+        createdAt: 1000,
+      );
+      final completer = Completer<List<NostrEvent>>();
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          pendingThreadReplies: {'thread-root': completer.future},
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      await pushThread(tester, threadHead: threadHead);
+      expect(
+        find.byKey(const ValueKey('thread-message-group-thread-root')),
+        findsOneWidget,
+      );
+
+      completer.complete(longThreadReplies());
+      await tester.pumpAndSettle();
+
+      expectPinnedToNewestReply(tester, 'thread-message-group-reply-29');
+    });
+
     testWidgets(
-      'initial thread hydration keeps the head visible instead of following the tail',
+      'reopening an already-hydrated thread pins to the newest reply',
       (tester) async {
+        // The replies provider is keepAlive-cached, so a reopened thread
+        // hydrates synchronously on first build — the pin must fire on that
+        // path too, not only after an async fetch.
         final rootEvent = _textMsg(
           id: 'thread-root',
           pubkey: 'alice',
           content: 'Thread root',
           createdAt: 1000,
         );
-        final replies = [
-          for (var i = 0; i < 30; i++)
-            _textMsg(
-              id: 'reply-$i',
-              pubkey: 'bob',
-              content: 'Reply $i',
-              createdAt: 1100 + i,
-              extraTags: const [
-                ['e', 'thread-root', '', 'reply'],
-              ],
-            ),
-        ];
-        final completer = Completer<List<NostrEvent>>();
 
         await tester.pumpWidget(
           _buildTestable(
             messages: [rootEvent],
-            pendingThreadReplies: {'thread-root': completer.future},
+            threadReplies: {'thread-root': longThreadReplies()},
             users: const {
               'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
               'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
@@ -2397,35 +2482,144 @@ void main() {
         await tester.pumpAndSettle();
 
         final threadHead = formatTimeline([rootEvent]).single;
-        Navigator.of(tester.element(find.byType(ChannelDetailPage))).push(
-          MaterialPageRoute<void>(
-            builder: (_) => ThreadDetailPage(
-              threadHead: threadHead,
-              allMessages: [threadHead],
-              channelId: _channelId,
-              currentPubkey: 'self',
-              isMember: true,
-              isArchived: false,
-            ),
+        await pushThread(tester, threadHead: threadHead);
+        expectPinnedToNewestReply(tester, 'thread-message-group-reply-29');
+
+        // Pop and re-push: replies resolve synchronously from cache this time.
+        Navigator.of(tester.element(find.byType(ThreadDetailPage))).pop();
+        await tester.pumpAndSettle();
+        await pushThread(tester, threadHead: threadHead);
+        expectPinnedToNewestReply(tester, 'thread-message-group-reply-29');
+      },
+    );
+
+    testWidgets('a short thread keeps the head visible at the top', (
+      tester,
+    ) async {
+      // Load-bearing for the #3485 rationale: when nothing overflows, the
+      // pin must not move the list.
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+        createdAt: 1000,
+      );
+      final replies = [
+        for (var i = 0; i < 2; i++)
+          _textMsg(
+            id: 'reply-$i',
+            pubkey: 'bob',
+            content: 'Reply $i',
+            createdAt: 1100 + i,
+            extraTags: const [
+              ['e', 'thread-root', '', 'reply'],
+            ],
+          ),
+      ];
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          threadReplies: {'thread-root': replies},
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      await pushThread(tester, threadHead: threadHead);
+
+      final headFinder = find.byKey(
+        const ValueKey('thread-message-group-thread-root'),
+      );
+      expect(headFinder, findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('thread-message-group-reply-1')),
+        findsOneWidget,
+      );
+      final listRect = tester.getRect(
+        find.byKey(const ValueKey('thread-message-list')),
+      );
+      expect(
+        tester.getTopLeft(headFinder).dy,
+        lessThan(listRect.top + listRect.height / 3),
+      );
+    });
+
+    testWidgets('a resolvable deep-link target beats the bottom-pin', (
+      tester,
+    ) async {
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+        createdAt: 1000,
+      );
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          threadReplies: {'thread-root': longThreadReplies()},
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+            'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      await pushThread(
+        tester,
+        threadHead: threadHead,
+        initialMessageId: 'reply-10',
+      );
+
+      expect(
+        find.byKey(const ValueKey('thread-message-group-reply-10')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('thread-message-group-reply-29')),
+        findsNothing,
+      );
+    });
+
+    testWidgets(
+      'an unresolvable deep-link target falls back to the bottom-pin',
+      (tester) async {
+        // Desktop precedence: a missed target (deleted/unknown reply) falls
+        // back to pinToBottomOnMount rather than leaving the user at the head.
+        final rootEvent = _textMsg(
+          id: 'thread-root',
+          pubkey: 'alice',
+          content: 'Thread root',
+          createdAt: 1000,
+        );
+
+        await tester.pumpWidget(
+          _buildTestable(
+            messages: [rootEvent],
+            threadReplies: {'thread-root': longThreadReplies()},
+            users: const {
+              'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+              'bob': UserProfile(pubkey: 'bob', displayName: 'Bob'),
+            },
           ),
         );
         await tester.pumpAndSettle();
-        expect(
-          find.byKey(const ValueKey('thread-message-group-thread-root')),
-          findsOneWidget,
+
+        final threadHead = formatTimeline([rootEvent]).single;
+        await pushThread(
+          tester,
+          threadHead: threadHead,
+          initialMessageId: 'ghost-reply',
         );
 
-        completer.complete(replies);
-        await tester.pumpAndSettle();
-
-        expect(
-          find.byKey(const ValueKey('thread-message-group-thread-root')),
-          findsOneWidget,
-        );
-        expect(
-          find.byKey(const ValueKey('thread-message-group-reply-29')),
-          findsNothing,
-        );
+        expectPinnedToNewestReply(tester, 'thread-message-group-reply-29');
       },
     );
 

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -2415,7 +2415,7 @@ void main() {
       // Bottom-aligned within the list's own tail padding; anything further up
       // means a blank region below the newest reply (jumpTo-style misplacement).
       expect(newestBottom, lessThanOrEqualTo(listRect.bottom + 1));
-      expect(newestBottom, greaterThan(listRect.bottom - 120));
+      expect(newestBottom, greaterThan(listRect.bottom - 60));
     }
 
     testWidgets('initial thread hydration opens pinned to the newest reply', (
@@ -2485,13 +2485,47 @@ void main() {
         await pushThread(tester, threadHead: threadHead);
         expectPinnedToNewestReply(tester, 'thread-message-group-reply-29');
 
-        // Pop and re-push: replies resolve synchronously from cache this time.
+        // Pop and re-push: threadRepliesProvider is a keepAlive family and
+        // the ProviderScope outlives the route, so the second open reads the
+        // already-resolved value — fetchedReplies is non-null on the very
+        // first build, the path a real cached reopen takes.
         Navigator.of(tester.element(find.byType(ThreadDetailPage))).pop();
         await tester.pumpAndSettle();
         await pushThread(tester, threadHead: threadHead);
         expectPinnedToNewestReply(tester, 'thread-message-group-reply-29');
       },
     );
+
+    testWidgets('a head-only thread keeps the head visible without scrolling', (
+      tester,
+    ) async {
+      // Pins the empty-replies guard in the initial-pin effect.
+      final rootEvent = _textMsg(
+        id: 'thread-root',
+        pubkey: 'alice',
+        content: 'Thread root',
+        createdAt: 1000,
+      );
+
+      await tester.pumpWidget(
+        _buildTestable(
+          messages: [rootEvent],
+          threadReplies: const {'thread-root': []},
+          users: const {
+            'alice': UserProfile(pubkey: 'alice', displayName: 'Alice'),
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final threadHead = formatTimeline([rootEvent]).single;
+      await pushThread(tester, threadHead: threadHead);
+
+      expect(
+        find.byKey(const ValueKey('thread-message-group-thread-root')),
+        findsOneWidget,
+      );
+    });
 
     testWidgets('a short thread keeps the head visible at the top', (
       tester,


### PR DESCRIPTION
## Summary

- Threads on mobile now open pinned to the newest reply, matching desktop's thread panel — while keeping #3485's top-anchored layout (short threads still show the head at the top, no composer jam).
- One-shot initial pin in `thread_detail_page.dart`: fires on the first hydrated frame — including cache-hydrated reopens, where the keepAlive replies provider resolves synchronously on first build — using the tail-follow's end-clamped `scrollTo` idiom.
- Desktop-parity precedence: a resolvable `initialMessageId` deep-link wins over the pin; an unresolvable (deleted/missing) target falls back to the pin, mirroring `useAnchoredScroll`'s missed-target behavior. A user who scrolls during a slow hydration is never overridden.
- Extracts a small `indexForMessageId` helper shared by the deep-link jump and the pin.

## Why

#3485 moved the thread list from `reverse: true` to top-anchored and its comment says the layout matches desktop's thread panel — it does, but desktop pairs that layout with an explicit bottom-pin on open (`pinToBottomOnMount` in `useAnchoredScroll.ts`). Mobile got the layout half without the pin half, so long threads open at the head and the newest replies sit below the fold. This completes the parity #3485 claimed; #1499 was the earlier (reversed-list) fix the redesign superseded.

The hydration test that pinned head-visible behavior is flipped to the completed contract and renamed (`initial thread hydration opens pinned to the newest reply`); the day-divider test asserting the top-anchored layout is untouched and still passes.

## Validation

- `flutter analyze` — clean (CI)
- `flutter test` — full mobile suite green (CI); `flutter test test/features/channels/channel_detail_page_test.dart` locally: 62 passing, including new scenarios for the cached reopen, short thread (head stays at top), head-only thread, resolvable deep-link precedence, and unresolvable-target fallback, with bottom-alignment asserted against the list rect rather than key-visibility alone
- `dart format` / mobile file-size ratchet — clean
- Full mobile CI (analyze, test, Android build) green on the fork before opening this PR

## Screenshots

Scroll-position change (no visual/layout delta beyond where the list opens); before/after device screenshots available on request from a physical Android device.

---

Note: open PR #4274 also touches `thread_detail_page.dart` (tablet workspace layout) — this diff is deliberately surgical (one effect + one helper) so either side rebases trivially.

### Related issue

Fixes #4354 (searched existing issues/PRs: #1499 fixed this pre-#3485 via reversed list, superseded; no open duplicates)

### Testing

See Validation above.
