### PR TITLE
fix(desktop): harden Windows installs against Defender block and orphaned Node

### DIFF
--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -333,10 +333,7 @@ fn install_acp_runtime_blocking(
     // For the codex runtime, "found" is not enough — the resolved binary must also
     // pass the 1.x version gate. An outdated 0.16.x adapter must be overwritten by
     // the new npm install so the CODEX_CONFIG spawn contract works correctly.
-    let adapter_path = runtime
-        .commands
-        .iter()
-        .find_map(|cmd| crate::managed_agents::resolve_command(cmd));
+    let adapter_path = resolve_adapter_path(runtime.commands, runtime.adapter_install_commands);
     let adapter_probe_path = crate::managed_agents::readiness::cli_probe::augmented_path();
     if let Some(cmds) = plan_adapter_install(
         runtime_id,
@@ -1020,7 +1017,7 @@ use install_report::InstallReporter;
 mod managed_node;
 use managed_node::{
     ensure_managed_node_runtime_blocking, managed_node_runtime_supported, managed_npm_command,
-    npm_eacces_hint,
+    npm_eacces_hint, resolve_adapter_path,
 };
 
 #[tauri::command]

--- a/desktop/src-tauri/src/commands/agent_discovery.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery.rs
@@ -1741,7 +1741,7 @@ mod tests {
     #[test]
     fn test_powershell_command_argv_exact() {
         // Catalog format: body wrapped in one outer double-quote pair (Bash-layer serialization).
-        let body = "irm https://chatgpt.com/codex/install.ps1 | iex";
+        let body = "$ErrorActionPreference='Stop'; $installer=Join-Path $env:TEMP 'buzz-install-codex.ps1'; Invoke-RestMethod https://chatgpt.com/codex/install.ps1 -OutFile $installer; & $installer; exit $LASTEXITCODE";
         let cmd = super::install_powershell_command(&format!(
             r#"powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "{body}""#
         ));
@@ -1771,12 +1771,12 @@ mod tests {
         );
     }
 
-    /// Claude Code catalog command (discovery.rs:107) must dequote to the bare pipeline.
+    /// Claude Code catalog command must dequote to the two-step download-then-execute body.
     #[cfg(windows)]
     #[test]
     fn test_powershell_command_claude_catalog_dequoted() {
         let cmd = super::install_powershell_command(
-            r#"powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "irm https://claude.ai/install.ps1 | iex""#,
+            r#"powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; $installer=Join-Path $env:TEMP 'buzz-install-claude.ps1'; Invoke-RestMethod https://claude.ai/install.ps1 -OutFile $installer; & $installer; exit $LASTEXITCODE""#,
         );
         assert_eq!(
             cmd.get_args()
@@ -1787,22 +1787,22 @@ mod tests {
                 "-ExecutionPolicy",
                 "Bypass",
                 "-Command",
-                "irm https://claude.ai/install.ps1 | iex",
+                "$ErrorActionPreference='Stop'; $installer=Join-Path $env:TEMP 'buzz-install-claude.ps1'; Invoke-RestMethod https://claude.ai/install.ps1 -OutFile $installer; & $installer; exit $LASTEXITCODE",
             ],
             "Claude catalog command must be dequoted correctly"
         );
     }
 
-    /// Goose Windows catalog command (discovery.rs:78) must dequote to a bare pipeline
-    /// with a literal `$env:` prefix — no backslash before the dollar sign.
-    /// This proves the `\$` → `$` escape fix: post-#2750 the spawn is native and
+    /// Goose Windows catalog command must dequote to the two-step download-then-execute body
+    /// with the `$env:CONFIGURE` prefix intact — no backslash before the dollar sign.
+    /// This proves the `\$` → `$` contract: post-#2750 the spawn is native and
     /// PowerShell receives the body verbatim, so a residual `\` would produce
     /// `\$env:CONFIGURE='false'` which is a malformed statement.
     #[cfg(windows)]
     #[test]
     fn test_powershell_command_goose_catalog_dequoted() {
         let cmd = super::install_powershell_command(
-            r#"powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$env:CONFIGURE='false'; irm https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1 | iex""#,
+            r#"powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$env:CONFIGURE='false'; $ErrorActionPreference='Stop'; $installer=Join-Path $env:TEMP 'buzz-install-goose.ps1'; Invoke-RestMethod https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1 -OutFile $installer; & $installer; exit $LASTEXITCODE""#,
         );
         assert_eq!(
             cmd.get_args()
@@ -1813,7 +1813,7 @@ mod tests {
                 "-ExecutionPolicy",
                 "Bypass",
                 "-Command",
-                "$env:CONFIGURE='false'; irm https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1 | iex",
+                "$env:CONFIGURE='false'; $ErrorActionPreference='Stop'; $installer=Join-Path $env:TEMP 'buzz-install-goose.ps1'; Invoke-RestMethod https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1 -OutFile $installer; & $installer; exit $LASTEXITCODE",
             ],
             "Goose catalog command must dequote with bare $env: (no backslash before $)"
         );

--- a/desktop/src-tauri/src/commands/agent_discovery/managed_node.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/managed_node.rs
@@ -102,25 +102,155 @@ fn managed_node_failed_step(stderr: String) -> InstallStepResult {
     }
 }
 
-fn managed_node_runtime_ready() -> bool {
+pub(super) fn managed_node_runtime_ready() -> bool {
     let Some(node) = crate::managed_agents::buzz_managed_node_bin_path() else {
         return false;
     };
     if !node.is_file() {
         return false;
     }
-    let mut cmd = std::process::Command::new(&node);
+    probe_node(&node, MANAGED_NODE_VERSION, Duration::from_secs(3))
+}
+
+/// Run `executable --version` with a bounded deadline and return `true` only
+/// when it exits 0 and its trimmed stdout equals `expected_version`.
+///
+/// Transport: stdout is redirected to a temp file so no exit path can block on
+/// an inherited handle (a descendant retaining a pipe write-end would otherwise
+/// prevent EOF indefinitely).
+///
+/// Cleanup: the child runs in its own process group on Unix (`process_group(0)`)
+/// so an unconditional group SIGKILL on every exit path terminates all
+/// descendants.  On Windows, `terminate_process` issues `taskkill /T /F` for
+/// tree-wide cleanup.  SIGKILL to an already-dead group returns ESRCH (no-op).
+pub(super) fn probe_node(
+    executable: &std::path::Path,
+    expected_version: &str,
+    timeout: Duration,
+) -> bool {
+    let tmp = match tempfile::NamedTempFile::new() {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+    let out_file = match tmp.reopen() {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+
+    let mut cmd = std::process::Command::new(executable);
     cmd.arg("--version")
         .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::from(out_file))
         .stderr(std::process::Stdio::null());
     crate::util::configure_no_window(&mut cmd);
-    let output = cmd.output();
-    output
-        .ok()
-        .filter(|output| output.status.success())
-        .map(|output| String::from_utf8_lossy(&output.stdout).trim() == MANAGED_NODE_VERSION)
-        .unwrap_or(false)
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    let Ok(mut child) = cmd.spawn() else {
+        return false;
+    };
+
+    let deadline = std::time::Instant::now() + timeout;
+    let exit_status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    kill_probe_group(child.id());
+                    let _ = child.wait();
+                    return false;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => {
+                kill_probe_group(child.id());
+                let _ = child.wait();
+                return false;
+            }
+        }
+    };
+
+    // Group-kill unconditionally: SIGKILL to a dead group is ESRCH (no-op).
+    kill_probe_group(child.id());
+
+    if !exit_status.success() {
+        return false;
+    }
+
+    let mut output = String::new();
+    if std::io::Read::read_to_string(&mut tmp.as_file(), &mut output).is_err() {
+        return false;
+    }
+    output.trim() == expected_version
+}
+
+/// Kill the probe's process group/tree unconditionally (no TERM grace — this
+/// is a probe, not an agent session).  ESRCH on a dead group is fine.
+fn kill_probe_group(pid: u32) {
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(-(pid as i32), libc::SIGKILL);
+    }
+    #[cfg(windows)]
+    {
+        let _ = crate::managed_agents::terminate_process(pid);
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = pid;
+    }
+}
+
+/// Returns `true` when the managed Node runtime is absent or no longer executes —
+/// meaning any existing npm adapter shims are broken and must be reinstalled.
+///
+/// This fires when the pinned Node version changes (e.g. v24.11.0 → v24.18.0):
+/// the old dir stays on disk, shims appear installed, but they fail at run time
+/// because the Node binary they reference is gone.  Treating the adapter as
+/// missing forces `ensure_managed_node_runtime_blocking` to re-download Node and
+/// npm to reinstall the shims.
+pub(super) fn managed_node_orphaned() -> bool {
+    managed_node_runtime_supported() && !managed_node_runtime_ready()
+}
+
+/// Returns `true` when an adapter at `resolved` should be invalidated.
+///
+/// Only a Buzz-managed shim (path under `managed_prefix`) with an orphaned
+/// runtime is invalidated; external adapters are always preserved.
+pub(super) fn should_invalidate_adapter(
+    resolved: &std::path::Path,
+    managed_prefix: &std::path::Path,
+    orphaned: bool,
+) -> bool {
+    orphaned && resolved.starts_with(managed_prefix)
+}
+
+/// Resolve the adapter binary path, accounting for the Node-orphan case.
+/// Resolves first; invalidates only managed-prefix shims when Node is orphaned.
+pub(super) fn resolve_adapter_path(
+    commands: &[&str],
+    adapter_install_commands: &[&str],
+) -> Option<std::path::PathBuf> {
+    let resolved = commands
+        .iter()
+        .find_map(|cmd| crate::managed_agents::resolve_command(cmd));
+
+    let needs_managed_npm = adapter_install_commands
+        .iter()
+        .any(|cmd| is_npm_global_install(cmd));
+    if needs_managed_npm {
+        if let (Some(ref path), Some(ref managed_bin)) =
+            (&resolved, crate::managed_agents::buzz_managed_npm_bin_dir())
+        {
+            if should_invalidate_adapter(path, managed_bin, managed_node_orphaned()) {
+                return None;
+            }
+        }
+    }
+
+    resolved
 }
 
 fn managed_node_install_lock() -> &'static Mutex<()> {
@@ -538,211 +668,5 @@ pub(super) fn npm_eacces_hint(stderr: &str, _command: &str) -> Option<String> {
 // ── end managed npm adapter installs ──────────────────────────────────────────
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_npm_eacces_hint_guidance_mentions_buzz_private_dir() {
-        let hint = npm_eacces_hint("EACCES: permission denied", "npm install -g foo").unwrap();
-        assert!(
-            hint.contains("Buzz's private Node tools directory"),
-            "hint: {hint}"
-        );
-    }
-
-    #[test]
-    fn test_rewrite_npm_install_uses_private_prefix() {
-        assert_eq!(
-            rewrite_npm_global_install(
-                "npm install -g @agentclientprotocol/codex-acp",
-                "'/tmp/Buzz Node'"
-            ),
-            "npm install --global --prefix '/tmp/Buzz Node' @agentclientprotocol/codex-acp"
-        );
-    }
-
-    #[test]
-    fn test_rewrite_npm_i_uses_private_prefix() {
-        assert_eq!(
-            rewrite_npm_global_install("npm i -g some-package", "'/tmp/buzz'"),
-            "npm i --global --prefix '/tmp/buzz' some-package"
-        );
-    }
-
-    #[test]
-    fn test_rewrite_npm_uninstall_uses_private_prefix() {
-        assert_eq!(
-            rewrite_npm_global_install("npm uninstall -g @zed-industries/codex-acp", "'/tmp/buzz'"),
-            "npm uninstall --global --prefix '/tmp/buzz' @zed-industries/codex-acp"
-        );
-    }
-
-    #[test]
-    fn test_rewrite_ignores_non_global_command() {
-        assert_eq!(
-            rewrite_npm_global_install("npm install foo", "'/tmp/buzz'"),
-            "npm install foo"
-        );
-    }
-
-    #[test]
-    fn test_shell_quote_escapes_single_quotes() {
-        assert_eq!(
-            shell_quote(std::path::Path::new("/tmp/Buzz's Node")),
-            "'/tmp/Buzz'\\''s Node'"
-        );
-    }
-
-    // ── zip validation tests ──────────────────────────────────────────────────
-
-    /// Build an in-memory zip archive with the supplied entry names and return
-    /// a temporary file containing it (zip::ZipArchive requires Seek).
-    fn make_zip_with_entries(entry_names: &[&str]) -> tempfile::NamedTempFile {
-        let mut buf: Vec<u8> = Vec::new();
-        {
-            let mut writer = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
-            let opts = zip::write::SimpleFileOptions::default();
-            for name in entry_names {
-                writer.start_file(*name, opts).unwrap();
-            }
-            writer.finish().unwrap();
-        }
-        let mut tmp = tempfile::NamedTempFile::new().unwrap();
-        std::io::Write::write_all(&mut tmp, &buf).unwrap();
-        tmp
-    }
-
-    #[test]
-    fn test_validate_zip_accepts_normal_entries() {
-        let tmp = make_zip_with_entries(&[
-            "node-v24.18.0-win-x64/node.exe",
-            "node-v24.18.0-win-x64/npm.cmd",
-            "node-v24.18.0-win-x64/npm",
-        ]);
-        let file = std::fs::File::open(tmp.path()).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        assert!(validate_managed_node_zip_entries(&archive).is_ok());
-    }
-
-    #[test]
-    fn test_validate_zip_rejects_absolute_path() {
-        let tmp = make_zip_with_entries(&["/etc/passwd"]);
-        let file = std::fs::File::open(tmp.path()).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        let err = validate_managed_node_zip_entries(&archive).unwrap_err();
-        assert!(
-            err.contains("absolute path"),
-            "expected 'absolute path' in: {err}"
-        );
-    }
-
-    #[test]
-    fn test_validate_zip_rejects_path_traversal() {
-        let tmp = make_zip_with_entries(&["../../../etc/passwd"]);
-        let file = std::fs::File::open(tmp.path()).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        let err = validate_managed_node_zip_entries(&archive).unwrap_err();
-        assert!(
-            err.contains("path traversal"),
-            "expected 'path traversal' in: {err}"
-        );
-    }
-
-    #[test]
-    fn test_validate_zip_rejects_backslash_rooted() {
-        // Windows-style absolute path using backslash — must reject on every host.
-        let tmp = make_zip_with_entries(&["\\Windows\\system32\\evil.dll"]);
-        let file = std::fs::File::open(tmp.path()).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        let err = validate_managed_node_zip_entries(&archive).unwrap_err();
-        assert!(
-            err.contains("absolute path"),
-            "expected 'absolute path' in: {err}"
-        );
-    }
-
-    #[test]
-    fn test_validate_zip_rejects_drive_prefix() {
-        // Windows drive-letter absolute path — must reject on every host.
-        let tmp = make_zip_with_entries(&["C:\\evil\\payload.exe"]);
-        let file = std::fs::File::open(tmp.path()).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        let err = validate_managed_node_zip_entries(&archive).unwrap_err();
-        assert!(
-            err.contains("absolute path"),
-            "expected 'absolute path' in: {err}"
-        );
-    }
-
-    #[test]
-    fn test_validate_zip_rejects_backslash_traversal() {
-        // Path traversal using Windows separator — must reject on every host.
-        let tmp = make_zip_with_entries(&["node-v24.18.0-win-x64\\..\\..\\evil"]);
-        let file = std::fs::File::open(tmp.path()).unwrap();
-        let archive = zip::ZipArchive::new(file).unwrap();
-        let err = validate_managed_node_zip_entries(&archive).unwrap_err();
-        assert!(
-            err.contains("path traversal"),
-            "expected 'path traversal' in: {err}"
-        );
-    }
-
-    // ── verify_node_tree layout tests ─────────────────────────────────────────
-
-    #[test]
-    fn test_verify_node_tree_unix_layout_passes() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let bin = tmp.path().join("bin");
-        std::fs::create_dir_all(&bin).unwrap();
-        std::fs::write(bin.join("node"), b"").unwrap();
-        std::fs::write(bin.join("npm"), b"").unwrap();
-        // On non-Windows the unix branch is active — this must pass.
-        #[cfg(not(windows))]
-        assert!(verify_node_tree(tmp.path()).is_ok());
-        // On Windows the windows branch is active — unix layout must fail.
-        #[cfg(windows)]
-        assert!(verify_node_tree(tmp.path()).is_err());
-    }
-
-    #[test]
-    fn test_verify_node_tree_unix_layout_missing_npm_fails() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let bin = tmp.path().join("bin");
-        std::fs::create_dir_all(&bin).unwrap();
-        std::fs::write(bin.join("node"), b"").unwrap();
-        // npm intentionally absent
-        #[cfg(not(windows))]
-        {
-            let err = verify_node_tree(tmp.path()).unwrap_err();
-            assert!(err.contains("bin/npm"), "err: {err}");
-        }
-    }
-
-    #[test]
-    fn test_verify_node_tree_windows_layout_passes() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        std::fs::write(tmp.path().join("node.exe"), b"").unwrap();
-        std::fs::write(tmp.path().join("npm.cmd"), b"").unwrap();
-        std::fs::write(tmp.path().join("npm"), b"").unwrap();
-        // On Windows the windows branch is active — this must pass.
-        #[cfg(windows)]
-        assert!(verify_node_tree(tmp.path()).is_ok());
-        // On non-Windows the unix branch is active — windows-layout root files
-        // don't satisfy bin/node + bin/npm, so this must fail.
-        #[cfg(not(windows))]
-        assert!(verify_node_tree(tmp.path()).is_err());
-    }
-
-    #[test]
-    fn test_verify_node_tree_windows_layout_missing_npm_shim_fails() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        std::fs::write(tmp.path().join("node.exe"), b"").unwrap();
-        std::fs::write(tmp.path().join("npm.cmd"), b"").unwrap();
-        // npm POSIX shim intentionally absent
-        #[cfg(windows)]
-        {
-            let err = verify_node_tree(tmp.path()).unwrap_err();
-            assert!(err.contains("npm"), "err: {err}");
-        }
-    }
-}
+#[path = "managed_node_tests.rs"]
+mod tests;

