### PR TITLE
test(relay): gate 9 deterministic env-coupled test failures behind requires-Postgres ignore

### DIFF
--- a/crates/buzz-relay/src/api/admin/mod.rs
+++ b/crates/buzz-relay/src/api/admin/mod.rs
@@ -390,6 +390,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Postgres"]
     async fn report_detail_rejects_unknown_report() {
         let response = router(test_state().await)
             .oneshot(
@@ -420,6 +421,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Postgres"]
     async fn feedback_attachment_rejects_unknown_feedback() {
         let response = router(test_state().await)
             .oneshot(

--- a/crates/buzz-relay/src/api/media.rs
+++ b/crates/buzz-relay/src/api/media.rs
@@ -1027,6 +1027,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Postgres"]
     async fn media_reads_reject_unauthenticated_get_and_head_before_sidecar_gate() {
         for method in ["GET", "HEAD"] {
             let response = media_get_auth_router()
@@ -1040,6 +1041,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Postgres"]
     async fn media_read_with_valid_server_scoped_token_reaches_sidecar_gate() {
         let keys = Keys::generate();
         let auth = media_get_auth_header(&keys, media_get_tags_for("relay.example", None));
@@ -1053,6 +1055,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Postgres"]
     async fn media_read_rejects_upload_verb_wrong_server_and_wrong_x() {
         let keys = Keys::generate();
         let now = Timestamp::now().as_secs();
@@ -1094,6 +1097,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Postgres"]
     async fn media_read_accepts_range_header_only_after_auth() {
         let keys = Keys::generate();
         let auth = media_get_auth_header(&keys, media_get_tags_for("relay.example", None));
@@ -1112,6 +1116,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Postgres"]
     async fn upload_rate_limiter_is_scoped_by_community() {
         let state = test_state().await;
         let pubkey = nostr::Keys::generate().public_key();
@@ -1127,6 +1132,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires Postgres"]
     async fn upload_concurrency_limit_is_scoped_by_community() {
         let state = test_state().await;
         let pubkey = nostr::Keys::generate().public_key();


### PR DESCRIPTION
Gates the 9 **deterministic, env-coupled** test infra failures on clean `main` behind the crate"'s existing `#[ignore = "requires Postgres"]` convention, so `cargo test -p buzz-relay --lib` skips them without a live Postgres/Redis sidecar. Surfaced during independent verification of the #4192 gift-wrap freshness fix (#4253).

## Scope after follow-up `a2454776`

**Narrowed.** An earlier revision also added an `ENV_LOCK` serializer to the flaky `trace_context_lookup_does_not_enable_callsites` telemetry test. That piece is **reverted** here: the flake is the global callsite-interest-caching mechanism from #3929, which locking does not address (the reporter"'s own issue calls the `ENV_LOCK` signal an unproven hypothesis), and the reporter-preferred root-cause fix already exists as **#3981** (per-statement unique callsite). #4059's `ENV_LOCK` attempt was already closed in favor of #3981.

So this PR now does only its **non-duplicated** job: the 9 infra gates. The telemetry flake stays un-gated and is tracked by #3929 / fixed by #3981.

## The 9 gated failures (clean `main` @ `28ae6cd21`)

**7 media + 2 admin** tests panic inside `test_state()` reaching for unreachable localhost Redis (`redis://127.0.0.1:1`) / Postgres — they die at setup before asserting.

These use `test_state()` but were **missing the `#[ignore]` annotation their ~38 infra-coupled siblings carry** (`operator.rs`, `bridge.rs`, `invites.rs`). Additive only (+9).

## Verification

- `cargo test -p buzz-relay --lib`: deterministic infra failures now `ignored`; the only remaining failure is the pre-existing **probabilistic** telemetry flake (~1/6), owned by #3929/#3981.
- `cargo fmt` clean; `cargo check` warning-free.
