### PR TITLE
fix(acp): preserve Buzz routing for Hermes tools

### DIFF
--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -213,6 +213,44 @@ pub struct AcpClient {
     goose_usage: UsageTracker,
 }
 
+/// Build the Buzz routing environment aliases understood by Hermes' sandbox.
+///
+/// Hermes intentionally strips messaging credentials from model-authored shell
+/// commands. Its `_HERMES_FORCE_` host bridge restores an explicitly supplied
+/// variable after that scrub. Without these aliases, a wrapper or other local
+/// fallback can supply stale global Buzz credentials and publish a turn on a
+/// different relay from the one that delivered it.
+pub(crate) fn forced_buzz_env_for_hermes(
+    command: &str,
+    relay_url: &str,
+    private_key: &str,
+    mut get_env: impl FnMut(&str) -> Option<String>,
+) -> Vec<(String, String)> {
+    if !matches!(
+        crate::config::normalize_agent_command_identity(command).as_str(),
+        "hermes" | "hermes-agent" | "hermes-acp"
+    ) {
+        return Vec::new();
+    }
+
+    let mut env = vec![
+        (
+            "_HERMES_FORCE_BUZZ_RELAY_URL".to_string(),
+            relay_url.to_string(),
+        ),
+        (
+            "_HERMES_FORCE_BUZZ_PRIVATE_KEY".to_string(),
+            private_key.to_string(),
+        ),
+    ];
+    env.extend(["BUZZ_AUTH_TAG"].into_iter().filter_map(|name| {
+        get_env(name)
+            .filter(|value| !value.is_empty())
+            .map(|value| (format!("_HERMES_FORCE_{name}"), value))
+    }));
+    env
+}
+
 /// Recursively merge `overlay` into `base`, with `overlay` winning on scalar/shape
 /// collisions.  When both sides have an object for the same key, the merge recurses so
 /// unrelated nested keys from `base` are preserved.
