### PR TITLE
fix(desktop): preserve imported key text when returning to key import (#2320)

### DIFF
--- a/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
+++ b/desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx
@@ -93,6 +93,11 @@ export function MachineOnboardingFlow({
     "backup" | "phone" | null
   >(null);
   const [phoneRecoveryStep, setPhoneRecoveryStep] = React.useState("loading");
+  // Owned here (not in the form) so navigating Back out of setup → key-import
+  // preserves the already-entered private key instead of clearing it. Cleared
+  // on a successful import and on "start new identity" so a stale key never
+  // lingers across identity switches.
+  const [keyDraft, setKeyDraft] = React.useState("");
   const [selectedPubkey, setSelectedPubkey] = React.useState<string | null>(
     null,
   );
@@ -171,6 +176,7 @@ export function MachineOnboardingFlow({
     setIsPending(true);
     setError(null);
     try {
+      setKeyDraft("");
       const identity = await persistCurrentIdentity();
       queryClient.setQueryData(["identity"], identity);
       setSelectedPubkey(identity.pubkey);
@@ -191,6 +197,8 @@ export function MachineOnboardingFlow({
   const importExistingIdentity = React.useCallback(
     async (nsec: string, password?: string) => {
       const identity = await importIdentity(nsec, password);
+      // The draft survives import on purpose: pressing Back from setup must
+      // re-show the key the user entered (masked), not an empty field.
       continueWithIdentity(identity.pubkey);
       queryClient.setQueryData(["identity"], identity);
       setIdentityWasImported(true);
@@ -348,6 +356,7 @@ export function MachineOnboardingFlow({
                 <div className="flex flex-col items-center">
                   <NostrKeyImportForm
                     backLabel="Back"
+                    nsecValue={keyDraft}
                     onBack={() => {
                       setKeyImportStage("key-entry");
                       if (identityLost) {
@@ -356,6 +365,7 @@ export function MachineOnboardingFlow({
                       setPage("identity");
                     }}
                     onImport={importExistingIdentity}
+                    onNsecChange={setKeyDraft}
                     onStageChange={setKeyImportStage}
                     showBack={!identityLost}
                     variant="spotlight"

--- a/desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx
+++ b/desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx
@@ -38,6 +38,11 @@ type NostrKeyImportFormProps = {
   mode?: "key" | "backup";
   /** Dialogs keep their actions inside the surface instead of the onboarding dock. */
   footerMode?: "onboarding" | "inline";
+  /** Controlled entered-key value. When provided with `onNsecChange`, the
+   * caller owns the key text so it survives remounts (e.g. onboarding Back
+   * navigation). The field stays masked (`type="password"`). */
+  nsecValue?: string;
+  onNsecChange?: (value: string) => void;
   /** "spotlight" is the first-launch treatment: glowy centered input, no drop zone, pill buttons. */
   variant?: "default" | "spotlight";
 };
@@ -59,9 +64,23 @@ export function NostrKeyImportForm({
   showBack = true,
   mode = "key",
   footerMode = "onboarding",
+  nsecValue,
+  onNsecChange,
   variant = "default",
 }: NostrKeyImportFormProps) {
-  const [nsecInput, setNsecInput] = React.useState("");
+  const [internalNsecInput, setInternalNsecInput] = React.useState("");
+  const isControlled = nsecValue !== undefined;
+  const nsecInput = isControlled ? nsecValue : internalNsecInput;
+  const setNsecInput = React.useCallback(
+    (value: string) => {
+      if (isControlled) {
+        onNsecChange?.(value);
+      } else {
+        setInternalNsecInput(value);
+      }
+    },
+    [isControlled, onNsecChange],
+  );
   const [passphrase, setPassphrase] = React.useState("");
   const [isImporting, setIsImporting] = React.useState(false);
   const [importError, setImportError] = React.useState<string | null>(null);
@@ -156,31 +175,34 @@ export function NostrKeyImportForm({
     fileInputRef.current?.click();
   }, [isInteractionDisabled]);
 
-  const handleFiles = React.useCallback(async (files: FileList | null) => {
-    const file = files?.[0];
-    if (!file) {
-      return;
-    }
+  const handleFiles = React.useCallback(
+    async (files: FileList | null) => {
+      const file = files?.[0];
+      if (!file) {
+        return;
+      }
 
-    if (file.size > NOSTR_KEY_FILE_MAX_BYTES) {
-      setImportError(
-        "That file is too large to be a key backup or private key. Choose another file.",
-      );
-      return;
-    }
+      if (file.size > NOSTR_KEY_FILE_MAX_BYTES) {
+        setImportError(
+          "That file is too large to be a key backup or private key. Choose another file.",
+        );
+        return;
+      }
 
-    try {
-      const text = await file.text();
-      const firstLine =
-        text.split(/\r?\n/).find((line) => line.trim().length > 0) ?? "";
-      setNsecInput(firstLine.trim());
-      setImportError(null);
-    } catch (error) {
-      setImportError(
-        error instanceof Error ? error.message : "Couldn't read that file.",
-      );
-    }
-  }, []);
+      try {
+        const text = await file.text();
+        const firstLine =
+          text.split(/\r?\n/).find((line) => line.trim().length > 0) ?? "";
+        setNsecInput(firstLine.trim());
+        setImportError(null);
+      } catch (error) {
+        setImportError(
+          error instanceof Error ? error.message : "Couldn't read that file.",
+        );
+      }
+    },
+    [setNsecInput],
+  );
 
   const handleSubmit = React.useCallback(async () => {
     // Guard here, not just on the submit button: the button now lives in the
@@ -235,7 +257,7 @@ export function NostrKeyImportForm({
     setImportError(null);
     setIsRevealed(false);
     onStageChange?.("key-entry");
-  }, [isPasswordStage, onBack, onStageChange]);
+  }, [isPasswordStage, onBack, onStageChange, setNsecInput]);
 
   return (
     <form


### PR DESCRIPTION
## Problem

When a user imports an existing private key during onboarding and proceeds to
the setup step, pressing **Back** returns them to the key-import page with the
private-key field **empty** — the key they already entered has to be pasted or
dropped again.

Root cause: the entered key lived only in `NostrKeyImportForm`'s local
`useState`. Returning to the key-import page remounts the form, so that state
reset to `""`.

Nostr keys are long and users frequently re-check the harness/setup step before
committing, so losing the typed key on Back is a recurring friction point in the
import flow.

## Change

Lift the entered-key value out of the form's local state into
`MachineOnboardingFlow` state, and pass it to `NostrKeyImportForm` as a
controlled `nsecValue`/`onNsecChange` pair. A remount now restores the (still
masked, `type="password"`) key the user entered.

- Draft survives a **successful import** — that is the reported flow:
  import → setup → Back must re-show the key.
- Draft is cleared when the user deliberately abandons the key via
  **"Start new identity"** so a stale key never lingers into a fresh identity.
- The reveal/masked toggle and the reveal-must-not-stick-across-a-cleared-field
  behavior are unchanged.

## Files

- `desktop/src/features/onboarding/ui/MachineOnboardingFlow.tsx` — own the
  `keyDraft` state; pass `nsecValue`/`onNsecChange`; clear on "start new".
- `desktop/src/features/onboarding/ui/NostrKeyImportForm.tsx` — accept optional
  controlled `nsecValue`/`onNsecChange`; fall back to internal state when
  uncontrolled (other callers like `KeyringLockedScreen` are unaffected).

## Verification

- `pnpm run typecheck` — clean.
- `pnpm exec biome check` (both files) — clean.
- `pnpm run check:file-sizes` — clean.
- `pnpm test` — 3906/3906 pass.

Fixes #2320
