### PR TITLE
fix(terminal): repaint the whole viewport when the active session changes

### DIFF
--- a/desktop/src/features/terminal/TerminalSubstrate.test.mjs
+++ b/desktop/src/features/terminal/TerminalSubstrate.test.mjs
@@ -53,6 +53,7 @@ after(() => dom.window.close());
 beforeEach(() => {
   cleanup?.();
   reducedMotion = false;
+  paintLog.length = 0;
   dom.window.localStorage.clear();
   dom.window.HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
     bottom: 782,
@@ -65,18 +66,50 @@ beforeEach(() => {
     y: 0,
     toJSON() {},
   });
-  dom.window.HTMLCanvasElement.prototype.getContext = () => ({
+  dom.window.HTMLCanvasElement.prototype.getContext = function () {
+    return paintRecorder(this);
+  };
+});
+
+// The default stub discards everything it is handed, so an assertion made
+// against it cannot distinguish "repainted" from "drew nothing". This records
+// every draw call against the canvas that received it, so the tests below are
+// about commands actually issued and can exclude the banner canvas.
+const paintLog = [];
+
+function paintRecorder(canvas) {
+  return {
     clearRect() {},
-    fillRect() {},
+    fillRect(x, y, width, height) {
+      paintLog.push({
+        canvas,
+        height,
+        kind: "fill",
+        style: this.fillStyle,
+        width,
+        x,
+        y,
+      });
+    },
     fillStyle: "",
-    fillText() {},
+    fillText(text, x, y) {
+      paintLog.push({ canvas, kind: "text", text, x, y });
+    },
     font: "",
     restore() {},
     save() {},
     setTransform() {},
     textBaseline: "",
-  });
-});
+  };
+}
+
+/** Draws issued to the grid canvas only, newest paint pass included. */
+function gridDraws(view) {
+  const grid = view.container.querySelector(
+    ".buzz-terminal-viewport > canvas:not(.buzz-terminal-welcome)",
+  );
+  return paintLog.filter((entry) => entry.canvas === grid);
+}
 
 function fixture(overrides = {}) {
   const calls = { input: [], scroll: [] };
@@ -378,4 +411,175 @@ test("reduced motion keeps the terminal cursor solid", async () => {
   } finally {
     window.setInterval = originalSetInterval;
   }
+});
+
+const TWO_SESSIONS = [
+  { active: true, closing: false, id: "one", title: "SHELL" },
+  { active: false, closing: false, id: "two", title: "LOG" },
+];
+
+function frameWith(text, generation = 1) {
+  return {
+    cursor: { column: 0, line: 0, visible: false },
+    full: false,
+    rows: [
+      {
+        line: 0,
+        spans: [
+          {
+            style: { fg: 0, bg: 0, flags: 0 },
+            clusters: [{ column: 0, text, width: text.length }],
+          },
+        ],
+      },
+    ],
+    viewport: { columns: 112, generation, screenLines: 46 },
+  };
+}
+
+const SWAPPED_SESSIONS = [
+  { active: false, closing: false, id: "one", title: "SHELL" },
+  { active: true, closing: false, id: "two", title: "LOG" },
+];
+
+test("switching back to an idle session repaints its retained rows", async () => {
+  const subject = fixture({
+    sessionFrames: [
+      { frame: frameWith("one"), sessionId: "one" },
+      { frame: frameWith("two"), sessionId: "two" },
+    ],
+    sessions: TWO_SESSIONS,
+  });
+  await ready(subject.view);
+  await waitFor(() =>
+    assert.ok(gridDraws(subject.view).some((entry) => entry.text === "one")),
+  );
+
+  // A round trip is required, not a single switch: `paint()` is what drains the
+  // dirty set, so a grid that has never been painted still holds every line and
+  // repaints on first switch by luck. Only a session that was painted and then
+  // deactivated has an empty dirty set while holding rows.
+  subject.rerender({ sessions: SWAPPED_SESSIONS });
+  await waitFor(() =>
+    assert.ok(gridDraws(subject.view).some((entry) => entry.text === "two")),
+  );
+
+  paintLog.length = 0;
+  subject.rerender({ sessions: TWO_SESSIONS });
+  await waitFor(() =>
+    assert.ok(
+      gridDraws(subject.view).some((entry) => entry.text === "one"),
+      "returning to an idle session must repaint its retained rows",
+    ),
+  );
+  assert.equal(
+    gridDraws(subject.view).some((entry) => entry.text === "two"),
+    false,
+    "the outgoing session's rows must not be repainted",
+  );
+});
+
+test("switching to a session with no frame yet clears the outgoing pixels", async () => {
+  const subject = fixture({
+    sessionFrames: [{ frame: frameWith("one"), sessionId: "one" }],
+    sessions: TWO_SESSIONS,
+  });
+  await ready(subject.view);
+  await waitFor(() =>
+    assert.ok(gridDraws(subject.view).some((entry) => entry.text === "one")),
+  );
+
+  // Session "two" has delivered no frame, so it has no grid: `markAllDirty()`
+  // and `paint()` are both no-ops and only a background fill can erase "one".
+  paintLog.length = 0;
+  subject.rerender({ sessions: SWAPPED_SESSIONS });
+  await waitFor(() =>
+    assert.ok(
+      gridDraws(subject.view).some(
+        (entry) =>
+          entry.kind === "fill" &&
+          entry.x === 0 &&
+          entry.y === 0 &&
+          entry.width === 940.8 &&
+          entry.height === 782,
+      ),
+      "a full-viewport background fill must erase the outgoing session",
+    ),
+  );
+  assert.equal(
+    gridDraws(subject.view).some((entry) => entry.text === "one"),
+    false,
+  );
+});
+
+test("a frame on an unchanged session does not force a full repaint", async () => {
+  const subject = fixture({
+    sessionFrames: [{ frame: frameWith("one"), sessionId: "one" }],
+    sessions: TWO_SESSIONS,
+  });
+  await ready(subject.view);
+  await waitFor(() =>
+    assert.ok(gridDraws(subject.view).some((entry) => entry.text === "one")),
+  );
+
+  // Guards the damage model, not the bug: dropping the `paintedSessionRef`
+  // write leaves `sessionChanged` permanently true, which repaints the whole
+  // viewport on every frame. That looks correct on screen and passes every
+  // assertion above, so only a negative test can see it.
+  paintLog.length = 0;
+  subject.rerender({
+    sessionFrames: [{ frame: frameWith("more", 1), sessionId: "one" }],
+  });
+  await waitFor(() =>
+    assert.ok(gridDraws(subject.view).some((entry) => entry.text === "more")),
+  );
+  assert.equal(
+    gridDraws(subject.view).some(
+      (entry) =>
+        entry.kind === "fill" && entry.width === 940.8 && entry.height === 782,
+    ),
+    false,
+    "an incremental frame must not fill the whole viewport",
+  );
+});
+
+test("a switch during a bailed paint pass is honoured once painting resumes", async () => {
+  const subject = fixture({
+    sessionFrames: [{ frame: frameWith("one"), sessionId: "one" }],
+    sessions: TWO_SESSIONS,
+  });
+  await ready(subject.view);
+  await waitFor(() =>
+    assert.ok(gridDraws(subject.view).some((entry) => entry.text === "one")),
+  );
+
+  // The paint effect returns early when there is no 2d context. Writing
+  // `paintedSessionRef` before those returns would mark this switch as already
+  // painted, and the fill that erases "one" would never run.
+  dom.window.HTMLCanvasElement.prototype.getContext = () => null;
+  subject.rerender({ sessions: SWAPPED_SESSIONS });
+  paintLog.length = 0;
+
+  // Restoring the context is not enough to re-run the effect: its deps are the
+  // session, cursor, frames and palette. A frame for the now-inactive session
+  // re-triggers it without giving "two" a grid and without touching the palette,
+  // either of which would force the fill for an unrelated reason.
+  dom.window.HTMLCanvasElement.prototype.getContext = function () {
+    return paintRecorder(this);
+  };
+  subject.rerender({
+    sessionFrames: [{ frame: frameWith("one", 1), sessionId: "one" }],
+    sessions: SWAPPED_SESSIONS,
+  });
+  await waitFor(() =>
+    assert.ok(
+      gridDraws(subject.view).some(
+        (entry) =>
+          entry.kind === "fill" &&
+          entry.width === 940.8 &&
+          entry.height === 782,
+      ),
+      "the pending switch must still repaint after the bail",
+    ),
+  );
 });

