### PR TITLE
fix(desktop): mention channel-member agents and invocable relay agents

### DIFF
--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.test.mjs
@@ -5,7 +5,7 @@ import {
   coalesceAgentAutocompleteCandidates,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isAgentAutocompleteEligible,
   relayAgentIsSharedWithUser,
   shouldHideAgentFromMentions,
 } from "./agentAutocompleteEligibility.ts";
@@ -136,25 +136,32 @@ test("getMentionableAgentPubkeys: keeps managed agents and shared relay agents",
   assert.deepEqual(result, new Set([PUB_A, PUB_B, PUB_C]));
 });
 
-test("isAgentIdentityInManagedList: keeps people and only current managed agent identities", () => {
+test("isAgentAutocompleteEligible: keeps people, channel members, and current managed agent identities", () => {
   const managedAgentPubkeys = new Set([PUB_A]);
 
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentAutocompleteEligible(
       { isAgent: false, pubkey: PUB_B },
       managedAgentPubkeys,
     ),
     true,
   );
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentAutocompleteEligible(
       { isAgent: true, pubkey: PUB_A.toUpperCase() },
       managedAgentPubkeys,
     ),
     true,
   );
   assert.equal(
-    isAgentIdentityInManagedList(
+    isAgentAutocompleteEligible(
+      { isAgent: true, isMember: true, pubkey: PUB_B },
+      managedAgentPubkeys,
+    ),
+    true,
+  );
+  assert.equal(
+    isAgentAutocompleteEligible(
       { isAgent: true, pubkey: PUB_B },
       managedAgentPubkeys,
     ),
@@ -305,4 +312,81 @@ test("coalesceAgentAutocompleteCandidates: leaves non-agents alone", () => {
   const second = makeAgent({ pubkey: PUB_B, isAgent: false });
 
   assert.deepEqual(coalesce([first, second]), [first, second]);
+});
+
+// ── Composed gate: relay-only agents must survive both checks ──────────────
+//
+// Regression for the case where a viewer who manages no agents locally could
+// never mention an agent. `useMentions` runs `isAgentAutocompleteEligible`
+// before `shouldHideAgentFromMentions`, so that first gate must receive
+// `getMentionableAgentPubkeys(...)` (local managed ∪ relay agents shared with
+// the viewer). The channel-member clause alone does not cover a relay agent
+// that is invocable but not a member of the channel being typed in.
+
+test("relay agent allowlisting the viewer survives the composed mention gate", () => {
+  const managedAgentPubkeys = []; // viewer manages no agents locally
+  const relayAgents = [
+    {
+      pubkey: PUB_C,
+      respondTo: "allowlist",
+      respondToAllowlist: [CURRENT_PUBKEY],
+      channelIds: [],
+    },
+  ];
+  const mentionableAgentPubkeys = getMentionableAgentPubkeys({
+    currentPubkey: CURRENT_PUBKEY,
+    managedAgentPubkeys,
+    relayAgents,
+    sharedChannelIds: new Set(["general"]),
+  });
+  const candidate = { isAgent: true, isMember: false, pubkey: PUB_C };
+
+  assert.equal(
+    isAgentAutocompleteEligible(candidate, mentionableAgentPubkeys),
+    true,
+    "relay agent that allowlists the viewer must pass the first gate",
+  );
+  assert.equal(
+    shouldHideAgentFromMentions({
+      isAgent: true,
+      isMember: false,
+      pubkey: PUB_C,
+      mentionableAgentPubkeys,
+      directoryAgentPubkeys: new Set([PUB_C]),
+    }),
+    false,
+    "an invocable relay agent must not be hidden",
+  );
+
+  // The pre-fix behaviour, pinned so the regression cannot return quietly.
+  assert.equal(
+    isAgentAutocompleteEligible(candidate, new Set(managedAgentPubkeys)),
+    false,
+    "local-only set drops the relay agent — this is why the gate must not use it",
+  );
+});
+
+test("relay agent that excludes the viewer stays hidden", () => {
+  const mentionableAgentPubkeys = getMentionableAgentPubkeys({
+    currentPubkey: CURRENT_PUBKEY,
+    managedAgentPubkeys: [],
+    relayAgents: [
+      {
+        pubkey: PUB_C,
+        respondTo: "allowlist",
+        respondToAllowlist: [OTHER_OWNER_PUBKEY],
+        channelIds: [],
+      },
+    ],
+    sharedChannelIds: new Set(["general"]),
+  });
+
+  assert.equal(
+    isAgentAutocompleteEligible(
+      { isAgent: true, isMember: false, pubkey: PUB_C },
+      mentionableAgentPubkeys,
+    ),
+    false,
+    "widening the gate must not expose agents that exclude the viewer",
+  );
 });

--- a/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
+++ b/desktop/src/features/agents/lib/agentAutocompleteEligibility.ts
@@ -54,13 +54,24 @@ export function getMentionableAgentPubkeys({
   return pubkeys;
 }
 
-export function isAgentIdentityInManagedList(
-  candidate: { isAgent?: boolean; pubkey: string },
-  managedAgentPubkeys: ReadonlySet<string>,
+/**
+ * First-pass autocomplete gate. Non-agents and channel members always pass;
+ * any other agent must appear in `allowedAgentPubkeys`.
+ *
+ * Callers decide what "allowed" means, and the choice is load-bearing. Mention
+ * autocomplete must pass `getMentionableAgentPubkeys(...)` (local managed ∪
+ * relay agents shared with the viewer) — passing the locally-managed set alone
+ * drops every relay agent before `shouldHideAgentFromMentions` can admit it,
+ * so a viewer who manages no agents locally can mention none of them.
+ */
+export function isAgentAutocompleteEligible(
+  candidate: { isAgent?: boolean; isMember?: boolean; pubkey: string },
+  allowedAgentPubkeys: ReadonlySet<string>,
 ) {
   return (
     candidate.isAgent !== true ||
-    managedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
+    candidate.isMember === true ||
+    allowedAgentPubkeys.has(normalizePubkey(candidate.pubkey))
   );
 }
 

--- a/desktop/src/features/channels/ui/MembersSidebar.tsx
+++ b/desktop/src/features/channels/ui/MembersSidebar.tsx
@@ -9,7 +9,7 @@ import {
 import { attachManagedAgentToChannel } from "@/features/agents/channelAgents";
 import {
   coalesceAgentAutocompleteCandidates,
-  isAgentIdentityInManagedList,
+  isAgentAutocompleteEligible,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import { useIsArchivedPredicate } from "@/features/identity-archive/hooks";
 import { useClassifiedMembers } from "@/features/channels/lib/useClassifiedMembers";
@@ -282,7 +282,7 @@ export function MembersSidebar({
           )) ||
         memberPubkeys.has(pubkey) ||
         isArchivedDiscovery(pubkey) ||
-        !isAgentIdentityInManagedList(candidate, managedAgentPubkeys)
+        !isAgentAutocompleteEligible(candidate, managedAgentPubkeys)
       ) {
         return;
       }

--- a/desktop/src/features/messages/lib/useMentions.ts
+++ b/desktop/src/features/messages/lib/useMentions.ts
@@ -16,7 +16,7 @@ import {
   coalesceAutocompleteCandidatesByKey,
   getMentionableAgentPubkeys,
   getSharedChannelIds,
-  isAgentIdentityInManagedList,
+  isAgentAutocompleteEligible,
   shouldHideAgentFromMentions,
 } from "@/features/agents/lib/agentAutocompleteEligibility";
 import {
@@ -246,7 +246,7 @@ export function useMentions(
       if (isArchivedDiscovery(pubkey)) {
         return;
       }
-      if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) {
+      if (!isAgentAutocompleteEligible(candidate, mentionableAgentPubkeys)) {
         return;
       }
       if (
@@ -420,7 +420,6 @@ export function useMentions(
     managedAgentNamesByPubkey,
     managedAgentPersonaIds,
     managedAgentPersonaIdsByPubkey,
-    managedAgentPubkeys,
     managedAgentsQuery.data,
     memberPubkeys,
     members,


### PR DESCRIPTION
## Problem

On a client that manages no agents locally, `@`-mention autocomplete shows no agents at all — not channel members, not relay-directory entries. Reported in #3671, #3125, #3776, and #4128.

`useMentions.ts` gated every candidate on the **locally-managed** agent set:

```ts
if (!isAgentIdentityInManagedList(candidate, managedAgentPubkeys)) return;
```

`managedAgentPubkeys` is derived solely from `managedAgentsQuery.data`. When a viewer manages nothing locally that set is empty, so every candidate with `isAgent === true` is dropped right there — both the channel-member candidates and the relay-directory candidates that `mentionCandidates` builds further down.

Everything written downstream to handle this — `mentionableAgentPubkeys`, `shouldHideAgentFromMentions`, `relayAgentIsSharedWithUser` — sits *after* that gate and therefore never runs. `shouldHideAgentFromMentions`'s "invocable => always show" branch is unreachable in the shipped build.

## Fix

Two changes, both in the first-pass gate:

1. `isAgentAutocompleteEligible` (renamed from `isAgentIdentityInManagedList`) also admits `candidate.isMember === true`, so agents that are members of the channel you are typing in pass.
2. `useMentions` passes `getMentionableAgentPubkeys(...)` — local managed ∪ relay agents shared with the viewer — instead of the local-only set, so an agent that is invocable but *not* a channel member also passes.

Both are needed for the full intended behavior. (1) fixes the reported channel-member symptom; without (2), every eligible relay-directory candidate that is not a channel member is still dropped before the relay-aware filter can admit it — those candidates are pushed with `isMember: false`, so clause (1) can never match them.

Security posture is unchanged: admission still runs through `relayAgentIsSharedWithUser`, so an agent that does not allowlist you never enters the set. The added test `relay agent that excludes the viewer stays hidden` pins that.

### `MembersSidebar` deliberately not widened

`MembersSidebar.tsx` keeps passing `managedAgentPubkeys`. Only the helper name changes there. Adding an agent to a channel should answer to channel membership policy, not to an agent's `respond_to` setting, and conflating the two would let mention semantics silently widen who can be added to a channel. The new `isMember === true` clause is inert at that call site — the sidebar already returns early for anyone in `memberPubkeys`.

## Tests

New cases in `agentAutocompleteEligibility.test.mjs`:

- `isAgentAutocompleteEligible: keeps people, channel members, and current managed agent identities` — the member clause.
- `relay agent allowlisting the viewer survives the composed mention gate` — composes the gate with `shouldHideAgentFromMentions` for a relay agent that is invocable but not a member, and pins the pre-fix behaviour (local-only set => dropped) so the regression cannot come back quietly.
- `relay agent that excludes the viewer stays hidden` — the negative case.

Verified on this branch:

- `pnpm test` — **3925 passed, 0 failed**
- `tsc --noEmit` — clean
- `biome check .` — no errors (2 pre-existing `useTemplate` infos in `personaCatalogRelay.test.mjs`, untouched)
- `check:file-sizes`, `check:px-text`, `check:pubkey-truncation` — pass

Note for whoever iterates on this: `useMentions.ts` sits right at the 1000-line ratchet, so the change had to be net-neutral. Dropping `managedAgentPubkeys` from the `mentionCandidates` dependency array is also required — after the swap it is no longer read inside that memo, and leaving it trips `lint/correctness/useExhaustiveDependencies`.

## Not covered here

A Playwright spec driving the autocomplete itself is not included. The unit tests pin the gate's behaviour, not the wiring from `useMentions` into the dropdown. The E2E bridge does have the pieces for it — `handleListRelayAgents` plus the `mock.relayAgents` and `mock.managedAgents` config seeds — so a spec that seeds one allowlisting relay agent, no managed agents, and asserts on the `@` menu looks reachable without new infrastructure. Happy to add it here if a reviewer wants it in the same PR.

## Credit

Supersedes #4357, which is the origin of the channel-member clause and its test. That work is carried here with authorship preserved via `Co-authored-by`, plus the relay-agent half of the gate and the composed-gate regression tests.

## Adjacent, not fixed here

`respond_to: "anyone"` is a trap for profiles published without `channel_ids`. `relayAgentIsSharedWithUser` requires `agent.channelIds.some((id) => sharedChannelIds.has(id))` for that route, and `agents_from_events` defaults `channel_ids` to `[]` when the profile omits it — so switching an agent from `allowlist` to the seemingly-broader `anyone` makes it *vanish* from other people's autocomplete. Happy to file that separately if it is not already tracked.

