### PR TITLE
fix(4307): default is_member to true when missing in channel fromJson

### DIFF
--- a/mobile/lib/features/channels/channel.dart
+++ b/mobile/lib/features/channels/channel.dart
@@ -64,7 +64,15 @@ class Channel {
     participantPubkeys:
         (json['participant_pubkeys'] as List<dynamic>? ?? const [])
             .cast<String>(),
-    isMember: json['is_member'] as bool? ?? false,
+    // Relay responses for a channel the requester can read imply membership
+    // unless the payload explicitly says otherwise — the member_count and
+    // member_pubkeys are what actually signal non-membership. Deserializing
+    // a missing is_member default to `false` told mobile "not a member" for
+    // every newly joined channel, so the app hid the very channels the user
+    // could read and landed them in an empty community (#4307). Desktop
+    // defaults the same field to `true` (tauriChannels.ts), which is the
+    // contract the relay authors assume.
+    isMember: json['is_member'] as bool? ?? true,
     ttlSeconds: json['ttl_seconds'] as int?,
     ttlDeadline: json['ttl_deadline'] != null
         ? DateTime.parse(json['ttl_deadline'] as String)

--- a/mobile/test/features/channels/channel_test.dart
+++ b/mobile/test/features/channels/channel_test.dart
@@ -68,7 +68,10 @@ void main() {
       expect(channel.isPrivate, isTrue);
     });
 
-    test('defaults is_member to false when missing', () {
+    test('defaults is_member to true when missing — parity with desktop', () {
+      // Regression test for #4307: relay payloads that omit is_member
+      // should default to true (matching desktop tauriChannels.ts)
+      // because a readable channel implies the requester is a member.
       final json = {
         'id': 'abc-123',
         'name': 'test',
@@ -81,8 +84,26 @@ void main() {
 
       final channel = Channel.fromJson(json);
 
-      expect(channel.isMember, isFalse);
+      expect(channel.isMember, isTrue,
+          reason: 'Missing is_member must default to true, not false');
       expect(channel.isForum, isTrue);
+    });
+
+    test('respects explicit is_member: false', () {
+      final json = {
+        'id': 'abc-123',
+        'name': 'test',
+        'channel_type': 'forum',
+        'visibility': 'open',
+        'created_by': 'deadbeef',
+        'created_at': '2025-01-01T00:00:00+00:00',
+        'member_count': 0,
+        'is_member': false,
+      };
+
+      final channel = Channel.fromJson(json);
+
+      expect(channel.isMember, isFalse);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #4307

When a relay returns channel data without an `is_member` field, mobile was defaulting to `false`, which told the app "you are not a member" for every newly joined channel. This caused the app to hide the very channels the user could read and had just joined, landing them in an empty community after claiming an invite.

Desktop already defaults the same field to `true` (`tauriChannels.ts:76`), which is the contract the relay authors assume — a readable channel implies membership unless the payload explicitly says otherwise.

## Changes

**`mobile/lib/features/channels/channel.dart`**
- `fromJson`: changed `is_member` default from `?? false` to `?? true`, matching desktop behavior

**`mobile/test/features/channels/channel_test.dart`**
- Updated existing test: "defaults is_member to false when missing" → "defaults is_member to true when missing — parity with desktop"
- Added regression test: "respects explicit is_member: false" — verifies explicit `false` is still honored

## Testing

Flutter/dart is not available in the local environment. Code verified by inspection:
- `json['is_member'] as bool? ?? true` — null (missing) → `true`, explicit `false` → `false`
- All other test files construct `Channel` objects directly with explicit `isMember:` values, not via `fromJson`, so they are unaffected

## Parity reference

Desktop (`desktop/src/shared/api/tauriChannels.ts:76`):
```typescript
is_member: channel.is_member ?? true,
```
