### PR TITLE
fix(desktop): log WebKitWebProcess termination instead of silent freeze (#4359)

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -205,6 +205,11 @@ pub fn run() {
                     // on macOS/Windows.
                     linux_media::enable_media_capture(&webview);
 
+                    // Linux/WebKitGTK: surface renderer (WebKitWebProcess)
+                    // crashes as a log line instead of a silent dead window;
+                    // no-op on macOS/Windows. See #4359.
+                    linux_media::install_web_process_terminated_handler(&webview);
+
                     // macOS applies the restored geometry asynchronously. Wait
                     // for several identical outer bounds and for React to
                     // commit the startup surface before revealing it.

--- a/desktop/src-tauri/src/linux_media.rs
+++ b/desktop/src-tauri/src/linux_media.rs
@@ -102,10 +102,44 @@ pub fn enable_media_capture<R: tauri::Runtime>(webview: &tauri::Webview<R>) {
     }
 }
 
+/// Log when the `WebKitWebProcess` (renderer) terminates, so a renderer crash
+/// surfaces as a diagnosable log line instead of a silent dead window.
+///
+/// Without a handler the renderer can die (e.g. an upstream PipeWire/GStreamer
+/// segfault, OOM, or a WebKit bug) while the main `buzz-desktop` and
+/// `WebKitNetworkProcess` processes stay alive, leaving a frozen window with no
+/// log output. WebKitGTK emits `web-process-terminated` for exactly this case;
+/// `WebProcessTerminationReason` distinguishes `Crashed` / `ExceededMemoryLimit`
+/// / `TerminatedByApi`. A no-op on non-Linux targets.
+#[cfg(target_os = "linux")]
+pub fn install_web_process_terminated_handler<R: tauri::Runtime>(webview: &tauri::Webview<R>) {
+    use webkit2gtk::{glib::prelude::Cast, WebViewExt};
+
+    let webview = webview.clone();
+    let result = webview.with_webview(|platform_webview| {
+        platform_webview
+            .inner()
+            .connect_web_process_terminated(|_webview, reason| {
+                eprintln!(
+                    "buzz-desktop: WebKitWebProcess terminated (reason: {reason:?}); \
+                     the window may appear frozen. See #4359."
+                );
+            });
+    });
+
+    if let Err(error) = result {
+        eprintln!("buzz-desktop: could not install web-process-terminated handler: {error}");
+    }
+}
+
 /// No-op stub so shared startup code can call [`enable_media_capture`] on every
 /// platform. macOS and Windows route media permissions through the OS.
 #[cfg(not(target_os = "linux"))]
 pub fn enable_media_capture<R: tauri::Runtime>(_webview: &tauri::Webview<R>) {}
+
+/// No-op stub on non-Linux targets; there is no `WebKitWebProcess` to observe.
+#[cfg(not(target_os = "linux"))]
+pub fn install_web_process_terminated_handler<R: tauri::Runtime>(_webview: &tauri::Webview<R>) {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## What

Installs a `web-process-terminated` handler on the Linux WebKitGTK webview so a renderer (`WebKitWebProcess`) crash surfaces as a **diagnosable log line** instead of a silent dead window.

This is the **detect + readback half** of #4359. The renderer-recovery behavior (auto-reload vs. a "click to restart" affordance) is the one design call flagged in #4359 and is intentionally **out of scope** here — this PR only makes the crash observable, which is non-controversial and independently useful.

## Why

Surfaced by the diagnosis in #4358: when the renderer dies (upstream PipeWire/GStreamer segfault, OOM, or a WebKit bug), the main `buzz-desktop` process and `WebKitNetworkProcess` stay alive with no renderer, so the window reads as a **freeze** — no crash dialog, no log line, no recovery path. WebKitGTK emits a purpose-built `web-process-terminated` signal; Buzz installed no handler for it (verified: zero references in `desktop/src-tauri`).

## How

- `desktop/src-tauri/src/linux_media.rs`: new `install_web_process_terminated_handler`, a sibling of the existing `enable_media_capture`. Same idiom — `webview.with_webview(|pw| pw.inner())` then a `WebViewExt::connect_*` call, with the module's `eprintln!("buzz-desktop: ...")` logging and `#[cfg]`-gated real impl + no-op stubs.
- `desktop/src-tauri/src/lib.rs`: wire it in `on_webview_ready`, right after `enable_media_capture`.

The handler logs `WebProcessTerminationReason` (`Crashed` / `ExceededMemoryLimit` / `TerminatedByApi`), so reports like #4358 gain a concrete reason line instead of an unexplained hang.

## Verification / honest caveats

- Host `cargo check --lib` and `cargo clippy --lib` are **clean** — but on macOS, which compiles the `#[cfg(not(target_os = "linux"))]` **stub**, not the real body.
- The real Linux-cfg body was verified **against the `webkit2gtk 2.0.2` crate source**: `connect_web_process_terminated` is on `WebViewExt` (`web_view.rs:6240`, the same trait that owns the existing `connect_permission_request` at :5815), `#[cfg_attr(docsrs, doc(cfg(feature = "v2_20")))]` — enabled by the `v2_22` feature pinned in `Cargo.toml`. Closure signature `Fn(&Self, WebProcessTerminationReason)` matches.
- **No Linux toolchain is available on this host**, so the Linux compile path is not machine-verified locally. It is a single-call sibling to an existing, compiling pattern and should be confirmed by Linux CI.

## Testing

- [x] `cargo check --lib` (host/macOS stub path)
- [x] `cargo clippy --lib` (host/macOS stub path)
- [ ] Linux compile + clippy — deferred to CI (no local Linux toolchain)
- [ ] Manual: kill `WebKitWebProcess` on a Linux build, confirm the `buzz-desktop: WebKitWebProcess terminated (reason: …)` line appears

Fixes #4359 (detect + readback half).
