### PR TITLE
fix(compose): add pair-relay sidecar and ignore local compose secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ identity.key
 
 # Helm dependency tarballs — regenerable from Chart.lock via `helm dependency build`
 deploy/charts/*/charts/*.tgz
+deploy/compose/.env
+deploy/compose/.local-keys.txt

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -20,6 +20,7 @@ services:
       BUZZ_GIT_REPO_PATH: /data/git
       BUZZ_AUTO_MIGRATE: ${BUZZ_AUTO_MIGRATE:-false}
       BUZZ_GIT_CONFORMANCE_PROBE: ${BUZZ_GIT_CONFORMANCE_PROBE:-true}
+      # BUZZ_PAIRING_RELAY_URL comes from env_file (.env) and is advertised in NIP-11.
     ports:
       - "${BUZZ_HTTP_PORT:-3000}:3000"
     volumes:
@@ -44,6 +45,29 @@ services:
       timeout: 3s
       retries: 12
       start_period: 30s
+    restart: unless-stopped
+    networks:
+      - buzz-net
+
+  # Ephemeral NIP-AB pairing sidecar (same image). Closed/NIP-43 relays need this
+  # so unpaired phones can complete identity transfer before joining membership.
+  pair-relay:
+    image: ${BUZZ_IMAGE:-ghcr.io/block/buzz:main}
+    entrypoint: ["/usr/local/bin/buzz-pair-relay"]
+    environment:
+      BUZZ_PAIR_RELAY_BIND_ADDR: 0.0.0.0:5000
+    ports:
+      - "${BUZZ_PAIR_HTTP_PORT:-3848}:5000"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/5000'",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
     restart: unless-stopped
     networks:
       - buzz-net


### PR DESCRIPTION
## Summary
- Add a `pair-relay` Compose service running `buzz-pair-relay` so NIP-AB mobile pairing works against membership-enforcing self-hosted relays.
- Ignore `deploy/compose/.env` and `deploy/compose/.local-keys.txt` so local secrets stay out of git.

## Notes
- This is a minimal capture of local WIP. Fuller pairing-bundle PRs already exist (#2736, #3875, #4082) with Caddy `/pair` routing and docs; happy to close this in favor of one of those if preferred.
- `deploy/compose/.env` is intentionally not committed.

## Test plan
- [ ] `git check-ignore -v deploy/compose/.env` reports the new gitignore rule
- [ ] `docker compose -f deploy/compose/compose.yml config` includes healthy `pair-relay` service
- [ ] Pairing URL can be supplied via compose env_file (`BUZZ_PAIRING_RELAY_URL`)

Made with [Cursor](https://cursor.com)