### PR TITLE
fix(mobile): retry messages after transient disconnects

### DIFF
--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -50,10 +50,15 @@ class _LiveSubscription {
 }
 
 class _PendingEvent {
+  final NostrEvent event;
   final Completer<NostrEvent> completer;
   final Timer timeout;
 
-  _PendingEvent({required this.completer, required this.timeout});
+  _PendingEvent({
+    required this.event,
+    required this.completer,
+    required this.timeout,
+  });
 }
 
 class _BufferedEvent {
@@ -248,7 +253,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   /// Publish an event and wait for the relay's OK confirmation.
   Future<NostrEvent> publish(
     NostrEvent event, {
-    Duration timeout = const Duration(seconds: 8),
+    Duration timeout = const Duration(seconds: 30),
   }) {
     final completer = Completer<NostrEvent>();
 
@@ -264,11 +269,19 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     });
 
     _pendingEvents[event.id] = _PendingEvent(
+      event: event,
       completer: completer,
       timeout: timer,
     );
 
-    _socket?.send(['EVENT', event.toJson()]);
+    if (state.status == SessionStatus.connected) {
+      _sendEvent(event);
+    } else if (!_paused && state.status == SessionStatus.disconnected) {
+      _reconnectTimer?.cancel();
+      _reconnectDelayMs = _baseReconnectDelayMs;
+      final config = ref.read(relayConfigProvider);
+      unawaited(_connect(config));
+    }
     return completer.future;
   }
 
@@ -377,18 +390,19 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     _hasConnectedOnce = true;
     _reconnectDelayMs = _baseReconnectDelayMs;
     state = const SessionState(status: SessionStatus.connected);
+    _replayPendingEvents();
     _replayLiveSubscriptions();
   }
 
   void _handleDisconnected(int generation, Object? error) {
     if (_disposed || generation != _connectionGeneration) return;
     _cancelAllHistory(error);
-    _rejectAllPending(error);
     _eventBuffer.clear();
     _flushTimer?.cancel();
     _flushTimer = null;
     if (error is RelayAuthRejectedException) {
       _reconnectTimer?.cancel();
+      _rejectAllPending(error);
       state = const SessionState(status: SessionStatus.disconnected);
       return;
     }
@@ -423,6 +437,17 @@ class RelaySessionNotifier extends Notifier<SessionState> {
           ? sub.filter.copyWithSince(since)
           : sub.filter;
       _sendReq(entry.key, filter);
+    }
+  }
+
+  /// Re-submit unacknowledged events after a transient reconnect.
+  ///
+  /// Events retain their original signed ID, so relay-side duplicate handling
+  /// makes this safe when the first publish was stored but its OK frame was
+  /// lost with the connection.
+  void _replayPendingEvents() {
+    for (final pending in _pendingEvents.values) {
+      _sendEvent(pending.event);
     }
   }
 
