### PR TITLE
fix(desktop): make the due-reminder notification open its message

### DIFF
--- a/desktop/src/features/reminders/useReminderNotifications.ts
+++ b/desktop/src/features/reminders/useReminderNotifications.ts
@@ -6,6 +6,10 @@ import {
   useRemindersQuery,
 } from "@/features/reminders/hooks";
 import { dueSince } from "@/features/reminders/lib/reminderFilters";
+import {
+  hasNavigableTarget,
+  resolveReminderDestination,
+} from "@/features/reminders/lib/reminderNavigation";
 import type { Reminder } from "@/features/reminders/lib/reminderTypes";
 import {
   requestDockBounce,
@@ -105,14 +109,43 @@ export function useReminderNotifications(
           )
         : `${due.length} reminders are due`;
 
-    void sendDesktopNotification({
-      title: formatNotificationTitle({ prefix: "Reminder due", channelLabel }),
-      body,
-    }).then((didSend) => {
+    // A single due reminder carries its message target, so make the
+    // notification click-through to that message — the same landing as clicking
+    // the row in the inbox. Coalesced multi-reminder toasts have no single
+    // destination, so they omit the target and fall back to opening Home.
+    const singleTarget =
+      due.length === 1 && hasNavigableTarget(due[0].content.target)
+        ? due[0].content.target
+        : undefined;
+
+    void (async () => {
+      const destination = singleTarget
+        ? await resolveReminderDestination(singleTarget)
+        : null;
+
+      const didSend = await sendDesktopNotification({
+        title: formatNotificationTitle({
+          prefix: "Reminder due",
+          channelLabel,
+        }),
+        body,
+        target: destination
+          ? {
+              channelId: destination.channelId,
+              channelName: channelLabel,
+              content: singleTarget?.preview,
+              eventId: destination.messageId,
+              kind: null,
+              pubkey: singleTarget?.authorPubkey,
+              threadRootId: destination.threadRootId,
+            }
+          : undefined,
+      });
+
       if (!didSend) return;
       playNotificationSound(resolveSlotSound(current, "needs_action"));
       void requestDockBounce();
-    });
+    })();
   });
 
   React.useEffect(() => {


### PR DESCRIPTION
Follow-up to #4494, second half of #4493.

## Problem

`useReminderNotifications` sent the fire-on-due notification with a title and body but no `target`:

```ts
// desktop/src/features/reminders/useReminderNotifications.ts (before)
void sendDesktopNotification({
  title: formatNotificationTitle({ prefix: "Reminder due", channelLabel }),
  body,
}).then(...)
```

Every other desktop notification in the app passes a `DesktopNotificationTarget` — see `use-feed-desktop-notifications.ts:115` and the DM path in `useAppShellDesktopNotifications.ts:67`. That target is what `listenForDesktopNotificationActions` → `handleDesktopNotificationAction` uses to reveal the window and open the message.

Without it, a reminder notification is inert: the user is told a reminder is due, clicks it, and nothing happens. They then have to find the reminder by hand.

## What changed

Attach the reminder's message target when exactly one reminder is due, so the notification lands on that message in its thread — the same destination as clicking the row in the inbox.

- Reuses `resolveReminderDestination` / `hasNavigableTarget` from `reminderNavigation.ts`, so the notification and the in-app row click resolve the thread root identically instead of growing a second code path.
- Note-only reminders and targets with empty `channelId` / `eventId` / `authorPubkey` are rejected by `hasNavigableTarget`, so they keep sending no target rather than routing to `/channels/` with an empty param.
- A coalesced multi-reminder notification has no single destination, so it also keeps sending no target and falls back to `goHome()` — matching the existing decision to drop channel context in that case.
- `kind` is left `null`; `toSearchHit` defaults it to `9`, which is what the inbox click path effectively assumes too.

The send is now inside an async IIFE because the destination resolution awaits a `getEventById`. `resolveReminderDestination` catches its own fetch failure and degrades to `threadRootId: null` (channel-level landing), so a relay hiccup delays the notification slightly but never suppresses it.

One file, +38/-5.

## About the "Done" button

The original suggestion in #4493 was a `Done` action *on* the notification. I did not do that, and I think it should be a separate decision rather than folded in here.

A real action button is not a small change on this stack: nothing in the repo calls `registerActionTypes`, macOS and Windows go through `new window.Notification(...)` which supports no buttons, and the Linux path in `src-tauri/src/commands/notifications.rs:77` declares a single `"default"` action purely to make the whole notification clickable. Adding a named `Done` action means per-platform action registration, a second D-Bus action plus routing on Linux, and a bridge from the action handler to `completeReminder` outside React — with behaviour that would differ by platform.

Click-through gets most of the value for a fraction of the surface area: one click puts the user on the message, where the inbox row (after #4494) has `Complete` right there. Happy to take the action-button work as its own PR if a maintainer wants it.

## Verification

At `d8179c8`, hermit active, from `desktop/`:

- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec biome check src/features/reminders` — clean.
- `pnpm test` — `3906 pass / 0 fail` (full desktop unit suite).
- `pnpm exec playwright test --project=smoke --grep reminders` — `9 passed`.

**Not covered by an automated test.** `useReminderNotifications` has no existing test seam — there are no unit tests for `src/features/reminders/` and the notification path needs either Tauri IPC or a stubbed `window.Notification`, so a test here would mostly assert against the mock rather than the product. I did not want to invent a new harness pattern inside a bug fix. The click-routing half of this path is already exercised by the feed and DM notification code that shares `handleDesktopNotificationAction`; what is new here is only the target payload. Reviewer's call if that is not good enough — I will add coverage in whatever shape you prefer.
