### PR TITLE
fix(desktop): paint an opaque ground under the Buzz Term splash

### DIFF
--- a/desktop/src/features/terminal/terminalBannerPainter.test.mjs
+++ b/desktop/src/features/terminal/terminalBannerPainter.test.mjs
@@ -33,10 +33,14 @@ function canvas() {
   const draws = [];
   const clears = [];
   const colors = [];
+  const fills = [];
   const context = {
     _fillStyle: "",
     clearRect(...args) {
       clears.push(args);
+    },
+    fillRect(...args) {
+      fills.push({ args, color: this._fillStyle, glyphsBefore: draws.length });
     },
     fillText(...args) {
       draws.push(args);
@@ -62,6 +66,7 @@ function canvas() {
     clears,
     colors,
     draws,
+    fills,
   };
 }
 
@@ -78,6 +83,19 @@ test("paints every emitted banner glyph at terminal cell coordinates", () => {
   assert.equal(target.canvas.width, 2000);
   assert.equal(target.canvas.height, 1200);
   assert.deepEqual(target.clears, [[0, 0, 1000, 600]]);
+});
+
+test("lays an opaque theme background under the banner before any glyph", () => {
+  const banner = buildTerminalBanner(112, 46, 17 / 8.4);
+  assert.ok(banner);
+  const target = canvas();
+  assert.equal(paintTerminalBanner(target.canvas, banner, palette, 2), true);
+  assert.equal(target.fills.length, 1);
+  const [ground] = target.fills;
+  assert.deepEqual(ground.args, [0, 0, 1000, 600]);
+  assert.equal(ground.color, palette.background);
+  assert.equal(ground.glyphsBefore, 0);
+  assert.ok(target.draws.length > 0);
 });
 
 test("uses visibly distinct theme-derived colors across banner layers", () => {

--- a/desktop/src/features/terminal/terminalBannerPainter.ts
+++ b/desktop/src/features/terminal/terminalBannerPainter.ts
@@ -19,6 +19,11 @@ export function paintTerminalBanner(
   if (!context) return false;
   context.setTransform(dpr, 0, 0, dpr, 0, 0);
   context.clearRect(0, 0, bounds.width, bounds.height);
+  // The overlay sits above the grid canvas, so it needs its own opaque
+  // ground: without one the shell output painted underneath shows through
+  // the gaps between banner glyphs.
+  context.fillStyle = palette.background;
+  context.fillRect(0, 0, bounds.width, bounds.height);
   context.font = TERMINAL_CELL_METRICS.font;
   context.textBaseline = "alphabetic";
 


### PR DESCRIPTION
Follow-up to #4410, per Eva's ruling in the #4347 bug batch. Targets `max/tui-renderer`, not main.

## The problem

`paintTerminalBanner` does `clearRect` and then draws glyphs — **no background fill** — and `.buzz-terminal-welcome` sets no CSS background either (inset / pointer-events / position / z-index only). The overlay canvas therefore composites over whatever the grid canvas last painted.

Measured on a real 111×46 viewport with a real palette: **1 `clearRect`, 0 background `fillRect`, 1925 glyphs**, about 38% cell coverage. The rest is see-through.

This is pre-existing, not introduced by #4410. It was invisible because the shell prompt dismissed the banner within milliseconds of spawn, so nobody ever saw the compositing. Making the splash survive until reveal is what exposes it — and it would turn Tyler's "splash does not show" into "splash shows badly" on any shell with an MOTD, `neofetch`, or a restored session.

## The fix

One `fillRect` with `palette.background` before the glyph loop — the same theme source the grid uses for its own cell background (`terminalRenderer.ts:182`). Not the skip-grid-paint variant: that couples the splash to the render loop for the same visual result.

## Test

`lays an opaque theme background under the banner before any glyph` asserts the fill exists, covers the full CSS-pixel bounds, uses `palette.background`, and lands **before** any `fillText`. The painter tests build a real palette by hand, so they can actually see the painter — the substrate tests cannot (see the null-palette note below).

Mutation matrix, run against that test:

| mutant | result |
|---|---|
| control (unmutated) | 4/4 pass |
| drop the `fillRect` — the bug itself | KILLED |
| fill with `palette.foreground` | KILLED |
| fill half the width | KILLED |
| move the fill *after* the glyph loop | KILLED |

The ordering mutant is the one worth naming: a fill that lands after the glyphs is opaque and covers the right area, and would pass any assertion that only checks existence, color and bounds — it just erases the banner. `glyphsBefore` is what discriminates it.

## Verification

- `pnpm --dir desktop test`: **3968/3968 pass** (3967 before, +1 new)
- `pnpm --dir desktop typecheck`: clean
- `pnpm --dir desktop check`: clean (`CHECK_FILE_SIZES_BASE=ee862deb2`, the actual base)
- `git diff --check`: clean
- push gates: branch-skew, desktop-check, desktop-test, rust-tests, mobile-test, desktop-tauri-checks — all green

Based on `ee862deb2` (integration head after #4410 merged).

## Standing limitation, unchanged by this PR

Every terminal test in the desktop suite renders with `terminalPalette = null` — `ThemeProvider` only populates it from an async `applyTheme` that never resolves under jsdom, so the paint effect returns at its first guard. Nothing downstream of that guard is exercised by the substrate tests. This PR's assertion lives in the painter tests, which supply a palette directly, so it is not affected — but the fixture defect is real and Eva has it in the field notes as post-batch work.