--- a/desktop/src-tauri/src/commands/agent_discovery/managed_node_tests.rs
+++ b/desktop/src-tauri/src/commands/agent_discovery/managed_node_tests.rs
@@ -1,0 +1,481 @@
+use super::*;
+
+#[test]
+fn test_npm_eacces_hint_guidance_mentions_buzz_private_dir() {
+    let hint = npm_eacces_hint("EACCES: permission denied", "npm install -g foo").unwrap();
+    assert!(
+        hint.contains("Buzz's private Node tools directory"),
+        "hint: {hint}"
+    );
+}
+
+#[test]
+fn test_rewrite_npm_install_uses_private_prefix() {
+    assert_eq!(
+        rewrite_npm_global_install(
+            "npm install -g @agentclientprotocol/codex-acp",
+            "'/tmp/Buzz Node'"
+        ),
+        "npm install --global --prefix '/tmp/Buzz Node' @agentclientprotocol/codex-acp"
+    );
+}
+
+#[test]
+fn test_rewrite_npm_i_uses_private_prefix() {
+    assert_eq!(
+        rewrite_npm_global_install("npm i -g some-package", "'/tmp/buzz'"),
+        "npm i --global --prefix '/tmp/buzz' some-package"
+    );
+}
+
+#[test]
+fn test_rewrite_npm_uninstall_uses_private_prefix() {
+    assert_eq!(
+        rewrite_npm_global_install("npm uninstall -g @zed-industries/codex-acp", "'/tmp/buzz'"),
+        "npm uninstall --global --prefix '/tmp/buzz' @zed-industries/codex-acp"
+    );
+}
+
+#[test]
+fn test_rewrite_ignores_non_global_command() {
+    assert_eq!(
+        rewrite_npm_global_install("npm install foo", "'/tmp/buzz'"),
+        "npm install foo"
+    );
+}
+
+#[test]
+fn test_shell_quote_escapes_single_quotes() {
+    assert_eq!(
+        shell_quote(std::path::Path::new("/tmp/Buzz's Node")),
+        "'/tmp/Buzz'\\''s Node'"
+    );
+}
+
+// ── zip validation tests ──────────────────────────────────────────────────────
+
+/// Build an in-memory zip archive with the supplied entry names and return
+/// a temporary file containing it (zip::ZipArchive requires Seek).
+fn make_zip_with_entries(entry_names: &[&str]) -> tempfile::NamedTempFile {
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut writer = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts = zip::write::SimpleFileOptions::default();
+        for name in entry_names {
+            writer.start_file(*name, opts).unwrap();
+        }
+        writer.finish().unwrap();
+    }
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    std::io::Write::write_all(&mut tmp, &buf).unwrap();
+    tmp
+}
+
+#[test]
+fn test_validate_zip_accepts_normal_entries() {
+    let tmp = make_zip_with_entries(&[
+        "node-v24.18.0-win-x64/node.exe",
+        "node-v24.18.0-win-x64/npm.cmd",
+        "node-v24.18.0-win-x64/npm",
+    ]);
+    let file = std::fs::File::open(tmp.path()).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    assert!(validate_managed_node_zip_entries(&archive).is_ok());
+}
+
+#[test]
+fn test_validate_zip_rejects_absolute_path() {
+    let tmp = make_zip_with_entries(&["/etc/passwd"]);
+    let file = std::fs::File::open(tmp.path()).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    let err = validate_managed_node_zip_entries(&archive).unwrap_err();
+    assert!(
+        err.contains("absolute path"),
+        "expected 'absolute path' in: {err}"
+    );
+}
+
+#[test]
+fn test_validate_zip_rejects_path_traversal() {
+    let tmp = make_zip_with_entries(&["../../../etc/passwd"]);
+    let file = std::fs::File::open(tmp.path()).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    let err = validate_managed_node_zip_entries(&archive).unwrap_err();
+    assert!(
+        err.contains("path traversal"),
+        "expected 'path traversal' in: {err}"
+    );
+}
+
+#[test]
+fn test_validate_zip_rejects_backslash_rooted() {
+    // Windows-style absolute path using backslash — must reject on every host.
+    let tmp = make_zip_with_entries(&["\\Windows\\system32\\evil.dll"]);
+    let file = std::fs::File::open(tmp.path()).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    let err = validate_managed_node_zip_entries(&archive).unwrap_err();
+    assert!(
+        err.contains("absolute path"),
+        "expected 'absolute path' in: {err}"
+    );
+}
+
+#[test]
+fn test_validate_zip_rejects_drive_prefix() {
+    // Windows drive-letter absolute path — must reject on every host.
+    let tmp = make_zip_with_entries(&["C:\\evil\\payload.exe"]);
+    let file = std::fs::File::open(tmp.path()).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    let err = validate_managed_node_zip_entries(&archive).unwrap_err();
+    assert!(
+        err.contains("absolute path"),
+        "expected 'absolute path' in: {err}"
+    );
+}
+
+#[test]
+fn test_validate_zip_rejects_backslash_traversal() {
+    // Path traversal using Windows separator — must reject on every host.
+    let tmp = make_zip_with_entries(&["node-v24.18.0-win-x64\\..\\..\\evil"]);
+    let file = std::fs::File::open(tmp.path()).unwrap();
+    let archive = zip::ZipArchive::new(file).unwrap();
+    let err = validate_managed_node_zip_entries(&archive).unwrap_err();
+    assert!(
+        err.contains("path traversal"),
+        "expected 'path traversal' in: {err}"
+    );
+}
+
+// ── verify_node_tree layout tests ─────────────────────────────────────────────
+
+#[test]
+fn test_verify_node_tree_unix_layout_passes() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::write(bin.join("node"), b"").unwrap();
+    std::fs::write(bin.join("npm"), b"").unwrap();
+    // On non-Windows the unix branch is active — this must pass.
+    #[cfg(not(windows))]
+    assert!(verify_node_tree(tmp.path()).is_ok());
+    // On Windows the windows branch is active — unix layout must fail.
+    #[cfg(windows)]
+    assert!(verify_node_tree(tmp.path()).is_err());
+}
+
+#[test]
+fn test_verify_node_tree_unix_layout_missing_npm_fails() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = tmp.path().join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::write(bin.join("node"), b"").unwrap();
+    // npm intentionally absent
+    #[cfg(not(windows))]
+    {
+        let err = verify_node_tree(tmp.path()).unwrap_err();
+        assert!(err.contains("bin/npm"), "err: {err}");
+    }
+}
+
+#[test]
+fn test_verify_node_tree_windows_layout_passes() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("node.exe"), b"").unwrap();
+    std::fs::write(tmp.path().join("npm.cmd"), b"").unwrap();
+    std::fs::write(tmp.path().join("npm"), b"").unwrap();
+    // On Windows the windows branch is active — this must pass.
+    #[cfg(windows)]
+    assert!(verify_node_tree(tmp.path()).is_ok());
+    // On non-Windows the unix branch is active — windows-layout root files
+    // don't satisfy bin/node + bin/npm, so this must fail.
+    #[cfg(not(windows))]
+    assert!(verify_node_tree(tmp.path()).is_err());
+}
+
+#[test]
+fn test_verify_node_tree_windows_layout_missing_npm_shim_fails() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("node.exe"), b"").unwrap();
+    std::fs::write(tmp.path().join("npm.cmd"), b"").unwrap();
+    // npm POSIX shim intentionally absent
+    #[cfg(windows)]
+    {
+        let err = verify_node_tree(tmp.path()).unwrap_err();
+        assert!(err.contains("npm"), "err: {err}");
+    }
+}
+
+// ── should_invalidate_adapter / orphan policy pure unit tests ─────────────────
+
+#[test]
+fn test_should_invalidate_adapter_invalidates_managed_shim_when_orphaned() {
+    let prefix = std::path::Path::new("/managed/npm/bin");
+    let shim = prefix.join("codex-acp");
+    assert!(
+        should_invalidate_adapter(&shim, prefix, true),
+        "managed shim + orphaned runtime must be invalidated"
+    );
+}
+
+#[test]
+fn test_should_invalidate_adapter_keeps_external_adapter_when_orphaned() {
+    let prefix = std::path::Path::new("/managed/npm/bin");
+    let external = std::path::Path::new("/usr/local/bin/codex-acp");
+    assert!(
+        !should_invalidate_adapter(external, prefix, true),
+        "external adapter must not be invalidated even when Node is orphaned"
+    );
+}
+
+#[test]
+fn test_should_invalidate_adapter_keeps_managed_shim_when_node_healthy() {
+    let prefix = std::path::Path::new("/managed/npm/bin");
+    let shim = prefix.join("codex-acp");
+    assert!(
+        !should_invalidate_adapter(&shim, prefix, false),
+        "managed shim must not be invalidated when Node is healthy"
+    );
+}
+
+#[test]
+fn test_resolve_adapter_path_returns_none_when_binary_absent() {
+    let commands: &[&str] = &["nonexistent-buzz-test-binary-xyz"];
+    let adapter_install_commands: &[&str] = &["curl -fsSL https://example.com | bash"];
+    assert!(
+        resolve_adapter_path(commands, adapter_install_commands).is_none(),
+        "must return None when the command is not on PATH"
+    );
+}
+
+// ── probe_node seam regressions ───────────────────────────────────────────────
+//
+// All four scenarios drive probe_node() directly — the same
+// tempfile/deadline/cleanup/status/version path used by managed_node_runtime_ready.
+// Each test CAN fail if production:
+//   - drops process_group(0)          → descendant-holds-stdout assertion (d) fails
+//                                       (tempfile transport still returns promptly;
+//                                        the sleep survives and kill($!,0) returns 0)
+//   - skips group-kill on a path      → hung-binary test exceeds margin
+//   - ignores exit_status.success()   → nonzero-exit test returns true
+//   - skips version comparison        → wrong-version test returns true
+//
+// Script files are written into a TempDir (no open write fd at spawn time)
+// to avoid ETXTBSY on Linux.
+
+/// Scenario 1 — descendant holds stdout write-end, direct child exits immediately.
+///
+/// The script backgrounds a 60-second sleep (inheriting stdout), records both the
+/// script's own PID (`$$`) and the sleep's PID (`$!`) to sidecar files, then exits
+/// with the expected version string.  Four assertions:
+///   (a) bounded return — would hang ~60 s if tempfile transport regressed to pipe;
+///   (b) correct result;
+///   (c) process group dead after return — catches skipped-cleanup-on-success: if
+///       the group-kill is absent but `process_group(0)` is still present, a live
+///       member in the group is detectable;
+///   (d) descendant PID dead after return — catches dropped `process_group(0)`: if
+///       the call is removed the sleep stays in the runner's group (not the probe's),
+///       `kill(-pgid,0)` is vacuously ESRCH, but `kill(desc_pid,0)` returns 0 and
+///       this assertion fails.  This is the canonical mutation for (c).
+#[cfg(unix)]
+#[test]
+fn test_probe_node_descendant_holds_stdout_returns_promptly_and_kills_group() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let script = tmp_dir.path().join("probe.sh");
+    let pgid_file = tmp_dir.path().join("pgid");
+    let desc_pid_file = tmp_dir.path().join("desc_pid");
+    let pgid_file_path = pgid_file.to_str().unwrap().to_owned();
+    let desc_pid_file_path = desc_pid_file.to_str().unwrap().to_owned();
+    // Line 1 of script: record the script's own PID (= PGID after process_group(0)).
+    // Line 2: background the sleep and record its PID.
+    // Line 3: emit the expected version and exit so the direct child exits promptly.
+    let script_content = format!(
+        "#!/bin/sh\necho $$ > {pgid_file_path}\n/bin/sleep 60 &\necho $! > {desc_pid_file_path}\necho v24.18.0\nexit 0\n"
+    );
+    std::fs::write(&script, script_content.as_bytes()).unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let probe_timeout = std::time::Duration::from_secs(3);
+    let t = std::time::Instant::now();
+    let result = probe_node(&script, "v24.18.0", probe_timeout);
+    let elapsed = t.elapsed();
+
+    // Give the group-kill a moment to propagate before checking liveness.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    // (a) bounded return — tempfile transport must not hang on the descendant's
+    //     retained pipe write-end.
+    assert!(
+        elapsed < probe_timeout + std::time::Duration::from_secs(2),
+        "probe_node hung — likely descendant retained pipe write-end: elapsed {elapsed:?}"
+    );
+    // (b) correct result
+    assert!(result, "probe_node must return true for matching version");
+
+    // (c) process group dead — catches skipped-cleanup: if the group-kill on the
+    //     success path is removed while process_group(0) is still present, the
+    //     sleep remains in the probe's group and kill(-pgid,0) returns 0.
+    let pgid_str = std::fs::read_to_string(&pgid_file)
+        .expect("script must have written its PID to the pgid sidecar");
+    let pgid: i32 = pgid_str
+        .trim()
+        .parse()
+        .expect("pgid sidecar must contain a numeric PID");
+    let group_alive = unsafe { libc::kill(-pgid, 0) } == 0;
+    assert!(
+        !group_alive,
+        "process group {pgid} must be dead after probe_node"
+    );
+
+    // (d) descendant PID dead — catches dropped process_group(0): without that
+    //     call the sleep is never in the probe's group, so kill(-pgid,0) is
+    //     vacuously ESRCH while the sleep survives.  Asserting the descendant's
+    //     own PID is dead proves the sleep was actually killed.
+    let desc_pid_str = std::fs::read_to_string(&desc_pid_file)
+        .expect("script must have written the sleep PID to the desc_pid sidecar");
+    let desc_pid: libc::pid_t = desc_pid_str
+        .trim()
+        .parse()
+        .expect("desc_pid sidecar must contain a numeric PID");
+    // Pre-assert cleanup: if the descendant is somehow still alive, kill it so
+    // a failing test does not leave a 60-second sleep in the runner's process group.
+    let desc_alive = unsafe { libc::kill(desc_pid, 0) } == 0;
+    if desc_alive {
+        unsafe { libc::kill(desc_pid, libc::SIGKILL) };
+    }
+    assert!(
+        !desc_alive,
+        "descendant PID {desc_pid} must be dead after probe_node — \
+         if process_group(0) is dropped, the sleep escapes into the runner's group \
+         and is never killed by the group-kill"
+    );
+}
+
+/// Scenario 2 — direct hang: probe_node must traverse the real try_wait
+/// deadline and return false.  Does NOT call kill_probe_group directly.
+///
+/// This test FAILS if the deadline loop in probe_node is broken or if the
+/// timeout/kill path is not exercised (e.g., missing group-kill exits the
+/// loop early via a different mechanism).
+#[cfg(unix)]
+#[test]
+fn test_probe_node_times_out_on_hung_binary() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let script = tmp_dir.path().join("hung.sh");
+    std::fs::write(&script, b"#!/bin/sh\n/bin/sleep 30\n").unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let probe_timeout = std::time::Duration::from_secs(3);
+    let t = std::time::Instant::now();
+    let result = probe_node(&script, "v24.18.0", probe_timeout);
+    let elapsed = t.elapsed();
+
+    assert!(!result, "probe_node must return false for a hung binary");
+    // Must have traversed the deadline (not returned early via a bug).
+    assert!(
+        elapsed >= probe_timeout,
+        "probe_node returned before deadline: {elapsed:?} < {probe_timeout:?}"
+    );
+    // Must not hang past the deadline by more than the poll interval + margin.
+    assert!(
+        elapsed < probe_timeout + std::time::Duration::from_secs(3),
+        "probe_node exceeded deadline by too much: {elapsed:?}"
+    );
+}
+
+/// Scenario 3 — non-zero exit: probe_node must return false even when stdout
+/// contains the expected version string.
+///
+/// This test FAILS if probe_node skips or inverts the exit_status.success() check.
+#[cfg(unix)]
+#[test]
+fn test_probe_node_returns_false_on_nonzero_exit() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let script = tmp_dir.path().join("fail.sh");
+    // Prints the expected version string but exits non-zero.
+    std::fs::write(&script, b"#!/bin/sh\necho v24.18.0\nexit 1\n").unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let result = probe_node(&script, "v24.18.0", std::time::Duration::from_secs(3));
+    assert!(
+        !result,
+        "probe_node must return false when the process exits non-zero"
+    );
+}
+
+/// Scenario 4 — wrong version output: probe_node must return false when stdout
+/// does not match expected_version.
+///
+/// This test FAILS if probe_node skips or incorrectly performs the version comparison.
+#[cfg(unix)]
+#[test]
+fn test_probe_node_returns_false_on_wrong_version_output() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let script = tmp_dir.path().join("wrongver.sh");
+    std::fs::write(&script, b"#!/bin/sh\necho v99.0.0\nexit 0\n").unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let result = probe_node(&script, "v24.18.0", std::time::Duration::from_secs(3));
+    assert!(
+        !result,
+        "probe_node must return false when stdout version does not match expected"
+    );
+}
+
+/// Windows-shaped seam: non-zero exit via .bat file.
+///
+/// Drives the same probe_node path on Windows (terminate_process / taskkill /T /F).
+/// This test FAILS if probe_node ignores exit_status.success() on Windows.
+#[cfg(windows)]
+#[test]
+fn test_probe_node_windows_returns_false_on_nonzero_exit() {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let bat = tmp_dir.path().join("fail.bat");
+    // Prints the expected version but exits non-zero — must still fail.
+    std::fs::write(&bat, b"@echo off\r\necho v24.18.0\r\nexit /b 1\r\n").unwrap();
+
+    let result = probe_node(&bat, "v24.18.0", std::time::Duration::from_secs(3));
+    assert!(
+        !result,
+        "probe_node must return false when the .bat exits non-zero (Windows)"
+    );
+}
+
+/// Windows-shaped seam: wrong version output via .bat file.
+///
+/// This test FAILS if probe_node skips the version comparison on Windows.
+#[cfg(windows)]
+#[test]
+fn test_probe_node_windows_returns_false_on_wrong_version_output() {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    let bat = tmp_dir.path().join("wrongver.bat");
+    std::fs::write(&bat, b"@echo off\r\necho v99.0.0\r\nexit /b 0\r\n").unwrap();
+
+    let result = probe_node(&bat, "v24.18.0", std::time::Duration::from_secs(3));
+    assert!(
+        !result,
+        "probe_node must return false when stdout version does not match (Windows)"
+    );
+}
+
+/// Returns false when the node binary path does not exist (fast path, no spawn).
+#[test]
+fn test_managed_node_runtime_ready_returns_false_when_binary_absent() {
+    let Some(node) = crate::managed_agents::buzz_managed_node_bin_path() else {
+        assert!(
+            !managed_node_runtime_ready(),
+            "managed_node_runtime_ready must return false when no path resolves"
+        );
+        return;
+    };
+    if node.is_file() {
+        return;
+    }
+    assert!(
+        !managed_node_runtime_ready(),
+        "managed_node_runtime_ready must return false when the binary file does not exist"
+    );
+}