@@ -616,6 +641,10 @@ class RelaySessionNotifier extends Notifier<SessionState> {
 
   void _sendClose(String subId) {
     _socket?.send(['CLOSE', subId]);
+  }
+
+  void _sendEvent(NostrEvent event) {
+    _socket?.send(['EVENT', event.toJson()]);
   }
 
   void _unsubscribe(String subId) {

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -52,12 +52,13 @@ class _LiveSubscription {
 class _PendingEvent {
   final NostrEvent event;
   final Completer<NostrEvent> completer;
-  final Timer timeout;
+  final Duration acknowledgementTimeout;
+  Timer? timeout;
 
   _PendingEvent({
     required this.event,
     required this.completer,
-    required this.timeout,
+    required this.acknowledgementTimeout,
   });
 }
 
@@ -92,6 +93,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   static const _baseReconnectDelayMs = 1000;
   static const _maxReconnectDelayMs = 30000;
   static const _eventBatchMs = 16;
+  static const _reconnectPublishTimeout = Duration(seconds: 30);
   static const _reconnectReplaySkewSeconds = 5;
   static const _maxRecentDeliveryKeys = 5000;
 
@@ -253,30 +255,32 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   /// Publish an event and wait for the relay's OK confirmation.
   Future<NostrEvent> publish(
     NostrEvent event, {
-    Duration timeout = const Duration(seconds: 30),
+    Duration timeout = const Duration(seconds: 8),
   }) {
+    if (_paused) {
+      return Future.error(
+        Exception('Cannot publish while app is in background'),
+      );
+    }
     final completer = Completer<NostrEvent>();
-
-    final timer = Timer(timeout, () {
-      final pending = _pendingEvents.remove(event.id);
-      if (pending != null && !pending.completer.isCompleted) {
-        pending.completer.completeError(
-          TimeoutException(
-            'Event ${event.id} not acknowledged within $timeout',
-          ),
-        );
-      }
-    });
-
-    _pendingEvents[event.id] = _PendingEvent(
+    final pending = _PendingEvent(
       event: event,
       completer: completer,
-      timeout: timer,
+      acknowledgementTimeout: timeout,
     );
+    _pendingEvents[event.id] = pending;
 
     if (state.status == SessionStatus.connected) {
-      _sendEvent(event);
-    } else if (!_paused && state.status == SessionStatus.disconnected) {
+      _sendPendingEvent(pending);
+    } else {
+      _armPendingTimeout(
+        event.id,
+        _reconnectPublishTimeout,
+        'Event ${event.id} could not reconnect within '
+        '$_reconnectPublishTimeout',
+      );
+    }
+    if (!_paused && state.status == SessionStatus.disconnected) {
       _reconnectTimer?.cancel();
       _reconnectDelayMs = _baseReconnectDelayMs;
       final config = ref.read(relayConfigProvider);
@@ -406,6 +410,14 @@ class RelaySessionNotifier extends Notifier<SessionState> {
       state = const SessionState(status: SessionStatus.disconnected);
       return;
     }
+    for (final eventId in _pendingEvents.keys) {
+      _armPendingTimeout(
+        eventId,
+        _reconnectPublishTimeout,
+        'Event $eventId could not reconnect within '
+        '$_reconnectPublishTimeout',
+      );
+    }
     _scheduleReconnect();
   }
 
@@ -447,8 +459,30 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   /// lost with the connection.
   void _replayPendingEvents() {
     for (final pending in _pendingEvents.values) {
-      _sendEvent(pending.event);
+      _sendPendingEvent(pending);
     }
+  }
+
+  void _sendPendingEvent(_PendingEvent pending) {
+    _armPendingTimeout(
+      pending.event.id,
+      pending.acknowledgementTimeout,
+      'Event ${pending.event.id} not acknowledged within '
+      '${pending.acknowledgementTimeout}',
+    );
+    _sendEvent(pending.event);
+  }
+
+  void _armPendingTimeout(String eventId, Duration timeout, String message) {
+    final pending = _pendingEvents[eventId];
+    if (pending == null) return;
+    pending.timeout?.cancel();
+    pending.timeout = Timer(timeout, () {
+      final expired = _pendingEvents.remove(eventId);
+      if (expired != null && !expired.completer.isCompleted) {
+        expired.completer.completeError(TimeoutException(message));
+      }
+    });
   }
 
   void _handleMessage(List<dynamic> data) {
@@ -562,7 +596,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
 
     final pending = _pendingEvents.remove(eventId);
     if (pending == null) return;
-    pending.timeout.cancel();
+    pending.timeout?.cancel();
 
     if (accepted) {
       // We don't have the full event here; create a minimal placeholder.
@@ -665,7 +699,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
 
   void _rejectAllPending(Object? error) {
     for (final entry in _pendingEvents.values) {
-      entry.timeout.cancel();
+      entry.timeout?.cancel();
       if (!entry.completer.isCompleted) {
         entry.completer.completeError(error ?? Exception('Connection lost'));
       }

--- a/mobile/lib/shared/relay/relay_session.dart
+++ b/mobile/lib/shared/relay/relay_session.dart
@@ -53,12 +53,17 @@ class _PendingEvent {
   final NostrEvent event;
   final Completer<NostrEvent> completer;
   final Duration acknowledgementTimeout;
+  final DateTime deadline;
+  final bool retryOnReconnect;
+  bool wasSent = false;
   Timer? timeout;
 
   _PendingEvent({
     required this.event,
     required this.completer,
     required this.acknowledgementTimeout,
+    required this.deadline,
+    required this.retryOnReconnect,
   });
 }
 
@@ -112,6 +117,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   bool _paused = false;
   bool _hasConnectedOnce = false;
   int _connectionGeneration = 0;
+  RelayAuthRejectedException? _authRejectedError;
 
   @override
   SessionState build() {
@@ -121,6 +127,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     // Reset disposed flag — build() may re-run on the same Notifier instance
     // after a provider dependency changes (e.g. auth completing).
     _disposed = false;
+    _authRejectedError = null;
 
     ref.onDispose(_dispose);
 
@@ -262,11 +269,19 @@ class RelaySessionNotifier extends Notifier<SessionState> {
         Exception('Cannot publish while app is in background'),
       );
     }
+    final authRejectedError = _authRejectedError;
+    if (authRejectedError != null) return Future.error(authRejectedError);
+    final retryOnReconnect = event.kind == EventKind.streamMessage;
+    final deadline = DateTime.now().add(
+      retryOnReconnect ? _reconnectPublishTimeout : timeout,
+    );
     final completer = Completer<NostrEvent>();
     final pending = _PendingEvent(
       event: event,
       completer: completer,
       acknowledgementTimeout: timeout,
+      deadline: deadline,
+      retryOnReconnect: retryOnReconnect,
     );
     _pendingEvents[event.id] = pending;
 
@@ -324,6 +339,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
 
   /// Force a reconnect (e.g., returning from background).
   Future<void> reconnect() async {
+    _authRejectedError = null;
     await _socket?.disconnect();
     _reconnectDelayMs = _baseReconnectDelayMs;
     final config = ref.read(relayConfigProvider);
@@ -392,6 +408,7 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   void _handleConnected(int generation) {
     if (_disposed || generation != _connectionGeneration) return;
     _hasConnectedOnce = true;
+    _authRejectedError = null;
     _reconnectDelayMs = _baseReconnectDelayMs;
     state = const SessionState(status: SessionStatus.connected);
     _replayPendingEvents();
@@ -406,9 +423,17 @@ class RelaySessionNotifier extends Notifier<SessionState> {
     _flushTimer = null;
     if (error is RelayAuthRejectedException) {
       _reconnectTimer?.cancel();
+      _authRejectedError = error;
       _rejectAllPending(error);
       state = const SessionState(status: SessionStatus.disconnected);
       return;
+    }
+    final nonRetryable = [
+      for (final entry in _pendingEvents.entries)
+        if (entry.value.wasSent && !entry.value.retryOnReconnect) entry.key,
+    ];
+    for (final eventId in nonRetryable) {
+      _rejectPendingEvent(eventId, error ?? Exception('Connection lost'));
     }
     for (final eventId in _pendingEvents.keys) {
       _armPendingTimeout(
@@ -459,11 +484,14 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   /// lost with the connection.
   void _replayPendingEvents() {
     for (final pending in _pendingEvents.values) {
-      _sendPendingEvent(pending);
+      if (!pending.wasSent || pending.retryOnReconnect) {
+        _sendPendingEvent(pending);
+      }
     }
   }
 
   void _sendPendingEvent(_PendingEvent pending) {
+    pending.wasSent = true;
     _armPendingTimeout(
       pending.event.id,
       pending.acknowledgementTimeout,
@@ -476,13 +504,27 @@ class RelaySessionNotifier extends Notifier<SessionState> {
   void _armPendingTimeout(String eventId, Duration timeout, String message) {
     final pending = _pendingEvents[eventId];
     if (pending == null) return;
+    final remaining = pending.deadline.difference(DateTime.now());
+    final boundedTimeout = remaining < timeout ? remaining : timeout;
     pending.timeout?.cancel();
-    pending.timeout = Timer(timeout, () {
-      final expired = _pendingEvents.remove(eventId);
-      if (expired != null && !expired.completer.isCompleted) {
-        expired.completer.completeError(TimeoutException(message));
-      }
-    });
+    pending.timeout = Timer(
+      boundedTimeout.isNegative ? Duration.zero : boundedTimeout,
+      () {
+        final expired = _pendingEvents.remove(eventId);
+        if (expired != null && !expired.completer.isCompleted) {
+          expired.completer.completeError(TimeoutException(message));
+        }
+      },
+    );
+  }
+
+  void _rejectPendingEvent(String eventId, Object error) {
+    final pending = _pendingEvents.remove(eventId);
+    if (pending == null) return;
+    pending.timeout?.cancel();
+    if (!pending.completer.isCompleted) {
+      pending.completer.completeError(error);
+    }
   }
 
   void _handleMessage(List<dynamic> data) {

--- a/mobile/test/features/channels/send_message_provider_test.dart
+++ b/mobile/test/features/channels/send_message_provider_test.dart
@@ -66,9 +66,48 @@ void main() {
     expect(completedIds, isEmpty);
     expect(removedIds, [localMessages.single.id]);
   });
+
+  test(
+    'publishes nested replies with the outer root and direct parent',
+    () async {
+      final session = _PendingPublishRelaySession();
+      final send = SendMessage(
+        signedEventRelay: SignedEventRelay(
+          session: session,
+          nsec: nostr.Keys.generate().nsec,
+        ),
+        fetchMembers: (_) async => const [],
+        readUserCache: () => const {},
+        addLocalMessage: (_, _) {},
+        completeLocalMessage: (_, _) {},
+        removeLocalMessage: (_, _) {},
+      );
+
+      final result = send(
+        channelId: _channelId,
+        content: 'en di?',
+        parentEventId: _parentEventId,
+        rootEventId: _rootEventId,
+      );
+      await session.published;
+
+      expect(session.event.tags, [
+        ['h', _channelId],
+        ['e', _rootEventId, '', 'root'],
+        ['e', _parentEventId, '', 'reply'],
+      ]);
+
+      session.accept();
+      await result;
+    },
+  );
 }
 
 const _channelId = '11111111-1111-4111-8111-111111111111';
+const _rootEventId =
+    '6bcca718f6849cc616e3e49c09e969391175bf5bacc4fc498d7d4d0d6aa8dc12';
+const _parentEventId =
+    '26c605599e18fc72af785bd74b7ad16cfa431b574102dccd9296f8d5b46dc022';
 
 class _PendingPublishRelaySession extends RelaySessionNotifier {
   final Completer<NostrEvent> _result = Completer<NostrEvent>();

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -154,6 +154,43 @@ void main() {
     expect(session.state.reconnectAttempt, 1);
   });
 
+  test(
+    'replays an unacknowledged publish after a transient reconnect',
+    () async {
+      final session = RelaySessionNotifier();
+      final socket = _ControlledRelaySocket(
+        wsUrl: 'wss://relay.example',
+        nsec: null,
+        onMessage: (_) {},
+        onConnected: () {},
+        onDisconnected: (_) {},
+      );
+      final container = ProviderContainer(
+        overrides: [relaySessionProvider.overrideWith(() => session)],
+      );
+      addTearDown(container.dispose);
+      container.read(relaySessionProvider);
+      session.debugAttachSocketForTest(socket);
+
+      final published = session.publish(_event());
+      expect(socket.sent, [
+        ['EVENT', _event().toJson()],
+      ]);
+
+      session.debugHandleDisconnected(Exception('connection lost'));
+      expect(session.state.status, SessionStatus.reconnecting);
+
+      session.debugHandleConnected();
+      expect(socket.sent, [
+        ['EVENT', _event().toJson()],
+        ['EVENT', _event().toJson()],
+      ]);
+
+      session.debugHandleMessage(['OK', _event().id, true, 'duplicate:']);
+      await expectLater(published, completes);
+    },
+  );
+
   test('classifies relay internal auth errors as transient', () {
     expect(
       classifyRelayAuthFailure(
@@ -402,6 +439,7 @@ class _AuthenticatedAuthNotifier extends AuthNotifier {
 class _ControlledRelaySocket extends RelaySocket {
   final void Function() _connected;
   final void Function(Object? error) _disconnected;
+  final List<List<dynamic>> sent = [];
 
   _ControlledRelaySocket({
     required super.wsUrl,
@@ -417,6 +455,9 @@ class _ControlledRelaySocket extends RelaySocket {
 
   @override
   void dispose() {}
+
+  @override
+  void send(List<dynamic> payload) => sent.add(payload);
 
   void connectSuccessfully() => _connected();
 

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -172,9 +172,9 @@ void main() {
       container.read(relaySessionProvider);
       session.debugAttachSocketForTest(socket);
 
-      final published = session.publish(_event());
+      final published = session.publish(_messageEvent());
       expect(socket.sent, [
-        ['EVENT', _event().toJson()],
+        ['EVENT', _messageEvent().toJson()],
       ]);
 
       session.debugHandleDisconnected(Exception('connection lost'));
@@ -182,11 +182,16 @@ void main() {
 
       session.debugHandleConnected();
       expect(socket.sent, [
-        ['EVENT', _event().toJson()],
-        ['EVENT', _event().toJson()],
+        ['EVENT', _messageEvent().toJson()],
+        ['EVENT', _messageEvent().toJson()],
       ]);
 
-      session.debugHandleMessage(['OK', _event().id, true, 'duplicate:']);
+      session.debugHandleMessage([
+        'OK',
+        _messageEvent().id,
+        true,
+        'duplicate:',
+      ]);
       await expectLater(published, completes);
     },
   );
@@ -210,15 +215,15 @@ void main() {
       session.debugAttachSocketForTest(socket);
       session.debugHandleDisconnected(Exception('connection lost'));
 
-      final published = session.publish(_event());
+      final published = session.publish(_messageEvent());
       expect(socket.sent, isEmpty);
 
       session.debugHandleConnected();
       expect(socket.sent, [
-        ['EVENT', _event().toJson()],
+        ['EVENT', _messageEvent().toJson()],
       ]);
 
-      session.debugHandleMessage(['OK', _event().id, true, '']);
+      session.debugHandleMessage(['OK', _messageEvent().id, true, '']);
       await expectLater(published, completes);
     },
   );
@@ -241,14 +246,14 @@ void main() {
       container.read(relaySessionProvider);
       session.debugAttachSocketForTest(socket);
 
-      final published = session.publish(_event());
-      session.debugHandleMessage(['OK', _event().id, true, '']);
+      final published = session.publish(_messageEvent());
+      session.debugHandleMessage(['OK', _messageEvent().id, true, '']);
       await published;
 
       session.debugHandleDisconnected(Exception('connection lost'));
       session.debugHandleConnected();
       expect(socket.sent, [
-        ['EVENT', _event().toJson()],
+        ['EVENT', _messageEvent().toJson()],
       ]);
     },
   );
@@ -271,7 +276,7 @@ void main() {
       container.read(relaySessionProvider);
       session.debugAttachSocketForTest(socket);
 
-      final published = session.publish(_event());
+      final published = session.publish(_messageEvent());
       session.debugHandleDisconnected(
         const RelayAuthRejectedException('restricted: access revoked'),
       );
@@ -279,10 +284,36 @@ void main() {
 
       session.debugHandleConnected();
       expect(socket.sent, [
-        ['EVENT', _event().toJson()],
+        ['EVENT', _messageEvent().toJson()],
       ]);
     },
   );
+
+  test('does not replay response-bearing events after disconnect', () async {
+    final session = RelaySessionNotifier();
+    final socket = _ControlledRelaySocket(
+      wsUrl: 'wss://relay.example',
+      nsec: null,
+      onMessage: (_) {},
+      onConnected: () {},
+      onDisconnected: (_) {},
+    );
+    final container = ProviderContainer(
+      overrides: [relaySessionProvider.overrideWith(() => session)],
+    );
+    addTearDown(container.dispose);
+    container.read(relaySessionProvider);
+    session.debugAttachSocketForTest(socket);
+
+    final published = session.publish(_event());
+    session.debugHandleDisconnected(Exception('connection lost'));
+    await expectLater(published, throwsException);
+
+    session.debugHandleConnected();
+    expect(socket.sent, [
+      ['EVENT', _event().toJson()],
+    ]);
+  });
 
   test('classifies relay internal auth errors as transient', () {
     expect(
@@ -581,6 +612,20 @@ NostrEvent _event() {
       ['h', _channelId],
     ],
     content: 'hello',
+    sig: 'sig',
+  );
+}
+
+NostrEvent _messageEvent() {
+  return const NostrEvent(
+    id: 'message-1',
+    pubkey: 'alice',
+    createdAt: 20,
+    kind: EventKind.streamMessage,
+    tags: [
+      ['h', _channelId],
+    ],
+    content: 'en di?',
     sig: 'sig',
   );
 }

--- a/mobile/test/shared/relay/relay_session_test.dart
+++ b/mobile/test/shared/relay/relay_session_test.dart
@@ -191,6 +191,99 @@ void main() {
     },
   );
 
+  test(
+    'buffers a publish while reconnecting until the socket returns',
+    () async {
+      final session = RelaySessionNotifier();
+      final socket = _ControlledRelaySocket(
+        wsUrl: 'wss://relay.example',
+        nsec: null,
+        onMessage: (_) {},
+        onConnected: () {},
+        onDisconnected: (_) {},
+      );
+      final container = ProviderContainer(
+        overrides: [relaySessionProvider.overrideWith(() => session)],
+      );
+      addTearDown(container.dispose);
+      container.read(relaySessionProvider);
+      session.debugAttachSocketForTest(socket);
+      session.debugHandleDisconnected(Exception('connection lost'));
+
+      final published = session.publish(_event());
+      expect(socket.sent, isEmpty);
+
+      session.debugHandleConnected();
+      expect(socket.sent, [
+        ['EVENT', _event().toJson()],
+      ]);
+
+      session.debugHandleMessage(['OK', _event().id, true, '']);
+      await expectLater(published, completes);
+    },
+  );
+
+  test(
+    'does not replay a publish already acknowledged before reconnect',
+    () async {
+      final session = RelaySessionNotifier();
+      final socket = _ControlledRelaySocket(
+        wsUrl: 'wss://relay.example',
+        nsec: null,
+        onMessage: (_) {},
+        onConnected: () {},
+        onDisconnected: (_) {},
+      );
+      final container = ProviderContainer(
+        overrides: [relaySessionProvider.overrideWith(() => session)],
+      );
+      addTearDown(container.dispose);
+      container.read(relaySessionProvider);
+      session.debugAttachSocketForTest(socket);
+
+      final published = session.publish(_event());
+      session.debugHandleMessage(['OK', _event().id, true, '']);
+      await published;
+
+      session.debugHandleDisconnected(Exception('connection lost'));
+      session.debugHandleConnected();
+      expect(socket.sent, [
+        ['EVENT', _event().toJson()],
+      ]);
+    },
+  );
+
+  test(
+    'auth rejection fails pending publishes without replaying them',
+    () async {
+      final session = RelaySessionNotifier();
+      final socket = _ControlledRelaySocket(
+        wsUrl: 'wss://relay.example',
+        nsec: null,
+        onMessage: (_) {},
+        onConnected: () {},
+        onDisconnected: (_) {},
+      );
+      final container = ProviderContainer(
+        overrides: [relaySessionProvider.overrideWith(() => session)],
+      );
+      addTearDown(container.dispose);
+      container.read(relaySessionProvider);
+      session.debugAttachSocketForTest(socket);
+
+      final published = session.publish(_event());
+      session.debugHandleDisconnected(
+        const RelayAuthRejectedException('restricted: access revoked'),
+      );
+      await expectLater(published, throwsA(isA<RelayAuthRejectedException>()));
+
+      session.debugHandleConnected();
+      expect(socket.sent, [
+        ['EVENT', _event().toJson()],
+      ]);
+    },
+  );
+
   test('classifies relay internal auth errors as transient', () {
     expect(
       classifyRelayAuthFailure(


### PR DESCRIPTION
## Summary
- keep unacknowledged mobile events pending across transient relay reconnects
- replay the same signed event ID so a lost acknowledgement cannot duplicate a message
- cover the reported nested Alies thread reply and reconnect path with regressions

## Test Plan
- [x] `just mobile-check`
- [x] `just mobile-test`
- [x] verify a nested reply carries the outer root and direct parent tags
- [x] verify an unacknowledged event is replayed and completes after reconnect