### PR TITLE
Fix live updates in mobile threads

### DIFF
--- a/mobile/lib/features/channels/channel_messages_provider.dart
+++ b/mobile/lib/features/channels/channel_messages_provider.dart
@@ -237,25 +237,7 @@ class ChannelMessagesNotifier extends Notifier<AsyncValue<List<NostrEvent>>> {
       event.kind,
     );
     final thread = isTimelineRow ? event.threadReference : null;
-    if (thread?.parentId != null) {
-      final rootId = thread?.rootId;
-      if (rootId != null) {
-        ref.invalidate(
-          threadRepliesProvider(
-            ThreadRepliesArgs(channelId: channelId, rootId: rootId),
-          ),
-        );
-      }
-      final parentId = thread?.parentId;
-      if (parentId != null && parentId != rootId) {
-        ref.invalidate(
-          threadRepliesProvider(
-            ThreadRepliesArgs(channelId: channelId, rootId: parentId),
-          ),
-        );
-      }
-      if (!_isBroadcastReply(event)) return false;
-    }
+    if (thread?.parentId != null && !_isBroadcastReply(event)) return false;
     // Thread summaries are neither a timeline row nor an aux event, but they are
     // how the root's "N replies" row learns a reply landed — a reply itself
     // never reaches the main timeline. Dropping them here meant the count only

--- a/mobile/lib/features/channels/thread_replies_provider.dart
+++ b/mobile/lib/features/channels/thread_replies_provider.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
+import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../shared/relay/relay.dart';
@@ -29,25 +31,205 @@ class _ThreadCursor {
   const _ThreadCursor({required this.createdAt, required this.eventId});
 }
 
