### PR TITLE
fix(desktop): reveal Complete/Snooze/Cancel on inbox reminder rows

### DIFF
--- a/desktop/src/features/reminders/ui/RemindersPanel.tsx
+++ b/desktop/src/features/reminders/ui/RemindersPanel.tsx
@@ -162,7 +162,7 @@ function ReminderRow({
   return (
     <div
       className={cn(
-        "flex items-start gap-3 transition-colors",
+        "group/reminder-row flex items-start gap-3 transition-colors",
         isInboxList
           ? "border-b border-border/45 px-4 py-4 hover:bg-muted/40 focus-within:bg-muted/40"
           : "rounded-md border p-3",
@@ -220,8 +220,19 @@ function ReminderRow({
           </p>
         ) : null}
       </button>
-      {isDone || isInboxList ? null : (
-        <div className="flex shrink-0 items-center gap-1">
+      {isDone ? null : (
+        <div
+          className={cn(
+            "flex shrink-0 items-center gap-1",
+            // In the inbox list the actions stay out of the way until the row
+            // is hovered, focused, or selected — without this the only way to
+            // complete a reminder is to open the detail pane, which reads as
+            // "reminders can't be cleared".
+            isInboxList &&
+              "opacity-0 transition-opacity group-hover/reminder-row:opacity-100 group-focus-within/reminder-row:opacity-100",
+            isInboxList && isSelected && "opacity-100",
+          )}
+        >
           <Button
             className="h-7 w-7 p-0"
             disabled={isActing}


### PR DESCRIPTION
Fixes #4493

Once a reminder came due there was no visible way to clear it from the inbox Reminders list, so the Inbox badge kept counting a reminder the user had already dealt with.

`ReminderRow` suppressed its own action cluster whenever it was rendered in the inbox:

```tsx
// desktop/src/features/reminders/ui/RemindersPanel.tsx:223 (before)
{isDone || isInboxList ? null : (
  <div className="flex shrink-0 items-center gap-1">
    ...Complete / SnoozeMenu / Cancel
  </div>
)}
```

`InboxListPane.tsx:585` is the only caller passing `presentation="inbox-list"`, so in the inbox those buttons were never rendered. Complete / Snooze / Cancel existed only in `ReminderDetailPane`, reached by selecting a row — a real path, but nothing on the row hints that selecting it unlocks actions, and the standalone `/reminders` route that used to show them inline is now a redirect to `/`.

## What changed

Render the existing Complete / Snooze / Cancel controls in the `inbox-list` presentation too, revealed on row hover, keyboard focus, or selection so the list stays visually calm at rest.

- Drops `isInboxList` from the suppression condition — `isDone` still hides actions on completed rows.
- Adds a `group/reminder-row` marker on the row so the cluster can be hover-revealed with `group-hover/reminder-row:opacity-100`, plus `group-focus-within` for keyboard users and a `isSelected` override so the selected row keeps its actions visible.

One file, +14/-3. No new components, service calls, or event shapes — the mutations and the detail-pane path are untouched.

## Verification

At `8484874`, hermit active, from `desktop/`:

- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec biome check src/features/reminders` — clean.
- `pnpm test` — `3906 pass / 0 fail` (full desktop unit suite).
- `pnpm exec playwright test --project=smoke --grep reminders` — `11 passed`.
- Wrote a throwaway mock-mode spec that seeds an overdue reminder, opens the Reminders filter, hovers the row, asserts `Complete` becomes visible, and clicks it. Passed; screenshot confirmed the check / clock / X on the row. Spec removed before commit.

Because the actions use `opacity-0` rather than conditional rendering, they stay in the tab order and `group-focus-within` reveals them on focus, so the affordance is reachable without a pointer.

## Not included

The fire-on-due notification in `useReminderNotifications.ts` still has no `Done` action, so a reminder cannot be cleared from the toast that announces it. Noted in #4493; better as its own change.
