### PR TITLE
feat(terminal): reach the scrollback the engine was already keeping

### DIFF
--- a/desktop/src-tauri/crates/buzz-terminal/src/damage.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/damage.rs
@@ -169,18 +169,61 @@ pub struct RawFrame {
     viewport: crate::Viewport,
 }
 
+/// The grid line a screen row reads from.
+///
+/// The grid indexes the active area from 0 and scrollback with *negative*
+/// lines, so scrolling back `n` lines means every screen row reads `n` lines
+/// higher. At the live edge the offset is zero and this is the identity, which
+/// is why the unscrolled path is unchanged rather than merely equivalent.
+fn row_of(screen_row: usize, display_offset: usize) -> Line {
+    Line(screen_row as i32 - display_offset as i32)
+}
+
+/// Where the cursor sits on screen, given how far the viewport is scrolled
+/// back.
+///
+/// The grid keeps the cursor in *active-area* coordinates, which do not move
+/// when the user scrolls; the renderer paints *screen rows*, which do. The two
+/// agree only at the live edge, so the conversion has to happen somewhere, and
+/// it happens here rather than in the renderer -- the renderer is not told the
+/// display offset, and giving it one would put this same arithmetic on the far
+/// side of a transport.
+///
+/// Scrolling far enough pushes the cursor off the bottom of the viewport, and
+/// then it is reported as not visible. Without that clamp a caret drawn at a
+/// clamped row would sit on some unrelated line of history, which reads as
+/// corruption rather than as scrollback.
+fn cursor_frame(
+    cursor_point: alacritty_terminal::index::Point,
+    display_offset: usize,
+    screen_lines: usize,
+    shown: bool,
+) -> CursorFrame {
+    let line = cursor_point.line.0.max(0) as usize + display_offset;
+    CursorFrame {
+        line: line.min(screen_lines.saturating_sub(1)),
+        column: cursor_point.column.0,
+        visible: shown && line < screen_lines,
+    }
+}
+
 /// Copy the damaged rows out of the terminal. **Runs under the lock; does no
 /// encoding.** Keep this function boring — everything added here is lock hold.
 pub fn capture(terminal: &mut crate::Terminal) -> RawFrame {
     let viewport = terminal.viewport();
+    let display_offset = terminal.display_offset();
     let term = terminal.term_mut();
     let columns = term.columns();
     let screen_lines = term.screen_lines();
     let cursor_point = term.grid().cursor.point;
-    let visible = term
+    let shown = term
         .mode()
         .contains(alacritty_terminal::term::TermMode::SHOW_CURSOR);
 
+    // Upstream's partial iterator already reports **screen** rows: it offsets
+    // each damaged active-area line by the display offset and drops the ones
+    // that scrolling pushed off the bottom (`TermDamageIterator::new`). So both
+    // arms below speak the same coordinate, and `row_of` converts once.
     let (lines, full) = match term.damage() {
         TermDamage::Full => ((0..screen_lines).collect::<Vec<_>>(), true),
         TermDamage::Partial(iter) => (
@@ -194,14 +237,10 @@ pub fn capture(terminal: &mut crate::Terminal) -> RawFrame {
     let grid = term.grid();
     let mut rows = Vec::with_capacity(lines.len());
     for line in lines {
-        let row = &grid[Line(line as i32)];
+        let row = &grid[row_of(line, display_offset)];
         rows.push((line, row[..Column(columns)].to_vec()));
     }
-    let cursor = CursorFrame {
-        line: cursor_point.line.0.max(0) as usize,
-        column: cursor_point.column.0,
-        visible,
-    };
+    let cursor = cursor_frame(cursor_point, display_offset, screen_lines, shown);
 
     term.reset_damage();
     RawFrame {
@@ -232,25 +271,22 @@ pub fn capture(terminal: &mut crate::Terminal) -> RawFrame {
 /// than a damaged-rows copy, so it belongs on attach, not in the frame loop.
 pub fn capture_all(terminal: &mut crate::Terminal) -> RawFrame {
     let viewport = terminal.viewport();
+    let display_offset = terminal.display_offset();
     let term = terminal.term_mut();
     let columns = term.columns();
     let screen_lines = term.screen_lines();
     let cursor_point = term.grid().cursor.point;
-    let visible = term
+    let shown = term
         .mode()
         .contains(alacritty_terminal::term::TermMode::SHOW_CURSOR);
 
     let grid = term.grid();
     let mut rows = Vec::with_capacity(screen_lines);
     for line in 0..screen_lines {
-        let row = &grid[Line(line as i32)];
+        let row = &grid[row_of(line, display_offset)];
         rows.push((line, row[..Column(columns)].to_vec()));
     }
-    let cursor = CursorFrame {
-        line: cursor_point.line.0.max(0) as usize,
-        column: cursor_point.column.0,
-        visible,
-    };
+    let cursor = cursor_frame(cursor_point, display_offset, screen_lines, shown);
 
     // No `damage()` and no `reset_damage()`: see the note above.
     RawFrame {

--- a/desktop/src-tauri/crates/buzz-terminal/src/lib.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/lib.rs
@@ -243,6 +243,43 @@ impl Terminal {
         self.viewport()
     }
 
+    /// Move the viewport through scrollback. **Positive moves *into* history.**
+    ///
+    /// That is upstream's sign (`Scroll::Delta`), kept rather than flipped: a
+    /// second convention in the middle of the stack is a bug waiting for the
+    /// one caller who reads the wrong doc comment. The DOM has the opposite
+    /// sense, and the embedder converts once, at the command boundary.
+    ///
+    /// Returns whether the viewport actually moved. Both ends of history clamp
+    /// silently upstream, and a caller that repaints on every request would
+    /// repaint for the whole tail of a momentum gesture after it had already
+    /// hit the top. Every scroll that *does* move is a full repaint, because
+    /// `Term::scroll_display` marks the grid fully damaged.
+    pub fn scroll(&mut self, lines: i32) -> bool {
+        self.scroll_display(alacritty_terminal::grid::Scroll::Delta(lines))
+    }
+
+    /// Return the viewport to the live edge. Returns whether it moved.
+    ///
+    /// Output alone does not do this: once scrolled back, the grid pins the
+    /// viewport and lets new lines accumulate above it
+    /// (`Grid::scroll_up`). Coming back is therefore an explicit act, and the
+    /// embedder ties it to user input.
+    pub fn scroll_to_bottom(&mut self) -> bool {
+        self.scroll_display(alacritty_terminal::grid::Scroll::Bottom)
+    }
+
+    /// How far the viewport sits above the live edge, in lines.
+    pub fn display_offset(&self) -> usize {
+        self.term.grid().display_offset()
+    }
+
+    fn scroll_display(&mut self, scroll: alacritty_terminal::grid::Scroll) -> bool {
+        let before = self.display_offset();
+        self.term.scroll_display(scroll);
+        self.display_offset() != before
+    }
+
     pub fn term(&self) -> &Term<Listener> {
         &self.term
     }

--- a/desktop/src-tauri/crates/buzz-terminal/src/shared.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/src/shared.rs
@@ -229,6 +229,22 @@ impl SharedTerminal {
         encoder.encode(raw)
     }
 
+    /// Move the viewport through scrollback. Renderer plane.
+    ///
+    /// Positive moves into history; see [`crate::Terminal::scroll`]. Returns
+    /// whether it moved, so the caller can skip capture and publication for
+    /// the momentum tail that arrives after history has run out.
+    pub fn scroll(&self, lines: i32) -> bool {
+        self.acquire(&self.renderer).scroll(lines)
+    }
+
+    /// Return the viewport to the live edge. Renderer plane. Returns whether
+    /// it moved, so an unscrolled terminal costs one comparison per keystroke
+    /// and no repaint.
+    pub fn scroll_to_bottom(&self) -> bool {
+        self.acquire(&self.renderer).scroll_to_bottom()
+    }
+
     /// Apply a coalesced resize. Renderer plane: this competes with the
     /// renderer for the same lock and can hold it for milliseconds.
     pub fn resize(&self, size: crate::Size) -> crate::Viewport {

--- a/desktop/src-tauri/crates/buzz-terminal/tests/scrollback.rs
+++ b/desktop/src-tauri/crates/buzz-terminal/tests/scrollback.rs
@@ -1,0 +1,399 @@
+//! Reaching the scrollback the engine has always been keeping.
+//!
+//! The grid retains 10k lines in production and, before this, nothing could
+//! move the viewport off the live edge. Three things have to hold at once for
+//! that to become usable, and each one fails silently on its own:
+//!
+//! 1. **Direction.** A flipped sign still scrolls, still clamps, and still
+//!    repaints. Only a human notices. So the direction is asserted here, in
+//!    test names, rather than left to the caller to get right.
+//! 2. **Coordinates.** Capture reads screen rows out of a grid indexed from
+//!    the live edge. Off-by-the-offset shows *some* plausible text.
+//! 3. **Dedup.** The renderer's per-row hashes describe the screen it last
+//!    saw. Scrolling changes every row without changing the grid, so a scroll
+//!    that consumed the full-damage flag would leave those hashes describing
+//!    a viewport that is no longer shown -- and they would then suppress a row
+//!    that really did change.
+
+use buzz_terminal::damage::{Encoder, Frame};
+use buzz_terminal::fences::Fences;
+use buzz_terminal::{Action, SharedTerminal, Size, Terminal};
+use std::sync::mpsc::Receiver;
+
+/// The receiver is returned rather than dropped: dropping it disconnects the
+/// channel and every subsequent listener send silently fails.
+fn terminal(
+    columns: usize,
+    screen_lines: usize,
+    scrollback: usize,
+) -> (SharedTerminal, Receiver<Action>) {
+    let size = Size {
+        columns,
+        screen_lines,
+        scrollback,
+    };
+    let (term, actions) = Terminal::new(size, Fences::ALL);
+    (SharedTerminal::new(term), actions)
+}
+
+/// The text of every row the frame carries, indexed by screen row.
+///
+/// Blank rows are kept as empty strings rather than filtered out: this suite
+/// is about *which row shows which line*, and dropping the blanks would
+/// renumber every row after one.
+fn rows_by_line(frame: &Frame) -> Vec<(usize, String)> {
+    frame
+        .rows
+        .iter()
+        .map(|row| {
+            (
+                row.line,
+                row.spans
+                    .iter()
+                    .map(|span| span.text.as_str())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string(),
+            )
+        })
+        .collect()
+}
+
+/// Just the text, in screen order. Only meaningful for a full frame.
+fn screen(frame: &Frame) -> Vec<String> {
+    rows_by_line(frame)
+        .into_iter()
+        .map(|(_, text)| text)
+        .collect()
+}
+
+/// Fill history with numbered lines, then take a caught-up renderer.
+///
+/// Returns the terminal and an encoder that has already consumed the damage
+/// from that output, so anything a later assertion sees is caused by the
+/// thing under test rather than by the fixture.
+fn scrolled_terminal(lines: usize) -> (SharedTerminal, Receiver<Action>, Encoder) {
+    let (shared, actions) = terminal(20, 4, 100);
+    let payload = (1..=lines)
+        .map(|n| format!("L{n:02}"))
+        .collect::<Vec<_>>()
+        .join("\r\n");
+    shared.feed_fully(payload.as_bytes());
+    let mut renderer = Encoder::new();
+    let _ = shared.render(&mut renderer);
+    (shared, actions, renderer)
+}
+
+#[test]
+fn the_fixture_starts_at_the_live_edge_showing_the_newest_lines() {
+    let (shared, _actions, _) = scrolled_terminal(10);
+    let mut encoder = Encoder::new();
+    assert_eq!(
+        screen(&shared.snapshot(&mut encoder)),
+        vec!["L07", "L08", "L09", "L10"]
+    );
+    assert_eq!(shared.lock().display_offset(), 0);
+}
+
+/// **The direction, at the engine boundary.** Positive goes *into* history.
+///
+/// This is upstream's convention and the reason the embedder negates the DOM
+/// delta exactly once. If this assertion and `terminal_scroll`'s negation are
+/// ever flipped together the pair still passes -- which is why the embedder's
+/// own direction test asserts against the DOM sign rather than against this
+/// one.
+#[test]
+fn positive_lines_scroll_backwards_into_history() {
+    let (shared, _actions, _) = scrolled_terminal(10);
+
+    assert!(shared.scroll(2), "two lines of history exist to move into");
+
+    let mut encoder = Encoder::new();
+    assert_eq!(
+        screen(&shared.snapshot(&mut encoder)),
+        vec!["L05", "L06", "L07", "L08"],
+        "scrolling back two lines must show two older lines"
+    );
+    assert_eq!(shared.lock().display_offset(), 2);
+}
+
+#[test]
+fn negative_lines_scroll_forwards_towards_the_live_edge() {
+    let (shared, _actions, _) = scrolled_terminal(10);
+    assert!(shared.scroll(3));
+
+    assert!(shared.scroll(-1), "one line back towards the edge");
+
+    let mut encoder = Encoder::new();
+    assert_eq!(
+        screen(&shared.snapshot(&mut encoder)),
+        vec!["L05", "L06", "L07", "L08"]
+    );
+    assert_eq!(shared.lock().display_offset(), 2);
+}
+
+/// The momentum guard. A trackpad flick keeps delivering events for about a
+/// second after the fingers lift; once history runs out every one of them
+/// must be free.
+#[test]
+fn scrolling_past_the_oldest_line_clamps_and_reports_no_movement() {
+    let (shared, _actions, _) = scrolled_terminal(10);
+    // Six lines of history: ten written, four on screen.
+    assert!(shared.scroll(6));
+    assert_eq!(shared.lock().display_offset(), 6);
+
+    assert!(
+        !shared.scroll(1),
+        "there is nothing older, so nothing moved"
+    );
+    assert!(
+        !shared.scroll(1_000),
+        "and a whole flick of it still moves nothing"
+    );
+    assert_eq!(shared.lock().display_offset(), 6);
+
+    let mut encoder = Encoder::new();
+    assert_eq!(
+        screen(&shared.snapshot(&mut encoder)),
+        vec!["L01", "L02", "L03", "L04"],
+        "the top of history is the oldest line, not a blank grid"
+    );
+}
+
+#[test]
+fn scrolling_forwards_at_the_live_edge_reports_no_movement() {
+    let (shared, _actions, _) = scrolled_terminal(10);
+    assert!(!shared.scroll(-1));
+    assert!(!shared.scroll(-1_000));
+    assert_eq!(shared.lock().display_offset(), 0);
+}
+
+#[test]
+fn snapping_to_the_bottom_moves_only_when_scrolled_back() {
+    let (shared, _actions, _) = scrolled_terminal(10);
+    assert!(
+        !shared.scroll_to_bottom(),
+        "already live: a keystroke must not cost a repaint"
+    );
+
+    assert!(shared.scroll(4));
+    assert!(shared.scroll_to_bottom(), "scrolled back: this is the snap");
+    assert_eq!(shared.lock().display_offset(), 0);
+
+    let mut encoder = Encoder::new();
+    assert_eq!(
+        screen(&shared.snapshot(&mut encoder)),
+        vec!["L07", "L08", "L09", "L10"]
+    );
+}
+
+/// Why the snap has to exist at all: output does **not** bring the viewport
+/// back. The grid pins a scrolled-back viewport and piles new lines above it
+/// (`Grid::scroll_up` advances `display_offset` when it is non-zero), which is
+/// the behaviour you want while reading -- and means the echo of a keystroke
+/// would otherwise land on a screen the user cannot see.
+#[test]
+fn output_while_scrolled_back_leaves_the_viewport_where_the_reader_put_it() {
+    let (shared, _actions, mut renderer) = scrolled_terminal(10);
+    assert!(shared.scroll(3));
+
+    shared.feed_fully(b"\r\nL11\r\nL12");
+
+    let mut encoder = Encoder::new();
+    assert_eq!(
+        screen(&shared.snapshot(&mut encoder)),
+        vec!["L04", "L05", "L06", "L07"],
+        "the reader stays put while new output accumulates below"
+    );
+
+    // And the snap still returns to the *new* live edge, not the old one.
+    assert!(shared.scroll_to_bottom());
+    let after = shared.render(&mut renderer);
+    assert!(after.full, "a viewport move is a repaint");
+    assert_eq!(screen(&after), vec!["L09", "L10", "L11", "L12"]);
+}
+
+/// **The silent-corruption case.**
+///
+/// The renderer's `Encoder` holds one content hash per screen row. Scrolling
+/// changes what every row shows without changing a single cell, so those
+/// hashes are stale the instant the viewport moves. The engine's protection is
+/// that `scroll_display` marks the grid fully damaged and the embedder
+/// republishes via `snapshot`, which does not consume damage -- so the
+/// full-damage flag survives for the renderer's own next `render()`, which is
+/// what clears its hashes.
+///
+/// The discriminating part is the row content. Row 0 after the scroll holds
+/// `L04`; if a stale hash for row 0 -- taken when it held `L07` -- survived,
+/// the row would still ship, because the hashes differ. So the test scrolls to
+/// a position where the *pre-scroll* text reappears at the *same screen row*:
+/// scrolling back 4 puts `L03..L06` on screen, and then scrolling forward 4
+/// restores exactly the rows the hashes describe. A renderer whose hashes were
+/// never cleared suppresses the whole screen there, and the user is left
+/// looking at history that has scrolled away.
+#[test]
+fn a_scroll_does_not_leave_the_renderer_deduping_against_a_viewport_it_no_longer_shows() {
+    let (shared, _actions, mut renderer) = scrolled_terminal(10);
+
+    // The embedder's scroll path: move, then republish by snapshot.
+    assert!(shared.scroll(4));
+    let mut scroll_encoder = Encoder::new();
+    let republished = shared.snapshot(&mut scroll_encoder);
+    assert_eq!(screen(&republished), vec!["L03", "L04", "L05", "L06"]);
+
+    // The renderer thread's own next capture must still be told to repaint.
+    let after_scroll = shared.render(&mut renderer);
+    assert!(
+        after_scroll.full,
+        "the scroll's snapshot must not have eaten the full-damage flag"
+    );
+    assert_eq!(screen(&after_scroll), vec!["L03", "L04", "L05", "L06"]);
+
+    // Now back to where the renderer's *original* hashes were taken. Every row
+    // matches a hash it already holds, so only a cleared cache ships them.
+    assert!(shared.scroll(-4));
+    let mut back_encoder = Encoder::new();
+    let _ = shared.snapshot(&mut back_encoder);
+    let after_return = shared.render(&mut renderer);
+    assert!(after_return.full);
+    assert_eq!(
+        screen(&after_return),
+        vec!["L07", "L08", "L09", "L10"],
+        "returning to a previously-hashed viewport must still repaint it"
+    );
+}
+
+/// A row that genuinely changes while the viewport is scrolled back must
+/// still reach the renderer. This is the same dedup hazard from the other
+/// side: content changing under a stale hash rather than a stale hash under
+/// unchanged content.
+#[test]
+fn a_row_that_changes_while_scrolled_back_still_ships() {
+    let (shared, _actions, mut renderer) = scrolled_terminal(10);
+    assert!(shared.scroll(2));
+    let mut scroll_encoder = Encoder::new();
+    let _ = shared.snapshot(&mut scroll_encoder);
+    let _ = shared.render(&mut renderer);
+
+    // Rewrite the top line of the active area, which is screen row 2 while
+    // scrolled back two.
+    shared.feed_fully(b"\x1b[1;1HCHANGED\x1b[K");
+
+    let frame = shared.render(&mut renderer);
+    let changed = rows_by_line(&frame)
+        .into_iter()
+        .find(|(_, text)| text == "CHANGED");
+    assert_eq!(
+        changed,
+        Some((2, "CHANGED".to_string())),
+        "the rewritten active row must ship, at its scrolled screen position; got {:?}",
+        rows_by_line(&frame)
+    );
+}
+
+/// The cursor plane travels with the viewport, because the renderer paints it
+/// at a screen row and the grid stores it at an active-area row.
+#[test]
+fn the_cursor_moves_down_the_screen_as_the_viewport_scrolls_back() {
+    let (shared, _actions, _) = scrolled_terminal(10);
+    let mut encoder = Encoder::new();
+    let live = shared.snapshot(&mut encoder);
+    assert_eq!(live.cursor.line, 3, "cursor sits on the last active row");
+    assert!(live.cursor.visible);
+
+    assert!(shared.scroll(2));
+    let mut scrolled_encoder = Encoder::new();
+    let scrolled = shared.snapshot(&mut scrolled_encoder);
+    assert_eq!(
+        scrolled.cursor.line, 3,
+        "row 3 + 2 is off a four-row screen, so it clamps to the last row"
+    );
+    assert!(
+        !scrolled.cursor.visible,
+        "scrolled off the bottom, so it must not be painted on an unrelated line"
+    );
+}
+
+/// The clamp above is not the whole story: a cursor that is merely pushed
+/// *down* -- still on screen -- must report its new row, not its old one. A
+/// capture that ignored the offset entirely would pass the clamp test above
+/// (row 3 is where the cursor already was) and fail this one.
+///
+/// Parking the cursor on the top row with `ESC[H` is what leaves it room to
+/// move: at the live edge it is on row 0, and scrolling back two puts it on
+/// row 2 of a four-row screen, still visible.
+#[test]
+fn a_cursor_still_on_screen_reports_its_scrolled_row() {
+    let (shared, _actions, _) = scrolled_terminal(10);
+    shared.feed_fully(b"\x1b[H");
+
+    let mut live_encoder = Encoder::new();
+    let live = shared.snapshot(&mut live_encoder);
+    assert_eq!(live.cursor.line, 0, "parked on the top row");
+    assert!(live.cursor.visible);
+
+    assert!(shared.scroll(2));
+    let mut encoder = Encoder::new();
+    let frame = shared.snapshot(&mut encoder);
+    assert_eq!(
+        frame.cursor.line, 2,
+        "the caret follows the row it is written on down the screen"
+    );
+    assert!(
+        frame.cursor.visible,
+        "still inside the viewport, so still painted"
+    );
+}
+
+#[test]
+fn the_cursor_becomes_visible_again_on_the_way_back() {
+    let (shared, _actions, _) = scrolled_terminal(10);
+    assert!(shared.scroll(3));
+    assert!(shared.scroll_to_bottom());
+
+    let mut encoder = Encoder::new();
+    let frame = shared.snapshot(&mut encoder);
+    assert_eq!(frame.cursor.line, 3);
+    assert!(frame.cursor.visible);
+}
+
+/// The alternate screen has no scrollback by construction: `Term::new` builds
+/// the inactive grid with a zero scroll limit. So scrolling inside `vim` or
+/// `less` must be a clamped no-op, leaving the application's own scrolling to
+/// the application. Asserted rather than assumed -- a viewport that drifted
+/// here would show the primary screen's history behind a full-screen app.
+#[test]
+fn the_alternate_screen_has_no_scrollback_to_reach() {
+    let (shared, _actions, _) = scrolled_terminal(10);
+
+    shared.feed_fully(b"\x1b[?1049h");
+    shared.feed_fully(b"ALT");
+
+    assert!(!shared.scroll(1), "no history exists on the alt screen");
+    assert!(!shared.scroll(1_000));
+    assert_eq!(shared.lock().display_offset(), 0);
+
+    // And the primary screen's position is undisturbed on the way back.
+    shared.feed_fully(b"\x1b[?1049l");
+    assert!(shared.scroll(2));
+    assert_eq!(shared.lock().display_offset(), 2);
+}
+
+/// A terminal configured with no history cannot scroll at all. The guard is
+/// upstream's clamp against `history_size()`, and this pins it: without it the
+/// offset would advance and capture would index above the grid.
+#[test]
+fn a_terminal_without_scrollback_never_moves() {
+    let (shared, _actions) = terminal(20, 4, 0);
+    shared.feed_fully(b"a\r\nb\r\nc\r\nd\r\ne\r\nf");
+
+    assert!(!shared.scroll(1));
+    assert!(!shared.scroll(1_000));
+    assert_eq!(shared.lock().display_offset(), 0);
+
+    let mut encoder = Encoder::new();
+    assert_eq!(
+        screen(&shared.snapshot(&mut encoder)),
+        vec!["c", "d", "e", "f"]
+    );
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -342,9 +342,6 @@ pub fn run() {
         builder.plugin(tauri_plugin_updater::Builder::new().build())
     };
 
-    #[cfg(not(buzz_updater_enabled))]
-    let builder = builder;
-
     let app = builder
         .register_asynchronous_uri_scheme_protocol("buzz-media", |ctx, request, responder| {
             let app = ctx.app_handle().clone();
@@ -660,6 +657,7 @@ pub fn run() {
             terminal_runtime::terminal_close,
             terminal_runtime::terminal_input,
             terminal_runtime::terminal_resize,
+            terminal_runtime::terminal_scroll,
             terminal_runtime::terminal_ack,
             terminal_runtime::terminal_viewport_ready,
             terminal_runtime::terminal_focus,

--- a/desktop/src-tauri/src/terminal_runtime.rs
+++ b/desktop/src-tauri/src/terminal_runtime.rs
@@ -719,22 +719,57 @@ fn publish_viewport(session: &Session) -> Result<()> {
     Ok(())
 }
 
+/// A wheel delta in whole cells, carrying the **DOM's** sign.
+///
+/// A newtype rather than a bare `i32` so the engine's opposite convention
+/// cannot be reached by accident: `SharedTerminal::scroll` takes an `i32`, so
+/// handing it this value straight from the wire is a type error rather than a
+/// silently reversed terminal. Deleting the conversion is caught by the tests
+/// below; *bypassing* it is caught by the compiler.
+///
+/// Serde already reads a one-field tuple struct as its inner value, so no
+/// `transparent` attribute is needed -- verified by the wire test below, which
+/// deserializes from a bare number.
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub(crate) struct DomLines(i32);
+
+/// Scroll `terminal` by a DOM wheel delta in cells.
+///
+/// This is the only place the two sign conventions meet, so it is a named
+/// function rather than a `-` in an argument list: inlined, the conversion is
+/// executed by every scroll test and asserted by none of them, and deleting it
+/// leaves both the Rust and the frontend suites green while reversing the
+/// terminal on a real trackpad. It takes the terminal rather than returning a
+/// number so the tests below drive the same call `terminal_scroll` makes,
+/// instead of a conversion that agrees with itself.
+///
+/// The DOM sign is the spec because the OS-reported delta is the only stable
+/// thing here. macOS "natural scrolling" flips what a given finger motion
+/// reports, so a rule stated as "swipe up goes back" is correct for one
+/// preference setting and backwards for the other. Stated against `deltaY` it
+/// is correct for both, and matches whatever the page around the terminal
+/// does: **negative DOM lines -- the direction that scrolls a web page toward
+/// the top of the document -- go back into history**, which is positive in the
+/// engine's `Scroll::Delta` convention.
+///
+/// `saturating_neg` because this arrives over IPC: plain unary negation on
+/// `i32::MIN` panics in debug and wraps to `i32::MIN` in release, so a crafted
+/// command could scroll the wrong way. Saturating leaves it going back, which
+/// the engine then clamps at the oldest line.
+///
+/// Returns whether the viewport actually moved.
+fn scroll_by_dom_lines(terminal: &SharedTerminal, dom_lines: DomLines) -> bool {
+    terminal.scroll(dom_lines.0.saturating_neg())
+}
+
 /// Scroll the viewport through scrollback.
 ///
-/// `lines` is a **DOM wheel delta in cells**: negative is the direction that
-/// scrolls a web page toward the top of the document, which must scroll the
-/// terminal into history. That is the whole reason for the negation below --
-/// and it is the reason the spec is written against `deltaY` rather than
-/// against finger direction. macOS "natural scrolling" flips the delta the OS
-/// reports, so a rule stated as "swipe up goes back" is correct for one
-/// preference setting and backwards for the other, while this one is correct
-/// for both, and matches whatever the page around the terminal does.
-///
-/// This is the only place the two sign conventions meet.
+/// `lines` is a DOM wheel delta in cells; see [`scroll_by_dom_lines`] for the
+/// sign convention and why it is written against `deltaY`.
 #[tauri::command]
 pub(crate) fn terminal_scroll(
     session_id: String,
-    lines: i32,
+    lines: DomLines,
     state: tauri::State<'_, TerminalSessions>,
 ) -> Result<()> {
     state.with_session(&session_id, |session| {
@@ -742,7 +777,7 @@ pub(crate) fn terminal_scroll(
         // fingers lift. Once history runs out the engine clamps and reports
         // that nothing moved, so the tail costs a lock and a compare rather
         // than a full-grid copy and a frame each.
-        if !session.terminal.scroll(-lines) {
+        if !scroll_by_dom_lines(&session.terminal, lines) {
             return Ok(());
         }
         publish_viewport(session)
@@ -981,6 +1016,128 @@ mod tests {
         assert_eq!(
             (size.columns, size.screen_lines, size.scrollback),
             (100, 40, 10_000)
+        );
+    }
+
+    /// A terminal with four lines of history and a two-row viewport, used by
+    /// the sign tests below.
+    fn scrollable() -> SharedTerminal {
+        let size = buzz_terminal::Size {
+            columns: 8,
+            screen_lines: 2,
+            scrollback: 16,
+        };
+        let (term, actions) =
+            buzz_terminal::Terminal::new(size, buzz_terminal::fences::Fences::ALL);
+        // Leaked deliberately: dropping the receiver disconnects the channel
+        // and every later listener send fails silently.
+        std::mem::forget(actions);
+        let shared = SharedTerminal::new(term);
+        shared.feed_fully(b"L1\r\nL2\r\nL3\r\nL4");
+        shared
+    }
+
+    fn screen(terminal: &SharedTerminal) -> Vec<String> {
+        let mut encoder = buzz_terminal::damage::Encoder::new();
+        terminal
+            .snapshot(&mut encoder)
+            .rows
+            .iter()
+            .map(|row| {
+                row.spans
+                    .iter()
+                    .map(|span| span.text.as_str())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    /// The newtype is on the wire, so it has to deserialize from the bare
+    /// number the frontend sends. The frontend test mocks `invoke` and cannot
+    /// see this; if the wrapper did not read transparently, every scroll would
+    /// fail to deserialize and the terminal would silently stop scrolling.
+    #[test]
+    fn a_wheel_delta_deserializes_from_the_bare_number_the_frontend_sends() {
+        #[derive(Deserialize)]
+        struct Args {
+            lines: DomLines,
+        }
+        let args: Args = serde_json::from_str(r#"{"lines":-2}"#).unwrap();
+        assert_eq!(args.lines.0, -2);
+
+        let terminal = scrollable();
+        assert!(scroll_by_dom_lines(&terminal, args.lines));
+        assert_eq!(
+            screen(&terminal),
+            vec!["L1", "L2"],
+            "the value off the wire must scroll back, not forwards"
+        );
+    }
+
+    /// **The DOM->engine crossing, asserted rather than executed in passing.**
+    ///
+    /// The direction under test: *negative DOM lines go back into history.*
+    /// Negative is what a wheel reports for the gesture that scrolls a web
+    /// page toward the top of the document, and the engine's `Scroll::Delta`
+    /// takes positive for backwards, so the boundary negates.
+    ///
+    /// This asserts on the text that lands on screen rather than on the
+    /// converted number. A test of the arithmetic alone passes just as well
+    /// against an engine that reads the sign the other way -- two one-sided
+    /// tests are not a test of the crossing.
+    #[test]
+    fn a_negative_dom_delta_scrolls_backwards_into_history() {
+        let terminal = scrollable();
+        assert_eq!(
+            screen(&terminal),
+            vec!["L3", "L4"],
+            "starts at the live edge"
+        );
+
+        assert!(scroll_by_dom_lines(&terminal, DomLines(-2)));
+        assert_eq!(
+            screen(&terminal),
+            vec!["L1", "L2"],
+            "a page-upwards gesture must reach older lines, not newer ones"
+        );
+
+        assert!(scroll_by_dom_lines(&terminal, DomLines(2)));
+        assert_eq!(
+            screen(&terminal),
+            vec!["L3", "L4"],
+            "and a page-downwards gesture returns to the live edge"
+        );
+    }
+
+    /// The momentum tail: once history runs out the engine clamps, and the
+    /// boundary must report that nothing moved so the command skips the
+    /// republish rather than shipping an identical frame per event.
+    #[test]
+    fn a_dom_delta_past_the_oldest_line_reports_no_movement() {
+        let terminal = scrollable();
+        assert!(scroll_by_dom_lines(&terminal, DomLines(-2)));
+        assert!(
+            !scroll_by_dom_lines(&terminal, DomLines(-1_000)),
+            "there is nothing older, so nothing moved"
+        );
+        assert_eq!(screen(&terminal), vec!["L1", "L2"]);
+    }
+
+    /// `lines` arrives over IPC, so it can be any `i32`. Plain unary negation
+    /// panics on `i32::MIN` in debug and wraps back to `i32::MIN` in release --
+    /// the release case being the dangerous one, since it silently reverses
+    /// the direction. Saturating keeps the direction the caller asked for and
+    /// lets the engine clamp.
+    #[test]
+    fn the_most_negative_dom_delta_saturates_backwards_instead_of_wrapping_forwards() {
+        let terminal = scrollable();
+        assert!(scroll_by_dom_lines(&terminal, DomLines(i32::MIN)));
+        assert_eq!(
+            screen(&terminal),
+            vec!["L1", "L2"],
+            "a hostile delta must clamp at the oldest line, not flip direction"
         );
     }
 }

--- a/desktop/src-tauri/src/terminal_runtime.rs
+++ b/desktop/src-tauri/src/terminal_runtime.rs
@@ -642,7 +642,17 @@ pub(crate) fn terminal_input(
             .lock()
             .map_err(|e| e.to_string())?
             .write_all(data.as_bytes())
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string())?;
+        // Typing returns you to the live edge, as every terminal does. It has
+        // to be explicit: the grid pins a scrolled-back viewport and lets new
+        // output pile up above it, so the echo of this keystroke would land on
+        // a screen the user cannot see. Doing it here rather than in the
+        // renderer covers pasted text and encoded keys for free, and costs a
+        // comparison -- not a repaint -- when nothing was scrolled.
+        if session.terminal.scroll_to_bottom() {
+            publish_viewport(session)?;
+        }
+        Ok(())
     })
 }
 
@@ -678,6 +688,64 @@ pub(crate) fn terminal_resize(
             session.publish(publication);
         }
         Ok(viewport.into())
+    })
+}
+
+/// Republish the viewport after the *viewport itself* moved without the grid
+/// changing.
+///
+/// A snapshot, not a damage capture, and that is load-bearing twice over.
+/// `capture_all` deliberately leaves damage alone (`damage.rs`), so the
+/// full-damage flag that `scroll_display` just set survives for the reader
+/// thread's next `render()` to consume -- which is what clears *its* dedup
+/// hashes. Take the damage here instead and those hashes would go on
+/// describing the rows the renderer had before the scroll, free to suppress a
+/// row that genuinely changed underneath it.
+///
+/// The encoder is fresh and local because its only job is to encode one frame
+/// that is `full` by construction; sharing the reader's would be sharing dedup
+/// state across two coordinate systems.
+fn publish_viewport(session: &Session) -> Result<()> {
+    let mut encoder = buzz_terminal::damage::Encoder::new();
+    let publication = session
+        .publisher
+        .lock()
+        .map_err(|e| e.to_string())?
+        .offer(session.terminal.snapshot(&mut encoder))
+        .map_err(|_| "terminal scroll snapshot rejected".to_string())?;
+    if let Some(publication) = publication {
+        session.publish(publication);
+    }
+    Ok(())
+}
+
+/// Scroll the viewport through scrollback.
+///
+/// `lines` is a **DOM wheel delta in cells**: negative is the direction that
+/// scrolls a web page toward the top of the document, which must scroll the
+/// terminal into history. That is the whole reason for the negation below --
+/// and it is the reason the spec is written against `deltaY` rather than
+/// against finger direction. macOS "natural scrolling" flips the delta the OS
+/// reports, so a rule stated as "swipe up goes back" is correct for one
+/// preference setting and backwards for the other, while this one is correct
+/// for both, and matches whatever the page around the terminal does.
+///
+/// This is the only place the two sign conventions meet.
+#[tauri::command]
+pub(crate) fn terminal_scroll(
+    session_id: String,
+    lines: i32,
+    state: tauri::State<'_, TerminalSessions>,
+) -> Result<()> {
+    state.with_session(&session_id, |session| {
+        // Momentum keeps delivering events for a second or so after the
+        // fingers lift. Once history runs out the engine clamps and reports
+        // that nothing moved, so the tail costs a lock and a compare rather
+        // than a full-grid copy and a frame each.
+        if !session.terminal.scroll(-lines) {
+            return Ok(());
+        }
+        publish_viewport(session)
     })
 }
 

--- a/desktop/src-tauri/src/terminal_runtime.rs
+++ b/desktop/src-tauri/src/terminal_runtime.rs
@@ -15,6 +15,10 @@ use uuid::Uuid;
 
 use crate::terminal_transport::{FramePublisher, OfferError, Publication, SubscriptionId};
 
+mod scroll_sign;
+
+use scroll_sign::{scroll_by_dom_lines, DomLines};
+
 const MAX_LIVE_SESSIONS: usize = 20;
 const MAX_INPUT_BYTES: usize = 1024 * 1024;
 
@@ -719,49 +723,6 @@ fn publish_viewport(session: &Session) -> Result<()> {
     Ok(())
 }
 
-/// A wheel delta in whole cells, carrying the **DOM's** sign.
-///
-/// A newtype rather than a bare `i32` so the engine's opposite convention
-/// cannot be reached by accident: `SharedTerminal::scroll` takes an `i32`, so
-/// handing it this value straight from the wire is a type error rather than a
-/// silently reversed terminal. Deleting the conversion is caught by the tests
-/// below; *bypassing* it is caught by the compiler.
-///
-/// Serde already reads a one-field tuple struct as its inner value, so no
-/// `transparent` attribute is needed -- verified by the wire test below, which
-/// deserializes from a bare number.
-#[derive(Debug, Clone, Copy, Deserialize)]
-pub(crate) struct DomLines(i32);
-
-/// Scroll `terminal` by a DOM wheel delta in cells.
-///
-/// This is the only place the two sign conventions meet, so it is a named
-/// function rather than a `-` in an argument list: inlined, the conversion is
-/// executed by every scroll test and asserted by none of them, and deleting it
-/// leaves both the Rust and the frontend suites green while reversing the
-/// terminal on a real trackpad. It takes the terminal rather than returning a
-/// number so the tests below drive the same call `terminal_scroll` makes,
-/// instead of a conversion that agrees with itself.
-///
-/// The DOM sign is the spec because the OS-reported delta is the only stable
-/// thing here. macOS "natural scrolling" flips what a given finger motion
-/// reports, so a rule stated as "swipe up goes back" is correct for one
-/// preference setting and backwards for the other. Stated against `deltaY` it
-/// is correct for both, and matches whatever the page around the terminal
-/// does: **negative DOM lines -- the direction that scrolls a web page toward
-/// the top of the document -- go back into history**, which is positive in the
-/// engine's `Scroll::Delta` convention.
-///
-/// `saturating_neg` because this arrives over IPC: plain unary negation on
-/// `i32::MIN` panics in debug and wraps to `i32::MIN` in release, so a crafted
-/// command could scroll the wrong way. Saturating leaves it going back, which
-/// the engine then clamps at the oldest line.
-///
-/// Returns whether the viewport actually moved.
-fn scroll_by_dom_lines(terminal: &SharedTerminal, dom_lines: DomLines) -> bool {
-    terminal.scroll(dom_lines.0.saturating_neg())
-}
-
 /// Scroll the viewport through scrollback.
 ///
 /// `lines` is a DOM wheel delta in cells; see [`scroll_by_dom_lines`] for the
@@ -1016,128 +977,6 @@ mod tests {
         assert_eq!(
             (size.columns, size.screen_lines, size.scrollback),
             (100, 40, 10_000)
-        );
-    }
-
-    /// A terminal with four lines of history and a two-row viewport, used by
-    /// the sign tests below.
-    fn scrollable() -> SharedTerminal {
-        let size = buzz_terminal::Size {
-            columns: 8,
-            screen_lines: 2,
-            scrollback: 16,
-        };
-        let (term, actions) =
-            buzz_terminal::Terminal::new(size, buzz_terminal::fences::Fences::ALL);
-        // Leaked deliberately: dropping the receiver disconnects the channel
-        // and every later listener send fails silently.
-        std::mem::forget(actions);
-        let shared = SharedTerminal::new(term);
-        shared.feed_fully(b"L1\r\nL2\r\nL3\r\nL4");
-        shared
-    }
-
-    fn screen(terminal: &SharedTerminal) -> Vec<String> {
-        let mut encoder = buzz_terminal::damage::Encoder::new();
-        terminal
-            .snapshot(&mut encoder)
-            .rows
-            .iter()
-            .map(|row| {
-                row.spans
-                    .iter()
-                    .map(|span| span.text.as_str())
-                    .collect::<String>()
-                    .trim_end()
-                    .to_string()
-            })
-            .collect()
-    }
-
-    /// The newtype is on the wire, so it has to deserialize from the bare
-    /// number the frontend sends. The frontend test mocks `invoke` and cannot
-    /// see this; if the wrapper did not read transparently, every scroll would
-    /// fail to deserialize and the terminal would silently stop scrolling.
-    #[test]
-    fn a_wheel_delta_deserializes_from_the_bare_number_the_frontend_sends() {
-        #[derive(Deserialize)]
-        struct Args {
-            lines: DomLines,
-        }
-        let args: Args = serde_json::from_str(r#"{"lines":-2}"#).unwrap();
-        assert_eq!(args.lines.0, -2);
-
-        let terminal = scrollable();
-        assert!(scroll_by_dom_lines(&terminal, args.lines));
-        assert_eq!(
-            screen(&terminal),
-            vec!["L1", "L2"],
-            "the value off the wire must scroll back, not forwards"
-        );
-    }
-
-    /// **The DOM->engine crossing, asserted rather than executed in passing.**
-    ///
-    /// The direction under test: *negative DOM lines go back into history.*
-    /// Negative is what a wheel reports for the gesture that scrolls a web
-    /// page toward the top of the document, and the engine's `Scroll::Delta`
-    /// takes positive for backwards, so the boundary negates.
-    ///
-    /// This asserts on the text that lands on screen rather than on the
-    /// converted number. A test of the arithmetic alone passes just as well
-    /// against an engine that reads the sign the other way -- two one-sided
-    /// tests are not a test of the crossing.
-    #[test]
-    fn a_negative_dom_delta_scrolls_backwards_into_history() {
-        let terminal = scrollable();
-        assert_eq!(
-            screen(&terminal),
-            vec!["L3", "L4"],
-            "starts at the live edge"
-        );
-
-        assert!(scroll_by_dom_lines(&terminal, DomLines(-2)));
-        assert_eq!(
-            screen(&terminal),
-            vec!["L1", "L2"],
-            "a page-upwards gesture must reach older lines, not newer ones"
-        );
-
-        assert!(scroll_by_dom_lines(&terminal, DomLines(2)));
-        assert_eq!(
-            screen(&terminal),
-            vec!["L3", "L4"],
-            "and a page-downwards gesture returns to the live edge"
-        );
-    }
-
-    /// The momentum tail: once history runs out the engine clamps, and the
-    /// boundary must report that nothing moved so the command skips the
-    /// republish rather than shipping an identical frame per event.
-    #[test]
-    fn a_dom_delta_past_the_oldest_line_reports_no_movement() {
-        let terminal = scrollable();
-        assert!(scroll_by_dom_lines(&terminal, DomLines(-2)));
-        assert!(
-            !scroll_by_dom_lines(&terminal, DomLines(-1_000)),
-            "there is nothing older, so nothing moved"
-        );
-        assert_eq!(screen(&terminal), vec!["L1", "L2"]);
-    }
-
-    /// `lines` arrives over IPC, so it can be any `i32`. Plain unary negation
-    /// panics on `i32::MIN` in debug and wraps back to `i32::MIN` in release --
-    /// the release case being the dangerous one, since it silently reverses
-    /// the direction. Saturating keeps the direction the caller asked for and
-    /// lets the engine clamp.
-    #[test]
-    fn the_most_negative_dom_delta_saturates_backwards_instead_of_wrapping_forwards() {
-        let terminal = scrollable();
-        assert!(scroll_by_dom_lines(&terminal, DomLines(i32::MIN)));
-        assert_eq!(
-            screen(&terminal),
-            vec!["L1", "L2"],
-            "a hostile delta must clamp at the oldest line, not flip direction"
         );
     }
 }

--- a/desktop/src-tauri/src/terminal_runtime/scroll_sign.rs
+++ b/desktop/src-tauri/src/terminal_runtime/scroll_sign.rs
@@ -1,0 +1,179 @@
+//! The one place the DOM's wheel sign meets the engine's scroll sign.
+//!
+//! Its own module because the crossing is the whole subject: the conversion is
+//! two characters of code and roughly a hundred lines of tests and reasoning
+//! about which way is back, and inlining that into the command file buries it
+//! among unrelated session plumbing.
+
+use buzz_terminal::SharedTerminal;
+use serde::Deserialize;
+
+/// A wheel delta in whole cells, carrying the **DOM's** sign.
+///
+/// A newtype rather than a bare `i32` so the engine's opposite convention
+/// cannot be reached by accident: `SharedTerminal::scroll` takes an `i32`, so
+/// handing it this value straight from the wire is a type error rather than a
+/// silently reversed terminal. Deleting the conversion is caught by the tests
+/// below; *bypassing* it is caught by the compiler.
+///
+/// Serde already reads a one-field tuple struct as its inner value, so no
+/// `transparent` attribute is needed -- verified by the wire test below, which
+/// deserializes from a bare number.
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub(crate) struct DomLines(i32);
+
+/// Scroll `terminal` by a DOM wheel delta in cells.
+///
+/// This is the only place the two sign conventions meet, so it is a named
+/// function rather than a `-` in an argument list: inlined, the conversion is
+/// executed by every scroll test and asserted by none of them, and deleting it
+/// leaves both the Rust and the frontend suites green while reversing the
+/// terminal on a real trackpad. It takes the terminal rather than returning a
+/// number so the tests below drive the same call `terminal_scroll` makes,
+/// instead of a conversion that agrees with itself.
+///
+/// The DOM sign is the spec because the OS-reported delta is the only stable
+/// thing here. macOS "natural scrolling" flips what a given finger motion
+/// reports, so a rule stated as "swipe up goes back" is correct for one
+/// preference setting and backwards for the other. Stated against `deltaY` it
+/// is correct for both, and matches whatever the page around the terminal
+/// does: **negative DOM lines -- the direction that scrolls a web page toward
+/// the top of the document -- go back into history**, which is positive in the
+/// engine's `Scroll::Delta` convention.
+///
+/// `saturating_neg` because this arrives over IPC: plain unary negation on
+/// `i32::MIN` panics in debug and wraps to `i32::MIN` in release, so a crafted
+/// command could scroll the wrong way. Saturating leaves it going back, which
+/// the engine then clamps at the oldest line.
+///
+/// Returns whether the viewport actually moved.
+pub(super) fn scroll_by_dom_lines(terminal: &SharedTerminal, dom_lines: DomLines) -> bool {
+    terminal.scroll(dom_lines.0.saturating_neg())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A terminal with four lines of history and a two-row viewport, used by
+    /// the sign tests below.
+    fn scrollable() -> SharedTerminal {
+        let size = buzz_terminal::Size {
+            columns: 8,
+            screen_lines: 2,
+            scrollback: 16,
+        };
+        let (term, actions) =
+            buzz_terminal::Terminal::new(size, buzz_terminal::fences::Fences::ALL);
+        // Leaked deliberately: dropping the receiver disconnects the channel
+        // and every later listener send fails silently.
+        std::mem::forget(actions);
+        let shared = SharedTerminal::new(term);
+        shared.feed_fully(b"L1\r\nL2\r\nL3\r\nL4");
+        shared
+    }
+
+    fn screen(terminal: &SharedTerminal) -> Vec<String> {
+        let mut encoder = buzz_terminal::damage::Encoder::new();
+        terminal
+            .snapshot(&mut encoder)
+            .rows
+            .iter()
+            .map(|row| {
+                row.spans
+                    .iter()
+                    .map(|span| span.text.as_str())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string()
+            })
+            .collect()
+    }
+
+    /// The newtype is on the wire, so it has to deserialize from the bare
+    /// number the frontend sends. The frontend test mocks `invoke` and cannot
+    /// see this; if the wrapper did not read transparently, every scroll would
+    /// fail to deserialize and the terminal would silently stop scrolling.
+    #[test]
+    fn a_wheel_delta_deserializes_from_the_bare_number_the_frontend_sends() {
+        #[derive(Deserialize)]
+        struct Args {
+            lines: DomLines,
+        }
+        let args: Args = serde_json::from_str(r#"{"lines":-2}"#).unwrap();
+        assert_eq!(args.lines.0, -2);
+
+        let terminal = scrollable();
+        assert!(scroll_by_dom_lines(&terminal, args.lines));
+        assert_eq!(
+            screen(&terminal),
+            vec!["L1", "L2"],
+            "the value off the wire must scroll back, not forwards"
+        );
+    }
+
+    /// **The DOM->engine crossing, asserted rather than executed in passing.**
+    ///
+    /// The direction under test: *negative DOM lines go back into history.*
+    /// Negative is what a wheel reports for the gesture that scrolls a web
+    /// page toward the top of the document, and the engine's `Scroll::Delta`
+    /// takes positive for backwards, so the boundary negates.
+    ///
+    /// This asserts on the text that lands on screen rather than on the
+    /// converted number. A test of the arithmetic alone passes just as well
+    /// against an engine that reads the sign the other way -- two one-sided
+    /// tests are not a test of the crossing.
+    #[test]
+    fn a_negative_dom_delta_scrolls_backwards_into_history() {
+        let terminal = scrollable();
+        assert_eq!(
+            screen(&terminal),
+            vec!["L3", "L4"],
+            "starts at the live edge"
+        );
+
+        assert!(scroll_by_dom_lines(&terminal, DomLines(-2)));
+        assert_eq!(
+            screen(&terminal),
+            vec!["L1", "L2"],
+            "a page-upwards gesture must reach older lines, not newer ones"
+        );
+
+        assert!(scroll_by_dom_lines(&terminal, DomLines(2)));
+        assert_eq!(
+            screen(&terminal),
+            vec!["L3", "L4"],
+            "and a page-downwards gesture returns to the live edge"
+        );
+    }
+
+    /// The momentum tail: once history runs out the engine clamps, and the
+    /// boundary must report that nothing moved so the command skips the
+    /// republish rather than shipping an identical frame per event.
+    #[test]
+    fn a_dom_delta_past_the_oldest_line_reports_no_movement() {
+        let terminal = scrollable();
+        assert!(scroll_by_dom_lines(&terminal, DomLines(-2)));
+        assert!(
+            !scroll_by_dom_lines(&terminal, DomLines(-1_000)),
+            "there is nothing older, so nothing moved"
+        );
+        assert_eq!(screen(&terminal), vec!["L1", "L2"]);
+    }
+
+    /// `lines` arrives over IPC, so it can be any `i32`. Plain unary negation
+    /// panics on `i32::MIN` in debug and wraps back to `i32::MIN` in release --
+    /// the release case being the dangerous one, since it silently reverses
+    /// the direction. Saturating keeps the direction the caller asked for and
+    /// lets the engine clamp.
+    #[test]
+    fn the_most_negative_dom_delta_saturates_backwards_instead_of_wrapping_forwards() {
+        let terminal = scrollable();
+        assert!(scroll_by_dom_lines(&terminal, DomLines(i32::MIN)));
+        assert_eq!(
+            screen(&terminal),
+            vec!["L1", "L2"],
+            "a hostile delta must clamp at the oldest line, not flip direction"
+        );
+    }
+}

--- a/desktop/src/features/terminal/TerminalBootstrap.test.mjs
+++ b/desktop/src/features/terminal/TerminalBootstrap.test.mjs
@@ -318,3 +318,67 @@ test("opening a tab keeps terminal ownership while its attachment is pending", a
   await act(async () => attachResolver());
   view.unmount();
 });
+
+// The wheel-to-IPC path end to end. `TerminalSubstrate` already proves it
+// accumulates pixels into whole cells and `buzz-terminal` already proves which
+// way the engine goes; the seam between them is this file's business, and the
+// thing that can silently rot here is the *sign*. A negation added in the
+// bridge would leave every unit test green and scroll the terminal the wrong
+// way, so this asserts the delta reaches `terminal_scroll` unchanged: positive
+// `deltaY` -- the gesture that scrolls a page toward the bottom of the
+// document -- must arrive positive, and the backend owns the flip.
+test("wheel deltas reach terminal_scroll with the DOM sign intact", async () => {
+  const { createElement } = await import("react");
+  const { act, fireEvent, render, waitFor } = await import(
+    "@testing-library/react"
+  );
+  const { ThemeProvider } = await import("@/shared/theme/ThemeProvider");
+  const { TerminalBootstrap } = await import("./TerminalBootstrap.tsx");
+
+  const view = render(
+    createElement(
+      ThemeProvider,
+      null,
+      createElement("div", {
+        className: "buzz-huddle-app-surface",
+        tabIndex: -1,
+      }),
+      createElement(TerminalBootstrap, {
+        channelId: "channel-1",
+        channelName: "general",
+        npub: "npub1owner",
+        relayUrl: "wss://relay.example",
+        threadId: null,
+      }),
+    ),
+  );
+  await waitFor(() =>
+    assert.ok(calls.some(({ command }) => command === "terminal_attach")),
+  );
+  await act(async () => {
+    await Promise.resolve();
+  });
+  const substrate = view.container.querySelector(".buzz-terminal-substrate");
+
+  // Two cells' worth of pixels (cell height is 17), backwards.
+  await act(async () => {
+    fireEvent.wheel(substrate, { deltaMode: 0, deltaY: -34 });
+  });
+  const scrolls = () =>
+    calls.filter(({ command }) => command === "terminal_scroll");
+  await waitFor(() => assert.equal(scrolls().length, 1));
+  assert.equal(
+    scrolls()[0].args.lines,
+    -2,
+    "a backwards wheel must arrive negative; the backend owns the negation",
+  );
+  assert.equal(scrolls()[0].args.sessionId, "session-1");
+
+  await act(async () => {
+    fireEvent.wheel(substrate, { deltaMode: 0, deltaY: 34 });
+  });
+  await waitFor(() => assert.equal(scrolls().length, 2));
+  assert.equal(scrolls()[1].args.lines, 2, "and forwards must arrive positive");
+
+  view.unmount();
+});

--- a/desktop/src/features/terminal/TerminalBootstrap.tsx
+++ b/desktop/src/features/terminal/TerminalBootstrap.tsx
@@ -254,7 +254,7 @@ export function TerminalBootstrap({
       }}
       onInput={(text) => send(active?.connection?.input(text))}
       onNewSession={createSession}
-      onScroll={() => {}}
+      onScroll={(lines) => send(active?.connection?.scroll(lines))}
       onSelectSession={setActiveKey}
       onTerminalFocusChange={(focused) =>
         send(active?.connection?.focus(focused))

--- a/desktop/src/features/terminal/TerminalSubstrate.tsx
+++ b/desktop/src/features/terminal/TerminalSubstrate.tsx
@@ -44,7 +44,8 @@ type TerminalSubstrateProps = {
   onFrameConsumed?: (frame: TerminalFrame) => void;
   onViewportSize?: (size: TerminalViewportSize) => void;
   onInput: (text: string) => void;
-  onScroll: (deltaPx: number) => void;
+  /** Whole cells scrolled, keeping the DOM's sign: negative goes back. */
+  onScroll: (lines: number) => void;
   onTerminalFocusChange: (focused: boolean) => void;
   onSelectSession: (id: string) => void;
   onCloseSession: (id: string) => void;

--- a/desktop/src/features/terminal/terminalClient.ts
+++ b/desktop/src/features/terminal/terminalClient.ts
@@ -116,6 +116,18 @@ export class TerminalConnection {
     });
   }
 
+  /**
+   * Scroll the viewport by whole cells.
+   *
+   * `lines` keeps the DOM's sign: negative is the direction that scrolls a
+   * page toward the top of the document. The backend owns the conversion to
+   * the engine's opposite convention, so this layer carries no policy about
+   * which way history is.
+   */
+  scroll(lines: number): Promise<void> {
+    return invoke("terminal_scroll", { sessionId: this.sessionId, lines });
+  }
+
   focus(focused: boolean): Promise<void> {
     return invoke("terminal_focus", { sessionId: this.sessionId, focused });
   }


### PR DESCRIPTION
Bug 4 of Tyler's Buzz Term report: the engine keeps 10k lines of scrollback and nothing could reach them. `TerminalBootstrap` passed `onScroll={() => {}}` and there was no `terminal_scroll` command on the other side.

Targets `max/tui-renderer`. Based on `feedd2fe7` (post-#4405, post-#4407).

## What changed

**`buzz-terminal`** — `scroll(lines) -> bool` and `scroll_to_bottom() -> bool`, both reporting whether the viewport actually *moved*. Capture becomes offset-aware by one subtraction: screen row `r` reads grid line `r - display_offset`, the identity at the live edge. Upstream's `TermDamageIterator` already offsets damaged lines into screen coordinates, so both damage arms speak the same coordinate and only one conversion is needed. The cursor plane converts from the grid's active-area row to the screen row the renderer paints, and reports itself invisible once scrolling pushes it off the bottom rather than painting a caret on an unrelated line of history.

**`terminal_scroll`** — the only place the two sign conventions meet. The wire carries the DOM's sign; the negation lives here. The spec is written against `deltaY`, not finger direction: macOS natural scrolling flips what the OS reports, so "swipe up goes back" is correct for one preference setting and backwards for the other. Against `deltaY` the invariant is stable — **the gesture that scrolls a web page toward the top scrolls the terminal into history**.

**Republication via `snapshot`** — reusing the resize path's property that it does not consume damage. This is the whole defence against the silent case: the renderer's per-row hashes describe the screen it last saw, a scroll changes every row without changing a cell, and a scroll that ate the full-damage flag would leave those hashes free to suppress a row that really did change.

**Snap-to-bottom in `terminal_input`** — output alone never returns the viewport (the grid deliberately pins a scrolled-back reader), so it has to be explicit. At the PTY write it covers pasted text and encoded keys for free.

## Verification

91 tests in `buzz-terminal` (14 new in `tests/scrollback.rs`), 2121 in `buzz-desktop --lib`, 3966 frontend, typecheck and `pnpm check` clean — all at `4d7c82f9a` with a clean tree.

Mutation-tested rather than re-read. 9 engine mutants, all killed, plus two classifier controls (a deliberate syntax error that must read INVALID, an off-by-one that must read KILLED) because an earlier run of this harness scored every mutant `INVALID` — a *failing test* also makes cargo print `error: test failed` at line-start, and the compile-error probe was matching that first. The reader was broken, not the mutants.

| mutant | verdict |
|---|---|
| capture ignores the offset | KILLED ×7 |
| `row_of` sign flipped | KILLED ×9 |
| cursor plane ignores the offset | KILLED ×3 |
| offscreen cursor still "visible" | KILLED ×2 |
| scroll always reports moved | KILLED ×6 |
| scroll never reports moved | KILLED ×12 |
| engine scroll direction flipped | KILLED ×13 |
| snap goes to top, not bottom | KILLED ×4 |
| cursor row unclamped | KILLED ×2 |

Two more on the frontend seam — a negation sneaking into the bridge, and the bridge dropping the call — both killed by the new `TerminalBootstrap` test.

Verdicts were byte-identical on `6d159d124` and `feedd2fe7`, including the four Eva expected might move across #4407's cursor-aware `Frame::is_empty`. That stability is real rather than luck: I mutated #4407's `is_empty` change directly and only `cursor.rs::space_over_blank_cell_publishes_cursor_only_frame` failed. No scrollback test routes its kill through frame suppression, so the seam change can't move them.

## Note on the size ratchet

Registering the command puts `desktop/src-tauri/src/lib.rs` one line over the 1000-line ratchet, which sat exactly at its limit. The line comes back from deleting `#[cfg(not(buzz_updater_enabled))] let builder = builder;` — an identity rebinding that does nothing on either arm of the cfg. Verified by compiling both arms, with a control proving the enabled arm is genuinely exercised (a poison symbol under `#[cfg(buzz_updater_enabled)]` breaks arm B and not arm A). The previous commit to this file bought headroom by deleting blank separator lines; I didn't want to repeat that.

Scope is viewport scrolling: no selection, no search.
