### PR TITLE
fix(buzz-acp): clean up orphaned 👀 reaction on queue auto-expiry

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -3092,6 +3092,21 @@ fn dispatch_pending(
         dispatched_channels.push((channel_id, typing_scope));
         *last_activity = tokio::time::Instant::now();
     }
+    // Best-effort: clean up 👀 on events orphaned by queue auto-expiry (a
+    // stuck prompt task that never called mark_complete — see the "BUG:
+    // in-flight channel expired" log in `EventQueue`). The task's own
+    // `ReactionGuard` never got to run, so nothing else removes this
+    // reaction; without this, the message looks like an agent is still
+    // working on it long after the task was abandoned.
+    let expired_reaction_ids = queue.take_expired_reaction_ids();
+    if !expired_reaction_ids.is_empty() {
+        let rc = ctx.rest_client.clone();
+        tokio::spawn(async move {
+            for eid in &expired_reaction_ids {
+                pool::reaction_remove(&rc, eid, "👀").await;
+            }
+        });
+    }
     tracing::debug!(
         dispatched = dispatched_channels.len(),
         queue_depth = queue.pending_channels(),

--- a/crates/buzz-acp/src/queue.rs
+++ b/crates/buzz-acp/src/queue.rs
@@ -139,8 +139,19 @@ pub struct EventQueue {
     in_flight_channels: HashSet<Uuid>,
     /// Per-channel deadline for auto-expiring stuck in-flight entries.
     in_flight_deadlines: HashMap<Uuid, Instant>,
-    /// Number of events in each in-flight batch (for expiry logging).
-    in_flight_batch_sizes: HashMap<Uuid, usize>,
+    /// Event IDs in each in-flight batch — used for expiry logging and, on
+    /// auto-expiry, to clean up the orphaned 👀 reaction (see
+    /// `expired_reaction_ids`).
+    in_flight_batch_event_ids: HashMap<Uuid, Vec<String>>,
+    /// Event IDs orphaned by auto-expiry (see `flush_next`/`has_flushable_work`),
+    /// accumulated here for the caller to drain via `take_expired_reaction_ids`.
+    ///
+    /// Auto-expiry recovers a stuck in-flight channel so new work isn't
+    /// blocked forever, but the original prompt task's `ReactionGuard` never
+    /// got to run its cleanup — its 👀 reaction would otherwise be orphaned
+    /// on the message permanently, looking like the agent is still working
+    /// on a task it silently abandoned.
+    expired_reaction_ids: Vec<String>,
     retry_after: HashMap<Uuid, Instant>,
     /// Per-channel retry attempt counter for exponential backoff / dead-lettering.
     retry_counts: HashMap<Uuid, u32>,
@@ -181,7 +192,8 @@ impl EventQueue {
             queues: HashMap::new(),
             in_flight_channels: HashSet::new(),
             in_flight_deadlines: HashMap::new(),
-            in_flight_batch_sizes: HashMap::new(),
+            in_flight_batch_event_ids: HashMap::new(),
+            expired_reaction_ids: Vec::new(),
             retry_after: HashMap::new(),
             retry_counts: HashMap::new(),
             dedup_mode,
@@ -268,7 +280,11 @@ impl EventQueue {
             .map(|(id, _)| *id)
             .collect();
         for id in expired {
-            let lost_events = self.in_flight_batch_sizes.remove(&id).unwrap_or(0);
+            let lost_event_ids = self
+                .in_flight_batch_event_ids
+                .remove(&id)
+                .unwrap_or_default();
+            let lost_events = lost_event_ids.len();
             tracing::error!(
                 channel_id = %id,
                 lost_events,
@@ -278,6 +294,10 @@ impl EventQueue {
             );
             self.in_flight_channels.remove(&id);
             self.in_flight_deadlines.remove(&id);
+            // The stuck prompt task's ReactionGuard never got to run its
+            // cleanup — surface these IDs so the caller can remove the
+            // orphaned 👀 the same way `drain_channel` does.
+            self.expired_reaction_ids.extend(lost_event_ids);
             // Recover any withheld goose-native steer events for the expired
             // channel back to the queue front so normal dispatch delivers
             // them. Unlike the in-flight batch above (already delivered to a
@@ -319,7 +339,10 @@ impl EventQueue {
                         self.in_flight_channels.insert(id);
                         self.in_flight_deadlines
                             .insert(id, now + self.in_flight_deadline);
-                        self.in_flight_batch_sizes.insert(id, cancelled.len());
+                        self.in_flight_batch_event_ids.insert(
+                            id,
+                            cancelled.iter().map(|be| be.event.id.to_hex()).collect(),
+                        );
                         return Some(FlushBatch {
                             channel_id: id,
                             events: cancelled,
@@ -357,7 +380,10 @@ impl EventQueue {
         self.in_flight_channels.insert(channel_id);
         self.in_flight_deadlines
             .insert(channel_id, now + self.in_flight_deadline);
-        self.in_flight_batch_sizes.insert(channel_id, events.len());
+        self.in_flight_batch_event_ids.insert(
+            channel_id,
+            events.iter().map(|be| be.event.id.to_hex()).collect(),
+        );
 
         // Merge any cancelled events stored by requeue_as_cancelled().
         let cancelled_events = self
@@ -392,7 +418,7 @@ impl EventQueue {
     pub fn mark_complete(&mut self, channel_id: Uuid) {
         self.in_flight_channels.remove(&channel_id);
         self.in_flight_deadlines.remove(&channel_id);
-        self.in_flight_batch_sizes.remove(&channel_id);
+        self.in_flight_batch_event_ids.remove(&channel_id);
         let now = Instant::now();
         match self.retry_after.get(&channel_id) {
             // Active throttle → channel was requeued; keep retry_counts intact.
@@ -407,6 +433,17 @@ impl EventQueue {
                 self.retry_counts.remove(&channel_id);
             }
         }
+    }
+
+    /// Drain and return event IDs orphaned by auto-expiry since the last call.
+    ///
+    /// `flush_next`/`has_flushable_work` auto-expire a stuck in-flight channel
+    /// so new work isn't blocked forever, but the original prompt task's
+    /// `ReactionGuard` never got to run its cleanup — its 👀 reaction is
+    /// otherwise orphaned on the message permanently. The caller should spawn
+    /// best-effort removal for each returned ID, mirroring `drain_channel`.
+    pub fn take_expired_reaction_ids(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.expired_reaction_ids)
     }
 
     /// Re-queue a batch of events that failed to process.
@@ -564,7 +601,11 @@ impl EventQueue {
             .map(|(id, _)| *id)
             .collect();
         for id in expired {
-            let lost_events = self.in_flight_batch_sizes.remove(&id).unwrap_or(0);
+            let lost_event_ids = self
+                .in_flight_batch_event_ids
+                .remove(&id)
+                .unwrap_or_default();
+            let lost_events = lost_event_ids.len();
             tracing::error!(
                 channel_id = %id,
                 lost_events,
@@ -574,9 +615,11 @@ impl EventQueue {
             );
             self.in_flight_channels.remove(&id);
             self.in_flight_deadlines.remove(&id);
-            // Symmetric with the flush_next expiry block: recover withheld
+            // Symmetric with the flush_next expiry block: surface the
+            // orphaned event IDs for 👀 cleanup, and recover withheld
             // goose-native steer events for the expired channel so they are
             // not permanently orphaned in the side table.
+            self.expired_reaction_ids.extend(lost_event_ids);
             self.recover_withheld_for_expired_channel(id);
         }
 
@@ -4369,7 +4412,8 @@ mod tests {
         // event for an in-flight goose-native steer.
         q.in_flight_channels.insert(ch);
         q.in_flight_deadlines.insert(ch, Instant::now());
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_batch_event_ids
+            .insert(ch, vec!["dummy-1".to_string()]);
         assert!(q.mark_native_steer_pending(ch, &event_id));
 
         // Force the in-flight deadline to be in the past, simulating the
@@ -4435,8 +4479,29 @@ mod tests {
         q.in_flight_channels.insert(ch);
         q.in_flight_deadlines
             .insert(ch, Instant::now() - Duration::from_secs(1));
-        q.in_flight_batch_sizes.insert(ch, 3);
+        q.in_flight_batch_event_ids.insert(
+            ch,
+            vec![
+                "dummy-1".to_string(),
+                "dummy-2".to_string(),
+                "dummy-3".to_string(),
+            ],
+        );
         assert!(q.has_flushable_work());
+
+        // The stuck batch's event IDs must surface for 👀 cleanup — this is
+        // the fix for the "stale eyes reaction" bug: auto-expiry recovering
+        // the channel must not silently orphan the reaction too.
+        let mut expired_ids = q.take_expired_reaction_ids();
+        expired_ids.sort();
+        assert_eq!(
+            expired_ids,
+            vec![
+                "dummy-1".to_string(),
+                "dummy-2".to_string(),
+                "dummy-3".to_string()
+            ]
+        );
 
         // After recovery, the queue front-to-back order must match the
         // original FIFO: e1, e2, e3.
@@ -4595,7 +4660,8 @@ mod tests {
         q.in_flight_channels.insert(ch);
         q.in_flight_deadlines
             .insert(ch, Instant::now() + Duration::from_secs(100));
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_batch_event_ids
+            .insert(ch, vec!["dummy-1".to_string()]);
 
         q.mark_complete(ch);
         assert!(!q.in_flight_deadlines.contains_key(&ch));
@@ -4643,7 +4709,8 @@ mod tests {
         // (Instant::now() — by the time flush_next runs, now >= deadline).
         q.in_flight_channels.insert(ch);
         q.in_flight_deadlines.insert(ch, Instant::now());
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_batch_event_ids
+            .insert(ch, vec!["dummy-1".to_string()]);
 
         // Also push an event so flush_next has something to do after expiry.
         q.push(make_queued(ch, "after-expiry"));
@@ -4655,6 +4722,15 @@ mod tests {
             .expect("channel should be dispatchable after auto-expiry");
         assert_eq!(batch.channel_id, ch);
         assert_eq!(batch.events[0].event.content, "after-expiry");
+
+        // The stuck batch's event ID must surface for 👀 cleanup — this is
+        // the fix for the "stale eyes reaction" bug: auto-expiry recovering
+        // the channel must not silently orphan the reaction too.
+        assert_eq!(
+            q.take_expired_reaction_ids(),
+            vec!["dummy-1".to_string()],
+            "auto-expiry must surface the orphaned event ID for reaction cleanup"
+        );
     }
 
     /// F2 case 2.2 — `flush_next` path.
@@ -4672,7 +4748,8 @@ mod tests {
         q.in_flight_channels.insert(ch);
         q.in_flight_deadlines
             .insert(ch, Instant::now() + Duration::from_secs(9999));
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_batch_event_ids
+            .insert(ch, vec!["dummy-1".to_string()]);
 
         // Push an event for another channel so flush_next has work to do.
         let ch2 = Uuid::new_v4();
@@ -4710,7 +4787,8 @@ mod tests {
         q.in_flight_channels.insert(ch);
         q.in_flight_deadlines
             .insert(ch, Instant::now() + Duration::from_secs(9999));
-        q.in_flight_batch_sizes.insert(ch, 1);
+        q.in_flight_batch_event_ids
+            .insert(ch, vec!["dummy-1".to_string()]);
 
         // No other channels — nothing flushable.
         assert!(


### PR DESCRIPTION
## Summary

- `flush_next`/`has_flushable_work` auto-expire a stuck in-flight channel (logged as `"BUG: in-flight channel expired without mark_complete"`) so new work isn't blocked forever, but the original prompt task's `ReactionGuard` never got to run its cleanup — its 👀 "seen" reaction stayed on the message permanently, making it look like an agent was still working on a task it had silently abandoned.
- `EventQueue` now tracks the actual event IDs in each in-flight batch (`in_flight_batch_event_ids`, previously just a count in `in_flight_batch_sizes`), accumulates any orphaned by auto-expiry (`expired_reaction_ids`), and exposes them via a new `take_expired_reaction_ids()`.
- `dispatch_pending` drains this after each `flush_next` cycle and spawns best-effort 👀 removal, mirroring the existing `drain_channel` cleanup path for channel-removal orphaning.

Reproduced live: a message to an agent in a real channel kept a stale 👀 from the agent's pubkey after it had already moved on and replied to a later message — confirmed no reaction-cleanup call ever fired for the original event.

## Test plan

- [x] `cargo test -p buzz-acp --lib` — 664 passed, including two new/extended regression tests asserting `take_expired_reaction_ids()` returns the orphaned IDs after both the `flush_next` and `has_flushable_work` auto-expiry paths
- [x] `cargo clippy -p buzz-acp --all-targets -- -D warnings` — clean (pinned toolchain, `./bin/cargo`)
- [x] `cargo fmt -p buzz-acp -- --check` — clean
- [x] `cargo build -p buzz-acp` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)