### PR TITLE
fix(buzz-acp): stop hermes-acp/amp-acp crashing on Windows model discovery

### DIFF
--- a/crates/buzz-acp/src/config.rs
+++ b/crates/buzz-acp/src/config.rs
@@ -697,11 +697,23 @@ pub(crate) fn normalize_agent_command_identity(command: &str) -> String {
         .collect()
 }
 
+/// Zero-arg runtimes must be listed here explicitly, not left to fall through
+/// to `None`. Windows cannot represent an empty-string environment variable —
+/// `SetEnvironmentVariable(name, "")` deletes the variable instead of setting
+/// it — so when the desktop spawns one of these agents with an empty args
+/// list, `BUZZ_ACP_AGENT_ARGS` never reaches the child process on Windows and
+/// clap falls back to its own `default_value = "acp"`. Any runtime missing
+/// from this list then receives a spurious `acp` argv token on Windows only
+/// (Linux/macOS pass the real empty string through untouched), which for a
+/// runtime that doesn't understand an `acp` subcommand (e.g. `hermes-acp`)
+/// crashes the child before it can respond to ACP `initialize`, surfacing to
+/// the user as "agent process exited unexpectedly" / an empty model list.
 fn default_agent_args(command: &str) -> Option<Vec<String>> {
     match normalize_agent_command_identity(command).as_str() {
         "goose" => Some(vec!["acp".to_string()]),
         "codex" | "codex-acp" | "claude-agent-acp" | "claude-code-acp" | "claude-code"
-        | "claudecode" | "buzz-agent" => Some(Vec::new()),
+        | "claudecode" | "buzz-agent" | "hermes" | "hermes-agent" | "hermes-acp"
+        | "amp" | "amp-acp" => Some(Vec::new()),
         _ => None,
     }
 }
@@ -1575,6 +1587,33 @@ mod tests {
             normalize_agent_args("claude-agent-acp", vec!["acp".into()]),
             Vec::<String>::new()
         );
+    }
+
+    #[test]
+    fn normalizes_hermes_and_amp_args_to_empty() {
+        // Regression test: on Windows, `BUZZ_ACP_AGENT_ARGS=""` is dropped
+        // from the child's environment (Windows cannot represent an
+        // empty-string env var), so clap falls back to its own
+        // `default_value = "acp"` and the spawned process sees a lone "acp"
+        // argv token it never asked for. hermes-acp and amp-acp don't take
+        // an `acp` subcommand and crash on it (block/buzz#hermes-model-load).
+        for command in ["hermes", "hermes-agent", "hermes-acp", "amp", "amp-acp"] {
+            assert_eq!(
+                normalize_agent_args(command, Vec::new()),
+                Vec::<String>::new(),
+                "command={command}"
+            );
+            assert_eq!(
+                normalize_agent_args(command, vec!["".into()]),
+                Vec::<String>::new(),
+                "command={command}"
+            );
+            assert_eq!(
+                normalize_agent_args(command, vec!["acp".into()]),
+                Vec::<String>::new(),
+                "command={command}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

On Windows, `hermes-acp` (and `amp-acp`) crash immediately when Buzz Desktop tries to load their model list, surfacing to the user as "agent process exited unexpectedly" / an empty model dropdown ("Using built-in model options. Could not load live models").

**Root cause:** Windows cannot represent an empty-string environment variable — `SetEnvironmentVariable(name, "")` deletes the variable instead of setting it to empty. When Desktop spawns a zero-arg runtime like `hermes-acp` (`agent_args: &[]` in the preset), it sets `BUZZ_ACP_AGENT_ARGS` to an empty string, which Windows drops entirely from the child's environment. clap then falls back to its own `default_value = "acp"` for that arg, so `hermes-acp` receives an `acp` argv token it doesn't understand and exits before completing the ACP `initialize` handshake.

`normalize_agent_args()` in `crates/buzz-acp/src/config.rs` already has a legacy-collapse safety net for exactly this shape (a lone `"acp"` token collapses back to `[]` for zero-arg providers), but it only fires for runtimes listed in `default_agent_args()`. `hermes`, `hermes-agent`, `hermes-acp`, `amp`, and `amp-acp` were missing from that list, so the spurious `acp` token passed straight through instead of being collapsed.

Linux/macOS are unaffected (they pass the real empty string through untouched). Codex/Claude presets are unaffected because they already pass `["acp"]` explicitly, which happens to match clap's default and masks the bug.

## Change

Add `hermes` / `hermes-agent` / `hermes-acp` / `amp` / `amp-acp` to the zero-arg runtime list in `default_agent_args()`, mirroring the existing Codex/Claude entries. Added a regression test (`normalizes_hermes_and_amp_args_to_empty`) covering all three input shapes (no args, one empty-string arg, a lone `"acp"` arg) for each of the five command spellings.

## Test plan

- [x] `./bin/cargo test -p buzz-acp --lib config::` — 114/114 passed, including the new regression test
- [x] Built `buzz-acp` and reproduced the exact Windows failure mode locally (env var absent) against `hermes-acp` — model discovery now succeeds and returns the full model list instead of exiting
- [x] Confirmed no change in behavior for `goose`/`codex`/`claude*` (already-covered cases, existing tests still pass)
