### PR TITLE
fix(4384): use object-scale-down instead of object-contain for inline images

### DIFF
--- a/desktop/src/shared/ui/markdown/ProgressiveImage.tsx
+++ b/desktop/src/shared/ui/markdown/ProgressiveImage.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/shared/lib/cn";
 
 const IMAGE_CLASS =
-  "absolute inset-0 block h-full w-full rounded-2xl object-contain";
+  "absolute inset-0 block h-full w-full rounded-2xl object-scale-down";
 
 function isSameImageSource(
   left: string | undefined,


### PR DESCRIPTION
## Summary

Fixes #4384

Small markdown images (badges, icons) that lack a NIP-92 `dim` tag were upscaled to fill the 384×256 fallback reserve box on first view. A 46×20 shield badge would render as a giant blurry block because `object-contain` scales both up and down.

The fix is a single-word change: `object-contain` → `object-scale-down`. `object-scale-down` behaves like `object-none` when the image is smaller than the content box (no upscaling) and like `object-contain` when larger (scales down to fit). Small images now render at their natural size inside the reserve box, matching the cached second-view behavior the code already intends.

Large images are unaffected — they still scale down into the same box.

## Changes

**`desktop/src/shared/ui/markdown/ProgressiveImage.tsx`**
- `IMAGE_CLASS`: `object-contain` → `object-scale-down`

## Testing

- `pnpm run typecheck` — clean
- `pnpm exec biome check` — clean
- No new tests added (no existing test file for ProgressiveImage; the change is a single CSS class)
