### PR TITLE
fix(desktop,relay): restore multi-channel workflows list

### DIFF
--- a/crates/buzz-relay/src/handlers/req.rs
+++ b/crates/buzz-relay/src/handlers/req.rs
@@ -847,19 +847,34 @@ fn filters_are_nip43_membership_only(filters: &[Filter]) -> bool {
         })
 }
 
-/// Extract a channel UUID from a single filter's `#h` tag.
+/// Extract a **single** channel UUID from a filter's `#h` tag.
+///
+/// Returns `Some(id)` only when the filter names exactly one channel UUID.
+/// Multi-value `#h` (NIP-01 OR across channels) returns `None` so callers do
+/// not push an arbitrary first value as `EventQuery.channel_id` — that bug
+/// made Desktop's batched workflow list return empty while per-channel CLI
+/// list worked (multi-`#h` collapsed to one channel that often had zero
+/// workflows).
 fn extract_channel_id_from_filter(filter: &Filter) -> Option<uuid::Uuid> {
+    let mut found: Option<uuid::Uuid> = None;
     for (tag_key, tag_values) in filter.generic_tags.iter() {
-        let key = tag_key.to_string();
-        if key == "h" {
-            for val in tag_values {
-                if let Ok(id) = val.parse::<uuid::Uuid>() {
-                    return Some(id);
+        if tag_key.to_string() != "h" {
+            continue;
+        }
+        for val in tag_values {
+            let Ok(id) = val.parse::<uuid::Uuid>() else {
+                continue;
+            };
+            match found {
+                Some(existing) if existing != id => {
+                    // Multiple distinct channel IDs — not a single-channel filter.
+                    return None;
                 }
+                _ => found = Some(id),
             }
         }
     }
-    None
+    found
 }
 
 /// Convert a single NIP-01 filter into an [`EventQuery`] for the database.
@@ -1319,6 +1334,31 @@ mod tests {
 
         assert!(query.channel_ids.is_none());
         assert_eq!(query.channel_id, Some(channel));
+    }
+
+    #[test]
+    fn single_h_filter_extracts_channel_id() {
+        let channel = uuid::Uuid::new_v4();
+        let filter =
+            Filter::new().custom_tag(SingleLetterTag::lowercase(Alphabet::H), channel.to_string());
+        assert_eq!(extract_channel_id_from_filter(&filter), Some(channel));
+    }
+
+    #[test]
+    fn multi_h_filter_does_not_collapse_to_first_channel() {
+        // Regression: multi-value #h used to return the first UUID only, so SQL
+        // was scoped to an arbitrary channel. Desktop batched workflow list then
+        // returned empty when that first channel had no kind:30620 events.
+        let a = uuid::Uuid::new_v4();
+        let b = uuid::Uuid::new_v4();
+        let filter = Filter::new()
+            .custom_tag(SingleLetterTag::lowercase(Alphabet::H), a.to_string())
+            .custom_tag(SingleLetterTag::lowercase(Alphabet::H), b.to_string());
+        assert_eq!(
+            extract_channel_id_from_filter(&filter),
+            None,
+            "multi-#h must not push a single channel_id"
+        );
     }
 
     /// S2 invariant: the bounded-concurrency pipeline (phase 2) must yield

--- a/desktop/src-tauri/src/commands/workflows.rs
+++ b/desktop/src-tauri/src/commands/workflows.rs
@@ -68,13 +68,20 @@ pub async fn get_channel_workflows(
 
 /// Fetch workflows across many channels in a single relay round-trip.
 ///
-/// The Workflows overview screen previously issued one `get_channel_workflows`
-/// query per member channel (`Promise.all` fanout in `WorkflowsView`), i.e. N
-/// relay POSTs. A nostr `#h` filter matches ANY of its listed values, so one
-/// query with all channel ids returns the same set. Each `WorkflowWire` carries
-/// its own `channel_id` (from the event's `h` tag), so the frontend can still
-/// group results by channel. Neither this nor the per-channel command sets a
-/// `limit`, so batching does not change result completeness.
+/// Uses one `POST /query` with **N filters** (one single-value `#h` per channel).
+/// NIP-01 ORs filters in a request, and each single-`#h` filter is SQL-pushable
+/// as `channel_id` on the relay.
+///
+/// Do **not** pack all channel ids into one multi-value `#h` filter. The relay's
+/// `extract_channel_id_from_filter` historically collapsed multi-`#h` to the
+/// first value only, so a batched query like
+/// `{ kinds: [30620], "#h": [welcome, skills, general] }` could return only the
+/// workflows for an arbitrary channel — often empty — while per-channel CLI
+/// list still showed the real data. That mismatch produced Desktop's
+/// "No workflows yet" empty state after a successful Save.
+///
+/// Each `WorkflowWire` carries its own `channel_id` (from the event's `h` tag)
+/// so the frontend can group results by channel.
 #[tauri::command]
 pub async fn get_channels_workflows(
     channel_ids: Vec<String>,
@@ -84,14 +91,20 @@ pub async fn get_channels_workflows(
         return Ok(Vec::new());
     }
 
-    let events = query_relay(
-        &state,
-        &[serde_json::json!({
-            "kinds": [30620],
-            "#h": channel_ids,
-        })],
-    )
-    .await?;
+    // One filter per channel — single-value `#h` so the relay pushes channel_id
+    // correctly. Multi-value `#h` is not equivalent on current Groundfeed SQL
+    // pushdown (see module comment above).
+    let filters: Vec<serde_json::Value> = channel_ids
+        .iter()
+        .map(|channel_id| {
+            serde_json::json!({
+                "kinds": [30620],
+                "#h": [channel_id],
+            })
+        })
+        .collect();
+
+    let events = query_relay(&state, &filters).await?;
 
     Ok(events.iter().map(workflow_from_event).collect())
 }

--- a/desktop/src/app/routes/WorkflowsRouteScreen.tsx
+++ b/desktop/src/app/routes/WorkflowsRouteScreen.tsx
@@ -17,6 +17,7 @@ export function WorkflowsRouteScreen({
   return (
     <WorkflowsScreen
       channels={memberChannels}
+      channelsLoading={channelsQuery.isLoading}
       onCloseWorkflow={closeWorkflowDetail}
       onSelectWorkflow={(workflowId) => {
         void goWorkflow(workflowId);

--- a/desktop/src/features/workflows/ui/WorkflowsScreen.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowsScreen.tsx
@@ -10,6 +10,8 @@ const WorkflowsView = React.lazy(async () => {
 
 type WorkflowsScreenProps = {
   channels: Channel[];
+  /** True while the member-channel list is still loading (avoid false empty state). */
+  channelsLoading?: boolean;
   onCloseWorkflow: () => void;
   onSelectWorkflow: (workflowId: string) => void;
   selectedWorkflowId: string | null;
@@ -17,6 +19,7 @@ type WorkflowsScreenProps = {
 
 export function WorkflowsScreen({
   channels,
+  channelsLoading = false,
   onCloseWorkflow,
   onSelectWorkflow,
   selectedWorkflowId,
@@ -26,6 +29,7 @@ export function WorkflowsScreen({
       <React.Suspense fallback={<ViewLoadingFallback kind="workflows" />}>
         <WorkflowsView
           channels={channels}
+          channelsLoading={channelsLoading}
           onCloseWorkflow={onCloseWorkflow}
           onSelectWorkflow={onSelectWorkflow}
           selectedWorkflowId={selectedWorkflowId}

--- a/desktop/src/features/workflows/ui/WorkflowsView.tsx
+++ b/desktop/src/features/workflows/ui/WorkflowsView.tsx
@@ -19,6 +19,8 @@ import { Skeleton } from "@/shared/ui/skeleton";
 
 type WorkflowsViewProps = {
   channels: Channel[];
+  /** True while the channel membership list is still loading. */
+  channelsLoading?: boolean;
   onCloseWorkflow: () => void;
   onSelectWorkflow: (workflowId: string) => void;
   selectedWorkflowId: string | null;
@@ -66,6 +68,7 @@ function WorkflowsListSkeleton() {
 
 export function WorkflowsView({
   channels,
+  channelsLoading = false,
   onCloseWorkflow,
   onSelectWorkflow,
   selectedWorkflowId,
@@ -106,6 +109,11 @@ export function WorkflowsView({
   });
 
   const allWorkflows = allWorkflowsQuery.data ?? [];
+  // Disabled query (no member channels yet) is not "loading" in RQ v5, so without
+  // channelsLoading we would flash "No workflows yet" while membership loads.
+  const showListSkeleton =
+    channelsLoading ||
+    (memberChannels.length > 0 && allWorkflowsQuery.isLoading);
 
   const triggerMutation = useMutation({
     mutationFn: (workflowId: string) => triggerWorkflow(workflowId),
@@ -196,7 +204,7 @@ export function WorkflowsView({
           </Button>
         </div>
 
-        {allWorkflowsQuery.isLoading ? (
+        {showListSkeleton ? (
           <WorkflowsListSkeleton />
         ) : allWorkflowsQuery.isError ? (
           <div className="flex flex-1 flex-col items-center justify-center gap-2 text-muted-foreground">

--- a/desktop/src/shared/api/tauriWorkflows.ts
+++ b/desktop/src/shared/api/tauriWorkflows.ts
@@ -172,9 +172,11 @@ export async function getChannelWorkflows(
 /**
  * Fetch workflows across many channels in a single relay round-trip.
  *
- * Replaces the per-channel `Promise.all(getChannelWorkflows)` fanout on the
- * Workflows overview: the backend `#h` filter matches any listed channel, and
- * each returned workflow carries its own `channelId` so callers can group.
+ * The Tauri command issues one `POST /query` with one single-value `#h` filter
+ * per channel (NIP-01 OR). Do not assume multi-value `#h` is equivalent — the
+ * relay SQL pushdown historically collapsed multi-`#h` to a single channel,
+ * which made the Desktop list show "No workflows yet" while CLI per-channel
+ * list still had rows. Each returned workflow carries its own `channelId`.
  */
 export async function getChannelsWorkflows(
   channelIds: string[],


### PR DESCRIPTION
## Summary

Desktop Workflows showed **No workflows yet** after successful saves even when CLI `buzz workflows list --channel <uuid>` returned rows.

**Root cause:** `get_channels_workflows` packed all member channel IDs into one multi-value `#h` filter. Relay `extract_channel_id_from_filter` collapsed multi-`#h` to the lexicographically first channel UUID and pushed that as SQL `channel_id`, so the query often returned only an empty channel (e.g. `#general`).

**Fix (defense in depth):**
1. **Desktop** — one single-value `#h` filter per channel in a single `POST /query` (NIP-01 OR; each filter is SQL-pushable).
2. **Relay** — multi-value `#h` returns `None` from the singular extractor (same as bridge/count siblings), so multi-`#h` widens correctly instead of pinning one channel.
3. **UX** — avoid flashing the empty state while channel membership is still loading.

Live Groundfeed repro before this change:
- `#h: [welcome]` → workflows present
- `#h: [welcome, skills, general]` → **0**
- two single-`#h` filters OR → full set

## Related work on block/buzz

Others hit the same bug; these open PRs address the **relay** half (not merged as of this PR):

- https://github.com/block/buzz/pull/2452 — stop collapsing multi-value `#h`
- https://github.com/block/buzz/pull/4393 — same extractor fix for #4381
- https://github.com/block/buzz/pull/2350 — preserve multi-channel workflow queries

This PR is complementary: it keeps the Desktop list correct even against unfixed relays, and still hardens the relay path.

## Test plan

- [x] `cargo test -p buzz-relay multi_h_filter_does_not_collapse` / `single_h_filter_extracts` pass
- [x] `cargo test --manifest-path desktop/src-tauri/Cargo.toml workflows` (11 unit tests) pass
- [ ] Rebuild Desktop from this branch; open Workflows → list should show workflows across member channels (not empty when CLI list is non-empty)
- [ ] Optional: against Groundfeed, confirm multi-channel overview after Desktop rebuild