### PR TITLE
fix(infra): use on-disk H2 for dev Keycloak so it survives connection churn

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
     container_name: buzz-keycloak
     command: start-dev --http-port=8080
     environment:
-      KC_DB: dev-mem
+      KC_DB: dev-file
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
     ports:


### PR DESCRIPTION
## Summary

`docker-compose.yml` backs the dev Keycloak with `KC_DB: dev-mem`. H2 destroys an in-memory database once its last connection closes, so the container starts cleanly and then begins failing about 15 minutes later, when the pool has retired its idle connections and the first scheduled task fires:

```
ERROR [org.keycloak.services.scheduled.ScheduledTaskRunner] (Timer-0)
Failed to run scheduled task ClearExpiredEvents:
... Table "REALM" not found (this database is empty)
```

From then on the admin console returns HTTP 500. It's easy to miss because `just setup` finishes well before the first failure — Keycloak looks fine at the end of onboarding and is broken by the time anyone actually reaches for it.

`dev-file` keeps the same throwaway H2 but on disk inside the container, where connection churn can't drop it. No volume is mounted, so the database is still discarded on `docker compose down` — the throwaway intent of the dev stack is unchanged.

### Related issue

No existing issue found. Searched open and closed issues and PRs for "keycloak", "dev-mem", and "KC_DB".

The closest related work is #4170, which fixes a *different* Keycloak bug in the same service block: its healthcheck probes a port Keycloak doesn't serve health on, so the container reports `unhealthy` permanently. That bug is independent of this one — this container stays `unhealthy` with or without this change, and stays broken-after-15-minutes with or without #4170. I've deliberately kept them separate rather than duplicating that fix here. The two touch adjacent lines in the same `environment:` block, so whichever lands second may need a trivial rebase.

### Testing

Verified against this file alone (`docker compose -f docker-compose.yml`, no local overrides):

- **Before** — reproduced the failure above roughly 15 minutes after boot, with the admin console then returning 500.
- **After** — 17 minute soak with no `ClearExpiredEvents` failure, no `Table "REALM" not found`, and zero `ERROR` lines in the container log. Admin console at `:8180` still redirects to login.
- `/opt/keycloak/data/h2/keycloakdb.mv.db` is present afterwards, confirming the database is genuinely file-backed rather than the failure just not having fired yet.
- `docker compose config --quiet` validates.

Tested on macOS/arm64 against `quay.io/keycloak/keycloak:26.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)