### PR TITLE
fix(desktop): retain terminal focus after tab actions

### DIFF
--- a/desktop/src/features/terminal/TerminalSubstrate.test.mjs
+++ b/desktop/src/features/terminal/TerminalSubstrate.test.mjs
@@ -159,6 +159,30 @@ test("mounted IME paths neither toggle nor emit preedit text", async () => {
   assert.deepEqual(calls.input, ["か"]);
 });
 
+test("tab actions restore terminal input focus", async () => {
+  const { view } = fixture();
+  await ready(view);
+  toggleChord();
+  const input = view.getByLabelText("Terminal input");
+  await waitFor(() => assert.equal(document.activeElement, input));
+
+  const actions = [
+    ["select", view.getByRole("tab")],
+    ["close", view.getByLabelText("Close SHELL")],
+    ["new", view.getByLabelText("New Buzz Term tab")],
+  ];
+  for (const [label, target] of actions) {
+    target.focus();
+    assert.equal(document.activeElement, target, `${label} takes focus`);
+    fireEvent.click(target);
+    assert.equal(
+      document.activeElement,
+      input,
+      `${label} restores terminal focus`,
+    );
+  }
+});
+
 const EMPTY_FRAME = {
   cursor: { column: 0, line: 0, visible: false },
   full: false,

--- a/desktop/src/features/terminal/TerminalSubstrate.tsx
+++ b/desktop/src/features/terminal/TerminalSubstrate.tsx
@@ -391,6 +391,13 @@ export function TerminalSubstrate({
     gridRef.current?.paint(context, TERMINAL_CELL_METRICS, terminalPalette);
   }, [activeSessionId, cursorPainted, frames, terminalPalette]);
 
+  const runTabAction = (action: () => void) => {
+    action();
+    if (owner === "terminal") {
+      textareaRef.current?.focus({ preventScroll: true });
+    }
+  };
+
   return (
     <section
       aria-label="Buzz Term"
@@ -431,7 +438,7 @@ export function TerminalSubstrate({
                 aria-selected={session.active}
                 className="buzz-terminal-tab-select"
                 disabled={session.closing}
-                onClick={() => onSelectSession(session.id)}
+                onClick={() => runTabAction(() => onSelectSession(session.id))}
                 role="tab"
                 type="button"
               >
@@ -444,7 +451,7 @@ export function TerminalSubstrate({
                 aria-label={`Close ${session.title}`}
                 className="buzz-terminal-close"
                 disabled={session.closing}
-                onClick={() => onCloseSession(session.id)}
+                onClick={() => runTabAction(() => onCloseSession(session.id))}
                 type="button"
               >
                 ×
@@ -454,7 +461,7 @@ export function TerminalSubstrate({
           <button
             aria-label="New Buzz Term tab"
             className="buzz-terminal-new-tab"
-            onClick={onNewSession}
+            onClick={() => runTabAction(onNewSession)}
             type="button"
           >
             +


### PR DESCRIPTION
## Summary
- return focus to the hidden terminal input after select, close, and new-tab actions while terminal mode owns input
- keep Buzz-mode tab interactions unchanged
- cover all three tab-bar actions with a mounted focus regression

## Verification
- `pnpm test` — 3973 passed
- `pnpm typecheck`
- `pnpm check`
- `git diff --check`
- regression control with the production focus helper removed stalls at the focus assertion until timeout (the test does not pass on revert)
- `git merge-tree 1350422539fdd5d88d9e24b61960370f25fe1078 050cfc89e3c4a54583222736a7049e91cb9cd984 1350422539fdd5d88d9e24b61960370f25fe1078` — clean/no output

Base: `max/tui-renderer` at `1350422539fdd5d88d9e24b61960370f25fe1078`
Head: `050cfc89e3c4a54583222736a7049e91cb9cd984`
