### PR TITLE
fix(desktop): make composer attachment remove button keyboard-reachable (#2389)

### DIFF
--- a/desktop/src/features/messages/ui/ComposerAttachments.tsx
+++ b/desktop/src/features/messages/ui/ComposerAttachments.tsx
@@ -488,7 +488,7 @@ const MediaAttachmentItem = React.forwardRef<
             <button
               type="button"
               onClick={() => onRemove(attachment.url)}
-              className="absolute -right-1 -top-1 hidden h-4 w-4 items-center justify-center rounded-full bg-foreground text-background group-hover:flex"
+              className="absolute -right-1 -top-1 hidden h-4 w-4 items-center justify-center rounded-full bg-foreground text-background group-hover:flex group-focus-within:flex"
             >
               <X className="h-2.5 w-2.5" />
             </button>
@@ -581,7 +581,7 @@ export const ComposerAttachments = React.memo(function ComposerAttachments({
                       <button
                         type="button"
                         onClick={() => onRemove(attachment.url)}
-                        className="absolute -right-1 -top-1 hidden h-4 w-4 items-center justify-center rounded-full bg-foreground text-background group-hover:flex"
+                        className="absolute -right-1 -top-1 hidden h-4 w-4 items-center justify-center rounded-full bg-foreground text-background group-hover:flex group-focus-within:flex"
                       >
                         <X className="h-2.5 w-2.5" />
                       </button>


### PR DESCRIPTION
## What

Fixes #2389 — the "remove" (×) button on message-composer attachments was only reachable by mouse. It renders `hidden group-hover:flex`, so it is `display:none` until hover and therefore excluded from the keyboard tab order.

## Change

Add `group-focus-within:flex` alongside the existing hover rule on both remove buttons in `ComposerAttachments.tsx`:

- the generic file chip remove button
- the image/video thumbnail remove button

Now the button appears whenever focus is anywhere inside the attachment chip, so it is reachable and activatable entirely from the keyboard — exactly the fix proposed in the issue.

## Scope

- 1 file, 2 lines (both remove buttons), no behavior change for mouse users.
- No dependency on hover state for keyboard navigation.

## Verification

- `pnpm typecheck` — clean (`tsc --noEmit`, no errors)
- `pnpm exec biome check src/features/messages/ui/ComposerAttachments.tsx` — clean
- `pnpm check:file-sizes` — clean
- Desktop unit suite — **3906/3906 pass**

Signed-off-by: Sarthak Singh <sarthak.singh@juspay.in>