-final threadRepliesProvider =
-    FutureProvider.family<List<NostrEvent>, ThreadRepliesArgs>((
-      ref,
-      args,
-    ) async {
-      final session = ref.watch(relaySessionProvider.notifier);
-      final replies = <NostrEvent>[];
-      _ThreadCursor? cursor;
-      for (var page = 0; page < 500; page++) {
-        final events = await session.queryRelay([
-          _threadRepliesFilter(args, cursor),
-        ]);
-        replies.addAll(events);
-        if (events.length < 200) return replies;
-        final last = events.last;
-        cursor = _ThreadCursor(createdAt: last.createdAt, eventId: last.id);
-      }
-      throw Exception('Thread ${args.rootId} exceeded the page safety limit.');
+/// Provides one thread's replies from a subscribe-first live stream merged
+/// with paged history.
+///
+/// Registering the live subscription before querying history closes the race
+/// where a reply can arrive between those two operations. The subscription is
+/// owned by [RelaySessionNotifier], so it stays registered while that session
+/// reconnects and benefits from its last-seen replay.
+class ThreadRepliesNotifier extends AsyncNotifier<List<NostrEvent>> {
+  static const _replaySkewSeconds = 5;
+
+  final ThreadRepliesArgs args;
+  final Duration _retryBaseDelay;
+  final Map<String, NostrEvent> _repliesById = {};
+  void Function()? _unsubscribe;
+  Future<bool>? _subscribeFuture;
+  Future<void>? _historyFuture;
+  Timer? _retryTimer;
+  int _retryAttempt = 0;
+  bool _disposed = false;
+
+  ThreadRepliesNotifier(
+    this.args, {
+    @visibleForTesting Duration retryBaseDelay = const Duration(seconds: 2),
+  }) : _retryBaseDelay = retryBaseDelay;
+
+  @override
+  Future<List<NostrEvent>> build() async {
+    _disposed = false;
+    ref.onDispose(() {
+      _disposed = true;
+      _retryTimer?.cancel();
+      _retryTimer = null;
+      _unsubscribe?.call();
+      _unsubscribe = null;
     });
+
+    final session = ref.read(relaySessionProvider.notifier);
+    await _ensureSubscribed(session);
+
+    try {
+      await _ensureHistory(session);
+    } catch (error, stackTrace) {
+      if (_disposed) return _sortedReplies();
+      if (_repliesById.isEmpty) {
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+      debugPrint(
+        '[ThreadRepliesNotifier] history sync failed for '
+        '${args.rootId}: $error',
+      );
+    }
+    return _sortedReplies();
+  }
+
+  Set<String> get authoritativeEventIds => Set.unmodifiable(_repliesById.keys);
+
+  Future<bool> _ensureSubscribed(RelaySessionNotifier session) async {
+    if (_disposed) return false;
+    if (_unsubscribe != null) return true;
+    final inFlight = _subscribeFuture;
+    if (inFlight != null) return inFlight;
+
+    final attempt = _startSubscription(session);
+    _subscribeFuture = attempt;
+    try {
+      return await attempt;
+    } finally {
+      if (identical(_subscribeFuture, attempt)) {
+        _subscribeFuture = null;
+      }
+    }
+  }
+
+  Future<bool> _startSubscription(RelaySessionNotifier session) async {
+    var closedBeforeReady = false;
+    try {
+      final unsubscribe = await session.subscribe(
+        _threadLiveRepliesFilter(args),
+        _handleReply,
+        onClosed: (message) {
+          closedBeforeReady = true;
+          _handleSubscriptionClosed(session, message);
+        },
+      );
+      if (_disposed || closedBeforeReady) {
+        unsubscribe();
+        return false;
+      }
+      _unsubscribe = unsubscribe;
+      _retryTimer?.cancel();
+      _retryTimer = null;
+      _retryAttempt = 0;
+      return true;
+    } catch (error) {
+      if (!_disposed) {
+        debugPrint(
+          '[ThreadRepliesNotifier] live subscription failed for '
+          '${args.rootId}: $error',
+        );
+        _scheduleSubscriptionRetry(session);
+      }
+      return false;
+    }
+  }
+
+  void _handleSubscriptionClosed(RelaySessionNotifier session, String message) {
+    if (_disposed) return;
+    debugPrint(
+      '[ThreadRepliesNotifier] live subscription closed for '
+      '${args.rootId}: $message',
+    );
+    _unsubscribe = null;
+    _scheduleSubscriptionRetry(session);
+  }
+
+  void _scheduleSubscriptionRetry(RelaySessionNotifier session) {
+    if (_disposed) return;
+    _retryTimer?.cancel();
+    final delayMs = min(
+      _retryBaseDelay.inMilliseconds << min(_retryAttempt, 4),
+      30000,
+    );
+    _retryAttempt++;
+    _retryTimer = Timer(Duration(milliseconds: delayMs), () {
+      _retryTimer = null;
+      unawaited(_retrySubscription(session));
+    });
+  }
+
+  Future<void> _retrySubscription(RelaySessionNotifier session) async {
+    if (!await _ensureSubscribed(session) || _disposed) return;
+    try {
+      await _ensureHistory(session);
+    } catch (error) {
+      if (!_disposed) {
+        debugPrint(
+          '[ThreadRepliesNotifier] history resync failed for '
+          '${args.rootId}: $error',
+        );
+      }
+    }
+  }
+
+  Future<void> _ensureHistory(RelaySessionNotifier session) async {
+    final inFlight = _historyFuture;
+    if (inFlight != null) return inFlight;
+
+    final fetch = _fetchHistory(session);
+    _historyFuture = fetch;
+    try {
+      await fetch;
+    } finally {
+      if (identical(_historyFuture, fetch)) {
+        _historyFuture = null;
+      }
+    }
+  }
+
+  Future<void> _fetchHistory(RelaySessionNotifier session) async {
+    _ThreadCursor? cursor;
+    for (var page = 0; page < 500; page++) {
+      final events = await session.queryRelay([
+        _threadRepliesFilter(args, cursor),
+      ]);
+      if (_disposed) return;
+
+      for (final event in events) {
+        _repliesById[event.id] = event;
+      }
+      state = AsyncData(_sortedReplies());
+
+      if (events.length < 200) return;
+      final last = events.last;
+      cursor = _ThreadCursor(createdAt: last.createdAt, eventId: last.id);
+    }
+    throw Exception('Thread ${args.rootId} exceeded the page safety limit.');
+  }
+
+  void _handleReply(NostrEvent event) {
+    if (_disposed || event.channelId != args.channelId) return;
+    if (!event.tags.any(
+      (tag) => tag.length >= 2 && tag[0] == 'e' && tag[1] == args.rootId,
+    )) {
+      return;
+    }
+    if (_repliesById.containsKey(event.id)) return;
+
+    _repliesById[event.id] = event;
+    state = AsyncData(_sortedReplies());
+  }
+
+  List<NostrEvent> _sortedReplies() =>
+      _mergeReplies(const <NostrEvent>[], _repliesById.values);
+}
+
+final threadRepliesProvider = AsyncNotifierProvider.autoDispose
+    .family<ThreadRepliesNotifier, List<NostrEvent>, ThreadRepliesArgs>(
+      ThreadRepliesNotifier.new,
+    );
 
 NostrFilter _threadRepliesFilter(
   ThreadRepliesArgs args,
@@ -65,6 +247,19 @@ NostrFilter _threadRepliesFilter(
       if (cursor != null) 'thread_cursor': cursor.createdAt,
       if (cursor != null) 'thread_cursor_id': cursor.eventId,
     },
+  );
+}
+
+NostrFilter _threadLiveRepliesFilter(ThreadRepliesArgs args) {
+  final now = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
+  return NostrFilter(
+    kinds: EventKind.channelTimelineContentKinds,
+    tags: {
+      '#e': [args.rootId],
+      '#h': [args.channelId],
+    },
+    since: now - ThreadRepliesNotifier._replaySkewSeconds,
+    limit: 200,
   );
 }
 
@@ -99,18 +294,17 @@ final threadLocalRepliesProvider =
 
 /// Relay-backed replies merged with signed local replies that are still
 /// waiting for acknowledgement.
-final threadRepliesWithLocalProvider =
-    Provider.family<AsyncValue<List<NostrEvent>>, ThreadRepliesArgs>((
-      ref,
-      args,
-    ) {
+final threadRepliesWithLocalProvider = Provider.autoDispose
+    .family<AsyncValue<List<NostrEvent>>, ThreadRepliesArgs>((ref, args) {
       final relayReplies = ref.watch(threadRepliesProvider(args));
+      final authoritativeIds = ref
+          .watch(threadRepliesProvider(args).notifier)
+          .authoritativeEventIds;
       final localReplies = ref.watch(threadLocalRepliesProvider(args));
-      final authoritative = relayReplies.value;
-      if (authoritative != null && localReplies.isNotEmpty) {
-        final authoritativeIds = authoritative.map((event) => event.id).toSet();
+      if (authoritativeIds.isNotEmpty && localReplies.isNotEmpty) {
         if (localReplies.any((event) => authoritativeIds.contains(event.id))) {
           Future.microtask(() {
+            if (!ref.mounted) return;
             ref
                 .read(threadLocalRepliesProvider(args).notifier)
                 .confirm(authoritativeIds);
@@ -120,11 +314,18 @@ final threadRepliesWithLocalProvider =
           });
         }
       }
-      if (localReplies.isEmpty) return relayReplies;
       return relayReplies.when(
         data: (events) => AsyncData(_mergeReplies(events, localReplies)),
-        loading: () => AsyncData(localReplies),
-        error: (error, stackTrace) => AsyncData(localReplies),
+        loading: () {
+          return localReplies.isEmpty
+              ? const AsyncLoading()
+              : AsyncData(localReplies);
+        },
+        error: (error, stackTrace) {
+          return localReplies.isEmpty
+              ? AsyncError(error, stackTrace)
+              : AsyncData(localReplies);
+        },
       );
     });
 

--- a/mobile/test/features/channels/channel_detail_page_test.dart
+++ b/mobile/test/features/channels/channel_detail_page_test.dart
@@ -199,11 +199,21 @@ Widget _buildTestable({
       for (final entry in threadReplies.entries)
         threadRepliesProvider(
           ThreadRepliesArgs(channelId: _channelId, rootId: entry.key),
-        ).overrideWith((ref) async => entry.value),
+        ).overrideWith(
+          () => _FakeThreadRepliesNotifier(
+            ThreadRepliesArgs(channelId: _channelId, rootId: entry.key),
+            entry.value,
+          ),
+        ),
       for (final entry in pendingThreadReplies.entries)
         threadRepliesProvider(
           ThreadRepliesArgs(channelId: _channelId, rootId: entry.key),
-        ).overrideWith((ref) => entry.value),
+        ).overrideWith(
+          () => _FakeThreadRepliesNotifier(
+            ThreadRepliesArgs(channelId: _channelId, rootId: entry.key),
+            entry.value,
+          ),
+        ),
       // Stub the relay client provider so preloadMembers doesn't crash.
       relayClientProvider.overrideWithValue(
         RelayClient(baseUrl: 'http://localhost:3000'),
@@ -2693,6 +2703,16 @@ class _ErrorMessagesNotifier extends ChannelMessagesNotifier {
   @override
   AsyncValue<List<NostrEvent>> build() =>
       AsyncError('Connection failed', StackTrace.current);
+}
+
+class _FakeThreadRepliesNotifier extends ThreadRepliesNotifier {
+  final Future<List<NostrEvent>> _replies;
+
+  _FakeThreadRepliesNotifier(super.args, FutureOr<List<NostrEvent>> replies)
+    : _replies = Future.value(replies);
+
+  @override
+  Future<List<NostrEvent>> build() => _replies;
 }
 
 class _ReconnectingRelaySession extends RelaySessionNotifier {

--- a/mobile/test/features/channels/channel_messages_provider_test.dart
+++ b/mobile/test/features/channels/channel_messages_provider_test.dart
@@ -366,15 +366,6 @@ void main() {
         queryResults: [
           [_event(id: 'history', createdAt: 10), _bounds()],
           <NostrEvent>[],
-          [
-            _event(
-              id: 'reply',
-              createdAt: 20,
-              extraTags: const [
-                ['e', 'root', '', 'reply'],
-              ],
-            ),
-          ],
         ],
       );
       final container = _buildContainer(relaySession);
@@ -384,7 +375,12 @@ void main() {
       await relaySession.subscribed;
       await _pumpEventQueue();
       const args = ThreadRepliesArgs(channelId: _channelId, rootId: 'root');
-      container.read(threadRepliesWithLocalProvider(args));
+      final threadSubscription = container.listen(
+        threadRepliesWithLocalProvider(args),
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(threadSubscription.close);
       await _pumpEventQueue();
       final notifier = container.read(
         channelMessagesProvider(_channelId).notifier,
@@ -426,6 +422,7 @@ void main() {
       );
       expect(container.read(threadLocalRepliesProvider(args)), isEmpty);
       expect(container.read(pendingLocalMessagesProvider(_channelId)), isEmpty);
+      expect(relaySession.queryFilters, hasLength(2));
 
       final rejected = _event(
         id: 'rejected',
@@ -447,13 +444,12 @@ void main() {
   );
 
   test(
-    'thread live echo keeps ownership until the authoritative refetch succeeds',
+    'thread live echo retires ownership without an invalidating refetch',
     () async {
       final relaySession = _RecordingRelaySessionNotifier(
         queryResults: [
           [_event(id: 'history', createdAt: 10), _bounds()],
           <NostrEvent>[],
-          Exception('thread refetch failed'),
         ],
       );
       final container = _buildContainer(relaySession);
@@ -463,7 +459,12 @@ void main() {
       await relaySession.subscribed;
       await _pumpEventQueue();
       const args = ThreadRepliesArgs(channelId: _channelId, rootId: 'root');
-      container.read(threadRepliesWithLocalProvider(args));
+      final threadSubscription = container.listen(
+        threadRepliesWithLocalProvider(args),
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(threadSubscription.close);
       await _pumpEventQueue();
       final notifier = container.read(
         channelMessagesProvider(_channelId).notifier,
@@ -480,15 +481,8 @@ void main() {
       relaySession.emit(reply);
       await _pumpEventQueue();
 
-      expect(container.read(pendingLocalMessagesProvider(_channelId)).keys, [
-        'reply',
-      ]);
-      expect(
-        container
-            .read(threadLocalRepliesProvider(args))
-            .map((event) => event.id),
-        ['reply'],
-      );
+      expect(container.read(pendingLocalMessagesProvider(_channelId)), isEmpty);
+      expect(container.read(threadLocalRepliesProvider(args)), isEmpty);
       expect(
         container
             .read(threadRepliesWithLocalProvider(args))
@@ -496,6 +490,7 @@ void main() {
             ?.map((event) => event.id),
         ['reply'],
       );
+      expect(relaySession.queryFilters, hasLength(2));
     },
   );
 

--- a/mobile/test/features/channels/thread_replies_provider_test.dart
+++ b/mobile/test/features/channels/thread_replies_provider_test.dart
@@ -1,0 +1,350 @@
+import 'dart:async';
+
+import 'package:buzz/features/channels/pending_local_messages_provider.dart';
+import 'package:buzz/features/channels/thread_replies_provider.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  test(
+    'subscribes before history and keeps a reply delivered during the query',
+    () async {
+      final relaySession = _ThreadRelaySessionNotifier();
+      final container = ProviderContainer(
+        overrides: [relaySessionProvider.overrideWith(() => relaySession)],
+      );
+      addTearDown(container.dispose);
+
+      const args = ThreadRepliesArgs(channelId: _channelId, rootId: _rootId);
+      final subscription = container.listen(
+        threadRepliesWithLocalProvider(args),
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+
+      await relaySession.subscribed;
+      await _pumpEventQueue();
+      expect(relaySession.operations.take(2), ['subscribe', 'query']);
+      final content = '@Naadir ${List.filled(2693, 'x').join()}';
+      final reply = _reply(id: 'live-reply', createdAt: 20, content: content);
+
+      relaySession.emit(reply);
+      await _pumpEventQueue();
+
+      expect(
+        container
+            .read(threadRepliesWithLocalProvider(args))
+            .value
+            ?.map((event) => event.id),
+        ['live-reply'],
+      );
+      expect(
+        container
+            .read(threadRepliesWithLocalProvider(args))
+            .value
+            ?.single
+            .content,
+        content,
+      );
+
+      // A stale HTTP snapshot must not erase the websocket reply.
+      relaySession.completeQuery(const []);
+      await _pumpEventQueue();
+
+      expect(
+        container
+            .read(threadRepliesWithLocalProvider(args))
+            .value
+            ?.map((event) => event.id),
+        ['live-reply'],
+      );
+      expect(relaySession.liveFilters, hasLength(1));
+      final filter = relaySession.liveFilters.single;
+      expect(filter.kinds, EventKind.channelTimelineContentKinds);
+      expect(filter.tags['#h'], [_channelId]);
+      expect(filter.tags['#e'], [_rootId]);
+      expect(filter.since, isNotNull);
+    },
+  );
+
+  test(
+    'retains the live subscription and accepts replay after a long reconnect',
+    () async {
+      final relaySession = _ThreadRelaySessionNotifier();
+      relaySession.completeQuery(const []);
+      final container = ProviderContainer(
+        overrides: [relaySessionProvider.overrideWith(() => relaySession)],
+      );
+      addTearDown(container.dispose);
+
+      const args = ThreadRepliesArgs(channelId: _channelId, rootId: _rootId);
+      final subscription = container.listen(
+        threadRepliesWithLocalProvider(args),
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+
+      await relaySession.subscribed;
+      await container.read(threadRepliesProvider(args).future);
+
+      relaySession.emit(_reply(id: 'before-gap', createdAt: 100));
+      await _pumpEventQueue();
+
+      relaySession.setStatus(SessionStatus.disconnected);
+      await _pumpEventQueue();
+      relaySession.setStatus(SessionStatus.connected);
+      await _pumpEventQueue();
+
+      expect(relaySession.subscribeCount, 1);
+      expect(relaySession.unsubscribeCount, 0);
+
+      // RelaySession reuses this registered callback when replaying from
+      // lastSeenCreatedAt - 5s. This event happened 20 seconds after the last
+      // seen reply, so rebuilding a now-5s subscription would have lost it.
+      relaySession.emitReplayed(_reply(id: 'during-long-gap', createdAt: 120));
+      await _pumpEventQueue();
+
+      expect(
+        container
+            .read(threadRepliesWithLocalProvider(args))
+            .value
+            ?.map((event) => event.id),
+        ['before-gap', 'during-long-gap'],
+      );
+      expect(relaySession.subscribeCount, 1);
+      expect(relaySession.unsubscribeCount, 0);
+    },
+  );
+
+  test('a live relay echo confirms the optimistic local reply', () async {
+    final relaySession = _ThreadRelaySessionNotifier();
+    final container = ProviderContainer(
+      overrides: [relaySessionProvider.overrideWith(() => relaySession)],
+    );
+    addTearDown(container.dispose);
+
+    const args = ThreadRepliesArgs(channelId: _channelId, rootId: _rootId);
+    final subscription = container.listen(
+      threadRepliesWithLocalProvider(args),
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+
+    await relaySession.subscribed;
+    await _pumpEventQueue();
+    final reply = _reply(id: 'local-echo', createdAt: 30);
+    container.read(threadLocalRepliesProvider(args).notifier).add(reply);
+    container
+        .read(pendingLocalMessagesProvider(_channelId).notifier)
+        .add(reply);
+
+    relaySession.emit(reply);
+    await _pumpEventQueue();
+
+    expect(container.read(threadLocalRepliesProvider(args)), isEmpty);
+    expect(container.read(pendingLocalMessagesProvider(_channelId)), isEmpty);
+    expect(
+      container
+          .read(threadRepliesWithLocalProvider(args))
+          .value
+          ?.map((event) => event.id),
+      ['local-echo'],
+    );
+
+    relaySession.completeQuery(const []);
+    await _pumpEventQueue();
+  });
+
+  test('retries an initial live subscription failure', () async {
+    const args = ThreadRepliesArgs(channelId: _channelId, rootId: _rootId);
+    final relaySession = _ThreadRelaySessionNotifier(failuresBeforeSuccess: 1)
+      ..completeQuery(const []);
+    final container = ProviderContainer(
+      overrides: [
+        relaySessionProvider.overrideWith(() => relaySession),
+        threadRepliesProvider(args).overrideWith(
+          () => ThreadRepliesNotifier(args, retryBaseDelay: Duration.zero),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final subscription = container.listen(
+      threadRepliesWithLocalProvider(args),
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+
+    await _waitUntil(() => relaySession.subscribeCount == 2);
+    expect(relaySession.activeListenerCount, 1);
+
+    relaySession.emit(_reply(id: 'after-retry', createdAt: 40));
+    await _pumpEventQueue();
+
+    expect(
+      container
+          .read(threadRepliesWithLocalProvider(args))
+          .value
+          ?.map((event) => event.id),
+      ['after-retry'],
+    );
+  });
+
+  test('replaces a live subscription closed after readiness', () async {
+    const args = ThreadRepliesArgs(channelId: _channelId, rootId: _rootId);
+    final relaySession = _ThreadRelaySessionNotifier()..completeQuery(const []);
+    final container = ProviderContainer(
+      overrides: [
+        relaySessionProvider.overrideWith(() => relaySession),
+        threadRepliesProvider(args).overrideWith(
+          () => ThreadRepliesNotifier(args, retryBaseDelay: Duration.zero),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final subscription = container.listen(
+      threadRepliesWithLocalProvider(args),
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+
+    await container.read(threadRepliesProvider(args).future);
+    expect(relaySession.activeListenerCount, 1);
+
+    relaySession.closeLiveSubscription('rate-limited: quota exceeded');
+    await _waitUntil(() => relaySession.subscribeCount == 2);
+    expect(relaySession.activeListenerCount, 1);
+
+    relaySession.emit(_reply(id: 'after-close', createdAt: 50));
+    await _pumpEventQueue();
+
+    expect(
+      container
+          .read(threadRepliesWithLocalProvider(args))
+          .value
+          ?.map((event) => event.id),
+      ['after-close'],
+    );
+  });
+}
+
+const _channelId = '11111111-1111-4111-8111-111111111111';
+const _rootId = 'thread-root';
+
+Future<void> _pumpEventQueue() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}
+
+Future<void> _waitUntil(bool Function() predicate) async {
+  for (var attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+  fail('Condition was not met before timeout.');
+}
+
+NostrEvent _reply({
+  required String id,
+  required int createdAt,
+  String? content,
+}) {
+  return NostrEvent(
+    id: id,
+    pubkey: 'fable',
+    createdAt: createdAt,
+    kind: EventKind.streamMessage,
+    tags: const [
+      ['h', _channelId],
+      ['e', _rootId, '', 'reply'],
+      ['p', 'owner'],
+    ],
+    content: content ?? id,
+    sig: 'sig',
+  );
+}
+
+class _ThreadRelaySessionNotifier extends RelaySessionNotifier {
+  int failuresBeforeSuccess;
+  final Completer<List<NostrEvent>> _query = Completer<List<NostrEvent>>();
+  final Completer<void> _subscribed = Completer<void>();
+  final List<_LiveRegistration> _registrations = [];
+  final List<NostrFilter> liveFilters = [];
+  final List<String> operations = [];
+  int subscribeCount = 0;
+  int unsubscribeCount = 0;
+
+  _ThreadRelaySessionNotifier({this.failuresBeforeSuccess = 0});
+
+  Future<void> get subscribed => _subscribed.future;
+  int get activeListenerCount => _registrations.length;
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  void setStatus(SessionStatus status) {
+    state = SessionState(status: status);
+  }
+
+  @override
+  Future<List<NostrEvent>> queryRelay(
+    List<NostrFilter> filters, {
+    Duration timeout = const Duration(seconds: 8),
+  }) {
+    operations.add('query');
+    return _query.future;
+  }
+
+  @override
+  Future<void Function()> subscribe(
+    NostrFilter filter,
+    void Function(NostrEvent) onEvent, {
+    void Function(String message)? onClosed,
+  }) async {
+    operations.add('subscribe');
+    subscribeCount++;
+    liveFilters.add(filter);
+    if (!_subscribed.isCompleted) _subscribed.complete();
+    if (failuresBeforeSuccess > 0) {
+      failuresBeforeSuccess--;
+      throw Exception('rate-limited: quota exceeded');
+    }
+    final registration = _LiveRegistration(onEvent, onClosed);
+    _registrations.add(registration);
+    return () {
+      unsubscribeCount++;
+      _registrations.remove(registration);
+    };
+  }
+
+  void emit(NostrEvent event) {
+    for (final registration in List.of(_registrations)) {
+      registration.onEvent(event);
+    }
+  }
+
+  void emitReplayed(NostrEvent event) => emit(event);
+
+  void closeLiveSubscription(String message) {
+    final registration = _registrations.removeAt(0);
+    registration.onClosed?.call(message);
+  }
+
+  void completeQuery(List<NostrEvent> events) {
+    if (!_query.isCompleted) _query.complete(events);
+  }
+}
+
+class _LiveRegistration {
+  final void Function(NostrEvent) onEvent;
+  final void Function(String message)? onClosed;
+
+  const _LiveRegistration(this.onEvent, this.onClosed);
+}


### PR DESCRIPTION
## What changed

- Replace the one-shot thread reply provider with a subscribe-first, auto-disposed async notifier.
- Merge thread-scoped live replies with paged relay history without allowing a stale history snapshot to erase newer events.
- Preserve the RelaySession subscription across reconnect/replay.
- Retry initial subscription failures and late relay `CLOSED` events with capped backoff and history resynchronization.
- Remove the redundant channel-level thread invalidation that could dispose the direct listener during the same delivery batch.
- Confirm optimistic local and pending reply overlays when the relay echoes the event.
- Preserve the newer upstream thread-summary flow while rebasing over current `main`.

## Why

Mobile thread replies were loaded by a one-shot HTTP query, while typing indicators used a separate live subscription. An open thread could therefore continue showing an agent as typing while a valid, relay-accepted reply remained absent until the app was restarted.

The fix establishes the live subscription before the history query, closes the delivery race, and makes reconnect behavior explicit and testable.

## User impact

Replies posted while a thread is open now appear live, survive stale history snapshots, and are recovered after relay reconnects or subscription closures.

## Validation

- Rebasing conflict resolved against current upstream `main` (`318fbf8`)
- `flutter analyze` — no issues
- Focused channel/thread/UI suite — 78 passed
- Full `flutter test` — 1,027 passed, 1 intentional skip
- DCO check — passed

Coverage includes subscribe-before-query delivery, a 2.7 KB reply, reconnect replay after a long gap, optimistic-local confirmation, initial subscription failure retry, late `CLOSED` replacement, removal of the invalidating refetch, and compatibility with upstream thread summaries.