### PR TITLE
fix(desktop): sync persona respond-to edits onto the linked agent instance

### DIFF
--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.test.mjs
@@ -58,6 +58,8 @@ function persona(overrides = {}) {
     isBuiltIn: false,
     isActive: true,
     envVars: { NEW_KEY: "2" },
+    respondTo: "owner-only",
+    respondToAllowlist: [],
     createdAt: "2026-01-01T00:00:00Z",
     updatedAt: "2026-01-01T00:00:00Z",
     ...overrides,
@@ -148,6 +150,67 @@ test("personaManagedAgentUpdate leaves runtime fields alone when runtime is unch
         runtimes: [runtime({ id: "goose", command: "goose" })],
       },
     ),
+    null,
+  );
+});
+
+test("personaManagedAgentUpdate syncs an edited respond-to mode to the linked agent", () => {
+  assert.deepEqual(
+    personaManagedAgentUpdate(
+      agent({
+        name: "Fizz Prime",
+        systemPrompt: "New prompt",
+        model: "new-model",
+        envVars: { NEW_KEY: "2" },
+      }),
+      persona({ respondTo: "anyone" }),
+    ),
+    {
+      pubkey: "deadbeef".repeat(8),
+      respondTo: "anyone",
+      respondToAllowlist: [],
+    },
+  );
+});
+
+test("personaManagedAgentUpdate syncs an edited respond-to allowlist to the linked agent", () => {
+  const allowlist = ["a".repeat(64), "b".repeat(64)];
+
+  assert.deepEqual(
+    personaManagedAgentUpdate(
+      agent({
+        name: "Fizz Prime",
+        systemPrompt: "New prompt",
+        model: "new-model",
+        envVars: { NEW_KEY: "2" },
+        respondTo: "allowlist",
+        respondToAllowlist: ["a".repeat(64)],
+      }),
+      persona({ respondTo: "allowlist", respondToAllowlist: allowlist }),
+    ),
+    {
+      pubkey: "deadbeef".repeat(8),
+      respondTo: "allowlist",
+      respondToAllowlist: allowlist,
+    },
+  );
+});
+
+test("personaManagedAgentUpdate leaves respond-to alone when unchanged or unset", () => {
+  const settled = agent({
+    name: "Fizz Prime",
+    systemPrompt: "New prompt",
+    model: "new-model",
+    envVars: { NEW_KEY: "2" },
+    respondTo: "anyone",
+  });
+
+  assert.equal(
+    personaManagedAgentUpdate(settled, persona({ respondTo: "anyone" })),
+    null,
+  );
+  assert.equal(
+    personaManagedAgentUpdate(settled, persona({ respondTo: null })),
     null,
   );
 });

--- a/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
+++ b/desktop/src/features/profile/ui/UserProfilePanelUtils.ts
@@ -292,6 +292,21 @@ export function personaManagedAgentUpdate(
     hasChanges = true;
   }
 
+  // The persona carries the authored respond-to gate; the harness spawn env is
+  // built from the *instance* record (`build_respond_to_env`). Without this the
+  // card renders the persona's mode while the running agent keeps whatever it
+  // was minted with, and no restart ever reconciles them. Mode and allowlist
+  // travel together — the backend replaces the allowlist only when it is sent.
+  if (
+    persona.respondTo != null &&
+    (persona.respondTo !== agent.respondTo ||
+      !stringArrayEqual(persona.respondToAllowlist, agent.respondToAllowlist))
+  ) {
+    input.respondTo = persona.respondTo;
+    input.respondToAllowlist = [...persona.respondToAllowlist];
+    hasChanges = true;
+  }
+
   const runtimeChanged =
     options.previousPersona !== undefined &&
     options.previousPersona.runtime !== persona.runtime;


### PR DESCRIPTION
Fixes #4487.

## Problem

Editing an agent's respond-to on its persona card writes the persona and leaves the running agent on its old gate, permanently.

`personaManagedAgentUpdate` is the function that pushes a persona edit down onto the linked managed-agent instance. It propagates `displayName`, `systemPrompt`, `model`, `envVars` and the runtime-derived commands. It does not propagate `respondTo` / `respondToAllowlist`, even though `UpdateManagedAgentRequest` accepts both.

The harness spawn env is built from the instance record (`build_respond_to_env`), and `resolve_mint_behavioral_defaults` reads the definition at mint time only. Nothing reconciles the two afterwards, so an agent minted as `owner-only` stays `owner-only` for good: the card renders the persona's mode while every `buzz-acp starting:` line prints the stale instance value, and a restart re-reads that same stale value.

The failure is silent on both sides. The card asserts a gate the process does not enforce, and the drop itself (`inbound author gate`) is `tracing::debug!` while the harness logs at INFO, so a correctly delivered and correctly dropped mention leaves no trace at the default log level. It looks exactly like an event that never arrived. That cost us three days and four wrong theories before we read the agent's own startup line.

## Change

One block in `personaManagedAgentUpdate`. Mode and allowlist travel together, matching the backend contract where a present allowlist replaces the stored one and allowlist mode with an empty list is rejected. A null persona `respondTo` means unset and leaves the instance alone, so personas that never authored a behavior group are unaffected.

## Tests

Three new cases in `UserProfilePanelUtils.test.mjs`: mode change propagates, allowlist change propagates, and unchanged-or-unset produces no update. The persona fixture gains `respondTo` / `respondToAllowlist` so it matches the `AgentPersona` type it stands in for.

`pnpm test` in `desktop/`: 3888 pass, 0 fail. `biome check` and `tsc --noEmit` clean on the touched files.

## Not in scope

Two adjacent issues found while tracing this, left out deliberately and described in #4487:

- `useAgentManagement.ts:48` hardcodes `respondToAllowlist: []` when relaying an inbound agent-management `update`, so allowlist mode over that path can only fail validation.
- The resolved gate is not logged at INFO on spawn and is not surfaced on the card, which is what made this expensive rather than trivial to diagnose.