--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -9,10 +9,10 @@ use crate::managed_agents::{
     AcpAvailabilityStatus, AcpRuntimeCatalogEntry, AuthStatus, CommandAvailabilityInfo,
     HarnessSource,
 };
-
 mod presets;
 mod runtime_metadata;
-
+#[macro_use]
+mod windows_install;
 use presets::{preset_catalog_entry, PRESET_HARNESSES};
 pub(crate) use presets::{preset_harness_definitions, preset_harness_ids};
 pub(crate) use runtime_metadata::KnownAcpRuntime;
@@ -85,7 +85,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         cli_install_commands: &["curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash"],
         // Goose's stable release currently publishes only the Unix installer;
         // its official Windows instructions intentionally point at this main-branch script.
-        cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"$env:CONFIGURE='false'; irm https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1 | iex\""],
+        cli_install_commands_windows: &[windows_install_command!("goose", "https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1", "$env:CONFIGURE='false'; ")],
         adapter_install_commands: &[],
         cli_install_instructions_url: "https://goose-docs.ai/docs/getting-started/installation/",
         adapter_install_instructions_url: "",
@@ -117,7 +117,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         mcp_hooks: false,
         underlying_cli: Some("claude"),
         cli_install_commands: &["curl -fsSL https://claude.ai/install.sh | bash"],
