### PR TITLE
fix(mobile): make direct messages agent-aware and linear

### DIFF
--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -354,6 +354,7 @@ class ChannelDetailPage extends HookConsumerWidget {
                         final entries = buildMainTimelineEntries(
                           messages,
                           relaySummaries: summaries,
+                          flattenReplies: resolvedChannel.isDm,
                         );
                         return _MessageList(
                           entries: entries,

--- a/mobile/lib/features/channels/channel_detail_page.dart
+++ b/mobile/lib/features/channels/channel_detail_page.dart
@@ -354,7 +354,6 @@ class ChannelDetailPage extends HookConsumerWidget {
                         final entries = buildMainTimelineEntries(
                           messages,
                           relaySummaries: summaries,
-                          flattenReplies: resolvedChannel.isDm,
                         );
                         return _MessageList(
                           entries: entries,

--- a/mobile/lib/features/channels/channel_messages_provider.dart
+++ b/mobile/lib/features/channels/channel_messages_provider.dart
@@ -60,7 +60,6 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
   bool _initInFlight = false;
   bool _usingChannelWindow = false;
   bool _initialWindowQueryInFlight = false;
-  bool _isDirectMessage = false;
   bool _loadsFullTimeline = false;
   int _initVersion = 0;
   ChannelWindowStore _windowStore = const ChannelWindowStore.empty();
@@ -86,7 +85,6 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
   @override
   AsyncValue<List<NostrEvent>> build() {
     final sessionState = ref.watch(relaySessionProvider);
-    _isDirectMessage = ref.watch(channelIsDirectMessageProvider(channelId));
     _loadsFullTimeline = ref.watch(channelLoadsFullTimelineProvider(channelId));
     ref.onDispose(() {
       _initVersion++;
@@ -338,7 +336,7 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
   void addLocalMessage(NostrEvent event) {
     ref.read(pendingLocalMessagesProvider(channelId).notifier).add(event);
     final thread = event.threadReference;
-    if (thread.parentId != null && !_isDirectMessage) {
+    if (thread.parentId != null) {
       final rootId = thread.rootId;
       if (rootId == null) {
         throw StateError('Reply ${event.id} has a parent but no thread root.');
@@ -381,7 +379,7 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
     if (pending == null) return;
 
     final thread = pending.threadReference;
-    if (thread.parentId != null && !_isDirectMessage) {
+    if (thread.parentId != null) {
       final rootId = thread.rootId;
       if (rootId == null) {
         throw StateError('Reply $eventId has a parent but no thread root.');

--- a/mobile/lib/features/channels/channel_messages_provider.dart
+++ b/mobile/lib/features/channels/channel_messages_provider.dart
@@ -2,6 +2,8 @@ import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../shared/relay/relay.dart';
+import 'channel.dart';
+import 'channels_provider.dart';
 import 'pending_local_messages_provider.dart';
 import 'channel_window.dart';
 import 'thread_replies_provider.dart';
@@ -10,6 +12,42 @@ const _channelLiveEventKinds = [
   ...EventKind.channelEventKinds,
   EventKind.channelThreadSummary,
 ];
+
+bool shouldLoadFullChannelTimeline(
+  AsyncValue<List<Channel>> channels,
+  String channelId,
+) {
+  final knownChannels = channels.asData?.value;
+  if (knownChannels == null) return true;
+  for (final channel in knownChannels) {
+    if (channel.id == channelId) return channel.isDm;
+  }
+  // Missing metadata must not hide replies. Non-DM UI still groups the extra
+  // events into threads, so loading the full set is the conservative fallback.
+  return true;
+}
+
+bool isConfirmedDirectMessage(
+  AsyncValue<List<Channel>> channels,
+  String channelId,
+) {
+  final knownChannels = channels.asData?.value;
+  if (knownChannels == null) return false;
+  for (final channel in knownChannels) {
+    if (channel.id == channelId) return channel.isDm;
+  }
+  return false;
+}
+
+final channelLoadsFullTimelineProvider = Provider.family<bool, String>(
+  (ref, channelId) =>
+      shouldLoadFullChannelTimeline(ref.watch(channelsProvider), channelId),
+);
+
+final channelIsDirectMessageProvider = Provider.family<bool, String>(
+  (ref, channelId) =>
+      isConfirmedDirectMessage(ref.watch(channelsProvider), channelId),
+);
 
 /// Provides the message list for a specific channel. Registers a live
 /// subscription first, then syncs history via the server-assembled channel
@@ -22,6 +60,8 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
   bool _initInFlight = false;
   bool _usingChannelWindow = false;
   bool _initialWindowQueryInFlight = false;
+  bool _isDirectMessage = false;
+  bool _loadsFullTimeline = false;
   int _initVersion = 0;
   ChannelWindowStore _windowStore = const ChannelWindowStore.empty();
   final Set<String> _liveSummaryRootsDuringInitialWindowQuery = {};
@@ -46,6 +86,8 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
   @override
   AsyncValue<List<NostrEvent>> build() {
     final sessionState = ref.watch(relaySessionProvider);
+    _isDirectMessage = ref.watch(channelIsDirectMessageProvider(channelId));
+    _loadsFullTimeline = ref.watch(channelLoadsFullTimelineProvider(channelId));
     ref.onDispose(() {
       _initVersion++;
       _clearSubscription();
@@ -135,6 +177,15 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
   Future<List<NostrEvent>> _fetchNewestHistory(
     RelaySessionNotifier session,
   ) async {
+    if (_loadsFullTimeline) {
+      _usingChannelWindow = false;
+      final history = await session.fetchHistory(
+        NostrFilters.messages(channelId),
+      );
+      history.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+      return history;
+    }
+
     try {
       _initialWindowQueryInFlight = true;
       final page = await _fetchWindowPage(session, null);
@@ -287,7 +338,7 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
   void addLocalMessage(NostrEvent event) {
     ref.read(pendingLocalMessagesProvider(channelId).notifier).add(event);
     final thread = event.threadReference;
-    if (thread.parentId != null) {
+    if (thread.parentId != null && !_isDirectMessage) {
       final rootId = thread.rootId;
       if (rootId == null) {
         throw StateError('Reply ${event.id} has a parent but no thread root.');
@@ -330,7 +381,7 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
     if (pending == null) return;
 
     final thread = pending.threadReference;
-    if (thread.parentId != null) {
+    if (thread.parentId != null && !_isDirectMessage) {
       final rootId = thread.rootId;
       if (rootId == null) {
         throw StateError('Reply $eventId has a parent but no thread root.');

--- a/mobile/lib/features/channels/compose_bar.dart
+++ b/mobile/lib/features/channels/compose_bar.dart
@@ -61,6 +61,29 @@ typedef ComposeBarOnSend =
       List<List<String>> mediaTags,
     });
 
+List<String> messageNotificationPubkeys({
+  required Iterable<String> explicitMentions,
+  required Iterable<ChannelMember> channelMembers,
+  required String? currentPubkey,
+  required bool isDirectMessage,
+}) {
+  final current = currentPubkey?.toLowerCase();
+  final seen = <String>{};
+  final recipients = <String>[];
+
+  void add(String pubkey) {
+    final normalized = pubkey.toLowerCase();
+    if (normalized == current || !seen.add(normalized)) return;
+    recipients.add(pubkey);
+  }
+
+  explicitMentions.forEach(add);
+  if (isDirectMessage) {
+    channelMembers.map((member) => member.pubkey).forEach(add);
+  }
+  return recipients;
+}
+
 class ComposeBar extends HookConsumerWidget {
   final String channelId;
   final String channelName;
@@ -467,7 +490,15 @@ class ComposeBar extends HookConsumerWidget {
       // Mentioning humans outside the channel prompts "Invite" / "Do
       // nothing" (send without inviting) — mirrors desktop's
       // NonMemberMentionDialog. Agents keep the existing silent auto-add.
-      var mentionPubkeys = pubkeys;
+      final directMessageMembers = isDmChannel
+          ? await ref.read(channelMembersProvider(channelId).future)
+          : const <ChannelMember>[];
+      var mentionPubkeys = messageNotificationPubkeys(
+        explicitMentions: pubkeys,
+        channelMembers: directMessageMembers,
+        currentPubkey: currentPubkey,
+        isDirectMessage: isDmChannel,
+      );
       final referenceMentionTags = <List<String>>[];
       var inviteHumanPubkeys = const <String>[];
       if (nonMemberHumans.isNotEmpty) {

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -109,7 +109,15 @@ class ThreadDetailPage extends HookConsumerWidget {
       childrenByParent.putIfAbsent(pid, () => []).add(msg);
     }
 
-    final replies = childrenByParent[threadHead.id] ?? const [];
+    // In a DM the turns of one thread read as a single conversation, so every
+    // descendant of this root is shown in chronological order. A new direct
+    // message still opens its own thread; only this root's turns are merged.
+    final replies = buildThreadReplies(
+      allMsgs,
+      threadHead,
+      childrenByParent,
+      linearize: ref.watch(channelIsDirectMessageProvider(channelId)),
+    );
     final itemScrollController = useMemoized(ItemScrollController.new);
     final itemPositionsListener = useMemoized(ItemPositionsListener.create);
     final didJumpToInitialMessage = useRef(false);

--- a/mobile/lib/features/channels/thread_detail_page.dart
+++ b/mobile/lib/features/channels/thread_detail_page.dart
@@ -112,11 +112,14 @@ class ThreadDetailPage extends HookConsumerWidget {
     // In a DM the turns of one thread read as a single conversation, so every
     // descendant of this root is shown in chronological order. A new direct
     // message still opens its own thread; only this root's turns are merged.
+    final linearizeThread = ref.watch(
+      channelIsDirectMessageProvider(channelId),
+    );
     final replies = buildThreadReplies(
       allMsgs,
       threadHead,
       childrenByParent,
-      linearize: ref.watch(channelIsDirectMessageProvider(channelId)),
+      linearize: linearizeThread,
     );
     final itemScrollController = useMemoized(ItemScrollController.new);
     final itemPositionsListener = useMemoized(ItemPositionsListener.create);
@@ -344,9 +347,14 @@ class ThreadDetailPage extends HookConsumerWidget {
 
                   // Check if this reply itself has children (nested thread).
                   final nestedChildren = childrenByParent[reply.id];
+                  final hasNestedChildren =
+                      nestedChildren != null && nestedChildren.isNotEmpty;
                   final nestedSummary =
-                      nestedChildren != null && nestedChildren.isNotEmpty
-                      ? _buildNestedSummary(reply.id, nestedChildren)
+                      shouldShowNestedThreadSummary(
+                        linearize: linearizeThread,
+                        hasNestedChildren: hasNestedChildren,
+                      )
+                      ? _buildNestedSummary(reply.id, nestedChildren!)
                       : null;
 
                   return Padding(

--- a/mobile/lib/features/channels/timeline_message.dart
+++ b/mobile/lib/features/channels/timeline_message.dart
@@ -508,7 +508,14 @@ List<TimelineMessage> formatTimeline(
 List<MainTimelineEntry> buildMainTimelineEntries(
   List<TimelineMessage> messages, {
   Map<String, ChannelWindowThreadSummary>? relaySummaries,
+  bool flattenReplies = false,
 }) {
+  if (flattenReplies) {
+    return [
+      for (final message in messages) MainTimelineEntry(message: message),
+    ];
+  }
+
   // Index direct children by parentId.
   final childrenByParent = <String, List<TimelineMessage>>{};
   for (final msg in messages) {

--- a/mobile/lib/features/channels/timeline_message.dart
+++ b/mobile/lib/features/channels/timeline_message.dart
@@ -547,21 +547,28 @@ List<TimelineMessage> buildThreadReplies(
 }) {
   // A nested branch head is not a root, so its descendants keep the normal
   // parent/child shape even in a linearized conversation.
-  final isRoot = threadHead.rootId == null || threadHead.rootId == threadHead.id;
+  final isRoot =
+      threadHead.rootId == null || threadHead.rootId == threadHead.id;
   if (!linearize || !isRoot) {
     return childrenByParent[threadHead.id] ?? const [];
   }
 
-  final descendants = [
-    for (final message in allMessages)
-      if (message.id != threadHead.id && message.rootId == threadHead.id)
-        message,
-  ]..sort((left, right) {
-    final byTime = left.createdAt.compareTo(right.createdAt);
-    return byTime != 0 ? byTime : left.id.compareTo(right.id);
-  });
+  final descendants =
+      [
+        for (final message in allMessages)
+          if (message.id != threadHead.id && message.rootId == threadHead.id)
+            message,
+      ]..sort((left, right) {
+        final byTime = left.createdAt.compareTo(right.createdAt);
+        return byTime != 0 ? byTime : left.id.compareTo(right.id);
+      });
   return descendants;
 }
+
+bool shouldShowNestedThreadSummary({
+  required bool linearize,
+  required bool hasNestedChildren,
+}) => !linearize && hasNestedChildren;
 
 bool _isBroadcastReply(TimelineMessage message) {
   return message.tags.any(

--- a/mobile/lib/features/channels/timeline_message.dart
+++ b/mobile/lib/features/channels/timeline_message.dart
@@ -508,14 +508,7 @@ List<TimelineMessage> formatTimeline(
 List<MainTimelineEntry> buildMainTimelineEntries(
   List<TimelineMessage> messages, {
   Map<String, ChannelWindowThreadSummary>? relaySummaries,
-  bool flattenReplies = false,
 }) {
-  if (flattenReplies) {
-    return [
-      for (final message in messages) MainTimelineEntry(message: message),
-    ];
-  }
-
   // Index direct children by parentId.
   final childrenByParent = <String, List<TimelineMessage>>{};
   for (final msg in messages) {
@@ -536,6 +529,38 @@ List<MainTimelineEntry> buildMainTimelineEntries(
           ),
         ),
   ];
+}
+
+/// Replies to show under an open thread head.
+///
+/// [linearize] mirrors the desktop's agent-conversation rule: every descendant
+/// of the same root is presented as one chronological sequence at depth 1,
+/// instead of only the head's direct children with deeper turns hidden behind
+/// nested sub-threads. The flattening is scoped to a single root — it never
+/// merges separate threads of the same channel into one stream, and the NIP-10
+/// parent/reply tags stay untouched in the protocol.
+List<TimelineMessage> buildThreadReplies(
+  List<TimelineMessage> allMessages,
+  TimelineMessage threadHead,
+  Map<String, List<TimelineMessage>> childrenByParent, {
+  bool linearize = false,
+}) {
+  // A nested branch head is not a root, so its descendants keep the normal
+  // parent/child shape even in a linearized conversation.
+  final isRoot = threadHead.rootId == null || threadHead.rootId == threadHead.id;
+  if (!linearize || !isRoot) {
+    return childrenByParent[threadHead.id] ?? const [];
+  }
+
+  final descendants = [
+    for (final message in allMessages)
+      if (message.id != threadHead.id && message.rootId == threadHead.id)
+        message,
+  ]..sort((left, right) {
+    final byTime = left.createdAt.compareTo(right.createdAt);
+    return byTime != 0 ? byTime : left.id.compareTo(right.id);
+  });
+  return descendants;
 }
 
 bool _isBroadcastReply(TimelineMessage message) {

--- a/mobile/lib/shared/mentions/agent_identity_provider.dart
+++ b/mobile/lib/shared/mentions/agent_identity_provider.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:nostr/nostr.dart' as nostr;
 
 import '../../shared/crypto/nip_oa.dart';
 import '../../shared/relay/relay.dart';
@@ -65,9 +67,182 @@ final agentDirectoryProvider = FutureProvider<List<AgentDirectoryEntry>>((
   final sessionState = ref.watch(relaySessionProvider);
   if (sessionState.status != SessionStatus.connected) return const [];
   final session = ref.read(relaySessionProvider.notifier);
-  final events = await session.fetchHistory(NostrFilters.agentProfiles());
-  return [for (final event in events) AgentDirectoryEntry.fromEvent(event)];
+  final results = await Future.wait([
+    session.fetchHistory(NostrFilters.agentProfiles()),
+    ref.watch(archivedIdentityPubkeysProvider.future),
+  ]);
+  return activeAgentDirectoryEntries(
+    results[0] as List<NostrEvent>,
+    archivedPubkeys: results[1] as Set<String>,
+  );
 });
+
+/// HTTP client used to read the relay's NIP-11 signing identity.
+final relayIdentityHttpClientProvider = Provider<http.Client>((ref) {
+  final client = http.Client();
+  ref.onDispose(client.close);
+  return client;
+});
+
+/// Relay signing pubkey advertised by NIP-11 `self`.
+final relayIdentityPubkeyProvider = FutureProvider<String?>((ref) async {
+  final baseUrl = ref.watch(relayConfigProvider).baseUrl;
+  try {
+    final response = await ref
+        .read(relayIdentityHttpClientProvider)
+        .get(
+          Uri.parse(baseUrl),
+          headers: const {'Accept': 'application/nostr+json'},
+        )
+        .timeout(const Duration(seconds: 5));
+    if (response.statusCode < 200 || response.statusCode >= 300) return null;
+    final decoded = jsonDecode(response.body);
+    final relayPubkey = decoded is Map<String, dynamic>
+        ? decoded['self'] as String?
+        : null;
+    final normalized = relayPubkey?.toLowerCase();
+    return normalized != null && _isHex64(normalized) ? normalized : null;
+  } catch (_) {
+    return null;
+  }
+});
+
+class _ArchiveIdentitySubscription extends Notifier<int> {
+  void Function()? _unsubscribe;
+  int _subscriptionVersion = 0;
+
+  @override
+  int build() {
+    final sessionState = ref.watch(relaySessionProvider);
+    final subscriptionVersion = ++_subscriptionVersion;
+    _clearSubscription();
+    ref.onDispose(() {
+      _subscriptionVersion++;
+      _clearSubscription();
+    });
+
+    if (sessionState.status != SessionStatus.connected) return 0;
+    Future.microtask(() => _subscribe(subscriptionVersion));
+    return 0;
+  }
+
+  Future<void> _subscribe(int subscriptionVersion) async {
+    try {
+      final relayPubkey = await ref.read(relayIdentityPubkeyProvider.future);
+      if (relayPubkey == null || !_isCurrent(subscriptionVersion)) return;
+      final session = ref.read(relaySessionProvider.notifier);
+      final unsubscribe = await session.subscribe(
+        NostrFilters.archivedIdentities(
+          relayPubkey,
+        ).copyWithSince(DateTime.now().millisecondsSinceEpoch ~/ 1000),
+        (_) {
+          if (_isCurrent(subscriptionVersion)) state++;
+        },
+      );
+      if (!_isCurrent(subscriptionVersion)) {
+        unsubscribe();
+        return;
+      }
+      _unsubscribe = unsubscribe;
+    } catch (error) {
+      if (_isCurrent(subscriptionVersion)) {
+        debugPrint('[ArchiveIdentitySubscription] failed: $error');
+      }
+    }
+  }
+
+  bool _isCurrent(int subscriptionVersion) =>
+      subscriptionVersion == _subscriptionVersion;
+
+  void _clearSubscription() {
+    _unsubscribe?.call();
+    _unsubscribe = null;
+  }
+}
+
+final archiveIdentityUpdateProvider =
+    NotifierProvider.autoDispose<_ArchiveIdentitySubscription, int>(
+      _ArchiveIdentitySubscription.new,
+    );
+
+/// Current relay-scoped archive state, verified against NIP-11 `self`.
+final archivedIdentityPubkeysProvider = FutureProvider<Set<String>>((
+  ref,
+) async {
+  ref.watch(archiveIdentityUpdateProvider);
+  final sessionState = ref.watch(relaySessionProvider);
+  if (sessionState.status != SessionStatus.connected) return const {};
+  final relayPubkey = await ref.watch(relayIdentityPubkeyProvider.future);
+  if (relayPubkey == null) return const {};
+  final session = ref.read(relaySessionProvider.notifier);
+  final snapshots = await session.fetchHistory(
+    NostrFilters.archivedIdentities(relayPubkey),
+  );
+  return archivedIdentityPubkeysFromSnapshots(
+    snapshots,
+    relayPubkey: relayPubkey,
+    verifySignature: _hasValidNostrSignature,
+  );
+});
+
+List<AgentDirectoryEntry> activeAgentDirectoryEntries(
+  Iterable<NostrEvent> events, {
+  required Set<String> archivedPubkeys,
+}) => [
+  for (final event in events)
+    if (!archivedPubkeys.contains(event.pubkey.toLowerCase()))
+      AgentDirectoryEntry.fromEvent(event),
+];
+
+Set<String> archivedIdentityPubkeysFromSnapshots(
+  Iterable<NostrEvent> snapshots, {
+  required String relayPubkey,
+  required bool Function(NostrEvent event) verifySignature,
+}) {
+  final normalizedRelayPubkey = relayPubkey.toLowerCase();
+  final valid =
+      snapshots
+          .where(
+            (event) =>
+                event.kind == 13535 &&
+                event.pubkey.toLowerCase() == normalizedRelayPubkey &&
+                _hasExactlyOneNip70Tag(event.tags) &&
+                verifySignature(event),
+          )
+          .toList()
+        ..sort((a, b) {
+          final byTimestamp = b.createdAt.compareTo(a.createdAt);
+          return byTimestamp != 0 ? byTimestamp : a.id.compareTo(b.id);
+        });
+  if (valid.isEmpty) return const {};
+  return {
+    for (final tag in valid.first.tags)
+      if (tag.length >= 2 && tag[0] == 'p' && _isHex64(tag[1]))
+        tag[1].toLowerCase(),
+  };
+}
+
+bool _hasExactlyOneNip70Tag(List<List<String>> tags) {
+  var count = 0;
+  for (final tag in tags) {
+    if (tag.isEmpty || tag.first != '-') continue;
+    if (tag.length != 1) return false;
+    count++;
+  }
+  return count == 1;
+}
+
+bool _hasValidNostrSignature(NostrEvent event) {
+  try {
+    nostr.Event.fromJson(jsonEncode(event.toJson()));
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+bool _isHex64(String value) =>
+    value.length == 64 && RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(value);
 
 /// Verified NIP-OA owner pubkey per agent pubkey, from the agents' kind:0
 /// profiles. An entry exists only when the `auth` tag verifies — mirrors

--- a/mobile/lib/shared/relay/nostr_filters.dart
+++ b/mobile/lib/shared/relay/nostr_filters.dart
@@ -209,6 +209,10 @@ abstract final class NostrFilters {
   static NostrFilter agentProfiles() =>
       const NostrFilter(kinds: [10100], limit: 100);
 
+  /// Latest relay-signed NIP-IA archive snapshot (kind:13535).
+  static NostrFilter archivedIdentities(String relayPubkey) =>
+      NostrFilter(kinds: const [13535], authors: [relayPubkey], limit: 1);
+
   /// User status (NIP-38, kind:30315).
   static NostrFilter userStatus(String pubkey) =>
       NostrFilter(kinds: [30315], authors: [pubkey], limit: 1);

--- a/mobile/test/features/channels/channel_messages_provider_test.dart
+++ b/mobile/test/features/channels/channel_messages_provider_test.dart
@@ -4,12 +4,124 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:buzz/features/channels/channel.dart';
 import 'package:buzz/features/channels/channel_messages_provider.dart';
 import 'package:buzz/features/channels/pending_local_messages_provider.dart';
 import 'package:buzz/features/channels/thread_replies_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
 void main() {
+  test('unknown channel metadata uses the reply-preserving history path', () {
+    expect(
+      shouldLoadFullChannelTimeline(
+        const AsyncLoading<List<Channel>>(),
+        _channelId,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldLoadFullChannelTimeline(
+        AsyncError<List<Channel>>(StateError('unavailable'), StackTrace.empty),
+        _channelId,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldLoadFullChannelTimeline(
+        const AsyncData<List<Channel>>([]),
+        _channelId,
+      ),
+      isTrue,
+    );
+  });
+
+  test('unknown channel metadata is not treated as a confirmed DM', () {
+    expect(
+      isConfirmedDirectMessage(const AsyncLoading<List<Channel>>(), _channelId),
+      isFalse,
+    );
+    expect(
+      isConfirmedDirectMessage(
+        AsyncError<List<Channel>>(StateError('unavailable'), StackTrace.empty),
+        _channelId,
+      ),
+      isFalse,
+    );
+    expect(
+      isConfirmedDirectMessage(const AsyncData<List<Channel>>([]), _channelId),
+      isFalse,
+    );
+  });
+
+  test('optimistic DM replies render linearly and roll back', () async {
+    final relaySession = _RecordingRelaySessionNotifier();
+    final container = _buildContainer(relaySession, isDirectMessage: true);
+    addTearDown(container.dispose);
+
+    container.read(channelMessagesProvider(_channelId));
+    await relaySession.subscribed;
+    relaySession.completeHistory([_event(id: 'root', createdAt: 10)]);
+    await _pumpEventQueue();
+
+    final reply = _event(
+      id: 'local-reply',
+      createdAt: 20,
+      extraTags: const [
+        ['e', 'root', '', 'reply'],
+      ],
+    );
+    final notifier = container.read(
+      channelMessagesProvider(_channelId).notifier,
+    );
+    notifier.addLocalMessage(reply);
+
+    expect(
+      container
+          .read(channelMessagesProvider(_channelId))
+          .value
+          ?.map((event) => event.id),
+      ['root', 'local-reply'],
+    );
+
+    notifier.removeLocalMessage(reply.id);
+    expect(
+      container
+          .read(channelMessagesProvider(_channelId))
+          .value
+          ?.map((event) => event.id),
+      ['root'],
+    );
+  });
+
+  test('loads DM replies into the linear websocket timeline', () async {
+    final relaySession = _RecordingRelaySessionNotifier();
+    final container = _buildContainer(relaySession, isDirectMessage: true);
+    addTearDown(container.dispose);
+
+    container.read(channelMessagesProvider(_channelId));
+    await relaySession.subscribed;
+    relaySession.completeHistory([
+      _event(id: 'root', createdAt: 10),
+      _event(
+        id: 'reply',
+        createdAt: 20,
+        extraTags: const [
+          ['e', 'root', '', 'reply'],
+        ],
+      ),
+    ]);
+    await _pumpEventQueue();
+
+    expect(relaySession.operations, ['subscribe', 'fetch']);
+    expect(
+      container
+          .read(channelMessagesProvider(_channelId))
+          .value
+          ?.map((event) => event.id),
+      ['root', 'reply'],
+    );
+  });
+
   test(
     'keeps live events that arrive while initial history is loading',
     () async {
@@ -614,9 +726,20 @@ void main() {
 
 const _channelId = '11111111-1111-4111-8111-111111111111';
 
-ProviderContainer _buildContainer(_RecordingRelaySessionNotifier relaySession) {
+ProviderContainer _buildContainer(
+  _RecordingRelaySessionNotifier relaySession, {
+  bool isDirectMessage = false,
+}) {
   return ProviderContainer(
-    overrides: [relaySessionProvider.overrideWith(() => relaySession)],
+    overrides: [
+      relaySessionProvider.overrideWith(() => relaySession),
+      channelIsDirectMessageProvider.overrideWith(
+        (ref, channelId) => isDirectMessage,
+      ),
+      channelLoadsFullTimelineProvider.overrideWith(
+        (ref, channelId) => isDirectMessage,
+      ),
+    ],
   );
 }
 

--- a/mobile/test/features/channels/channel_messages_provider_test.dart
+++ b/mobile/test/features/channels/channel_messages_provider_test.dart
@@ -53,7 +53,7 @@ void main() {
     );
   });
 
-  test('optimistic DM replies render linearly and roll back', () async {
+  test('optimistic DM replies stay in their thread and roll back', () async {
     final relaySession = _RecordingRelaySessionNotifier();
     final container = _buildContainer(relaySession, isDirectMessage: true);
     addTearDown(container.dispose);
@@ -63,6 +63,7 @@ void main() {
     relaySession.completeHistory([_event(id: 'root', createdAt: 10)]);
     await _pumpEventQueue();
 
+    final args = ThreadRepliesArgs(channelId: _channelId, rootId: 'root');
     final reply = _event(
       id: 'local-reply',
       createdAt: 20,
@@ -75,15 +76,22 @@ void main() {
     );
     notifier.addLocalMessage(reply);
 
+    // A DM reply belongs to its root's thread, not to the main timeline.
+    // Promoting it would merge separate conversations into one stream.
+    expect(
+      container.read(threadLocalRepliesProvider(args)).map((event) => event.id),
+      ['local-reply'],
+    );
     expect(
       container
           .read(channelMessagesProvider(_channelId))
           .value
           ?.map((event) => event.id),
-      ['root', 'local-reply'],
+      ['root'],
     );
 
     notifier.removeLocalMessage(reply.id);
+    expect(container.read(threadLocalRepliesProvider(args)), isEmpty);
     expect(
       container
           .read(channelMessagesProvider(_channelId))
@@ -93,7 +101,7 @@ void main() {
     );
   });
 
-  test('loads DM replies into the linear websocket timeline', () async {
+  test('loads the full DM history so thread replies stay available', () async {
     final relaySession = _RecordingRelaySessionNotifier();
     final container = _buildContainer(relaySession, isDirectMessage: true);
     addTearDown(container.dispose);

--- a/mobile/test/features/channels/compose_bar_dm_recipients_test.dart
+++ b/mobile/test/features/channels/compose_bar_dm_recipients_test.dart
@@ -1,0 +1,33 @@
+import 'package:buzz/features/channels/channel_management_provider.dart';
+import 'package:buzz/features/channels/compose_bar.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('DM messages notify every participant except the sender', () {
+    final recipients = messageNotificationPubkeys(
+      explicitMentions: const ['agent'],
+      channelMembers: [_member('owner'), _member('agent'), _member('observer')],
+      currentPubkey: 'OWNER',
+      isDirectMessage: true,
+    );
+
+    expect(recipients, ['agent', 'observer']);
+  });
+
+  test('regular channel messages only notify explicit mentions', () {
+    final recipients = messageNotificationPubkeys(
+      explicitMentions: const ['agent'],
+      channelMembers: [_member('owner'), _member('observer')],
+      currentPubkey: 'owner',
+      isDirectMessage: false,
+    );
+
+    expect(recipients, ['agent']);
+  });
+}
+
+ChannelMember _member(String pubkey) => ChannelMember(
+  pubkey: pubkey,
+  role: 'member',
+  joinedAt: DateTime.fromMillisecondsSinceEpoch(0),
+);

--- a/mobile/test/features/channels/timeline_message_test.dart
+++ b/mobile/test/features/channels/timeline_message_test.dart
@@ -774,6 +774,19 @@ void main() {
   });
 
   group('buildMainTimelineEntries', () {
+    test('flattens thread replies into direct-message timelines', () {
+      final messages = formatTimeline([
+        _textMsg(id: 'a', createdAt: 1000),
+        _replyMsg(id: 'r1', parentId: 'a', createdAt: 2000),
+        _replyMsg(id: 'r2', parentId: 'r1', rootId: 'a', createdAt: 3000),
+      ]);
+
+      final entries = buildMainTimelineEntries(messages, flattenReplies: true);
+
+      expect(entries.map((entry) => entry.message.id), ['a', 'r1', 'r2']);
+      expect(entries.every((entry) => entry.summary == null), isTrue);
+    });
+
     test('returns only root messages', () {
       final messages = formatTimeline([
         _textMsg(id: 'a', createdAt: 1000),

--- a/mobile/test/features/channels/timeline_message_test.dart
+++ b/mobile/test/features/channels/timeline_message_test.dart
@@ -856,6 +856,25 @@ void main() {
     });
   });
 
+  group('shouldShowNestedThreadSummary', () {
+    test('hides nested thread affordances inside a linearized DM root', () {
+      expect(
+        shouldShowNestedThreadSummary(linearize: true, hasNestedChildren: true),
+        isFalse,
+      );
+    });
+
+    test('preserves nested thread affordances for normal threads', () {
+      expect(
+        shouldShowNestedThreadSummary(
+          linearize: false,
+          hasNestedChildren: true,
+        ),
+        isTrue,
+      );
+    });
+  });
+
   group('buildMainTimelineEntries', () {
     test('keeps separate direct-message threads as separate entries', () {
       final messages = formatTimeline([

--- a/mobile/test/features/channels/timeline_message_test.dart
+++ b/mobile/test/features/channels/timeline_message_test.dart
@@ -773,18 +773,104 @@ void main() {
     });
   });
 
-  group('buildMainTimelineEntries', () {
-    test('flattens thread replies into direct-message timelines', () {
+  group('buildThreadReplies', () {
+    Map<String, List<TimelineMessage>> childrenOf(
+      List<TimelineMessage> messages,
+    ) {
+      final byParent = <String, List<TimelineMessage>>{};
+      for (final message in messages) {
+        final parentId = message.parentId;
+        if (parentId == null) continue;
+        byParent.putIfAbsent(parentId, () => []).add(message);
+      }
+      return byParent;
+    }
+
+    test('keeps direct children only when not linearized', () {
       final messages = formatTimeline([
         _textMsg(id: 'a', createdAt: 1000),
         _replyMsg(id: 'r1', parentId: 'a', createdAt: 2000),
         _replyMsg(id: 'r2', parentId: 'r1', rootId: 'a', createdAt: 3000),
       ]);
+      final head = messages.firstWhere((message) => message.id == 'a');
 
-      final entries = buildMainTimelineEntries(messages, flattenReplies: true);
+      final replies = buildThreadReplies(messages, head, childrenOf(messages));
 
-      expect(entries.map((entry) => entry.message.id), ['a', 'r1', 'r2']);
-      expect(entries.every((entry) => entry.summary == null), isTrue);
+      expect(replies.map((message) => message.id), ['r1']);
+    });
+
+    test('linearizes every descendant of the same root in order', () {
+      final messages = formatTimeline([
+        _textMsg(id: 'a', createdAt: 1000),
+        _replyMsg(id: 'r2', parentId: 'r1', rootId: 'a', createdAt: 3000),
+        _replyMsg(id: 'r1', parentId: 'a', createdAt: 2000),
+        _replyMsg(id: 'r3', parentId: 'r2', rootId: 'a', createdAt: 4000),
+      ]);
+      final head = messages.firstWhere((message) => message.id == 'a');
+
+      final replies = buildThreadReplies(
+        messages,
+        head,
+        childrenOf(messages),
+        linearize: true,
+      );
+
+      expect(replies.map((message) => message.id), ['r1', 'r2', 'r3']);
+    });
+
+    test('never merges a different thread of the same channel', () {
+      final messages = formatTimeline([
+        _textMsg(id: 'a', createdAt: 1000),
+        _replyMsg(id: 'r1', parentId: 'a', createdAt: 2000),
+        _textMsg(id: 'b', createdAt: 3000),
+        _replyMsg(id: 'r2', parentId: 'b', createdAt: 4000),
+      ]);
+      final head = messages.firstWhere((message) => message.id == 'a');
+
+      final replies = buildThreadReplies(
+        messages,
+        head,
+        childrenOf(messages),
+        linearize: true,
+      );
+
+      expect(replies.map((message) => message.id), ['r1']);
+    });
+
+    test('a nested branch head keeps its direct children', () {
+      final messages = formatTimeline([
+        _textMsg(id: 'a', createdAt: 1000),
+        _replyMsg(id: 'r1', parentId: 'a', createdAt: 2000),
+        _replyMsg(id: 'r2', parentId: 'r1', rootId: 'a', createdAt: 3000),
+      ]);
+      final branchHead = messages.firstWhere((message) => message.id == 'r1');
+
+      final replies = buildThreadReplies(
+        messages,
+        branchHead,
+        childrenOf(messages),
+        linearize: true,
+      );
+
+      expect(replies.map((message) => message.id), ['r2']);
+    });
+  });
+
+  group('buildMainTimelineEntries', () {
+    test('keeps separate direct-message threads as separate entries', () {
+      final messages = formatTimeline([
+        _textMsg(id: 'a', createdAt: 1000),
+        _replyMsg(id: 'r1', parentId: 'a', createdAt: 2000),
+        _replyMsg(id: 'r2', parentId: 'r1', rootId: 'a', createdAt: 3000),
+        _textMsg(id: 'b', createdAt: 4000),
+      ]);
+
+      final entries = buildMainTimelineEntries(messages);
+
+      // A new direct message opens its own thread; replies never get promoted
+      // into the main timeline, which would merge both conversations.
+      expect(entries.map((entry) => entry.message.id), ['a', 'b']);
+      expect(entries[0].summary?.replyCount, 1);
     });
 
     test('returns only root messages', () {

--- a/mobile/test/shared/mentions/agent_identity_provider_test.dart
+++ b/mobile/test/shared/mentions/agent_identity_provider_test.dart
@@ -2,12 +2,128 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:nostr/nostr.dart' as nostr;
 import 'package:buzz/features/channels/agent_activity/working_bots_provider.dart';
 import 'package:buzz/features/channels/channel_management_provider.dart';
 import 'package:buzz/shared/mentions/agent_identity_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
 void main() {
+  test('filters archived identities from the active agent directory', () {
+    final active = _agentProfileEvent(
+      pubkey: _agentPubkey,
+      displayName: 'Active agent',
+    );
+    final archived = _agentProfileEvent(
+      pubkey: _archivedAgentPubkey,
+      displayName: 'Retired agent',
+    );
+
+    expect(
+      activeAgentDirectoryEntries(
+        [active, archived],
+        archivedPubkeys: const {_archivedAgentPubkey},
+      ).map((entry) => entry.pubkey),
+      [_agentPubkey],
+    );
+  });
+
+  test('uses the newest valid relay archive snapshot', () {
+    final older = _archiveSnapshot(
+      id: 'b',
+      createdAt: 10,
+      pubkeys: const [_agentPubkey],
+    );
+    final newer = _archiveSnapshot(
+      id: 'c',
+      createdAt: 20,
+      pubkeys: const [_archivedAgentPubkey],
+    );
+    final forged = _archiveSnapshot(
+      id: 'a',
+      createdAt: 30,
+      pubkeys: const [_agentPubkey],
+      pubkey: 'forged-relay',
+    );
+
+    expect(
+      archivedIdentityPubkeysFromSnapshots(
+        [older, newer, forged],
+        relayPubkey: _relayPubkey,
+        verifySignature: (_) => true,
+      ),
+      const {_archivedAgentPubkey},
+    );
+  });
+
+  test('rejects missing, malformed, and duplicate NIP-70 tags', () {
+    for (final protectionTags in <List<List<String>>>[
+      const [],
+      const [
+        ['-', 'extra'],
+      ],
+      const [
+        ['-'],
+        ['-'],
+      ],
+    ]) {
+      final snapshot = _archiveSnapshot(
+        id: 'invalid',
+        createdAt: 10,
+        pubkeys: const [_archivedAgentPubkey],
+        protectionTags: protectionTags,
+      );
+
+      expect(
+        archivedIdentityPubkeysFromSnapshots(
+          [snapshot],
+          relayPubkey: _relayPubkey,
+          verifySignature: (_) => true,
+        ),
+        isEmpty,
+      );
+    }
+  });
+
+  test('a live relay archive snapshot removes an active identity', () async {
+    final relayKeys = nostr.Keys.generate();
+    final relaySession = _ArchiveRelaySessionNotifier(
+      _signedArchiveSnapshot(relayKeys, const []),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        relaySessionProvider.overrideWith(() => relaySession),
+        relayIdentityPubkeyProvider.overrideWith(
+          (ref) async => relayKeys.public,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final keepAlive = container.listen(
+      archivedIdentityPubkeysProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(keepAlive.close);
+
+    expect(
+      await container.read(archivedIdentityPubkeysProvider.future),
+      isEmpty,
+    );
+    await relaySession.subscribed;
+
+    final archivedSnapshot = _signedArchiveSnapshot(relayKeys, const [
+      _archivedAgentPubkey,
+    ]);
+    relaySession.snapshot = archivedSnapshot;
+    relaySession.emit(archivedSnapshot);
+    await _pumpEventQueue();
+
+    expect(await container.read(archivedIdentityPubkeysProvider.future), {
+      _archivedAgentPubkey,
+    });
+  });
+
   test('refreshes channel bot roles from live membership updates', () async {
     final relaySession = _MembershipRelaySessionNotifier([
       _membershipEvent(role: 'bot'),
@@ -139,6 +255,58 @@ void main() {
 const _channelId = '11111111-1111-4111-8111-111111111111';
 const _agentPubkey =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _archivedAgentPubkey =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _relayPubkey =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+NostrEvent _agentProfileEvent({
+  required String pubkey,
+  required String displayName,
+}) => NostrEvent(
+  id: 'profile-$pubkey',
+  pubkey: pubkey,
+  createdAt: 1,
+  kind: 10100,
+  tags: const [],
+  content: '{"display_name":"$displayName"}',
+  sig: 'sig',
+);
+
+NostrEvent _archiveSnapshot({
+  required String id,
+  required int createdAt,
+  required List<String> pubkeys,
+  String pubkey = _relayPubkey,
+  List<List<String>> protectionTags = const [
+    ['-'],
+  ],
+}) => NostrEvent(
+  id: id,
+  pubkey: pubkey,
+  createdAt: createdAt,
+  kind: 13535,
+  tags: [
+    ...protectionTags,
+    for (final archivedPubkey in pubkeys) ['p', archivedPubkey],
+  ],
+  content: '',
+  sig: 'sig',
+);
+
+NostrEvent _signedArchiveSnapshot(nostr.Keys keys, List<String> pubkeys) =>
+    NostrEvent.fromJson(
+      nostr.Event.from(
+        kind: 13535,
+        content: '',
+        tags: [
+          ['-'],
+          for (final pubkey in pubkeys) ['p', pubkey],
+        ],
+        secretKey: keys.secret,
+        verify: false,
+      ).toMap(),
+    );
 
 NostrEvent _membershipEvent({required String role}) => NostrEvent(
   id: 'membership-$role',
@@ -203,6 +371,42 @@ class _MembershipRelaySessionNotifier extends RelaySessionNotifier {
       if (_matches(subscription.filter, event)) {
         subscription.onEvent(event);
       }
+    }
+  }
+}
+
+class _ArchiveRelaySessionNotifier extends RelaySessionNotifier {
+  NostrEvent snapshot;
+  final Completer<void> _subscribed = Completer<void>();
+  final List<void Function(NostrEvent)> _listeners = [];
+
+  _ArchiveRelaySessionNotifier(this.snapshot);
+
+  Future<void> get subscribed => _subscribed.future;
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<List<NostrEvent>> fetchHistory(
+    NostrFilter filter, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async => [snapshot];
+
+  @override
+  Future<void Function()> subscribe(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+  }) async {
+    _listeners.add(onEvent);
+    if (!_subscribed.isCompleted) _subscribed.complete();
+    return () => _listeners.remove(onEvent);
+  }
+
+  void emit(NostrEvent event) {
+    for (final listener in List.of(_listeners)) {
+      listener(event);
     }
   }
 }


### PR DESCRIPTION
## Summary

- add protocol-level `p` tags for every other participant in a direct-message channel while preserving and deduplicating explicit recipients
- load historical and live NIP-10 replies into DM timelines so agent turns are never missing from the conversation
- present the turns of a single thread linearly **within that thread's root**, instead of nesting each turn one level deeper
- keep the DM main timeline showing thread roots, so a new direct message still opens its own thread
- preserve normal threaded behavior for non-DM channels and use conservative full-history loading when metadata is unavailable
- add optimistic DM replies with rollback and authoritative echo reconciliation
- filter archived NIP-IA agent identities using relay-authored, signature-valid snapshots with exactly one well-formed NIP-70 `['-']` tag

## Why

The official Android client currently requires users to explicitly mention/select subscription-based agents because plain DM sends do not include recipient `p` tags. Valid NIP-10 agent replies are also presented as separate nested threads, and historical replies can be omitted from the initial DM timeline.

The defect being fixed is that **each turn inside a thread created another nested sub-thread**, so a back-and-forth with an agent grew one level deeper per reply and became unreadable.

## Scope of the linear presentation

This is deliberately scoped, because the two behaviors are easy to confuse:

- **A new direct message opens a new thread.** That is correct and is not changed here.
- **Inside one thread, the turns read as a single conversation.** Every descendant of that thread's root is presented in chronological order at depth 1, and the nested sub-thread affordance is suppressed for those turns since they are already shown inline.
- **The flattening is per `root_event_id`, never per DM.** Separate threads of the same DM are never merged into one stream.
- **A nested branch head keeps the normal parent/child shape**, and NIP-10 `root`/`reply` tags are left untouched — the linearity is presentation only, so protocol causality is preserved.

Normal channels retain their existing thread model.

## Related work

This PR combines and extends parts of the following open work:

- #3258 covers automatic DM participant `p` tags
- #3344 covers retaining live thread replies in the channel window
- #4240 flattens replies for `buzz-acp`, while this implementation scopes the behavior to a single thread root in positively confirmed DMs regardless of agent harness, and includes historical/optimistic paths

## Safety properties

- unknown/loading/error channel metadata is not treated as a confirmed DM
- the sender is excluded from automatic recipients
- explicit recipients are preserved and deduplicated
- non-DM channels retain normal NIP-10 threading
- separate threads within the same DM are never merged
- archived identity snapshots require the configured relay author, a valid signature, and exactly one `['-']` tag

## Test plan

- `flutter test test/features/channels/channel_messages_provider_test.dart test/features/channels/compose_bar_dm_recipients_test.dart test/features/channels/timeline_message_test.dart test/shared/mentions/agent_identity_provider_test.dart` — all passed, including coverage that two threads of the same DM stay separate, that every descendant of one root is linearized in order, that a nested branch head keeps its direct children, and that nested-thread affordances are suppressed only inside a linearized root
- `flutter analyze` — no issues in the touched directories
- `git diff --check`

Every commit includes the required DCO sign-off.
