### PR TITLE
fix(mobile): backfill presence from relay snapshots

### DIFF
--- a/mobile/lib/features/profile/presence_cache_provider.dart
+++ b/mobile/lib/features/profile/presence_cache_provider.dart
@@ -14,16 +14,19 @@ import '../../shared/relay/relay.dart';
 class PresenceCacheNotifier extends Notifier<Map<String, String>> {
   static const _batchDelay = Duration(milliseconds: 50);
   static const _refreshInterval = Duration(seconds: 60);
+  static const _presenceTtl = Duration(seconds: 180);
 
   final Set<String> _tracked = {};
   final Set<String> _pending = {};
   final Map<String, String> _statuses = {};
   final Map<String, int> _lastLiveSequence = {};
-  final Map<String, int> _lastLiveCreatedAt = {};
+  final Map<String, int> _lastStatusCreatedAt = {};
+  final Map<String, DateTime> _positiveObservedAt = {};
   Timer? _batchTimer;
   Timer? _refreshTimer;
   void Function()? _presenceUnsub;
   String? _relayIdentity;
+  bool _snapshotInFlight = false;
   int _subscriptionVersion = 0;
   int _changeSequence = 0;
 
@@ -60,7 +63,8 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
     _pending.clear();
     _statuses.clear();
     _lastLiveSequence.clear();
-    _lastLiveCreatedAt.clear();
+    _lastStatusCreatedAt.clear();
+    _positiveObservedAt.clear();
     _changeSequence = 0;
   }
 
@@ -108,18 +112,21 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
     final status = event.content;
     if (!_isPresenceStatus(status)) return;
 
-    final previousCreatedAt = _lastLiveCreatedAt[pubkey];
+    final previousCreatedAt = _lastStatusCreatedAt[pubkey];
     if (previousCreatedAt != null && event.createdAt < previousCreatedAt) {
       return;
     }
