### PR TITLE
fix(4369): invalidate session on -32603 dead-child error in run_prompt_task

### DIFF
--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -2278,7 +2278,16 @@ pub async fn run_prompt_task(
             // AgentError means the agent caught a problem before mutating
             // session state (e.g. bad LLM response). The session is healthy —
             // don't invalidate it. Other errors may have corrupted state.
-            if !matches!(e, AcpError::AgentError { .. }) {
+            //
+            // Exception (#4369): -32603 "Internal error" from `session/prompt`
+            // means the underlying agent child process died out-of-band. The
+            // session is dead, not healthy — invalidate so the retry misses
+            // the session cache and create_session_and_apply_model builds a
+            // fresh session on the next attempt. False positives are cheap
+            // (one extra session/new); false negatives wedge the channel.
+            let is_dead_session =
+                matches!(e, AcpError::AgentError { code: -32603, .. });
+            if is_dead_session || !matches!(e, AcpError::AgentError { .. }) {
                 agent.state.invalidate(&source);
             }
             let usage = agent.acp.take_turn_usage();


### PR DESCRIPTION
## Summary

Fixes #4369

When a session's underlying agent child process dies out-of-band (e.g. an operator kills the `claude` sessions), the next `session/prompt` returns JSON-RPC `-32603 "Internal error"`. `run_prompt_task`'s error arm classifies **every** `AcpError::AgentError` as "application error — pipe intact" and deliberately skips session invalidation.

Result: `SessionState.sessions[channel_id]` keeps pointing at the dead session. The requeued batch retries (`MAX_RETRIES = 10`, exponential backoff), hits the session cache, and re-prompts the same dead session every attempt until the batch dead-letters. Nothing heals the map short of restarting the process. Real-world impact: two channels deaf for ~4 hours, 52 owner events dead-lettered.

## Fix

In `crates/buzz-acp/src/pool.rs` `run_prompt_task`'s `Err(e)` arm, carve out `-32603` as session-invalidating while leaving the general `AgentError` healthy-session exemption intact:

```rust
let is_dead_session =
    matches!(e, AcpError::AgentError { code: -32603, .. });
if is_dead_session || !matches!(e, AcpError::AgentError { .. }) {
    agent.state.invalidate(&source);
}
```

The requeued attempt then misses the session cache and `create_session_and_apply_model` builds a fresh session. False positives are cheap (one extra `session/new`); false negatives wedge the channel — the asymmetry favours invalidating. The classification is keyed on the JSON-RPC wire code (`-32603`), not a new error variant, so it stays close to the `agent-client-protocol` surface.

## Why not a liveness probe / `session/load`

A proactive probe adds a round-trip on the hot path for every prompt. The carve-out only pays the rebuild cost when the session is already known-dead, and it composes with the existing `MAX_RETRIES` requeue path and the already-proven `max_turns_per_session` invalidate-and-recreate idiom.

## Testing

- `cargo check -p buzz-acp` — clean
- `cargo test -p buzz-acp` — 664 passed, 0 failed

No new test added: `run_prompt_task` is exercised through the pool lifecycle integration tests (`tests/pool_lifecycle_state.rs`), which do not simulate a mid-batch child-process death; the change is a single classification branch reviewed against the existing `AgentError` handling.
