### PR TITLE
fix(desktop): keep terminal fade compositor-stable

### DIFF
--- a/desktop/src/features/terminal/fadeController.test.mjs
+++ b/desktop/src/features/terminal/fadeController.test.mjs
@@ -8,20 +8,30 @@ import {
   REVEAL_DURATION_MS,
 } from "./fadeController.ts";
 
+function deferred() {
+  let resolve;
+  const promise = new Promise((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 function fixture() {
   const calls = [];
-  let resolveFinished;
+  const completions = [deferred()];
   const animation = {
     currentTime: 0,
     playbackRate: 0,
-    finished: new Promise((resolve) => {
-      resolveFinished = resolve;
-    }),
+    finished: completions[0].promise,
     play() {
       calls.push("play");
+      completions.push(deferred());
+      this.finished = completions.at(-1).promise;
     },
     reverse() {
       calls.push("reverse");
+      completions.push(deferred());
+      this.finished = completions.at(-1).promise;
     },
     cancel() {
       calls.push("cancel");
@@ -37,8 +47,8 @@ function fixture() {
   return {
     animation,
     calls,
+    completions,
     controller: new FadeController(surface),
-    resolveFinished,
     surface,
   };
 }
@@ -54,6 +64,39 @@ test("reversal reuses the one timeline and scales return playback", () => {
   );
   assert.equal(calls.at(-1), "reverse");
   assert.equal(calls[0].options.easing, FADE_EASING);
+});
+
+test("fade durations are half the original timing", () => {
+  assert.equal(REVEAL_DURATION_MS, 360);
+  assert.equal(CONCEAL_DURATION_MS, 210);
+});
+
+test("completed fades retain the timeline but release its compositor hint", async () => {
+  const { calls, completions, controller, surface } = fixture();
+
+  assert.equal(controller.toggle(false), "reveal");
+  completions[0].resolve();
+  await Promise.resolve();
+  assert.equal(surface.style.willChange, "auto");
+
+  assert.equal(controller.toggle(false), "conceal");
+  assert.equal(calls.includes("cancel"), false);
+  assert.equal(surface.style.willChange, "opacity");
+  assert.equal(calls.filter((call) => typeof call === "object").length, 1);
+});
+
+test("a stale completion cannot release the hint during a reversal", async () => {
+  const { completions, controller, surface } = fixture();
+
+  controller.toggle(false);
+  controller.toggle(false);
+  completions[0].resolve();
+  await Promise.resolve();
+  assert.equal(surface.style.willChange, "opacity");
+
+  completions[1].resolve();
+  await Promise.resolve();
+  assert.equal(surface.style.willChange, "auto");
 });
 
 test("reduced motion settles immediately without allocating an animation", () => {

--- a/desktop/src/features/terminal/fadeController.ts
+++ b/desktop/src/features/terminal/fadeController.ts
@@ -1,5 +1,5 @@
-export const REVEAL_DURATION_MS = 720;
-export const CONCEAL_DURATION_MS = 420;
+export const REVEAL_DURATION_MS = 360;
+export const CONCEAL_DURATION_MS = 210;
 export const FADE_EASING = "cubic-bezier(.2,.8,.2,1)";
 
 type Direction = "reveal" | "conceal";
@@ -78,11 +78,11 @@ export class FadeController {
     void animation.finished
       .then(() => {
         if (this.#animation === animation && this.#token === token) {
-          this.settle(next);
+          this.#surface.style.willChange = "auto";
         }
       })
       .catch(() => {
-        // Reversal/cancellation rejects `finished`; the newer token owns state.
+        // Reversal/cancellation rejects `finished`; the live timeline owns state.
       });
     return next;
   }


### PR DESCRIPTION
## Summary

- keep the filled terminal fade timeline after animation completion so the next direction reverses the existing effect instead of canceling, reallocating, seeking, and reversing a new one
- release `will-change: opacity` at rest while retaining that timeline, then restore the hint before each toggle
- halve reveal/conceal durations from 720/420ms to 360/210ms while preserving their ratio

## Evidence and claim boundary

This removes the JS-visible reallocation seam and pins that mechanism in a regression test. It does **not** by itself prove the macOS compositor flicker is gone: compositor-only layer behavior is invisible to `getComputedStyle`, `document.getAnimations()`, and this host's JS tests. Native pixel verdict remains the integrated live pass / user acceptance.

The retained filled animation may preserve browser-internal animation state, but it does not deliberately pin a composited layer at rest: the completion handler restores `willChange = "auto"`. Explicit reduced-motion, fallback, and unmount settlement still cancels and releases the timeline.

## Verification

Exact pushed head `b8a962ac4f4062d96581c969751fbd23311161b1`:

- desktop tests: 3970/3970
- desktop typecheck: pass
- `pnpm --dir desktop check`: pass
- push gates: branch-skew, desktop-check, desktop-test, mobile-test, rust-tests, desktop-tauri-checks all pass
- Rust push gates rerun with `$HOME/.cargo/bin` first on `PATH` (pinned Rust 1.95 toolchain); the earlier attempt correctly failed under Homebrew Rust 1.89 and did not push
- `git diff --check`: pass
