### PR TITLE
fix(mobile): hide archived identities from discovery

### DIFF
--- a/mobile/lib/features/channels/channel_management_provider.dart
+++ b/mobile/lib/features/channels/channel_management_provider.dart
@@ -231,6 +231,41 @@ List<DirectoryUser> directoryUsersFromProfileEvents(List<NostrEvent> events) {
   });
 }
 
+/// Excludes relay-archived identities from forward-looking discovery.
+///
+/// The current identity remains visible by construction, matching NIP-IA's
+/// anti-shadowban self-exemption even if a caller has not removed it yet.
+bool isIdentityVisibleForDiscovery(
+  String pubkey, {
+  required Set<String> archivedPubkeys,
+  String? currentPubkey,
+}) {
+  final normalized = pubkey.toLowerCase();
+  return normalized == currentPubkey?.toLowerCase() ||
+      !archivedPubkeys.contains(normalized);
+}
+
+@visibleForTesting
+List<DirectoryUser> filterArchivedDirectoryUsers(
+  Iterable<DirectoryUser> users, {
+  required Set<String> archivedPubkeys,
+  String? currentPubkey,
+}) {
+  final archived = archivedPubkeys
+      .map((pubkey) => pubkey.toLowerCase())
+      .toSet();
+  final self = currentPubkey?.toLowerCase();
+  return [
+    for (final user in users)
+      if (isIdentityVisibleForDiscovery(
+        user.pubkey,
+        archivedPubkeys: archived,
+        currentPubkey: self,
+      ))
+        user,
+  ];
+}
+
 /// People and agents discoverable on the active relay.
 ///
 /// This mirrors desktop's empty-query people directory by listing kind:0
@@ -252,14 +287,19 @@ final relayDirectoryUsersProvider =
       ref.watch(relayConfigProvider);
       final session = ref.watch(relaySessionProvider.notifier);
       final currentPubkey = ref.watch(currentPubkeyProvider)?.toLowerCase();
+      final archivedPubkeys = await ref.watch(
+        relayArchivedIdentityPubkeysProvider.future,
+      );
       final directoryEvents = await session.queryRelay([
         const NostrFilter(kinds: [0], limit: 50, extensions: {'page': 1}),
       ]);
       var users = directoryUsersFromProfileEvents(directoryEvents);
       if (users.isNotEmpty) {
-        return users
-            .where((user) => user.pubkey.toLowerCase() != currentPubkey)
-            .toList();
+        return filterArchivedDirectoryUsers(
+          users.where((user) => user.pubkey.toLowerCase() != currentPubkey),
+          archivedPubkeys: archivedPubkeys,
+          currentPubkey: currentPubkey,
+        );
       }
 
       final membershipEvents = await session.fetchHistory(
@@ -299,7 +339,11 @@ final relayDirectoryUsersProvider =
                 ? labelComparison
                 : a.pubkey.compareTo(b.pubkey);
           });
-      return users;
+      return filterArchivedDirectoryUsers(
+        users,
+        archivedPubkeys: archivedPubkeys,
+        currentPubkey: currentPubkey,
+      );
     });
 
 /// Prefix-searches the active relay's kind:0 people directory.
@@ -329,12 +373,19 @@ final relayDirectorySearchProvider = FutureProvider.autoDispose
       ref.watch(relayConfigProvider);
       final session = ref.watch(relaySessionProvider.notifier);
       final currentPubkey = ref.watch(currentPubkeyProvider)?.toLowerCase();
+      final archivedPubkeys = await ref.watch(
+        relayArchivedIdentityPubkeysProvider.future,
+      );
       final events = await session.queryRelay([
         NostrFilters.searchUsers(trimmed, limit: 50),
       ]);
-      return directoryUsersFromProfileEvents(
-        events,
-      ).where((user) => user.pubkey.toLowerCase() != currentPubkey).toList();
+      return filterArchivedDirectoryUsers(
+        directoryUsersFromProfileEvents(
+          events,
+        ).where((user) => user.pubkey.toLowerCase() != currentPubkey),
+        archivedPubkeys: archivedPubkeys,
+        currentPubkey: currentPubkey,
+      );
     });
 
 /// Build [ChannelDetails] from a kind:39000 metadata event.