--- a/desktop/src/features/terminal/TerminalSubstrate.tsx
+++ b/desktop/src/features/terminal/TerminalSubstrate.tsx
@@ -99,6 +99,7 @@ export function TerminalSubstrate({
   const appliedFramesRef = React.useRef(new WeakSet<TerminalFrame>());
   const gridRef = React.useRef<TerminalGrid | null>(null);
   const paintedPaletteRef = React.useRef(terminalPalette);
+  const paintedSessionRef = React.useRef<string | null>(null);
   const previousFocusRef = React.useRef<HTMLElement | null>(null);
   const reportedFocusRef = React.useRef<boolean | null>(null);
   const scrollBySessionRef = React.useRef(new Map<string, number>());
@@ -375,15 +376,25 @@ export function TerminalSubstrate({
       canvas.width !== pixelWidth || canvas.height !== pixelHeight;
     const paletteChanged = paintedPaletteRef.current !== terminalPalette;
     paintedPaletteRef.current = terminalPalette;
+    // A grid drains its dirty set in paint(), so a session that was painted and
+    // then deactivated comes back holding rows with nothing marked dirty. Both
+    // refs are written after the early returns above, so a pass that bails
+    // keeps the switch pending instead of swallowing it.
+    const sessionChanged = paintedSessionRef.current !== activeSessionId;
+    paintedSessionRef.current = activeSessionId;
+    const repaintAll = resized || paletteChanged || sessionChanged;
     if (resized) {
       canvas.width = pixelWidth;
       canvas.height = pixelHeight;
     }
-    if (resized || paletteChanged) {
+    if (repaintAll) {
       gridRef.current?.markAllDirty();
     }
     context.setTransform(dpr, 0, 0, dpr, 0, 0);
-    if (resized || paletteChanged) {
+    if (repaintAll) {
+      // Not grid-guarded: switching to a session that has delivered no frame
+      // yet has no grid to mark or paint, so this fill is the only thing that
+      // erases the outgoing session's pixels.
       context.fillStyle = terminalPalette.background;
       context.fillRect(0, 0, bounds.width, bounds.height);
     }


### PR DESCRIPTION
Bug 6 of Tyler's Buzz Term batch (#4347): switching tabs left the previous session's text on screen. Base `max/tui-renderer` @ `135042253`.

## Mechanism

Eva's initial root-cause and my own first version of it were both wrong in the same way, and the correction changes what a sufficient fix is.

`TerminalGrid` drains its dirty set in **`paint()`**, not in `apply()` — the sole `#dirty.clear()` is the last statement of `paint` (`terminalRenderer.ts:230`); `apply()` only ever adds (`:139-146`). Measured directly:

```
after construct+apply, painted line-bands: [0, 17, 34, 51, 68]   // all rows
second paint, nothing applied:             []                    // drained
after apply(line 2) then paint:            lines 0 and 2 only
```

So an inactive session **accumulates** dirty lines while off-screen and repaints correctly on the first switch to it. **A single switch is not a reproduction.** The failure needs a round trip: A → B → A. Only a grid that has been painted (drained) and then deactivated comes back holding rows with an empty dirty set. The paint effect swapped `gridRef` on `activeSessionId` change without marking anything, so `paint()` drew zero lines and the canvas kept the outgoing session's pixels — except the cursor line, which `apply()`/`setCursorPainted` re-dirty. That is exactly Tyler's report: *"Switching between tabs does not remove the text from the screen. It does move the cursor line into position, though."*

My first regression test asserted the original mechanism and **passed at base** — it would have shipped as a test that never protected anything.

## Fix

13 lines. Track the painted session in a ref, derive `sessionChanged` beside `resized`/`paletteChanged`, and name the union `repaintAll`.

`markAllDirty()` alone is **not sufficient**. Switching to a session that has delivered no frame yet has no grid at all, so `markAllDirty()` and `paint()` are both no-ops on the optional chain, and only the background fill can erase the outgoing session. Hence the fill is deliberately not grid-guarded. It also covers full canvas bounds rather than `columns * cellWidth`, which would leave a right-hand gutter.

Both refs are read-then-written **after** the effect's early returns, so a pass that bails on a missing canvas or context keeps the switch pending rather than swallowing it.

## Verification

Four tests, each pinned by a mutant that only it kills. Mutant sweep **7/7 killed**, every verdict from a mutant proven to have applied (harness prints the produced diff and reports `NO-OP -- INVALID` instead of a verdict when an anchor misses):

| mutant | killed by |
|---|---|
| M1 drop `sessionChanged` from the trigger | 3 tests |
| M2 `markAllDirty` not on session change | idle-session round trip |
| M3 fill not on session change | no-frame + bailed-pass |
| M4 fill made grid-conditional (the naive fix) | no-frame + bailed-pass |
| M5 `sessionChanged` can never be true | 3 tests |
| M6 ref never updated | unchanged-session negative test |
| M7 ref write hoisted above the early returns | 3 tests |

Two tests exist **only** because a mutant survived:

- **M6** — dropping the ref write leaves `sessionChanged` permanently true, so every frame repaints the whole viewport. Screen output is correct; it just discards the damage model the renderer exists for. All three then-existing tests passed. Only a negative assertion sees it, so there is now one.
- **M7** — I had written a comment claiming the bail-out ordering was safe with nothing enforcing it. Writing that test took two instrument fixes: the first re-triggered via a prop that isn't in the effect's dep array (the effect never re-ran), and then the mutant was landing at line 187 inside `reportViewportSize`, because `const canvas = canvasRef.current;` occurs three times and `perl -0p` takes the first. Re-anchored on the `gridRef.current = activeSessionId ? … : null` assignment, unique to the paint effect.

The suite's `getContext` stub discarded every argument, which makes **any** assertion about painting vacuous. It now records draw calls keyed by canvas element, so the banner canvas cannot be mistaken for the grid.

- Full frontend suite (not a scoped run): **3975/3975 pass**, 0 fail.
- `pnpm typecheck` clean. `pnpm check` clean on both my files; the 2 `useTemplate` infos are pre-existing in `personaCatalogRelay.test.mjs`, confirmed with a stash control at base.
- All pre-push hooks green (`desktop-check`, `desktop-test`, `mobile-test`, `rust-tests`, `desktop-tauri-checks`).

**Overlap with Mari's bug-5 lane** (`mari/tui-tab-focus`, same file): `git merge-tree` clean, and the merged result runs **3977/3977 pass** — the two lanes coexist behaviourally, not just textually. Worth noting the first clean reading came from a broken instrument: two-arg `merge-tree` against a *descendant* returns exit 0 on a guaranteed conflict, because that is a fast-forward, not a merge. Re-verified with a sibling-branch negative control that correctly reports exit 1 + `CONFLICT`.

## For reviewers

A one-switch manual check is a **false all-clear**. Verify with A → B → A, and additionally switch to a freshly-opened tab that has produced no output yet.

Co-authored-by: tlongwell-block <109685178+tlongwell-block@users.noreply.github.com>
Signed-off-by: tlongwell-block <109685178+tlongwell-block@users.noreply.github.com>
