### PR TITLE
feat(acp): publish opt-in agent responses

### DIFF
--- a/crates/buzz-acp/README.md
+++ b/crates/buzz-acp/README.md
@@ -125,6 +125,7 @@ All configuration is via environment variables (or CLI flags — every env var h
 |------|---------|---------|-------------|
 | `--agents` | `BUZZ_ACP_AGENTS` | `1` | Number of agent subprocesses (1–32). |
 | `--lazy-pool` | `BUZZ_ACP_LAZY_POOL` | `false` | Connect, subscribe, and queue accepted work before starting ACP/LLM subprocesses. The first accepted event wakes one pool initialization task; failures retry with bounded exponential backoff while work remains. |
+| `--publish-response` | `BUZZ_ACP_PUBLISH_RESPONSE` | `false` | Publish a successful, non-empty ACP text response as an agent-authored reply to the latest triggering channel event. Uses the harness's authenticated `POST /events` path; heartbeats, failures, cancellations, and incomplete turns are never published. Enable only for agents that do not already post their ordinary replies. |
 | `--heartbeat-interval` | `BUZZ_ACP_HEARTBEAT_INTERVAL` | `0` | Seconds between heartbeat prompts. `0` = disabled. Must be `0` or ≥10 when enabled. |
 | `--heartbeat-prompt` | `BUZZ_ACP_HEARTBEAT_PROMPT` | (built-in) | Custom heartbeat prompt text. Conflicts with `--heartbeat-prompt-file`. |
 | `--heartbeat-prompt-file` | `BUZZ_ACP_HEARTBEAT_PROMPT_FILE` | — | Read heartbeat prompt from a file. Conflicts with `--heartbeat-prompt`. |

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -20,6 +20,9 @@ use crate::usage::{TurnUsage, UsageTracker};
 /// Lines exceeding this limit are rejected to prevent OOM from rogue agents.
 const MAX_LINE_SIZE: usize = 10_000_000; // 10 MB
 
+/// Buzz stream-message content limit. Accumulation is capped here so an agent
+/// cannot grow harness memory without bound and the result remains publishable.
+const MAX_RESPONSE_TEXT_BYTES: usize = 64 * 1024;
 /// An MCP server configuration passed to `session/new`.
 ///
 /// Corresponds to the `McpServerStdio` variant in the ACP schema.
@@ -211,6 +214,12 @@ pub struct AcpClient {
     /// deltas. Both goose and buzz-agent emit this notification; goose gates
     /// on client capability advertisement, buzz-agent emits unconditionally.
     goose_usage: UsageTracker,
+    /// Text streamed as `agent_message_chunk` notifications for the current prompt.
+    /// Reset before every prompt and consumed by the harness after a successful turn.
+    response_text: String,
+    /// Latest event positively acknowledged by a non-cancelling native steer.
+    /// Reset with each prompt and consumed with the completed response.
+    response_anchor: Option<crate::queue::BatchEvent>,
 }
 
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
@@ -550,6 +559,8 @@ impl AcpClient {
             steering_supported: false,
             steer_rx: None,
             goose_usage: UsageTracker::default(),
+            response_text: String::new(),
+            response_anchor: None,
         })
     }
 
