### PR TITLE
fix(desktop): discover Codex Desktop's Windows install dir

### DIFF
--- a/desktop/src-tauri/src/managed_agents/discovery.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery.rs
@@ -53,8 +53,15 @@ fn common_binary_paths() -> &'static [PathBuf] {
                 paths.push(PathBuf::from(appdata).join("npm"));
             }
             if let Some(local) = std::env::var_os("LOCALAPPDATA") {
+                let local = PathBuf::from(local);
+                // Codex Desktop unpacks its bundled CLI to
+                // %LOCALAPPDATA%\OpenAI\Codex\bin — no `Programs` segment. Its
+                // installer adds that dir to the user PATH in the registry, but
+                // an app launched before that write inherits a PATH without it,
+                // so probing is what makes those installs discoverable.
+                paths.push(local.join("OpenAI").join("Codex").join("bin"));
                 paths.push(
-                    PathBuf::from(local)
+                    local
                         .join("Programs")
                         .join("OpenAI")
                         .join("Codex")

--- a/desktop/src-tauri/src/managed_agents/discovery/tests/managed_path_resolution.rs
+++ b/desktop/src-tauri/src/managed_agents/discovery/tests/managed_path_resolution.rs
@@ -26,6 +26,41 @@ fn common_binary_paths_probes_legacy_goose_install_dir() {
     );
 }
 
+/// Codex Desktop installs its bundled CLI to `%LOCALAPPDATA%\OpenAI\Codex\bin`,
+/// not `%LOCALAPPDATA%\Programs\OpenAI\Codex\bin`. Only the `Programs` variant
+/// was probed, so a Buzz process that inherited a PATH predating the Codex
+/// installer's registry write reported Codex as not installed.
+///
+/// Asserts the probe list for the same reason as the Goose case above:
+/// `common_binary_paths` is a process-lifetime `OnceLock`.
+#[cfg(windows)]
+#[test]
+fn common_binary_paths_probes_codex_desktop_install_dir() {
+    use std::path::PathBuf;
+
+    let local = std::env::var_os("LOCALAPPDATA").expect("LOCALAPPDATA is always set on Windows");
+    let local = PathBuf::from(local);
+    let desktop_dir = local.join("OpenAI").join("Codex").join("bin");
+    let standalone_dir = local
+        .join("Programs")
+        .join("OpenAI")
+        .join("Codex")
+        .join("bin");
+
+    let probed = super::super::common_binary_paths();
+
+    assert!(
+        probed.contains(&desktop_dir),
+        "Codex Desktop install dir {} must be probed, got: {probed:?}",
+        desktop_dir.display()
+    );
+    assert!(
+        probed.contains(&standalone_dir),
+        "standalone Codex install dir {} must stay probed, got: {probed:?}",
+        standalone_dir.display()
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn resolve_command_prefers_buzz_managed_npm_shim_over_path() {


### PR DESCRIPTION
Codex Desktop unpacks its bundled CLI to `%LOCALAPPDATA%\OpenAI\Codex\bin`, but `common_binary_paths()` probed only `%LOCALAPPDATA%\Programs\OpenAI\Codex\bin`. That directory does not exist for a Codex Desktop install, so Buzz reported Codex as not installed.

PATH normally covers this — the Codex installer adds its bin dir to the user PATH in the registry — but a Buzz process launched before that write inherits a PATH without it, and per `resolve_command_uncached` binaries outside PATH are found only by scanning `common_binary_paths()`. Wrong probe plus stale PATH left a working, logged-in Codex install undiscoverable.

Probes both locations rather than replacing the existing one, since the standalone installer target is unchanged. Same shape as the legacy Goose Windows install dir probe directly below it.

## Summary
<!-- What does this change and why? -->

### Related issue
<!-- Fixes #1234, or N/A. Before opening: search existing issues/PRs for duplicates — link the closest one, or say "none found". -->

### Testing
<!-- How was this verified? UI change? Include before/after screenshots (or a short recording). -->
