### PR TITLE
fix(4381): return None for multi-value #h in singular req extractor

### DIFF
--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -848,15 +848,20 @@ fn filters_are_nip43_membership_only(filters: &[Filter]) -> bool {
 }
 
 /// Extract a channel UUID from a single filter's `#h` tag.
+///
+/// Returns `None` for a multi-value `#h` — NIP-01 treats the tag list as an
+/// OR set, so scoping to just the first channel would drop events from the
+/// rest (#4381). Callers widen to the accessible set and let `filters_match`
+/// enforce the OR. This matches the sibling extractors at `api/bridge.rs:235`
+/// and `handlers/count.rs:17`.
 fn extract_channel_id_from_filter(filter: &Filter) -> Option<uuid::Uuid> {
     for (tag_key, tag_values) in filter.generic_tags.iter() {
         let key = tag_key.to_string();
         if key == "h" {
-            for val in tag_values {
-                if let Ok(id) = val.parse::<uuid::Uuid>() {
-                    return Some(id);
-                }
+            if tag_values.len() != 1 {
+                return None;
             }
+            return tag_values.iter().next()?.parse::<uuid::Uuid>().ok();
         }
     }
     None
@@ -1577,6 +1582,33 @@ mod tests {
             filter_with_channel(channel_id),
         ];
         assert_eq!(extract_channel_id_from_filters(&filters), Some(channel_id));
+    }
+
+    #[test]
+    fn test_extract_channel_id_from_filter_single_channel() {
+        let channel_id = uuid::Uuid::new_v4();
+        let filter = filter_with_channel(channel_id);
+        assert_eq!(extract_channel_id_from_filter(&filter), Some(channel_id));
+    }
+
+    #[test]
+    fn test_extract_channel_id_from_filter_multi_value_h_returns_none() {
+        // #4381: a multi-value #h must not silently scope to the first channel —
+        // NIP-01 treats it as an OR set. Returning None widens the query to the
+        // accessible set so filters_match can enforce the OR.
+        let channel_a = uuid::Uuid::new_v4();
+        let channel_b = uuid::Uuid::new_v4();
+        let filter = Filter::new().custom_tags(
+            SingleLetterTag::lowercase(Alphabet::H),
+            [channel_a.to_string(), channel_b.to_string()],
+        );
+        assert_eq!(extract_channel_id_from_filter(&filter), None);
+    }
+
+    #[test]
+    fn test_extract_channel_id_from_filter_no_h_tag_returns_none() {
+        let filter = Filter::new();
+        assert_eq!(extract_channel_id_from_filter(&filter), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #4381

On the HTTP bridge (`POST /query`), a filter carrying multiple `#h` values returned events from only one channel — always the lexicographically smallest — silently dropping events from every other listed channel. The Desktop Workflows overview (which sends exactly this multi-`#h` filter) showed "No workflows yet" even though workflows existed and ran on schedule. NIP-45 `COUNT` undercounted the same way via the same query builder.

## Root cause

Two `#h` extractors disagreed inside the same request (`api/bridge.rs:1227`):

- `build_event_query_from_filter` used the singular `extract_channel_id_from_filter` (`handlers/req.rs:851`), which returned the **first** parseable `#h` UUID. Since `nostr`'s `GenericTags` is `BTreeMap<SingleLetterTag, BTreeSet<String>>`-backed, "first" is the lexicographically smallest channel ID.
- `apply_access_scope_to_query` used the bridge's `extract_channel_from_filter` (`bridge.rs:235`), which correctly returns `None` for multi-value `#h`.

The narrow `channel_id` predicate reached SQL, so the other channels' rows were never fetched and the `filters_match` post-filter couldn't recover them.

## Fix

The singular extractor at `handlers/req.rs:851` now returns `None` for a multi-value `#h`, matching its three siblings:

- `api/bridge.rs:235` — already returns `None`
- `handlers/count.rs:17` — already returns `None`
- `handlers/req.rs:1022` (plural) — already widens to global on distinct channels

Returning `None` widens the database query to the caller's accessible channel set and lets the `filters_match` post-filter enforce the NIP-01 OR set — the same path WS `REQ` already takes.

## Testing

- `cargo test -p buzz-relay handlers::req::tests` — 50/50 pass
- `cargo fmt -p buzz-relay -- --check` — clean
- 3 new regression tests for `extract_channel_id_from_filter` (the singular form had no direct unit coverage before; all existing tests targeted the plural `extract_channel_id_from_filters`):
  - `test_extract_channel_id_from_filter_single_channel` — single `#h` still returns the channel
  - `test_extract_channel_id_from_filter_multi_value_h_returns_none` — OR set widens to global
  - `test_extract_channel_id_from_filter_no_h_tag_returns_none` — absent `#h` is global