@@ -751,6 +762,8 @@ impl AcpClient {
         idle_timeout: std::time::Duration,
         max_duration: std::time::Duration,
     ) -> Result<StopReason, AcpError> {
+        self.response_text.clear();
+        self.response_anchor = None;
         let params = build_prompt_params(session_id, prompt_blocks);
         let hard_deadline = tokio::time::Instant::now() + max_duration;
         self.current_hard_deadline = Some(hard_deadline);
@@ -862,6 +875,17 @@ impl AcpClient {
     /// publish a kind 44200 NIP-AM event.
     pub fn take_turn_usage(&mut self) -> Option<TurnUsage> {
         self.goose_usage.take()
+    }
+
+    /// Consume the ACP text streamed for the most recently completed prompt.
+    pub fn take_response_text(&mut self) -> String {
+        std::mem::take(&mut self.response_text)
+    }
+
+    /// Consume the latest event successfully injected into this prompt by a
+    /// non-cancelling steer, if any.
+    pub fn take_response_anchor(&mut self) -> Option<crate::queue::BatchEvent> {
+        self.response_anchor.take()
     }
 
     /// Install a per-turn steer request channel for goose-native
@@ -1302,6 +1326,7 @@ impl AcpClient {
             u64,
             SteerTransport,
             tokio::sync::oneshot::Sender<crate::pool::SteerAck>,
+            Option<crate::queue::BatchEvent>,
         )> = None;
 
         let now = Instant::now();
@@ -1327,7 +1352,7 @@ impl AcpClient {
             // exists). Check the classified deadline here so a steady-
             // stream agent is still bounded.
             if Instant::now() >= next_deadline {
-                if let Some((_, _, ack_tx)) = pending_steer.take() {
+                if let Some((_, _, ack_tx, _)) = pending_steer.take() {
                     // Prompt is timing out — release the withheld event via
                     // PromptCompletedNeutral (no fallback signal: there is
                     // no in-flight turn to signal once we return, and
@@ -1429,7 +1454,12 @@ impl AcpClient {
                             );
                             match self.write_ndjson(&msg).await {
                                 Ok(()) => {
-                                    pending_steer = Some((id, transport, req.ack_tx));
+                                    pending_steer = Some((
+                                        id,
+                                        transport,
+                                        req.ack_tx,
+                                        req.response_anchor,
+                                    ));
                                 }
                                 Err(e) => {
                                     tracing::warn!(
@@ -1452,7 +1482,7 @@ impl AcpClient {
                     // would catch this anyway, but firing the deadline arm
                     // here makes the wakeup immediate (no extra reader poll
                     // round-trip when stdout is idle).
-                    if let Some((_, _, ack_tx)) = pending_steer.take() {
+                    if let Some((_, _, ack_tx, _)) = pending_steer.take() {
                         let _ = ack_tx.send(crate::pool::SteerAck::PromptCompletedNeutral);
                     }
                     if idle_fires_first {
@@ -1476,13 +1506,13 @@ impl AcpClient {
 
             match read_result {
                 None => {
-                    if let Some((_, _, ack_tx)) = pending_steer.take() {
+                    if let Some((_, _, ack_tx, _)) = pending_steer.take() {
                         let _ = ack_tx.send(crate::pool::SteerAck::PromptCompletedNeutral);
                     }
                     return Err(AcpError::AgentExited);
                 }
                 Some(Err(LinesCodecError::MaxLineLengthExceeded)) => {
-                    if let Some((_, _, ack_tx)) = pending_steer.take() {
+                    if let Some((_, _, ack_tx, _)) = pending_steer.take() {
                         let _ = ack_tx.send(crate::pool::SteerAck::PromptCompletedNeutral);
                     }
                     return Err(AcpError::Protocol(
@@ -1490,7 +1520,7 @@ impl AcpClient {
                     ));
                 }
                 Some(Err(e)) => {
-                    if let Some((_, _, ack_tx)) = pending_steer.take() {
+                    if let Some((_, _, ack_tx, _)) = pending_steer.take() {
                         let _ = ack_tx.send(crate::pool::SteerAck::PromptCompletedNeutral);
                     }
                     return Err(AcpError::Io(std::io::Error::other(e)));
@@ -1533,13 +1563,13 @@ impl AcpClient {
                     // share the `no method` guard.
                     if let Some(id) = msg.get("id") {
                         if msg.get("method").is_none() {
-                            if let Some((steer_id, _, _)) = pending_steer.as_ref() {
+                            if let Some((steer_id, _, _, _)) = pending_steer.as_ref() {
                                 if *id == serde_json::json!(*steer_id) {
                                     // Take the ack_tx out and route the
                                     // response. We do not return — keep
                                     // reading until the prompt response
                                     // arrives.
-                                    let (_, transport, ack_tx) =
+                                    let (_, transport, ack_tx, response_anchor) =
                                         pending_steer.take().expect("just checked");
                                     let ack = if let Some(error) = msg.get("error") {
                                         let code = error
@@ -1629,19 +1659,22 @@ impl AcpClient {
                                             }
                                         }
                                     };
+                                    if matches!(ack, crate::pool::SteerAck::Success) {
+                                        self.response_anchor = response_anchor;
+                                    }
                                     let _ = ack_tx.send(ack);
                                     continue;
                                 }
                             }
                             if *id == serde_json::json!(expected_id) {
                                 if let Some(error) = msg.get("error") {
-                                    if let Some((_, _, ack_tx)) = pending_steer.take() {
+                                    if let Some((_, _, ack_tx, _)) = pending_steer.take() {
                                         let _ = ack_tx
                                             .send(crate::pool::SteerAck::PromptCompletedNeutral);
                                     }
                                     return Err(agent_error_from_json(error));
                                 }
-                                if let Some((_, _, ack_tx)) = pending_steer.take() {
+                                if let Some((_, _, ack_tx, _)) = pending_steer.take() {
                                     let _ =
                                         ack_tx.send(crate::pool::SteerAck::PromptCompletedNeutral);
                                 }
@@ -1715,6 +1748,28 @@ impl AcpClient {
             "agent_message_chunk" => {
                 if let Some(text) = update["content"]["text"].as_str() {
                     tracing::info!(target: "acp::stream", "{text}");
+                    let remaining =
+                        MAX_RESPONSE_TEXT_BYTES.saturating_sub(self.response_text.len());
+                    if remaining > 0 {
+                        let end = text
+                            .char_indices()
+                            .map(|(index, _)| index)
+                            .take_while(|index| *index <= remaining)
+                            .last()
+                            .unwrap_or(0);
+                        let end = if text.len() <= remaining {
+                            text.len()
+                        } else {
+                            end
+                        };
+                        self.response_text.push_str(&text[..end]);
+                    }
+                    if text.len() > remaining {
+                        tracing::warn!(
+                            limit = MAX_RESPONSE_TEXT_BYTES,
+                            "ACP response text exceeded Buzz message limit and was truncated"
+                        );
+                    }
                 }
                 false
             }
@@ -3526,6 +3581,55 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn successful_prompt_accumulates_agent_message_chunks_in_order() {
+        let script = r#"
+            read -r _prompt
+            echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"text":"Hello "}}}}'
+            echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"text":"Buzz"}}}}'
+            echo '{"jsonrpc":"2.0","id":0,"result":{"stopReason":"end_turn"}}'
+        "#;
+        let mut client = spawn_script(script).await;
+        let stop = client
+            .session_prompt_with_idle_timeout(
+                "session",
+                "prompt",
+                std::time::Duration::from_secs(2),
+                std::time::Duration::from_secs(5),
+            )
+            .await
+            .expect("prompt should complete");
+
+        assert_eq!(stop, StopReason::EndTurn);
+        assert_eq!(client.take_response_text(), "Hello Buzz");
+        assert_eq!(client.take_response_text(), "");
+    }
+
+    #[tokio::test]
+    async fn each_prompt_resets_response_accumulation() {
+        let script = r#"
+            read -r _first
+            echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"text":"stale"}}}}'
+            echo '{"jsonrpc":"2.0","id":0,"result":{"stopReason":"end_turn"}}'
+            read -r _second
+            echo '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"text":"fresh"}}}}'
+            echo '{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}'
+        "#;
+        let mut client = spawn_script(script).await;
+        for expected in ["stale", "fresh"] {
+            client
+                .session_prompt_with_idle_timeout(
+                    "session",
+                    "prompt",
+                    std::time::Duration::from_secs(2),
+                    std::time::Duration::from_secs(5),
+                )
+                .await
+                .expect("prompt should complete");
+            assert_eq!(client.take_response_text(), expected);
+        }
+    }
+
     // ── Goose-native steer arm tests ──────────────────────────────────────
     //
     // These exercise the seam between `install_steer_rx` and the read
@@ -3561,11 +3665,19 @@ mod tests {
 
         // Fire-and-forget: send a SteerRequest from a separate task so
         // the read loop picks it up via the select! arm.
+        let response_anchor = crate::queue::BatchEvent {
+            event: nostr::EventBuilder::new(nostr::Kind::Custom(9), "undelivered steer")
+                .sign_with_keys(&nostr::Keys::generate())
+                .expect("anchor event"),
+            prompt_tag: "mentions".into(),
+            received_at: std::time::Instant::now(),
+        };
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<crate::pool::SteerAck>();
         let send_task = tokio::spawn(async move {
             steer_tx
                 .send(crate::pool::SteerRequest {
                     prompt_blocks: vec!["test steer body".into()],
+                    response_anchor: Some(response_anchor),
                     ack_tx,
                 })
                 .await
@@ -3599,6 +3711,10 @@ mod tests {
             crate::pool::SteerAck::Err(crate::pool::SteerError::ExpectedRunIdMissing) => {}
             other => panic!("expected SteerAck::Err(ExpectedRunIdMissing), got {other:?}"),
         }
+        assert!(
+            client.take_response_anchor().is_none(),
+            "failed steer must not replace the response anchor"
+        );
     }
 
     /// Steer with `active_run_id` set writes the JSON-RPC request and
@@ -3630,11 +3746,22 @@ mod tests {
         let (steer_tx, steer_rx) = tokio::sync::mpsc::channel::<crate::pool::SteerRequest>(1);
         client.install_steer_rx(steer_rx);
 
+        let anchor_keys = nostr::Keys::generate();
+        let anchor_event = nostr::EventBuilder::new(nostr::Kind::Custom(9), "steered event")
+            .sign_with_keys(&anchor_keys)
+            .expect("anchor event");
+        let anchor_id = anchor_event.id;
+        let response_anchor = crate::queue::BatchEvent {
+            event: anchor_event,
+            prompt_tag: "mentions".into(),
+            received_at: std::time::Instant::now(),
+        };
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<crate::pool::SteerAck>();
         let send_task = tokio::spawn(async move {
             steer_tx
                 .send(crate::pool::SteerRequest {
                     prompt_blocks: vec!["test steer body".into()],
+                    response_anchor: Some(response_anchor),
                     ack_tx,
                 })
                 .await
@@ -3673,6 +3800,14 @@ mod tests {
             crate::pool::SteerAck::Success => {}
             other => panic!("expected SteerAck::Success, got {other:?}"),
         }
+        assert_eq!(
+            client
+                .take_response_anchor()
+                .expect("successful steer should retain response anchor")
+                .event
+                .id,
+            anchor_id
+        );
     }
 
     /// Steer-success renewal keeps the turn alive past the original hard
@@ -3707,6 +3842,7 @@ mod tests {
             steer_tx
                 .send(crate::pool::SteerRequest {
                     prompt_blocks: vec!["steer body".into()],
+                    response_anchor: None,
                     ack_tx,
                 })
                 .await
@@ -3781,6 +3917,7 @@ mod tests {
             steer_tx
                 .send(crate::pool::SteerRequest {
                     prompt_blocks: vec!["steer body".into()],
+                    response_anchor: None,
                     ack_tx,
                 })
                 .await
@@ -4031,6 +4168,7 @@ mod tests {
             steer_tx
                 .send(crate::pool::SteerRequest {
                     prompt_blocks: vec!["steer body".into()],
+                    response_anchor: None,
                     ack_tx,
                 })
                 .await
@@ -4084,6 +4222,7 @@ mod tests {
             steer_tx
                 .send(crate::pool::SteerRequest {
                     prompt_blocks: vec!["steer body".into()],
+                    response_anchor: None,
                     ack_tx,
                 })
                 .await

--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -482,6 +482,11 @@ pub struct CliArgs {
     /// Connect and subscribe before starting the ACP/LLM subprocess pool.
     #[arg(long, env = "BUZZ_ACP_LAZY_POOL", default_value_t = false)]
     pub lazy_pool: bool,
+
+    /// Publish successful ACP text responses as threaded Buzz channel replies.
+    /// Disabled by default to avoid duplicate posts from agents that already send replies.
+    #[arg(long, env = "BUZZ_ACP_PUBLISH_RESPONSE", default_value_t = false)]
+    pub publish_response: bool,
 }
 
 /// Merged NIP-01 subscription filter for a single channel.
@@ -559,6 +564,8 @@ pub struct Config {
     pub exit_after_inactivity_secs: u64,
     /// Whether ACP/LLM subprocess initialization is deferred until accepted work arrives.
     pub lazy_pool: bool,
+    /// Whether successful channel-turn ACP text is published by the harness.
+    pub publish_response: bool,
     /// Agent owner pubkey (hex). Used for `--respond-to=owner-only` gate.
     /// Replaces the old REST-based owner lookup.
     pub agent_owner: Option<String>,
@@ -1107,6 +1114,7 @@ impl Config {
             relay_observer: args.relay_observer,
             exit_after_inactivity_secs: args.exit_after_inactivity,
             lazy_pool: args.lazy_pool,
+            publish_response: args.publish_response,
             agent_owner: args.agent_owner.map(|s| s.trim().to_ascii_lowercase()),
             no_base_prompt: args.no_base_prompt,
             base_prompt_content,
@@ -1478,6 +1486,7 @@ mod tests {
             relay_observer: false,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
+            publish_response: false,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -2204,6 +2213,19 @@ channels = "ALL"
         let args = CliArgs::try_parse_from(["buzz-acp", "--private-key", &key, "--lazy-pool=true"]);
         assert!(args.is_err(), "bool flags do not take an explicit value");
         assert!(CliArgs::parse_from(["buzz-acp", "--private-key", &key, "--lazy-pool"]).lazy_pool);
+    }
+
+    #[test]
+    fn publish_response_defaults_off_and_requires_explicit_opt_in() {
+        let key = "1".repeat(64);
+        let default_args = CliArgs::parse_from(["buzz-acp", "--private-key", &key]);
+        assert!(!default_args.publish_response);
+
+        let enabled_args =
+            CliArgs::parse_from(["buzz-acp", "--private-key", &key, "--publish-response"]);
+        assert!(enabled_args.publish_response);
+        let config = Config::from_args(enabled_args).expect("opt-in config should be valid");
+        assert!(config.publish_response);
     }
 
     #[test]

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -66,6 +66,18 @@ const MODELS_TIMEOUT: Duration = Duration::from_secs(10);
 /// human interaction, so it must not share the short probe timeout.
 const AUTHENTICATE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
+const AUTOMATIC_RESPONSE_INSTRUCTION: &str = "[ACP Response Delivery]\n\
+For the ordinary reply to the triggering Buzz channel message: Return the ordinary reply as your final ACP text response. Do not run `buzz messages send` for that ordinary reply; the buzz-acp harness will publish the successful final ACP text with the correct agent identity and thread tags. Continue to retain the Buzz CLI for other operations such as reads, reactions, channel management, explicit additional messages, and requested cross-channel coordination.";
+
+fn effective_base_prompt(base_prompt: Option<&str>, publish_response: bool) -> Option<String> {
+    match (base_prompt, publish_response) {
+        (Some(base), true) => Some(format!("{base}\n\n{AUTOMATIC_RESPONSE_INSTRUCTION}")),
+        (None, true) => Some(AUTOMATIC_RESPONSE_INSTRUCTION.to_string()),
+        (Some(base), false) => Some(base.to_string()),
+        (None, false) => None,
+    }
+}
+
 /// Publish a kind:20001 presence update event via the WebSocket connection.
 ///
 /// Ephemeral kinds (20000-29999) are rejected by the HTTP bridge, so presence
@@ -1578,6 +1590,15 @@ async fn tokio_main() -> Result<()> {
     }
 
     let base_prompt_content = config.base_prompt_content.take();
+    let configured_base_prompt = if config.no_base_prompt {
+        None
+    } else {
+        base_prompt_content
+            .as_deref()
+            .or(Some(include_str!("base_prompt.md")))
+    };
+    let base_prompt = effective_base_prompt(configured_base_prompt, config.publish_response)
+        .map(|content| Box::leak(content.into_boxed_str()) as &'static str);
     let ctx = Arc::new(PromptContext {
         mcp_servers: build_mcp_servers(&config),
         initial_message: config.initial_message.clone(),
@@ -1588,13 +1609,7 @@ async fn tokio_main() -> Result<()> {
         system_prompt: config.system_prompt.clone(),
         session_title: config.session_title.clone(),
         team_instructions: config.team_instructions.clone(),
-        base_prompt: if config.no_base_prompt {
-            None
-        } else if let Some(content) = base_prompt_content {
-            Some(Box::leak(content.into_boxed_str()))
-        } else {
-            Some(include_str!("base_prompt.md"))
-        },
+        base_prompt,
         heartbeat_prompt: config.heartbeat_prompt.clone(),
         cwd: std::env::current_dir()
             .unwrap_or_else(|_| std::path::PathBuf::from("/"))
@@ -1612,6 +1627,7 @@ async fn tokio_main() -> Result<()> {
         memory_enabled: config.memory_enabled,
         harness_name: crate::config::normalize_agent_command_identity(&config.agent_command),
         relay_url: config.relay_url.clone(),
+        publish_response: config.publish_response,
     });
 
     if !config.memory_enabled {
@@ -2954,6 +2970,7 @@ fn try_native_steer(
     let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<pool::SteerAck>();
     let request = pool::SteerRequest {
         prompt_blocks: vec![body],
+        response_anchor: Some(be),
         ack_tx,
     };
 
@@ -3741,6 +3758,16 @@ mod agent_draft_prompt_tests {
         assert!(prompt
             .contains("add them explicitly with `buzz channels add-member` only when authorized"));
         assert!(prompt.contains("never changes membership automatically"));
+    }
+
+    #[test]
+    fn automatic_publication_instruction_replaces_only_ordinary_reply_delivery() {
+        let prompt = crate::effective_base_prompt(Some(include_str!("base_prompt.md")), true)
+            .expect("enabled mode should always provide an instruction");
+        assert!(prompt.contains("Return the ordinary reply as your final ACP text response"));
+        assert!(prompt.contains("Do not run `buzz messages send` for that ordinary reply"));
+        assert!(prompt.contains("retain the Buzz CLI for other operations"));
+        assert!(prompt.contains("`buzz reactions`"));
     }
 }
 
@@ -5134,6 +5161,7 @@ mod build_mcp_servers_tests {
             relay_observer: false,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
+            publish_response: false,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,
@@ -5356,6 +5384,7 @@ mod error_outcome_emission_tests {
             relay_observer: false,
             exit_after_inactivity_secs: 0,
             lazy_pool: false,
+            publish_response: false,
             agent_owner: None,
             no_base_prompt: false,
             base_prompt_content: None,

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -36,7 +36,7 @@ use crate::acp::{
 use crate::config::{compose_session_title, DedupMode, PermissionMode};
 use crate::observer;
 use crate::queue::{
-    CancelReason, ContextMessage, ConversationContext, FlushBatch, PromptChannelInfo,
+    BatchEvent, CancelReason, ContextMessage, ConversationContext, FlushBatch, PromptChannelInfo,
     PromptProfile, PromptProfileLookup, ThreadTags,
 };
 use crate::relay::{ChannelInfo, RestClient};
@@ -326,6 +326,9 @@ pub struct SteerRequest {
     /// `queue::native_steer_framing()` + `queue::format_event_block` so
     /// the wording cannot drift from the cancel+merge fallback path.
     pub prompt_blocks: Vec<String>,
+    /// Event incorporated by this steer. The ACP client retains it as the
+    /// response anchor only after the agent positively acknowledges delivery.
+    pub response_anchor: Option<BatchEvent>,
     /// Oneshot for the read loop to report the outcome.
     pub ack_tx: tokio::sync::oneshot::Sender<SteerAck>,
 }
@@ -551,6 +554,99 @@ pub struct PromptContext {
     /// the desktop keys per (agent, relay) pair, e.g. `session_config_captured`,
     /// mirroring the `managed_agent_runtime_lifecycle` frames.
     pub relay_url: String,
+    /// Publish successful channel ACP text through the authenticated HTTP bridge.
+    pub publish_response: bool,
+}
+
+fn should_publish_automatic_response(
+    enabled: bool,
+    source: &PromptSource,
+    outcome: &PromptOutcome,
+    response_text: &str,
+) -> bool {
+    enabled
+        && matches!(source, PromptSource::Channel(_))
+        && matches!(outcome, PromptOutcome::Ok(StopReason::EndTurn))
+        && !response_text.trim().is_empty()
+}
+
+fn build_automatic_response_event(
+    keys: &nostr::Keys,
+    batch: &FlushBatch,
+    response_anchor: Option<&BatchEvent>,
+    response_text: &str,
+) -> Result<nostr::Event, buzz_sdk::SdkError> {
+    // A positively acknowledged non-cancelling steer becomes the response
+    // target. Otherwise match `queue::format_prompt`: the last current event
+    // defines scope. Cancelled events are prior-turn context, and their relay
+    // timestamps must never redirect this response to an older thread.
+    let latest = response_anchor
+        .or_else(|| batch.events.last())
+        .ok_or_else(|| buzz_sdk::SdkError::InvalidInput("response batch has no events".into()))?;
+    let thread_tags = crate::queue::parse_thread_tags(&latest.event);
+    let root_event_id = thread_tags
+        .root_event_id
+        .as_deref()
+        .and_then(|id| nostr::EventId::from_hex(id).ok())
+        .unwrap_or(latest.event.id);
+    let thread_ref = buzz_sdk::ThreadRef {
+        root_event_id,
+        parent_event_id: latest.event.id,
+    };
+    let author = latest.event.pubkey.to_hex();
+    buzz_sdk::build_message(
+        batch.channel_id,
+        response_text,
+        Some(&thread_ref),
+        &[author.as_str()],
+        false,
+        &[],
+    )?
+    .sign_with_keys(keys)
+    .map_err(|error| buzz_sdk::SdkError::InvalidInput(format!("response sign failed: {error}")))
+}
+
+async fn maybe_publish_automatic_response(
+    ctx: &PromptContext,
+    source: &PromptSource,
+    outcome: &PromptOutcome,
+    batch: Option<&FlushBatch>,
+    response_anchor: Option<&BatchEvent>,
+    response_text: &str,
+) {
+    if !should_publish_automatic_response(ctx.publish_response, source, outcome, response_text) {
+        return;
+    }
+    let Some(batch) = batch else {
+        return;
+    };
+    let event = match build_automatic_response_event(
+        &ctx.agent_keys,
+        batch,
+        response_anchor,
+        response_text,
+    ) {
+        Ok(event) => event,
+        Err(error) => {
+            tracing::warn!(channel = %batch.channel_id, "automatic ACP response build failed: {error}");
+            return;
+        }
+    };
+    match tokio::time::timeout(Duration::from_secs(5), ctx.rest_client.submit_event(&event)).await {
+        Ok(Ok(_)) => tracing::info!(
+            channel = %batch.channel_id,
+            event_id = %event.id,
+            "published automatic ACP response"
+        ),
+        Ok(Err(error)) => tracing::warn!(
+            channel = %batch.channel_id,
+            "automatic ACP response publish failed: {error}"
+        ),
+        Err(_) => tracing::warn!(
+            channel = %batch.channel_id,
+            "automatic ACP response publish timed out"
+        ),
+    }
 }
 
 impl AgentPool {
@@ -2055,6 +2151,18 @@ pub async fn run_prompt_task(
                             &source,
                             &control_signal,
                         );
+                        let response_text = agent.acp.take_response_text();
+                        let response_anchor = agent.acp.take_response_anchor();
+                        let outcome = PromptOutcome::Ok(StopReason::EndTurn);
+                        maybe_publish_automatic_response(
+                            &ctx,
+                            &source,
+                            &outcome,
+                            batch.as_ref(),
+                            response_anchor.as_ref(),
+                            &response_text,
+                        )
+                        .await;
                         let usage = agent.acp.take_turn_usage();
                         publish_agent_turn_metric(
                             &ctx,
@@ -2070,7 +2178,7 @@ pub async fn run_prompt_task(
                             &turn_id,
                             agent,
                             source,
-                            PromptOutcome::Ok(StopReason::EndTurn),
+                            outcome,
                             None, // turn succeeded — batch was processed, no requeue
                         );
                         return;
@@ -2083,6 +2191,19 @@ pub async fn run_prompt_task(
     match prompt_result {
         Ok(stop_reason) => {
             log_stop_reason(&source, &stop_reason);
+
+            let response_text = agent.acp.take_response_text();
+            let response_anchor = agent.acp.take_response_anchor();
+            let outcome = PromptOutcome::Ok(stop_reason.clone());
+            maybe_publish_automatic_response(
+                &ctx,
+                &source,
+                &outcome,
+                batch.as_ref(),
+                response_anchor.as_ref(),
+                &response_text,
+            )
+            .await;
 
             let should_rotate = matches!(
                 stop_reason,
@@ -2128,14 +2249,7 @@ pub async fn run_prompt_task(
             )
             .await;
 
-            send_prompt_result(
-                &result_tx,
-                &turn_id,
-                agent,
-                source,
-                PromptOutcome::Ok(stop_reason),
-                None,
-            );
+            send_prompt_result(&result_tx, &turn_id, agent, source, outcome, None);
         }
         Err(AcpError::AgentExited) => {
             tracing::error!(target: "pool::prompt", "agent {} exited during prompt", agent.index);
@@ -6413,7 +6527,240 @@ mod tests {
             memory_enabled: false,
             harness_name: "goose".to_string(),
             relay_url: "ws://127.0.0.1:3000".to_string(),
+            publish_response: false,
         }
+    }
+
+    #[test]
+    fn automatic_response_event_replies_to_latest_trigger_and_mentions_author() {
+        use nostr::{EventBuilder, Kind, Tag};
+
+        let channel_id = Uuid::new_v4();
+        let author = nostr::Keys::generate();
+        let root = EventBuilder::new(Kind::Custom(9), "root")
+            .tags([Tag::parse(["h", &channel_id.to_string()]).expect("h tag")])
+            .sign_with_keys(&author)
+            .expect("root event");
+        let latest = EventBuilder::new(Kind::Custom(9), "latest")
+            .tags([
+                Tag::parse(["h", &channel_id.to_string()]).expect("h tag"),
+                Tag::parse(["e", &root.id.to_hex(), "", "reply"]).expect("reply tag"),
+            ])
+            .sign_with_keys(&author)
+            .expect("latest event");
+        let batch = FlushBatch {
+            channel_id,
+            events: vec![crate::queue::BatchEvent {
+                event: latest.clone(),
+                prompt_tag: "mentions".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let agent = nostr::Keys::generate();
+
+        let response = build_automatic_response_event(&agent, &batch, None, "done")
+            .expect("response event should build");
+        assert_eq!(response.pubkey, agent.public_key());
+        assert_eq!(response.content, "done");
+        let tags: Vec<Vec<String>> = response
+            .tags
+            .iter()
+            .map(|tag| tag.as_slice().to_vec())
+            .collect();
+        assert!(tags.contains(&vec!["h".into(), channel_id.to_string()]));
+        assert!(tags.contains(&vec![
+            "e".into(),
+            root.id.to_hex(),
+            "".into(),
+            "root".into()
+        ]));
+        assert!(tags.contains(&vec![
+            "e".into(),
+            latest.id.to_hex(),
+            "".into(),
+            "reply".into()
+        ]));
+        assert!(tags.contains(&vec!["p".into(), author.public_key().to_hex()]));
+    }
+
+    #[test]
+    fn automatic_response_ignores_newer_cancelled_event_when_selecting_reply_target() {
+        use nostr::{EventBuilder, Kind, Tag, Timestamp};
+
+        let channel_id = Uuid::new_v4();
+        let current_author = nostr::Keys::generate();
+        let cancelled_author = nostr::Keys::generate();
+        let current_root = EventBuilder::new(Kind::Custom(9), "current root")
+            .tags([Tag::parse(["h", &channel_id.to_string()]).expect("h tag")])
+            .custom_created_at(Timestamp::from(50))
+            .sign_with_keys(&current_author)
+            .expect("current root");
+        let current = EventBuilder::new(Kind::Custom(9), "current trigger")
+            .tags([
+                Tag::parse(["h", &channel_id.to_string()]).expect("h tag"),
+                Tag::parse(["e", &current_root.id.to_hex(), "", "reply"]).expect("reply tag"),
+            ])
+            .custom_created_at(Timestamp::from(100))
+            .sign_with_keys(&current_author)
+            .expect("current trigger");
+        let cancelled = EventBuilder::new(Kind::Custom(9), "prior cancelled trigger")
+            .tags([Tag::parse(["h", &channel_id.to_string()]).expect("h tag")])
+            .custom_created_at(Timestamp::from(200))
+            .sign_with_keys(&cancelled_author)
+            .expect("cancelled trigger");
+        let batch = FlushBatch {
+            channel_id,
+            events: vec![crate::queue::BatchEvent {
+                event: current.clone(),
+                prompt_tag: "mentions".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![crate::queue::BatchEvent {
+                event: cancelled.clone(),
+                prompt_tag: "cancelled".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancel_reason: Some(crate::queue::CancelReason::Steer),
+        };
+
+        let response =
+            build_automatic_response_event(&nostr::Keys::generate(), &batch, None, "done")
+                .expect("response event should build");
+        let tags: Vec<Vec<String>> = response
+            .tags
+            .iter()
+            .map(|tag| tag.as_slice().to_vec())
+            .collect();
+
+        assert!(tags.contains(&vec![
+            "e".into(),
+            current_root.id.to_hex(),
+            "".into(),
+            "root".into()
+        ]));
+        assert!(tags.contains(&vec![
+            "e".into(),
+            current.id.to_hex(),
+            "".into(),
+            "reply".into()
+        ]));
+        assert!(tags.contains(&vec!["p".into(), current_author.public_key().to_hex()]));
+        assert!(!tags
+            .iter()
+            .any(|tag| tag.get(1) == Some(&cancelled.id.to_hex())));
+        assert!(!tags
+            .iter()
+            .any(|tag| tag.get(1) == Some(&cancelled_author.public_key().to_hex())));
+    }
+
+    #[test]
+    fn automatic_response_prefers_successful_native_steer_anchor() {
+        use nostr::{EventBuilder, Kind, Tag};
+
+        let channel_id = Uuid::new_v4();
+        let original_author = nostr::Keys::generate();
+        let steered_author = nostr::Keys::generate();
+        let original = EventBuilder::new(Kind::Custom(9), "original")
+            .tags([Tag::parse(["h", &channel_id.to_string()]).expect("h tag")])
+            .sign_with_keys(&original_author)
+            .expect("original event");
+        let steered_root = EventBuilder::new(Kind::Custom(9), "steered root")
+            .tags([Tag::parse(["h", &channel_id.to_string()]).expect("h tag")])
+            .sign_with_keys(&steered_author)
+            .expect("steered root");
+        let steered = EventBuilder::new(Kind::Custom(9), "steered trigger")
+            .tags([
+                Tag::parse(["h", &channel_id.to_string()]).expect("h tag"),
+                Tag::parse(["e", &steered_root.id.to_hex(), "", "reply"]).expect("reply tag"),
+            ])
+            .sign_with_keys(&steered_author)
+            .expect("steered trigger");
+        let batch = FlushBatch {
+            channel_id,
+            events: vec![BatchEvent {
+                event: original.clone(),
+                prompt_tag: "mentions".into(),
+                received_at: std::time::Instant::now(),
+            }],
+            cancelled_events: vec![],
+            cancel_reason: None,
+        };
+        let anchor = BatchEvent {
+            event: steered.clone(),
+            prompt_tag: "mentions".into(),
+            received_at: std::time::Instant::now(),
+        };
+
+        let response =
+            build_automatic_response_event(&nostr::Keys::generate(), &batch, Some(&anchor), "done")
+                .expect("response event should build");
+        let tags: Vec<Vec<String>> = response
+            .tags
+            .iter()
+            .map(|tag| tag.as_slice().to_vec())
+            .collect();
+
+        assert!(tags.contains(&vec![
+            "e".into(),
+            steered_root.id.to_hex(),
+            "".into(),
+            "root".into()
+        ]));
+        assert!(tags.contains(&vec![
+            "e".into(),
+            steered.id.to_hex(),
+            "".into(),
+            "reply".into()
+        ]));
+        assert!(tags.contains(&vec!["p".into(), steered_author.public_key().to_hex()]));
+        assert!(!tags
+            .iter()
+            .any(|tag| tag.get(1) == Some(&original.id.to_hex())));
+        assert!(!tags
+            .iter()
+            .any(|tag| tag.get(1) == Some(&original_author.public_key().to_hex())));
+    }
+
+    #[test]
+    fn automatic_response_is_gated_to_enabled_successful_nonempty_channel_turns() {
+        assert!(should_publish_automatic_response(
+            true,
+            &PromptSource::Channel(Uuid::new_v4()),
+            &PromptOutcome::Ok(StopReason::EndTurn),
+            "answer",
+        ));
+        assert!(!should_publish_automatic_response(
+            false,
+            &PromptSource::Channel(Uuid::new_v4()),
+            &PromptOutcome::Ok(StopReason::EndTurn),
+            "answer",
+        ));
+        assert!(!should_publish_automatic_response(
+            true,
+            &PromptSource::Heartbeat,
+            &PromptOutcome::Ok(StopReason::EndTurn),
+            "answer",
+        ));
+        assert!(!should_publish_automatic_response(
+            true,
+            &PromptSource::Channel(Uuid::new_v4()),
+            &PromptOutcome::Cancelled,
+            "answer",
+        ));
+        assert!(!should_publish_automatic_response(
+            true,
+            &PromptSource::Channel(Uuid::new_v4()),
+            &PromptOutcome::Ok(StopReason::MaxTokens),
+            "answer",
+        ));
+        assert!(!should_publish_automatic_response(
+            true,
+            &PromptSource::Channel(Uuid::new_v4()),
+            &PromptOutcome::Ok(StopReason::EndTurn),
+            "  \n",
+        ));
     }
 
     // ── render_canvas_section ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add opt-in `buzz-acp` publication of successful ACP text responses via `--publish-response` / `BUZZ_ACP_PUBLISH_RESPONSE`
- publish through the harness's existing authenticated `POST /events` client instead of exposing Buzz credentials to agent terminal subprocesses
- preserve the actual response target across normal, cancel/merge, and successful native-steer paths; retain its thread root/parent and p-tag its author while suppressing publication for disabled mode, empty output, errors, cancellations, and heartbeats
- adjust the enabled-mode delivery instruction so ordinary replies are returned as ACP text while Buzz CLI guidance remains available for other operations

## Why

Some ACP agents can generate a successful `agent_message_chunk` response but cannot safely invoke `buzz messages send` because the agent tool sandbox does not receive the harness's Buzz credentials. The result is a completed model turn with no visible Buzz reply.

This change keeps credentials in `buzz-acp` and makes harness publication explicitly opt-in to avoid duplicate posts for agents that already publish through the Buzz CLI.

## Testing

- `just ci`
- `cargo test -p buzz-acp` — 681 tests passed (672 unit, 9 integration)
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `cargo build -p buzz-acp --release`
- live private-channel smoke test: a Hermes ACP agent received `reply exactly: BUZZ_ACP_PUBLISHED`, completed with an 18-character text response, `buzz-acp` logged `published automatic ACP response` with an accepted event ID, and Buzz rendered the exact threaded reply under the agent identity

## Security and delivery behavior

- default remains off
- no Buzz credentials are passed into the ACP agent's terminal sandbox
- signed message submission uses the existing authenticated generic Nostr `POST /events` path
- accumulated response is capped at 64 KiB
- only successful non-empty channel turns publish

## Related work

No duplicate open issue or pull request found.
