### PR TITLE
fix(desktop): keep the Buzz Term splash until the terminal is revealed

### DIFF
--- a/desktop/src/features/terminal/TerminalSubstrate.test.mjs
+++ b/desktop/src/features/terminal/TerminalSubstrate.test.mjs
@@ -179,19 +179,53 @@ const VISIBLE_FRAME = {
 };
 
 async function expectWelcome(view, present) {
+  // Compare a boolean, never the node: an AssertionError carrying a mounted
+  // element inspects it to build its message, and `__reactFiber$` makes that
+  // walk the whole fiber graph — a failure takes ~2min to report instead of ms.
   await waitFor(() =>
-    present
-      ? assert.ok(view.container.querySelector(".buzz-terminal-welcome"))
-      : assert.equal(
-          view.container.querySelector(".buzz-terminal-welcome"),
-          null,
-        ),
+    assert.equal(
+      view.container.querySelector(".buzz-terminal-welcome") !== null,
+      present,
+    ),
   );
 }
 
-test("non-empty output from the active PTY dismisses the welcome overlay", async () => {
+async function reveal(view) {
+  const substrate = view.container.querySelector(".buzz-terminal-substrate");
+  toggleChord();
+  await waitFor(() =>
+    assert.equal(substrate.dataset.terminalOwner, "terminal"),
+  );
+}
+
+test("spawn-time output before the first reveal keeps the welcome overlay", async () => {
   const subject = fixture({ frame: EMPTY_FRAME });
   await ready(subject.view);
+  await expectWelcome(subject.view, true);
+
+  subject.rerender({ frame: VISIBLE_FRAME });
+  await expectWelcome(subject.view, true);
+
+  await reveal(subject.view);
+  await expectWelcome(subject.view, true);
+});
+
+test("the first keystroke dismisses the welcome overlay", async () => {
+  const subject = fixture({ frame: VISIBLE_FRAME });
+  await ready(subject.view);
+  await reveal(subject.view);
+  await expectWelcome(subject.view, true);
+
+  fireEvent.input(subject.view.getByLabelText("Terminal input"), {
+    target: { value: "l" },
+  });
+  await expectWelcome(subject.view, false);
+});
+
+test("non-empty output after the reveal dismisses the welcome overlay", async () => {
+  const subject = fixture({ frame: EMPTY_FRAME });
+  await ready(subject.view);
+  await reveal(subject.view);
   await expectWelcome(subject.view, true);
 
   subject.rerender({ frame: VISIBLE_FRAME });
@@ -201,6 +235,7 @@ test("non-empty output from the active PTY dismisses the welcome overlay", async
 test("empty active output keeps the welcome overlay", async () => {
   const subject = fixture({ frame: EMPTY_FRAME });
   await ready(subject.view);
+  await reveal(subject.view);
   await expectWelcome(subject.view, true);
 
   subject.rerender({
@@ -221,6 +256,7 @@ test("non-empty output from an inactive PTY keeps the welcome overlay", async ()
     ],
   });
   await ready(subject.view);
+  await reveal(subject.view);
   await expectWelcome(subject.view, true);
 
   subject.rerender({

--- a/desktop/src/features/terminal/TerminalSubstrate.tsx
+++ b/desktop/src/features/terminal/TerminalSubstrate.tsx
@@ -101,6 +101,7 @@ export function TerminalSubstrate({
   const previousFocusRef = React.useRef<HTMLElement | null>(null);
   const reportedFocusRef = React.useRef<boolean | null>(null);
   const scrollBySessionRef = React.useRef(new Map<string, number>());
+  const revealedRef = React.useRef(false);
   const activeSession = sessions.find((session) => session.active);
   const activeSessionId = activeSession?.id ?? null;
   const frames = React.useMemo(
@@ -141,6 +142,7 @@ export function TerminalSubstrate({
     const appSurface = getAppSurface();
     if (!appSurface) return;
     if (next === "terminal") {
+      revealedRef.current = true;
       previousFocusRef.current =
         document.activeElement instanceof HTMLElement
           ? document.activeElement
@@ -312,9 +314,13 @@ export function TerminalSubstrate({
       consumeFrame(delivered.frame);
       if (
         delivered.sessionId === activeSessionId &&
+        revealedRef.current &&
         hasVisibleOutput(delivered.frame)
       ) {
-        // Policy: first visible output from the active PTY removes the overlay.
+        // Policy: the banner is a splash for the reveal, so spawn-time shell
+        // output must not dismiss it. Only visible output from the active PTY
+        // that arrives after the terminal has been revealed (or the first
+        // keystroke, see sendInput) removes the overlay.
         setWelcomeVisible(false);
       }
     }


### PR DESCRIPTION
## What

Bug 1 of the #4347 batch: the Buzz Term splash banner never showed.

`TerminalBootstrap` spawns the PTY the moment `AppShell` mounts, and `TerminalSubstrate` dismissed the welcome banner on *any* visible output from the active session. A real shell prints its prompt immediately, so the banner was reliably dead long before the user ever pressed ⌘J. The dismissal policy was written for a blank PTY that does not exist in practice.

## Policy

Dismiss the banner on **the first keystroke sent to the PTY**, or on **visible output that arrives after the terminal has been revealed at least once** (`revealedRef`, set in `commitOwner("terminal")`).

I took both arms rather than keystroke-only. Keystroke-only is simpler, but it leaves the banner painted over live scrollback if you reveal the terminal, type nothing, and a background job prints — the banner is a splash for the reveal, not a modal that requires input to clear. Both arms also keep the three inherited dismissal tests meaningful: they still discriminate active-vs-inactive session and empty-vs-visible frames, now after a reveal step.

## Also: a two-minute failure in the test helper

While mutation-testing I found the inherited `expectWelcome` helper compares a DOM node against `null`:

```js
assert.equal(view.container.querySelector(".buzz-terminal-welcome"), null)
```

When that assertion *fails*, node builds the `AssertionError` message by inspecting the element. A React-mounted node carries `__reactFiber$…`, so the inspect walks the whole fiber graph: **a red run took ~126s to report where a green run takes 1.3s.** Reproduced at pristine `78cfe1e7e` with the dismissal line deleted (1.3s green → 106s red), so this is inherited, not introduced here. Comparing a boolean instead fixes it; failures in these rows now report in about a second.

## Verification

At merge head `0cba404a9` (merged `origin/max/tui-renderer` @ `feedd2fe7`, which includes #4405 and #4407):

- `pnpm test` — **3967 passed, 0 failed**
- `pnpm typecheck` — clean
- `pnpm check` (biome + file-sizes with `CHECK_FILE_SIZES_BASE=feedd2fe7`, px-text, pubkey-truncation) — clean
- Push hooks green: branch-skew, desktop-check, desktop-test, desktop-tauri-checks

**Mutation matrix, 5/5 killed** (re-run at the merged head, not just at my pre-merge SHA):

| # | Mutant | Result |
|---|--------|--------|
| M1 | drop the `revealedRef` gate on output — *the original bug* | killed by 2 rows |
| M2 | drop keystroke dismissal | killed |
| M3 | never mark revealed | killed |
| M4 | initialise `revealedRef` to `true` | killed by 2 rows |
| M5 | drop output dismissal entirely | killed |

#4407 touched both of my files (`TerminalSubstrate.tsx` / `.test.mjs`) and git auto-merged them without conflict. A clean auto-merge is not a correct merge, so I read the combined diff: Max's blink state (`cursorPainted` / `cursorReset` / `reducedMotion`) is disjoint from the welcome gate, and my `setWelcomeVisible(false)` survives intact in `sendInput`. Both of his cursor rows pass alongside mine.

## Scope

Welcome/splash dismissal policy only. No renderer, no Rust, no owner-state changes — Bug 2's `forceBuzzFallback` work is Mari's and already merged underneath this.
