### PR TITLE
fix(relay,cli): surface fan-out delivered count for agent-draft control frames (#3791)

### DIFF
--- a/crates/buzz-cli/src/commands/agents.rs
+++ b/crates/buzz-cli/src/commands/agents.rs
@@ -9,6 +9,41 @@ use crate::error::CliError;
 use crate::validate::{read_or_stdin, validate_hex64};
 use crate::{AgentsCmd, RespondToArg};
 
+/// The copy an owner sees after a successful draft publish.
+struct DraftAdvisory {
+    message: String,
+    /// Relay-reported count of locally-connected subscribers (None on older
+    /// relays that send no advisory).
+    delivered_to_local: Option<u64>,
+}
+
+/// Honest-delivery advisory for ephemeral agent-management drafts (#3791).
+///
+/// Drafts are kind-24200 ephemeral frames and are **never stored** by the
+/// relay, so `{"accepted": true}` means only "fanned out to whoever was
+/// connected right now," not "Desktop received it." When the relay reports it
+/// reached 0 local subscribers, replace the unconditional success copy with a
+/// delivery warning instead of telling the owner the draft is waiting for
+/// review. The count is advisory on multi-node relays (the Desktop may be
+/// attached to a different pod via pubsub), so we surface it rather than
+/// error.
+fn draft_delivery_advisory(relay_message: Option<&str>) -> DraftAdvisory {
+    let delivered_to_local = relay_message.and_then(|m| {
+        m.strip_prefix("delivered_to_local=")
+            .and_then(|n| n.trim().parse::<u64>().ok())
+    });
+    let message = match delivered_to_local {
+        Some(0) => "Accepted by the relay but reached 0 connected Buzz Desktop instances. Agent drafts are ephemeral and never stored — if Desktop was offline, this draft is lost. Reopen Buzz Desktop and re-run the command.".to_string(),
+        Some(n) => format!("Draft sent to Buzz Desktop for owner review (reached {n} connected instance(s)). Nothing changes until the owner saves it."),
+        // Older relays send an empty message; keep the legacy copy.
+        None => "Draft sent to Buzz Desktop for owner review. Nothing changes until the owner saves it.".to_string(),
+    };
+    DraftAdvisory {
+        message,
+        delivered_to_local,
+    }
+}
+
 pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), CliError> {
     match command {
         AgentsCmd::DraftCreate {
@@ -29,15 +64,16 @@ pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), Cli
             let response = client.publish_ephemeral_event(built.event).await?;
             let mut output: serde_json::Value = serde_json::from_str(&response)
                 .map_err(|e| CliError::Other(format!("invalid relay response: {e}")))?;
+            let advisory =
+                draft_delivery_advisory(output.get("message").and_then(serde_json::Value::as_str));
             if let Some(obj) = output.as_object_mut() {
                 obj.insert("request_id".into(), built.request_id.into());
                 obj.insert("action".into(), built.action.into());
                 obj.insert("saved".into(), false.into());
-                obj.insert(
-                    "message".into(),
-                    "Draft sent to Buzz Desktop for owner review. Nothing changes until the owner saves it."
-                        .into(),
-                );
+                if let Some(n) = advisory.delivered_to_local {
+                    obj.insert("delivered_to_local".into(), n.into());
+                }
+                obj.insert("message".into(), advisory.message.into());
             }
             println!("{output}");
             Ok(())
@@ -71,15 +107,16 @@ pub async fn dispatch(command: AgentsCmd, client: &BuzzClient) -> Result<(), Cli
             let response = client.publish_ephemeral_event(built.event).await?;
             let mut output: serde_json::Value = serde_json::from_str(&response)
                 .map_err(|e| CliError::Other(format!("invalid relay response: {e}")))?;
+            let advisory =
+                draft_delivery_advisory(output.get("message").and_then(serde_json::Value::as_str));
             if let Some(obj) = output.as_object_mut() {
                 obj.insert("request_id".into(), built.request_id.into());
                 obj.insert("action".into(), built.action.into());
                 obj.insert("saved".into(), false.into());
-                obj.insert(
-                    "message".into(),
-                    "Draft sent to Buzz Desktop for owner review. Nothing changes until the owner saves it."
-                        .into(),
-                );
+                if let Some(n) = advisory.delivered_to_local {
+                    obj.insert("delivered_to_local".into(), n.into());
+                }
+                obj.insert("message".into(), advisory.message.into());
             }
             println!("{output}");
             Ok(())
@@ -714,5 +751,41 @@ mod tests {
             .expect("sign");
         let result = verify_archived_event(&event, &self_hex).expect("should pass");
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn draft_advisory_warns_when_zero_delivered() {
+        let advisory = draft_delivery_advisory(Some("delivered_to_local=0"));
+        assert_eq!(advisory.delivered_to_local, Some(0));
+        assert!(
+            advisory.message.contains("reached 0 connected"),
+            "zero-delivery must warn: {}",
+            advisory.message
+        );
+        assert!(
+            advisory.message.contains("ephemeral"),
+            "warning should explain why the draft may be lost"
+        );
+    }
+
+    #[test]
+    fn draft_advisory_reports_count_when_delivered() {
+        let advisory = draft_delivery_advisory(Some("delivered_to_local=1"));
+        assert_eq!(advisory.delivered_to_local, Some(1));
+        assert!(
+            advisory.message.contains("reached 1 connected instance(s)"),
+            "delivered drafts keep success copy with the count: {}",
+            advisory.message
+        );
+    }
+
+    #[test]
+    fn draft_advisory_handles_advisory_less_relay() {
+        let advisory = draft_delivery_advisory(Some(""));
+        assert_eq!(advisory.delivered_to_local, None);
+        assert!(
+            advisory.message.starts_with("Draft sent to Buzz Desktop"),
+            "advisory-less relays keep the legacy copy"
+        );
     }
 }

--- a/crates/buzz-relay/src/api/git/transport.rs
+++ b/crates/buzz-relay/src/api/git/transport.rs
@@ -1850,7 +1850,7 @@ async fn finalize_push(state: &Arc<AppState>, ctx: PushContext) -> Response {
                         // Routed through the guarded send path for uniformity;
                         // the access gate no-ops for this globally-scoped
                         // (channel_id = None) ref-state event.
-                        crate::handlers::event::fan_out_event_to_local_subscribers(
+                        let _ = crate::handlers::event::fan_out_event_to_local_subscribers(
                             state,
                             ctx.tenant.community(),
                             &stored,

--- a/crates/buzz-relay/src/audio/handler.rs
+++ b/crates/buzz-relay/src/audio/handler.rs
@@ -1315,7 +1315,7 @@ async fn emit_participant_event(
     //    path so a stale subscription on a removed/non-member connection cannot
     //    receive this channel's audio lifecycle event (same gate as
     //    dispatch_persistent_event in the ingest handler).
-    crate::handlers::event::fan_out_event_to_local_subscribers(state, tenant.community(), &stored)
+    let _ = crate::handlers::event::fan_out_event_to_local_subscribers(state, tenant.community(), &stored)
         .await;
 
     // 4. Cross-node broadcast via Redis pub/sub.

--- a/crates/buzz-relay/src/handlers/event.rs
+++ b/crates/buzz-relay/src/handlers/event.rs
@@ -242,19 +242,20 @@ pub(crate) async fn fan_out_event_to_local_subscribers(
     state: &AppState,
     community_id: CommunityId,
     stored: &StoredEvent,
-) {
+) -> usize {
     let matches = state.sub_registry.fan_out_scoped(community_id, stored);
     let matches = filter_fanout_by_access(state, community_id, stored, matches, None).await;
     metrics::histogram!("buzz_fanout_recipients").record(matches.len() as f64);
     if matches.is_empty() {
-        return;
+        return 0;
     }
 
+    let recipient_count = matches.len();
     let event_json = match serde_json::to_string(&stored.event) {
         Ok(json) => json,
         Err(e) => {
             error!(event_id = %stored.event.id.to_hex(), "Failed to serialize event for fan-out: {e}");
-            return;
+            return recipient_count;
         }
     };
     let frames = fanout_frame_cache(
@@ -275,6 +276,7 @@ pub(crate) async fn fan_out_event_to_local_subscribers(
             "fan-out: {drop_count} connection(s) cancelled due to full/closed buffers"
         );
     }
+    recipient_count
 }
 
 /// Fan out one event received from Redis pub/sub to this relay's local subscribers.
@@ -862,7 +864,7 @@ async fn handle_ephemeral_event(
         // receive this private-channel ephemeral event.
         // Pass the channel_id so fan_out() uses the channel-kind index.
         let stored_event = StoredEvent::new(event.clone(), Some(ch_id));
-        fan_out_event_to_local_subscribers(&state, conn.tenant.community(), &stored_event).await;
+        let _ = fan_out_event_to_local_subscribers(&state, conn.tenant.community(), &stored_event).await;
     } else {
         // Channel-less ephemeral events (e.g., NIP-AB pairing kind:24134).
         //
@@ -890,7 +892,7 @@ async fn handle_ephemeral_event(
         // filter_fanout_by_access no-ops for channel-less events except the
         // author-only-kind gate.
         let stored_event = StoredEvent::new(event.clone(), None);
-        fan_out_event_to_local_subscribers(&state, conn.tenant.community(), &stored_event).await;
+        let _ = fan_out_event_to_local_subscribers(&state, conn.tenant.community(), &stored_event).await;
     }
 
     conn.send(RelayMessage::ok(event_id_hex, true, ""));
@@ -1086,9 +1088,23 @@ async fn handle_agent_observer_event(
         direction = ?route.direction,
         "Agent observer fan-out"
     );
-    fan_out_event_to_local_subscribers(&state, conn.tenant.community(), &stored_event).await;
+    let delivered_to_local =
+        fan_out_event_to_local_subscribers(&state, conn.tenant.community(), &stored_event).await;
 
-    conn.send(RelayMessage::ok(event_id_hex, true, ""));
+    // Control frames (owner → agent/agent-management) are the ones a publisher
+    // actively waits on — e.g. `buzz agents draft-create` (#3791), where the
+    // draft is ephemeral and never stored, so "accepted" previously meant only
+    // "fanned out," not "received." Surface the local recipient count as an
+    // advisory so a CLI can tell the owner a draft landed nowhere. Advisory
+    // only: on a multi-node relay the intended subscriber may be attached to a
+    // different pod and still receive the frame via pubsub. Telemetry frames
+    // keep the empty-message fast path.
+    let message = if matches!(route.direction, AgentObserverDirection::Control) {
+        format!("delivered_to_local={delivered_to_local}")
+    } else {
+        String::new()
+    };
+    conn.send(RelayMessage::ok(event_id_hex, true, &message));
 }
 
 fn agent_observer_route(event: &Event) -> Result<Option<AgentObserverRoute>, String> {
@@ -2454,6 +2470,27 @@ mod tests {
         ///
         /// Turning this test green is the definition of "Attack 4 is
         /// closed" for the global-event seam.
+        ///
+        /// #3791: the fan-out helper now returns the recipient count. With no
+        /// subscribers it must be 0 — the value the observer control frame
+        /// surfaces as `delivered_to_local=0` so `buzz agents draft-create`
+        /// can warn the owner instead of reporting a silent drop.
+        #[tokio::test]
+        async fn fan_out_recipient_count_is_zero_with_no_subscribers() {
+            let state = test_state().await;
+            let community = buzz_core::tenant::CommunityId::from_uuid(Uuid::from_u128(0xAAAA));
+
+            let presence = EventBuilder::new(Kind::Custom(KIND_PRESENCE_UPDATE as u16), "online")
+                .sign_with_keys(&Keys::generate())
+                .expect("sign presence");
+            let stored = buzz_core::StoredEvent::new(presence, None);
+
+            let count =
+                crate::handlers::event::fan_out_event_to_local_subscribers(&state, community, &stored)
+                    .await;
+            assert_eq!(count, 0, "no registered subscribers → zero recipients");
+        }
+
         #[tokio::test]
         async fn channel_less_event_must_drop_recipient_in_different_community() {
             let state = test_state().await;

--- a/crates/buzz-relay/src/handlers/side_effects.rs
+++ b/crates/buzz-relay/src/handlers/side_effects.rs
@@ -883,7 +883,7 @@ pub fn emit_live_thread_summary(
             warn!(root = %root_hex, "live thread summary Redis publish failed: {e}");
         }
         let stored = StoredEvent::new(event, Some(channel_id));
-        crate::handlers::event::fan_out_event_to_local_subscribers(
+        let _ = crate::handlers::event::fan_out_event_to_local_subscribers(
             &state,
             tenant.community(),
             &stored,
@@ -969,7 +969,7 @@ pub async fn emit_membership_notification(
 
     // Routed through the guarded send path for uniformity; the access gate no-ops
     // for these globally-scoped (channel_id = None) events.
-    crate::handlers::event::fan_out_event_to_local_subscribers(state, tenant.community(), &stored)
+    let _ = crate::handlers::event::fan_out_event_to_local_subscribers(state, tenant.community(), &stored)
         .await;
 
     info!(
@@ -2862,7 +2862,7 @@ async fn emit_initial_ref_state(
     if was_inserted {
         // Routed through the guarded send path for uniformity; the access gate
         // no-ops for this globally-scoped (channel_id = None) ref-state event.
-        crate::handlers::event::fan_out_event_to_local_subscribers(
+        let _ = crate::handlers::event::fan_out_event_to_local_subscribers(
             state,
             tenant.community(),
             &stored,
@@ -3014,7 +3014,7 @@ async fn publish_nip43_delta(
 
     // Routed through the guarded send path for uniformity; the access gate
     // no-ops for this globally-scoped (channel_id = None) NIP-43 event.
-    crate::handlers::event::fan_out_event_to_local_subscribers(state, tenant.community(), &stored)
+    let _ = crate::handlers::event::fan_out_event_to_local_subscribers(state, tenant.community(), &stored)
         .await;
 
     info!(


### PR DESCRIPTION
## Problem (root-caused in #3791 by @jbforge)

`buzz agents draft-create` prints success unconditionally. The relay routes the agent-management draft as **kind 24200** (ephemeral, never stored), fans it out to whoever is connected at that instant, and replies OK with an **empty message**. If Buzz Desktop isn't connected, the draft is silently discarded — but the CLI reports "Draft sent to Buzz Desktop for owner review." This is the reported VPS→Desktop drop.

## What this PR does (the honest-CLI fix — jbforge's Option 1)

Low-cost, additive, no protocol change:

1. **`fan_out_event_to_local_subscribers` now returns the recipient count** it already computed but discarded. Its 10 other call sites are unchanged in behavior (`let _ =`).
2. **Control-direction observer frames** (`owner → agent/agent-management`, the frames a publisher waits on — e.g. `draft-create`) get a `delivered_to_local=N` suffix on their OK message. Telemetry frames keep the empty fast path.
3. **CLI** parses the advisory and, on `N=0`, replaces the unconditional success copy with a delivery warning explaining the draft may be lost. It also surfaces `delivered_to_local` in the JSON output for scripting.

A `N=0` on a **multi-node relay does not prove non-delivery** (the Desktop may be attached to a different pod and receive the frame via pubsub), so this is surfaced as an **advisory**, not an error.

## What this deliberately does NOT do

- **No persistence / retention buffer** (jbforge's Option 2). That's the only change that makes the reporter's disconnected-VPS workflow actually deliver, and it's a protocol change that wants maintainer direction on kind choice + replay semantics first.
- **No headless approve path** (Option 3) — orthogonal.
- Behavior for all non-control frames is byte-identical; telemetry keeps the fast path.

## Tests

- **CLI** (`crates/buzz-cli/src/commands/agents.rs`): 3 new advisory tests — `delivered_to_local=0` warns + explains ephemerality; `=1` keeps success copy with count; advisory-less (older relay) keeps legacy copy. `cargo test -p buzz-cli --lib` → 277/277; clippy clean.
- **Relay** (`crates/buzz-relay/src/handlers/event.rs`, redteam module): new `fan_out_recipient_count_is_zero_with_no_subscribers` pins the `0` return. Broker-local relay clippy clean; `handlers::event::tests` 25/25 green; `redteam` 5/5.
- Host: macOS `aarch64-apple-darwin`. The relay change is platform-independent; the Linux-side `#[cfg]` paths are unaffected.