@@ -603,16 +654,21 @@ class ChannelActions {
     final trimmed = query.trim();
     if (trimmed.isEmpty) return const [];
 
+    final archivedPubkeys = await _ref.read(
+      relayArchivedIdentityPubkeysProvider.future,
+    );
     final events = await _session.queryRelay([
       NostrFilters.searchUsers(trimmed, limit: limit),
     ]);
-    return directoryUsersFromProfileEvents(events)
-        .where(
-          (user) =>
-              _currentPubkey == null ||
-              user.pubkey.toLowerCase() != _currentPubkey,
-        )
-        .toList();
+    return filterArchivedDirectoryUsers(
+      directoryUsersFromProfileEvents(events).where(
+        (user) =>
+            _currentPubkey == null ||
+            user.pubkey.toLowerCase() != _currentPubkey,
+      ),
+      archivedPubkeys: archivedPubkeys,
+      currentPubkey: _currentPubkey,
+    );
   }
 
   Future<Channel> _refreshChannelsAndRead(String channelId) async {

--- a/mobile/lib/features/channels/members_sheet.dart
+++ b/mobile/lib/features/channels/members_sheet.dart
@@ -4,6 +4,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../../shared/theme/theme.dart';
+import '../../shared/relay/relay.dart';
 import '../../shared/widgets/avatar_image.dart';
 import '../../shared/widgets/buzz_loading_indicator.dart';
 import '../profile/user_cache_provider.dart';
@@ -29,8 +30,20 @@ class MembersSheet extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final membersAsync = ref.watch(channelMembersProvider(channel.id));
     final allMembers = membersAsync.asData?.value ?? const <ChannelMember>[];
-    final people = allMembers.where((member) => !member.isBot).toList();
-    final bots = allMembers.where((member) => member.isBot).toList();
+    final archivedPubkeys =
+        ref.watch(relayArchivedIdentityPubkeysProvider).asData?.value ??
+        const <String>{};
+    final visibleMembers = allMembers
+        .where(
+          (member) => isIdentityVisibleForDiscovery(
+            member.pubkey,
+            archivedPubkeys: archivedPubkeys,
+            currentPubkey: currentPubkey,
+          ),
+        )
+        .toList();
+    final people = visibleMembers.where((member) => !member.isBot).toList();
+    final bots = visibleMembers.where((member) => member.isBot).toList();
     final userCache = ref.watch(userCacheProvider);
     final typingBotPubkeys = ref.watch(workingBotPubkeysProvider(channel.id));
     final statusCache = ref.watch(userStatusCacheProvider);
@@ -64,12 +77,12 @@ class MembersSheet extends HookConsumerWidget {
 
     // Preload profiles for all members so avatars appear.
     useEffect(() {
-      if (allMembers.isNotEmpty) {
+      if (visibleMembers.isNotEmpty) {
         ref
             .read(userCacheProvider.notifier)
-            .preload(allMembers.map((m) => m.pubkey).toList());
+            .preload(visibleMembers.map((m) => m.pubkey).toList());
         // Track user statuses for people (not bots).
-        final peoplePubkeys = allMembers
+        final peoplePubkeys = visibleMembers
             .where((m) => !m.isBot)
             .map((m) => m.pubkey)
             .toList();
@@ -78,7 +91,7 @@ class MembersSheet extends HookConsumerWidget {
         }
       }
       return null;
-    }, [allMembers.length]);
+    }, [visibleMembers.length]);
 
     return Padding(
       padding: EdgeInsets.fromLTRB(

--- a/mobile/lib/features/channels/mentions/mention_candidates.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates.dart
@@ -51,6 +51,7 @@ List<MentionCandidate> buildMentionCandidates({
   required Map<String, UserProfile> userCache,
   required Map<String, String> ownerByAgentPubkey,
   List<UserProfile> searchResults = const [],
+  Set<String> archivedPubkeys = const {},
   String? currentPubkey,
 }) {
   final candidates = <MentionCandidate>[];
@@ -58,6 +59,13 @@ List<MentionCandidate> buildMentionCandidates({
 
   for (final member in members) {
     final pk = member.pubkey.toLowerCase();
+    if (!isIdentityVisibleForDiscovery(
+      pk,
+      archivedPubkeys: archivedPubkeys,
+      currentPubkey: currentPubkey,
+    )) {
+      continue;
+    }
     if (!seen.add(pk)) continue;
     final profile = userCache[pk];
     final ownerPubkey = ownerByAgentPubkey[pk] ?? profile?.ownerPubkey;
@@ -89,6 +97,13 @@ List<MentionCandidate> buildMentionCandidates({
 
   for (final agent in relayAgents) {
     final pk = agent.pubkey;
+    if (!isIdentityVisibleForDiscovery(
+      pk,
+      archivedPubkeys: archivedPubkeys,
+      currentPubkey: currentPubkey,
+    )) {
+      continue;
+    }
     if (seen.contains(pk)) continue;
     if (!sharedAgentPubkeys.contains(pk)) continue;
     seen.add(pk);
@@ -111,6 +126,13 @@ List<MentionCandidate> buildMentionCandidates({
   final currentLower = currentPubkey?.toLowerCase();
   for (final profile in searchResults) {
     final pk = profile.pubkey.toLowerCase();
+    if (!isIdentityVisibleForDiscovery(
+      pk,
+      archivedPubkeys: archivedPubkeys,
+      currentPubkey: currentPubkey,
+    )) {
+      continue;
+    }
     if (seen.contains(pk)) continue;
     final ownerPubkey = ownerByAgentPubkey[pk] ?? profile.ownerPubkey;
     final isAgent = ownerPubkey != null || directoryPubkeys.contains(pk);

--- a/mobile/lib/features/channels/mentions/mention_candidates_provider.dart
+++ b/mobile/lib/features/channels/mentions/mention_candidates_provider.dart
@@ -31,9 +31,14 @@ final mentionUserSearchProvider = FutureProvider.autoDispose
       if (disposed) return const [];
 
       final session = ref.read(relaySessionProvider.notifier);
+      final currentPubkey = ref.watch(currentPubkeyProvider)?.toLowerCase();
+      final archivedPubkeysFuture = ref.watch(
+        relayArchivedIdentityPubkeysProvider.future,
+      );
       final events = await session.queryRelay([
         NostrFilters.searchUsers(trimmed),
       ]);
+      final archivedPubkeys = await archivedPubkeysFuture;
 
       // Keep only the latest kind:0 event per pubkey (the bridge does not
       // honor the `kinds` filter under search, and may return several
@@ -49,7 +54,10 @@ final mentionUserSearchProvider = FutureProvider.autoDispose
       }
 
       return [
-        for (final event in latestByPubkey.values) _profileFromEvent(event),
+        for (final event in latestByPubkey.values)
+          if (event.pubkey.toLowerCase() == currentPubkey ||
+              !archivedPubkeys.contains(event.pubkey.toLowerCase()))
+            _profileFromEvent(event),
       ];
     });
 
@@ -84,6 +92,9 @@ final mentionCandidatesProvider = Provider.family
           ref.watch(channelsProvider).asData?.value ?? const <Channel>[];
       final userCache = ref.watch(userCacheProvider);
       final currentPubkey = ref.watch(currentPubkeyProvider);
+      final archivedPubkeys =
+          ref.watch(relayArchivedIdentityPubkeysProvider).asData?.value ??
+          const <String>{};
       final searchResults =
           ref.watch(mentionUserSearchProvider(args.query)).asData?.value ??
           const <UserProfile>[];
@@ -100,6 +111,7 @@ final mentionCandidatesProvider = Provider.family
         userCache: userCache,
         ownerByAgentPubkey: owners,
         searchResults: searchResults,
+        archivedPubkeys: archivedPubkeys,
         currentPubkey: currentPubkey,
       );
 

--- a/mobile/lib/shared/relay/identity_archive_provider.dart
+++ b/mobile/lib/shared/relay/identity_archive_provider.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:nostr/nostr.dart' as nostr;
+
+import 'nostr_models.dart';
+import 'relay_provider.dart';
+import 'relay_session.dart';
+
+const _archivedIdentitiesKind = 13535;
+final _hexPubkeyPattern = RegExp(r'^[0-9a-f]{64}$');
+
+/// HTTP client used to read the active relay's NIP-11 information document.
+///
+/// Exposed as a provider so tests can supply deterministic relay metadata.
+final identityArchiveHttpClientProvider = Provider<http.Client>((ref) {
+  final client = http.Client();
+  ref.onDispose(client.close);
+  return client;
+});
+
+/// Returns the relay identity advertised by a NIP-11 document.
+///
+/// NIP-IA snapshots are authoritative only when signed by this exact key.
+String? relaySelfPubkeyFromDocument(String body) {
+  try {
+    final document = jsonDecode(body);
+    if (document is! Map<String, dynamic>) return null;
+    final relaySelf = document['self'];
+    if (relaySelf is! String) return null;
+    final normalized = relaySelf.trim().toLowerCase();
+    return _hexPubkeyPattern.hasMatch(normalized) ? normalized : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Parses a trusted NIP-IA archived-identities snapshot.
+///
+/// Returns `null` when the event is not a structurally and cryptographically
+/// valid kind:13535 snapshot signed by [relaySelfPubkey]. Invalid snapshots
+/// must fail open at the UI boundary rather than hiding active identities.
+Set<String>? archivedIdentityPubkeysFromSnapshot({
+  required NostrEvent event,
+  required String relaySelfPubkey,
+}) {
+  final normalizedRelaySelf = relaySelfPubkey.trim().toLowerCase();
+  if (!_hexPubkeyPattern.hasMatch(normalizedRelaySelf) ||
+      event.kind != _archivedIdentitiesKind ||
+      event.pubkey.toLowerCase() != normalizedRelaySelf) {
+    return null;
+  }
+
+  final nip70Tags = event.tags.where((tag) => tag.isNotEmpty && tag[0] == '-');
+  if (nip70Tags.length != 1 || nip70Tags.single.length != 1) {
+    return null;
+  }
+
+  try {
+    final verified = nostr.Event.fromJson(jsonEncode(event.toJson()));
+    if (verified.id != event.id ||
+        verified.pubkey.toLowerCase() != normalizedRelaySelf) {
+      return null;
+    }
+  } catch (_) {
+    return null;
+  }
+
+  return {
+    for (final tag in event.tags)
+      if (tag.length >= 2 &&
+          tag[0] == 'p' &&
+          _hexPubkeyPattern.hasMatch(tag[1].toLowerCase()))
+        tag[1].toLowerCase(),
+  };
+}
+
+/// Relay-scoped archived identity set used by forward-looking discovery UI.
+///
+/// The provider deliberately fails open on NIP-11, relay, or verification
+/// errors. Historical events remain untouched; consumers only exclude these
+/// pubkeys from people and agent pickers.
+final relayArchivedIdentityPubkeysProvider =
+    FutureProvider.autoDispose<Set<String>>((ref) async {
+      final config = ref.watch(relayConfigProvider);
+      final client = ref.watch(identityArchiveHttpClientProvider);
+      final session = ref.watch(relaySessionProvider.notifier);
+
+      try {
+        final response = await client
+            .get(
+              Uri.parse(config.baseUrl),
+              headers: const {'Accept': 'application/nostr+json'},
+            )
+            .timeout(const Duration(seconds: 5));
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          return const {};
+        }
+
+        final relaySelf = relaySelfPubkeyFromDocument(response.body);
+        if (relaySelf == null) return const {};
+
+        final events = await session.queryRelay([
+          NostrFilter(
+            kinds: const [_archivedIdentitiesKind],
+            authors: [relaySelf],
+            limit: 5,
+          ),
+        ]);
+        events.sort((left, right) {
+          final timeOrder = right.createdAt.compareTo(left.createdAt);
+          return timeOrder != 0 ? timeOrder : left.id.compareTo(right.id);
+        });
+
+        for (final event in events) {
+          final archived = archivedIdentityPubkeysFromSnapshot(
+            event: event,
+            relaySelfPubkey: relaySelf,
+          );
+          if (archived != null) return archived;
+        }
+      } catch (_) {
+        // Archive state is a discovery hint, not an access-control boundary.
+        // A failed trust check must not turn into a client-side shadowban.
+      }
+
+      return const {};
+    });

--- a/mobile/lib/shared/relay/relay.dart
+++ b/mobile/lib/shared/relay/relay.dart
@@ -1,4 +1,5 @@
 export 'app_lifecycle_provider.dart';
+export 'identity_archive_provider.dart';
 export 'identity_scoped_prefs.dart';
 export 'media_auth.dart';
 export 'media_image.dart';

--- a/mobile/test/features/channels/channel_management_provider_test.dart
+++ b/mobile/test/features/channels/channel_management_provider_test.dart
@@ -11,6 +11,41 @@ import 'package:buzz/shared/relay/relay.dart';
 /// also exposed on `ChannelDetails` MUST be propagated here — otherwise
 /// `mergeDetails` silently clears that state on the merged Channel.
 void main() {
+  test(
+    'archived directory filter keeps only canonical and self identities',
+    () {
+      const archived = DirectoryUser(
+        pubkey:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        displayName: 'OPUS',
+      );
+      const canonical = DirectoryUser(
+        pubkey:
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        displayName: 'OPUS',
+      );
+      const self = DirectoryUser(
+        pubkey:
+            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        displayName: 'Mr. Wayne',
+      );
+
+      final filtered = filterArchivedDirectoryUsers(
+        const [archived, canonical, self],
+        archivedPubkeys: const {
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        },
+        currentPubkey: self.pubkey,
+      );
+
+      expect(filtered.map((user) => user.pubkey), [
+        canonical.pubkey,
+        self.pubkey,
+      ]);
+    },
+  );
+
   test('extracts unique relay members from current and legacy tags', () {
     final pubkeys = relayMemberPubkeysFromEvents([
       NostrEvent(
@@ -211,15 +246,73 @@ void main() {
       sig: 'sig',
     );
 
-    ProviderContainer buildContainer(_DirectoryFakeRelaySession session) {
+    ProviderContainer buildContainer(
+      _DirectoryFakeRelaySession session, {
+      Set<String> archivedPubkeys = const {},
+    }) {
       return ProviderContainer(
         retry: (_, _) => null,
         overrides: [
           relaySessionProvider.overrideWith(() => session),
           myPubkeyProvider.overrideWithValue('me'),
+          relayArchivedIdentityPubkeysProvider.overrideWith(
+            (ref) async => archivedPubkeys,
+          ),
         ],
       );
     }
+
+    test('browse and search omit archived duplicate profiles', () async {
+      const archivedKey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const canonicalKey =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      final session = _DirectoryFakeRelaySession(
+        profileEvents: [
+          profile(archivedKey, 'OPUS'),
+          profile(canonicalKey, 'OPUS'),
+        ],
+      );
+      final container = buildContainer(
+        session,
+        archivedPubkeys: const {archivedKey},
+      );
+      addTearDown(container.dispose);
+
+      final browseResults = await container.read(
+        relayDirectoryUsersProvider.future,
+      );
+      final searchResults = await container.read(
+        relayDirectorySearchProvider('opus').future,
+      );
+
+      expect(browseResults.map((user) => user.pubkey), [canonicalKey]);
+      expect(searchResults.map((user) => user.pubkey), [canonicalKey]);
+    });
+
+    test('global people search omits archived duplicate profiles', () async {
+      const archivedKey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const canonicalKey =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      final session = _DirectoryFakeRelaySession(
+        profileEvents: [
+          profile(archivedKey, 'OPUS'),
+          profile(canonicalKey, 'OPUS'),
+        ],
+      );
+      final container = buildContainer(
+        session,
+        archivedPubkeys: const {archivedKey},
+      );
+      addTearDown(container.dispose);
+
+      final results = await container
+          .read(channelActionsProvider)
+          .searchUsers('opus');
+
+      expect(results.map((user) => user.pubkey), [canonicalKey]);
+    });
 
     test('browse directory refetches when the relay config changes', () async {
       final session = _DirectoryFakeRelaySession(

--- a/mobile/test/features/channels/mentions/mention_candidates_provider_test.dart
+++ b/mobile/test/features/channels/mentions/mention_candidates_provider_test.dart
@@ -1,0 +1,64 @@
+import 'package:buzz/features/channels/mentions/mention_candidates_provider.dart';
+import 'package:buzz/shared/relay/relay.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  test('mention user search omits archived profiles but keeps self', () async {
+    const archivedKey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const canonicalKey =
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const selfKey =
+        'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+    final container = ProviderContainer(
+      retry: (_, _) => null,
+      overrides: [
+        relaySessionProvider.overrideWith(
+          () => _MentionSearchFakeRelaySession([
+            _profile(archivedKey, 'OPUS'),
+            _profile(canonicalKey, 'OPUS'),
+            _profile(selfKey, 'Mr. Wayne'),
+          ]),
+        ),
+        myPubkeyProvider.overrideWithValue(selfKey),
+        relayArchivedIdentityPubkeysProvider.overrideWith(
+          (ref) async => const {archivedKey, selfKey},
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final provider = mentionUserSearchProvider('opus');
+    final subscription = container.listen(provider, (_, _) {});
+    addTearDown(subscription.close);
+    final results = await container.read(provider.future);
+
+    expect(results.map((profile) => profile.pubkey), [canonicalKey, selfKey]);
+  });
+}
+
+NostrEvent _profile(String pubkey, String name) => NostrEvent(
+  id: '$pubkey-profile',
+  pubkey: pubkey,
+  createdAt: 1700000000,
+  kind: 0,
+  tags: const [],
+  content: '{"display_name":"$name"}',
+  sig: 'sig',
+);
+
+class _MentionSearchFakeRelaySession extends RelaySessionNotifier {
+  _MentionSearchFakeRelaySession(this.profileEvents);
+
+  final List<NostrEvent> profileEvents;
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<List<NostrEvent>> queryRelay(
+    List<NostrFilter> filters, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async => profileEvents;
+}

--- a/mobile/test/features/channels/mentions/mention_candidates_test.dart
+++ b/mobile/test/features/channels/mentions/mention_candidates_test.dart
@@ -280,5 +280,36 @@ void main() {
       expect(candidates, hasLength(1));
       expect(candidates.single.isMember, isTrue);
     });
+
+    test('archive filtering covers every source and keeps self visible', () {
+      final archivedMember = '4' * 64;
+      final archivedAgent = '5' * 64;
+      final archivedSearchResult = '6' * 64;
+      final candidates = buildMentionCandidates(
+        members: [member(archivedMember), member(userPubkey)],
+        relayAgents: [
+          AgentDirectoryEntry(
+            pubkey: archivedAgent,
+            respondTo: 'anyone',
+            channelIds: const ['chan-1'],
+          ),
+        ],
+        sharedChannelIds: const {'chan-1'},
+        userCache: const {},
+        ownerByAgentPubkey: const {},
+        searchResults: [
+          UserProfile(pubkey: archivedSearchResult, displayName: 'Archived'),
+        ],
+        archivedPubkeys: {
+          archivedMember,
+          archivedAgent,
+          archivedSearchResult,
+          userPubkey,
+        },
+        currentPubkey: userPubkey,
+      );
+
+      expect(candidates.map((candidate) => candidate.pubkey), [userPubkey]);
+    });
   });
 }

--- a/mobile/test/shared/relay/identity_archive_provider_test.dart
+++ b/mobile/test/shared/relay/identity_archive_provider_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:nostr/nostr.dart' as nostr;
+
+import 'package:buzz/shared/relay/relay.dart';
+
+void main() {
+  const relaySecret =
+      '0000000000000000000000000000000000000000000000000000000000000003';
+  final relayPubkey = nostr.Keys(relaySecret).public;
+  const archivedPubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  NostrEvent snapshot({
+    int kind = 13535,
+    List<List<String>>? tags,
+    String? secretKey,
+  }) {
+    final event = nostr.Event.from(
+      kind: kind,
+      content: '',
+      tags:
+          tags ??
+          const [
+            ['-'],
+            ['p', archivedPubkey],
+          ],
+      secretKey: secretKey ?? relaySecret,
+      createdAt: 1_700_000_000,
+    );
+    return NostrEvent.fromJson(event.toMap());
+  }
+
+  test('reads a valid NIP-11 relay self key', () {
+    expect(relaySelfPubkeyFromDocument('{"self":"$relayPubkey"}'), relayPubkey);
+    expect(relaySelfPubkeyFromDocument('{"self":"not-a-key"}'), isNull);
+    expect(relaySelfPubkeyFromDocument('not-json'), isNull);
+  });
+
+  test('accepts a signed kind:13535 snapshot from NIP-11 self', () {
+    expect(
+      archivedIdentityPubkeysFromSnapshot(
+        event: snapshot(),
+        relaySelfPubkey: relayPubkey,
+      ),
+      {archivedPubkey},
+    );
+  });
+
+  test('rejects snapshots with the wrong kind, author, or NIP-70 tag', () {
+    final otherSecret =
+        '0000000000000000000000000000000000000000000000000000000000000004';
+    expect(
+      archivedIdentityPubkeysFromSnapshot(
+        event: snapshot(kind: 13534),
+        relaySelfPubkey: relayPubkey,
+      ),
+      isNull,
+    );
+    expect(
+      archivedIdentityPubkeysFromSnapshot(
+        event: snapshot(secretKey: otherSecret),
+        relaySelfPubkey: relayPubkey,
+      ),
+      isNull,
+    );
+    expect(
+      archivedIdentityPubkeysFromSnapshot(
+        event: snapshot(
+          tags: const [
+            ['p', archivedPubkey],
+          ],
+        ),
+        relaySelfPubkey: relayPubkey,
+      ),
+      isNull,
+    );
+    expect(
+      archivedIdentityPubkeysFromSnapshot(
+        event: snapshot(
+          tags: const [
+            ['-'],
+            ['-'],
+            ['p', archivedPubkey],
+          ],
+        ),
+        relaySelfPubkey: relayPubkey,
+      ),
+      isNull,
+    );
+  });
+
+  test('ignores malformed p tags without invalidating a trusted snapshot', () {
+    expect(
+      archivedIdentityPubkeysFromSnapshot(
+        event: snapshot(
+          tags: const [
+            ['-'],
+            ['p'],
+            ['p', 'not-a-key'],
+            ['p', archivedPubkey, 'ignored-metadata'],
+          ],
+        ),
+        relaySelfPubkey: relayPubkey,
+      ),
+      {archivedPubkey},
+    );
+  });
+
+  test('rejects a snapshot whose signed event data was altered', () {
+    final signed = snapshot();
+    final altered = NostrEvent(
+      id: signed.id,
+      pubkey: signed.pubkey,
+      createdAt: signed.createdAt,
+      kind: signed.kind,
+      tags: const [
+        ['-'],
+        ['p', archivedPubkey],
+        [
+          'p',
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        ],
+      ],
+      content: signed.content,
+      sig: signed.sig,
+    );
+
+    expect(
+      archivedIdentityPubkeysFromSnapshot(
+        event: altered,
+        relaySelfPubkey: relayPubkey,
+      ),
+      isNull,
+    );
+  });
+
+  test('provider binds the snapshot query to NIP-11 self', () async {
+    final relaySession = _ArchiveFakeRelaySession(events: [snapshot()]);
+    final httpClient = MockClient((request) async {
+      expect(request.url, Uri.parse('https://relay.example'));
+      expect(request.headers['accept'], 'application/nostr+json');
+      return http.Response('{"self":"$relayPubkey"}', 200);
+    });
+    final container = ProviderContainer(
+      retry: (_, _) => null,
+      overrides: [
+        relaySessionProvider.overrideWith(() => relaySession),
+        identityArchiveHttpClientProvider.overrideWithValue(httpClient),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(httpClient.close);
+    container
+        .read(relayConfigProvider.notifier)
+        .update(baseUrl: 'https://relay.example', nsec: null);
+
+    final archived = await container.read(
+      relayArchivedIdentityPubkeysProvider.future,
+    );
+
+    expect(archived, {archivedPubkey});
+    expect(relaySession.filters, hasLength(1));
+    expect(relaySession.filters.single.kinds, [13535]);
+    expect(relaySession.filters.single.authors, [relayPubkey]);
+  });
+
+  test('provider fails open when the relay snapshot is untrusted', () async {
+    final signed = snapshot();
+    final altered = NostrEvent(
+      id: signed.id,
+      pubkey: signed.pubkey,
+      createdAt: signed.createdAt,
+      kind: signed.kind,
+      tags: const [
+        ['-'],
+        ['p', archivedPubkey],
+        [
+          'p',
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        ],
+      ],
+      content: signed.content,
+      sig: signed.sig,
+    );
+    final relaySession = _ArchiveFakeRelaySession(events: [altered]);
+    final httpClient = MockClient(
+      (_) async => http.Response('{"self":"$relayPubkey"}', 200),
+    );
+    final container = ProviderContainer(
+      retry: (_, _) => null,
+      overrides: [
+        relaySessionProvider.overrideWith(() => relaySession),
+        identityArchiveHttpClientProvider.overrideWithValue(httpClient),
+      ],
+    );
+    addTearDown(container.dispose);
+    addTearDown(httpClient.close);
+    container
+        .read(relayConfigProvider.notifier)
+        .update(baseUrl: 'https://relay.example', nsec: null);
+
+    expect(
+      await container.read(relayArchivedIdentityPubkeysProvider.future),
+      isEmpty,
+    );
+  });
+}
+
+class _ArchiveFakeRelaySession extends RelaySessionNotifier {
+  _ArchiveFakeRelaySession({required this.events});
+
+  final List<NostrEvent> events;
+  List<NostrFilter> filters = const [];
+
+  @override
+  SessionState build() => const SessionState(status: SessionStatus.connected);
+
+  @override
+  Future<List<NostrEvent>> queryRelay(
+    List<NostrFilter> filters, {
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    this.filters = filters;
+    return events;
+  }
+}


### PR DESCRIPTION
## Summary

- read the relay-authoritative NIP-IA kind:13535 snapshot, trust-anchored to the NIP-11 `self` key
- verify the snapshot event, required NIP-70 tag, author, kind, and archived pubkey tags
- filter archived identities from every forward-looking mobile discovery surface: New DM browse/search, global People search, @mention candidates, and the active Members sheet
- preserve historical profile/message resolution and the NIP-IA self exemption
- fail open on network or trust failures so archive metadata cannot become a client-side shadowban

## Verification

- focused archive/discovery suite — 38 passed
- `flutter analyze` — no issues
- full mobile suite — 1,033 passed, 1 skipped, 1 unrelated existing failure reproduced on an untouched `main` worktree
- initial iOS integration head — `Buzz.app` built successfully for the iOS 26.5 simulator

Desktop already applies NIP-IA filtering to the equivalent new-message surface. This brings mobile discovery behavior into parity while leaving historical identities resolvable in existing messages and profiles.
