### PR TITLE
feat(desktop): add floating huddle voice controls

### DIFF
--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -133,6 +133,7 @@ export default defineConfig({
         "**/harness-catalog-screenshots.spec.ts",
         "**/inline-custom-harness.spec.ts",
         "**/huddle-transcription.spec.ts",
+        "**/voice-overlay.spec.ts",
       ],
       use: {
         ...devices["Desktop Chrome"],

--- a/desktop/src-tauri/capabilities/voice-overlay.json
+++ b/desktop/src-tauri/capabilities/voice-overlay.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "voice-overlay",
+  "description": "Minimal capability for the floating Buzz Voice controller",
+  "windows": ["voice-overlay"],
+  "permissions": [
+    "core:event:allow-listen",
+    "core:event:allow-unlisten",
+    "core:event:allow-emit-to",
+    "core:window:allow-start-dragging",
+    "core:window:allow-close"
+  ]
+}

--- a/desktop/src-tauri/src/huddle/mod.rs
+++ b/desktop/src-tauri/src/huddle/mod.rs
@@ -28,6 +28,7 @@ pub mod agents;
 pub mod audio_output;
 pub mod jitter;
 pub mod models;
+pub mod overlay;
 pub mod pipeline;
 pub mod playout;
 pub mod pocket;

--- a/desktop/src-tauri/src/huddle/overlay.rs
+++ b/desktop/src-tauri/src/huddle/overlay.rs
@@ -1,0 +1,135 @@
+use serde::Deserialize;
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+
+const VOICE_OVERLAY_LABEL: &str = "voice-overlay";
+
+#[derive(Debug, PartialEq, Eq)]
+enum OpenVoiceOverlayEffect {
+    Create,
+    Reveal,
+}
+
+fn open_voice_overlay_effect(window_exists: bool) -> OpenVoiceOverlayEffect {
+    if window_exists {
+        OpenVoiceOverlayEffect::Reveal
+    } else {
+        OpenVoiceOverlayEffect::Create
+    }
+}
+
+fn reveal_window(window: &WebviewWindow, context: &str) -> Result<(), String> {
+    if let Err(error) = window.unminimize() {
+        eprintln!("buzz-desktop: failed to restore {context}: {error}");
+    }
+    if let Err(error) = window.set_always_on_top(true) {
+        eprintln!("buzz-desktop: failed to keep {context} on top: {error}");
+    }
+    window
+        .show()
+        .map_err(|error| format!("failed to show {context}: {error}"))?;
+    if let Err(error) = window.set_focus() {
+        eprintln!("buzz-desktop: failed to focus {context}: {error}");
+    }
+    Ok(())
+}
+
+fn open_voice_overlay(app: &AppHandle) -> Result<(), String> {
+    match open_voice_overlay_effect(app.get_webview_window(VOICE_OVERLAY_LABEL).is_some()) {
+        OpenVoiceOverlayEffect::Reveal => {
+            let window = app
+                .get_webview_window(VOICE_OVERLAY_LABEL)
+                .ok_or_else(|| "voice overlay disappeared while opening".to_owned())?;
+            reveal_window(&window, "voice overlay")
+        }
+        OpenVoiceOverlayEffect::Create => WebviewWindowBuilder::new(
+            app,
+            VOICE_OVERLAY_LABEL,
+            WebviewUrl::App("index.html#/voice-overlay".into()),
+        )
+        .title("Buzz Voice")
+        .inner_size(376.0, 148.0)
+        .min_inner_size(320.0, 148.0)
+        .max_inner_size(520.0, 220.0)
+        .resizable(true)
+        .maximizable(false)
+        .minimizable(false)
+        .decorations(false)
+        .always_on_top(true)
+        .skip_taskbar(true)
+        .visible(false)
+        .focused(false)
+        .shadow(true)
+        .center()
+        .build()
+        .map(|_| ())
+        .or_else(|error| {
+            if let Some(window) = app.get_webview_window(VOICE_OVERLAY_LABEL) {
+                reveal_window(&window, "voice overlay")
+            } else {
+                Err(format!("failed to create voice overlay: {error}"))
+            }
+        }),
+    }
+}
+
+fn show_main_window(app: &AppHandle) -> Result<(), String> {
+    let window = app
+        .get_webview_window("main")
+        .ok_or_else(|| "main window is unavailable".to_owned())?;
+    window
+        .unminimize()
+        .map_err(|error| format!("failed to restore main window: {error}"))?;
+    window
+        .show()
+        .map_err(|error| format!("failed to show main window: {error}"))?;
+    window
+        .set_focus()
+        .map_err(|error| format!("failed to focus main window: {error}"))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VoiceOverlayWindowAction {
+    Open,
+    Ready,
+    ShowMain,
+}
+
+#[tauri::command]
+pub async fn voice_overlay_window(
+    app: AppHandle,
+    window: WebviewWindow,
+    action: VoiceOverlayWindowAction,
+) -> Result<(), String> {
+    match action {
+        VoiceOverlayWindowAction::Open => open_voice_overlay(&app),
+        VoiceOverlayWindowAction::Ready => {
+            if window.label() != VOICE_OVERLAY_LABEL {
+                return Err("voice overlay ready called from an unexpected window".to_owned());
+            }
+            reveal_window(&window, "voice overlay")
+        }
+        VoiceOverlayWindowAction::ShowMain => show_main_window(&app),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{open_voice_overlay_effect, OpenVoiceOverlayEffect};
+
+    #[test]
+    fn opening_without_an_existing_overlay_creates_one() {
+        assert_eq!(
+            open_voice_overlay_effect(false),
+            OpenVoiceOverlayEffect::Create
+        );
+    }
+
+    #[test]
+    fn repeated_open_reveals_the_single_existing_overlay() {
+        assert_eq!(
+            open_voice_overlay_effect(true),
+            OpenVoiceOverlayEffect::Reveal
+        );
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -562,7 +562,6 @@ pub fn run() {
             }
 
             try_regenerate_nest(&app_handle);
-
             if let Some(mgr) = huddle::models::global_model_manager() {
                 mgr.start_stt_download(state.http_client.clone());
                 mgr.start_tts_download(state.http_client.clone());
@@ -909,6 +908,7 @@ pub fn run() {
             list_audio_output_devices,
             set_audio_output_device,
             get_audio_output_device,
+            huddle::overlay::voice_overlay_window,
             start_pairing,
             confirm_pairing_sas,
             cancel_pairing,

--- a/desktop/src/features/huddle/VoiceOverlayRoot.tsx
+++ b/desktop/src/features/huddle/VoiceOverlayRoot.tsx
@@ -1,0 +1,323 @@
+import { invoke } from "@tauri-apps/api/core";
+import { emitTo, listen } from "@tauri-apps/api/event";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
+import {
+  Captions,
+  Mic,
+  MicOff,
+  Move,
+  PhoneOff,
+  Radio,
+  Volume2,
+  VolumeX,
+  X,
+} from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import {
+  type VoiceOverlayAction,
+  type VoiceOverlayMediaState,
+  type VoiceOverlayPhase,
+  VOICE_OVERLAY_ACTION_EVENT,
+  VOICE_OVERLAY_READY_EVENT,
+  VOICE_OVERLAY_STATE_EVENT,
+  voiceOverlayMediaSnapshot,
+} from "./lib/voiceOverlayProtocol";
+
+type NativeHuddleState = {
+  phase: VoiceOverlayPhase;
+  participants: string[];
+  agent_pubkeys: string[];
+  tts_enabled: boolean;
+  transcription_enabled: boolean;
+  voice_input_mode: "push_to_talk" | "voice_activity";
+};
+
+const defaultMediaState: VoiceOverlayMediaState = {
+  version: 1,
+  phase: "idle",
+  participantCount: 0,
+  agentCount: 0,
+  ttsEnabled: true,
+  transcriptionEnabled: false,
+  isLeaving: false,
+  error: null,
+  isMuted: false,
+  micConnected: false,
+  micLevel: 0,
+  pttActive: false,
+  voiceInputMode: "voice_activity",
+};
+
+function snapshotFromNativeState(
+  state: NativeHuddleState,
+  current: VoiceOverlayMediaState,
+): VoiceOverlayMediaState {
+  return voiceOverlayMediaSnapshot({
+    ...current,
+    version: 1,
+    phase: state.phase,
+    participantCount: state.participants.length,
+    agentCount: state.agent_pubkeys.length,
+    ttsEnabled: state.tts_enabled,
+    transcriptionEnabled: state.transcription_enabled,
+    voiceInputMode: state.voice_input_mode,
+    isLeaving: state.phase === "leaving",
+  });
+}
+
+function participantSummary(participants: number, agents: number): string {
+  const participantLabel = participants === 1 ? "participant" : "participants";
+  const agentLabel = agents === 1 ? "agent" : "agents";
+  return `${participants} ${participantLabel} · ${agents} ${agentLabel}`;
+}
+
+async function sendMainAction(action: VoiceOverlayAction) {
+  await emitTo("main", VOICE_OVERLAY_ACTION_EVENT, action);
+}
+
+export function VoiceOverlayRoot() {
+  const [snapshot, setSnapshot] = React.useState(defaultMediaState);
+  const [transportError, setTransportError] = React.useState<string | null>(
+    null,
+  );
+
+  const refreshNativeState = React.useCallback(async () => {
+    const state = await invoke<NativeHuddleState>("get_huddle_state");
+    setSnapshot((current) => snapshotFromNativeState(state, current));
+    setTransportError(null);
+  }, []);
+
+  const dispatchAction = React.useCallback(
+    async (action: VoiceOverlayAction) => {
+      try {
+        await sendMainAction(action);
+        setTransportError(null);
+      } catch {
+        setTransportError("Voice controls could not reach the main window.");
+      }
+    },
+    [],
+  );
+
+  React.useLayoutEffect(() => {
+    void invoke("voice_overlay_window", { action: "ready" }).catch(() => {
+      // Browser E2E and unsupported hosts render without native reveal.
+    });
+  }, []);
+
+  React.useEffect(() => {
+    let disposed = false;
+    const cleanups: Array<() => void> = [];
+
+    void refreshNativeState().catch(() => {
+      if (!disposed) {
+        setTransportError("Voice state is unavailable.");
+      }
+    });
+
+    void (async () => {
+      const unlistenNative = await listen<NativeHuddleState>(
+        "huddle-state-changed",
+        (event) => {
+          if (!disposed) {
+            setSnapshot((current) =>
+              snapshotFromNativeState(event.payload, current),
+            );
+            setTransportError(null);
+          }
+        },
+      );
+      if (disposed) {
+        unlistenNative();
+        return;
+      }
+      cleanups.push(() => void unlistenNative());
+
+      const unlistenOwner = await listen<VoiceOverlayMediaState>(
+        VOICE_OVERLAY_STATE_EVENT,
+        (event) => {
+          if (!disposed && event.payload.version === 1) {
+            setSnapshot(voiceOverlayMediaSnapshot(event.payload));
+            setTransportError(null);
+          }
+        },
+      );
+      if (disposed) {
+        unlistenOwner();
+        return;
+      }
+      cleanups.push(() => void unlistenOwner());
+
+      await emitTo("main", VOICE_OVERLAY_READY_EVENT);
+    })().catch(() => {
+      if (!disposed) {
+        setTransportError("Voice controls could not reach the main window.");
+      }
+    });
+
+    return () => {
+      disposed = true;
+      for (const cleanup of cleanups) cleanup();
+    };
+  }, [refreshNativeState]);
+
+  const displayedError = transportError ?? snapshot.error;
+  const isActive =
+    snapshot.phase === "active" || snapshot.phase === "connected";
+  const isPtt = snapshot.voiceInputMode === "push_to_talk";
+  const micLabel = !snapshot.micConnected
+    ? "Microphone syncing"
+    : snapshot.isMuted
+      ? "Unmute microphone"
+      : "Mute microphone";
+
+  return (
+    <main
+      className="min-h-dvh bg-transparent p-2 text-foreground"
+      data-testid="voice-overlay"
+    >
+      <section className="overflow-hidden rounded-2xl border bg-background/95 shadow-2xl backdrop-blur-xl">
+        <header
+          className="flex h-10 items-center gap-2 border-b px-3"
+          data-tauri-drag-region
+        >
+          <Move className="h-3.5 w-3.5 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-semibold">Buzz Voice</p>
+            <p className="truncate text-xs text-muted-foreground">
+              {isActive
+                ? participantSummary(
+                    snapshot.participantCount,
+                    snapshot.agentCount,
+                  )
+                : "No active huddle"}
+            </p>
+          </div>
+          <Button
+            aria-label="Close floating voice controls"
+            className="h-7 w-7 rounded-full"
+            onClick={() => void getCurrentWebviewWindow().close()}
+            size="icon"
+            variant="ghost"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </header>
+
+        <div className="flex items-center justify-center gap-2 px-3 py-3">
+          <Button
+            aria-label={micLabel}
+            aria-pressed={snapshot.isMuted}
+            className={cn(
+              "relative h-11 w-11 rounded-full",
+              snapshot.pttActive &&
+                !snapshot.isMuted &&
+                "ring-2 ring-green-500",
+            )}
+            disabled={!snapshot.micConnected || !isActive}
+            onClick={() =>
+              void dispatchAction({ version: 1, type: "toggle_mute" })
+            }
+            size="icon"
+            variant={snapshot.isMuted ? "destructive" : "secondary"}
+          >
+            {snapshot.isMuted || !snapshot.micConnected ? (
+              <MicOff className="h-4 w-4" />
+            ) : (
+              <Mic className="h-4 w-4" />
+            )}
+            {!snapshot.isMuted && snapshot.micConnected && (
+              <span
+                aria-hidden="true"
+                className="absolute bottom-1 h-1 rounded-full bg-green-500 transition-[width]"
+                style={{ width: `${Math.max(4, snapshot.micLevel * 24)}px` }}
+              />
+            )}
+          </Button>
+
+          <Button
+            aria-label={isPtt ? "Use voice activity" : "Use push to talk"}
+            aria-pressed={isPtt}
+            className="h-11 w-11 rounded-full"
+            disabled={!isActive}
+            onClick={() =>
+              void dispatchAction({
+                version: 1,
+                type: "set_voice_input_mode",
+                mode: isPtt ? "voice_activity" : "push_to_talk",
+              })
+            }
+            size="icon"
+            variant={isPtt ? "default" : "secondary"}
+          >
+            <Radio className="h-4 w-4" />
+          </Button>
+
+          <Button
+            aria-label={
+              snapshot.transcriptionEnabled
+                ? "Stop transcript"
+                : "Start transcript"
+            }
+            aria-pressed={snapshot.transcriptionEnabled}
+            className="h-11 w-11 rounded-full"
+            disabled={!isActive}
+            onClick={() =>
+              void dispatchAction({
+                version: 1,
+                type: "toggle_transcription",
+              })
+            }
+            size="icon"
+            variant={snapshot.transcriptionEnabled ? "default" : "secondary"}
+          >
+            <Captions className="h-4 w-4" />
+          </Button>
+
+          <Button
+            aria-label={
+              snapshot.ttsEnabled ? "Mute agent voice" : "Hear agent voice"
+            }
+            aria-pressed={!snapshot.ttsEnabled}
+            className="h-11 w-11 rounded-full"
+            disabled={!isActive}
+            onClick={() =>
+              void dispatchAction({ version: 1, type: "toggle_tts" })
+            }
+            size="icon"
+            variant="secondary"
+          >
+            {snapshot.ttsEnabled ? (
+              <Volume2 className="h-4 w-4" />
+            ) : (
+              <VolumeX className="h-4 w-4" />
+            )}
+          </Button>
+
+          <Button
+            aria-label="Leave huddle"
+            className="h-11 w-11 rounded-full"
+            disabled={!isActive || snapshot.isLeaving}
+            onClick={() => void dispatchAction({ version: 1, type: "leave" })}
+            size="icon"
+            variant="destructive"
+          >
+            <PhoneOff className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {displayedError && (
+          <p
+            className="border-t px-3 py-2 text-xs text-destructive"
+            role="alert"
+          >
+            {displayedError}
+          </p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/desktop/src/features/huddle/VoiceOverlayRoot.tsx
+++ b/desktop/src/features/huddle/VoiceOverlayRoot.tsx
@@ -18,9 +18,13 @@ import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import {
   type VoiceOverlayAction,
+  type VoiceOverlayActionInput,
   type VoiceOverlayMediaState,
   type VoiceOverlayPhase,
+  createVoiceOverlayActionTracker,
+  parseVoiceOverlayActionResult,
   VOICE_OVERLAY_ACTION_EVENT,
+  VOICE_OVERLAY_ACTION_RESULT_EVENT,
   VOICE_OVERLAY_READY_EVENT,
   VOICE_OVERLAY_STATE_EVENT,
   voiceOverlayMediaSnapshot,
@@ -83,6 +87,23 @@ export function VoiceOverlayRoot() {
   const [transportError, setTransportError] = React.useState<string | null>(
     null,
   );
+  const [actionPending, setActionPending] = React.useState(false);
+  const actionPendingRef = React.useRef(false);
+  const actionTrackerRef = React.useRef<ReturnType<
+    typeof createVoiceOverlayActionTracker
+  > | null>(null);
+  if (!actionTrackerRef.current) {
+    actionTrackerRef.current = createVoiceOverlayActionTracker({
+      setTimer: (callback, delayMs) => window.setTimeout(callback, delayMs),
+      clearTimer: (timerId) => window.clearTimeout(timerId),
+      onSlow: () => setTransportError("Voice action is still working…"),
+      onExpired: () => {
+        actionPendingRef.current = false;
+        setActionPending(false);
+        setTransportError("Voice controls did not respond.");
+      },
+    });
+  }
 
   const refreshNativeState = React.useCallback(async () => {
     const state = await invoke<NativeHuddleState>("get_huddle_state");
@@ -91,11 +112,20 @@ export function VoiceOverlayRoot() {
   }, []);
 
   const dispatchAction = React.useCallback(
-    async (action: VoiceOverlayAction) => {
+    async (action: VoiceOverlayActionInput) => {
+      if (actionPendingRef.current) return;
+      actionPendingRef.current = true;
+      setActionPending(true);
+      const requestId = crypto.randomUUID();
+      const message = { ...action, requestId } as VoiceOverlayAction;
+      actionTrackerRef.current?.start(requestId);
+      setTransportError(null);
       try {
-        await sendMainAction(action);
-        setTransportError(null);
+        await sendMainAction(message);
       } catch {
+        actionTrackerRef.current?.settle(requestId);
+        actionPendingRef.current = false;
+        setActionPending(false);
         setTransportError("Voice controls could not reach the main window.");
       }
     },
@@ -112,13 +142,28 @@ export function VoiceOverlayRoot() {
     let disposed = false;
     const cleanups: Array<() => void> = [];
 
-    void refreshNativeState().catch(() => {
-      if (!disposed) {
-        setTransportError("Voice state is unavailable.");
-      }
-    });
-
     void (async () => {
+      const unlistenActionResult = await listen(
+        VOICE_OVERLAY_ACTION_RESULT_EVENT,
+        (event) => {
+          if (disposed) return;
+          const result = parseVoiceOverlayActionResult(event.payload);
+          if (!result || !actionTrackerRef.current?.settle(result.requestId)) {
+            return;
+          }
+          actionPendingRef.current = false;
+          setActionPending(false);
+          setTransportError(
+            result.ok ? null : `Voice action failed: ${result.error}`,
+          );
+        },
+      );
+      if (disposed) {
+        unlistenActionResult();
+        return;
+      }
+      cleanups.push(() => void unlistenActionResult());
+
       const unlistenNative = await listen<NativeHuddleState>(
         "huddle-state-changed",
         (event) => {
@@ -126,7 +171,6 @@ export function VoiceOverlayRoot() {
             setSnapshot((current) =>
               snapshotFromNativeState(event.payload, current),
             );
-            setTransportError(null);
           }
         },
       );
@@ -141,7 +185,6 @@ export function VoiceOverlayRoot() {
         (event) => {
           if (!disposed && event.payload.version === 1) {
             setSnapshot(voiceOverlayMediaSnapshot(event.payload));
-            setTransportError(null);
           }
         },
       );
@@ -150,6 +193,12 @@ export function VoiceOverlayRoot() {
         return;
       }
       cleanups.push(() => void unlistenOwner());
+
+      try {
+        await refreshNativeState();
+      } catch {
+        if (!disposed) setTransportError("Voice state is unavailable.");
+      }
 
       await emitTo("main", VOICE_OVERLAY_READY_EVENT);
     })().catch(() => {
@@ -161,6 +210,8 @@ export function VoiceOverlayRoot() {
     return () => {
       disposed = true;
       for (const cleanup of cleanups) cleanup();
+      actionTrackerRef.current?.dispose();
+      actionPendingRef.current = false;
     };
   }, [refreshNativeState]);
 
@@ -217,7 +268,7 @@ export function VoiceOverlayRoot() {
                 !snapshot.isMuted &&
                 "ring-2 ring-green-500",
             )}
-            disabled={!snapshot.micConnected || !isActive}
+            disabled={actionPending || !snapshot.micConnected || !isActive}
             onClick={() =>
               void dispatchAction({ version: 1, type: "toggle_mute" })
             }
@@ -242,7 +293,7 @@ export function VoiceOverlayRoot() {
             aria-label={isPtt ? "Use voice activity" : "Use push to talk"}
             aria-pressed={isPtt}
             className="h-11 w-11 rounded-full"
-            disabled={!isActive}
+            disabled={actionPending || !isActive}
             onClick={() =>
               void dispatchAction({
                 version: 1,
@@ -264,7 +315,7 @@ export function VoiceOverlayRoot() {
             }
             aria-pressed={snapshot.transcriptionEnabled}
             className="h-11 w-11 rounded-full"
-            disabled={!isActive}
+            disabled={actionPending || !isActive}
             onClick={() =>
               void dispatchAction({
                 version: 1,
@@ -283,7 +334,7 @@ export function VoiceOverlayRoot() {
             }
             aria-pressed={!snapshot.ttsEnabled}
             className="h-11 w-11 rounded-full"
-            disabled={!isActive}
+            disabled={actionPending || !isActive}
             onClick={() =>
               void dispatchAction({ version: 1, type: "toggle_tts" })
             }
@@ -300,7 +351,7 @@ export function VoiceOverlayRoot() {
           <Button
             aria-label="Leave huddle"
             className="h-11 w-11 rounded-full"
-            disabled={!isActive || snapshot.isLeaving}
+            disabled={actionPending || !isActive || snapshot.isLeaving}
             onClick={() => void dispatchAction({ version: 1, type: "leave" })}
             size="icon"
             variant="destructive"

--- a/desktop/src/features/huddle/components/HuddleBar.tsx
+++ b/desktop/src/features/huddle/components/HuddleBar.tsx
@@ -4,6 +4,7 @@ import {
   Bot,
   Captions,
   MessageSquareText,
+  PictureInPicture2,
   PhoneOff,
   SmilePlus,
 } from "lucide-react";
@@ -31,7 +32,9 @@ import { useHuddle } from "../HuddleContext";
 import { AddAgentDialog, type AgentAddResult } from "./AddAgentDialog";
 import { MicControls, SpeakerControls } from "./MicControls";
 import { HuddleParticipantsControl } from "./ParticipantList";
+import { VoiceOverlayBridge } from "./VoiceOverlayBridge";
 import { truncatePubkey } from "@/shared/lib/pubkey";
+import { voiceOverlayMediaSnapshot } from "../lib/voiceOverlayProtocol";
 
 // Mirrors HuddleState in src-tauri/src/huddle/mod.rs.
 type HuddleState = {
@@ -532,6 +535,16 @@ export function HuddleBar({
     }
   }
 
+  async function handleToggleTts() {
+    try {
+      await invoke("set_tts_enabled", { enabled: !ttsEnabled });
+      const nextState = await invoke<HuddleState>("get_huddle_state");
+      setState(nextState);
+    } catch (error) {
+      console.error("Failed to toggle TTS:", error);
+    }
+  }
+
   function handleOpenThread() {
     if (!parentChannelId || !huddleThreadEventId) return;
     onOpenThread?.(parentChannelId, huddleThreadEventId);
@@ -547,6 +560,31 @@ export function HuddleBar({
         className,
       )}
     >
+      <VoiceOverlayBridge
+        snapshot={voiceOverlayMediaSnapshot({
+          version: 1,
+          phase: barState.phase,
+          participantCount: barState.participants.length,
+          agentCount: barState.agent_pubkeys.length,
+          ttsEnabled,
+          transcriptionEnabled,
+          isLeaving,
+          error: huddleError,
+          isMuted,
+          micConnected,
+          micLevel,
+          pttActive,
+          voiceInputMode,
+        })}
+        onLeave={handleLeave}
+        onSetVoiceInputMode={setVoiceInputMode}
+        onShowMain={() =>
+          invoke("voice_overlay_window", { action: "show_main" })
+        }
+        onToggleMute={() => setIsMuted((muted) => !muted)}
+        onToggleTranscription={handleToggleTranscript}
+        onToggleTts={handleToggleTts}
+      />
       <div className="flex min-w-0 items-center gap-3 overflow-hidden">
         {/* Error banner */}
         {huddleError && (
@@ -649,19 +687,31 @@ export function HuddleBar({
               aecMissing && !headphonesHintDismissed && !isDrawerClosing
             }
             onHeadphonesHintDismiss={() => setHeadphonesHintDismissed(true)}
-            onToggleTts={async () => {
-              try {
-                await invoke("set_tts_enabled", { enabled: !ttsEnabled });
-                const s = await invoke<HuddleState>("get_huddle_state");
-                setState(s);
-              } catch (e) {
-                console.error("Failed to toggle TTS:", e);
-              }
-            }}
+            onToggleTts={handleToggleTts}
             outputDevices={outputDevices}
             selectedOutputDevice={selectedOutputDevice}
             onSelectOutputDevice={setSelectedOutputDevice}
           />
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                aria-label="Open floating voice controls"
+                className="buzz-huddle-control-button h-12 w-12 shrink-0 rounded-md"
+                onClick={() =>
+                  void invoke("voice_overlay_window", { action: "open" })
+                }
+                size="icon"
+                type="button"
+                variant="secondary"
+              >
+                <PictureInPicture2 className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="buzz-huddle-tooltip" side="top">
+              Float voice controls
+            </TooltipContent>
+          </Tooltip>
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/desktop/src/features/huddle/components/HuddleBar.tsx
+++ b/desktop/src/features/huddle/components/HuddleBar.tsx
@@ -507,14 +507,14 @@ export function HuddleBar({
       if (backendClean) {
         setState(null);
       } else {
-        locallyLeavingChannelRef.current = null;
-        stateGenerationRef.current += 1;
+        throw new Error("Could not leave the huddle cleanly.");
       }
       // If cleanup failed, keep the bar visible so the user can retry.
     } catch (e) {
       locallyLeavingChannelRef.current = null;
       stateGenerationRef.current += 1;
       console.error("Failed to leave huddle:", e);
+      throw e;
     } finally {
       setIsLeaving(false);
     }
@@ -532,6 +532,7 @@ export function HuddleBar({
       const message = e instanceof Error ? e.message : String(e);
       setTranscriptError(`Transcript failed: ${message}`);
       console.error("Failed to toggle huddle transcript:", e);
+      throw e;
     }
   }
 
@@ -542,6 +543,7 @@ export function HuddleBar({
       setState(nextState);
     } catch (error) {
       console.error("Failed to toggle TTS:", error);
+      throw error;
     }
   }
 
@@ -563,7 +565,7 @@ export function HuddleBar({
       <VoiceOverlayBridge
         snapshot={voiceOverlayMediaSnapshot({
           version: 1,
-          phase: barState.phase,
+          phase: isDrawerClosing ? "idle" : barState.phase,
           participantCount: barState.participants.length,
           agentCount: barState.agent_pubkeys.length,
           ttsEnabled,
@@ -687,7 +689,7 @@ export function HuddleBar({
               aecMissing && !headphonesHintDismissed && !isDrawerClosing
             }
             onHeadphonesHintDismiss={() => setHeadphonesHintDismissed(true)}
-            onToggleTts={handleToggleTts}
+            onToggleTts={() => void handleToggleTts().catch(() => {})}
             outputDevices={outputDevices}
             selectedOutputDevice={selectedOutputDevice}
             onSelectOutputDevice={setSelectedOutputDevice}
@@ -811,7 +813,7 @@ export function HuddleBar({
                 }
                 aria-pressed={transcriptionEnabled}
                 className="buzz-huddle-control-button h-12 w-12 shrink-0 rounded-md"
-                onClick={() => void handleToggleTranscript()}
+                onClick={() => void handleToggleTranscript().catch(() => {})}
                 size="icon"
                 type="button"
                 variant="ghost"
@@ -850,7 +852,7 @@ export function HuddleBar({
               className="h-12 gap-2 px-4"
               disabled={isLeaving}
               aria-busy={isLeaving}
-              onClick={() => void handleLeave()}
+              onClick={() => void handleLeave().catch(() => {})}
               size="sm"
               variant="destructive"
             >

--- a/desktop/src/features/huddle/components/VoiceOverlayBridge.tsx
+++ b/desktop/src/features/huddle/components/VoiceOverlayBridge.tsx
@@ -1,0 +1,116 @@
+import { emitTo, listen } from "@tauri-apps/api/event";
+import * as React from "react";
+
+import {
+  parseVoiceOverlayAction,
+  type VoiceInputMode,
+  type VoiceOverlayMediaState,
+  VOICE_OVERLAY_ACTION_EVENT,
+  VOICE_OVERLAY_READY_EVENT,
+  VOICE_OVERLAY_STATE_EVENT,
+  VOICE_OVERLAY_WINDOW_LABEL,
+} from "../lib/voiceOverlayProtocol";
+
+type VoiceOverlayBridgeProps = {
+  snapshot: VoiceOverlayMediaState;
+  onToggleMute: () => void | Promise<void>;
+  onSetVoiceInputMode: (mode: VoiceInputMode) => void | Promise<void>;
+  onToggleTranscription: () => void | Promise<void>;
+  onToggleTts: () => void | Promise<void>;
+  onLeave: () => void | Promise<void>;
+  onShowMain: () => void | Promise<void>;
+};
+
+export function VoiceOverlayBridge({
+  snapshot,
+  onToggleMute,
+  onSetVoiceInputMode,
+  onToggleTranscription,
+  onToggleTts,
+  onLeave,
+  onShowMain,
+}: VoiceOverlayBridgeProps) {
+  const snapshotRef = React.useRef(snapshot);
+  snapshotRef.current = snapshot;
+
+  const handlersRef = React.useRef({
+    onToggleMute,
+    onSetVoiceInputMode,
+    onToggleTranscription,
+    onToggleTts,
+    onLeave,
+    onShowMain,
+  });
+  handlersRef.current = {
+    onToggleMute,
+    onSetVoiceInputMode,
+    onToggleTranscription,
+    onToggleTts,
+    onLeave,
+    onShowMain,
+  };
+
+  const publishSnapshot = React.useCallback((next: VoiceOverlayMediaState) => {
+    void emitTo(
+      VOICE_OVERLAY_WINDOW_LABEL,
+      VOICE_OVERLAY_STATE_EVENT,
+      next,
+    ).catch(() => {
+      // The floating controller is optional and may not be open.
+    });
+  }, []);
+
+  React.useEffect(() => {
+    publishSnapshot(snapshot);
+  }, [publishSnapshot, snapshot]);
+
+  React.useEffect(() => {
+    let disposed = false;
+    const cleanups: Array<() => void> = [];
+
+    void listen(VOICE_OVERLAY_READY_EVENT, () => {
+      if (!disposed) publishSnapshot(snapshotRef.current);
+    }).then((unlisten) => {
+      if (disposed) void unlisten();
+      else cleanups.push(() => void unlisten());
+    });
+
+    void listen(VOICE_OVERLAY_ACTION_EVENT, (event) => {
+      if (disposed) return;
+      const action = parseVoiceOverlayAction(event.payload);
+      if (!action) return;
+
+      const handlers = handlersRef.current;
+      switch (action.type) {
+        case "toggle_mute":
+          void handlers.onToggleMute();
+          break;
+        case "set_voice_input_mode":
+          void handlers.onSetVoiceInputMode(action.mode);
+          break;
+        case "toggle_transcription":
+          void handlers.onToggleTranscription();
+          break;
+        case "toggle_tts":
+          void handlers.onToggleTts();
+          break;
+        case "leave":
+          void handlers.onLeave();
+          break;
+        case "show_main":
+          void handlers.onShowMain();
+          break;
+      }
+    }).then((unlisten) => {
+      if (disposed) void unlisten();
+      else cleanups.push(() => void unlisten());
+    });
+
+    return () => {
+      disposed = true;
+      for (const cleanup of cleanups) cleanup();
+    };
+  }, [publishSnapshot]);
+
+  return null;
+}

--- a/desktop/src/features/huddle/components/VoiceOverlayBridge.tsx
+++ b/desktop/src/features/huddle/components/VoiceOverlayBridge.tsx
@@ -3,9 +3,11 @@ import * as React from "react";
 
 import {
   parseVoiceOverlayAction,
+  runVoiceOverlayAction,
   type VoiceInputMode,
   type VoiceOverlayMediaState,
   VOICE_OVERLAY_ACTION_EVENT,
+  VOICE_OVERLAY_ACTION_RESULT_EVENT,
   VOICE_OVERLAY_READY_EVENT,
   VOICE_OVERLAY_STATE_EVENT,
   VOICE_OVERLAY_WINDOW_LABEL,
@@ -60,6 +62,19 @@ export function VoiceOverlayBridge({
     });
   }, []);
 
+  const publishActionResult = React.useCallback(
+    (result: Awaited<ReturnType<typeof runVoiceOverlayAction>>) => {
+      void emitTo(
+        VOICE_OVERLAY_WINDOW_LABEL,
+        VOICE_OVERLAY_ACTION_RESULT_EVENT,
+        result,
+      ).catch(() => {
+        // The floating controller may have closed while the action completed.
+      });
+    },
+    [],
+  );
+
   React.useEffect(() => {
     publishSnapshot(snapshot);
   }, [publishSnapshot, snapshot]);
@@ -80,27 +95,10 @@ export function VoiceOverlayBridge({
       const action = parseVoiceOverlayAction(event.payload);
       if (!action) return;
 
-      const handlers = handlersRef.current;
-      switch (action.type) {
-        case "toggle_mute":
-          void handlers.onToggleMute();
-          break;
-        case "set_voice_input_mode":
-          void handlers.onSetVoiceInputMode(action.mode);
-          break;
-        case "toggle_transcription":
-          void handlers.onToggleTranscription();
-          break;
-        case "toggle_tts":
-          void handlers.onToggleTts();
-          break;
-        case "leave":
-          void handlers.onLeave();
-          break;
-        case "show_main":
-          void handlers.onShowMain();
-          break;
-      }
+      void (async () => {
+        const result = await runVoiceOverlayAction(action, handlersRef.current);
+        publishActionResult(result);
+      })();
     }).then((unlisten) => {
       if (disposed) void unlisten();
       else cleanups.push(() => void unlisten());
@@ -110,7 +108,7 @@ export function VoiceOverlayBridge({
       disposed = true;
       for (const cleanup of cleanups) cleanup();
     };
-  }, [publishSnapshot]);
+  }, [publishActionResult, publishSnapshot]);
 
   return null;
 }

--- a/desktop/src/features/huddle/lib/voiceOverlayProtocol.test.mjs
+++ b/desktop/src/features/huddle/lib/voiceOverlayProtocol.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseVoiceOverlayAction,
+  voiceOverlayMediaSnapshot,
+} from "./voiceOverlayProtocol.ts";
+
+test("parseVoiceOverlayAction accepts every supported controller action", () => {
+  assert.deepEqual(
+    parseVoiceOverlayAction({ version: 1, type: "toggle_mute" }),
+    {
+      version: 1,
+      type: "toggle_mute",
+    },
+  );
+  assert.deepEqual(
+    parseVoiceOverlayAction({
+      version: 1,
+      type: "set_voice_input_mode",
+      mode: "push_to_talk",
+    }),
+    { version: 1, type: "set_voice_input_mode", mode: "push_to_talk" },
+  );
+  assert.deepEqual(
+    parseVoiceOverlayAction({
+      version: 1,
+      type: "set_voice_input_mode",
+      mode: "voice_activity",
+    }),
+    { version: 1, type: "set_voice_input_mode", mode: "voice_activity" },
+  );
+  for (const type of [
+    "toggle_transcription",
+    "toggle_tts",
+    "leave",
+    "show_main",
+  ]) {
+    assert.deepEqual(parseVoiceOverlayAction({ version: 1, type }), {
+      version: 1,
+      type,
+    });
+  }
+});
+
+test("parseVoiceOverlayAction rejects malformed or unsupported window messages", () => {
+  const invalidPayloads = [
+    null,
+    "toggle_mute",
+    {},
+    { type: "toggle_mute" },
+    { version: 2, type: "toggle_mute" },
+    { version: 1, type: "toggle_mute", unexpected: true },
+    { version: 1, type: "set_voice_input_mode" },
+    { version: 1, type: "set_voice_input_mode", mode: "always_on" },
+    { version: 1, type: "leave", channelId: "another-channel" },
+    { version: 1, type: "run_command", command: "rm -rf /" },
+  ];
+
+  for (const payload of invalidPayloads) {
+    assert.equal(parseVoiceOverlayAction(payload), null);
+  }
+});
+
+test("voiceOverlayMediaSnapshot clamps microphone levels and hides activity while muted", () => {
+  assert.deepEqual(
+    voiceOverlayMediaSnapshot({
+      version: 1,
+      phase: "active",
+      participantCount: 3,
+      agentCount: 1,
+      ttsEnabled: true,
+      transcriptionEnabled: true,
+      isLeaving: false,
+      error: null,
+      isMuted: false,
+      micConnected: true,
+      micLevel: 1.7,
+      pttActive: true,
+      voiceInputMode: "push_to_talk",
+    }),
+    {
+      version: 1,
+      phase: "active",
+      participantCount: 3,
+      agentCount: 1,
+      ttsEnabled: true,
+      transcriptionEnabled: true,
+      isLeaving: false,
+      error: null,
+      isMuted: false,
+      micConnected: true,
+      micLevel: 1,
+      pttActive: true,
+      voiceInputMode: "push_to_talk",
+    },
+  );
+
+  assert.deepEqual(
+    voiceOverlayMediaSnapshot({
+      version: 1,
+      phase: "connected",
+      participantCount: 2,
+      agentCount: 0,
+      ttsEnabled: false,
+      transcriptionEnabled: false,
+      isLeaving: true,
+      error: "Voice connection interrupted",
+      isMuted: true,
+      micConnected: true,
+      micLevel: 0.8,
+      pttActive: true,
+      voiceInputMode: "voice_activity",
+    }),
+    {
+      version: 1,
+      phase: "connected",
+      participantCount: 2,
+      agentCount: 0,
+      ttsEnabled: false,
+      transcriptionEnabled: false,
+      isLeaving: true,
+      error: "Voice connection interrupted",
+      isMuted: true,
+      micConnected: true,
+      micLevel: 0,
+      pttActive: false,
+      voiceInputMode: "voice_activity",
+    },
+  );
+});

--- a/desktop/src/features/huddle/lib/voiceOverlayProtocol.test.mjs
+++ b/desktop/src/features/huddle/lib/voiceOverlayProtocol.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import * as voiceOverlayProtocol from "./voiceOverlayProtocol.ts";
 import {
   parseVoiceOverlayAction,
   voiceOverlayMediaSnapshot,
@@ -8,27 +9,44 @@ import {
 
 test("parseVoiceOverlayAction accepts every supported controller action", () => {
   assert.deepEqual(
-    parseVoiceOverlayAction({ version: 1, type: "toggle_mute" }),
+    parseVoiceOverlayAction({
+      version: 1,
+      requestId: "request-1",
+      type: "toggle_mute",
+    }),
     {
       version: 1,
+      requestId: "request-1",
       type: "toggle_mute",
     },
   );
   assert.deepEqual(
     parseVoiceOverlayAction({
       version: 1,
+      requestId: "request-2",
       type: "set_voice_input_mode",
       mode: "push_to_talk",
     }),
-    { version: 1, type: "set_voice_input_mode", mode: "push_to_talk" },
+    {
+      version: 1,
+      requestId: "request-2",
+      type: "set_voice_input_mode",
+      mode: "push_to_talk",
+    },
   );
   assert.deepEqual(
     parseVoiceOverlayAction({
       version: 1,
+      requestId: "request-3",
       type: "set_voice_input_mode",
       mode: "voice_activity",
     }),
-    { version: 1, type: "set_voice_input_mode", mode: "voice_activity" },
+    {
+      version: 1,
+      requestId: "request-3",
+      type: "set_voice_input_mode",
+      mode: "voice_activity",
+    },
   );
   for (const type of [
     "toggle_transcription",
@@ -36,10 +54,18 @@ test("parseVoiceOverlayAction accepts every supported controller action", () => 
     "leave",
     "show_main",
   ]) {
-    assert.deepEqual(parseVoiceOverlayAction({ version: 1, type }), {
-      version: 1,
-      type,
-    });
+    assert.deepEqual(
+      parseVoiceOverlayAction({
+        version: 1,
+        requestId: `request-${type}`,
+        type,
+      }),
+      {
+        version: 1,
+        requestId: `request-${type}`,
+        type,
+      },
+    );
   }
 });
 
@@ -49,17 +75,241 @@ test("parseVoiceOverlayAction rejects malformed or unsupported window messages",
     "toggle_mute",
     {},
     { type: "toggle_mute" },
-    { version: 2, type: "toggle_mute" },
-    { version: 1, type: "toggle_mute", unexpected: true },
-    { version: 1, type: "set_voice_input_mode" },
-    { version: 1, type: "set_voice_input_mode", mode: "always_on" },
-    { version: 1, type: "leave", channelId: "another-channel" },
-    { version: 1, type: "run_command", command: "rm -rf /" },
+    { version: 1, type: "toggle_mute" },
+    { version: 2, requestId: "request-1", type: "toggle_mute" },
+    { version: 1, requestId: "", type: "toggle_mute" },
+    {
+      version: 1,
+      requestId: "request-1",
+      type: "toggle_mute",
+      unexpected: true,
+    },
+    { version: 1, requestId: "request-1", type: "set_voice_input_mode" },
+    {
+      version: 1,
+      requestId: "request-1",
+      type: "set_voice_input_mode",
+      mode: "always_on",
+    },
+    {
+      version: 1,
+      requestId: "request-1",
+      type: "leave",
+      channelId: "another-channel",
+    },
+    {
+      version: 1,
+      requestId: "request-1",
+      type: "run_command",
+      command: "rm -rf /",
+    },
   ];
 
   for (const payload of invalidPayloads) {
     assert.equal(parseVoiceOverlayAction(payload), null);
   }
+});
+
+test("parseVoiceOverlayActionResult accepts strict success and failure acknowledgements", () => {
+  assert.equal(
+    typeof voiceOverlayProtocol.parseVoiceOverlayActionResult,
+    "function",
+  );
+  const parseVoiceOverlayActionResult =
+    voiceOverlayProtocol.parseVoiceOverlayActionResult;
+
+  assert.deepEqual(
+    parseVoiceOverlayActionResult({
+      version: 1,
+      requestId: "request-1",
+      ok: true,
+    }),
+    { version: 1, requestId: "request-1", ok: true },
+  );
+  assert.deepEqual(
+    parseVoiceOverlayActionResult({
+      version: 1,
+      requestId: "request-2",
+      ok: false,
+      error: "Transcript failed",
+    }),
+    {
+      version: 1,
+      requestId: "request-2",
+      ok: false,
+      error: "Transcript failed",
+    },
+  );
+
+  for (const payload of [
+    null,
+    { version: 1, requestId: "", ok: true },
+    { version: 1, requestId: "request-1", ok: false },
+    { version: 1, requestId: "request-1", ok: true, error: "unexpected" },
+    { version: 1, requestId: "request-1", ok: false, error: "" },
+  ]) {
+    assert.equal(parseVoiceOverlayActionResult(payload), null);
+  }
+});
+
+test("voice action tracking accepts a late acknowledgement after the slow warning", () => {
+  assert.equal(
+    typeof voiceOverlayProtocol.createVoiceOverlayActionTracker,
+    "function",
+  );
+  const scheduled = new Map();
+  const cleared = [];
+  const slow = [];
+  const expired = [];
+  let nextTimerId = 1;
+  const tracker = voiceOverlayProtocol.createVoiceOverlayActionTracker({
+    setTimer(callback, delayMs) {
+      const timerId = nextTimerId++;
+      scheduled.set(timerId, { callback, delayMs });
+      return timerId;
+    },
+    clearTimer(timerId) {
+      cleared.push(timerId);
+      scheduled.delete(timerId);
+    },
+    onSlow(requestId) {
+      slow.push(requestId);
+    },
+    onExpired(requestId) {
+      expired.push(requestId);
+    },
+  });
+
+  tracker.start("request-1");
+  assert.deepEqual(
+    [...scheduled.values()].map(({ delayMs }) => delayMs),
+    [2_000, 30_000],
+  );
+  scheduled.get(1).callback();
+
+  assert.deepEqual(slow, ["request-1"]);
+  assert.deepEqual(expired, []);
+  assert.equal(tracker.settle("request-1"), true);
+  assert.deepEqual(cleared, [1, 2]);
+  assert.equal(tracker.settle("request-1"), false);
+});
+
+test("voice action tracking expires unanswered requests and disposes timers", () => {
+  assert.equal(
+    typeof voiceOverlayProtocol.createVoiceOverlayActionTracker,
+    "function",
+  );
+  const scheduled = new Map();
+  const cleared = [];
+  const expired = [];
+  let nextTimerId = 1;
+  const tracker = voiceOverlayProtocol.createVoiceOverlayActionTracker({
+    setTimer(callback, delayMs) {
+      const timerId = nextTimerId++;
+      scheduled.set(timerId, { callback, delayMs });
+      return timerId;
+    },
+    clearTimer(timerId) {
+      cleared.push(timerId);
+      scheduled.delete(timerId);
+    },
+    onSlow() {},
+    onExpired(requestId) {
+      expired.push(requestId);
+    },
+  });
+
+  tracker.start("request-1");
+  scheduled.get(2).callback();
+
+  assert.deepEqual(expired, ["request-1"]);
+  assert.equal(tracker.settle("request-1"), false);
+
+  tracker.start("request-2");
+  tracker.dispose();
+  assert.deepEqual(cleared, [1, 2, 3, 4]);
+});
+
+test("voice action tracking suppresses callbacks after an early acknowledgement", () => {
+  const scheduled = new Map();
+  const slow = [];
+  const expired = [];
+  let nextTimerId = 1;
+  const tracker = voiceOverlayProtocol.createVoiceOverlayActionTracker({
+    setTimer(callback, delayMs) {
+      const timerId = nextTimerId++;
+      scheduled.set(timerId, { callback, delayMs });
+      return timerId;
+    },
+    clearTimer() {},
+    onSlow(requestId) {
+      slow.push(requestId);
+    },
+    onExpired(requestId) {
+      expired.push(requestId);
+    },
+  });
+
+  tracker.start("request-1");
+  assert.equal(tracker.settle("request-1"), true);
+  scheduled.get(1).callback();
+  scheduled.get(2).callback();
+
+  assert.deepEqual(slow, []);
+  assert.deepEqual(expired, []);
+});
+
+test("voice action execution reports falsy handler rejections as failures", async () => {
+  assert.equal(typeof voiceOverlayProtocol.runVoiceOverlayAction, "function");
+  const action = {
+    version: 1,
+    requestId: "request-falsy-error",
+    type: "toggle_mute",
+  };
+
+  for (const rejection of [undefined, null, "", 0, false]) {
+    const result = await voiceOverlayProtocol.runVoiceOverlayAction(action, {
+      onToggleMute: () => Promise.reject(rejection),
+      onSetVoiceInputMode: () => {},
+      onToggleTranscription: () => {},
+      onToggleTts: () => {},
+      onLeave: () => {},
+      onShowMain: () => {},
+    });
+    assert.equal(result.version, 1);
+    assert.equal(result.requestId, "request-falsy-error");
+    assert.equal(result.ok, false);
+    assert.equal(typeof result.error, "string");
+    assert.ok(result.error.length > 0);
+  }
+});
+
+test("voice action execution returns one matching success acknowledgement", async () => {
+  let calls = 0;
+  const result = await voiceOverlayProtocol.runVoiceOverlayAction(
+    {
+      version: 1,
+      requestId: "request-success",
+      type: "toggle_transcription",
+    },
+    {
+      onToggleMute: () => {},
+      onSetVoiceInputMode: () => {},
+      onToggleTranscription: () => {
+        calls += 1;
+      },
+      onToggleTts: () => {},
+      onLeave: () => {},
+      onShowMain: () => {},
+    },
+  );
+
+  assert.equal(calls, 1);
+  assert.deepEqual(result, {
+    version: 1,
+    requestId: "request-success",
+    ok: true,
+  });
 });
 
 test("voiceOverlayMediaSnapshot clamps microphone levels and hides activity while muted", () => {
@@ -126,6 +376,41 @@ test("voiceOverlayMediaSnapshot clamps microphone levels and hides activity whil
       micLevel: 0,
       pttActive: false,
       voiceInputMode: "voice_activity",
+    },
+  );
+});
+
+test("voiceOverlayMediaSnapshot clears stale media state when the huddle becomes idle", () => {
+  assert.deepEqual(
+    voiceOverlayMediaSnapshot({
+      version: 1,
+      phase: "idle",
+      participantCount: 3,
+      agentCount: 1,
+      ttsEnabled: true,
+      transcriptionEnabled: true,
+      isLeaving: true,
+      error: null,
+      isMuted: false,
+      micConnected: true,
+      micLevel: 0.8,
+      pttActive: true,
+      voiceInputMode: "push_to_talk",
+    }),
+    {
+      version: 1,
+      phase: "idle",
+      participantCount: 0,
+      agentCount: 0,
+      ttsEnabled: true,
+      transcriptionEnabled: true,
+      isLeaving: false,
+      error: null,
+      isMuted: false,
+      micConnected: false,
+      micLevel: 0,
+      pttActive: false,
+      voiceInputMode: "push_to_talk",
     },
   );
 });

--- a/desktop/src/features/huddle/lib/voiceOverlayProtocol.ts
+++ b/desktop/src/features/huddle/lib/voiceOverlayProtocol.ts
@@ -4,14 +4,131 @@ export const VOICE_OVERLAY_WINDOW_LABEL = "voice-overlay";
 export const VOICE_OVERLAY_READY_EVENT = "buzz://voice-overlay/ready";
 export const VOICE_OVERLAY_STATE_EVENT = "buzz://voice-overlay/state";
 export const VOICE_OVERLAY_ACTION_EVENT = "buzz://voice-overlay/action";
+export const VOICE_OVERLAY_ACTION_RESULT_EVENT =
+  "buzz://voice-overlay/action-result";
 
-export type VoiceOverlayAction =
+export type VoiceOverlayActionInput =
   | { version: 1; type: "toggle_mute" }
-  | { version: 1; type: "set_voice_input_mode"; mode: VoiceInputMode }
+  | {
+      version: 1;
+      type: "set_voice_input_mode";
+      mode: VoiceInputMode;
+    }
   | {
       version: 1;
       type: "toggle_transcription" | "toggle_tts" | "leave" | "show_main";
     };
+
+export type VoiceOverlayAction = VoiceOverlayActionInput & {
+  requestId: string;
+};
+
+export type VoiceOverlayActionResult =
+  | { version: 1; requestId: string; ok: true }
+  | { version: 1; requestId: string; ok: false; error: string };
+
+export type VoiceOverlayActionHandlers = {
+  onToggleMute: () => void | Promise<void>;
+  onSetVoiceInputMode: (mode: VoiceInputMode) => void | Promise<void>;
+  onToggleTranscription: () => void | Promise<void>;
+  onToggleTts: () => void | Promise<void>;
+  onLeave: () => void | Promise<void>;
+  onShowMain: () => void | Promise<void>;
+};
+
+function voiceOverlayActionErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return (
+    message.trim().slice(0, 240) ||
+    "Voice action failed without an error message."
+  );
+}
+
+export async function runVoiceOverlayAction(
+  action: VoiceOverlayAction,
+  handlers: VoiceOverlayActionHandlers,
+): Promise<VoiceOverlayActionResult> {
+  try {
+    switch (action.type) {
+      case "toggle_mute":
+        await handlers.onToggleMute();
+        break;
+      case "set_voice_input_mode":
+        await handlers.onSetVoiceInputMode(action.mode);
+        break;
+      case "toggle_transcription":
+        await handlers.onToggleTranscription();
+        break;
+      case "toggle_tts":
+        await handlers.onToggleTts();
+        break;
+      case "leave":
+        await handlers.onLeave();
+        break;
+      case "show_main":
+        await handlers.onShowMain();
+        break;
+    }
+    return { version: 1, requestId: action.requestId, ok: true };
+  } catch (error) {
+    return {
+      version: 1,
+      requestId: action.requestId,
+      ok: false,
+      error: voiceOverlayActionErrorMessage(error),
+    };
+  }
+}
+
+type VoiceOverlayActionTrackerOptions = {
+  setTimer: (callback: () => void, delayMs: number) => number;
+  clearTimer: (timerId: number) => void;
+  onSlow: (requestId: string) => void;
+  onExpired: (requestId: string) => void;
+  slowAfterMs?: number;
+  expireAfterMs?: number;
+};
+
+export function createVoiceOverlayActionTracker({
+  setTimer,
+  clearTimer,
+  onSlow,
+  onExpired,
+  slowAfterMs = 2_000,
+  expireAfterMs = 30_000,
+}: VoiceOverlayActionTrackerOptions) {
+  const pending = new Map<
+    string,
+    { slowTimerId: number; expiryTimerId: number }
+  >();
+
+  const settle = (requestId: string): boolean => {
+    const timers = pending.get(requestId);
+    if (!timers) return false;
+    pending.delete(requestId);
+    clearTimer(timers.slowTimerId);
+    clearTimer(timers.expiryTimerId);
+    return true;
+  };
+
+  return {
+    start(requestId: string) {
+      settle(requestId);
+      const slowTimerId = setTimer(() => {
+        if (pending.has(requestId)) onSlow(requestId);
+      }, slowAfterMs);
+      const expiryTimerId = setTimer(() => {
+        if (!settle(requestId)) return;
+        onExpired(requestId);
+      }, expireAfterMs);
+      pending.set(requestId, { slowTimerId, expiryTimerId });
+    },
+    settle,
+    dispose() {
+      for (const requestId of [...pending.keys()]) settle(requestId);
+    },
+  };
+}
 
 export type VoiceOverlayPhase =
   | "idle"
@@ -45,8 +162,12 @@ export function parseVoiceOverlayAction(
   }
 
   const action = value as Record<string, unknown>;
+  const requestId =
+    typeof action.requestId === "string" ? action.requestId.trim() : "";
   if (
     action.version === 1 &&
+    requestId.length > 0 &&
+    requestId.length <= 128 &&
     [
       "toggle_mute",
       "toggle_transcription",
@@ -54,10 +175,11 @@ export function parseVoiceOverlayAction(
       "leave",
       "show_main",
     ].includes(String(action.type)) &&
-    Object.keys(action).length === 2
+    Object.keys(action).length === 3
   ) {
     return {
       version: 1,
+      requestId,
       type: action.type as Exclude<
         VoiceOverlayAction["type"],
         "set_voice_input_mode"
@@ -67,11 +189,52 @@ export function parseVoiceOverlayAction(
 
   if (
     action.version === 1 &&
+    requestId.length > 0 &&
+    requestId.length <= 128 &&
     action.type === "set_voice_input_mode" &&
-    Object.keys(action).length === 3 &&
+    Object.keys(action).length === 4 &&
     (action.mode === "push_to_talk" || action.mode === "voice_activity")
   ) {
-    return { version: 1, type: action.type, mode: action.mode };
+    return {
+      version: 1,
+      requestId,
+      type: action.type,
+      mode: action.mode,
+    };
+  }
+
+  return null;
+}
+
+export function parseVoiceOverlayActionResult(
+  value: unknown,
+): VoiceOverlayActionResult | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const result = value as Record<string, unknown>;
+  const requestId =
+    typeof result.requestId === "string" ? result.requestId.trim() : "";
+  if (
+    result.version !== 1 ||
+    requestId.length === 0 ||
+    requestId.length > 128
+  ) {
+    return null;
+  }
+
+  if (result.ok === true && Object.keys(result).length === 3) {
+    return { version: 1, requestId, ok: true };
+  }
+
+  const error = typeof result.error === "string" ? result.error.trim() : "";
+  if (
+    result.ok === false &&
+    error.length > 0 &&
+    Object.keys(result).length === 4
+  ) {
+    return { version: 1, requestId, ok: false, error };
   }
 
   return null;
@@ -80,20 +243,21 @@ export function parseVoiceOverlayAction(
 export function voiceOverlayMediaSnapshot(
   state: VoiceOverlayMediaState,
 ): VoiceOverlayMediaState {
+  const isIdle = state.phase === "idle";
   const isMuted = state.isMuted;
   return {
     version: 1,
     phase: state.phase,
-    participantCount: state.participantCount,
-    agentCount: state.agentCount,
+    participantCount: isIdle ? 0 : state.participantCount,
+    agentCount: isIdle ? 0 : state.agentCount,
     ttsEnabled: state.ttsEnabled,
     transcriptionEnabled: state.transcriptionEnabled,
-    isLeaving: state.isLeaving,
+    isLeaving: isIdle ? false : state.isLeaving,
     error: state.error,
     isMuted,
-    micConnected: state.micConnected,
-    micLevel: isMuted ? 0 : Math.min(1, Math.max(0, state.micLevel)),
-    pttActive: isMuted ? false : state.pttActive,
+    micConnected: isIdle ? false : state.micConnected,
+    micLevel: isIdle || isMuted ? 0 : Math.min(1, Math.max(0, state.micLevel)),
+    pttActive: isIdle || isMuted ? false : state.pttActive,
     voiceInputMode: state.voiceInputMode,
   };
 }

--- a/desktop/src/features/huddle/lib/voiceOverlayProtocol.ts
+++ b/desktop/src/features/huddle/lib/voiceOverlayProtocol.ts
@@ -1,0 +1,99 @@
+export type VoiceInputMode = "push_to_talk" | "voice_activity";
+
+export const VOICE_OVERLAY_WINDOW_LABEL = "voice-overlay";
+export const VOICE_OVERLAY_READY_EVENT = "buzz://voice-overlay/ready";
+export const VOICE_OVERLAY_STATE_EVENT = "buzz://voice-overlay/state";
+export const VOICE_OVERLAY_ACTION_EVENT = "buzz://voice-overlay/action";
+
+export type VoiceOverlayAction =
+  | { version: 1; type: "toggle_mute" }
+  | { version: 1; type: "set_voice_input_mode"; mode: VoiceInputMode }
+  | {
+      version: 1;
+      type: "toggle_transcription" | "toggle_tts" | "leave" | "show_main";
+    };
+
+export type VoiceOverlayPhase =
+  | "idle"
+  | "creating"
+  | "connecting"
+  | "connected"
+  | "active"
+  | "leaving";
+
+export type VoiceOverlayMediaState = {
+  version: 1;
+  phase: VoiceOverlayPhase;
+  participantCount: number;
+  agentCount: number;
+  ttsEnabled: boolean;
+  transcriptionEnabled: boolean;
+  isLeaving: boolean;
+  error: string | null;
+  isMuted: boolean;
+  micConnected: boolean;
+  micLevel: number;
+  pttActive: boolean;
+  voiceInputMode: VoiceInputMode;
+};
+
+export function parseVoiceOverlayAction(
+  value: unknown,
+): VoiceOverlayAction | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const action = value as Record<string, unknown>;
+  if (
+    action.version === 1 &&
+    [
+      "toggle_mute",
+      "toggle_transcription",
+      "toggle_tts",
+      "leave",
+      "show_main",
+    ].includes(String(action.type)) &&
+    Object.keys(action).length === 2
+  ) {
+    return {
+      version: 1,
+      type: action.type as Exclude<
+        VoiceOverlayAction["type"],
+        "set_voice_input_mode"
+      >,
+    };
+  }
+
+  if (
+    action.version === 1 &&
+    action.type === "set_voice_input_mode" &&
+    Object.keys(action).length === 3 &&
+    (action.mode === "push_to_talk" || action.mode === "voice_activity")
+  ) {
+    return { version: 1, type: action.type, mode: action.mode };
+  }
+
+  return null;
+}
+
+export function voiceOverlayMediaSnapshot(
+  state: VoiceOverlayMediaState,
+): VoiceOverlayMediaState {
+  const isMuted = state.isMuted;
+  return {
+    version: 1,
+    phase: state.phase,
+    participantCount: state.participantCount,
+    agentCount: state.agentCount,
+    ttsEnabled: state.ttsEnabled,
+    transcriptionEnabled: state.transcriptionEnabled,
+    isLeaving: state.isLeaving,
+    error: state.error,
+    isMuted,
+    micConnected: state.micConnected,
+    micLevel: isMuted ? 0 : Math.min(1, Math.max(0, state.micLevel)),
+    pttActive: isMuted ? false : state.pttActive,
+    voiceInputMode: state.voiceInputMode,
+  };
+}

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -8,12 +8,16 @@ import { UpdaterProvider } from "@/features/settings/hooks/UpdaterProvider";
 import { migrateLegacyCommunityStorageBeforeRender } from "@/features/communities/legacyCommunityStorage";
 import { CommunitiesProvider } from "@/features/communities/useCommunities";
 import { CommunityOnboardingProvider } from "@/features/onboarding/communityOnboarding";
-import { ThemeProvider } from "@/shared/theme/ThemeProvider";
+import {
+  applyCachedThemeVars,
+  ThemeProvider,
+} from "@/shared/theme/ThemeProvider";
 import { EmojiBurstProvider } from "@/shared/ui/EmojiBurstProvider";
 import { PoofBurstProvider } from "@/shared/ui/PoofBurstProvider";
 import { Toaster } from "@/shared/ui/sonner";
 import { TooltipProvider } from "@/shared/ui/tooltip";
 import { recoverLocalStorageQuotaOnStartup } from "@/shared/lib/localStorageQuota";
+import { VoiceOverlayRoot } from "@/features/huddle/VoiceOverlayRoot";
 
 type E2eWindow = Window & {
   __BUZZ_E2E__?: unknown;
@@ -94,6 +98,21 @@ function renderApp() {
   );
 }
 
+function renderVoiceOverlay() {
+  applyCachedThemeVars();
+  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <React.StrictMode>
+      <TooltipProvider delayDuration={300}>
+        <VoiceOverlayRoot />
+      </TooltipProvider>
+    </React.StrictMode>,
+  );
+}
+
+function isVoiceOverlayWindow() {
+  return window.location.hash === "#/voice-overlay";
+}
+
 async function installE2eBridgeIfConfigured() {
   // The mock bridge is compiled only into dev and explicit E2E builds. A
   // pre-bootstrap global alone must never activate mock IPC in production.
@@ -113,6 +132,10 @@ async function bootstrap() {
   configureDevE2eBridgeFromUrl();
   recoverLocalStorageQuotaOnStartup();
   await installE2eBridgeIfConfigured();
+  if (isVoiceOverlayWindow()) {
+    renderVoiceOverlay();
+    return;
+  }
   await migrateLegacyCommunityStorageBeforeRender();
   renderApp();
 }

--- a/desktop/src/shared/theme/ThemeProvider.tsx
+++ b/desktop/src/shared/theme/ThemeProvider.tsx
@@ -396,7 +396,7 @@ async function applyBuzzVibrancy(themeName: string) {
 }
 
 /** Apply cached CSS vars synchronously to prevent FOUC. */
-function applyCachedVars(): string | null {
+export function applyCachedThemeVars(): string | null {
   try {
     const cached = window.localStorage.getItem(CACHE_KEY);
     if (!cached) return null;
@@ -486,7 +486,7 @@ export function ThemeProvider({
 }: ThemeProviderProps) {
   // Apply cached vars synchronously before first render
   const [selectedTheme, setSelectedTheme] = useState<string>(() => {
-    applyCachedVars();
+    applyCachedThemeVars();
     return readStoredTheme(defaultTheme);
   });
   const [isDark, setIsDark] = useState<boolean>(() => {

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1095,6 +1095,7 @@ declare global {
     __BUZZ_E2E_SET_MOCK_HUDDLE_SNAPSHOT__?: (input: {
       members: MockHuddleMemberSeed[];
       transcriptionEnabled: boolean;
+      phase?: "active" | "idle";
     }) => Promise<void>;
     __BUZZ_E2E_PUSH_MOCK_FEED_ITEM__?: (item: RawFeedItem) => RawFeedItem;
     /** Replace an existing feed item by id (or push if not found) and fire the updated event. */
@@ -2971,7 +2972,7 @@ let mockPersonas: RawPersona[] = [];
 let mockTeams: RawTeam[] = [];
 
 type MockHuddleState = {
-  phase: "active";
+  phase: "active" | "idle";
   parent_channel_id: string;
   ephemeral_channel_id: string;
   participants: string[];
@@ -9641,12 +9642,14 @@ export function maybeInstallE2eTauriMocks() {
   window.__BUZZ_E2E_SET_MOCK_HUDDLE_SNAPSHOT__ = async ({
     members,
     transcriptionEnabled,
+    phase,
   }) => {
     if (!mockHuddle) {
       throw new Error("No mock huddle is configured.");
     }
     mockHuddle.members = structuredClone(members);
     mockHuddle.state.transcription_enabled = transcriptionEnabled;
+    if (phase) mockHuddle.state.phase = phase;
     refreshMockHuddleMembership();
     persistMockHuddle();
     await emitMockHuddleState();

--- a/desktop/src/testing/e2eBridge.ts
+++ b/desktop/src/testing/e2eBridge.ts
@@ -1088,6 +1088,10 @@ declare global {
       command: string,
       payload?: Record<string, unknown>,
     ) => Promise<unknown>;
+    __BUZZ_E2E_EMIT_TAURI_EVENT__?: (
+      event: string,
+      payload?: unknown,
+    ) => Promise<void>;
     __BUZZ_E2E_SET_MOCK_HUDDLE_SNAPSHOT__?: (input: {
       members: MockHuddleMemberSeed[];
       transcriptionEnabled: boolean;
@@ -9630,6 +9634,9 @@ export function maybeInstallE2eTauriMocks() {
   window.__BUZZ_E2E_COMMAND_PAYLOADS__ = [];
   window.__BUZZ_E2E_COMMAND_LOG__ = [];
   window.__BUZZ_E2E_SIGNED_EVENTS__ = [];
+  window.__BUZZ_E2E_EMIT_TAURI_EVENT__ = async (event, payload) => {
+    await emit(event, payload);
+  };
   window.__BUZZ_E2E_WEBVIEW_ZOOM__ = 1;
   window.__BUZZ_E2E_SET_MOCK_HUDDLE_SNAPSHOT__ = async ({
     members,
@@ -9949,6 +9956,8 @@ export function maybeInstallE2eTauriMocks() {
     window.__BUZZ_E2E_COMMAND_LOG__?.push({ command, payload });
 
     switch (command) {
+      case "voice_overlay_window":
+        return null;
       case "get_huddle_state": {
         const snapshot = mockHuddle ? structuredClone(mockHuddle.state) : null;
         const delayMs = activeConfig?.mock?.huddleStateReadDelayMs ?? 0;

--- a/desktop/tests/e2e/voice-overlay.spec.ts
+++ b/desktop/tests/e2e/voice-overlay.spec.ts
@@ -36,6 +36,85 @@ test("renders a compact controller for the active huddle", async ({ page }) => {
   ).toBeVisible();
 });
 
+test("clears the floating controller when the huddle becomes idle", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    huddle: {
+      parentChannelId: HUDDLE_PARENT_ID,
+      ephemeralChannelId: HUDDLE_CHANNEL_ID,
+      members: [{ pubkey: TEST_IDENTITIES.tyler.pubkey, role: "member" }],
+    },
+  });
+
+  await page.goto("/#/voice-overlay");
+  const overlay = page.getByTestId("voice-overlay");
+  await expect(overlay.getByText("1 participant · 0 agents")).toBeVisible();
+
+  await page.evaluate(async () => {
+    await window.__BUZZ_E2E_SET_MOCK_HUDDLE_SNAPSHOT__?.({
+      members: [{ pubkey: "test-participant", role: "member" }],
+      transcriptionEnabled: false,
+      phase: "idle",
+    });
+  });
+
+  await expect(overlay.getByText("No active huddle")).toBeVisible();
+  await expect(
+    overlay.getByRole("button", { name: "Leave huddle" }),
+  ).toBeDisabled();
+});
+
+test("shows a matching action failure and ignores an unrelated result", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(window.crypto, "randomUUID", {
+      configurable: true,
+      value: () => "00000000-0000-4000-8000-000000000001",
+    });
+  });
+  await installMockBridge(page, {
+    huddle: {
+      parentChannelId: HUDDLE_PARENT_ID,
+      ephemeralChannelId: HUDDLE_CHANNEL_ID,
+      members: [{ pubkey: TEST_IDENTITIES.tyler.pubkey, role: "member" }],
+    },
+  });
+
+  await page.goto("/#/voice-overlay");
+  const overlay = page.getByTestId("voice-overlay");
+  await overlay.getByRole("button", { name: "Start transcript" }).click();
+
+  await page.evaluate(async () => {
+    await window.__BUZZ_E2E_EMIT_TAURI_EVENT__?.(
+      "buzz://voice-overlay/action-result",
+      {
+        version: 1,
+        requestId: "unrelated-request",
+        ok: false,
+        error: "Wrong request",
+      },
+    );
+  });
+  await expect(overlay.getByRole("alert")).toHaveCount(0);
+
+  await page.evaluate(async () => {
+    await window.__BUZZ_E2E_EMIT_TAURI_EVENT__?.(
+      "buzz://voice-overlay/action-result",
+      {
+        version: 1,
+        requestId: "00000000-0000-4000-8000-000000000001",
+        ok: false,
+        error: "Transcript failed",
+      },
+    );
+  });
+  await expect(overlay.getByRole("alert")).toHaveText(
+    "Voice action failed: Transcript failed",
+  );
+});
+
 test("routes typed overlay actions through the main huddle owner", async ({
   page,
 }) => {
@@ -55,7 +134,11 @@ test("routes typed overlay actions through the main huddle owner", async ({
   await page.evaluate(async () => {
     await window.__BUZZ_E2E_EMIT_TAURI_EVENT__?.(
       "buzz://voice-overlay/action",
-      { version: 1, type: "toggle_transcription" },
+      {
+        version: 1,
+        requestId: "e2e-toggle-transcription",
+        type: "toggle_transcription",
+      },
     );
   });
   await expect

--- a/desktop/tests/e2e/voice-overlay.spec.ts
+++ b/desktop/tests/e2e/voice-overlay.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test";
+
+import { installMockBridge, TEST_IDENTITIES } from "../helpers/bridge";
+
+const HUDDLE_CHANNEL_ID = "11111111-1111-4111-8111-111111111111";
+const HUDDLE_PARENT_ID = "9a1657ac-f7aa-5db0-b632-d8bbeb6dfb50";
+
+test("renders a compact controller for the active huddle", async ({ page }) => {
+  await page.setViewportSize({ width: 376, height: 148 });
+  await installMockBridge(page, {
+    huddle: {
+      parentChannelId: HUDDLE_PARENT_ID,
+      ephemeralChannelId: HUDDLE_CHANNEL_ID,
+      members: [
+        { pubkey: TEST_IDENTITIES.tyler.pubkey, role: "member" },
+        { pubkey: TEST_IDENTITIES.alice.pubkey, role: "bot" },
+      ],
+      transcriptionEnabled: true,
+    },
+  });
+
+  await page.goto("/#/voice-overlay");
+
+  const overlay = page.getByTestId("voice-overlay");
+  await expect(overlay).toBeVisible();
+  await expect(overlay.getByText("Buzz Voice")).toBeVisible();
+  await expect(overlay.getByText("2 participants · 1 agent")).toBeVisible();
+  await expect(
+    overlay.getByRole("button", { name: "Stop transcript" }),
+  ).toHaveAttribute("aria-pressed", "true");
+  await expect(
+    overlay.getByRole("button", { name: "Hear agent voice" }),
+  ).toHaveAttribute("aria-pressed", "true");
+  await expect(
+    overlay.getByRole("button", { name: "Leave huddle" }),
+  ).toBeVisible();
+});
+
+test("routes typed overlay actions through the main huddle owner", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    huddle: {
+      parentChannelId: HUDDLE_PARENT_ID,
+      ephemeralChannelId: HUDDLE_CHANNEL_ID,
+      members: [{ pubkey: TEST_IDENTITIES.tyler.pubkey, role: "member" }],
+      transcriptionEnabled: true,
+    },
+  });
+
+  await page.goto("/");
+  await expect(
+    page.getByRole("button", { name: "Open floating voice controls" }),
+  ).toBeVisible();
+  await page.evaluate(async () => {
+    await window.__BUZZ_E2E_EMIT_TAURI_EVENT__?.(
+      "buzz://voice-overlay/action",
+      { version: 1, type: "toggle_transcription" },
+    );
+  });
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        (window.__BUZZ_E2E_COMMAND_LOG__ ?? []).filter(
+          (entry) => entry.command === "set_huddle_transcription_enabled",
+        ),
+      ),
+    )
+    .toEqual([
+      {
+        command: "set_huddle_transcription_enabled",
+        payload: { enabled: false },
+      },
+    ]);
+});
+
+test("opens the floating controller from the active huddle bar", async ({
+  page,
+}) => {
+  await installMockBridge(page, {
+    huddle: {
+      parentChannelId: HUDDLE_PARENT_ID,
+      ephemeralChannelId: HUDDLE_CHANNEL_ID,
+      members: [{ pubkey: TEST_IDENTITIES.tyler.pubkey, role: "member" }],
+    },
+  });
+
+  await page.goto("/");
+  await page
+    .getByRole("button", { name: "Open floating voice controls" })
+    .click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        (window.__BUZZ_E2E_COMMAND_LOG__ ?? []).filter(
+          (entry) => entry.command === "voice_overlay_window",
+        ),
+      ),
+    )
+    .toEqual([
+      { command: "voice_overlay_window", payload: { action: "open" } },
+    ]);
+});


### PR DESCRIPTION
## Summary

- add a compact, always-on-top Buzz Voice controller for active Huddles
- reuse the existing Huddle microphone, transcription, and text-to-speech pipeline so the main window remains the sole media owner
- synchronize controls and state through a typed, versioned event bridge with correlated action acknowledgements
- add a singleton Tauri window with a minimal capability and cached theme values

## Verification

- complete desktop frontend suite: 3,933/3,933 passed
- Playwright voice-overlay tests: 5/5 passed, including active-to-idle cleanup and matched/unrelated result handling
- frontend static checks, typecheck, and E2E build
- Rust desktop suite: 2,108 passed, 14 OS-keychain tests ignored; 3 diagnostics passed
- Clippy for all targets with warnings denied
- Rust formatting and diff checks
- two independent final reviews: ship; no blocker, high, or medium findings

Originating Buzz channel: `e6e68e5d-c244-4363-8eff-33de0ea90197`