-        cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://claude.ai/install.ps1 | iex\""],
+        cli_install_commands_windows: &[windows_install_command!("claude", "https://claude.ai/install.ps1")],
         adapter_install_commands: &["npm install -g @agentclientprotocol/claude-agent-acp"],
         cli_install_instructions_url: "https://code.claude.com/docs/en/getting-started",
         adapter_install_instructions_url: "https://github.com/agentclientprotocol/claude-agent-acp",
@@ -149,7 +149,7 @@ const KNOWN_ACP_RUNTIMES: &[KnownAcpRuntime] = &[
         mcp_hooks: false,
         underlying_cli: Some("codex"),
         cli_install_commands: &["curl -fsSL https://chatgpt.com/codex/install.sh | sh"],
-        cli_install_commands_windows: &["powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://chatgpt.com/codex/install.ps1 | iex\""],
+        cli_install_commands_windows: &[windows_install_command!("codex", "https://chatgpt.com/codex/install.ps1")],
         adapter_install_commands: &["npm install -g @agentclientprotocol/codex-acp"],
         cli_install_instructions_url: "https://developers.openai.com/codex/cli/",
         adapter_install_instructions_url: "https://github.com/agentclientprotocol/codex-acp",

--- a/desktop/src-tauri/src/managed_agents/discovery/windows_install.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/windows_install.rs
@@ -79,8 +79,6 @@ macro_rules! windows_install_command {
     };
 }
 
