### PR TITLE
fix(acp): authenticate relay workflow authorship

### DIFF
--- a/crates/buzz-acp/src/lib.rs
+++ b/crates/buzz-acp/src/lib.rs
@@ -257,6 +257,36 @@ async fn author_allowed(
     }
 }
 
+/// Return the author identity evaluated by the inbound security gate.
+///
+/// Workflow `send_message` events are signed by the relay because it executes
+/// the scheduled action, while the first `p` tag records the workflow owner who
+/// authorized that action. Honor that delegated identity only when the signer
+/// matches the relay identity discovered from NIP-11. An ordinary user cannot
+/// bypass `respond-to` by adding a `buzz:workflow` tag to their own event.
+fn event_author_for_gate(event: &nostr::Event, trusted_relay_pubkey: Option<&str>) -> String {
+    let signer = event.pubkey.to_hex();
+    let is_trusted_workflow = event.kind.as_u16() as u32 == KIND_STREAM_MESSAGE
+        && trusted_relay_pubkey.is_some_and(|relay| relay.eq_ignore_ascii_case(&signer))
+        && event.tags.iter().any(|tag| {
+            let values = tag.as_slice();
+            values.first().map(String::as_str) == Some("buzz:workflow")
+                && values.get(1).map(String::as_str) == Some("true")
+        });
+    if !is_trusted_workflow {
+        return signer;
+    }
+
+    event
+        .tags
+        .iter()
+        .find(|tag| tag.as_slice().first().map(String::as_str) == Some("p"))
+        .and_then(|tag| tag.as_slice().get(1))
+        .and_then(|value| PublicKey::from_hex(value).ok())
+        .map(|pubkey| pubkey.to_hex())
+        .unwrap_or(signer)
+}
+
 /// Resolve whether `channel_id` is a DM, for the inbound author gate.
 ///
 /// Resolution order:
@@ -1406,6 +1436,25 @@ async fn tokio_main() -> Result<()> {
 
     tracing::info!("connected to relay at {}", config.relay_url);
 
+    let trusted_relay_pubkey = match relay.rest_client().nip11_relay_pubkey().await {
+        Ok(Some(pubkey)) => {
+            tracing::info!(relay_pubkey = %pubkey, "trusted NIP-11 relay identity resolved");
+            Some(pubkey)
+        }
+        Ok(None) => {
+            tracing::warn!(
+                "NIP-11 did not advertise a valid relay identity — workflow delegated authorship disabled"
+            );
+            None
+        }
+        Err(error) => {
+            tracing::warn!(
+                "failed to resolve NIP-11 relay identity: {error} — workflow delegated authorship disabled"
+            );
+            None
+        }
+    };
+
     relay
         .subscribe_membership_notifications()
         .await
@@ -2215,7 +2264,10 @@ async fn tokio_main() -> Result<()> {
                             // explicit pubkey list on top, for external people;
                             // it never revokes same-owner team bots.
                             {
-                                let author = buzz_event.event.pubkey.to_hex();
+                                let author = event_author_for_gate(
+                                    &buzz_event.event,
+                                    trusted_relay_pubkey.as_deref(),
+                                );
                                 // DM hardening: resolve channel type (fail-closed
                                 // to DM) so allowlist/anyone modes cannot be
                                 // exercised by non-owner authors inside DMs.
@@ -4520,6 +4572,118 @@ mod owner_cache_tests {
 #[cfg(test)]
 mod author_gate_tests {
     use super::*;
+
+    fn workflow_event(
+        signer: &nostr::Keys,
+        delegated_author: &nostr::PublicKey,
+        mentioned_agent: &nostr::PublicKey,
+    ) -> nostr::Event {
+        use nostr::{EventBuilder, Kind, Tag};
+
+        EventBuilder::new(
+            Kind::Custom(KIND_STREAM_MESSAGE as u16),
+            "@Rui run the monitor",
+        )
+        .tags([
+            Tag::parse(["p", &delegated_author.to_hex()]).expect("delegated author tag"),
+            Tag::parse(["h", &Uuid::new_v4().to_string()]).expect("channel tag"),
+            Tag::parse(["buzz:workflow", "true"]).expect("workflow tag"),
+            Tag::parse(["p", &mentioned_agent.to_hex()]).expect("agent mention tag"),
+        ])
+        .sign_with_keys(signer)
+        .expect("workflow event signs")
+    }
+
+    #[test]
+    fn trusted_relay_workflow_uses_delegated_author_for_gate() {
+        let relay = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let agent = nostr::Keys::generate();
+        let event = workflow_event(&relay, &owner.public_key(), &agent.public_key());
+
+        assert_eq!(
+            event_author_for_gate(&event, Some(&relay.public_key().to_hex())),
+            owner.public_key().to_hex()
+        );
+    }
+
+    #[test]
+    fn untrusted_workflow_tag_cannot_spoof_delegated_author() {
+        let relay = nostr::Keys::generate();
+        let attacker = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let agent = nostr::Keys::generate();
+        let event = workflow_event(&attacker, &owner.public_key(), &agent.public_key());
+
+        assert_eq!(
+            event_author_for_gate(&event, Some(&relay.public_key().to_hex())),
+            attacker.public_key().to_hex()
+        );
+        assert_eq!(
+            event_author_for_gate(&event, None),
+            attacker.public_key().to_hex()
+        );
+    }
+
+    #[test]
+    fn trusted_relay_non_workflow_event_keeps_relay_signer() {
+        use nostr::{EventBuilder, Kind, Tag};
+
+        let relay = nostr::Keys::generate();
+        let owner = nostr::Keys::generate();
+        let event = EventBuilder::new(
+            Kind::Custom(KIND_STREAM_MESSAGE as u16),
+            "relay-authored message",
+        )
+        .tags([Tag::parse(["p", &owner.public_key().to_hex()]).expect("p tag")])
+        .sign_with_keys(&relay)
+        .expect("event signs");
+
+        assert_eq!(
+            event_author_for_gate(&event, Some(&relay.public_key().to_hex())),
+            relay.public_key().to_hex()
+        );
+    }
+
+    #[test]
+    fn trusted_relay_workflow_without_valid_owner_keeps_relay_signer() {
+        use nostr::{EventBuilder, Kind, Tag};
+
+        let relay = nostr::Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "workflow message")
+            .tags([
+                Tag::parse(["p", "not-a-pubkey"]).expect("malformed owner tag"),
+                Tag::parse(["buzz:workflow", "true"]).expect("workflow tag"),
+            ])
+            .sign_with_keys(&relay)
+            .expect("event signs");
+
+        assert_eq!(
+            event_author_for_gate(&event, Some(&relay.public_key().to_hex())),
+            relay.public_key().to_hex()
+        );
+    }
+
+    #[test]
+    fn malformed_first_owner_cannot_fall_through_to_later_recipient() {
+        use nostr::{EventBuilder, Kind, Tag};
+
+        let relay = nostr::Keys::generate();
+        let mentioned_agent = nostr::Keys::generate();
+        let event = EventBuilder::new(Kind::Custom(KIND_STREAM_MESSAGE as u16), "workflow message")
+            .tags([
+                Tag::parse(["p", "not-a-pubkey"]).expect("malformed owner tag"),
+                Tag::parse(["buzz:workflow", "true"]).expect("workflow tag"),
+                Tag::parse(["p", &mentioned_agent.public_key().to_hex()]).expect("recipient tag"),
+            ])
+            .sign_with_keys(&relay)
+            .expect("event signs");
+
+        assert_eq!(
+            event_author_for_gate(&event, Some(&relay.public_key().to_hex())),
+            relay.public_key().to_hex()
+        );
+    }
 
     /// A `RestClient` for tests. The author-gate decisions exercised here all
     /// resolve from the owner pubkey or sibling cache before any HTTP call, so

--- a/crates/buzz-acp/src/relay.rs
+++ b/crates/buzz-acp/src/relay.rs
@@ -118,7 +118,7 @@ use buzz_core::kind::{
     KIND_TYPING_INDICATOR,
 };
 use futures_util::{SinkExt, StreamExt};
-use nostr::{Event, EventBuilder, Keys, Kind, RelayUrl, Tag};
+use nostr::{Event, EventBuilder, Keys, Kind, PublicKey, RelayUrl, Tag};
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
 use tokio::time::timeout;
@@ -156,6 +156,47 @@ pub(crate) fn channel_type_from_tags(tags: &[serde_json::Value]) -> String {
     } else {
         "stream".to_string()
     }
+}
+
+fn parse_nip11_relay_pubkey(document: &Value) -> Option<String> {
+    document
+        .get("self")
+        .and_then(Value::as_str)
+        .and_then(|value| PublicKey::from_hex(value).ok())
+        .map(|pubkey| pubkey.to_hex())
+}
+
+fn nip11_identity_transport_is_trusted(base_url: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(base_url) else {
+        return false;
+    };
+    if url.scheme() == "https" {
+        return true;
+    }
+
+    url.scheme() == "http"
+        && url
+            .host_str()
+            .is_some_and(|host| matches!(host, "localhost" | "127.0.0.1" | "[::1]"))
+}
+
+fn nip11_identity_response_is_trusted(base_url: &str, response_url: &str) -> bool {
+    if !nip11_identity_transport_is_trusted(base_url)
+        || !nip11_identity_transport_is_trusted(response_url)
+    {
+        return false;
+    }
+
+    let (Ok(base), Ok(response)) = (
+        reqwest::Url::parse(base_url),
+        reqwest::Url::parse(response_url),
+    ) else {
+        return false;
+    };
+
+    base.scheme() == response.scheme()
+        && base.host_str() == response.host_str()
+        && base.port_or_known_default() == response.port_or_known_default()
 }
 
 /// Build the discovered-channel subscribe set from the membership UUIDs and the
@@ -259,6 +300,35 @@ fn unix_now_secs() -> u64 {
 }
 
 impl RestClient {
+    /// Fetch the relay signer advertised by NIP-11.
+    ///
+    /// ACP uses this identity to authenticate relay-executed workflow messages
+    /// before evaluating their delegated workflow-owner `p` tag.
+    pub async fn nip11_relay_pubkey(&self) -> Result<Option<String>, RelayError> {
+        if !nip11_identity_transport_is_trusted(&self.base_url) {
+            return Ok(None);
+        }
+
+        let response = self
+            .http
+            .get(&self.base_url)
+            .header(reqwest::header::ACCEPT, "application/nostr+json")
+            .send()
+            .await
+            .map_err(|error| RelayError::Http(format!("NIP-11 request failed: {error}")))?;
+        if !nip11_identity_response_is_trusted(&self.base_url, response.url().as_str()) {
+            return Ok(None);
+        }
+        let response = response
+            .error_for_status()
+            .map_err(|error| RelayError::Http(format!("NIP-11 request failed: {error}")))?;
+        let document = response
+            .json::<Value>()
+            .await
+            .map_err(|error| RelayError::Http(format!("invalid NIP-11 document: {error}")))?;
+        Ok(parse_nip11_relay_pubkey(&document))
+    }
+
     /// Sign a NIP-98 HTTP Auth event (kind:27235) for the given method/URL/body.
     ///
     /// Returns the `Authorization: Nostr <base64>` header value (without the
@@ -4007,6 +4077,66 @@ async fn wait_for_any_ok(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_valid_relay_identity_from_nip11() {
+        let relay = Keys::generate();
+        let document = serde_json::json!({ "self": relay.public_key().to_hex() });
+
+        assert_eq!(
+            parse_nip11_relay_pubkey(&document),
+            Some(relay.public_key().to_hex())
+        );
+    }
+
+    #[test]
+    fn rejects_missing_or_invalid_nip11_relay_identity() {
+        assert_eq!(parse_nip11_relay_pubkey(&serde_json::json!({})), None);
+        assert_eq!(
+            parse_nip11_relay_pubkey(&serde_json::json!({ "self": "not-a-pubkey" })),
+            None
+        );
+    }
+
+    #[test]
+    fn trusts_nip11_identity_only_over_tls_or_loopback() {
+        assert!(nip11_identity_transport_is_trusted(
+            "https://relay.example.com"
+        ));
+        assert!(nip11_identity_transport_is_trusted("http://localhost:3000"));
+        assert!(nip11_identity_transport_is_trusted("http://127.0.0.1:3000"));
+        assert!(nip11_identity_transport_is_trusted("http://[::1]:3000"));
+        assert!(!nip11_identity_transport_is_trusted(
+            "http://relay.example.com"
+        ));
+        assert!(!nip11_identity_transport_is_trusted(
+            "http://100.86.114.121:3000"
+        ));
+    }
+
+    #[test]
+    fn trusts_nip11_response_only_from_the_configured_origin() {
+        assert!(nip11_identity_response_is_trusted(
+            "https://relay.example.com",
+            "https://relay.example.com/nip11"
+        ));
+        assert!(nip11_identity_response_is_trusted(
+            "https://relay.example.com:443",
+            "https://relay.example.com/"
+        ));
+        assert!(!nip11_identity_response_is_trusted(
+            "https://relay.example.com",
+            "https://attacker.example.com/"
+        ));
+        assert!(!nip11_identity_response_is_trusted(
+            "https://relay.example.com",
+            "https://relay.example.com:8443/"
+        ));
+        assert!(!nip11_identity_response_is_trusted(
+            "http://localhost:3000",
+            "https://relay.example.com/"
+        ));
+    }
 
     #[test]
     fn relay_ws_to_http_plain() {

--- a/crates/buzz-acp/src/setup_mode.rs
+++ b/crates/buzz-acp/src/setup_mode.rs
@@ -73,7 +73,7 @@ pub(crate) enum AcpAvailabilityStatus {
 use crate::{
     author_allowed,
     config::Config,
-    event_mentions_agent, filter,
+    event_author_for_gate, event_mentions_agent, filter,
     relay::{HarnessRelay, RelayEventPublisher},
 };
 
@@ -382,6 +382,21 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
 
     let publisher = relay.event_publisher();
     let rest_client = relay.rest_client();
+    let trusted_relay_pubkey = match rest_client.nip11_relay_pubkey().await {
+        Ok(Some(pubkey)) => Some(pubkey),
+        Ok(None) => {
+            tracing::warn!(
+                "setup-mode: NIP-11 did not advertise a valid relay identity — workflow delegated authorship disabled"
+            );
+            None
+        }
+        Err(error) => {
+            tracing::warn!(
+                "setup-mode: failed to resolve NIP-11 relay identity: {error} — workflow delegated authorship disabled"
+            );
+            None
+        }
+    };
 
     let channel_info = crate::pool::ChannelInfoResolver::new(channel_info_map, rest_client.clone());
 
@@ -428,7 +443,7 @@ pub(crate) async fn run_setup_listener(config: Config, payload: SetupPayload) ->
         // Apply the same author gate as normal mode so the nudge only goes
         // to authors the real agent would have answered. Same DM hardening:
         // in DMs only owner/siblings get a nudge (fail-closed on unknown type).
-        let author_hex = buzz_event.event.pubkey.to_hex();
+        let author_hex = event_author_for_gate(&buzz_event.event, trusted_relay_pubkey.as_deref());
         let is_dm = crate::is_dm_channel(buzz_event.channel_id, &channel_info).await;
         let allowed = author_allowed(
             &config.respond_to,


### PR DESCRIPTION
## Summary
- authenticate relay-executed workflow messages through the relay NIP-11 identity
- evaluate the protocol-defined first `p` tag as delegated workflow owner while failing closed for malformed or spoofed envelopes
- apply the same author resolution in normal and setup listeners
- reject insecure and cross-origin NIP-11 identity discovery

## Verification
- `env -u BUZZ_ACP_LAZY_POOL cargo test -p buzz-acp`
- `cargo clippy -p buzz-acp --all-targets -- -D warnings`
- `cargo fmt --all --check`

Originating Buzz channel: `05278651-7d98-4fa0-b542-3856cec9567e`