-    _lastLiveCreatedAt[pubkey] = event.createdAt;
+    _lastStatusCreatedAt[pubkey] = event.createdAt;
     _changeSequence++;
     _lastLiveSequence[pubkey] = _changeSequence;
     _setStatus(pubkey, status);
   }
 
   void _scheduleSnapshot() {
-    if (_pending.isEmpty || _presenceUnsub == null || _batchTimer != null) {
+    if (_pending.isEmpty ||
+        _presenceUnsub == null ||
+        _batchTimer != null ||
+        _snapshotInFlight) {
       return;
     }
     _batchTimer = Timer(_batchDelay, _flushPending);
@@ -138,7 +145,13 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
 
     final pubkeys = _pending.toList(growable: false);
     _pending.clear();
-    await _fetchPresenceSnapshot(pubkeys, _subscriptionVersion);
+    _snapshotInFlight = true;
+    try {
+      await _fetchPresenceSnapshot(pubkeys, _subscriptionVersion);
+    } finally {
+      _snapshotInFlight = false;
+      _scheduleSnapshot();
+    }
   }
 
   Future<void> _fetchPresenceSnapshot(
@@ -158,7 +171,7 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
       if (subscriptionVersion != _subscriptionVersion) return;
 
       final requested = pubkeys.toSet();
-      final snapshot = <String, String>{};
+      final snapshot = <String, NostrEvent>{};
       for (final event in events) {
         if (event.kind != EventKind.presenceUpdate) continue;
         // `/query` returns relay-signed synthetic events whose trusted p-tag
@@ -167,12 +180,37 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
         final subject = event.getTagValue('p')?.toLowerCase();
         if (subject == null || !requested.contains(subject)) continue;
         if (!_isPresenceStatus(event.content)) continue;
-        snapshot[subject] = event.content;
+        final existing = snapshot[subject];
+        if (existing == null || event.createdAt > existing.createdAt) {
+          snapshot[subject] = event;
+        }
       }
 
       for (final pubkey in pubkeys) {
         if ((_lastLiveSequence[pubkey] ?? 0) > querySequence) continue;
-        _setStatus(pubkey, snapshot[pubkey] ?? 'offline');
+        final event = snapshot[pubkey];
+        if (event != null) {
+          final previousCreatedAt = _lastStatusCreatedAt[pubkey];
+          if (previousCreatedAt != null &&
+              event.createdAt < previousCreatedAt) {
+            continue;
+          }
+          _lastStatusCreatedAt[pubkey] = event.createdAt;
+          _setStatus(pubkey, event.content);
+          continue;
+        }
+
+        // Redis is updated before the live heartbeat is fanned out. A missing
+        // key can therefore mean expiry, but the relay also deliberately
+        // degrades Redis read failures to an empty snapshot. Preserve a fresh
+        // positive observation for one relay TTL so a transient read failure
+        // cannot make an online DM flash offline.
+        final observedAt = _positiveObservedAt[pubkey];
+        if (observedAt != null &&
+            DateTime.now().difference(observedAt) < _presenceTtl) {
+          continue;
+        }
+        _setStatus(pubkey, 'offline');
       }
     } catch (error) {
       debugPrint('[PresenceCacheNotifier] presence snapshot failed: $error');
@@ -183,6 +221,11 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
       status == 'online' || status == 'away' || status == 'offline';
 
   void _setStatus(String pubkey, String status) {
+    if (status == 'online' || status == 'away') {
+      _positiveObservedAt[pubkey] = DateTime.now();
+    } else {
+      _positiveObservedAt.remove(pubkey);
+    }
     if (_statuses[pubkey] == status) return;
     _statuses[pubkey] = status;
     state = Map.unmodifiable(_statuses);

--- a/mobile/lib/features/profile/presence_cache_provider.dart
+++ b/mobile/lib/features/profile/presence_cache_provider.dart
@@ -42,6 +42,8 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
     final sessionState = ref.watch(relaySessionProvider);
 
     ref.onDispose(() {
+      _subscriptionVersion++;
+      _pending.clear();
       _batchTimer?.cancel();
       _batchTimer = null;
       _refreshTimer?.cancel();

--- a/mobile/lib/features/profile/presence_cache_provider.dart
+++ b/mobile/lib/features/profile/presence_cache_provider.dart
@@ -7,45 +7,74 @@ import '../../shared/relay/relay.dart';
 
 /// In-memory cache of other users' presence.
 ///
-/// Subscribes to kind:20001 presence events over the relay WebSocket for
-/// real-time updates. There is no longer a REST backstop — agents that
-/// publish presence purely over WS are fine, and TTL expiry will be handled
-/// by the relay-side `presence:true` filter extension when that lands.
+/// Live kind:20001 updates arrive over the relay WebSocket. An authenticated
+/// `/query` snapshot backfills tracked identities immediately and periodically,
+/// so a newly opened or resumed app does not have to wait for the next
+/// heartbeat and TTL expiry is eventually reflected as `offline`.
 class PresenceCacheNotifier extends Notifier<Map<String, String>> {
+  static const _batchDelay = Duration(milliseconds: 50);
+  static const _refreshInterval = Duration(seconds: 60);
+
   final Set<String> _tracked = {};
+  final Set<String> _pending = {};
+  final Map<String, String> _statuses = {};
+  final Map<String, int> _lastLiveSequence = {};
+  final Map<String, int> _lastLiveCreatedAt = {};
+  Timer? _batchTimer;
+  Timer? _refreshTimer;
   void Function()? _presenceUnsub;
+  String? _relayIdentity;
   int _subscriptionVersion = 0;
+  int _changeSequence = 0;
 
   @override
   Map<String, String> build() {
+    final relayConfig = ref.watch(relayConfigProvider);
+    final relayIdentity =
+        '${relayConfig.baseUrl}|${pubkeyFromNsec(relayConfig.nsec) ?? ''}';
+    if (_relayIdentity != null && _relayIdentity != relayIdentity) {
+      _resetForRelayChange();
+    }
+    _relayIdentity = relayIdentity;
     final sessionState = ref.watch(relaySessionProvider);
 
     ref.onDispose(() {
+      _batchTimer?.cancel();
+      _batchTimer = null;
+      _refreshTimer?.cancel();
+      _refreshTimer = null;
       _presenceUnsub?.call();
       _presenceUnsub = null;
     });
 
     if (sessionState.status == SessionStatus.connected) {
-      _subscribePresenceUpdates();
+      unawaited(_subscribePresenceUpdates());
     }
 
-    return {};
+    return Map.unmodifiable(_statuses);
   }
 
-  /// Track presence for [pubkeys].
-  ///
-  /// Currently a no-op for the actual fetch — we rely on live kind:20001
-  /// events. The tracked set is still used to filter incoming events so the
-  /// cache doesn't grow unbounded.
+  void _resetForRelayChange() {
+    _subscriptionVersion++;
+    _tracked.clear();
+    _pending.clear();
+    _statuses.clear();
+    _lastLiveSequence.clear();
+    _lastLiveCreatedAt.clear();
+    _changeSequence = 0;
+  }
+
+  /// Track presence for [pubkeys] and backfill newly tracked identities.
   void track(List<String> pubkeys) {
-    final normalized = pubkeys.map((pk) => pk.toLowerCase()).toList();
-    _tracked.addAll(normalized);
-    // TODO(presence): once the relay supports a `presence:true` filter
-    // extension, issue a one-shot fetch here for the latest known state per
-    // pubkey. Until then, presence is "online whenever they publish".
+    for (final rawPubkey in pubkeys) {
+      final pubkey = rawPubkey.trim().toLowerCase();
+      if (pubkey.isEmpty || !_tracked.add(pubkey)) continue;
+      _pending.add(pubkey);
+    }
+    _scheduleSnapshot();
   }
 
-  /// Subscribe to kind:20001 presence events over WebSocket.
+  /// Subscribe before querying so a heartbeat cannot fall into a startup gap.
   Future<void> _subscribePresenceUpdates() async {
     _presenceUnsub?.call();
     _presenceUnsub = null;
@@ -58,13 +87,14 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
         const NostrFilter(kinds: [EventKind.presenceUpdate], limit: 0),
         _handlePresenceEvent,
       );
-      // Guard: if build() re-fired while we were awaiting, discard this
-      // subscription to avoid leaking it.
       if (version != _subscriptionVersion) {
         unsub();
         return;
       }
       _presenceUnsub = unsub;
+      _pending.addAll(_tracked);
+      _scheduleSnapshot();
+      _ensureRefreshTimer();
     } catch (error) {
       debugPrint(
         '[PresenceCacheNotifier] presence subscription failed: $error',
@@ -76,11 +106,86 @@ class PresenceCacheNotifier extends Notifier<Map<String, String>> {
     final pubkey = event.pubkey.toLowerCase();
     if (!_tracked.contains(pubkey)) return;
     final status = event.content;
-    if (status != 'online' && status != 'away' && status != 'offline') return;
-    if (state[pubkey] == status) return;
-    final updated = Map<String, String>.from(state);
-    updated[pubkey] = status;
-    state = updated;
+    if (!_isPresenceStatus(status)) return;
+
+    final previousCreatedAt = _lastLiveCreatedAt[pubkey];
+    if (previousCreatedAt != null && event.createdAt < previousCreatedAt) {
+      return;
+    }
+    _lastLiveCreatedAt[pubkey] = event.createdAt;
+    _changeSequence++;
+    _lastLiveSequence[pubkey] = _changeSequence;
+    _setStatus(pubkey, status);
+  }
+
+  void _scheduleSnapshot() {
+    if (_pending.isEmpty || _presenceUnsub == null || _batchTimer != null) {
+      return;
+    }
+    _batchTimer = Timer(_batchDelay, _flushPending);
+  }
+
+  void _ensureRefreshTimer() {
+    _refreshTimer ??= Timer.periodic(_refreshInterval, (_) {
+      _pending.addAll(_tracked);
+      _scheduleSnapshot();
+    });
+  }
+
+  Future<void> _flushPending() async {
+    _batchTimer = null;
+    if (_pending.isEmpty || _presenceUnsub == null) return;
+
+    final pubkeys = _pending.toList(growable: false);
+    _pending.clear();
+    await _fetchPresenceSnapshot(pubkeys, _subscriptionVersion);
+  }
+
+  Future<void> _fetchPresenceSnapshot(
+    List<String> pubkeys,
+    int subscriptionVersion,
+  ) async {
+    final querySequence = _changeSequence;
+    try {
+      final session = ref.read(relaySessionProvider.notifier);
+      final events = await session.queryRelay([
+        NostrFilter(
+          kinds: const [EventKind.presenceUpdate],
+          authors: pubkeys,
+          limit: pubkeys.length,
+        ),
+      ]);
+      if (subscriptionVersion != _subscriptionVersion) return;
+
+      final requested = pubkeys.toSet();
+      final snapshot = <String, String>{};
+      for (final event in events) {
+        if (event.kind != EventKind.presenceUpdate) continue;
+        // `/query` returns relay-signed synthetic events whose trusted p-tag
+        // identifies the subject. Live WS events deliberately never use this
+        // tag, because an arbitrary publisher could spoof it.
+        final subject = event.getTagValue('p')?.toLowerCase();
+        if (subject == null || !requested.contains(subject)) continue;
+        if (!_isPresenceStatus(event.content)) continue;
+        snapshot[subject] = event.content;
+      }
+
+      for (final pubkey in pubkeys) {
+        if ((_lastLiveSequence[pubkey] ?? 0) > querySequence) continue;
+        _setStatus(pubkey, snapshot[pubkey] ?? 'offline');
+      }
+    } catch (error) {
+      debugPrint('[PresenceCacheNotifier] presence snapshot failed: $error');
+    }
+  }
+
+  bool _isPresenceStatus(String status) =>
+      status == 'online' || status == 'away' || status == 'offline';
+
+  void _setStatus(String pubkey, String status) {
+    if (_statuses[pubkey] == status) return;
+    _statuses[pubkey] = status;
+    state = Map.unmodifiable(_statuses);
   }
 }
 

--- a/mobile/test/features/profile/presence_cache_provider_test.dart
+++ b/mobile/test/features/profile/presence_cache_provider_test.dart
@@ -1,94 +1,173 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:buzz/features/profile/presence_cache_provider.dart';
 import 'package:buzz/shared/relay/relay.dart';
 
-/// Tests for [PresenceCacheNotifier] in the pure-Nostr world.
-///
-/// The cache is now purely WS-driven: the notifier subscribes to kind:20001
-/// (presence updates) over the relay session and only mutates state for
-/// pubkeys that have been registered via [PresenceCacheNotifier.track].
-/// There is no longer a REST backstop — the previous test seeded state via
-/// a `GET /api/presence` call which has been removed.
 void main() {
   test('WS presence event updates cache for tracked pubkey', () async {
     final relaySession = _RecordingRelaySessionNotifier();
     final container = _buildContainer(relaySession: relaySession);
     addTearDown(container.dispose);
 
-    // Initialize the notifier (triggers build → subscribes to WS).
     container.read(presenceCacheProvider);
-    await _pumpEventQueue();
+    await _waitFor(() => relaySession.filters.isNotEmpty);
 
-    // Track alice, then emit her initial 'online' status.
     container.read(presenceCacheProvider.notifier).track(['alice']);
     relaySession.emit(_presence('alice', 'online'));
     expect(container.read(presenceCacheProvider)['alice'], 'online');
 
-    // Simulate a WS presence event: alice goes away.
-    relaySession.emit(_presence('alice', 'away'));
+    relaySession.emit(_presence('alice', 'away', createdAt: 1001));
     expect(container.read(presenceCacheProvider)['alice'], 'away');
   });
 
-  test('WS presence event ignores untracked pubkeys', () async {
+  test(
+    'backfills tracked presence from authenticated query snapshot',
+    () async {
+      final relaySession = _RecordingRelaySessionNotifier()
+        ..queryResults = [_snapshot('alice', 'online')];
+      final container = _buildContainer(relaySession: relaySession);
+      addTearDown(container.dispose);
+
+      container.read(presenceCacheProvider);
+      await _waitFor(() => relaySession.filters.isNotEmpty);
+      container.read(presenceCacheProvider.notifier).track(['ALICE']);
+
+      await _waitFor(
+        () => container.read(presenceCacheProvider)['alice'] == 'online',
+      );
+      expect(relaySession.queries, hasLength(1));
+      final filter = relaySession.queries.single.single;
+      expect(filter.kinds, [EventKind.presenceUpdate]);
+      expect(filter.authors, ['alice']);
+      expect(filter.limit, 1);
+    },
+  );
+
+  test('snapshot marks a missing tracked identity offline', () async {
     final relaySession = _RecordingRelaySessionNotifier();
     final container = _buildContainer(relaySession: relaySession);
     addTearDown(container.dispose);
 
     container.read(presenceCacheProvider);
-    await _pumpEventQueue();
-
-    // Track only alice.
+    await _waitFor(() => relaySession.filters.isNotEmpty);
     container.read(presenceCacheProvider.notifier).track(['alice']);
 
-    // Emit event for bob (untracked).
-    relaySession.emit(_presence('bob', 'online'));
-
-    // Bob should NOT appear in the cache.
-    expect(container.read(presenceCacheProvider).containsKey('bob'), isFalse);
+    await _waitFor(
+      () => container.read(presenceCacheProvider)['alice'] == 'offline',
+    );
   });
 
-  test('WS presence event ignores invalid status values', () async {
-    final relaySession = _RecordingRelaySessionNotifier();
+  test('live heartbeat wins over an older in-flight snapshot', () async {
+    final snapshotCompleter = Completer<List<NostrEvent>>();
+    final relaySession = _RecordingRelaySessionNotifier()
+      ..queryCompleter = snapshotCompleter;
     final container = _buildContainer(relaySession: relaySession);
     addTearDown(container.dispose);
 
     container.read(presenceCacheProvider);
+    await _waitFor(() => relaySession.filters.isNotEmpty);
+    container.read(presenceCacheProvider.notifier).track(['alice']);
+    await _waitFor(() => relaySession.queries.isNotEmpty);
+
+    relaySession.emit(_presence('alice', 'online'));
+    snapshotCompleter.complete([_snapshot('alice', 'away')]);
     await _pumpEventQueue();
 
-    container.read(presenceCacheProvider.notifier).track(['alice']);
-    relaySession.emit(_presence('alice', 'online'));
     expect(container.read(presenceCacheProvider)['alice'], 'online');
-
-    // Emit event with garbage status — should be rejected.
-    relaySession.emit(_presence('alice', 'garbage-status'));
-
-    // Status should remain 'online'.
-    expect(container.read(presenceCacheProvider)['alice'], 'online');
   });
 
-  test('WS presence event skips no-op updates', () async {
+  test('live event never trusts a spoofed p-tag subject', () async {
     final relaySession = _RecordingRelaySessionNotifier();
     final container = _buildContainer(relaySession: relaySession);
     addTearDown(container.dispose);
 
     container.read(presenceCacheProvider);
-    await _pumpEventQueue();
-
+    await _waitFor(() => relaySession.filters.isNotEmpty);
     container.read(presenceCacheProvider.notifier).track(['alice']);
-    relaySession.emit(_presence('alice', 'online'));
+    relaySession.emit(
+      _presence(
+        'mallory',
+        'online',
+        tags: const [
+          ['p', 'alice'],
+        ],
+      ),
+    );
 
-    // Listen for state changes after initial setup.
-    var stateChangeCount = 0;
-    container.listen(presenceCacheProvider, (prev, next) => stateChangeCount++);
-
-    // Emit event with same status as current.
-    relaySession.emit(_presence('alice', 'online'));
-
-    // No state change should occur — it's a no-op.
-    expect(stateChangeCount, 0);
+    expect(container.read(presenceCacheProvider).containsKey('alice'), isFalse);
   });
+
+  test(
+    'WS presence event ignores untracked pubkeys and invalid status',
+    () async {
+      final relaySession = _RecordingRelaySessionNotifier();
+      final container = _buildContainer(relaySession: relaySession);
+      addTearDown(container.dispose);
+
+      container.read(presenceCacheProvider);
+      await _waitFor(() => relaySession.filters.isNotEmpty);
+      container.read(presenceCacheProvider.notifier).track(['alice']);
+
+      relaySession.emit(_presence('bob', 'online'));
+      relaySession.emit(_presence('alice', 'garbage-status'));
+
+      final cache = container.read(presenceCacheProvider);
+      expect(cache.containsKey('bob'), isFalse);
+      expect(cache.containsKey('alice'), isFalse);
+    },
+  );
+
+  test(
+    'older replayed heartbeat cannot overwrite a newer live status',
+    () async {
+      final relaySession = _RecordingRelaySessionNotifier();
+      final container = _buildContainer(relaySession: relaySession);
+      addTearDown(container.dispose);
+
+      container.read(presenceCacheProvider);
+      await _waitFor(() => relaySession.filters.isNotEmpty);
+      container.read(presenceCacheProvider.notifier).track(['alice']);
+
+      relaySession.emit(_presence('alice', 'away', createdAt: 1001));
+      relaySession.emit(_presence('alice', 'online', createdAt: 1000));
+
+      expect(container.read(presenceCacheProvider)['alice'], 'away');
+    },
+  );
+
+  test(
+    'keeps cached presence during reconnect and then resynchronizes',
+    () async {
+      final relaySession = _RecordingRelaySessionNotifier()
+        ..queryResults = [_snapshot('alice', 'online')];
+      final container = _buildContainer(relaySession: relaySession);
+      addTearDown(container.dispose);
+
+      container.read(presenceCacheProvider);
+      await _waitFor(() => relaySession.filters.isNotEmpty);
+      container.read(presenceCacheProvider.notifier).track(['alice']);
+      await _waitFor(
+        () => container.read(presenceCacheProvider)['alice'] == 'online',
+      );
+
+      relaySession.setStatus(SessionStatus.reconnecting);
+      container.read(presenceCacheProvider);
+      await _pumpEventQueue();
+      expect(container.read(presenceCacheProvider)['alice'], 'online');
+
+      relaySession.queryResults = [_snapshot('alice', 'away')];
+      final queryCount = relaySession.queries.length;
+      relaySession.setStatus(SessionStatus.connected);
+      container.read(presenceCacheProvider);
+      await _waitFor(() => relaySession.queries.length > queryCount);
+      await _waitFor(
+        () => container.read(presenceCacheProvider)['alice'] == 'away',
+      );
+    },
+  );
 
   test('subscribes to kind:20001 with limit 0', () async {
     final relaySession = _RecordingRelaySessionNotifier();
@@ -96,56 +175,52 @@ void main() {
     addTearDown(container.dispose);
 
     container.read(presenceCacheProvider);
-    await _pumpEventQueue();
+    await _waitFor(() => relaySession.filters.isNotEmpty);
 
-    // Should have subscribed with the correct filter.
     expect(relaySession.filters, hasLength(1));
     expect(relaySession.filters.single.kinds, [EventKind.presenceUpdate]);
     expect(relaySession.filters.single.limit, 0);
   });
-
-  test('WS event uses pubkey variable, not literal string', () async {
-    // Regression test for the map key bug where `{...state, pubkey: status}`
-    // used the literal string "pubkey" instead of the variable's value.
-    final relaySession = _RecordingRelaySessionNotifier();
-    final container = _buildContainer(relaySession: relaySession);
-    addTearDown(container.dispose);
-
-    container.read(presenceCacheProvider);
-    await _pumpEventQueue();
-
-    container.read(presenceCacheProvider.notifier).track([
-      'deadbeef',
-      'cafebabe',
-    ]);
-
-    // Seed cafebabe -> offline, then set deadbeef online.
-    relaySession.emit(_presence('cafebabe', 'offline'));
-    relaySession.emit(_presence('deadbeef', 'online'));
-
-    final cache = container.read(presenceCacheProvider);
-    // deadbeef should be online (the actual pubkey, not a literal "pubkey" key).
-    expect(cache['deadbeef'], 'online');
-    // cafebabe should still be offline (not clobbered).
-    expect(cache['cafebabe'], 'offline');
-    // There should be no literal "pubkey" key in the map.
-    expect(cache.containsKey('pubkey'), isFalse);
-  });
 }
 
-NostrEvent _presence(String pubkey, String status) => NostrEvent(
-  id: 'evt-$pubkey-$status',
+NostrEvent _presence(
+  String pubkey,
+  String status, {
+  int createdAt = 1000,
+  List<List<String>> tags = const [],
+}) => NostrEvent(
+  id: 'evt-$pubkey-$status-$createdAt',
   pubkey: pubkey,
-  createdAt: 1000,
+  createdAt: createdAt,
   kind: EventKind.presenceUpdate,
-  tags: const [],
+  tags: tags,
   content: status,
   sig: 'sig',
+);
+
+NostrEvent _snapshot(String subject, String status) => NostrEvent(
+  id: 'snapshot-$subject-$status',
+  pubkey: 'relay',
+  createdAt: 2000,
+  kind: EventKind.presenceUpdate,
+  tags: [
+    ['p', subject],
+  ],
+  content: status,
+  sig: 'relay-sig',
 );
 
 Future<void> _pumpEventQueue() async {
   await Future<void>.delayed(Duration.zero);
   await Future<void>.delayed(Duration.zero);
+}
+
+Future<void> _waitFor(bool Function() predicate) async {
+  for (var attempt = 0; attempt < 50; attempt++) {
+    if (predicate()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail('condition was not met before timeout');
 }
 
 ProviderContainer _buildContainer({
@@ -161,7 +236,10 @@ ProviderContainer _buildContainer({
 
 class _RecordingRelaySessionNotifier extends RelaySessionNotifier {
   final List<NostrFilter> filters = [];
+  final List<List<NostrFilter>> queries = [];
   final List<void Function(NostrEvent)> _listeners = [];
+  List<NostrEvent> queryResults = [];
+  Completer<List<NostrEvent>>? queryCompleter;
 
   @override
   SessionState build() => const SessionState(status: SessionStatus.connected);
@@ -180,11 +258,23 @@ class _RecordingRelaySessionNotifier extends RelaySessionNotifier {
     };
   }
 
-  /// Emit an event synchronously to all live subscribers.
+  @override
+  Future<List<NostrEvent>> queryRelay(
+    List<NostrFilter> filters, {
+    Duration timeout = const Duration(seconds: 8),
+  }) {
+    queries.add(filters);
+    return queryCompleter?.future ?? Future.value(queryResults);
+  }
+
   void emit(NostrEvent event) {
     for (final listener in List.of(_listeners)) {
       listener(event);
     }
+  }
+
+  void setStatus(SessionStatus status) {
+    state = SessionState(status: status);
   }
 }
 

--- a/mobile/test/features/profile/presence_cache_provider_test.dart
+++ b/mobile/test/features/profile/presence_cache_provider_test.dart
@@ -251,6 +251,24 @@ void main() {
       expect(container.read(presenceCacheProvider), isEmpty);
     },
   );
+
+  test('dispose discards an in-flight snapshot', () async {
+    final snapshotCompleter = Completer<List<NostrEvent>>();
+    final relaySession = _RecordingRelaySessionNotifier()
+      ..queryCompleter = snapshotCompleter;
+    final container = _buildContainer(relaySession: relaySession);
+
+    container.read(presenceCacheProvider);
+    await _waitFor(() => relaySession.filters.isNotEmpty);
+    container.read(presenceCacheProvider.notifier).track(['alice']);
+    await _waitFor(() => relaySession.queries.isNotEmpty);
+
+    container.dispose();
+    snapshotCompleter.complete([_snapshot('alice', 'online')]);
+    await _pumpEventQueue();
+
+    expect(relaySession.filters, isEmpty);
+  });
 }
 
 NostrEvent _presence(

--- a/mobile/test/features/profile/presence_cache_provider_test.dart
+++ b/mobile/test/features/profile/presence_cache_provider_test.dart
@@ -79,6 +79,22 @@ void main() {
     expect(container.read(presenceCacheProvider)['alice'], 'online');
   });
 
+  test('fresh live status survives a temporarily empty snapshot', () async {
+    final relaySession = _RecordingRelaySessionNotifier();
+    final container = _buildContainer(relaySession: relaySession);
+    addTearDown(container.dispose);
+
+    container.read(presenceCacheProvider);
+    await _waitFor(() => relaySession.filters.isNotEmpty);
+    container.read(presenceCacheProvider.notifier).track(['alice']);
+    relaySession.emit(_presence('alice', 'online'));
+
+    await _waitFor(() => relaySession.queries.isNotEmpty);
+    await _pumpEventQueue();
+
+    expect(container.read(presenceCacheProvider)['alice'], 'online');
+  });
+
   test('live event never trusts a spoofed p-tag subject', () async {
     final relaySession = _RecordingRelaySessionNotifier();
     final container = _buildContainer(relaySession: relaySession);
@@ -138,6 +154,24 @@ void main() {
     },
   );
 
+  test('snapshot timestamp rejects an older replayed live heartbeat', () async {
+    final relaySession = _RecordingRelaySessionNotifier()
+      ..queryResults = [_snapshot('alice', 'online')];
+    final container = _buildContainer(relaySession: relaySession);
+    addTearDown(container.dispose);
+
+    container.read(presenceCacheProvider);
+    await _waitFor(() => relaySession.filters.isNotEmpty);
+    container.read(presenceCacheProvider.notifier).track(['alice']);
+    await _waitFor(
+      () => container.read(presenceCacheProvider)['alice'] == 'online',
+    );
+
+    relaySession.emit(_presence('alice', 'away', createdAt: 1999));
+
+    expect(container.read(presenceCacheProvider)['alice'], 'online');
+  });
+
   test(
     'keeps cached presence during reconnect and then resynchronizes',
     () async {
@@ -181,6 +215,42 @@ void main() {
     expect(relaySession.filters.single.kinds, [EventKind.presenceUpdate]);
     expect(relaySession.filters.single.limit, 0);
   });
+
+  test(
+    'relay change clears cache and discards an in-flight snapshot',
+    () async {
+      final relayConfig = _FakeRelayConfigNotifier();
+      final relaySession = _RecordingRelaySessionNotifier()
+        ..queryResults = [_snapshot('alice', 'online')];
+      final container = _buildContainer(
+        relaySession: relaySession,
+        relayConfig: relayConfig,
+      );
+      addTearDown(container.dispose);
+
+      container.read(presenceCacheProvider);
+      await _waitFor(() => relaySession.filters.isNotEmpty);
+      container.read(presenceCacheProvider.notifier).track(['alice']);
+      await _waitFor(
+        () => container.read(presenceCacheProvider)['alice'] == 'online',
+      );
+
+      final staleQuery = Completer<List<NostrEvent>>();
+      relaySession.queryCompleter = staleQuery;
+      final queryCount = relaySession.queries.length;
+      container.read(presenceCacheProvider.notifier).track(['bob']);
+      await _waitFor(() => relaySession.queries.length > queryCount);
+
+      relayConfig.setRelay('https://other-relay.example');
+      container.read(presenceCacheProvider);
+      expect(container.read(presenceCacheProvider), isEmpty);
+
+      staleQuery.complete([_snapshot('bob', 'online')]);
+      await _pumpEventQueue();
+
+      expect(container.read(presenceCacheProvider), isEmpty);
+    },
+  );
 }
 
 NostrEvent _presence(
@@ -225,10 +295,14 @@ Future<void> _waitFor(bool Function() predicate) async {
 
 ProviderContainer _buildContainer({
   required _RecordingRelaySessionNotifier relaySession,
+  _FakeRelayConfigNotifier? relayConfig,
 }) {
   return ProviderContainer(
     overrides: [
       appLifecycleProvider.overrideWith(() => _FakeAppLifecycleNotifier()),
+      relayConfigProvider.overrideWith(
+        () => relayConfig ?? _FakeRelayConfigNotifier(),
+      ),
       relaySessionProvider.overrideWith(() => relaySession),
     ],
   );
@@ -281,4 +355,13 @@ class _RecordingRelaySessionNotifier extends RelaySessionNotifier {
 class _FakeAppLifecycleNotifier extends AppLifecycleNotifier {
   @override
   AppLifecycleState build() => AppLifecycleState.resumed;
+}
+
+class _FakeRelayConfigNotifier extends RelayConfigNotifier {
+  @override
+  RelayConfig build() => const RelayConfig(baseUrl: 'https://relay.example');
+
+  void setRelay(String baseUrl) {
+    state = RelayConfig(baseUrl: baseUrl);
+  }
 }


### PR DESCRIPTION
## Summary
- subscribe to live presence before querying tracked DM identities
- backfill and periodically refresh presence from the relay Redis snapshot
- preserve newer live heartbeats across snapshot races, transient Redis misses, reconnects, relay/account changes, and provider disposal

## Test Plan
- [x] `just mobile-check`
- [x] `flutter test test/features/profile/presence_cache_provider_test.dart` (13 passed)
- [x] `just mobile-test` (1029 passed, 1 skipped)