### PR TITLE
fix(desktop): retain external bot channel mentions

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -5,7 +5,7 @@ import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  passesManagedAgentIdentityGate,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
@@ -136,26 +136,40 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
-test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
+test("passesManagedAgentIdentityGate: keeps people, managed agents, and bot-role channel members", () => {
   const managedAgentPubkeys = new Set([PUB_A]);
 
   assert.equal(
-    isAgentIdentityInManagedList(
+    passesManagedAgentIdentityGate(
       { isAgent: false, pubkey: PUB_B },
       managedAgentPubkeys,
     ),
     true,
   );
   assert.equal(
-    isAgentIdentityInManagedList(
+    passesManagedAgentIdentityGate(
       { isAgent: true, pubkey: PUB_A.toUpperCase() },
       managedAgentPubkeys,
     ),
     true,
   );
   assert.equal(
-    isAgentIdentityInManagedList(
+    passesManagedAgentIdentityGate(
       { isAgent: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+    ),
+    false,
+  );
+  assert.equal(
+    passesManagedAgentIdentityGate(
+      { isAgent: true, isMember: true, pubkey: PUB_B, role: "bot" },
+      managedAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    passesManagedAgentIdentityGate(
+      { isAgent: true, isMember: true, pubkey: PUB_B, role: "member" },
       managedAgentPubkeys,
     ),
     false,

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -54,11 +54,22 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
-export function isAgentIdentityInManagedList(
-  candidate: { isAgent?: boolean; pubkey: string },
+/**
+ * Keep people and locally managed agent identities, plus authoritative bot-role
+ * channel members. The bot-role exception lets external bridge identities be
+ * mentioned without admitting arbitrary global profile-only agent records.
+ */
+export function passesManagedAgentIdentityGate(
+  candidate: {
+    isAgent?: boolean;
+    isMember?: boolean;
+    pubkey: string;
+    role?: string | null;
+  },
   managedAgentPubkeys: ReadonlySet<string>,
 ) {
   return (
+    (candidate.isMember === true && candidate.role === "bot") ||
     candidate.isAgent !== true ||
     managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
   );

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -9,7 +9,7 @@ import {
 import { attachManagedAgentToChannel } from "@/features/agents/channelAgents";
 import {
   coalesceAgentAutocompleteCandidates,
-  isAgentIdentityInManagedList,
+  passesManagedAgentIdentityGate,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
@@ -282,7 +282,7 @@ export function MembersSidebar({
           )) ||
         memberPubkeys.has(pubkey) ||
         isArchivedDiscovery(pubkey) ||
-        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+        !passesManagedAgentIdentityGate(candidate, managedAgentPubkeys)
       ) {
         return;
       }

--- a/desktop/src/features/messages/lib/mentionSuggestionMapping.test.mjs
+++ b/desktop/src/features/messages/lib/mentionSuggestionMapping.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mapMentionCandidateToSuggestion } from "./mentionSuggestionMapping.ts";
+
+test("external bot-role channel members are not labeled out of channel", () => {
+  const suggestion = mapMentionCandidateToSuggestion({
+    candidate: {
+      kind: "identity",
+      pubkey: "a".repeat(64),
+      isAgent: true,
+      isMember: true,
+      role: "bot",
+    },
+    label: "Copper",
+    channelType: "stream",
+  });
+
+  assert.equal(suggestion.displayName, "Copper");
+  assert.equal(suggestion.isAgent, true);
+  assert.equal(suggestion.notInChannel, false);
+});

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,7 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  passesManagedAgentIdentityGate,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,7 +246,7 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (!passesManagedAgentIdentityGate(candidate, managedAgentPubkeys)) {
         return;
       }
       if (


### PR DESCRIPTION
## What changed

- retain authoritative channel members with `role: "bot"` in Desktop mention autocomplete even when the bot is not locally managed
- preserve the managed-agent gate for global and other nonmember agent results
- add regression coverage for eligibility and the “not in channel” presentation state

## Why

External ACP/OpenClaw bridges can be valid relay channel members without being managed by the local Buzz Desktop. The mention pipeline classified those members as agents, then discarded them because their pubkeys were absent from the local managed-agent set. Global search could subsequently reintroduce the same identity as a nonmember, producing a misleading “not in channel” label and a message without the bot’s `p` tag.

This change trusts the authoritative channel membership role while leaving nonmember discovery restrictions intact.

## User impact

Channel-member external bots such as Copper remain selectable as in-channel mentions, allowing Desktop to emit the recipient tag required by the bridge. Arbitrary global agent profiles remain excluded unless locally managed.

## Validation

- `pnpm --dir desktop test` — 3,907 passed
- `pnpm --dir desktop typecheck`
- `pnpm --dir desktop check`
- `just ci` — full Rust, Desktop, Tauri, web, and mobile gates passed

Originating Buzz conversation: Copper Lab (`554ebbcb-81fc-487b-81a7-4820814ee036`).