-pub(crate) use windows_install_command;
-
 #[cfg(test)]
 mod tests {
     use crate::managed_agents::known_acp_runtime_exact;
@@ -202,26 +200,6 @@ mod tests {
                 < command.find("Invoke-RestMethod").unwrap(),
             "the env prefix must be set before the installer runs. Got: {command}"
         );
-    }
-
-    /// The install command is echoed into the install log, which flows through
-    /// the redaction pipeline. A literal that looks like a credential would be
-    /// scrubbed and render the logged command unreadable.
-    #[test]
-    fn test_no_windows_install_command_embeds_credential_like_literals() {
-        for (id, command) in windows_install_commands() {
-            assert!(
-                !command.contains('@'),
-                "{id}: no URL userinfo — a `user:pass@host` literal would be redacted out of \
-                 the install log. Got: {command}"
-            );
-            for marker in ["TOKEN", "SECRET", "PASSWORD", "APIKEY"] {
-                assert!(
-                    !command.to_ascii_uppercase().contains(marker),
-                    "{id}: install commands must carry no {marker}-like literal. Got: {command}"
-                );
-            }
-        }
     }
 
     /// The vendor URLs are the payload; pin them so a refactor of the shared

--- a/desktop/src-tauri/src/managed_agents/discovery/windows_install.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/windows_install.rs
@@ -1,0 +1,247 @@
+//! Defender-safe construction of the Windows PowerShell CLI install commands.
+//!
+//! # Why the shape matters
+//!
+//! Windows Defender's ML classifier flags the bare `irm <url> | iex` command
+//! line as `Trojan:Win32/Commando.A!ml` — piping a downloaded string straight
+//! into `Invoke-Expression` is a textbook dropper signature, so the *command
+//! line itself* is scored, independent of what the URL actually serves. The
+//! spawn is denied before PowerShell runs, surfacing as
+//! `failed to spawn shell: Access is denied. (os error 5)`, and the block is
+//! sticky: Defender's "Allow" button does not clear it.
+//!
+//! [`windows_install_command!`] emits the two-step form instead — download the
+//! vendor script to a file, then execute the file — which does not match that
+//! signature. All three runtimes use it, not only the one observed failing:
+//! Goose and Claude escaped by scoring under the classifier threshold, which is
+//! luck rather than design, and the threshold is not ours to depend on.
+//!
+//! # Why one macro instead of three literals
+//!
+//! The catalog needs `&'static str`, so the commands must be built at compile
+//! time from literals. Emitting them from a single macro means the security
+//! shape is defined once and cannot drift between runtimes as URLs change —
+//! a per-runtime literal would let one entry silently regress to `iex`.
+//!
+//! # Exit-code fidelity
+//!
+//! [#2892](https://github.com/block/buzz/pull/2892) established that an install
+//! step must not report success when the download failed. Two pieces preserve
+//! that here, and both are load-bearing:
+//!
+//! - `$ErrorActionPreference='Stop'` makes a failed `Invoke-RestMethod`
+//!   terminate the whole command. Without it a failed download falls through to
+//!   `& $installer` on a path that does not exist, and PowerShell exits **0** —
+//!   the exact masking #2892 removed, in a new dress. `Stop` also prevents
+//!   executing a *stale* installer left in `$env:TEMP` by an earlier run.
+//! - `exit $LASTEXITCODE` propagates the vendor script's own exit code. Without
+//!   it PowerShell reports its own status and a vendor failure of `3` flattens
+//!   to `1`, losing the distinction the retry logic reads.
+//!
+//! Verified against `pwsh` over a local HTTP server: vendor exit 3 surfaces as
+//! 3, vendor exit 0 as 0, a 404 and an unresolvable host as non-zero, and a
+//! planted stale installer is never executed. The old `irm | iex` shape
+//! produces identical codes for all four, so this is not a behavior change.
+//!
+//! # Quoting contract
+//!
+//! The emitted body is wrapped in one double-quote pair, which
+//! `install_powershell_command` strips before handing the body to PowerShell.
+//! The body therefore uses **only single quotes** internally; a double quote
+//! would terminate that pair early and truncate the command.
+
+/// Build the Windows CLI install command for one runtime.
+///
+/// `slug` names the downloaded script (`buzz-install-<slug>.ps1`) so concurrent
+/// installs of different runtimes cannot overwrite each other's file. The
+/// optional third argument carries a runtime's env prefix (Goose's
+/// `$env:CONFIGURE='false'; `) and must end with `; `.
+///
+/// See the module docs for why each fragment is present.
+macro_rules! windows_install_command {
+    ($slug:literal, $url:literal) => {
+        windows_install_command!($slug, $url, "")
+    };
+    ($slug:literal, $url:literal, $env_prefix:literal) => {
+        concat!(
+            "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"",
+            $env_prefix,
+            "$ErrorActionPreference='Stop'; ",
+            "$installer=Join-Path $env:TEMP 'buzz-install-",
+            $slug,
+            ".ps1'; ",
+            "Invoke-RestMethod ",
+            $url,
+            " -OutFile $installer; ",
+            "& $installer; ",
+            "exit $LASTEXITCODE\"",
+        )
+    };
+}
+
+pub(crate) use windows_install_command;
+
+#[cfg(test)]
+mod tests {
+    use crate::managed_agents::known_acp_runtime_exact;
+
+    /// Every runtime that ships a Windows install command. `cli_install_commands_windows`
+    /// is read directly rather than through `cli_install_commands_for_os()` so these
+    /// assertions cover the Windows strings while running on the Linux CI host.
+    fn windows_install_commands() -> Vec<(&'static str, &'static str)> {
+        ["goose", "claude", "codex"]
+            .into_iter()
+            .flat_map(|id| {
+                known_acp_runtime_exact(id)
+                    .expect("runtime must exist in the catalog")
+                    .cli_install_commands_windows
+                    .iter()
+                    .map(move |command| (id, *command))
+            })
+            .collect()
+    }
+
+    /// The whole point of the change: no runtime may carry the flagged
+    /// download-and-execute-in-one-line signature.
+    #[test]
+    fn test_no_windows_install_command_pipes_a_download_into_iex() {
+        for (id, command) in windows_install_commands() {
+            assert!(
+                !command.contains("| iex"),
+                "{id}: `irm | iex` is the shape Defender flags as Trojan:Win32/Commando.A!ml; \
+                 download to a file and execute the file instead. Got: {command}"
+            );
+            assert!(
+                !command.contains("Invoke-Expression"),
+                "{id}: Invoke-Expression on downloaded content carries the same signature. \
+                 Got: {command}"
+            );
+        }
+    }
+
+    /// All three runtimes must be hardened, not just the one observed failing.
+    /// Goose and Claude escaped only by scoring under the classifier threshold.
+    #[test]
+    fn test_every_windows_install_command_downloads_to_a_file_then_executes_it() {
+        let commands = windows_install_commands();
+        assert_eq!(
+            commands.len(),
+            3,
+            "expected exactly one Windows install command for each of goose, claude, codex"
+        );
+        for (id, command) in commands {
+            assert!(
+                command.contains("-OutFile $installer"),
+                "{id}: must download the vendor script to a file. Got: {command}"
+            );
+            assert!(
+                command.contains("& $installer"),
+                "{id}: must execute the downloaded file. Got: {command}"
+            );
+            assert!(
+                command.contains(&format!("buzz-install-{id}.ps1")),
+                "{id}: script name must be runtime-specific so concurrent installs of \
+                 different runtimes cannot overwrite each other. Got: {command}"
+            );
+        }
+    }
+
+    /// Guards the #2892 regression: without `Stop`, a failed download falls
+    /// through to a missing file and PowerShell exits 0, reporting a failed
+    /// install as a success. Without `exit $LASTEXITCODE`, the vendor's own
+    /// exit code is replaced by PowerShell's.
+    #[test]
+    fn test_every_windows_install_command_preserves_failure_exit_codes() {
+        for (id, command) in windows_install_commands() {
+            assert!(
+                command.contains("$ErrorActionPreference='Stop'"),
+                "{id}: a failed download must abort instead of running a missing or stale \
+                 installer and exiting 0 (see #2892). Got: {command}"
+            );
+            assert!(
+                command.contains("exit $LASTEXITCODE"),
+                "{id}: the vendor script's exit code must propagate. Got: {command}"
+            );
+        }
+    }
+
+    /// `install_powershell_command` strips exactly one outer double-quote pair.
+    /// An inner double quote would close that pair early and truncate the body.
+    #[test]
+    fn test_every_windows_install_command_quotes_the_body_exactly_once() {
+        for (id, command) in windows_install_commands() {
+            let body = command
+                .split_once(" -Command ")
+                .map(|(_, body)| body)
+                .unwrap_or_else(|| panic!("{id}: command must pass a -Command body: {command}"));
+            assert!(
+                body.starts_with('"') && body.ends_with('"'),
+                "{id}: body must be wrapped in one double-quote pair. Got: {body}"
+            );
+            assert_eq!(
+                body.matches('"').count(),
+                2,
+                "{id}: body must contain no inner double quotes — one would terminate the \
+                 outer pair early and truncate the command. Got: {body}"
+            );
+        }
+    }
+
+    /// Goose's installer reads `CONFIGURE` to stay non-interactive; losing the
+    /// prefix hangs the install waiting on input that never comes.
+    #[test]
+    fn test_goose_windows_install_command_keeps_its_env_prefix() {
+        let goose = known_acp_runtime_exact("goose").unwrap();
+        let command = goose.cli_install_commands_windows[0];
+        assert!(
+            command.contains("$env:CONFIGURE='false'"),
+            "goose must stay non-interactive. Got: {command}"
+        );
+        assert!(
+            command.find("$env:CONFIGURE='false'").unwrap()
+                < command.find("Invoke-RestMethod").unwrap(),
+            "the env prefix must be set before the installer runs. Got: {command}"
+        );
+    }
+
+    /// The install command is echoed into the install log, which flows through
+    /// the redaction pipeline. A literal that looks like a credential would be
+    /// scrubbed and render the logged command unreadable.
+    #[test]
+    fn test_no_windows_install_command_embeds_credential_like_literals() {
+        for (id, command) in windows_install_commands() {
+            assert!(
+                !command.contains('@'),
+                "{id}: no URL userinfo — a `user:pass@host` literal would be redacted out of \
+                 the install log. Got: {command}"
+            );
+            for marker in ["TOKEN", "SECRET", "PASSWORD", "APIKEY"] {
+                assert!(
+                    !command.to_ascii_uppercase().contains(marker),
+                    "{id}: install commands must carry no {marker}-like literal. Got: {command}"
+                );
+            }
+        }
+    }
+
+    /// The vendor URLs are the payload; pin them so a refactor of the shared
+    /// shape cannot silently retarget a download.
+    #[test]
+    fn test_windows_install_commands_target_the_official_vendor_urls() {
+        for (id, expected) in [
+            (
+                "goose",
+                "https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1",
+            ),
+            ("claude", "https://claude.ai/install.ps1"),
+            ("codex", "https://chatgpt.com/codex/install.ps1"),
+        ] {
+            let runtime = known_acp_runtime_exact(id).unwrap();
+            let command = runtime.cli_install_commands_windows[0];
+            assert!(
+                command.contains(&format!("Invoke-RestMethod {expected} -OutFile")),
+                "{id}: must download from {expected}. Got: {command}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes two Windows-specific install failures: Windows Defender blocking the bare `irm|iex` PowerShell install command, and managed Node shims pointing at a version-bumped (now-absent) Node directory.

The Defender block (Trojan:Win32/Commando.A!ml) fires before PowerShell runs and is not clearable via Allow. The Node orphaning means shims in the managed npm prefix resolve but fail at runtime with 'node not recognized' because they reference the deleted old Node path.

- Replace all three Windows CLI install commands (Goose, Claude, Codex) with a two-step shape — `Invoke-RestMethod` to a named temp file, then execute — to eliminate the dropper signature; a new `windows_install_command!` macro in `discovery/windows_install.rs` generates all three strings at compile time so the shape cannot drift between runtimes
- `$ErrorActionPreference='Stop'` aborts on download failure instead of falling through to a missing-file exit-0; `exit $LASTEXITCODE` propagates the vendor script's own exit code
- Add `probe_node(executable, expected_version, timeout)` as a bounded seam: stdout goes to a temp file (not a pipe) so no exit path can block on an inherited handle; the child runs in its own process group on Unix so an unconditional group SIGKILL on every exit path terminates all descendants; on Windows `taskkill /T /F` provides the same tree-wide cleanup; `managed_node_runtime_ready()` is a thin wrapper that resolves the managed Node path and calls the seam
- Add `resolve_adapter_path()` in `managed_node.rs`: resolves the candidate first, then calls `should_invalidate_adapter()` — a pure predicate that returns `true` only when the resolved path is under `buzz_managed_npm_bin_dir()` AND the managed Node runtime is orphaned; external adapters outside the managed prefix are always preserved

Note: CI cannot reproduce the Defender block (no live Defender ML classifier). Proof of fix is structural — the command shape no longer matches the dropper signature. Canary validation on a real Windows machine with Defender enabled is the definitive check.