@@ -452,6 +490,7 @@ impl AcpClient {
         command: &str,
         args: &[String],
         extra_env: &[(String, String)],
+        forced_env: &[(String, String)],
         has_generated_codex_config: bool,
     ) -> Result<Self, AcpError> {
         use std::process::Stdio;
@@ -511,6 +550,13 @@ impl AcpClient {
         }
         if let Some(merged) = codex_config_value {
             cmd.env("CODEX_CONFIG", merged);
+        }
+
+        // Harness-owned routing aliases must beat both inherited and persona env.
+        // Keep this separate from `extra_env` so persona values cannot opt into
+        // forced precedence by choosing the same `_HERMES_FORCE_BUZZ_` prefix.
+        for (key, value) in forced_env {
+            cmd.env(key, value);
         }
 
         // Spawn the agent in its own process group so SIGKILL doesn't propagate
@@ -2880,7 +2926,7 @@ mod tests {
     }
 
     async fn spawn_script(script: &str) -> AcpClient {
-        AcpClient::spawn("bash", &["-c".into(), script.into()], &[], false)
+        AcpClient::spawn("bash", &["-c".into(), script.into()], &[], &[], false)
             .await
             .expect("failed to spawn test script")
     }
@@ -2893,6 +2939,7 @@ mod tests {
         file_name: &str,
         var: &str,
         extra_env: &[(String, String)],
+        forced_env: &[(String, String)],
     ) -> String {
         use std::os::unix::fs::PermissionsExt;
 
@@ -2912,6 +2959,7 @@ mod tests {
             path.to_str().expect("probe path is UTF-8"),
             &[],
             extra_env,
+            forced_env,
             false,
         )
         .await
@@ -2941,19 +2989,77 @@ mod tests {
         }
 
         assert_eq!(
-            spawn_named_and_read_child_env("hermes-acp", VAR, &[]).await,
+            spawn_named_and_read_child_env("hermes-acp", VAR, &[], &[]).await,
             "1",
             "Hermes spawns must default {VAR}=1"
         );
         assert_eq!(
-            spawn_named_and_read_child_env("hermes-acp", VAR, &[(VAR.into(), "0".into())]).await,
+            spawn_named_and_read_child_env("hermes-acp", VAR, &[(VAR.into(), "0".into())], &[],)
+                .await,
             "0",
             "an explicit extra_env entry must override the runtime default"
         );
         assert_eq!(
-            spawn_named_and_read_child_env("other-agent", VAR, &[]).await,
+            spawn_named_and_read_child_env("other-agent", VAR, &[], &[]).await,
             "<unset>",
             "non-Hermes spawns must not receive Hermes defaults"
+        );
+    }
+
+    #[test]
+    fn hermes_spawn_forwards_buzz_routing_env_through_hermes_sandbox_aliases() {
+        let values = std::collections::HashMap::from([
+            ("BUZZ_RELAY_URL", "wss://community-a.example"),
+            ("BUZZ_PRIVATE_KEY", "nsec1test"),
+            ("BUZZ_AUTH_TAG", "test-auth-tag"),
+            ("BUZZ_API_TOKEN", "must-not-be-forwarded"),
+        ]);
+
+        let env = forced_buzz_env_for_hermes(
+            "/opt/bin/hermes-acp",
+            "wss://community-a.example",
+            "nsec1test",
+            |name| values.get(name).map(|value| (*value).to_string()),
+        );
+
+        assert_eq!(
+            env,
+            vec![
+                (
+                    "_HERMES_FORCE_BUZZ_RELAY_URL".to_string(),
+                    "wss://community-a.example".to_string(),
+                ),
+                (
+                    "_HERMES_FORCE_BUZZ_PRIVATE_KEY".to_string(),
+                    "nsec1test".to_string(),
+                ),
+                (
+                    "_HERMES_FORCE_BUZZ_AUTH_TAG".to_string(),
+                    "test-auth-tag".to_string(),
+                ),
+            ]
+        );
+        assert!(
+            forced_buzz_env_for_hermes("goose", "wss://unused", "unused", |_| {
+                Some("value".to_string())
+            })
+            .is_empty()
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn forced_spawn_env_beats_persona_value_structurally() {
+        const VAR: &str = "_HERMES_FORCE_BUZZ_RELAY_URL";
+        assert_eq!(
+            spawn_named_and_read_child_env(
+                "hermes-acp",
+                VAR,
+                &[(VAR.into(), "wss://persona.example".into())],
+                &[(VAR.into(), "wss://resolved.example".into())],
+            )
+            .await,
+            "wss://resolved.example"
         );
     }
 
@@ -3549,7 +3655,7 @@ mod tests {
     /// which is fine — these tests don't read from the agent, they just
     /// feed JSON into the parser.
     async fn spawn_inert_client() -> AcpClient {
-        AcpClient::spawn("cat", &[], &[], false)
+        AcpClient::spawn("cat", &[], &[], &[], false)
             .await
             .expect("spawn cat as inert client")
     }

--- a/crates/buzz-acp/src/acp.rs
+++ b/crates/buzz-acp/src/acp.rs
@@ -217,9 +217,8 @@ pub struct AcpClient {
 ///
 /// Hermes intentionally strips messaging credentials from model-authored shell
 /// commands. Its `_HERMES_FORCE_` host bridge restores an explicitly supplied
-/// variable after that scrub. Without these aliases, a wrapper or other local
-/// fallback can supply stale global Buzz credentials and publish a turn on a
-/// different relay from the one that delivered it.
+/// variable after that scrub, keeping terminal tools on the relay and identity
+/// resolved by the harness that received the turn.
 pub(crate) fn forced_buzz_env_for_hermes(
     command: &str,
     relay_url: &str,

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -4048,6 +4048,7 @@ async fn spawn_and_init(
 
 async fn spawn_auth_client(agent: &AuthAgentArgs) -> Result<AcpClient, acp::AcpError> {
     let agent_args = config::normalize_agent_args(&agent.agent_command, agent.agent_args.clone());
+    // Auth discovery never publishes Buzz events, so it needs no forced routing env.
     AcpClient::spawn(&agent.agent_command, &agent_args, &[], &[], false).await
 }
 
@@ -4176,7 +4177,8 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
         .to_string();
 
     // Spawn outside the timeout so we always own the child for cleanup.
-    // `models` subcommand doesn't use persona packs — no extra env, no codex config.
+    // `models` does not publish Buzz events, so it needs no forced routing env;
+    // it also uses no persona packs or generated Codex config.
     let mut client =
         match AcpClient::spawn(&args.agent.agent_command, &agent_args, &[], &[], false).await {
             Ok(c) => c,
@@ -5185,14 +5187,10 @@ mod build_mcp_servers_tests {
     }
 
     #[test]
-    fn hermes_spawn_env_uses_resolved_config_after_persona_overrides() {
+    fn hermes_spawn_env_uses_resolved_config_values() {
         let mut config = test_config();
         config.agent_command = "/opt/bin/hermes-acp".into();
         config.relay_url = "wss://source-community.example".into();
-        config.persona_env_vars.push((
-            "_HERMES_FORCE_BUZZ_RELAY_URL".into(),
-            "wss://stale-global.example".into(),
-        ));
         let expected_private_key = config.keys.secret_key().to_secret_hex();
 
         let env = forced_agent_spawn_env(&config);

--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -1827,11 +1827,14 @@ async fn tokio_main() -> Result<()> {
                 let cmd = config.agent_command.clone();
                 let args = config.agent_args.clone();
                 let env = config.persona_env_vars.clone();
+                let forced_env = forced_agent_spawn_env(&config);
                 let has_codex = config.has_generated_codex_config;
                 let observer = observer.clone();
                 let guard = RespawnGuard::new(idx, respawn_tx.clone());
                 respawn_tasks.spawn(async move {
-                    let result = spawn_and_init(&cmd, &args, &env, has_codex, idx, observer).await;
+                    let result =
+                        spawn_and_init(&cmd, &args, &env, &forced_env, has_codex, idx, observer)
+                            .await;
                     guard.send(result);
                 });
             }
@@ -3608,13 +3611,14 @@ fn recover_panicked_agent(
     let cmd = config.agent_command.clone();
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
+    let forced_env = forced_agent_spawn_env(config);
     let has_codex = config.has_generated_codex_config;
     let guard = RespawnGuard::new(i, respawn_tx.clone());
     respawn_tasks.spawn(async move {
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, i, observer).await;
+        let result = spawn_and_init(&cmd, &args, &env, &forced_env, has_codex, i, observer).await;
         guard.send(result);
     });
 }
@@ -3802,6 +3806,7 @@ fn spawn_respawn_task(
     let cmd = config.agent_command.clone();
     let args = config.agent_args.clone();
     let env = config.persona_env_vars.clone();
+    let forced_env = forced_agent_spawn_env(config);
     let has_codex = config.has_generated_codex_config;
     let guard = RespawnGuard::new(index, respawn_tx.clone());
     respawn_tasks.spawn(async move {
@@ -3814,7 +3819,8 @@ fn spawn_respawn_task(
             tokio::time::sleep(delay).await;
         }
 
-        let result = spawn_and_init(&cmd, &args, &env, has_codex, index, observer).await;
+        let result =
+            spawn_and_init(&cmd, &args, &env, &forced_env, has_codex, index, observer).await;
         guard.send(result);
     });
 
@@ -3857,9 +3863,19 @@ struct PoolStartup {
     command: String,
     args: Vec<String>,
     extra_env: Vec<(String, String)>,
+    forced_env: Vec<(String, String)>,
     has_generated_codex_config: bool,
     model: Option<String>,
     observer: Option<observer::ObserverHandle>,
+}
+
+fn forced_agent_spawn_env(config: &Config) -> Vec<(String, String)> {
+    acp::forced_buzz_env_for_hermes(
+        &config.agent_command,
+        &config.relay_url,
+        &config.keys.secret_key().to_secret_hex(),
+        |name| std::env::var(name).ok(),
+    )
 }
 
 impl PoolStartup {
@@ -3869,6 +3885,7 @@ impl PoolStartup {
             command: config.agent_command.clone(),
             args: config.agent_args.clone(),
             extra_env: config.persona_env_vars.clone(),
+            forced_env: forced_agent_spawn_env(config),
             has_generated_codex_config: config.has_generated_codex_config,
             model: config.model.clone(),
             observer,
@@ -3888,6 +3905,7 @@ async fn initialize_agent_pool(
             &startup.command,
             &startup.args,
             &startup.extra_env,
+            &startup.forced_env,
             startup.has_generated_codex_config,
         )
         .await;
@@ -3988,13 +4006,20 @@ async fn spawn_and_init(
     command: &str,
     args: &[String],
     extra_env: &[(String, String)],
+    forced_env: &[(String, String)],
     has_generated_codex_config: bool,
     agent_index: usize,
     observer: Option<observer::ObserverHandle>,
 ) -> Result<(AcpClient, u32, String)> {
-    let mut acp = AcpClient::spawn(command, args, extra_env, has_generated_codex_config)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
+    let mut acp = AcpClient::spawn(
+        command,
+        args,
+        extra_env,
+        forced_env,
+        has_generated_codex_config,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("failed to spawn agent: {e}"))?;
     acp.set_observer(observer, agent_index);
 
     match acp.initialize().await {
@@ -4023,7 +4048,7 @@ async fn spawn_and_init(
 
 async fn spawn_auth_client(agent: &AuthAgentArgs) -> Result<AcpClient, acp::AcpError> {
     let agent_args = config::normalize_agent_args(&agent.agent_command, agent.agent_args.clone());
-    AcpClient::spawn(&agent.agent_command, &agent_args, &[], false).await
+    AcpClient::spawn(&agent.agent_command, &agent_args, &[], &[], false).await
 }
 
 fn extract_auth_methods(init_result: &serde_json::Value) -> Vec<serde_json::Value> {
@@ -4153,7 +4178,7 @@ async fn run_models(args: ModelsArgs) -> Result<()> {
     // Spawn outside the timeout so we always own the child for cleanup.
     // `models` subcommand doesn't use persona packs — no extra env, no codex config.
     let mut client =
-        match AcpClient::spawn(&args.agent.agent_command, &agent_args, &[], false).await {
+        match AcpClient::spawn(&args.agent.agent_command, &agent_args, &[], &[], false).await {
             Ok(c) => c,
             Err(e) => {
                 eprintln!("error: failed to spawn agent: {e}");
@@ -5160,6 +5185,33 @@ mod build_mcp_servers_tests {
     }
 
     #[test]
+    fn hermes_spawn_env_uses_resolved_config_after_persona_overrides() {
+        let mut config = test_config();
+        config.agent_command = "/opt/bin/hermes-acp".into();
+        config.relay_url = "wss://source-community.example".into();
+        config.persona_env_vars.push((
+            "_HERMES_FORCE_BUZZ_RELAY_URL".into(),
+            "wss://stale-global.example".into(),
+        ));
+        let expected_private_key = config.keys.secret_key().to_secret_hex();
+
+        let env = forced_agent_spawn_env(&config);
+
+        assert_eq!(
+            env.iter()
+                .find(|(name, _)| name == "_HERMES_FORCE_BUZZ_RELAY_URL")
+                .map(|(_, value)| value.as_str()),
+            Some("wss://source-community.example")
+        );
+        assert_eq!(
+            env.iter()
+                .find(|(name, _)| name == "_HERMES_FORCE_BUZZ_PRIVATE_KEY")
+                .map(|(_, value)| value.as_str()),
+            Some(expected_private_key.as_str())
+        );
+    }
+
+    #[test]
     fn session_new_mcp_server_forwards_buzz_auth_tag() {
         let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("BUZZ_AUTH_TAG", "test-attestation-tag");
@@ -5384,7 +5436,7 @@ mod error_outcome_emission_tests {
     async fn dummy_agent(index: usize) -> OwnedAgent {
         OwnedAgent {
             index,
-            acp: AcpClient::spawn("cat", &[], &[], false)
+            acp: AcpClient::spawn("cat", &[], &[], &[], false)
                 .await
                 .expect("spawn cat as inert agent"),
             state: Default::default(),

--- a/crates/buzz-acp/src/pool.rs
+++ b/crates/buzz-acp/src/pool.rs
@@ -5919,6 +5919,7 @@ mod tests {
             "bash",
             &["-c".to_string(), "sleep 10".to_string()],
             &[],
+            &[],
             false,
         )
         .await
@@ -5976,6 +5977,7 @@ mod tests {
         let acp = AcpClient::spawn(
             "bash",
             &["-c".to_string(), "sleep 10".to_string()],
+            &[],
             &[],
             false,
         )


### PR DESCRIPTION
## Summary
- forward the resolved Buzz relay, signing key, and auth tag into Hermes terminal subprocesses through Hermes' forced-environment bridge
- keep routing values in a separate harness-owned precedence layer so persona env cannot override them
- exclude `BUZZ_API_TOKEN`, preserve non-Hermes isolation, and cover respawn paths

## Verification
- correct-shape Hermes 0.19.1 terminal probe restored `_HERMES_FORCE_BUZZ_RELAY_URL` as `BUZZ_RELAY_URL`
- `cargo fmt --all -- --check`
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `env -u BUZZ_ACP_LAZY_POOL cargo test -p buzz-acp` (671 unit + 9 integration)

Buzz channel: `09c9e1c1-3e39-4463-bea4-a6f4b8070f54`